### PR TITLE
feat(engine): PR-6.75 — C0-full+C1 read/write conflict profiler; sound CR 603.3b same-event trigger ordering

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -17,11 +17,18 @@
 //!
 //! Commutation is proven **modulo the source-actor residual** (§1.2 side
 //! condition): per-source granted state (lifelink CR 702.15 / deathtouch
-//! CR 702.2) and the CR 800.4a player-loss object-removal cascade modulate
-//! resolution without appearing in the normalized AST or any profiled read.
-//! Both channels were auto-ordered UNCONDITIONALLY by the pre-C1 short-circuit
-//! and are inherited unchanged (zero ordering-decision change). Damage kinds are
-//! therefore RECIPIENT-classified, not source-bound (CR 704.5a / CR 800.4a).
+//! CR 702.2), the `DamagedPlayerIsEventSourceOwner` referent (a damage-cause
+//! source-owner read, `types/ability.rs`), and the CR 800.4a player-loss
+//! object-removal cascade modulate resolution without appearing in the normalized
+//! AST or any profiled read. Both channels were auto-ordered UNCONDITIONALLY by
+//! the pre-C1 short-circuit and are inherited unchanged (zero ordering-decision
+//! change). Damage kinds are therefore RECIPIENT-classified, not source-bound
+//! (CR 704.5a / CR 800.4a). PR-6.75 c5 note: the batch-T1 path now clears at
+//! `Uniform` (controller-equal) as well as `UniformAligned` (owner-equal), so —
+//! unlike the owner-aligned span gate — it no longer equalizes source OWNER across
+//! members. The `DamagedPlayerIsEventSourceOwner` / lifelink / deathtouch residual
+//! exposure on the batch path is thus identical to the same-event T1 path already
+//! documented, and bounded by the §7.1 `old=false, new=true` zero-movement grep.
 //!
 //! A SECOND inherited fail-open: `reads_event_live` is consulted ONLY on the
 //! batch path (`profiles_conflict`: the `all_same_source` fast path and the
@@ -366,11 +373,11 @@ fn zones_of_filter(f: &TargetFilter) -> ZoneSpan {
 // ---------------------------------------------------------------------------
 
 /// CR 102.2 + CR 109.5: a relative player-identity span for scope-gated feed
-/// refinement. Meaningful ONLY under `GroupStructure.same_controller` (all
+/// refinement. Meaningful ONLY under `ControllerUniformity::UniformAligned` (all
 /// members' relative sets `You`/`Opponents` then denote the SAME concrete players
 /// — `You == {c0}`, `Opponents == all − {c0}`, disjoint at any player count). Dead
-/// otherwise: `profiles_conflict` never consults a span when `same_controller` is
-/// false, so every value is byte-inert in the ungated path.
+/// otherwise: `profiles_conflict` never consults a span when the gate is off
+/// (not `UniformAligned`), so every value is byte-inert in the ungated path.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum PlayerSpan {
     /// No player-keyed read/write on this side — overlaps nothing. Also the
@@ -400,7 +407,7 @@ impl PlayerSpan {
 }
 
 /// CR 102.2 + CR 109.5 relative-player overlap: two spans can name a common
-/// player iff — under `same_controller` — their relative sets intersect. `None`
+/// player iff — under `UniformAligned` — their relative sets intersect. `None`
 /// overlaps nothing; `Any` overlaps every non-`None`; `You`×`Opponents` is the
 /// only disjoint concrete pair (mirrors `census_overlap`).
 fn player_span_overlap(a: PlayerSpan, b: PlayerSpan) -> bool {
@@ -556,6 +563,14 @@ pub(crate) struct RwProfile {
     /// D5: one of the 12 retained-prompt event-context refs is present.
     /// Consulted ONLY by the batch branch (commit 2).
     legacy_batch_prompt: bool,
+    /// CR 603.10a (PR-6.75 c5): the resolution consumes a binding resolved per
+    /// member instance — per-source tracked/chosen storage, an attachment, or an
+    /// event/replacement-context referent outside the legacy-12 /
+    /// `writes_event_object` carriers — so members' resolution functions are NOT one
+    /// shared `f`. Refutes batch-T1 (`!reads_member_bound` conjunct). Walk-computed
+    /// single-bit read fact (precedent: `legacy_batch_prompt`); `drop_writes` keeps
+    /// it (a read).
+    reads_member_bound: bool,
     /// Writes scoped to the member's own Source/Recipient object.
     writes_self: KindSet,
     /// Board-/player-/stack-scoped writes (INCLUDES creation, event-object, and
@@ -607,7 +622,7 @@ pub(crate) struct RwProfile {
     /// The ability writes the mana pool (`Effect::Mana`).
     writes_pool: bool,
     // --- PR-6.75 gate-scoped player-identity spans (consulted ONLY under
-    // GroupStructure.same_controller; every value is byte-inert otherwise). ---
+    // ControllerUniformity::UniformAligned; every value is byte-inert otherwise). ---
     /// CR 109.5/102.2: relative-player span of the player-resource READS
     /// (`HandSize`; life reads stay unrefined ⇒ effective-Any). A single merged
     /// span across kinds — mixing kinds degrades to `Any` (ceiling documented).
@@ -640,6 +655,7 @@ impl RwProfile {
             reads_frozen: KindSet::EMPTY,
             reads_event_live: false,
             legacy_batch_prompt: false,
+            reads_member_bound: false,
             writes_self: KindSet::EMPTY,
             writes_external: KindSet::EMPTY,
             writes_event_object: KindSet::EMPTY,
@@ -680,6 +696,9 @@ impl RwProfile {
         p.writes_player_span = PlayerSpan::Any;
         p.reads_membership_ctrl = PlayerSpan::Any;
         p.writes_membership_external_ctrl = PlayerSpan::Any;
+        // CR 603.10a: an unclassified subtree may consult a per-member binding ⇒
+        // fail-closed (refuses batch-T1).
+        p.reads_member_bound = true;
         p
     }
 
@@ -690,6 +709,7 @@ impl RwProfile {
         self.reads_frozen = self.reads_frozen.union(o.reads_frozen);
         self.reads_event_live |= o.reads_event_live;
         self.legacy_batch_prompt |= o.legacy_batch_prompt;
+        self.reads_member_bound |= o.reads_member_bound;
         self.writes_self = self.writes_self.union(o.writes_self);
         self.writes_external = self.writes_external.union(o.writes_external);
         self.writes_event_object = self.writes_event_object.union(o.writes_event_object);
@@ -756,6 +776,37 @@ impl RwProfile {
 // GroupStructure.
 // ---------------------------------------------------------------------------
 
+/// CR 603.3b + CR 110.2 + CR 108.3 + CR 805.7: the controller structure of an
+/// ordering group, as one ordered refinement axis (parameterizes the former
+/// `same_controller` + would-be `controllers_uniform` two-correlated-bool sibling
+/// cluster). `Mixed` is the fail-closed floor; each higher level unlocks strictly
+/// more refinement. Ordering is meaningful only for the two consulting sites
+/// (`profiles_conflict` batch-T1 checks `!= Mixed`; the span/fused gate checks
+/// `UniformAligned`) — the enum itself is not `Ord`.
+///
+/// `Mixed` is reachable ONLY via team-pooled trigger placement (CR 805.7):
+/// `begin_trigger_ordering` partitions groups by controller (CR 109.5 triggered-
+/// ability "you" = the controller when it triggered), so every non-team topology
+/// is controller-uniform by construction.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ControllerUniformity {
+    /// Divergent pending controllers (CR 805.7 team pool). No refinement consulted
+    /// ⇒ conflict decision is byte-identical to the pre-uniformity engine.
+    Mixed,
+    /// Every member's `pending.controller` is one shared player `c0` (CR 109.5).
+    /// The relative player-identity spans still cannot be trusted (owner may
+    /// diverge), but the batch-T1 identical-function fast path is sound: an f that
+    /// consults no source binding, no member-bound storage, and no live event is
+    /// one shared f(state, c0).
+    Uniform,
+    /// `Uniform` AND each live source object is both controlled and owned by `c0`
+    /// (CR 108.3 owner). Only then do the relative player-identity spans
+    /// (`You`/`Opponents`) denote the same concrete players across members, and
+    /// owner-keyed self-write destinations (CR 400.3 hand/graveyard) become
+    /// controller-resolvable — the precondition of the span/fused gate.
+    UniformAligned,
+}
+
 pub(crate) struct GroupStructure {
     /// All members fired on ONE trigger event.
     pub(crate) same_event: bool,
@@ -776,15 +827,13 @@ pub(crate) struct GroupStructure {
     pub(crate) event_object_present: bool,
     /// The live source census, for the membership census-overlap row (§2).
     pub(crate) source_census: SourceCensus,
-    /// PR-6.75 (CR 603.3b + CR 110.2 + CR 108.3): the group is controller-uniform
-    /// AND owner-aligned — every member's pending controller is one shared player
-    /// `c0` and each live source object is both controlled and owned by `c0`. ONLY
-    /// then do the relative player-identity spans (`You`/`Opponents`) denote the
-    /// same concrete players across members (owner-alignment additionally makes
-    /// owner-keyed self-write destinations, CR 400.3 hand/graveyard, controller-
-    /// resolvable). `false` ⇒ NO span/fused refinement is consulted ⇒ the conflict
-    /// decision is byte-identical to the pre-PR engine (structural zero-delta).
-    pub(crate) same_controller: bool,
+    /// PR-6.75 (CR 603.3b + CR 110.2 + CR 108.3 + CR 805.7): the controller
+    /// structure of this ordering group. `UniformAligned` reproduces the former
+    /// `same_controller == true` exactly (span/fused gate consults it verbatim);
+    /// `Uniform` additionally unlocks only the batch-T1 identical-function fast
+    /// path (`!= Mixed`); `Mixed` consults no refinement ⇒ byte-identical to the
+    /// pre-uniformity engine (structural zero-delta).
+    pub(crate) controller_uniformity: ControllerUniformity,
 }
 
 // ---------------------------------------------------------------------------
@@ -793,7 +842,7 @@ pub(crate) struct GroupStructure {
 
 /// PR-6.75 gate-scoped span bundle for `feeds` — the effective (already
 /// effective-Any-promoted) relative-player spans of the player-resource and
-/// membership rows plus the `gate` (`same_controller`). When `gate` is false the
+/// membership rows plus the `gate` (`UniformAligned`). When `gate` is false the
 /// span conjuncts collapse to `true`, so the feed matrix is byte-identical.
 #[derive(Clone, Copy)]
 struct SpanGate {
@@ -835,7 +884,7 @@ fn feeds(
     write_zones: &ZoneSpan,
     spans: SpanGate,
 ) -> bool {
-    // PR-6.75 (CR 102.2/109.5): under `same_controller`, a player-keyed read and
+    // PR-6.75 (CR 102.2/109.5): under `UniformAligned`, a player-keyed read and
     // write of the SAME kind conflict only when their relative-player spans can
     // name a common player. `!gate` ⇒ byte-identical (conjunct is `true`).
     let player_ok = !spans.gate || player_span_overlap(spans.read_player, spans.write_player);
@@ -912,6 +961,26 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
         return false;
     }
     if s.all_same_source && !p.reads_event_live {
+        return false;
+    }
+    // CR 603.3b batch T1 (PR-6.75 c5): in a controller-uniform co-departure group of
+    // normalized-identical members, a resolution that consults neither its source
+    // binding (`source_independent`: CR 603.10a), nor per-member bound storage
+    // (`reads_member_bound`), nor its firing event (`reads_event_live` / event-object
+    // writes) is ONE function f(state, c0) shared by every member — any permutation
+    // is f∘…∘f, so CR 603.3b ordering is unobservable. Sound modulo the source-actor
+    // residual (module doc), inherited unchanged from the pre-C1 batch short-circuit.
+    // Never bypasses the freeze-invalidation row below: that row requires a
+    // frozen/src/event-live read, all excluded here. `Mixed` (CR 805.7 team pool)
+    // fails closed — the divergent-controller cause-source channel is order-observable
+    // (Dodecapod / EventSourceControlledBy).
+    if !s.same_event
+        && !matches!(s.controller_uniformity, ControllerUniformity::Mixed)
+        && p.source_independent()
+        && !p.reads_member_bound
+        && !p.reads_event_live
+        && !p.writes_event_object.any()
+    {
         return false;
     }
 
@@ -1011,7 +1080,10 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
     // per-player fixed-point input among identical members ⇒ dropped under the
     // gate; unioned back into `reads_player` when ungated (byte-identical to today,
     // where the count read was recorded in `reads_player`).
-    let effective_reads_player = if s.same_controller {
+    let effective_reads_player = if matches!(
+        s.controller_uniformity,
+        ControllerUniformity::UniformAligned
+    ) {
         p.reads_player
     } else {
         p.reads_player.union(p.reads_player_fused)
@@ -1029,7 +1101,10 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
         effective_external.set_membership,
     );
     let board_spans = SpanGate {
-        gate: s.same_controller,
+        gate: matches!(
+            s.controller_uniformity,
+            ControllerUniformity::UniformAligned
+        ),
         read_player: effective_span(p.reads_player_span, board_player_read_present),
         write_player: effective_span(p.writes_player_span, board_player_write_present),
         read_mctrl: effective_span(p.reads_membership_ctrl, board_reads.set_membership),
@@ -1264,7 +1339,7 @@ fn place_membership_write(
         p.writes_external.set(StateKind::HandLibrary);
         // §4.3.4 (CR 400.3 + owner-alignment gate): a SELF hand/library move
         // (Rekindled Flame's `Bounce{SelfRef}` → hand) touches the owner-of-self's
-        // hand, which equals the controller's under `same_controller` ⇒ You.
+        // hand, which equals the controller's under `UniformAligned` ⇒ You.
         // External/event/created endpoints leave the span unrefined (`None` ⇒
         // effective-Any at conflict time).
         if matches!(sc, WriteScope::SelfSource) {
@@ -1462,6 +1537,16 @@ fn target_is_legacy_ref(f: &TargetFilter) -> bool {
 fn flag_legacy_write_target(p: &mut RwProfile, target: &TargetFilter) {
     if target_is_legacy_ref(target) {
         p.legacy_batch_prompt = true;
+    }
+}
+
+/// Set `reads_member_bound` when an effect WRITE target names a per-member-bound
+/// referent (CR 603.10a, PR-6.75 c5) — the write path's counterpart to
+/// `member_bound_target_filter` read-position wiring. A `ChangeZone{TrackedSet}`
+/// return (Day of the Dragons) writes a per-source set ⇒ members diverge.
+fn flag_member_bound_write_target(p: &mut RwProfile, target: &TargetFilter) {
+    if member_bound_target_filter(target) {
+        p.reads_member_bound = true;
     }
 }
 
@@ -2058,6 +2143,224 @@ fn legacy_filter_prop(p: &FilterProp) -> bool {
         }
         FilterProp::AnyOf { props } => props.iter().any(legacy_filter_prop),
         FilterProp::Not { prop } => legacy_filter_prop(prop),
+        FilterProp::Token
+        | FilterProp::NonToken
+        | FilterProp::WasPlayed
+        | FilterProp::Blocking
+        | FilterProp::BlockingSource
+        | FilterProp::CombatRelation { .. }
+        | FilterProp::Unblocked
+        | FilterProp::AttackingAlone
+        | FilterProp::BlockingAlone
+        | FilterProp::Tapped
+        | FilterProp::Untapped
+        | FilterProp::IsSaddled
+        | FilterProp::SaddledSource
+        | FilterProp::ConvokedSource
+        | FilterProp::HasHasteOrControlledSinceTurnBegan
+        | FilterProp::WithKeyword { .. }
+        | FilterProp::HasKeywordKind { .. }
+        | FilterProp::WithoutKeyword { .. }
+        | FilterProp::WithoutKeywordKind { .. }
+        | FilterProp::ManaValueParity { .. }
+        | FilterProp::ManaCostIn { .. }
+        | FilterProp::InZone { .. }
+        | FilterProp::Foretold
+        | FilterProp::EnchantedBy
+        | FilterProp::EquippedBy
+        | FilterProp::AttachedToSource
+        | FilterProp::AttachedToRecipient
+        | FilterProp::Another
+        | FilterProp::Unpaired
+        | FilterProp::OtherThanTriggerObject
+        | FilterProp::HasColor { .. }
+        | FilterProp::PowerGTSource
+        | FilterProp::ColorCount { .. }
+        | FilterProp::ManaSymbolCount { .. }
+        | FilterProp::HasSupertype { .. }
+        | FilterProp::IsChosenCreatureType
+        | FilterProp::IsChosenColor
+        | FilterProp::IsChosenCardType
+        | FilterProp::IsChosenLandOrNonlandKind
+        | FilterProp::HasSingleTarget
+        | FilterProp::Modal
+        | FilterProp::NotColor { .. }
+        | FilterProp::NotSupertype { .. }
+        | FilterProp::Suspected
+        | FilterProp::Renowned
+        | FilterProp::ToughnessGTPower
+        | FilterProp::PowerExceedsBase
+        | FilterProp::InAnyZone { .. }
+        | FilterProp::WasDealtDamageThisTurn
+        | FilterProp::EnteredThisTurn
+        | FilterProp::ZoneChangedThisTurn { .. }
+        | FilterProp::BlockedThisTurn
+        | FilterProp::AttackedOrBlockedThisTurn
+        | FilterProp::CountersPutOnThisTurn { .. }
+        | FilterProp::FaceDown
+        | FilterProp::HasXInManaCost
+        | FilterProp::HasXInActivationCost
+        | FilterProp::WasKicked
+        | FilterProp::HasManaAbility
+        | FilterProp::HasNoAbilities
+        | FilterProp::Named { .. }
+        | FilterProp::SameName
+        | FilterProp::SameNameAsParentTarget
+        | FilterProp::IsCommander
+        | FilterProp::Modified
+        | FilterProp::Historic
+        | FilterProp::NotHistoric
+        | FilterProp::Other { .. } => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Member-bound referent detection (CR 603.10a, PR-6.75 c5).
+//
+// A `TargetFilter`/`ControllerRef`/`FilterProp` is MEMBER-BOUND when the object
+// or player it resolves to is bound per member instance — per-source tracked or
+// chosen storage, an attachment, or an event/replacement-context referent — so
+// two normalized-identical members do NOT share one resolution function `f`.
+// Position-agnostic and exhaustive (wildcard-free) so a future variant must be
+// classified — mirrors `legacy_target_filter`'s descent structure exactly.
+//
+// Each FALSE arm's soundness rests on ONE of:
+//   * source carrier — `SelfRef`/`SourceOrPaired` set `writes_self`/`reads_src`
+//     ⇒ `source_independent()` already false.
+//   * event-object carrier — `TriggeringSource` / parentless `ParentTarget` set
+//     `writes_event_object` ⇒ T1's `!writes_event_object.any()` conjunct fires.
+//   * legacy-12 carrier — the 9 frozen `TargetFilter` tags set
+//     `legacy_batch_prompt` (OR-ed OUTSIDE `profiles_conflict`).
+//   * resolution-local — `ScopedPlayer`/`LastRevealed`/`LastCreated`: bound
+//     within the single resolution, no cross-member storage.
+//   * member-invariant under uniformity — `Controller`/`Player`/`AllPlayers`/
+//     `DefendingPlayer`/`Named`/`Specific*`: one shared `c0` (or a constant) ⇒
+//     identical for every member.
+//   * `Owner`: owner-partition-commutative among identical members — owner is NOT
+//     controller-invariant, but an owner-keyed partition of identical members
+//     composes commutatively (each member's owner-slice is disjoint and the
+//     aggregate is order-free), so it needs no member-bound refusal.
+// ---------------------------------------------------------------------------
+
+/// CR 603.10a: does `f` resolve to a per-member-bound object/player? Mirrors
+/// `legacy_target_filter`'s descent (composites + `Typed.controller`/`properties`)
+/// but classifies for member-boundness, not the frozen-12 tags.
+fn member_bound_target_filter(f: &TargetFilter) -> bool {
+    match f {
+        // Per-source tracked/exiled/chosen storage, attachments, event- and
+        // replacement-context referents (fail-closed: `ParentTargetSlot`/
+        // `StackAbility` are parent/stack-context referents outside the legacy-12
+        // and `writes_event_object` carriers).
+        TargetFilter::TrackedSet { .. }
+        | TargetFilter::TrackedSetFiltered { .. }
+        | TargetFilter::ExiledBySource
+        | TargetFilter::ExiledCardByIndex { .. }
+        | TargetFilter::ChosenCard
+        | TargetFilter::HasChosenName
+        | TargetFilter::SourceChosenPlayer
+        | TargetFilter::ChosenDamageSource
+        | TargetFilter::AttachedTo
+        | TargetFilter::Neighbor { .. }
+        | TargetFilter::OriginalController
+        | TargetFilter::EventTarget
+        | TargetFilter::TriggeringSourceController
+        | TargetFilter::PostReplacementSourceController
+        | TargetFilter::PostReplacementDamageTarget
+        | TargetFilter::PostReplacementDamageTargetOwner
+        | TargetFilter::ParentTargetSlot { .. }
+        | TargetFilter::StackAbility { .. } => true,
+        TargetFilter::Not { filter } => member_bound_target_filter(filter),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(member_bound_target_filter)
+        }
+        TargetFilter::Typed(tf) => {
+            tf.controller
+                .as_ref()
+                .is_some_and(member_bound_controller_ref)
+                || tf.properties.iter().any(member_bound_filter_prop)
+        }
+        // Source carriers (`writes_self`/`reads_src`), event-object carriers, the
+        // legacy-12 tags (`legacy_batch_prompt`), resolution-local refs, and
+        // uniformity-/owner-partition-invariant refs — all documented above.
+        TargetFilter::SelfRef
+        | TargetFilter::SourceOrPaired
+        | TargetFilter::TriggeringSource
+        | TargetFilter::ParentTarget
+        | TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::StackSpell
+        | TargetFilter::CostPaidObject
+        | TargetFilter::ScopedPlayer
+        | TargetFilter::LastCreated
+        | TargetFilter::LastRevealed
+        | TargetFilter::None
+        | TargetFilter::Any
+        | TargetFilter::Player
+        | TargetFilter::Controller
+        | TargetFilter::SpecificObject { .. }
+        | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::DefendingPlayer
+        | TargetFilter::Named { .. }
+        | TargetFilter::Owner
+        | TargetFilter::AllPlayers => false,
+    }
+}
+
+/// CR 603.10a: a `ControllerRef` is member-bound when it names a per-source chosen
+/// player or an attachment-relative player. `You`/`Opponent`/`ScopedPlayer`/
+/// `DefendingPlayer` are member-invariant under uniformity; `TargetPlayer` is
+/// closed by the no-ordering-input target gate; the three legacy-12 refs ride
+/// `legacy_batch_prompt`.
+fn member_bound_controller_ref(x: &ControllerRef) -> bool {
+    match x {
+        ControllerRef::ChosenPlayer { .. }
+        | ControllerRef::SourceChosenPlayer
+        | ControllerRef::EnchantedPlayer => true,
+        ControllerRef::ParentTargetController
+        | ControllerRef::ParentTargetOwner
+        | ControllerRef::TriggeringPlayer
+        | ControllerRef::You
+        | ControllerRef::Opponent
+        | ControllerRef::ScopedPlayer
+        | ControllerRef::TargetPlayer
+        | ControllerRef::DefendingPlayer => false,
+    }
+}
+
+/// CR 603.10a: a `FilterProp` interior nests a member-bound referent when its
+/// inner `TargetFilter` / `ControllerRef` / `QuantityExpr` does. Mirrors
+/// `legacy_filter_prop`'s exhaustive descent; quantity nesting reuses the
+/// authoritative `rw_quantity_expr` member-bound bit.
+fn member_bound_filter_prop(p: &FilterProp) -> bool {
+    match p {
+        FilterProp::CanEnchant { target } => member_bound_target_filter(target),
+        FilterProp::DifferentNameFrom { filter }
+        | FilterProp::TargetsOnly { filter }
+        | FilterProp::Targets { filter } => member_bound_target_filter(filter),
+        FilterProp::SharesQuality { reference, .. } => {
+            reference.as_deref().is_some_and(member_bound_target_filter)
+        }
+        FilterProp::Counters { count, .. } => rw_quantity_expr(count).reads_member_bound,
+        FilterProp::Cmc { value, .. } | FilterProp::PtComparison { value, .. } => {
+            rw_quantity_expr(value).reads_member_bound
+        }
+        FilterProp::ProtectorMatches { controller }
+        | FilterProp::Owned { controller }
+        | FilterProp::MostPrevalentCreatureTypeIn {
+            scope: controller, ..
+        } => member_bound_controller_ref(controller),
+        FilterProp::Attacking { defender: c }
+        | FilterProp::AttackedThisTurn { defender: c }
+        | FilterProp::HasAttachment { controller: c, .. }
+        | FilterProp::HasAnyAttachmentOf { controller: c, .. }
+        | FilterProp::NameMatchesAnyPermanent { controller: c } => {
+            c.as_ref().is_some_and(member_bound_controller_ref)
+        }
+        FilterProp::AnyOf { props } => props.iter().any(member_bound_filter_prop),
+        FilterProp::Not { prop } => member_bound_filter_prop(prop),
         FilterProp::Token
         | FilterProp::NonToken
         | FilterProp::WasPlayed
@@ -2785,6 +3088,15 @@ fn legacy_ref() -> RwProfile {
     p.legacy_batch_prompt = true;
     p
 }
+/// CR 603.10a (PR-6.75 c5): a standalone per-source look-back player referent
+/// (source-chosen / attachment-relative) at a scope/anchor position — carries the
+/// member-bound channel `member_bound_controller_ref` classifies for `Typed`
+/// filters, fail-closed at the scope positions that never route through a filter.
+fn member_bound_read() -> RwProfile {
+    let mut p = RwProfile::empty();
+    p.reads_member_bound = true;
+    p
+}
 fn writes_pool_profile() -> RwProfile {
     let mut p = RwProfile::empty();
     p.writes_pool = true;
@@ -2820,6 +3132,9 @@ fn board_membership_read(filter: &TargetFilter) -> RwProfile {
     // the Heart's "creatures an opponent controls" ⇒ Opponents). Unrefined /
     // composite filters ⇒ Any.
     p.reads_membership_ctrl = ctrl_span_of_filter(filter);
+    // CR 603.10a (PR-6.75 c5): a read whose filter names a per-member-bound set /
+    // attachment / chosen referent is member-distinct ⇒ refuses batch-T1.
+    p.reads_member_bound |= member_bound_target_filter(filter);
     p
 }
 
@@ -3254,6 +3569,7 @@ fn rw_effect(
                 .merge(census_of_filter(target));
         }
         flag_legacy_write_target(&mut p, target);
+        flag_member_bound_write_target(&mut p, target);
         (p, Some(sc))
     };
     // Membership move targeting `target` with the given zone endpoints.
@@ -3265,6 +3581,7 @@ fn rw_effect(
         let mut p = RwProfile::empty();
         place_membership_write(&mut p, sc, census_of_filter(target), origin, dest);
         flag_legacy_write_target(&mut p, target);
+        flag_member_bound_write_target(&mut p, target);
         (p, Some(sc))
     };
     // Deferred body (CR 603.7): descend reads, drop writes. Resolved in a future
@@ -4533,11 +4850,6 @@ fn rw_effect(
             count: _,
         }
         | Effect::TargetOnly { target: _ }
-        | Effect::Choose {
-            choice_type: _,
-            persist: _,
-            selection: _,
-        }
         | Effect::LoseTheGame { target: _ }
         | Effect::WinTheGame { target: _ }
         | Effect::RemoveAllDamage { target: _ }
@@ -4548,6 +4860,18 @@ fn rw_effect(
         | Effect::NoOp
         | Effect::EndTheTurn
         | Effect::EndCombatPhase => (RwProfile::empty(), None),
+
+        // CR 603.10a (PR-6.75 c5): a PERSISTED choice writes per-source storage
+        // (`chosen_attributes`) that a later resolution reads ⇒ member-bound; a
+        // resolution-local choice (`persist: false`) leaves no cross-member binding
+        // (slithermuse's `Choose{Opponent, persist:false}`).
+        Effect::Choose { persist, .. } => {
+            let mut p = RwProfile::empty();
+            if *persist {
+                p.reads_member_bound = true;
+            }
+            (p, None)
+        }
 
         // ---- Histogram-absent ⇒ fail-closed conservative ----
         Effect::StartYourEngines { .. }
@@ -4735,16 +5059,32 @@ fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
         | QuantityRef::DistinctCardTypes { .. }
         | QuantityRef::BasicLandTypeCount { .. }
         | QuantityRef::PartySize { .. } => reads_zone_membership(),
+        // CR 603.10a (PR-6.75 c5): per-source tracked/exiled/chosen storage and
+        // per-instance cast-context memory (X paid, kicker/convoke/vote/additional-
+        // cost counts) are bound per member instance — each trigger stack object
+        // carries its own stored value ⇒ refuse batch-T1 (fail-closed).
         QuantityRef::CardsExiledBySource
         | QuantityRef::ExiledCardPower { .. }
         | QuantityRef::TrackedSetSize
         | QuantityRef::FilteredTrackedSetSize { .. }
         | QuantityRef::TrackedSetAggregate { .. }
-        | QuantityRef::ExiledFromHandThisResolution
+        | QuantityRef::ChosenNumber
+        | QuantityRef::CostXPaid
+        | QuantityRef::KickerCount
+        | QuantityRef::AdditionalCostPaymentCount
+        | QuantityRef::AdditionalCostPaymentCountFor { .. }
+        | QuantityRef::ConvokedCreatureCount
+        | QuantityRef::VoteCount { .. } => {
+            let mut p = RwProfile::empty();
+            p.reads_member_bound = true;
+            p
+        }
+        // Resolution-local / turn- / commander-scoped: no per-source binding
+        // (member-invariant under uniformity).
+        QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount
         | QuantityRef::TurnsTaken
         | QuantityRef::CrimesCommittedThisTurn
-        | QuantityRef::ChosenNumber
         | QuantityRef::AttackedThisTurn { .. }
         | QuantityRef::DescendedThisTurn
         // CR 701.65b/701.66b/701.67c: controller-scoped per-turn accumulator; no
@@ -4752,16 +5092,10 @@ fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
         | QuantityRef::BendTypesThisTurn
         | QuantityRef::LandsPlayedThisTurn { .. }
         | QuantityRef::DungeonsCompleted
-        | QuantityRef::CostXPaid
-        | QuantityRef::KickerCount
-        | QuantityRef::AdditionalCostPaymentCount
-        | QuantityRef::AdditionalCostPaymentCountFor { .. }
-        | QuantityRef::ConvokedCreatureCount
         | QuantityRef::ColorsInCommandersColorIdentity
         | QuantityRef::CommanderCastFromCommandZoneCount
         | QuantityRef::CommanderManaValue { .. }
-        | QuantityRef::Speed { .. }
-        | QuantityRef::VoteCount { .. } => RwProfile::empty(),
+        | QuantityRef::Speed { .. } => RwProfile::empty(),
         QuantityRef::ZoneCardCount {
             zone,
             card_types,
@@ -4886,13 +5220,21 @@ fn rw_ability_condition(x: &AbilityCondition) -> RwProfile {
         AbilityCondition::TargetMatchesFilter {
             filter: _,
             use_lki,
-            subject_slot: _,
+            subject_slot,
         } => {
-            if *use_lki {
+            let mut p = if *use_lki {
                 frozen_source_read()
             } else {
                 reads_board_of(StateKind::ObjectPt)
+            };
+            // CR 608.2c (PR-6.75 c5): Some(n) tests a specific DECLARED chain slot
+            // resolved per member instance — the same per-member binding
+            // member_bound_target_filter flags for TargetFilter::ParentTargetSlot.
+            // Fail-closed: refuse batch-T1 (a member-bound read).
+            if subject_slot.is_some() {
+                p.reads_member_bound = true;
             }
+            p
         }
         // PR-6.75 residual: two context-free-unclassifiable singletons stay safe
         // conservative over-prompts here, with no recognizer. Paroxysm's present-
@@ -5166,7 +5508,7 @@ fn rw_static_condition(x: &StaticCondition) -> RwProfile {
 /// are read-free; event-context refs contribute event reads (and D5 flags for
 /// the 12 tags). Composite filters descend to catch nested event refs.
 fn rw_target_filter(x: &TargetFilter) -> RwProfile {
-    match x {
+    let mut p = match x {
         // D5 carriers (9 TargetFilter tags of the 12).
         TargetFilter::TriggeringSpellController
         | TargetFilter::TriggeringSpellOwner
@@ -5224,7 +5566,12 @@ fn rw_target_filter(x: &TargetFilter) -> RwProfile {
         | TargetFilter::Named { .. }
         | TargetFilter::Owner
         | TargetFilter::AllPlayers => RwProfile::empty(),
-    }
+    };
+    // CR 603.10a (PR-6.75 c5): a member-bound referent used as a read carrier
+    // (target_chooser / nested filter) refuses batch-T1. Position-agnostic —
+    // `member_bound_target_filter` descends composites itself.
+    p.reads_member_bound |= member_bound_target_filter(x);
+    p
 }
 
 fn rw_player_filter(x: &PlayerFilter) -> RwProfile {
@@ -5263,6 +5610,9 @@ fn rw_player_filter(x: &PlayerFilter) -> RwProfile {
             p
         }
         PlayerFilter::AllExcept { exclude } => rw_player_filter(exclude),
+        // CR 603.10a: the owners of the per-source exile set are a member-bound
+        // look-back referent ⇒ refuse batch-T1.
+        PlayerFilter::OwnersOfCardsExiledBySource => member_bound_read(),
         PlayerFilter::Controller
         | PlayerFilter::Opponent
         | PlayerFilter::DefendingPlayer
@@ -5272,7 +5622,6 @@ fn rw_player_filter(x: &PlayerFilter) -> RwProfile {
         | PlayerFilter::HighestSpeed
         | PlayerFilter::ZoneChangedThisWay
         | PlayerFilter::PerformedActionThisWay { .. }
-        | PlayerFilter::OwnersOfCardsExiledBySource
         | PlayerFilter::VotedFor { .. }
         | PlayerFilter::ChosenPlayer { .. } => RwProfile::empty(),
     }
@@ -5285,13 +5634,14 @@ fn rw_player_scope(x: &PlayerScope) -> RwProfile {
             Some(e) => rw_player_scope(e),
             None => RwProfile::empty(),
         },
+        // CR 603.10a: per-source look-back referent ⇒ member-bound.
+        PlayerScope::SourceChosenPlayer => member_bound_read(),
         PlayerScope::Controller
         | PlayerScope::ScopedPlayer
         | PlayerScope::Target
         | PlayerScope::Opponent { .. }
         | PlayerScope::RecipientController
-        | PlayerScope::DefendingPlayer
-        | PlayerScope::SourceChosenPlayer => RwProfile::empty(),
+        | PlayerScope::DefendingPlayer => RwProfile::empty(),
     }
 }
 
@@ -5301,14 +5651,17 @@ fn rw_controller_ref(x: &ControllerRef) -> RwProfile {
         ControllerRef::ParentTargetController
         | ControllerRef::ParentTargetOwner
         | ControllerRef::TriggeringPlayer => legacy_ref(),
+        // CR 603.10a: per-source look-back referents (Vote anchored on the source's
+        // chosen player is a global APNAP interaction, not rescued by owner-partition
+        // commutativity) ⇒ member-bound.
+        ControllerRef::SourceChosenPlayer | ControllerRef::EnchantedPlayer => member_bound_read(),
         ControllerRef::You
         | ControllerRef::Opponent
         | ControllerRef::ScopedPlayer
         | ControllerRef::TargetPlayer
         | ControllerRef::DefendingPlayer
-        | ControllerRef::ChosenPlayer { .. }
-        | ControllerRef::SourceChosenPlayer
-        | ControllerRef::EnchantedPlayer => RwProfile::empty(),
+        // resolution-local (ResolvedAbility.chosen_players)
+        | ControllerRef::ChosenPlayer { .. } => RwProfile::empty(),
     }
 }
 
@@ -5320,9 +5673,11 @@ fn rw_controller_ref(x: &ControllerRef) -> RwProfile {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{AbilityKind, Comparator, CountScope, PtValue};
+    use crate::types::ability::{
+        AbilityKind, ChoiceType, Comparator, CountScope, PtValue, TargetSelectionMode,
+    };
     use crate::types::counter::CounterType;
-    use crate::types::identifiers::ObjectId;
+    use crate::types::identifiers::{ObjectId, TrackedSetId};
     use crate::types::player::PlayerId;
 
     // ---- builders ----
@@ -5463,6 +5818,13 @@ mod tests {
     fn batch() -> GroupStructure {
         gs(false, false, true, false, true, SourceCensus::unknown())
     }
+    /// A controller-uniform (not owner-aligned) co-departure batch — the PR-6.75 c5
+    /// batch-T1 shape.
+    fn batch_uniform() -> GroupStructure {
+        let mut s = batch();
+        s.controller_uniformity = ControllerUniformity::Uniform;
+        s
+    }
     fn gs(
         same_event: bool,
         all_same_source: bool,
@@ -5478,14 +5840,193 @@ mod tests {
             event_object_excludes_sources: excludes,
             event_object_present: present,
             source_census,
-            // PR-6.75: default false ⇒ every prior verdict is byte-preserved (spans
-            // unconsulted). The §4.3 span pins below set it true explicitly.
-            same_controller: false,
+            // PR-6.75: default `Mixed` ⇒ every prior verdict is byte-preserved (no
+            // span/fused refinement and no batch-T1 consulted). Uniformity pins pass
+            // `Uniform`/`UniformAligned` explicitly.
+            controller_uniformity: ControllerUniformity::Mixed,
         }
     }
 
     fn conflicts(a: &ResolvedAbility, s: &GroupStructure) -> bool {
         profiles_conflict(&ability_rw_profile(a), s)
+    }
+
+    // ===================== PR-6.75 c5 batch-T1 unit pins (B-4 / B-7) =====================
+
+    fn typed_ctrl(c: ControllerRef) -> TargetFilter {
+        let mut tf = TypedFilter::creature();
+        tf.controller = Some(c);
+        TargetFilter::Typed(tf)
+    }
+
+    /// B-7 — `member_bound_target_filter` family axis (each TRUE row is a per-source
+    /// tracked/chosen/attachment/event-context referent; each FALSE row rides
+    /// another carrier or is uniformity-/owner-invariant). Nested composites descend.
+    #[test]
+    fn b7_member_bound_target_filter_families() {
+        let ts = || TargetFilter::TrackedSet {
+            id: TrackedSetId(0),
+        };
+        // TRUE: tracked/exiled/chosen/attachment/event-context refs + nesting.
+        for f in [
+            ts(),
+            TargetFilter::Not {
+                filter: Box::new(ts()),
+            },
+            TargetFilter::And {
+                filters: vec![TargetFilter::Controller, ts()],
+            },
+            TargetFilter::TrackedSetFiltered {
+                id: TrackedSetId(0),
+                filter: Box::new(creature()),
+                caused_by: None,
+            },
+            TargetFilter::ChosenCard,
+            TargetFilter::HasChosenName,
+            TargetFilter::AttachedTo,
+            TargetFilter::EventTarget,
+            TargetFilter::TriggeringSourceController,
+            TargetFilter::OriginalController,
+            typed_ctrl(ControllerRef::SourceChosenPlayer),
+        ] {
+            assert!(
+                member_bound_target_filter(&f),
+                "member-bound TRUE expected for {f:?}"
+            );
+        }
+        // FALSE: source carriers, legacy-12, resolution-local, uniformity-/owner-invariant.
+        for f in [
+            TargetFilter::SelfRef,
+            TargetFilter::TriggeringSource,
+            TargetFilter::ParentTarget,
+            TargetFilter::Controller,
+            TargetFilter::Owner,
+            TargetFilter::ScopedPlayer,
+            TargetFilter::LastRevealed,
+            TargetFilter::DefendingPlayer,
+            typed_ctrl(ControllerRef::You),
+            TargetFilter::None,
+        ] {
+            assert!(
+                !member_bound_target_filter(&f),
+                "member-bound FALSE expected for {f:?}"
+            );
+        }
+    }
+
+    /// B-7 — the quantity-arm split: per-source tracked/exiled/cast-context refs set
+    /// `reads_member_bound`; turn-/commander-scoped refs stay clean.
+    #[test]
+    fn b7_quantity_member_bound_split() {
+        for r in [
+            QuantityRef::TrackedSetSize,
+            QuantityRef::CardsExiledBySource,
+            QuantityRef::CostXPaid,
+            QuantityRef::ChosenNumber,
+            QuantityRef::ConvokedCreatureCount,
+        ] {
+            assert!(
+                rw_quantity_ref(&r).reads_member_bound,
+                "quantity member-bound expected for {r:?}"
+            );
+        }
+        for r in [
+            QuantityRef::TurnsTaken,
+            QuantityRef::DungeonsCompleted,
+            QuantityRef::ExiledFromHandThisResolution,
+        ] {
+            assert!(
+                !rw_quantity_ref(&r).reads_member_bound,
+                "quantity member-unbound expected for {r:?}"
+            );
+        }
+    }
+
+    /// B-7 — `Choose{persist:true}` stores per-source `chosen_attributes` (member-
+    /// bound); `persist:false` is resolution-local (slithermuse, member-unbound).
+    #[test]
+    fn b7_choose_persist_member_bound() {
+        let choose = |persist: bool| Effect::Choose {
+            choice_type: ChoiceType::Opponent { restriction: None },
+            persist,
+            selection: TargetSelectionMode::default(),
+        };
+        assert!(
+            ability_rw_profile(&ra(choose(true))).reads_member_bound,
+            "persist:true ⇒ member-bound"
+        );
+        assert!(
+            !ability_rw_profile(&ra(choose(false))).reads_member_bound,
+            "persist:false ⇒ member-unbound"
+        );
+    }
+
+    /// B-7 — the `gs()` default is fail-closed `Mixed` (every prior verdict byte-
+    /// preserved: no span/fused refinement and no batch-T1 consulted).
+    #[test]
+    fn b7_gs_default_is_mixed() {
+        assert!(matches!(
+            batch().controller_uniformity,
+            ControllerUniformity::Mixed
+        ));
+        assert!(matches!(
+            batch_uniform().controller_uniformity,
+            ControllerUniformity::Uniform
+        ));
+    }
+
+    /// B-7 — the batch-T1 clause in `profiles_conflict`: a source-independent,
+    /// member-unbound, no-event profile whose sibling membership feed WOULD conflict
+    /// is auto-ordered under `Uniform`, prompted under `Mixed`, and prompted under
+    /// `Uniform` once `reads_member_bound` is set. Pins the `!= Mixed` and
+    /// `!reads_member_bound` conjuncts against the SAME feed.
+    #[test]
+    fn b7_batch_t1_clause_conjuncts() {
+        let feed = || {
+            let mut p = RwProfile::empty();
+            p.reads_board = KindSet::one(StateKind::SetMembership);
+            p.reads_membership_census = Census::Any;
+            p.reads_membership_zones = ZoneSpan::Any;
+            p.writes_external = KindSet::one(StateKind::SetMembership);
+            p.writes_membership_external_census = Census::Any;
+            p.writes_membership_external_zones = ZoneSpan::Any;
+            p
+        };
+        assert!(
+            !profiles_conflict(&feed(), &batch_uniform()),
+            "T1: uniform + source-independent + member-unbound ⇒ auto"
+        );
+        assert!(
+            profiles_conflict(&feed(), &batch()),
+            "T1 != Mixed conjunct: Mixed ⇒ gate off ⇒ membership feed prompts"
+        );
+        let mut mb = feed();
+        mb.reads_member_bound = true;
+        assert!(
+            profiles_conflict(&mb, &batch_uniform()),
+            "T1 !reads_member_bound conjunct: member-bound ⇒ T1 refused ⇒ feed prompts"
+        );
+    }
+
+    /// B-4 — the `!writes_event_object.any()` conjunct. An event-object counter
+    /// write (unreachable in isolation via the AST — every event-object write also
+    /// sets `legacy_batch_prompt`/`reads_member_bound` — so pinned on a constructed
+    /// profile) refuses T1, letting the counter feed prompt; clearing it auto-orders.
+    #[test]
+    fn b4_writes_event_object_conjunct() {
+        let mut p = RwProfile::empty();
+        p.reads_board = KindSet::one(StateKind::ObjectCounters);
+        p.writes_external = KindSet::one(StateKind::ObjectCounters);
+        p.writes_event_object = KindSet::one(StateKind::ObjectCounters);
+        assert!(
+            profiles_conflict(&p, &batch_uniform()),
+            "B-4: event-object write refuses T1 ⇒ counter feed reached ⇒ prompt"
+        );
+        p.writes_event_object = KindSet::EMPTY;
+        assert!(
+            !profiles_conflict(&p, &batch_uniform()),
+            "B-4 revert: without the event-object write, T1 auto-orders"
+        );
     }
 
     // ===================== base shapes =====================

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -23,6 +23,19 @@
 //! and are inherited unchanged (zero ordering-decision change). Damage kinds are
 //! therefore RECIPIENT-classified, not source-bound (CR 704.5a / CR 800.4a).
 //!
+//! A SECOND inherited fail-open: `reads_event_live` is consulted ONLY on the
+//! batch path (`profiles_conflict`: the `all_same_source` fast path and the
+//! freeze-invalidation row, both guarded `!same_event`) — never in same-event
+//! feed analysis. So a same-event group that WRITES the triggering object and
+//! then READS that now-modified object's characteristic ("put a +1/+1 counter on
+//! it, then transform ~ if that creature's power ≥ 6" ×2 — order-observable,
+//! `source_independent` false so the T1 fast path is skipped, yet the
+//! event-object read×write feed is uncaught ⇒ auto) is not gated. This is
+//! DISTINCT from the PR-6.25 Case A board-write × source-read feed (which IS
+//! caught). Like the source-actor residual it is inherited from the pre-C1
+//! always-auto short-circuit (NOT a regression) and is left OPEN deliberately:
+//! closing it would ADD a prompt = a D3 widening needing its own proof.
+//!
 //! # M3 binding mandate (review-blocking)
 //!
 //! Every NON-fully-conservative arm binds ALL payload fields of its variant;
@@ -53,15 +66,13 @@
 //! (CopyTokenOf template read), CR 702.15 / CR 702.2 / CR 704.5a / CR 800.4a
 //! (source-actor residual).
 
-// Consumers land in commit 2 (triggers.rs rewiring); until then the classifier
-// is exercised only by its #[cfg(test)] unit pairings. Mirrors the inc2b axis-3
-// readout pattern (landed with allow(dead_code) until its consumer). Commit 2
-// removes this attribute.
-#![allow(dead_code)]
+// Consumers landed in commit 2: `game::triggers::group_is_order_independent`
+// calls `ability_rw_profile` / `trigger_condition_rw_profile` / `profiles_conflict`
+// on the legacy same-event and departure-batch ordering paths (CR 603.3b).
 
 use crate::types::ability::FilterProp;
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, ControllerRef, CountScope, Duration, Effect, ModalChoice,
+    AbilityCondition, AbilityDefinition, ControllerRef, Duration, Effect, ModalChoice,
     MultiTargetSpec, ObjectScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef,
     RepeatContinuation, ResolvedAbility, StaticCondition, TargetFilter, TriggerCondition,
     TypeFilter, TypedFilter,
@@ -270,6 +281,72 @@ impl SourceCensus {
 }
 
 // ---------------------------------------------------------------------------
+// ZoneSpan (§2 census-overlap refinement — the ZONE axis of the SetMembership
+// same-kind row; CR 400.1 a zone is where objects live).
+// ---------------------------------------------------------------------------
+
+/// CR 400.1: the zone(s) a `SetMembership` read observes / a membership write
+/// touches. A whole-zone or `InZone`-free read is `Any` (fail-closed); a
+/// creation write touches only its DESTINATION (battlefield for a token); a move
+/// is recorded fail-closed `Any` (both endpoints matter but are not tracked
+/// precisely). The membership feed row (§2) requires zone overlap IN ADDITION to
+/// type-census overlap, so a battlefield-destination token creation cannot feed
+/// a graveyard-count read (Tombstone Stairwell). `merge` is fail-closed — `Any`
+/// swallows any precise set — so a mix of a precise write and an unrefined `Any`
+/// write yields `Any` (never fewer conflicts than a single unrefined write).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub(crate) enum ZoneSpan {
+    /// No membership read/write on this side — overlaps nothing.
+    None,
+    /// Unextractable / untracked — assume overlap (fail-closed).
+    Any,
+    /// A concrete zone set.
+    Zones(std::collections::HashSet<Zone>),
+}
+
+impl ZoneSpan {
+    fn one(z: Zone) -> ZoneSpan {
+        ZoneSpan::Zones(std::iter::once(z).collect())
+    }
+    fn merge(&mut self, o: ZoneSpan) {
+        let taken = std::mem::replace(self, ZoneSpan::None);
+        *self = match (taken, o) {
+            (ZoneSpan::None, x) | (x, ZoneSpan::None) => x,
+            (ZoneSpan::Any, _) | (_, ZoneSpan::Any) => ZoneSpan::Any,
+            (ZoneSpan::Zones(mut a), ZoneSpan::Zones(b)) => {
+                a.extend(b);
+                ZoneSpan::Zones(a)
+            }
+        };
+    }
+}
+
+/// CR 400.1 zone overlap: two spans can name a common zone iff they share one;
+/// `None` overlaps nothing, `Any` overlaps every non-`None` (mirrors
+/// `census_overlap`).
+fn zone_overlap(a: &ZoneSpan, b: &ZoneSpan) -> bool {
+    match (a, b) {
+        (ZoneSpan::None, _) | (_, ZoneSpan::None) => false,
+        (ZoneSpan::Any, _) | (_, ZoneSpan::Any) => true,
+        (ZoneSpan::Zones(x), ZoneSpan::Zones(y)) => x.intersection(y).next().is_some(),
+    }
+}
+
+/// CR 400.1: the zones a read filter observes — its explicit `InZone`/`InAnyZone`
+/// constraints (`TargetFilter::extract_zones`), or `Any` when it declares none (a
+/// bare board read defaults to the battlefield, but we stay fail-closed rather
+/// than assume it, so an `InZone`-free read still conflicts with every membership
+/// write as before; only a filter with an EXPLICIT zone gets precise treatment).
+fn zones_of_filter(f: &TargetFilter) -> ZoneSpan {
+    let zones = f.extract_zones();
+    if zones.is_empty() {
+        ZoneSpan::Any
+    } else {
+        ZoneSpan::Zones(zones.into_iter().collect())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // RwProfile (§2 D-profile).
 // ---------------------------------------------------------------------------
 
@@ -310,12 +387,27 @@ pub(crate) struct RwProfile {
     /// the battlefield or whose origin is exile — re-enters/overwrites a
     /// departed member's LKI. Feeds the freeze-invalidation row.
     writes_reentry_hazard: bool,
-    /// A self-scoped `SetMembership` write exists; its census = the source.
+    /// A `SetMembership` write whose census IS the source's typeline, resolved
+    /// against `source_census` at conflict time: either a self-scoped move
+    /// (`ChangeZone{SelfRef}`) or a `CopyTokenOf{SelfRef}` created copy (CR 707.2,
+    /// §1.3.1-F). `membership_census_of` merges `source_census` when this is set.
     writes_membership_self: bool,
     /// Census of external/creation/event-object `SetMembership` writes.
     writes_membership_external_census: Census,
+    /// CR 400.1: zones the external/creation/event-object `SetMembership` writes
+    /// touch (ZONE axis of the membership feed row — a battlefield creation vs a
+    /// graveyard read is zone-disjoint, Tombstone Stairwell).
+    writes_membership_external_zones: ZoneSpan,
     /// Census requirements of all `SetMembership` reads.
     reads_membership_census: Census,
+    /// CR 400.1: zones all `SetMembership` reads observe (from their filter's
+    /// `InZone`; `Any` when unextractable — fail-closed).
+    reads_membership_zones: ZoneSpan,
+    /// CR 122.1: census of EXTERNAL `ObjectCounters` writes' target filters —
+    /// object-scope disjointness for the source-scoped counter read (§2; a quest
+    /// read on an enchantment source × a +1/+1 write on creatures is
+    /// object-disjoint, Earthbender Ascension). `Any` when unrefined (fail-closed).
+    writes_external_counter_census: Census,
     /// A resolution-time payment (`unless_pay` / `PayCost`) is present (CR
     /// 603.5). With `writes_pool`, trips the Mana×unless-pay guard.
     has_pay_or_unless: bool,
@@ -339,7 +431,10 @@ impl RwProfile {
             writes_reentry_hazard: false,
             writes_membership_self: false,
             writes_membership_external_census: Census::None,
+            writes_membership_external_zones: ZoneSpan::None,
             reads_membership_census: Census::None,
+            reads_membership_zones: ZoneSpan::None,
+            writes_external_counter_census: Census::None,
             has_pay_or_unless: false,
             writes_pool: false,
         }
@@ -352,12 +447,15 @@ impl RwProfile {
         p.writes_self = KindSet::ALL;
         p.writes_external = KindSet::ALL;
         p.writes_membership_external_census = Census::Any;
+        p.writes_membership_external_zones = ZoneSpan::Any;
         p.writes_membership_self = true;
         p.reads_membership_census = Census::Any;
+        p.reads_membership_zones = ZoneSpan::Any;
+        p.writes_external_counter_census = Census::Any;
         p
     }
 
-    fn merge(&mut self, o: RwProfile) {
+    pub(crate) fn merge(&mut self, o: RwProfile) {
         self.reads_src = self.reads_src.union(o.reads_src);
         self.reads_board = self.reads_board.union(o.reads_board);
         self.reads_player = self.reads_player.union(o.reads_player);
@@ -372,8 +470,13 @@ impl RwProfile {
         self.writes_membership_self |= o.writes_membership_self;
         self.writes_membership_external_census
             .merge(o.writes_membership_external_census);
+        self.writes_membership_external_zones
+            .merge(o.writes_membership_external_zones);
         self.reads_membership_census
             .merge(o.reads_membership_census);
+        self.reads_membership_zones.merge(o.reads_membership_zones);
+        self.writes_external_counter_census
+            .merge(o.writes_external_counter_census);
         self.has_pay_or_unless |= o.has_pay_or_unless;
         self.writes_pool |= o.writes_pool;
     }
@@ -386,6 +489,13 @@ impl RwProfile {
         self.reads_src.is_empty() && self.writes_self.is_empty() && self.reads_frozen.is_empty()
     }
 
+    /// D5 (CR 603.10a): true iff one of the 12 retained-prompt event-context refs
+    /// is present. Consulted ONLY by the batch branch (`batch_conflict`) to keep
+    /// the legacy departure-batch prompting parity (D3 zero widening).
+    pub(crate) fn legacy_batch_prompt(&self) -> bool {
+        self.legacy_batch_prompt
+    }
+
     /// Drop all writes (deferred-body descent, CR 603.7: writes happen
     /// post-window, so reads descend but writes are not counted).
     fn drop_writes(&mut self) {
@@ -396,6 +506,8 @@ impl RwProfile {
         self.writes_reentry_hazard = false;
         self.writes_membership_self = false;
         self.writes_membership_external_census = Census::None;
+        self.writes_membership_external_zones = ZoneSpan::None;
+        self.writes_external_counter_census = Census::None;
         self.writes_pool = false;
     }
 }
@@ -437,7 +549,14 @@ pub(crate) struct GroupStructure {
 /// aggregate reads already carry a `SetMembership` tag. `Other` conflicts with
 /// everything. `PlayerLife → SetMembership` is deliberately ABSENT (the CR 800.4a
 /// player-loss cascade is the documented source-actor residual, §1.2).
-fn feeds(reads: KindSet, writes: KindSet, read_census: &Census, write_census: &Census) -> bool {
+fn feeds(
+    reads: KindSet,
+    writes: KindSet,
+    read_census: &Census,
+    write_census: &Census,
+    read_zones: &ZoneSpan,
+    write_zones: &ZoneSpan,
+) -> bool {
     if (writes.other && reads.any()) || (reads.other && writes.any()) {
         return true;
     }
@@ -465,8 +584,14 @@ fn feeds(reads: KindSet, writes: KindSet, read_census: &Census, write_census: &C
     if reads.journal_cards && writes.hand_library {
         return true;
     }
-    // SetMembership same-kind, census-refined (§2).
-    if reads.set_membership && writes.set_membership && census_overlap(read_census, write_census) {
+    // SetMembership same-kind, census- AND zone-refined (§2; CR 205 type tags +
+    // CR 400.1 zones). A battlefield token creation cannot feed a graveyard read
+    // even though both name "creature" — their zones are disjoint (Tombstone).
+    if reads.set_membership
+        && writes.set_membership
+        && census_overlap(read_census, write_census)
+        && zone_overlap(read_zones, write_zones)
+    {
         return true;
     }
     false
@@ -525,12 +650,34 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
     if s.same_event && s.event_object_excludes_sources && s.event_object_present {
         src_writes = src_writes.minus(p.writes_event_object);
     }
+    // CR 122.1 object-scope disjointness (§2 Earthbender): an EXTERNAL counter
+    // write feeds a SOURCE-scoped counter read only if the write filter can match
+    // the source (census overlap; fail-closed — an unrefined counter write is
+    // `Any`, and `None` here means no external counter write). A quest read on an
+    // enchantment source × a +1/+1 write on creatures is object-disjoint ⇒ drop
+    // `ObjectCounters` from the source-read feed. The same-source SELF counter
+    // write is added AFTER this gate (a self write on the shared source DOES feed).
+    if p.reads_src.object_counters && src_writes.object_counters {
+        let ext_counter_census = if matches!(p.writes_external_counter_census, Census::None) {
+            Census::Any // membership present but census unrecorded ⇒ fail-closed
+        } else {
+            p.writes_external_counter_census.clone()
+        };
+        if !census_overlap(&s.source_census.as_census(), &ext_counter_census) {
+            src_writes = src_writes.minus(KindSet::one(StateKind::ObjectCounters));
+        }
+    }
     let src_self_membership = s.all_same_source && p.writes_membership_self;
     let src_write_census = membership_census_of(
         src_writes,
         &p.writes_membership_external_census,
         src_self_membership,
         s,
+    );
+    let src_write_zones = membership_zones_of(
+        src_writes,
+        &p.writes_membership_external_zones,
+        src_self_membership,
     );
     if s.all_same_source {
         src_writes = src_writes.union(p.writes_self);
@@ -540,6 +687,8 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
         src_writes,
         &p.reads_membership_census,
         &src_write_census,
+        &p.reads_membership_zones,
+        &src_write_zones,
     ) {
         return true;
     }
@@ -552,12 +701,19 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
         p.writes_membership_self,
         s,
     );
+    let board_write_zones = membership_zones_of(
+        board_writes,
+        &p.writes_membership_external_zones,
+        p.writes_membership_self,
+    );
     let board_reads = p.reads_board.union(p.reads_player);
     if feeds(
         board_reads,
         board_writes,
         &p.reads_membership_census,
         &board_write_census,
+        &p.reads_membership_zones,
+        &board_write_zones,
     ) {
         return true;
     }
@@ -582,6 +738,25 @@ fn membership_census_of(
         c.merge(s.source_census.as_census());
     }
     c
+}
+
+/// CR 400.1: the membership-write ZONE span for an effective write set — the
+/// external/creation zones if any external membership write is present, plus
+/// `Any` (fail-closed) when a self membership move is in scope (its endpoints are
+/// untracked). Mirrors `membership_census_of`.
+fn membership_zones_of(
+    write_kinds: KindSet,
+    external_zones: &ZoneSpan,
+    self_in_scope: bool,
+) -> ZoneSpan {
+    let mut z = ZoneSpan::None;
+    if write_kinds.set_membership {
+        z.merge(external_zones.clone());
+    }
+    if self_in_scope {
+        z.merge(ZoneSpan::Any);
+    }
+    z
 }
 
 // ---------------------------------------------------------------------------
@@ -704,6 +879,12 @@ fn place_membership_write(
     let hazard = matches!(sc, WriteScope::External)
         && (dest == Zone::Battlefield || origin == Some(Zone::Exile))
         && origin != Some(Zone::Library);
+    // CR 400.1: a MOVE touches both endpoints (origin removal + dest addition), so
+    // a graveyard-count read IS fed by a graveyard→battlefield return.
+    let mut move_zones = ZoneSpan::one(dest);
+    if let Some(o) = origin {
+        move_zones.merge(ZoneSpan::one(o));
+    }
     match sc {
         WriteScope::SelfSource => {
             p.writes_self.set(StateKind::SetMembership);
@@ -712,19 +893,23 @@ fn place_membership_write(
         WriteScope::External => {
             p.writes_external.set(StateKind::SetMembership);
             p.writes_membership_external_census.merge(census);
+            p.writes_membership_external_zones.merge(move_zones);
             p.writes_reentry_hazard |= hazard;
         }
         WriteScope::EventObject => {
             p.writes_external.set(StateKind::SetMembership);
             p.writes_event_object.set(StateKind::SetMembership);
-            // Event object identity is unknown at profile time ⇒ census Any.
+            // Event object identity is unknown at profile time ⇒ census + zone Any
+            // (the precise `move_zones` is used only by the External/Created arms).
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.writes_reentry_hazard |= hazard;
         }
         WriteScope::Created => {
             p.writes_external.set(StateKind::SetMembership);
             p.writes_created.set(StateKind::SetMembership);
             p.writes_membership_external_census.merge(census);
+            p.writes_membership_external_zones.merge(move_zones);
         }
     }
     if is_hand_or_library(dest) || origin.is_some_and(is_hand_or_library) {
@@ -806,7 +991,14 @@ fn filter_is_self_scoped(f: &TargetFilter) -> bool {
 
 /// CR 111.1: the filter's `valid_card` provably excludes every group member's
 /// source (an `Another` component) — the object-disjointness signal (§2 rule 2).
-/// A helper for the commit-2 chokepoint; exposed here beside the rule it feeds.
+/// Consumed by the parity sweep's STATIC event-object-disjointness model
+/// (`triggers_ordering_parity_tests`). The production chokepoint
+/// (`group_is_order_independent`) instead uses the DYNAMIC id-disjointness check
+/// (the event object's id vs the members' `source_id`s) because `valid_card` is
+/// not carried on `PendingTrigger`; the dynamic check is a sound, at-least-as-
+/// precise witness of the same relation. `#[allow(dead_code)]` covers the
+/// non-test lib build where only the sweep (a `#[cfg(test)]` consumer) calls it.
+#[allow(dead_code)]
 pub(crate) fn filter_excludes_source(f: &TargetFilter) -> bool {
     match f {
         TargetFilter::Typed(tf) => tf
@@ -815,6 +1007,59 @@ pub(crate) fn filter_excludes_source(f: &TargetFilter) -> bool {
             .any(|p| matches!(p, FilterProp::Another)),
         TargetFilter::And { filters } => filters.iter().any(filter_excludes_source),
         _ => false,
+    }
+}
+
+/// CR 205: does a printed source's type census overlap a filter's type census
+/// (fail-closed — either side unextractable ⇒ `Any` ⇒ overlap)? Used by the
+/// parity sweep's condition-based reachability guard (§1.3.1-F): a same-event
+/// 2-copy group is unreachable when the source itself matches an
+/// `Another`-self-exclusion count the intervening-if requires to be zero
+/// (Thopter Assembly). `#[allow(dead_code)]` covers the non-test lib build where
+/// only the sweep (a `#[cfg(test)]` consumer) calls it.
+#[allow(dead_code)]
+pub(crate) fn source_census_overlaps_filter(s: &SourceCensus, f: &TargetFilter) -> bool {
+    census_overlap(&s.as_census(), &census_of_filter(f))
+}
+
+/// D5 (CR 603.10a): the 9 `TargetFilter` carriers of the 12 retained-prompt
+/// event-context refs (the other 3 — `EventContextAmount`,
+/// `EventContextSourceCostX`, `ManaSpentToCast` — are `QuantityRef`s, handled by
+/// the read path). The frozen serde oracle
+/// (`value_contains_trigger_event_context_ref`) matched these tags ANYWHERE in
+/// the serialized ability — read OR write position — so a tag as an effect WRITE
+/// TARGET must also set `legacy_batch_prompt` for the batch branch to retain its
+/// prompt (D3 zero-widening). Each of the 9 is a unit variant serializing to a
+/// bare string, exactly what the oracle matched; the struct-variant
+/// `ParentTargetSlot` is deliberately EXCLUDED (it serializes as an object key,
+/// which the oracle's value-walk never matches). Composite filters are descended
+/// so a nested tag is still caught (position-agnostic like the oracle).
+fn target_is_legacy_ref(f: &TargetFilter) -> bool {
+    match f {
+        TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::TriggeringSource
+        | TargetFilter::ParentTarget
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::StackSpell
+        | TargetFilter::CostPaidObject => true,
+        TargetFilter::Not { filter } => target_is_legacy_ref(filter),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(target_is_legacy_ref)
+        }
+        _ => false,
+    }
+}
+
+/// Set `legacy_batch_prompt` when an effect write target carries a D5 event-
+/// context ref (§D5, CR 603.10a) — mirrors the read-carrier path
+/// (`rw_target_filter` → `legacy_ref`) for write position. Position-agnostic:
+/// applied at every write-target-bearing arm so the tag anywhere ⇒ prompt.
+fn flag_legacy_write_target(p: &mut RwProfile, target: &TargetFilter) {
+    if target_is_legacy_ref(target) {
+        p.legacy_batch_prompt = true;
     }
 }
 
@@ -836,6 +1081,10 @@ fn reads_board_of(k: StateKind) -> RwProfile {
 fn reads_zone_membership() -> RwProfile {
     let mut p = reads_board_of(StateKind::SetMembership);
     p.reads_membership_census = Census::Any;
+    // CR 400.1: a whole-zone read's zone is not extractable here (GraveyardSize
+    // = graveyard, Devotion = battlefield, … — one helper, many zones) ⇒ `Any`,
+    // fail-closed (conflicts with every membership write, as before).
+    p.reads_membership_zones = ZoneSpan::Any;
     p
 }
 fn reads_player_of(k: StateKind) -> RwProfile {
@@ -897,6 +1146,10 @@ fn board_membership_read(filter: &TargetFilter) -> RwProfile {
         p.reads_board = KindSet::one(StateKind::SetMembership);
     }
     p.reads_membership_census = census_of_filter(filter);
+    // CR 400.1: the zone(s) the read counts, from the filter's explicit `InZone`
+    // (Tombstone Stairwell's Zombie count reads the GRAVEYARD, not the battlefield
+    // its own tokens enter). No `InZone` ⇒ `Any` (fail-closed, unchanged behavior).
+    p.reads_membership_zones = zones_of_filter(filter);
     p
 }
 
@@ -1233,7 +1486,11 @@ fn damage_writes(target: &TargetFilter) -> RwProfile {
         p.writes_external.set(StateKind::SetMembership);
         p.writes_membership_external_census
             .merge(census_of_filter(target));
+        // CR 120.3e + CR 704.5g: lethal damage moves a creature battlefield →
+        // graveyard as an SBA ⇒ both zones (fail-closed Any).
+        p.writes_membership_external_zones.merge(ZoneSpan::Any);
     }
+    flag_legacy_write_target(&mut p, target);
     p
 }
 
@@ -1248,6 +1505,18 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         let sc = scope_of(target, chain_root);
         let mut p = RwProfile::empty();
         place_object_write(&mut p, kind, sc);
+        // CR 122.1 object-scope disjointness (§2): record the census of an EXTERNAL
+        // counter write's target filter, so a source-scoped counter read only
+        // conflicts when the write filter can match the source (Earthbender: a
+        // `+1/+1` write on creatures can't reach an enchantment source's quest
+        // counter). Self/created writes are handled by their own scoping.
+        if kind == StateKind::ObjectCounters
+            && matches!(sc, WriteScope::External | WriteScope::EventObject)
+        {
+            p.writes_external_counter_census
+                .merge(census_of_filter(target));
+        }
+        flag_legacy_write_target(&mut p, target);
         (p, Some(sc))
     };
     // Membership move targeting `target` with the given zone endpoints.
@@ -1258,6 +1527,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         let sc = scope_of(target, chain_root);
         let mut p = RwProfile::empty();
         place_membership_write(&mut p, sc, census_of_filter(target), origin, dest);
+        flag_legacy_write_target(&mut p, target);
         (p, Some(sc))
     };
     // Deferred body (CR 603.7): descend reads, drop writes.
@@ -1296,6 +1566,9 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             p.writes_external.set(StateKind::SetMembership);
             p.writes_membership_external_census
                 .merge(census_of_filter(target));
+            // CR 704.5g: SBA deaths move battlefield → graveyard (fail-closed Any).
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
+            flag_legacy_write_target(&mut p, target);
             if player_filter.is_some() {
                 p.merge(life_writes());
             }
@@ -1376,18 +1649,23 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         }
 
         // ---- Life ----
-        Effect::GainLife { amount, player: _ } => {
+        Effect::GainLife { amount, player } => {
             let mut p = life_writes();
+            flag_legacy_write_target(&mut p, player);
             p.merge(rw_quantity_expr(amount));
             (p, None)
         }
-        Effect::LoseLife { amount, target: _ } => {
+        Effect::LoseLife { amount, target } => {
             let mut p = life_writes();
+            if let Some(t) = target {
+                flag_legacy_write_target(&mut p, t);
+            }
             p.merge(rw_quantity_expr(amount));
             (p, None)
         }
-        Effect::SetLifeTotal { target: _, amount } => {
+        Effect::SetLifeTotal { target, amount } => {
             let mut p = life_writes();
+            flag_legacy_write_target(&mut p, target);
             p.merge(rw_quantity_expr(amount));
             (p, None)
         }
@@ -1398,10 +1676,11 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         }
         Effect::GivePlayerCounter {
             count,
-            target: _,
+            target,
             counter_kind: _,
         } => {
             let mut p = ext_write(StateKind::PlayerLife);
+            flag_legacy_write_target(&mut p, target);
             p.merge(rw_quantity_expr(count));
             (p, None)
         }
@@ -1448,11 +1727,14 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             selection: _,
         } => {
             let (mut p, sc) = obj(StateKind::ObjectCounters, target);
-            place_object_write(
-                &mut p,
-                StateKind::ObjectCounters,
-                scope_of(source, chain_root),
-            );
+            let source_sc = scope_of(source, chain_root);
+            place_object_write(&mut p, StateKind::ObjectCounters, source_sc);
+            // CR 122.1 object-scope (§2): the donor is also an external counter write.
+            if matches!(source_sc, WriteScope::External | WriteScope::EventObject) {
+                p.writes_external_counter_census
+                    .merge(census_of_filter(source));
+            }
+            flag_legacy_write_target(&mut p, source);
             if let Some(c) = count {
                 p.merge(rw_quantity_expr(c));
             }
@@ -1460,6 +1742,8 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         }
         Effect::Bolster { count } => {
             let mut p = ext_write(StateKind::ObjectCounters);
+            // Untargeted external counter write ⇒ census Any (fail-closed, §2).
+            p.writes_external_counter_census.merge(Census::Any);
             p.merge(rw_quantity_expr(count));
             (p, Some(WriteScope::External))
         }
@@ -1467,6 +1751,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let (mut p, sc) = obj(StateKind::ObjectCounters, subject);
             p.writes_external.set(StateKind::SetMembership);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.merge(rw_quantity_expr(amount));
             (p, sc)
         }
@@ -1481,17 +1766,22 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         Effect::Proliferate => {
             let mut p = ext_write(StateKind::ObjectCounters);
             p.writes_external.set(StateKind::PlayerLife);
+            // Any counter on any permanent/player with a counter ⇒ census Any.
+            p.writes_external_counter_census.merge(Census::Any);
             (p, Some(WriteScope::External))
         }
         Effect::Amass { count, subtype: _ } => {
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::ObjectCounters);
+            p.writes_external_counter_census.merge(Census::Any);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.merge(rw_quantity_expr(count));
             (p, Some(WriteScope::External))
         }
         Effect::Intensify { amount, scope: _ } => {
             let mut p = ext_write(StateKind::ObjectCounters);
+            p.writes_external_counter_census.merge(Census::Any);
             p.merge(rw_quantity_expr(amount));
             (p, Some(WriteScope::External))
         }
@@ -1648,6 +1938,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.merge(rw_quantity_expr(count));
             (p, None)
         }
@@ -1661,6 +1952,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.merge(rw_quantity_expr(count));
             (p, None)
         }
@@ -1676,6 +1968,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.merge(rw_quantity_expr(count));
             (p, None)
         }
@@ -1693,6 +1986,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             (p, None)
         }
         Effect::Explore => {
@@ -1704,6 +1998,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             (p, None)
         }
         Effect::Connive { target, count } => {
@@ -1716,6 +2011,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             (p, None)
         }
         Effect::Discover {
@@ -1726,6 +2022,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_external.set(StateKind::StackShape);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.merge(rw_quantity_expr(mana_value_limit));
             (p, None)
         }
@@ -1744,6 +2041,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.merge(rw_quantity_expr(count));
             (p, None)
         }
@@ -1756,6 +2054,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.merge(rw_quantity_expr(count));
             (p, None)
         }
@@ -1763,12 +2062,14 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             (p, None)
         }
         Effect::Cloak { target: _, count } => {
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.merge(rw_quantity_expr(count));
             (p, None)
         }
@@ -1779,6 +2080,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         } => {
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             (p, None)
         }
         Effect::PhaseOut { target } => obj_membership_scope(target, chain_root),
@@ -1786,6 +2088,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_external.set(StateKind::StackShape);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             (p, None)
         }
 
@@ -1811,6 +2114,12 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             p.writes_created.set(StateKind::SetMembership);
             p.writes_membership_external_census
                 .merge(census_of_types(types));
+            // CR 111.1 + CR 400.1: a token is CREATED on the battlefield — it
+            // touches ONLY that zone (no origin), so it cannot feed a graveyard /
+            // hand / library read (Tombstone Stairwell: battlefield Zombie tokens
+            // vs a graveyard-creature count are zone-disjoint).
+            p.writes_membership_external_zones
+                .merge(ZoneSpan::one(Zone::Battlefield));
             for (_ct, q) in enter_with_counters {
                 p.merge(rw_quantity_expr(q));
             }
@@ -1820,7 +2129,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         Effect::CopyTokenOf {
             target,
             owner: _,
-            source_filter: _,
+            source_filter,
             enters_attacking: _,
             tapped: _,
             count,
@@ -1830,13 +2139,33 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             let mut p = RwProfile::empty();
             p.writes_external.set(StateKind::SetMembership);
             p.writes_created.set(StateKind::SetMembership);
-            p.writes_membership_external_census.merge(Census::Any);
-            // CR 707.2: a SelfRef template copies the source's copiable values —
-            // conservatively recorded reads_src (fail-closed; census clears in
-            // practice, §1.3.1-F).
+            // CR 707.2: the created token acquires the copy SOURCE's copiable
+            // values (card type / subtypes), so its membership census is the
+            // source's typeline — NOT `Census::Any`.
             if matches!(target, TargetFilter::SelfRef) {
+                // A SelfRef copy's census is the group's live source census,
+                // resolved at `profiles_conflict` time — reproduce the SelfRef
+                // membership-move representation (`writes_membership_self`), which
+                // `membership_census_of` resolves against `source_census`. This
+                // is what clears Scute Swarm (creature token ≠ its Lands read,
+                // census-disjoint — §1.3.1-F) instead of over-conflicting on Any.
+                p.writes_membership_self = true;
+                // Copiable-values read (fail-closed source dependence).
                 p.reads_src.set(StateKind::ObjectPt);
+            } else {
+                // Non-SelfRef: census from the copy-source filter where
+                // extractable (`source_filter` for the "for each" variant, else
+                // the targeted `target`), else `Census::Any` (fail-closed).
+                let copy_source = source_filter.as_ref().unwrap_or(target);
+                p.writes_membership_external_census
+                    .merge(census_of_filter(copy_source));
+                // CR 111.1: the copy is created on the battlefield.
+                p.writes_membership_external_zones
+                    .merge(ZoneSpan::one(Zone::Battlefield));
             }
+            // D5: an event-context write target (e.g. `CopyTokenOf{TriggeringSource}`)
+            // retains the batch prompt (CR 603.10a).
+            flag_legacy_write_target(&mut p, target);
             p.merge(rw_quantity_expr(count));
             (p, Some(WriteScope::Created))
         }
@@ -1849,6 +2178,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             p.writes_external.set(StateKind::SetMembership);
             p.writes_created.set(StateKind::SetMembership);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             if is_hand_or_library(*destination) {
                 p.writes_external.set(StateKind::HandLibrary);
             }
@@ -1859,6 +2189,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             p.writes_external.set(StateKind::SetMembership);
             p.writes_created.set(StateKind::SetMembership);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.merge(rw_quantity_expr(count));
             (p, Some(WriteScope::Created))
         }
@@ -1867,6 +2198,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             p.writes_external.set(StateKind::SetMembership);
             p.writes_created.set(StateKind::SetMembership);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             (p, Some(WriteScope::Created))
         }
         Effect::Investigate => {
@@ -1878,6 +2210,9 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
                     "clue".into(),
                     "artifact".into(),
                 ])));
+            // CR 111.1: the Clue token is created on the battlefield.
+            p.writes_membership_external_zones
+                .merge(ZoneSpan::one(Zone::Battlefield));
             (p, Some(WriteScope::Created))
         }
 
@@ -1971,6 +2306,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         } => {
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             (p, Some(WriteScope::External))
         }
 
@@ -2010,6 +2346,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             p.writes_external.set(StateKind::SetMembership);
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
             if let Some(c) = count {
                 p.merge(rw_quantity_expr(c));
             }
@@ -2173,28 +2510,46 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         // M3: all fields bound (no `..` on a non-conservative RHS) so a future
         // read/write-bearing field forces reclassification. Count/min/max leaves
         // here are fixed numbers (ability_scan does not descend them). ----
-        Effect::Attach {
+        // CR 702.95 soulbond / CR 701 attach: an attachment/pairing DESIGNATION.
+        // It mutates only pairing/attachment state, which EVERY reader consults
+        // through a FROZEN source condition (SourceIsPaired / SourceAttachedTo-
+        // Creature / SourceIsEquipped ⇒ `frozen_source_read`, never fed), so no
+        // LIVE read observes it ⇒ NO observable RW kind. The plan's status-tail
+        // `Other` default is parity-safe only where no co-occurring read exists,
+        // but Deadeye Navigator's soulbond trigger reads `SourceMatchesFilter`
+        // ObjectPt alongside the `PairWith` write, so `Other` (which conflicts with
+        // any read) falsely prompts. Order-independence proof: two identical
+        // soulbond triggers off ONE creature-enters event each pair their own
+        // source with the event object; pairing is a symmetric designation and the
+        // ObjectPt read sees only the frozen pre-write source ⇒ identical board in
+        // either order (no feed — attachment/pairing state is read only frozen).
+        // The write target still flags D5 batch parity (CR 603.10a).
+        Effect::PairWith { target }
+        | Effect::Attach {
             attachment: _,
-            target: _,
+            target,
+        } => {
+            let mut p = RwProfile::empty();
+            flag_legacy_write_target(&mut p, target);
+            (p, None)
         }
-        | Effect::PairWith { target: _ }
-        | Effect::Goad { target: _ }
-        | Effect::GoadAll { target: _ }
-        | Effect::ExtraTurn { target: _ }
-        | Effect::Suspect {
-            target: _,
-            scope: _,
-        }
-        | Effect::Unsuspect {
-            target: _,
-            scope: _,
-        }
-        | Effect::BecomePrepared { target: _ }
+        // Target-bearing status effects: `target` is a write recipient, so a D5
+        // event-context ref there retains the batch prompt (CR 603.10a).
+        Effect::Goad { target }
+        | Effect::GoadAll { target }
+        | Effect::ExtraTurn { target }
+        | Effect::Suspect { target, scope: _ }
+        | Effect::Unsuspect { target, scope: _ }
+        | Effect::BecomePrepared { target }
         | Effect::ApplyPerpetual {
-            target: _,
+            target,
             modification: _,
+        } => {
+            let mut p = ext_write(StateKind::Other);
+            flag_legacy_write_target(&mut p, target);
+            (p, None)
         }
-        | Effect::OpenAttractions { count: _ }
+        Effect::OpenAttractions { count: _ }
         | Effect::RegisterBending { kind: _ }
         | Effect::BlightEffect {
             player: _,
@@ -2213,11 +2568,12 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         | Effect::VentureIntoDungeon
         | Effect::SolveCase => (ext_write(StateKind::Other), None),
         Effect::ForceAttack {
-            target: _,
+            target,
             required_player: _,
             duration,
         } => {
             let mut p = ext_write(StateKind::Other);
+            flag_legacy_write_target(&mut p, target);
             p.merge(rw_duration(duration));
             (p, None)
         }
@@ -2397,6 +2753,7 @@ fn obj_membership_scope(
         Some(Zone::Battlefield),
         Zone::Exile,
     );
+    flag_legacy_write_target(&mut p, target);
     (p, Some(sc))
 }
 
@@ -2596,7 +2953,23 @@ fn rw_ability_condition(x: &AbilityCondition) -> RwProfile {
         | AbilityCondition::NthResolutionThisTurn { n: _ } => {
             reads_player_of(StateKind::JournalCast)
         }
-        AbilityCondition::RevealedHasCardType { .. } => RwProfile::conservative(),
+        // CR 701.20 + CR 603.3b: "if a card revealed THIS WAY has card type T" —
+        // a read of the card the member's OWN parent reveal surfaced (a per-
+        // resolution local, like an `ObjectScope::Recipient` read-modify-write:
+        // §2 read-carrier closure). No sibling write can change the TYPE of the
+        // card MY reveal surfaces; a sibling that reorders/moves the library only
+        // changes WHICH card each identical member reveals, and identical
+        // top-consuming functions compose order-independently (CR 603.3b T1:
+        // f∘f = f∘f). Order-independence proof: two Delvers of Secrets off one
+        // upkeep each look at the top card (a non-mutating Dig) and Transform{Self}
+        // iff it is instant/sorcery — both read the SAME frozen top card and each
+        // transforms its OWN source ⇒ identical board in either order; two Lurking
+        // Predators off one spell cast each reveal-and-route the then-current top,
+        // so the top-N cards are each routed by their own type regardless of which
+        // copy processed which ⇒ identical library/battlefield in either order (no
+        // feed — the read is the write's own reveal output). So `conservative()`
+        // (which the coarse fallback assigned) falsely conflicts.
+        AbilityCondition::RevealedHasCardType { .. } => RwProfile::empty(),
         AbilityCondition::SourceEnteredThisTurn
         | AbilityCondition::AdditionalCostPaid { .. }
         | AbilityCondition::CastVariantPaid { .. }
@@ -2643,11 +3016,20 @@ fn rw_trigger_condition(x: &TriggerCondition) -> RwProfile {
     match x {
         TriggerCondition::GainedLife { minimum: _ }
         | TriggerCondition::LostLife
-        | TriggerCondition::DealtDamageBySourceThisTurn
         | TriggerCondition::LostLifeLastTurn => reads_player_of(StateKind::JournalLife),
-        TriggerCondition::DealtDamageThisTurnBySource { source: _ } => {
-            reads_player_of(StateKind::JournalLife)
-        }
+        // CR 120.3e + CR 603.3b: "dealt damage this turn" is combat/marked-damage
+        // history (CR 120), NOT a life-total change (CR 119) — a frozen per-turn
+        // fact about the damaged object, settled at damage time. A sibling
+        // GainLife/LoseLife (a `PlayerLife`/`JournalLife` write) cannot alter it, so
+        // it must NOT ride the life-journal row (the coarse conflation that flipped
+        // Abattoir Ghoul). Order-independence proof: two Abattoir Ghouls off ONE
+        // creature's death both read the SAME frozen "dealt damage this turn" flag
+        // and gain that creature's (LKI-frozen) toughness ⇒ identical life in either
+        // order (no feed: a life write doesn't change a damage-history fact).
+        // `frozen_source_read` never feeds while the freeze is valid (marks
+        // source/history dependence; fail-closed on a reentry hazard).
+        TriggerCondition::DealtDamageBySourceThisTurn
+        | TriggerCondition::DealtDamageThisTurnBySource { source: _ } => frozen_source_read(),
         TriggerCondition::LifeTotalGE { minimum: _ } => reads_player_of(StateKind::PlayerLife),
         TriggerCondition::ControlsType { filter }
         | TriggerCondition::ControlCount { filter, .. }
@@ -2828,13 +3210,16 @@ fn rw_target_filter(x: &TargetFilter) -> RwProfile {
         | TargetFilter::TriggeringPlayer
         | TargetFilter::TriggeringSource
         | TargetFilter::ParentTarget
-        | TargetFilter::ParentTargetSlot { .. }
         | TargetFilter::ParentTargetController
         | TargetFilter::ParentTargetOwner
         | TargetFilter::StackSpell
         | TargetFilter::CostPaidObject => legacy_ref(),
-        // Non-D5 event refs.
-        TargetFilter::EventTarget
+        // Non-D5 event refs. `ParentTargetSlot` is NOT one of the 12 retained tags
+        // (it serializes as an object key the frozen serde oracle never matched —
+        // the write path `target_is_legacy_ref` excludes it too), so it must NOT
+        // set `legacy_batch_prompt`; it is a live event read like the others here.
+        TargetFilter::ParentTargetSlot { .. }
+        | TargetFilter::EventTarget
         | TargetFilter::TriggeringSourceController
         | TargetFilter::PostReplacementSourceController
         | TargetFilter::PostReplacementDamageTarget
@@ -2961,17 +3346,6 @@ fn rw_controller_ref(x: &ControllerRef) -> RwProfile {
         | ControllerRef::ChosenPlayer { .. }
         | ControllerRef::SourceChosenPlayer
         | ControllerRef::EnchantedPlayer => RwProfile::empty(),
-    }
-}
-
-fn rw_count_scope(x: &CountScope) -> RwProfile {
-    match x {
-        CountScope::Controller
-        | CountScope::Owner
-        | CountScope::ScopedPlayer
-        | CountScope::SourceChosenPlayer
-        | CountScope::All
-        | CountScope::Opponents => RwProfile::empty(),
     }
 }
 
@@ -3352,6 +3726,50 @@ mod tests {
             ),
         );
         assert!(conflicts(&a, &batch()));
+    }
+
+    #[test]
+    fn zone_census_battlefield_write_vs_graveyard_read_discriminates() {
+        // Tombstone Stairwell: a battlefield Zombie-token creation (Token{creature}
+        // ⇒ SetMembership dest = Battlefield) whose COUNT reads the GRAVEYARD
+        // creature count. The write and the read overlap on TYPE (creature) but
+        // their ZONES are disjoint (CR 400.1: a fresh token touches only the
+        // battlefield; the count reads the graveyard) ⇒ no feed ⇒ clean. The
+        // frozen source condition (`SourceEnteredThisTurn`) only disables the T1
+        // source-independent fast path so the feed rows are reached — exactly what
+        // Tombstone's `SourceInZone{Battlefield}` intervening-if does.
+        let in_zone = |z: Zone| {
+            let mut tf = TypedFilter::creature();
+            tf.properties.push(FilterProp::InZone { zone: z });
+            TargetFilter::Typed(tf)
+        };
+        let disjoint = cond(
+            ra(token(
+                &["Creature"],
+                qref(obj_count(in_zone(Zone::Graveyard))),
+            )),
+            AbilityCondition::SourceEnteredThisTurn,
+        );
+        assert!(
+            !conflicts(&disjoint, &se()),
+            "battlefield token write × GRAVEYARD creature-count read ⇒ zone-disjoint ⇒ clean"
+        );
+
+        // The SAME read/write with the count scoped to the BATTLEFIELD (matching
+        // zones) ⇒ census AND zone overlap ⇒ conflict. This is the discriminating
+        // witness: a zone-BLIND census would report the disjoint pairing as a
+        // conflict too, so dropping the zone check flips the first assertion.
+        let same_zone = cond(
+            ra(token(
+                &["Creature"],
+                qref(obj_count(in_zone(Zone::Battlefield))),
+            )),
+            AbilityCondition::SourceEnteredThisTurn,
+        );
+        assert!(
+            conflicts(&same_zone, &se()),
+            "battlefield token write × BATTLEFIELD creature-count read ⇒ same zone ⇒ conflict"
+        );
     }
 
     // ===================== (v) chain-root =====================

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -1,0 +1,3427 @@
+//! CR 603.3b: the PR-6.75 read/write **conflict** profiler — a second
+//! compiler-exhaustive, wildcard-free walk of a resolved ability's typed AST,
+//! sibling to `ability_scan.rs`. Where `ability_scan` answers three 1-bit
+//! read-axis questions, this module answers the richer question the legacy
+//! trigger-ordering paths need (§1.2 of the PR-6.75 plan, PR-6.25 §3 C0(ii)):
+//! *which kinds of game state does an ability READ, which does it WRITE, and at
+//! what scope* — so `group_is_order_independent` can auto-order a same-event or
+//! co-departure group of normalized-identical siblings only when their
+//! resolution functions provably commute (CR 603.3b), and prompt otherwise.
+//!
+//! The gate predicate is fail-closed and **kind/scope-aware**: two identical
+//! siblings conflict iff one member's WRITE lands in a location class the other
+//! member's LIVE read observes (a read/write *feed*). Members are normalized-
+//! identical, so a sibling's write-set equals my own.
+//!
+//! # Soundness scope (documented residual)
+//!
+//! Commutation is proven **modulo the source-actor residual** (§1.2 side
+//! condition): per-source granted state (lifelink CR 702.15 / deathtouch
+//! CR 702.2) and the CR 800.4a player-loss object-removal cascade modulate
+//! resolution without appearing in the normalized AST or any profiled read.
+//! Both channels were auto-ordered UNCONDITIONALLY by the pre-C1 short-circuit
+//! and are inherited unchanged (zero ordering-decision change). Damage kinds are
+//! therefore RECIPIENT-classified, not source-bound (CR 704.5a / CR 800.4a).
+//!
+//! # M3 binding mandate (review-blocking)
+//!
+//! Every NON-fully-conservative arm binds ALL payload fields of its variant;
+//! `{ .. }` field elision is permitted ONLY on arms whose RHS is
+//! maximal-conservative (`RwProfile::conservative()`). A precise arm that elides
+//! a field would classify whatever that field carries as nothing — fail-OPEN
+//! (the inc1 5-hole class). Same discipline as `ability_scan.rs`.
+//!
+//! # Traversal closure & fail-closed defaults
+//!
+//! Closed under payload reachability across the same type set as `ability_scan`
+//! (`Effect`, `QuantityRef`, `QuantityExpr`, `AbilityCondition`,
+//! `TriggerCondition`, `TargetFilter`, `ObjectScope`, `PlayerFilter`,
+//! `PlayerScope`, `ControllerRef`, `CountScope`, `StaticCondition`, `Duration`),
+//! plus the choice/RNG `AbilityDefinition` sub-bodies (§2 choice-wrapper / RNG
+//! union descent). A future variant must fail to compile until classified. An
+//! effect KIND absent from the plan's §1.3.1-D group-reachable histogram (zero
+//! printed presence, nothing to flip) may take `RwProfile::conservative()`.
+//! Sub-enums the walk does not descend (`FilterProp` interiors,
+//! `PermissionGrantee`, `CombineSource`, `DamageSource`) are handled like
+//! `ability_scan`'s conservative subtrees; the §5.2 parity sweep (commit 2) is
+//! the arbiter for any D5 tag that hides only there.
+//!
+//! CR annotations: CR 603.3b (gate), CR 603.10a + CR 400.7 (frozen-read kinds +
+//! freeze-invalidation row), CR 603.4 (condition inclusion), CR 603.5
+//! (resolution-time-choice exclusions + Mana×unless-pay guard), CR 603.7
+//! (deferred-body arms), CR 707.10 / CR 707.10c (CopySpell), CR 707.2
+//! (CopyTokenOf template read), CR 702.15 / CR 702.2 / CR 704.5a / CR 800.4a
+//! (source-actor residual).
+
+// Consumers land in commit 2 (triggers.rs rewiring); until then the classifier
+// is exercised only by its #[cfg(test)] unit pairings. Mirrors the inc2b axis-3
+// readout pattern (landed with allow(dead_code) until its consumer). Commit 2
+// removes this attribute.
+#![allow(dead_code)]
+
+use crate::types::ability::FilterProp;
+use crate::types::ability::{
+    AbilityCondition, AbilityDefinition, ControllerRef, CountScope, Duration, Effect, ModalChoice,
+    MultiTargetSpec, ObjectScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef,
+    RepeatContinuation, ResolvedAbility, StaticCondition, TargetFilter, TriggerCondition,
+    TypeFilter, TypedFilter,
+};
+use crate::types::game_state::TargetSelectionConstraint;
+use crate::types::zones::Zone;
+use std::collections::BTreeSet;
+
+// ---------------------------------------------------------------------------
+// State-kind lattice (§ D-profile).
+// ---------------------------------------------------------------------------
+
+/// A class of mutable game state, for CR 603.3b sibling-conflict analysis.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum StateKind {
+    /// CR 208/209: object power/toughness (live, after layers).
+    ObjectPt,
+    /// CR 122.1: counters on an object.
+    ObjectCounters,
+    /// CR 400: zone membership / control (which objects are where / whose).
+    SetMembership,
+    /// CR 119: player life (and energy/poison/player counters CR 122.1, folded
+    /// here as monotone player resources).
+    PlayerLife,
+    /// CR 401/402: hand + library contents/order.
+    HandLibrary,
+    /// CR 119.3: per-turn life-change journal (fed by `PlayerLife` writes).
+    JournalLife,
+    /// CR 120.6: per-turn draw/discard journal (fed by `HandLibrary` writes).
+    JournalCards,
+    /// CR 601: per-turn/per-game cast journal (no in-resolution write feeds it).
+    JournalCast,
+    /// CR 405: the stack's shape (copies pushed, spells countered).
+    StackShape,
+    /// CR 301.5/302.6: tap state.
+    TapState,
+    /// Unclassifiable — conflicts with everything (fail-closed).
+    Other,
+}
+
+/// Explicit-bool set over `StateKind` — mirrors `Axes`' style (no bitmagic).
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+pub(crate) struct KindSet {
+    object_pt: bool,
+    object_counters: bool,
+    set_membership: bool,
+    player_life: bool,
+    hand_library: bool,
+    journal_life: bool,
+    journal_cards: bool,
+    journal_cast: bool,
+    stack_shape: bool,
+    tap_state: bool,
+    other: bool,
+}
+
+impl KindSet {
+    const EMPTY: KindSet = KindSet {
+        object_pt: false,
+        object_counters: false,
+        set_membership: false,
+        player_life: false,
+        hand_library: false,
+        journal_life: false,
+        journal_cards: false,
+        journal_cast: false,
+        stack_shape: false,
+        tap_state: false,
+        other: false,
+    };
+    const ALL: KindSet = KindSet {
+        object_pt: true,
+        object_counters: true,
+        set_membership: true,
+        player_life: true,
+        hand_library: true,
+        journal_life: true,
+        journal_cards: true,
+        journal_cast: true,
+        stack_shape: true,
+        tap_state: true,
+        other: true,
+    };
+
+    fn one(k: StateKind) -> KindSet {
+        let mut s = KindSet::EMPTY;
+        s.set(k);
+        s
+    }
+    fn set(&mut self, k: StateKind) {
+        match k {
+            StateKind::ObjectPt => self.object_pt = true,
+            StateKind::ObjectCounters => self.object_counters = true,
+            StateKind::SetMembership => self.set_membership = true,
+            StateKind::PlayerLife => self.player_life = true,
+            StateKind::HandLibrary => self.hand_library = true,
+            StateKind::JournalLife => self.journal_life = true,
+            StateKind::JournalCards => self.journal_cards = true,
+            StateKind::JournalCast => self.journal_cast = true,
+            StateKind::StackShape => self.stack_shape = true,
+            StateKind::TapState => self.tap_state = true,
+            StateKind::Other => self.other = true,
+        }
+    }
+    fn union(self, o: KindSet) -> KindSet {
+        KindSet {
+            object_pt: self.object_pt || o.object_pt,
+            object_counters: self.object_counters || o.object_counters,
+            set_membership: self.set_membership || o.set_membership,
+            player_life: self.player_life || o.player_life,
+            hand_library: self.hand_library || o.hand_library,
+            journal_life: self.journal_life || o.journal_life,
+            journal_cards: self.journal_cards || o.journal_cards,
+            journal_cast: self.journal_cast || o.journal_cast,
+            stack_shape: self.stack_shape || o.stack_shape,
+            tap_state: self.tap_state || o.tap_state,
+            other: self.other || o.other,
+        }
+    }
+    fn minus(self, o: KindSet) -> KindSet {
+        KindSet {
+            object_pt: self.object_pt && !o.object_pt,
+            object_counters: self.object_counters && !o.object_counters,
+            set_membership: self.set_membership && !o.set_membership,
+            player_life: self.player_life && !o.player_life,
+            hand_library: self.hand_library && !o.hand_library,
+            journal_life: self.journal_life && !o.journal_life,
+            journal_cards: self.journal_cards && !o.journal_cards,
+            journal_cast: self.journal_cast && !o.journal_cast,
+            stack_shape: self.stack_shape && !o.stack_shape,
+            tap_state: self.tap_state && !o.tap_state,
+            other: self.other && !o.other,
+        }
+    }
+    fn is_empty(self) -> bool {
+        self == KindSet::EMPTY
+    }
+    fn any(self) -> bool {
+        !self.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Census (§2 census-overlap refinement of the SetMembership same-kind row).
+// ---------------------------------------------------------------------------
+
+/// Extractable type-tag requirements (core types + subtypes + token-ness),
+/// lowercased into a common tag space.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub(crate) enum Census {
+    /// No object moved (absent/no-op write) — overlaps nothing.
+    None,
+    /// Unextractable / unbounded — assume overlap (fail-closed).
+    Any,
+    /// A concrete positive tag set.
+    Tags(BTreeSet<String>),
+}
+
+impl Census {
+    fn merge(&mut self, o: Census) {
+        let taken = std::mem::replace(self, Census::None);
+        *self = match (taken, o) {
+            (Census::None, x) | (x, Census::None) => x,
+            (Census::Any, _) | (_, Census::Any) => Census::Any,
+            (Census::Tags(mut a), Census::Tags(b)) => {
+                a.extend(b);
+                Census::Tags(a)
+            }
+        };
+    }
+}
+
+/// CR 205 tag-set overlap: two censuses can name a common object iff they share
+/// a tag; `None` overlaps nothing, `Any` overlaps every non-`None`.
+fn census_overlap(a: &Census, b: &Census) -> bool {
+    match (a, b) {
+        (Census::None, _) | (_, Census::None) => false,
+        (Census::Any, _) | (_, Census::Any) => true,
+        (Census::Tags(x), Census::Tags(y)) => x.intersection(y).next().is_some(),
+    }
+}
+
+/// The group's live source objects' type census. Read once at the
+/// `begin_trigger_ordering` chokepoint. A missing source ⇒ `None` ⇒ overlap
+/// assumed (fail-closed).
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SourceCensus {
+    tags: Option<BTreeSet<String>>,
+}
+
+impl SourceCensus {
+    pub(crate) fn from_tags<I: IntoIterator<Item = String>>(tags: I) -> Self {
+        SourceCensus {
+            tags: Some(tags.into_iter().map(|t| t.to_lowercase()).collect()),
+        }
+    }
+    pub(crate) fn unknown() -> Self {
+        SourceCensus { tags: None }
+    }
+    fn as_census(&self) -> Census {
+        match &self.tags {
+            None => Census::Any,
+            Some(t) => Census::Tags(t.clone()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RwProfile (§2 D-profile).
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub(crate) struct RwProfile {
+    /// Source-scoped reads ONLY (live unless the structure freezes them, CR
+    /// 603.10a). Recipient reads are NOT recorded — a Recipient read is the
+    /// write's own modify-input (read-modify-write); identical members' composed
+    /// per-object totals are symmetric (Canopy Gargantuan proof §1.3.1-G).
+    reads_src: KindSet,
+    /// Board-/graveyard-/stack-top-scoped mutable reads. Aggregates carry
+    /// `SetMembership` alongside their value kind, so membership writes feed them.
+    reads_board: KindSet,
+    /// Life totals / hand size / journals — sibling-mutable player state.
+    reads_player: KindSet,
+    /// CR 603.10a look-back class: `HadCounters`, source cast-time facts. Never
+    /// conflict WHILE THE FREEZE IS VALID (see `writes_reentry_hazard`).
+    reads_frozen: KindSet,
+    /// Event reads not proven frozen (`EventSource`/`EventTarget`/…). Consulted
+    /// by T1's fast path and the freeze-invalidation row; the batch structure
+    /// treats them as frozen.
+    reads_event_live: bool,
+    /// D5: one of the 12 retained-prompt event-context refs is present.
+    /// Consulted ONLY by the batch branch (commit 2).
+    legacy_batch_prompt: bool,
+    /// Writes scoped to the member's own Source/Recipient object.
+    writes_self: KindSet,
+    /// Board-/player-/stack-scoped writes (INCLUDES creation, event-object, and
+    /// LastCreated writes — everything not self). Board reads see all of these.
+    writes_external: KindSet,
+    /// Sub-portion of `writes_external` targeting the EVENT object
+    /// (`TriggeringSource`-class + parentless `ParentTarget`, §2 rule 1/2).
+    writes_event_object: KindSet,
+    /// Sub-portion of `writes_external` from fresh-id creation / `LastCreated`
+    /// (§2 rule 1). Fresh ObjectIds cannot be a sibling's source.
+    writes_created: KindSet,
+    /// CR 603.10a/B1: an EXTERNAL move of EXISTING objects whose destination is
+    /// the battlefield or whose origin is exile — re-enters/overwrites a
+    /// departed member's LKI. Feeds the freeze-invalidation row.
+    writes_reentry_hazard: bool,
+    /// A self-scoped `SetMembership` write exists; its census = the source.
+    writes_membership_self: bool,
+    /// Census of external/creation/event-object `SetMembership` writes.
+    writes_membership_external_census: Census,
+    /// Census requirements of all `SetMembership` reads.
+    reads_membership_census: Census,
+    /// A resolution-time payment (`unless_pay` / `PayCost`) is present (CR
+    /// 603.5). With `writes_pool`, trips the Mana×unless-pay guard.
+    has_pay_or_unless: bool,
+    /// The ability writes the mana pool (`Effect::Mana`).
+    writes_pool: bool,
+}
+
+impl RwProfile {
+    fn empty() -> RwProfile {
+        RwProfile {
+            reads_src: KindSet::EMPTY,
+            reads_board: KindSet::EMPTY,
+            reads_player: KindSet::EMPTY,
+            reads_frozen: KindSet::EMPTY,
+            reads_event_live: false,
+            legacy_batch_prompt: false,
+            writes_self: KindSet::EMPTY,
+            writes_external: KindSet::EMPTY,
+            writes_event_object: KindSet::EMPTY,
+            writes_created: KindSet::EMPTY,
+            writes_reentry_hazard: false,
+            writes_membership_self: false,
+            writes_membership_external_census: Census::None,
+            reads_membership_census: Census::None,
+            has_pay_or_unless: false,
+            writes_pool: false,
+        }
+    }
+
+    /// Fail-closed maximal profile for untraversed / unclassified subtrees.
+    fn conservative() -> RwProfile {
+        let mut p = RwProfile::empty();
+        p.reads_board = KindSet::ALL;
+        p.writes_self = KindSet::ALL;
+        p.writes_external = KindSet::ALL;
+        p.writes_membership_external_census = Census::Any;
+        p.writes_membership_self = true;
+        p.reads_membership_census = Census::Any;
+        p
+    }
+
+    fn merge(&mut self, o: RwProfile) {
+        self.reads_src = self.reads_src.union(o.reads_src);
+        self.reads_board = self.reads_board.union(o.reads_board);
+        self.reads_player = self.reads_player.union(o.reads_player);
+        self.reads_frozen = self.reads_frozen.union(o.reads_frozen);
+        self.reads_event_live |= o.reads_event_live;
+        self.legacy_batch_prompt |= o.legacy_batch_prompt;
+        self.writes_self = self.writes_self.union(o.writes_self);
+        self.writes_external = self.writes_external.union(o.writes_external);
+        self.writes_event_object = self.writes_event_object.union(o.writes_event_object);
+        self.writes_created = self.writes_created.union(o.writes_created);
+        self.writes_reentry_hazard |= o.writes_reentry_hazard;
+        self.writes_membership_self |= o.writes_membership_self;
+        self.writes_membership_external_census
+            .merge(o.writes_membership_external_census);
+        self.reads_membership_census
+            .merge(o.reads_membership_census);
+        self.has_pay_or_unless |= o.has_pay_or_unless;
+        self.writes_pool |= o.writes_pool;
+    }
+
+    /// CR 603.3b T1 (§1.2): the resolution function never consults the source
+    /// binding — no source read, no self write, no source-referential frozen
+    /// read. Fail-closed (the walk routes source predicates into `reads_src` /
+    /// `reads_frozen`).
+    pub(crate) fn source_independent(&self) -> bool {
+        self.reads_src.is_empty() && self.writes_self.is_empty() && self.reads_frozen.is_empty()
+    }
+
+    /// Drop all writes (deferred-body descent, CR 603.7: writes happen
+    /// post-window, so reads descend but writes are not counted).
+    fn drop_writes(&mut self) {
+        self.writes_self = KindSet::EMPTY;
+        self.writes_external = KindSet::EMPTY;
+        self.writes_event_object = KindSet::EMPTY;
+        self.writes_created = KindSet::EMPTY;
+        self.writes_reentry_hazard = false;
+        self.writes_membership_self = false;
+        self.writes_membership_external_census = Census::None;
+        self.writes_pool = false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GroupStructure.
+// ---------------------------------------------------------------------------
+
+pub(crate) struct GroupStructure {
+    /// All members fired on ONE trigger event.
+    pub(crate) same_event: bool,
+    /// All members share one `source_id`.
+    pub(crate) all_same_source: bool,
+    /// Every member's trigger is a ZoneChanged-from-battlefield whose object is
+    /// that member's own source (departure batch — CR 603.10a frozen reads).
+    pub(crate) all_sources_self_departed: bool,
+    /// The shared `valid_card` filter provably excludes every member's source
+    /// (extractable `Another`/not-self, §2 rule 2).
+    pub(crate) event_object_excludes_sources: bool,
+    /// The group's trigger event carries an event object (ZoneChanged / a source
+    /// event). FALSE for `Phase` triggers ⇒ a `TriggeringSource` / parentless
+    /// `ParentTarget` write resolves to None and is a no-op (targeting.rs:951
+    /// `_ => None`; bounce.rs empty-target no-op — §2 rule 1 parentless clause).
+    /// Beyond the plan's five listed fields; required to mechanize the
+    /// resolver-referent pin the context-free profile cannot express.
+    pub(crate) event_object_present: bool,
+    /// The live source census, for the membership census-overlap row (§2).
+    pub(crate) source_census: SourceCensus,
+}
+
+// ---------------------------------------------------------------------------
+// feeds matrix (§2).
+// ---------------------------------------------------------------------------
+
+/// CR 603.3b feed matrix: same-kind rows + the cross rows (`ObjectCounters →
+/// ObjectPt`, `PlayerLife → JournalLife`, `HandLibrary → JournalCards`), with the
+/// `SetMembership` same-kind row refined by census overlap.
+/// `SetMembership → aggregate {ObjectPt,ObjectCounters}` needs no explicit row —
+/// aggregate reads already carry a `SetMembership` tag. `Other` conflicts with
+/// everything. `PlayerLife → SetMembership` is deliberately ABSENT (the CR 800.4a
+/// player-loss cascade is the documented source-actor residual, §1.2).
+fn feeds(reads: KindSet, writes: KindSet, read_census: &Census, write_census: &Census) -> bool {
+    if (writes.other && reads.any()) || (reads.other && writes.any()) {
+        return true;
+    }
+    if (reads.object_pt && writes.object_pt)
+        || (reads.object_counters && writes.object_counters)
+        || (reads.player_life && writes.player_life)
+        || (reads.hand_library && writes.hand_library)
+        || (reads.journal_life && writes.journal_life)
+        || (reads.journal_cards && writes.journal_cards)
+        || (reads.journal_cast && writes.journal_cast)
+        || (reads.stack_shape && writes.stack_shape)
+        || (reads.tap_state && writes.tap_state)
+    {
+        return true;
+    }
+    // CR 122.1 + CR 613.4: counters change P/T.
+    if reads.object_pt && writes.object_counters {
+        return true;
+    }
+    // CR 119.3: a life write feeds a life-change journal read.
+    if reads.journal_life && writes.player_life {
+        return true;
+    }
+    // CR 120.6: a hand/library write feeds a draw/discard journal read.
+    if reads.journal_cards && writes.hand_library {
+        return true;
+    }
+    // SetMembership same-kind, census-refined (§2).
+    if reads.set_membership && writes.set_membership && census_overlap(read_census, write_census) {
+        return true;
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// The conflict predicate (§1.2 pseudocode, implemented exactly).
+// ---------------------------------------------------------------------------
+
+/// CR 603.3b: do two normalized-identical siblings' resolution functions FAIL to
+/// commute under the given group structure? Sound modulo the source-actor
+/// residual (module doc). Fail-closed.
+pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
+    // Mana×unless-pay guard (D4-R1, CR 603.5): pool write + unless-pay/pay-cost
+    // breaks the identical-choice-set symmetry. 0 printed co-occurrences.
+    if p.writes_pool && p.has_pay_or_unless {
+        return true;
+    }
+    // T1 identical-function fast paths (§1.2), sound modulo the source-actor
+    // residual.
+    if s.same_event && (s.all_same_source || p.source_independent()) {
+        return false;
+    }
+    if s.all_same_source && !p.reads_event_live {
+        return false;
+    }
+
+    let freeze_valid = !p.writes_reentry_hazard;
+    let frozen_src = s.all_sources_self_departed && freeze_valid;
+    let live_src_reads = if frozen_src {
+        KindSet::EMPTY
+    } else {
+        p.reads_src
+    };
+
+    // Event-object writes resolve to None (no-op) when the trigger carries no
+    // event object (§2 rule 1 parentless clause; targeting.rs:951).
+    let effective_external = if s.event_object_present {
+        p.writes_external
+    } else {
+        p.writes_external.minus(p.writes_event_object)
+    };
+
+    // Freeze-invalidation row (B1) — a DIRECT conjunct on the batch path.
+    if !s.same_event
+        && !freeze_valid
+        && (p.reads_frozen.any() || p.reads_src.any() || p.reads_event_live)
+    {
+        return true;
+    }
+
+    // SRC-read sibling writes: external existing objects, plus self only when
+    // all members share one source; event-object writes excluded under
+    // object-disjointness; created/LastCreated writes always excluded.
+    let mut src_writes = effective_external.minus(p.writes_created);
+    if s.same_event && s.event_object_excludes_sources && s.event_object_present {
+        src_writes = src_writes.minus(p.writes_event_object);
+    }
+    let src_self_membership = s.all_same_source && p.writes_membership_self;
+    let src_write_census = membership_census_of(
+        src_writes,
+        &p.writes_membership_external_census,
+        src_self_membership,
+        s,
+    );
+    if s.all_same_source {
+        src_writes = src_writes.union(p.writes_self);
+    }
+    if feeds(
+        live_src_reads,
+        src_writes,
+        &p.reads_membership_census,
+        &src_write_census,
+    ) {
+        return true;
+    }
+
+    // BOARD/PLAYER-read sibling writes: everything (incl. self).
+    let board_writes = effective_external.union(p.writes_self);
+    let board_write_census = membership_census_of(
+        board_writes,
+        &p.writes_membership_external_census,
+        p.writes_membership_self,
+        s,
+    );
+    let board_reads = p.reads_board.union(p.reads_player);
+    if feeds(
+        board_reads,
+        board_writes,
+        &p.reads_membership_census,
+        &board_write_census,
+    ) {
+        return true;
+    }
+
+    false
+}
+
+/// The membership-write census applying to an effective write set: external
+/// census if any external membership write is present, unioned with the source
+/// census if a self membership write is in scope.
+fn membership_census_of(
+    write_kinds: KindSet,
+    external_census: &Census,
+    self_in_scope: bool,
+    s: &GroupStructure,
+) -> Census {
+    let mut c = Census::None;
+    if write_kinds.set_membership {
+        c.merge(external_census.clone());
+    }
+    if self_in_scope {
+        c.merge(s.source_census.as_census());
+    }
+    c
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points.
+// ---------------------------------------------------------------------------
+
+/// Profile a resolved ability's reads/writes (CR 603.3b). A top-level
+/// `ParentTarget` is parentless (§2 rule 1) ⇒ chain-root context starts empty.
+pub(crate) fn ability_rw_profile(a: &ResolvedAbility) -> RwProfile {
+    let mut p = RwProfile::empty();
+    walk_ability(a, None, &mut p);
+    p
+}
+
+/// Profile a bare trigger-level `condition` (CR 603.4 intervening-if — re-checked
+/// at resolution, so its reads are order-relevant).
+pub(crate) fn trigger_condition_rw_profile(c: &TriggerCondition) -> RwProfile {
+    rw_trigger_condition(c)
+}
+
+// ---------------------------------------------------------------------------
+// Chain-root scope for anaphoric `ParentTarget` writes (§2 rule 1).
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum WriteScope {
+    /// The member's own source (SelfRef / SourceOrPaired).
+    SelfSource,
+    /// An existing external object / player / board.
+    External,
+    /// The event object (`TriggeringSource`-class + parentless `ParentTarget`).
+    EventObject,
+    /// A fresh-id creation / LastCreated object.
+    Created,
+}
+
+/// CR 603.4 + CR 608.2c: the write scope of an effect target. `ParentTarget`
+/// resolves to the CHAIN ROOT (`nearest object-referent ancestor`,
+/// filter.rs:3063-3085); a PARENTLESS `ParentTarget` resolves to the EVENT object
+/// on a ZoneChanged trigger (targeting.rs:946-950) — represented as `EventObject`,
+/// which `profiles_conflict` drops when the trigger carries no event object.
+/// Exhaustive & wildcard-free: a future `TargetFilter` variant must be classified.
+fn scope_of(target: &TargetFilter, chain_root: Option<WriteScope>) -> WriteScope {
+    match target {
+        TargetFilter::SelfRef | TargetFilter::SourceOrPaired => WriteScope::SelfSource,
+        TargetFilter::TriggeringSource => WriteScope::EventObject,
+        TargetFilter::ParentTarget | TargetFilter::ParentTargetSlot { .. } => {
+            chain_root.unwrap_or(WriteScope::EventObject)
+        }
+        TargetFilter::LastCreated => WriteScope::Created,
+        TargetFilter::None
+        | TargetFilter::Any
+        | TargetFilter::Player
+        | TargetFilter::Controller
+        | TargetFilter::Typed(..)
+        | TargetFilter::Not { .. }
+        | TargetFilter::Or { .. }
+        | TargetFilter::And { .. }
+        | TargetFilter::StackAbility { .. }
+        | TargetFilter::StackSpell
+        | TargetFilter::SpecificObject { .. }
+        | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::Neighbor { .. }
+        | TargetFilter::ScopedPlayer
+        | TargetFilter::AttachedTo
+        | TargetFilter::LastRevealed
+        | TargetFilter::CostPaidObject
+        | TargetFilter::ChosenCard
+        | TargetFilter::TrackedSet { .. }
+        | TargetFilter::TrackedSetFiltered { .. }
+        | TargetFilter::ExiledBySource
+        | TargetFilter::ExiledCardByIndex { .. }
+        | TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::EventTarget
+        | TargetFilter::TriggeringSourceController
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::SourceChosenPlayer
+        | TargetFilter::OriginalController
+        | TargetFilter::PostReplacementSourceController
+        | TargetFilter::PostReplacementDamageTarget
+        | TargetFilter::PostReplacementDamageTargetOwner
+        | TargetFilter::DefendingPlayer
+        | TargetFilter::HasChosenName
+        | TargetFilter::ChosenDamageSource
+        | TargetFilter::Named { .. }
+        | TargetFilter::Owner
+        | TargetFilter::AllPlayers => WriteScope::External,
+    }
+}
+
+/// Place a non-membership object write (`ObjectPt`/`ObjectCounters`/`TapState`/
+/// `Other`) by scope.
+fn place_object_write(p: &mut RwProfile, kind: StateKind, sc: WriteScope) {
+    match sc {
+        WriteScope::SelfSource => p.writes_self.set(kind),
+        WriteScope::External => p.writes_external.set(kind),
+        WriteScope::EventObject => {
+            p.writes_external.set(kind);
+            p.writes_event_object.set(kind);
+        }
+        WriteScope::Created => {
+            p.writes_external.set(kind);
+            p.writes_created.set(kind);
+        }
+    }
+}
+
+/// Place a `SetMembership` (zone/control) write with its census + reentry-hazard
+/// (CR 603.10a/B1) + hand/library endpoint tagging.
+fn place_membership_write(
+    p: &mut RwProfile,
+    sc: WriteScope,
+    census: Census,
+    origin: Option<Zone>,
+    dest: Zone,
+) {
+    let hazard = matches!(sc, WriteScope::External)
+        && (dest == Zone::Battlefield || origin == Some(Zone::Exile))
+        && origin != Some(Zone::Library);
+    match sc {
+        WriteScope::SelfSource => {
+            p.writes_self.set(StateKind::SetMembership);
+            p.writes_membership_self = true;
+        }
+        WriteScope::External => {
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_membership_external_census.merge(census);
+            p.writes_reentry_hazard |= hazard;
+        }
+        WriteScope::EventObject => {
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_event_object.set(StateKind::SetMembership);
+            // Event object identity is unknown at profile time ⇒ census Any.
+            p.writes_membership_external_census.merge(Census::Any);
+            p.writes_reentry_hazard |= hazard;
+        }
+        WriteScope::Created => {
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_created.set(StateKind::SetMembership);
+            p.writes_membership_external_census.merge(census);
+        }
+    }
+    if is_hand_or_library(dest) || origin.is_some_and(is_hand_or_library) {
+        p.writes_external.set(StateKind::HandLibrary);
+    }
+}
+
+fn is_hand_or_library(z: Zone) -> bool {
+    matches!(z, Zone::Hand | Zone::Library)
+}
+
+/// CR 205: extract a type-tag census from a filter used as a read/write selector.
+/// `Typed` yields its core-type + subtype + token-ness tags; `Not`/broad filters
+/// ⇒ `Any` (fail-closed); `And`/`Or` union their components.
+fn census_of_filter(f: &TargetFilter) -> Census {
+    match f {
+        TargetFilter::Typed(tf) => census_of_typed(tf),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            let mut c = Census::None;
+            for x in filters {
+                c.merge(census_of_filter(x));
+            }
+            if matches!(c, Census::None) {
+                Census::Any
+            } else {
+                c
+            }
+        }
+        _ => Census::Any,
+    }
+}
+
+fn census_of_typed(tf: &TypedFilter) -> Census {
+    let mut tags: BTreeSet<String> = BTreeSet::new();
+    for t in &tf.type_filters {
+        match t {
+            TypeFilter::Creature => tags.insert("creature".into()),
+            TypeFilter::Land => tags.insert("land".into()),
+            TypeFilter::Artifact => tags.insert("artifact".into()),
+            TypeFilter::Enchantment => tags.insert("enchantment".into()),
+            TypeFilter::Instant => tags.insert("instant".into()),
+            TypeFilter::Sorcery => tags.insert("sorcery".into()),
+            TypeFilter::Planeswalker => tags.insert("planeswalker".into()),
+            TypeFilter::Battle => tags.insert("battle".into()),
+            TypeFilter::Kindred => tags.insert("kindred".into()),
+            TypeFilter::Subtype(s) => tags.insert(s.to_lowercase()),
+            // Broad / non-positive / disjunctive type constraints ⇒ unextractable.
+            TypeFilter::Permanent | TypeFilter::Card | TypeFilter::Any => return Census::Any,
+            TypeFilter::Non(_) | TypeFilter::AnyOf(_) => return Census::Any,
+        };
+    }
+    for prop in &tf.properties {
+        match prop {
+            FilterProp::Token => {
+                tags.insert("token".into());
+            }
+            FilterProp::NonToken => {
+                tags.insert("nontoken".into());
+            }
+            _ => {}
+        }
+    }
+    if tags.is_empty() {
+        Census::Any
+    } else {
+        Census::Tags(tags)
+    }
+}
+
+/// A read filter that provably counts only the member's own source (a `SelfRef`
+/// conjunct) — routes to per-member-private `reads_src` (§2 read-carrier closure).
+fn filter_is_self_scoped(f: &TargetFilter) -> bool {
+    match f {
+        TargetFilter::SelfRef => true,
+        TargetFilter::And { filters } => filters.iter().any(filter_is_self_scoped),
+        _ => false,
+    }
+}
+
+/// CR 111.1: the filter's `valid_card` provably excludes every group member's
+/// source (an `Another` component) — the object-disjointness signal (§2 rule 2).
+/// A helper for the commit-2 chokepoint; exposed here beside the rule it feeds.
+pub(crate) fn filter_excludes_source(f: &TargetFilter) -> bool {
+    match f {
+        TargetFilter::Typed(tf) => tf
+            .properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::Another)),
+        TargetFilter::And { filters } => filters.iter().any(filter_excludes_source),
+        _ => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Read builders.
+// ---------------------------------------------------------------------------
+
+fn reads_board_of(k: StateKind) -> RwProfile {
+    let mut p = RwProfile::empty();
+    p.reads_board = KindSet::one(k);
+    p
+}
+/// CR 400.1 + CR 205: a whole-zone / unfiltered `SetMembership` board read
+/// (GraveyardSize, Devotion, …) over a zone's contents; the census is a
+/// card-type tag-set (CR 205). The filter is fully unextractable, so its census is `Census::Any`
+/// (§2: unextractable ⇒ overlap assumed, fail-CLOSED). Must NOT use
+/// `reads_board_of(SetMembership)`, which leaves `Census::None` (the write-side
+/// "no object moved" sentinel) and would make the membership feed row never fire.
+fn reads_zone_membership() -> RwProfile {
+    let mut p = reads_board_of(StateKind::SetMembership);
+    p.reads_membership_census = Census::Any;
+    p
+}
+fn reads_player_of(k: StateKind) -> RwProfile {
+    let mut p = RwProfile::empty();
+    p.reads_player = KindSet::one(k);
+    p
+}
+fn reads_src_of(k: StateKind) -> RwProfile {
+    let mut p = RwProfile::empty();
+    p.reads_src = KindSet::one(k);
+    p
+}
+/// CR 603.10a: a source-referential look-back / cast-time fact — frozen, never
+/// sibling-fed, but marks source-dependence (`source_independent` false).
+fn frozen_source_read() -> RwProfile {
+    let mut p = RwProfile::empty();
+    p.reads_frozen = KindSet::one(StateKind::SetMembership);
+    p
+}
+fn reads_frozen_of(k: StateKind) -> RwProfile {
+    let mut p = RwProfile::empty();
+    p.reads_frozen = KindSet::one(k);
+    p
+}
+fn reads_event_live() -> RwProfile {
+    let mut p = RwProfile::empty();
+    p.reads_event_live = true;
+    p
+}
+fn legacy_ref() -> RwProfile {
+    let mut p = reads_event_live();
+    p.legacy_batch_prompt = true;
+    p
+}
+fn writes_pool_profile() -> RwProfile {
+    let mut p = RwProfile::empty();
+    p.writes_pool = true;
+    p
+}
+fn ext_write(k: StateKind) -> RwProfile {
+    let mut p = RwProfile::empty();
+    p.writes_external.set(k);
+    p
+}
+fn self_write(k: StateKind) -> RwProfile {
+    let mut p = RwProfile::empty();
+    p.writes_self.set(k);
+    p
+}
+
+/// A board aggregate read over `filter`: `reads_board{SetMembership}` (with
+/// census) unless the filter is provably self-scoped ⇒ per-member-private
+/// `reads_src` (§2).
+fn board_membership_read(filter: &TargetFilter) -> RwProfile {
+    let mut p = RwProfile::empty();
+    if filter_is_self_scoped(filter) {
+        p.reads_src = KindSet::one(StateKind::SetMembership);
+    } else {
+        p.reads_board = KindSet::one(StateKind::SetMembership);
+    }
+    p.reads_membership_census = census_of_filter(filter);
+    p
+}
+
+/// A board VALUE aggregate (power/counter aggregate) over `filter`: records the
+/// value kind AND `SetMembership` (a membership write changes the aggregate, §2).
+fn board_value_aggregate_read(filter: &TargetFilter, value: StateKind) -> RwProfile {
+    let mut p = board_membership_read(filter);
+    if filter_is_self_scoped(filter) {
+        p.reads_src.set(value);
+    } else {
+        p.reads_board.set(value);
+    }
+    p
+}
+
+/// Read an object characteristic at a given scope (§2 read-carrier closure):
+/// Source ⇒ `reads_src`; Recipient ⇒ nothing (read-modify-write); event objects
+/// ⇒ `reads_event_live`; other object scopes ⇒ `reads_board`.
+fn read_object_scope(scope: &ObjectScope, kind: StateKind) -> RwProfile {
+    match scope {
+        ObjectScope::Source => reads_src_of(kind),
+        ObjectScope::Recipient => RwProfile::empty(),
+        ObjectScope::Target | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
+            reads_board_of(kind)
+        }
+        ObjectScope::EventSource | ObjectScope::EventTarget => reads_event_live(),
+        // D5 carrier: `CostPaidObject` is one of the 12 retained refs.
+        ObjectScope::CostPaidObject => legacy_ref(),
+    }
+}
+
+/// (player_recipient, object_recipient) for a damage/target filter — recipient
+/// classification (CR 704.5a / CR 800.4a source-actor residual documented in the
+/// module doc; damage kinds are recipient-classified, not source-bound).
+fn target_recipient(f: &TargetFilter) -> (bool, bool) {
+    match f {
+        TargetFilter::Player
+        | TargetFilter::Controller
+        | TargetFilter::Owner
+        | TargetFilter::AllPlayers
+        | TargetFilter::DefendingPlayer
+        | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::ScopedPlayer
+        | TargetFilter::SourceChosenPlayer
+        | TargetFilter::OriginalController
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringSourceController
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::PostReplacementSourceController
+        | TargetFilter::PostReplacementDamageTargetOwner => (true, false),
+        // "any target" and player-or-object filters ⇒ both recipients.
+        TargetFilter::Any | TargetFilter::Or { .. } => (true, true),
+        // Everything else is object-scoped for damage purposes.
+        _ => (false, true),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ability walk (mirrors `resolved_ability_axes`, with chain-root threading).
+// ---------------------------------------------------------------------------
+
+fn walk_ability(a: &ResolvedAbility, chain_root: Option<WriteScope>, acc: &mut RwProfile) {
+    let ResolvedAbility {
+        effect,
+        sub_ability,
+        else_ability,
+        condition,
+        duration,
+        player_scope,
+        starting_with,
+        repeat_for,
+        multi_target,
+        target_constraints,
+        unless_pay,
+        target_chooser,
+        repeat_until,
+        modal,
+        mode_abilities,
+        targets: _,
+        source_id: _,
+        source_incarnation: _,
+        controller: _,
+        original_controller: _,
+        scoped_player: _,
+        kind: _,
+        context: _,
+        optional_targeting: _,
+        optional: _,
+        optional_for: _,
+        target_choice_timing: _,
+        description: _,
+        min_x_value: _,
+        cant_be_copied: _,
+        copy_count_status: _,
+        forward_result: _,
+        distribution: _,
+        chosen_x: _,
+        cost_paid_object: _,
+        effect_context_object: _,
+        ability_index: _,
+        may_trigger_origin: _,
+        target_selection_mode: _,
+        chosen_players: _,
+        sub_link: _,
+        dig_found_nothing_for_parent_target: _,
+    } = a;
+
+    let (eff, own_scope) = rw_effect(effect, chain_root);
+    acc.merge(eff);
+    let child_root = own_scope.or(chain_root);
+
+    if let Some(sub) = sub_ability {
+        walk_ability(sub, child_root, acc);
+    }
+    if let Some(els) = else_ability {
+        walk_ability(els, chain_root, acc);
+    }
+    if let Some(c) = condition {
+        acc.merge(rw_ability_condition(c));
+    }
+    if let Some(d) = duration {
+        acc.merge(rw_duration(d));
+    }
+    if let Some(ps) = player_scope {
+        acc.merge(rw_player_filter(ps));
+    }
+    if let Some(sw) = starting_with {
+        acc.merge(rw_controller_ref(sw));
+    }
+    if let Some(rf) = repeat_for {
+        acc.merge(rw_quantity_expr(rf));
+    }
+    if let Some(MultiTargetSpec { min, max }) = multi_target {
+        acc.merge(rw_quantity_expr(min));
+        if let Some(max) = max {
+            acc.merge(rw_quantity_expr(max));
+        }
+    }
+    for c in target_constraints {
+        acc.merge(rw_target_constraint(c));
+    }
+    // CR 603.5: unless-pay is a resolution-time choice — no read-kind, but arms
+    // the Mana×unless-pay guard.
+    if unless_pay.is_some() {
+        acc.has_pay_or_unless = true;
+    }
+    if let Some(tc) = target_chooser {
+        acc.merge(rw_target_filter(tc));
+    }
+    if let Some(ru) = repeat_until {
+        acc.merge(rw_repeat_continuation(ru));
+    }
+    if let Some(m) = modal {
+        acc.merge(rw_modal_choice(m));
+    }
+    // CR 700.2b: reflexive-modal per-mode defs are not descended — conservative.
+    if !mode_abilities.is_empty() {
+        acc.merge(RwProfile::conservative());
+    }
+}
+
+/// Descend a choice/RNG sub-body (`AbilityDefinition`). `..`-free so a future
+/// field forces a decision (§2 choice-wrapper / RNG union descent).
+fn walk_definition(a: &AbilityDefinition, chain_root: Option<WriteScope>, acc: &mut RwProfile) {
+    let AbilityDefinition {
+        effect,
+        sub_ability,
+        else_ability,
+        condition,
+        duration,
+        player_scope,
+        starting_with,
+        repeat_for,
+        multi_target,
+        target_constraints,
+        unless_pay,
+        modal,
+        mode_abilities,
+        target_chooser,
+        repeat_until,
+        kind: _,
+        cost: _,
+        description: _,
+        target_prompt: _,
+        activation_restrictions: _,
+        activator_filter: _,
+        activation_zone: _,
+        ability_tag: _,
+        optional_targeting: _,
+        optional: _,
+        optional_for: _,
+        target_choice_timing: _,
+        distribute: _,
+        min_x_value: _,
+        cant_be_copied: _,
+        cost_reduction: _,
+        forward_result: _,
+        target_selection_mode: _,
+        sub_link: _,
+        iteration_kind_binding: _,
+    } = a;
+
+    let (eff, own_scope) = rw_effect(effect, chain_root);
+    acc.merge(eff);
+    let child_root = own_scope.or(chain_root);
+
+    if let Some(sub) = sub_ability {
+        walk_definition(sub, child_root, acc);
+    }
+    if let Some(els) = else_ability {
+        walk_definition(els, chain_root, acc);
+    }
+    if let Some(c) = condition {
+        acc.merge(rw_ability_condition(c));
+    }
+    if let Some(d) = duration {
+        acc.merge(rw_duration(d));
+    }
+    if let Some(ps) = player_scope {
+        acc.merge(rw_player_filter(ps));
+    }
+    if let Some(sw) = starting_with {
+        acc.merge(rw_controller_ref(sw));
+    }
+    if let Some(rf) = repeat_for {
+        acc.merge(rw_quantity_expr(rf));
+    }
+    if let Some(MultiTargetSpec { min, max }) = multi_target {
+        acc.merge(rw_quantity_expr(min));
+        if let Some(max) = max {
+            acc.merge(rw_quantity_expr(max));
+        }
+    }
+    for c in target_constraints {
+        acc.merge(rw_target_constraint(c));
+    }
+    if unless_pay.is_some() {
+        acc.has_pay_or_unless = true;
+    }
+    if let Some(tc) = target_chooser {
+        acc.merge(rw_target_filter(tc));
+    }
+    if let Some(ru) = repeat_until {
+        acc.merge(rw_repeat_continuation(ru));
+    }
+    if let Some(m) = modal {
+        acc.merge(rw_modal_choice(m));
+    }
+    if !mode_abilities.is_empty() {
+        acc.merge(RwProfile::conservative());
+    }
+}
+
+fn rw_modal_choice(m: &ModalChoice) -> RwProfile {
+    let ModalChoice {
+        dynamic_max_choices,
+        chooser,
+        min_choices: _,
+        max_choices: _,
+        mode_count: _,
+        mode_descriptions: _,
+        allow_repeat_modes: _,
+        constraints: _,
+        mode_costs: _,
+        mode_pawprints: _,
+        entwine_cost: _,
+        selection: _,
+    } = m;
+    let mut p = rw_player_filter(chooser);
+    if let Some(q) = dynamic_max_choices {
+        p.merge(rw_quantity_expr(q));
+    }
+    p
+}
+
+fn rw_repeat_continuation(r: &RepeatContinuation) -> RwProfile {
+    match r {
+        RepeatContinuation::ControllerChoice => RwProfile::empty(),
+        RepeatContinuation::UntilStopConditions {
+            stop_on_put_to_hand: _,
+            stop_on_duplicate_exiled_names: _,
+        } => RwProfile::empty(),
+        RepeatContinuation::WhileCondition {
+            condition,
+            max_iterations: _,
+        } => rw_ability_condition(condition),
+    }
+}
+
+fn rw_target_constraint(c: &TargetSelectionConstraint) -> RwProfile {
+    match c {
+        TargetSelectionConstraint::DifferentTargetPlayers => RwProfile::empty(),
+        TargetSelectionConstraint::DifferentObjectControllers => RwProfile::empty(),
+        TargetSelectionConstraint::TotalManaValue {
+            value,
+            comparator: _,
+        } => rw_quantity_expr(value),
+    }
+}
+
+fn rw_duration(x: &Duration) -> RwProfile {
+    match x {
+        Duration::UntilEndOfTurn
+        | Duration::UntilEndOfCombat
+        | Duration::UntilHostLeavesPlay
+        | Duration::Permanent => RwProfile::empty(),
+        Duration::UntilNextTurnOf { player, .. }
+        | Duration::UntilEndOfNextTurnOf { player, .. }
+        | Duration::UntilNextStepOf { player, .. } => rw_player_scope(player),
+        Duration::ForAsLongAs { condition } => rw_static_condition(condition),
+    }
+}
+
+/// CR 119.3: a player-life write plus its life-change journal (CR 119.3).
+fn life_writes() -> RwProfile {
+    let mut p = RwProfile::empty();
+    p.writes_external.set(StateKind::PlayerLife);
+    p.writes_external.set(StateKind::JournalLife);
+    p
+}
+
+/// CR 120 damage: recipient-classified writes (source-actor residual documented
+/// in the module doc — CR 702.15 / CR 702.2 / CR 704.5a / CR 800.4a).
+fn damage_writes(target: &TargetFilter) -> RwProfile {
+    let (player, object) = target_recipient(target);
+    let mut p = RwProfile::empty();
+    if player {
+        p.merge(life_writes());
+    }
+    if object {
+        p.writes_external.set(StateKind::SetMembership);
+        p.writes_membership_external_census
+            .merge(census_of_filter(target));
+    }
+    p
+}
+
+// ---------------------------------------------------------------------------
+// Effect classification (mirrors `scan_effect`; write-kind per §2 categories).
+// Returns (profile, primary object-write scope for chain-root propagation).
+// ---------------------------------------------------------------------------
+
+fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<WriteScope>) {
+    // Object write of `kind` targeting `target`, placed by scope.
+    let obj = |kind: StateKind, target: &TargetFilter| -> (RwProfile, Option<WriteScope>) {
+        let sc = scope_of(target, chain_root);
+        let mut p = RwProfile::empty();
+        place_object_write(&mut p, kind, sc);
+        (p, Some(sc))
+    };
+    // Membership move targeting `target` with the given zone endpoints.
+    let mem = |target: &TargetFilter,
+               origin: Option<Zone>,
+               dest: Zone|
+     -> (RwProfile, Option<WriteScope>) {
+        let sc = scope_of(target, chain_root);
+        let mut p = RwProfile::empty();
+        place_membership_write(&mut p, sc, census_of_filter(target), origin, dest);
+        (p, Some(sc))
+    };
+    // Deferred body (CR 603.7): descend reads, drop writes.
+    let deferred = |def: &AbilityDefinition| -> RwProfile {
+        let mut p = RwProfile::empty();
+        walk_definition(def, None, &mut p);
+        p.drop_writes();
+        p
+    };
+
+    match x {
+        // ---- Damage (recipient-classified, CR 120) ----
+        Effect::DealDamage {
+            amount,
+            target,
+            damage_source: _,
+            excess,
+        } => {
+            let mut p = damage_writes(target);
+            p.merge(rw_quantity_expr(amount));
+            // CR 120.4a: the excess-redirect rider deals overkill to the damaged
+            // permanent's controller — a player-life write not captured by
+            // object-recipient damage_writes.
+            if excess.is_some() {
+                p.merge(life_writes());
+            }
+            (p, None)
+        }
+        Effect::DamageAll {
+            amount,
+            target,
+            player_filter,
+            damage_source: _,
+        } => {
+            let mut p = RwProfile::empty();
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_membership_external_census
+                .merge(census_of_filter(target));
+            if player_filter.is_some() {
+                p.merge(life_writes());
+            }
+            p.merge(rw_quantity_expr(amount));
+            (p, None)
+        }
+        Effect::DamageEachPlayer {
+            amount,
+            player_filter: _,
+        } => {
+            let mut p = life_writes();
+            p.merge(rw_quantity_expr(amount));
+            (p, None)
+        }
+        Effect::Fight { target, subject } => {
+            let mut p = damage_writes(target);
+            p.merge(damage_writes(subject));
+            (p, None)
+        }
+
+        // ---- Hand / library ----
+        Effect::Draw { count, target: _ } => {
+            let mut p = ext_write(StateKind::HandLibrary);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::Discard {
+            count,
+            target: _,
+            unless_filter: _,
+            filter: _,
+            selection: _,
+        } => {
+            let mut p = ext_write(StateKind::HandLibrary);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::DiscardCard {
+            target: _,
+            count: _,
+        } => (ext_write(StateKind::HandLibrary), None),
+        Effect::Scry { count, target: _ } => {
+            let mut p = ext_write(StateKind::HandLibrary);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::Surveil { count, target: _ } => {
+            let mut p = ext_write(StateKind::HandLibrary);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::Shuffle { target: _ } => (ext_write(StateKind::HandLibrary), None),
+        Effect::PutAtLibraryPosition {
+            target: _,
+            count,
+            position: _,
+        } => {
+            let mut p = ext_write(StateKind::HandLibrary);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::Learn => (ext_write(StateKind::HandLibrary), None),
+        Effect::DraftFromSpellbook {
+            destination: _,
+            tapped: _,
+        } => (ext_write(StateKind::HandLibrary), None),
+        Effect::Clash => (ext_write(StateKind::HandLibrary), None),
+        Effect::ChooseDrawnThisTurnPayOrTopdeck {
+            count,
+            life_payment,
+            player: _,
+        } => {
+            let mut p = ext_write(StateKind::HandLibrary);
+            p.merge(life_writes());
+            p.merge(rw_quantity_expr(count));
+            p.merge(rw_quantity_expr(life_payment));
+            (p, None)
+        }
+
+        // ---- Life ----
+        Effect::GainLife { amount, player: _ } => {
+            let mut p = life_writes();
+            p.merge(rw_quantity_expr(amount));
+            (p, None)
+        }
+        Effect::LoseLife { amount, target: _ } => {
+            let mut p = life_writes();
+            p.merge(rw_quantity_expr(amount));
+            (p, None)
+        }
+        Effect::SetLifeTotal { target: _, amount } => {
+            let mut p = life_writes();
+            p.merge(rw_quantity_expr(amount));
+            (p, None)
+        }
+        Effect::GainEnergy { amount } => {
+            let mut p = ext_write(StateKind::PlayerLife);
+            p.merge(rw_quantity_expr(amount));
+            (p, None)
+        }
+        Effect::GivePlayerCounter {
+            count,
+            target: _,
+            counter_kind: _,
+        } => {
+            let mut p = ext_write(StateKind::PlayerLife);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+
+        // ---- Counters (ObjectCounters) ----
+        Effect::PutCounter {
+            count,
+            target,
+            counter_type: _,
+        } => {
+            let (mut p, sc) = obj(StateKind::ObjectCounters, target);
+            p.merge(rw_quantity_expr(count));
+            (p, sc)
+        }
+        Effect::PutCounterAll {
+            count,
+            target,
+            counter_type: _,
+        } => {
+            let (mut p, sc) = obj(StateKind::ObjectCounters, target);
+            p.merge(rw_quantity_expr(count));
+            (p, sc)
+        }
+        Effect::RemoveCounter {
+            counter_type: _,
+            count,
+            target,
+        } => {
+            let (mut p, sc) = obj(StateKind::ObjectCounters, target);
+            p.merge(rw_quantity_expr(count));
+            (p, sc)
+        }
+        Effect::MultiplyCounter {
+            target,
+            counter_type: _,
+            multiplier: _,
+        } => obj(StateKind::ObjectCounters, target),
+        Effect::MoveCounters {
+            source,
+            count,
+            target,
+            counter_type: _,
+            mode: _,
+            selection: _,
+        } => {
+            let (mut p, sc) = obj(StateKind::ObjectCounters, target);
+            place_object_write(
+                &mut p,
+                StateKind::ObjectCounters,
+                scope_of(source, chain_root),
+            );
+            if let Some(c) = count {
+                p.merge(rw_quantity_expr(c));
+            }
+            (p, sc)
+        }
+        Effect::Bolster { count } => {
+            let mut p = ext_write(StateKind::ObjectCounters);
+            p.merge(rw_quantity_expr(count));
+            (p, Some(WriteScope::External))
+        }
+        Effect::Endure { amount, subject } => {
+            let (mut p, sc) = obj(StateKind::ObjectCounters, subject);
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_membership_external_census.merge(Census::Any);
+            p.merge(rw_quantity_expr(amount));
+            (p, sc)
+        }
+        Effect::AddPendingETBCounters {
+            count,
+            counter_type: _,
+        } => {
+            let mut p = self_write(StateKind::ObjectCounters);
+            p.merge(rw_quantity_expr(count));
+            (p, Some(WriteScope::SelfSource))
+        }
+        Effect::Proliferate => {
+            let mut p = ext_write(StateKind::ObjectCounters);
+            p.writes_external.set(StateKind::PlayerLife);
+            (p, Some(WriteScope::External))
+        }
+        Effect::Amass { count, subtype: _ } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::ObjectCounters);
+            p.writes_membership_external_census.merge(Census::Any);
+            p.merge(rw_quantity_expr(count));
+            (p, Some(WriteScope::External))
+        }
+        Effect::Intensify { amount, scope: _ } => {
+            let mut p = ext_write(StateKind::ObjectCounters);
+            p.merge(rw_quantity_expr(amount));
+            (p, Some(WriteScope::External))
+        }
+        Effect::Double {
+            target,
+            target_kind: _,
+        } => {
+            let (mut p, sc) = obj(StateKind::ObjectCounters, target);
+            p.writes_external.set(StateKind::PlayerLife);
+            (p, sc)
+        }
+
+        // ---- Zone moves (SetMembership) ----
+        Effect::Destroy {
+            target,
+            cant_regenerate: _,
+        } => mem(target, Some(Zone::Battlefield), Zone::Graveyard),
+        Effect::DestroyAll {
+            target,
+            cant_regenerate: _,
+        } => mem(target, Some(Zone::Battlefield), Zone::Graveyard),
+        Effect::Sacrifice {
+            target,
+            count,
+            min_count: _,
+        } => {
+            let (mut p, sc) = mem(target, Some(Zone::Battlefield), Zone::Graveyard);
+            p.merge(rw_quantity_expr(count));
+            (p, sc)
+        }
+        Effect::Bounce {
+            target,
+            destination,
+            selection: _,
+        } => mem(
+            target,
+            Some(Zone::Battlefield),
+            destination.unwrap_or(Zone::Hand),
+        ),
+        Effect::BounceAll {
+            target,
+            count,
+            destination,
+        } => {
+            let (mut p, sc) = mem(
+                target,
+                Some(Zone::Battlefield),
+                destination.unwrap_or(Zone::Hand),
+            );
+            if let Some(c) = count {
+                p.merge(rw_quantity_expr(c));
+            }
+            (p, sc)
+        }
+        Effect::ChangeZone {
+            origin,
+            destination,
+            target,
+            owner_library: _,
+            enter_transformed: _,
+            enters_under: _,
+            enter_tapped: _,
+            enters_attacking: _,
+            up_to: _,
+            enter_with_counters,
+            conditional_enter_with_counters,
+            face_down_profile: _,
+            enters_modified_if: _,
+        } => {
+            let (mut p, sc) = mem(target, *origin, *destination);
+            for (_ct, q) in enter_with_counters {
+                p.merge(rw_quantity_expr(q));
+            }
+            for (_f, _ct, q) in conditional_enter_with_counters {
+                p.merge(rw_quantity_expr(q));
+            }
+            (p, sc)
+        }
+        Effect::ChangeZoneAll {
+            origin,
+            destination,
+            target,
+            enter_with_counters,
+            enters_under: _,
+            enter_tapped: _,
+            face_down_profile: _,
+            library_position: _,
+            random_order: _,
+        } => {
+            let (mut p, sc) = mem(target, *origin, *destination);
+            for (_ct, q) in enter_with_counters {
+                p.merge(rw_quantity_expr(q));
+            }
+            (p, sc)
+        }
+        Effect::Mill {
+            count,
+            target: _,
+            destination: _,
+        } => {
+            let mut p = RwProfile::empty();
+            place_membership_write(
+                &mut p,
+                WriteScope::External,
+                Census::Any,
+                Some(Zone::Library),
+                Zone::Graveyard,
+            );
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::ExileTop {
+            player: _,
+            count,
+            face_down: _,
+        } => {
+            let mut p = RwProfile::empty();
+            place_membership_write(
+                &mut p,
+                WriteScope::External,
+                Census::Any,
+                Some(Zone::Library),
+                Zone::Exile,
+            );
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::ExileFromTopUntil {
+            player: _,
+            until: _,
+        } => {
+            let mut p = RwProfile::empty();
+            place_membership_write(
+                &mut p,
+                WriteScope::External,
+                Census::Any,
+                Some(Zone::Library),
+                Zone::Exile,
+            );
+            (p, None)
+        }
+        Effect::Dig {
+            player: _,
+            count,
+            filter: _,
+            destination: _,
+            keep_count: _,
+            up_to: _,
+            rest_destination: _,
+            reveal: _,
+            enter_tapped: _,
+            source: _,
+        } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::Seek {
+            filter: _,
+            count,
+            from_top: _,
+            destination: _,
+            enter_tapped: _,
+        } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::SearchLibrary {
+            source_zones: _,
+            filter: _,
+            count,
+            reveal: _,
+            target_player: _,
+            selection_constraint: _,
+            split: _,
+        } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::ChooseFromZone {
+            filter: _,
+            count: _,
+            zone: _,
+            additional_zones: _,
+            zone_owner: _,
+            chooser: _,
+            up_to: _,
+            selection: _,
+            constraint: _,
+        } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            (p, None)
+        }
+        Effect::Explore => {
+            let mut p = self_write(StateKind::ObjectCounters);
+            p.writes_external.set(StateKind::HandLibrary);
+            (p, None)
+        }
+        Effect::Forage => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            (p, None)
+        }
+        Effect::Connive { target, count } => {
+            let (mut p, sc) = obj(StateKind::ObjectCounters, target);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.merge(rw_quantity_expr(count));
+            (p, sc)
+        }
+        Effect::CollectEvidence { amount: _ } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            (p, None)
+        }
+        Effect::Discover {
+            mana_value_limit,
+            player: _,
+        } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_external.set(StateKind::StackShape);
+            p.writes_membership_external_census.merge(Census::Any);
+            p.merge(rw_quantity_expr(mana_value_limit));
+            (p, None)
+        }
+        Effect::RevealUntil {
+            player: _,
+            filter: _,
+            count,
+            enters_under: _,
+            matched_disposition: _,
+            kept_destination: _,
+            rest_destination: _,
+            enter_tapped: _,
+            enters_attacking: _,
+            kept_optional_to: _,
+        } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::Manifest {
+            target: _,
+            count,
+            enters_under: _,
+            profile: _,
+        } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::ManifestDread => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            (p, None)
+        }
+        Effect::Cloak { target: _, count } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::Meld {
+            source: _,
+            partner: _,
+            result: _,
+        } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_membership_external_census.merge(Census::Any);
+            (p, None)
+        }
+        Effect::PhaseOut { target } => obj_membership_scope(target, chain_root),
+        Effect::MadnessCast { cost: _ } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::StackShape);
+            p.writes_membership_external_census.merge(Census::Any);
+            (p, None)
+        }
+
+        // ---- Creation (SetMembership, fresh ids) ----
+        Effect::Token {
+            name: _,
+            power: _,
+            toughness: _,
+            types,
+            colors: _,
+            keywords: _,
+            tapped: _,
+            count,
+            owner: _,
+            attach_to: _,
+            enters_attacking: _,
+            supertypes: _,
+            static_abilities: _,
+            enter_with_counters,
+        } => {
+            let mut p = RwProfile::empty();
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_created.set(StateKind::SetMembership);
+            p.writes_membership_external_census
+                .merge(census_of_types(types));
+            for (_ct, q) in enter_with_counters {
+                p.merge(rw_quantity_expr(q));
+            }
+            p.merge(rw_quantity_expr(count));
+            (p, Some(WriteScope::Created))
+        }
+        Effect::CopyTokenOf {
+            target,
+            owner: _,
+            source_filter: _,
+            enters_attacking: _,
+            tapped: _,
+            count,
+            extra_keywords: _,
+            additional_modifications: _,
+        } => {
+            let mut p = RwProfile::empty();
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_created.set(StateKind::SetMembership);
+            p.writes_membership_external_census.merge(Census::Any);
+            // CR 707.2: a SelfRef template copies the source's copiable values —
+            // conservatively recorded reads_src (fail-closed; census clears in
+            // practice, §1.3.1-F).
+            if matches!(target, TargetFilter::SelfRef) {
+                p.reads_src.set(StateKind::ObjectPt);
+            }
+            p.merge(rw_quantity_expr(count));
+            (p, Some(WriteScope::Created))
+        }
+        Effect::Conjure {
+            cards: _,
+            destination,
+            tapped: _,
+        } => {
+            let mut p = RwProfile::empty();
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_created.set(StateKind::SetMembership);
+            p.writes_membership_external_census.merge(Census::Any);
+            if is_hand_or_library(*destination) {
+                p.writes_external.set(StateKind::HandLibrary);
+            }
+            (p, Some(WriteScope::Created))
+        }
+        Effect::Incubate { count } => {
+            let mut p = RwProfile::empty();
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_created.set(StateKind::SetMembership);
+            p.writes_membership_external_census.merge(Census::Any);
+            p.merge(rw_quantity_expr(count));
+            (p, Some(WriteScope::Created))
+        }
+        Effect::Populate => {
+            let mut p = RwProfile::empty();
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_created.set(StateKind::SetMembership);
+            p.writes_membership_external_census.merge(Census::Any);
+            (p, Some(WriteScope::Created))
+        }
+        Effect::Investigate => {
+            let mut p = RwProfile::empty();
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_created.set(StateKind::SetMembership);
+            p.writes_membership_external_census
+                .merge(Census::Tags(BTreeSet::from([
+                    "clue".into(),
+                    "artifact".into(),
+                ])));
+            (p, Some(WriteScope::Created))
+        }
+
+        // ---- P/T & type (ObjectPt) ----
+        Effect::Pump {
+            power: _,
+            toughness: _,
+            target,
+        } => obj(StateKind::ObjectPt, target),
+        Effect::PumpAll {
+            power: _,
+            toughness: _,
+            target,
+        } => obj(StateKind::ObjectPt, target),
+        Effect::DoublePT {
+            target,
+            mode: _,
+            factor: _,
+        } => obj(StateKind::ObjectPt, target),
+        Effect::DoublePTAll {
+            target,
+            mode: _,
+            factor: _,
+        } => obj(StateKind::ObjectPt, target),
+        Effect::SwitchPT { target } => obj(StateKind::ObjectPt, target),
+        Effect::Transform { target } => obj(StateKind::ObjectPt, target),
+        Effect::BecomeCopy {
+            target,
+            duration: _,
+            mana_value_limit: _,
+            additional_modifications: _,
+        } => {
+            let (mut p, sc) = obj(StateKind::ObjectPt, target);
+            place_object_write(
+                &mut p,
+                StateKind::SetMembership,
+                scope_of(target, chain_root),
+            );
+            (p, sc)
+        }
+        Effect::Animate {
+            power: _,
+            toughness: _,
+            types: _,
+            remove_types: _,
+            target,
+            keywords: _,
+        } => {
+            let (mut p, sc) = obj(StateKind::ObjectPt, target);
+            place_object_write(
+                &mut p,
+                StateKind::SetMembership,
+                scope_of(target, chain_root),
+            );
+            (p, sc)
+        }
+        Effect::TurnFaceUp { target } => {
+            let (mut p, sc) = obj(StateKind::ObjectPt, target);
+            place_object_write(
+                &mut p,
+                StateKind::SetMembership,
+                scope_of(target, chain_root),
+            );
+            (p, sc)
+        }
+        Effect::TurnFaceDown { target, profile: _ } => obj(StateKind::ObjectPt, target),
+        Effect::GenericEffect {
+            static_abilities: _,
+            duration,
+            target,
+        } => {
+            let tf = target.clone().unwrap_or(TargetFilter::SelfRef);
+            let (mut p, sc) = obj(StateKind::ObjectPt, &tf);
+            place_object_write(&mut p, StateKind::SetMembership, scope_of(&tf, chain_root));
+            if let Some(d) = duration {
+                p.merge(rw_duration(d));
+            }
+            (p, sc)
+        }
+
+        // ---- Control (SetMembership external) ----
+        Effect::GainControl { target: _ }
+        | Effect::GainControlAll { target: _ }
+        | Effect::GiveControl {
+            target: _,
+            recipient: _,
+        }
+        | Effect::ExchangeControl {
+            target_a: _,
+            target_b: _,
+        } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_membership_external_census.merge(Census::Any);
+            (p, Some(WriteScope::External))
+        }
+
+        // ---- Stack (StackShape) ----
+        Effect::CopySpell {
+            target,
+            retarget: _,
+            copier: _,
+            additional_modifications: _,
+            starting_loyalty_from_casualty_sacrifice: _,
+        } => {
+            // CR 707.10/707.10c: SelfRef / explicit-target copies read the
+            // original by id (clean); the untargeted top-of-stack fallback reads
+            // the mutable stack top (D4).
+            let mut p = ext_write(StateKind::StackShape);
+            if !matches!(
+                target,
+                TargetFilter::SelfRef
+                    | TargetFilter::StackSpell
+                    | TargetFilter::SpecificObject { .. }
+            ) {
+                p.reads_board.set(StateKind::StackShape);
+            }
+            (p, None)
+        }
+        Effect::Counter {
+            target: _,
+            source_rider: _,
+            countered_spell_zone: _,
+        } => (ext_write(StateKind::StackShape), None),
+        Effect::CastCopyOfCard {
+            target: _,
+            count,
+            cost: _,
+        } => {
+            let mut p = ext_write(StateKind::StackShape);
+            p.writes_external.set(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            if let Some(c) = count {
+                p.merge(rw_quantity_expr(c));
+            }
+            (p, None)
+        }
+        Effect::CastFromZone {
+            target: _,
+            without_paying_mana_cost: _,
+            mode: _,
+            cast_transformed: _,
+            alt_ability_cost: _,
+            constraint: _,
+            duration: _,
+            driver: _,
+            mana_spend_permission: _,
+        } => {
+            let mut p = ext_write(StateKind::HandLibrary);
+            p.writes_external.set(StateKind::StackShape);
+            (p, None)
+        }
+        Effect::ExileResolvingSpellInsteadOfGraveyard => (ext_write(StateKind::StackShape), None),
+
+        // ---- Pool ----
+        Effect::Mana {
+            produced: _,
+            restrictions: _,
+            grants: _,
+            expiry: _,
+            target: _,
+        } => (writes_pool_profile(), None),
+
+        // ---- Tap ----
+        Effect::SetTapState {
+            target,
+            scope: _,
+            state: _,
+        } => obj(StateKind::TapState, target),
+
+        // ---- Deferred bodies (CR 603.7): reads descended, writes NOT counted ----
+        Effect::CreateDelayedTrigger {
+            condition: _,
+            effect,
+            uses_tracked_set: _,
+        } => (deferred(effect), None),
+        Effect::CreateDrawReplacement { replacement_effect } => {
+            let (mut b, _) = rw_effect(replacement_effect, None);
+            b.drop_writes();
+            (b, None)
+        }
+        Effect::PreventDamage {
+            amount_dynamic,
+            target: _,
+            damage_source_filter: _,
+            prevention_duration: _,
+            amount: _,
+            scope: _,
+        } => {
+            let mut p = RwProfile::empty();
+            if let Some(q) = amount_dynamic {
+                p.merge(rw_quantity_expr(q));
+            }
+            (p, None)
+        }
+        Effect::PayCost {
+            cost: _,
+            scale,
+            payer: _,
+        } => {
+            let mut p = RwProfile::empty();
+            p.has_pay_or_unless = true;
+            if let Some(q) = scale {
+                p.merge(rw_quantity_expr(q));
+            }
+            (p, None)
+        }
+        Effect::AddTargetReplacement { .. }
+        | Effect::AddRestriction { .. }
+        | Effect::ReduceNextSpellCost { .. }
+        | Effect::GrantNextSpellAbility { .. }
+        | Effect::CreateEmblem { .. }
+        | Effect::CreateDamageReplacement { .. }
+        | Effect::Regenerate { .. }
+        | Effect::GrantCastingPermission { .. } => (RwProfile::empty(), None),
+
+        // ---- Choice wrappers (union descent, §2) ----
+        Effect::ChooseOneOf { chooser, branches } => {
+            let mut p = rw_player_filter(chooser);
+            for b in branches {
+                walk_definition(b, chain_root, &mut p);
+            }
+            (p, None)
+        }
+        Effect::Vote {
+            choices: _,
+            per_choice_effect,
+            starting_with,
+            voter_scope: _,
+            tally_mode: _,
+            // CR 701.38a/b: visibility is reveal-timing only (inert); subject's
+            // Objects case is an unmodeled residual of this incomplete arm (which
+            // also drops outcome_template) — not introduced by the rebase.
+            subject: _,
+            visibility: _,
+        } => {
+            let mut p = rw_controller_ref(starting_with);
+            for b in per_choice_effect {
+                walk_definition(b, chain_root, &mut p);
+            }
+            (p, None)
+        }
+
+        // ---- RNG (no read-kind; descend sub-effects, §2/D4) ----
+        Effect::RollDie {
+            count,
+            sides: _,
+            results,
+            modifier: _,
+        } => {
+            let mut p = rw_quantity_expr(count);
+            for r in results {
+                walk_definition(&r.effect, chain_root, &mut p);
+            }
+            (p, None)
+        }
+        Effect::FlipCoin {
+            win_effect,
+            lose_effect,
+            flipper: _,
+        } => {
+            let mut p = RwProfile::empty();
+            if let Some(w) = win_effect {
+                walk_definition(w, chain_root, &mut p);
+            }
+            if let Some(l) = lose_effect {
+                walk_definition(l, chain_root, &mut p);
+            }
+            (p, None)
+        }
+        Effect::FlipCoins {
+            count,
+            win_effect,
+            lose_effect,
+            flipper: _,
+        } => {
+            let mut p = rw_quantity_expr(count);
+            if let Some(w) = win_effect {
+                walk_definition(w, chain_root, &mut p);
+            }
+            if let Some(l) = lose_effect {
+                walk_definition(l, chain_root, &mut p);
+            }
+            (p, None)
+        }
+        Effect::FlipCoinUntilLose { win_effect } => {
+            let mut p = RwProfile::empty();
+            walk_definition(win_effect, chain_root, &mut p);
+            (p, None)
+        }
+
+        // ---- Status / designation tail (fail-closed writes_external{Other}).
+        // M3: all fields bound (no `..` on a non-conservative RHS) so a future
+        // read/write-bearing field forces reclassification. Count/min/max leaves
+        // here are fixed numbers (ability_scan does not descend them). ----
+        Effect::Attach {
+            attachment: _,
+            target: _,
+        }
+        | Effect::PairWith { target: _ }
+        | Effect::Goad { target: _ }
+        | Effect::GoadAll { target: _ }
+        | Effect::ExtraTurn { target: _ }
+        | Effect::Suspect {
+            target: _,
+            scope: _,
+        }
+        | Effect::Unsuspect {
+            target: _,
+            scope: _,
+        }
+        | Effect::BecomePrepared { target: _ }
+        | Effect::ApplyPerpetual {
+            target: _,
+            modification: _,
+        }
+        | Effect::OpenAttractions { count: _ }
+        | Effect::RegisterBending { kind: _ }
+        | Effect::BlightEffect {
+            player: _,
+            count: _,
+        }
+        | Effect::ChooseObjectsIntoTrackedSet {
+            chooser: _,
+            filter: _,
+            min: _,
+            max: _,
+        }
+        | Effect::BecomeMonarch
+        | Effect::RingTemptsYou
+        | Effect::TimeTravel
+        | Effect::Planeswalk
+        | Effect::VentureIntoDungeon
+        | Effect::SolveCase => (ext_write(StateKind::Other), None),
+        Effect::ForceAttack {
+            target: _,
+            required_player: _,
+            duration,
+        } => {
+            let mut p = ext_write(StateKind::Other);
+            p.merge(rw_duration(duration));
+            (p, None)
+        }
+        Effect::AdditionalPhase {
+            target: _,
+            count,
+            phase: _,
+            after: _,
+            followed_by: _,
+            attacker_restriction: _,
+        } => {
+            let mut p = ext_write(StateKind::Other);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::AssembleContraptions { count } => {
+            let mut p = ext_write(StateKind::Other);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::PutSticker {
+            target: _,
+            count,
+            max_ticket_cost,
+            kind: _,
+            ticket_cost_payment: _,
+        } => {
+            let mut p = ext_write(StateKind::Other);
+            p.merge(rw_quantity_expr(count));
+            if let Some(q) = max_ticket_cost {
+                p.merge(rw_quantity_expr(q));
+            }
+            (p, None)
+        }
+
+        // ---- No observable WRITE kind (info / terminal / plumbing). M3: bind
+        // all fields. `RevealHand.count` is a dynamic `Option<QuantityExpr>` read
+        // (ability_scan descends it) ⇒ surfaced below; all other leaves here are
+        // concrete/announced values. ----
+        Effect::RevealHand {
+            count,
+            target: _,
+            card_filter: _,
+            selection: _,
+            choice_optional: _,
+            reveal: _,
+        } => {
+            let mut p = RwProfile::empty();
+            if let Some(q) = count {
+                p.merge(rw_quantity_expr(q));
+            }
+            (p, None)
+        }
+        Effect::ApplyPostReplacementDamage {
+            context: _,
+            target: _,
+            amount: _,
+            is_combat: _,
+        }
+        | Effect::Cleanup {
+            clear_remembered: _,
+            clear_chosen_player: _,
+            clear_chosen_color: _,
+            clear_chosen_type: _,
+            clear_chosen_card: _,
+            clear_imprinted: _,
+            clear_triggers: _,
+            clear_coin_flips: _,
+        }
+        | Effect::RuntimeHandled { handler: _ }
+        | Effect::Reveal { target: _ }
+        | Effect::RevealTop {
+            player: _,
+            count: _,
+        }
+        | Effect::TargetOnly { target: _ }
+        | Effect::Choose {
+            choice_type: _,
+            persist: _,
+            selection: _,
+        }
+        | Effect::LoseTheGame { target: _ }
+        | Effect::WinTheGame { target: _ }
+        | Effect::RemoveAllDamage { target: _ }
+        | Effect::Unimplemented {
+            name: _,
+            description: _,
+        }
+        | Effect::NoOp
+        | Effect::EndTheTurn
+        | Effect::EndCombatPhase => (RwProfile::empty(), None),
+
+        // ---- Histogram-absent ⇒ fail-closed conservative ----
+        Effect::StartYourEngines { .. }
+        | Effect::ChangeSpeed { .. }
+        | Effect::EachDealsDamageEqualToPower { .. }
+        | Effect::CounterAll { .. }
+        | Effect::SearchOutsideGame { .. }
+        | Effect::RevealFromHand { .. }
+        | Effect::ChooseDamageSource { .. }
+        | Effect::PhaseIn { .. }
+        | Effect::ForceBlock { .. }
+        | Effect::BecomeUnprepared { .. }
+        | Effect::BecomeSaddled { .. }
+        | Effect::SetClassLevel { .. }
+        | Effect::FreeCastFromZones { .. }
+        | Effect::CreateTokenCopyFromPool { .. }
+        | Effect::Myriad
+        | Effect::Encore
+        | Effect::CombineHost { .. }
+        | Effect::ChooseAugmentAndCombineWithHost { .. }
+        | Effect::ExileHaunting { .. }
+        | Effect::HideawayConceal { .. }
+        | Effect::CopyTokenBlockingAttacker { .. }
+        | Effect::GainActivatedAbilitiesOfTarget { .. }
+        | Effect::ChooseCard { .. }
+        | Effect::ReturnAsAura { .. }
+        | Effect::EpicCopy { .. }
+        | Effect::SeparateIntoPiles { .. }
+        | Effect::ControlNextTurn { .. }
+        | Effect::UnattachAll { .. }
+        | Effect::ExploreAll { .. }
+        | Effect::Tribute { .. }
+        | Effect::ProliferateTarget { .. }
+        | Effect::Exploit { .. }
+        | Effect::LoseAllPlayerCounters { .. }
+        | Effect::Heist { .. }
+        | Effect::HeistExile
+        | Effect::Cascade
+        | Effect::Ripple { .. }
+        | Effect::MiracleCast { .. }
+        | Effect::PutOnTopOrBottom { .. }
+        | Effect::GiftDelivery { .. }
+        | Effect::Detain { .. }
+        | Effect::SetRoomDoorLock { .. }
+        | Effect::ChangeTargets { .. }
+        | Effect::GrantExtraLoyaltyActivations { .. }
+        | Effect::SkipNextTurn { .. }
+        | Effect::SkipNextStep { .. }
+        | Effect::RemoveFromCombat { .. }
+        | Effect::ExchangeLifeWithStat { .. }
+        | Effect::ExchangeLifeTotals { .. }
+        | Effect::SetDayNight { .. }
+        | Effect::Monstrosity { .. }
+        | Effect::Specialize
+        | Effect::Renown { .. }
+        | Effect::Adapt { .. }
+        | Effect::Harness
+        | Effect::ChooseAndSacrificeRest { .. }
+        | Effect::RememberCard { .. }
+        | Effect::ForEachCategoryExile { .. }
+        | Effect::VentureInto { .. }
+        | Effect::TakeTheInitiative
+        | Effect::RollToVisitAttractions
+        | Effect::AssembleContraptionsFromRollDifference
+        | Effect::CrankContraptions { .. }
+        | Effect::ReassembleContraption { .. }
+        | Effect::AssembleContraptionOnSprocket { .. }
+        | Effect::ReassembleContraptionOnSprocket { .. }
+        | Effect::ApplySticker { .. }
+        | Effect::ProcessRadCounters => (RwProfile::conservative(), None),
+    }
+}
+
+/// A membership write scoped by target (used where the scope matters for chain
+/// propagation, e.g. `PhaseOut`).
+fn obj_membership_scope(
+    target: &TargetFilter,
+    chain_root: Option<WriteScope>,
+) -> (RwProfile, Option<WriteScope>) {
+    let sc = scope_of(target, chain_root);
+    let mut p = RwProfile::empty();
+    place_membership_write(
+        &mut p,
+        sc,
+        census_of_filter(target),
+        Some(Zone::Battlefield),
+        Zone::Exile,
+    );
+    (p, Some(sc))
+}
+
+/// CR 205: extract a census from a token's type strings.
+fn census_of_types(types: &[String]) -> Census {
+    if types.is_empty() {
+        return Census::Any;
+    }
+    Census::Tags(types.iter().map(|t| t.to_lowercase()).collect())
+}
+
+// ---------------------------------------------------------------------------
+// Quantity reads (mirror `scan_quantity_*`).
+// ---------------------------------------------------------------------------
+
+fn rw_quantity_expr(x: &QuantityExpr) -> RwProfile {
+    match x {
+        QuantityExpr::Ref { qty } => rw_quantity_ref(qty),
+        QuantityExpr::Fixed { value: _ } => RwProfile::empty(),
+        QuantityExpr::DivideRounded {
+            inner,
+            divisor: _,
+            rounding: _,
+        }
+        | QuantityExpr::Offset { inner, offset: _ }
+        | QuantityExpr::ClampMin { inner, minimum: _ }
+        | QuantityExpr::Multiply { inner, factor: _ }
+        | QuantityExpr::UpTo { max: inner } => rw_quantity_expr(inner),
+        QuantityExpr::Power { exponent, base: _ } => rw_quantity_expr(exponent),
+        QuantityExpr::Difference { left, right } => {
+            let mut p = rw_quantity_expr(left);
+            p.merge(rw_quantity_expr(right));
+            p
+        }
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            let mut p = RwProfile::empty();
+            for e in exprs {
+                p.merge(rw_quantity_expr(e));
+            }
+            p
+        }
+    }
+}
+
+fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
+    match x {
+        QuantityRef::HandSize { .. } => reads_player_of(StateKind::HandLibrary),
+        QuantityRef::LifeTotal { player: _ } | QuantityRef::LifeAboveStarting => {
+            reads_player_of(StateKind::PlayerLife)
+        }
+        QuantityRef::StartingLifeTotal => RwProfile::empty(),
+        QuantityRef::GraveyardSize { .. } => reads_zone_membership(),
+        QuantityRef::ObjectCount { filter }
+        | QuantityRef::ObjectCountDistinct { filter, .. }
+        | QuantityRef::ObjectCountBySharedQuality { filter, .. }
+        | QuantityRef::ControlledByEachPlayer { filter, .. }
+        | QuantityRef::DistinctColorsAmongPermanents { filter } => board_membership_read(filter),
+        QuantityRef::CountersOnObjects {
+            filter,
+            counter_type: _,
+        }
+        | QuantityRef::DistinctCounterKindsAmong { filter } => {
+            board_value_aggregate_read(filter, StateKind::ObjectCounters)
+        }
+        QuantityRef::Aggregate {
+            filter,
+            function: _,
+            property: _,
+        } => board_value_aggregate_read(filter, StateKind::ObjectPt),
+        QuantityRef::PlayerCount { filter: _ } => RwProfile::empty(),
+        QuantityRef::CountersOn { scope, .. } | QuantityRef::Intensity { scope, .. } => {
+            read_object_scope(scope, StateKind::ObjectCounters)
+        }
+        QuantityRef::Power { scope, .. }
+        | QuantityRef::Toughness { scope, .. }
+        | QuantityRef::ObjectManaValue { scope, .. }
+        | QuantityRef::ObjectColorCount { scope, .. }
+        | QuantityRef::ObjectNameWordCount { scope, .. }
+        | QuantityRef::ObjectTypelineComponentCount { scope, .. }
+        | QuantityRef::ManaSymbolsInManaCost { scope, .. } => {
+            read_object_scope(scope, StateKind::ObjectPt)
+        }
+        QuantityRef::TargetObjectManaValue { filter: _ } => reads_board_of(StateKind::ObjectPt),
+        QuantityRef::PlayerCounter { scope: _, kind: _ } => reads_player_of(StateKind::PlayerLife),
+        // CR 122.1f: the target's controller's player-counter total (poison ==
+        // "poisoned"). A target-relative player-mutable read — same proxy as the
+        // `PlayerCounter` sibling above (StateKind has no dedicated player-counter
+        // kind; player counters ride the `PlayerLife` sibling-mutable player-state
+        // row, which `Effect::GivePlayerCounter` writes for the matching feed).
+        QuantityRef::TargetControllerCounter { kind: _ } => reads_player_of(StateKind::PlayerLife),
+        QuantityRef::Variable { name: _ } | QuantityRef::SelfManaValue => RwProfile::empty(),
+        QuantityRef::TargetZoneCardCount { zone: _ } => reads_zone_membership(),
+        QuantityRef::Devotion { .. }
+        | QuantityRef::DistinctCardTypes { .. }
+        | QuantityRef::BasicLandTypeCount { .. }
+        | QuantityRef::PartySize { .. } => reads_zone_membership(),
+        QuantityRef::CardsExiledBySource
+        | QuantityRef::ExiledCardPower { .. }
+        | QuantityRef::TrackedSetSize
+        | QuantityRef::FilteredTrackedSetSize { .. }
+        | QuantityRef::TrackedSetAggregate { .. }
+        | QuantityRef::ExiledFromHandThisResolution
+        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::TurnsTaken
+        | QuantityRef::CrimesCommittedThisTurn
+        | QuantityRef::ChosenNumber
+        | QuantityRef::AttackedThisTurn { .. }
+        | QuantityRef::DescendedThisTurn
+        // CR 701.65b/701.66b/701.67c: controller-scoped per-turn accumulator; no
+        // per-source binding, member-invariant under uniformity (Avatar Aang).
+        | QuantityRef::BendTypesThisTurn
+        | QuantityRef::LandsPlayedThisTurn { .. }
+        | QuantityRef::DungeonsCompleted
+        | QuantityRef::CostXPaid
+        | QuantityRef::KickerCount
+        | QuantityRef::AdditionalCostPaymentCount
+        | QuantityRef::AdditionalCostPaymentCountFor { .. }
+        | QuantityRef::ConvokedCreatureCount
+        | QuantityRef::ColorsInCommandersColorIdentity
+        | QuantityRef::CommanderCastFromCommandZoneCount
+        | QuantityRef::CommanderManaValue { .. }
+        | QuantityRef::Speed { .. }
+        | QuantityRef::VoteCount { .. } => RwProfile::empty(),
+        QuantityRef::ZoneCardCount { filter, .. } => match filter {
+            Some(f) => board_membership_read(f),
+            None => reads_zone_membership(),
+        },
+        // Object-population "this turn" journals ⇒ membership-fed board reads.
+        QuantityRef::EnteredThisTurn { filter }
+        | QuantityRef::SacrificedThisTurn { filter, .. }
+        | QuantityRef::BattlefieldEntriesThisTurn { filter, .. }
+        | QuantityRef::ZoneChangeCountThisTurn { filter, .. }
+        | QuantityRef::ZoneChangeAggregateThisTurn { filter, .. }
+        | QuantityRef::TokensCreatedThisTurn { filter, .. } => board_membership_read(filter),
+        QuantityRef::CounterAddedThisTurn { .. } => reads_board_of(StateKind::ObjectCounters),
+        // Player-resource journals.
+        QuantityRef::LifeLostThisTurn { player: _ }
+        | QuantityRef::LifeGainedThisTurn { player: _ }
+        | QuantityRef::DamageDealtThisTurn { .. } => reads_player_of(StateKind::JournalLife),
+        QuantityRef::CardsDrawnThisTurn { player: _ }
+        | QuantityRef::CardsDiscardedThisTurn { .. } => reads_player_of(StateKind::JournalCards),
+        QuantityRef::SpellsCastThisTurn { .. }
+        | QuantityRef::SpellsCastLastTurn
+        | QuantityRef::SpellsCastThisGame { .. }
+        | QuantityRef::LoyaltyAbilitiesActivatedThisTurn { .. }
+        | QuantityRef::PlayerActionsThisTurn { .. } => reads_player_of(StateKind::JournalCast),
+        QuantityRef::UnspentMana { color: _ } => reads_player_of(StateKind::PlayerLife),
+        QuantityRef::AttachmentsOnLeavingObject { .. } => reads_event_live(),
+        QuantityRef::TimesCostPaidThisResolution => reads_event_live(),
+        // D5 carriers.
+        QuantityRef::EventContextAmount
+        | QuantityRef::EventContextSourceCostX
+        | QuantityRef::ManaSpentToCast { .. } => legacy_ref(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Condition reads.
+// ---------------------------------------------------------------------------
+
+fn rw_ability_condition(x: &AbilityCondition) -> RwProfile {
+    match x {
+        AbilityCondition::QuantityCheck {
+            lhs,
+            rhs,
+            comparator: _,
+        } => {
+            let mut p = rw_quantity_expr(lhs);
+            p.merge(rw_quantity_expr(rhs));
+            p
+        }
+        AbilityCondition::PreviousEffectAmount {
+            rhs,
+            comparator: _,
+            channel: _,
+        } => rw_quantity_expr(rhs),
+        AbilityCondition::ObjectsShareQuality {
+            subject: _,
+            reference: _,
+            quality: _,
+        } => reads_board_of(StateKind::ObjectPt),
+        AbilityCondition::TargetMatchesFilter {
+            filter: _,
+            use_lki: _,
+            subject_slot: _,
+        } => reads_board_of(StateKind::ObjectPt),
+        AbilityCondition::SourceMatchesFilter { filter: _ } => reads_src_of(StateKind::ObjectPt),
+        AbilityCondition::SourceIsTapped => reads_src_of(StateKind::TapState),
+        AbilityCondition::ControllerControlsMatching { filter } => board_membership_read(filter),
+        AbilityCondition::ScopedPlayerMatches { filter } => rw_player_filter(filter),
+        AbilityCondition::TriggeringSpellTargetsFilter { filter: _ }
+        | AbilityCondition::ZoneChangeObjectMatchesFilter { .. }
+        | AbilityCondition::ZoneChangedThisWay { filter: _ }
+        | AbilityCondition::CostPaidObjectMatchesFilter { filter: _ } => reads_event_live(),
+        AbilityCondition::EventOutcomeWon => reads_event_live(),
+        AbilityCondition::SpellCastWithVariantThisTurn { variant: _ }
+        | AbilityCondition::NthResolutionThisTurn { n: _ } => {
+            reads_player_of(StateKind::JournalCast)
+        }
+        AbilityCondition::RevealedHasCardType { .. } => RwProfile::conservative(),
+        AbilityCondition::SourceEnteredThisTurn
+        | AbilityCondition::AdditionalCostPaid { .. }
+        | AbilityCondition::CastVariantPaid { .. }
+        | AbilityCondition::SourceAttachedToCreature
+        | AbilityCondition::ControllerControlledMatchingAsCast { .. }
+        | AbilityCondition::SourceLacksKeyword { .. }
+        | AbilityCondition::WasStartingPlayer { .. } => frozen_source_read(),
+        AbilityCondition::ConditionInstead { inner }
+        | AbilityCondition::Not { condition: inner } => rw_ability_condition(inner),
+        AbilityCondition::And { conditions } | AbilityCondition::Or { conditions } => {
+            let mut p = RwProfile::empty();
+            for c in conditions {
+                p.merge(rw_ability_condition(c));
+            }
+            p
+        }
+        AbilityCondition::AdditionalCostPaidInstead
+        | AbilityCondition::AlternativeManaCostPaid
+        | AbilityCondition::EffectOutcome { .. }
+        | AbilityCondition::WhenYouDo
+        | AbilityCondition::CastFromZone { .. }
+        | AbilityCondition::CastDuringPhase { .. }
+        | AbilityCondition::CurrentPhaseIs { .. }
+        | AbilityCondition::CastTimingPermission { .. }
+        | AbilityCondition::ManaColorSpent { .. }
+        | AbilityCondition::TargetSharesNameWithOtherExiledThisWay { .. }
+        | AbilityCondition::CastVariantPaidInstead { .. }
+        | AbilityCondition::HasMaxSpeed
+        | AbilityCondition::IsMonarch
+        | AbilityCondition::IsInitiative
+        | AbilityCondition::HasCityBlessing
+        | AbilityCondition::IsRingBearer
+        | AbilityCondition::TargetHasKeywordInstead { .. }
+        | AbilityCondition::HasObjectTarget
+        | AbilityCondition::IsYourTurn
+        | AbilityCondition::FirstCombatPhaseOfTurn
+        | AbilityCondition::FirstEndStepOfTurn
+        | AbilityCondition::DayNightIsNeither
+        | AbilityCondition::DayNightIs { .. } => RwProfile::empty(),
+    }
+}
+
+fn rw_trigger_condition(x: &TriggerCondition) -> RwProfile {
+    match x {
+        TriggerCondition::GainedLife { minimum: _ }
+        | TriggerCondition::LostLife
+        | TriggerCondition::DealtDamageBySourceThisTurn
+        | TriggerCondition::LostLifeLastTurn => reads_player_of(StateKind::JournalLife),
+        TriggerCondition::DealtDamageThisTurnBySource { source: _ } => {
+            reads_player_of(StateKind::JournalLife)
+        }
+        TriggerCondition::LifeTotalGE { minimum: _ } => reads_player_of(StateKind::PlayerLife),
+        TriggerCondition::ControlsType { filter }
+        | TriggerCondition::ControlCount { filter, .. }
+        | TriggerCondition::ControlsNone { filter }
+        | TriggerCondition::DefendingPlayerControlsNone { filter } => board_membership_read(filter),
+        TriggerCondition::QuantityComparison {
+            lhs,
+            rhs,
+            comparator: _,
+        } => {
+            let mut p = rw_quantity_expr(lhs);
+            p.merge(rw_quantity_expr(rhs));
+            p
+        }
+        TriggerCondition::HadCounters { .. } => reads_frozen_of(StateKind::ObjectCounters),
+        TriggerCondition::HasCounters { .. } => reads_src_of(StateKind::ObjectCounters),
+        TriggerCondition::CounterAddedThisTurn => reads_board_of(StateKind::ObjectCounters),
+        TriggerCondition::SourceIsTapped => reads_src_of(StateKind::TapState),
+        TriggerCondition::SourceMatchesFilter { filter: _ } => reads_src_of(StateKind::ObjectPt),
+        TriggerCondition::NoSpellsCastLastTurn
+        | TriggerCondition::TwoOrMoreSpellsCastLastTurn
+        | TriggerCondition::CastSpellThisTurn { .. }
+        | TriggerCondition::SpellCastWithVariantThisTurn { .. } => {
+            reads_player_of(StateKind::JournalCast)
+        }
+        TriggerCondition::DuringPlayersTurn { player } => rw_player_filter(player),
+        TriggerCondition::SourceEnteredThisTurn
+        | TriggerCondition::SourceIsHarnessed
+        | TriggerCondition::SourceIsAttacking
+        | TriggerCondition::SourceIsTransformed
+        | TriggerCondition::SourceIsFaceUp
+        | TriggerCondition::SourceIsFaceDown
+        | TriggerCondition::SourceInZone { .. }
+        | TriggerCondition::IsRenowned { .. }
+        | TriggerCondition::WasStartingPlayer { .. } => frozen_source_read(),
+        TriggerCondition::ZoneChangeObjectMatchesFilter { .. }
+        | TriggerCondition::ZoneChangeObjectIsTapped
+        | TriggerCondition::EventDamageSourceMatchesFilter { .. }
+        | TriggerCondition::DamagedPlayerIsEventSourceOwner
+        | TriggerCondition::TriggeringSpellTargetsFilter { .. } => reads_event_live(),
+        TriggerCondition::ManaColorSpent { .. } | TriggerCondition::ManaSpentCondition { .. } => {
+            reads_player_of(StateKind::JournalCast)
+        }
+        TriggerCondition::And { conditions } | TriggerCondition::Or { conditions } => {
+            let mut p = RwProfile::empty();
+            for c in conditions {
+                p.merge(rw_trigger_condition(c));
+            }
+            p
+        }
+        TriggerCondition::Not { condition } => rw_trigger_condition(condition),
+        TriggerCondition::AttackersDeclaredCount { .. } => RwProfile::empty(),
+        TriggerCondition::Descended
+        | TriggerCondition::EchoDue
+        | TriggerCondition::MinCoAttackers { .. }
+        | TriggerCondition::SolveConditionMet
+        | TriggerCondition::ClassLevelGE { .. }
+        | TriggerCondition::AttractionVisitRoll { .. }
+        | TriggerCondition::WasCast { .. }
+        | TriggerCondition::WasPlayed
+        | TriggerCondition::AdditionalCostPaid { .. }
+        | TriggerCondition::CastVariantPaid { .. }
+        | TriggerCondition::CastVariantPaidPersistent { .. }
+        | TriggerCondition::ActivatedAbilityIsNonMana
+        | TriggerCondition::FirstTimeObjectTappedThisTurn
+        | TriggerCondition::WasType { .. }
+        | TriggerCondition::AttackedThisTurn
+        | TriggerCondition::FirstCombatPhaseOfTurn
+        | TriggerCondition::HasMaxSpeed
+        | TriggerCondition::IsMonarch
+        | TriggerCondition::IsInitiative
+        | TriggerCondition::NoMonarch
+        | TriggerCondition::HasCityBlessing
+        | TriggerCondition::CompletedDungeon { .. }
+        | TriggerCondition::TributeNotPaid
+        | TriggerCondition::CastDuringPhase { .. }
+        | TriggerCondition::CastTimingPermission { .. }
+        | TriggerCondition::ControlsCommander { .. }
+        | TriggerCondition::ChosenLabelIs { .. }
+        | TriggerCondition::ExceptFirstDrawInDrawStep
+        | TriggerCondition::PlacedByAbilitySource => RwProfile::empty(),
+    }
+}
+
+fn rw_static_condition(x: &StaticCondition) -> RwProfile {
+    match x {
+        StaticCondition::DevotionGE { .. }
+        | StaticCondition::SharesColorWithMostCommonColorAmongPermanents => reads_zone_membership(),
+        StaticCondition::IsPresent { filter } => match filter {
+            Some(f) => board_membership_read(f),
+            None => reads_zone_membership(),
+        },
+        StaticCondition::DefendingPlayerControls { filter } => board_membership_read(filter),
+        StaticCondition::QuantityComparison {
+            lhs,
+            rhs,
+            comparator: _,
+        } => {
+            let mut p = rw_quantity_expr(lhs);
+            p.merge(rw_quantity_expr(rhs));
+            p
+        }
+        StaticCondition::HasCounters { .. } => reads_src_of(StateKind::ObjectCounters),
+        StaticCondition::IsTapped { scope, .. } => read_object_scope(scope, StateKind::TapState),
+        StaticCondition::SourceIsTapped => reads_src_of(StateKind::TapState),
+        StaticCondition::OpponentPoisonAtLeast { count: _ } => {
+            reads_player_of(StateKind::PlayerLife)
+        }
+        StaticCondition::SpellCastWithVariantThisTurn { .. } => {
+            reads_player_of(StateKind::JournalCast)
+        }
+        StaticCondition::SourceMatchesFilter { filter: _ } => reads_src_of(StateKind::ObjectPt),
+        StaticCondition::And { conditions } | StaticCondition::Or { conditions } => {
+            let mut p = RwProfile::empty();
+            for c in conditions {
+                p.merge(rw_static_condition(c));
+            }
+            p
+        }
+        StaticCondition::Not { condition } => rw_static_condition(condition),
+        StaticCondition::UnlessPay { .. } => RwProfile::conservative(),
+        StaticCondition::SourceAttackingAlone
+        | StaticCondition::SourceIsAttacking
+        | StaticCondition::SourceIsBlocking
+        | StaticCondition::SourceIsBlocked
+        | StaticCondition::SourceEnteredThisTurn
+        | StaticCondition::SourceHasDealtDamage
+        | StaticCondition::SourceIsSaddled
+        | StaticCondition::SourceIsEquipped
+        | StaticCondition::SourceIsEnchanted
+        | StaticCondition::SourceIsMonstrous
+        | StaticCondition::SourceIsHarnessed
+        | StaticCondition::SourceAttachedToCreature
+        | StaticCondition::SourceIsPaired
+        | StaticCondition::SourceInZone { .. }
+        | StaticCondition::WasStartingPlayer { .. } => frozen_source_read(),
+        StaticCondition::RecipientHasCounters { .. }
+        | StaticCondition::RecipientMatchesFilter { .. }
+        | StaticCondition::RecipientAttackingOwnerTarget { .. } => RwProfile::empty(),
+        StaticCondition::ChosenColorIs { .. }
+        | StaticCondition::ChosenLabelIs { .. }
+        | StaticCondition::HasMaxSpeed
+        | StaticCondition::SpeedGE { .. }
+        | StaticCondition::DayNightIs { .. }
+        | StaticCondition::CastVariantPaid { .. }
+        | StaticCondition::ClassLevelGE { .. }
+        | StaticCondition::IsMonarch
+        | StaticCondition::IsInitiative
+        | StaticCondition::NoMonarch
+        | StaticCondition::HasCityBlessing
+        | StaticCondition::CompletedADungeon
+        | StaticCondition::Unrecognized { .. }
+        | StaticCondition::DuringYourTurn
+        | StaticCondition::WasCast { .. }
+        | StaticCondition::IsRingBearer
+        | StaticCondition::RingLevelAtLeast { .. }
+        | StaticCondition::ControlsCommander { .. }
+        | StaticCondition::SourceControllerEquals { .. }
+        | StaticCondition::EnchantedIsFaceDown
+        | StaticCondition::AdditionalCostPaid
+        | StaticCondition::CastingAsVariant { .. }
+        | StaticCondition::None => RwProfile::empty(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filter / player / scope reads.
+// ---------------------------------------------------------------------------
+
+/// A filter used as a READ carrier (target_chooser, nested filters). Selectors
+/// are read-free; event-context refs contribute event reads (and D5 flags for
+/// the 12 tags). Composite filters descend to catch nested event refs.
+fn rw_target_filter(x: &TargetFilter) -> RwProfile {
+    match x {
+        // D5 carriers (9 TargetFilter tags of the 12).
+        TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::TriggeringSource
+        | TargetFilter::ParentTarget
+        | TargetFilter::ParentTargetSlot { .. }
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::StackSpell
+        | TargetFilter::CostPaidObject => legacy_ref(),
+        // Non-D5 event refs.
+        TargetFilter::EventTarget
+        | TargetFilter::TriggeringSourceController
+        | TargetFilter::PostReplacementSourceController
+        | TargetFilter::PostReplacementDamageTarget
+        | TargetFilter::PostReplacementDamageTargetOwner
+        | TargetFilter::ChosenDamageSource => reads_event_live(),
+        TargetFilter::Not { filter } | TargetFilter::TrackedSetFiltered { filter, .. } => {
+            rw_target_filter(filter)
+        }
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            let mut p = RwProfile::empty();
+            for f in filters {
+                p.merge(rw_target_filter(f));
+            }
+            p
+        }
+        TargetFilter::None
+        | TargetFilter::Any
+        | TargetFilter::Player
+        | TargetFilter::Controller
+        | TargetFilter::SelfRef
+        | TargetFilter::SourceOrPaired
+        | TargetFilter::Typed(..)
+        | TargetFilter::StackAbility { .. }
+        | TargetFilter::SpecificObject { .. }
+        | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::Neighbor { .. }
+        | TargetFilter::ScopedPlayer
+        | TargetFilter::AttachedTo
+        | TargetFilter::LastCreated
+        | TargetFilter::LastRevealed
+        | TargetFilter::ChosenCard
+        | TargetFilter::TrackedSet { .. }
+        | TargetFilter::ExiledBySource
+        | TargetFilter::ExiledCardByIndex { .. }
+        | TargetFilter::SourceChosenPlayer
+        | TargetFilter::OriginalController
+        | TargetFilter::DefendingPlayer
+        | TargetFilter::HasChosenName
+        | TargetFilter::Named { .. }
+        | TargetFilter::Owner
+        | TargetFilter::AllPlayers => RwProfile::empty(),
+    }
+}
+
+fn rw_player_filter(x: &PlayerFilter) -> RwProfile {
+    match x {
+        PlayerFilter::OpponentLostLife | PlayerFilter::OpponentGainedLife => {
+            reads_player_of(StateKind::JournalLife)
+        }
+        PlayerFilter::OpponentDealtCombatDamage { source: _ } => {
+            reads_player_of(StateKind::JournalLife)
+        }
+        // D5 carrier.
+        PlayerFilter::TriggeringPlayer => legacy_ref(),
+        PlayerFilter::OpponentOtherThanTriggering
+        | PlayerFilter::OpponentOfTriggeringPlayer
+        | PlayerFilter::OpponentOfTriggeringPlayerNotAttacked
+        | PlayerFilter::ParentObjectTargetController
+        | PlayerFilter::ParentObjectTargetOwner => reads_event_live(),
+        PlayerFilter::ControlsCount {
+            filter,
+            count,
+            relation: _,
+            comparator: _,
+        } => {
+            let mut p = board_membership_read(filter);
+            p.merge(rw_quantity_expr(count));
+            p
+        }
+        PlayerFilter::PlayerAttribute {
+            attr,
+            value,
+            relation: _,
+            comparator: _,
+        } => {
+            let mut p = rw_quantity_ref(attr);
+            p.merge(rw_quantity_expr(value));
+            p
+        }
+        PlayerFilter::AllExcept { exclude } => rw_player_filter(exclude),
+        PlayerFilter::Controller
+        | PlayerFilter::Opponent
+        | PlayerFilter::DefendingPlayer
+        | PlayerFilter::HasLostTheGame
+        | PlayerFilter::OpponentAttacked { .. }
+        | PlayerFilter::All
+        | PlayerFilter::HighestSpeed
+        | PlayerFilter::ZoneChangedThisWay
+        | PlayerFilter::PerformedActionThisWay { .. }
+        | PlayerFilter::OwnersOfCardsExiledBySource
+        | PlayerFilter::VotedFor { .. }
+        | PlayerFilter::ChosenPlayer { .. } => RwProfile::empty(),
+    }
+}
+
+fn rw_player_scope(x: &PlayerScope) -> RwProfile {
+    match x {
+        PlayerScope::ParentObjectTargetController => reads_event_live(),
+        PlayerScope::AllPlayers { exclude, .. } => match exclude {
+            Some(e) => rw_player_scope(e),
+            None => RwProfile::empty(),
+        },
+        PlayerScope::Controller
+        | PlayerScope::ScopedPlayer
+        | PlayerScope::Target
+        | PlayerScope::Opponent { .. }
+        | PlayerScope::RecipientController
+        | PlayerScope::DefendingPlayer
+        | PlayerScope::SourceChosenPlayer => RwProfile::empty(),
+    }
+}
+
+fn rw_controller_ref(x: &ControllerRef) -> RwProfile {
+    match x {
+        // D5 carriers.
+        ControllerRef::ParentTargetController
+        | ControllerRef::ParentTargetOwner
+        | ControllerRef::TriggeringPlayer => legacy_ref(),
+        ControllerRef::You
+        | ControllerRef::Opponent
+        | ControllerRef::ScopedPlayer
+        | ControllerRef::TargetPlayer
+        | ControllerRef::DefendingPlayer
+        | ControllerRef::ChosenPlayer { .. }
+        | ControllerRef::SourceChosenPlayer
+        | ControllerRef::EnchantedPlayer => RwProfile::empty(),
+    }
+}
+
+fn rw_count_scope(x: &CountScope) -> RwProfile {
+    match x {
+        CountScope::Controller
+        | CountScope::Owner
+        | CountScope::ScopedPlayer
+        | CountScope::SourceChosenPlayer
+        | CountScope::All
+        | CountScope::Opponents => RwProfile::empty(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// N-E unit pairings (§5.4). Build ASTs directly; assert profile+conflict.
+// Each pairing is discriminating: the paired assertions bracket exactly one
+// classification decision (see the revert-fail table in the impl report).
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ability::{AbilityKind, Comparator, PtValue};
+    use crate::types::counter::CounterType;
+    use crate::types::identifiers::ObjectId;
+    use crate::types::player::PlayerId;
+
+    // ---- builders ----
+    fn ra(effect: Effect) -> ResolvedAbility {
+        ResolvedAbility::new(effect, vec![], ObjectId(1), PlayerId(0))
+    }
+    fn cond(mut a: ResolvedAbility, c: AbilityCondition) -> ResolvedAbility {
+        a.condition = Some(c);
+        a
+    }
+    fn qfix(v: i32) -> QuantityExpr {
+        QuantityExpr::Fixed { value: v }
+    }
+    fn qref(r: QuantityRef) -> QuantityExpr {
+        QuantityExpr::Ref { qty: r }
+    }
+    fn creature() -> TargetFilter {
+        TargetFilter::Typed(TypedFilter::creature())
+    }
+    fn sub(t: &str) -> TargetFilter {
+        TargetFilter::Typed(TypedFilter::creature().subtype(t.to_string()))
+    }
+    fn power_src() -> QuantityRef {
+        QuantityRef::Power {
+            scope: ObjectScope::Source,
+        }
+    }
+    fn tough_recip() -> QuantityRef {
+        QuantityRef::Toughness {
+            scope: ObjectScope::Recipient,
+        }
+    }
+    fn counters_src() -> QuantityRef {
+        QuantityRef::CountersOn {
+            scope: ObjectScope::Source,
+            counter_type: None,
+        }
+    }
+    fn obj_count(f: TargetFilter) -> QuantityRef {
+        QuantityRef::ObjectCount { filter: f }
+    }
+    fn put_counter_all(count: QuantityExpr, target: TargetFilter) -> Effect {
+        Effect::PutCounterAll {
+            count,
+            target,
+            counter_type: CounterType::Plus1Plus1,
+        }
+    }
+    fn put_counter(count: QuantityExpr, target: TargetFilter) -> Effect {
+        Effect::PutCounter {
+            count,
+            target,
+            counter_type: CounterType::Plus1Plus1,
+        }
+    }
+    fn remove_counter(target: TargetFilter) -> Effect {
+        Effect::RemoveCounter {
+            counter_type: None,
+            count: qfix(1),
+            target,
+        }
+    }
+    fn gain_life(amount: QuantityExpr) -> Effect {
+        Effect::GainLife {
+            amount,
+            player: TargetFilter::Controller,
+        }
+    }
+    fn sacrifice_self() -> Effect {
+        Effect::Sacrifice {
+            target: TargetFilter::SelfRef,
+            count: qfix(1),
+            min_count: 0,
+        }
+    }
+    fn token(types: &[&str], count: QuantityExpr) -> Effect {
+        Effect::Token {
+            name: "t".into(),
+            power: PtValue::Fixed(1),
+            toughness: PtValue::Fixed(1),
+            types: types.iter().map(|s| s.to_string()).collect(),
+            colors: vec![],
+            keywords: vec![],
+            tapped: false,
+            count,
+            owner: TargetFilter::Controller,
+            attach_to: None,
+            enters_attacking: false,
+            supertypes: vec![],
+            static_abilities: vec![],
+            enter_with_counters: vec![],
+        }
+    }
+    fn change_zone(origin: Option<Zone>, dest: Zone, target: TargetFilter) -> Effect {
+        Effect::ChangeZone {
+            origin,
+            destination: dest,
+            target,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: crate::types::zones::EtbTapState::default(),
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        }
+    }
+    fn copy_spell(target: TargetFilter) -> Effect {
+        Effect::CopySpell {
+            target,
+            retarget: crate::types::ability::CopyRetargetPermission::KeepOriginalTargets,
+            copier: None,
+            additional_modifications: vec![],
+            starting_loyalty_from_casualty_sacrifice: false,
+        }
+    }
+    fn qcheck(lhs: QuantityRef, rhs: i32) -> AbilityCondition {
+        AbilityCondition::QuantityCheck {
+            lhs: qref(lhs),
+            rhs: qfix(rhs),
+            comparator: Comparator::GE,
+        }
+    }
+
+    // ---- group structures ----
+    fn se() -> GroupStructure {
+        gs(true, false, false, false, true, SourceCensus::unknown())
+    }
+    fn se_phase() -> GroupStructure {
+        gs(true, false, false, false, false, SourceCensus::unknown())
+    }
+    fn se_disjoint() -> GroupStructure {
+        gs(true, false, false, true, true, SourceCensus::unknown())
+    }
+    fn batch() -> GroupStructure {
+        gs(false, false, true, false, true, SourceCensus::unknown())
+    }
+    fn gs(
+        same_event: bool,
+        all_same_source: bool,
+        self_departed: bool,
+        excludes: bool,
+        present: bool,
+        source_census: SourceCensus,
+    ) -> GroupStructure {
+        GroupStructure {
+            same_event,
+            all_same_source,
+            all_sources_self_departed: self_departed,
+            event_object_excludes_sources: excludes,
+            event_object_present: present,
+            source_census,
+        }
+    }
+
+    fn conflicts(a: &ResolvedAbility, s: &GroupStructure) -> bool {
+        profiles_conflict(&ability_rw_profile(a), s)
+    }
+
+    // ===================== base shapes =====================
+
+    #[test]
+    fn base_chaotic_goo_flipcoin_self_counters_clean() {
+        // FlipCoin{win: PutCounter(SelfRef), lose: RemoveCounter(SelfRef)} — no
+        // reads ⇒ clean even though the self-writes disable source-independence.
+        let e = Effect::FlipCoin {
+            win_effect: Some(Box::new(def(put_counter(qfix(1), TargetFilter::SelfRef)))),
+            lose_effect: Some(Box::new(def(remove_counter(TargetFilter::SelfRef)))),
+            flipper: TargetFilter::Controller,
+        };
+        let p = ability_rw_profile(&ra(e));
+        assert!(
+            p.writes_self.object_counters,
+            "FlipCoin body descends to self-counter write"
+        );
+        assert!(!profiles_conflict(&p, &se_phase()));
+    }
+
+    #[test]
+    fn base_gutter_grime_live_src_counter_read_vs_token_membership_clean() {
+        // Observer alive: CountersOn{Source} LIVE read × token membership write —
+        // counters vs membership don't feed (T3).
+        let e = token(&["Creature", "Ooze"], qref(counters_src()));
+        assert!(!conflicts(&ra(e), &batch()));
+    }
+
+    #[test]
+    fn base_mana_crypt_flipcoin_player_damage_clean() {
+        let e = Effect::FlipCoin {
+            win_effect: None,
+            lose_effect: Some(Box::new(def(Effect::DealDamage {
+                amount: qfix(3),
+                target: TargetFilter::Controller,
+                damage_source: None,
+                excess: None,
+            }))),
+            flipper: TargetFilter::Controller,
+        };
+        assert!(!conflicts(&ra(e), &se_phase()));
+    }
+
+    #[test]
+    fn base_fruit_src_pt_read_vs_life_write_clean() {
+        // Toughness{Source} read × life write — no feed (ObjectPt vs PlayerLife).
+        let e = gain_life(qref(QuantityRef::Toughness {
+            scope: ObjectScope::Source,
+        }));
+        assert!(!conflicts(&ra(e), &se()));
+    }
+
+    #[test]
+    fn base_quirion_dryad_write_only_self_counter_clean() {
+        assert!(!conflicts(
+            &ra(put_counter(qfix(1), TargetFilter::SelfRef)),
+            &se()
+        ));
+    }
+
+    #[test]
+    fn base_copyspell_selfref_clean_vs_topofstack_conflict() {
+        // Walk-classification discriminator (D4, CR 707.10/707.10c): SelfRef/
+        // explicit reads the original by id (no board read); the untargeted
+        // fallback reads the MUTABLE stack top.
+        let self_p = ability_rw_profile(&ra(copy_spell(TargetFilter::SelfRef)));
+        let fallback_p = ability_rw_profile(&ra(copy_spell(TargetFilter::Any)));
+        assert!(!self_p.reads_board.stack_shape, "SelfRef reads by id");
+        assert!(
+            fallback_p.reads_board.stack_shape,
+            "fallback reads the mutable stack top"
+        );
+        // Under same-event the two identical source-independent copies commute
+        // (f∘f) ⇒ both auto. The fallback's mutable-read hazard is order-relevant
+        // on the distinct-event path, where the fallback conflicts and SelfRef
+        // stays clean — the classification distinction made observable.
+        assert!(conflicts(&ra(copy_spell(TargetFilter::Any)), &batch()));
+        assert!(!conflicts(&ra(copy_spell(TargetFilter::SelfRef)), &batch()));
+    }
+
+    #[test]
+    fn base_case_a_live_power_read_vs_board_counter_write_conflict() {
+        // "put +1/+1 on each creature; draw if power>=6" — live Power{Source}
+        // read × PutCounterAll board write; counters feed P/T.
+        let a = cond(
+            ra(put_counter_all(qfix(1), creature())),
+            qcheck(power_src(), 6),
+        );
+        assert!(conflicts(&a, &se()));
+    }
+
+    #[test]
+    fn base_graveyard_return_board_membership_conflict() {
+        // board creature-count read × return-to-battlefield membership write,
+        // census overlap (creature).
+        let a = cond(
+            ra(change_zone(
+                Some(Zone::Graveyard),
+                Zone::Battlefield,
+                creature(),
+            )),
+            qcheck(obj_count(creature()), 1),
+        );
+        assert!(conflicts(&a, &batch()));
+    }
+
+    // ===================== (i) Mana × unless-pay guard =====================
+
+    #[test]
+    fn ne_i_mana_unless_pay_guard() {
+        // echo: unless-pay + self-sac, NO pool write ⇒ clean.
+        let mut echo = ability_rw_profile(&ra(sacrifice_self()));
+        echo.has_pay_or_unless = true;
+        assert!(!echo.writes_pool);
+        assert!(!profiles_conflict(&echo, &se()));
+        // synthetic: pool write + unless-pay ⇒ combination guard ⇒ conflict.
+        let mut synth = RwProfile::empty();
+        synth.writes_pool = true;
+        synth.has_pay_or_unless = true;
+        assert!(profiles_conflict(&synth, &se()));
+    }
+
+    // ===================== (ii) Recipient vs Source =====================
+
+    #[test]
+    fn ne_ii_recipient_vs_source() {
+        // Canopy Gargantuan: Toughness{Recipient} ⇒ read-modify-write, no
+        // sibling-read record ⇒ clean.
+        let gargantuan = ra(put_counter_all(qref(tough_recip()), creature()));
+        assert!(!conflicts(&gargantuan, &se()));
+        // Ouroboroid: Power{Source} live read × PutCounterAll external write ⇒
+        // counters feed P/T ⇒ conflict.
+        let ouroboroid = ra(put_counter_all(qref(power_src()), creature()));
+        assert!(conflicts(&ouroboroid, &se()));
+    }
+
+    // ===================== (iii) T1 completion =====================
+
+    #[test]
+    fn ne_iii_t1_source_independence() {
+        // Endless Ranks: board count read × token membership write, no self
+        // write ⇒ source-independent ⇒ same-event fast path ⇒ clean.
+        let endless = ra(token(
+            &["Creature", "Zombie"],
+            qref(obj_count(sub("Zombie"))),
+        ));
+        assert!(ability_rw_profile(&endless).source_independent());
+        assert!(!conflicts(&endless, &se()));
+        // + a self-counter rider ⇒ source-DEPENDENT ⇒ falls to the board row ⇒
+        // census overlap (zombie) ⇒ conflict.
+        let mut dependent = endless.clone();
+        dependent = dependent.sub_ability(ra(put_counter(qfix(1), TargetFilter::SelfRef)));
+        assert!(!ability_rw_profile(&dependent).source_independent());
+        assert!(conflicts(&dependent, &se()));
+    }
+
+    // ===================== (iv) census overlap =====================
+
+    #[test]
+    fn ne_iv_census_overlap() {
+        // Pestilence: creature-count read × self-sac of an ENCHANTMENT source ⇒
+        // census-disjoint ⇒ clean.
+        let pestilence = cond(ra(sacrifice_self()), qcheck(obj_count(creature()), 1));
+        let s = gs(
+            true,
+            false,
+            false,
+            false,
+            false,
+            SourceCensus::from_tags(["Enchantment".to_string()]),
+        );
+        assert!(!profiles_conflict(&ability_rw_profile(&pestilence), &s));
+        // Docent: Wizard-count read × Wizard-token write + self-transform ⇒
+        // overlap ⇒ conflict.
+        let docent = cond(
+            ra(token(&["Creature", "Wizard"], qfix(1))).sub_ability(ra(Effect::Transform {
+                target: TargetFilter::SelfRef,
+            })),
+            qcheck(obj_count(sub("Wizard")), 1),
+        );
+        assert!(conflicts(&docent, &se()));
+    }
+
+    #[test]
+    fn major1_unfiltered_zone_membership_read_conflicts() {
+        // MAJOR-1: a whole-zone `GraveyardSize` read carries census `Any`
+        // (unextractable ⇒ overlap assumed). "return all creature cards from
+        // your graveyard to the battlefield; draw if graveyard has >=3 cards" —
+        // board GraveyardSize read × sibling return-to-battlefield membership
+        // write ⇒ census-overlap conflict on the departure-batch path (where the
+        // same-event f∘f short-circuit does not apply).
+        let a = cond(
+            ra(change_zone(
+                Some(Zone::Graveyard),
+                Zone::Battlefield,
+                creature(),
+            )),
+            qcheck(
+                QuantityRef::GraveyardSize {
+                    player: PlayerScope::Controller,
+                },
+                3,
+            ),
+        );
+        assert!(conflicts(&a, &batch()));
+    }
+
+    // ===================== (v) chain-root =====================
+
+    #[test]
+    fn ne_v_chain_root() {
+        // Smoldering Egg: PutCounter{SelfRef} → RemoveCounter{ParentTarget} +
+        // CountersOn{Source} read ⇒ chain root SelfRef ⇒ self-write ⇒ clean.
+        let egg = cond(
+            ra(put_counter(qfix(1), TargetFilter::SelfRef))
+                .sub_ability(ra(remove_counter(TargetFilter::ParentTarget))),
+            qcheck(counters_src(), 1),
+        );
+        assert!(!conflicts(&egg, &se()));
+        // Re-rooted at a Typed filter (root NOT SelfRef) ⇒ external counter write
+        // × live src-counter read ⇒ conflict.
+        let rerooted = cond(
+            ra(put_counter(qfix(1), creature()))
+                .sub_ability(ra(remove_counter(TargetFilter::ParentTarget))),
+            qcheck(counters_src(), 1),
+        );
+        assert!(conflicts(&rerooted, &se()));
+    }
+
+    // ===================== (vi) event-object disjointness =====================
+
+    #[test]
+    fn ne_vi_event_object_disjointness() {
+        // Railway Brawler: PutCounter{TriggeringSource, count: Power{Source}} with
+        // a source-excluding valid_card ⇒ event-object write excluded from
+        // src-read scoping ⇒ clean.
+        let brawler = ra(put_counter(
+            qref(power_src()),
+            TargetFilter::TriggeringSource,
+        ));
+        assert!(!conflicts(&brawler, &se_disjoint()));
+        // Without source-exclusion the event object can be a sibling's source ⇒
+        // external counter write feeds the live Power{Source} read ⇒ conflict.
+        assert!(conflicts(&brawler, &se()));
+    }
+
+    // ===================== (vii) parentless-root =====================
+
+    #[test]
+    fn ne_vii_parentless_root() {
+        // Root Bounce{ParentTarget} (parentless) + a SelfRef-scoped membership
+        // read. On a ZoneChanged trigger the referent is the EVENT object.
+        let ast = cond(
+            ra(Effect::Bounce {
+                target: TargetFilter::ParentTarget,
+                destination: None,
+                selection: crate::types::ability::BounceSelection::Targeted,
+            }),
+            qcheck(
+                obj_count(TargetFilter::And {
+                    filters: vec![TargetFilter::SelfRef],
+                }),
+                1,
+            ),
+        );
+        // (a) source-excluding valid_card ⇒ rule 2 clears ⇒ clean.
+        assert!(!conflicts(&ast, &se_disjoint()));
+        // (b) no exclusion ⇒ event object can be a sibling source ⇒ conflict.
+        assert!(conflicts(&ast, &se()));
+        // (c) Phase trigger (no event object) ⇒ None ⇒ no write ⇒ clean.
+        assert!(!conflicts(&ast, &se_phase()));
+    }
+
+    // ---- test-local helper ----
+    fn def(effect: Effect) -> AbilityDefinition {
+        AbilityDefinition::new(AbilityKind::Spell, effect)
+    }
+}

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -361,6 +361,176 @@ fn zones_of_filter(f: &TargetFilter) -> ZoneSpan {
 }
 
 // ---------------------------------------------------------------------------
+// PlayerSpan (PR-6.75): gate-scoped relative player-identity span for the
+// player-resource and membership-controller feed rows. Mirrors Census/ZoneSpan.
+// ---------------------------------------------------------------------------
+
+/// CR 102.2 + CR 109.5: a relative player-identity span for scope-gated feed
+/// refinement. Meaningful ONLY under `GroupStructure.same_controller` (all
+/// members' relative sets `You`/`Opponents` then denote the SAME concrete players
+/// — `You == {c0}`, `Opponents == all − {c0}`, disjoint at any player count). Dead
+/// otherwise: `profiles_conflict` never consults a span when `same_controller` is
+/// false, so every value is byte-inert in the ungated path.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum PlayerSpan {
+    /// No player-keyed read/write on this side — overlaps nothing. Also the
+    /// top-level "unscoped" pscope sentinel (no enclosing per-player iteration).
+    None,
+    /// The controller `c0` (CR 109.5 "you/your").
+    You,
+    /// Every opponent of `c0` (CR 102.2/102.3).
+    Opponents,
+    /// Unextractable / mixed / unrefined — assume overlap (fail-closed).
+    Any,
+}
+
+impl PlayerSpan {
+    /// Mixing `You`+`Opponents` or anything+`Any` ⇒ `Any`; `None` is identity.
+    fn merge(self, o: PlayerSpan) -> PlayerSpan {
+        match (self, o) {
+            (PlayerSpan::None, x) | (x, PlayerSpan::None) => x,
+            (PlayerSpan::Any, _) | (_, PlayerSpan::Any) => PlayerSpan::Any,
+            (PlayerSpan::You, PlayerSpan::You) => PlayerSpan::You,
+            (PlayerSpan::Opponents, PlayerSpan::Opponents) => PlayerSpan::Opponents,
+            (PlayerSpan::You, PlayerSpan::Opponents) | (PlayerSpan::Opponents, PlayerSpan::You) => {
+                PlayerSpan::Any
+            }
+        }
+    }
+}
+
+/// CR 102.2 + CR 109.5 relative-player overlap: two spans can name a common
+/// player iff — under `same_controller` — their relative sets intersect. `None`
+/// overlaps nothing; `Any` overlaps every non-`None`; `You`×`Opponents` is the
+/// only disjoint concrete pair (mirrors `census_overlap`).
+fn player_span_overlap(a: PlayerSpan, b: PlayerSpan) -> bool {
+    match (a, b) {
+        (PlayerSpan::None, _) | (_, PlayerSpan::None) => false,
+        (PlayerSpan::Any, _) | (_, PlayerSpan::Any) => true,
+        (PlayerSpan::You, PlayerSpan::You) | (PlayerSpan::Opponents, PlayerSpan::Opponents) => true,
+        (PlayerSpan::You, PlayerSpan::Opponents) | (PlayerSpan::Opponents, PlayerSpan::You) => {
+            false
+        }
+    }
+}
+
+/// Effective-Any rule (§4.1 fail-closed): a span consulted while its kind-bit is
+/// present in the effective set but whose value was never refined (`None`) reads
+/// as `Any`. This is what lets the ~40 `ext_write`/`life_writes` and other
+/// unrefined callers stay conservative WITHOUT edits — an unrefined player /
+/// membership read or write overlaps every player.
+fn effective_span(span: PlayerSpan, kind_present: bool) -> PlayerSpan {
+    if kind_present && span == PlayerSpan::None {
+        PlayerSpan::Any
+    } else {
+        span
+    }
+}
+
+/// CR 108.3 + CR 110.2: the controller-field span of a membership write set —
+/// external membership ctrl when an external membership write is present, merged
+/// with `You` when a self membership write is in scope (the chokepoint guarantees
+/// `obj.controller == c0`). Mirrors `membership_census_of`.
+fn membership_ctrl_of(
+    write_kinds: KindSet,
+    external_ctrl: PlayerSpan,
+    self_in_scope: bool,
+) -> PlayerSpan {
+    let mut c = PlayerSpan::None;
+    if write_kinds.set_membership {
+        c = c.merge(external_ctrl);
+    }
+    if self_in_scope {
+        c = c.merge(PlayerSpan::You);
+    }
+    c
+}
+
+/// CR 109.5 / CR 102.2: relative player span of a `PlayerScope` (HandSize/player
+/// reads). `ScopedPlayer` is a documented ceiling — not threaded into the quantity
+/// walk — and every non-{Controller,Opponent} scope is a multi-player / unrefined
+/// population ⇒ `Any` (fail-closed).
+fn player_span_of_scope(ps: &PlayerScope) -> PlayerSpan {
+    match ps {
+        PlayerScope::Controller => PlayerSpan::You,
+        PlayerScope::Opponent { .. } => PlayerSpan::Opponents,
+        _ => PlayerSpan::Any,
+    }
+}
+
+/// CR 109.5 / CR 102.2: relative player span of a `ControllerRef` (membership
+/// read/write controller key). `You`⇒You, `Opponent`⇒Opponents, everything else
+/// (ScopedPlayer/Target/Chosen/… — unrefined or multi-player) ⇒ `Any`.
+fn player_span_of_ctrl_ref(cr: &ControllerRef) -> PlayerSpan {
+    match cr {
+        ControllerRef::You => PlayerSpan::You,
+        ControllerRef::Opponent => PlayerSpan::Opponents,
+        _ => PlayerSpan::Any,
+    }
+}
+
+/// CR 108.3 / CR 110.2: relative player span of a filter's controller key. Only a
+/// bare `Typed` filter carries an unambiguous controller; composite / broad
+/// filters ⇒ `Any` (fail-closed).
+fn ctrl_span_of_filter(f: &TargetFilter) -> PlayerSpan {
+    match f {
+        TargetFilter::Typed(tf) => tf
+            .controller
+            .as_ref()
+            .map_or(PlayerSpan::Any, player_span_of_ctrl_ref),
+        _ => PlayerSpan::Any,
+    }
+}
+
+/// CR 109.4 / CR 109.5: relative player span of an `AbilityDefinition`/
+/// `ResolvedAbility` `player_scope` (the per-player iteration context threaded
+/// through the walk). `Controller`⇒You, `Opponent`⇒Opponents; every other filter
+/// (`All`/`DefendingPlayer`/`AllExcept`/… — may include or vary across players)
+/// ⇒ `Any` (fail-closed).
+fn player_span_of_filter(pf: &PlayerFilter) -> PlayerSpan {
+    match pf {
+        PlayerFilter::Controller => PlayerSpan::You,
+        PlayerFilter::Opponent => PlayerSpan::Opponents,
+        _ => PlayerSpan::Any,
+    }
+}
+
+/// CR 400.3 (+ engine owner-default battlefield entry, `change_zone.rs:79`): a
+/// `SearchLibrary` of the controller's OWN library (no `target_player`, or a
+/// `Controller`-form one) selects only cards whose owner is the controller, so a
+/// chained battlefield entry enters under `You`. Emitted as the chain move-owner
+/// fact (threaded like `chain_root`) so the ChangeZone consumer can claim a `You`
+/// membership-controller span. A search of another player's library (`target_player
+/// Some(other)`) yields no fact ⇒ the consumer stays `Any`.
+///
+/// §10.4 ENGINE COUPLING: this fact plus the `ChangeZone` consumer below are the
+/// TWO annotated ends of the entry-default coupling — if `change_zone.rs:79`'s
+/// "None keeps the default (owner's control)" ever changes to the CR 110.2a
+/// instructing-player default, this span rule must be revisited.
+fn effect_move_owner(x: &Effect) -> Option<PlayerSpan> {
+    match x {
+        Effect::SearchLibrary { target_player, .. }
+            if target_player.is_none()
+                || matches!(target_player, Some(TargetFilter::Controller)) =>
+        {
+            Some(PlayerSpan::You)
+        }
+        _ => None,
+    }
+}
+
+/// The opaque forwarded move-target class (`Any`/`ParentTarget`) whose concrete
+/// cards are supplied by an earlier chain link (e.g. the search selection), so its
+/// controller span is carried by the inherited chain move-owner fact rather than
+/// the filter itself.
+fn is_opaque_forwarded_target(f: &TargetFilter) -> bool {
+    matches!(
+        f,
+        TargetFilter::Any | TargetFilter::ParentTarget | TargetFilter::ParentTargetSlot { .. }
+    )
+}
+
+// ---------------------------------------------------------------------------
 // RwProfile (§2 D-profile).
 // ---------------------------------------------------------------------------
 
@@ -436,6 +606,29 @@ pub(crate) struct RwProfile {
     has_pay_or_unless: bool,
     /// The ability writes the mana pool (`Effect::Mana`).
     writes_pool: bool,
+    // --- PR-6.75 gate-scoped player-identity spans (consulted ONLY under
+    // GroupStructure.same_controller; every value is byte-inert otherwise). ---
+    /// CR 109.5/102.2: relative-player span of the player-resource READS
+    /// (`HandSize`; life reads stay unrefined ⇒ effective-Any). A single merged
+    /// span across kinds — mixing kinds degrades to `Any` (ceiling documented).
+    reads_player_span: PlayerSpan,
+    /// CR 109.5/102.2: relative-player span of the player-resource WRITES
+    /// (`Discard` scope / self hand-move ⇒ You). Merged across kinds.
+    writes_player_span: PlayerSpan,
+    /// CR 110.2: controller-field span of all `SetMembership` READS (from the
+    /// filter's `controller`; unrefined ⇒ effective-Any).
+    reads_membership_ctrl: PlayerSpan,
+    /// CR 110.2: controller-field span of EXTERNAL `SetMembership` writes
+    /// (SearchLibrary self-library ⇒ You, ChangeZone entry ⇒ chain move-owner).
+    /// Self writes contribute `You` via `membership_ctrl_of`. Unrefined external
+    /// writes stay `None` here and read as `Any` (effective-Any) at conflict time.
+    writes_membership_external_ctrl: PlayerSpan,
+    /// §4.4 fused read-modify-write player read (`Discard{count: HandSize{
+    /// ScopedPlayer}, target: Controller}` — "discards their hand"). Kept OUT of
+    /// `reads_player`/`reads_player_span`: dropped under the gate (identical
+    /// members' per-player fixed points compose symmetrically, Canopy Gargantuan
+    /// RwProfile doc), unioned back into `reads_player` when ungated (byte-identical).
+    reads_player_fused: KindSet,
 }
 
 impl RwProfile {
@@ -461,6 +654,11 @@ impl RwProfile {
             writes_external_counter_census: Census::None,
             has_pay_or_unless: false,
             writes_pool: false,
+            reads_player_span: PlayerSpan::None,
+            writes_player_span: PlayerSpan::None,
+            reads_membership_ctrl: PlayerSpan::None,
+            writes_membership_external_ctrl: PlayerSpan::None,
+            reads_player_fused: KindSet::EMPTY,
         }
     }
 
@@ -477,6 +675,11 @@ impl RwProfile {
         p.reads_membership_census = Census::Any;
         p.reads_membership_zones = ZoneSpan::Any;
         p.writes_external_counter_census = Census::Any;
+        // PR-6.75: an unclassified subtree may read/write any player ⇒ spans `Any`.
+        p.reads_player_span = PlayerSpan::Any;
+        p.writes_player_span = PlayerSpan::Any;
+        p.reads_membership_ctrl = PlayerSpan::Any;
+        p.writes_membership_external_ctrl = PlayerSpan::Any;
         p
     }
 
@@ -506,6 +709,13 @@ impl RwProfile {
             .merge(o.writes_external_counter_census);
         self.has_pay_or_unless |= o.has_pay_or_unless;
         self.writes_pool |= o.writes_pool;
+        self.reads_player_span = self.reads_player_span.merge(o.reads_player_span);
+        self.writes_player_span = self.writes_player_span.merge(o.writes_player_span);
+        self.reads_membership_ctrl = self.reads_membership_ctrl.merge(o.reads_membership_ctrl);
+        self.writes_membership_external_ctrl = self
+            .writes_membership_external_ctrl
+            .merge(o.writes_membership_external_ctrl);
+        self.reads_player_fused = self.reads_player_fused.union(o.reads_player_fused);
     }
 
     /// CR 603.3b T1 (§1.2): the resolution function never consults the source
@@ -537,6 +747,8 @@ impl RwProfile {
         self.writes_membership_external_zones = ZoneSpan::None;
         self.writes_external_counter_census = Census::None;
         self.writes_pool = false;
+        self.writes_player_span = PlayerSpan::None;
+        self.writes_membership_external_ctrl = PlayerSpan::None;
     }
 }
 
@@ -564,11 +776,48 @@ pub(crate) struct GroupStructure {
     pub(crate) event_object_present: bool,
     /// The live source census, for the membership census-overlap row (§2).
     pub(crate) source_census: SourceCensus,
+    /// PR-6.75 (CR 603.3b + CR 110.2 + CR 108.3): the group is controller-uniform
+    /// AND owner-aligned — every member's pending controller is one shared player
+    /// `c0` and each live source object is both controlled and owned by `c0`. ONLY
+    /// then do the relative player-identity spans (`You`/`Opponents`) denote the
+    /// same concrete players across members (owner-alignment additionally makes
+    /// owner-keyed self-write destinations, CR 400.3 hand/graveyard, controller-
+    /// resolvable). `false` ⇒ NO span/fused refinement is consulted ⇒ the conflict
+    /// decision is byte-identical to the pre-PR engine (structural zero-delta).
+    pub(crate) same_controller: bool,
 }
 
 // ---------------------------------------------------------------------------
 // feeds matrix (§2).
 // ---------------------------------------------------------------------------
+
+/// PR-6.75 gate-scoped span bundle for `feeds` — the effective (already
+/// effective-Any-promoted) relative-player spans of the player-resource and
+/// membership rows plus the `gate` (`same_controller`). When `gate` is false the
+/// span conjuncts collapse to `true`, so the feed matrix is byte-identical.
+#[derive(Clone, Copy)]
+struct SpanGate {
+    gate: bool,
+    read_player: PlayerSpan,
+    write_player: PlayerSpan,
+    read_mctrl: PlayerSpan,
+    write_mctrl: PlayerSpan,
+}
+
+impl SpanGate {
+    /// The ungated bundle (src-row call, §4.5): no player-kind reads route to
+    /// `reads_src`, so the player/membership rows never fire here — `gate = false`
+    /// keeps the conjuncts inert.
+    fn ungated() -> SpanGate {
+        SpanGate {
+            gate: false,
+            read_player: PlayerSpan::None,
+            write_player: PlayerSpan::None,
+            read_mctrl: PlayerSpan::None,
+            write_mctrl: PlayerSpan::None,
+        }
+    }
+}
 
 /// CR 603.3b feed matrix: same-kind rows + the cross rows (`ObjectCounters →
 /// ObjectPt`, `PlayerLife → JournalLife`, `HandLibrary → JournalCards`), with the
@@ -584,14 +833,19 @@ fn feeds(
     write_census: &Census,
     read_zones: &ZoneSpan,
     write_zones: &ZoneSpan,
+    spans: SpanGate,
 ) -> bool {
+    // PR-6.75 (CR 102.2/109.5): under `same_controller`, a player-keyed read and
+    // write of the SAME kind conflict only when their relative-player spans can
+    // name a common player. `!gate` ⇒ byte-identical (conjunct is `true`).
+    let player_ok = !spans.gate || player_span_overlap(spans.read_player, spans.write_player);
+    // PR-6.75 (CR 110.2): same, for the membership same-kind row's controller key.
+    let mctrl_ok = !spans.gate || player_span_overlap(spans.read_mctrl, spans.write_mctrl);
     if (writes.other && reads.any()) || (reads.other && writes.any()) {
         return true;
     }
     if (reads.object_pt && writes.object_pt)
         || (reads.object_counters && writes.object_counters)
-        || (reads.player_life && writes.player_life)
-        || (reads.hand_library && writes.hand_library)
         || (reads.journal_life && writes.journal_life)
         || (reads.journal_cards && writes.journal_cards)
         || (reads.journal_cast && writes.journal_cast)
@@ -601,6 +855,13 @@ fn feeds(
         // sequencing READ. No profiled read produces `turn_structure` today, so
         // this row is dormant — but a future sequencing read fails closed here.
         || (reads.turn_structure && writes.turn_structure)
+    {
+        return true;
+    }
+    // CR 119 / CR 401/402: player-resource same-kind rows, gate-refined by the
+    // relative-player span (Rekindled/Brink — opp-hand read × your-hand write).
+    if (reads.player_life && writes.player_life && player_ok)
+        || (reads.hand_library && writes.hand_library && player_ok)
     {
         return true;
     }
@@ -617,12 +878,15 @@ fn feeds(
         return true;
     }
     // SetMembership same-kind, census- AND zone-refined (§2; CR 205 type tags +
-    // CR 400.1 zones). A battlefield token creation cannot feed a graveyard read
-    // even though both name "creature" — their zones are disjoint (Tombstone).
+    // CR 400.1 zones), and PR-6.75 controller-refined (`mctrl_ok`, CR 110.2). A
+    // battlefield token creation cannot feed a graveyard read even though both
+    // name "creature" — their zones are disjoint (Tombstone); and an opponents'-
+    // board count cannot feed a your-cards battlefield entry (Defense of the Heart).
     if reads.set_membership
         && writes.set_membership
         && census_overlap(read_census, write_census)
         && zone_overlap(read_zones, write_zones)
+        && mctrl_ok
     {
         return true;
     }
@@ -722,6 +986,9 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
         &src_write_census,
         &p.reads_membership_zones,
         &src_write_zones,
+        // §4.5: no player-kind read routes to `reads_src`, so the gated rows never
+        // fire here — pass the inert ungated bundle (fail-closed, documented).
+        SpanGate::ungated(),
     ) {
         return true;
     }
@@ -740,7 +1007,34 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
         p.writes_membership_self,
         &p.writes_membership_self_zones,
     );
-    let board_reads = p.reads_board.union(p.reads_player);
+    // §4.4 fused RMW: the "discards their hand" count read is a symmetric
+    // per-player fixed-point input among identical members ⇒ dropped under the
+    // gate; unioned back into `reads_player` when ungated (byte-identical to today,
+    // where the count read was recorded in `reads_player`).
+    let effective_reads_player = if s.same_controller {
+        p.reads_player
+    } else {
+        p.reads_player.union(p.reads_player_fused)
+    };
+    let board_reads = p.reads_board.union(effective_reads_player);
+    // PR-6.75 effective spans (effective-Any promotes an unrefined-but-present
+    // kind to `Any`). The external membership-ctrl is promoted only when an
+    // EXTERNAL membership write is present (`effective_external.set_membership`);
+    // a self-only membership write contributes `You` via `membership_ctrl_of`.
+    let board_player_read_present =
+        effective_reads_player.player_life || effective_reads_player.hand_library;
+    let board_player_write_present = board_writes.player_life || board_writes.hand_library;
+    let eff_external_ctrl = effective_span(
+        p.writes_membership_external_ctrl,
+        effective_external.set_membership,
+    );
+    let board_spans = SpanGate {
+        gate: s.same_controller,
+        read_player: effective_span(p.reads_player_span, board_player_read_present),
+        write_player: effective_span(p.writes_player_span, board_player_write_present),
+        read_mctrl: effective_span(p.reads_membership_ctrl, board_reads.set_membership),
+        write_mctrl: membership_ctrl_of(board_writes, eff_external_ctrl, p.writes_membership_self),
+    };
     if feeds(
         board_reads,
         board_writes,
@@ -748,6 +1042,7 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
         &board_write_census,
         &p.reads_membership_zones,
         &board_write_zones,
+        board_spans,
     ) {
         return true;
     }
@@ -805,7 +1100,7 @@ fn membership_zones_of(
 /// `ParentTarget` is parentless (§2 rule 1) ⇒ chain-root context starts empty.
 pub(crate) fn ability_rw_profile(a: &ResolvedAbility) -> RwProfile {
     let mut p = RwProfile::empty();
-    walk_ability(a, None, &mut p);
+    walk_ability(a, None, None, PlayerSpan::None, &mut p);
     // CR 603.10a + CR 603.3b: `legacy_batch_prompt` is computed AUTHORITATIVELY by
     // the decoupled `contains_legacy_event_ref` visitor, not by whichever leaf
     // sites the read/write walk happened to descend into. This overwrites (never
@@ -967,6 +1262,14 @@ fn place_membership_write(
     }
     if is_hand_or_library(dest) || origin.is_some_and(is_hand_or_library) {
         p.writes_external.set(StateKind::HandLibrary);
+        // §4.3.4 (CR 400.3 + owner-alignment gate): a SELF hand/library move
+        // (Rekindled Flame's `Bounce{SelfRef}` → hand) touches the owner-of-self's
+        // hand, which equals the controller's under `same_controller` ⇒ You.
+        // External/event/created endpoints leave the span unrefined (`None` ⇒
+        // effective-Any at conflict time).
+        if matches!(sc, WriteScope::SelfSource) {
+            p.writes_player_span = PlayerSpan::You;
+        }
     }
 }
 
@@ -2513,6 +2816,10 @@ fn board_membership_read(filter: &TargetFilter) -> RwProfile {
     // (Tombstone Stairwell's Zombie count reads the GRAVEYARD, not the battlefield
     // its own tokens enter). No `InZone` ⇒ `Any` (fail-closed, unchanged behavior).
     p.reads_membership_zones = zones_of_filter(filter);
+    // §4.3.7 (CR 110.2): the controller-field span the read observes (Defense of
+    // the Heart's "creatures an opponent controls" ⇒ Opponents). Unrefined /
+    // composite filters ⇒ Any.
+    p.reads_membership_ctrl = ctrl_span_of_filter(filter);
     p
 }
 
@@ -2610,7 +2917,13 @@ fn target_recipient(f: &TargetFilter) -> (bool, bool) {
 // Ability walk (mirrors `resolved_ability_axes`, with chain-root threading).
 // ---------------------------------------------------------------------------
 
-fn walk_ability(a: &ResolvedAbility, chain_root: Option<WriteScope>, acc: &mut RwProfile) {
+fn walk_ability(
+    a: &ResolvedAbility,
+    chain_root: Option<WriteScope>,
+    chain_move_owner: Option<PlayerSpan>,
+    pscope_in: PlayerSpan,
+    acc: &mut RwProfile,
+) {
     let ResolvedAbility {
         effect,
         sub_ability,
@@ -2656,15 +2969,21 @@ fn walk_ability(a: &ResolvedAbility, chain_root: Option<WriteScope>, acc: &mut R
         dig_found_nothing_for_parent_target: _,
     } = a;
 
-    let (eff, own_scope) = rw_effect(effect, chain_root);
+    // §4.3.2: a definition's own `player_scope` overrides the inherited scope for
+    // its effect and descendants (matches runtime scoped iteration).
+    let pscope = player_scope
+        .as_ref()
+        .map_or(pscope_in, player_span_of_filter);
+    let (eff, own_scope) = rw_effect(effect, chain_root, pscope, chain_move_owner);
     acc.merge(eff);
     let child_root = own_scope.or(chain_root);
+    let child_move_owner = effect_move_owner(effect).or(chain_move_owner);
 
     if let Some(sub) = sub_ability {
-        walk_ability(sub, child_root, acc);
+        walk_ability(sub, child_root, child_move_owner, pscope, acc);
     }
     if let Some(els) = else_ability {
-        walk_ability(els, chain_root, acc);
+        walk_ability(els, chain_root, chain_move_owner, pscope, acc);
     }
     if let Some(c) = condition {
         acc.merge(rw_ability_condition(c));
@@ -2710,13 +3029,19 @@ fn walk_ability(a: &ResolvedAbility, chain_root: Option<WriteScope>, acc: &mut R
     // cross-choice sibling pair — is order-observable. Independent reflexive-modal
     // choices commute (Voltstorm Angel). Fail-closed: the union over-approximates.
     for m in mode_abilities {
-        walk_definition(m, child_root, acc);
+        walk_definition(m, child_root, child_move_owner, pscope, acc);
     }
 }
 
 /// Descend a choice/RNG sub-body (`AbilityDefinition`). `..`-free so a future
 /// field forces a decision (§2 choice-wrapper / RNG union descent).
-fn walk_definition(a: &AbilityDefinition, chain_root: Option<WriteScope>, acc: &mut RwProfile) {
+fn walk_definition(
+    a: &AbilityDefinition,
+    chain_root: Option<WriteScope>,
+    chain_move_owner: Option<PlayerSpan>,
+    pscope_in: PlayerSpan,
+    acc: &mut RwProfile,
+) {
     let AbilityDefinition {
         effect,
         sub_ability,
@@ -2755,15 +3080,21 @@ fn walk_definition(a: &AbilityDefinition, chain_root: Option<WriteScope>, acc: &
         iteration_kind_binding: _,
     } = a;
 
-    let (eff, own_scope) = rw_effect(effect, chain_root);
+    // §4.3.2: own `player_scope` overrides the inherited scope (Brink's Discard
+    // sub-ability carries `player_scope: Opponent`).
+    let pscope = player_scope
+        .as_ref()
+        .map_or(pscope_in, player_span_of_filter);
+    let (eff, own_scope) = rw_effect(effect, chain_root, pscope, chain_move_owner);
     acc.merge(eff);
     let child_root = own_scope.or(chain_root);
+    let child_move_owner = effect_move_owner(effect).or(chain_move_owner);
 
     if let Some(sub) = sub_ability {
-        walk_definition(sub, child_root, acc);
+        walk_definition(sub, child_root, child_move_owner, pscope, acc);
     }
     if let Some(els) = else_ability {
-        walk_definition(els, chain_root, acc);
+        walk_definition(els, chain_root, chain_move_owner, pscope, acc);
     }
     if let Some(c) = condition {
         acc.merge(rw_ability_condition(c));
@@ -2803,7 +3134,7 @@ fn walk_definition(a: &AbilityDefinition, chain_root: Option<WriteScope>, acc: &
     }
     // §voltstorm (CR 700.2): descend each mode as a union (see `walk_ability`).
     for m in mode_abilities {
-        walk_definition(m, child_root, acc);
+        walk_definition(m, child_root, child_move_owner, pscope, acc);
     }
 }
 
@@ -2900,7 +3231,12 @@ fn damage_writes(target: &TargetFilter) -> RwProfile {
 // Returns (profile, primary object-write scope for chain-root propagation).
 // ---------------------------------------------------------------------------
 
-fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<WriteScope>) {
+fn rw_effect(
+    x: &Effect,
+    chain_root: Option<WriteScope>,
+    pscope: PlayerSpan,
+    chain_move_owner: Option<PlayerSpan>,
+) -> (RwProfile, Option<WriteScope>) {
     // Object write of `kind` targeting `target`, placed by scope.
     let obj = |kind: StateKind, target: &TargetFilter| -> (RwProfile, Option<WriteScope>) {
         let sc = scope_of(target, chain_root);
@@ -2931,10 +3267,11 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         flag_legacy_write_target(&mut p, target);
         (p, Some(sc))
     };
-    // Deferred body (CR 603.7): descend reads, drop writes.
+    // Deferred body (CR 603.7): descend reads, drop writes. Resolved in a future
+    // scope context ⇒ pscope resets to unscoped (`None`; reads stay conservative).
     let deferred = |def: &AbilityDefinition| -> RwProfile {
         let mut p = RwProfile::empty();
-        walk_definition(def, None, &mut p);
+        walk_definition(def, None, None, PlayerSpan::None, &mut p);
         p.drop_writes();
         p
     };
@@ -2998,13 +3335,43 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         }
         Effect::Discard {
             count,
-            target: _,
+            target,
             unless_filter: _,
             filter: _,
             selection: _,
         } => {
             let mut p = ext_write(StateKind::HandLibrary);
-            p.merge(rw_quantity_expr(count));
+            // CR 401/402 (+ CR 400.3 owner-keyed hand): the discarding player's
+            // hand. From the scoped-player iteration context when present (Brink:
+            // each opponent ⇒ Opponents), else the effect target (`Controller` ⇒
+            // You), else `Any` (fail-closed).
+            p.writes_player_span = if pscope != PlayerSpan::None {
+                pscope
+            } else if matches!(target, TargetFilter::Controller) {
+                PlayerSpan::You
+            } else {
+                PlayerSpan::Any
+            };
+            // §4.4 fused read-modify-write: `Discard{count: HandSize{ScopedPlayer},
+            // target: Controller}` — "discards their hand" reads the very hand this
+            // instruction empties. Its per-player fixed point composes symmetrically
+            // among identical members (Canopy Gargantuan RwProfile doc), so record
+            // it in `reads_player_fused` (dropped under the gate, unioned back into
+            // `reads_player` when ungated ⇒ byte-identical). Otherwise the count is a
+            // genuine player read.
+            let fused = matches!(
+                count,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize {
+                        player: PlayerScope::ScopedPlayer
+                    }
+                }
+            ) && matches!(target, TargetFilter::Controller);
+            if fused {
+                p.reads_player_fused.set(StateKind::HandLibrary);
+            } else {
+                p.merge(rw_quantity_expr(count));
+            }
             (p, None)
         }
         Effect::DiscardCard {
@@ -3243,7 +3610,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             target,
             owner_library: _,
             enter_transformed: _,
-            enters_under: _,
+            enters_under,
             enter_tapped: _,
             enters_attacking: _,
             up_to: _,
@@ -3253,6 +3620,30 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             enters_modified_if: _,
         } => {
             let (mut p, sc) = mem(target, *origin, *destination);
+            // §4.3.6 / §10.4 ENGINE COUPLING (CR 110.2 + CR 110.2a; the entering
+            // controller default is the moved card's OWNER, `change_zone.rs:79`
+            // "None keeps the default (owner's control)" — NOT the CR 110.2a
+            // instructing-player default). The membership-controller span of an
+            // EXTERNAL battlefield entry:
+            //   * `enters_under Some(cref)` ⇒ the ControllerRef's span (CR 110.2a).
+            //   * no `enters_under`, opaque forwarded set (`Any`/`ParentTarget`)
+            //     from `Library` ⇒ the inherited chain move-owner fact (CR 400.3: a
+            //     library holds only its owner's cards; a search of the controller's
+            //     own library ⇒ owner == controller ⇒ You — Defense of the Heart).
+            //   * otherwise `Any` (fail-closed). If `change_zone.rs:79`'s default
+            //     ever changes, revisit this arm and `effect_move_owner`.
+            if *destination == Zone::Battlefield && matches!(sc, Some(WriteScope::External)) {
+                p.writes_membership_external_ctrl = match enters_under {
+                    Some(cref) => player_span_of_ctrl_ref(cref),
+                    None => {
+                        if *origin == Some(Zone::Library) && is_opaque_forwarded_target(target) {
+                            chain_move_owner.unwrap_or(PlayerSpan::Any)
+                        } else {
+                            PlayerSpan::Any
+                        }
+                    }
+                };
+            }
             for (_ct, q) in enter_with_counters {
                 p.merge(rw_quantity_expr(q));
             }
@@ -3362,7 +3753,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             filter: _,
             count,
             reveal: _,
-            target_player: _,
+            target_player,
             selection_constraint: _,
             split: _,
         } => {
@@ -3370,6 +3761,16 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             p.writes_external.set(StateKind::HandLibrary);
             p.writes_membership_external_census.merge(Census::Any);
             p.writes_membership_external_zones.merge(ZoneSpan::Any);
+            // §4.3.5 (CR 400.3): searching the controller's OWN library (no
+            // `target_player`, or a `Controller`-form one) touches only owner ==
+            // controller cards ⇒ the phantom membership write's controller / hand
+            // spans are You. A search of another player's library leaves both
+            // unrefined (`None` ⇒ effective-Any). The chained ChangeZone entry
+            // consumes the emitted `effect_move_owner` fact (§10.4 both ends).
+            if target_player.is_none() || matches!(target_player, Some(TargetFilter::Controller)) {
+                p.writes_membership_external_ctrl = PlayerSpan::You;
+                p.writes_player_span = PlayerSpan::You;
+            }
             p.merge(rw_quantity_expr(count));
             (p, None)
         }
@@ -3824,7 +4225,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             uses_tracked_set: _,
         } => (deferred(effect), None),
         Effect::CreateDrawReplacement { replacement_effect } => {
-            let (mut b, _) = rw_effect(replacement_effect, None);
+            let (mut b, _) = rw_effect(replacement_effect, None, pscope, chain_move_owner);
             b.drop_writes();
             (b, None)
         }
@@ -3867,7 +4268,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         Effect::ChooseOneOf { chooser, branches } => {
             let mut p = rw_player_filter(chooser);
             for b in branches {
-                walk_definition(b, chain_root, &mut p);
+                walk_definition(b, chain_root, chain_move_owner, pscope, &mut p);
             }
             (p, None)
         }
@@ -3885,7 +4286,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         } => {
             let mut p = rw_controller_ref(starting_with);
             for b in per_choice_effect {
-                walk_definition(b, chain_root, &mut p);
+                walk_definition(b, chain_root, chain_move_owner, pscope, &mut p);
             }
             (p, None)
         }
@@ -3899,7 +4300,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         } => {
             let mut p = rw_quantity_expr(count);
             for r in results {
-                walk_definition(&r.effect, chain_root, &mut p);
+                walk_definition(&r.effect, chain_root, chain_move_owner, pscope, &mut p);
             }
             (p, None)
         }
@@ -3910,10 +4311,10 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         } => {
             let mut p = RwProfile::empty();
             if let Some(w) = win_effect {
-                walk_definition(w, chain_root, &mut p);
+                walk_definition(w, chain_root, chain_move_owner, pscope, &mut p);
             }
             if let Some(l) = lose_effect {
-                walk_definition(l, chain_root, &mut p);
+                walk_definition(l, chain_root, chain_move_owner, pscope, &mut p);
             }
             (p, None)
         }
@@ -3925,16 +4326,16 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         } => {
             let mut p = rw_quantity_expr(count);
             if let Some(w) = win_effect {
-                walk_definition(w, chain_root, &mut p);
+                walk_definition(w, chain_root, chain_move_owner, pscope, &mut p);
             }
             if let Some(l) = lose_effect {
-                walk_definition(l, chain_root, &mut p);
+                walk_definition(l, chain_root, chain_move_owner, pscope, &mut p);
             }
             (p, None)
         }
         Effect::FlipCoinUntilLose { win_effect } => {
             let mut p = RwProfile::empty();
-            walk_definition(win_effect, chain_root, &mut p);
+            walk_definition(win_effect, chain_root, chain_move_owner, pscope, &mut p);
             (p, None)
         }
 
@@ -4278,7 +4679,13 @@ fn rw_quantity_expr(x: &QuantityExpr) -> RwProfile {
 
 fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
     match x {
-        QuantityRef::HandSize { .. } => reads_player_of(StateKind::HandLibrary),
+        // §4.3.1 (CR 401/402): a hand-size read, refined by its player axis
+        // (Rekindled `Opponent` ⇒ Opponents, Brink cond `Controller` ⇒ You).
+        QuantityRef::HandSize { player } => {
+            let mut p = reads_player_of(StateKind::HandLibrary);
+            p.reads_player_span = player_span_of_scope(player);
+            p
+        }
         QuantityRef::LifeTotal { player: _ } | QuantityRef::LifeAboveStarting => {
             reads_player_of(StateKind::PlayerLife)
         }
@@ -5071,6 +5478,9 @@ mod tests {
             event_object_excludes_sources: excludes,
             event_object_present: present,
             source_census,
+            // PR-6.75: default false ⇒ every prior verdict is byte-preserved (spans
+            // unconsulted). The §4.3 span pins below set it true explicitly.
+            same_controller: false,
         }
     }
 
@@ -6076,17 +6486,18 @@ mod tests {
             "subtract clears TurnStructure"
         );
         let (nc, nz) = (Census::None, ZoneSpan::None);
+        let sg = SpanGate::ungated();
         assert!(
-            feeds(ts, ts, &nc, &nc, &nz, &nz),
+            feeds(ts, ts, &nc, &nc, &nz, &nz, sg),
             "TurnStructure read × write ⇒ self-conflict"
         );
         let pt = KindSet::one(StateKind::ObjectPt);
         assert!(
-            !feeds(pt, ts, &nc, &nc, &nz, &nz),
+            !feeds(pt, ts, &nc, &nc, &nz, &nz, sg),
             "TurnStructure write does not feed ObjectPt"
         );
         assert!(
-            !feeds(ts, pt, &nc, &nc, &nz, &nz),
+            !feeds(ts, pt, &nc, &nc, &nz, &nz, sg),
             "ObjectPt write does not feed TurnStructure"
         );
     }
@@ -6094,5 +6505,159 @@ mod tests {
     // ---- test-local helper ----
     fn def(effect: Effect) -> AbilityDefinition {
         AbilityDefinition::new(AbilityKind::Spell, effect)
+    }
+
+    // ===================== PR-6.75 S-7 per-arm span pins =====================
+    // Shape-level pins on each refined extraction arm's span field, paired
+    // positive/negative on the arm's own axis. These SUPPORT the S1–S6
+    // production-path discriminators (which drive `group_is_order_independent`).
+
+    fn discard(count: QuantityExpr, target: TargetFilter) -> Effect {
+        Effect::Discard {
+            count,
+            target,
+            unless_filter: None,
+            filter: None,
+            selection: crate::types::ability::CardSelectionMode::Chosen,
+        }
+    }
+    fn handsize(player: PlayerScope) -> QuantityExpr {
+        qref(QuantityRef::HandSize { player })
+    }
+    fn opp_scope() -> PlayerScope {
+        PlayerScope::Opponent {
+            aggregate: crate::types::ability::AggregateFunction::Min,
+        }
+    }
+    fn scoped(mut a: ResolvedAbility, pf: PlayerFilter) -> ResolvedAbility {
+        a.player_scope = Some(pf);
+        a
+    }
+    fn search_own() -> Effect {
+        Effect::SearchLibrary {
+            source_zones: vec![Zone::Library],
+            filter: creature(),
+            count: qfix(1),
+            reveal: false,
+            target_player: None,
+            selection_constraint: crate::types::ability::SearchSelectionConstraint::None,
+            split: None,
+        }
+    }
+    fn change_zone_under(target: TargetFilter, enters_under: Option<ControllerRef>) -> Effect {
+        Effect::ChangeZone {
+            origin: Some(Zone::Library),
+            destination: Zone::Battlefield,
+            target,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under,
+            enter_tapped: crate::types::zones::EtbTapState::default(),
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        }
+    }
+    fn bounce(target: TargetFilter) -> Effect {
+        Effect::Bounce {
+            target,
+            destination: None,
+            selection: crate::types::ability::BounceSelection::default(),
+        }
+    }
+
+    #[test]
+    fn s7_handsize_read_span_player_axis() {
+        // §4.3.1: HandSize player axis → reads_player_span (You vs Opponents).
+        let you = ability_rw_profile(&ra(Effect::Draw {
+            count: handsize(PlayerScope::Controller),
+            target: TargetFilter::Controller,
+        }));
+        assert_eq!(you.reads_player_span, PlayerSpan::You);
+        let opp = ability_rw_profile(&ra(Effect::Draw {
+            count: handsize(opp_scope()),
+            target: TargetFilter::Controller,
+        }));
+        assert_eq!(opp.reads_player_span, PlayerSpan::Opponents);
+    }
+
+    #[test]
+    fn s7_discard_write_span_scope_threading() {
+        // §4.3.3: scoped-Opponent Discard ⇒ Opponents; unscoped, target Controller ⇒ You.
+        let scoped_opp = scoped(
+            ra(discard(qfix(1), TargetFilter::Controller)),
+            PlayerFilter::Opponent,
+        );
+        assert_eq!(
+            ability_rw_profile(&scoped_opp).writes_player_span,
+            PlayerSpan::Opponents
+        );
+        let you = ra(discard(qfix(1), TargetFilter::Controller));
+        assert_eq!(ability_rw_profile(&you).writes_player_span, PlayerSpan::You);
+    }
+
+    #[test]
+    fn s7_discard_fused_pattern_match_and_non_match() {
+        // §4.4: fused count HandSize{ScopedPlayer} + target Controller ⇒
+        // reads_player_fused, NOT reads_player.
+        let fused = ability_rw_profile(&ra(discard(
+            handsize(PlayerScope::ScopedPlayer),
+            TargetFilter::Controller,
+        )));
+        assert!(fused.reads_player_fused.hand_library);
+        assert!(!fused.reads_player.hand_library);
+        // Non-fused: a genuine opp-hand count ⇒ reads_player, NOT fused.
+        let plain = ability_rw_profile(&ra(discard(
+            handsize(opp_scope()),
+            TargetFilter::Controller,
+        )));
+        assert!(plain.reads_player.hand_library);
+        assert!(!plain.reads_player_fused.hand_library);
+        // Non-fused: HandSize{ScopedPlayer} but target NOT Controller ⇒ not fused.
+        let wrong_target = ability_rw_profile(&ra(discard(
+            handsize(PlayerScope::ScopedPlayer),
+            TargetFilter::Any,
+        )));
+        assert!(!wrong_target.reads_player_fused.hand_library);
+        assert!(wrong_target.reads_player.hand_library);
+    }
+
+    #[test]
+    fn s7_search_change_zone_chain_fact() {
+        // §4.3.5/6: Search(own library) → ChangeZone{Library→Bf, Any} ⇒ You.
+        let present = ra(search_own()).sub_ability(ra(change_zone_under(TargetFilter::Any, None)));
+        assert_eq!(
+            ability_rw_profile(&present).writes_membership_external_ctrl,
+            PlayerSpan::You
+        );
+        // Explicit enters_under Opponent conflicts with the search's You ⇒ Any.
+        let opp_entry = ra(search_own()).sub_ability(ra(change_zone_under(
+            TargetFilter::Any,
+            Some(ControllerRef::Opponent),
+        )));
+        assert_eq!(
+            ability_rw_profile(&opp_entry).writes_membership_external_ctrl,
+            PlayerSpan::Any
+        );
+        // Absent chain (bare ChangeZone, no search, no enters_under) ⇒ Any (fail-closed).
+        let absent = ability_rw_profile(&ra(change_zone_under(TargetFilter::Any, None)));
+        assert_eq!(absent.writes_membership_external_ctrl, PlayerSpan::Any);
+    }
+
+    #[test]
+    fn s7_self_bounce_hand_span() {
+        // §4.3.4: a self hand-move (Bounce{SelfRef}→hand) ⇒ You; an external bounce
+        // leaves the hand write unrefined (None ⇒ effective-Any at conflict time).
+        assert_eq!(
+            ability_rw_profile(&ra(bounce(TargetFilter::SelfRef))).writes_player_span,
+            PlayerSpan::You
+        );
+        assert_eq!(
+            ability_rw_profile(&ra(bounce(creature()))).writes_player_span,
+            PlayerSpan::None
+        );
     }
 }

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -30,18 +30,41 @@
 //! exposure on the batch path is thus identical to the same-event T1 path already
 //! documented, and bounded by the §7.1 `old=false, new=true` zero-movement grep.
 //!
-//! A SECOND inherited fail-open: `reads_event_live` is consulted ONLY on the
-//! batch path (`profiles_conflict`: the `all_same_source` fast path and the
-//! freeze-invalidation row, both guarded `!same_event`) — never in same-event
-//! feed analysis. So a same-event group that WRITES the triggering object and
-//! then READS that now-modified object's characteristic ("put a +1/+1 counter on
-//! it, then transform ~ if that creature's power ≥ 6" ×2 — order-observable,
-//! `source_independent` false so the T1 fast path is skipped, yet the
-//! event-object read×write feed is uncaught ⇒ auto) is not gated. This is
-//! DISTINCT from the PR-6.25 Case A board-write × source-read feed (which IS
-//! caught). Like the source-actor residual it is inherited from the pre-C1
-//! always-auto short-circuit (NOT a regression) and is left OPEN deliberately:
-//! closing it would ADD a prompt = a D3 widening needing its own proof.
+//! ## The event-object read/write feed (R4 review) — CLOSED at both depths
+//!
+//! A same-event group that WRITES the shared triggering object and then READS its
+//! LIVE characteristic ("put a +1/+1 counter on it, then transform ~ if that
+//! creature's power ≥ 6" ×2) is order-observable (CR 608.2h: the read uses the event
+//! object's CURRENT information). `reads_event_live` records no KindSet, so the
+//! `feeds()` matrix is structurally blind to it — the feed is instead gated by
+//! `reads_and_writes_event_object` (`reads_event_live && writes_event_object.any()`):
+//! the same-event discriminator (`s.same_event && s.event_object_present &&
+//! reads_and_writes_event_object`) PROMPTS it, and the T1 fast-path disjunct excludes
+//! it. The BATCH depth is protected differently: a co-departure event object is a
+//! DEPARTED, FROZEN LKI (CR 603.10a) — a write no-ops (stable read ⇒ auto correct) or
+//! is a reentry hazard ⇒ the freeze-invalidation row prompts. The `event_object_present`
+//! conjunct mirrors `effective_external` (a write to a non-present event object no-ops,
+//! targeting.rs:951), so a Phase-mode trigger stays auto (no live object ⇒ no feed).
+//!
+//! ## Residuals that REMAIN — both SYMMETRIC across batch and same-event depths
+//!
+//! 1. The **source-actor residual** (above): per-source granted state and the
+//!    CR 800.4a player-loss cascade, invisible to the normalized AST.
+//! 2. A **board-wide external write × event-live read**: a `writes_external` write NOT
+//!    scoped to the event object (e.g. "each creature") that happens to mutate the
+//!    event object, feeding an event-live read. `reads_and_writes_event_object` keys on
+//!    `writes_event_object` (event-object-SCOPED writes) only, and `feeds()` stays blind
+//!    (the live read carries no KindSet) — so this is uncaught. It is SYMMETRIC: the
+//!    batch T1 conjunct also keys on `writes_event_object` (not `writes_external`), so
+//!    the batch depth is equally open. Closing it needs either KindSet-recording
+//!    event-live reads (so `feeds()` catches board writes) or promoting any
+//!    `writes_external` to an event-object write under `reads_event_live` (a large
+//!    over-prompt) — out of scope; documented-open.
+//!
+//! Both residuals are profile-INVISIBLE (the dependency is absent from the profiled
+//! read/write sets) and equal-strength across depths. The gate is therefore sound
+//! MODULO these two symmetric residuals — the exact scope the `group_is_order_
+//! independent` contract (triggers.rs) records.
 //!
 //! # M3 binding mandate (review-blocking)
 //!
@@ -556,9 +579,12 @@ pub(crate) struct RwProfile {
     /// CR 603.10a look-back class: `HadCounters`, source cast-time facts. Never
     /// conflict WHILE THE FREEZE IS VALID (see `writes_reentry_hazard`).
     reads_frozen: KindSet,
-    /// Event reads not proven frozen (`EventSource`/`EventTarget`/…). Consulted
-    /// by T1's fast path and the freeze-invalidation row; the batch structure
-    /// treats them as frozen.
+    /// An event-context read: a LIVE event-object characteristic (`EventSource`/
+    /// `EventTarget`) OR a frozen event-context amount (`EventContextAmount`/
+    /// `EventOutcomeWon`/… via `legacy_ref`) — the bit does not distinguish them.
+    /// Consulted by T1's fast path, the freeze-invalidation row, and the same-event
+    /// event-object discriminator (which thus conservatively over-prompts the frozen
+    /// sub-case — a write can't feed a frozen amount, so it stays order-invariant).
     reads_event_live: bool,
     /// D5: one of the 12 retained-prompt event-context refs is present.
     /// Consulted ONLY by the batch branch (commit 2).
@@ -744,6 +770,20 @@ impl RwProfile {
     /// `reads_frozen`).
     pub(crate) fn source_independent(&self) -> bool {
         self.reads_src.is_empty() && self.writes_self.is_empty() && self.reads_frozen.is_empty()
+    }
+
+    /// CR 603.3b + CR 608.2h: the same-event event-object read/write feed — the
+    /// resolution WRITES the shared triggering object (`writes_event_object`) AND
+    /// READS its live characteristic (`reads_event_live`, which records NO KindSet,
+    /// so `feeds()` is structurally blind to this feed). On the same-event path every
+    /// member shares ONE live event object (CR 608.2h current-information read), so a
+    /// member's write is observed by a sibling's live read ⇒ order-observable.
+    /// Fail-closed conjunction of two profiled facts. Consumed by
+    /// `profiles_conflict`'s same-event discriminator and (as the class predicate) by
+    /// the ordering-parity sweep — a single source of truth (mirrors
+    /// `source_independent`).
+    pub(crate) fn reads_and_writes_event_object(&self) -> bool {
+        self.reads_event_live && self.writes_event_object.any()
     }
 
     /// D5 (CR 603.10a): true iff one of the 12 retained-prompt event-context refs
@@ -973,9 +1013,23 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
     // ExiledBySource / ChosenCard, `member_bound_target_filter`) is NOT one shared
     // f(state) — member A reads A's storage, member B reads B's — so the identical-
     // function commutation proof breaks and the group must prompt (discriminator
-    // below). `all_same_source` stays exempt: one shared source ⇒ one shared storage
-    // ⇒ f_A = f_B literally, order-independent.
-    if s.same_event && (s.all_same_source || (p.source_independent() && !p.reads_member_bound)) {
+    // below). It ALSO requires `!reads_and_writes_event_object`: a same-event group
+    // can be `source_independent` yet WRITE the shared triggering object and READ its
+    // live characteristic (`writes_event_object` ∉ `writes_self`, `reads_event_live` ∉
+    // `reads_src`) — an order-observable feed `feeds()` cannot see (CR 608.2h; the
+    // event-object discriminator below). The event-object conjunct is gated on
+    // `s.event_object_present` — mirroring `effective_external` (below), which drops
+    // `writes_event_object` when the trigger carries no event object (the write
+    // no-ops, targeting.rs:951): with no live event object there is no feed, so such
+    // a group stays on the fast path (auto). `all_same_source` stays exempt: one
+    // shared source ⇒ one shared storage AND one shared event object ⇒ f_A = f_B
+    // literally (deterministic accumulation), order-independent.
+    if s.same_event
+        && (s.all_same_source
+            || (p.source_independent()
+                && !p.reads_member_bound
+                && !(s.event_object_present && p.reads_and_writes_event_object())))
+    {
         return false;
     }
     // CR 603.3b + CR 603.10a: the same-event member-bound discriminator (the batch
@@ -986,6 +1040,28 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
     // handles member-bound via its own conjunct plus the freeze/feed rows, so batch
     // ordering decisions are byte-inert.
     if s.same_event && p.reads_member_bound {
+        return true;
+    }
+    // CR 603.3b + CR 608.2h: the same-event event-object read/write feed
+    // discriminator. `reads_event_live` (EventSource/EventTarget characteristic
+    // reads, CR 608.2h current-information) records NO KindSet, so `feeds()` cannot
+    // see a `writes_event_object` mutation feeding an event-object LIVE read. Same-
+    // event members share ONE live event object ⇒ a member's event-object write is
+    // observed by a sibling's live read ⇒ order-observable. DERIVED (not copied) from
+    // the batch-T1 event-object conjunct (`!reads_event_live && !writes_event_object
+    // .any()`): that guard is a disjunction-of-negations because refusing the batch
+    // fast path only DEFERS to the feed rows, whereas this returns a PROMPT, so it
+    // fires only on a real feed = BOTH endpoints (a conjunction, `reads_and_writes_
+    // event_object`). Gated on `s.event_object_present` (mirrors `effective_external`
+    // below): no live event object ⇒ the `writes_event_object` write no-ops
+    // (targeting.rs:951) ⇒ no feed ⇒ auto (a genuine feed always has a live event
+    // object, so this never drops one). `all_same_source` stays auto-ordered (returned
+    // false at the fast path above — one shared source ⇒ identical f over one shared
+    // event object, deterministic accumulation, order-immaterial). Guarded by
+    // `s.same_event`; the batch path is byte-inert (its event-object reads are frozen
+    // LKI, CR 603.10a, handled by the freeze-invalidation row below — the
+    // batch/same-event asymmetry).
+    if s.same_event && s.event_object_present && p.reads_and_writes_event_object() {
         return true;
     }
     if s.all_same_source && !p.reads_event_live {
@@ -6136,6 +6212,64 @@ mod tests {
         assert!(
             !profiles_conflict(&p, &batch_uniform()),
             "B-4 revert: without the event-object write, T1 auto-orders"
+        );
+    }
+
+    /// R4 — the same-event event-object read/write feed discriminator
+    /// (`profiles_conflict`: `s.same_event && s.event_object_present &&
+    /// reads_and_writes_event_object`, CR 603.3b + CR 608.2h). A same-event group of
+    /// DISTINCT sources that WRITES the shared triggering object AND READS its live
+    /// characteristic is order-observable — but `feeds()` is structurally blind
+    /// (`reads_event_live` records no KindSet). This pins the fix + all three guards.
+    /// Revert-fail (measured): the NEG is `source_independent`, so BOTH edits are
+    /// load-bearing — dropping the `:992` fast-path exclusion auto-orders it at the
+    /// T1 disjunct, and dropping the discriminator lets it fall through every row to
+    /// the final `return false` (the feed rows never see the KindSet-less live read).
+    #[test]
+    fn r4_same_event_event_object_feed_conjunct() {
+        let feed = || {
+            let mut p = RwProfile::empty();
+            p.reads_event_live = true;
+            p.writes_external = KindSet::one(StateKind::ObjectCounters);
+            p.writes_event_object = KindSet::one(StateKind::ObjectCounters);
+            p
+        };
+        // NEG (the fix): same-event, event object present, live read × event-object
+        // write ⇒ PROMPT. `se()` is distinct-source, event_object_present true.
+        assert!(
+            profiles_conflict(&feed(), &se()),
+            "R4 NEG: same-event event-object read×write feed ⇒ prompt"
+        );
+        // Conjunction guard A — the live READ alone (no event-object write) ⇒ AUTO.
+        // Proves it is a feed (both endpoints), not a blanket same-event event-live
+        // prompt: `reads_event_live` alone stays source-independent T1-clean.
+        let mut read_only = feed();
+        read_only.writes_external = KindSet::EMPTY;
+        read_only.writes_event_object = KindSet::EMPTY;
+        assert!(
+            !profiles_conflict(&read_only, &se()),
+            "R4 guard-A: event-live read with NO event-object write ⇒ auto"
+        );
+        // Conjunction guard B — the event-object WRITE alone (no live read) ⇒ AUTO
+        // (an unread write is applied identically by every member, order-invariant).
+        let mut write_only = feed();
+        write_only.reads_event_live = false;
+        assert!(
+            !profiles_conflict(&write_only, &se()),
+            "R4 guard-B: event-object write with NO event-live read ⇒ auto"
+        );
+        // event_object_present guard — the full feed but a Phase event (no live event
+        // object; the write no-ops, targeting.rs:951) ⇒ AUTO (mirrors effective_external).
+        assert!(
+            !profiles_conflict(&feed(), &se_phase()),
+            "R4 event_object_present guard: no live event object ⇒ write no-ops ⇒ auto"
+        );
+        // all_same_source guard — the feed on ONE shared source ⇒ identical f over one
+        // shared event object (deterministic accumulation) ⇒ AUTO.
+        let same_src = gs(true, true, false, false, true, SourceCensus::unknown());
+        assert!(
+            !profiles_conflict(&feed(), &same_src),
+            "R4 all_same_source guard: shared source ⇒ f_A = f_B ⇒ auto"
         );
     }
 

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -753,6 +753,17 @@ impl RwProfile {
         self.legacy_batch_prompt
     }
 
+    /// CR 603.10a: true iff the resolution reads per-member-bound storage
+    /// (`member_bound_target_filter` carriers). Test-only read accessor for the
+    /// parity sweep's same-event over-prompt CLASS classifier (mirrors the
+    /// discriminator gate `profiles_conflict`: `if s.same_event && p.reads_member_bound`).
+    /// Production reads the field directly in `profiles_conflict`, so the accessor
+    /// exists only for the cross-module `ordering_parity_tests`.
+    #[cfg(test)]
+    pub(crate) fn reads_member_bound(&self) -> bool {
+        self.reads_member_bound
+    }
+
     /// Drop all writes (deferred-body descent, CR 603.7: writes happen
     /// post-window, so reads descend but writes are not counted).
     fn drop_writes(&mut self) {
@@ -956,9 +967,26 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
         return true;
     }
     // T1 identical-function fast paths (§1.2), sound modulo the source-actor
-    // residual.
-    if s.same_event && (s.all_same_source || p.source_independent()) {
+    // residual. The `source_independent` disjunct additionally requires
+    // `!reads_member_bound`: a same-event group of DISTINCT sources whose identical
+    // resolution reads per-source bound storage (CR 603.10a look-back — TrackedSet /
+    // ExiledBySource / ChosenCard, `member_bound_target_filter`) is NOT one shared
+    // f(state) — member A reads A's storage, member B reads B's — so the identical-
+    // function commutation proof breaks and the group must prompt (discriminator
+    // below). `all_same_source` stays exempt: one shared source ⇒ one shared storage
+    // ⇒ f_A = f_B literally, order-independent.
+    if s.same_event && (s.all_same_source || (p.source_independent() && !p.reads_member_bound)) {
         return false;
+    }
+    // CR 603.3b + CR 603.10a: the same-event member-bound discriminator (the batch
+    // path's `!reads_member_bound` conjunct, mirrored for same-event depth). A
+    // same-event group that reaches here with per-source bound storage has distinct
+    // sources (`all_same_source` was auto-ordered above) and cannot prove
+    // commutation — prompt fail-closed. Guarded by `s.same_event`; the batch path
+    // handles member-bound via its own conjunct plus the freeze/feed rows, so batch
+    // ordering decisions are byte-inert.
+    if s.same_event && p.reads_member_bound {
+        return true;
     }
     if s.all_same_source && !p.reads_event_live {
         return false;

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -75,7 +75,7 @@ use crate::types::ability::{
     AbilityCondition, AbilityDefinition, ContinuousModification, ControllerRef, Duration, Effect,
     ModalChoice, MultiTargetSpec, ObjectScope, PlayerFilter, PlayerScope, QuantityExpr,
     QuantityRef, RepeatContinuation, ResolvedAbility, StaticCondition, StaticDefinition,
-    TargetFilter, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
+    TargetFilter, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::game_state::TargetSelectionConstraint;
 use crate::types::zones::Zone;
@@ -109,6 +109,14 @@ pub(crate) enum StateKind {
     StackShape,
     /// CR 301.5/302.6: tap state.
     TapState,
+    /// CR 500 (turn structure) + CR 506.4c (remove from combat) + CR 614.10
+    /// (skip step/turn): game-sequencing writes — extra turns/phases, skipped
+    /// steps, combat removal. Idempotent/additive among identical siblings (two
+    /// extra turns commute; removing an already-removed creature is a no-op) and
+    /// observed by NO profiled read, so this kind only self-conflicts (a future
+    /// sequencing READ would fail-closed against it) — never the `Other`
+    /// catch-all, which conflicts with every read.
+    TurnStructure,
     /// Unclassifiable — conflicts with everything (fail-closed).
     Other,
 }
@@ -126,6 +134,7 @@ pub(crate) struct KindSet {
     journal_cast: bool,
     stack_shape: bool,
     tap_state: bool,
+    turn_structure: bool,
     other: bool,
 }
 
@@ -141,6 +150,7 @@ impl KindSet {
         journal_cast: false,
         stack_shape: false,
         tap_state: false,
+        turn_structure: false,
         other: false,
     };
     const ALL: KindSet = KindSet {
@@ -154,6 +164,7 @@ impl KindSet {
         journal_cast: true,
         stack_shape: true,
         tap_state: true,
+        turn_structure: true,
         other: true,
     };
 
@@ -174,6 +185,7 @@ impl KindSet {
             StateKind::JournalCast => self.journal_cast = true,
             StateKind::StackShape => self.stack_shape = true,
             StateKind::TapState => self.tap_state = true,
+            StateKind::TurnStructure => self.turn_structure = true,
             StateKind::Other => self.other = true,
         }
     }
@@ -189,6 +201,7 @@ impl KindSet {
             journal_cast: self.journal_cast || o.journal_cast,
             stack_shape: self.stack_shape || o.stack_shape,
             tap_state: self.tap_state || o.tap_state,
+            turn_structure: self.turn_structure || o.turn_structure,
             other: self.other || o.other,
         }
     }
@@ -204,6 +217,7 @@ impl KindSet {
             journal_cast: self.journal_cast && !o.journal_cast,
             stack_shape: self.stack_shape && !o.stack_shape,
             tap_state: self.tap_state && !o.tap_state,
+            turn_structure: self.turn_structure && !o.turn_structure,
             other: self.other && !o.other,
         }
     }
@@ -392,6 +406,15 @@ pub(crate) struct RwProfile {
     /// (`ChangeZone{SelfRef}`) or a `CopyTokenOf{SelfRef}` created copy (CR 707.2,
     /// §1.3.1-F). `membership_census_of` merges `source_census` when this is set.
     writes_membership_self: bool,
+    /// CR 400.1: the zone(s) a self-scoped `SetMembership` write touches. A self
+    /// MOVE (`ChangeZone{SelfRef}`) records its actual origin+destination; a self
+    /// CREATION (`CopyTokenOf{SelfRef}`, CR 111.1) touches only the battlefield.
+    /// Previously every self membership write forced `Any` (fail-closed), so a
+    /// battlefield self-copy falsely fed a graveyard/departure read (Compy Swarm ×
+    /// "a creature died this turn"). `Any` stays the default when a self write's
+    /// endpoints are unrecorded, and a self-sacrifice (bf→graveyard) still overlaps
+    /// a graveyard read (Chorale of the Void).
+    writes_membership_self_zones: ZoneSpan,
     /// Census of external/creation/event-object `SetMembership` writes.
     writes_membership_external_census: Census,
     /// CR 400.1: zones the external/creation/event-object `SetMembership` writes
@@ -430,6 +453,7 @@ impl RwProfile {
             writes_created: KindSet::EMPTY,
             writes_reentry_hazard: false,
             writes_membership_self: false,
+            writes_membership_self_zones: ZoneSpan::None,
             writes_membership_external_census: Census::None,
             writes_membership_external_zones: ZoneSpan::None,
             reads_membership_census: Census::None,
@@ -449,6 +473,7 @@ impl RwProfile {
         p.writes_membership_external_census = Census::Any;
         p.writes_membership_external_zones = ZoneSpan::Any;
         p.writes_membership_self = true;
+        p.writes_membership_self_zones = ZoneSpan::Any;
         p.reads_membership_census = Census::Any;
         p.reads_membership_zones = ZoneSpan::Any;
         p.writes_external_counter_census = Census::Any;
@@ -468,6 +493,8 @@ impl RwProfile {
         self.writes_created = self.writes_created.union(o.writes_created);
         self.writes_reentry_hazard |= o.writes_reentry_hazard;
         self.writes_membership_self |= o.writes_membership_self;
+        self.writes_membership_self_zones
+            .merge(o.writes_membership_self_zones);
         self.writes_membership_external_census
             .merge(o.writes_membership_external_census);
         self.writes_membership_external_zones
@@ -505,6 +532,7 @@ impl RwProfile {
         self.writes_created = KindSet::EMPTY;
         self.writes_reentry_hazard = false;
         self.writes_membership_self = false;
+        self.writes_membership_self_zones = ZoneSpan::None;
         self.writes_membership_external_census = Census::None;
         self.writes_membership_external_zones = ZoneSpan::None;
         self.writes_external_counter_census = Census::None;
@@ -569,6 +597,10 @@ fn feeds(
         || (reads.journal_cast && writes.journal_cast)
         || (reads.stack_shape && writes.stack_shape)
         || (reads.tap_state && writes.tap_state)
+        // CR 500 / CR 506.4c / CR 614.10: sequencing writes only conflict with a
+        // sequencing READ. No profiled read produces `turn_structure` today, so
+        // this row is dormant — but a future sequencing read fails closed here.
+        || (reads.turn_structure && writes.turn_structure)
     {
         return true;
     }
@@ -678,6 +710,7 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
         src_writes,
         &p.writes_membership_external_zones,
         src_self_membership,
+        &p.writes_membership_self_zones,
     );
     if s.all_same_source {
         src_writes = src_writes.union(p.writes_self);
@@ -705,6 +738,7 @@ pub(crate) fn profiles_conflict(p: &RwProfile, s: &GroupStructure) -> bool {
         board_writes,
         &p.writes_membership_external_zones,
         p.writes_membership_self,
+        &p.writes_membership_self_zones,
     );
     let board_reads = p.reads_board.union(p.reads_player);
     if feeds(
@@ -748,13 +782,17 @@ fn membership_zones_of(
     write_kinds: KindSet,
     external_zones: &ZoneSpan,
     self_in_scope: bool,
+    self_zones: &ZoneSpan,
 ) -> ZoneSpan {
     let mut z = ZoneSpan::None;
     if write_kinds.set_membership {
         z.merge(external_zones.clone());
     }
     if self_in_scope {
-        z.merge(ZoneSpan::Any);
+        // CR 400.1: the recorded self-write endpoints (fail-closed `Any` when a
+        // self write left them unrecorded) — no longer a blanket `Any`, so a
+        // battlefield self-copy is zone-disjoint from a graveyard read.
+        z.merge(self_zones.clone());
     }
     z
 }
@@ -900,6 +938,10 @@ fn place_membership_write(
         WriteScope::SelfSource => {
             p.writes_self.set(StateKind::SetMembership);
             p.writes_membership_self = true;
+            // CR 400.1: record the actual self-move endpoints (Chorale of the
+            // Void's self-sacrifice bf→graveyard keeps overlapping a graveyard
+            // "left this turn" read).
+            p.writes_membership_self_zones.merge(move_zones);
         }
         WriteScope::External => {
             p.writes_external.set(StateKind::SetMembership);
@@ -953,9 +995,13 @@ fn census_of_filter(f: &TargetFilter) -> Census {
     }
 }
 
-fn census_of_typed(tf: &TypedFilter) -> Census {
-    let mut tags: BTreeSet<String> = BTreeSet::new();
-    for t in &tf.type_filters {
+/// CR 205: collect core-type + subtype tags from a bare `TypeFilter` slice into
+/// `tags`. Returns `Some(Census::Any)` on the first broad / negative / disjunctive
+/// constraint (unextractable ⇒ fail-closed); `None` when every entry was a
+/// concrete positive tag. Shared by `census_of_typed` and the
+/// `QuantityRef::ZoneCardCount { card_types }` census (§L1).
+fn collect_type_tags(type_filters: &[TypeFilter], tags: &mut BTreeSet<String>) -> Option<Census> {
+    for t in type_filters {
         match t {
             TypeFilter::Creature => tags.insert("creature".into()),
             TypeFilter::Land => tags.insert("land".into()),
@@ -968,9 +1014,17 @@ fn census_of_typed(tf: &TypedFilter) -> Census {
             TypeFilter::Kindred => tags.insert("kindred".into()),
             TypeFilter::Subtype(s) => tags.insert(s.to_lowercase()),
             // Broad / non-positive / disjunctive type constraints ⇒ unextractable.
-            TypeFilter::Permanent | TypeFilter::Card | TypeFilter::Any => return Census::Any,
-            TypeFilter::Non(_) | TypeFilter::AnyOf(_) => return Census::Any,
+            TypeFilter::Permanent | TypeFilter::Card | TypeFilter::Any => return Some(Census::Any),
+            TypeFilter::Non(_) | TypeFilter::AnyOf(_) => return Some(Census::Any),
         };
+    }
+    None
+}
+
+fn census_of_typed(tf: &TypedFilter) -> Census {
+    let mut tags: BTreeSet<String> = BTreeSet::new();
+    if let Some(c) = collect_type_tags(&tf.type_filters, &mut tags) {
+        return c;
     }
     for prop in &tf.properties {
         match prop {
@@ -987,6 +1041,32 @@ fn census_of_typed(tf: &TypedFilter) -> Census {
         Census::Any
     } else {
         Census::Tags(tags)
+    }
+}
+
+/// CR 604.3 + CR 205: census of a `QuantityRef::ZoneCardCount { card_types }`
+/// list — the same tag extraction as `census_of_typed` but over a bare
+/// `TypeFilter` slice with no properties. Empty `card_types` (all cards) ⇒ `Any`.
+fn census_of_zone_card_types(card_types: &[TypeFilter]) -> Census {
+    let mut tags: BTreeSet<String> = BTreeSet::new();
+    if let Some(c) = collect_type_tags(card_types, &mut tags) {
+        return c;
+    }
+    if tags.is_empty() {
+        Census::Any
+    } else {
+        Census::Tags(tags)
+    }
+}
+
+/// CR 400.1: the concrete battlefield-external zone a `ZoneRef` names, for the
+/// `QuantityRef::ZoneCardCount { zone }` membership-read zone (§L1).
+fn zone_of_zone_ref(z: &ZoneRef) -> Zone {
+    match z {
+        ZoneRef::Graveyard => Zone::Graveyard,
+        ZoneRef::Exile => Zone::Exile,
+        ZoneRef::Library => Zone::Library,
+        ZoneRef::Hand => Zone::Hand,
     }
 }
 
@@ -1017,6 +1097,14 @@ pub(crate) fn filter_excludes_source(f: &TargetFilter) -> bool {
             .iter()
             .any(|p| matches!(p, FilterProp::Another)),
         TargetFilter::And { filters } => filters.iter().any(filter_excludes_source),
+        // §L6 (CR 303.4d + CR 301.5c): the object an Aura/Equipment is ATTACHED to
+        // is a DIFFERENT object than the source itself — an Aura can't enchant
+        // itself (CR 303.4d) and an Equipment can't equip itself (CR 301.5c). So an
+        // `AttachedTo` `valid_card` (the enchanted/equipped creature — e.g. the
+        // Ordeals' "whenever enchanted creature attacks") provably excludes every
+        // group member's source, dropping the event-object counter write from the
+        // source-scoped counter-read feed.
+        TargetFilter::AttachedTo => true,
         _ => false,
     }
 }
@@ -2428,6 +2516,18 @@ fn board_membership_read(filter: &TargetFilter) -> RwProfile {
     p
 }
 
+/// §L2 (CR 400.7 + CR 400.1): a zone-change per-turn journal read, keyed to its
+/// DESTINATION zone when known. A `None` destination stays fail-closed (`Any`
+/// zones, via `board_membership_read`). Never overrides a self-scoped read (whose
+/// filter routes to `reads_src`, not the membership feed).
+fn journal_zone_change_read(filter: &TargetFilter, to: Option<&Zone>) -> RwProfile {
+    let mut p = board_membership_read(filter);
+    if let (Some(z), false) = (to, filter_is_self_scoped(filter)) {
+        p.reads_membership_zones = ZoneSpan::one(*z);
+    }
+    p
+}
+
 /// A board VALUE aggregate (power/counter aggregate) over `filter`: records the
 /// value kind AND `SetMembership` (a membership write changes the aggregate, §2).
 fn board_value_aggregate_read(filter: &TargetFilter, value: StateKind) -> RwProfile {
@@ -2453,6 +2553,27 @@ fn read_object_scope(scope: &ObjectScope, kind: StateKind) -> RwProfile {
         ObjectScope::EventSource | ObjectScope::EventTarget => reads_event_live(),
         // D5 carrier: `CostPaidObject` is one of the 12 retained refs.
         ObjectScope::CostPaidObject => legacy_ref(),
+    }
+}
+
+/// §L7 (CR 608.2c + CR 603.3b): classify one `ObjectsShareQuality` operand by
+/// scope. `LastRevealed` is the card the member's OWN reveal surfaced this
+/// resolution — a per-resolution local (like `ObjectScope::Recipient`), observed
+/// by no sibling write (mirrors `RevealedHasCardType => EMPTY`). A source operand
+/// reads the source's own FIXED printed type — not a mutable board characteristic
+/// a sibling reorders — so it too contributes NO observable read (crucially it
+/// must NOT set `reads_src`, which would flip an otherwise source-INDEPENDENT
+/// ability off the sound T1 fast path and re-expose an unrelated board-read×write
+/// as a false prompt — Plane-Merge Elf's PumpAll, Sensation Gorger's HandSize
+/// discard). Every OTHER operand (a live board object) keeps the fail-closed
+/// board `ObjectPt` characteristic read.
+fn share_quality_operand_read(f: &TargetFilter) -> RwProfile {
+    match f {
+        TargetFilter::LastRevealed | TargetFilter::SelfRef | TargetFilter::SourceOrPaired => {
+            RwProfile::empty()
+        }
+        // Fail-closed: any other reference is a live board characteristic read.
+        _ => reads_board_of(StateKind::ObjectPt),
     }
 }
 
@@ -2583,9 +2704,13 @@ fn walk_ability(a: &ResolvedAbility, chain_root: Option<WriteScope>, acc: &mut R
     if let Some(m) = modal {
         acc.merge(rw_modal_choice(m));
     }
-    // CR 700.2b: reflexive-modal per-mode defs are not descended — conservative.
-    if !mode_abilities.is_empty() {
-        acc.merge(RwProfile::conservative());
+    // §voltstorm (CR 700.2): a modal resolves exactly ONE mode. Descend every
+    // mode as a UNION (mirrors `Effect::ChooseOneOf` branch descent): if the union
+    // of all modes' reads/writes has no feed, then no single choice — and no
+    // cross-choice sibling pair — is order-observable. Independent reflexive-modal
+    // choices commute (Voltstorm Angel). Fail-closed: the union over-approximates.
+    for m in mode_abilities {
+        walk_definition(m, child_root, acc);
     }
 }
 
@@ -2676,8 +2801,9 @@ fn walk_definition(a: &AbilityDefinition, chain_root: Option<WriteScope>, acc: &
     if let Some(m) = modal {
         acc.merge(rw_modal_choice(m));
     }
-    if !mode_abilities.is_empty() {
-        acc.merge(RwProfile::conservative());
+    // §voltstorm (CR 700.2): descend each mode as a union (see `walk_ability`).
+    for m in mode_abilities {
+        walk_definition(m, child_root, acc);
     }
 }
 
@@ -3425,6 +3551,13 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
                 // is what clears Scute Swarm (creature token ≠ its Lands read,
                 // census-disjoint — §1.3.1-F) instead of over-conflicting on Any.
                 p.writes_membership_self = true;
+                // CR 111.1: a token copy is CREATED on the battlefield — its self
+                // membership write touches only that zone, NOT the blanket `Any` a
+                // self MOVE gets. So it is zone-disjoint from a graveyard/departure
+                // read (Compy Swarm / Phoenix Fleet Airship's "a creature died /
+                // you sacrificed a permanent this turn" ×2).
+                p.writes_membership_self_zones
+                    .merge(ZoneSpan::one(Zone::Battlefield));
                 // Copiable-values read (fail-closed source dependence).
                 p.reads_src.set(StateKind::ObjectPt);
             } else {
@@ -3595,13 +3728,19 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         } => {
             // CR 707.10/707.10c: SelfRef / explicit-target copies read the
             // original by id (clean); the untargeted top-of-stack fallback reads
-            // the mutable stack top (D4).
+            // the mutable stack top (D4). §L9: `TriggeringSource` (the spell that
+            // caused the trigger) and a chain-referenced `ParentTarget` also
+            // address the original BY ID, not the mutable stack shape — independent
+            // copies commute (Pyromancer Ascension / Ominous Lockbox / Curse of
+            // Echoes / Locus of Enlightenment).
             let mut p = ext_write(StateKind::StackShape);
             if !matches!(
                 target,
                 TargetFilter::SelfRef
                     | TargetFilter::StackSpell
                     | TargetFilter::SpecificObject { .. }
+                    | TargetFilter::TriggeringSource
+                    | TargetFilter::ParentTarget
             ) {
                 p.reads_board.set(StateKind::StackShape);
             }
@@ -3612,6 +3751,24 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             source_rider: _,
             countered_spell_zone: _,
         } => (ext_write(StateKind::StackShape), None),
+        // §L9 (CR 115.7): changing the target(s) of a spell/ability on the stack is
+        // a StackShape write, NOT the maximal-conservative fallback (which set a
+        // board `ObjectPt`/… read that falsely conflicted with the sibling
+        // CopySpell). Each per-player copy retargets its OWN copy independently, so
+        // identical siblings commute (Curse of Echoes). Fail-closed batch parity
+        // via the D5 write-target flag.
+        Effect::ChangeTargets {
+            target,
+            scope: _,
+            forced_to,
+        } => {
+            let mut p = ext_write(StateKind::StackShape);
+            flag_legacy_write_target(&mut p, target);
+            if let Some(ft) = forced_to {
+                flag_legacy_write_target(&mut p, ft);
+            }
+            (p, None)
+        }
         Effect::CastCopyOfCard {
             target: _,
             count,
@@ -3812,15 +3969,36 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         // event-context ref there retains the batch prompt (CR 603.10a).
         Effect::Goad { target }
         | Effect::GoadAll { target }
-        | Effect::ExtraTurn { target }
-        | Effect::Suspect { target, scope: _ }
-        | Effect::Unsuspect { target, scope: _ }
         | Effect::BecomePrepared { target }
         | Effect::ApplyPerpetual {
             target,
             modification: _,
         } => {
             let mut p = ext_write(StateKind::Other);
+            flag_legacy_write_target(&mut p, target);
+            (p, None)
+        }
+        // §L12 (CR 701.60 suspect / CR 701.60a unsuspect): suspected is an
+        // IDEMPOTENT designation — suspecting an already-suspected creature is a
+        // no-op, and identical siblings suspect/unsuspect the SAME (or self)
+        // targets, so the write is order-invariant. Like `PairWith`/`Attach`, no
+        // LIVE read observes it (the status is read only via source-referential
+        // `SourceMatchesFilter{Suspected}`), so NO observable RW kind — never the
+        // `Other` catch-all, which falsely conflicted with Frantic Scapegoat's
+        // "if ~ is suspected" source read. The write target still flags D5 batch
+        // parity (CR 603.10a).
+        Effect::Suspect { target, scope: _ } | Effect::Unsuspect { target, scope: _ } => {
+            let mut p = RwProfile::empty();
+            flag_legacy_write_target(&mut p, target);
+            (p, None)
+        }
+        // §L14 (CR 500 + CR 505.6): extra turns/phases are game-SEQUENCING writes
+        // (two extra turns commute) — a dedicated turn-structure kind that no
+        // profiled read observes, NOT the `Other` catch-all (which falsely
+        // conflicted with a co-occurring source counter/life read on Lighthouse
+        // Chronologist / Second Chance / Regenerations Restored / Time Bends).
+        Effect::ExtraTurn { target } => {
+            let mut p = ext_write(StateKind::TurnStructure);
             flag_legacy_write_target(&mut p, target);
             (p, None)
         }
@@ -3852,16 +4030,45 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
             p.merge(rw_duration(duration));
             (p, None)
         }
+        // §L14 (CR 500.8): an additional phase/step is a turn-structure write.
         Effect::AdditionalPhase {
             target: _,
             count,
             phase: _,
             after: _,
             followed_by: _,
-            attacker_restriction: _,
+            attacker_restriction,
         } => {
-            let mut p = ext_write(StateKind::Other);
+            let mut p = ext_write(StateKind::TurnStructure);
             p.merge(rw_quantity_expr(count));
+            // CR 608.2h + 611.2c: Some(filter) snapshots the eligible-attacker set
+            // at resolution (a board membership read) before installing the
+            // restriction on the added combat.
+            if let Some(filter) = attacker_restriction {
+                p.merge(board_membership_read(filter));
+            }
+            (p, None)
+        }
+        // §L13 (CR 614.10) + §L14: skipping a step/turn is a turn-structure write.
+        Effect::SkipNextStep {
+            target: _,
+            step: _,
+            count,
+            scope: _,
+        }
+        | Effect::SkipNextTurn { target: _, count } => {
+            let mut p = ext_write(StateKind::TurnStructure);
+            p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        // §L13 (CR 506.4c): removing a creature from combat is idempotent (a
+        // no-op on an already-removed creature) and observed by no profiled read —
+        // a turn/combat-structure write, NOT the maximal-conservative fallback
+        // that falsely conflicted (Gustcloak Savior / Lost in the Woods / Time
+        // Bends to My Will).
+        Effect::RemoveFromCombat { target } => {
+            let mut p = ext_write(StateKind::TurnStructure);
+            flag_legacy_write_target(&mut p, target);
             (p, None)
         }
         Effect::AssembleContraptions { count } => {
@@ -3984,11 +4191,7 @@ fn rw_effect(x: &Effect, chain_root: Option<WriteScope>) -> (RwProfile, Option<W
         | Effect::GiftDelivery { .. }
         | Effect::Detain { .. }
         | Effect::SetRoomDoorLock { .. }
-        | Effect::ChangeTargets { .. }
         | Effect::GrantExtraLoyaltyActivations { .. }
-        | Effect::SkipNextTurn { .. }
-        | Effect::SkipNextStep { .. }
-        | Effect::RemoveFromCombat { .. }
         | Effect::ExchangeLifeWithStat { .. }
         | Effect::ExchangeLifeTotals { .. }
         | Effect::SetDayNight { .. }
@@ -4152,18 +4355,63 @@ fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
         | QuantityRef::CommanderManaValue { .. }
         | QuantityRef::Speed { .. }
         | QuantityRef::VoteCount { .. } => RwProfile::empty(),
-        QuantityRef::ZoneCardCount { filter, .. } => match filter {
+        QuantityRef::ZoneCardCount {
+            zone,
+            card_types,
+            filter,
+            scope: _,
+        } => match filter {
             Some(f) => board_membership_read(f),
-            None => reads_zone_membership(),
+            // §L1 (CR 604.3 + CR 205 + CR 400.1): extract the census from
+            // `card_types` and the read zone from the `ZoneRef`, instead of
+            // discarding both to `Any`/`Any`. "creature cards in your graveyard"
+            // observes only the GRAVEYARD for a CREATURE census — zone-disjoint
+            // from a battlefield token write (Hallowed Spiritkeeper) and
+            // census-disjoint from creature writes when counting lands (Cavalier
+            // of Flame / Scouring Swarm). `scope` (controller/owner) is not
+            // carried into the membership feed (fail-closed on controller).
+            None => {
+                let mut p = reads_board_of(StateKind::SetMembership);
+                p.reads_membership_census = census_of_zone_card_types(card_types);
+                p.reads_membership_zones = ZoneSpan::one(zone_of_zone_ref(zone));
+                p
+            }
         },
-        // Object-population "this turn" journals ⇒ membership-fed board reads.
+        // §L2: object-population per-turn journals. A ZONE-CHANGE journal counts a
+        // SETTLED event keyed by its DESTINATION zone (CR 400.7 + CR 400.1), so a
+        // battlefield token CREATION is zone-disjoint from a graveyard "died this
+        // turn" read (Compy Swarm / Dripping-Tongue Zubera) while a self-sacrifice
+        // bf→graveyard still overlaps (Chorale of the Void, held). ENTRY journals
+        // keep the filter's zones (fail-closed) — a creation DOES feed them.
+        QuantityRef::ZoneChangeCountThisTurn {
+            to,
+            filter,
+            from: _,
+        } => journal_zone_change_read(filter, to.as_ref()),
+        QuantityRef::ZoneChangeAggregateThisTurn {
+            to,
+            filter,
+            from: _,
+            function: _,
+            property: _,
+        } => journal_zone_change_read(filter, to.as_ref()),
+        // CR 701.21a: a sacrifice moves the permanent to its owner's graveyard.
+        QuantityRef::SacrificedThisTurn { filter, player: _ } => {
+            let mut p = board_membership_read(filter);
+            p.reads_membership_zones = ZoneSpan::one(Zone::Graveyard);
+            p
+        }
         QuantityRef::EnteredThisTurn { filter }
-        | QuantityRef::SacrificedThisTurn { filter, .. }
         | QuantityRef::BattlefieldEntriesThisTurn { filter, .. }
-        | QuantityRef::ZoneChangeCountThisTurn { filter, .. }
-        | QuantityRef::ZoneChangeAggregateThisTurn { filter, .. }
         | QuantityRef::TokensCreatedThisTurn { filter, .. } => board_membership_read(filter),
-        QuantityRef::CounterAddedThisTurn { .. } => reads_board_of(StateKind::ObjectCounters),
+        // §L2 (CR 122.3 + CR 603.3b): "a +1/+1 counter was put on a permanent this
+        // turn" is a settled, MONOTONE-UP per-turn journal — counters are only
+        // ADDED to it, so a sibling PutCounter keeps an intervening-if satisfied
+        // and identical siblings resolve order-invariantly. Modeled as a frozen
+        // look-back read (CR 603.10a — never fed while the freeze is valid) rather
+        // than a LIVE counter read, so a self PutCounter does not falsely conflict
+        // (Fairgrounds Trumpeter). Fail-closed on a departure reentry hazard.
+        QuantityRef::CounterAddedThisTurn { .. } => reads_frozen_of(StateKind::ObjectCounters),
         // Player-resource journals.
         QuantityRef::LifeLostThisTurn { player: _ }
         | QuantityRef::LifeGainedThisTurn { player: _ }
@@ -4205,16 +4453,49 @@ fn rw_ability_condition(x: &AbilityCondition) -> RwProfile {
             comparator: _,
             channel: _,
         } => rw_quantity_expr(rhs),
+        // §L7 (CR 608.2c + CR 603.3b): route EACH operand by scope. An operand
+        // that is the card THIS resolution revealed (`LastRevealed`) is a
+        // per-resolution local — no sibling write observes it (mirror
+        // `RevealedHasCardType => EMPTY`); a source operand is a source-scoped
+        // read. Only a LIVE board operand keeps the board `ObjectPt` read. Clears
+        // "if the revealed card shares a creature type with ~" (Winnower Patrol /
+        // Kithkin Zephyrnaut / Mudbutton Clanger / Waterspout Weavers).
         AbilityCondition::ObjectsShareQuality {
-            subject: _,
-            reference: _,
+            subject,
+            reference,
             quality: _,
-        } => reads_board_of(StateKind::ObjectPt),
+        } => {
+            let mut p = share_quality_operand_read(subject);
+            p.merge(share_quality_operand_read(reference));
+            p
+        }
+        // §L3 (CR 400.7 + CR 603.10a): "if that creature WAS a [type]" reads the
+        // target's LAST-KNOWN information — a frozen read of the departed/event
+        // object, settled at the event and never altered by a sibling board write.
+        // Present-tense (`use_lki: false`) stays a LIVE board `ObjectPt` read
+        // (fail-closed). Clears "if that [died/entered] creature was X, put a
+        // counter on ~" (Taborax / Uglúk / Venom / Locus Cobra / Overgrowth
+        // Elemental / Magnanimous Magistrate / Prowling Geistcatcher).
         AbilityCondition::TargetMatchesFilter {
             filter: _,
-            use_lki: _,
+            use_lki,
             subject_slot: _,
-        } => reads_board_of(StateKind::ObjectPt),
+        } => {
+            if *use_lki {
+                frozen_source_read()
+            } else {
+                reads_board_of(StateKind::ObjectPt)
+            }
+        }
+        // PR-6.75 residual: two context-free-unclassifiable singletons stay safe
+        // conservative over-prompts here, with no recognizer. Paroxysm's present-
+        // tense `TargetMatchesFilter { use_lki: false }` fires on a card the member
+        // itself revealed this resolution (a per-resolution local, not a live board
+        // read), but that provenance is not visible on the AST at this leaf, so the
+        // fail-closed live `ObjectPt` read is retained. Flamewake Phoenix's
+        // begin-combat return is gated on controlling a creature with power >= 4 (a
+        // P/T-constrained control census) — proving disjointness needs the runtime
+        // source P/T the profile cannot see, so its control read stays fail-closed.
         AbilityCondition::SourceMatchesFilter { filter: _ } => reads_src_of(StateKind::ObjectPt),
         AbilityCondition::SourceIsTapped => reads_src_of(StateKind::TapState),
         AbilityCondition::ControllerControlsMatching { filter } => board_membership_read(filter),
@@ -4632,7 +4913,7 @@ fn rw_controller_ref(x: &ControllerRef) -> RwProfile {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{AbilityKind, Comparator, PtValue};
+    use crate::types::ability::{AbilityKind, Comparator, CountScope, PtValue};
     use crate::types::counter::CounterType;
     use crate::types::identifiers::ObjectId;
     use crate::types::player::PlayerId;
@@ -5279,6 +5560,534 @@ mod tests {
         assert!(
             !tlegacy(&TriggerCondition::SourceIsTapped),
             "SourceIsTapped carries no frozen tag"
+        );
+    }
+
+    // ===================== PR-6.75 commit-4 read/write levers =====================
+    // Each lever gets a discriminating POSITIVE (the commuting shape no longer
+    // conflicts) + NEGATIVE control (a structurally-adjacent NON-commuting shape
+    // still conflicts, so the POS can't pass vacuously). Revert-fail evidence (the
+    // pre-lever mutation that turns each POS red) is recorded in the driver report.
+
+    /// §L1: `QuantityRef::ZoneCardCount { zone, card_types, filter: None }` now
+    /// extracts BOTH the read census (from `card_types`, CR 205) and the read zone
+    /// (from `ZoneRef`, CR 400.1) instead of collapsing to `Any`/`Any`. "creature
+    /// cards in your graveyard" reads a GRAVEYARD/creature census — zone-disjoint
+    /// from a battlefield creature token, but zone+census-overlapping a creature
+    /// written INTO the graveyard.
+    #[test]
+    fn l1_zone_card_count_census_and_zone_extraction() {
+        let gy_creatures = QuantityRef::ZoneCardCount {
+            zone: ZoneRef::Graveyard,
+            card_types: vec![TypeFilter::Creature],
+            filter: None,
+            scope: CountScope::Controller,
+        };
+        // POS: graveyard/creature read × battlefield creature-token write —
+        // census overlaps (creature) but zones are disjoint ⇒ no feed.
+        let pos = cond(
+            ra(token(&["Creature"], qfix(1))),
+            qcheck(gy_creatures.clone(), 1),
+        );
+        assert!(
+            !conflicts(&pos, &batch()),
+            "graveyard-creature read × battlefield token ⇒ zone-disjoint ⇒ clean"
+        );
+        // NEG: same read × a creature written INTO the graveyard — census AND zone
+        // overlap ⇒ conflict. A zone-blind (pre-lever `Any`) census would also
+        // conflict on the POS, so this pins the discrimination on the zone axis.
+        let neg = cond(
+            ra(change_zone(
+                Some(Zone::Battlefield),
+                Zone::Graveyard,
+                creature(),
+            )),
+            qcheck(gy_creatures, 1),
+        );
+        assert!(
+            conflicts(&neg, &batch()),
+            "graveyard-creature read × creature-to-graveyard write ⇒ zone+census overlap ⇒ conflict"
+        );
+    }
+
+    /// §L2 (CR 400.7 + CR 400.1): a per-turn zone-change journal read is keyed to
+    /// its DESTINATION zone, so a "died this turn" (→graveyard) read is disjoint
+    /// from a battlefield token creation while an "entered this turn" (→battlefield)
+    /// read overlaps it. `SacrificedThisTurn` is graveyard-keyed the same way.
+    #[test]
+    fn l2_zone_journal_reads_keyed_to_destination_zone() {
+        let died = |to: Zone| QuantityRef::ZoneChangeCountThisTurn {
+            from: Some(Zone::Battlefield),
+            to: Some(to),
+            filter: creature(),
+        };
+        // POS: "a creature died this turn" (→graveyard) × battlefield token ⇒
+        // zone-disjoint ⇒ clean.
+        let pos = cond(
+            ra(token(&["Creature"], qfix(1))),
+            qcheck(died(Zone::Graveyard), 1),
+        );
+        assert!(
+            !conflicts(&pos, &batch()),
+            "died(graveyard) × battlefield token ⇒ clean"
+        );
+        // NEG: "a creature entered this turn" (→battlefield) × the same token ⇒
+        // zone overlap ⇒ conflict.
+        let neg = cond(
+            ra(token(&["Creature"], qfix(1))),
+            qcheck(died(Zone::Battlefield), 1),
+        );
+        assert!(
+            conflicts(&neg, &batch()),
+            "entered(battlefield) × battlefield token ⇒ conflict"
+        );
+
+        // SacrificedThisTurn is pinned to the graveyard (CR 701.21a): disjoint from
+        // a battlefield token, overlapping a creature moved into the graveyard.
+        let sac = QuantityRef::SacrificedThisTurn {
+            player: PlayerScope::Controller,
+            filter: creature(),
+        };
+        let sac_pos = cond(ra(token(&["Creature"], qfix(1))), qcheck(sac.clone(), 1));
+        assert!(
+            !conflicts(&sac_pos, &batch()),
+            "sacrificed(graveyard) × battlefield token ⇒ clean"
+        );
+        let sac_neg = cond(
+            ra(change_zone(
+                Some(Zone::Battlefield),
+                Zone::Graveyard,
+                creature(),
+            )),
+            qcheck(sac, 1),
+        );
+        assert!(
+            conflicts(&sac_neg, &batch()),
+            "sacrificed(graveyard) × creature-to-graveyard ⇒ conflict"
+        );
+    }
+
+    /// §L2 (CR 122.3 + CR 603.10a): "a counter was put on a permanent this turn" is
+    /// a settled monotone-up look-back — a FROZEN read that a sibling PutCounter
+    /// never feeds (Fairgrounds Trumpeter). A LIVE counter read on the same self
+    /// write still conflicts.
+    #[test]
+    fn l2_counter_added_this_turn_is_frozen_lookback() {
+        let added = QuantityRef::CounterAddedThisTurn {
+            actor: CountScope::Controller,
+            counters: crate::types::counter::CounterMatch::Any,
+            target: creature(),
+        };
+        // POS: frozen journal read × self PutCounter ⇒ never fed ⇒ clean.
+        let pos = cond(
+            ra(put_counter(qfix(1), TargetFilter::SelfRef)),
+            qcheck(added, 1),
+        );
+        assert!(
+            !conflicts(&pos, &se()),
+            "monotone journal look-back × self counter ⇒ clean"
+        );
+        // NEG: a LIVE board counter read (`CountersOn{Target}`) × the same self
+        // counter write ⇒ same-kind ObjectCounters feed ⇒ conflict.
+        let live = QuantityRef::CountersOn {
+            scope: ObjectScope::Target,
+            counter_type: None,
+        };
+        let neg = cond(
+            ra(put_counter(qfix(1), TargetFilter::SelfRef)),
+            qcheck(live, 1),
+        );
+        assert!(
+            conflicts(&neg, &se()),
+            "live board counter read × self counter write ⇒ conflict"
+        );
+    }
+
+    /// §L3 (CR 400.7 + CR 603.10a): "if that creature WAS a [type]"
+    /// (`use_lki: true`) is a frozen LKI read of the departed/event object, never
+    /// altered by a sibling board write. Present-tense (`use_lki: false`) stays a
+    /// live board `ObjectPt` read.
+    #[test]
+    fn l3_target_matches_filter_lki_is_frozen_read() {
+        let put_self = || ra(put_counter(qfix(1), TargetFilter::SelfRef));
+        // POS: LKI "was a Cleric" × PutCounter{self} ⇒ frozen read ⇒ clean
+        // (Taborax / Uglúk / Overgrowth Elemental).
+        let pos = cond(
+            put_self(),
+            AbilityCondition::TargetMatchesFilter {
+                filter: creature(),
+                use_lki: true,
+                subject_slot: None,
+            },
+        );
+        assert!(
+            !conflicts(&pos, &se()),
+            "LKI 'was X' read × self counter ⇒ frozen ⇒ clean"
+        );
+        // NEG: present-tense "is a Cleric" × the same write ⇒ live ObjectPt read ×
+        // ObjectCounters write ⇒ CR 613.4 feed ⇒ conflict.
+        let neg = cond(
+            put_self(),
+            AbilityCondition::TargetMatchesFilter {
+                filter: creature(),
+                use_lki: false,
+                subject_slot: None,
+            },
+        );
+        assert!(
+            conflicts(&neg, &se()),
+            "live 'is X' read × self counter ⇒ conflict"
+        );
+    }
+
+    /// §L6 (CR 303.4d + CR 301.5c): an Aura/Equipment is never attached to itself
+    /// (an Aura can't enchant itself, an Equipment can't equip itself),
+    /// so an `AttachedTo` `valid_card` (the enchanted creature — the Ordeals'
+    /// "whenever enchanted creature attacks") provably EXCLUDES every source. The
+    /// classifier output is wired straight into the group structure so the excluded
+    /// event-object counter write drops from the source-counter-read feed.
+    #[test]
+    fn l6_attached_to_excludes_source() {
+        // Direct classifier assertions (the lever).
+        assert!(
+            filter_excludes_source(&TargetFilter::AttachedTo),
+            "AttachedTo excludes source"
+        );
+        assert!(
+            !filter_excludes_source(&TargetFilter::SelfRef),
+            "SelfRef does not exclude"
+        );
+        assert!(
+            !filter_excludes_source(&creature()),
+            "a bare creature filter does not exclude"
+        );
+
+        // Ordeal shape: source Aura reads its own 3-counter quest, event-object
+        // write puts a counter on the enchanted creature (TriggeringSource).
+        let ordeal = cond(
+            ra(put_counter(qfix(1), TargetFilter::TriggeringSource)),
+            qcheck(counters_src(), 3),
+        );
+        // POS: AttachedTo ⇒ excludes=true ⇒ event-object write dropped ⇒ clean.
+        let pos = gs(
+            true,
+            false,
+            false,
+            filter_excludes_source(&TargetFilter::AttachedTo),
+            true,
+            SourceCensus::unknown(),
+        );
+        assert!(!profiles_conflict(&ability_rw_profile(&ordeal), &pos));
+        // NEG: SelfRef ⇒ excludes=false ⇒ the counter write feeds the read ⇒ conflict.
+        let neg = gs(
+            true,
+            false,
+            false,
+            filter_excludes_source(&TargetFilter::SelfRef),
+            true,
+            SourceCensus::unknown(),
+        );
+        assert!(profiles_conflict(&ability_rw_profile(&ordeal), &neg));
+    }
+
+    /// §L7 (CR 608.2c + CR 603.3b): an `ObjectsShareQuality` operand that is the
+    /// card THIS resolution revealed (`LastRevealed`) is a per-resolution local —
+    /// observed by no sibling write (mirrors `RevealedHasCardType => EMPTY`). A live
+    /// board operand keeps the fail-closed `ObjectPt` read.
+    #[test]
+    fn l7_objects_share_quality_last_revealed_is_local() {
+        let share = |subject: TargetFilter, reference: TargetFilter| {
+            AbilityCondition::ObjectsShareQuality {
+                subject,
+                reference,
+                quality: crate::types::ability::SharedQuality::CreatureType,
+            }
+        };
+        // POS: revealed-card × revealed-card ⇒ both local ⇒ no read × self counter
+        // write ⇒ clean (Winnower Patrol / Kithkin Zephyrnaut).
+        let pos = cond(
+            ra(put_counter(qfix(1), TargetFilter::SelfRef)),
+            share(TargetFilter::LastRevealed, TargetFilter::LastRevealed),
+        );
+        assert!(
+            !conflicts(&pos, &se()),
+            "revealed × revealed operands ⇒ local ⇒ clean"
+        );
+        // NEG: a LIVE board operand (a creature you control) × revealed card ⇒
+        // board ObjectPt read × ObjectCounters write ⇒ conflict.
+        let neg = cond(
+            ra(put_counter(qfix(1), TargetFilter::SelfRef)),
+            share(creature(), TargetFilter::LastRevealed),
+        );
+        assert!(
+            conflicts(&neg, &se()),
+            "live board operand × revealed card ⇒ conflict"
+        );
+    }
+
+    /// §L9 (CR 707.10 + CR 115.7): a `CopySpell` targeting `TriggeringSource` /
+    /// `ParentTarget` reads the original BY ID, not the mutable stack top — so
+    /// independent copies commute (Pyromancer Ascension / Curse of Echoes /
+    /// Ominous Lockbox). `ChangeTargets` is a precise StackShape write, not the
+    /// maximal-conservative board read.
+    #[test]
+    fn l9_copy_spell_by_id_and_change_targets_stack_write() {
+        // POS: id-referential copies carry no StackShape BOARD read ⇒ commute.
+        for by_id in [TargetFilter::TriggeringSource, TargetFilter::ParentTarget] {
+            let p = ability_rw_profile(&ra(copy_spell(by_id.clone())));
+            assert!(
+                !p.reads_board.stack_shape,
+                "{by_id:?} copies the original by id"
+            );
+            assert!(
+                !conflicts(&ra(copy_spell(by_id.clone())), &batch()),
+                "{by_id:?} copies commute"
+            );
+        }
+        // NEG: the untargeted top-of-stack fallback reads the MUTABLE stack top.
+        let fb = ability_rw_profile(&ra(copy_spell(TargetFilter::Any)));
+        assert!(
+            fb.reads_board.stack_shape,
+            "untargeted fallback reads the stack top"
+        );
+        assert!(conflicts(&ra(copy_spell(TargetFilter::Any)), &batch()));
+
+        // ChangeTargets: a StackShape write only — NOT the conservative board read.
+        let ct = ability_rw_profile(&ra(Effect::ChangeTargets {
+            target: TargetFilter::StackSpell,
+            scope: crate::types::game_state::RetargetScope::Single,
+            forced_to: None,
+        }));
+        assert!(
+            ct.writes_external.stack_shape,
+            "ChangeTargets writes StackShape"
+        );
+        assert!(
+            !ct.reads_board.object_pt,
+            "ChangeTargets is not the maximal-conservative read"
+        );
+        assert!(
+            !conflicts(
+                &ra(Effect::ChangeTargets {
+                    target: TargetFilter::StackSpell,
+                    scope: crate::types::game_state::RetargetScope::Single,
+                    forced_to: None,
+                }),
+                &batch()
+            ),
+            "independent per-copy retargets commute"
+        );
+    }
+
+    /// §L12 (CR 701.60 + CR 701.60a): suspect/unsuspect is an idempotent
+    /// designation with NO observable RW kind — never the `Other` catch-all that
+    /// falsely conflicted with Frantic Scapegoat's "if ~ is suspected" source read.
+    #[test]
+    fn l12_suspect_unsuspect_no_observable_write() {
+        // "if ~ is suspected" — a source read (SourceMatchesFilter ⇒ reads_src).
+        let is_suspected = || AbilityCondition::SourceMatchesFilter { filter: creature() };
+        // POS: Suspect (empty profile) × the source read ⇒ no write to feed ⇒ clean.
+        for status in [
+            Effect::Suspect {
+                target: creature(),
+                scope: crate::types::ability::EffectScope::Single,
+            },
+            Effect::Unsuspect {
+                target: creature(),
+                scope: crate::types::ability::EffectScope::Single,
+            },
+        ] {
+            let pos = cond(ra(status), is_suspected());
+            assert!(
+                !conflicts(&pos, &se()),
+                "idempotent status designation × source read ⇒ clean"
+            );
+        }
+        // NEG control: an effect that DOES write `Other` (Goad) × the same source
+        // read ⇒ `Other` conflicts with any read ⇒ conflict.
+        let neg = cond(ra(Effect::Goad { target: creature() }), is_suspected());
+        assert!(
+            conflicts(&neg, &se()),
+            "an `Other` write × source read ⇒ conflict"
+        );
+    }
+
+    /// §L13 (CR 506.4c + CR 614.10): removing from combat / skipping a step or turn
+    /// is an idempotent SEQUENCING write (`TurnStructure`) observed by no profiled
+    /// read — not the maximal-conservative fallback (Gustcloak Savior / Lost in the
+    /// Woods / Time Bends). `TurnStructure` only self-conflicts.
+    #[test]
+    fn l13_remove_from_combat_and_skips_are_turn_structure() {
+        for eff in [
+            Effect::RemoveFromCombat {
+                target: TargetFilter::Any,
+            },
+            Effect::SkipNextStep {
+                target: TargetFilter::Controller,
+                step: crate::types::ability::StepSkipTarget::CombatPhase,
+                count: qfix(1),
+                scope: crate::types::ability::SkipScope::NextOccurrence,
+            },
+            Effect::SkipNextTurn {
+                target: TargetFilter::Controller,
+                count: qfix(1),
+            },
+        ] {
+            let p = ability_rw_profile(&ra(eff.clone()));
+            assert!(
+                p.writes_external.turn_structure,
+                "{eff:?} is a TurnStructure write"
+            );
+            assert!(
+                !p.reads_board.object_pt,
+                "{eff:?} is not the conservative fallback"
+            );
+        }
+        // POS: RemoveFromCombat (TurnStructure write) × a live board ObjectPt read ⇒
+        // TurnStructure feeds no ObjectPt read ⇒ clean.
+        let pos = cond(
+            ra(Effect::RemoveFromCombat {
+                target: TargetFilter::Any,
+            }),
+            AbilityCondition::TargetMatchesFilter {
+                filter: creature(),
+                use_lki: false,
+                subject_slot: None,
+            },
+        );
+        assert!(
+            !conflicts(&pos, &batch()),
+            "TurnStructure write × board ObjectPt read ⇒ clean"
+        );
+        // NEG: the dormant self-conflict row — a (hand-built) TurnStructure READ ×
+        // a TurnStructure write DOES feed (fail-closed for any future sequencing read).
+        let mut self_conflict = RwProfile::empty();
+        self_conflict.reads_board.set(StateKind::TurnStructure);
+        self_conflict.writes_external.set(StateKind::TurnStructure);
+        assert!(
+            profiles_conflict(&self_conflict, &batch()),
+            "TurnStructure read × write ⇒ conflict"
+        );
+    }
+
+    /// §L14 (CR 500 + CR 500.8): extra turns / additional phases are `TurnStructure`
+    /// sequencing writes (two extra turns commute), not the `Other` catch-all that
+    /// falsely conflicted with a co-occurring source read (Lighthouse Chronologist /
+    /// Second Chance / Regenerations Restored / Time Bends).
+    #[test]
+    fn l14_extra_turn_and_phase_are_turn_structure_not_other() {
+        // AdditionalPhase is likewise a TurnStructure write, never `Other`.
+        let ap = ability_rw_profile(&ra(Effect::AdditionalPhase {
+            target: TargetFilter::Controller,
+            phase: crate::types::phase::Phase::PostCombatMain,
+            after: crate::types::phase::Phase::PostCombatMain,
+            followed_by: vec![],
+            count: qfix(1),
+            attacker_restriction: None,
+        }));
+        assert!(
+            ap.writes_external.turn_structure,
+            "AdditionalPhase is a TurnStructure write"
+        );
+        assert!(
+            !ap.writes_external.other,
+            "AdditionalPhase is not the `Other` catch-all"
+        );
+
+        // A source counter read co-occurring with the sequencing write.
+        let extra_turn = || {
+            cond(
+                ra(Effect::ExtraTurn {
+                    target: TargetFilter::Controller,
+                }),
+                qcheck(counters_src(), 3),
+            )
+        };
+        // POS: ExtraTurn (TurnStructure) × source counter read ⇒ no feed ⇒ clean.
+        assert!(
+            !conflicts(&extra_turn(), &se()),
+            "TurnStructure write × source counter read ⇒ clean"
+        );
+        // NEG: the SAME read × an `Other` write (Goad) ⇒ conflict — proving
+        // TurnStructure is not `Other`.
+        let other = cond(
+            ra(Effect::Goad { target: creature() }),
+            qcheck(counters_src(), 3),
+        );
+        assert!(
+            conflicts(&other, &se()),
+            "`Other` write × source counter read ⇒ conflict"
+        );
+    }
+
+    /// §voltstorm (CR 700.2): a modal resolves ONE mode; the classifier descends
+    /// every `mode_abilities` entry as a UNION rather than falling to
+    /// `conservative()`. If the union has no feed, no single choice (and no
+    /// cross-choice sibling pair) is order-observable (Voltstorm Angel).
+    #[test]
+    fn voltstorm_mode_abilities_descend_as_union() {
+        // Base effect is inert (PairWith{Self} ⇒ empty profile), isolating the union.
+        let base = || Effect::PairWith {
+            target: TargetFilter::SelfRef,
+        };
+        // POS: all modes independent (a life gain and a draw — writes, no reads) ⇒
+        // union has no feed ⇒ clean.
+        let mut pos = ra(base());
+        pos.mode_abilities = vec![
+            def(gain_life(qfix(1))),
+            def(Effect::Draw {
+                count: qfix(1),
+                target: TargetFilter::Controller,
+            }),
+        ];
+        assert!(
+            !conflicts(&pos, &batch()),
+            "independent modes ⇒ union clean"
+        );
+        // NEG: one mode writes counters on creatures, another reads a board
+        // ObjectPt ⇒ the UNION feeds (counters change P/T) ⇒ conflict.
+        let mut reader = def(gain_life(qfix(1)));
+        reader.condition = Some(AbilityCondition::TargetMatchesFilter {
+            filter: creature(),
+            use_lki: false,
+            subject_slot: None,
+        });
+        let mut neg = ra(base());
+        neg.mode_abilities = vec![def(put_counter_all(qfix(1), creature())), reader];
+        assert!(
+            conflicts(&neg, &batch()),
+            "one mode reads what another mode writes ⇒ union conflict"
+        );
+    }
+
+    /// The new `StateKind::TurnStructure` kind: `KindSet` add/union/subtract behave,
+    /// and the `feeds` matrix isolates it — a sequencing read × sequencing write
+    /// conflicts, but it neither feeds nor is fed by `ObjectPt`.
+    #[test]
+    fn turn_structure_kind_isolated_self_conflict() {
+        let ts = KindSet::one(StateKind::TurnStructure);
+        assert!(ts.turn_structure);
+        assert!(
+            KindSet::EMPTY.union(ts).turn_structure,
+            "union carries TurnStructure"
+        );
+        assert!(
+            !ts.minus(ts).turn_structure,
+            "subtract clears TurnStructure"
+        );
+        let (nc, nz) = (Census::None, ZoneSpan::None);
+        assert!(
+            feeds(ts, ts, &nc, &nc, &nz, &nz),
+            "TurnStructure read × write ⇒ self-conflict"
+        );
+        let pt = KindSet::one(StateKind::ObjectPt);
+        assert!(
+            !feeds(pt, ts, &nc, &nc, &nz, &nz),
+            "TurnStructure write does not feed ObjectPt"
+        );
+        assert!(
+            !feeds(ts, pt, &nc, &nc, &nz, &nz),
+            "ObjectPt write does not feed TurnStructure"
         );
     }
 

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -72,10 +72,10 @@
 
 use crate::types::ability::FilterProp;
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, ControllerRef, Duration, Effect, ModalChoice,
-    MultiTargetSpec, ObjectScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef,
-    RepeatContinuation, ResolvedAbility, StaticCondition, TargetFilter, TriggerCondition,
-    TypeFilter, TypedFilter,
+    AbilityCondition, AbilityDefinition, ContinuousModification, ControllerRef, Duration, Effect,
+    ModalChoice, MultiTargetSpec, ObjectScope, PlayerFilter, PlayerScope, QuantityExpr,
+    QuantityRef, RepeatContinuation, ResolvedAbility, StaticCondition, StaticDefinition,
+    TargetFilter, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
 };
 use crate::types::game_state::TargetSelectionConstraint;
 use crate::types::zones::Zone;
@@ -768,13 +768,24 @@ fn membership_zones_of(
 pub(crate) fn ability_rw_profile(a: &ResolvedAbility) -> RwProfile {
     let mut p = RwProfile::empty();
     walk_ability(a, None, &mut p);
+    // CR 603.10a + CR 603.3b: `legacy_batch_prompt` is computed AUTHORITATIVELY by
+    // the decoupled `contains_legacy_event_ref` visitor, not by whichever leaf
+    // sites the read/write walk happened to descend into. This overwrites (never
+    // ORs) the walk's intermediate value: the visitor is a superset of the walk's
+    // legacy leaf-hooking and additionally covers the effect target/count
+    // positions the walk drops (the D5 fail-open holes).
+    p.legacy_batch_prompt = contains_legacy_event_ref(a);
     p
 }
 
 /// Profile a bare trigger-level `condition` (CR 603.4 intervening-if — re-checked
 /// at resolution, so its reads are order-relevant).
 pub(crate) fn trigger_condition_rw_profile(c: &TriggerCondition) -> RwProfile {
-    rw_trigger_condition(c)
+    let mut p = rw_trigger_condition(c);
+    // CR 603.10a: authoritative D5 flag for the trigger-level condition (merged
+    // into the batch profile by `group_is_order_independent`).
+    p.legacy_batch_prompt = legacy_trigger_condition(c);
+    p
 }
 
 // ---------------------------------------------------------------------------
@@ -1060,6 +1071,1270 @@ fn target_is_legacy_ref(f: &TargetFilter) -> bool {
 fn flag_legacy_write_target(p: &mut RwProfile, target: &TargetFilter) {
     if target_is_legacy_ref(target) {
         p.legacy_batch_prompt = true;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// D5 decoupled legacy event-context visitor (CR 603.10a + CR 603.3b).
+//
+// `legacy_batch_prompt` must be true whenever the resolved ability references
+// ANY of the 12 frozen event-context tags in ANY position — the batch/departure
+// ordering path keeps prompting them for strict D3 parity with the deleted serde
+// allowlist (CR 603.10a look-back reads). The read/write PROFILE walk sets the
+// flag only at the leaf detectors it happens to DESCEND into; an arm that ignores
+// its target/count field (`Discard { target: _ }`, `PutAtLibraryPosition`,
+// `Sacrifice`'s `EventContextAmount` count, …) silently dropped the tag and the
+// batch group auto-ordered where the shipped engine prompted (a fail-open D5/D3
+// widening).
+//
+// This visitor is the SINGLE AUTHORITY for `legacy_batch_prompt` (wired into
+// `ability_rw_profile` / `trigger_condition_rw_profile`), DECOUPLED from the
+// profile walk's descent decisions: it performs its own exhaustive, wildcard-free
+// descent of every position where one of the 5 tag-bearing typed enums appears,
+// so the flag can never again depend on whether the profiling walk descended. A
+// future variant of any visited enum fails to COMPILE until classified (CR
+// 603.3b ordering correctness). It intentionally reproduces the profile walk's
+// legacy coverage for non-effect positions (already proven equal to the frozen
+// serde oracle by the §5.2 parity sweep) and ADDS the effect target/count
+// positions the walk drops.
+//
+// The 12 frozen tags and their carrier enums:
+//   * TargetFilter: TriggeringSpellController, TriggeringSpellOwner,
+//     TriggeringPlayer, TriggeringSource, ParentTarget, ParentTargetController,
+//     ParentTargetOwner, StackSpell, CostPaidObject.
+//   * QuantityRef: EventContextAmount, EventContextSourceCostX, ManaSpentToCast.
+//   * ObjectScope: CostPaidObject.  * PlayerFilter: TriggeringPlayer.
+//   * ControllerRef: TriggeringPlayer, ParentTargetController, ParentTargetOwner.
+// `TargetFilter::ParentTargetSlot` is EXCLUDED — it is NOT one of the 12 (it
+// serializes as an object key the frozen serde oracle's value-walk never matched).
+// ---------------------------------------------------------------------------
+
+/// D5 (CR 603.10a): does a resolved ability reference any of the 12 frozen
+/// event-context tags anywhere in its typed AST? The single authority for
+/// `legacy_batch_prompt` (CR 603.3b batch-ordering parity).
+fn contains_legacy_event_ref(a: &ResolvedAbility) -> bool {
+    legacy_effect(&a.effect)
+        || a.sub_ability
+            .as_deref()
+            .is_some_and(contains_legacy_event_ref)
+        || a.else_ability
+            .as_deref()
+            .is_some_and(contains_legacy_event_ref)
+        || a.condition.as_ref().is_some_and(legacy_ability_condition)
+        || a.duration.as_ref().is_some_and(legacy_duration)
+        || a.player_scope.as_ref().is_some_and(legacy_player_filter)
+        || a.starting_with.as_ref().is_some_and(legacy_controller_ref)
+        || a.repeat_for.as_ref().is_some_and(legacy_quantity_expr)
+        || a.multi_target.as_ref().is_some_and(legacy_multi_target)
+        || a.target_constraints.iter().any(legacy_target_constraint)
+        || a.target_chooser.as_ref().is_some_and(legacy_target_filter)
+        || a.repeat_until
+            .as_ref()
+            .is_some_and(legacy_repeat_continuation)
+        || a.modal.as_ref().is_some_and(legacy_modal_choice)
+        || a.mode_abilities.iter().any(legacy_definition)
+}
+
+/// D5: the same descent over a nested `AbilityDefinition` body (deferred
+/// triggers, choice branches, coin/die sub-effects, modal modes).
+fn legacy_definition(a: &AbilityDefinition) -> bool {
+    legacy_effect(&a.effect)
+        || a.sub_ability.as_deref().is_some_and(legacy_definition)
+        || a.else_ability.as_deref().is_some_and(legacy_definition)
+        || a.condition.as_ref().is_some_and(legacy_ability_condition)
+        || a.duration.as_ref().is_some_and(legacy_duration)
+        || a.player_scope.as_ref().is_some_and(legacy_player_filter)
+        || a.starting_with.as_ref().is_some_and(legacy_controller_ref)
+        || a.repeat_for.as_ref().is_some_and(legacy_quantity_expr)
+        || a.multi_target.as_ref().is_some_and(legacy_multi_target)
+        || a.target_constraints.iter().any(legacy_target_constraint)
+        || a.target_chooser.as_ref().is_some_and(legacy_target_filter)
+        || a.repeat_until
+            .as_ref()
+            .is_some_and(legacy_repeat_continuation)
+        || a.modal.as_ref().is_some_and(legacy_modal_choice)
+        || a.mode_abilities.iter().any(legacy_definition)
+}
+
+fn legacy_multi_target(m: &MultiTargetSpec) -> bool {
+    legacy_quantity_expr(&m.min) || m.max.as_ref().is_some_and(legacy_quantity_expr)
+}
+
+fn legacy_target_constraint(c: &TargetSelectionConstraint) -> bool {
+    match c {
+        TargetSelectionConstraint::TotalManaValue { value, .. } => legacy_quantity_expr(value),
+        TargetSelectionConstraint::DifferentTargetPlayers
+        | TargetSelectionConstraint::DifferentObjectControllers => false,
+    }
+}
+
+fn legacy_repeat_continuation(r: &RepeatContinuation) -> bool {
+    match r {
+        RepeatContinuation::WhileCondition { condition, .. } => legacy_ability_condition(condition),
+        RepeatContinuation::ControllerChoice | RepeatContinuation::UntilStopConditions { .. } => {
+            false
+        }
+    }
+}
+
+fn legacy_modal_choice(m: &ModalChoice) -> bool {
+    legacy_player_filter(&m.chooser)
+        || m.dynamic_max_choices
+            .as_ref()
+            .is_some_and(legacy_quantity_expr)
+}
+
+/// D5 trigger-level condition entry (CR 603.4 intervening-if — re-checked at
+/// resolution, so a legacy ref there also retains the batch prompt).
+fn legacy_trigger_condition(x: &TriggerCondition) -> bool {
+    match x {
+        TriggerCondition::QuantityComparison { lhs, rhs, .. } => {
+            legacy_quantity_expr(lhs) || legacy_quantity_expr(rhs)
+        }
+        TriggerCondition::DuringPlayersTurn { player } => legacy_player_filter(player),
+        TriggerCondition::And { conditions } | TriggerCondition::Or { conditions } => {
+            conditions.iter().any(legacy_trigger_condition)
+        }
+        TriggerCondition::Not { condition } => legacy_trigger_condition(condition),
+        TriggerCondition::GainedLife { .. }
+        | TriggerCondition::LostLife
+        | TriggerCondition::LostLifeLastTurn
+        | TriggerCondition::DealtDamageBySourceThisTurn
+        | TriggerCondition::DealtDamageThisTurnBySource { .. }
+        | TriggerCondition::LifeTotalGE { .. }
+        | TriggerCondition::ControlsType { .. }
+        | TriggerCondition::ControlCount { .. }
+        | TriggerCondition::ControlsNone { .. }
+        | TriggerCondition::DefendingPlayerControlsNone { .. }
+        | TriggerCondition::HadCounters { .. }
+        | TriggerCondition::HasCounters { .. }
+        | TriggerCondition::CounterAddedThisTurn
+        | TriggerCondition::SourceIsTapped
+        | TriggerCondition::SourceMatchesFilter { .. }
+        | TriggerCondition::NoSpellsCastLastTurn
+        | TriggerCondition::TwoOrMoreSpellsCastLastTurn
+        | TriggerCondition::CastSpellThisTurn { .. }
+        | TriggerCondition::SpellCastWithVariantThisTurn { .. }
+        | TriggerCondition::SourceEnteredThisTurn
+        | TriggerCondition::SourceIsHarnessed
+        | TriggerCondition::SourceIsAttacking
+        | TriggerCondition::SourceIsTransformed
+        | TriggerCondition::SourceIsFaceUp
+        | TriggerCondition::SourceIsFaceDown
+        | TriggerCondition::SourceInZone { .. }
+        | TriggerCondition::IsRenowned { .. }
+        | TriggerCondition::WasStartingPlayer { .. }
+        | TriggerCondition::ZoneChangeObjectMatchesFilter { .. }
+        | TriggerCondition::ZoneChangeObjectIsTapped
+        | TriggerCondition::EventDamageSourceMatchesFilter { .. }
+        | TriggerCondition::DamagedPlayerIsEventSourceOwner
+        | TriggerCondition::TriggeringSpellTargetsFilter { .. }
+        | TriggerCondition::ManaColorSpent { .. }
+        | TriggerCondition::ManaSpentCondition { .. }
+        | TriggerCondition::AttackersDeclaredCount { .. }
+        | TriggerCondition::Descended
+        | TriggerCondition::EchoDue
+        | TriggerCondition::MinCoAttackers { .. }
+        | TriggerCondition::SolveConditionMet
+        | TriggerCondition::ClassLevelGE { .. }
+        | TriggerCondition::AttractionVisitRoll { .. }
+        | TriggerCondition::WasCast { .. }
+        | TriggerCondition::WasPlayed
+        | TriggerCondition::AdditionalCostPaid { .. }
+        | TriggerCondition::CastVariantPaid { .. }
+        | TriggerCondition::CastVariantPaidPersistent { .. }
+        | TriggerCondition::ActivatedAbilityIsNonMana
+        | TriggerCondition::FirstTimeObjectTappedThisTurn
+        | TriggerCondition::WasType { .. }
+        | TriggerCondition::AttackedThisTurn
+        | TriggerCondition::FirstCombatPhaseOfTurn
+        | TriggerCondition::HasMaxSpeed
+        | TriggerCondition::IsMonarch
+        | TriggerCondition::IsInitiative
+        | TriggerCondition::NoMonarch
+        | TriggerCondition::HasCityBlessing
+        | TriggerCondition::CompletedDungeon { .. }
+        | TriggerCondition::TributeNotPaid
+        | TriggerCondition::CastDuringPhase { .. }
+        | TriggerCondition::CastTimingPermission { .. }
+        | TriggerCondition::ControlsCommander { .. }
+        | TriggerCondition::ChosenLabelIs { .. }
+        | TriggerCondition::ExceptFirstDrawInDrawStep
+        | TriggerCondition::PlacedByAbilitySource => false,
+    }
+}
+
+fn legacy_ability_condition(x: &AbilityCondition) -> bool {
+    match x {
+        AbilityCondition::QuantityCheck { lhs, rhs, .. } => {
+            legacy_quantity_expr(lhs) || legacy_quantity_expr(rhs)
+        }
+        AbilityCondition::PreviousEffectAmount { rhs, .. } => legacy_quantity_expr(rhs),
+        AbilityCondition::ScopedPlayerMatches { filter } => legacy_player_filter(filter),
+        AbilityCondition::ConditionInstead { inner }
+        | AbilityCondition::Not { condition: inner } => legacy_ability_condition(inner),
+        AbilityCondition::And { conditions } | AbilityCondition::Or { conditions } => {
+            conditions.iter().any(legacy_ability_condition)
+        }
+        AbilityCondition::ObjectsShareQuality { .. }
+        | AbilityCondition::TargetMatchesFilter { .. }
+        | AbilityCondition::SourceMatchesFilter { .. }
+        | AbilityCondition::SourceIsTapped
+        | AbilityCondition::ControllerControlsMatching { .. }
+        | AbilityCondition::TriggeringSpellTargetsFilter { .. }
+        | AbilityCondition::ZoneChangeObjectMatchesFilter { .. }
+        | AbilityCondition::ZoneChangedThisWay { .. }
+        | AbilityCondition::CostPaidObjectMatchesFilter { .. }
+        | AbilityCondition::EventOutcomeWon
+        | AbilityCondition::SpellCastWithVariantThisTurn { .. }
+        | AbilityCondition::NthResolutionThisTurn { .. }
+        | AbilityCondition::RevealedHasCardType { .. }
+        | AbilityCondition::SourceEnteredThisTurn
+        | AbilityCondition::AdditionalCostPaid { .. }
+        | AbilityCondition::CastVariantPaid { .. }
+        | AbilityCondition::SourceAttachedToCreature
+        | AbilityCondition::ControllerControlledMatchingAsCast { .. }
+        | AbilityCondition::SourceLacksKeyword { .. }
+        | AbilityCondition::WasStartingPlayer { .. }
+        | AbilityCondition::AdditionalCostPaidInstead
+        | AbilityCondition::AlternativeManaCostPaid
+        | AbilityCondition::EffectOutcome { .. }
+        | AbilityCondition::WhenYouDo
+        | AbilityCondition::CastFromZone { .. }
+        | AbilityCondition::CastDuringPhase { .. }
+        | AbilityCondition::CurrentPhaseIs { .. }
+        | AbilityCondition::CastTimingPermission { .. }
+        | AbilityCondition::ManaColorSpent { .. }
+        | AbilityCondition::TargetSharesNameWithOtherExiledThisWay { .. }
+        | AbilityCondition::CastVariantPaidInstead { .. }
+        | AbilityCondition::HasMaxSpeed
+        | AbilityCondition::IsMonarch
+        | AbilityCondition::IsInitiative
+        | AbilityCondition::HasCityBlessing
+        | AbilityCondition::IsRingBearer
+        | AbilityCondition::TargetHasKeywordInstead { .. }
+        | AbilityCondition::HasObjectTarget
+        | AbilityCondition::IsYourTurn
+        | AbilityCondition::FirstCombatPhaseOfTurn
+        | AbilityCondition::FirstEndStepOfTurn
+        | AbilityCondition::DayNightIsNeither
+        | AbilityCondition::DayNightIs { .. } => false,
+    }
+}
+
+fn legacy_static_condition(x: &StaticCondition) -> bool {
+    match x {
+        StaticCondition::QuantityComparison { lhs, rhs, .. } => {
+            legacy_quantity_expr(lhs) || legacy_quantity_expr(rhs)
+        }
+        StaticCondition::IsTapped { scope, .. } => legacy_object_scope(scope),
+        StaticCondition::And { conditions } | StaticCondition::Or { conditions } => {
+            conditions.iter().any(legacy_static_condition)
+        }
+        StaticCondition::Not { condition } => legacy_static_condition(condition),
+        StaticCondition::DevotionGE { .. }
+        | StaticCondition::SharesColorWithMostCommonColorAmongPermanents
+        | StaticCondition::IsPresent { .. }
+        | StaticCondition::DefendingPlayerControls { .. }
+        | StaticCondition::HasCounters { .. }
+        | StaticCondition::SourceIsTapped
+        | StaticCondition::OpponentPoisonAtLeast { .. }
+        | StaticCondition::SpellCastWithVariantThisTurn { .. }
+        | StaticCondition::SourceMatchesFilter { .. }
+        | StaticCondition::UnlessPay { .. }
+        | StaticCondition::SourceAttackingAlone
+        | StaticCondition::SourceIsAttacking
+        | StaticCondition::SourceIsBlocking
+        | StaticCondition::SourceIsBlocked
+        | StaticCondition::SourceEnteredThisTurn
+        | StaticCondition::SourceHasDealtDamage
+        | StaticCondition::SourceIsSaddled
+        | StaticCondition::SourceIsEquipped
+        | StaticCondition::SourceIsEnchanted
+        | StaticCondition::SourceIsMonstrous
+        | StaticCondition::SourceIsHarnessed
+        | StaticCondition::SourceAttachedToCreature
+        | StaticCondition::SourceIsPaired
+        | StaticCondition::SourceInZone { .. }
+        | StaticCondition::WasStartingPlayer { .. }
+        | StaticCondition::RecipientHasCounters { .. }
+        | StaticCondition::RecipientMatchesFilter { .. }
+        | StaticCondition::RecipientAttackingOwnerTarget { .. }
+        | StaticCondition::ChosenColorIs { .. }
+        | StaticCondition::ChosenLabelIs { .. }
+        | StaticCondition::HasMaxSpeed
+        | StaticCondition::SpeedGE { .. }
+        | StaticCondition::DayNightIs { .. }
+        | StaticCondition::CastVariantPaid { .. }
+        | StaticCondition::ClassLevelGE { .. }
+        | StaticCondition::IsMonarch
+        | StaticCondition::IsInitiative
+        | StaticCondition::NoMonarch
+        | StaticCondition::HasCityBlessing
+        | StaticCondition::CompletedADungeon
+        | StaticCondition::Unrecognized { .. }
+        | StaticCondition::DuringYourTurn
+        | StaticCondition::WasCast { .. }
+        | StaticCondition::IsRingBearer
+        | StaticCondition::RingLevelAtLeast { .. }
+        | StaticCondition::ControlsCommander { .. }
+        | StaticCondition::SourceControllerEquals { .. }
+        | StaticCondition::EnchantedIsFaceDown
+        | StaticCondition::AdditionalCostPaid
+        | StaticCondition::CastingAsVariant { .. }
+        | StaticCondition::None => false,
+    }
+}
+
+fn legacy_duration(x: &Duration) -> bool {
+    match x {
+        Duration::ForAsLongAs { condition } => legacy_static_condition(condition),
+        Duration::UntilEndOfTurn
+        | Duration::UntilEndOfCombat
+        | Duration::UntilHostLeavesPlay
+        | Duration::Permanent
+        | Duration::UntilNextTurnOf { .. }
+        | Duration::UntilEndOfNextTurnOf { .. }
+        | Duration::UntilNextStepOf { .. } => false,
+    }
+}
+
+fn legacy_quantity_expr(x: &QuantityExpr) -> bool {
+    match x {
+        QuantityExpr::Ref { qty } => legacy_quantity_ref(qty),
+        QuantityExpr::Fixed { value: _ } => false,
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::ClampMin { inner, .. }
+        | QuantityExpr::Multiply { inner, .. }
+        | QuantityExpr::UpTo { max: inner } => legacy_quantity_expr(inner),
+        QuantityExpr::Power { exponent, base: _ } => legacy_quantity_expr(exponent),
+        QuantityExpr::Difference { left, right } => {
+            legacy_quantity_expr(left) || legacy_quantity_expr(right)
+        }
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            exprs.iter().any(legacy_quantity_expr)
+        }
+    }
+}
+
+fn legacy_quantity_ref(x: &QuantityRef) -> bool {
+    match x {
+        // 3 of the 12 frozen tags are QuantityRefs.
+        QuantityRef::EventContextAmount
+        | QuantityRef::EventContextSourceCostX
+        | QuantityRef::ManaSpentToCast { .. } => true,
+        // Object-scope carriers: `ObjectScope::CostPaidObject` is a 12th tag.
+        QuantityRef::CountersOn { scope, .. }
+        | QuantityRef::Intensity { scope, .. }
+        | QuantityRef::Power { scope, .. }
+        | QuantityRef::Toughness { scope, .. }
+        | QuantityRef::ObjectManaValue { scope, .. }
+        | QuantityRef::ObjectColorCount { scope, .. }
+        | QuantityRef::ObjectNameWordCount { scope, .. }
+        | QuantityRef::ObjectTypelineComponentCount { scope, .. }
+        | QuantityRef::ManaSymbolsInManaCost { scope, .. } => legacy_object_scope(scope),
+        QuantityRef::HandSize { .. }
+        | QuantityRef::LifeTotal { .. }
+        | QuantityRef::LifeAboveStarting
+        | QuantityRef::StartingLifeTotal
+        | QuantityRef::GraveyardSize { .. }
+        | QuantityRef::ObjectCount { .. }
+        | QuantityRef::ObjectCountDistinct { .. }
+        | QuantityRef::ObjectCountBySharedQuality { .. }
+        | QuantityRef::ControlledByEachPlayer { .. }
+        | QuantityRef::DistinctColorsAmongPermanents { .. }
+        | QuantityRef::CountersOnObjects { .. }
+        | QuantityRef::DistinctCounterKindsAmong { .. }
+        | QuantityRef::Aggregate { .. }
+        | QuantityRef::PlayerCount { .. }
+        | QuantityRef::TargetObjectManaValue { .. }
+        | QuantityRef::PlayerCounter { .. }
+        | QuantityRef::TargetControllerCounter { .. }
+        | QuantityRef::Variable { .. }
+        | QuantityRef::SelfManaValue
+        | QuantityRef::TargetZoneCardCount { .. }
+        | QuantityRef::Devotion { .. }
+        | QuantityRef::DistinctCardTypes { .. }
+        | QuantityRef::BasicLandTypeCount { .. }
+        | QuantityRef::PartySize { .. }
+        | QuantityRef::CardsExiledBySource
+        | QuantityRef::ExiledCardPower { .. }
+        | QuantityRef::TrackedSetSize
+        | QuantityRef::FilteredTrackedSetSize { .. }
+        | QuantityRef::TrackedSetAggregate { .. }
+        | QuantityRef::ExiledFromHandThisResolution
+        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::TurnsTaken
+        | QuantityRef::CrimesCommittedThisTurn
+        | QuantityRef::ChosenNumber
+        | QuantityRef::AttackedThisTurn { .. }
+        | QuantityRef::DescendedThisTurn
+        // CR 701.65b/701.66b/701.67c: controller-scoped per-turn bend accumulator
+        // (Avatar Aang), same class as CrimesCommittedThisTurn — not a frozen tag.
+        | QuantityRef::BendTypesThisTurn
+        | QuantityRef::LandsPlayedThisTurn { .. }
+        | QuantityRef::DungeonsCompleted
+        | QuantityRef::CostXPaid
+        | QuantityRef::KickerCount
+        | QuantityRef::AdditionalCostPaymentCount
+        | QuantityRef::AdditionalCostPaymentCountFor { .. }
+        | QuantityRef::ConvokedCreatureCount
+        | QuantityRef::ColorsInCommandersColorIdentity
+        | QuantityRef::CommanderCastFromCommandZoneCount
+        | QuantityRef::CommanderManaValue { .. }
+        | QuantityRef::Speed { .. }
+        | QuantityRef::VoteCount { .. }
+        | QuantityRef::ZoneCardCount { .. }
+        | QuantityRef::EnteredThisTurn { .. }
+        | QuantityRef::SacrificedThisTurn { .. }
+        | QuantityRef::BattlefieldEntriesThisTurn { .. }
+        | QuantityRef::ZoneChangeCountThisTurn { .. }
+        | QuantityRef::ZoneChangeAggregateThisTurn { .. }
+        | QuantityRef::TokensCreatedThisTurn { .. }
+        | QuantityRef::CounterAddedThisTurn { .. }
+        | QuantityRef::LifeLostThisTurn { .. }
+        | QuantityRef::LifeGainedThisTurn { .. }
+        | QuantityRef::DamageDealtThisTurn { .. }
+        | QuantityRef::CardsDrawnThisTurn { .. }
+        | QuantityRef::CardsDiscardedThisTurn { .. }
+        | QuantityRef::SpellsCastThisTurn { .. }
+        | QuantityRef::SpellsCastLastTurn
+        | QuantityRef::SpellsCastThisGame { .. }
+        | QuantityRef::LoyaltyAbilitiesActivatedThisTurn { .. }
+        | QuantityRef::PlayerActionsThisTurn { .. }
+        | QuantityRef::UnspentMana { .. }
+        | QuantityRef::AttachmentsOnLeavingObject { .. }
+        | QuantityRef::TimesCostPaidThisResolution => false,
+    }
+}
+
+fn legacy_object_scope(s: &ObjectScope) -> bool {
+    match s {
+        ObjectScope::CostPaidObject => true,
+        ObjectScope::Source
+        | ObjectScope::Recipient
+        | ObjectScope::Target
+        | ObjectScope::Anaphoric
+        | ObjectScope::Demonstrative
+        | ObjectScope::EventSource
+        | ObjectScope::EventTarget => false,
+    }
+}
+
+fn legacy_player_filter(x: &PlayerFilter) -> bool {
+    match x {
+        PlayerFilter::TriggeringPlayer => true,
+        PlayerFilter::ControlsCount { count, .. } => legacy_quantity_expr(count),
+        PlayerFilter::PlayerAttribute { attr, value, .. } => {
+            legacy_quantity_ref(attr) || legacy_quantity_expr(value)
+        }
+        PlayerFilter::AllExcept { exclude } => legacy_player_filter(exclude),
+        PlayerFilter::OpponentLostLife
+        | PlayerFilter::OpponentGainedLife
+        | PlayerFilter::OpponentDealtCombatDamage { .. }
+        | PlayerFilter::OpponentOtherThanTriggering
+        | PlayerFilter::OpponentOfTriggeringPlayer
+        | PlayerFilter::OpponentOfTriggeringPlayerNotAttacked
+        | PlayerFilter::ParentObjectTargetController
+        | PlayerFilter::ParentObjectTargetOwner
+        | PlayerFilter::Controller
+        | PlayerFilter::Opponent
+        | PlayerFilter::DefendingPlayer
+        | PlayerFilter::HasLostTheGame
+        | PlayerFilter::OpponentAttacked { .. }
+        | PlayerFilter::All
+        | PlayerFilter::HighestSpeed
+        | PlayerFilter::ZoneChangedThisWay
+        | PlayerFilter::PerformedActionThisWay { .. }
+        | PlayerFilter::OwnersOfCardsExiledBySource
+        | PlayerFilter::VotedFor { .. }
+        | PlayerFilter::ChosenPlayer { .. } => false,
+    }
+}
+
+fn legacy_controller_ref(x: &ControllerRef) -> bool {
+    match x {
+        ControllerRef::ParentTargetController
+        | ControllerRef::ParentTargetOwner
+        | ControllerRef::TriggeringPlayer => true,
+        ControllerRef::You
+        | ControllerRef::Opponent
+        | ControllerRef::ScopedPlayer
+        | ControllerRef::TargetPlayer
+        | ControllerRef::DefendingPlayer
+        | ControllerRef::ChosenPlayer { .. }
+        | ControllerRef::SourceChosenPlayer
+        | ControllerRef::EnchantedPlayer => false,
+    }
+}
+
+/// The 9 `TargetFilter` carriers of the 12 tags, position-agnostic: a nested tag
+/// inside `Not`/`And`/`Or`/`TrackedSetFiltered` is caught (mirrors the frozen
+/// serde oracle's whole-value walk). `ParentTargetSlot` is deliberately excluded.
+fn legacy_target_filter(f: &TargetFilter) -> bool {
+    match f {
+        TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::TriggeringSource
+        | TargetFilter::ParentTarget
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::StackSpell
+        | TargetFilter::CostPaidObject => true,
+        TargetFilter::Not { filter } | TargetFilter::TrackedSetFiltered { filter, .. } => {
+            legacy_target_filter(filter)
+        }
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(legacy_target_filter)
+        }
+        // A `Typed` filter carries a `controller` (`ControllerRef`) and
+        // `properties` (`FilterProp`), each of which can nest a frozen tag
+        // (e.g. `creature <ParentTargetController> controls`, or a
+        // `SharesQuality`/`PtComparison` prop referencing a `TriggeringSource`
+        // filter / `CostPaidObject` scope). The serde oracle walked these; we
+        // must too. `type_filters` (`TypeFilter`) carry no tag.
+        TargetFilter::Typed(tf) => {
+            tf.controller.as_ref().is_some_and(legacy_controller_ref)
+                || tf.properties.iter().any(legacy_filter_prop)
+        }
+        TargetFilter::ParentTargetSlot { .. }
+        | TargetFilter::EventTarget
+        | TargetFilter::TriggeringSourceController
+        | TargetFilter::PostReplacementSourceController
+        | TargetFilter::PostReplacementDamageTarget
+        | TargetFilter::PostReplacementDamageTargetOwner
+        | TargetFilter::ChosenDamageSource
+        | TargetFilter::None
+        | TargetFilter::Any
+        | TargetFilter::Player
+        | TargetFilter::Controller
+        | TargetFilter::SelfRef
+        | TargetFilter::SourceOrPaired
+        | TargetFilter::StackAbility { .. }
+        | TargetFilter::SpecificObject { .. }
+        | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::Neighbor { .. }
+        | TargetFilter::ScopedPlayer
+        | TargetFilter::AttachedTo
+        | TargetFilter::LastCreated
+        | TargetFilter::LastRevealed
+        | TargetFilter::ChosenCard
+        | TargetFilter::TrackedSet { .. }
+        | TargetFilter::ExiledBySource
+        | TargetFilter::ExiledCardByIndex { .. }
+        | TargetFilter::SourceChosenPlayer
+        | TargetFilter::OriginalController
+        | TargetFilter::DefendingPlayer
+        | TargetFilter::HasChosenName
+        | TargetFilter::Named { .. }
+        | TargetFilter::Owner
+        | TargetFilter::AllPlayers => false,
+    }
+}
+
+/// A `FilterProp` interior can nest each of the tag-bearing enums: a
+/// `TargetFilter` (`SharesQuality`/`CanEnchant`/`Targets`/…), a `QuantityExpr`
+/// (`Counters`/`Cmc`/`PtComparison` values → `EventContext*` / `CostPaidObject`
+/// scope), a `ControllerRef` (`Owned`/`Attacking`/…), or a nested `FilterProp`
+/// (`AnyOf`/`Not`). Exhaustive & wildcard-free so a future prop must be
+/// classified (a `_ =>` here would silently re-open the D5 hole class).
+fn legacy_filter_prop(p: &FilterProp) -> bool {
+    match p {
+        FilterProp::CanEnchant { target } => legacy_target_filter(target),
+        FilterProp::DifferentNameFrom { filter }
+        | FilterProp::TargetsOnly { filter }
+        | FilterProp::Targets { filter } => legacy_target_filter(filter),
+        FilterProp::SharesQuality { reference, .. } => {
+            reference.as_deref().is_some_and(legacy_target_filter)
+        }
+        FilterProp::Counters { count, .. } => legacy_quantity_expr(count),
+        FilterProp::Cmc { value, .. } | FilterProp::PtComparison { value, .. } => {
+            legacy_quantity_expr(value)
+        }
+        FilterProp::ProtectorMatches { controller }
+        | FilterProp::Owned { controller }
+        | FilterProp::MostPrevalentCreatureTypeIn {
+            scope: controller, ..
+        } => legacy_controller_ref(controller),
+        FilterProp::Attacking { defender: c }
+        | FilterProp::AttackedThisTurn { defender: c }
+        | FilterProp::HasAttachment { controller: c, .. }
+        | FilterProp::HasAnyAttachmentOf { controller: c, .. }
+        | FilterProp::NameMatchesAnyPermanent { controller: c } => {
+            c.as_ref().is_some_and(legacy_controller_ref)
+        }
+        FilterProp::AnyOf { props } => props.iter().any(legacy_filter_prop),
+        FilterProp::Not { prop } => legacy_filter_prop(prop),
+        FilterProp::Token
+        | FilterProp::NonToken
+        | FilterProp::WasPlayed
+        | FilterProp::Blocking
+        | FilterProp::BlockingSource
+        | FilterProp::CombatRelation { .. }
+        | FilterProp::Unblocked
+        | FilterProp::AttackingAlone
+        | FilterProp::BlockingAlone
+        | FilterProp::Tapped
+        | FilterProp::Untapped
+        | FilterProp::IsSaddled
+        | FilterProp::SaddledSource
+        | FilterProp::ConvokedSource
+        | FilterProp::HasHasteOrControlledSinceTurnBegan
+        | FilterProp::WithKeyword { .. }
+        | FilterProp::HasKeywordKind { .. }
+        | FilterProp::WithoutKeyword { .. }
+        | FilterProp::WithoutKeywordKind { .. }
+        | FilterProp::ManaValueParity { .. }
+        | FilterProp::ManaCostIn { .. }
+        | FilterProp::InZone { .. }
+        | FilterProp::Foretold
+        | FilterProp::EnchantedBy
+        | FilterProp::EquippedBy
+        | FilterProp::AttachedToSource
+        | FilterProp::AttachedToRecipient
+        | FilterProp::Another
+        | FilterProp::Unpaired
+        | FilterProp::OtherThanTriggerObject
+        | FilterProp::HasColor { .. }
+        | FilterProp::PowerGTSource
+        | FilterProp::ColorCount { .. }
+        | FilterProp::ManaSymbolCount { .. }
+        | FilterProp::HasSupertype { .. }
+        | FilterProp::IsChosenCreatureType
+        | FilterProp::IsChosenColor
+        | FilterProp::IsChosenCardType
+        | FilterProp::IsChosenLandOrNonlandKind
+        | FilterProp::HasSingleTarget
+        | FilterProp::Modal
+        | FilterProp::NotColor { .. }
+        | FilterProp::NotSupertype { .. }
+        | FilterProp::Suspected
+        | FilterProp::Renowned
+        | FilterProp::ToughnessGTPower
+        | FilterProp::PowerExceedsBase
+        | FilterProp::InAnyZone { .. }
+        | FilterProp::WasDealtDamageThisTurn
+        | FilterProp::EnteredThisTurn
+        | FilterProp::ZoneChangedThisTurn { .. }
+        | FilterProp::BlockedThisTurn
+        | FilterProp::AttackedOrBlockedThisTurn
+        | FilterProp::CountersPutOnThisTurn { .. }
+        | FilterProp::FaceDown
+        | FilterProp::HasXInManaCost
+        | FilterProp::HasXInActivationCost
+        | FilterProp::WasKicked
+        | FilterProp::HasManaAbility
+        | FilterProp::HasNoAbilities
+        | FilterProp::Named { .. }
+        | FilterProp::SameName
+        | FilterProp::SameNameAsParentTarget
+        | FilterProp::IsCommander
+        | FilterProp::Modified
+        | FilterProp::Historic
+        | FilterProp::NotHistoric
+        | FilterProp::Other { .. } => false,
+    }
+}
+
+/// A static ability granted by an effect (`Token`/`GenericEffect`/`CreateEmblem`)
+/// can nest a frozen tag in its affected filter, its `as long as` gate, or a
+/// granted modification (e.g. a `GrantTrigger` whose body references
+/// `ParentTarget` — Rekindling Phoenix's token upkeep trigger).
+fn legacy_static_definition(s: &StaticDefinition) -> bool {
+    s.affected.as_ref().is_some_and(legacy_target_filter)
+        || s.condition.as_ref().is_some_and(legacy_static_condition)
+        || s.modifications.iter().any(legacy_continuous_modification)
+}
+
+/// A layer-6 grant (`GrantAbility`/`GrantTrigger`/`GrantStaticAbility`), an
+/// all-of-source grant filter, or a dynamic P/T/counter value can each nest a
+/// frozen tag. Exhaustive & wildcard-free so a future modification is classified.
+fn legacy_continuous_modification(m: &ContinuousModification) -> bool {
+    match m {
+        ContinuousModification::GrantAbility { definition } => legacy_definition(definition),
+        ContinuousModification::GrantStaticAbility { definition } => {
+            legacy_static_definition(definition)
+        }
+        ContinuousModification::GrantTrigger { trigger } => legacy_trigger_definition(trigger),
+        ContinuousModification::GrantAllActivatedAbilitiesOf { source, .. }
+        | ContinuousModification::GrantAllTriggeredAbilitiesOf { source } => {
+            legacy_target_filter(source)
+        }
+        ContinuousModification::SetDynamicPower { value }
+        | ContinuousModification::SetDynamicToughness { value }
+        | ContinuousModification::SetPowerDynamic { value }
+        | ContinuousModification::SetToughnessDynamic { value }
+        | ContinuousModification::AddDynamicPower { value }
+        | ContinuousModification::AddDynamicToughness { value }
+        | ContinuousModification::AddDynamicKeyword { value, .. }
+        | ContinuousModification::AddCounterOnEnter { count: value, .. } => {
+            legacy_quantity_expr(value)
+        }
+        ContinuousModification::CopyValues { .. }
+        | ContinuousModification::SetName { .. }
+        | ContinuousModification::AddPower { .. }
+        | ContinuousModification::AddToughness { .. }
+        | ContinuousModification::SetPower { .. }
+        | ContinuousModification::SetToughness { .. }
+        | ContinuousModification::AddKeyword { .. }
+        | ContinuousModification::RemoveKeyword { .. }
+        | ContinuousModification::RemoveAllAbilities
+        | ContinuousModification::AddType { .. }
+        | ContinuousModification::RemoveType { .. }
+        | ContinuousModification::AddSubtype { .. }
+        | ContinuousModification::RemoveSubtype { .. }
+        | ContinuousModification::SetCardTypes { .. }
+        | ContinuousModification::RemoveAllSubtypes { .. }
+        | ContinuousModification::AddAllCreatureTypes
+        | ContinuousModification::AddAllBasicLandTypes
+        | ContinuousModification::AddAllLandTypes
+        | ContinuousModification::AddChosenSubtype { .. }
+        | ContinuousModification::AddChosenColor
+        | ContinuousModification::RemoveChosenKeyword
+        | ContinuousModification::AddChosenKeyword
+        | ContinuousModification::SetColor { .. }
+        | ContinuousModification::AddColor { .. }
+        // A granted rule-modification mode (`AddStaticMode`) carries no frozen tag
+        // in the corpus; the §5.2 sweep is the arbiter if one ever hides there.
+        | ContinuousModification::AddStaticMode { .. }
+        | ContinuousModification::SwitchPowerToughness
+        | ContinuousModification::AssignDamageFromToughness
+        | ContinuousModification::AssignDamageAsThoughUnblocked
+        | ContinuousModification::AssignNoCombatDamage
+        | ContinuousModification::ChangeController
+        | ContinuousModification::SetBasicLandType { .. }
+        | ContinuousModification::SetChosenBasicLandType
+        // CR 612.8 + 613.1c: Layer-3 name-set from source's chosen name (Psychic
+        // Paper); a granted continuous mod, no frozen event-context tag.
+        | ContinuousModification::SetChosenName
+        | ContinuousModification::RetainPrintedTriggerFromSource { .. }
+        | ContinuousModification::RetainPrintedAbilityFromSource { .. }
+        | ContinuousModification::AddSupertype { .. }
+        | ContinuousModification::RemoveSupertype { .. }
+        | ContinuousModification::SetStartingLoyalty { .. }
+        | ContinuousModification::RemoveManaCost => false,
+    }
+}
+
+/// A granted / emblem `TriggerDefinition` can carry a frozen tag in its firing
+/// filters (`valid_card`/`valid_source`), its intervening-if condition, or its
+/// execute body.
+fn legacy_trigger_definition(td: &TriggerDefinition) -> bool {
+    td.execute.as_deref().is_some_and(legacy_definition)
+        || td.condition.as_ref().is_some_and(legacy_trigger_condition)
+        || td.valid_card.as_ref().is_some_and(legacy_target_filter)
+        || td.valid_source.as_ref().is_some_and(legacy_target_filter)
+}
+
+/// D5: every effect position where a frozen tag can appear. `{ .. }` elides
+/// fields that carry no tag-bearing enum; the match is exhaustive at the VARIANT
+/// level (a new `Effect` variant fails to compile). Effect TARGET/COUNT positions
+/// are checked here even where the read/write profile walk drops them — this is
+/// the class of 50 D5 holes this visitor closes (CR 603.10a).
+fn legacy_effect(x: &Effect) -> bool {
+    // Small helpers for optional carriers.
+    let otf = |o: &Option<TargetFilter>| o.as_ref().is_some_and(legacy_target_filter);
+    let oqe = |o: &Option<QuantityExpr>| o.as_ref().is_some_and(legacy_quantity_expr);
+    let ocr = |o: &Option<ControllerRef>| o.as_ref().is_some_and(legacy_controller_ref);
+    let odur = |o: &Option<Duration>| o.as_ref().is_some_and(legacy_duration);
+    let odef = |o: &Option<Box<AbilityDefinition>>| o.as_deref().is_some_and(legacy_definition);
+    match x {
+        // ---- Single `TargetFilter` target (only tag-bearing field) ----
+        Effect::Pump { target, .. }
+        | Effect::PairWith { target }
+        | Effect::Destroy { target, .. }
+        | Effect::Regenerate { target }
+        | Effect::RemoveAllDamage { target }
+        | Effect::Counter { target, .. }
+        | Effect::CounterAll { target }
+        | Effect::SetTapState { target, .. }
+        | Effect::MultiplyCounter { target, .. }
+        | Effect::DoublePT { target, .. }
+        | Effect::DoublePTAll { target, .. }
+        | Effect::PumpAll { target, .. }
+        | Effect::GainControl { target }
+        | Effect::GainControlAll { target }
+        | Effect::ControlNextTurn { target, .. }
+        | Effect::Bounce { target, .. }
+        | Effect::DestroyAll { target, .. }
+        | Effect::SwitchPT { target }
+        | Effect::ExileHaunting { target }
+        | Effect::HideawayConceal { target }
+        | Effect::ChooseCard { target, .. }
+        | Effect::Transform { target }
+        | Effect::Shuffle { target }
+        | Effect::Reveal { target }
+        | Effect::TargetOnly { target }
+        | Effect::Suspect { target, .. }
+        | Effect::Unsuspect { target, .. }
+        | Effect::PhaseOut { target }
+        | Effect::PhaseIn { target }
+        | Effect::ForceBlock { target }
+        | Effect::BecomePrepared { target }
+        | Effect::BecomeUnprepared { target }
+        | Effect::BecomeSaddled { target }
+        | Effect::ProliferateTarget { target }
+        | Effect::Exploit { target }
+        | Effect::LoseAllPlayerCounters { target }
+        | Effect::Heist { target, .. }
+        | Effect::PutOnTopOrBottom { target }
+        | Effect::Goad { target }
+        | Effect::GoadAll { target }
+        | Effect::Detain { target }
+        | Effect::SetRoomDoorLock { target, .. }
+        | Effect::RemoveFromCombat { target }
+        | Effect::ApplyPerpetual { target, .. }
+        | Effect::TurnFaceUp { target }
+        | Effect::TurnFaceDown { target, .. }
+        | Effect::ExtraTurn { target }
+        | Effect::Double { target, .. }
+        | Effect::CrankContraptions { target }
+        | Effect::ReassembleContraption { target, .. }
+        | Effect::AssembleContraptionOnSprocket { target, .. }
+        | Effect::ReassembleContraptionOnSprocket { target, .. }
+        | Effect::ApplySticker { target, .. }
+        | Effect::RememberCard { target }
+        | Effect::GrantCastingPermission { target, .. }
+        | Effect::AddTargetReplacement { target, .. }
+        | Effect::DiscardCard { target, .. }
+        | Effect::Animate { target, .. } => legacy_target_filter(target),
+
+        Effect::GainActivatedAbilitiesOfTarget {
+            target,
+            recipient,
+            duration,
+        } => legacy_target_filter(target) || legacy_target_filter(recipient) || odur(duration),
+
+        // ---- Single filter-typed field under a different name ----
+        Effect::ExploreAll { filter: target, .. }
+        | Effect::FreeCastFromZones { filter: target, .. }
+        | Effect::ChooseDamageSource {
+            source_filter: target,
+        }
+        | Effect::ReturnAsAura {
+            enchant_filter: target,
+            ..
+        }
+        | Effect::RevealTop { player: target, .. }
+        | Effect::BlightEffect { player: target, .. }
+        | Effect::ExileFromTopUntil { player: target, .. }
+        | Effect::ExchangeLifeWithStat { player: target, .. } => legacy_target_filter(target),
+
+        // `host` is `Box<TargetFilter>` — deref-coerced in the call.
+        Effect::CombineHost { host, .. } => legacy_target_filter(host),
+
+        // ---- `count`/`amount` (QuantityExpr) + `target` ----
+        Effect::Draw { count, target }
+        | Effect::Mill { count, target, .. }
+        | Effect::Scry { count, target }
+        | Effect::Surveil { count, target }
+        | Effect::RemoveCounter { count, target, .. }
+        | Effect::Sacrifice { target, count, .. }
+        | Effect::PutCounter { count, target, .. }
+        | Effect::PutCounterAll { count, target, .. }
+        | Effect::Connive { target, count }
+        | Effect::GivePlayerCounter { count, target, .. }
+        | Effect::PutAtLibraryPosition { target, count, .. }
+        | Effect::SkipNextTurn { target, count }
+        | Effect::SkipNextStep { target, count, .. }
+        | Effect::AdditionalPhase { target, count, .. }
+        | Effect::Cloak { target, count }
+        | Effect::GrantExtraLoyaltyActivations {
+            amount: count,
+            target,
+        } => legacy_quantity_expr(count) || legacy_target_filter(target),
+        Effect::SetLifeTotal { target, amount } | Effect::DealDamage { amount, target, .. } => {
+            legacy_quantity_expr(amount) || legacy_target_filter(target)
+        }
+        Effect::Endure {
+            amount: count,
+            subject: target,
+        }
+        | Effect::Discover {
+            mana_value_limit: count,
+            player: target,
+        }
+        | Effect::ExileTop {
+            count,
+            player: target,
+            ..
+        } => legacy_quantity_expr(count) || legacy_target_filter(target),
+
+        // ---- `count`-only (QuantityExpr) ----
+        Effect::Monstrosity { count }
+        | Effect::Incubate { count }
+        | Effect::Amass { count, .. }
+        | Effect::Renown { count }
+        | Effect::Bolster { count }
+        | Effect::Adapt { count }
+        | Effect::AssembleContraptions { count }
+        | Effect::AddPendingETBCounters { count, .. } => legacy_quantity_expr(count),
+        Effect::GainEnergy { amount } | Effect::Intensify { amount, .. } => {
+            legacy_quantity_expr(amount)
+        }
+
+        // ---- Pairs of filters / mixed shapes ----
+        Effect::Fight { target, subject } => {
+            legacy_target_filter(target) || legacy_target_filter(subject)
+        }
+        Effect::EachDealsDamageEqualToPower { sources, recipient } => {
+            legacy_target_filter(sources) || legacy_target_filter(recipient)
+        }
+        Effect::Attach { attachment, target } | Effect::UnattachAll { attachment, target } => {
+            legacy_target_filter(attachment) || legacy_target_filter(target)
+        }
+        Effect::ExchangeControl { target_a, target_b }
+        | Effect::ExchangeLifeTotals {
+            player_a: target_a,
+            player_b: target_b,
+        } => legacy_target_filter(target_a) || legacy_target_filter(target_b),
+        Effect::GiveControl { target, recipient }
+        | Effect::CopyTokenBlockingAttacker {
+            source_filter: target,
+            owner: recipient,
+        }
+        | Effect::ChooseObjectsIntoTrackedSet {
+            chooser: target,
+            filter: recipient,
+            ..
+        } => legacy_target_filter(target) || legacy_target_filter(recipient),
+        Effect::ChooseAugmentAndCombineWithHost { filter, host, .. } => {
+            legacy_target_filter(filter) || legacy_target_filter(host)
+        }
+        Effect::GainLife { amount, player } => {
+            legacy_quantity_expr(amount) || legacy_target_filter(player)
+        }
+        Effect::LoseLife { amount, target } => legacy_quantity_expr(amount) || otf(target),
+        Effect::DamageAll {
+            amount,
+            target,
+            player_filter,
+            ..
+        } => {
+            legacy_quantity_expr(amount)
+                || legacy_target_filter(target)
+                || player_filter.as_ref().is_some_and(legacy_player_filter)
+        }
+        Effect::DamageEachPlayer {
+            amount,
+            player_filter,
+        } => legacy_quantity_expr(amount) || legacy_player_filter(player_filter),
+        Effect::Discard {
+            count,
+            target,
+            unless_filter,
+            filter,
+            ..
+        } => {
+            legacy_quantity_expr(count)
+                || legacy_target_filter(target)
+                || otf(unless_filter)
+                || otf(filter)
+        }
+        Effect::Dig {
+            player,
+            count,
+            filter,
+            ..
+        } => {
+            legacy_target_filter(player)
+                || legacy_quantity_expr(count)
+                || legacy_target_filter(filter)
+        }
+        Effect::Seek { filter, count, .. } | Effect::SearchOutsideGame { filter, count, .. } => {
+            legacy_target_filter(filter) || legacy_quantity_expr(count)
+        }
+        Effect::SearchLibrary {
+            filter,
+            count,
+            target_player,
+            ..
+        } => legacy_target_filter(filter) || legacy_quantity_expr(count) || otf(target_player),
+        Effect::ChooseAndSacrificeRest {
+            choose_filter,
+            sacrifice_filter,
+            total_power_cap,
+            ..
+        } => {
+            legacy_target_filter(choose_filter)
+                || legacy_target_filter(sacrifice_filter)
+                || oqe(total_power_cap)
+        }
+        Effect::ChangeSpeed {
+            player_scope,
+            amount,
+            ..
+        } => legacy_player_filter(player_scope) || legacy_quantity_expr(amount),
+        Effect::StartYourEngines { player_scope } => legacy_player_filter(player_scope),
+        Effect::ChooseOneOf { chooser, branches } => {
+            legacy_player_filter(chooser) || branches.iter().any(legacy_definition)
+        }
+        Effect::PutSticker {
+            target,
+            count,
+            max_ticket_cost,
+            ..
+        } => legacy_target_filter(target) || legacy_quantity_expr(count) || oqe(max_ticket_cost),
+        Effect::ChooseDrawnThisTurnPayOrTopdeck {
+            count,
+            life_payment,
+            player,
+        } => {
+            legacy_quantity_expr(count)
+                || legacy_quantity_expr(life_payment)
+                || legacy_target_filter(player)
+        }
+
+        // ---- Options-only carriers ----
+        Effect::Mana { target, .. }
+        | Effect::LoseTheGame { target }
+        | Effect::WinTheGame { target } => otf(target),
+        Effect::ChooseFromZone { filter, .. } => otf(filter),
+        Effect::ReduceNextSpellCost { spell_filter, .. }
+        | Effect::GrantNextSpellAbility { spell_filter, .. } => otf(spell_filter),
+        Effect::PreventDamage {
+            amount_dynamic,
+            target,
+            ..
+        } => oqe(amount_dynamic) || legacy_target_filter(target),
+        Effect::PayCost { scale, payer, .. } => oqe(scale) || legacy_target_filter(payer),
+        Effect::ChangeTargets {
+            target, forced_to, ..
+        } => legacy_target_filter(target) || otf(forced_to),
+        Effect::CreateDamageReplacement {
+            source_filter,
+            redirect_object_filter,
+            recipient_object_filter,
+            ..
+        } => otf(source_filter) || otf(redirect_object_filter) || otf(recipient_object_filter),
+
+        // ---- ControllerRef / Duration riders on a target ----
+        Effect::Manifest {
+            target,
+            count,
+            enters_under,
+            ..
+        } => legacy_target_filter(target) || legacy_quantity_expr(count) || ocr(enters_under),
+        Effect::RevealUntil {
+            player,
+            filter,
+            count,
+            enters_under,
+            ..
+        } => {
+            legacy_target_filter(player)
+                || legacy_target_filter(filter)
+                || legacy_quantity_expr(count)
+                || ocr(enters_under)
+        }
+        Effect::BecomeCopy {
+            target, duration, ..
+        }
+        | Effect::CastFromZone {
+            target, duration, ..
+        } => legacy_target_filter(target) || odur(duration),
+        Effect::GenericEffect {
+            duration,
+            target,
+            static_abilities,
+        } => odur(duration) || otf(target) || static_abilities.iter().any(legacy_static_definition),
+        Effect::CreateEmblem { statics, triggers } => {
+            statics.iter().any(legacy_static_definition)
+                || triggers.iter().any(legacy_trigger_definition)
+        }
+        Effect::ForceAttack {
+            target,
+            required_player,
+            duration,
+        } => {
+            legacy_target_filter(target)
+                || legacy_target_filter(required_player)
+                || legacy_duration(duration)
+        }
+
+        // ---- Token creation / counters with enter-with-counters ----
+        Effect::Token {
+            count,
+            owner,
+            attach_to,
+            enter_with_counters,
+            static_abilities,
+            ..
+        } => {
+            legacy_quantity_expr(count)
+                || legacy_target_filter(owner)
+                || otf(attach_to)
+                || enter_with_counters
+                    .iter()
+                    .any(|(_, q)| legacy_quantity_expr(q))
+                || static_abilities.iter().any(legacy_static_definition)
+        }
+        Effect::CopyTokenOf {
+            target,
+            owner,
+            source_filter,
+            count,
+            ..
+        } => {
+            legacy_target_filter(target)
+                || legacy_target_filter(owner)
+                || otf(source_filter)
+                || legacy_quantity_expr(count)
+        }
+        Effect::CreateTokenCopyFromPool {
+            owner,
+            type_filter,
+            mv_bound,
+            count,
+            ..
+        } => {
+            legacy_target_filter(owner)
+                || legacy_target_filter(type_filter)
+                || legacy_quantity_expr(mv_bound)
+                || legacy_quantity_expr(count)
+        }
+        Effect::ChangeZone {
+            target,
+            enters_under,
+            enter_with_counters,
+            conditional_enter_with_counters,
+            enters_modified_if,
+            ..
+        } => {
+            legacy_target_filter(target)
+                || ocr(enters_under)
+                || enter_with_counters
+                    .iter()
+                    .any(|(_, q)| legacy_quantity_expr(q))
+                || conditional_enter_with_counters
+                    .iter()
+                    .any(|(f, _, q)| legacy_target_filter(f) || legacy_quantity_expr(q))
+                || otf(enters_modified_if)
+        }
+        Effect::ChangeZoneAll {
+            target,
+            enters_under,
+            enter_with_counters,
+            ..
+        } => {
+            legacy_target_filter(target)
+                || ocr(enters_under)
+                || enter_with_counters
+                    .iter()
+                    .any(|(_, q)| legacy_quantity_expr(q))
+        }
+        Effect::MoveCounters {
+            source,
+            count,
+            target,
+            ..
+        } => legacy_target_filter(source) || oqe(count) || legacy_target_filter(target),
+        Effect::BounceAll { target, count, .. } | Effect::CastCopyOfCard { target, count, .. } => {
+            legacy_target_filter(target) || oqe(count)
+        }
+        Effect::RevealHand {
+            target,
+            card_filter,
+            count,
+            ..
+        } => legacy_target_filter(target) || legacy_target_filter(card_filter) || oqe(count),
+
+        // ---- Nested ability/effect bodies ----
+        Effect::Vote {
+            per_choice_effect,
+            starting_with,
+            ..
+        } => {
+            legacy_controller_ref(starting_with)
+                || per_choice_effect.iter().any(|d| legacy_definition(d))
+        }
+        Effect::SeparateIntoPiles {
+            object_filter,
+            chosen_pile_effect,
+            ..
+        } => legacy_target_filter(object_filter) || legacy_definition(chosen_pile_effect),
+        Effect::EpicCopy { spell } => contains_legacy_event_ref(spell),
+        Effect::CreateDelayedTrigger { effect, .. } => legacy_definition(effect),
+        Effect::CreateDrawReplacement { replacement_effect } => legacy_effect(replacement_effect),
+        Effect::RollDie { count, results, .. } => {
+            legacy_quantity_expr(count) || results.iter().any(|r| legacy_definition(&r.effect))
+        }
+        Effect::FlipCoin {
+            win_effect,
+            lose_effect,
+            flipper,
+        } => odef(win_effect) || odef(lose_effect) || legacy_target_filter(flipper),
+        Effect::FlipCoins {
+            count,
+            win_effect,
+            lose_effect,
+            flipper,
+        } => {
+            legacy_quantity_expr(count)
+                || odef(win_effect)
+                || odef(lose_effect)
+                || legacy_target_filter(flipper)
+        }
+        Effect::FlipCoinUntilLose { win_effect } => legacy_definition(win_effect),
+        Effect::RevealFromHand {
+            filter, on_decline, ..
+        } => legacy_target_filter(filter) || odef(on_decline),
+        Effect::CopySpell { target, copier, .. } => legacy_target_filter(target) || ocr(copier),
+
+        // ---- No tag-bearing field (info / terminal / plumbing / undescended
+        // sub-structures the profile walk also does not descend for legacy —
+        // §5.2 sweep is the arbiter). ----
+        Effect::Explore
+        | Effect::Investigate
+        | Effect::Tribute { .. }
+        | Effect::TimeTravel
+        | Effect::BecomeMonarch
+        | Effect::NoOp
+        | Effect::Proliferate
+        | Effect::Populate
+        | Effect::Clash
+        | Effect::EndTheTurn
+        | Effect::EndCombatPhase
+        | Effect::Myriad
+        | Effect::Encore
+        | Effect::Meld { .. }
+        | Effect::RegisterBending { .. }
+        | Effect::Cleanup { .. }
+        | Effect::Learn
+        | Effect::Forage
+        | Effect::Harness
+        | Effect::CollectEvidence { .. }
+        | Effect::Specialize
+        | Effect::SolveCase
+        | Effect::SetClassLevel { .. }
+        | Effect::AddRestriction { .. }
+        | Effect::ExileResolvingSpellInsteadOfGraveyard
+        | Effect::RingTemptsYou
+        | Effect::VentureIntoDungeon
+        | Effect::VentureInto { .. }
+        | Effect::TakeTheInitiative
+        | Effect::Planeswalk
+        | Effect::OpenAttractions { .. }
+        | Effect::RollToVisitAttractions
+        | Effect::AssembleContraptionsFromRollDifference
+        | Effect::ProcessRadCounters
+        | Effect::ForEachCategoryExile { .. }
+        | Effect::GiftDelivery { .. }
+        | Effect::SetDayNight { .. }
+        | Effect::Conjure { .. }
+        | Effect::DraftFromSpellbook { .. }
+        | Effect::RuntimeHandled { .. }
+        | Effect::HeistExile
+        | Effect::Cascade
+        | Effect::Ripple { .. }
+        | Effect::MiracleCast { .. }
+        | Effect::MadnessCast { .. }
+        | Effect::ManifestDread
+        | Effect::Choose { .. }
+        | Effect::ApplyPostReplacementDamage { .. }
+        | Effect::Unimplemented { .. } => false,
     }
 }
 
@@ -3836,6 +5111,175 @@ mod tests {
         assert!(conflicts(&ast, &se()));
         // (c) Phase trigger (no event object) ⇒ None ⇒ no write ⇒ clean.
         assert!(!conflicts(&ast, &se_phase()));
+    }
+
+    // ===================== D5 legacy-visitor tag × position matrix =====================
+
+    /// Mechanical proof that `legacy_batch_prompt` (via the authoritative
+    /// `contains_legacy_event_ref` visitor, driven through the production
+    /// `ability_rw_profile` / `trigger_condition_rw_profile` entry points) fires
+    /// for EACH of the 12 frozen event-context tags in EACH structural position —
+    /// including the effect target/count positions the read/write walk drops (the
+    /// D5 holes). This is the coverage whose absence let the 50-card fail-open ship.
+    /// Revert-fail witness: dropping the `p.legacy_batch_prompt =
+    /// contains_legacy_event_ref(a)` override flips every `Discard`/
+    /// `PutAtLibraryPosition`/`Sacrifice`-count/`GainEnergy` assertion below to
+    /// false (the walk never routes those fields through a legacy leaf detector).
+    #[test]
+    fn d5_legacy_visitor_tag_x_position_matrix() {
+        use crate::types::ability::{
+            CardSelectionMode, CastManaObjectScope, CastManaSpentMetric, ControllerRef,
+            LibraryPosition, PlayerFilter,
+        };
+
+        // Production profiling entry points — NOT the private visitor directly.
+        let legacy = |a: &ResolvedAbility| ability_rw_profile(a).legacy_batch_prompt();
+        let tlegacy = |c: &TriggerCondition| trigger_condition_rw_profile(c).legacy_batch_prompt();
+
+        // Dropped-target effects (the D5 hole class: `target: _` in `rw_effect`).
+        let discard = |t: TargetFilter| Effect::Discard {
+            count: qfix(1),
+            target: t,
+            unless_filter: None,
+            filter: None,
+            selection: CardSelectionMode::Chosen,
+        };
+        let put_at_lib = |t: TargetFilter| Effect::PutAtLibraryPosition {
+            target: t,
+            count: qfix(1),
+            position: LibraryPosition::Top,
+        };
+        let destroy = |t: TargetFilter| Effect::Destroy {
+            target: t,
+            cant_regenerate: false,
+        };
+
+        // ---- The 9 TargetFilter carriers × 5 positions ----
+        let tf_tags = [
+            TargetFilter::TriggeringSpellController,
+            TargetFilter::TriggeringSpellOwner,
+            TargetFilter::TriggeringPlayer,
+            TargetFilter::TriggeringSource,
+            TargetFilter::ParentTarget,
+            TargetFilter::ParentTargetController,
+            TargetFilter::ParentTargetOwner,
+            TargetFilter::StackSpell,
+            TargetFilter::CostPaidObject,
+        ];
+        for tag in &tf_tags {
+            // dropped-target effect positions (the fail-open holes).
+            assert!(legacy(&ra(discard(tag.clone()))), "Discard target {tag:?}");
+            assert!(
+                legacy(&ra(put_at_lib(tag.clone()))),
+                "PutAtLibraryPosition target {tag:?}"
+            );
+            // routed effect target.
+            assert!(legacy(&ra(destroy(tag.clone()))), "Destroy target {tag:?}");
+            // sub-ability (chained) target.
+            assert!(
+                legacy(&ra(gain_life(qfix(1))).sub_ability(ra(discard(tag.clone())))),
+                "sub-ability target {tag:?}"
+            );
+            // nested filter position.
+            assert!(
+                legacy(&ra(destroy(TargetFilter::And {
+                    filters: vec![creature(), tag.clone()],
+                }))),
+                "nested And filter {tag:?}"
+            );
+        }
+
+        // ---- The 3 QuantityRef carriers × 3 positions ----
+        let qr_tags = [
+            QuantityRef::EventContextAmount,
+            QuantityRef::EventContextSourceCostX,
+            QuantityRef::ManaSpentToCast {
+                scope: CastManaObjectScope::TriggeringSpell,
+                metric: CastManaSpentMetric::Total,
+            },
+        ];
+        for tag in &qr_tags {
+            // effect count (god-eternal bontu class).
+            assert!(
+                legacy(&ra(Effect::Sacrifice {
+                    target: creature(),
+                    count: qref(tag.clone()),
+                    min_count: 0,
+                })),
+                "Sacrifice count {tag:?}"
+            );
+            // effect amount (dropped-target effect with a dynamic amount).
+            assert!(
+                legacy(&ra(Effect::GainEnergy {
+                    amount: qref(tag.clone()),
+                })),
+                "GainEnergy amount {tag:?}"
+            );
+            // trigger-level intervening-if condition.
+            assert!(
+                tlegacy(&TriggerCondition::QuantityComparison {
+                    lhs: qref(tag.clone()),
+                    rhs: qfix(0),
+                    comparator: Comparator::GE,
+                }),
+                "trigger condition {tag:?}"
+            );
+        }
+
+        // ---- ObjectScope::CostPaidObject (the 12th tag) as a quantity scope ----
+        assert!(
+            legacy(&ra(Effect::GainEnergy {
+                amount: qref(QuantityRef::Power {
+                    scope: ObjectScope::CostPaidObject,
+                }),
+            })),
+            "CostPaidObject quantity scope"
+        );
+
+        // ---- PlayerFilter::TriggeringPlayer (effect player_filter + ability scope) ----
+        assert!(
+            legacy(&ra(Effect::DamageEachPlayer {
+                amount: qfix(1),
+                player_filter: PlayerFilter::TriggeringPlayer,
+            })),
+            "DamageEachPlayer player_filter TriggeringPlayer"
+        );
+        let mut with_scope = ra(gain_life(qfix(1)));
+        with_scope.player_scope = Some(PlayerFilter::TriggeringPlayer);
+        assert!(legacy(&with_scope), "ability player_scope TriggeringPlayer");
+
+        // ---- ControllerRef carriers (ability starting_with) ----
+        for cr in [
+            ControllerRef::TriggeringPlayer,
+            ControllerRef::ParentTargetController,
+            ControllerRef::ParentTargetOwner,
+        ] {
+            let mut a = ra(gain_life(qfix(1)));
+            a.starting_with = Some(cr.clone());
+            assert!(legacy(&a), "starting_with {cr:?}");
+        }
+
+        // ---- NEGATIVE controls (discrimination: no tag ⇒ false) ----
+        assert!(
+            !legacy(&ra(discard(TargetFilter::Controller))),
+            "Discard{{Controller}} carries no frozen tag"
+        );
+        assert!(
+            !legacy(&ra(destroy(creature()))),
+            "Destroy{{creature}} carries no frozen tag"
+        );
+        assert!(
+            !legacy(&ra(Effect::Sacrifice {
+                target: creature(),
+                count: qfix(1),
+                min_count: 0,
+            })),
+            "Sacrifice with a fixed count carries no frozen tag"
+        );
+        assert!(
+            !tlegacy(&TriggerCondition::SourceIsTapped),
+            "SourceIsTapped carries no frozen tag"
+        );
     }
 
     // ---- test-local helper ----

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2171,6 +2171,10 @@ fn legacy_filter_prop(p: &FilterProp) -> bool {
         }
         FilterProp::AnyOf { props } => props.iter().any(legacy_filter_prop),
         FilterProp::Not { prop } => legacy_filter_prop(prop),
+        // Resolution-chain tracked-set membership (leaf; only a `TrackedSetId`) —
+        // not one of the frozen-12 event-context refs. Member-boundness is handled
+        // in `member_bound_filter_prop`.
+        FilterProp::InTrackedSet { .. } => false,
         FilterProp::Token
         | FilterProp::NonToken
         | FilterProp::WasPlayed
@@ -2389,6 +2393,11 @@ fn member_bound_filter_prop(p: &FilterProp) -> bool {
         }
         FilterProp::AnyOf { props } => props.iter().any(member_bound_filter_prop),
         FilterProp::Not { prop } => member_bound_filter_prop(prop),
+        // CR 603.10a (PR-6.75 c5): membership in the active resolution-chain tracked
+        // set — the property form of the member-bound `TargetFilter::TrackedSet`
+        // selector (chain-first via `chain_tracked_set_id`). Per-source published
+        // storage ⇒ member-bound.
+        FilterProp::InTrackedSet { .. } => true,
         FilterProp::Token
         | FilterProp::NonToken
         | FilterProp::WasPlayed
@@ -2704,6 +2713,31 @@ fn legacy_effect(x: &Effect) -> bool {
         Effect::EachDealsDamageEqualToPower { sources, recipient } => {
             legacy_target_filter(sources) || legacy_target_filter(recipient)
         }
+        // CR 120: each source deals damage; `recipient` (`Shared`) can be a context
+        // anaphor (ParentTarget/TriggeringSource) ⇒ descend all tag-bearing fields.
+        Effect::EachSourceDealsDamage {
+            sources,
+            amount,
+            recipient,
+        } => {
+            legacy_target_filter(sources)
+                || legacy_quantity_expr(amount)
+                || match recipient {
+                    crate::types::ability::EachDamageRecipient::Shared(f) => {
+                        legacy_target_filter(f)
+                    }
+                    crate::types::ability::EachDamageRecipient::EachController => false,
+                }
+        }
+        Effect::ChooseCounterKind { target } => legacy_target_filter(target),
+        Effect::PutChosenCounter { target, count } => {
+            legacy_quantity_expr(count) || legacy_target_filter(target)
+        }
+        Effect::CreatePlaneswalkReplacement { replacement_effect } => {
+            legacy_effect(replacement_effect)
+        }
+        // Payload-less keyword action (planar chaos, CR 311.7) — no tag-bearing field.
+        Effect::ChaosEnsues => false,
         Effect::Attach { attachment, target } | Effect::UnattachAll { attachment, target } => {
             legacy_target_filter(attachment) || legacy_target_filter(target)
         }
@@ -3671,6 +3705,54 @@ fn rw_effect(
             p.merge(damage_writes(subject));
             (p, None)
         }
+        // CR 120.1 + CR 608.2c: each object matching `sources` (enumerated on the
+        // battlefield at resolution ⇒ a board membership read) deals `amount` damage.
+        // `Shared` ⇒ target damage_writes; `EachController` ⇒ each source's controller
+        // takes life loss (CR 120.3a).
+        Effect::EachSourceDealsDamage {
+            sources,
+            amount,
+            recipient,
+        } => {
+            let mut p = board_membership_read(sources);
+            p.merge(match recipient {
+                crate::types::ability::EachDamageRecipient::Shared(filter) => damage_writes(filter),
+                crate::types::ability::EachDamageRecipient::EachController => life_writes(),
+            });
+            p.merge(rw_quantity_expr(amount));
+            (p, None)
+        }
+        // CR 122 + CR 603.10a (PR-6.75 c5): inspects the distinct counter kinds on
+        // `target` (an ObjectCounters board read) and persists the pick as
+        // ChosenAttribute::Counter on the SOURCE — a per-source binding a later
+        // PutChosenCounter consumes (member-bound; mirrors Effect::Choose{persist}).
+        // No board WRITE: the placement is the separate PutChosenCounter.
+        Effect::ChooseCounterKind { target: _ } => {
+            let mut p = reads_board_of(StateKind::ObjectCounters);
+            p.reads_member_bound = true;
+            (p, None)
+        }
+        // CR 122.1 + CR 122.6 + CR 603.10a (PR-6.75 c5): adds `count` counters of the
+        // source's persisted ChosenAttribute::Counter kind to `target`. An
+        // ObjectCounters write (like PutCounter) that CONSUMES the per-source
+        // chosen-kind binding ⇒ member-bound read.
+        Effect::PutChosenCounter { target, count } => {
+            let (mut p, sc) = obj(StateKind::ObjectCounters, target);
+            p.reads_member_bound = true;
+            p.merge(rw_quantity_expr(count));
+            (p, sc)
+        }
+        // CR 614.1a + CR 611.2c + CR 603.7 (PR-6.75): a floating planeswalk
+        // replacement is a deferred body — descend reads, drop writes (resolves in a
+        // future scope). Mirrors CreateDrawReplacement.
+        Effect::CreatePlaneswalkReplacement { replacement_effect } => {
+            let (mut b, _) = rw_effect(replacement_effect, None, pscope, chain_move_owner);
+            b.drop_writes();
+            (b, None)
+        }
+        // CR 311.7 + CR 901.9b: fire the active plane's chaos trigger (mirrors
+        // Planeswalk / VentureIntoDungeon).
+        Effect::ChaosEnsues => (ext_write(StateKind::Other), None),
 
         // ---- Hand / library ----
         Effect::Draw { count, target: _ } => {

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -71,6 +71,23 @@
 //! verdict is a SOUNDNESS claim ("resolving can never enter a non-priority
 //! `WaitingFor`, for ANY state") and requires a resolver trace cited in the arm
 //! plus a `..`-free destructure so a future field forces re-audit.
+//!
+//! # Consumers of the read-axis classifiers after PR-6.75
+//!
+//! CR 603.3b: the legacy UNGATED trigger-ordering paths (same firing event, and
+//! the explicitly-simultaneous ZoneChanged departure batch) no longer consume the
+//! event-context / sibling-mutable read classifiers of this scanner. They consume
+//! the richer kind/scope read/write conflict profile in the sibling module
+//! `ability_rw.rs` (`ability_rw_profile` / `trigger_condition_rw_profile` /
+//! `profiles_conflict`), which answers "which kinds of state does the ability READ
+//! and WRITE, at what scope" — the precise read/write predicate those paths require
+//! (PR-6.25 §3 C0(ii)). The event-context and sibling-mutable read classifiers here
+//! are now consumed ONLY by the gated growing-cascade C2 distinct-event term
+//! (`group_is_order_independent`, gated on `loop_detection.is_on()`), where a
+//! conservative verdict means a prompt — fail-safe when the detector is OFF and a
+//! safe over-reject when ON. The projected-resource classifier (question 3) and the
+//! resolution-time choice classifier (question 4) are unchanged. See `ability_rw.rs`
+//! for the conflict model and its CR 603.3b commutation argument.
 
 use crate::types::ability::{
     AbilityCondition, ControllerRef, CountScope, Duration, EachDamageRecipient, Effect,

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -82,10 +82,12 @@
 //! `profiles_conflict`), which answers "which kinds of state does the ability READ
 //! and WRITE, at what scope" — the precise read/write predicate those paths require
 //! (PR-6.25 §3 C0(ii)). The event-context and sibling-mutable read classifiers here
-//! are now consumed ONLY by the gated growing-cascade C2 distinct-event term
-//! (`group_is_order_independent`, gated on `loop_detection.is_on()`), where a
-//! conservative verdict means a prompt — fail-safe when the detector is OFF and a
-//! safe over-reject when ON. The projected-resource classifier (question 3) and the
+//! are now consumed ONLY by the C2 distinct-event term (`group_is_order_independent`
+//! / `trigger_events_match_for_ordering`), ungated from loop detection (adopted from
+//! #5084) and conjoined with `!batch_conflict` — so a coarse C2-clean verdict may
+//! auto-order a distinct-event group only when the precise `ability_rw` profiler also
+//! agrees it is conflict-clean; a conservative verdict here means a prompt (safe
+//! over-reject). The projected-resource classifier (question 3) and the
 //! resolution-time choice classifier (question 4) are unchanged. See `ability_rw.rs`
 //! for the conflict model and its CR 603.3b commutation argument.
 

--- a/crates/engine/src/game/engine_priority.rs
+++ b/crates/engine/src/game/engine_priority.rs
@@ -174,6 +174,15 @@ pub(crate) fn run_post_action_pipeline_from(
     events.extend(delayed_events);
     state.consumed_before_priority_trigger_events.clear();
 
+    // CR 603.3b: check_delayed_triggers may have paused the batch on a same-controller
+    // ordering choice; surface it before check_state_triggers / the priority fallthrough
+    // clobber it. Scoped to OrderTriggers so the Breeches target-selection pause (which
+    // sets pending_trigger and is re-derived at begin_pending_trigger_target_selection)
+    // is untouched.
+    if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
+        return Ok(state.waiting_for.clone());
+    }
+
     // CR 603.8: Check state triggers after event-based triggers.
     // State triggers fire when a condition is true, checked whenever a player
     // would receive priority.

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -1,3 +1,4 @@
+pub mod ability_rw;
 pub mod ability_scan;
 pub mod ability_utils;
 pub mod arithmetic;

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3442,7 +3442,6 @@ fn trigger_events_match_for_ordering(
     same_event_conflict: bool,
     batch_conflict: bool,
     c2_order_independent: bool,
-    loop_detection_on: bool,
 ) -> bool {
     // C1 (CR 603.3b): same firing event auto-orders only when the identical
     // siblings' resolution functions provably COMMUTE — the `ability_rw` kind/
@@ -3487,13 +3486,19 @@ fn trigger_events_match_for_ordering(
         }
     }
 
-    // C2 (GATED on `loop_detection.is_on()`, UNCHANGED): when the growing-cascade
-    // detector is ON, a distinct-event group the fail-closed C0 walker deems order
-    // independent (reads neither event context nor sibling-mutable state) also
-    // auto-resolves so the loop-detect ring can accumulate the super-critical
-    // fan-out. When OFF this term is false, so distinct-event non-ZoneChanged
-    // groups PROMPT exactly as pre-feature (default gameplay byte-preserved).
-    loop_detection_on && c2_order_independent
+    // C2 (adopted from #5084 + a series soundness conjunct, CR 603.3b): distinct
+    // firing events whose ability reads neither event context nor sibling-mutable
+    // state are indistinguishable for ordering. Independent of loop detection (which
+    // only controls optional infinite-combo shortcutting) — #5084's ungating. The
+    // `&& !batch_conflict` conjunct is series-specific and was NOT in #5084 (upstream
+    // had no batch profiler): the coarse `ability_scan` C2 walker is BLIND to the
+    // source-actor residual (CR 805.7 cause-source-controller, lifelink/deathtouch
+    // CR 702.15/702.2) that the precise `ability_rw` profiler catches via the
+    // controller-uniformity gate. Without it, C2 would override that gate and
+    // re-open the Dodecapod Mixed-controller under-prompt (condition1_dodecapod).
+    // Precision dominates coarseness: C2 may auto-order only when the batch profiler
+    // ALSO agrees the group is conflict-clean.
+    c2_order_independent && !batch_conflict
 }
 
 /// CR 603.3c/603.3d + CR 601.2c/601.2d: A trigger requires ordering-relevant
@@ -3575,14 +3580,11 @@ fn group_source_census(
 // (`ability_rw_profile(reference)` OR-merged with the trigger-level condition's
 // `trigger_condition_rw_profile`, CR 603.4) against the group's structure
 // (`all_same_source`, `all_sources_self_departed`, `event_object_present`/
-// `event_object_excludes_sources`, `source_census`). `is_on` threads
-// `loop_detection.is_on()` to the gated C2 term; `state` supplies the live source
-// census (CR 205).
-fn group_is_order_independent(
-    state: &GameState,
-    group: &[PendingTriggerContext],
-    is_on: bool,
-) -> bool {
+// `event_object_excludes_sources`, `source_census`). `state` supplies the live
+// source census (CR 205). The C2 distinct-event term is ungated (adopted from
+// #5084) — loop detection governs infinite-combo shortcutting, not this finite
+// CR 603.3b ordering UX.
+fn group_is_order_independent(state: &GameState, group: &[PendingTriggerContext]) -> bool {
     let Some((first, rest)) = group.split_first() else {
         return false;
     };
@@ -3706,7 +3708,6 @@ fn group_is_order_independent(
                 same_event_conflict,
                 batch_conflict,
                 c2_order_independent,
-                is_on,
             )
             && t.subject_match_count == first.pending.subject_match_count
             && t.may_trigger_origin == first.pending.may_trigger_origin
@@ -3762,11 +3763,8 @@ fn begin_trigger_ordering(
     // no-input triggers, commute under any permutation — auto-order them so the
     // player isn't prompted for an immaterial choice (matching MTG Arena). Any
     // field divergence is a safe false-negative: the group still prompts.
-    let loop_detection_on = state.loop_detection.is_on();
     for g in groups.iter_mut() {
-        if g.triggers.len() <= 1
-            || group_is_order_independent(state, &g.triggers, loop_detection_on)
-        {
+        if g.triggers.len() <= 1 || group_is_order_independent(state, &g.triggers) {
             g.ordered = true;
         }
     }
@@ -21430,10 +21428,11 @@ pub mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // PR-6.25 (folded into PR-6.5 inc2a): C0 classifier wiring + C1 + gated-C2.
+    // PR-6.25 (folded into PR-6.5 inc2a): C0 classifier wiring + C1 + C2.
     // C0 = the fail-closed `ability_scan` walker replacing the fail-open string
     // allowlist; C1 = same-event auto-order gated on soundness (ungated CR 603.3b
-    // fix); C2 = distinct-event auto-resolve gated on `loop_detection.is_on()`.
+    // fix); C2 = distinct-event auto-resolve (ungated, adopted from #5084 — loop
+    // detection governs infinite-combo shortcutting, not this finite ordering UX).
     // -----------------------------------------------------------------------
 
     /// Build a no-ordering-input pending trigger (empty targets/constraints, no
@@ -21550,7 +21549,7 @@ pub mod tests {
                     ),
                 ];
                 assert!(
-                    group_is_order_independent(&state, &group, mode.is_on()),
+                    group_is_order_independent(&state, &group),
                     "pre-feature: same-event identical group auto-orders ({mode:?})"
                 );
                 match begin_trigger_ordering(&mut state, group) {
@@ -21563,13 +21562,12 @@ pub mod tests {
         }
     }
 
-    /// C2 (GATED on `loop_detection.is_on()`): two byte-identical no-input SOUND
-    /// triggers off DISTINCT life-loss events (the ≥3p all-opponent-drain fan-out).
-    /// OFF ⇒ still PROMPT (pre-feature preserved); ON ⇒ auto-resolve so the ring
-    /// can accumulate. Revert-fail: dropping the `is_on()` conjunct makes the OFF
-    /// arm auto-resolve, flipping its assertion.
+    /// C2 (adopted from #5084): two byte-identical no-input SOUND triggers off
+    /// DISTINCT life-loss events (the ≥3p all-opponent-drain fan-out) auto-order
+    /// even when loop detection is OFF. Loop detection controls infinite-combo
+    /// shortcutting; it does not gate finite CR 603.3b ordering UX.
     #[test]
-    fn pr625_c2_distinct_event_gate_off_prompts_on_auto_resolves() {
+    fn pr625_c2_distinct_event_auto_orders_even_when_loop_detection_off() {
         let ev_a = Some(GameEvent::LifeChanged {
             player_id: PlayerId(0),
             amount: -1,
@@ -21599,13 +21597,13 @@ pub mod tests {
             ),
         ];
         assert!(
-            !group_is_order_independent(&off, &off_group, false),
-            "C2 OFF: distinct-event sound group must PROMPT (pre-feature preserved)"
+            group_is_order_independent(&off, &off_group),
+            "C2 OFF: distinct-event sound group must auto-order"
         );
         match begin_trigger_ordering(&mut off, off_group) {
-            TriggerOrderingDisposition::PromptForChoice(_) => {}
-            TriggerOrderingDisposition::NoChoiceNeeded(_) => {
-                panic!("C2 OFF: distinct-event group must prompt when loop_detection Off")
+            TriggerOrderingDisposition::NoChoiceNeeded(_) => {}
+            TriggerOrderingDisposition::PromptForChoice(_) => {
+                panic!("C2 OFF: distinct-event group must auto-order when loop_detection Off")
             }
         }
 
@@ -21629,7 +21627,7 @@ pub mod tests {
             ),
         ];
         assert!(
-            group_is_order_independent(&on, &on_group, true),
+            group_is_order_independent(&on, &on_group),
             "C2 ON: distinct-event sound group must auto-resolve"
         );
         match begin_trigger_ordering(&mut on, on_group) {
@@ -21674,7 +21672,7 @@ pub mod tests {
             ),
         ];
         assert!(
-            !group_is_order_independent(&on, &group, true),
+            !group_is_order_independent(&on, &group),
             "C0: sibling-mutable distinct-event group must NOT auto-resolve even ON"
         );
         match begin_trigger_ordering(&mut on, group) {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -5234,94 +5234,39 @@ pub fn check_delayed_triggers(state: &mut GameState, events: &[GameEvent]) -> Ve
 
     let mut new_events = Vec::new();
 
-    // CR 603.3b + CR 101.4 + CR 805.6/805.7: Full APNAP stack-placement order
-    // by player, or by team in shared-team-turn formats.
-    // The old `state.turn_number` tiebreaker was constant across this batch, so
-    // dropping it changes nothing; `sort_by_key` is stable, preserving the
-    // prior same-controller ordering before stack placement.
-    to_fire.sort_by_key(|(trigger, _)| trigger_apnap_rank(state, trigger.controller));
+    // CR 603.3b + CR 101.4: APNAP stack-placement order for the firing batch.
+    // Stable sort; the per-batch timestamp (state.turn_number) is constant, so it
+    // preserves the prior same-controller order the ordering pass then consumes.
+    let mut pending: Vec<PendingTriggerContext> = to_fire
+        .into_iter()
+        .map(|(trigger, trigger_event)| {
+            delayed_trigger_to_context(
+                state,
+                trigger,
+                trigger_event.expect("every to_fire entry carries its trigger event"),
+            )
+        })
+        .collect();
+    pending.sort_by_key(|ctx| {
+        (
+            trigger_apnap_rank(state, ctx.pending.controller),
+            ctx.pending.timestamp,
+        )
+    });
 
-    // CR 603.3 + CR 603.3d + CR 601.2c: Dispatch each firing delayed trigger
-    // through the shared trigger dispatcher rather than a bare stack push. The
-    // dispatcher sets up `pending_trigger` / `pending_trigger_entry` and begins
-    // target selection (`WaitingFor::TriggerTargetSelection`) for a delayed
-    // trigger whose ability needs a player-chosen target — e.g. Breeches, the
-    // Blastmaker's reflexive "When you lose the flip, ~ deals damage … to any
-    // target" (CR 603.12). Context-ref-only delayed triggers (Flickerwisp's
-    // `ParentTarget` return, dies/leaves triggers using `TriggeringSource`)
-    // report `Pushed` and reach the stack with no input, identical to the prior
-    // bare push. When a trigger pauses for input, the remaining triggers are
-    // stashed into `deferred_triggers` and reach the stack once the active one
-    // resolves, mirroring `dispatch_collected_triggers` (issue #416).
-    let mut iter = to_fire.into_iter();
-    for (trigger, trigger_event) in iter.by_ref() {
-        let pending = PendingTrigger {
-            source_id: trigger.source_id,
-            controller: trigger.controller,
-            condition: None,
-            ability: trigger.ability,
-            timestamp: state.turn_number,
-            target_constraints: Vec::new(),
-            distribute: None,
-            trigger_event,
-            modal: None,
-            mode_abilities: vec![],
-            description: None,
-            may_trigger_origin: None,
-            subject_match_count: None,
-            die_result: None,
-        };
-        let context = PendingTriggerContext::delayed(pending);
-        match dispatch_pending_trigger_context_with_origin(state, context, &mut new_events) {
-            TriggerDispatchDisposition::Paused => {
-                // The active delayed trigger paused on player input (target /
-                // mode / distribution). Stash the remaining firing triggers so
-                // they reach the stack once the active one is finalized.
-                state
-                    .deferred_triggers
-                    .extend(iter.map(|(trigger, trigger_event)| {
-                        PendingTriggerContext::delayed(PendingTrigger {
-                            source_id: trigger.source_id,
-                            controller: trigger.controller,
-                            condition: None,
-                            ability: trigger.ability,
-                            timestamp: state.turn_number,
-                            target_constraints: Vec::new(),
-                            distribute: None,
-                            trigger_event,
-                            modal: None,
-                            mode_abilities: vec![],
-                            description: None,
-                            may_trigger_origin: None,
-                            subject_match_count: None,
-                            die_result: None,
-                        })
-                    }));
-                break;
-            }
-            // CR 603.3: A delayed triggered ability goes on the stack the next
-            // time a player would receive priority. The dispatcher already
-            // placed it there (`Pushed`) or it pauses for input (`Paused`
-            // above) — nothing more to do.
-            TriggerDispatchDisposition::Pushed => {}
-            // CR 603.3d: The dispatcher dropped the trigger because a slot could
-            // not be auto-resolved. For a delayed trigger this is the Good King
-            // Mog case — the unresolved slot is a *resolution-time filter* ("a
-            // token that's a copy of a non-Saga token you control"), NOT a
-            // CR 115.1d target (it uses no "target" keyword), so CR 603.3d does
-            // not remove it; place it on the stack directly per CR 603.3.
-            // Resolution-time selection then handles the empty filter set (e.g.
-            // copies no token). This restores the pre-dispatch unconditional-push
-            // contract for the non-targeted resolution-filter case. Breeches'
-            // lose branch ("deals damage … to any target") always has a legal
-            // target, so it pauses through the dispatcher and never reaches here.
-            TriggerDispatchDisposition::DroppedTargetUnresolved => {}
-            // CR 603.3c: no legal mode — the modal ability is removed from the
-            // stack and is a terminal no-stack outcome; do NOT resurrect it.
-            // CR 605.1b: a triggered mana ability resolved inline without using
-            // the stack; re-pushing it would duplicate the produced mana.
-            TriggerDispatchDisposition::DroppedNoLegalMode
-            | TriggerDispatchDisposition::ResolvedInline => {}
+    // CR 603.3b + CR 603.7: Route the firing batch through the ordering authority
+    // (mirrors the phase-delayed path process_collected_triggers_with_delayed_phase_events)
+    // so simultaneous same-controller order-dependent delayed triggers get the mandatory
+    // ordering choice instead of a fixed dispatch order. Contexts carry the Delayed
+    // dispatch origin, so the shared dispatcher applies every delayed-specific
+    // disposition (Good King Mog DroppedTargetUnresolved→Pushed, Breeches pause,
+    // no-legal-mode/inline-mana) unchanged.
+    match begin_trigger_ordering(state, pending) {
+        TriggerOrderingDisposition::PromptForChoice(wf) => {
+            state.waiting_for = *wf;
+        }
+        TriggerOrderingDisposition::NoChoiceNeeded(pending) => {
+            dispatch_deferred_triggers_in_order(state, pending, &mut new_events);
         }
     }
 
@@ -11629,6 +11574,149 @@ pub mod tests {
             ability.scoped_player,
             Some(PlayerId(1)),
             "Phase trigger must bind scoped_player to the active player so 'that player draws' resolves correctly on opponent's turn"
+        );
+    }
+
+    // CR 603.3b: Two same-controller, non-phase (`WhenDies`) one-shot delayed
+    // triggers with DISTINCT effects (Draw vs GainLife) firing off ONE death event
+    // must route through `begin_trigger_ordering` and produce the mandatory
+    // ordering prompt — not a fixed direct-dispatch order. Discriminating: the
+    // effects differ, so `group_is_order_independent` is false (candidate !=
+    // reference in the ability-equality check), forcing a genuine prompt. Reverting
+    // `check_delayed_triggers` to the pre-fix direct-dispatch tail makes both
+    // triggers hit the stack immediately (stack.len()==2, waiting_for != OrderTriggers,
+    // returned Vec non-empty), failing every REVERT-TO-RED assert below.
+    #[test]
+    fn non_phase_delayed_same_controller_batch_prompts_and_resolves_ordered() {
+        let mut state = setup();
+        let controller = PlayerId(0);
+        state.active_player = controller;
+        state.priority_player = controller;
+        state.players[0].life = 20;
+        // Stock P0's library so the Draw is observable (hand+1, library->0).
+        create_object(
+            &mut state,
+            CardId(0x0603_3B10),
+            controller,
+            "Drawn Card".to_string(),
+            Zone::Library,
+        );
+
+        let source_draw = create_object(
+            &mut state,
+            CardId(0x0603_3B11),
+            controller,
+            "Draw Delayed Source".to_string(),
+            Zone::Battlefield,
+        );
+        let source_gain = create_object(
+            &mut state,
+            CardId(0x0603_3B12),
+            controller,
+            "GainLife Delayed Source".to_string(),
+            Zone::Battlefield,
+        );
+        // Victim whose death fires both delayed triggers (WhenDies filter Any).
+        let victim = make_creature(&mut state, controller, "Victim", 1, 1);
+
+        // DT1: "when [a creature] dies, draw a card" (Draw).
+        state.delayed_triggers.push(DelayedTrigger {
+            condition: DelayedTriggerCondition::WhenDies {
+                filter: TargetFilter::Any,
+            },
+            ability: ResolvedAbility::new(
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+                vec![],
+                source_draw,
+                controller,
+            ),
+            controller,
+            source_id: source_draw,
+            one_shot: true,
+        });
+        // DT2: "when [a creature] dies, gain 1 life" (GainLife) — distinct effect.
+        state.delayed_triggers.push(DelayedTrigger {
+            condition: DelayedTriggerCondition::WhenDies {
+                filter: TargetFilter::Any,
+            },
+            ability: ResolvedAbility::new(
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+                vec![],
+                source_gain,
+                controller,
+            ),
+            controller,
+            source_id: source_gain,
+            one_shot: true,
+        });
+
+        let death = zone_changed_event(
+            victim,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            vec![CoreType::Creature],
+            Vec::new(),
+        );
+        let returned = check_delayed_triggers(&mut state, &[death]);
+
+        // REVERT-TO-RED (all fail on the pre-fix direct-dispatch tail):
+        assert!(
+            returned.is_empty(),
+            "paused-for-ordering batch must not have dispatched any events yet"
+        );
+        assert!(
+            matches!(state.waiting_for, WaitingFor::OrderTriggers { player, .. } if player == controller),
+            "distinct same-controller non-phase delayed triggers must prompt P0 to order, got {:?}",
+            state.waiting_for
+        );
+        assert_eq!(
+            state.stack.len(),
+            0,
+            "nothing may reach the stack before the ordering choice is submitted"
+        );
+        let order = state
+            .pending_trigger_order
+            .as_ref()
+            .expect("OrderTriggers prompt must populate pending_trigger_order");
+        assert_eq!(order.groups.len(), 1, "one same-controller group");
+        assert_eq!(order.groups[0].controller, controller);
+        assert_eq!(order.groups[0].triggers.len(), 2, "two triggers to order");
+
+        // POST-PROMPT: submit an explicit order; both triggers reach the stack.
+        crate::game::engine::apply_as_current(
+            &mut state,
+            crate::types::actions::GameAction::OrderTriggers { order: vec![1, 0] },
+        )
+        .expect("OrderTriggers must apply");
+        assert_eq!(
+            state.stack.len(),
+            2,
+            "both ordered delayed triggers must be on the stack after the choice"
+        );
+
+        // Resolve both; the two distinct effects both take hold.
+        let mut events = Vec::new();
+        crate::game::stack::resolve_top(&mut state, &mut events);
+        crate::game::stack::resolve_top(&mut state, &mut events);
+        assert_eq!(
+            state.players[0].hand.len(),
+            1,
+            "Draw delayed trigger resolved"
+        );
+        assert_eq!(
+            state.players[0].library.len(),
+            0,
+            "the stocked card was drawn"
+        );
+        assert_eq!(
+            state.players[0].life, 21,
+            "GainLife delayed trigger resolved"
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3398,47 +3398,19 @@ pub(crate) fn normalize_ability_identity(ability: &mut ResolvedAbility) {
     }
 }
 
-/// Legacy fail-open event-context allowlist. RETAINED for the pre-feature
-/// same-event and ZoneChanged same-departure-batch auto-resolve paths, whose
-/// shipped behavior depends on this classifier's exact (fail-open) semantics —
-/// notably co-departing death triggers that read `EventSource` power (issue
-/// #4269) auto-order today because this allowlist does NOT list `EventSource`.
-/// The fail-closed `ability_scan` walker is used ONLY for the new gated-C2
-/// distinct-event term; replacing this allowlist wholesale on the legacy paths
-/// regresses those cards (see inc2a report — C0 full replacement is DEFERRED).
-fn value_contains_trigger_event_context_ref(value: &serde_json::Value) -> bool {
-    match value {
-        serde_json::Value::String(tag) => matches!(
-            tag.as_str(),
-            "TriggeringSpellController"
-                | "TriggeringSpellOwner"
-                | "TriggeringPlayer"
-                | "TriggeringSource"
-                | "ParentTarget"
-                | "ParentTargetController"
-                | "ParentTargetOwner"
-                | "StackSpell"
-                | "CostPaidObject"
-                | "EventContextAmount"
-                | "EventContextSourceCostX"
-                | "ManaSpentToCast"
-        ),
-        serde_json::Value::Array(values) => {
-            values.iter().any(value_contains_trigger_event_context_ref)
-        }
-        serde_json::Value::Object(map) => {
-            map.values().any(value_contains_trigger_event_context_ref)
-        }
-        _ => false,
-    }
-}
-
-fn ability_uses_trigger_event_context(ability: &ResolvedAbility) -> bool {
-    serde_json::to_value(ability)
-        .map(|value| value_contains_trigger_event_context_ref(&value))
-        .unwrap_or(true)
-}
-
+/// CR 603.2c + CR 603.10a: Are two ZoneChanged events part of ONE explicitly
+/// simultaneous departure batch? True iff both moved between the same zones and
+/// each event's `co_departed` set names the other's object — i.e. the two
+/// objects left together in a single state-based / effect batch, so their death
+/// triggers see a shared LKI freeze (CR 603.10a) and their placement order is
+/// unobservable (CR 603.2c). The mutual `co_departed` sets are stamped by the
+/// same producers in ALL detector modes: `zones::mark_simultaneous_departures`
+/// (zones.rs:787) over `zones::departed_subset` (zones.rs:816) at the four
+/// batch-departure sites (sba.rs:679/:835/:1264/:1319), and the SBA-batch stamp
+/// `zones::stamp_simultaneous_from_slice` (zones.rs:832, called sba.rs:258).
+/// Reachable in ALL modes; single caller (`trigger_events_match_for_ordering`'s
+/// batch branch), retained because the OFF-path departure-batch auto-resolve is
+/// live.
 fn zone_changes_are_same_departure_batch(a: &GameEvent, b: &GameEvent) -> bool {
     let (
         GameEvent::ZoneChanged {
@@ -3467,28 +3439,45 @@ fn zone_changes_are_same_departure_batch(a: &GameEvent, b: &GameEvent) -> bool {
 fn trigger_events_match_for_ordering(
     first: &PendingTrigger,
     candidate: &PendingTrigger,
-    legacy_uses_trigger_event: bool,
+    same_event_conflict: bool,
+    batch_conflict: bool,
     c2_order_independent: bool,
+    loop_detection_on: bool,
 ) -> bool {
-    // Same firing event (CR 603.2c): pre-feature auto-order, UNCHANGED. Gating
-    // this on soundness is the C1 CR 603.3b fix — DEFERRED (see inc2a report):
-    // the committed `ability_scan` walker classifies ~46 common effect kinds
-    // (CopySpell/Token/Pump/Mana/ChangeZone/…) as conservative, so `sibling`
-    // reads true for them; gating same-event on that axis would over-prompt
-    // printed copy/token keywords (Demonstrate, Replicate) in all modes,
-    // contradicting the "affects no printed card" guarantee. Needs a precise
-    // read/write predicate first.
+    // C1 (CR 603.3b): same firing event auto-orders only when the identical
+    // siblings' resolution functions provably COMMUTE — the `ability_rw` kind/
+    // scope read/write conflict profile (§1.2), the precise read/write predicate
+    // the shipped deferral demanded (replacing the C0-full fail-open serde
+    // allowlist). Commutation is proven MODULO the documented source-actor
+    // residual: per-source granted lifelink/deathtouch-class state (CR 702.15 /
+    // CR 702.2) and the CR 800.4a player-loss object-removal cascade modulate
+    // resolution without appearing in the normalized AST or any profiled read
+    // (see the `ability_rw` module doc). Both channels were auto-ordered
+    // UNCONDITIONALLY by the pre-C1 short-circuit and are inherited unchanged
+    // (zero ordering-decision change; strictly less total unsoundness; the
+    // constructive close is ledgered). The visible surface of this gate is
+    // exactly the proven-order-dependent groups (PR-6.25 §1 Case A: two
+    // byte-identical "+1/+1 on each creature; draw if this creature's power ≥ 6"
+    // off one event — a counter write feeds the sibling's live power read), which
+    // the shipped engine silently auto-ordered, removing the controller's
+    // mandatory CR 603.3b ordering choice.
     if first.trigger_event == candidate.trigger_event {
-        return true;
+        return !same_event_conflict;
     }
 
-    // Distinct firing events. Pre-feature (and OFF): only an explicitly
-    // simultaneous ZoneChanged same-departure batch (CR 603.2c) with no
-    // event-context read auto-resolves. Gated by the LEGACY allowlist (not the
-    // walker) so shipped co-departing death triggers reading `EventSource` power
-    // (issue #4269) keep auto-ordering — the walker correctly flags EventSource
-    // event-context, which would defeat this batch path.
-    if !legacy_uses_trigger_event {
+    // C0-full (CR 603.2c + CR 603.10a): explicitly simultaneous ZoneChanged
+    // departure batch. The departed sources' object reads (`Power{Source}` — the
+    // #4269 Nested Shambler class parses `Power { scope: Source }`, NOT
+    // `EventSource`) are LKI-FROZEN at battlefield exit (zones.rs freeze at exit;
+    // quantity.rs zone-guarded reads select the LKI snapshot for a departed
+    // source, CR 603.10a) AND STAY frozen only while no group write can re-enter a
+    // member's object: ObjectId is stable across zone moves, so an external move
+    // with battlefield destination (or exile origin) re-binds the same id to live
+    // state / overwrites the LKI snapshot — the `ability_rw` freeze-invalidation
+    // row prompts those groups fail-closed. Otherwise only a live-read/write feed
+    // (or a retained legacy-prompt event ref, D3 parity) makes `batch_conflict`
+    // true; a conflict-clean co-departure batch auto-resolves.
+    if !batch_conflict {
         if let (Some(first_event), Some(candidate_event)) =
             (&first.trigger_event, &candidate.trigger_event)
         {
@@ -3498,11 +3487,13 @@ fn trigger_events_match_for_ordering(
         }
     }
 
-    // Distinct firing events whose ability reads neither event context nor
-    // sibling-mutable state are indistinguishable for CR 603.3b ordering. This
-    // finite ordering UX is intentionally independent from loop detection,
-    // which only controls optional infinite-combo shortcutting.
-    c2_order_independent
+    // C2 (GATED on `loop_detection.is_on()`, UNCHANGED): when the growing-cascade
+    // detector is ON, a distinct-event group the fail-closed C0 walker deems order
+    // independent (reads neither event context nor sibling-mutable state) also
+    // auto-resolves so the loop-detect ring can accumulate the super-critical
+    // fan-out. When OFF this term is false, so distinct-event non-ZoneChanged
+    // groups PROMPT exactly as pre-feature (default gameplay byte-preserved).
+    loop_detection_on && c2_order_independent
 }
 
 /// CR 603.3c/603.3d + CR 601.2c/601.2d: A trigger requires ordering-relevant
@@ -3522,6 +3513,32 @@ fn trigger_has_no_ordering_input(t: &PendingTrigger) -> bool {
         && t.ability.distribution.is_none()
 }
 
+/// CR 205: The union of the group's LIVE source objects' type census — core
+/// types + subtypes + token-ness, lowercased into the tag space `ability_rw`'s
+/// membership-overlap row compares against. A member whose source object is
+/// missing from `state.objects` ⇒ census unknown ⇒ overlap assumed (fail-closed).
+/// Read ONCE here at the ordering chokepoint (the same atomic-ordering-window
+/// assumption the shipped classifier already makes).
+fn group_source_census(
+    state: &GameState,
+    group: &[PendingTriggerContext],
+) -> crate::game::ability_rw::SourceCensus {
+    let mut tags: Vec<String> = Vec::new();
+    for ctx in group {
+        let Some(obj) = state.objects.get(&ctx.pending.source_id) else {
+            return crate::game::ability_rw::SourceCensus::unknown();
+        };
+        for ct in &obj.card_types.core_types {
+            tags.push(ct.to_string());
+        }
+        for st in &obj.card_types.subtypes {
+            tags.push(st.clone());
+        }
+        tags.push(if obj.is_token { "token" } else { "nontoken" }.to_string());
+    }
+    crate::game::ability_rw::SourceCensus::from_tags(tags)
+}
+
 /// CR 603.3b: Returns true when every trigger in `group` is mutually
 /// INDISTINGUISHABLE, so the controller's CR 603.3b freedom to place them "in
 /// any order they choose" is genuinely immaterial and the engine may auto-order
@@ -3535,25 +3552,32 @@ fn trigger_has_no_ordering_input(t: &PendingTrigger) -> bool {
 /// the trigger-level `condition`, the batched `subject_match_count`
 /// (CR 603.2c — one event with multiple occurrences fires a batched trigger
 /// once per occurrence, each carrying its own subject count; read at
-/// resolution), and the `may_trigger_origin`.
-// CR 603.2c / CR 603.4: `trigger_event` (the firing event itself) is NOT part
-// of the equality check for explicitly simultaneous ZoneChanged departure
-// batches — when N co-departing events all match the same trigger definition
-// and the effect is fixed (e.g. three Liliana, Dreadhorde General draws from
-// one board wipe), placement order is unobservable and a prompt is noise — and
-// for any distinct-event group the C0 walker deems order independent. The
-// same-event and ZoneChanged paths keep using the legacy allowlist
-// `ability_uses_trigger_event_context` (its exact fail-open semantics are
-// shipped behavior — see that fn's doc). The C2 term instead consults the
-// fail-closed `ability_scan` walker over TWO distinct axes
-// (categorical-boundary rule): (i) `ability_uses_event_context` — the concrete
-// firing event is resolution-visible, and (ii) `ability_reads_sibling_mutable`
-// — a source/recipient or board-scoped aggregate a sibling copy resolving
-// first could change. `subject_match_count` is kept in the equality because
-// that is the per-batch count the effect reads at resolution and *can* differ
-// across pending triggers if two distinct batched events satisfy the same
-// definition.
-fn group_is_order_independent(group: &[PendingTriggerContext]) -> bool {
+/// resolution), the `may_trigger_origin`, AND the stamped `die_result`
+/// (CR 706.2 + CR 603.12 — the captured roll is part of the resolution
+/// function's identity; a pair differing only in it is not the same state
+/// transformation).
+// CR 603.3b: `trigger_event` (the firing event itself) is NOT compared as an
+// equality field — instead `trigger_events_match_for_ordering` classifies the
+// pair by the `ability_rw` read/write CONFLICT profile (§1.2). A same-event
+// group auto-orders iff its identical siblings' resolution functions provably
+// COMMUTE (`same_event_conflict` false, C1 / CR 603.3b), replacing the shipped
+// fail-open serde allowlist; an explicitly-simultaneous ZoneChanged departure
+// batch auto-orders iff `batch_conflict` false (C0-full / CR 603.2c + CR 603.10a
+// LKI freeze, plus the D5 retained-prompt parity via `legacy_batch_prompt`); and,
+// when the growing-cascade detector is ON, a distinct-event group the fail-closed
+// `ability_scan` walker deems order-independent also auto-orders (C2, unchanged,
+// gated). The conflict verdicts are computed ONCE from `profile`
+// (`ability_rw_profile(reference)` OR-merged with the trigger-level condition's
+// `trigger_condition_rw_profile`, CR 603.4) against the group's structure
+// (`all_same_source`, `all_sources_self_departed`, `event_object_present`/
+// `event_object_excludes_sources`, `source_census`). `is_on` threads
+// `loop_detection.is_on()` to the gated C2 term; `state` supplies the live source
+// census (CR 205).
+fn group_is_order_independent(
+    state: &GameState,
+    group: &[PendingTriggerContext],
+    is_on: bool,
+) -> bool {
     let Some((first, rest)) = group.split_first() else {
         return false;
     };
@@ -3565,9 +3589,75 @@ fn group_is_order_independent(group: &[PendingTriggerContext]) -> bool {
     }
     let mut reference = first.pending.ability.clone();
     normalize_ability_identity(&mut reference);
-    // Legacy allowlist: drives the pre-feature same-event / ZoneChanged paths.
-    let legacy_uses_trigger_event = ability_uses_trigger_event_context(&reference);
-    // C0 (fail-closed AST walker): two distinct soundness axes (event context,
+
+    // CR 603.3b conflict profile (replaces the fail-open serde allowlist): the
+    // ability's read/write profile OR-merged with the trigger-level
+    // intervening-`if` condition (CR 603.4 — re-checked at resolution, so its
+    // reads are order-relevant).
+    let mut profile = crate::game::ability_rw::ability_rw_profile(&reference);
+    if let Some(cond) = &first.pending.condition {
+        profile.merge(crate::game::ability_rw::trigger_condition_rw_profile(cond));
+    }
+
+    // GroupStructure (computed once). `all_same_source`: every member shares one
+    // source. `all_sources_self_departed`: every member's firing event is a
+    // battlefield-departure of its OWN source (event-structural, state-free —
+    // the CR 603.10a frozen-read premise).
+    let all_same_source = group
+        .iter()
+        .all(|ctx| ctx.pending.source_id == first.pending.source_id);
+    let all_sources_self_departed = group.iter().all(|ctx| {
+        matches!(
+            &ctx.pending.trigger_event,
+            Some(GameEvent::ZoneChanged { object_id, from: Some(Zone::Battlefield), .. })
+                if *object_id == ctx.pending.source_id
+        )
+    });
+    // The firing event's object (CR 603.7c). `extract_source_from_event` is the
+    // resolver authority for `TriggeringSource`-class writes; `None` ⇒ no event
+    // object (e.g. `Phase`) ⇒ those writes no-op at resolution (targeting.rs), so
+    // the profile drops them. `event_object_excludes_sources` is the object-
+    // disjointness signal (§2 rule 2), computed DYNAMICALLY for this group: the
+    // one shared event object is provably no member's source iff its id differs
+    // from every member's `source_id` (valid_card is not carried on
+    // `PendingTrigger`; the concrete event-object id is a sound and at-least-as-
+    // precise witness of the "another"/not-self relation — writes to an object
+    // that is no group source cannot feed any member's `reads_src`).
+    let event_object_id = first
+        .pending
+        .trigger_event
+        .as_ref()
+        .and_then(crate::game::targeting::extract_source_from_event);
+    let event_object_present = event_object_id.is_some();
+    let event_object_excludes_sources =
+        event_object_id.is_some_and(|eid| group.iter().all(|ctx| ctx.pending.source_id != eid));
+    let source_census = group_source_census(state, group);
+
+    let same_event_structure = crate::game::ability_rw::GroupStructure {
+        same_event: true,
+        all_same_source,
+        all_sources_self_departed,
+        event_object_excludes_sources,
+        event_object_present,
+        source_census: source_census.clone(),
+    };
+    let batch_structure = crate::game::ability_rw::GroupStructure {
+        same_event: false,
+        all_same_source,
+        all_sources_self_departed,
+        event_object_excludes_sources,
+        event_object_present,
+        source_census,
+    };
+    let same_event_conflict =
+        crate::game::ability_rw::profiles_conflict(&profile, &same_event_structure);
+    // D3 / D5: the batch branch keeps prompting the 12 retained event-context
+    // refs (`legacy_batch_prompt`) for strict parity, plus the freeze-invalidation
+    // / live-read/write feed rows from `profiles_conflict`.
+    let batch_conflict = profile.legacy_batch_prompt()
+        || crate::game::ability_rw::profiles_conflict(&profile, &batch_structure);
+
+    // C2 (fail-closed AST walker): two distinct soundness axes (event context,
     // sibling-mutable) — consumed ONLY by the gated-C2 distinct-event term.
     let c2_order_independent = !crate::game::ability_scan::ability_uses_event_context(&reference)
         && !crate::game::ability_scan::ability_reads_sibling_mutable(&reference);
@@ -3579,11 +3669,16 @@ fn group_is_order_independent(group: &[PendingTriggerContext]) -> bool {
             && trigger_events_match_for_ordering(
                 &first.pending,
                 t,
-                legacy_uses_trigger_event,
+                same_event_conflict,
+                batch_conflict,
                 c2_order_independent,
+                is_on,
             )
             && t.subject_match_count == first.pending.subject_match_count
             && t.may_trigger_origin == first.pending.may_trigger_origin
+            // CR 706.2 + CR 603.12: the stamped die-roll result is part of the
+            // resolution function's identity (defense-in-depth; N-F pins it).
+            && t.die_result == first.pending.die_result
             && {
                 let mut candidate = t.ability.clone();
                 normalize_ability_identity(&mut candidate);
@@ -3633,8 +3728,11 @@ fn begin_trigger_ordering(
     // no-input triggers, commute under any permutation — auto-order them so the
     // player isn't prompted for an immaterial choice (matching MTG Arena). Any
     // field divergence is a safe false-negative: the group still prompts.
+    let loop_detection_on = state.loop_detection.is_on();
     for g in groups.iter_mut() {
-        if g.triggers.len() <= 1 || group_is_order_independent(&g.triggers) {
+        if g.triggers.len() <= 1
+            || group_is_order_independent(state, &g.triggers, loop_detection_on)
+        {
             g.ordered = true;
         }
     }
@@ -21289,14 +21387,20 @@ pub mod tests {
         )
     }
 
-    /// C1 status (DEFERRED — see inc2a report): the same-event short-circuit
-    /// stays pre-feature (unconditional auto-order) in BOTH detector modes, because
-    /// gating it on the committed walker's conservative `sibling` axis would
-    /// over-prompt printed copy/token/pump keywords. This test pins the preserved
-    /// pre-feature behavior: a same-event identical no-input group auto-resolves
-    /// (NoChoiceNeeded) regardless of whether its ability reads sibling-mutable
-    /// state. When C1's precise soundness gate lands, the sibling-mutable arm here
-    /// must flip to PromptForChoice (its future revert-fail).
+    /// C1 (CR 603.3b, LANDED in PR-6.75): the same-event branch now auto-orders
+    /// iff the `ability_rw` conflict profile shows the identical siblings' writes
+    /// don't feed each other's live reads (`!same_event_conflict`). Both arms of
+    /// this fixture STILL auto-order (assertions unchanged): the sound arm
+    /// (`GainLife` fixed) reads nothing; the "sibling-mutable" arm
+    /// (`GainLife = Power{Source}`, distinct sources) reads source P/T LIVE but
+    /// writes only `PlayerLife`/`JournalLife` — and `ObjectPt` reads are NOT fed
+    /// by `PlayerLife` writes, so the resolution functions commute and the group
+    /// correctly stays auto (no conflict). The earlier prophecy that the
+    /// sibling-mutable arm "must flip to PromptForChoice" was WRONG under the
+    /// kind/scope conflict gate — a bare source READ is not a feed; only a
+    /// read/write feed (e.g. Case A's counter write into a live power read)
+    /// prompts. That real order-dependent surface is pinned by N-C in the parity
+    /// test module, not here.
     #[test]
     fn pr625_c1_same_event_groups_auto_order_pre_feature_preserved() {
         let event = Some(GameEvent::LifeChanged {
@@ -21324,7 +21428,7 @@ pub mod tests {
                     ),
                 ];
                 assert!(
-                    group_is_order_independent(&group),
+                    group_is_order_independent(&state, &group, mode.is_on()),
                     "pre-feature: same-event identical group auto-orders ({mode:?})"
                 );
                 match begin_trigger_ordering(&mut state, group) {
@@ -21337,12 +21441,13 @@ pub mod tests {
         }
     }
 
-    /// C2: two byte-identical no-input SOUND triggers off DISTINCT life-loss
-    /// events (the ≥3p all-opponent-drain fan-out) auto-order even when loop
-    /// detection is OFF. Loop detection controls infinite-combo shortcutting;
-    /// it does not gate finite CR 603.3b ordering UX.
+    /// C2 (GATED on `loop_detection.is_on()`): two byte-identical no-input SOUND
+    /// triggers off DISTINCT life-loss events (the ≥3p all-opponent-drain fan-out).
+    /// OFF ⇒ still PROMPT (pre-feature preserved); ON ⇒ auto-resolve so the ring
+    /// can accumulate. Revert-fail: dropping the `is_on()` conjunct makes the OFF
+    /// arm auto-resolve, flipping its assertion.
     #[test]
-    fn pr625_c2_distinct_event_auto_orders_even_when_loop_detection_off() {
+    fn pr625_c2_distinct_event_gate_off_prompts_on_auto_resolves() {
         let ev_a = Some(GameEvent::LifeChanged {
             player_id: PlayerId(0),
             amount: -1,
@@ -21372,13 +21477,13 @@ pub mod tests {
             ),
         ];
         assert!(
-            group_is_order_independent(&off_group),
-            "C2 OFF: distinct-event sound group must auto-order"
+            !group_is_order_independent(&off, &off_group, false),
+            "C2 OFF: distinct-event sound group must PROMPT (pre-feature preserved)"
         );
         match begin_trigger_ordering(&mut off, off_group) {
-            TriggerOrderingDisposition::NoChoiceNeeded(_) => {}
-            TriggerOrderingDisposition::PromptForChoice(_) => {
-                panic!("C2 OFF: distinct-event group must auto-order when loop_detection Off")
+            TriggerOrderingDisposition::PromptForChoice(_) => {}
+            TriggerOrderingDisposition::NoChoiceNeeded(_) => {
+                panic!("C2 OFF: distinct-event group must prompt when loop_detection Off")
             }
         }
 
@@ -21402,7 +21507,7 @@ pub mod tests {
             ),
         ];
         assert!(
-            group_is_order_independent(&on_group),
+            group_is_order_independent(&on, &on_group, true),
             "C2 ON: distinct-event sound group must auto-resolve"
         );
         match begin_trigger_ordering(&mut on, on_group) {
@@ -21447,7 +21552,7 @@ pub mod tests {
             ),
         ];
         assert!(
-            !group_is_order_independent(&group),
+            !group_is_order_independent(&on, &group, true),
             "C0: sibling-mutable distinct-event group must NOT auto-resolve even ON"
         );
         match begin_trigger_ordering(&mut on, group) {
@@ -25244,6 +25349,12 @@ pub mod tests {
 #[cfg(test)]
 #[path = "triggers_dedup_regression_tests.rs"]
 mod dedup_regression_tests;
+
+// CR 603.3b: PR-6.75 trigger-ordering conflict-gate tests — the corpus parity
+// sweep (C0-full allowlist parity) + the C1/C0-full discriminators (N-A..N-F).
+#[cfg(test)]
+#[path = "triggers_ordering_parity_tests.rs"]
+mod ordering_parity_tests;
 
 #[cfg(test)]
 #[path = "triggers_devour_runtime_tests.rs"]

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3544,7 +3544,12 @@ fn group_source_census(
 /// any order they choose" is genuinely immaterial and the engine may auto-order
 /// them with no prompt (matching MTG Arena). Conservative by construction: any
 /// field divergence makes this return false and the group still prompts (a safe
-/// false-negative); it can never auto-order order-sensitive triggers.
+/// false-negative); it never auto-orders triggers whose order-dependence is VISIBLE
+/// in the profiled read/write sets (CR 603.3b). Sound MODULO two profile-INVISIBLE
+/// residuals documented in the `ability_rw` module doc — the source-actor granted-
+/// state channel and the board-wide-write × event-live-read channel — each SYMMETRIC
+/// across the same-event and departure-batch depths, so neither introduces an
+/// asymmetric auto-order.
 ///
 /// Two triggers are indistinguishable when both require no ordering input and
 /// they match on the normalized ability (CR 603.4 intervening-`if` rides in

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3633,23 +3633,31 @@ fn group_is_order_independent(
         event_object_id.is_some_and(|eid| group.iter().all(|ctx| ctx.pending.source_id != eid));
     let source_census = group_source_census(state, group);
 
-    // PR-6.75 (CR 603.3b + CR 110.2 + CR 108.3): controller-private group — every
-    // member's pending controller is one shared player `c0` AND each live source
-    // object is both controlled and owned by `c0`. Owner-alignment makes owner-keyed
-    // self-write destinations (CR 400.3 hand/graveyard) controller-resolvable.
-    // Computed live from `state.objects` (mirrors `group_source_census`): a missing
-    // object or any drift between the pending controller and the live object's
-    // controller/owner ⇒ fail-closed `false`, closing the fire-vs-ordering
-    // control-change race.
-    let same_controller = {
+    // PR-6.75 (CR 603.3b + CR 110.2 + CR 108.3 + CR 805.7): the group's controller
+    // structure, computed LIVE from `state.objects` (mirrors `group_source_census`).
+    // `Uniform` iff every member's pending controller is one shared `c0` (CR 109.5
+    // triggered-ability "you"); `UniformAligned` iff additionally each live source
+    // object is controlled AND owned by `c0` (CR 108.3) — the precondition for
+    // owner-keyed self-write destinations (CR 400.3 hand/graveyard) to be
+    // controller-resolvable. A missing object or any drift between the pending
+    // controller and the live object's controller/owner fails closed (never upgrades
+    // past `Uniform`), closing the fire-vs-ordering control-change race. `Mixed`
+    // (divergent pending controllers) is reachable only via team-pooled placement
+    // (CR 805.7).
+    let controller_uniformity = {
         let c0 = first.pending.controller;
-        group.iter().all(|ctx| {
-            ctx.pending.controller == c0
-                && state
-                    .objects
-                    .get(&ctx.pending.source_id)
-                    .is_some_and(|o| o.controller == c0 && o.owner == c0)
-        })
+        if !group.iter().all(|ctx| ctx.pending.controller == c0) {
+            crate::game::ability_rw::ControllerUniformity::Mixed
+        } else if group.iter().all(|ctx| {
+            state
+                .objects
+                .get(&ctx.pending.source_id)
+                .is_some_and(|o| o.controller == c0 && o.owner == c0)
+        }) {
+            crate::game::ability_rw::ControllerUniformity::UniformAligned
+        } else {
+            crate::game::ability_rw::ControllerUniformity::Uniform
+        }
     };
 
     let same_event_structure = crate::game::ability_rw::GroupStructure {
@@ -3659,7 +3667,7 @@ fn group_is_order_independent(
         event_object_excludes_sources,
         event_object_present,
         source_census: source_census.clone(),
-        same_controller,
+        controller_uniformity,
     };
     let batch_structure = crate::game::ability_rw::GroupStructure {
         same_event: false,
@@ -3668,7 +3676,7 @@ fn group_is_order_independent(
         event_object_excludes_sources,
         event_object_present,
         source_census,
-        same_controller,
+        controller_uniformity,
     };
     let same_event_conflict =
         crate::game::ability_rw::profiles_conflict(&profile, &same_event_structure);

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3633,6 +3633,25 @@ fn group_is_order_independent(
         event_object_id.is_some_and(|eid| group.iter().all(|ctx| ctx.pending.source_id != eid));
     let source_census = group_source_census(state, group);
 
+    // PR-6.75 (CR 603.3b + CR 110.2 + CR 108.3): controller-private group — every
+    // member's pending controller is one shared player `c0` AND each live source
+    // object is both controlled and owned by `c0`. Owner-alignment makes owner-keyed
+    // self-write destinations (CR 400.3 hand/graveyard) controller-resolvable.
+    // Computed live from `state.objects` (mirrors `group_source_census`): a missing
+    // object or any drift between the pending controller and the live object's
+    // controller/owner ⇒ fail-closed `false`, closing the fire-vs-ordering
+    // control-change race.
+    let same_controller = {
+        let c0 = first.pending.controller;
+        group.iter().all(|ctx| {
+            ctx.pending.controller == c0
+                && state
+                    .objects
+                    .get(&ctx.pending.source_id)
+                    .is_some_and(|o| o.controller == c0 && o.owner == c0)
+        })
+    };
+
     let same_event_structure = crate::game::ability_rw::GroupStructure {
         same_event: true,
         all_same_source,
@@ -3640,6 +3659,7 @@ fn group_is_order_independent(
         event_object_excludes_sources,
         event_object_present,
         source_census: source_census.clone(),
+        same_controller,
     };
     let batch_structure = crate::game::ability_rw::GroupStructure {
         same_event: false,
@@ -3648,6 +3668,7 @@ fn group_is_order_independent(
         event_object_excludes_sources,
         event_object_present,
         source_census,
+        same_controller,
     };
     let same_event_conflict =
         crate::game::ability_rw::profiles_conflict(&profile, &same_event_structure);

--- a/crates/engine/src/game/triggers_ordering_parity_tests.rs
+++ b/crates/engine/src/game/triggers_ordering_parity_tests.rs
@@ -20,17 +20,20 @@ use crate::game::ability_rw::{
     trigger_condition_rw_profile, GroupStructure, SourceCensus,
 };
 use crate::game::ability_utils::{build_resolved_from_def, build_target_slots};
+use crate::game::game_object::GameObject;
 use crate::test_support::shared_card_db;
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, Comparator, Effect, ObjectScope, QuantityExpr,
-    QuantityRef, ResolvedAbility, TargetFilter, TriggerCondition, TriggerDefinition, TypedFilter,
+    AbilityCondition, AbilityDefinition, AggregateFunction, Comparator, ControllerRef, Effect,
+    ObjectScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef, ResolvedAbility,
+    SearchSelectionConstraint, TargetFilter, TriggerCondition, TriggerConstraint,
+    TriggerDefinition, TypedFilter,
 };
 use crate::types::card::CardFace;
 use crate::types::card_type::Supertype;
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, ZoneChangeRecord};
-use crate::types::identifiers::ObjectId;
+use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::player::PlayerId;
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
@@ -328,6 +331,23 @@ fn ability_rw_profile_merged(
     p
 }
 
+/// PR-6.75 (CR 603.3b + CR 500.1): the CLOSED sweep-side controller-privacy
+/// predicate. A `Phase` trigger carrying the `OnlyDuringYourTurn` constraint fires
+/// only when `state.active_player == controller` (fire-time gate,
+/// `triggers.rs:702` → `check_trigger_constraint`), and one `PhaseChanged` event
+/// has exactly one active player — so EVERY reachable same-event group of such a
+/// trigger is same-controller. Fail-closed for every other shape: "each [player's]"
+/// phases parse to `constraint: None` (`oracle_trigger.rs`), opponent possessives
+/// to `OnlyDuringOpponentsTurn`, and enchanted/chosen-player forms to a
+/// `valid_target` with `constraint: None` — all ⇒ `false` here. The owner-alignment
+/// half of `same_controller` is computed LIVE and fail-closed in production; the
+/// sweep models the reachable canonical group (an exotic donated-source variant
+/// merely over-prompts in production, never under-prompts).
+fn trigger_is_controller_private(trig: &TriggerDefinition) -> bool {
+    matches!(trig.mode, TriggerMode::Phase)
+        && matches!(trig.constraint, Some(TriggerConstraint::OnlyDuringYourTurn))
+}
+
 #[test]
 fn ordering_parity_sweep() {
     let db = shared_card_db();
@@ -380,22 +400,28 @@ fn ordering_parity_sweep() {
             let has_src_read = reads_source_pt_or_counter(&value);
             let hadcounters = matches!(trig.condition, Some(TriggerCondition::HadCounters { .. }));
 
-            let mk =
-                |same_event: bool, all_same_source: bool, self_departed: bool| GroupStructure {
-                    same_event,
-                    all_same_source,
-                    all_sources_self_departed: self_departed,
-                    event_object_excludes_sources: if self_ref { false } else { excludes },
-                    event_object_present: event_present,
-                    source_census: census.clone(),
-                };
+            let mk = |same_event: bool,
+                      all_same_source: bool,
+                      self_departed: bool,
+                      same_controller: bool| GroupStructure {
+                same_event,
+                all_same_source,
+                all_sources_self_departed: self_departed,
+                event_object_excludes_sources: if self_ref { false } else { excludes },
+                event_object_present: event_present,
+                source_census: census.clone(),
+                same_controller,
+            };
 
             // --- Same-event, distinct-source observer (S2) ---
             // §5.2: only where a 2-copy same-event group is REACHABLE (CLASS-A
             // guard — skip legendary / per-source-event / condition-self-excluding
-            // shapes where the structure can never form).
+            // shapes where the structure can never form). PR-6.75: the modeled
+            // canonical S2 group is controller-private exactly for the fire-time-
+            // pinned Phase+OnlyDuringYourTurn class (`trigger_is_controller_private`);
+            // production additionally computes owner-alignment live and fail-closed.
             if !self_ref && same_event_group_reachable(face, trig, &census) {
-                let se = mk(true, false, false);
+                let se = mk(true, false, false, trigger_is_controller_private(trig));
                 let conflict = profiles_conflict(&profile, &se);
                 let decision_new = !conflict; // decision_old (same-event) == auto == true
                 compared += 1;
@@ -415,10 +441,13 @@ fn ordering_parity_sweep() {
 
             // --- Departure-batch structures (S3 self-departed / S5 mixed obs) ---
             if is_departure {
+                // §5: batch rows model `same_controller = false` (different-
+                // controller co-deaths are reachable) — the static sweep's batch
+                // model is fail-closed; production computes it live.
                 let batch = if self_ref {
-                    mk(false, false, true) // self-dies
+                    mk(false, false, true, false) // self-dies
                 } else {
-                    mk(false, false, false) // observer batch
+                    mk(false, false, false, false) // observer batch
                 };
                 let batch_conflict = legacy_prompt || profiles_conflict(&profile, &batch);
                 let decision_new = !batch_conflict;
@@ -920,5 +949,413 @@ fn n_g_dropped_target_legacy_ref_retains_batch_prompt() {
     assert!(
         group_is_order_independent(&state, &control_group, false),
         "identical Discard with no frozen tag (Controller) ⇒ auto-order"
+    );
+}
+
+// ===================================================================
+// PR-6.75 `same_controller` span discriminators (S1–S6), driven through the
+// production authority `group_is_order_independent`. POSITIVE (auto) groups
+// install source objects owned AND controlled by the pending controller so the
+// LIVE `same_controller` check holds; each NEG breaks exactly ONE axis (span
+// disjointness, controller-uniformity, or owner-alignment) and must re-prompt —
+// the paired positive reach-guard proves the auto is delivered by the refined
+// row, not an upstream fast-path short-circuit.
+// ===================================================================
+
+/// Install a battlefield source with explicit owner + controller (the live-state
+/// precondition the chokepoint reads: `o.controller == o.owner == c0`).
+fn install_source(state: &mut GameState, id: u64, owner: u8, controller: u8) {
+    let mut o = GameObject::new(
+        ObjectId(id),
+        CardId(1),
+        PlayerId(owner),
+        "Src".to_string(),
+        Zone::Battlefield,
+    );
+    o.owner = PlayerId(owner);
+    o.controller = PlayerId(controller);
+    state.objects.insert(ObjectId(id), o);
+}
+
+/// A pending-trigger context with an explicit controller (S4/S5/S6 vary it).
+fn ctx_c(
+    source: u64,
+    controller: u8,
+    ability: ResolvedAbility,
+    condition: Option<TriggerCondition>,
+    event: Option<GameEvent>,
+) -> PendingTriggerContext {
+    PendingTriggerContext::single(PendingTrigger {
+        source_id: ObjectId(source),
+        controller: PlayerId(controller),
+        condition,
+        ability,
+        timestamp: 0,
+        target_constraints: Vec::new(),
+        distribute: None,
+        trigger_event: event,
+        modal: None,
+        mode_abilities: vec![],
+        description: None,
+        may_trigger_origin: None,
+        subject_match_count: None,
+        die_result: None,
+    })
+}
+
+fn creatures_of(cr: ControllerRef) -> TargetFilter {
+    let mut tf = TypedFilter::creature();
+    tf.controller = Some(cr);
+    TargetFilter::Typed(tf)
+}
+
+fn sacrifice_self() -> Effect {
+    Effect::Sacrifice {
+        target: TargetFilter::SelfRef,
+        count: qfix(1),
+        min_count: 0,
+    }
+}
+/// Defense-of-the-Heart shape: search the CONTROLLER's own library (no
+/// `target_player`) → the phantom write earns a `You` chain move-owner fact.
+fn search_own_creatures() -> Effect {
+    Effect::SearchLibrary {
+        source_zones: vec![Zone::Library],
+        filter: creature(),
+        count: QuantityExpr::UpTo {
+            max: Box::new(qfix(2)),
+        },
+        reveal: false,
+        target_player: None,
+        selection_constraint: SearchSelectionConstraint::None,
+        split: None,
+    }
+}
+/// The chained opaque battlefield entry (`Library → Battlefield`, `Any` target,
+/// no `enters_under`) that consumes the search's `You` move-owner fact.
+fn change_zone_lib_to_bf() -> Effect {
+    Effect::ChangeZone {
+        origin: Some(Zone::Library),
+        destination: Zone::Battlefield,
+        target: TargetFilter::Any,
+        owner_library: false,
+        enter_transformed: false,
+        enters_under: None,
+        enter_tapped: crate::types::zones::EtbTapState::default(),
+        enters_attacking: false,
+        up_to: false,
+        enter_with_counters: vec![],
+        conditional_enter_with_counters: vec![],
+        face_down_profile: None,
+        enters_modified_if: None,
+    }
+}
+fn shuffle_ctrl() -> Effect {
+    Effect::Shuffle {
+        target: TargetFilter::Controller,
+    }
+}
+fn bounce_self() -> Effect {
+    Effect::Bounce {
+        target: TargetFilter::SelfRef,
+        destination: None,
+        selection: crate::types::ability::BounceSelection::default(),
+    }
+}
+fn discard_hand(count: QuantityExpr, target: TargetFilter) -> Effect {
+    Effect::Discard {
+        count,
+        target,
+        unless_filter: None,
+        filter: None,
+        selection: crate::types::ability::CardSelectionMode::Chosen,
+    }
+}
+fn obj_count_cmp(filter: TargetFilter, cmp: Comparator, rhs: i32) -> TriggerCondition {
+    TriggerCondition::QuantityComparison {
+        lhs: qref(QuantityRef::ObjectCount { filter }),
+        rhs: qfix(rhs),
+        comparator: cmp,
+    }
+}
+fn handsize_cmp(player: PlayerScope, cmp: Comparator, rhs: i32) -> TriggerCondition {
+    TriggerCondition::QuantityComparison {
+        lhs: qref(QuantityRef::HandSize { player }),
+        rhs: qfix(rhs),
+        comparator: cmp,
+    }
+}
+
+/// Defense-of-the-Heart chain: `Sacrifice{SelfRef}` → `SearchLibrary` →
+/// `ChangeZone{Library→Bf, Any}` → `Shuffle`.
+fn defense_ability() -> ResolvedAbility {
+    let cz = ra(change_zone_lib_to_bf()).sub_ability(ra(shuffle_ctrl()));
+    let search = ra(search_own_creatures()).sub_ability(cz);
+    ra(sacrifice_self()).sub_ability(search)
+}
+
+/// S-1 — Defense of the Heart shape. POS: same-event 2-copy, both P0, sources
+/// installed owner==controller==P0; the opponents'-board census read is
+/// ctrl-disjoint (Opponents) from the your-library battlefield entry (You) ⇒
+/// AUTO. NEG reach-guard: flip the read's controller to `You` ⇒ ctrl spans
+/// overlap ⇒ PROMPT. The NEG also proves the auto is NOT a `source_independent`
+/// fast-path fluke — `Sacrifice{SelfRef}` keeps `source_independent` false in
+/// both, so only the membership-ctrl span differs.
+#[test]
+fn s1_defense_membership_ctrl_span() {
+    let mut state = empty_state();
+    install_source(&mut state, 10, 0, 0);
+    install_source(&mut state, 11, 0, 0);
+    let ev = shared_etb_event();
+
+    let pos_cond = || obj_count_cmp(creatures_of(ControllerRef::Opponent), Comparator::GE, 3);
+    let pos = vec![
+        ctx_c(10, 0, defense_ability(), Some(pos_cond()), ev.clone()),
+        ctx_c(11, 0, defense_ability(), Some(pos_cond()), ev.clone()),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos, false),
+        "S1 POS: opponents'-board read × your-library entry are ctrl-disjoint ⇒ auto"
+    );
+
+    let neg_cond = || obj_count_cmp(creatures_of(ControllerRef::You), Comparator::GE, 3);
+    let neg = vec![
+        ctx_c(10, 0, defense_ability(), Some(neg_cond()), ev.clone()),
+        ctx_c(11, 0, defense_ability(), Some(neg_cond()), ev),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &neg, false),
+        "S1 NEG: your-board read × your-library entry ctrl spans overlap ⇒ prompt"
+    );
+}
+
+/// S-2 — Rekindled Flame shape (`Bounce{SelfRef}` + `HandSize{Opponent} EQ 0`
+/// intervening-if). POS: opp-hand read (Opponents) × your-hand self-bounce write
+/// (You) ⇒ AUTO. Sibling NEG: read `HandSize{Controller}` (You) ⇒ hand spans
+/// overlap ⇒ PROMPT.
+#[test]
+fn s2_rekindled_player_hand_span() {
+    let mut state = empty_state();
+    install_source(&mut state, 10, 0, 0);
+    install_source(&mut state, 11, 0, 0);
+    let ev = shared_etb_event();
+
+    let pos_cond = || {
+        handsize_cmp(
+            PlayerScope::Opponent {
+                aggregate: AggregateFunction::Min,
+            },
+            Comparator::EQ,
+            0,
+        )
+    };
+    let pos = vec![
+        ctx_c(10, 0, ra(bounce_self()), Some(pos_cond()), ev.clone()),
+        ctx_c(11, 0, ra(bounce_self()), Some(pos_cond()), ev.clone()),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos, false),
+        "S2 POS: opp-hand read × your-hand self-bounce are player-disjoint ⇒ auto"
+    );
+
+    let neg_cond = || handsize_cmp(PlayerScope::Controller, Comparator::EQ, 0);
+    let neg = vec![
+        ctx_c(10, 0, ra(bounce_self()), Some(neg_cond()), ev.clone()),
+        ctx_c(11, 0, ra(bounce_self()), Some(neg_cond()), ev),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &neg, false),
+        "S2 NEG: your-hand read × your-hand write overlap ⇒ prompt"
+    );
+}
+
+/// Brink-of-Madness chain: `Sacrifice{SelfRef}` → scoped-Opponent
+/// `Discard{count, target: Controller}`.
+fn brink_ability(count: QuantityExpr) -> ResolvedAbility {
+    let mut discard = ra(discard_hand(count, TargetFilter::Controller));
+    discard.player_scope = Some(PlayerFilter::Opponent);
+    ra(sacrifice_self()).sub_ability(discard)
+}
+
+/// S-3 — Brink of Madness fused RMW discriminator. POS: `count:
+/// HandSize{ScopedPlayer}` is the fused "discards their hand" read ⇒ dropped
+/// under the gate, leaving the your-hand intervening-if (You) vs the opp-hand
+/// Discard write (Opponents) ⇒ AUTO. Fusion NEG: the SAME opp-scoped Discard but
+/// `count: HandSize{Opponent}` — a genuine (non-fused) opp-hand observation that
+/// is NOT dropped ⇒ read span degrades to Any ⇒ overlaps the write ⇒ PROMPT.
+/// Isolates the fusion arm exactly (same write both sides).
+#[test]
+fn s3_brink_fused_discard_span() {
+    let mut state = empty_state();
+    install_source(&mut state, 10, 0, 0);
+    install_source(&mut state, 11, 0, 0);
+    let ev = shared_etb_event();
+    let cond = || handsize_cmp(PlayerScope::Controller, Comparator::EQ, 0);
+
+    let fused = qref(QuantityRef::HandSize {
+        player: PlayerScope::ScopedPlayer,
+    });
+    let pos = vec![
+        ctx_c(
+            10,
+            0,
+            brink_ability(fused.clone()),
+            Some(cond()),
+            ev.clone(),
+        ),
+        ctx_c(11, 0, brink_ability(fused), Some(cond()), ev.clone()),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos, false),
+        "S3 POS: fused HandSize{{ScopedPlayer}} count dropped ⇒ You-cond × Opp-write disjoint ⇒ auto"
+    );
+
+    let unfused = qref(QuantityRef::HandSize {
+        player: PlayerScope::Opponent {
+            aggregate: AggregateFunction::Min,
+        },
+    });
+    let neg = vec![
+        ctx_c(
+            10,
+            0,
+            brink_ability(unfused.clone()),
+            Some(cond()),
+            ev.clone(),
+        ),
+        ctx_c(11, 0, brink_ability(unfused), Some(cond()), ev),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &neg, false),
+        "S3 NEG: non-fused opp-hand count read is a live player read ⇒ prompt"
+    );
+}
+
+/// S-4 — load-bearing shared-event observer (the gate is load-bearing). Two
+/// Rekindled-shape triggers off ONE event with controllers P0 and P1: mixed
+/// controllers ⇒ `same_controller = false` ⇒ the spans are UNCONSULTED ⇒ the
+/// hand row fires ⇒ PROMPT. Revert-fail foil (same shapes, both P0): the ONLY
+/// change is the controller/owner of source 11 ⇒ `same_controller = true` ⇒
+/// AUTO. Deleting the gate in `profiles_conflict` would flip the P0/P1 case to
+/// auto (RED).
+#[test]
+fn s4_gate_is_load_bearing() {
+    let mut state = empty_state();
+    install_source(&mut state, 10, 0, 0);
+    install_source(&mut state, 11, 1, 1); // owned + controlled by P1
+    let ev = shared_etb_event();
+    let cond = || {
+        handsize_cmp(
+            PlayerScope::Opponent {
+                aggregate: AggregateFunction::Min,
+            },
+            Comparator::EQ,
+            0,
+        )
+    };
+
+    let mixed = vec![
+        ctx_c(10, 0, ra(bounce_self()), Some(cond()), ev.clone()),
+        ctx_c(11, 1, ra(bounce_self()), Some(cond()), ev.clone()),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &mixed, false),
+        "S4 NEG: mixed controllers ⇒ same_controller false ⇒ spans unconsulted ⇒ prompt"
+    );
+
+    // Revert-fail foil: reinstall source 11 under P0 and flip the pending
+    // controller — the sole change that makes the group controller-private.
+    install_source(&mut state, 11, 0, 0);
+    let uniform = vec![
+        ctx_c(10, 0, ra(bounce_self()), Some(cond()), ev.clone()),
+        ctx_c(11, 0, ra(bounce_self()), Some(cond()), ev),
+    ];
+    assert!(
+        group_is_order_independent(&state, &uniform, false),
+        "S4 foil: both P0 ⇒ same_controller true ⇒ span disjointness clears ⇒ auto"
+    );
+}
+
+/// S-5 — MULTIPLAYER (3 players). (a) members P0 and P1: mixed controllers ⇒
+/// same_controller false ⇒ PROMPT (at 3p, P1's opponents include P0, so treating
+/// them as controller-private would be unsound — the gate correctly refuses).
+/// (b) both members P0: `You == {P0}` vs `Opponents == {P1,P2}` disjointness is
+/// NOT a two-player artifact ⇒ AUTO at N players.
+#[test]
+fn s5_multiplayer_three_players() {
+    let mut state = GameState::new(crate::types::format::FormatConfig::standard(), 3, 7);
+    install_source(&mut state, 10, 0, 0);
+    install_source(&mut state, 11, 1, 1);
+    install_source(&mut state, 12, 0, 0);
+    let ev = shared_etb_event();
+    let cond = || {
+        handsize_cmp(
+            PlayerScope::Opponent {
+                aggregate: AggregateFunction::Min,
+            },
+            Comparator::EQ,
+            0,
+        )
+    };
+
+    let mixed = vec![
+        ctx_c(10, 0, ra(bounce_self()), Some(cond()), ev.clone()),
+        ctx_c(11, 1, ra(bounce_self()), Some(cond()), ev.clone()),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &mixed, false),
+        "S5a: 3p mixed controllers ⇒ same_controller false ⇒ prompt"
+    );
+
+    let both_p0 = vec![
+        ctx_c(10, 0, ra(bounce_self()), Some(cond()), ev.clone()),
+        ctx_c(12, 0, ra(bounce_self()), Some(cond()), ev),
+    ];
+    assert!(
+        group_is_order_independent(&state, &both_p0, false),
+        "S5b: 3p both P0 ⇒ You={{P0}} vs Opponents={{P1,P2}} disjoint ⇒ auto (not a 2p artifact)"
+    );
+}
+
+/// S-6 — owner-alignment discriminator (the `o.owner == c0` conjunct is
+/// load-bearing). Rekindled shape, both members controlled by P0, but source 11
+/// is OWNED by P1 (donated / control-changed). NEG: owner mismatch ⇒
+/// same_controller false ⇒ PROMPT — and this is a REAL under-prompt guard: the
+/// self-bounce would put source 11 in P1's hand, which the `HandSize{Opponent}`
+/// read observes. Revert-fail foil (source 11 owned by P0): same_controller true
+/// ⇒ AUTO. Dropping the owner conjunct would auto the NEG (RED).
+#[test]
+fn s6_owner_alignment() {
+    let mut state = empty_state();
+    install_source(&mut state, 10, 0, 0);
+    install_source(&mut state, 11, 1, 0); // owner P1, controller P0 (donated)
+    let ev = shared_etb_event();
+    let cond = || {
+        handsize_cmp(
+            PlayerScope::Opponent {
+                aggregate: AggregateFunction::Min,
+            },
+            Comparator::EQ,
+            0,
+        )
+    };
+
+    let donated = vec![
+        ctx_c(10, 0, ra(bounce_self()), Some(cond()), ev.clone()),
+        ctx_c(11, 0, ra(bounce_self()), Some(cond()), ev.clone()),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &donated, false),
+        "S6 NEG: source owned by an opponent ⇒ owner-misaligned ⇒ prompt (real under-prompt guard)"
+    );
+
+    install_source(&mut state, 11, 0, 0); // now owner == controller == P0
+    let aligned = vec![
+        ctx_c(10, 0, ra(bounce_self()), Some(cond()), ev.clone()),
+        ctx_c(11, 0, ra(bounce_self()), Some(cond()), ev),
+    ];
+    assert!(
+        group_is_order_independent(&state, &aligned, false),
+        "S6 foil: owner == controller == P0 ⇒ same_controller true ⇒ auto"
     );
 }

--- a/crates/engine/src/game/triggers_ordering_parity_tests.rs
+++ b/crates/engine/src/game/triggers_ordering_parity_tests.rs
@@ -1,0 +1,856 @@
+//! CR 603.3b: PR-6.75 trigger-ordering conflict-gate tests.
+//!
+//! Two families:
+//!   * The §5.2 **allowlist-parity sweep** — the corpus-wide proof that the new
+//!     `ability_rw` conflict gate reproduces the DELETED 12-string serde
+//!     allowlist's decision on every printed no-ordering-input trigger, modulo
+//!     the seven proven-order-dependent category-(1) rows (the CR 603.3b fix).
+//!     A FROZEN in-test copy of the deleted walk is the reference oracle.
+//!   * The **discriminators** N-A/N-B/N-B2/N-C/N-D/N-F — hand-built groups run
+//!     through the production ordering-soundness authority
+//!     (`group_is_order_independent`), each paired so exactly one classification
+//!     decision is bracketed (revert-fails recorded in the impl report).
+//!
+//! N-E (the per-arm profile pairings) already lives in `ability_rw`'s unit tests
+//! and is NOT duplicated here.
+
+use super::*;
+use crate::game::ability_rw::{
+    ability_rw_profile, filter_excludes_source, profiles_conflict, source_census_overlaps_filter,
+    trigger_condition_rw_profile, GroupStructure, SourceCensus,
+};
+use crate::game::ability_utils::{build_resolved_from_def, build_target_slots};
+use crate::test_support::shared_card_db;
+use crate::types::ability::{
+    AbilityCondition, AbilityDefinition, Comparator, Effect, ObjectScope, QuantityExpr,
+    QuantityRef, ResolvedAbility, TargetFilter, TriggerCondition, TriggerDefinition, TypedFilter,
+};
+use crate::types::card::CardFace;
+use crate::types::card_type::Supertype;
+use crate::types::counter::CounterType;
+use crate::types::events::GameEvent;
+use crate::types::game_state::{GameState, ZoneChangeRecord};
+use crate::types::identifiers::ObjectId;
+use crate::types::player::PlayerId;
+use crate::types::triggers::TriggerMode;
+use crate::types::zones::Zone;
+use std::collections::BTreeSet;
+
+// ===================================================================
+// Frozen reference oracle: verbatim copy of the DELETED serde walk
+// (was value_contains_trigger_event_context_ref / :3395-3420). Kept here so the
+// parity sweep remains provable after the production fn is gone.
+// ===================================================================
+
+fn legacy_value_contains_event_context_ref(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(tag) => matches!(
+            tag.as_str(),
+            "TriggeringSpellController"
+                | "TriggeringSpellOwner"
+                | "TriggeringPlayer"
+                | "TriggeringSource"
+                | "ParentTarget"
+                | "ParentTargetController"
+                | "ParentTargetOwner"
+                | "StackSpell"
+                | "CostPaidObject"
+                | "EventContextAmount"
+                | "EventContextSourceCostX"
+                | "ManaSpentToCast"
+        ),
+        serde_json::Value::Array(values) => {
+            values.iter().any(legacy_value_contains_event_context_ref)
+        }
+        serde_json::Value::Object(map) => map.values().any(legacy_value_contains_event_context_ref),
+        _ => false,
+    }
+}
+
+/// The old `ability_uses_trigger_event_context`: serialize the ability, walk for
+/// one of the 12 tags.
+fn legacy_allowlist(ability: &ResolvedAbility) -> bool {
+    serde_json::to_value(ability)
+        .map(|v| legacy_value_contains_event_context_ref(&v))
+        .unwrap_or(true)
+}
+
+/// The AST bears an `Effect::Unimplemented` (serde tag `Unimplemented`).
+fn ast_bears_unimplemented(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(s) => s == "Unimplemented",
+        serde_json::Value::Array(vs) => vs.iter().any(ast_bears_unimplemented),
+        serde_json::Value::Object(map) => {
+            // `Unimplemented` is a struct-variant key OR a `"type":"Unimplemented"` tag.
+            map.contains_key("Unimplemented") || map.values().any(ast_bears_unimplemented)
+        }
+        _ => false,
+    }
+}
+
+// ===================================================================
+// §5.2 allowlist-parity sweep
+// ===================================================================
+
+/// The canonical category-(1) rows (§5.2): provably order-dependent printed
+/// groups whose same-event auto→prompt flip IS the CR 603.3b fix. Each carries
+/// its in-plan order-dependence proof (see PR-6.75-C0FULL-C1-PLAN.md §5.2). A
+/// same-event diff on any OTHER card is an implementation finding, never a new
+/// row (STRICT PROOF-GATE).
+const CATEGORY_1_ROWS: &[&str] = &[
+    // Ouroboroid: each copy's Power{Source} read is fed by the other's
+    // PutCounterAll — token/counter totals differ by order.
+    "ouroboroid",
+    // Docent of Perfection: each copy's Wizard-token write feeds the shared
+    // census threshold — WHICH copy transforms depends on order.
+    "docent of perfection",
+    // Sidequest: Hunt the Mark: token write feeds the shared census threshold.
+    "sidequest: hunt the mark",
+    // Promise of Tomorrow: first copy's mass return flips the second's CR 603.4
+    // re-check — whose stash returns depends on order.
+    "promise of tomorrow",
+    // Spawn of Mayhem: damage order across the 10-life threshold decides which
+    // copy gets the counter.
+    "spawn of mayhem",
+    // Your Inescapable Doom: PutCounter{Any} write × sibling CountersOn{Source}
+    // read — same-kind counter feed (CR 904.3 two-copy scheme deck).
+    "your inescapable doom",
+    // Complex Automaton: ObjectCount{Permanent} intervening-if read × self-Bounce
+    // whose moved census (permanent) overlaps the read filter.
+    "complex automaton",
+];
+
+/// The census of a printed card's source (core types + subtypes + non-token).
+fn face_census(face: &CardFace) -> SourceCensus {
+    let mut tags: Vec<String> = Vec::new();
+    for ct in &face.card_type.core_types {
+        tags.push(ct.to_string());
+    }
+    for st in &face.card_type.subtypes {
+        tags.push(st.clone());
+    }
+    tags.push("nontoken".to_string());
+    SourceCensus::from_tags(tags)
+}
+
+/// Whether the firing event carries an object (production uses
+/// `extract_source_from_event`; phase/turn/global modes carry none).
+fn mode_carries_event_object(mode: &TriggerMode) -> bool {
+    !matches!(
+        mode,
+        TriggerMode::Phase
+            | TriggerMode::TurnBegin
+            | TriggerMode::NewGame
+            | TriggerMode::BecomeMonarch
+            | TriggerMode::TakesInitiative
+            | TriggerMode::LosesGame
+    )
+}
+
+/// Whether the mode is a battlefield-departure (dies / LTB / sacrifice) — the
+/// departure-batch structures are reachable only for these.
+fn mode_is_battlefield_departure(
+    mode: &TriggerMode,
+    def: &crate::types::ability::TriggerDefinition,
+) -> bool {
+    match mode {
+        TriggerMode::LeavesBattlefield | TriggerMode::Destroyed | TriggerMode::Sacrificed => true,
+        // Zone-change modes are departures only when origin is the battlefield.
+        TriggerMode::ChangesZone | TriggerMode::ChangesZoneAll => {
+            def.origin == Some(Zone::Battlefield) || def.origin_zones.contains(&Zone::Battlefield)
+        }
+        _ => false,
+    }
+}
+
+/// §5.2 per-trigger structure-reachability (CLASS-A guard): whether a same-event
+/// 2-copy group is corpus-REACHABLE for this trigger. Applying a same-event
+/// structure where two distinct non-legendary sources can NEVER share the firing
+/// event, or where a 2-copy group can never form, is meaningless — a decision
+/// diff there must NOT be counted (§5.2). Returns false (exempt from the
+/// same-event structures) when:
+///   * LEGENDARY — two same-name legendaries can't coexist under one controller
+///     (CR 704.5j legend rule), so a 2-copy same-event group never persists; the
+///     plan's `same_event` class is measured over NON-legendary cards (§1.3).
+///     (gisela, the broken blade; doors of durin.)
+///   * PER-SOURCE event mode — the event IS the source's own action, so two
+///     distinct sources fire on DISTINCT events: self-scoped `DamageDone`/
+///     `DamageDoneOnce` (combat damage is a per-source `DamageDealt` event keyed
+///     by `source_id`, events.rs:408 — valeron wardens, acolyte of the inferno),
+///     or a Saga-chapter `CounterAdded` on a SelfRef `valid_card` (per-source lore
+///     counter). An OBSERVER DamageDone ("whenever a creature deals damage") is
+///     NOT exempt (it CAN be shared).
+///   * CONDITION self-exclusion (§1.3.1-F, CR 603.4) — the shared intervening-if
+///     counts `Another`-self-exclusion objects the SOURCE itself matches and
+///     requires that count to be 0; with two copies each sees the other (≥ 1) ⇒
+///     each re-check is FALSE at trigger time ⇒ neither fires ⇒ no group forms
+///     (thopter assembly; dust stalker).
+fn same_event_group_reachable(
+    face: &CardFace,
+    trig: &TriggerDefinition,
+    census: &SourceCensus,
+) -> bool {
+    if face.card_type.supertypes.contains(&Supertype::Legendary) {
+        return false;
+    }
+    match trig.mode {
+        // Damage triggers carry their SUBJECT in `valid_source` (`valid_card` is
+        // ALWAYS None for them — make_base leaves it, oracle_trigger sets
+        // valid_source), so a SELF-damage trigger is `valid_source == SelfRef`.
+        // Combat damage is a per-source `GameEvent::DamageDealt{source_id}`
+        // (events.rs:408), so two distinct self-sources never share it ⇒ exempt.
+        // An OBSERVER damage trigger (`valid_source` non-SelfRef, e.g. "whenever a
+        // creature you control deals damage") CAN fire two copies off ONE source's
+        // damage event ⇒ NOT exempt (gating on `valid_card` here would wrongly
+        // exempt every observer, since `valid_card` is None for all of them).
+        TriggerMode::DamageDone | TriggerMode::DamageDoneOnce
+            if matches!(trig.valid_source, Some(TargetFilter::SelfRef)) =>
+        {
+            return false
+        }
+        TriggerMode::CounterAdded if matches!(trig.valid_card, Some(TargetFilter::SelfRef)) => {
+            return false
+        }
+        _ => {}
+    }
+    if let Some(cond) = &trig.condition {
+        if condition_excludes_second_copy(cond, census) {
+            return false;
+        }
+    }
+    true
+}
+
+/// §1.3.1-F (CR 603.4): does the shared intervening-if become FALSE whenever a
+/// second identical source exists? True when it counts objects matching an
+/// `Another`-self-exclusion filter the source ITSELF matches and requires that
+/// count to be 0 (or `< 1`) — each of two copies then sees the other (count ≥ 1),
+/// so neither trigger's re-check passes at trigger time.
+fn condition_excludes_second_copy(cond: &TriggerCondition, census: &SourceCensus) -> bool {
+    match cond {
+        TriggerCondition::QuantityComparison {
+            lhs,
+            rhs,
+            comparator,
+        } => {
+            let Some(filter) = object_count_filter(lhs) else {
+                return false;
+            };
+            let Some(n) = fixed_value(rhs) else {
+                return false;
+            };
+            filter_excludes_source(filter)
+                && source_census_overlaps_filter(census, filter)
+                && count_ge_one_falsifies(*comparator, n)
+        }
+        // "controls no Another-X" ≡ count == 0.
+        TriggerCondition::ControlsNone { filter } => {
+            filter_excludes_source(filter) && source_census_overlaps_filter(census, filter)
+        }
+        // A single false conjunct falsifies the whole AND ⇒ the trigger can't fire.
+        TriggerCondition::And { conditions } => conditions
+            .iter()
+            .any(|c| condition_excludes_second_copy(c, census)),
+        _ => false,
+    }
+}
+
+fn object_count_filter(q: &QuantityExpr) -> Option<&TargetFilter> {
+    match q {
+        QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { filter },
+        } => Some(filter),
+        _ => None,
+    }
+}
+fn fixed_value(q: &QuantityExpr) -> Option<i32> {
+    match q {
+        QuantityExpr::Fixed { value } => Some(*value),
+        _ => None,
+    }
+}
+/// Is `count <cmp> n` FALSE for every `count ≥ 1`? (`EQ 0` / `LE ≤0` / `LT ≤1`.)
+fn count_ge_one_falsifies(cmp: Comparator, n: i32) -> bool {
+    match cmp {
+        Comparator::EQ => n == 0,
+        Comparator::LE => n <= 0,
+        Comparator::LT => n <= 1,
+        _ => false,
+    }
+}
+
+/// A no-ordering-input trigger shape (mirrors `trigger_has_no_ordering_input`):
+/// no modal / division / target announcement (CR 603.3c/3d). `build_target_slots`
+/// is the production target-collection authority; an error is treated as
+/// has-input (conservatively excluded).
+fn sweep_no_ordering_input(
+    state: &GameState,
+    resolved: &ResolvedAbility,
+    def: &AbilityDefinition,
+) -> bool {
+    def.modal.is_none()
+        && def.mode_abilities.is_empty()
+        && def.target_constraints.is_empty()
+        && resolved.multi_target.is_none()
+        && resolved.distribution.is_none()
+        && build_target_slots(state, resolved)
+            .map(|slots| slots.is_empty())
+            .unwrap_or(false)
+}
+
+/// A trigger's ability reads a live source P/T / counter characteristic
+/// (`Power`/`Toughness`/`CountersOn` at `ObjectScope::Source`).
+fn reads_source_pt_or_counter(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(map) => {
+            let is_src_read = ["Power", "Toughness", "CountersOn"].iter().any(|k| {
+                map.get(*k).is_some_and(|inner| {
+                    serde_json::to_string(inner)
+                        .map(|s| s.contains("\"Source\""))
+                        .unwrap_or(false)
+                })
+            });
+            is_src_read || map.values().any(reads_source_pt_or_counter)
+        }
+        serde_json::Value::Array(vs) => vs.iter().any(reads_source_pt_or_counter),
+        _ => false,
+    }
+}
+
+fn ability_rw_profile_merged(
+    resolved: &ResolvedAbility,
+    trig_condition: Option<&TriggerCondition>,
+) -> crate::game::ability_rw::RwProfile {
+    let mut p = ability_rw_profile(resolved);
+    if let Some(tc) = trig_condition {
+        p.merge(trigger_condition_rw_profile(tc));
+    }
+    p
+}
+
+#[test]
+fn ordering_parity_sweep() {
+    let db = shared_card_db();
+    let full_db = std::env::var_os("FORGE_TEST_FULL_DB").is_some();
+    // A minimal state solely for `build_target_slots` structural collection.
+    let state = GameState::new_two_player(1);
+    let src = ObjectId(1);
+    let ctrl = PlayerId(0);
+
+    let mut swept = 0usize;
+    let mut compared = 0usize;
+    let mut unexplained: Vec<String> = Vec::new();
+    let mut cat1_hit: BTreeSet<String> = BTreeSet::new();
+
+    // Non-vacuity floors (full-DB; the committed fixture is a subset).
+    let mut floor_batch_self_srcread = 0usize;
+    let mut floor_batch_obs = 0usize;
+    let mut floor_hadcounters_batch_self = 0usize;
+    let mut floor_retained_prompt = 0usize;
+    let mut floor_t1_source_indep = 0usize;
+
+    for (_key, face) in db.face_iter() {
+        let name = face.name.to_lowercase();
+        let census = face_census(face);
+        for trig in &face.triggers {
+            let Some(def) = trig.execute.as_deref() else {
+                continue;
+            };
+            let resolved = build_resolved_from_def(def, src, ctrl);
+            let value = serde_json::to_value(&resolved).unwrap_or(serde_json::Value::Null);
+            if ast_bears_unimplemented(&value) {
+                continue;
+            }
+            if !sweep_no_ordering_input(&state, &resolved, def) {
+                continue;
+            }
+            swept += 1;
+
+            let profile = ability_rw_profile_merged(&resolved, trig.condition.as_ref());
+            let legacy_serde = legacy_allowlist(&resolved);
+            let legacy_prompt = profile.legacy_batch_prompt();
+            let self_ref = matches!(trig.valid_card, Some(TargetFilter::SelfRef));
+            let excludes = trig
+                .valid_card
+                .as_ref()
+                .map(filter_excludes_source)
+                .unwrap_or(false);
+            let event_present = mode_carries_event_object(&trig.mode);
+            let is_departure = mode_is_battlefield_departure(&trig.mode, trig);
+            let has_src_read = reads_source_pt_or_counter(&value);
+            let hadcounters = matches!(trig.condition, Some(TriggerCondition::HadCounters { .. }));
+
+            let mk =
+                |same_event: bool, all_same_source: bool, self_departed: bool| GroupStructure {
+                    same_event,
+                    all_same_source,
+                    all_sources_self_departed: self_departed,
+                    event_object_excludes_sources: if self_ref { false } else { excludes },
+                    event_object_present: event_present,
+                    source_census: census.clone(),
+                };
+
+            // --- Same-event, distinct-source observer (S2) ---
+            // §5.2: only where a 2-copy same-event group is REACHABLE (CLASS-A
+            // guard — skip legendary / per-source-event / condition-self-excluding
+            // shapes where the structure can never form).
+            if !self_ref && same_event_group_reachable(face, trig, &census) {
+                let se = mk(true, false, false);
+                let conflict = profiles_conflict(&profile, &se);
+                let decision_new = !conflict; // decision_old (same-event) == auto == true
+                compared += 1;
+                if !decision_new {
+                    // A same-event diff (auto -> prompt): must be a category-(1) row.
+                    if CATEGORY_1_ROWS.contains(&name.as_str()) {
+                        cat1_hit.insert(name.clone());
+                    } else {
+                        unexplained.push(format!(
+                            "SAME-EVENT auto->prompt on '{name}' (not a category-(1) row)"
+                        ));
+                    }
+                } else if profile.source_independent() {
+                    floor_t1_source_indep += 1;
+                }
+            }
+
+            // --- Departure-batch structures (S3 self-departed / S5 mixed obs) ---
+            if is_departure {
+                let batch = if self_ref {
+                    mk(false, false, true) // self-dies
+                } else {
+                    mk(false, false, false) // observer batch
+                };
+                let batch_conflict = legacy_prompt || profiles_conflict(&profile, &batch);
+                let decision_new = !batch_conflict;
+                let decision_old = !legacy_serde;
+                compared += 1;
+                if decision_new != decision_old {
+                    // Batch parity is ZERO-diff by design (D3). Any batch diff is a
+                    // finding — no category exists for it.
+                    unexplained.push(format!(
+                        "BATCH decision diff on '{name}' (old={decision_old}, new={decision_new}, \
+                         legacy_serde={legacy_serde}, legacy_prompt={legacy_prompt})"
+                    ));
+                }
+                // Retained-prompt parity (D5): every legacy-ref trigger must still
+                // prompt on the batch path.
+                if legacy_prompt {
+                    assert!(
+                        batch_conflict,
+                        "retained-prompt parity: '{name}' carries a legacy event-context ref \
+                         but its batch group auto-orders"
+                    );
+                    floor_retained_prompt += 1;
+                }
+                if decision_new {
+                    if self_ref {
+                        if has_src_read {
+                            floor_batch_self_srcread += 1;
+                        }
+                        if hadcounters {
+                            floor_hadcounters_batch_self += 1;
+                        }
+                    } else {
+                        floor_batch_obs += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "ordering_parity_sweep: full_db={full_db} swept={swept} compared={compared} \
+         unexplained={} cat1_hit={:?}",
+        unexplained.len(),
+        cat1_hit
+    );
+    eprintln!(
+        "floors: batch_self_srcread={floor_batch_self_srcread} batch_obs={floor_batch_obs} \
+         hadcounters_batch_self={floor_hadcounters_batch_self} \
+         retained_prompt={floor_retained_prompt} t1_source_indep={floor_t1_source_indep}"
+    );
+
+    assert!(
+        unexplained.is_empty(),
+        "STRICT PROOF-GATE: {} unexplained decision diff(s):\n{}",
+        unexplained.len(),
+        unexplained.join("\n")
+    );
+
+    // Non-vacuity: the iteration must actually have classified triggers.
+    assert!(swept > 0, "sweep visited zero triggers (fixture missing?)");
+    assert!(compared > 0, "sweep compared zero decisions");
+
+    if full_db {
+        // §5.2 positive floors (full-DB measured minima).
+        assert!(
+            floor_batch_self_srcread >= 40,
+            "batch_self src-P/T/counter readers auto floor: {floor_batch_self_srcread} < 40"
+        );
+        assert!(
+            floor_batch_obs >= 8,
+            "batch_obs auto floor: {floor_batch_obs} < 8"
+        );
+        assert!(
+            floor_hadcounters_batch_self >= 57,
+            "HadCounters batch_self auto floor: {floor_hadcounters_batch_self} < 57"
+        );
+        assert!(
+            floor_retained_prompt >= 1,
+            "retained-prompt floor: {floor_retained_prompt} < 1"
+        );
+        assert!(
+            floor_t1_source_indep >= 38,
+            "T1 source-independent auto floor: {floor_t1_source_indep} < 38"
+        );
+    }
+}
+
+// ===================================================================
+// Discriminators N-A / N-B / N-B2 / N-C / N-D / N-F
+// (group_is_order_independent = the production ordering-soundness authority;
+//  true = auto/no prompt, false = prompt/OrderTriggers)
+// ===================================================================
+
+fn ctx(
+    source: u64,
+    ability: ResolvedAbility,
+    condition: Option<TriggerCondition>,
+    event: Option<GameEvent>,
+    die_result: Option<i32>,
+) -> PendingTriggerContext {
+    PendingTriggerContext::single(PendingTrigger {
+        source_id: ObjectId(source),
+        controller: PlayerId(0),
+        condition,
+        ability,
+        timestamp: 0,
+        target_constraints: Vec::new(),
+        distribute: None,
+        trigger_event: event,
+        modal: None,
+        mode_abilities: vec![],
+        description: None,
+        may_trigger_origin: None,
+        subject_match_count: None,
+        die_result,
+    })
+}
+
+fn ra(effect: Effect) -> ResolvedAbility {
+    ResolvedAbility::new(effect, vec![], ObjectId(1), PlayerId(0))
+}
+fn qfix(v: i32) -> QuantityExpr {
+    QuantityExpr::Fixed { value: v }
+}
+fn qref(r: QuantityRef) -> QuantityExpr {
+    QuantityExpr::Ref { qty: r }
+}
+fn creature() -> TargetFilter {
+    TargetFilter::Typed(TypedFilter::creature())
+}
+fn power_src() -> QuantityRef {
+    QuantityRef::Power {
+        scope: ObjectScope::Source,
+    }
+}
+fn put_counter_all(count: QuantityExpr) -> Effect {
+    Effect::PutCounterAll {
+        count,
+        target: creature(),
+        counter_type: CounterType::Plus1Plus1,
+    }
+}
+fn token_power_src() -> Effect {
+    Effect::Token {
+        name: "Elemental".into(),
+        power: crate::types::ability::PtValue::Fixed(1),
+        toughness: crate::types::ability::PtValue::Fixed(1),
+        types: vec!["Creature".into()],
+        colors: vec![],
+        keywords: vec![],
+        tapped: false,
+        count: qref(power_src()),
+        owner: TargetFilter::Controller,
+        attach_to: None,
+        enters_attacking: false,
+        supertypes: vec![],
+        static_abilities: vec![],
+        enter_with_counters: vec![],
+    }
+}
+fn return_all_creatures_gy_to_bf() -> Effect {
+    Effect::ChangeZone {
+        origin: Some(Zone::Graveyard),
+        destination: Zone::Battlefield,
+        target: creature(),
+        owner_library: false,
+        enter_transformed: false,
+        enters_under: None,
+        enter_tapped: crate::types::zones::EtbTapState::default(),
+        enters_attacking: false,
+        up_to: false,
+        enter_with_counters: vec![],
+        conditional_enter_with_counters: vec![],
+        face_down_profile: None,
+        enters_modified_if: None,
+    }
+}
+fn gain_life_fixed() -> Effect {
+    Effect::GainLife {
+        amount: qfix(1),
+        player: TargetFilter::Controller,
+    }
+}
+fn power_ge(n: i32) -> AbilityCondition {
+    AbilityCondition::QuantityCheck {
+        lhs: qref(power_src()),
+        rhs: qfix(n),
+        comparator: Comparator::GE,
+    }
+}
+fn cond(mut a: ResolvedAbility, c: AbilityCondition) -> ResolvedAbility {
+    a.condition = Some(c);
+    a
+}
+
+/// A self-departure ZoneChanged event (object leaves the battlefield to the
+/// graveyard), co-departing with `co`.
+fn self_departure(id: u64, co: &[u64]) -> Option<GameEvent> {
+    Some(GameEvent::ZoneChanged {
+        object_id: ObjectId(id),
+        from: Some(Zone::Battlefield),
+        to: Zone::Graveyard,
+        record: Box::new(ZoneChangeRecord {
+            co_departed: co.iter().map(|&x| ObjectId(x)).collect(),
+            ..ZoneChangeRecord::test_minimal(ObjectId(id), Some(Zone::Battlefield), Zone::Graveyard)
+        }),
+    })
+}
+
+/// One shared ETB event of a third object (id 99) — both observers fire on it.
+fn shared_etb_event() -> Option<GameEvent> {
+    Some(GameEvent::ZoneChanged {
+        object_id: ObjectId(99),
+        from: Some(Zone::Hand),
+        to: Zone::Battlefield,
+        record: Box::new(ZoneChangeRecord::test_minimal(
+            ObjectId(99),
+            Some(Zone::Hand),
+            Zone::Battlefield,
+        )),
+    })
+}
+
+fn empty_state() -> GameState {
+    GameState::new_two_player(9)
+}
+
+/// N-A: two Nested Shamblers (Token{count: Power{Source}}) co-departing in one
+/// SBA batch ⇒ their Source-power reads are LKI-frozen ⇒ NO OrderTriggers prompt.
+/// (The frozen 3+1 token counts are a quantity-resolution concern pinned by
+/// `quantity.rs`'s LKI tests; this asserts the ORDERING verdict this PR owns.)
+#[test]
+fn n_a_shambler_co_departure_auto_orders() {
+    let state = empty_state();
+    let group = vec![
+        ctx(
+            10,
+            ra(token_power_src()),
+            None,
+            self_departure(10, &[11]),
+            None,
+        ),
+        ctx(
+            11,
+            ra(token_power_src()),
+            None,
+            self_departure(11, &[10]),
+            None,
+        ),
+    ];
+    assert!(
+        group_is_order_independent(&state, &group, false),
+        "co-departing Shamblers read frozen LKI power ⇒ must auto-order (no prompt)"
+    );
+}
+
+/// N-B: the frozen-vs-live discriminator. Same AST (PutCounterAll{Power{Source}}
+/// — CR 122.1 counters feed P/T) resolves differently by group structure:
+///   * co-departure batch ⇒ Source read FROZEN ⇒ no feed ⇒ AUTO.
+///   * same-event alive pair ⇒ Source read LIVE ⇒ counter write feeds it ⇒ PROMPT.
+///
+/// Proves the freeze is applied exactly on the departure-batch path.
+#[test]
+fn n_b_frozen_vs_live_discriminator() {
+    let state = empty_state();
+    let ability = || ra(put_counter_all(qref(power_src())));
+
+    let batch = vec![
+        ctx(10, ability(), None, self_departure(10, &[11]), None),
+        ctx(11, ability(), None, self_departure(11, &[10]), None),
+    ];
+    assert!(
+        group_is_order_independent(&state, &batch, false),
+        "co-departure: frozen Source read ⇒ auto"
+    );
+
+    let ev = shared_etb_event();
+    let same_event = vec![
+        ctx(10, ability(), None, ev.clone(), None),
+        ctx(11, ability(), None, ev, None),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &same_event, false),
+        "same-event alive: live Source read fed by sibling counter write ⇒ prompt"
+    );
+}
+
+/// N-B2: the freeze-invalidation hostile. A co-departing pair that ALSO returns
+/// creature cards from the graveyard to the battlefield (external existing-object
+/// move, battlefield destination ⇒ re-entry hazard) re-binds a member's ObjectId
+/// to live state, so the frozen Source read is invalidated ⇒ PROMPT. The plain
+/// pair (no return clause) stays auto ⇒ the row prompts exactly the hazard groups.
+#[test]
+fn n_b2_freeze_invalidation_hostile() {
+    let state = empty_state();
+    let hazard = || ra(token_power_src()).sub_ability(ra(return_all_creatures_gy_to_bf()));
+    let hazard_group = vec![
+        ctx(10, hazard(), None, self_departure(10, &[11]), None),
+        ctx(11, hazard(), None, self_departure(11, &[10]), None),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &hazard_group, false),
+        "battlefield-return hazard invalidates the LKI freeze ⇒ prompt"
+    );
+
+    let plain = vec![
+        ctx(
+            10,
+            ra(token_power_src()),
+            None,
+            self_departure(10, &[11]),
+            None,
+        ),
+        ctx(
+            11,
+            ra(token_power_src()),
+            None,
+            self_departure(11, &[10]),
+            None,
+        ),
+    ];
+    assert!(
+        group_is_order_independent(&state, &plain, false),
+        "plain Shambler shape (no hazard write) ⇒ auto — the row is hazard-scoped"
+    );
+}
+
+/// N-C: Case A (CR 603.3b). Two byte-identical "put +1/+1 on each creature you
+/// control; draw if this creature's power ≥ 6" off ONE event: the counter write
+/// feeds the sibling's live Source-power read ⇒ order-observable ⇒ PROMPT.
+#[test]
+fn n_c_case_a_same_event_prompts() {
+    let state = empty_state();
+    let ability = || cond(ra(put_counter_all(qfix(1))), power_ge(6));
+    let ev = shared_etb_event();
+    let group = vec![
+        ctx(10, ability(), None, ev.clone(), None),
+        ctx(11, ability(), None, ev, None),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &group, false),
+        "Case A: counter write feeds live power threshold ⇒ prompt (CR 603.3b fix)"
+    );
+}
+
+/// N-D: intervening-if Case A. The threshold rides the TRIGGER-level condition
+/// (CR 603.4 — re-checked at resolution) instead of the ability. The merged
+/// `trigger_condition_rw_profile` carries the Source read ⇒ PROMPT. Revert-fail:
+/// dropping the trigger-condition merge auto-orders it.
+#[test]
+fn n_d_intervening_if_case_a_prompts() {
+    let state = empty_state();
+    let trig_cond = || TriggerCondition::QuantityComparison {
+        lhs: qref(power_src()),
+        rhs: qfix(6),
+        comparator: Comparator::GE,
+    };
+    let ev = shared_etb_event();
+    let group = vec![
+        ctx(
+            10,
+            ra(put_counter_all(qfix(1))),
+            Some(trig_cond()),
+            ev.clone(),
+            None,
+        ),
+        ctx(
+            11,
+            ra(put_counter_all(qfix(1))),
+            Some(trig_cond()),
+            ev,
+            None,
+        ),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &group, false),
+        "intervening-if Source read fed by sibling counter write ⇒ prompt"
+    );
+}
+
+/// N-F: die_result conjunct unit pin (CR 706.2 + CR 603.12). Two otherwise-
+/// identical no-input source-independent triggers off one event with DIFFERENT
+/// stamped die results are NOT the same state transformation ⇒ not order-
+/// independent; EQUAL die results are admitted. Revert-fail: removing the
+/// conjunct admits the differing pair.
+#[test]
+fn n_f_die_result_conjunct() {
+    let state = empty_state();
+    let ev = shared_etb_event();
+    let differing = vec![
+        ctx(10, ra(gain_life_fixed()), None, ev.clone(), Some(3)),
+        ctx(11, ra(gain_life_fixed()), None, ev.clone(), Some(5)),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &differing, false),
+        "differing die_result ⇒ not order-independent"
+    );
+
+    let equal = vec![
+        ctx(10, ra(gain_life_fixed()), None, ev.clone(), Some(3)),
+        ctx(11, ra(gain_life_fixed()), None, ev, Some(3)),
+    ];
+    assert!(
+        group_is_order_independent(&state, &equal, false),
+        "equal die_result + source-independent same-event pair ⇒ admitted (auto)"
+    );
+}
+
+/// CLASS-A guard, FIX A: the `DamageDone` same-event exemption keys on
+/// `valid_source` (damage triggers leave `valid_card` None — they carry their
+/// subject in `valid_source`). A SELF-damage trigger (`valid_source == SelfRef`)
+/// is per-source ⇒ exempt from the S2 comparison; an OBSERVER damage trigger
+/// (`valid_source` non-SelfRef) fires two copies off ONE source's damage event
+/// ⇒ compared. Revert-fail: gating on `valid_card` (None for BOTH) would exempt
+/// the observer too, voiding the D3 same-event parity proof for observer damage.
+#[test]
+fn class_a_damage_done_exempts_self_source_not_observer() {
+    let face = CardFace::default(); // non-legendary
+    let census = SourceCensus::unknown();
+
+    let mut self_dmg = TriggerDefinition::new(TriggerMode::DamageDone);
+    self_dmg.valid_source = Some(TargetFilter::SelfRef);
+    assert!(
+        !same_event_group_reachable(&face, &self_dmg, &census),
+        "self-damage (valid_source=SelfRef) ⇒ per-source ⇒ exempt from S2"
+    );
+
+    let mut observer = TriggerDefinition::new(TriggerMode::DamageDone);
+    observer.valid_source = Some(TargetFilter::Typed(TypedFilter::creature()));
+    // valid_card stays None (as for every real damage trigger).
+    assert!(
+        same_event_group_reachable(&face, &observer, &census),
+        "observer damage (valid_source non-SelfRef) ⇒ shared source event ⇒ compared"
+    );
+}

--- a/crates/engine/src/game/triggers_ordering_parity_tests.rs
+++ b/crates/engine/src/game/triggers_ordering_parity_tests.rs
@@ -215,6 +215,38 @@ const BATCH_GENUINE_ROWS: &[&str] = &[
     "day of the dragons",
 ];
 
+/// R3 HIGH-1 (PR #5072 review): SAME-EVENT GENUINE member-bound order-dependence —
+/// the REAL under-prompts the maintainer review caught. The base engine auto-ordered
+/// ALL same-event groups unconditionally (CR 603.3b DEFERRED); the same-event member-
+/// bound discriminator (`profiles_conflict`: `if s.same_event && p.reads_member_bound`)
+/// now correctly PROMPTS them. Kept SEPARATE from the conservative class-count below
+/// (rider-3 §7 honesty), analogous to `BATCH_GENUINE_ROWS`. Every member reads
+/// per-source bound storage AND routes a SHARED object into it, so the identical-
+/// function commutation proof genuinely fails (not merely conservatively).
+const SAME_EVENT_MEMBER_BOUND_GENUINE: &[&str] = &[
+    // Imprint-contention (CR 603.10a look-back): two copies race to imprint the ONE
+    // shared triggering creature; only the first exiles it (CR 701.13), and which
+    // source's per-source pile holds it is observable via each source's later
+    // "return each other card exiled with this".
+    "mimic vat",
+    "mirror of life trapping",
+    // Hand-swap re-capture (CR 603.3b): each copy exiles the shared hand into its own
+    // per-source pile then returns its prior pile — copy A feeds copy B, so the
+    // hand/pile partition is order-dependent.
+    "moonring mirror",
+    "duplicity",
+    // Shared-pool consumption under per-copy-divergent chosen card types (CR 701.21):
+    // an overlap permanent one copy sacrifices denies the other a target. Genuine on
+    // rules grounds; its `reads_member_bound` bit comes from a non-obvious AST carrier
+    // (the obvious `IsChosenCreatureType` is classified non-member-bound). See §7.
+    "world queller",
+    // blood tyrant: genuine via a DIFFERENT axis — a `PutCounter{SelfRef}` self-write
+    // whose per-copy counter split is order-observable when a player hits 0 life
+    // between resolutions (CR 704.5a / CR 800.4a). NON-source-independent; caught
+    // incidentally by the member-bound discriminator (its `TrackedSetSize` read).
+    "blood tyrant",
+];
+
 /// The census of a printed card's source (core types + subtypes + non-token).
 fn face_census(face: &CardFace) -> SourceCensus {
     let mut tags: Vec<String> = Vec::new();
@@ -436,6 +468,12 @@ fn ordering_parity_sweep() {
     let mut cat1_hit: BTreeSet<String> = BTreeSet::new();
     let mut over_prompt_hit: BTreeSet<String> = BTreeSet::new();
     let mut batch_genuine_hit: BTreeSet<String> = BTreeSet::new();
+    // R3 HIGH-1: same-event member-bound genuine hits (completeness-asserted like
+    // BATCH_GENUINE_ROWS) + the conservative class-count's derived membership
+    // (BTreeSet ⇒ the eprintln evidence emits sorted, so it's a stable artifact the
+    // rebased head can regenerate — rider-1).
+    let mut se_mb_genuine_hit: BTreeSet<String> = BTreeSet::new();
+    let mut se_member_bound_class: BTreeSet<String> = BTreeSet::new();
 
     // Non-vacuity floors (full-DB; the committed fixture is a subset).
     let mut floor_batch_obs = 0usize;
@@ -514,12 +552,35 @@ fn ordering_parity_sweep() {
                 compared += 1;
                 if !decision_new {
                     // A same-event diff (auto -> prompt): a proven category-(1)
-                    // genuine flip, or a documented-conservative over-prompt (this
-                    // arm is inherently over-prompt-direction — decision_old == auto).
+                    // genuine flip, a same-event member-bound flip (genuine sub-set,
+                    // or the conservative member-bound over-prompt CLASS), or a
+                    // documented-conservative over-prompt. This arm is inherently
+                    // over-prompt-direction — decision_old == auto (base engine
+                    // auto-ordered ALL same-event unconditionally), so it can NEVER
+                    // flag an under-prompt (rider-2 safety).
                     if CATEGORY_1_ROWS.contains(&name.as_str()) {
                         cat1_hit.insert(name.clone());
+                    } else if SAME_EVENT_MEMBER_BOUND_GENUINE.contains(&name.as_str()) {
+                        // Checked BEFORE the class-count so a genuine flip is never
+                        // mislabeled conservative (rider-3 honesty).
+                        se_mb_genuine_hit.insert(name.clone());
                     } else if DOCUMENTED_OVER_PROMPT.contains(&name.as_str()) {
                         over_prompt_hit.insert(name.clone());
+                    } else if profile.reads_member_bound() {
+                        // R3 HIGH-1: the same-event member-bound over-prompt CLASS.
+                        // Predicate-keyed (mirrors the discriminator's own gate
+                        // `s.same_event && p.reads_member_bound` exactly — one
+                        // predicate, two consumers), membership DERIVED not enumerated
+                        // (rider-1: corpus-churn-robust — a 48-name allowlist would
+                        // break on every regen). CONSERVATIVE by construction: an
+                        // identical-member group whose resolution reads per-source
+                        // bound storage cannot be PROVEN to commute, so it prompts
+                        // fail-closed. Most members are order-immaterial (disjoint
+                        // per-source referents, same controller optimizes both); the
+                        // genuinely order-dependent members are carved out above. The
+                        // sorted membership is emitted below as the §7 evidence
+                        // artifact.
+                        se_member_bound_class.insert(name.clone());
                     } else {
                         unexplained.push(format!(
                             "SAME-EVENT auto->prompt on '{name}' (not a category-(1) row)"
@@ -600,16 +661,28 @@ fn ordering_parity_sweep() {
 
     eprintln!(
         "ordering_parity_sweep: full_db={full_db} swept={swept} compared={compared} \
-         unexplained={} cat1_hit={:?} over_prompt_hit={} batch_genuine_hit={}",
+         unexplained={} cat1_hit={:?} over_prompt_hit={} batch_genuine_hit={} \
+         se_mb_genuine={:?} se_member_bound_class={}",
         unexplained.len(),
         cat1_hit,
         over_prompt_hit.len(),
-        batch_genuine_hit.len()
+        batch_genuine_hit.len(),
+        se_mb_genuine_hit,
+        se_member_bound_class.len()
     );
     eprintln!(
         "floors: batch_obs={floor_batch_obs} \
          hadcounters_batch_self={floor_hadcounters_batch_self} \
          retained_prompt={floor_retained_prompt} t1_source_indep={floor_t1_source_indep}"
+    );
+    // R3 HIGH-1 (rider-1): mechanically-emitted DERIVED membership of the same-event
+    // member-bound over-prompt CLASS — the §7 / handoff evidence artifact. Sorted
+    // (BTreeSet), so it is a stable diff the rebased head regenerates. Enumeration
+    // lives HERE (evidence), never in the code allowlist.
+    eprintln!(
+        "se_member_bound_class members ({}): {:?}",
+        se_member_bound_class.len(),
+        se_member_bound_class
     );
 
     assert!(
@@ -655,6 +728,12 @@ fn ordering_parity_sweep() {
         );
         // t1_source_indep: measured 2871 @ b1b3c873e; floor = ⌊2871·0.95⌋.
         // Deterministic tripwire for the `source_independent` predicate (M1 → 0).
+        // R3 HIGH-1: measured drops to 2830 (−40) — the 40 source-INDEPENDENT members
+        // of the same-event member-bound over-prompt CLASS now correctly PROMPT
+        // (discriminator) instead of auto-ordering, so they no longer increment this
+        // auto counter. The floor is UNCHANGED (2830 > 2727, still passes) — this is
+        // an accounted movement, NOT a blanket bump (rider-4); the moved population is
+        // exactly the source-independent slice of `se_member_bound_class`.
         assert!(
             floor_t1_source_indep >= 2727,
             "T1 source-independent auto floor: {floor_t1_source_indep} < 2727"
@@ -676,6 +755,30 @@ fn ordering_parity_sweep() {
         assert_eq!(
             batch_genuine_hit, expected_batch_genuine,
             "BATCH_GENUINE_ROWS stale/unhit entries"
+        );
+        // R3 HIGH-1: the 6 same-event member-bound GENUINE flips (5 member-bound +
+        // blood tyrant). Exact-set like BATCH_GENUINE_ROWS — a genuine card dropping
+        // out (parse/corpus drift) OR a new genuine flip appearing forces the §7
+        // honesty bookkeeping to update rather than silently landing in the
+        // conservative class-count.
+        let expected_se_mb_genuine: BTreeSet<String> = SAME_EVENT_MEMBER_BOUND_GENUINE
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            se_mb_genuine_hit, expected_se_mb_genuine,
+            "SAME_EVENT_MEMBER_BOUND_GENUINE stale/unhit entries"
+        );
+        // se_member_bound_class: measured 42 @ corpus bce9695e5; floor = measured −
+        // ~15% churn tolerance (`>=`, corpus-churn-robust per rider-1 — the class is
+        // predicate-keyed so its membership churns with the corpus). NON-vacuity /
+        // mutation tripwire: deleting the discriminator row (`s.same_event &&
+        // p.reads_member_bound`) makes every member auto-order ⇒ this count collapses
+        // to 0 ⇒ floor trips. Guards the HIGH-1 fix itself against silent regression.
+        assert!(
+            se_member_bound_class.len() >= 35,
+            "same-event member-bound over-prompt class floor: {} < 35",
+            se_member_bound_class.len()
         );
         // cat-1 exact-hit: the 6 measured same-event flips. Your Inescapable Doom is
         // expected-UNHIT (its counter feed parses to Any so the sweep never forms its
@@ -1680,6 +1783,68 @@ fn b2_dotd_member_bound_pin() {
     assert!(
         !group_is_order_independent(&state, &neg, false),
         "B-2 NEG: DotD TrackedSet return ⇒ member-bound ⇒ T1 refused ⇒ prompt"
+    );
+}
+
+/// R3 HIGH-1 (maintainer #5072 review): the SAME-EVENT member-bound discriminator.
+/// The batch path refuses `reads_member_bound` (b2 above); this pins the mirrored
+/// refusal at same-event depth. A same-event group of DISTINCT sources whose
+/// identical `source_independent` resolution reads per-source bound storage
+/// (`ChangeZone{TrackedSet → Battlefield}`, CR 603.10a look-back) is NOT one shared
+/// f(state) — source 10 reads set(10), source 11 reads set(11) — so CR 603.3b
+/// ordering is observable ⇒ PROMPT.
+///
+/// Revert-fail (both edits independently load-bearing): (1) restoring the bare
+/// `p.source_independent()` disjunct at `profiles_conflict`'s same-event fast path
+/// takes the member-bound group down the fast path ⇒ AUTO (RED); (2) deleting the
+/// `if s.same_event && p.reads_member_bound { return true }` discriminator lets it
+/// fall through to the feed rows, which check read/write KIND overlap not per-source
+/// storage (the TrackedSet return writes membership with no matching read) ⇒ AUTO
+/// (RED). Before this PR's same-event predicate the base engine auto-ordered ALL
+/// same-event groups unconditionally, so this closes a hole in THIS PR's gate.
+#[test]
+fn high1_same_event_member_bound_prompts() {
+    let state = empty_state();
+    let member_bound = || {
+        ra(change_zone_return(TargetFilter::TrackedSet {
+            id: crate::types::identifiers::TrackedSetId(0),
+        }))
+    };
+    let ev = shared_etb_event();
+
+    // NEG (the fix): same event (object 99), DISTINCT sources 10/11, member-bound
+    // source-independent return ⇒ must PROMPT.
+    let neg = vec![
+        ctx(10, member_bound(), None, ev.clone(), None),
+        ctx(11, member_bound(), None, ev.clone(), None),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &neg, false),
+        "HIGH-1 NEG: same-event distinct-source member-bound ⇒ f_A≠f_B ⇒ prompt"
+    );
+
+    // POS-a (scope guard): a same-event source-independent NON-member-bound pair
+    // (gain 1 life) stays AUTO — the discriminator is scoped to member-bound, not a
+    // blanket same-event prompt.
+    let pos_unbound = vec![
+        ctx(10, ra(gain_life_fixed()), None, ev.clone(), None),
+        ctx(11, ra(gain_life_fixed()), None, ev.clone(), None),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos_unbound, false),
+        "HIGH-1 POS-a: same-event source-independent non-member-bound ⇒ auto"
+    );
+
+    // POS-b (all_same_source guard): the SAME member-bound ability on ONE shared
+    // source (10) is one shared storage ⇒ f_A = f_B literally ⇒ AUTO. Proves the
+    // discriminator only refuses distinct-source member-bound groups.
+    let pos_same_source = vec![
+        ctx(10, member_bound(), None, ev.clone(), None),
+        ctx(10, member_bound(), None, ev, None),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos_same_source, false),
+        "HIGH-1 POS-b: all_same_source member-bound ⇒ shared storage ⇒ auto"
     );
 }
 

--- a/crates/engine/src/game/triggers_ordering_parity_tests.rs
+++ b/crates/engine/src/game/triggers_ordering_parity_tests.rs
@@ -1037,6 +1037,31 @@ fn empty_state() -> GameState {
     GameState::new_two_player(9)
 }
 
+/// R4: read the SHARED event object's LIVE power (`EventSource` scope ⇒
+/// `reads_event_live`, CR 608.2h current-information read).
+fn power_event() -> QuantityRef {
+    QuantityRef::Power {
+        scope: ObjectScope::EventSource,
+    }
+}
+/// R4: write the SHARED event object (`TriggeringSource` ⇒ `writes_event_object`):
+/// +1/+1 counters.
+fn put_counter_on_event(count: QuantityExpr) -> Effect {
+    Effect::PutCounter {
+        counter_type: CounterType::Plus1Plus1,
+        count,
+        target: TargetFilter::TriggeringSource,
+    }
+}
+/// R4: a same-event firing event that carries NO object — `extract_source_from_event`
+/// returns `None` (CR: `Phase` has no event object), so `group_is_order_independent`
+/// threads `event_object_present = false`.
+fn shared_phase_event() -> Option<GameEvent> {
+    Some(GameEvent::PhaseChanged {
+        phase: crate::types::phase::Phase::End,
+    })
+}
+
 /// N-A: two Nested Shamblers (Token{count: Power{Source}}) co-departing in one
 /// SBA batch ⇒ their Source-power reads are LKI-frozen ⇒ NO OrderTriggers prompt.
 /// (The frozen 3+1 token counts are a quantity-resolution concern pinned by
@@ -1940,6 +1965,101 @@ fn high1_same_event_member_bound_prompts() {
     assert!(
         group_is_order_independent(&state, &pos_same_source, false),
         "HIGH-1 POS-b: all_same_source member-bound ⇒ shared storage ⇒ auto"
+    );
+}
+
+/// R4 (maintainer #5072 review): the SAME-EVENT event-object read/write discriminator
+/// AT THE CALLER LEVEL. `group_is_order_independent` derives `event_object_present`
+/// from the pending trigger's firing event (`extract_source_from_event`, triggers.rs)
+/// and threads it into the GroupStructure — the predicate-level
+/// `r4_same_event_event_object_feed_conjunct` (ability_rw) pins `profiles_conflict`
+/// but NOT this caller threading. A future caller that mis-threaded
+/// `event_object_present` (or dropped the same-event structure) could auto-order the
+/// R4 shape while the predicate test stays green — the hot-path seam this pins.
+///
+/// The feed: two DISTINCT sources fire on ONE shared ETB event (object 99); each
+/// identical resolution READS that creature's LIVE power (`Power{EventSource}` ⇒
+/// `reads_event_live`, CR 608.2h) and WRITES it (`PutCounter{TriggeringSource}` ⇒
+/// `writes_event_object`), so a sibling's write feeds the other's live read ⇒
+/// order-observable ⇒ PROMPT. The feed is `source_independent`, so it exercises BOTH
+/// edits: without the `:992` fast-path exclusion it would auto-order at the T1
+/// disjunct; without the discriminator it falls through every row to the final
+/// `return false` (`feeds()` is blind to the KindSet-less live read) ⇒ AUTO (RED).
+///
+/// Guards prove the discriminator is not a blanket same-event prompt: read-only ⇒ auto
+/// (needs the write), write-only ⇒ auto (needs the read), no-event-object ⇒ auto (the
+/// `event_object_present` thread — the identical feed prompts WITH an event object and
+/// autos WITHOUT), all_same_source ⇒ auto (identical f over one shared object).
+#[test]
+fn r4_same_event_event_object_prompts_at_caller() {
+    let state = empty_state();
+    let feed = || ra(put_counter_on_event(qref(power_event())));
+    let ev = shared_etb_event();
+
+    // NEG (the fix): distinct sources 10/11, shared event object 99, live read × event-
+    // object write ⇒ PROMPT (caller threads event_object_present = true).
+    let neg = vec![
+        ctx(10, feed(), None, ev.clone(), None),
+        ctx(11, feed(), None, ev.clone(), None),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &neg, false),
+        "R4 NEG: same-event distinct-source event-object read×write feed ⇒ prompt"
+    );
+
+    // Guard read-only — a live power read that WRITES player life, not the event object
+    // (no `writes_event_object`) ⇒ AUTO. Proves the conjunction needs both endpoints.
+    let read_only = || {
+        ra(Effect::GainLife {
+            amount: qref(power_event()),
+            player: TargetFilter::Controller,
+        })
+    };
+    let pos_read = vec![
+        ctx(10, read_only(), None, ev.clone(), None),
+        ctx(11, read_only(), None, ev.clone(), None),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos_read, false),
+        "R4 guard read-only: event-live read with NO event-object write ⇒ auto"
+    );
+
+    // Guard write-only — a fixed-count event-object write with NO live read ⇒ AUTO
+    // (an unread write is applied identically by every member, order-invariant).
+    let write_only = || ra(put_counter_on_event(qfix(1)));
+    let pos_write = vec![
+        ctx(10, write_only(), None, ev.clone(), None),
+        ctx(11, write_only(), None, ev.clone(), None),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos_write, false),
+        "R4 guard write-only: event-object write with NO live read ⇒ auto"
+    );
+
+    // Guard no-event-object — the SAME feed on a Phase event (`extract_source_from_
+    // event` → None ⇒ `event_object_present` threads FALSE) ⇒ AUTO. Directly pins the
+    // caller threading: the identical ability prompts WITH an event object (NEG), autos
+    // WITHOUT (here). A caller that always-threaded present=true would wrongly prompt.
+    let ph = shared_phase_event();
+    let pos_no_event = vec![
+        ctx(10, feed(), None, ph.clone(), None),
+        ctx(11, feed(), None, ph, None),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos_no_event, false),
+        "R4 guard no-event-object: Phase event ⇒ event_object_present false ⇒ auto"
+    );
+
+    // Guard all_same_source — the feed on ONE shared source (10) ⇒ identical f over one
+    // shared event object (deterministic accumulation) ⇒ AUTO. Proves the discriminator
+    // only refuses DISTINCT-source groups.
+    let pos_same_source = vec![
+        ctx(10, feed(), None, ev.clone(), None),
+        ctx(10, feed(), None, ev, None),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos_same_source, false),
+        "R4 guard all_same_source: shared source ⇒ f_A = f_B ⇒ auto"
     );
 }
 

--- a/crates/engine/src/game/triggers_ordering_parity_tests.rs
+++ b/crates/engine/src/game/triggers_ordering_parity_tests.rs
@@ -123,6 +123,98 @@ const CATEGORY_1_ROWS: &[&str] = &[
     "complex automaton",
 ];
 
+/// §7 documented-conservative over-prompts: cards whose sweep decision-diff is a
+/// PROVEN-SAFE conservative prompt (auto would also be sound, but no in-scope
+/// structural recognizer proves it context-free). Listing here ONLY suppresses the
+/// sweep's unexplained-flag — it never changes a runtime ordering decision.
+/// Suppression is direction-gated: only old=auto→new=prompt (over-prompt) rows may
+/// match; an under-prompt diff is NEVER suppressible (fail-closed, CR 603.3b).
+/// Grouped by class; each entry carries its one-line safety argument (§7 ledger
+/// source of truth).
+const DOCUMENTED_OVER_PROMPT: &[&str] = &[
+    // ---- L8-held: a self-scoped write can flip a sibling's re-checked
+    // intervening-if (CR 603.4), but the flip is monotone/self-limiting, so
+    // identical siblings still commute semantically. The L8 idempotence recognizer
+    // is deliberately HELD (a wrong recognizer would UNDER-prompt = rules-wrong;
+    // the conservative prompt is fail-closed = rules-correct). ----
+    // end-step ZoneChangeCountThisTurn read × self-Sacrifice — self-limiting.
+    "chorale of the void",
+    // Mill membership write × ZoneCardCount(gy, Creature) self-transform threshold —
+    // monotone graveyard growth.
+    "deathbonnet sprout",
+    // HandSize(you > opp) read × self-return-to-hand — the write monotonically
+    // strengthens the condition.
+    "death of a thousand stings",
+    // Upkeep hand-size read × self-return-to-hand (same shape as death of a
+    // thousand stings).
+    "exile into darkness",
+    // SourceIsTapped read; the Glimmer-token write feeds the Glimmer-count branch —
+    // self-limiting.
+    "glimmer seeker",
+    // ControlCount(SelfRef) read × Meld consumes the shared pair — self-limiting.
+    "graf rats",
+    // Control(blue) read × CopyTokenOf{self} blue-token write — monotone;
+    // already-true stays true.
+    "mirror-sigil sergeant",
+    // GraveyardSize read × self-return-from-graveyard — self-limiting threshold.
+    "persistent marshstalker",
+    // Control(another nonland) read × self-Sacrifice — self-limiting.
+    "reclusive wight",
+    // Not(SourceIsTapped) read × untap-ALL write — idempotent.
+    "reveille squad",
+    // Token write × ObjectCount == 13 self-sacrifice — equality over symmetric writes.
+    "stensia uprising",
+    // Mill + self-exile + put-on-top writes × ZoneCardCount(Library == 0) read.
+    "stillness in motion",
+    // ---- osseous-class: owner-keyed read × owner-misaligned write ----
+    // DistinctCardTypes{your gy} GE 4 read × opponent-Sacrifice write that lands in
+    // the sacrificed permanent's OWNER's graveyard (CR 701.21a): a control-changed
+    // permanent you own makes the write-span truly Any; only the monotone GE
+    // comparator commutes it (deferred L8).
+    "osseous sticktwister",
+    // ---- context-free-unclassifiable singletons ----
+    // RevealTop → Destroy{ParentTarget}: the filter-on-revealed read is
+    // resolution-local, but the AST has no scope distinguishing it from a live
+    // board read.
+    "paroxysm",
+    // ControlsType{Creature power GE 4} re-check × graveyard→battlefield self-return
+    // commutes ONLY because the phoenix's own power (2 < 4) — runtime P/T, invisible
+    // to a context-free recognizer.
+    "flamewake phoenix",
+    // ---- parse-blocked commutes (underneath the mis-parse, the structure
+    // commutes) ----
+    // RemoveCounter{TriggeringSource} mis-parse (should be SelfRef): each removes
+    // its own time counter.
+    "deep-sea kraken",
+    // HasCounters(oil) mis-reads the source Golem (should be the entering creature):
+    // both writes are monotone oil-adds on the shared object.
+    "ichorplate golem",
+    // ---- owner-misalignment (osseous-class), batch — aligned-safe via sum-symmetry ----
+    // dies-batch GainLife{ZoneCardCount(your gy, Creature)} + self-exile-from-gy:
+    // the count-read × graveyard-self-exile is a genuine structural RW conflict, so
+    // production prompts; but for the OWNER-ALIGNED co-departure (all copies land in
+    // your graveyard) each resolution removes exactly itself, so the multiset of
+    // per-copy gains {1..N} — and the total — is order-invariant. No in-scope
+    // recognizer proves that sum-symmetry, so the prompt is conservative. (Owner-
+    // MISaligned copies go to a different graveyard and are correctly prompted by
+    // the same conflict — see the impl-report soundness note.)
+    "skyfisher spider",
+];
+
+/// Batch-depth GENUINE order-dependence (kept SEPARATE from the same-event
+/// CATEGORY_1_ROWS — different oracle: these diff against the legacy serde walk).
+/// The new prompt is CORRECT (CR 603.3b: the controller chooses the order), i.e.
+/// an intended prompt the legacy engine wrongly auto-ordered — not an over-prompt.
+const BATCH_GENUINE_ROWS: &[&str] = &[
+    // LTB: Sacrifice{Dragons-you-control, count: ObjectCount{same}} → sub
+    // ChangeZone{TrackedSet(0) → Battlefield, enters_under: You} (AST measured).
+    // Each co-departing member returns ITS OWN tracked exile set, and returned
+    // creatures can be Dragons the OTHER member's re-sacrifice then consumes —
+    // final state differs by order (CR 603.3b intended prompt). Runtime pin:
+    // b2_dotd_member_bound_pin (reads_member_bound refuses batch-T1).
+    "day of the dragons",
+];
+
 /// The census of a printed card's source (core types + subtypes + non-token).
 fn face_census(face: &CardFace) -> SourceCensus {
     let mut tags: Vec<String> = Vec::new();
@@ -301,25 +393,6 @@ fn sweep_no_ordering_input(
             .unwrap_or(false)
 }
 
-/// A trigger's ability reads a live source P/T / counter characteristic
-/// (`Power`/`Toughness`/`CountersOn` at `ObjectScope::Source`).
-fn reads_source_pt_or_counter(value: &serde_json::Value) -> bool {
-    match value {
-        serde_json::Value::Object(map) => {
-            let is_src_read = ["Power", "Toughness", "CountersOn"].iter().any(|k| {
-                map.get(*k).is_some_and(|inner| {
-                    serde_json::to_string(inner)
-                        .map(|s| s.contains("\"Source\""))
-                        .unwrap_or(false)
-                })
-            });
-            is_src_read || map.values().any(reads_source_pt_or_counter)
-        }
-        serde_json::Value::Array(vs) => vs.iter().any(reads_source_pt_or_counter),
-        _ => false,
-    }
-}
-
 fn ability_rw_profile_merged(
     resolved: &ResolvedAbility,
     trig_condition: Option<&TriggerCondition>,
@@ -361,9 +434,10 @@ fn ordering_parity_sweep() {
     let mut compared = 0usize;
     let mut unexplained: Vec<String> = Vec::new();
     let mut cat1_hit: BTreeSet<String> = BTreeSet::new();
+    let mut over_prompt_hit: BTreeSet<String> = BTreeSet::new();
+    let mut batch_genuine_hit: BTreeSet<String> = BTreeSet::new();
 
     // Non-vacuity floors (full-DB; the committed fixture is a subset).
-    let mut floor_batch_self_srcread = 0usize;
     let mut floor_batch_obs = 0usize;
     let mut floor_hadcounters_batch_self = 0usize;
     let mut floor_retained_prompt = 0usize;
@@ -397,7 +471,6 @@ fn ordering_parity_sweep() {
                 .unwrap_or(false);
             let event_present = mode_carries_event_object(&trig.mode);
             let is_departure = mode_is_battlefield_departure(&trig.mode, trig);
-            let has_src_read = reads_source_pt_or_counter(&value);
             let hadcounters = matches!(trig.condition, Some(TriggerCondition::HadCounters { .. }));
 
             let mk =
@@ -440,9 +513,13 @@ fn ordering_parity_sweep() {
                 let decision_new = !conflict; // decision_old (same-event) == auto == true
                 compared += 1;
                 if !decision_new {
-                    // A same-event diff (auto -> prompt): must be a category-(1) row.
+                    // A same-event diff (auto -> prompt): a proven category-(1)
+                    // genuine flip, or a documented-conservative over-prompt (this
+                    // arm is inherently over-prompt-direction — decision_old == auto).
                     if CATEGORY_1_ROWS.contains(&name.as_str()) {
                         cat1_hit.insert(name.clone());
+                    } else if DOCUMENTED_OVER_PROMPT.contains(&name.as_str()) {
+                        over_prompt_hit.insert(name.clone());
                     } else {
                         unexplained.push(format!(
                             "SAME-EVENT auto->prompt on '{name}' (not a category-(1) row)"
@@ -473,12 +550,23 @@ fn ordering_parity_sweep() {
                 let decision_old = !legacy_serde;
                 compared += 1;
                 if decision_new != decision_old {
-                    // Batch parity is ZERO-diff by design (D3). Any batch diff is a
-                    // finding — no category exists for it.
-                    unexplained.push(format!(
-                        "BATCH decision diff on '{name}' (old={decision_old}, new={decision_new}, \
-                         legacy_serde={legacy_serde}, legacy_prompt={legacy_prompt})"
-                    ));
+                    // Fail-closed direction gate: only the conservative direction
+                    // (old=auto → new=prompt) is allowlistable; an under-prompt diff
+                    // (old=prompt → new=auto) is ALWAYS unexplained — a rules-required
+                    // prompt is NEVER suppressible (CR 603.3b soundness invariant).
+                    let over_prompt_direction = decision_old && !decision_new;
+                    if over_prompt_direction && BATCH_GENUINE_ROWS.contains(&name.as_str()) {
+                        batch_genuine_hit.insert(name.clone());
+                    } else if over_prompt_direction
+                        && DOCUMENTED_OVER_PROMPT.contains(&name.as_str())
+                    {
+                        over_prompt_hit.insert(name.clone());
+                    } else {
+                        unexplained.push(format!(
+                            "BATCH decision diff on '{name}' (old={decision_old}, new={decision_new}, \
+                             legacy_serde={legacy_serde}, legacy_prompt={legacy_prompt})"
+                        ));
+                    }
                 }
                 // Retained-prompt parity (D5): every legacy-ref trigger must still
                 // prompt on the batch path.
@@ -492,9 +580,13 @@ fn ordering_parity_sweep() {
                 }
                 if decision_new {
                     if self_ref {
-                        if has_src_read {
-                            floor_batch_self_srcread += 1;
-                        }
+                        // batch_self_srcread floor REMOVED: the {self-departure ∧
+                        // Power/Toughness/CountersOn{Source} read} cell is EMPTY
+                        // in-corpus — dies-triggers reading "its power/counters" parse
+                        // to event-context scopes (TriggeringSource-class), so post-N-G
+                        // that whole class correctly prompts and is counted by
+                        // retained_prompt; the freeze-auto behavior it witnessed is
+                        // pinned by units N-A/N-B.
                         if hadcounters {
                             floor_hadcounters_batch_self += 1;
                         }
@@ -508,12 +600,14 @@ fn ordering_parity_sweep() {
 
     eprintln!(
         "ordering_parity_sweep: full_db={full_db} swept={swept} compared={compared} \
-         unexplained={} cat1_hit={:?}",
+         unexplained={} cat1_hit={:?} over_prompt_hit={} batch_genuine_hit={}",
         unexplained.len(),
-        cat1_hit
+        cat1_hit,
+        over_prompt_hit.len(),
+        batch_genuine_hit.len()
     );
     eprintln!(
-        "floors: batch_self_srcread={floor_batch_self_srcread} batch_obs={floor_batch_obs} \
+        "floors: batch_obs={floor_batch_obs} \
          hadcounters_batch_self={floor_hadcounters_batch_self} \
          retained_prompt={floor_retained_prompt} t1_source_indep={floor_t1_source_indep}"
     );
@@ -530,26 +624,77 @@ fn ordering_parity_sweep() {
     assert!(compared > 0, "sweep compared zero decisions");
 
     if full_db {
-        // §5.2 positive floors (full-DB measured minima).
+        // §5.2 positive floors (full-DB measured minima @ b1b3c873e; floor =
+        // measured − 5% corpus-churn tolerance so a classifier regression trips it).
+        // The `batch_self_srcread` floor is REMOVED — its cell is empty in-corpus
+        // (see the loop comment); its old ≥40 was a D5 fail-open-hole artifact now
+        // counted by `retained_prompt`.
+
+        // batch_obs: measured 494 @ b1b3c873e; floor = ⌊494·0.95⌋. Zero batch-T1
+        // dependence (all 5 T1-carried autos are self_ref) — guards sweep
+        // reachability + mass-classification health; a classifier regression (M6/M8)
+        // collapses it toward 0.
         assert!(
-            floor_batch_self_srcread >= 40,
-            "batch_self src-P/T/counter readers auto floor: {floor_batch_self_srcread} < 40"
+            floor_batch_obs >= 469,
+            "batch_obs auto floor: {floor_batch_obs} < 469"
         );
+        // hadcounters_batch_self: measured 1 @ b1b3c873e; floor = measured − 0. Sole
+        // witness: Promising Duskmage (HadCounters{P1P1} dies → Draw — a pure
+        // CR 603.10a frozen look-back read, auto under a valid freeze). N=1 corpus
+        // cell; fragility accepted (only full-DB witness of the frozen-look-back auto
+        // class). Mutation M5 (freeze_valid=false) drops it to 0.
         assert!(
-            floor_batch_obs >= 8,
-            "batch_obs auto floor: {floor_batch_obs} < 8"
+            floor_hadcounters_batch_self >= 1,
+            "HadCounters batch_self auto floor: {floor_hadcounters_batch_self} < 1"
         );
+        // retained_prompt: measured 285 @ b1b3c873e; floor = ⌈285·0.95⌉. Makes the D5
+        // legacy-prompt override population a real regression tripwire (M4 → 0).
         assert!(
-            floor_hadcounters_batch_self >= 57,
-            "HadCounters batch_self auto floor: {floor_hadcounters_batch_self} < 57"
+            floor_retained_prompt >= 271,
+            "retained-prompt floor: {floor_retained_prompt} < 271"
         );
+        // t1_source_indep: measured 2871 @ b1b3c873e; floor = ⌊2871·0.95⌋.
+        // Deterministic tripwire for the `source_independent` predicate (M1 → 0).
         assert!(
-            floor_retained_prompt >= 1,
-            "retained-prompt floor: {floor_retained_prompt} < 1"
+            floor_t1_source_indep >= 2727,
+            "T1 source-independent auto floor: {floor_t1_source_indep} < 2727"
         );
-        assert!(
-            floor_t1_source_indep >= 38,
-            "T1 source-independent auto floor: {floor_t1_source_indep} < 38"
+
+        // Ledger completeness (full-DB only — the committed fixture lacks these
+        // cards). Every allowlist entry MUST be consumed: an unhit entry is stale
+        // bookkeeping (the card cleared — remove it — or its name drifted).
+        let expected_over_prompt: BTreeSet<String> = DOCUMENTED_OVER_PROMPT
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            over_prompt_hit, expected_over_prompt,
+            "DOCUMENTED_OVER_PROMPT stale/unhit entries"
+        );
+        let expected_batch_genuine: BTreeSet<String> =
+            BATCH_GENUINE_ROWS.iter().map(|s| s.to_string()).collect();
+        assert_eq!(
+            batch_genuine_hit, expected_batch_genuine,
+            "BATCH_GENUINE_ROWS stale/unhit entries"
+        );
+        // cat-1 exact-hit: the 6 measured same-event flips. Your Inescapable Doom is
+        // expected-UNHIT (its counter feed parses to Any so the sweep never forms its
+        // group); if that parser gap is ever fixed it starts hitting and this assert
+        // forces the bookkeeping update.
+        let expected_cat1: BTreeSet<String> = [
+            "complex automaton",
+            "docent of perfection",
+            "ouroboroid",
+            "promise of tomorrow",
+            "sidequest: hunt the mark",
+            "spawn of mayhem",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(
+            cat1_hit, expected_cat1,
+            "CATEGORY_1_ROWS measured-hit set drift"
         );
     }
 }

--- a/crates/engine/src/game/triggers_ordering_parity_tests.rs
+++ b/crates/engine/src/game/triggers_ordering_parity_tests.rs
@@ -1086,7 +1086,7 @@ fn n_a_shambler_co_departure_auto_orders() {
         ),
     ];
     assert!(
-        group_is_order_independent(&state, &group, false),
+        group_is_order_independent(&state, &group),
         "co-departing Shamblers read frozen LKI power ⇒ must auto-order (no prompt)"
     );
 }
@@ -1107,7 +1107,7 @@ fn n_b_frozen_vs_live_discriminator() {
         ctx(11, ability(), None, self_departure(11, &[10]), None),
     ];
     assert!(
-        group_is_order_independent(&state, &batch, false),
+        group_is_order_independent(&state, &batch),
         "co-departure: frozen Source read ⇒ auto"
     );
 
@@ -1117,7 +1117,7 @@ fn n_b_frozen_vs_live_discriminator() {
         ctx(11, ability(), None, ev, None),
     ];
     assert!(
-        !group_is_order_independent(&state, &same_event, false),
+        !group_is_order_independent(&state, &same_event),
         "same-event alive: live Source read fed by sibling counter write ⇒ prompt"
     );
 }
@@ -1136,7 +1136,7 @@ fn n_b2_freeze_invalidation_hostile() {
         ctx(11, hazard(), None, self_departure(11, &[10]), None),
     ];
     assert!(
-        !group_is_order_independent(&state, &hazard_group, false),
+        !group_is_order_independent(&state, &hazard_group),
         "battlefield-return hazard invalidates the LKI freeze ⇒ prompt"
     );
 
@@ -1157,7 +1157,7 @@ fn n_b2_freeze_invalidation_hostile() {
         ),
     ];
     assert!(
-        group_is_order_independent(&state, &plain, false),
+        group_is_order_independent(&state, &plain),
         "plain Shambler shape (no hazard write) ⇒ auto — the row is hazard-scoped"
     );
 }
@@ -1175,7 +1175,7 @@ fn n_c_case_a_same_event_prompts() {
         ctx(11, ability(), None, ev, None),
     ];
     assert!(
-        !group_is_order_independent(&state, &group, false),
+        !group_is_order_independent(&state, &group),
         "Case A: counter write feeds live power threshold ⇒ prompt (CR 603.3b fix)"
     );
 }
@@ -1210,7 +1210,7 @@ fn n_d_intervening_if_case_a_prompts() {
         ),
     ];
     assert!(
-        !group_is_order_independent(&state, &group, false),
+        !group_is_order_independent(&state, &group),
         "intervening-if Source read fed by sibling counter write ⇒ prompt"
     );
 }
@@ -1229,7 +1229,7 @@ fn n_f_die_result_conjunct() {
         ctx(11, ra(gain_life_fixed()), None, ev.clone(), Some(5)),
     ];
     assert!(
-        !group_is_order_independent(&state, &differing, false),
+        !group_is_order_independent(&state, &differing),
         "differing die_result ⇒ not order-independent"
     );
 
@@ -1238,7 +1238,7 @@ fn n_f_die_result_conjunct() {
         ctx(11, ra(gain_life_fixed()), None, ev, Some(3)),
     ];
     assert!(
-        group_is_order_independent(&state, &equal, false),
+        group_is_order_independent(&state, &equal),
         "equal die_result + source-independent same-event pair ⇒ admitted (auto)"
     );
 }
@@ -1313,7 +1313,7 @@ fn n_g_dropped_target_legacy_ref_retains_batch_prompt() {
         ),
     ];
     assert!(
-        !group_is_order_independent(&state, &legacy_group, false),
+        !group_is_order_independent(&state, &legacy_group),
         "Discard{{TriggeringPlayer}} on a departure batch carries a frozen tag ⇒ retain prompt"
     );
 
@@ -1334,7 +1334,7 @@ fn n_g_dropped_target_legacy_ref_retains_batch_prompt() {
         ),
     ];
     assert!(
-        group_is_order_independent(&state, &control_group, false),
+        group_is_order_independent(&state, &control_group),
         "identical Discard with no frozen tag (Controller) ⇒ auto-order"
     );
 }
@@ -1501,7 +1501,7 @@ fn s1_defense_membership_ctrl_span() {
         ctx_c(11, 0, defense_ability(), Some(pos_cond()), ev.clone()),
     ];
     assert!(
-        group_is_order_independent(&state, &pos, false),
+        group_is_order_independent(&state, &pos),
         "S1 POS: opponents'-board read × your-library entry are ctrl-disjoint ⇒ auto"
     );
 
@@ -1511,7 +1511,7 @@ fn s1_defense_membership_ctrl_span() {
         ctx_c(11, 0, defense_ability(), Some(neg_cond()), ev),
     ];
     assert!(
-        !group_is_order_independent(&state, &neg, false),
+        !group_is_order_independent(&state, &neg),
         "S1 NEG: your-board read × your-library entry ctrl spans overlap ⇒ prompt"
     );
 }
@@ -1541,7 +1541,7 @@ fn s2_rekindled_player_hand_span() {
         ctx_c(11, 0, ra(bounce_self()), Some(pos_cond()), ev.clone()),
     ];
     assert!(
-        group_is_order_independent(&state, &pos, false),
+        group_is_order_independent(&state, &pos),
         "S2 POS: opp-hand read × your-hand self-bounce are player-disjoint ⇒ auto"
     );
 
@@ -1551,7 +1551,7 @@ fn s2_rekindled_player_hand_span() {
         ctx_c(11, 0, ra(bounce_self()), Some(neg_cond()), ev),
     ];
     assert!(
-        !group_is_order_independent(&state, &neg, false),
+        !group_is_order_independent(&state, &neg),
         "S2 NEG: your-hand read × your-hand write overlap ⇒ prompt"
     );
 }
@@ -1593,7 +1593,7 @@ fn s3_brink_fused_discard_span() {
         ctx_c(11, 0, brink_ability(fused), Some(cond()), ev.clone()),
     ];
     assert!(
-        group_is_order_independent(&state, &pos, false),
+        group_is_order_independent(&state, &pos),
         "S3 POS: fused HandSize{{ScopedPlayer}} count dropped ⇒ You-cond × Opp-write disjoint ⇒ auto"
     );
 
@@ -1613,7 +1613,7 @@ fn s3_brink_fused_discard_span() {
         ctx_c(11, 0, brink_ability(unfused), Some(cond()), ev),
     ];
     assert!(
-        !group_is_order_independent(&state, &neg, false),
+        !group_is_order_independent(&state, &neg),
         "S3 NEG: non-fused opp-hand count read is a live player read ⇒ prompt"
     );
 }
@@ -1646,7 +1646,7 @@ fn s4_gate_is_load_bearing() {
         ctx_c(11, 1, ra(bounce_self()), Some(cond()), ev.clone()),
     ];
     assert!(
-        !group_is_order_independent(&state, &mixed, false),
+        !group_is_order_independent(&state, &mixed),
         "S4 NEG: mixed controllers ⇒ Mixed ⇒ spans unconsulted ⇒ prompt"
     );
 
@@ -1658,7 +1658,7 @@ fn s4_gate_is_load_bearing() {
         ctx_c(11, 0, ra(bounce_self()), Some(cond()), ev),
     ];
     assert!(
-        group_is_order_independent(&state, &uniform, false),
+        group_is_order_independent(&state, &uniform),
         "S4 foil: both P0 ⇒ UniformAligned ⇒ span disjointness clears ⇒ auto"
     );
 }
@@ -1690,7 +1690,7 @@ fn s5_multiplayer_three_players() {
         ctx_c(11, 1, ra(bounce_self()), Some(cond()), ev.clone()),
     ];
     assert!(
-        !group_is_order_independent(&state, &mixed, false),
+        !group_is_order_independent(&state, &mixed),
         "S5a: 3p mixed controllers ⇒ Mixed ⇒ prompt"
     );
 
@@ -1699,7 +1699,7 @@ fn s5_multiplayer_three_players() {
         ctx_c(12, 0, ra(bounce_self()), Some(cond()), ev),
     ];
     assert!(
-        group_is_order_independent(&state, &both_p0, false),
+        group_is_order_independent(&state, &both_p0),
         "S5b: 3p both P0 ⇒ You={{P0}} vs Opponents={{P1,P2}} disjoint ⇒ auto (not a 2p artifact)"
     );
 }
@@ -1732,7 +1732,7 @@ fn s6_owner_alignment() {
         ctx_c(11, 0, ra(bounce_self()), Some(cond()), ev.clone()),
     ];
     assert!(
-        !group_is_order_independent(&state, &donated, false),
+        !group_is_order_independent(&state, &donated),
         "S6 NEG: source owned by an opponent ⇒ owner-misaligned ⇒ prompt (real under-prompt guard)"
     );
 
@@ -1742,7 +1742,7 @@ fn s6_owner_alignment() {
         ctx_c(11, 0, ra(bounce_self()), Some(cond()), ev),
     ];
     assert!(
-        group_is_order_independent(&state, &aligned, false),
+        group_is_order_independent(&state, &aligned),
         "S6 foil: owner == controller == P0 ⇒ UniformAligned ⇒ auto"
     );
 }
@@ -1843,7 +1843,7 @@ fn b1_mindslicer_uniformity_gate() {
         ),
     ];
     assert!(
-        group_is_order_independent(&state, &pos, false),
+        group_is_order_independent(&state, &pos),
         "B-1 POS: uniform fused-discard co-departure batch ⇒ batch-T1 auto"
     );
 
@@ -1853,7 +1853,7 @@ fn b1_mindslicer_uniformity_gate() {
         ctx_c(11, 1, fused_discard_each(), None, self_departure(11, &[10])),
     ];
     assert!(
-        !group_is_order_independent(&state, &neg, false),
+        !group_is_order_independent(&state, &neg),
         "B-1 NEG: mixed-controller (team-pool) batch ⇒ Mixed ⇒ fused read × hand write ⇒ prompt"
     );
 }
@@ -1885,7 +1885,7 @@ fn b2_dotd_member_bound_pin() {
         ),
     ];
     assert!(
-        group_is_order_independent(&state, &pos, false),
+        group_is_order_independent(&state, &pos),
         "B-2 POS: uniform removes-all ⇒ batch-T1 auto"
     );
 
@@ -1901,7 +1901,7 @@ fn b2_dotd_member_bound_pin() {
         ctx(11, dotd(), None, self_departure(11, &[10]), None),
     ];
     assert!(
-        !group_is_order_independent(&state, &neg, false),
+        !group_is_order_independent(&state, &neg),
         "B-2 NEG: DotD TrackedSet return ⇒ member-bound ⇒ T1 refused ⇒ prompt"
     );
 }
@@ -1939,7 +1939,7 @@ fn high1_same_event_member_bound_prompts() {
         ctx(11, member_bound(), None, ev.clone(), None),
     ];
     assert!(
-        !group_is_order_independent(&state, &neg, false),
+        !group_is_order_independent(&state, &neg),
         "HIGH-1 NEG: same-event distinct-source member-bound ⇒ f_A≠f_B ⇒ prompt"
     );
 
@@ -1951,7 +1951,7 @@ fn high1_same_event_member_bound_prompts() {
         ctx(11, ra(gain_life_fixed()), None, ev.clone(), None),
     ];
     assert!(
-        group_is_order_independent(&state, &pos_unbound, false),
+        group_is_order_independent(&state, &pos_unbound),
         "HIGH-1 POS-a: same-event source-independent non-member-bound ⇒ auto"
     );
 
@@ -1963,7 +1963,7 @@ fn high1_same_event_member_bound_prompts() {
         ctx(10, member_bound(), None, ev, None),
     ];
     assert!(
-        group_is_order_independent(&state, &pos_same_source, false),
+        group_is_order_independent(&state, &pos_same_source),
         "HIGH-1 POS-b: all_same_source member-bound ⇒ shared storage ⇒ auto"
     );
 }
@@ -2003,7 +2003,7 @@ fn r4_same_event_event_object_prompts_at_caller() {
         ctx(11, feed(), None, ev.clone(), None),
     ];
     assert!(
-        !group_is_order_independent(&state, &neg, false),
+        !group_is_order_independent(&state, &neg),
         "R4 NEG: same-event distinct-source event-object read×write feed ⇒ prompt"
     );
 
@@ -2020,7 +2020,7 @@ fn r4_same_event_event_object_prompts_at_caller() {
         ctx(11, read_only(), None, ev.clone(), None),
     ];
     assert!(
-        group_is_order_independent(&state, &pos_read, false),
+        group_is_order_independent(&state, &pos_read),
         "R4 guard read-only: event-live read with NO event-object write ⇒ auto"
     );
 
@@ -2032,7 +2032,7 @@ fn r4_same_event_event_object_prompts_at_caller() {
         ctx(11, write_only(), None, ev.clone(), None),
     ];
     assert!(
-        group_is_order_independent(&state, &pos_write, false),
+        group_is_order_independent(&state, &pos_write),
         "R4 guard write-only: event-object write with NO live read ⇒ auto"
     );
 
@@ -2046,7 +2046,7 @@ fn r4_same_event_event_object_prompts_at_caller() {
         ctx(11, feed(), None, ph, None),
     ];
     assert!(
-        group_is_order_independent(&state, &pos_no_event, false),
+        group_is_order_independent(&state, &pos_no_event),
         "R4 guard no-event-object: Phase event ⇒ event_object_present false ⇒ auto"
     );
 
@@ -2058,7 +2058,7 @@ fn r4_same_event_event_object_prompts_at_caller() {
         ctx(10, feed(), None, ev, None),
     ];
     assert!(
-        group_is_order_independent(&state, &pos_same_source, false),
+        group_is_order_independent(&state, &pos_same_source),
         "R4 guard all_same_source: shared source ⇒ f_A = f_B ⇒ auto"
     );
 }
@@ -2092,7 +2092,7 @@ fn b3_source_independent_and_persist_false() {
         ),
     ];
     assert!(
-        group_is_order_independent(&state, &pos_slithermuse, false),
+        group_is_order_independent(&state, &pos_slithermuse),
         "B-3 POS-a: slithermuse persist:false choice is T1-clean ⇒ auto"
     );
 
@@ -2118,7 +2118,7 @@ fn b3_source_independent_and_persist_false() {
         ctx(11, self_sac(), None, self_departure(11, &[10]), None),
     ];
     assert!(
-        !group_is_order_independent(&state, &neg, false),
+        !group_is_order_independent(&state, &neg),
         "B-3 NEG: SelfRef self-move ⇒ writes_self ⇒ source_independent false ⇒ prompt"
     );
 }
@@ -2158,7 +2158,7 @@ fn b5_event_live_read_freeze_placement() {
         ),
     ];
     assert!(
-        group_is_order_independent(&state, &pos, false),
+        group_is_order_independent(&state, &pos),
         "B-5 POS: T1-clean uniform batch with a reentry hazard ⇒ auto (reach-guard)"
     );
 
@@ -2172,7 +2172,7 @@ fn b5_event_live_read_freeze_placement() {
         ctx(11, ev_read(), None, self_departure(11, &[10]), None),
     ];
     assert!(
-        !group_is_order_independent(&state, &neg, false),
+        !group_is_order_independent(&state, &neg),
         "B-5 NEG: Power{{EventSource}} read × reentry hazard ⇒ freeze row ⇒ prompt"
     );
 }
@@ -2200,7 +2200,7 @@ fn b6_multiplayer_uniform_vs_mixed() {
         ),
     ];
     assert!(
-        group_is_order_independent(&state, &pos, false),
+        group_is_order_independent(&state, &pos),
         "B-6 POS: 3p uniform P0 removes-all batch ⇒ auto"
     );
 
@@ -2221,7 +2221,7 @@ fn b6_multiplayer_uniform_vs_mixed() {
         ),
     ];
     assert!(
-        !group_is_order_independent(&state, &neg, false),
+        !group_is_order_independent(&state, &neg),
         "B-6 NEG: 3p mixed P0/P1 batch ⇒ Mixed ⇒ prompt"
     );
 }
@@ -2251,7 +2251,7 @@ fn condition1_dodecapod_mixed_controller_still_prompts() {
         ctx_c(11, 1, fused_discard_each(), None, self_departure(11, &[10])),
     ];
     assert!(
-        !group_is_order_independent(&state, &dodecapod, false),
+        !group_is_order_independent(&state, &dodecapod),
         "Condition-1: mixed-controller Dodecapod discard batch ⇒ Mixed ⇒ STILL PROMPTS \
          (auto would be an unsound under-prompt on the cause-source controller channel)"
     );

--- a/crates/engine/src/game/triggers_ordering_parity_tests.rs
+++ b/crates/engine/src/game/triggers_ordering_parity_tests.rs
@@ -247,6 +247,23 @@ const SAME_EVENT_MEMBER_BOUND_GENUINE: &[&str] = &[
     "blood tyrant",
 ];
 
+/// R4 (PR #5072 review): SAME-EVENT GENUINE event-object read/write order-dependence —
+/// the honesty list for the same-event event-object discriminator (`profiles_conflict`:
+/// `if s.same_event && s.event_object_present && p.reads_and_writes_event_object()`),
+/// analogous to `SAME_EVENT_MEMBER_BOUND_GENUINE`. **EMPTY — 0 genuine among the 13
+/// flips (all conservative).** GOVERNING THEOREM (why R4 differs from R3): the
+/// discriminator groups IDENTICAL siblings, and every R4 write targets either the
+/// SHARED event object (`TriggeringSource` / parentless `ParentTarget`) or each copy's
+/// OWN disjoint self. Identical `f∘f` on ONE shared object is relabel-invariant; disjoint
+/// self-writes never interact — so the final STATE is order-invariant either way. R3's
+/// genuine members instead wrote to PER-SOURCE storage (imprint pile A ≠ pile B), an
+/// asymmetric destination that IS order-divergent. R4 has no per-source-divergent write,
+/// hence 0 genuine. The class below is a pure fail-closed safety over-prompt: sound but
+/// never necessary. Full per-card both-orders evidence: `.pr675-r4-classification.md`.
+/// A populated-but-unhit entry trips the completeness assert (a future genuine card is
+/// added HERE, not manufactured). CR 603.3b + CR 608.2h.
+const SAME_EVENT_EVENT_OBJECT_GENUINE: &[&str] = &[];
+
 /// The census of a printed card's source (core types + subtypes + non-token).
 fn face_census(face: &CardFace) -> SourceCensus {
     let mut tags: Vec<String> = Vec::new();
@@ -474,6 +491,10 @@ fn ordering_parity_sweep() {
     // rebased head can regenerate — rider-1).
     let mut se_mb_genuine_hit: BTreeSet<String> = BTreeSet::new();
     let mut se_member_bound_class: BTreeSet<String> = BTreeSet::new();
+    // R4: same-event event-object genuine hits (empty exact-set) + the conservative
+    // event-object over-prompt class-count's derived membership (evidence artifact).
+    let mut se_event_object_genuine_hit: BTreeSet<String> = BTreeSet::new();
+    let mut se_event_object_class: BTreeSet<String> = BTreeSet::new();
 
     // Non-vacuity floors (full-DB; the committed fixture is a subset).
     let mut floor_batch_obs = 0usize;
@@ -564,6 +585,11 @@ fn ordering_parity_sweep() {
                         // Checked BEFORE the class-count so a genuine flip is never
                         // mislabeled conservative (rider-3 honesty).
                         se_mb_genuine_hit.insert(name.clone());
+                    } else if SAME_EVENT_EVENT_OBJECT_GENUINE.contains(&name.as_str()) {
+                        // R4 honesty list (EMPTY — 0 genuine). Checked before the
+                        // event-object class-count for symmetry with the member-bound
+                        // genuine list; a future genuine card is added to the const.
+                        se_event_object_genuine_hit.insert(name.clone());
                     } else if DOCUMENTED_OVER_PROMPT.contains(&name.as_str()) {
                         over_prompt_hit.insert(name.clone());
                     } else if profile.reads_member_bound() {
@@ -581,6 +607,25 @@ fn ordering_parity_sweep() {
                         // sorted membership is emitted below as the §7 evidence
                         // artifact.
                         se_member_bound_class.insert(name.clone());
+                    } else if se.event_object_present && profile.reads_and_writes_event_object() {
+                        // R4: the same-event event-object read/write over-prompt CLASS.
+                        // Predicate-keyed EXACTLY like the discriminator's own gate
+                        // (`s.same_event && s.event_object_present &&
+                        // p.reads_and_writes_event_object()` — one predicate, two
+                        // consumers), membership DERIVED (rider-1). Placed AFTER the
+                        // `reads_member_bound()` branch, so a both-carrier card is
+                        // attributed to `se_member_bound_class` (row order = attribution
+                        // order) ⇒ the two classes are DISJOINT BY CONSTRUCTION (asserted
+                        // below, rider-1). CONSERVATIVE by the governing theorem: every
+                        // write targets the SHARED event object (identical f∘f, relabel-
+                        // invariant) or disjoint self ⇒ order-invariant final state; 0
+                        // genuine (carved out above). NOTE: a Phase-mode trigger such as
+                        // `sidequest: catch a fish` sits OUTSIDE this class by the
+                        // `event_object_present` conjunct — no live event object ⇒ its
+                        // `TriggeringSource` write no-ops (targeting.rs:951) ⇒ it stays
+                        // AUTO, NOT a missed member. Sorted membership emitted below as
+                        // the §8 evidence artifact.
+                        se_event_object_class.insert(name.clone());
                     } else {
                         unexplained.push(format!(
                             "SAME-EVENT auto->prompt on '{name}' (not a category-(1) row)"
@@ -662,13 +707,16 @@ fn ordering_parity_sweep() {
     eprintln!(
         "ordering_parity_sweep: full_db={full_db} swept={swept} compared={compared} \
          unexplained={} cat1_hit={:?} over_prompt_hit={} batch_genuine_hit={} \
-         se_mb_genuine={:?} se_member_bound_class={}",
+         se_mb_genuine={:?} se_member_bound_class={} \
+         se_event_object_genuine={:?} se_event_object_class={}",
         unexplained.len(),
         cat1_hit,
         over_prompt_hit.len(),
         batch_genuine_hit.len(),
         se_mb_genuine_hit,
-        se_member_bound_class.len()
+        se_member_bound_class.len(),
+        se_event_object_genuine_hit,
+        se_event_object_class.len()
     );
     eprintln!(
         "floors: batch_obs={floor_batch_obs} \
@@ -683,6 +731,14 @@ fn ordering_parity_sweep() {
         "se_member_bound_class members ({}): {:?}",
         se_member_bound_class.len(),
         se_member_bound_class
+    );
+    // R4 (rider-1): DERIVED membership of the same-event event-object over-prompt CLASS
+    // — the §8 / handoff evidence artifact (mirrors se_member_bound_class). Sorted, so a
+    // stable diff the rebased head regenerates. Enumeration lives HERE, never in code.
+    eprintln!(
+        "se_event_object_class members ({}): {:?}",
+        se_event_object_class.len(),
+        se_event_object_class
     );
 
     assert!(
@@ -731,9 +787,13 @@ fn ordering_parity_sweep() {
         // R3 HIGH-1: measured drops to 2830 (−40) — the 40 source-INDEPENDENT members
         // of the same-event member-bound over-prompt CLASS now correctly PROMPT
         // (discriminator) instead of auto-ordering, so they no longer increment this
-        // auto counter. The floor is UNCHANGED (2830 > 2727, still passes) — this is
-        // an accounted movement, NOT a blanket bump (rider-4); the moved population is
-        // exactly the source-independent slice of `se_member_bound_class`.
+        // auto counter. R4: a FURTHER −11 (measured 2820 @ rebased corpus) — the
+        // source-independent slice of `se_event_object_class` (11 of the 13; the other
+        // 2 are non-source-independent, e.g. self-writing) now prompts via the event-
+        // object discriminator. The floor is UNCHANGED (2820 > 2727, still passes) —
+        // both are accounted movements, NOT blanket bumps (rider-4); the moved
+        // populations are exactly the source-independent slices of the two over-prompt
+        // classes.
         assert!(
             floor_t1_source_indep >= 2727,
             "T1 source-independent auto floor: {floor_t1_source_indep} < 2727"
@@ -779,6 +839,41 @@ fn ordering_parity_sweep() {
             se_member_bound_class.len() >= 35,
             "same-event member-bound over-prompt class floor: {} < 35",
             se_member_bound_class.len()
+        );
+        // R4: the same-event event-object GENUINE exact-set — EMPTY (0 genuine among
+        // the 13 flips; governing theorem: all writes are to the SHARED event object or
+        // disjoint self ⇒ relabel-invariant final state). A future genuine flip (parse/
+        // corpus drift) lands in `se_event_object_class` and trips the STRICT PROOF-GATE
+        // only if not added HERE — so this exact-set forces the §8 honesty bookkeeping.
+        let expected_se_event_object_genuine: BTreeSet<String> = SAME_EVENT_EVENT_OBJECT_GENUINE
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            se_event_object_genuine_hit, expected_se_event_object_genuine,
+            "SAME_EVENT_EVENT_OBJECT_GENUINE stale/unhit entries"
+        );
+        // se_event_object_class: measured 13 @ rebased corpus; floor = ⌊13·0.7⌋ (~30%
+        // churn tolerance, `>=`, predicate-keyed so membership churns with the corpus).
+        // NON-vacuity / mutation tripwire: deleting the discriminator row (`s.same_event
+        // && s.event_object_present && p.reads_and_writes_event_object()`) makes every
+        // member auto-order ⇒ this count collapses to 0 ⇒ floor trips. Guards the R4 fix
+        // against silent regression.
+        assert!(
+            se_event_object_class.len() >= 9,
+            "same-event event-object over-prompt class floor: {} < 9",
+            se_event_object_class.len()
+        );
+        // rider-1: the two same-event over-prompt classes are DISJOINT by construction
+        // (the `reads_member_bound()` classify branch precedes the event-object branch,
+        // so a both-carrier card is attributed to `se_member_bound_class`). Asserted so
+        // a future reorder that double-counts a card trips here.
+        assert!(
+            se_member_bound_class.is_disjoint(&se_event_object_class),
+            "rider-1: se_member_bound_class ∩ se_event_object_class must be empty; overlap = {:?}",
+            se_member_bound_class
+                .intersection(&se_event_object_class)
+                .collect::<Vec<_>>()
         );
         // cat-1 exact-hit: the 6 measured same-event flips. Your Inescapable Doom is
         // expected-UNHIT (its counter feed parses to Any so the sweep never forms its

--- a/crates/engine/src/game/triggers_ordering_parity_tests.rs
+++ b/crates/engine/src/game/triggers_ordering_parity_tests.rs
@@ -17,16 +17,16 @@
 use super::*;
 use crate::game::ability_rw::{
     ability_rw_profile, filter_excludes_source, profiles_conflict, source_census_overlaps_filter,
-    trigger_condition_rw_profile, GroupStructure, SourceCensus,
+    trigger_condition_rw_profile, ControllerUniformity, GroupStructure, SourceCensus,
 };
 use crate::game::ability_utils::{build_resolved_from_def, build_target_slots};
 use crate::game::game_object::GameObject;
 use crate::test_support::shared_card_db;
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, AggregateFunction, Comparator, ControllerRef, Effect,
-    ObjectScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef, ResolvedAbility,
-    SearchSelectionConstraint, TargetFilter, TriggerCondition, TriggerConstraint,
-    TriggerDefinition, TypedFilter,
+    AbilityCondition, AbilityDefinition, AggregateFunction, ChoiceType, Comparator, ControllerRef,
+    Effect, ObjectScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef, ResolvedAbility,
+    SearchSelectionConstraint, TargetFilter, TargetSelectionMode, TriggerCondition,
+    TriggerConstraint, TriggerDefinition, TypedFilter,
 };
 use crate::types::card::CardFace;
 use crate::types::card_type::Supertype;
@@ -340,7 +340,7 @@ fn ability_rw_profile_merged(
 /// phases parse to `constraint: None` (`oracle_trigger.rs`), opponent possessives
 /// to `OnlyDuringOpponentsTurn`, and enchanted/chosen-player forms to a
 /// `valid_target` with `constraint: None` — all ⇒ `false` here. The owner-alignment
-/// half of `same_controller` is computed LIVE and fail-closed in production; the
+/// owner-alignment half (`UniformAligned`) is computed LIVE and fail-closed in production; the
 /// sweep models the reachable canonical group (an exotic donated-source variant
 /// merely over-prompts in production, never under-prompts).
 fn trigger_is_controller_private(trig: &TriggerDefinition) -> bool {
@@ -400,18 +400,19 @@ fn ordering_parity_sweep() {
             let has_src_read = reads_source_pt_or_counter(&value);
             let hadcounters = matches!(trig.condition, Some(TriggerCondition::HadCounters { .. }));
 
-            let mk = |same_event: bool,
-                      all_same_source: bool,
-                      self_departed: bool,
-                      same_controller: bool| GroupStructure {
-                same_event,
-                all_same_source,
-                all_sources_self_departed: self_departed,
-                event_object_excludes_sources: if self_ref { false } else { excludes },
-                event_object_present: event_present,
-                source_census: census.clone(),
-                same_controller,
-            };
+            let mk =
+                |same_event: bool,
+                 all_same_source: bool,
+                 self_departed: bool,
+                 controller_uniformity: ControllerUniformity| GroupStructure {
+                    same_event,
+                    all_same_source,
+                    all_sources_self_departed: self_departed,
+                    event_object_excludes_sources: if self_ref { false } else { excludes },
+                    event_object_present: event_present,
+                    source_census: census.clone(),
+                    controller_uniformity,
+                };
 
             // --- Same-event, distinct-source observer (S2) ---
             // §5.2: only where a 2-copy same-event group is REACHABLE (CLASS-A
@@ -421,7 +422,20 @@ fn ordering_parity_sweep() {
             // pinned Phase+OnlyDuringYourTurn class (`trigger_is_controller_private`);
             // production additionally computes owner-alignment live and fail-closed.
             if !self_ref && same_event_group_reachable(face, trig, &census) {
-                let se = mk(true, false, false, trigger_is_controller_private(trig));
+                // §5.2: the modeled canonical S2 group is controller-private (fire-
+                // time-pinned Phase+OnlyDuringYourTurn) ⇒ `UniformAligned` (owner-
+                // alignment computed live in production); every other shape ⇒ `Mixed`
+                // (fail-closed). Only `UniformAligned` unlocks the span/fused gate.
+                let se = mk(
+                    true,
+                    false,
+                    false,
+                    if trigger_is_controller_private(trig) {
+                        ControllerUniformity::UniformAligned
+                    } else {
+                        ControllerUniformity::Mixed
+                    },
+                );
                 let conflict = profiles_conflict(&profile, &se);
                 let decision_new = !conflict; // decision_old (same-event) == auto == true
                 compared += 1;
@@ -441,13 +455,18 @@ fn ordering_parity_sweep() {
 
             // --- Departure-batch structures (S3 self-departed / S5 mixed obs) ---
             if is_departure {
-                // §5: batch rows model `same_controller = false` (different-
-                // controller co-deaths are reachable) — the static sweep's batch
-                // model is fail-closed; production computes it live.
+                // §5: batch rows model `ControllerUniformity::Uniform`. Production
+                // ordering groups are partitioned by `trigger_order_controller`
+                // (triggers.rs), so every non-team co-departure group is controller-
+                // uniform BY CONSTRUCTION; team-pooled groups (CR 805.7) compute the
+                // fact live and fail-closed to `Mixed` ⇒ over-prompt (never under-
+                // prompt). `Uniform` (not `UniformAligned`) keeps the span/fused gate
+                // OFF — the span model is byte-identical; the only clause it newly
+                // unlocks is batch-T1.
                 let batch = if self_ref {
-                    mk(false, false, true, false) // self-dies
+                    mk(false, false, true, ControllerUniformity::Uniform) // self-dies
                 } else {
-                    mk(false, false, false, false) // observer batch
+                    mk(false, false, false, ControllerUniformity::Uniform) // observer batch
                 };
                 let batch_conflict = legacy_prompt || profiles_conflict(&profile, &batch);
                 let decision_new = !batch_conflict;
@@ -953,10 +972,10 @@ fn n_g_dropped_target_legacy_ref_retains_batch_prompt() {
 }
 
 // ===================================================================
-// PR-6.75 `same_controller` span discriminators (S1–S6), driven through the
+// PR-6.75 controller-uniformity span discriminators (S1–S6), driven through the
 // production authority `group_is_order_independent`. POSITIVE (auto) groups
 // install source objects owned AND controlled by the pending controller so the
-// LIVE `same_controller` check holds; each NEG breaks exactly ONE axis (span
+// LIVE controller-uniformity check holds; each NEG breaks exactly ONE axis (span
 // disjointness, controller-uniformity, or owner-alignment) and must re-prompt —
 // the paired positive reach-guard proves the auto is delivered by the refined
 // row, not an upstream fast-path short-circuit.
@@ -1233,9 +1252,9 @@ fn s3_brink_fused_discard_span() {
 
 /// S-4 — load-bearing shared-event observer (the gate is load-bearing). Two
 /// Rekindled-shape triggers off ONE event with controllers P0 and P1: mixed
-/// controllers ⇒ `same_controller = false` ⇒ the spans are UNCONSULTED ⇒ the
+/// controllers ⇒ `Mixed` ⇒ the spans are UNCONSULTED ⇒ the
 /// hand row fires ⇒ PROMPT. Revert-fail foil (same shapes, both P0): the ONLY
-/// change is the controller/owner of source 11 ⇒ `same_controller = true` ⇒
+/// change is the controller/owner of source 11 ⇒ `UniformAligned` ⇒
 /// AUTO. Deleting the gate in `profiles_conflict` would flip the P0/P1 case to
 /// auto (RED).
 #[test]
@@ -1260,7 +1279,7 @@ fn s4_gate_is_load_bearing() {
     ];
     assert!(
         !group_is_order_independent(&state, &mixed, false),
-        "S4 NEG: mixed controllers ⇒ same_controller false ⇒ spans unconsulted ⇒ prompt"
+        "S4 NEG: mixed controllers ⇒ Mixed ⇒ spans unconsulted ⇒ prompt"
     );
 
     // Revert-fail foil: reinstall source 11 under P0 and flip the pending
@@ -1272,12 +1291,12 @@ fn s4_gate_is_load_bearing() {
     ];
     assert!(
         group_is_order_independent(&state, &uniform, false),
-        "S4 foil: both P0 ⇒ same_controller true ⇒ span disjointness clears ⇒ auto"
+        "S4 foil: both P0 ⇒ UniformAligned ⇒ span disjointness clears ⇒ auto"
     );
 }
 
 /// S-5 — MULTIPLAYER (3 players). (a) members P0 and P1: mixed controllers ⇒
-/// same_controller false ⇒ PROMPT (at 3p, P1's opponents include P0, so treating
+/// Mixed ⇒ PROMPT (at 3p, P1's opponents include P0, so treating
 /// them as controller-private would be unsound — the gate correctly refuses).
 /// (b) both members P0: `You == {P0}` vs `Opponents == {P1,P2}` disjointness is
 /// NOT a two-player artifact ⇒ AUTO at N players.
@@ -1304,7 +1323,7 @@ fn s5_multiplayer_three_players() {
     ];
     assert!(
         !group_is_order_independent(&state, &mixed, false),
-        "S5a: 3p mixed controllers ⇒ same_controller false ⇒ prompt"
+        "S5a: 3p mixed controllers ⇒ Mixed ⇒ prompt"
     );
 
     let both_p0 = vec![
@@ -1320,9 +1339,9 @@ fn s5_multiplayer_three_players() {
 /// S-6 — owner-alignment discriminator (the `o.owner == c0` conjunct is
 /// load-bearing). Rekindled shape, both members controlled by P0, but source 11
 /// is OWNED by P1 (donated / control-changed). NEG: owner mismatch ⇒
-/// same_controller false ⇒ PROMPT — and this is a REAL under-prompt guard: the
+/// Mixed ⇒ PROMPT — and this is a REAL under-prompt guard: the
 /// self-bounce would put source 11 in P1's hand, which the `HandSize{Opponent}`
-/// read observes. Revert-fail foil (source 11 owned by P0): same_controller true
+/// read observes. Revert-fail foil (source 11 owned by P0): UniformAligned
 /// ⇒ AUTO. Dropping the owner conjunct would auto the NEG (RED).
 #[test]
 fn s6_owner_alignment() {
@@ -1356,6 +1375,359 @@ fn s6_owner_alignment() {
     ];
     assert!(
         group_is_order_independent(&state, &aligned, false),
-        "S6 foil: owner == controller == P0 ⇒ same_controller true ⇒ auto"
+        "S6 foil: owner == controller == P0 ⇒ UniformAligned ⇒ auto"
+    );
+}
+
+// ===================================================================
+// PR-6.75 c5 — batch-T1 uniformity theorem discriminators (B-1..B-6 + the
+// executable Dodecapod negative), driven through the production authority
+// `group_is_order_independent`. Co-departure groups use DEAD sources (NOT
+// installed in `state.objects`) so the chokepoint yields `Uniform` (pending
+// controllers equal) rather than `UniformAligned` (live owner==controller) — the
+// exact production shape of an SBA co-death batch. Each NEG breaks ONE T1 conjunct
+// and is paired with a POS reach-guard proving the group reaches the batch-T1
+// clause (not short-circuited upstream).
+// ===================================================================
+
+/// Mindslicer's fused self-emptying discard ("each player discards their hand") —
+/// source-independent, no member-bound storage, no event read.
+fn fused_discard_each() -> ResolvedAbility {
+    let mut d = ra(discard_hand(
+        qref(QuantityRef::HandSize {
+            player: PlayerScope::ScopedPlayer,
+        }),
+        TargetFilter::Controller,
+    ));
+    d.player_scope = Some(PlayerFilter::All);
+    d
+}
+
+/// Yukora/Emrakul removes-all: sacrifice all your matching creatures, `count =
+/// ObjectCount` of the same filter — a pure f(state, controller).
+fn sacrifice_all_own_creatures() -> ResolvedAbility {
+    ra(Effect::Sacrifice {
+        target: creatures_of(ControllerRef::You),
+        count: qref(QuantityRef::ObjectCount {
+            filter: creatures_of(ControllerRef::You),
+        }),
+        min_count: 0,
+    })
+}
+
+/// A `ChangeZone{target → Battlefield, enters_under: You}` return (Exile → bf).
+fn change_zone_return(target: TargetFilter) -> Effect {
+    Effect::ChangeZone {
+        origin: Some(Zone::Exile),
+        destination: Zone::Battlefield,
+        target,
+        owner_library: false,
+        enter_transformed: false,
+        enters_under: Some(ControllerRef::You),
+        enter_tapped: crate::types::zones::EtbTapState::default(),
+        enters_attacking: false,
+        up_to: false,
+        enter_with_counters: vec![],
+        conditional_enter_with_counters: vec![],
+        face_down_profile: None,
+        enters_modified_if: None,
+    }
+}
+
+/// Slithermuse's resolution-local choice: `Choose{Opponent, persist:false}` → draw.
+/// `persist:false` writes NO source storage ⇒ member-unbound ⇒ T1-clean.
+fn choose_opponent_then_draw() -> ResolvedAbility {
+    let draw = ra(Effect::Draw {
+        count: qfix(1),
+        target: TargetFilter::Controller,
+    });
+    ra(Effect::Choose {
+        choice_type: ChoiceType::Opponent { restriction: None },
+        persist: false,
+        selection: TargetSelectionMode::default(),
+    })
+    .sub_ability(draw)
+}
+
+/// B-1 — the uniformity gate is load-bearing. Two byte-identical mindslicer fused
+/// discards co-depart with DEAD sources. POS: both P0 ⇒ `Uniform` ⇒ batch-T1
+/// clears ⇒ AUTO. NEG: controllers P0/P1 (a CR 805.7 team-pooled group) ⇒ `Mixed`
+/// ⇒ T1 gated OFF ⇒ the fused hand read unions back and overlaps the discard's
+/// hand write ⇒ PROMPT. Revert-fail (measured in the impl report): forcing
+/// `Uniform`/deleting the `!= Mixed` conjunct flips the NEG to AUTO (RED).
+#[test]
+fn b1_mindslicer_uniformity_gate() {
+    let state = empty_state();
+    let pos = vec![
+        ctx(
+            10,
+            fused_discard_each(),
+            None,
+            self_departure(10, &[11]),
+            None,
+        ),
+        ctx(
+            11,
+            fused_discard_each(),
+            None,
+            self_departure(11, &[10]),
+            None,
+        ),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos, false),
+        "B-1 POS: uniform fused-discard co-departure batch ⇒ batch-T1 auto"
+    );
+
+    // CR 805.7 team-pool: divergent pending controllers ⇒ `Mixed` ⇒ T1 off.
+    let neg = vec![
+        ctx_c(10, 0, fused_discard_each(), None, self_departure(10, &[11])),
+        ctx_c(11, 1, fused_discard_each(), None, self_departure(11, &[10])),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &neg, false),
+        "B-1 NEG: mixed-controller (team-pool) batch ⇒ Mixed ⇒ fused read × hand write ⇒ prompt"
+    );
+}
+
+/// B-2 — the member-bound flag is the Day-of-the-Dragons soundness pin. POS:
+/// yukora removes-all, uniform ⇒ T1 clears ⇒ AUTO. NEG: the DotD twin — the SAME
+/// removes-all PLUS a sub `ChangeZone{TrackedSet(0) → Battlefield}` return. The
+/// per-source tracked set sets `reads_member_bound` ⇒ T1 refused ⇒ the count-read
+/// × return-write membership feed (reached ONLY because T1 is blocked) ⇒ PROMPT.
+/// Revert-fail (measured): removing `TrackedSet` from `member_bound_target_filter`
+/// drops the flag ⇒ T1 fires and short-circuits before the feed ⇒ AUTO (RED).
+#[test]
+fn b2_dotd_member_bound_pin() {
+    let state = empty_state();
+    let pos = vec![
+        ctx(
+            10,
+            sacrifice_all_own_creatures(),
+            None,
+            self_departure(10, &[11]),
+            None,
+        ),
+        ctx(
+            11,
+            sacrifice_all_own_creatures(),
+            None,
+            self_departure(11, &[10]),
+            None,
+        ),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos, false),
+        "B-2 POS: uniform removes-all ⇒ batch-T1 auto"
+    );
+
+    let dotd = || {
+        sacrifice_all_own_creatures().sub_ability(ra(change_zone_return(
+            TargetFilter::TrackedSet {
+                id: crate::types::identifiers::TrackedSetId(0),
+            },
+        )))
+    };
+    let neg = vec![
+        ctx(10, dotd(), None, self_departure(10, &[11]), None),
+        ctx(11, dotd(), None, self_departure(11, &[10]), None),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &neg, false),
+        "B-2 NEG: DotD TrackedSet return ⇒ member-bound ⇒ T1 refused ⇒ prompt"
+    );
+}
+
+/// B-3 — the `source_independent` (self-write) conjunct + slithermuse's
+/// `persist:false` clear. POS-a: slithermuse's `Choose{Opponent, persist:false}`
+/// then draw, uniform ⇒ AUTO (a resolution-local choice is T1-clean). POS-b:
+/// yukora removes-all ⇒ AUTO (the reach-guard: proves the shape reaches T1). NEG: add a
+/// sub `ChangeZone{SelfRef, Battlefield → Graveyard}` self-sacrifice ⇒
+/// `writes_self` ⇒ `source_independent()` false ⇒ T1 refused ⇒ the `ObjectCount`
+/// membership read × the self bf→gy move feed ⇒ PROMPT (skyfisher class).
+/// Revert-fail (measured): dropping `source_independent()` from batch-T1 flips the
+/// NEG to AUTO (RED).
+#[test]
+fn b3_source_independent_and_persist_false() {
+    let state = empty_state();
+    let pos_slithermuse = vec![
+        ctx(
+            10,
+            choose_opponent_then_draw(),
+            None,
+            self_departure(10, &[11]),
+            None,
+        ),
+        ctx(
+            11,
+            choose_opponent_then_draw(),
+            None,
+            self_departure(11, &[10]),
+            None,
+        ),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos_slithermuse, false),
+        "B-3 POS-a: slithermuse persist:false choice is T1-clean ⇒ auto"
+    );
+
+    let self_sac = || {
+        sacrifice_all_own_creatures().sub_ability(ra(Effect::ChangeZone {
+            origin: Some(Zone::Battlefield),
+            destination: Zone::Graveyard,
+            target: TargetFilter::SelfRef,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: crate::types::zones::EtbTapState::default(),
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        }))
+    };
+    let neg = vec![
+        ctx(10, self_sac(), None, self_departure(10, &[11]), None),
+        ctx(11, self_sac(), None, self_departure(11, &[10]), None),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &neg, false),
+        "B-3 NEG: SelfRef self-move ⇒ writes_self ⇒ source_independent false ⇒ prompt"
+    );
+}
+
+/// B-5 — the `reads_event_live` conjunct and its clause PLACEMENT (T1 sits ABOVE
+/// the freeze-invalidation row). Both members `Draw{count} + ChangeZone{Any →
+/// Battlefield}` (a reentry hazard ⇒ freeze invalid). POS: `count: Fixed` ⇒ no
+/// event read ⇒ T1 clears ⇒ AUTO (reach-guard: the reentry hazard alone does not
+/// prompt a T1-clean uniform batch). NEG: `count: Power{EventSource}` ⇒
+/// `reads_event_live` ⇒ T1 refused ⇒ the freeze-invalidation row (reentry hazard ×
+/// event-live read) ⇒ PROMPT. Revert-fail (measured): deleting `!reads_event_live`
+/// from batch-T1 lets T1 fire and short-circuit BEFORE the freeze row ⇒ AUTO (RED).
+#[test]
+fn b5_event_live_read_freeze_placement() {
+    let state = empty_state();
+    let with_count = |count: QuantityExpr| {
+        ra(Effect::Draw {
+            count,
+            target: TargetFilter::Controller,
+        })
+        .sub_ability(ra(change_zone_return(TargetFilter::Any)))
+    };
+    let pos = vec![
+        ctx(
+            10,
+            with_count(qfix(1)),
+            None,
+            self_departure(10, &[11]),
+            None,
+        ),
+        ctx(
+            11,
+            with_count(qfix(1)),
+            None,
+            self_departure(11, &[10]),
+            None,
+        ),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos, false),
+        "B-5 POS: T1-clean uniform batch with a reentry hazard ⇒ auto (reach-guard)"
+    );
+
+    let ev_read = || {
+        with_count(qref(QuantityRef::Power {
+            scope: ObjectScope::EventSource,
+        }))
+    };
+    let neg = vec![
+        ctx(10, ev_read(), None, self_departure(10, &[11]), None),
+        ctx(11, ev_read(), None, self_departure(11, &[10]), None),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &neg, false),
+        "B-5 NEG: Power{{EventSource}} read × reentry hazard ⇒ freeze row ⇒ prompt"
+    );
+}
+
+/// B-6 — multiplayer (3 players). A uniform P0 removes-all co-departure group
+/// auto-orders at N players (POS); a mixed P0/P1 group prompts (NEG) — the
+/// uniformity gate is not a two-player artifact (S-5 style).
+#[test]
+fn b6_multiplayer_uniform_vs_mixed() {
+    let state = GameState::new(crate::types::format::FormatConfig::standard(), 3, 7);
+    let pos = vec![
+        ctx(
+            10,
+            sacrifice_all_own_creatures(),
+            None,
+            self_departure(10, &[11]),
+            None,
+        ),
+        ctx(
+            11,
+            sacrifice_all_own_creatures(),
+            None,
+            self_departure(11, &[10]),
+            None,
+        ),
+    ];
+    assert!(
+        group_is_order_independent(&state, &pos, false),
+        "B-6 POS: 3p uniform P0 removes-all batch ⇒ auto"
+    );
+
+    let neg = vec![
+        ctx_c(
+            10,
+            0,
+            sacrifice_all_own_creatures(),
+            None,
+            self_departure(10, &[11]),
+        ),
+        ctx_c(
+            11,
+            1,
+            sacrifice_all_own_creatures(),
+            None,
+            self_departure(11, &[10]),
+        ),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &neg, false),
+        "B-6 NEG: 3p mixed P0/P1 batch ⇒ Mixed ⇒ prompt"
+    );
+}
+
+/// ★ CONDITION 1 — the executable Dodecapod negative (the load-bearing negative
+/// for the whole controller-uniformity pivot). A genuinely order-observable
+/// MIXED-controller co-departure batch: two members controlled by P0 and P1 (a
+/// CR 805.7 team-pooled group in a 3-player game), each an `EventSourceControlledBy`
+/// -class consumer — a `Discard` whose downstream replacement (Dodecapod-style)
+/// reads the DISCARD CAUSE's source controller. Whichever member resolves first
+/// stamps ITS OWN source as the cause, so `event_source_controller != affected`
+/// flips between orders (events.rs `Discarded.source_id`; replacement.rs
+/// `EventSourceControlledBy`). The chokepoint yields `Mixed` ⇒ batch-T1 is gated
+/// OFF ⇒ the group STILL PROMPTS (auto-ordering would be an unsound under-prompt).
+/// Revert-fail (measured in the impl report): forcing the chokepoint to `Uniform`
+/// (or deleting the `!= Mixed` conjunct) auto-orders this mixed batch = RED —
+/// proving the uniformity gate is exactly what preserves the mixed-batch prompt.
+#[test]
+fn condition1_dodecapod_mixed_controller_still_prompts() {
+    let state = GameState::new(crate::types::format::FormatConfig::standard(), 3, 7);
+    // A source-independent "each player discards their hand" — the Dodecapod
+    // discard channel. Under a MIXED batch the cause-source controller is
+    // order-observable; the profile itself is T1-clean, so ONLY the `!= Mixed`
+    // uniformity gate keeps it prompting.
+    let dodecapod = vec![
+        ctx_c(10, 0, fused_discard_each(), None, self_departure(10, &[11])),
+        ctx_c(11, 1, fused_discard_each(), None, self_departure(11, &[10])),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &dodecapod, false),
+        "Condition-1: mixed-controller Dodecapod discard batch ⇒ Mixed ⇒ STILL PROMPTS \
+         (auto would be an unsound under-prompt on the cause-source controller channel)"
     );
 }

--- a/crates/engine/src/game/triggers_ordering_parity_tests.rs
+++ b/crates/engine/src/game/triggers_ordering_parity_tests.rs
@@ -854,3 +854,71 @@ fn class_a_damage_done_exempts_self_source_not_observer() {
         "observer damage (valid_source non-SelfRef) ⇒ shared source event ⇒ compared"
     );
 }
+
+/// N-G (D5, CR 603.10a): the fail-open batch-prompt hole this commit closes,
+/// proven through the production ordering authority. A co-departing pair of
+/// identical "when this leaves the battlefield, target player discards" triggers
+/// carries `TargetFilter::TriggeringPlayer` in the `Discard` TARGET position —
+/// one of the 12 frozen event-context tags. `rw_effect`'s `Discard` arm ignores
+/// its `target` field, so before this commit the read/write walk never routed
+/// the tag through a legacy leaf detector and `legacy_batch_prompt` stayed false:
+/// the departure batch auto-ordered where the shipped engine prompted.
+///
+/// Revert-fail witness: removing the `p.legacy_batch_prompt =
+/// contains_legacy_event_ref(a)` override in `ability_rw_profile` makes the
+/// legacy group auto-order and flips the first assertion. The `Controller`
+/// control (identical discard, no frozen tag) proves the prompt is driven by the
+/// tag itself, not by `Discard`'s effect shape.
+#[test]
+fn n_g_dropped_target_legacy_ref_retains_batch_prompt() {
+    let state = empty_state();
+    let discard = |t: TargetFilter| Effect::Discard {
+        count: qfix(1),
+        target: t,
+        unless_filter: None,
+        filter: None,
+        selection: crate::types::ability::CardSelectionMode::Chosen,
+    };
+
+    let legacy_group = vec![
+        ctx(
+            10,
+            ra(discard(TargetFilter::TriggeringPlayer)),
+            None,
+            self_departure(10, &[11]),
+            None,
+        ),
+        ctx(
+            11,
+            ra(discard(TargetFilter::TriggeringPlayer)),
+            None,
+            self_departure(11, &[10]),
+            None,
+        ),
+    ];
+    assert!(
+        !group_is_order_independent(&state, &legacy_group, false),
+        "Discard{{TriggeringPlayer}} on a departure batch carries a frozen tag ⇒ retain prompt"
+    );
+
+    let control_group = vec![
+        ctx(
+            10,
+            ra(discard(TargetFilter::Controller)),
+            None,
+            self_departure(10, &[11]),
+            None,
+        ),
+        ctx(
+            11,
+            ra(discard(TargetFilter::Controller)),
+            None,
+            self_departure(11, &[10]),
+            None,
+        ),
+    ];
+    assert!(
+        group_is_order_independent(&state, &control_group, false),
+        "identical Discard with no frozen tag (Controller) ⇒ auto-order"
+    );
+}

--- a/crates/engine/tests/integration/daretti_emblem_simultaneous_death.rs
+++ b/crates/engine/tests/integration/daretti_emblem_simultaneous_death.rs
@@ -294,16 +294,19 @@ fn daretti_emblem_simultaneous_artifact_death_produces_n_returns() {
     let stacked =
         engine::game::triggers::check_delayed_triggers(runner.state_mut(), &end_step_events);
 
+    // CR 603.3b (PR-6.75 HIGH-2): two simultaneous same-controller delayed triggered
+    // abilities with distinct returns are ordered by their controller before hitting
+    // the stack — check_delayed_triggers now routes its firing batch through
+    // begin_trigger_ordering (matching the phase-delayed path). The batch pauses on the
+    // OrderTriggers choice, so `stacked` is empty until the order is submitted; the
+    // drain_stack helper below drains the identity order and resolves both returns.
     assert!(
-        !stacked.is_empty(),
-        "CR 603.7b: the AtNextPhase{{End}} delayed triggers must fire at the end step"
+        matches!(runner.state().waiting_for, WaitingFor::OrderTriggers { .. }),
+        "CR 603.3b: the two simultaneous AtNextPhase{{End}} Daretti returns must prompt \
+         for ordering; waiting_for={:?}",
+        runner.state().waiting_for
     );
-    assert_eq!(
-        stacked.len(),
-        2,
-        "both delayed triggers must fire at the end step; got {} stack entries",
-        stacked.len()
-    );
+    let _ = stacked;
     assert!(
         runner.state().delayed_triggers.is_empty(),
         "CR 603.7b: both one-shot delayed triggers must be consumed after firing"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

PR-6.75 of the combo-detector series: **C0-full + C1 precision pass** — a typed read/write conflict-profile module (`ability_rw.rs`) and a CR 603.3b same-event trigger-ordering gate that is fail-closed over the profiled read/write sets (sound modulo two documented profile-invisible symmetric residuals — §8-R4), replacing the shipped fail-open allowlist with a fail-closed classifier. 13 commits, engine-only — 7 original, 5 review-response commits (all review findings from the 2026-07-04 rounds, §8), 1 rebase-adaptation (v0.15.0 new-variant exhaustiveness):

1. **commit 1** — `ability_rw` read/write conflict profiler: per-ability typed read/write span extraction with a fail-closed dual-walk (every new enum variant/field must be explicitly classified per-axis or the build breaks — no wildcards).
2. **commit 2** — C0-full + C1: the profiler becomes the trigger-ordering gate (CR 603.3b). Same-event path is monotone-safe: the old code unconditionally auto-ordered, so C1 can only ADD prompts, never remove one.
3. **commit 3** — position-agnostic D5 legacy-ref visitor (CR 603.10a): typed, compiler-exhaustive visitor closing the fail-open hole where legacy event refs in effect TARGET/COUNT positions were missed (50 cards would have silently auto-ordered).
4. **commit 4** — cheap read/write conflict levers (10 precision refinements; sweep 64→27).
5. **same_controller** — `ControllerUniformity` typed group property ({Mixed, Uniform, UniformAligned}; CR 805.7 team pools are the sole mixer; 27→24).
6. **batch-hard** — Batch-T1 uniformity theorem: controller-uniform + source-independent + no member-bound storage + no live-event read + no event-object write ⇒ f∘f idempotent ⇒ order-independent. Dodecapod is the counterexample proving mixed-controller batches are unclearable (executable negative test). 24→19.
7. **sweep-green** — full-DB parity sweep allowlist: 18 documented-conservative over-prompts + 1 genuine (Day of the Dragons), floors mutation-proven non-vacuous.
8. **HIGH-1 fix** (`b4ec14aa9`) — same-event member-bound discriminator (review finding 1; §8).
9. **HIGH-2 fix** (`5f109132b`) — non-phase delayed triggers routed through `begin_trigger_ordering` (review finding 2; §8).
10. **rebase adaptation** (`41843f974`) — v0.15.0 new-variant exhaustiveness classification for the dual-walk (§8).
11. **R4 fix** (`53838b08b`) — same-event event-object read/write feed closed (review round-4 finding; §8-R4).
12. **R5 caller-level regression test** (`83bb4084a`) — production-path `group_is_order_independent` pin for the R4 discriminator (review round-5 finding; §8-R5).
13. **C2-ungating adoption + soundness conjunct** (`01580f3bf`) — adopts #5084's loop-detection ungating of C2 finite ordering and closes the Dodecapod under-prompt the ungating surfaced (§8-R5).

## Files changed

- `crates/engine/src/game/ability_rw.rs` (new module, +7448)
- `crates/engine/src/game/ability_scan.rs` (+17)
- `crates/engine/src/game/engine_priority.rs` (+9)
- `crates/engine/src/game/mod.rs` (+1)
- `crates/engine/src/game/triggers.rs` (+414/−189)
- `crates/engine/src/game/triggers_ordering_parity_tests.rs` (new test module, +2138)
- `crates/engine/tests/integration/daretti_emblem_simultaneous_death.rs` (+11/−8 — updated to the new `OrderTriggers` contract, §8)

## Track

Developer

## LLM

Model: claude-opus-4-8
Thinking: high
Tier: Frontier

## Implementation method (required)

- [x] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)

Every commit in the series ran the full pipeline: signed-off plan (`PR-6.75-C0FULL-C1-PLAN.md`, 4-round plan review R1→R4-clean), per-commit implementer, per-commit adversarial `/review-impl` (each round's REQUIRED fixes applied before commit), plus one final cumulative adversarial review over the whole 7-commit diff (verdict: SHIP).

## CR references

**69 unique CR annotations** in the series diff, every one grep-verified against `docs/MagicCompRules.txt` before writing. Load-bearing: **CR 603.3b** (APNAP trigger ordering — the seam this PR fixes), CR 603.4 (intervening-if re-check), CR 603.10a (delayed/legacy refs), CR 805.7 (team trigger pools = the sole controller-mixer), CR 701.21a (sacrifice → owner's graveyard, the osseous/skyfisher class), CR 303.4d + CR 301.5c (Aura/Equipment can't attach to itself — §L6), CR 120.4a (excess damage → PlayerLife write), CR 608.2h, CR 704.5a/g/j, CR 904.3. One wrong pre-existing citation found by the cumulative review was fixed in-series (§L6: 701.3d/704.5j → 303.4d/301.5c).

## Verification

Developer-track checklist for this head (01580f3bf, rebased onto `upstream/main` cf7cd7cb9):

- `cargo fmt --all` — clean
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — clean, 0 lints (re-run at 01580f3bf)
- `./scripts/check-parser-combinators.sh` — clean (no parser files in the diff)
- `cargo test -p engine --features proptest` — **0 failures** at 01580f3bf (engine lib 15103 pass / 0 fail + all integration binaries pass)
- Corpus regenerated at 01580f3bf (provenance `client/public/card-data-meta.json`); 0 new Unimplemented entries (this PR adds no parser surface)
- `FORGE_TEST_FULL_DB=1 cargo test -p engine ordering_parity_sweep` — **GREEN: 0 unexplained** at the rebased head (details below)

**Commands run at this head (01580f3bf)** — three rebases during review-response, each verified by range-diff: onto 1badc1920 (9/9 `=` modulo one benign `use`-line 3-way with #4625) + one adaptation commit (§8); onto 4c0ac54f5 (11/11 `=`, pure base-move); onto cf7cd7cb9 (conflict resolution with #5084 — 10/12 `=`; commit-2 `!` = the C1 conflict resolution keeps the commit's own gated form, re-applied as the tail ungating commit so HEAD adopts #5084; HIGH-2 `!` = context-line only from #5084's visibility bump; §8-R5). No dual-walk exhaustiveness breaks in any rebase after the adaptation commit (#5090 adds no enum variant):

| Command | Result |
|---|---|
| `FORGE_TEST_FULL_DB=1 cargo test -p engine ordering_parity_sweep` (corpus regenerated at 01580f3bf, incl. #5080/#5090 parser changes) | **GREEN: 0 unexplained** over swept=13556 / compared=6208; `over_prompt_hit=18`, `batch_genuine_hit=1` (Day of the Dragons), `cat1_hit=6`, `se_mb_genuine=6` (§8 exact-set assert), `se_member_bound_class=43` (predicate-derived, floor ≥35), `se_event_object_class=13` + `SAME_EVENT_EVENT_OBJECT_GENUINE={}` (§8-R4, empty exact-set asserted, floor ≥9, disjointness vs member-bound asserted); all floors pass, `t1_source_indep=2820` (assert ≥2727). Zero movement across all three rebases — both upstream parser changes measured corpus-neutral; the C2-ungating is off the sweep's `profiles_conflict` path (predicted AND measured) |
| Mutation probe matrix M1–M9 (flip one classifier conjunct → full-DB sweep → confirm the named floor/assert trips → revert; run at the pre-review-fix tree) | every surviving floor and ledger assert has ≥1 discriminating mutation; **M4 surfaced 50 under-prompt-direction rows, 0 suppressible** — the direction gate cannot be masked by the allowlist. §8's new class floor has its own mutation proof: deleting the HIGH-1 discriminator collapses `se_member_bound_class` 43→0 and trips the floor + the genuine exact-set assert |
| `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` | 0 lints (at 01580f3bf) |
| `cargo test -p engine --features proptest` | **0 failures** (at 01580f3bf: engine lib 15103/0 + all integration binaries) |
| `cargo fmt --all` / parser-combinator gate vs true base | clean / no parser files in the diff |

**Behavioral trace of the trigger-ordering seam:** `begin_trigger_ordering` collects the same-event batch → partitions by controller (CR 805.7 team pools are the only path that mixes controllers; `condition1_dodecapod_mixed_controller_still_prompts` pins that mixed groups always prompt) → `group_is_order_independent` consults the `ability_rw` read/write profiles → any read/write span conflict ⇒ **prompt** (player orders, CR 603.3b); provably-disjoint spans ⇒ auto-order. **Monotone safety:** the pre-C1 path unconditionally auto-ordered same-event groups, so C1 can only ADD prompts — it cannot remove one.

**Under-prompt proof (the #1 risk):** the sweep's direction gate flags `decision_old && !decision_new` (previously-prompted → now-auto) rows into `unexplained`, which is asserted empty — an allowlist entry cannot hide an under-prompt by construction. The 7 newly-prompting category-1 cards are each measured genuinely order-dependent (table below); the 18 conservative over-prompts are documented with per-card reasons and completeness-asserted at full-DB. Discriminating runtime pins: `b2_dotd_member_bound_pin`, `b1_mindslicer_uniformity_gate`, the Dodecapod executable negative, freeze-auto discriminators N-A/N-B, and a mechanical 12-tag×position exhaustiveness matrix for the D5 visitor.

## Rules correctness (CR 603.3b)

Per the 2026-07-03 maintainer/user ruling: **C1 ships UNGATED** — it is a bug fix on the always-on legacy ordering path (the gated feature remains C2 from #4904/#4603). Rationale: rules correctness is the project's primary concern; the pre-C1 path could silently auto-order genuinely order-dependent same-event triggers (under-prompt = rules-wrong). C1 is a strict tightening: the direction gate in the parity sweep (`decision_old && !decision_new`) proves no card auto-orders under C1 that prompted before, and the 6 newly-prompting cards (+1 parse-blocked, table below) are measured genuinely order-dependent.

### §7 Full-DB parity sweep: final accounting (sweep GREEN)

**Honesty correction:** step-4 found 0 genuine at SAME-EVENT depth; commit-6's deeper BATCH analysis reclassified Day of the Dragons as genuinely order-dependent. The earlier "0 genuine among the 64" statement was correct for the same-event analysis it was made under and is superseded — not silently revised — by the batch-depth result. **D3's zero-widening premise did not hold at full-corpus scale.**

**Arithmetic:** the pre-allowlist full-DB sweep panicked at exactly **19** unexplained rows: **19 = 18 documented-conservative (17 same-event + 1 batch [Skyfisher Spider]) + 1 GENUINE (Day of the Dragons, batch)**. Skyfisher Spider and Day of the Dragons are both batch-arm diffs but land in DIFFERENT categories: skyfisher's prompt is conservative (owner-misalignment / osseous-class — its owner-ALIGNED co-departure is genuinely auto-safe via sum-symmetry [both the total 2N−1 and the per-copy multiset {1..N} are order-invariant, so even an intermediate "whenever you gain life" observer is order-blind], while the owner-MISaligned case IS order-observable but is correctly prompted by production — see the ledger), DotD's prompt is correct (order genuinely observable even when fully aligned).  After allowlisting, the sweep reports **0 unexplained** and is GREEN.

Measured at the pre-fold series tip (`FORGE_TEST_FULL_DB=1`): `swept=13543 compared=6206`; the four surviving floor metrics plus the removed `srcread`'s measurement `{srcread=0, obs=494, hadcounters=1, retained=285, t1=2871}`. Re-measured after rebase onto current main with a corpus regenerated at the rebased tip (provenance: `client/public/card-data-meta.json`, generator-stamped): zero drift on every gated metric (`swept` +4 benign corpus growth, `t1` −1 with 143 floor margin).

**Intended prompts (category 1) — same-event genuine (6 measured flips + 1 parse-blocked) + batch genuine (1):**

| Card | Depth | Order-dependence proof (one line) |
|------|-------|-----------------------------------|
| ouroboroid | same-event | each copy's `Power{Source}` read is fed by the other's `PutCounterAll` |
| docent of perfection | same-event | token write feeds the shared census threshold — which copy transforms depends on order |
| sidequest: hunt the mark | same-event | token write feeds the shared census threshold |
| promise of tomorrow | same-event | first copy's mass return flips the second's CR 603.4 re-check |
| spawn of mayhem | same-event | damage order across the 10-life threshold decides which copy gets the counter |
| complex automaton | same-event | `ObjectCount{Permanent}` intervening-if read × self-Bounce census overlap |
| your inescapable doom | same-event (parse-blocked) | proven order-dependent in-plan; current parse degrades its counter feed to `Any` so the sweep never forms its group (expected-UNHIT, asserted) |
| **day of the dragons** | **batch** | LTB `Sacrifice{Dragons, count: ObjectCount}` → `ChangeZone{TrackedSet(0) → battlefield}`: each member returns its OWN tracked set and the returned creatures can be Dragons the other member's re-sacrifice consumes (CR 603.3b) — pinned at runtime by `b2_dotd_member_bound_pin` |

**Documented-conservative over-prompt ledger (18)** — mirrors `DOCUMENTED_OVER_PROMPT` in `triggers_ordering_parity_tests.rs` (the source of truth; every entry completeness-asserted at full-DB):

- **L8-held (12), monotone/self-limiting intervening-if (CR 603.4):** chorale of the void, deathbonnet sprout, death of a thousand stings, exile into darkness, glimmer seeker, graf rats, mirror-sigil sergeant, persistent marshstalker, reclusive wight, reveille squad, stensia uprising, stillness in motion. The L8 idempotence recognizer is deliberately NOT built: a wrong recognizer under-prompts (rules-wrong); a conservative prompt is fail-closed (rules-correct).
- **Owner-keyed read × owner-misaligned write (1):** osseous sticktwister (CR 701.21a: sacrifice goes to the OWNER's graveyard; a control-changed permanent you own makes the write-span `Any`).
- **Context-free-unclassifiable singletons (2):** paroxysm (revealed-card read indistinguishable from a board read in the AST), flamewake phoenix (commutes only via runtime source power 2 < 4).
- **Parse-blocked commutes (2):** deep-sea kraken, ichorplate golem (both commute underneath; the mis-parse hides the structure).
- **Owner-misalignment / osseous-class, batch (1):** skyfisher spider — the owner-ALIGNED co-departure is auto-safe via sum-symmetry (total AND per-copy multiset {1..N} order-invariant); the owner-MISaligned case is order-observable (an opp-owned copy dies to its OWNER's graveyard, CR 701.21a/404, so its self-exile no-ops on your gy count) but is correctly prompted by the same count-read × graveyard-write conflict — no under-prompt. Same owner-misalignment meta-class as osseous; the aligned-safety sub-mechanism (sum-symmetry) is distinct from osseous's write-doesn't-feed-read.

**Floors:** re-tuned to full-DB measured values minus 5% corpus-churn tolerance (`batch_obs 494 → ≥469`, `retained_prompt 285 → ≥271`, `t1_source_indep 2871 → ≥2727`, `hadcounters_batch_self ≥1` witnessed by Promising Duskmage); `batch_self_srcread` REMOVED — its cell is empty in-corpus (its old ≥40 population was an artifact of the D5 fail-open hole that commit 3 closed; that freeze-auto class is now counted by `retained_prompt`, and the freeze-auto behavior is pinned by unit discriminators N-A/N-B). Every surviving floor and every ledger entry is mutation-proven non-vacuous (review probe matrix M1–M9: each mutation flips one classifier conjunct → full-DB sweep → the named floor trips or the named assert fails; M4 additionally proved the direction gate — 50 under-prompt rows surfaced, 0 suppressible).

### §8 Review-response (maintainer CHANGES_REQUESTED, 2026-07-04) — two HIGH findings closed + rebase onto v0.15.0

Two [HIGH] maintainer findings were addressed as new commits, then the whole 9-commit series was rebased onto the current `upstream/main` (v0.15.0+, `1badc1920`). The full-DB parity sweep was regenerated and re-run at the rebased head and is **GREEN (0 unexplained)**.

#### HIGH-1 — same-event member-bound trigger-ordering discriminator (commit `b4ec14aa9`, CR 603.3b / 603.10a)

`profiles_conflict`'s same-event fast path auto-ordered any `source_independent` group, but a group of DISTINCT sources whose identical resolution reads per-source bound storage (CR 603.10a look-back — `TrackedSet` / `ExiledBySource` / `ChosenCard`, via `member_bound_target_filter`) is NOT one shared `f(state)`: member A reads A's storage, member B reads B's, so the identical-function commutation proof breaks and the order can be observable. Since same-event order-independence is decided solely by `!same_event_conflict` (no `c2` backstop), this auto-ordered genuinely order-dependent groups. Fix mirrors the batch path's `!reads_member_bound` conjunct at same-event depth: exclude member-bound from the fast-path disjunct + add the fail-closed discriminator `if s.same_event && p.reads_member_bound { return true }`. `all_same_source` stays auto-ordered (shared storage ⇒ `f_A = f_B`); the batch path is byte-inert.

**NOT latent — the sweep caught it.** The fix flips **48** same-event cards auto→prompt (all over-prompt direction — the base engine auto-ordered every same-event group unconditionally, so these can never be under-prompts). Split:

- **6 GENUINE same-event order-dependence** (a NEW honesty category, `SAME_EVENT_MEMBER_BOUND_GENUINE`, exact-set asserted): **mimic vat**, **mirror of life trapping** (imprint-contention — two copies race to imprint the ONE shared triggering creature into their per-source pile, CR 603.10a); **moonring mirror**, **duplicity** (hand-swap re-capture — each copy exiles the shared hand into its own pile then returns its prior pile, A feeds B); **world queller** (shared-pool consumption under per-copy-divergent chosen types, CR 701.21 — genuine on rules grounds; its `reads_member_bound` bit comes from a non-obvious AST carrier, not the surface `IsChosenCreatureType`); **blood tyrant** (genuine via a DIFFERENT axis — a `PutCounter{SelfRef}` self-write whose per-copy split is order-observable when a player hits 0 life between resolutions, CR 704.5a/800.4a; caught incidentally by the member-bound discriminator).
- **Conservative over-prompt CLASS** (member-bound but order-immaterial: disjoint per-source referents, same controller optimizes both). Documented as a **predicate-keyed class** in the sweep (`se_member_bound_class`, keyed `same_event ∧ reads_member_bound ∧ auto→prompt` — the discriminator's own gate), NOT a per-card allowlist: membership is DERIVED + emitted as an evidence artifact, so it is robust to corpus churn. Measured **43** at the rebased corpus (was 42 pre-rebase; the +1 is **ichormoon gauntlet**, a `ChooseCounterKind`/`PutChosenCounter` card the v0.15.0 parser newly surfaced — a conservative counter-add, order-immaterial). A predicate-keyed class was chosen precisely so a corpus-churn member-bound card auto-absorbs without a manual allowlist edit; a 48-name allowlist would have broken the completeness assert at exactly this rebase.

Class floor `se_member_bound_class ≥ 35` (mutation-proof: deleting the discriminator collapses it to 0). `t1_source_indep` measured 2871→2830→2831 (the source-independent slice of the class now prompts instead of auto-ordering; assert ≥2727 unchanged, still passes — an accounted movement, not a floor bump).

#### HIGH-2 — non-phase delayed triggers routed through the CR 603.3b ordering gate (commit `5f109132b`, CR 603.3b / 603.7)

`check_delayed_triggers` (CR 603.7) APNAP-sorted its firing batch then DIRECTLY dispatched, bypassing `begin_trigger_ordering` — so two+ simultaneous same-controller order-dependent non-phase delayed triggered abilities reached the stack in fixed order with no CR 603.3b ordering choice. Pre-existing (byte-identical base↔HEAD); this PR made `begin_trigger_ordering` the sound authority but never wired this path. Fix routes the `to_fire` batch through `begin_trigger_ordering` (the phase-delayed path is the template), preserving every delayed-specific disposition (Good King Mog, Breeches reflexive pause, epic, multi-fire) via the shared `Delayed`-origin dispatcher, plus one `engine_priority` guard to surface the `OrderTriggers` prompt. Pure tightening: singletons and provably-commuting identical no-input groups still auto-order. One integration test (`daretti_emblem_simultaneous_death`) asserted the old direct-dispatch contract for two distinct-target simultaneous returns and is updated to a positive `OrderTriggers` pin.

**Issue #4809 (Braids/Spinal Embrace) is a DISTINCT phase-path seam, not this bug** — `AtNextPhase{End}` is phase-classified and already merged+ordered by the phase path (proven by the existing #5048 test); HIGH-2 neither closes nor regresses it. (Separate empirical follow-up.)

#### Rebase onto v0.15.0 — new-variant exhaustiveness (single adaptation commit `41843f974`)

The rebase surfaced 6 new upstream enum variants in the wildcard-free `ability_rw` dual-walk, all classified per rw-axis with grep-verified CRs (full table in the adaptation commit body): `FilterProp::InTrackedSet` (member-bound — chain tracked-set membership), `Effect::EachSourceDealsDamage` (CR 120), `ChooseCounterKind`/`PutChosenCounter` (member-bound, per-source chosen counter, CR 122.1/122.6), `CreatePlaneswalkReplacement` (deferred body), `ChaosEnsues` (CR 311.7). Corpus regenerated at the rebased head; sweep re-run GREEN.

**Convention note (vs the pre-PR rebase):** the earlier pre-PR rebase folded its 15 new-variant arms into their owning profiler commits (per-commit-compiles). This rebase's arms could NOT be folded that way — three of them depend on engine features born LATER in the series (`CreatePlaneswalkReplacement` uses `pscope`/`chain_move_owner`/the 4-arg `rw_effect` signature from the same_controller commit; `ChooseCounterKind`/`PutChosenCounter` set `reads_member_bound` from the batch-hard commit), so folding would require deliberately-wrong evolving stub arms across three commits. They ship as one honest adaptation commit instead. Per-commit-compiles for c1–c8 was already forfeited by the rebase itself (non-exhaustive vs the new base by construction); the sound bisect build points are the base and HEAD. This is measured necessity, not a convention lapse.

**Corrected arithmetic at the rebased corpus (`b76c53274962cbf0`):** the same-event member-bound bucket = **43 conservative + 6 genuine**; the original batch/same-event ledger (18 over-prompt + 6 cat-1 + 1 DotD genuine) is unchanged. Sweep: `swept=13556 compared=6208 unexplained=0`.

### §8-R4 Review-response (round 4) — same-event event-object feed CLOSED

The round-4 [HIGH] — the same-event gate was not fail-closed for the event-object read/write feed — was accepted (option 1: close the feed) and fixed as commit `53838b08b`, then the full series was rebased onto `4c0ac54f5`.

**The gap:** `read_object_scope` maps `EventSource`/`EventTarget` reads to `reads_event_live`, a bare bool with **no KindSet**, so the `feeds()` kind×kind matrix was structurally blind to a `writes_event_object` mutation feeding an event-object **live** read (CR 608.2h — the read uses the object's current information). Same-event members share ONE live event object, so a member's write is observed by a sibling's live read ⇒ order-observable. The batch path was NOT holed (asymmetry, not a symmetric miss): a co-departure batch event object has DEPARTED and is frozen LKI (CR 603.10a) — a write no-ops or trips the freeze-invalidation row.

**The fix (CR 603.3b / 608.2h):** new shared predicate `reads_and_writes_event_object() = reads_event_live && writes_event_object.any()` — a **conjunction**, derived not copied (the batch guard is a disjunction-of-negations because refusing a fast path only defers; a prompt-returning discriminator must witness a real feed = both endpoints). Same-event T1 fast-path `source_independent` branch gains the exclusion; new discriminator `if s.same_event && s.event_object_present && reads_and_writes_event_object() { return true }` after the member-bound row. Gated on `event_object_present` (mirrors `effective_external`: a write to a non-present event object no-ops per targeting.rs, so Phase-mode triggers stay auto — the gate can only drop vacuous prompts, zero under-prompt risk). `all_same_source` stays auto (identical f over one shared object); both edits `s.same_event`-guarded ⇒ batch byte-inert.

**Sweep: +13 same-event flips, all over-prompt direction, 0 GENUINE** (`SAME_EVENT_EVENT_OBJECT_GENUINE` ships EMPTY, exact-set asserted; `se_event_object_class=13`, predicate-keyed, membership derived + emitted, floor ≥9 mutation-proof, disjointness vs `se_member_bound_class` asserted). **Governing theorem** (why R4 has 0 genuine where R3 had 6): every R4 write targets the SHARED event object — k identical fs on one shared object compose to the same final state under every permutation (relabel-invariant) — while R3's genuine members wrote to PER-SOURCE storage (imprint pile A ≠ pile B), an order-divergent destination. The 13: 7 frozen-context reads (`EventContextAmount`/`EventOutcomeWon` — a write cannot feed a frozen amount), idempotent shared-object writes (untap/exile/destroy, CR 701.26a/26b/608.2b), additive-commutative counters. Per-card both-orders traces in the classification artifact. `sidequest: catch a fish` sits OUTSIDE the class by the `event_object_present` conjunct (Phase-mode, no live event object, write provably no-ops) — excluded, not missed.

**Claims-consistency (the R4 failure mode was a doc-vs-code gap):** the module doc now records the direct event-object feed as CLOSED at both depths, and enumerates the two residuals that REMAIN — the source-actor granted-state channel and a board-wide `writes_external` × event-live-read channel — both **SYMMETRIC across batch and same-event depths**. The `group_is_order_independent` contract comment now states exactly this: never auto-orders order-dependence visible in the profiled read/write sets; sound modulo two profile-invisible symmetric residuals.

**Second rebase (onto `4c0ac54f5`):** pure base-move, all 11 commits `=` in the range-diff; no new enum variants ⇒ no dual-walk breaks. #5088 (World-rule SBA, CR 704.5k) implements the rule cited for winter's night's practical unreachability — explicitly re-verified: the sweep uses structural reachability, winter's night remains a class member. Sweep at the fresh corpus: **zero movement** on every count vs pre-rebase.

### §8-R5 Review-response (round 5) — caller-level regression test + C2-ungating adoption

**R5-1 (the round-5 [HIGH], commit `83bb4084a`, test-only):** a production-path regression test now pins the R4 discriminator at the `group_is_order_independent` CALLER level (where `event_object_present` is threaded from the real pending trigger event) — distinct sources on one shared event object with an `EventSource`/`EventTarget` live read + a `TriggeringSource` event-object write ⇒ NOT order-independent; guard cases (read-only ⇒ auto, write-only/no-event-object ⇒ auto, all-same-source ⇒ auto) prove the discriminator rather than a blanket prompt. Revert-to-red measured at the caller level: disabling the discriminator reds the positive case.

**R5-2 (commit `01580f3bf`): adopting upstream #5084's C2-ungating surfaced a LATENT SERIES BUG, now fixed.** #5084 removed the loop-detection gate from the C2 finite-ordering term (maintainer rationale: loop detection governs infinite-combo shortcutting, not finite CR 603.3b ordering UX). Applying it verbatim turned two of this series' own discriminating NEGs red (`condition1_dodecapod_mixed_controller_still_prompts`, `b1_mindslicer_uniformity_gate`): the coarse `ability_scan`-computed C2 term is structurally blind to the source-actor residual, and as a disjunct it could OVERRIDE the precise batch/uniformity prompt for a Mixed-controller co-departure — a genuine under-prompt (the Dodecapod cause-source-controller channel). This was latent in the series all along (reachable only under loop-ON, which the NEGs never exercised); the ungating made it default-path. Fix: the C2 term becomes `c2_order_independent && !batch_conflict` — a precision-dominance rule (the coarse walker may auto-order only when the precise profiler agrees). This is NOT a revert of #5084: the loop-ungating stands, and #5084's own `pr625_c2` fan-out behavior is preserved (its group has `batch_conflict=false`); review-impl confirmed the conjunct is sound everywhere (a real co-departure batch never reaches the C2 term; for non-co-departure groups the conjunct is strictly more conservative). Revert-to-red: the bare `c2` form re-reds both NEGs; the conjunct form is 5/5 green.

**Third rebase (onto `cf7cd7cb9`, resolving the #5084 conflict):** range-diff 10/12 `=`; commit-2 `!` = the C1 conflict resolution retains that commit's own gated form with the ungating applied at the tail commit (HEAD adopts #5084); HIGH-2 `!` = context-line only (visibility bump). #5084's stack.rs self-counter batching was classified orthogonal to the gate (resolution-time, same-source, checkpoint-proven sequential-equivalent — triggers are already ordered before they reach the stack). #5090 adds no enum variant; corpus regenerated; sweep zero-movement (table above).

## Review summary

- Cumulative adversarial review over the whole series diff: **SHIP** — no new under-prompt exists (direction gate provably routes any under-prompt to the asserted-empty `unexplained`); ~50 CR annotations grep-verified in review; one CR-citation nit fixed in-series (§L6 now cites CR 303.4d "an Aura can't enchant itself" + CR 301.5c "an Equipment can't equip itself").
- R3 review-response (§8): both HIGH fixes ran the full pipeline (HIGH-1: classification verdicts → impl → adversarial review-impl APPROVE, both edits independently revert-to-red; HIGH-2: plan → plan verification → impl → review-impl APPROVE, Paused/Breeches idempotence proven by construction + 4 named discriminating tests; §F runtime revert-to-red pins prompt AND post-order resolution).
- R4 review-response (§8-R4): full pipeline (derived-shape checkpoint → impl → sweep + per-card classification → adversarial review-impl APPROVE 13/13 with claims-consistency as an explicit checklist item; discriminator revert-to-red measured).
- Follow-up filed: #5073 — wire the FORGE_TEST_FULL_DB sweep into a CI/release gate (default CI runs the fixture subset only).

## Combo-detector series

| Pos | PR | Delivers |
|-----|----|----------|
| PR-0 | #4092 | `ResourceVector` + modulo-resource loop equality (additive). |
| PR-1 | #4097 | Analysis sim harness feeding `ResourceVector`. |
| PR-2 | #4119 | Net-progress `detect_loop` → `LoopCertificate` + corpus harness. |
| PR-3 | #4480 | Live mandatory-loop winner shortcut (drain-cascade, CR 704.5a). |
| PR-4a | #4493 | Engine B static ability-graph extractor (scaffold + 5 families + SCC). |
| PR-4b | #4534 | Engine B effect/trigger breadth + life-symmetry cost. |
| PR-5 | #4547 | `cargo combo-verify` CLI over the 53-row corpus. |
| PR-6 | #4603 | `∞` unbounded-resource display — generalize infinite-mana to the whole `ResourceAxis` class (engine-owned `DerivedViews` projection). |
| PR-6.25 | (deferred R3) | Order-independence soundness fix for `group_is_order_independent` (latent CR 603.3b). Notes: `PR-6.25-DEFERRED-FINDINGS.md`. |
| PR-6.5 | #4904 | Growing-cascade detector for multiplayer win-acceleration (ω-coverability modulo growth) + C0 fail-closed walker + C2 gated order-independent auto-resolve. Notes: `PR-6.5-EPIC-GROWING-CASCADE.md`. |
| **PR-6.75 (this PR)** | **—** | **C0-full + C1 precision pass — `ability_rw` read/write conflict-profile module, latent CR 603.3b same-event fix, ungated per maintainer ruling.** |

**Predecessor: PR-6.5 — #4904 — https://github.com/phase-rs/phase/pull/4904** — delivered the C0 fail-closed walker skeleton and the C2 gated auto-resolve; this PR completes C0 to full read/write profiling and ships C1, turning the walker's classifications into the sound same-event ordering gate.

Related: #4603 (C2 gating policy), #4990 (S07 series whose `subject_slot` field is classified member-bound here).

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
