### PR TITLE
Remove resolved root31 backlog entries

### DIFF
--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 31
-- **Distinct cards implicated:** 4813
-- **Total card appearances across root causes:** 4847 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4811
+- **Total card appearances across root causes:** 4845 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -42,7 +42,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 28 | Trigger/activation timing or ordinal restriction dropped | 20 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
 | 29 | Disjunctive mana ability split into two Fixed abilities | 18 | oracle parser mana-ability handling — emit AnyOneColor{color_options} for 'Add A or B' |
 | 30 | Token/named-card name corrupted by normalization or overrun | 18 | oracle_util.rs SELF_REF normalization + Named-filter parsing — guard literal 'named X' spans |
-| 31 | Other / uncategorized misparse | 3 | manual triage |
+| 31 | Other / uncategorized misparse | 1 | manual triage |
 
 > The top **5** root causes cover ~50% of all misparse appearances; the top 10 cover the overwhelming majority. Fix these first.
 
@@ -5218,7 +5218,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 31. Other / uncategorized misparse  (3 cards)
+### 31. Other / uncategorized misparse  (1 card)
 
 **Signature.** Cluster did not match a canonical signature class.
 
@@ -5227,7 +5227,5 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 <details><summary>Cards</summary>
 
 - Flaccify
-- Rush of Dread
-- The Goose Mother
 
 </details>


### PR DESCRIPTION
## Summary

- Remove stale root-31 backlog entries for Rush of Dread and The Goose Mother.
- Update root-31 and global backlog counts to leave Flaccify as the only remaining uncategorized root-31 card.

## Files changed

- `docs/parser-misparse-backlog.md`

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan -> review-plan -> implement -> review-impl -> commit)
- [x] **Not** `/engine-implementer` - docs-only backlog cleanup; this PR does not change engine or parser logic.

If you did **not** use `/engine-implementer`, state why:

> Docs-only backlog pruning after verifying the referenced cards against the current parser output.

## CR references

None. This PR only updates parser-backlog documentation.

## Track

Developer

## LLM

Model: Codex
Thinking: high

## Current parser evidence

PR head: `cdb0db0e404ecb4e547adff51f179049a2267098`.

I built `oracle-gen` from this PR head in the ship worktree using the shared target directory, then ran the resulting binary from the main checkout so it could read the local gitignored MTGJSON payload:

```bash
/home/ntindle/code/phase/target/debug/oracle-gen data --filter "flaccify|rush of dread|the goose mother" --output /tmp/phase-root31-current-5076.json
```

The export contained exactly these keys:

```text
flaccify
rush of dread
the goose mother
```

Current parse results:

- Rush of Dread: 0 parse warnings, 3 spell abilities, no `Unimplemented` abilities. The three mode effects parse as `Sacrifice`, `Discard`, and `LoseLife`; each half quantity uses `DivideRounded` with `rounding: Up`.
- The Goose Mother: 0 parse warnings, 2 triggers, no unknown triggers. The ETB Food-token trigger uses `DivideRounded` over `CostXPaid` with `rounding: Up`; the attack trigger parses as `Attacks`.
- Flaccify: still one `Unimplemented` spell ability, `name: "unless_payment"`, description `Counter target spell unless its controller pays {3}{½}`. This remains in root 31 because the current mana-cost model has no half-mana representation.

## Verification

- `oracle-gen` targeted export for `flaccify|rush of dread|the goose mother` - clean export written to `/tmp/phase-root31-current-5076.json`.
- `jq` inspection of the export confirmed only Flaccify remains unsupported among the three root-31 cards.
- `git diff --check` - clean.

## Scope Expansion

None.
