### PR TITLE
fix(engine): control effects don't end when a player leaves the game (CR 800.4a / 702.26k)

### DIFF
--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -74,6 +74,12 @@ pub fn eliminate_players_simultaneously(
         return;
     }
 
+    // CR 800.4a: after ALL owned-exiles, end control effects the leaving players
+    // control and exile anything still under a leaver's control. Runs ONCE over
+    // the full `leaving_set` — the retain+sweep scope is what makes a co-leaver's
+    // steal of a survivor's object revert instead of being over-exiled.
+    end_control_effects_for_leaving_players(state, &leaving_set, events);
+
     // CR 704.3 + CR 104.4a: a SINGLE game-over check after all simultaneous
     // eliminations — so a finish where every remaining player lost at once
     // resolves to a draw (`winner: None`) rather than a spurious winner.
@@ -293,8 +299,10 @@ fn exile_owned_objects_on_player_left_game(
     player: PlayerId,
     events: &mut Vec<GameEvent>,
 ) {
-    let zones = [
-        Zone::Battlefield,
+    // CR 702.26k: phased-out permanents owned by a leaving player also leave the
+    // game; zone_object_ids(Battlefield) filters is_phased_in (targeting.rs:2009),
+    // so the battlefield leg iterates state.battlefield UNFILTERED.
+    let non_battlefield_zones = [
         Zone::Graveyard,
         Zone::Hand,
         Zone::Library,
@@ -302,14 +310,80 @@ fn exile_owned_objects_on_player_left_game(
         Zone::Command,
         Zone::Stack,
     ];
-    let mut to_exile: Vec<_> = zones
-        .into_iter()
-        .flat_map(|zone| super::targeting::zone_object_ids(state, zone))
+    let mut to_exile: Vec<_> = state
+        .battlefield
+        .iter()
+        .copied()
+        .chain(
+            non_battlefield_zones
+                .into_iter()
+                .flat_map(|zone| super::targeting::zone_object_ids(state, zone)),
+        )
         .filter(|id| state.objects.get(id).is_some_and(|obj| obj.owner == player))
         .collect();
     to_exile.sort_by_key(|id| id.0);
     to_exile.dedup();
 
+    for id in to_exile {
+        let req = crate::game::zone_pipeline::ZoneMoveRequest::player_left_game(id, Zone::Exile);
+        crate::game::zone_pipeline::move_object(state, req, events);
+    }
+}
+
+/// CR 800.4a: End every control effect that gives a LEAVING player control of an
+/// object, then exile anything still controlled by a leaver. Runs ONCE after all
+/// per-player owned-exiles, over the full `leaving_set`, so a co-leaver's steal of
+/// a survivor's object reverts symmetrically rather than being over-exiled by the
+/// per-player pass.
+fn end_control_effects_for_leaving_players(
+    state: &mut GameState,
+    leaving_set: &HashSet<PlayerId>,
+    events: &mut Vec<GameEvent>,
+) {
+    use crate::types::ability::ContinuousModification;
+    use crate::types::identifiers::ObjectId;
+
+    // CR 800.4a: any effect giving a LEAVING player control of an object ends.
+    // Prune every single-mod ChangeController TCE controlled by any leaver, over
+    // the FULL leaving_set (symmetric with the sweep below), so a co-leaver's
+    // steal of a survivor's object reverts rather than being over-exiled.
+    state.transient_continuous_effects.retain(|e| {
+        !(leaving_set.contains(&e.controller)
+            && e.modifications
+                .iter()
+                .any(|m| matches!(m, ContinuousModification::ChangeController)))
+    });
+
+    // CR 613.1b: recompute layers so control reverts to base_controller/owner for
+    // every object whose control TCE was pruned. evaluate_layers is pure (no events).
+    super::layers::mark_layers_full(state);
+    super::layers::evaluate_layers(state);
+
+    // CR 800.4a: "if there are any objects still controlled by that player, those
+    // objects are exiled" — e.g. an object whose base_controller reverted to a
+    // leaver ("enters under [leaver]'s control", zones.rs:1172) with no surviving
+    // control effect. Sweep only PHASED-IN battlefield objects: evaluate_layers
+    // above skips phased-OUT permanents (CR 702.26b — layers.rs:1602/1613-1615
+    // only reset controller for phased-in ids), so a survivor-OWNED permanent
+    // phased-out while stolen by a leaver still reads obj.controller == leaver
+    // after the re-derive. Such a permanent must stay frozen (CR 702.26b) and
+    // revert to its owner when it phases back in — it must NOT be exiled here. A
+    // leaver-OWNED phased-out permanent is already exiled by step 1 (the CR
+    // 702.26k unfiltered owned-exile leg), so restricting to phased-in objects
+    // loses no required exile. (step-1-exiled objects are already gone, so no
+    // already-exiled id reaches move_object.)
+    let mut to_exile: Vec<ObjectId> = state
+        .battlefield_phased_in_ids()
+        .into_iter()
+        .filter(|id| {
+            state
+                .objects
+                .get(id)
+                .is_some_and(|obj| leaving_set.contains(&obj.controller))
+        })
+        .collect();
+    to_exile.sort_by_key(|id| id.0);
+    to_exile.dedup();
     for id in to_exile {
         let req = crate::game::zone_pipeline::ZoneMoveRequest::player_left_game(id, Zone::Exile);
         crate::game::zone_pipeline::move_object(state, req, events);
@@ -1330,5 +1404,354 @@ mod tests {
                 winner: Some(PlayerId(1))
             }
         ));
+    }
+
+    // --- CR 800.4a: control effects end when a player leaves the game ---
+
+    use crate::types::ability::{ContinuousModification, Duration, TargetFilter};
+
+    fn setup_four_player() -> GameState {
+        let mut state = GameState::new(FormatConfig::free_for_all(), 4, 42);
+        state.turn_number = 1;
+        state
+    }
+
+    /// Create a battlefield object owned by `owner` and give `controller` control
+    /// of it via a real ChangeController TCE (mirrors gain_control.rs). Evaluates
+    /// layers so `obj.controller` reflects the effect. Returns the object id.
+    fn create_controlled_object(
+        state: &mut GameState,
+        owner: PlayerId,
+        controller: PlayerId,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(1),
+            owner,
+            "Stolen Bear".to_string(),
+            Zone::Battlefield,
+        );
+        state.add_transient_continuous_effect(
+            id,
+            controller,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id },
+            vec![ContinuousModification::ChangeController],
+            None,
+        );
+        super::super::layers::mark_layers_full(state);
+        super::super::layers::evaluate_layers(state);
+        id
+    }
+
+    fn controller_of(state: &GameState, id: ObjectId) -> PlayerId {
+        state.objects.get(&id).unwrap().controller
+    }
+
+    /// (a) Dynamic control reverts on a single leave: survivor P0 owns O, a TCE
+    /// gives leaver P1 control. Eliminating P1 must prune the TCE and revert O to
+    /// P0 — O stays on the battlefield, not exiled. Reverting the fix (never
+    /// pruning the TCE) leaves O.controller == P1 stuck under an absent player and
+    /// then step-4 exiles it, so `battlefield.contains(&o) && controller == P0`
+    /// both flip.
+    #[test]
+    fn control_effect_reverts_when_controller_leaves() {
+        let mut state = setup_three_player();
+        let o = create_controlled_object(&mut state, PlayerId(0), PlayerId(1));
+        assert_eq!(controller_of(&state, o), PlayerId(1));
+
+        let mut events = Vec::new();
+        eliminate_player(&mut state, PlayerId(1), &mut events);
+
+        assert!(
+            state.battlefield.contains(&o),
+            "survivor's object must remain on the battlefield after its thief leaves"
+        );
+        assert!(!state.exile.contains(&o));
+        assert_eq!(
+            controller_of(&state, o),
+            PlayerId(0),
+            "control reverts to the surviving owner (CR 800.4a + CR 613.1b)"
+        );
+    }
+
+    /// (a2) Aura/Mind-Control-style control reverts via owned-exile: P1 owns a
+    /// control-granting permanent (Aura) that gives P1 control of survivor P0's
+    /// creature C. Eliminating P1 exiles the Aura (step 1, owner=P1) which removes
+    /// its TCE source; the retain sweep drops the TCE and C reverts to P0.
+    #[test]
+    fn control_aura_reverts_when_owner_leaves() {
+        let mut state = setup_three_player();
+        // Survivor P0's creature.
+        let c = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Survivor Creature".to_string(),
+            Zone::Battlefield,
+        );
+        // P1's control Aura on the battlefield.
+        let aura = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Control Magic".to_string(),
+            Zone::Battlefield,
+        );
+        // Aura gives P1 control of C.
+        state.add_transient_continuous_effect(
+            aura,
+            PlayerId(1),
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: c },
+            vec![ContinuousModification::ChangeController],
+            None,
+        );
+        super::super::layers::mark_layers_full(&mut state);
+        super::super::layers::evaluate_layers(&mut state);
+        assert_eq!(controller_of(&state, c), PlayerId(1));
+
+        let mut events = Vec::new();
+        eliminate_player(&mut state, PlayerId(1), &mut events);
+
+        assert!(state.exile.contains(&aura), "P1's Aura is owned-exiled");
+        assert!(
+            state.battlefield.contains(&c),
+            "survivor's creature stays in play"
+        );
+        assert_eq!(controller_of(&state, c), PlayerId(0));
+    }
+
+    /// (b) Step-1 owned-exile + hostile negative. O is owned by the LEAVER P1 but
+    /// controlled by survivor P0 via a TCE → O is exiled by step-1 owned-exile.
+    /// Hostile: O2 owned by a LIVING third player P2, controlled by survivor P0 →
+    /// eliminating P1 must NOT exile O2 and must NOT disturb its controller.
+    #[test]
+    fn leaver_owned_but_survivor_controlled_is_exiled_living_owned_is_not() {
+        let mut state = setup_three_player();
+        // O: owned by leaver P1, controlled by survivor P0.
+        let o = create_controlled_object(&mut state, PlayerId(1), PlayerId(0));
+        assert_eq!(controller_of(&state, o), PlayerId(0));
+        // O2: owned by living P2, controlled by survivor P0.
+        let o2 = create_controlled_object(&mut state, PlayerId(2), PlayerId(0));
+        assert_eq!(controller_of(&state, o2), PlayerId(0));
+
+        let mut events = Vec::new();
+        eliminate_player(&mut state, PlayerId(1), &mut events);
+
+        assert!(
+            state.exile.contains(&o),
+            "object owned by the leaver leaves the game (step 1)"
+        );
+        assert!(!state.battlefield.contains(&o));
+        assert!(
+            state.battlefield.contains(&o2),
+            "object owned by a LIVING player must not leave the game"
+        );
+        assert_eq!(
+            controller_of(&state, o2),
+            PlayerId(0),
+            "a living player's control effect is untouched by an unrelated departure"
+        );
+    }
+
+    /// (g) Step-4 controller-leg — the reachable CR-800.4a step-3 exile. A
+    /// survivor-owned object whose `base_controller` is the leaver P1 (entered
+    /// under P1's control, zones.rs:1172) with NO surviving control TCE. After the
+    /// leaver leaves, layer re-derivation resets controller to base_controller ==
+    /// P1, and the step-4 sweep exiles it. Reverting the sweep leaves O on the
+    /// battlefield under an absent controller, so `exile.contains(&o)` flips.
+    #[test]
+    fn base_controller_reverts_to_leaver_then_step4_exiles() {
+        let mut state = setup_three_player();
+        let o = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Entered Under P1".to_string(),
+            Zone::Battlefield,
+        );
+        // Enters under P1's control: sets base_controller = controller = P1.
+        let mut events = Vec::new();
+        crate::game::zones::apply_battlefield_entry_controller_override(
+            &mut state,
+            &mut events,
+            o,
+            PlayerId(1),
+        );
+        super::super::layers::mark_layers_full(&mut state);
+        super::super::layers::evaluate_layers(&mut state);
+        assert_eq!(controller_of(&state, o), PlayerId(1));
+
+        let mut events = Vec::new();
+        eliminate_player(&mut state, PlayerId(1), &mut events);
+
+        assert!(
+            state.exile.contains(&o),
+            "an object still controlled by the leaver (via base_controller) is exiled (CR 800.4a)"
+        );
+        assert!(!state.battlefield.contains(&o));
+    }
+
+    /// (c) CR 702.26k: a phased-OUT permanent owned by the leaver leaves the game.
+    /// Pre-fix the battlefield leg used zone_object_ids which filters is_phased_in,
+    /// so this object was skipped; the unfiltered iteration exiles it.
+    #[test]
+    fn phased_out_owned_permanent_leaves_the_game() {
+        use crate::game::game_object::{PhaseOutCause, PhaseStatus};
+        let mut state = setup_three_player();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Phased Bear".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&id).unwrap().phase_status = PhaseStatus::PhasedOut {
+            cause: PhaseOutCause::Directly,
+        };
+        assert!(!state.objects.get(&id).unwrap().is_phased_in());
+
+        let mut events = Vec::new();
+        eliminate_player(&mut state, PlayerId(1), &mut events);
+
+        assert!(
+            !state.battlefield.contains(&id),
+            "phased-out permanent owned by the leaver must leave the battlefield (CR 702.26k)"
+        );
+        assert!(state.exile.contains(&id));
+    }
+
+    /// (d) An unrelated survivor's own creature and control effects are untouched
+    /// when a different, uninvolved player leaves.
+    #[test]
+    fn uninvolved_survivor_creature_untouched() {
+        let mut state = setup_three_player();
+        // P0 owns a plain creature it controls itself.
+        let own = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "P0 Bear".to_string(),
+            Zone::Battlefield,
+        );
+        let tce_count_before = state.transient_continuous_effects.len();
+
+        let mut events = Vec::new();
+        eliminate_player(&mut state, PlayerId(2), &mut events);
+
+        assert!(state.battlefield.contains(&own));
+        assert_eq!(controller_of(&state, own), PlayerId(0));
+        assert_eq!(
+            state.transient_continuous_effects.len(),
+            tce_count_before,
+            "no control effect is pruned when an uninvolved player leaves"
+        );
+    }
+
+    /// (e) 2HG idempotency: an entire team leaves; each teammate's owned object is
+    /// exiled exactly once (no double move_object / panic) and the other team wins.
+    #[test]
+    fn two_headed_giant_team_leaves_idempotent() {
+        let mut state = setup_2hg();
+        // Team A = {P0, P1}; Team B = {P2, P3} (free-for-all pairing in 2HG setup).
+        let o0 = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "A0 Bear".to_string(),
+            Zone::Battlefield,
+        );
+        let o1 = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "A1 Bear".to_string(),
+            Zone::Battlefield,
+        );
+
+        let mut events = Vec::new();
+        eliminate_players_simultaneously(&mut state, &[PlayerId(0), PlayerId(1)], &mut events);
+
+        assert!(state.exile.contains(&o0));
+        assert!(state.exile.contains(&o1));
+        // Exiled exactly once each (no duplicate ids in exile).
+        assert_eq!(state.exile.iter().filter(|&&x| x == o0).count(), 1);
+        assert_eq!(state.exile.iter().filter(|&&x| x == o1).count(), 1);
+        assert!(matches!(state.waiting_for, WaitingFor::GameOver { .. }));
+    }
+
+    /// (f) The hoist test (round-2 blocker). Co-leavers P1 < P2. Survivor P0 owns
+    /// S, controlled by the HIGHER-id co-leaver P2 via a TCE. Eliminating [P1, P2]
+    /// simultaneously must revert S to P0 and keep it on the battlefield. Under a
+    /// per-player structure the retain/sweep would run inside each do_eliminate:
+    /// when P1 is processed, P2's TCE is still live (S controlled by P2, a leaver)
+    /// and the per-P1 sweep would over-exile S. Hoisting the retain+sweep to run
+    /// ONCE over the full leaving_set is what lets S survive.
+    #[test]
+    fn hoisted_sweep_survivor_object_controlled_by_higher_id_coleaver_survives() {
+        let mut state = setup_four_player();
+        // Survivor P0 owns S; higher-id co-leaver P2 controls it.
+        let s = create_controlled_object(&mut state, PlayerId(0), PlayerId(2));
+        assert_eq!(controller_of(&state, s), PlayerId(2));
+
+        let mut events = Vec::new();
+        eliminate_players_simultaneously(&mut state, &[PlayerId(1), PlayerId(2)], &mut events);
+
+        assert!(
+            state.battlefield.contains(&s),
+            "survivor's object must survive when a co-leaver controlled it (hoist)"
+        );
+        assert!(!state.exile.contains(&s));
+        assert_eq!(
+            controller_of(&state, s),
+            PlayerId(0),
+            "control reverts to the surviving owner P0"
+        );
+    }
+
+    /// (h) Step-4 phased-out survivor guard. Survivor P0 OWNS a permanent that a
+    /// leaver P1 stole via a ChangeController TCE, and it is then phased OUT.
+    /// evaluate_layers skips phased-out permanents (CR 702.26b), so after the TCE
+    /// is pruned and layers re-derive, obj.controller is NOT reset and still reads
+    /// P1. A raw-battlefield step-4 sweep (pre-fix) would then over-EXILE this
+    /// survivor-owned permanent. Restricting the sweep to battlefield_phased_in_ids
+    /// leaves it frozen on the battlefield (it will revert to P0 on phase-in).
+    /// Revert the fix (raw state.battlefield sweep) and this object gets exiled,
+    /// flipping `battlefield.contains(&o)` and `!exile.contains(&o)`.
+    #[test]
+    fn phased_out_survivor_owned_stolen_permanent_not_over_exiled() {
+        use crate::game::game_object::{PhaseOutCause, PhaseStatus};
+        let mut state = setup_three_player();
+        // Survivor P0 OWNS the permanent; leaver P1 controls it via a TCE.
+        let o = create_controlled_object(&mut state, PlayerId(0), PlayerId(1));
+        assert_eq!(controller_of(&state, o), PlayerId(1));
+
+        // Phase it OUT while stolen. Layers freeze it (CR 702.26b): the controller
+        // field is not reset by evaluate_layers, so it stays == P1 (the leaver).
+        state.objects.get_mut(&o).unwrap().phase_status = PhaseStatus::PhasedOut {
+            cause: PhaseOutCause::Directly,
+        };
+        assert!(!state.objects.get(&o).unwrap().is_phased_in());
+        assert_eq!(
+            controller_of(&state, o),
+            PlayerId(1),
+            "phased-out permanent keeps its stale (leaver) controller — evaluate_layers skips it"
+        );
+
+        let mut events = Vec::new();
+        eliminate_player(&mut state, PlayerId(1), &mut events);
+
+        // The survivor-owned, phased-out permanent must NOT be over-exiled by the
+        // step-4 sweep: it stays frozen on the battlefield (CR 702.26b) and will
+        // revert to its owner P0 when it phases back in.
+        assert!(
+            state.battlefield.contains(&o),
+            "survivor-owned phased-out permanent must stay on the battlefield, not be over-exiled"
+        );
+        assert!(
+            !state.exile.contains(&o),
+            "survivor-owned phased-out permanent must not be exiled by the step-4 sweep"
+        );
     }
 }

--- a/crates/engine/tests/integration/issue_3289_oft_nabbed_goat.rs
+++ b/crates/engine/tests/integration/issue_3289_oft_nabbed_goat.rs
@@ -92,9 +92,17 @@ fn oft_nabbed_goat_controller_cannot_activate() {
 fn oft_nabbed_goat_opponent_activates_at_sorcery_speed() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
+    // Toughness 2 so the ability's self-inflicted -1/-1 counter (below) leaves the
+    // goat a 1/1 survivor rather than a 0/0 that dies as an SBA (CR 704.5f) — the
+    // test asserts the surviving goat is under the opponent's control.
     let goat = scenario
-        .add_creature_from_oracle(P0, "Oft-Nabbed Goat", 1, 1, GOAT_ORACLE)
+        .add_creature_from_oracle(P0, "Oft-Nabbed Goat", 2, 2, GOAT_ORACLE)
         .id();
+    // The ability's "Draw a card" is resolved by the activating opponent P1. Give
+    // P1 a library card so that draw does not empty their (default-empty) library
+    // and lose them the game (CR 704.5b) — an eliminated P1 would have its gained
+    // control of the goat end (CR 800.4a), which is not what this test exercises.
+    scenario.add_card_to_library_top(P1, "Plains");
 
     let mut runner = scenario.build();
     runner.state_mut().active_player = P1;


### PR DESCRIPTION
## Summary
When a player leaves a multiplayer/Commander game, `do_eliminate` never ended control effects that gave the leaver control of other players' objects (CR 800.4a), so a stolen permanent (Agent of Treachery, Mind Control, ~122 GainControl cards) stayed under the absent player's control forever; it also missed phased-out permanents owned by the leaver (CR 702.26k). Adds the CR 800.4a control-end cleanup (run once over the full leaving set) plus a phase-inclusive owned-object sweep.

## Files changed
- crates/engine/src/game/elimination.rs
- crates/engine/tests/integration/issue_3289_oft_nabbed_goat.rs

## CR references
CR 800.4a, CR 702.26k, CR 702.26b, CR 613.1b

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine --all-targets -- -D warnings` — clean
- `cargo test -p engine` — full suite pass / 0 fail (34 elimination tests incl. 9 new)
- 9 revert-failing scenario tests through `eliminate_player`/`eliminate_players_simultaneously` (dynamic control reverts; control-Aura reverts via owned-exile; base-controller-reverts-to-leaver exiled; phased-out owned leaves; co-leaver over-exile guard; phased-out survivor-owned not over-exiled; etc.)
- Also corrects the Oft-Nabbed Goat integration fixture, which relied on the pre-fix bug (an eliminated opponent keeping control of the stolen goat).
- `gen-card-data` / `coverage` / `semantic-audit` — N/A: engine-runtime rules fix (elimination path), no card parsing changed.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
