### PR TITLE
fix(parser): protect card-named literals during normalization

### DIFF
--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1579,6 +1579,32 @@ fn unmask_ring_tempts_you_phrase(text: String) -> String {
 }
 
 const KEYWORD_ACTION_PLACEHOLDER: &str = "\u{E0001}";
+const CARD_NAMED_LITERAL_PLACEHOLDER: &str = "\u{E0002}";
+
+const CARD_NAMED_LITERAL_PREFIXES: &[&str] = &["card named ", "cards named "];
+const CARD_NAMED_LITERAL_TERMINATORS: &[&str] = &[
+    " and a card named ",
+    " and cards named ",
+    " or a card named ",
+    " or cards named ",
+    " onto ",
+    " into ",
+    " from ",
+    " in ",
+    " was ",
+    " this turn",
+    " this game",
+    ":",
+    ", reveal ",
+    ", put ",
+    ", sacrifice ",
+    ", then ",
+    ", you ",
+    ", it ",
+    ", that ",
+    ", this ",
+    ".",
+];
 
 /// CR 701.40a / CR 701.58a / CR 701.62a: A handful of cards are *named* after a
 /// keyword action ("Manifest Dread" → "Manifest dread.", "Cloak" → "Cloak …").
@@ -1652,6 +1678,69 @@ fn unmask_card_name_keyword_action(text: String, originals: &[String]) -> String
     result
 }
 
+fn next_card_named_literal_prefix(lower: &str) -> Option<(usize, usize)> {
+    CARD_NAMED_LITERAL_PREFIXES
+        .iter()
+        .flat_map(|prefix| {
+            lower
+                .match_indices(prefix)
+                .map(move |(idx, _)| (idx, prefix.len()))
+        })
+        .filter(|(idx, _)| {
+            *idx == 0 || !lower.as_bytes()[idx.saturating_sub(1)].is_ascii_alphanumeric()
+        })
+        .min_by_key(|(idx, _)| *idx)
+}
+
+fn card_named_literal_span_len(lower: &str) -> usize {
+    CARD_NAMED_LITERAL_TERMINATORS
+        .iter()
+        .filter_map(|terminator| lower.match_indices(terminator).next().map(|(idx, _)| idx))
+        .min()
+        .unwrap_or(lower.len())
+}
+
+/// CR 201.2 / CR 201.5: the text after "card(s) named ..." is a literal card
+/// name, not a self-reference to the source card. Mask only that literal name
+/// span while `normalize_card_name_refs` runs so first-word fallback cannot
+/// rewrite cards like Emerald Collector's "Mox Emerald" into "Mox ~".
+fn mask_card_named_literal_spans(text: &str) -> (String, Vec<String>) {
+    let lower = text.to_ascii_lowercase();
+    let mut masked = String::with_capacity(text.len());
+    let mut originals = Vec::new();
+    let mut rest = text;
+    let mut lower_rest = lower.as_str();
+
+    while let Some((idx, prefix_len)) = next_card_named_literal_prefix(lower_rest) {
+        let name_start = idx + prefix_len;
+        let name_len = card_named_literal_span_len(&lower_rest[name_start..]);
+        if name_len == 0 {
+            masked.push_str(&rest[..name_start]);
+            rest = &rest[name_start..];
+            lower_rest = &lower_rest[name_start..];
+            continue;
+        }
+
+        let name_end = name_start + name_len;
+        masked.push_str(&rest[..name_start]);
+        masked.push_str(CARD_NAMED_LITERAL_PLACEHOLDER);
+        originals.push(rest[name_start..name_end].to_string());
+        rest = &rest[name_end..];
+        lower_rest = &lower_rest[name_end..];
+    }
+
+    masked.push_str(rest);
+    (masked, originals)
+}
+
+fn unmask_card_named_literal_spans(text: String, originals: &[String]) -> String {
+    let mut result = text;
+    for original in originals {
+        result = result.replacen(CARD_NAMED_LITERAL_PLACEHOLDER, original, 1);
+    }
+    result
+}
+
 pub fn normalize_card_name_refs(text: &str, card_name: &str) -> String {
     let pre = mask_ring_tempts_you_phrase(text);
     // CR 701.40a/701.58a/701.62a: protect the keyword-action body verb on cards
@@ -1661,6 +1750,7 @@ pub fn normalize_card_name_refs(text: &str, card_name: &str) -> String {
         Some((masked, originals)) => (masked, originals),
         None => (pre, Vec::new()),
     };
+    let (text, card_named_originals) = mask_card_named_literal_spans(&text);
     // Strip A- prefix (Alchemy rebalanced cards in MTGJSON)
     let effective_name = card_name.strip_prefix("A-").unwrap_or(card_name);
 
@@ -1876,6 +1966,7 @@ pub fn normalize_card_name_refs(text: &str, card_name: &str) -> String {
     let effective_name_str = effective_name;
     result = result.replace("named ~", &format!("named {effective_name_str}"));
 
+    result = unmask_card_named_literal_spans(result, &card_named_originals);
     result = unmask_card_name_keyword_action(result, &kw_action_originals);
     unmask_ring_tempts_you_phrase(result)
 }
@@ -2051,6 +2142,75 @@ mod tests {
                 "Manifest Dread"
             ),
             "Manifest dread. A manifested permanent you control gets +1/+1."
+        );
+    }
+
+    #[test]
+    fn normalize_card_named_literal_preserves_named_card_first_word() {
+        // CR 201.2 / CR 201.5: "Mox Emerald" is the literal card name being
+        // conjured, not a reference to Emerald Collector. The first-word
+        // fallback must not rewrite it to "Mox ~".
+        assert_eq!(
+            normalize_card_name_refs(
+                "Conjure a card named Mox Emerald into your hand.",
+                "Emerald Collector",
+            ),
+            "Conjure a card named Mox Emerald into your hand."
+        );
+    }
+
+    #[test]
+    fn normalize_card_named_literal_stops_before_trailing_instruction() {
+        assert_eq!(
+            normalize_card_name_refs(
+                "Search your library for a card named Dragonstorm Globe, reveal it, then this creature deals 1 damage.",
+                "Dragonstorm Forecaster",
+            ),
+            "Search your library for a card named Dragonstorm Globe, reveal it, then ~ deals 1 damage."
+        );
+    }
+
+    #[test]
+    fn normalize_card_named_literal_keeps_comma_inside_card_name() {
+        assert_eq!(
+            normalize_card_name_refs(
+                "Search your library for a card named Squee, Goblin Nabob, reveal it.",
+                "Nabob Collector",
+            ),
+            "Search your library for a card named Squee, Goblin Nabob, reveal it."
+        );
+    }
+
+    #[test]
+    fn normalize_card_named_literal_stops_before_colon_self_reference() {
+        assert_eq!(
+            normalize_card_name_refs(
+                "Grandeur — Discard another card named Tarox Bladewing: Tarox Bladewing gets +X/+X until end of turn.",
+                "Tarox Bladewing",
+            ),
+            "Grandeur — Discard another card named Tarox Bladewing: ~ gets +X/+X until end of turn."
+        );
+    }
+
+    #[test]
+    fn normalize_card_named_literal_stops_before_revealed_rider() {
+        assert_eq!(
+            normalize_card_name_refs(
+                "If a card named Stomping Slabs was revealed this way, Stomping Slabs deals 7 damage to any target.",
+                "Stomping Slabs",
+            ),
+            "If a card named Stomping Slabs was revealed this way, ~ deals 7 damage to any target."
+        );
+    }
+
+    #[test]
+    fn normalize_card_named_literal_keeps_comma_name_before_cost_list() {
+        assert_eq!(
+            normalize_card_name_refs(
+                "Grandeur — Discard another card named Skoa, Embermage, Sacrifice two Mountains: Skoa deals 4 damage to any target.",
+                "Skoa, Embermage",
+            ),
+            "Grandeur — Discard another card named Skoa, Embermage, Sacrifice two Mountains: ~ deals 4 damage to any target."
         );
     }
 

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -13,7 +13,7 @@ use crate::types::mana::{ManaColor, ManaCost};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::space1;
-use nom::combinator::{eof, opt};
+use nom::combinator::{eof, opt, peek, value};
 
 /// A borrowed pair of `(original, lowercase)` slices kept in lockstep.
 ///
@@ -1581,31 +1581,6 @@ fn unmask_ring_tempts_you_phrase(text: String) -> String {
 const KEYWORD_ACTION_PLACEHOLDER: &str = "\u{E0001}";
 const CARD_NAMED_LITERAL_PLACEHOLDER: &str = "\u{E0002}";
 
-const CARD_NAMED_LITERAL_PREFIXES: &[&str] = &["card named ", "cards named "];
-const CARD_NAMED_LITERAL_TERMINATORS: &[&str] = &[
-    " and a card named ",
-    " and cards named ",
-    " or a card named ",
-    " or cards named ",
-    " onto ",
-    " into ",
-    " from ",
-    " in ",
-    " was ",
-    " this turn",
-    " this game",
-    ":",
-    ", reveal ",
-    ", put ",
-    ", sacrifice ",
-    ", then ",
-    ", you ",
-    ", it ",
-    ", that ",
-    ", this ",
-    ".",
-];
-
 /// CR 701.40a / CR 701.58a / CR 701.62a: A handful of cards are *named* after a
 /// keyword action ("Manifest Dread" → "Manifest dread.", "Cloak" → "Cloak …").
 /// Multi-word self-reference normalization is case-insensitive, so it would
@@ -1678,25 +1653,177 @@ fn unmask_card_name_keyword_action(text: String, originals: &[String]) -> String
     result
 }
 
+fn parse_card_named_literal_prefix(input: &str) -> OracleResult<'_, usize> {
+    alt((
+        value("cards named ".len(), tag("cards named ")),
+        value("card named ".len(), tag("card named ")),
+    ))
+    .parse(input)
+}
+
+fn parse_card_named_article(input: &str) -> OracleResult<'_, ()> {
+    value((), alt((tag("a "), tag("another ")))).parse(input)
+}
+
+fn parse_card_named_list_boundary(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = space1::<_, OracleError<'_>>(input)?;
+    let (input, _) = alt((tag("and"), tag("or"))).parse(input)?;
+    let (input, _) = space1::<_, OracleError<'_>>(input)?;
+    let (input, _) = opt(parse_card_named_article).parse(input)?;
+    let (input, _) = parse_card_named_literal_prefix(input)?;
+    Ok((input, ()))
+}
+
+fn parse_card_named_zone_qualifier(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        alt((
+            tag("your "),
+            tag("their "),
+            tag("his "),
+            tag("her "),
+            tag("that player's "),
+            tag("target player's "),
+            tag("a player's "),
+            tag("each player's "),
+            tag("its owner's "),
+            tag("an opponent's "),
+            tag("each opponent's "),
+            tag("opponent's "),
+            tag("the "),
+            tag("a "),
+        )),
+    )
+    .parse(input)
+}
+
+fn parse_card_named_possessed_zone(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = opt(parse_card_named_zone_qualifier).parse(input)?;
+    let (input, _) = alt((
+        tag("hands"),
+        tag("hand"),
+        tag("graveyards"),
+        tag("graveyard"),
+        tag("libraries"),
+        tag("library"),
+    ))
+    .parse(input)?;
+    Ok((input, ()))
+}
+
+fn parse_card_named_any_zone(input: &str) -> OracleResult<'_, ()> {
+    alt((
+        value((), tag("the battlefield")),
+        value((), tag("battlefield")),
+        value((), tag("exile")),
+        parse_card_named_possessed_zone,
+    ))
+    .parse(input)
+}
+
+fn parse_card_named_zone_tail_boundary(input: &str) -> OracleResult<'_, ()> {
+    if input.is_empty() {
+        return Ok((input, ()));
+    }
+    value(
+        (),
+        peek(alt((
+            tag("."),
+            tag(","),
+            tag(";"),
+            tag(":"),
+            tag(" tapped"),
+            tag(" face down"),
+            tag(" under "),
+            tag(" this way"),
+            tag(" and "),
+            tag(" then "),
+        ))),
+    )
+    .parse(input)
+}
+
+fn parse_card_named_zone_boundary(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = space1::<_, OracleError<'_>>(input)?;
+    let (input, _) = alt((
+        value((), (tag("into "), parse_card_named_any_zone)),
+        value((), (tag("onto "), parse_card_named_any_zone)),
+        value((), (tag("from "), parse_card_named_any_zone)),
+        value((), (tag("in "), parse_card_named_any_zone)),
+    ))
+    .parse(input)?;
+    let (input, _) = parse_card_named_zone_tail_boundary(input)?;
+    Ok((input, ()))
+}
+
+fn parse_card_named_revealed_boundary(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = space1::<_, OracleError<'_>>(input)?;
+    let (input, _) = alt((tag("was"), tag("were"))).parse(input)?;
+    let (input, _) = space1::<_, OracleError<'_>>(input)?;
+    let (input, _) = tag("revealed").parse(input)?;
+    Ok((input, ()))
+}
+
+fn parse_card_named_turn_boundary(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = space1::<_, OracleError<'_>>(input)?;
+    let (input, _) = alt((tag("this turn"), tag("this game"))).parse(input)?;
+    Ok((input, ()))
+}
+
+fn parse_card_named_comma_instruction_boundary(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = tag(", ").parse(input)?;
+    let (input, _) = alt((
+        tag("reveal "),
+        tag("put "),
+        tag("sacrifice "),
+        tag("then "),
+        tag("you "),
+        tag("it "),
+        tag("that "),
+        tag("this "),
+    ))
+    .parse(input)?;
+    Ok((input, ()))
+}
+
+fn parse_card_named_clause_boundary(input: &str) -> OracleResult<'_, ()> {
+    value((), alt((tag("."), tag(":")))).parse(input)
+}
+
+fn parse_card_named_literal_boundary(input: &str) -> OracleResult<'_, ()> {
+    alt((
+        parse_card_named_list_boundary,
+        parse_card_named_zone_boundary,
+        parse_card_named_revealed_boundary,
+        parse_card_named_turn_boundary,
+        parse_card_named_comma_instruction_boundary,
+        parse_card_named_clause_boundary,
+    ))
+    .parse(input)
+}
+
 fn next_card_named_literal_prefix(lower: &str) -> Option<(usize, usize)> {
-    CARD_NAMED_LITERAL_PREFIXES
-        .iter()
-        .flat_map(|prefix| {
-            lower
-                .match_indices(prefix)
-                .map(move |(idx, _)| (idx, prefix.len()))
-        })
-        .filter(|(idx, _)| {
-            *idx == 0 || !lower.as_bytes()[idx.saturating_sub(1)].is_ascii_alphanumeric()
-        })
-        .min_by_key(|(idx, _)| *idx)
+    lower.char_indices().find_map(|(idx, _)| {
+        let is_word_boundary = idx == 0
+            || lower[..idx]
+                .chars()
+                .next_back()
+                .is_none_or(|c| !c.is_alphanumeric());
+        is_word_boundary
+            .then(|| parse_card_named_literal_prefix(&lower[idx..]).ok())
+            .flatten()
+            .map(|(_, prefix_len)| (idx, prefix_len))
+    })
 }
 
 fn card_named_literal_span_len(lower: &str) -> usize {
-    CARD_NAMED_LITERAL_TERMINATORS
-        .iter()
-        .filter_map(|terminator| lower.match_indices(terminator).next().map(|(idx, _)| idx))
-        .min()
+    lower
+        .char_indices()
+        .find_map(|(idx, _)| {
+            parse_card_named_literal_boundary(&lower[idx..])
+                .is_ok()
+                .then_some(idx)
+        })
         .unwrap_or(lower.len())
 }
 
@@ -2178,6 +2305,37 @@ mod tests {
                 "Nabob Collector",
             ),
             "Search your library for a card named Squee, Goblin Nabob, reveal it."
+        );
+    }
+
+    #[test]
+    fn normalize_card_named_literal_keeps_in_inside_card_name() {
+        assert_eq!(
+            normalize_card_name_refs(
+                "Search your library for a card named Lost in the Woods, reveal it.",
+                "Woods Collector",
+            ),
+            "Search your library for a card named Lost in the Woods, reveal it."
+        );
+    }
+
+    #[test]
+    fn normalize_card_named_literal_keeps_from_inside_card_name() {
+        assert_eq!(
+            normalize_card_name_refs(
+                "Conjure a card named Extract from Darkness into your hand.",
+                "Darkness Collector",
+            ),
+            "Conjure a card named Extract from Darkness into your hand."
+        );
+    }
+
+    #[test]
+    fn normalize_card_named_literal_prefix_requires_unicode_boundary() {
+        assert!(next_card_named_literal_prefix("nazgûlcard named mox emerald").is_none());
+        assert_eq!(
+            next_card_named_literal_prefix("nazgûl card named mox emerald"),
+            Some(("nazgûl ".len(), "card named ".len()))
         );
     }
 

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 31
-- **Distinct cards implicated:** 4813
-- **Total card appearances across root causes:** 4847 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4808
+- **Total card appearances across root causes:** 4842 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -41,7 +41,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 27 | Cross-target group / shared-quality constraint dropped | 20 | oracle_target.rs multi_target — add SameController/SameZone/DistinctNames/Parity constraints |
 | 28 | Trigger/activation timing or ordinal restriction dropped | 20 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
 | 29 | Disjunctive mana ability split into two Fixed abilities | 18 | oracle parser mana-ability handling — emit AnyOneColor{color_options} for 'Add A or B' |
-| 30 | Token/named-card name corrupted by normalization or overrun | 18 | oracle_util.rs SELF_REF normalization + Named-filter parsing — guard literal 'named X' spans |
+| 30 | Token/named-card name corrupted by normalization or overrun | 13 | oracle_util.rs SELF_REF normalization + Named-filter parsing — guard literal 'named X' spans |
 | 31 | Other / uncategorized misparse | 3 | manual triage |
 
 > The top **5** root causes cover ~50% of all misparse appearances; the top 10 cover the overwhelming majority. Fix these first.
@@ -5189,7 +5189,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 30. Token/named-card name corrupted by normalization or overrun  (18 cards)
+### 30. Token/named-card name corrupted by normalization or overrun  (13 cards)
 
 **Signature.** A quoted/literal card name is rewritten by '~' self-reference normalization, an 'or'-list of names isn't split, a zone phrase is absorbed into the name, or trailing punctuation is left on a list option.
 
@@ -5199,15 +5199,10 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 - Deathpact Angel
 - Dragonstorm Forecaster
-- Emerald Collector
 - Hecatomb
 - High Marshal Arguel
-- Jet Collector
 - Kookus
 - Liu Bei, Lord of Shu
-- Pearl Collector
-- Ruby Collector
-- Sapphire Collector
 - Sift Through Sands
 - Thran Golem
 - Thrasta, Tempest's Roar


### PR DESCRIPTION
## Files changed

- `crates/engine/src/parser/oracle_util.rs`
- `docs/parser-misparse-backlog.md`

## Track

Parser / Oracle normalization

## LLM

GPT-5 Codex

## Implementation method

Hand-authored from the root30 backlog item using the repo `oracle-parser`, `project-reference`, implementation-review, and GitHub publish workflows.

## Summary

Protect literal `card named ...` / `cards named ...` spans while `normalize_card_name_refs` performs source-card self-reference replacement. This prevents first-word fallback from rewriting named-card literals such as `Mox Emerald` to `Mox ~`.

The review follow-up replaced the earlier prefix/terminator string scan with nom boundary parsers and Unicode-aware word-boundary scanning, so names such as `Lost in the Woods`, `Extract from Darkness`, and non-ASCII prefixes are not split by raw substring terminators or ASCII byte checks.

Removed the five fully fixed Collector cards from root30 in `docs/parser-misparse-backlog.md`:

- Emerald Collector
- Jet Collector
- Pearl Collector
- Ruby Collector
- Sapphire Collector

Dragonstorm Forecaster remains listed: this change fixes the normalization corruption (`Dragonstorm Forecaster Globe` -> `Dragonstorm Globe`) but the `or` list is still parsed as one named filter.

## Changed-card audit

Local full `oracle-gen data` export comparison against `origin/main` at `c71e5819e`:

- `total_cards_compared`: 35,397
- `changed_cards`: 11
- `oracle_changed_cards`: 0

Raw changed cards:

- Arachnus Spinner: `arachnus spinner web` -> `arachnus web`
- Colossal Chorus: `Colossal Chorus Dreadmaw` -> `Colossal Dreadmaw` in the unsupported conjure description
- Dragonstorm Forecaster: `dragonstorm forecaster globe or boulderborn dragon` -> `dragonstorm globe or boulderborn dragon` (partial only; remains in backlog)
- Emerald Collector: `Mox ~` -> `Mox Emerald`
- Infestation: `Blowfly ~` -> `Blowfly Infestation`
- Jet Collector: `Mox ~` -> `Mox Jet`
- Nazahn, Revered Bladesmith: `Hammer of ~` -> `Hammer of Nazahn`
- Pearl Collector: `Mox ~` -> `Mox Pearl`
- Ruby Collector: `Mox ~` -> `Mox Ruby`
- Sapphire Collector: `Mox ~` -> `Mox Sapphire`
- Suntail Squadron: `Suntail Squadron Hawk` -> `Suntail Hawk`

Official local `coverage-parse-diff` on the same exports:

- `10 card(s), 18 signature(s)`
- `1 card(s) had Oracle-text changes (errata/reprint) - excluded as non-parser`

The non-removed cards are intentional same-root changes from protecting literal `card(s) named ...` spans. Only the five Collector cards were removed from the backlog because they are the fully fixed listed root30 entries.

## Verification

- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `RUSTC_WRAPPER= cargo test -p engine --lib normalize_card_named_literal` (9 passed)
- `RUSTC_WRAPPER= cargo clippy -p engine --all-targets -- -D warnings`
- `RUSTC_WRAPPER= cargo test -p engine`
- `target/tool/card-data-validate /tmp/phase-root30-diff/head/card-data.json`
- `git diff --check origin/main...HEAD`
- Local full export diff: `oracle-gen data` on `origin/main` vs this branch, then raw `jq` card-key comparison plus `coverage-parse-diff`

Local `oracle-gen` emitted the usual missing `data/mtgjson/SetList.json` warning; card parsing/export still completed.

Workspace-wide clippy is not included here because this local environment is missing `pkg-config`/OpenSSL discovery for `openssl-sys`; engine-target clippy passed.
