### PR TITLE
fix(parser): parse opponent-turn activation restrictions

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5270,6 +5270,31 @@ fn parse_activation_timing_restriction(phrase: &str) -> Option<Vec<ActivationRes
     None
 }
 
+/// CR 602.5b + CR 102.1 + CR 109.5: "Activate only during an opponent's turn"
+/// gates activation to turns where the activator is not the active player.
+fn parse_activate_only_during_opponents_turn_suffix(lower: &str) -> Option<usize> {
+    let (rest, prefix) = take_until::<_, _, OracleError<'_>>("activate only during ")
+        .parse(lower)
+        .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("activate only during ")
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("an opponent's turn"),
+        tag("an opponents turn"),
+    ))
+    .parse(rest)
+    .ok()?;
+
+    rest.trim().is_empty().then_some(prefix.len())
+}
+
+fn opponents_turn_activation_condition() -> ParsedCondition {
+    ParsedCondition::Not {
+        condition: Box::new(ParsedCondition::IsYourTurn),
+    }
+}
+
 pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConstraintAst) {
     let mut remaining = text.trim().trim_end_matches('.').trim().to_string();
     let mut constraints = ActivatedConstraintAst::default();
@@ -5416,6 +5441,21 @@ pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConst
                 .restrictions
                 .push(ActivationRestriction::AsInstant);
             if prefix.trim().is_empty() {
+                break;
+            }
+            continue;
+        }
+
+        if let Some(end) = parse_activate_only_during_opponents_turn_suffix(&lower) {
+            remaining = remaining[..end]
+                .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
+                .to_string();
+            constraints
+                .restrictions
+                .push(ActivationRestriction::RequiresCondition {
+                    condition: Some(opponents_turn_activation_condition()),
+                });
+            if remaining.is_empty() {
                 break;
             }
             continue;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5245,6 +5245,13 @@ fn parse_activation_timing_restriction(phrase: &str) -> Option<Vec<ActivationRes
         ),
         value(ActivationRestriction::AsInstant, tag("as an instant")),
         value(
+            opponents_turn_activation_restriction(),
+            alt((
+                tag("during an opponent's turn"),
+                tag("during an opponents turn"),
+            )),
+        ),
+        value(
             ActivationRestriction::DuringYourTurn,
             alt((tag("during your turn"), tag("during their turn"))),
         ),
@@ -5270,25 +5277,14 @@ fn parse_activation_timing_restriction(phrase: &str) -> Option<Vec<ActivationRes
     None
 }
 
-/// CR 602.5b + CR 102.1 + CR 109.5: "Activate only during an opponent's turn"
-/// gates activation to turns where the activator is not the active player.
-fn parse_activate_only_during_opponents_turn_suffix(lower: &str) -> Option<usize> {
-    let (rest, prefix) = take_until::<_, _, OracleError<'_>>("activate only during ")
-        .parse(lower)
-        .ok()?;
-    let (rest, _) = tag::<_, _, OracleError<'_>>("activate only during ")
-        .parse(rest)
-        .ok()?;
-    let (rest, _) = alt((
-        tag::<_, _, OracleError<'_>>("an opponent's turn"),
-        tag("an opponents turn"),
-    ))
-    .parse(rest)
-    .ok()?;
-
-    rest.trim().is_empty().then_some(prefix.len())
+fn opponents_turn_activation_restriction() -> ActivationRestriction {
+    ActivationRestriction::RequiresCondition {
+        condition: Some(opponents_turn_activation_condition()),
+    }
 }
 
+/// CR 602.5b + CR 102.1 + CR 109.5: "Activate only during an opponent's turn"
+/// gates activation to turns where the activator is not the active player.
 fn opponents_turn_activation_condition() -> ParsedCondition {
     ParsedCondition::Not {
         condition: Box::new(ParsedCondition::IsYourTurn),
@@ -5412,81 +5408,28 @@ pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConst
             continue;
         }
 
-        // CR 602.5b + CR 602.5c: "<timing> and only once [each turn]" pairings are
-        // NOT enumerated here. `peel_only_once_rider` (below) strips the limit
-        // rider and re-enters this loop so the bare "activate only <timing>" arm
-        // matches on the next pass — one composed suffix axis for the limit, one
-        // for the timing, rather than a hardcoded timing × limit table.
-
-        if let Some(prefix) = lower.strip_suffix("activate only as a sorcery") {
-            let end = remaining.len() - "activate only as a sorcery".len();
-            remaining = remaining[..end]
-                .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
-                .to_string();
-            constraints
-                .restrictions
-                .push(ActivationRestriction::AsSorcery);
-            if prefix.trim().is_empty() {
-                break;
+        // CR 602.5b: Delegate bare "Activate only <timing>" phrases to the same
+        // timing parser used by the "Any player may activate ... but only"
+        // composition path. The condition-only form stays on its specialized
+        // branch below so the once-per-turn rider is stripped before condition
+        // parsing.
+        if let Some((before, restriction)) = tp.rsplit_around("activate only ") {
+            if tag::<_, _, OracleError<'_>>("if ")
+                .parse(restriction.lower.trim_start())
+                .is_err()
+            {
+                if let Some(parsed) = parse_activation_timing_restriction(restriction.original) {
+                    constraints.restrictions.extend(parsed);
+                    remaining = before
+                        .original
+                        .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
+                        .to_string();
+                    if remaining.is_empty() {
+                        break;
+                    }
+                    continue;
+                }
             }
-            continue;
-        }
-
-        if let Some(prefix) = lower.strip_suffix("activate only as an instant") {
-            let end = remaining.len() - "activate only as an instant".len();
-            remaining = remaining[..end]
-                .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
-                .to_string();
-            constraints
-                .restrictions
-                .push(ActivationRestriction::AsInstant);
-            if prefix.trim().is_empty() {
-                break;
-            }
-            continue;
-        }
-
-        if let Some(end) = parse_activate_only_during_opponents_turn_suffix(&lower) {
-            remaining = remaining[..end]
-                .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
-                .to_string();
-            constraints
-                .restrictions
-                .push(ActivationRestriction::RequiresCondition {
-                    condition: Some(opponents_turn_activation_condition()),
-                });
-            if remaining.is_empty() {
-                break;
-            }
-            continue;
-        }
-
-        if let Some(prefix) = lower.strip_suffix("activate only during your turn") {
-            let end = remaining.len() - "activate only during your turn".len();
-            remaining = remaining[..end]
-                .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
-                .to_string();
-            constraints
-                .restrictions
-                .push(ActivationRestriction::DuringYourTurn);
-            if prefix.trim().is_empty() {
-                break;
-            }
-            continue;
-        }
-
-        if let Some(prefix) = lower.strip_suffix("activate only during your upkeep") {
-            let end = remaining.len() - "activate only during your upkeep".len();
-            remaining = remaining[..end]
-                .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
-                .to_string();
-            constraints
-                .restrictions
-                .push(ActivationRestriction::DuringYourUpkeep);
-            if prefix.trim().is_empty() {
-                break;
-            }
-            continue;
         }
 
         if let Some(prefix) = lower.strip_suffix("activate only during combat") {

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -96,6 +96,17 @@ fn ability_word_labeled_activated_ability_parses_cost_effect_restriction() {
     );
 }
 
+fn has_not_your_turn_activation_restriction(restrictions: &[ActivationRestriction]) -> bool {
+    restrictions.iter().any(|restriction| {
+        matches!(
+            restriction,
+            ActivationRestriction::RequiresCondition {
+                condition: Some(ParsedCondition::Not { condition })
+            } if matches!(condition.as_ref(), ParsedCondition::IsYourTurn)
+        )
+    })
+}
+
 #[test]
 fn activated_ability_opponent_turn_restriction_uses_not_your_turn_condition() {
     let r = parse(
@@ -109,12 +120,7 @@ fn activated_ability_opponent_turn_restriction_uses_not_your_turn_condition() {
     assert_eq!(r.abilities.len(), 1, "got {:#?}", r.abilities);
     let restrictions = &r.abilities[0].activation_restrictions;
     assert!(
-        restrictions.iter().any(|restriction| matches!(
-            restriction,
-            ActivationRestriction::RequiresCondition {
-                condition: Some(ParsedCondition::Not { condition })
-            } if matches!(condition.as_ref(), ParsedCondition::IsYourTurn)
-        )),
+        has_not_your_turn_activation_restriction(restrictions),
         "expected Not(IsYourTurn) activation restriction, got {:?}",
         restrictions
     );
@@ -6785,7 +6791,7 @@ fn parses_return_forest_cost_untap_activated_ability() {
 /// restriction, instead of dropping the whole sentence to Unimplemented.
 #[test]
 fn any_player_may_activate_but_only_records_timing_restriction() {
-    let activation_restrictions_for = |text: &str, name: &str| {
+    let activation_for = |text: &str, name: &str| {
         let parsed = parse(text, name, &[], &["Artifact"], &[]);
         assert!(
             parsed
@@ -6800,14 +6806,15 @@ fn any_player_may_activate_but_only_records_timing_restriction() {
             .into_iter()
             .find(|ability| !ability.activation_restrictions.is_empty())
             .expect("expected an activated ability with restrictions")
-            .activation_restrictions
     };
 
     // "as a sorcery" form (Endbringer's Revel / Scandalmonger / Task Mage Assembly).
-    let restrictions = activation_restrictions_for(
+    let activation = activation_for(
         "{T}: Draw a card. Any player may activate this ability but only as a sorcery.",
         "Test Any-Player Sorcery",
     );
+    assert_eq!(activation.activator_filter, Some(PlayerFilter::All));
+    let restrictions = &activation.activation_restrictions;
     assert!(
         restrictions.contains(&ActivationRestriction::AsSorcery),
         "expected AsSorcery, got {:?}",
@@ -6815,10 +6822,12 @@ fn any_player_may_activate_but_only_records_timing_restriction() {
     );
 
     // "during their turn" form (Volrath's Dungeon) → the activator's turn.
-    let restrictions = activation_restrictions_for(
+    let activation = activation_for(
         "{T}: Draw a card. Any player may activate this ability but only during their turn.",
         "Test Any-Player Turn",
     );
+    assert_eq!(activation.activator_filter, Some(PlayerFilter::All));
+    let restrictions = &activation.activation_restrictions;
     assert!(
         restrictions.contains(&ActivationRestriction::DuringYourTurn),
         "expected DuringYourTurn, got {:?}",
@@ -6826,21 +6835,37 @@ fn any_player_may_activate_but_only_records_timing_restriction() {
     );
 
     // "during their upkeep" form maps to the activator's upkeep restriction.
-    let restrictions = activation_restrictions_for(
+    let activation = activation_for(
         "{T}: Draw a card. Any player may activate this ability but only during their upkeep.",
         "Test Any-Player Upkeep",
     );
+    assert_eq!(activation.activator_filter, Some(PlayerFilter::All));
+    let restrictions = &activation.activation_restrictions;
     assert!(
         restrictions.contains(&ActivationRestriction::DuringYourUpkeep),
         "expected DuringYourUpkeep, got {:?}",
         restrictions
     );
 
+    let activation = activation_for(
+        "{T}: Draw a card. Any player may activate this ability but only during an opponent's turn.",
+        "Test Any-Player Opponent Turn",
+    );
+    assert_eq!(activation.activator_filter, Some(PlayerFilter::All));
+    let restrictions = &activation.activation_restrictions;
+    assert!(
+        has_not_your_turn_activation_restriction(restrictions),
+        "expected Not(IsYourTurn), got {:?}",
+        restrictions
+    );
+
     // "if <condition>" form (Lightning Storm) keeps the parsed condition gate.
-    let restrictions = activation_restrictions_for(
+    let activation = activation_for(
         "{T}: Draw a card. Any player may activate this ability but only if ~ is on the stack.",
         "Test Any-Player Condition",
     );
+    assert_eq!(activation.activator_filter, Some(PlayerFilter::All));
+    let restrictions = &activation.activation_restrictions;
     assert!(
         restrictions.iter().any(|restriction| matches!(
             restriction,
@@ -6859,6 +6884,14 @@ fn any_player_may_activate_but_only_records_timing_restriction() {
 fn opponents_may_activate_but_only_records_timing_restriction() {
     let activation_for = |text: &str, name: &str| {
         let parsed = parse(text, name, &[], &["Creature"], &[]);
+        assert!(
+            parsed
+                .abilities
+                .iter()
+                .all(|ability| !matches!(ability.effect.as_ref(), Effect::Unimplemented { .. })),
+            "expected no unimplemented fallback, got {:?}",
+            parsed.abilities
+        );
         parsed
             .abilities
             .into_iter()
@@ -6890,6 +6923,45 @@ fn opponents_may_activate_but_only_records_timing_restriction() {
             .contains(&ActivationRestriction::DuringYourTurn),
         "expected DuringYourTurn, got {:?}",
         during_turn.activation_restrictions
+    );
+
+    let opponent_turn = activation_for(
+        "{1}: Draw a card. Only your opponents may activate this ability and only during an opponent's turn.",
+        "Test Opponent Opponent Turn",
+    );
+    assert_eq!(opponent_turn.activator_filter, Some(PlayerFilter::Opponent));
+    assert!(
+        has_not_your_turn_activation_restriction(&opponent_turn.activation_restrictions),
+        "expected Not(IsYourTurn), got {:?}",
+        opponent_turn.activation_restrictions
+    );
+}
+
+#[test]
+fn quoted_sentence_before_activate_only_keeps_timing_restriction() {
+    let r = parse(
+        "{T}: Add {W}.\n{1}{W}, {T}, Sacrifice ~: Create a 1/1 colorless Pilot creature token with \"~ saddles Mounts and crews Vehicles as though its power were 2 greater.\" Activate only as a sorcery.",
+        "Country Roads",
+        &[],
+        &["Land"],
+        &[],
+    );
+    let activation = r
+        .abilities
+        .iter()
+        .find(|ability| {
+            ability
+                .description
+                .as_deref()
+                .is_some_and(|description| description.contains("Create a 1/1 colorless Pilot"))
+        })
+        .expect("expected token-making activated ability");
+    assert!(
+        activation
+            .activation_restrictions
+            .contains(&ActivationRestriction::AsSorcery),
+        "expected quoted-text suffix to preserve AsSorcery, got {:?}",
+        activation.activation_restrictions
     );
 }
 

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -96,6 +96,30 @@ fn ability_word_labeled_activated_ability_parses_cost_effect_restriction() {
     );
 }
 
+#[test]
+fn activated_ability_opponent_turn_restriction_uses_not_your_turn_condition() {
+    let r = parse(
+        "{T}: Add {C}{C}. Activate only during an opponent's turn.",
+        "Lavinia, Foil to Conspiracy",
+        &[],
+        &["Creature"],
+        &["Human", "Detective"],
+    );
+
+    assert_eq!(r.abilities.len(), 1, "got {:#?}", r.abilities);
+    let restrictions = &r.abilities[0].activation_restrictions;
+    assert!(
+        restrictions.iter().any(|restriction| matches!(
+            restriction,
+            ActivationRestriction::RequiresCondition {
+                condition: Some(ParsedCondition::Not { condition })
+            } if matches!(condition.as_ref(), ParsedCondition::IsYourTurn)
+        )),
+        "expected Not(IsYourTurn) activation restriction, got {:?}",
+        restrictions
+    );
+}
+
 /// The static half of M.O.D.O.K. ("Designed Only for Killing — Creatures your
 /// opponents control get -1/-1") already parses on its own ability-word label;
 /// this guards that the activated-ability fix above doesn't regress it.

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 31
-- **Distinct cards implicated:** 4811
-- **Total card appearances across root causes:** 4845 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4810
+- **Total card appearances across root causes:** 4844 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -39,7 +39,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 25 | Wrong / dropped effect duration | 32 | oracle_nom/duration.rs — add until-event / two-turn / permanent duration variants |
 | 26 | Delayed / future-phase trigger flattened to immediate effect | 21 | add-trigger: wrap future-phase effects in CreateDelayedTrigger |
 | 27 | Cross-target group / shared-quality constraint dropped | 20 | oracle_target.rs multi_target — add SameController/SameZone/DistinctNames/Parity constraints |
-| 28 | Trigger/activation timing or ordinal restriction dropped | 20 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
+| 28 | Trigger/activation timing or ordinal restriction dropped | 19 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
 | 29 | Disjunctive mana ability split into two Fixed abilities | 18 | oracle parser mana-ability handling — emit AnyOneColor{color_options} for 'Add A or B' |
 | 30 | Token/named-card name corrupted by normalization or overrun | 18 | oracle_util.rs SELF_REF normalization + Named-filter parsing — guard literal 'named X' spans |
 | 31 | Other / uncategorized misparse | 1 | manual triage |
@@ -5129,7 +5129,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 28. Trigger/activation timing or ordinal restriction dropped  (20 cards)
+### 28. Trigger/activation timing or ordinal restriction dropped  (19 cards)
 
 **Signature.** A timing/scope restriction (OnlyDuringYourTurn / OncePerTurn / 'during an opponent's turn' / Nth-spell ordinal / cast-timing) is null; the constraint tail is not parsed.
 
@@ -5146,7 +5146,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Highspire Bell-Ringer
 - Hurkyl's Final Meditation
 - Ichneumon Druid
-- Lavinia, Foil to Conspiracy
 - MACH-1, Swooping Scoundrel
 - Shadowheart, Sharran Cleric
 - Shichifukujin Dragon


### PR DESCRIPTION
## Summary
- Parse `Activate only during an opponent's turn` activation restrictions as `RequiresCondition(Not(IsYourTurn))`.
- Route the new opponent-turn timing phrase through the shared activation timing parser used by bare `Activate only ...`, `Any player may activate ... but only ...`, and `Only your opponents may activate ... and only ...` forms.
- Remove `Lavinia, Foil to Conspiracy` from root cause 28 in `docs/parser-misparse-backlog.md`.

## Files changed
- `crates/engine/src/parser/oracle.rs`
- `crates/engine/src/parser/oracle_tests.rs`
- `docs/parser-misparse-backlog.md`

## CR references
- `CR 602.5b`
- `CR 602.2`
- `CR 102.1`
- `CR 109.5`

## Track
Developer

## LLM
Model: GPT-5 Codex
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/home/ntindle/code/phase/target cargo test -p engine --lib timing_restriction` — 3 passed / 0 failed
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/home/ntindle/code/phase/target cargo test -p engine --lib activated_ability_opponent_turn_restriction_uses_not_your_turn_condition` — 1 passed / 0 failed
- `git diff --check` — clean
- Fresh full parsed export diff, `origin/main` (`db50424a3`) vs this branch after merging current main:
  - `base_count = 35397`, `head_count = 35397`
  - added cards: none
  - removed cards: none
  - changed cards: only `Lavinia, Foil to Conspiracy`
- Review agent pass on the uncommitted review-fix diff: no findings.

## Parsed Diff Detail
`Lavinia, Foil to Conspiracy` activation restriction changed from:

```json
{
  "type": "RequiresCondition",
  "data": { "condition": null }
}
```

to:

```json
{
  "type": "RequiresCondition",
  "data": {
    "condition": {
      "type": "Not",
      "condition": { "type": "IsYourTurn" }
    }
  }
}
```

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
