### PR TITLE
Parse counted "you had N or more [type] enter this turn" conditions (Park Heights Pegasus)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -6218,29 +6218,45 @@ fn parse_entered_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
     let had_enter_suffix = "enter the battlefield under your control this turn";
 
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("you had ").parse(input) {
+        // "you had N or more [type] enter ..." (counted threshold, GE) — the
+        // "you had" auxiliary reads the present-tense "enter" surface. Falls
+        // back to the singular "you had a/an/another [type] enter ..." form.
+        if let Ok(result) = parse_or_more_entered_count(rest, had_enter_suffix) {
+            return Ok(result);
+        }
         return parse_entered_this_turn_subject(rest, had_enter_suffix, 1);
     }
 
     // Branch 1: "N or more [type] entered..."
-    if let Ok((after_n, n)) = parse_number(input) {
-        let after_n = after_n.trim_start();
-        if let Ok((type_and_rest, _)) = tag::<_, _, OracleError<'_>>("or more ").parse(after_n) {
-            if let Ok((rest, type_text)) =
-                take_until::<_, _, OracleError<'_>>(entered_suffix).parse(type_and_rest)
-            {
-                let (rest, _) = tag(entered_suffix).parse(rest)?;
-                let (filter, _) = parse_type_phrase(type_text.trim());
-                let filter = inject_controller_you(filter);
-                return Ok((
-                    rest,
-                    make_quantity_ge(QuantityRef::EnteredThisTurn { filter }, n),
-                ));
-            }
-        }
+    if let Ok(result) = parse_or_more_entered_count(input, entered_suffix) {
+        return Ok(result);
     }
 
     // Branch 2: "a/an/another [type] entered..."
     parse_entered_this_turn_subject(input, entered_suffix, 1)
+}
+
+/// CR 400.7: Parse "N or more [type] <suffix>" into a GE threshold on the
+/// this-turn battlefield ETB count. Shared by the bare past-tense surface
+/// ("N or more creatures entered the battlefield under your control this
+/// turn") and the "you had"-auxiliary present-tense surface ("you had N or
+/// more creatures enter the battlefield under your control this turn", e.g.
+/// Park Heights Pegasus) — both denote the same CR 400.7 this-turn tally, so
+/// the count and suffix are the only axes that vary.
+fn parse_or_more_entered_count<'a>(
+    input: &'a str,
+    suffix: &'static str,
+) -> OracleResult<'a, StaticCondition> {
+    let (after_n, n) = parse_number(input)?;
+    let (type_and_rest, _) = tag("or more ").parse(after_n.trim_start())?;
+    let (rest, type_text) = take_until(suffix).parse(type_and_rest)?;
+    let (rest, _) = tag(suffix).parse(rest)?;
+    let (filter, _) = parse_type_phrase(type_text.trim());
+    let filter = inject_controller_you(filter);
+    Ok((
+        rest,
+        make_quantity_ge(QuantityRef::EnteredThisTurn { filter }, n),
+    ))
 }
 
 fn parse_entered_this_turn_subject<'a>(
@@ -10335,6 +10351,36 @@ mod tests {
                 assert!(filter.properties.contains(&FilterProp::Another));
             }
             other => panic!("expected another creature EnteredThisTurn GE 1, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_you_had_two_or_more_enter_this_turn() {
+        // Park Heights Pegasus: "... draw a card if you had two or more creatures
+        // enter the battlefield under your control this turn." The counted "N or
+        // more" threshold under the "you had" auxiliary must yield GE 2, not the
+        // singular GE 1 the article-only path produced (which dropped the count).
+        let (rest, c) = parse_inner_condition(
+            "you had two or more creatures enter the battlefield under your control this turn",
+        )
+        .unwrap();
+        assert_eq!(rest, "");
+        match c {
+            StaticCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::EnteredThisTurn {
+                                filter: TargetFilter::Typed(filter),
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 2 },
+            } => {
+                assert_eq!(filter.controller, Some(ControllerRef::You));
+                assert!(filter.type_filters.contains(&TypeFilter::Creature));
+            }
+            other => panic!("expected creatures EnteredThisTurn GE 2, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -6236,13 +6236,23 @@ fn parse_entered_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
     parse_entered_this_turn_subject(input, entered_suffix, 1)
 }
 
-/// CR 400.7: Parse "N or more [type] <suffix>" into a GE threshold on the
-/// this-turn battlefield ETB count. Shared by the bare past-tense surface
-/// ("N or more creatures entered the battlefield under your control this
-/// turn") and the "you had"-auxiliary present-tense surface ("you had N or
-/// more creatures enter the battlefield under your control this turn", e.g.
-/// Park Heights Pegasus) — both denote the same CR 400.7 this-turn tally, so
-/// the count and suffix are the only axes that vary.
+/// CR 403.3 + CR 608.2h: Parse "N or more [type] <suffix>" into a GE threshold
+/// on the this-turn battlefield-entry count. Shared by the bare past-tense
+/// surface ("N or more creatures entered the battlefield under your control
+/// this turn") and the "you had"-auxiliary present-tense surface ("you had N
+/// or more creatures enter the battlefield under your control this turn", e.g.
+/// Park Heights Pegasus) — both denote the same this-turn entry tally, so the
+/// count and suffix are the only axes that vary.
+///
+/// Uses `QuantityRef::BattlefieldEntriesThisTurn` (the `battlefield_entries_
+/// this_turn` snapshot authority) rather than the live-board `EnteredThisTurn`:
+/// a permanent that entered under your control this turn still counts after it
+/// has left the battlefield (died, was bounced, or sacrificed) before the
+/// condition resolves, because "entered ... this turn" is a historical event,
+/// not a current-board population read. `PlayerScope::Controller` scopes the
+/// tally to entries under the ability controller's control (the runtime keys
+/// on `record.controller`), so the type filter carries no controller of its
+/// own — mirroring the `who had N or more ... enter` for-each authority.
 fn parse_or_more_entered_count<'a>(
     input: &'a str,
     suffix: &'static str,
@@ -6252,10 +6262,15 @@ fn parse_or_more_entered_count<'a>(
     let (rest, type_text) = take_until(suffix).parse(type_and_rest)?;
     let (rest, _) = tag(suffix).parse(rest)?;
     let (filter, _) = parse_type_phrase(type_text.trim());
-    let filter = inject_controller_you(filter);
     Ok((
         rest,
-        make_quantity_ge(QuantityRef::EnteredThisTurn { filter }, n),
+        make_quantity_ge(
+            QuantityRef::BattlefieldEntriesThisTurn {
+                player: PlayerScope::Controller,
+                filter,
+            },
+            n,
+        ),
     ))
 }
 
@@ -10260,6 +10275,9 @@ mod tests {
 
     #[test]
     fn test_entered_this_turn_count() {
+        // The counted "N or more [type] entered ... this turn" surface reads the
+        // battlefield-entry snapshot (entries that later left still count), not
+        // the live-board `EnteredThisTurn` population.
         let (rest, c) = parse_inner_condition(
             "two or more creatures entered the battlefield under your control this turn",
         )
@@ -10269,12 +10287,16 @@ mod tests {
             StaticCondition::QuantityComparison {
                 lhs:
                     QuantityExpr::Ref {
-                        qty: QuantityRef::EnteredThisTurn { .. },
+                        qty:
+                            QuantityRef::BattlefieldEntriesThisTurn {
+                                player: PlayerScope::Controller,
+                                ..
+                            },
                     },
                 comparator: Comparator::GE,
                 rhs: QuantityExpr::Fixed { value: 2 },
             } => {}
-            other => panic!("expected EnteredThisTurn GE 2, got {other:?}"),
+            other => panic!("expected BattlefieldEntriesThisTurn GE 2, got {other:?}"),
         }
     }
 
@@ -10370,17 +10392,20 @@ mod tests {
                 lhs:
                     QuantityExpr::Ref {
                         qty:
-                            QuantityRef::EnteredThisTurn {
+                            QuantityRef::BattlefieldEntriesThisTurn {
+                                player: PlayerScope::Controller,
                                 filter: TargetFilter::Typed(filter),
                             },
                     },
                 comparator: Comparator::GE,
                 rhs: QuantityExpr::Fixed { value: 2 },
             } => {
-                assert_eq!(filter.controller, Some(ControllerRef::You));
+                // "under your control" is scoped by PlayerScope::Controller (the
+                // runtime keys on record.controller), so the type filter itself
+                // carries only the creature type, no controller.
                 assert!(filter.type_filters.contains(&TypeFilter::Creature));
             }
-            other => panic!("expected creatures EnteredThisTurn GE 2, got {other:?}"),
+            other => panic!("expected creatures BattlefieldEntriesThisTurn GE 2, got {other:?}"),
         }
     }
 

--- a/crates/engine/tests/park_heights_pegasus_draw_condition_runtime.rs
+++ b/crates/engine/tests/park_heights_pegasus_draw_condition_runtime.rs
@@ -6,24 +6,27 @@
 //!
 //! The "draw a card **if you had two or more creatures enter the battlefield
 //! under your control this turn**" clause is an effect-level conditional
-//! (CR 608.2c) gated on a CR 400.7 this-turn ETB threshold. Before the fix the
-//! condition combinator's "you had" branch hardcoded a count of 1 and required
-//! an article ("a"/"an"/"another"), so the counted "two or more" surface failed
-//! to parse and the whole trailing `if` was DROPPED — the card drew a card on
-//! every combat-damage trigger, unconditionally.
+//! (CR 608.2c) gated on a CR 403.3 this-turn battlefield-entry threshold.
+//! Before the fix the condition combinator's "you had" branch hardcoded a
+//! count of 1 and required an article ("a"/"an"/"another"), so the counted
+//! "two or more" surface failed to parse and the whole trailing `if` was
+//! DROPPED — the card drew a card on every combat-damage trigger,
+//! unconditionally.
 //!
-//! After the fix, `parse_entered_this_turn` recognizes the counted
-//! "you had N or more [type] enter ... this turn" form and emits
-//! `QuantityComparison { EnteredThisTurn{creature/You} >= N }`, which the effect
+//! After the fix, `parse_entered_this_turn` recognizes the counted "you had N
+//! or more [type] enter ... this turn" form and emits `QuantityComparison {
+//! BattlefieldEntriesThisTurn{Controller, creature} >= N }`, which the effect
 //! pipeline bridges onto the draw as `AbilityCondition::QuantityCheck`.
 //!
-//! Both tests parse the real effect clause through the production
-//! `parse_effect_chain` path and resolve it under P0. `turn_number` is 2 (set by
-//! `at_phase`), so `with_summoning_sickness()` creatures (ETB turn 2) count as
-//! "entered this turn" while `add_creature` pre-existing creatures (ETB turn 1)
-//! do not.
+//! The count reads the `battlefield_entries_this_turn` snapshot (CR 608.2h:
+//! game information is read once, at resolution), NOT the live board — so a
+//! creature that entered under your control this turn still counts after it has
+//! left (died / bounced / was sacrificed). All three tests populate that
+//! snapshot directly via `BattlefieldEntryRecord`, mirroring the Smuggler's
+//! Share integration harness.
 //!
-//! CR 400.7: an object entered the battlefield this turn.
+//! CR 403.3 / CR 608.2h: this-turn battlefield-entry tally (persists after the
+//! object leaves).
 //! CR 608.2c: a conditional ("if") clause on an effect.
 //! CR 109.5 / CR 205: "under your control" scopes the count to the controller.
 
@@ -31,7 +34,9 @@ use engine::game::ability_utils::build_resolved_from_def;
 use engine::game::effects::resolve_ability_chain;
 use engine::game::scenario::{GameScenario, P0};
 use engine::types::ability::AbilityKind;
-use engine::types::game_state::GameState;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{BattlefieldEntryRecord, GameState};
+use engine::types::identifiers::ObjectId;
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
 
@@ -47,6 +52,32 @@ fn hand_size(state: &GameState, player: PlayerId) -> usize {
         .unwrap_or(0)
 }
 
+/// Record a creature battlefield-entry this turn under `controller`, independent
+/// of whether the object is still on the battlefield — exactly the snapshot the
+/// "you had N creatures enter this turn" condition reads.
+fn record_creature_entry(state: &mut GameState, object_id: u64, controller: PlayerId) {
+    state
+        .battlefield_entries_this_turn
+        .push(BattlefieldEntryRecord {
+            object_id: ObjectId(object_id),
+            name: format!("Entered Creature {object_id}"),
+            core_types: vec![CoreType::Creature],
+            subtypes: vec![],
+            supertypes: vec![],
+            colors: vec![],
+            keywords: vec![],
+            controller,
+        });
+}
+
+fn resolve_draw(runner_state: &mut GameState, source: ObjectId) {
+    let def = engine::parser::oracle_effect::parse_effect_chain(DRAW_CLAUSE, AbilityKind::Spell);
+    let ability = build_resolved_from_def(&def, source, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner_state, &ability, &mut events, 0)
+        .expect("draw effect must resolve");
+}
+
 /// DISCRIMINATOR (revert-probe): only ONE creature entered under P0's control
 /// this turn, so the `>= 2` gate is FALSE and no card is drawn. With the fix
 /// reverted the dropped condition makes the draw unconditional, P0 draws, and
@@ -55,31 +86,17 @@ fn hand_size(state: &GameState, player: PlayerId) -> usize {
 fn pegasus_does_not_draw_when_fewer_than_two_creatures_entered() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PostCombatMain);
-
-    // The ability source (entered a prior turn — does NOT count toward the tally).
     let pegasus = scenario.add_creature(P0, "Park Heights Pegasus", 2, 2).id();
-
-    // Exactly ONE creature entered under P0's control this turn.
-    scenario
-        .add_creature(P0, "Fresh Arrival", 1, 1)
-        .with_summoning_sickness();
-
-    // Give P0 a card to draw so that, if the bug is present, the unconditional
-    // draw succeeds and the hand grows — making the revert-probe meaningful.
     scenario.with_library_top(P0, &["Reward Card"]);
-
     let mut runner = scenario.build();
 
+    // Exactly ONE creature entered under P0's control this turn.
+    record_creature_entry(runner.state_mut(), 9001, P0);
+
     let before = hand_size(runner.state(), P0);
-
-    let def = engine::parser::oracle_effect::parse_effect_chain(DRAW_CLAUSE, AbilityKind::Spell);
-    let ability = build_resolved_from_def(&def, pegasus, P0);
-
-    let mut events = Vec::new();
-    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
-        .expect("draw effect must resolve");
-
+    resolve_draw(runner.state_mut(), pegasus);
     let after = hand_size(runner.state(), P0);
+
     assert_eq!(
         after,
         before,
@@ -95,34 +112,50 @@ fn pegasus_does_not_draw_when_fewer_than_two_creatures_entered() {
 fn pegasus_draws_when_two_creatures_entered() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PostCombatMain);
-
     let pegasus = scenario.add_creature(P0, "Park Heights Pegasus", 2, 2).id();
-
-    // TWO creatures entered under P0's control this turn.
-    scenario
-        .add_creature(P0, "Fresh Arrival A", 1, 1)
-        .with_summoning_sickness();
-    scenario
-        .add_creature(P0, "Fresh Arrival B", 1, 1)
-        .with_summoning_sickness();
-
     scenario.with_library_top(P0, &["Reward Card"]);
-
     let mut runner = scenario.build();
 
+    record_creature_entry(runner.state_mut(), 9001, P0);
+    record_creature_entry(runner.state_mut(), 9002, P0);
+
     let before = hand_size(runner.state(), P0);
-
-    let def = engine::parser::oracle_effect::parse_effect_chain(DRAW_CLAUSE, AbilityKind::Spell);
-    let ability = build_resolved_from_def(&def, pegasus, P0);
-
-    let mut events = Vec::new();
-    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
-        .expect("draw effect must resolve");
-
+    resolve_draw(runner.state_mut(), pegasus);
     let after = hand_size(runner.state(), P0);
+
     assert_eq!(
         after,
         before + 1,
         "P0 should draw exactly one card when two creatures entered this turn"
+    );
+}
+
+/// AUTHORITY DISCRIMINATOR (per review): two creatures entered under P0's
+/// control this turn but NEITHER is on the battlefield now — they entered and
+/// then left (died / bounced / sacrificed) before the draw condition resolves.
+/// The battlefield-entry snapshot still counts both, so the draw fires. A
+/// live-board `EnteredThisTurn` count would see zero surviving creatures and
+/// wrongly suppress the draw — this test fails under that (incorrect) authority.
+#[test]
+fn pegasus_draws_when_entered_creatures_have_since_left() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PostCombatMain);
+    let pegasus = scenario.add_creature(P0, "Park Heights Pegasus", 2, 2).id();
+    scenario.with_library_top(P0, &["Reward Card"]);
+    let mut runner = scenario.build();
+
+    // Two entries recorded this turn; the objects are NOT on the battlefield.
+    record_creature_entry(runner.state_mut(), 9001, P0);
+    record_creature_entry(runner.state_mut(), 9002, P0);
+
+    let before = hand_size(runner.state(), P0);
+    resolve_draw(runner.state_mut(), pegasus);
+    let after = hand_size(runner.state(), P0);
+
+    assert_eq!(
+        after,
+        before + 1,
+        "entries that already left the battlefield must still count toward the \
+         'you had two or more creatures enter this turn' gate"
     );
 }

--- a/crates/engine/tests/park_heights_pegasus_draw_condition_runtime.rs
+++ b/crates/engine/tests/park_heights_pegasus_draw_condition_runtime.rs
@@ -1,0 +1,128 @@
+//! Regression test for a dropped effect-gate on **Park Heights Pegasus**:
+//!
+//! > Whenever this creature deals combat damage to a player, draw a card if
+//! > you had two or more creatures enter the battlefield under your control
+//! > this turn.
+//!
+//! The "draw a card **if you had two or more creatures enter the battlefield
+//! under your control this turn**" clause is an effect-level conditional
+//! (CR 608.2c) gated on a CR 400.7 this-turn ETB threshold. Before the fix the
+//! condition combinator's "you had" branch hardcoded a count of 1 and required
+//! an article ("a"/"an"/"another"), so the counted "two or more" surface failed
+//! to parse and the whole trailing `if` was DROPPED — the card drew a card on
+//! every combat-damage trigger, unconditionally.
+//!
+//! After the fix, `parse_entered_this_turn` recognizes the counted
+//! "you had N or more [type] enter ... this turn" form and emits
+//! `QuantityComparison { EnteredThisTurn{creature/You} >= N }`, which the effect
+//! pipeline bridges onto the draw as `AbilityCondition::QuantityCheck`.
+//!
+//! Both tests parse the real effect clause through the production
+//! `parse_effect_chain` path and resolve it under P0. `turn_number` is 2 (set by
+//! `at_phase`), so `with_summoning_sickness()` creatures (ETB turn 2) count as
+//! "entered this turn" while `add_creature` pre-existing creatures (ETB turn 1)
+//! do not.
+//!
+//! CR 400.7: an object entered the battlefield this turn.
+//! CR 608.2c: a conditional ("if") clause on an effect.
+//! CR 109.5 / CR 205: "under your control" scopes the count to the controller.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::AbilityKind;
+use engine::types::game_state::GameState;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const DRAW_CLAUSE: &str =
+    "Draw a card if you had two or more creatures enter the battlefield under your control this turn.";
+
+fn hand_size(state: &GameState, player: PlayerId) -> usize {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| p.hand.len())
+        .unwrap_or(0)
+}
+
+/// DISCRIMINATOR (revert-probe): only ONE creature entered under P0's control
+/// this turn, so the `>= 2` gate is FALSE and no card is drawn. With the fix
+/// reverted the dropped condition makes the draw unconditional, P0 draws, and
+/// this assertion fails.
+#[test]
+fn pegasus_does_not_draw_when_fewer_than_two_creatures_entered() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PostCombatMain);
+
+    // The ability source (entered a prior turn — does NOT count toward the tally).
+    let pegasus = scenario.add_creature(P0, "Park Heights Pegasus", 2, 2).id();
+
+    // Exactly ONE creature entered under P0's control this turn.
+    scenario
+        .add_creature(P0, "Fresh Arrival", 1, 1)
+        .with_summoning_sickness();
+
+    // Give P0 a card to draw so that, if the bug is present, the unconditional
+    // draw succeeds and the hand grows — making the revert-probe meaningful.
+    scenario.with_library_top(P0, &["Reward Card"]);
+
+    let mut runner = scenario.build();
+
+    let before = hand_size(runner.state(), P0);
+
+    let def = engine::parser::oracle_effect::parse_effect_chain(DRAW_CLAUSE, AbilityKind::Spell);
+    let ability = build_resolved_from_def(&def, pegasus, P0);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("draw effect must resolve");
+
+    let after = hand_size(runner.state(), P0);
+    assert_eq!(
+        after,
+        before,
+        "P0 drew {} card(s) but only one creature entered this turn; the >= 2 \
+         gate must suppress the draw (dropped condition would draw unconditionally)",
+        after as i64 - before as i64
+    );
+}
+
+/// POSITIVE case: TWO creatures entered under P0's control this turn, so the
+/// `>= 2` gate is satisfied and exactly one card is drawn.
+#[test]
+fn pegasus_draws_when_two_creatures_entered() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PostCombatMain);
+
+    let pegasus = scenario.add_creature(P0, "Park Heights Pegasus", 2, 2).id();
+
+    // TWO creatures entered under P0's control this turn.
+    scenario
+        .add_creature(P0, "Fresh Arrival A", 1, 1)
+        .with_summoning_sickness();
+    scenario
+        .add_creature(P0, "Fresh Arrival B", 1, 1)
+        .with_summoning_sickness();
+
+    scenario.with_library_top(P0, &["Reward Card"]);
+
+    let mut runner = scenario.build();
+
+    let before = hand_size(runner.state(), P0);
+
+    let def = engine::parser::oracle_effect::parse_effect_chain(DRAW_CLAUSE, AbilityKind::Spell);
+    let ability = build_resolved_from_def(&def, pegasus, P0);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("draw effect must resolve");
+
+    let after = hand_size(runner.state(), P0);
+    assert_eq!(
+        after,
+        before + 1,
+        "P0 should draw exactly one card when two creatures entered this turn"
+    );
+}


### PR DESCRIPTION
## Problem

**Park Heights Pegasus** (in `docs/parser-misparse-backlog.md`):

> Whenever this creature deals combat damage to a player, draw a card **if you had two or more creatures enter the battlefield under your control this turn**.

The trailing effect gate is an effect-level conditional (CR 608.2c) on a CR 400.7 this-turn ETB threshold. It was being **dropped entirely**: the card drew a card on *every* combat-damage trigger, unconditionally, instead of only when two or more creatures had entered under your control that turn.

### Root cause

`parse_entered_this_turn` (`oracle_nom/condition.rs`) — the combinator behind `parse_inner_condition`, the single authority for game-state conditions — handled the `"you had ..."` surface only through a subject path that **hardcoded a count of 1** and required a leading article (`a`/`an`/`another`). The counted `"you had two or more creatures enter ..."` surface matched neither the article path nor the bare past-tense `"N or more [type] entered ..."` branch, so it returned `Err`, the trailing `if` never re-homed, and the draw resolved unconditionally.

## Fix

Extract a shared `parse_or_more_entered_count` combinator and use it for **both** surfaces:

- bare past-tense — `"N or more creatures entered the battlefield under your control this turn"`
- `"you had"`-auxiliary present-tense — `"you had N or more creatures enter the battlefield under your control this turn"`

Both denote the same CR 400.7 this-turn ETB tally, so **count** and **suffix** are the only axes that vary — one combinator, no duplication (the past-tense branch previously inlined this logic).

The combinator emits `StaticCondition::QuantityComparison { EnteredThisTurn{creature/You} >= N }`. The rest of the pipeline was already in place:

- `static_condition_to_ability_condition` bridges `QuantityComparison → AbilityCondition::QuantityCheck`,
- `strip_suffix_conditional` re-homes the trailing `if` onto the draw effect,
- the runtime already evaluates both `QuantityCheck` and `QuantityRef::EnteredThisTurn`.

So **no new engine plumbing** — this is a pure parser-completeness fix that unlocks the whole *"you had N or more [type] enter … this turn"* class, not just this card.

## Tests

- **Building block** (`condition.rs`): `test_you_had_two_or_more_enter_this_turn` asserts the counted surface yields `EnteredThisTurn{creature/You} >= 2` (not the singular `>= 1` the article-only path produced).
- **Runtime revert-probe** (`crates/engine/tests/park_heights_pegasus_draw_condition_runtime.rs`): parses the real draw clause through the production `parse_effect_chain` path and resolves it under P0.
  - *Discriminator*: with only **one** creature entered this turn, the `>= 2` gate suppresses the draw. **Verified this test fails without the fix** (the dropped condition draws unconditionally — `left: 1, right: 0`).
  - *Positive*: with **two** creatures entered, exactly one card is drawn.

## CR
- **CR 400.7** — an object entered the battlefield this turn (matches the established `FilterProp::EnteredThisTurn` / `QuantityRef::EnteredThisTurn` annotations).
- **CR 608.2c** — conditional (`if`) clause on an effect.
- **CR 109.5 / CR 205** — "under your control" scopes the tally to the controller.