### PR TITLE
[codex] Reclassify basic land mana backlog bucket

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -439,34 +439,137 @@ impl KeywordTriggerInstaller {
     }
 }
 
+/// CR 305.6: A land with a basic land type has the matching intrinsic
+/// "{T}: Add [mana symbol]" mana ability. Card data groups multiple same-cost
+/// basic-land mana rows into one color-choice producer.
 pub fn synthesize_basic_land_mana(face: &mut CardFace) {
-    let land_mana: Vec<(&str, ManaColor)> = vec![
+    let colors: Vec<ManaColor> = [
         ("Plains", ManaColor::White),
         ("Island", ManaColor::Blue),
         ("Swamp", ManaColor::Black),
         ("Mountain", ManaColor::Red),
         ("Forest", ManaColor::Green),
-    ];
+    ]
+    .into_iter()
+    .filter_map(|(subtype, color)| {
+        face.card_type
+            .subtypes
+            .iter()
+            .any(|s| s == subtype)
+            .then_some(color)
+    })
+    .collect();
 
-    for (subtype, color) in land_mana {
-        if face.card_type.subtypes.iter().any(|s| s == subtype) {
-            face.abilities.push(
-                AbilityDefinition::new(
-                    AbilityKind::Activated,
-                    Effect::Mana {
-                        produced: ManaProduction::Fixed {
-                            colors: vec![color],
-                            contribution: ManaContribution::Base,
-                        },
-                        restrictions: vec![],
-                        grants: vec![],
-                        expiry: None,
-                        target: None,
-                    },
-                )
-                .cost(AbilityCost::Tap),
-            );
+    if colors.is_empty() {
+        return;
+    }
+
+    let produced = if colors.len() == 1 {
+        ManaProduction::Fixed {
+            colors: vec![colors[0]],
+            contribution: ManaContribution::Base,
         }
+    } else {
+        ManaProduction::AnyOneColor {
+            count: QuantityExpr::Fixed { value: 1 },
+            color_options: colors,
+            contribution: ManaContribution::Base,
+        }
+    };
+
+    face.abilities.push(
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced,
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Tap),
+    );
+}
+
+#[cfg(test)]
+mod basic_land_mana_synthesis_tests {
+    use super::*;
+
+    fn land_face(subtypes: &[&str]) -> CardFace {
+        CardFace {
+            card_type: CardType {
+                core_types: vec![CoreType::Land],
+                subtypes: subtypes
+                    .iter()
+                    .map(|subtype| (*subtype).to_string())
+                    .collect(),
+                ..CardType::default()
+            },
+            ..CardFace::default()
+        }
+    }
+
+    fn synthesized_mana(face: &CardFace) -> &ManaProduction {
+        assert_eq!(face.abilities.len(), 1);
+        let ability = &face.abilities[0];
+        assert_eq!(ability.kind, AbilityKind::Activated);
+        assert_eq!(ability.cost, Some(AbilityCost::Tap));
+
+        let Effect::Mana { produced, .. } = ability.effect.as_ref() else {
+            panic!(
+                "expected synthesized mana ability, got {:?}",
+                ability.effect
+            );
+        };
+        produced
+    }
+
+    #[test]
+    fn single_basic_land_subtype_stays_fixed_mana() {
+        let mut face = land_face(&["Forest"]);
+
+        synthesize_basic_land_mana(&mut face);
+
+        assert_eq!(
+            synthesized_mana(&face),
+            &ManaProduction::Fixed {
+                colors: vec![ManaColor::Green],
+                contribution: ManaContribution::Base,
+            }
+        );
+    }
+
+    #[test]
+    fn dual_basic_land_subtypes_synthesize_one_color_choice() {
+        let mut face = land_face(&["Mountain", "Forest"]);
+
+        synthesize_basic_land_mana(&mut face);
+
+        assert_eq!(
+            synthesized_mana(&face),
+            &ManaProduction::AnyOneColor {
+                count: QuantityExpr::Fixed { value: 1 },
+                color_options: vec![ManaColor::Red, ManaColor::Green],
+                contribution: ManaContribution::Base,
+            }
+        );
+    }
+
+    #[test]
+    fn triple_basic_land_subtypes_synthesize_one_color_choice() {
+        let mut face = land_face(&["Island", "Swamp", "Forest"]);
+
+        synthesize_basic_land_mana(&mut face);
+
+        assert_eq!(
+            synthesized_mana(&face),
+            &ManaProduction::AnyOneColor {
+                count: QuantityExpr::Fixed { value: 1 },
+                color_options: vec![ManaColor::Blue, ManaColor::Black, ManaColor::Green],
+                contribution: ManaContribution::Base,
+            }
+        );
     }
 }
 

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -439,137 +439,34 @@ impl KeywordTriggerInstaller {
     }
 }
 
-/// CR 305.6: A land with a basic land type has the matching intrinsic
-/// "{T}: Add [mana symbol]" mana ability. Card data groups multiple same-cost
-/// basic-land mana rows into one color-choice producer.
 pub fn synthesize_basic_land_mana(face: &mut CardFace) {
-    let colors: Vec<ManaColor> = [
+    let land_mana: Vec<(&str, ManaColor)> = vec![
         ("Plains", ManaColor::White),
         ("Island", ManaColor::Blue),
         ("Swamp", ManaColor::Black),
         ("Mountain", ManaColor::Red),
         ("Forest", ManaColor::Green),
-    ]
-    .into_iter()
-    .filter_map(|(subtype, color)| {
-        face.card_type
-            .subtypes
-            .iter()
-            .any(|s| s == subtype)
-            .then_some(color)
-    })
-    .collect();
+    ];
 
-    if colors.is_empty() {
-        return;
-    }
-
-    let produced = if colors.len() == 1 {
-        ManaProduction::Fixed {
-            colors,
-            contribution: ManaContribution::Base,
-        }
-    } else {
-        ManaProduction::AnyOneColor {
-            count: QuantityExpr::Fixed { value: 1 },
-            color_options: colors,
-            contribution: ManaContribution::Base,
-        }
-    };
-
-    face.abilities.push(
-        AbilityDefinition::new(
-            AbilityKind::Activated,
-            Effect::Mana {
-                produced,
-                restrictions: vec![],
-                grants: vec![],
-                expiry: None,
-                target: None,
-            },
-        )
-        .cost(AbilityCost::Tap),
-    );
-}
-
-#[cfg(test)]
-mod basic_land_mana_synthesis_tests {
-    use super::*;
-
-    fn land_face(subtypes: &[&str]) -> CardFace {
-        CardFace {
-            card_type: CardType {
-                core_types: vec![CoreType::Land],
-                subtypes: subtypes
-                    .iter()
-                    .map(|subtype| (*subtype).to_string())
-                    .collect(),
-                ..CardType::default()
-            },
-            ..CardFace::default()
-        }
-    }
-
-    fn synthesized_mana(face: &CardFace) -> &ManaProduction {
-        assert_eq!(face.abilities.len(), 1);
-        let ability = &face.abilities[0];
-        assert_eq!(ability.kind, AbilityKind::Activated);
-        assert_eq!(ability.cost, Some(AbilityCost::Tap));
-
-        let Effect::Mana { produced, .. } = ability.effect.as_ref() else {
-            panic!(
-                "expected synthesized mana ability, got {:?}",
-                ability.effect
+    for (subtype, color) in land_mana {
+        if face.card_type.subtypes.iter().any(|s| s == subtype) {
+            face.abilities.push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Mana {
+                        produced: ManaProduction::Fixed {
+                            colors: vec![color],
+                            contribution: ManaContribution::Base,
+                        },
+                        restrictions: vec![],
+                        grants: vec![],
+                        expiry: None,
+                        target: None,
+                    },
+                )
+                .cost(AbilityCost::Tap),
             );
-        };
-        produced
-    }
-
-    #[test]
-    fn single_basic_land_subtype_stays_fixed_mana() {
-        let mut face = land_face(&["Forest"]);
-
-        synthesize_basic_land_mana(&mut face);
-
-        assert_eq!(
-            synthesized_mana(&face),
-            &ManaProduction::Fixed {
-                colors: vec![ManaColor::Green],
-                contribution: ManaContribution::Base,
-            }
-        );
-    }
-
-    #[test]
-    fn dual_basic_land_subtypes_synthesize_one_color_choice() {
-        let mut face = land_face(&["Mountain", "Forest"]);
-
-        synthesize_basic_land_mana(&mut face);
-
-        assert_eq!(
-            synthesized_mana(&face),
-            &ManaProduction::AnyOneColor {
-                count: QuantityExpr::Fixed { value: 1 },
-                color_options: vec![ManaColor::Red, ManaColor::Green],
-                contribution: ManaContribution::Base,
-            }
-        );
-    }
-
-    #[test]
-    fn triple_basic_land_subtypes_synthesize_one_color_choice() {
-        let mut face = land_face(&["Island", "Swamp", "Forest"]);
-
-        synthesize_basic_land_mana(&mut face);
-
-        assert_eq!(
-            synthesized_mana(&face),
-            &ManaProduction::AnyOneColor {
-                count: QuantityExpr::Fixed { value: 1 },
-                color_options: vec![ManaColor::Blue, ManaColor::Black, ManaColor::Green],
-                contribution: ManaContribution::Base,
-            }
-        );
+        }
     }
 }
 

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -466,7 +466,7 @@ pub fn synthesize_basic_land_mana(face: &mut CardFace) {
 
     let produced = if colors.len() == 1 {
         ManaProduction::Fixed {
-            colors: vec![colors[0]],
+            colors,
             contribution: ManaContribution::Base,
         }
     } else {

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -40,9 +40,8 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 26 | Delayed / future-phase trigger flattened to immediate effect | 21 | add-trigger: wrap future-phase effects in CreateDelayedTrigger |
 | 27 | Cross-target group / shared-quality constraint dropped | 20 | oracle_target.rs multi_target — add SameController/SameZone/DistinctNames/Parity constraints |
 | 28 | Trigger/activation timing or ordinal restriction dropped | 20 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
-| 29 | Disjunctive mana ability split into two Fixed abilities | 18 | oracle parser mana-ability handling — emit AnyOneColor{color_options} for 'Add A or B' |
 | 30 | Token/named-card name corrupted by normalization or overrun | 18 | oracle_util.rs SELF_REF normalization + Named-filter parsing — guard literal 'named X' spans |
-| 31 | Other / uncategorized misparse | 1 | manual triage |
+| 31 | Other / uncategorized misparse | 6 | manual triage |
 
 > The top **5** root causes cover ~50% of all misparse appearances; the top 10 cover the overwhelming majority. Fix these first.
 
@@ -5160,35 +5159,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 29. Disjunctive mana ability split into two Fixed abilities  (18 cards)
-
-**Signature.** '{T}: Add {X} or {Y}' emits two separate Fixed single-color mana abilities instead of one ManaProduction::AnyOneColor disjunctive-choice ability (CR 106.1).
-
-**Fix hint.** oracle parser mana-ability handling — emit AnyOneColor{color_options} for 'Add A or B'
-
-<details><summary>Cards</summary>
-
-- Cabal Stronghold
-- Cinder Glade
-- Coastal Peak
-- Haunted Mire
-- Hedge Maze
-- Lush Portico
-- Molten Tributary
-- On Thin Ice
-- Open the Omenpaths
-- Prairie Stream
-- Radiant Grove
-- Radiant Summit
-- Rainbow Vale
-- Savannah
-- Scattered Groves
-- The Great Mound
-- Wooded Ridgeline
-- Zagoth Triome
-
-</details>
-
 ### 30. Token/named-card name corrupted by normalization or overrun  (18 cards)
 
 **Signature.** A quoted/literal card name is rewritten by '~' self-reference normalization, an 'or'-list of names isn't split, a zone phrase is absorbed into the name, or trailing punctuation is left on a list option.
@@ -5218,7 +5188,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 31. Other / uncategorized misparse  (1 card)
+### 31. Other / uncategorized misparse  (6 cards)
 
 **Signature.** Cluster did not match a canonical signature class.
 
@@ -5226,6 +5196,11 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 <details><summary>Cards</summary>
 
+- Cabal Stronghold
 - Flaccify
+- On Thin Ice
+- Open the Omenpaths
+- Rainbow Vale
+- The Great Mound
 
 </details>

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -2,9 +2,9 @@
 
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
-- **Canonical root causes:** 31
-- **Distinct cards implicated:** 4810
-- **Total card appearances across root causes:** 4844 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Canonical root causes:** 30
+- **Distinct cards implicated:** 4797
+- **Total card appearances across root causes:** 4831 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 


### PR DESCRIPTION
## Summary

This PR now treats root #29 as a backlog false-positive bucket rather than an engine/card-data behavior bug.

Reviewer feedback pointed out that CR 305.6 grants a separate intrinsic mana ability for each basic land type. That means typed duals/triomes should continue to expose separate fixed `{T}: Add <color>` abilities at the engine/card-data layer, because ability identity and `ability_index` observe those rows.

The PR therefore removes the invalid root #29 bucket from `docs/parser-misparse-backlog.md` instead of changing synthesis behavior:

- 13 typed-land entries are removed from the backlog as not actually misparsed under CR 305.6.
- The five entries that did not match this bucket's signature in the current export are moved to `Other / uncategorized misparse` for separate triage.
- Header totals are updated to match the removed false-positive appearances.

There is no net engine or parser code change against current `origin/main`.

## Validation

- `cargo fmt --all`
- `cargo test -p engine --lib basic_land_mana_synthesis_tests` passed before the behavior change was reverted.
- Final local diff check: `git diff origin/main -- crates/engine/src/database/synthesis.rs` is empty, so no parsed card-data change is expected from this PR.
- `git diff --check` passes.