### PR TITLE
fix(parser): preserve optional target counts

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5288,7 +5288,7 @@ fn parse_each_of_up_to_damage_target<'a>(
 /// `MultiTargetSpec`. Routing it through this list would strip the quantifier
 /// and collapse the count to a fixed 1 (issue #458).
 const MULTI_TARGET_VERBS: &[&str] = &[
-    "exile", "tap", "untap", "goad", "return", "destroy", "choose",
+    "exile", "tap", "untap", "goad", "detain", "return", "destroy", "choose",
 ];
 
 pub(super) const BOUNDED_TARGET_PHRASES: &[(&str, usize, usize)] = &[

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21,9 +21,10 @@ pub(crate) use lower::{
 // pub(super) re-exports used by sibling submodules via `super::fn_name()`.
 pub(super) use lower::{
     apply_where_x_to_filter, extract_bounded_target_multi_target,
-    extract_exact_target_multi_target, parse_dynamic_counter_suffix_body,
-    parse_multi_target_count_expr, parse_where_x_quantity_expression, strip_exact_target_prefix,
-    strip_optional_target_prefix, try_parse_pump,
+    extract_exact_target_multi_target, extract_optional_target_multi_target,
+    parse_dynamic_counter_suffix_body, parse_multi_target_count_expr,
+    parse_where_x_quantity_expression, strip_exact_target_prefix, strip_optional_target_prefix,
+    try_parse_pump,
 };
 // Test-only re-exports from lower module.
 #[cfg(test)]
@@ -11700,7 +11701,8 @@ fn lower_imperative_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectCl
         && triggers::extract_target_filter_from_effect(&clause.effect).is_some()
     {
         clause.multi_target = extract_exact_target_multi_target(text)
-            .or_else(|| extract_bounded_target_multi_target(text));
+            .or_else(|| extract_bounded_target_multi_target(text))
+            .or_else(|| extract_optional_target_multi_target(text));
     }
     if matches!(clause.effect, Effect::DealDamage { .. }) && clause.multi_target.is_none() {
         clause.multi_target = extract_deal_damage_multi_target(text);

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -20299,6 +20299,93 @@ fn strip_optional_target_prefix_up_to_x_target() {
 }
 
 #[test]
+fn detain_up_to_two_target_creatures_preserves_multi_target() {
+    let def = parse_effect_chain(
+        "Detain up to two target creatures your opponents control.",
+        AbilityKind::Spell,
+    );
+
+    assert_eq!(
+        def.multi_target,
+        Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 2 }))
+    );
+    let Effect::Detain { target } = def.effect.as_ref() else {
+        panic!("expected Detain effect, got {:?}", def.effect);
+    };
+    let TargetFilter::Typed(filter) = target else {
+        panic!("expected typed detain target, got {target:?}");
+    };
+    assert!(filter.type_filters.contains(&TypeFilter::Creature));
+    assert_eq!(filter.controller, Some(ControllerRef::Opponent));
+}
+
+#[test]
+fn detain_up_to_two_target_nonland_permanents_preserves_multi_target() {
+    let def = parse_effect_chain(
+        "Detain up to two target nonland permanents your opponents control.",
+        AbilityKind::Spell,
+    );
+
+    assert_eq!(
+        def.multi_target,
+        Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 2 }))
+    );
+    let Effect::Detain { target } = def.effect.as_ref() else {
+        panic!("expected Detain effect, got {:?}", def.effect);
+    };
+    let TargetFilter::Typed(filter) = target else {
+        panic!("expected typed detain target, got {target:?}");
+    };
+    assert!(filter.type_filters.contains(&TypeFilter::Permanent));
+    assert!(filter
+        .type_filters
+        .contains(&TypeFilter::Non(Box::new(TypeFilter::Land))));
+    assert_eq!(filter.controller, Some(ControllerRef::Opponent));
+}
+
+#[test]
+fn detain_single_target_permanent_remains_mandatory() {
+    let def = parse_effect_chain("Detain target permanent.", AbilityKind::Spell);
+
+    assert_eq!(def.multi_target, None);
+    let Effect::Detain { target } = def.effect.as_ref() else {
+        panic!("expected Detain effect, got {:?}", def.effect);
+    };
+    let TargetFilter::Typed(filter) = target else {
+        panic!("expected typed detain target, got {target:?}");
+    };
+    assert!(filter.type_filters.contains(&TypeFilter::Permanent));
+}
+
+#[test]
+fn chained_return_up_to_one_target_creature_card_preserves_multi_target() {
+    let def = parse_effect_chain(
+        "Each opponent sacrifices a creature of their choice and you return up to one target creature card from your graveyard to your hand.",
+        AbilityKind::Spell,
+    );
+
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("expected return sub-ability");
+    assert_eq!(
+        sub.multi_target,
+        Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 1 }))
+    );
+    let Effect::Bounce { target, .. } = sub.effect.as_ref() else {
+        panic!("expected Bounce sub-effect, got {:?}", sub.effect);
+    };
+    let TargetFilter::Typed(filter) = target else {
+        panic!("expected typed return target, got {target:?}");
+    };
+    assert!(filter.type_filters.contains(&TypeFilter::Creature));
+    assert_eq!(filter.controller, Some(ControllerRef::You));
+    assert!(filter.properties.contains(&FilterProp::InZone {
+        zone: Zone::Graveyard
+    }));
+}
+
+#[test]
 fn cast_variant_paid_instead_sneak() {
     let (cond, text) = strip_additional_cost_conditional(
         "if her sneak cost was paid this turn, instead return that card to the battlefield",

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4792
-- **Total card appearances across root causes:** 4826 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4788
+- **Total card appearances across root causes:** 4822 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -12,7 +12,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 | # | Root cause | # cards | Fix hint (where it likely lives) |
 |---|------------|--------:|----------------------------------|
-| 1 | Relative-clause / filter restriction on target dropped | 754 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
+| 1 | Relative-clause / filter restriction on target dropped | 753 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
 | 2 | Dropped intervening-if / gating condition (condition: null) | 606 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
 | 3 | Anaphor bound to wrong referent | 404 | oracle_quantity.rs context-ref resolution + game/ability_utils.rs forward_result wiring |
 | 4 | Conjoined / chained second effect clause dropped | 388 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
@@ -26,7 +26,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 12 | Modal 'choose one/N' parsed as independent abilities | 138 | oracle.rs modal dispatch — detect 'Choose one —' header, wrap modes in Effect::ChooseOneOf |
 | 13 | State/game-state condition → StaticCondition::Unrecognized | 134 | oracle_nom/condition.rs parse_inner_condition — add typed variant for the predicate class |
 | 14 | Granted/quoted ability or continuous modification dropped | 96 | oracle_static.rs continuous-modification extraction — emit all conjuncts incl. GrantAbility/GrantKeyword |
-| 15 | Multi-target / 'up to N' optionality or count dropped | 91 | oracle_target.rs strip_optional_target_prefix — preserve MultiTargetSpec and optional_targeting |
+| 15 | Multi-target / 'up to N' optionality or count dropped | 89 | oracle_target.rs strip_optional_target_prefix — preserve MultiTargetSpec and optional_targeting |
 | 16 | Keyword payload / multiplicity / mis-tokenization | 84 | game/keywords.rs + oracle keyword parsing — use typed discriminants and guard ability-word labels |
 | 17 | Copy 'except' / additional-modification clause dropped | 81 | oracle parser copy handling — populate BecomeCopy/CopyTokenOf additional_modifications from the except-list (CR 707.2) |
 | 18 | Subtype / type-change modification malformed or dropped | 79 | oracle_util.rs SUBTYPES + parse_enchanted_is_type — register subtypes and emit full type-change set |
@@ -37,7 +37,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 23 | Effect modeled with structurally wrong variant / ability class | 51 | add-engine-effect: select the correct Effect/ability variant for the clause class |
 | 24 | Variable X / where-X count unbound (sentinel or unresolved Variable) | 37 | oracle_cost.rs / oracle_quantity.rs — allow QuantityExpr in count fields and bind trailing 'where X is' clauses |
 | 25 | Wrong / dropped effect duration | 32 | oracle_nom/duration.rs — add until-event / two-turn / permanent duration variants |
-| 26 | Delayed / future-phase trigger flattened to immediate effect | 21 | add-trigger: wrap future-phase effects in CreateDelayedTrigger |
+| 26 | Delayed / future-phase trigger flattened to immediate effect | 20 | add-trigger: wrap future-phase effects in CreateDelayedTrigger |
 | 27 | Cross-target group / shared-quality constraint dropped | 20 | oracle_target.rs multi_target — add SameController/SameZone/DistinctNames/Parity constraints |
 | 28 | Trigger/activation timing or ordinal restriction dropped | 19 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
 | 30 | Token/named-card name corrupted by normalization or overrun | 13 | oracle_util.rs SELF_REF normalization + Named-filter parsing — guard literal 'named X' spans |
@@ -47,7 +47,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 ## Full card lists per root cause
 
-### 1. Relative-clause / filter restriction on target dropped  (754 cards)
+### 1. Relative-clause / filter restriction on target dropped  (753 cards)
 
 **Signature.** TargetFilter/affected emitted with empty or missing properties; a trailing restrictive clause (type, subtype, color, mana value, zone, combat/temporal/control predicate, exclusion) is silently dropped, over-broadening the filter.
 
@@ -779,7 +779,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Wine of Blood and Iron
 - Wingbright Thief
 - Winter Blast
-- Witch of the Moors
 - Witch's Vengeance
 - Witch-king of Angmar
 - Witch-king, Bringer of Ruin
@@ -4245,7 +4244,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 15. Multi-target / 'up to N' optionality or count dropped  (91 cards)
+### 15. Multi-target / 'up to N' optionality or count dropped  (89 cards)
 
 **Signature.** MultiTargetSpec / 'up to one/two target' optionality dropped to a mandatory single Typed target (or collapsed into DamageAll), losing the multi_target / up_to slot and per-target distinctness.
 
@@ -4254,7 +4253,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 <details><summary>Cards</summary>
 
 - A-Incriminate
-- Azorius Justiciar
 - Batroc the Leaper
 - Blue Dragon
 - Bon... placeholder
@@ -4295,7 +4293,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Jagged Lightning
 - Jaya's Immolating Inferno
 - Journey of Discovery
-- Lyev Decree
 - Magus of the Candelabra
 - March of Reckless Joy
 - Mass Manipulation
@@ -5065,7 +5062,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 26. Delayed / future-phase trigger flattened to immediate effect  (21 cards)
+### 26. Delayed / future-phase trigger flattened to immediate effect  (20 cards)
 
 **Signature.** An effect that should be a delayed triggered ability (next combat/end/draw step) is emitted as an immediate effect with no CreateDelayedTrigger wrapper (CR 603.7).
 
@@ -5077,7 +5074,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Arcane Archery
 - Arcanis, the Omnipotent Avatar
 - Archaic's Agony
-- Archon of the Triumvirate
 - Arming Gala
 - Armory Automaton
 - At Least It's a Dry Heat


### PR DESCRIPTION
## Summary

Preserve `up to N target ...` cardinality for targeted imperative effects that already lower to a normal target filter.

- include `detain` in the shared target-cardinality verb set
- recover optional `MultiTargetSpec` in the direct imperative lowering path, matching the IR lowering path
- add parser regressions for Detain `up to two`, mandatory single-target Detain, and chained `return up to one target creature card`
- remove the fixed/misclassified cards from `docs/parser-misparse-backlog.md`

## Root Cause

Some parser paths stripped `up to N target ...` so `parse_target` could classify the target filter, but did not thread the stripped target count back onto `AbilityDefinition.multi_target`. The IR lowering path already recovered optional target counts; the direct imperative path only recovered exact/bounded counts.

## Card-Data Diff Audit

Compared full generated `card-data.json` before/after against parser-equivalent base `cf7cd7cb93f5e28293ad68ad288062894c4f617a`; the later base update to `8901bfeee` only changed PR review scripts, not parser/card-data inputs.

Raw changed cards: 4

- `Archon of the Triumvirate`: `triggers[0].execute.multi_target` changed `null -> up_to(2)`
- `Azorius Justiciar`: `triggers[0].execute.multi_target` changed `null -> up_to(2)`
- `Lyev Decree`: `abilities[0].multi_target` changed `null -> up_to(2)`
- `Witch of the Moors`: `triggers[0].execute.sub_ability.multi_target` changed `null -> up_to(1)`

`coverage-parse-diff` reported no `parse_details` changes because the changed serialized field is `multi_target`; the raw card-data diff above is the expected impact set.

## Verification

- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `git diff --check origin/main...HEAD`
- `RUSTC_WRAPPER= ZIG_GLOBAL_CACHE_DIR=/tmp/phase-zig-global-cache ZIG_LOCAL_CACHE_DIR=/tmp/phase-zig-local-cache cargo test -p engine --lib detain`
- `RUSTC_WRAPPER= ZIG_GLOBAL_CACHE_DIR=/tmp/phase-zig-global-cache ZIG_LOCAL_CACHE_DIR=/tmp/phase-zig-local-cache cargo test -p engine --lib chained_return_up_to_one`
- `RUSTC_WRAPPER= ZIG_GLOBAL_CACHE_DIR=/tmp/phase-zig-global-cache ZIG_LOCAL_CACHE_DIR=/tmp/phase-zig-local-cache cargo clippy -p engine --all-targets -- -D warnings` (pre-merge from main; post-merge targeted tests above rerun)
- `target/tool/card-data-validate /tmp/phase-root15-diff/head/card-data.json`
- `target/tool/coverage-parse-diff /tmp/phase-root15-diff/base/card-data.json /tmp/phase-root15-diff/head/card-data.json --base-sha cf7cd7cb93f5e28293ad68ad288062894c4f617a --markdown /tmp/phase-root15-diff/parse-diff.md --json /tmp/phase-root15-diff/parse-diff.json`