### PR TITLE
feat(lobby): capture usage analytics in the Cloudflare broker DO

### DIFF
--- a/lobby-worker/broker-wasm/src/lib.rs
+++ b/lobby-worker/broker-wasm/src/lib.rs
@@ -169,6 +169,13 @@ impl WasmBroker {
         self.inner.lobby().is_empty()
     }
 
+    /// Number of currently registered lobby entries (games waiting for players).
+    /// Read-only, so the shell need not re-snapshot after calling — this is the
+    /// live "active games" gauge surfaced by the `/stats` endpoint.
+    pub fn active_games(&self) -> usize {
+        self.inner.lobby().len()
+    }
+
     /// Handle one raw client frame (the exact JSON the client sent over the
     /// WebSocket). Parsing + dispatch happen in Rust; the shell never inspects
     /// the protocol. `conn_json` is the per-socket [`ConnState`] from the WS

--- a/lobby-worker/src/lobby-do.ts
+++ b/lobby-worker/src/lobby-do.ts
@@ -25,6 +25,17 @@ import {
   type ConnAttachment,
 } from "./hello-gate";
 import { moderationErrorForLobbyFrame } from "./name-filter";
+import {
+  buildStatsPayload,
+  countGameOutbounds,
+  dayBucket,
+  DAILY_PREFIX,
+  DAILY_SERIES_LIMIT,
+  GAMES_CREATED_KEY,
+  GAMES_JOINED_KEY,
+  PLAYERS_PEAK_KEY,
+  type DailyStat,
+} from "./stats";
 
 // Instantiate the broker WASM once per isolate, at top level (CF imports `.wasm`
 // as a WebAssembly.Module; `initSync` wires the wasm-bindgen imports
@@ -72,6 +83,15 @@ interface CallResult {
 
 const SNAPSHOT_KEY = "broker_snapshot";
 
+// ── Usage analytics (durable, DO-storage-backed) ────────────────────────────
+// The single global DO is a globally-consistent ledger, so a handful of KV
+// counters here ARE the all-time totals — no fan-in across instances needed.
+// Only monotonic facts are persisted; live gauges (players online, active
+// games) are computed on read from the socket set + broker, never stored, so a
+// hibernation-missed decrement can't drift them. The storage keys, stored
+// shapes, and the pure folds/derivations live in `./stats`; this shell owns
+// only the `ctx.storage` I/O and Response construction.
+
 export class LobbyDO {
   private ctx: DurableObjectState;
   /** In-memory broker, restored from the DO-storage snapshot on first use after
@@ -94,6 +114,10 @@ export class LobbyDO {
 
   async fetch(request: Request): Promise<Response> {
     if (request.headers.get("Upgrade") !== "websocket") {
+      // Public usage/analytics snapshot (read by the in-app lobby stats panel).
+      if (new URL(request.url).pathname === "/stats") {
+        return this.statsResponse();
+      }
       // Plain GET → version/health endpoint (deploy smoke check asserts
       // protocol_version == released client's).
       return Response.json({
@@ -113,7 +137,9 @@ export class LobbyDO {
     this.broadcastPlayerCount();
     // Lobby occupancy heartbeat — once per connection (not per frame). Lets you
     // see usage and spot connection leaks (count that never returns to 0).
-    console.log({ event: "lobby_connect", players: this.ctx.getWebSockets().length });
+    const players = this.ctx.getWebSockets().length;
+    console.log({ event: "lobby_connect", players });
+    await this.recordPeakPlayers(players);
     return new Response(null, { status: 101, webSocket: client });
   }
 
@@ -169,6 +195,11 @@ export class LobbyDO {
       await this.ctx.storage.put(SNAPSHOT_KEY, broker.snapshot());
       await this.ensureAlarm();
     }
+
+    // Best-effort usage counters — recorded AFTER the authoritative broker
+    // snapshot so a storage fault here can never preempt persisting the lobby
+    // entry (which the hibernation-recovery path depends on).
+    await this.recordGameStats(result.outbounds);
   }
 
   async webSocketClose(ws: WebSocket): Promise<void> {
@@ -214,6 +245,67 @@ export class LobbyDO {
     if (!broker.is_empty()) {
       await this.ctx.storage.setAlarm(Date.now() + REAP_INTERVAL_MS);
     }
+  }
+
+  // ── Usage analytics ────────────────────────────────────────────────────
+
+  /** Fold GameCreated / PeerInfo outbounds into the durable totals + today's
+   *  bucket. GameCreated = a room was hosted; PeerInfo = a guest was handed the
+   *  host's peer id, i.e. a P2P match actually began. */
+  private async recordGameStats(outbounds: OutboundDto[]): Promise<void> {
+    const { created, joined } = countGameOutbounds(outbounds);
+    if (created === 0 && joined === 0) return;
+
+    const dailyKey = `${DAILY_PREFIX}${dayBucket(Date.now())}`;
+    const [createdTotal, joinedTotal, daily] = await Promise.all([
+      this.ctx.storage.get<number>(GAMES_CREATED_KEY),
+      this.ctx.storage.get<number>(GAMES_JOINED_KEY),
+      this.ctx.storage.get<DailyStat>(dailyKey),
+    ]);
+    const bucket = daily ?? { created: 0, joined: 0 };
+    // Batched write. The DO input gate serializes handler invocations, so this
+    // read-modify-write can't interleave with another frame's increment.
+    await this.ctx.storage.put({
+      [GAMES_CREATED_KEY]: (createdTotal ?? 0) + created,
+      [GAMES_JOINED_KEY]: (joinedTotal ?? 0) + joined,
+      [dailyKey]: { created: bucket.created + created, joined: bucket.joined + joined },
+    });
+  }
+
+  /** Raise the persisted concurrent-players high-water mark if `players`
+   *  exceeds it. Called on connect — the only moment the live count can rise. */
+  private async recordPeakPlayers(players: number): Promise<void> {
+    const peak = (await this.ctx.storage.get<number>(PLAYERS_PEAK_KEY)) ?? 0;
+    if (players > peak) await this.ctx.storage.put(PLAYERS_PEAK_KEY, players);
+  }
+
+  /** Build the `/stats` JSON: live gauges from the socket set + broker, durable
+   *  totals / peak / 30-day series from DO storage. Public, non-sensitive
+   *  counts, so a permissive CORS header lets the browser read it cross-origin. */
+  private async statsResponse(): Promise<Response> {
+    const broker = await this.loadBroker();
+    const [createdTotal, joinedTotal, peak, daily] = await Promise.all([
+      this.ctx.storage.get<number>(GAMES_CREATED_KEY),
+      this.ctx.storage.get<number>(GAMES_JOINED_KEY),
+      this.ctx.storage.get<number>(PLAYERS_PEAK_KEY),
+      this.ctx.storage.list<DailyStat>({
+        prefix: DAILY_PREFIX,
+        reverse: true,
+        limit: DAILY_SERIES_LIMIT,
+      }),
+    ]);
+    const payload = buildStatsPayload({
+      playersOnline: this.ctx.getWebSockets().length,
+      playersPeak: peak ?? 0,
+      activeGames: broker.active_games(),
+      gamesCreatedTotal: createdTotal ?? 0,
+      gamesJoinedTotal: joinedTotal ?? 0,
+      daily,
+      nowMs: Date.now(),
+    });
+    return Response.json(payload, {
+      headers: { "Access-Control-Allow-Origin": "*", "Cache-Control": "no-store" },
+    });
   }
 
   // ── Outbound side-effect interpretation ────────────────────────────────

--- a/lobby-worker/src/stats.ts
+++ b/lobby-worker/src/stats.ts
@@ -1,0 +1,114 @@
+// Usage-analytics functional core for the lobby Durable Object.
+//
+// Everything here is storage-key definitions plus pure folds / derivations over
+// data the DO shell reads from `ctx.storage` — no I/O, so it is unit-testable
+// under `node --test` the same way `hello-gate.ts` is. The DO owns all
+// `ctx.storage` reads/writes and `Response` construction; this module owns the
+// stored shapes and the math that turns them into the `/stats` payload.
+
+/** Storage keys for the durable, monotonic analytics facts. Live gauges
+ *  (players online, active games) are never stored — they are computed on read
+ *  by the DO from the socket set + broker — so only these persist. */
+export const GAMES_CREATED_KEY = "stats:games_created"; // total GameCreated (rooms hosted)
+export const GAMES_JOINED_KEY = "stats:games_joined"; // total PeerInfo (P2P matches begun)
+export const PLAYERS_PEAK_KEY = "stats:players_peak"; // high-water concurrent connections
+export const DAILY_PREFIX = "stats:daily:"; // per-UTC-day buckets, key `${prefix}YYYY-MM-DD`
+
+/** Newest-N daily buckets returned in the `/stats` series. */
+export const DAILY_SERIES_LIMIT = 30;
+
+/** Per-day rollup stored at `${DAILY_PREFIX}${date}`. */
+export interface DailyStat {
+  created: number;
+  joined: number;
+}
+
+/** One chronological day in the `/stats` series (a `DailyStat` tagged with its
+ *  UTC date). */
+export interface DailyStatPoint extends DailyStat {
+  date: string;
+}
+
+/** The `/stats` response body: live gauges + durable totals / peak / series. */
+export interface StatsPayload {
+  players_online: number;
+  players_peak: number;
+  active_games: number;
+  games_created_total: number;
+  games_joined_total: number;
+  games_created_today: number;
+  games_joined_today: number;
+  daily: DailyStatPoint[];
+}
+
+/** The subset of a broker outbound side effect that the analytics fold reads.
+ *  Structurally compatible with the DO's `OutboundDto`, kept local so this
+ *  module has no dependency on the DO shell. */
+interface GameOutbound {
+  kind: string;
+  msg?: unknown;
+}
+
+/** Fold the broker's outbounds into game counts: `GameCreated` = a room was
+ *  hosted; `PeerInfo` = a guest was handed the host's peer id, i.e. a P2P match
+ *  actually began. Only `ToSelf` outbounds carry these; everything else (lobby
+ *  broadcasts, subscriber registry ops) is ignored. */
+export function countGameOutbounds(
+  outbounds: readonly GameOutbound[],
+): { created: number; joined: number } {
+  let created = 0;
+  let joined = 0;
+  for (const o of outbounds) {
+    if (o.kind !== "ToSelf") continue;
+    const type = (o.msg as { type?: string } | undefined)?.type;
+    if (type === "GameCreated") created += 1;
+    else if (type === "PeerInfo") joined += 1;
+  }
+  return { created, joined };
+}
+
+/** UTC date bucket (YYYY-MM-DD) for `nowMs` — the daily-series key suffix. */
+export function dayBucket(nowMs: number): string {
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+/** Inputs to {@link buildStatsPayload}: the durable scalars, the live gauges,
+ *  the raw (newest-first, prefix-keyed) daily buckets, and an explicit clock. */
+export interface BuildStatsPayloadArgs {
+  playersOnline: number;
+  playersPeak: number;
+  activeGames: number;
+  gamesCreatedTotal: number;
+  gamesJoinedTotal: number;
+  /** Reverse-listed (newest-first) daily buckets keyed by full storage key
+   *  (`${DAILY_PREFIX}YYYY-MM-DD`), as returned by `ctx.storage.list`. */
+  daily: Map<string, DailyStat>;
+  /** Explicit `Date.now()` so the today-lookup is deterministic under test. */
+  nowMs: number;
+}
+
+/** Assemble the `/stats` body: strip the key prefix off the newest-first daily
+ *  map, cap at {@link DAILY_SERIES_LIMIT}, flip to chronological for charting,
+ *  and derive today's created/joined from the series via `nowMs`. */
+export function buildStatsPayload(args: BuildStatsPayloadArgs): StatsPayload {
+  const series: DailyStatPoint[] = [...args.daily.entries()]
+    .slice(0, DAILY_SERIES_LIMIT)
+    .map(([key, value]) => ({
+      date: key.slice(DAILY_PREFIX.length),
+      created: value.created,
+      joined: value.joined,
+    }))
+    .reverse();
+  const today = dayBucket(args.nowMs);
+  const todayStat = series.find((s) => s.date === today) ?? { created: 0, joined: 0 };
+  return {
+    players_online: args.playersOnline,
+    players_peak: args.playersPeak,
+    active_games: args.activeGames,
+    games_created_total: args.gamesCreatedTotal,
+    games_joined_total: args.gamesJoinedTotal,
+    games_created_today: todayStat.created,
+    games_joined_today: todayStat.joined,
+    daily: series,
+  };
+}

--- a/lobby-worker/test/stats.test.mjs
+++ b/lobby-worker/test/stats.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildStatsPayload,
+  countGameOutbounds,
+  dayBucket,
+  DAILY_PREFIX,
+} from "../src/stats.ts";
+
+test("countGameOutbounds counts GameCreated and PeerInfo, ignores the rest", () => {
+  const outbounds = [
+    { kind: "ToSelf", msg: { type: "GameCreated" } },
+    { kind: "ToSelf", msg: { type: "PeerInfo" } },
+    { kind: "ToSelf", msg: { type: "GameCreated" } },
+    // Same message types on a non-ToSelf scope must not count.
+    { kind: "ToSubscribers", msg: { type: "GameCreated" } },
+    { kind: "ToSubscribers", msg: { type: "PeerInfo" } },
+    // Other ToSelf message types are ignored.
+    { kind: "ToSelf", msg: { type: "LobbyUpdate" } },
+    { kind: "ToSelf" },
+    { kind: "SendPlayerCountToSelf" },
+  ];
+  assert.deepEqual(countGameOutbounds(outbounds), { created: 2, joined: 1 });
+});
+
+test("countGameOutbounds returns zero for an empty batch", () => {
+  assert.deepEqual(countGameOutbounds([]), { created: 0, joined: 0 });
+});
+
+test("countGameOutbounds sums multiple in one batch", () => {
+  const outbounds = [
+    { kind: "ToSelf", msg: { type: "PeerInfo" } },
+    { kind: "ToSelf", msg: { type: "PeerInfo" } },
+    { kind: "ToSelf", msg: { type: "GameCreated" } },
+  ];
+  assert.deepEqual(countGameOutbounds(outbounds), { created: 1, joined: 2 });
+});
+
+test("dayBucket returns the UTC YYYY-MM-DD for a fixed epoch", () => {
+  // 2026-07-03T18:04:55Z
+  assert.equal(dayBucket(Date.parse("2026-07-03T18:04:55.000Z")), "2026-07-03");
+  // Just before midnight UTC stays on the same day; the ms are truncated.
+  assert.equal(dayBucket(Date.parse("2026-07-03T23:59:59.999Z")), "2026-07-03");
+  // One ms later crosses into the next UTC day.
+  assert.equal(dayBucket(Date.parse("2026-07-04T00:00:00.000Z")), "2026-07-04");
+});
+
+test("buildStatsPayload passes durable scalars and live gauges through", () => {
+  const payload = buildStatsPayload({
+    playersOnline: 7,
+    playersPeak: 42,
+    activeGames: 3,
+    gamesCreatedTotal: 100,
+    gamesJoinedTotal: 80,
+    daily: new Map(),
+    nowMs: Date.parse("2026-07-03T12:00:00.000Z"),
+  });
+  assert.equal(payload.players_online, 7);
+  assert.equal(payload.players_peak, 42);
+  assert.equal(payload.active_games, 3);
+  assert.equal(payload.games_created_total, 100);
+  assert.equal(payload.games_joined_total, 80);
+  // No buckets at all → today derives to zero and the series is empty.
+  assert.equal(payload.games_created_today, 0);
+  assert.equal(payload.games_joined_today, 0);
+  assert.deepEqual(payload.daily, []);
+});
+
+test("buildStatsPayload derives today from the injected clock and orders chronologically", () => {
+  // Storage lists reverse (newest-first); keys carry the full prefix.
+  const daily = new Map([
+    [`${DAILY_PREFIX}2026-07-03`, { created: 5, joined: 4 }],
+    [`${DAILY_PREFIX}2026-07-02`, { created: 2, joined: 1 }],
+    [`${DAILY_PREFIX}2026-07-01`, { created: 9, joined: 8 }],
+  ]);
+  const payload = buildStatsPayload({
+    playersOnline: 0,
+    playersPeak: 0,
+    activeGames: 0,
+    gamesCreatedTotal: 16,
+    gamesJoinedTotal: 13,
+    daily,
+    nowMs: Date.parse("2026-07-03T09:30:00.000Z"),
+  });
+  // Series flipped to chronological (oldest-first), prefix stripped.
+  assert.deepEqual(payload.daily, [
+    { date: "2026-07-01", created: 9, joined: 8 },
+    { date: "2026-07-02", created: 2, joined: 1 },
+    { date: "2026-07-03", created: 5, joined: 4 },
+  ]);
+  // Today lookup uses nowMs, not the wall clock.
+  assert.equal(payload.games_created_today, 5);
+  assert.equal(payload.games_joined_today, 4);
+});
+
+test("buildStatsPayload reports zero for today when the bucket is missing", () => {
+  const daily = new Map([
+    [`${DAILY_PREFIX}2026-07-01`, { created: 3, joined: 2 }],
+  ]);
+  const payload = buildStatsPayload({
+    playersOnline: 0,
+    playersPeak: 0,
+    activeGames: 0,
+    gamesCreatedTotal: 3,
+    gamesJoinedTotal: 2,
+    daily,
+    nowMs: Date.parse("2026-07-05T00:00:00.000Z"),
+  });
+  assert.equal(payload.games_created_today, 0);
+  assert.equal(payload.games_joined_today, 0);
+});
+
+test("buildStatsPayload caps the series at 30 newest days", () => {
+  // 40 days, newest-first as storage would list them.
+  const entries = [];
+  for (let day = 40; day >= 1; day--) {
+    const date = `2026-01-${String(day).padStart(2, "0")}`;
+    entries.push([`${DAILY_PREFIX}${date}`, { created: day, joined: day }]);
+  }
+  const payload = buildStatsPayload({
+    playersOnline: 0,
+    playersPeak: 0,
+    activeGames: 0,
+    gamesCreatedTotal: 0,
+    gamesJoinedTotal: 0,
+    daily: new Map(entries),
+    nowMs: Date.parse("2026-02-15T00:00:00.000Z"),
+  });
+  assert.equal(payload.daily.length, 30);
+  // Kept the newest 30 (days 11..40), oldest-first after the flip.
+  assert.equal(payload.daily[0].date, "2026-01-11");
+  assert.equal(payload.daily[29].date, "2026-01-40");
+});


### PR DESCRIPTION
Record durable lobby usage counters in the single global SQLite-backed
Durable Object and expose them at GET /stats. The Rust broker core is
pure and its tracing logs are dropped in WASM, so instrumentation lives
in the DO shell: GameCreated/PeerInfo outbounds fold into all-time
totals + per-UTC-day buckets, and peak concurrent players is tracked on
connect. Live gauges (players online, active games) are computed on read
and never persisted. Pure folds/derivations live in stats.ts with node
tests; the DO shell owns only ctx.storage I/O.

Adds WasmBroker::active_games() (mirrors is_empty()) for the live
active-games gauge.
