### PR TITLE
fix(parser): parse targeted perpetual p/t grants

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7084,6 +7084,37 @@ fn try_parse_perpetual_modify_pt(tp: TextPair) -> Option<Effect> {
 
     let lower = tp.lower;
 
+    // Explicit target form: "Target creature perpetually gets -2/-0."
+    // `parse_target` owns the target/filter grammar; this arm only recognizes the
+    // perpetual P/T tail and rejects compound grants so mixed forms stay honest.
+    if peek(tag::<_, _, OracleError<'_>>("target "))
+        .parse(lower)
+        .is_ok()
+    {
+        let (target, after_target) = parse_target(lower);
+        if !matches!(target, TargetFilter::Any) {
+            let (rest, _) = space1::<_, OracleError<'_>>(after_target).ok()?;
+            let (rest, _) = tag::<_, _, OracleError<'_>>("perpetually ")
+                .parse(rest)
+                .ok()?;
+            let (rest, _) = alt((
+                tag::<_, _, OracleError<'_>>("gets "),
+                tag::<_, _, OracleError<'_>>("get "),
+            ))
+            .parse(rest)
+            .ok()?;
+            let (rest, (power_delta, toughness_delta)) =
+                nom_primitives::parse_pt_modifier(rest).ok()?;
+            return tail_done(rest).then_some(Effect::ApplyPerpetual {
+                target,
+                modification: crate::types::ability::PerpetualModification::ModifyPowerToughness {
+                    power_delta,
+                    toughness_delta,
+                },
+            });
+        }
+    }
+
     // Anaphoric back-reference: "that Vehicle perpetually gets +1/+0".
     if let Ok((after_that, _)) = tag::<_, _, OracleError<'_>>("that ").parse(lower) {
         let (rest, _) = take_until::<_, _, OracleError<'_>>("perpetually ")

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -29620,6 +29620,32 @@ fn perpetual_parser_maps_modify_pt() {
             ..
         }
     ));
+
+    let e = parse_effect("Target creature an opponent controls perpetually gets -1/-2.");
+    assert!(matches!(
+        e,
+        Effect::ApplyPerpetual {
+            target: TargetFilter::Typed(ref filter),
+            modification: PerpetualModification::ModifyPowerToughness {
+                power_delta: -1,
+                toughness_delta: -2,
+            },
+        } if filter.type_filters.contains(&crate::types::ability::TypeFilter::Creature)
+            && filter.controller == Some(crate::types::ability::ControllerRef::Opponent)
+    ));
+
+    let e = parse_effect("target creature you control perpetually gets +1/+0.");
+    assert!(matches!(
+        e,
+        Effect::ApplyPerpetual {
+            target: TargetFilter::Typed(ref filter),
+            modification: PerpetualModification::ModifyPowerToughness {
+                power_delta: 1,
+                toughness_delta: 0,
+            },
+        } if filter.type_filters.contains(&crate::types::ability::TypeFilter::Creature)
+            && filter.controller == Some(crate::types::ability::ControllerRef::You)
+    ));
 }
 
 #[test]

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4792
-- **Total card appearances across root causes:** 4826 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4788
+- **Total card appearances across root causes:** 4822 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -30,7 +30,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 16 | Keyword payload / multiplicity / mis-tokenization | 84 | game/keywords.rs + oracle keyword parsing — use typed discriminants and guard ability-word labels |
 | 17 | Copy 'except' / additional-modification clause dropped | 81 | oracle parser copy handling — populate BecomeCopy/CopyTokenOf additional_modifications from the except-list (CR 707.2) |
 | 18 | Subtype / type-change modification malformed or dropped | 79 | oracle_util.rs SUBTYPES + parse_enchanted_is_type — register subtypes and emit full type-change set |
-| 19 | Perpetual (Alchemy) duration mis-mapped to UntilEndOfTurn | 71 | oracle_nom/duration.rs — add Perpetual duration combinator branch |
+| 19 | Perpetual (Alchemy) duration mis-mapped to UntilEndOfTurn | 67 | oracle_nom/duration.rs — add Perpetual duration combinator branch |
 | 20 | Damage subject/recipient set incomplete | 70 | Effect::DealDamage handling — capture all damage subjects/recipients per CR 120 |
 | 21 | Token entry flags / keyword / attachment clause dropped | 52 | oracle parser token-description handling — preserve attacking/tapped flags, keyword grants, attach target |
 | 22 | Attacks-alone / while-saddled combat constraint dropped | 51 | oracle_trigger.rs scan_for_phase / attacks-trigger constraint parsing; add SourceAttackingAlone/MinCoAttackers + TriggerCondition::SourceIsSaddled |
@@ -4624,7 +4624,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 19. Perpetual (Alchemy) duration mis-mapped to UntilEndOfTurn  (71 cards)
+### 19. Perpetual (Alchemy) duration mis-mapped to UntilEndOfTurn  (67 cards)
 
 **Signature.** 'perpetually' grant emitted with UntilEndOfTurn/null instead of a Perpetual duration; modification expires too soon.
 
@@ -4639,7 +4639,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Courtly Provocateur
 - Creeping Tar Pit
 - Custodi Soulcaller
-- Davriel's Withering
 - Drop Tower
 - Edifice of Authority
 - Effluence Devourer
@@ -4652,7 +4651,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Grow Old Together
 - Hardened Bonds
 - Homarid Warrior
-- Hypnotic Pattern
 - Incessant Provocation
 - Indris, the Hydrostatic Surge
 - Inspiring Easel
@@ -4683,7 +4681,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Ravenous Pursuit
 - Reckless Ringleader
 - Sap Vitality
-- Scion of Shiv
 - Scrutiny of the Guildpact
 - Shadow of the Enemy
 - Shattered Seraph
@@ -4701,7 +4698,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Undersimplify
 - Unsavory Kitchen
 - Valiant Farewell
-- Wizened Githzerai
 - Wyll of the Fey Pact
 
 </details>


### PR DESCRIPTION
## Summary

- Parse `target ... perpetually gets +N/+M` as `ApplyPerpetual::ModifyPowerToughness` instead of a temporary pump.
- Reuse `parse_target` for the target/filter grammar and keep the new arm limited to a simple P/T tail.
- Remove four cards from `docs/parser-misparse-backlog.md` root #19 after fresh export evidence.

## Card-data audit

Full raw `card-data.json` base/head comparison changed exactly these cards:

- `davriel's withering`
- `davriel, soul broker`
- `hypnotic pattern`
- `prairie survivalist`
- `scintillating encore`
- `shattering finale`
- `valiant emberkin`

Intentional notes:

- `Davriel's Withering` and `Hypnotic Pattern` are fixed by this parser arm and removed from the backlog.
- `Scion of Shiv` and `Wizened Githzerai` were already correct on current `origin/main` in the fresh root #19 export, so they were removed as stale backlog entries.
- `Prairie Survivalist` stays in the backlog: this PR fixes its first target-prefix perpetual P/T clause, but its later anaphoric `It perpetually gets +1/+0` clause is still misparsed.
- `Scintillating Encore` changes the target-prefix perpetual P/T clause; the nested delayed-trigger `return it` target also becomes the trigger source, which matches the dying object referenced by the delayed trigger.
- Local `coverage-parse-diff` reported `oracle_changed: 0`; the raw full `card-data.json` diff above was manually inspected for the seven changed cards.

## Verification

- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `git diff --check`
- `cargo test -p engine --features cli --lib perpetual_parser_maps_modify_pt`
- `cargo clippy -p engine --all-targets -- -D warnings`
- Full base/head `oracle-gen` exports to `/tmp/phase-targetpt-full/{base,head}/card-data.json`
- Raw full `card-data.json` changed-key comparison
- `cargo run -p engine --features cli --bin card-data-validate -- /tmp/phase-targetpt-full/head/card-data.json` (`OK: 35397 cards parsed`)
- `cargo run -p engine --features cli --bin coverage-parse-diff -- ...` (`oracle_changed: 0`)