### PR TITLE
fix(parser): preserve legacy activation timing

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5282,6 +5282,10 @@ fn parse_activation_timing_restriction(phrase: &str) -> Option<Vec<ActivationRes
     None
 }
 
+// CR 602.1b: Activation instructions after the colon restrict when an ability
+// can be activated and are not part of the ability's effect.
+// CR 304.5 / CR 307.5: "Only as an instant" and "only as a sorcery" define
+// the priority and timing permissions for activating the ability.
 fn parse_activation_speed_parenthetical_body(phrase: &str) -> Option<Vec<ActivationRestriction>> {
     let lower = phrase.to_lowercase();
     let (_, rest_original) = nom_on_lower(phrase, &lower, |i| {
@@ -5299,6 +5303,8 @@ fn parse_activation_speed_parenthetical_body(phrase: &str) -> Option<Vec<Activat
         .then_some(restrictions)
 }
 
+// CR 602.1b: A parenthesized speed instruction after an activated ability is
+// still an activation restriction, so keep it visible before reminder stripping.
 fn preserve_activation_timing_parenthetical(raw_line: &str) -> Option<String> {
     let lower = raw_line.to_lowercase();
     let (_, parenthetical_original) = nom_on_lower(raw_line, &lower, |i| {
@@ -5309,9 +5315,8 @@ fn preserve_activation_timing_parenthetical(raw_line: &str) -> Option<String> {
     let prefix_len = raw_line.len() - parenthetical_original.len() - " (".len();
     let prefix = raw_line[..prefix_len].trim_end();
 
-    let parenthetical_lower = parenthetical_original.to_lowercase();
-    let Ok((tail, inner_lower)) = terminated(take_until::<_, _, OracleError<'_>>(")"), tag(")"))
-        .parse(parenthetical_lower.as_str())
+    let Ok((tail, inner_original)) = terminated(take_until::<_, _, OracleError<'_>>(")"), tag(")"))
+        .parse(parenthetical_original)
     else {
         return None;
     };
@@ -5319,8 +5324,7 @@ fn preserve_activation_timing_parenthetical(raw_line: &str) -> Option<String> {
         return None;
     }
 
-    let inner_original = parenthetical_original[..inner_lower.len()].trim();
-    let timing_text = inner_original.trim_end_matches('.').trim();
+    let timing_text = inner_original.trim().trim_end_matches('.').trim();
     parse_activation_speed_parenthetical_body(timing_text)?;
     Some(format!("{prefix} {timing_text}."))
 }
@@ -5706,6 +5710,10 @@ pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConst
     (remaining, constraints)
 }
 
+// CR 602.1d: Older cards referred to activating an activated ability as
+// "playing" that ability.
+// CR 602.1b + CR 307.5: "Play this ability as a sorcery" is a trailing
+// activation instruction, not part of the ability's effect.
 fn split_legacy_play_this_ability_timing(text: &str) -> Option<(&str, Vec<ActivationRestriction>)> {
     let lower = text.to_lowercase();
     let (_, restriction_original) = nom_on_lower(text, &lower, |i| {

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -2632,6 +2632,11 @@ pub(crate) fn parse_oracle_ir(
         // zero parsed abilities for these cards.
         let reminder_body_owned = extract_ability_word_reminder_body(raw_line);
         let raw_line: &str = reminder_body_owned.as_deref().unwrap_or(raw_line);
+        let activation_timing_parenthetical_owned =
+            preserve_activation_timing_parenthetical(raw_line);
+        let raw_line: &str = activation_timing_parenthetical_owned
+            .as_deref()
+            .unwrap_or(raw_line);
 
         let line = strip_reminder_text(raw_line);
         let ability_cant_be_copied = x_annotation_marks_ability_uncopyable(&line);
@@ -5277,6 +5282,49 @@ fn parse_activation_timing_restriction(phrase: &str) -> Option<Vec<ActivationRes
     None
 }
 
+fn parse_activation_speed_parenthetical_body(phrase: &str) -> Option<Vec<ActivationRestriction>> {
+    let lower = phrase.to_lowercase();
+    let (_, rest_original) = nom_on_lower(phrase, &lower, |i| {
+        value((), tag("activate only ")).parse(i)
+    })?;
+    let restrictions = parse_activation_timing_restriction(rest_original)?;
+    restrictions
+        .iter()
+        .all(|restriction| {
+            matches!(
+                restriction,
+                ActivationRestriction::AsInstant | ActivationRestriction::AsSorcery
+            )
+        })
+        .then_some(restrictions)
+}
+
+fn preserve_activation_timing_parenthetical(raw_line: &str) -> Option<String> {
+    let lower = raw_line.to_lowercase();
+    let (_, parenthetical_original) = nom_on_lower(raw_line, &lower, |i| {
+        let (i, _) = take_until::<_, _, OracleError<'_>>(" (activate only ").parse(i)?;
+        let (i, _) = tag::<_, _, OracleError<'_>>(" (").parse(i)?;
+        Ok((i, ()))
+    })?;
+    let prefix_len = raw_line.len() - parenthetical_original.len() - " (".len();
+    let prefix = raw_line[..prefix_len].trim_end();
+
+    let parenthetical_lower = parenthetical_original.to_lowercase();
+    let Ok((tail, inner_lower)) = terminated(take_until::<_, _, OracleError<'_>>(")"), tag(")"))
+        .parse(parenthetical_lower.as_str())
+    else {
+        return None;
+    };
+    if !tail.trim().trim_end_matches('.').trim().is_empty() {
+        return None;
+    }
+
+    let inner_original = parenthetical_original[..inner_lower.len()].trim();
+    let timing_text = inner_original.trim_end_matches('.').trim();
+    parse_activation_speed_parenthetical_body(timing_text)?;
+    Some(format!("{prefix} {timing_text}."))
+}
+
 fn opponents_turn_activation_restriction() -> ActivationRestriction {
     ActivationRestriction::RequiresCondition {
         condition: Some(opponents_turn_activation_condition()),
@@ -5371,6 +5419,17 @@ pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConst
                 }
                 continue;
             }
+        }
+
+        if let Some((before, restrictions)) = split_legacy_play_this_ability_timing(&remaining) {
+            remaining = before
+                .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
+                .to_string();
+            constraints.restrictions.extend(restrictions);
+            if remaining.is_empty() {
+                break;
+            }
+            continue;
         }
 
         const OPPONENTS_ACTIVATE_SUFFIX: &str = "only your opponents may activate this ability";
@@ -5645,6 +5704,31 @@ pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConst
     }
 
     (remaining, constraints)
+}
+
+fn split_legacy_play_this_ability_timing(text: &str) -> Option<(&str, Vec<ActivationRestriction>)> {
+    let lower = text.to_lowercase();
+    let (_, restriction_original) = nom_on_lower(text, &lower, |i| {
+        let (i, before) = take_until::<_, _, OracleError<'_>>("play this ability ").parse(i)?;
+        if !is_empty_or_sentence_boundary(before) {
+            return Err(nom::Err::Error(OracleError::new(
+                before,
+                nom::error::ErrorKind::Tag,
+            )));
+        }
+        let (i, _) = tag::<_, _, OracleError<'_>>("play this ability ").parse(i)?;
+        Ok((i, ()))
+    })?;
+    let prefix_len = text.len() - restriction_original.len() - "play this ability ".len();
+    let restrictions = parse_activation_timing_restriction(restriction_original)?;
+    Some((&text[..prefix_len], restrictions))
+}
+
+fn is_empty_or_sentence_boundary(text: &str) -> bool {
+    text.trim_end()
+        .chars()
+        .next_back()
+        .is_none_or(|ch| ch == '.')
 }
 
 /// CR 602.5b: Recognize a standalone `"Activate only once each turn"` cadence

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -127,6 +127,67 @@ fn activated_ability_opponent_turn_restriction_uses_not_your_turn_condition() {
     );
 }
 
+#[test]
+fn legacy_play_this_ability_as_sorcery_records_activation_restriction() {
+    let r = parse(
+        "When Shichifukujin Dragon comes into play, put seven +1/+1 counters on it.\n\
+         {R}{R}{R}, Sacrifice two +1/+1 counters: Put three +1/+1 counters on \
+         Shichifukujin Dragon at end of turn. Play this ability as a sorcery.",
+        "Shichifukujin Dragon",
+        &[],
+        &["Creature"],
+        &["Dragon"],
+    );
+
+    let activation = r
+        .abilities
+        .iter()
+        .find(|ability| {
+            ability
+                .description
+                .as_deref()
+                .is_some_and(|description| description.contains("Play this ability"))
+        })
+        .expect("expected legacy activated ability");
+    assert!(
+        activation
+            .activation_restrictions
+            .contains(&ActivationRestriction::AsSorcery),
+        "expected legacy play-this-ability wording to map to AsSorcery, got {:?}",
+        activation.activation_restrictions
+    );
+}
+
+#[test]
+fn parenthetical_activate_only_as_instant_records_activation_restriction() {
+    let r = parse(
+        "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\n\
+         {T}: Add {B}{B}{B}{B}. Target opponent gains control of Witch Engine. \
+         (Activate only as an instant.)",
+        "Witch Engine",
+        &[Keyword::Landwalk("Swamp".to_string())],
+        &["Creature"],
+        &["Horror"],
+    );
+
+    let activation =
+        r.abilities
+            .iter()
+            .find(|ability| {
+                ability.description.as_deref().is_some_and(|description| {
+                    description.contains("Target opponent gains control")
+                })
+            })
+            .expect("expected parenthetical activation-timing ability");
+    assert!(
+        activation
+            .activation_restrictions
+            .contains(&ActivationRestriction::AsInstant),
+        "expected parenthetical activation timing to map to AsInstant, got {:?}",
+        activation.activation_restrictions
+    );
+}
+
 /// The static half of M.O.D.O.K. ("Designed Only for Killing — Creatures your
 /// opponents control get -1/-1") already parses on its own ability-word label;
 /// this guards that the activated-ability fix above doesn't regress it.

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4788
-- **Total card appearances across root causes:** 4822 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4786
+- **Total card appearances across root causes:** 4820 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -39,7 +39,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 25 | Wrong / dropped effect duration | 32 | oracle_nom/duration.rs — add until-event / two-turn / permanent duration variants |
 | 26 | Delayed / future-phase trigger flattened to immediate effect | 20 | add-trigger: wrap future-phase effects in CreateDelayedTrigger |
 | 27 | Cross-target group / shared-quality constraint dropped | 20 | oracle_target.rs multi_target — add SameController/SameZone/DistinctNames/Parity constraints |
-| 28 | Trigger/activation timing or ordinal restriction dropped | 19 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
+| 28 | Trigger/activation timing or ordinal restriction dropped | 17 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
 | 30 | Token/named-card name corrupted by normalization or overrun | 13 | oracle_util.rs SELF_REF normalization + Named-filter parsing — guard literal 'named X' spans |
 | 31 | Other / uncategorized misparse | 6 | manual triage |
 
@@ -5124,7 +5124,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 28. Trigger/activation timing or ordinal restriction dropped  (19 cards)
+### 28. Trigger/activation timing or ordinal restriction dropped  (17 cards)
 
 **Signature.** A timing/scope restriction (OnlyDuringYourTurn / OncePerTurn / 'during an opponent's turn' / Nth-spell ordinal / cast-timing) is null; the constraint tail is not parsed.
 
@@ -5143,14 +5143,12 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Ichneumon Druid
 - MACH-1, Swooping Scoundrel
 - Shadowheart, Sharran Cleric
-- Shichifukujin Dragon
 - Skarrgan Hellkite
 - Skyblade's Boon
 - Tomb Tyrant
 - Trade Caravan
 - Uthros Research Craft
 - Uthros, Titanic Godcore
-- Witch Engine
 
 </details>
 


### PR DESCRIPTION
## Summary

- Preserve legacy activation timing text that would otherwise be stripped as parenthetical reminder text.
- Map `Play this ability as a sorcery` onto the existing activation timing restriction parser.
- Remove Shichifukujin Dragon and Witch Engine from root #28 in `docs/parser-misparse-backlog.md`.

## Root Cause

The parser already knew how to model `AsInstant` and `AsSorcery`, but two old Oracle forms bypassed that path:

- `Play this ability as a sorcery.` stayed in the activated ability text instead of being lifted into `activation_restrictions`.
- `(Activate only as an instant.)` was removed by `strip_reminder_text` before activated-ability constraint stripping could see it.

This fix keeps the change on the activation-constraint seam and delegates the actual timing parse to `parse_activation_timing_restriction`.

## Card-Data Audit

- Broad MTGJSON search included `Play this ability` and parenthetical `Activate only` candidates.
- The actual speed-only candidate set exported for before/after comparison was 8 cards:
  Charmed Pendant, Diamond Lion, Everythingamajig, Lion's Eye Diamond, Mana Screw, Rhystic Cave, Shichifukujin Dragon, Witch Engine.
- Raw parsed JSON comparison changed exactly:
  - Shichifukujin Dragon: adds `activation_restrictions: [{ "type": "AsSorcery" }]`.
  - Witch Engine: adds `activation_restrictions: [{ "type": "AsInstant" }]` and preserves the timing sentence in the parsed description.
- Boast/Forecast-style parentheticals are intentionally not preserved by this helper; it only accepts `AsInstant`/`AsSorcery` speed parentheticals.
- The CI parse-diff sticky reports exactly the expected 2 changed cards:
  - Shichifukujin Dragon: removes the bogus `CastFromZone (target=any target)` signature and changes `PutCounter.timing` from empty to `sorcery speed`.
  - Witch Engine: shows the mana ability signature removed/added after the preserved timing parenthetical changes the parsed ability shape; the raw parsed JSON field change is the expected `AsInstant` activation restriction.
- Backlog search confirmed the two removed cards had no other appearances in `docs/parser-misparse-backlog.md`.

## Review Follow-Up

- Addressed Gemini's unsafe-slicing comment by parsing the parenthetical body on the original string instead of slicing by lowercase byte length.
- Added verified CR annotations for CR 602.1b, CR 602.1d, CR 304.5, and CR 307.5.

## Verification

- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `git diff --check`
- `env -u RUSTC_WRAPPER ZIG_GLOBAL_CACHE_DIR=/tmp/phase-zig-cache cargo --config 'build.rustc-wrapper=""' test -p engine --features cli --lib legacy_play_this_ability_as_sorcery_records_activation_restriction`
- `env -u RUSTC_WRAPPER ZIG_GLOBAL_CACHE_DIR=/tmp/phase-zig-cache cargo --config 'build.rustc-wrapper=""' test -p engine --features cli --lib parenthetical_activate_only_as_instant_records_activation_restriction`
- `env -u RUSTC_WRAPPER cargo --config 'build.rustc-wrapper=""' run -p engine --features cli --bin oracle-gen -- --cards /tmp/phase-root28-legacy-timing-cards.txt --output /tmp/phase-root28-legacy-timing-after.json`
- `env -u RUSTC_WRAPPER cargo --config 'build.rustc-wrapper=""' run -p engine --features cli --bin card-data-validate -- /tmp/phase-root28-legacy-timing-after.json`
- `env -u RUSTC_WRAPPER cargo --config 'build.rustc-wrapper=""' run -p engine --features cli --bin coverage-parse-diff -- /tmp/phase-root28-legacy-timing-base.json /tmp/phase-root28-legacy-timing-after.json --markdown /tmp/phase-root28-legacy-timing-parse-diff.md --json /tmp/phase-root28-legacy-timing-parse-diff.json`
- CI: Rust lint/parser gate, Rust tests, card data generate/validate/coverage, final Rust coverage-gate, frontend, lobby worker, WASM, and Tauri all passed on head `b0bc685a`.
