### PR TITLE
feat(telemetry): first-party Tier 1 telemetry — client beacon, worker ingest, engine unimplemented accumulator

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -368,6 +368,9 @@ jobs:
           # cloud sync stays disabled and the app falls back to file backup.
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          # First-party telemetry ingest (lobby Worker → Analytics Engine, see
+          # docs/telemetry-proposal.md). Unset would compile telemetry to a no-op.
+          TELEMETRY_URL: "https://lobby.phase-rs.dev/telemetry"
         run: |
           cd client
           pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,6 +358,9 @@ jobs:
           # cloud sync stays disabled and the app falls back to file backup.
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          # First-party telemetry ingest (lobby Worker → Analytics Engine, see
+          # docs/telemetry-proposal.md). Unset would compile telemetry to a no-op.
+          TELEMETRY_URL: "https://lobby.phase-rs.dev/telemetry"
         run: |
           cd client
           pnpm install --frozen-lockfile
@@ -958,6 +961,9 @@ jobs:
           # Anon key is client-safe (RLS gates access).
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          # Telemetry ingest define reaches vite.config.ts via the same
+          # beforeBuildCommand path as the Supabase vars above.
+          TELEMETRY_URL: "https://lobby.phase-rs.dev/telemetry"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, useSearchParams } from "react-router";
 
 import { AppShell } from "./components/chrome/AppShell";
 import { AppToast } from "./components/chrome/AppToast";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { HostControlTile } from "./components/chrome/HostControlTile";
 import { EngineLostModal } from "./components/modal/EngineLostModal";
 import { NonFatalPanicToast } from "./components/modal/NonFatalPanicToast";
@@ -100,6 +101,7 @@ function AppContent() {
       {showSplash && (
         <SplashScreen progress={progress} onComplete={handleSplashComplete} label={loadLabel} />
       )}
+      <ErrorBoundary>
       <Suspense fallback={<div className="flex min-h-screen items-center justify-center"><div className="h-8 w-8 animate-spin rounded-full border-2 border-gray-500 border-t-white" /></div>}>
         <Routes>
           {/* Modern app shell (rail + tab bar + single scene) wraps every
@@ -119,6 +121,7 @@ function AppContent() {
           <Route path="/game/:id" element={<GameRouteElement />} />
         </Routes>
       </Suspense>
+      </ErrorBoundary>
       <HostControlTile />
       <AppToast />
       <EngineLostModal />

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2129,6 +2129,15 @@ export interface GameState {
   max_lands_per_turn: number;
   priority_pass_count: number;
   /**
+   * Mirrors `engine::types::game_state::GameState::unimplemented_oracle_ids`.
+   * Oracle ids (fallback: object names) of cards whose abilities hit an
+   * unimplemented effect at resolution this game. Diagnostics only — forwarded
+   * verbatim to the `game_end` telemetry event. Distinct from the per-object
+   * `unimplemented_mechanics` static parse-coverage projection. Absent when the
+   * set is empty (serde `skip_serializing_if`).
+   */
+  unimplemented_oracle_ids?: string[];
+  /**
    * Engine-authored derived projections, attached by adapters from the
    * wire-format `ClientGameState.derived` sibling field. Optional because
    * some wire paths (legacy cached state, older server builds) may not

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,58 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+import { reportBoundaryError } from "../services/telemetryEvents";
+
+/**
+ * Full-screen fallback shown after an uncaught render error. Kept as a small
+ * function component so it can use `useTranslation`; the class boundary itself
+ * cannot. The only recovery affordance is a hard reload — the React tree below
+ * the boundary is already unmounted and unrecoverable in place.
+ */
+function ErrorFallback() {
+  const { t } = useTranslation("common");
+  return (
+    <div className="fixed inset-0 z-[200] flex flex-col items-center justify-center gap-4 bg-gray-950 p-6 text-center text-white">
+      <h1 className="text-lg font-semibold text-slate-100">{t("errorBoundary.heading")}</h1>
+      <p className="max-w-md text-sm text-slate-400">{t("errorBoundary.body")}</p>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className="rounded-[14px] border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-100 transition hover:bg-white/10"
+      >
+        {t("errorBoundary.reload")}
+      </button>
+    </div>
+  );
+}
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * React error boundary for uncaught render errors (a real gap: only engine
+ * panics were handled before). Reports each caught error to telemetry as a
+ * `js_error` with `source: "boundary"` and renders a reload prompt so a broken
+ * render doesn't leave the user staring at a blank or half-painted screen.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, _info: ErrorInfo): void {
+    reportBoundaryError(error);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) return <ErrorFallback />;
+    return this.props.children;
+  }
+}

--- a/client/src/components/modal/StuckDecisionToast.tsx
+++ b/client/src/components/modal/StuckDecisionToast.tsx
@@ -4,19 +4,9 @@ import type { TFunction } from "i18next";
 
 import type { StuckDecisionDiagnostic } from "../../adapter/types";
 import { useGameStore } from "../../stores/gameStore";
+import { STUCK_DEBOUNCE_MS } from "../../constants/stuckDecision";
 
 const SESSION_SUPPRESS_KEY = "phase-rs:suppress-stuck-decision-toast";
-
-/**
- * How long the same wedged decision must persist before the toast surfaces.
- *
- * The engine can report an empty legal-action set transiently during normal
- * resolution (a decision point that is about to advance on the next store
- * update). Requiring the diagnostic to stay non-null across this debounce
- * window makes a transient blip impossible to surface — only a genuinely hung
- * game (the diagnostic never clears) trips the toast.
- */
-const STUCK_DEBOUNCE_MS = 3_000;
 
 /**
  * Non-blocking toast for a wedged (stuck) decision point.

--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -985,6 +985,8 @@ function CloudSyncSection() {
 
 function DataSection() {
   const { t } = useTranslation("settings");
+  const telemetryEnabled = usePreferencesStore((s) => s.telemetryEnabled);
+  const setTelemetryEnabled = usePreferencesStore((s) => s.setTelemetryEnabled);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1086,6 +1088,18 @@ function DataSection() {
       />
       {status && <p className="text-xs text-emerald-400">{status}</p>}
       {error && <p className="text-xs text-rose-400">{error}</p>}
+      <label className="mt-1 flex min-h-11 items-start gap-2">
+        <input
+          type="checkbox"
+          checked={telemetryEnabled}
+          onChange={(e) => setTelemetryEnabled(e.target.checked)}
+          className="mt-1 accent-cyan-500"
+        />
+        <span className="text-sm text-slate-200">
+          {t("data.telemetry")}
+          <span className="mt-0.5 block text-xs text-slate-400">{t("data.telemetryDescription")}</span>
+        </span>
+      </label>
     </SettingsSection>
   );
 }

--- a/client/src/constants/stuckDecision.ts
+++ b/client/src/constants/stuckDecision.ts
@@ -1,0 +1,15 @@
+/**
+ * How long the same wedged decision must persist before it is treated as a
+ * genuine stuck state.
+ *
+ * The engine can report an empty legal-action set transiently during normal
+ * resolution (a decision point that is about to advance on the next store
+ * update). Requiring the diagnostic to stay non-null across this debounce
+ * window makes a transient blip impossible to surface — only a genuinely hung
+ * game (the diagnostic never clears) trips it.
+ *
+ * Shared by `StuckDecisionToast` (the user-facing toast) and the telemetry
+ * `stuck_decision` event so both apply the same persistence gate. Kept in a
+ * React-free module so the telemetry install path never imports React.
+ */
+export const STUCK_DEBOUNCE_MS = 3_000;

--- a/client/src/game/controllers/gameLoopController.ts
+++ b/client/src/game/controllers/gameLoopController.ts
@@ -30,6 +30,20 @@ export interface GameLoopController {
 }
 
 export function createGameLoopController(config: GameLoopConfig): GameLoopController {
+  // Publish the AI seat bindings to the store so telemetry `game_end` can
+  // classify `winner_kind`. Only local "ai" mode starts client-side AI
+  // controllers (`start()` gates on `mode === "ai"`) with bindings this client
+  // owns. "local" is human hotseat (GameProvider passes fabricated `aiSeats`
+  // for BOTH "ai" and "local", so we gate on the mode, not on the presence of
+  // `config.aiSeats`, or hotseat would be mislabeled vs-AI). Online games CAN
+  // have AI seats, but those are server-hosted (`CreateGameWithSettings::ai_seats`)
+  // and not identifiable from client-owned config — a guest cannot know them —
+  // so we publish none and telemetry treats an online winner as unknown.
+  // Cleared with the rest of game state on `reset`.
+  const aiSeatIds =
+    config.mode === "ai" ? (config.aiSeats?.map((seat) => seat.playerId) ?? []) : [];
+  useGameStore.setState({ aiSeatIds });
+
   let active = false;
   let opponentController: OpponentController | null = null;
   let unsubscribe: (() => void) | null = null;

--- a/client/src/game/engineRecovery.ts
+++ b/client/src/game/engineRecovery.ts
@@ -32,6 +32,7 @@
 import { debugLog } from "./debugLog";
 import { useGameStore } from "../stores/gameStore";
 import { loadCheckpoints } from "../services/gamePersistence";
+import { trackEvent } from "../services/telemetry";
 import { AdapterError, AdapterErrorCode, type GameState } from "../adapter/types";
 
 /**
@@ -187,6 +188,16 @@ export function notifyEngineSlow(reason: string): void {
  */
 export async function routePanic(reason: string, panic?: string): Promise<void> {
   const rehydrated = await attemptStateRehydrate().catch(() => false);
+  // Telemetry fires on both branches regardless of the toast's session
+  // suppression — it answers "how often / which build / which mode".
+  const { gameMode, gameState } = useGameStore.getState();
+  trackEvent("engine_panic", {
+    fatal: !rehydrated,
+    reason,
+    panic,
+    game_mode: gameMode,
+    turn: gameState?.turn_number ?? null,
+  });
   if (rehydrated) {
     for (const fn of nonFatalPanicListeners) fn({ reason, panic });
     return;

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -228,5 +228,10 @@
     "settings": "Einstellungen",
     "languageSettings": "Sprache ({{lang}}) — Einstellungen öffnen",
     "languageTitle": "Sprache: {{lang}}"
+  },
+  "errorBoundary": {
+    "heading": "Etwas ist schiefgelaufen",
+    "body": "Die App ist auf einen unerwarteten Fehler gestoßen und kann auf diesem Bildschirm nicht fortfahren. Ein Neuladen behebt das meist.",
+    "reload": "Neu laden"
   }
 }

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -184,7 +184,9 @@
     "importedWithPreferences_one": "{{count}} Deck und Einstellungen importiert.",
     "importedWithPreferences_other": "{{count}} Decks und Einstellungen importiert.",
     "skippedMalformed_one": "{{count}} fehlerhaften Eintrag übersprungen.",
-    "skippedMalformed_other": "{{count}} fehlerhafte Einträge übersprungen."
+    "skippedMalformed_other": "{{count}} fehlerhafte Einträge übersprungen.",
+    "telemetry": "Anonyme Absturz- und Nutzungsberichte senden",
+    "telemetryDescription": "Hilft, Abstürze zu beheben und die Kartenunterstützung zu priorisieren. Kein Konto, keine persönlichen Daten – nur Fehler- und Spielzusammenfassungszählungen."
   },
   "resetAll": {
     "confirm": "Alle Einstellungen auf die Standardwerte zurücksetzen? Dies löscht jede Einstellung in diesem Dialog.",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -228,5 +228,10 @@
     "settings": "Settings",
     "languageSettings": "Language ({{lang}}) — open settings",
     "languageTitle": "Language: {{lang}}"
+  },
+  "errorBoundary": {
+    "heading": "Something went wrong",
+    "body": "The app hit an unexpected error and can't continue on this screen. Reloading usually fixes it.",
+    "reload": "Reload"
   }
 }

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -184,7 +184,9 @@
     "importedWithPreferences_one": "Imported {{count}} deck and preferences.",
     "importedWithPreferences_other": "Imported {{count}} decks and preferences.",
     "skippedMalformed_one": "Skipped {{count}} malformed entry.",
-    "skippedMalformed_other": "Skipped {{count}} malformed entries."
+    "skippedMalformed_other": "Skipped {{count}} malformed entries.",
+    "telemetry": "Send anonymous crash & usage reports",
+    "telemetryDescription": "Helps fix crashes and prioritize card support. No account, no personal data — just error and game-summary counts."
   },
   "resetAll": {
     "confirm": "Reset all preferences to defaults? This clears every setting in this dialog.",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -228,5 +228,10 @@
     "settings": "Ajustes",
     "languageSettings": "Idioma ({{lang}}) — abrir ajustes",
     "languageTitle": "Idioma: {{lang}}"
+  },
+  "errorBoundary": {
+    "heading": "Algo salió mal",
+    "body": "La aplicación encontró un error inesperado y no puede continuar en esta pantalla. Recargar suele solucionarlo.",
+    "reload": "Recargar"
   }
 }

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -184,7 +184,9 @@
     "importedWithPreferences_one": "Se importó {{count}} mazo y las preferencias.",
     "importedWithPreferences_other": "Se importaron {{count}} mazos y las preferencias.",
     "skippedMalformed_one": "Se omitió {{count}} entrada con formato incorrecto.",
-    "skippedMalformed_other": "Se omitieron {{count}} entradas con formato incorrecto."
+    "skippedMalformed_other": "Se omitieron {{count}} entradas con formato incorrecto.",
+    "telemetry": "Enviar informes anónimos de fallos y uso",
+    "telemetryDescription": "Ayuda a corregir fallos y priorizar la compatibilidad de cartas. Sin cuenta ni datos personales, solo recuentos de errores y resúmenes de partida."
   },
   "resetAll": {
     "confirm": "¿Restablecer todas las preferencias a sus valores predeterminados? Esto borra todos los ajustes de este diálogo.",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -228,5 +228,10 @@
     "settings": "Paramètres",
     "languageSettings": "Langue ({{lang}}) — ouvrir les paramètres",
     "languageTitle": "Langue : {{lang}}"
+  },
+  "errorBoundary": {
+    "heading": "Une erreur est survenue",
+    "body": "L'application a rencontré une erreur inattendue et ne peut pas continuer sur cet écran. Recharger règle généralement le problème.",
+    "reload": "Recharger"
   }
 }

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -184,7 +184,9 @@
     "importedWithPreferences_one": "{{count}} deck et les préférences importés.",
     "importedWithPreferences_other": "{{count}} decks et les préférences importés.",
     "skippedMalformed_one": "{{count}} entrée malformée ignorée.",
-    "skippedMalformed_other": "{{count}} entrées malformées ignorées."
+    "skippedMalformed_other": "{{count}} entrées malformées ignorées.",
+    "telemetry": "Envoyer des rapports anonymes de plantage et d'utilisation",
+    "telemetryDescription": "Aide à corriger les plantages et à prioriser la prise en charge des cartes. Aucun compte, aucune donnée personnelle — uniquement des comptages d'erreurs et de résumés de partie."
   },
   "resetAll": {
     "confirm": "Réinitialiser toutes les préférences aux valeurs par défaut ? Cela efface tous les paramètres de cette boîte de dialogue.",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -228,5 +228,10 @@
     "settings": "Impostazioni",
     "languageSettings": "Lingua ({{lang}}) — apri impostazioni",
     "languageTitle": "Lingua: {{lang}}"
+  },
+  "errorBoundary": {
+    "heading": "Qualcosa è andato storto",
+    "body": "L'app ha riscontrato un errore imprevisto e non può continuare in questa schermata. Ricaricare di solito risolve il problema.",
+    "reload": "Ricarica"
   }
 }

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -184,7 +184,9 @@
     "importedWithPreferences_one": "Importato {{count}} mazzo e le preferenze.",
     "importedWithPreferences_other": "Importati {{count}} mazzi e le preferenze.",
     "skippedMalformed_one": "Saltata {{count}} voce malformata.",
-    "skippedMalformed_other": "Saltate {{count}} voci malformate."
+    "skippedMalformed_other": "Saltate {{count}} voci malformate.",
+    "telemetry": "Invia segnalazioni anonime di arresti anomali e utilizzo",
+    "telemetryDescription": "Aiuta a correggere gli arresti anomali e a dare priorità al supporto delle carte. Nessun account, nessun dato personale — solo conteggi di errori e riepiloghi di partita."
   },
   "resetAll": {
     "confirm": "Reimpostare tutte le preferenze ai valori predefiniti? Questo cancella ogni impostazione in questa finestra.",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -228,5 +228,10 @@
     "settings": "Ustawienia",
     "languageSettings": "Język ({{lang}}) — otwórz ustawienia",
     "languageTitle": "Język: {{lang}}"
+  },
+  "errorBoundary": {
+    "heading": "Coś poszło nie tak",
+    "body": "Aplikacja napotkała nieoczekiwany błąd i nie może kontynuować na tym ekranie. Ponowne załadowanie zwykle to naprawia.",
+    "reload": "Załaduj ponownie"
   }
 }

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -184,7 +184,9 @@
     "importedWithPreferences_one": "Zaimportowano {{count}} talię i preferencje.",
     "importedWithPreferences_other": "Zaimportowano {{count}} talii i preferencje.",
     "skippedMalformed_one": "Pominięto {{count}} nieprawidłowy wpis.",
-    "skippedMalformed_other": "Pominięto {{count}} nieprawidłowych wpisów."
+    "skippedMalformed_other": "Pominięto {{count}} nieprawidłowych wpisów.",
+    "telemetry": "Wysyłaj anonimowe raporty o awariach i użyciu",
+    "telemetryDescription": "Pomaga naprawiać awarie i ustalać priorytety obsługi kart. Bez konta, bez danych osobowych — tylko liczniki błędów i podsumowań gier."
   },
   "resetAll": {
     "confirm": "Zresetować wszystkie preferencje do wartości domyślnych? Spowoduje to wyczyszczenie każdego ustawienia w tym oknie.",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -228,5 +228,10 @@
     "settings": "Configurações",
     "languageSettings": "Idioma ({{lang}}) — abrir configurações",
     "languageTitle": "Idioma: {{lang}}"
+  },
+  "errorBoundary": {
+    "heading": "Algo deu errado",
+    "body": "O aplicativo encontrou um erro inesperado e não pode continuar nesta tela. Recarregar geralmente resolve.",
+    "reload": "Recarregar"
   }
 }

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -184,7 +184,9 @@
     "importedWithPreferences_one": "Importado {{count}} deck e preferências.",
     "importedWithPreferences_other": "Importados {{count}} decks e preferências.",
     "skippedMalformed_one": "Ignorada {{count}} entrada malformada.",
-    "skippedMalformed_other": "Ignoradas {{count}} entradas malformadas."
+    "skippedMalformed_other": "Ignoradas {{count}} entradas malformadas.",
+    "telemetry": "Enviar relatórios anônimos de falhas e uso",
+    "telemetryDescription": "Ajuda a corrigir falhas e priorizar o suporte a cartas. Sem conta, sem dados pessoais — apenas contagens de erros e resumos de partida."
   },
   "resetAll": {
     "confirm": "Redefinir todas as preferências para os padrões? Isso limpa todas as configurações deste diálogo.",

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -10,6 +10,7 @@ import { registerServiceWorker } from "./pwa/registerServiceWorker";
 import { registerTauriUpdater } from "./pwa/tauriUpdater";
 import { installChunkReloadHandler } from "./pwa/chunkReloadHandler";
 import { installTauriExternalLinkHandler } from "./services/externalLinks";
+import { installTelemetry } from "./services/telemetryEvents";
 
 // StrictMode is scoped inside App.tsx instead of wrapping the root. P2P game
 // sessions own PeerJS resources whose cleanup is intentionally destructive, so
@@ -20,3 +21,4 @@ registerServiceWorker();
 registerTauriUpdater();
 installChunkReloadHandler();
 installTauriExternalLinkHandler();
+installTelemetry();

--- a/client/src/pwa/chunkReloadHandler.ts
+++ b/client/src/pwa/chunkReloadHandler.ts
@@ -1,5 +1,6 @@
 import { isMultiplayerGameLive, whenMultiplayerGameEnds } from "./multiplayerGuard";
 import { pushUpdateDebug, setUpdateStatus } from "./updateStatus";
+import { flushNow, trackEvent } from "../services/telemetry";
 
 /**
  * Vite fires `vite:preloadError` when a lazy-imported chunk fails to load —
@@ -33,12 +34,20 @@ export function installChunkReloadHandler(): void {
     // the console — we're handling it by reloading (or deferring).
     event.preventDefault();
 
+    const deferred = isMultiplayerGameLive();
+    // The failed chunk identifier lives in the event's `.payload` Error
+    // (its message carries the failing URL). Best-effort; truncated at enqueue.
+    const chunk = (event as { payload?: Error }).payload?.message;
+    trackEvent("chunk_reload", { reason: "preload-error", deferred, chunk });
+
     const doReload = () => {
       pushUpdateDebug("Chunk preload failed; reloading to pick up new bundle.", "warn");
+      // Drain the telemetry queue before navigating away.
+      flushNow();
       window.location.reload();
     };
 
-    if (isMultiplayerGameLive()) {
+    if (deferred) {
       pushUpdateDebug(
         "Chunk preload failed during multiplayer game; deferring reload until game ends.",
         "warn",

--- a/client/src/services/telemetry.ts
+++ b/client/src/services/telemetry.ts
@@ -1,0 +1,159 @@
+/**
+ * First-party, identity-free crash & usage telemetry.
+ *
+ * Design (see docs/telemetry-proposal.md §2, §6):
+ * - **Fail open.** Telemetry must never affect gameplay: every send is
+ *   fire-and-forget, dropped silently on failure, and wrapped so nothing here
+ *   can throw into app code.
+ * - **Build gate.** With no `__TELEMETRY_URL__` define (local dev, self-hosted
+ *   builds) this module is a permanent no-op — `trackEvent`/`flushNow` return
+ *   immediately and nothing is ever queued.
+ * - **Runtime gate.** The `telemetryEnabled` preference (default on) is checked
+ *   at enqueue time, so a mid-session toggle takes effect immediately.
+ * - **No identity.** No install id, no IP, no user-agent — the events carry only
+ *   the operational fields their call sites pass. The batch envelope adds build
+ *   metadata (version, hash, release, platform) and nothing request-derived.
+ */
+import { usePreferencesStore } from "../stores/preferencesStore";
+import { isTauri } from "./sidecar";
+
+/** Max characters retained for any single string field (defence against a
+ *  runaway panic message or stack frame bloating a batch). */
+const MAX_STRING_LEN = 300;
+/** Flush once the queue reaches this many events. */
+const FLUSH_AT_COUNT = 20;
+/** Flush this long after the first event was queued, if the count trigger
+ *  hasn't already fired. */
+const FLUSH_AFTER_MS = 10_000;
+/** Hard per-session cap on total events (abuse / runaway-loop backstop). */
+const MAX_EVENTS_PER_SESSION = 100;
+/** Hard per-session cap on `js_error` events specifically — an error loop must
+ *  not drown the batch. */
+const MAX_JS_ERRORS_PER_SESSION = 10;
+
+/** A queued event: the caller's fields plus the event name and a client
+ *  timestamp. Values are truncated (strings) at enqueue. */
+interface QueuedEvent {
+  event: string;
+  ts: number;
+  [field: string]: unknown;
+}
+
+/** The ingest URL, resolved once from the build define. Empty ⇒ permanent
+ *  no-op. */
+const TELEMETRY_URL = __TELEMETRY_URL__;
+/** True when telemetry can never send in this build. */
+const DISABLED = TELEMETRY_URL === "";
+
+const queue: QueuedEvent[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+let eventsThisSession = 0;
+let jsErrorsThisSession = 0;
+
+/** Truncate a single string field to the session cap. Non-strings pass through
+ *  untouched. */
+function truncate(value: unknown): unknown {
+  if (typeof value === "string" && value.length > MAX_STRING_LEN) {
+    return value.slice(0, MAX_STRING_LEN);
+  }
+  return value;
+}
+
+/** Coarse platform tag — `"tauri"` in the desktop webview, `"web"` otherwise.
+ *  No OS/version detail (that would edge toward fingerprinting). */
+function platform(): string {
+  return isTauri() ? "tauri" : "web";
+}
+
+/**
+ * Enqueue a telemetry event. Silently drops when telemetry is build-disabled,
+ * runtime-disabled, or over a session cap. Never throws.
+ */
+export function trackEvent(name: string, fields: Record<string, unknown> = {}): void {
+  try {
+    if (DISABLED) return;
+    if (!usePreferencesStore.getState().telemetryEnabled) return;
+    if (eventsThisSession >= MAX_EVENTS_PER_SESSION) return;
+    if (name === "js_error" && jsErrorsThisSession >= MAX_JS_ERRORS_PER_SESSION) return;
+
+    const event: QueuedEvent = { event: name, ts: Date.now() };
+    for (const [key, value] of Object.entries(fields)) {
+      event[key] = truncate(value);
+    }
+
+    queue.push(event);
+    eventsThisSession += 1;
+    if (name === "js_error") jsErrorsThisSession += 1;
+
+    if (queue.length >= FLUSH_AT_COUNT) {
+      flushNow();
+    } else if (flushTimer === null) {
+      flushTimer = setTimeout(flushNow, FLUSH_AFTER_MS);
+    }
+  } catch {
+    // Telemetry must never surface an error into app code.
+  }
+}
+
+/** Build the per-batch envelope (stamped once), per proposal §3. */
+function buildBatch(events: QueuedEvent[]): string {
+  return JSON.stringify({
+    schema: 1,
+    app_version: __APP_VERSION__,
+    build_hash: __BUILD_HASH__,
+    release: __IS_RELEASE_BUILD__,
+    platform: platform(),
+    events,
+  });
+}
+
+/**
+ * Flush the queue immediately. Exported for the chunk-reload path, which must
+ * drain before `window.location.reload()`. Safe to call at any time — a no-op
+ * when the queue is empty or telemetry is disabled.
+ */
+export function flushNow(): void {
+  try {
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    if (DISABLED || queue.length === 0) return;
+
+    const batch = queue.splice(0, queue.length);
+    const body = buildBatch(batch);
+
+    // A bare string body ⇒ Content-Type: text/plain ⇒ no CORS preflight.
+    if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
+      if (navigator.sendBeacon(TELEMETRY_URL, body)) return;
+    }
+    // Fallback: keepalive fetch survives the page teardown sendBeacon covers.
+    // Errors are swallowed — telemetry is fire-and-forget.
+    void fetch(TELEMETRY_URL, {
+      method: "POST",
+      keepalive: true,
+      body,
+      headers: { "Content-Type": "text/plain" },
+    }).catch(() => {});
+  } catch {
+    // Never throw into app code.
+  }
+}
+
+let lifecycleInstalled = false;
+
+/**
+ * Register the page-lifecycle flush hooks (`visibilitychange → hidden`,
+ * `pagehide`) so a queued batch is not lost when the user backgrounds or closes
+ * the tab. Idempotent; a no-op in build-disabled telemetry. Called by
+ * `installTelemetry`.
+ */
+export function installTelemetryLifecycle(): void {
+  if (DISABLED || lifecycleInstalled || typeof window === "undefined") return;
+  lifecycleInstalled = true;
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") flushNow();
+  });
+  window.addEventListener("pagehide", flushNow);
+}

--- a/client/src/services/telemetryEvents.ts
+++ b/client/src/services/telemetryEvents.ts
@@ -1,0 +1,149 @@
+/**
+ * Tier 1 telemetry event wiring (docs/telemetry-proposal.md §4 Tier 1).
+ *
+ * `installTelemetry()` is called once from `main.tsx` alongside the other
+ * `install*` bootstraps. It registers the global JS-error listeners, the
+ * page-lifecycle flush hooks, and the game-store subscriptions that emit
+ * `stuck_decision` and `game_end`. It deliberately imports NO React — it runs
+ * outside the component tree.
+ *
+ * The other two Tier 1 events fire from their own subsystems, which call
+ * `trackEvent` directly: `engine_panic` from `game/engineRecovery.ts`
+ * (`routePanic`) and `chunk_reload` from `pwa/chunkReloadHandler.ts`.
+ */
+import { STUCK_DEBOUNCE_MS } from "../constants/stuckDecision";
+import { useGameStore } from "../stores/gameStore";
+import { flushNow, installTelemetryLifecycle, trackEvent } from "./telemetry";
+
+/** Coarse route: the first path segment, so we bucket by area (deck / game /
+ *  draft / menu) without capturing ids or query strings. */
+function coarseRoute(): string {
+  if (typeof window === "undefined") return "";
+  const segment = window.location.pathname.split("/").filter(Boolean)[0];
+  return segment ? `/${segment}` : "/";
+}
+
+/** Extract the reportable shape of a thrown value. `top_frame` is the first
+ *  stack line (the throw site); the full stack is intentionally NOT sent. */
+function errorFields(
+  err: unknown,
+  message: string | undefined,
+  source: "boundary" | "window" | "unhandledrejection",
+): Record<string, unknown> {
+  const error = err instanceof Error ? err : undefined;
+  const stack = error?.stack ?? "";
+  const topFrame = stack.split("\n").find((line) => line.trim().startsWith("at"))?.trim();
+  return {
+    name: error?.name ?? "Error",
+    message: error?.message ?? message ?? String(err),
+    top_frame: topFrame,
+    source,
+    route: coarseRoute(),
+  };
+}
+
+/** Report a caught render error from the React ErrorBoundary (Part E). Exposed
+ *  so the boundary — which does import React — routes through the same shape. */
+export function reportBoundaryError(err: unknown): void {
+  trackEvent("js_error", errorFields(err, undefined, "boundary"));
+}
+
+function installErrorListeners(): void {
+  window.addEventListener("error", (event) => {
+    trackEvent("js_error", errorFields(event.error, event.message, "window"));
+  });
+  window.addEventListener("unhandledrejection", (event) => {
+    trackEvent("js_error", errorFields(event.reason, undefined, "unhandledrejection"));
+  });
+}
+
+/**
+ * Emit `stuck_decision` once per continuous stuck episode, using the same
+ * persistence debounce as the user-facing toast (independent of the toast's
+ * session-suppression latch). A transient wedge that clears within the window
+ * emits nothing.
+ */
+function installStuckDecisionTracking(): void {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let emittedForEpisode = false;
+
+  useGameStore.subscribe(
+    (s) => s.stuckDiagnostic,
+    (diagnostic) => {
+      if (!diagnostic) {
+        // Episode ended — reset so the next genuine wedge can emit.
+        if (timer !== null) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        emittedForEpisode = false;
+        return;
+      }
+      if (emittedForEpisode || timer !== null) return;
+      timer = setTimeout(() => {
+        timer = null;
+        const current = useGameStore.getState();
+        if (!current.stuckDiagnostic) return;
+        emittedForEpisode = true;
+        trackEvent("stuck_decision", {
+          waiting_for_kind: current.stuckDiagnostic.waitingForKind,
+          game_mode: current.gameMode,
+          phase: current.gameState?.phase,
+        });
+      }, STUCK_DEBOUNCE_MS);
+    },
+  );
+}
+
+/**
+ * Emit `game_end` once per game when the state's `waiting_for` first becomes
+ * `GameOver`. Deduped by `gameId` (multiplayer emits one per participating
+ * client — counts are per-client sessions, not per game). `spectate` mode is
+ * skipped entirely. Every payload value is an engine-provided field forwarded
+ * verbatim; `winner_kind` uses the client-owned `aiSeatIds` binding.
+ */
+function installGameEndTracking(): void {
+  let lastEmittedGameId: string | null = null;
+
+  useGameStore.subscribe(
+    (s) => s.waitingFor,
+    (waitingFor) => {
+      if (!waitingFor || waitingFor.type !== "GameOver") return;
+      const { gameId, gameMode, gameState, aiSeatIds } = useGameStore.getState();
+      if (gameMode === "spectate") return;
+      if (gameId === null || gameId === lastEmittedGameId) return;
+      lastEmittedGameId = gameId;
+
+      const winner = waitingFor.data.winner;
+      // Online games can have server-hosted AI seats the client can't identify
+      // (guests never see them), so a winner's human/AI nature is unknown here —
+      // emit null rather than mislabel a server AI winner as "human" (AE data is
+      // unrecoverable). `result` still distinguishes draws and `game_mode`
+      // segments the queries.
+      const winnerKind =
+        winner === null || gameMode === "online"
+          ? null
+          : aiSeatIds.includes(winner)
+            ? "ai"
+            : "human";
+      trackEvent("game_end", {
+        turn_count: gameState?.turn_number,
+        result: winner === null ? "draw" : "winner",
+        winner_kind: winnerKind,
+        game_mode: gameMode,
+        unimplemented_oracle_ids: (gameState?.unimplemented_oracle_ids ?? []).slice(0, 20),
+      });
+      // Flush promptly so a game_end isn't stranded if the user leaves the
+      // results screen before the batch timer fires.
+      flushNow();
+    },
+  );
+}
+
+/** Install all Tier 1 telemetry hooks. Idempotent-safe to call once at boot. */
+export function installTelemetry(): void {
+  installTelemetryLifecycle();
+  installErrorListeners();
+  installStuckDecisionTracking();
+  installGameEndTracking();
+}

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -128,6 +128,13 @@ interface GameStoreState {
    * calls the UI store, keeping the layer boundary clean.
    */
   startingContest: { events: GameEvent[]; startingPlayer: PlayerId } | null;
+  /**
+   * PlayerIds bound to AI controllers this game. Client-owned lobby/session
+   * config (NOT game-state derivation): set at game init from the resolved AI
+   * seat bindings and cleared on `reset`. Empty for human-only games (online /
+   * p2p). Consumed by telemetry `game_end` to classify `winner_kind`.
+   */
+  aiSeatIds: PlayerId[];
 }
 
 interface GameStoreActions {
@@ -187,6 +194,7 @@ const initialState: GameStoreState = {
   resolutionProgress: null,
   isResolvingAll: false,
   startingContest: null,
+  aiSeatIds: [],
 };
 
 export const useGameStore = create<GameStore>()(

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -309,6 +309,7 @@ function buildDefaultPreferences(): PreferencesState {
     artChain: [] as ArtChainEntry[],
     artOverrides: {} as Record<string, CardArtOverride>,
     flexLayout: defaultFlexLayout(),
+    telemetryEnabled: true,
   };
 }
 
@@ -400,6 +401,11 @@ interface PreferencesState {
   /** Persisted board layout (grid bands + per-widget offsets + active preset).
    *  See {@link FlexLayoutConfig}. Edited only in Flex Layout mode. */
   flexLayout: FlexLayoutConfig;
+  /** Whether anonymous, identity-free crash & usage telemetry may be sent.
+   *  Default on. Gates every send at enqueue time so a mid-session toggle takes
+   *  effect immediately. Builds without a `__TELEMETRY_URL__` define never send
+   *  regardless. See `services/telemetry.ts`. */
+  telemetryEnabled: boolean;
 }
 
 interface PreferencesActions {
@@ -495,6 +501,8 @@ interface PreferencesActions {
   applyFlexPreset: (config: FlexLayoutConfig) => void;
   /** Reset the layout to the default preset (clears all offsets). */
   resetFlexLayout: () => void;
+  /** Toggle anonymous crash & usage telemetry. */
+  setTelemetryEnabled: (enabled: boolean) => void;
 }
 
 type LegacyFlatAiPrefs = Partial<{
@@ -748,10 +756,11 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
         })),
       applyFlexPreset: (config) => set({ flexLayout: cloneFlexLayout(config) }),
       resetFlexLayout: () => set({ flexLayout: defaultFlexLayout() }),
+      setTelemetryEnabled: (enabled) => set({ telemetryEnabled: enabled }),
     }),
     {
       name: "phase-preferences",
-      version: 21,
+      version: 22,
       // v0 → v1: flat aiDifficulty + aiDeckName become aiSeats[0].
       // v1 → v2: discrete animationSpeed/combatPacing enums become numeric
       //          animationSpeedMultiplier/combatPacingMultiplier.
@@ -793,6 +802,9 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       //          merge, so existing users see no behavior change.
       // v20 → v21: Add multiplayerBoardLayout; legacy stores default to
       //          "focused", preserving the current focused-opponent layout.
+      // v21 → v22: Add telemetryEnabled; legacy stores default to `true` (opt-out,
+      //          identity-free crash & usage telemetry) via the shallow merge —
+      //          no explicit migration block needed (see flexLayout precedent).
       migrate: (persisted: unknown, version: number) => {
         if (!persisted || typeof persisted !== "object") return persisted;
         let migrated = persisted as Record<string, unknown>;

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -24,6 +24,7 @@ declare const __PREVIEW_SITE_URL__: string;
 declare const __IS_RELEASE_BUILD__: boolean;
 declare const __SUPABASE_URL__: string;
 declare const __SUPABASE_ANON_KEY__: string;
+declare const __TELEMETRY_URL__: string;
 
 // Fontsource packages ship only side-effect CSS (no type declarations); Vite
 // resolves the import at build time, but tsc needs an ambient module.

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -98,6 +98,10 @@ function dataFileDefines(mode: string): Record<string, string> {
     // keeps self-hosted builds working with no Supabase account.
     __SUPABASE_URL__: JSON.stringify(envVar("SUPABASE_URL")),
     __SUPABASE_ANON_KEY__: JSON.stringify(envVar("SUPABASE_ANON_KEY")),
+    // First-party telemetry ingest endpoint (lobby-worker `POST /telemetry`).
+    // Empty when unset (local dev, self-hosted builds) → the telemetry module
+    // compiles to a permanent no-op and nothing is ever sent anywhere.
+    __TELEMETRY_URL__: JSON.stringify(process.env.TELEMETRY_URL || ""),
     __CARD_DATA_URL__: JSON.stringify(process.env.CARD_DATA_URL || "/card-data.json"),
     // Per-locale content-i18n sidecar URL template ({lng} replaced at runtime).
     // The sidecars are listed in data-files.json, so on deploy they are uploaded

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -53,6 +53,9 @@ export default defineConfig({
       process.env.DEFAULT_MULTIPLAYER_SERVER_URL || "wss://lobby.phase-rs.dev/ws",
     ),
     __GIT_REPO_URL__: JSON.stringify("https://github.com/phase-rs/phase"),
+    __IS_RELEASE_BUILD__: JSON.stringify(false),
+    // Empty ⇒ telemetry is build-disabled in tests (no network egress).
+    __TELEMETRY_URL__: JSON.stringify(""),
   },
   test: {
     environment: "happy-dom",

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3264,6 +3264,18 @@ pub fn resolve_effect(
         Effect::Unimplemented { name, .. } => {
             // Log warning and return Ok (no-op) for unimplemented effects
             eprintln!("Warning: Unimplemented effect: {}", name);
+            // Diagnostics: record the source card so the telemetry `game_summary`
+            // surface can report which cards hit an unimplemented effect this game.
+            // Oracle id when available; object name fallback covers tokens/emblems
+            // (`printed_ref == None`).
+            if let Some(obj) = state.objects.get(&ability.source_id) {
+                let id = obj
+                    .printed_ref
+                    .as_ref()
+                    .map(|p| p.oracle_id.clone())
+                    .unwrap_or_else(|| obj.name.clone());
+                state.unimplemented_oracle_ids.insert(id);
+            }
             Ok(())
         }
     }
@@ -9112,6 +9124,62 @@ mod tests {
         let mut events = Vec::new();
         let result = resolve_effect(&mut state, &ability, &mut events);
         assert!(result.is_ok());
+    }
+
+    /// Telemetry `game_summary` surface: resolving an `Effect::Unimplemented`
+    /// records the source card's oracle id in `unimplemented_oracle_ids`
+    /// (name fallback for tokens/emblems with no `printed_ref`), and dedups on
+    /// repeated resolution. Diagnostics plumbing only — no rules behavior.
+    #[test]
+    fn unimplemented_effect_records_source_in_game_summary() {
+        let mut state = GameState::new_two_player(42);
+
+        // Card object with a printed oracle id.
+        let mut card = crate::game::game_object::GameObject::new(
+            ObjectId(7),
+            CardId(700),
+            PlayerId(0),
+            "Fancy Card".to_string(),
+            Zone::Stack,
+        );
+        card.printed_ref = Some(crate::types::card::PrintedCardRef {
+            oracle_id: "oracle-abc-123".to_string(),
+            face_name: "Fancy Card".to_string(),
+        });
+        state.objects.insert(ObjectId(7), card);
+
+        // Token object with no printed_ref — must fall back to the name.
+        let token = crate::game::game_object::GameObject::new(
+            ObjectId(8),
+            CardId(0),
+            PlayerId(0),
+            "Goblin Token".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.insert(ObjectId(8), token);
+
+        let unimplemented = |source: ObjectId| {
+            ResolvedAbility::new(
+                Effect::unimplemented("SomeEffect", "some fragment"),
+                vec![],
+                source,
+                PlayerId(0),
+            )
+        };
+        let mut events = Vec::new();
+
+        // Oracle-id path: resolves and records the oracle id.
+        resolve_effect(&mut state, &unimplemented(ObjectId(7)), &mut events).unwrap();
+        assert!(state.unimplemented_oracle_ids.contains("oracle-abc-123"));
+
+        // Dedup: a second resolution of the same source adds no new entry.
+        resolve_effect(&mut state, &unimplemented(ObjectId(7)), &mut events).unwrap();
+        assert_eq!(state.unimplemented_oracle_ids.len(), 1);
+
+        // Name-fallback path: a token with no printed_ref records its name.
+        resolve_effect(&mut state, &unimplemented(ObjectId(8)), &mut events).unwrap();
+        assert!(state.unimplemented_oracle_ids.contains("Goblin Token"));
+        assert_eq!(state.unimplemented_oracle_ids.len(), 2);
     }
 
     fn optional_gain_life(

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6445,6 +6445,23 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub unbounded_resources: BTreeMap<PlayerId, BTreeSet<ResourceAxis>>,
 
+    /// Oracle ids (fallback: object names) of cards whose abilities hit
+    /// `Effect::Unimplemented` at resolution this game. Diagnostics only —
+    /// records *runtime resolution hits*, is game-scoped, and survives zone
+    /// changes. This is distinct from the per-object `unimplemented_mechanics`
+    /// (`game/coverage.rs`), which is a static parse-coverage projection; this
+    /// accumulator is the telemetry `game_summary` surface. Not a duplication.
+    ///
+    /// INTENTIONALLY EXCLUDED from `PartialEq`, `normalize_for_loop`, and
+    /// `loop_fingerprint` (same family as `unbounded_resources`): this is
+    /// diagnostics/annotation state, not rules state for equality. CR 104.4b /
+    /// CR 732.2a loop detection compares two states reached at different times;
+    /// a populated live state must still compare equal to snapshots taken
+    /// before the unimplemented effect resolved, or loop detection yields false
+    /// negatives.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub unimplemented_oracle_ids: BTreeSet<String>,
+
     /// CR 732.2a: per-game runtime gate for the live combo (infinite-loop) detector.
     /// Default `Off` = exact pre-combo-detector behavior. This is the hot-path flag the
     /// detector gates read; it is PROJECTED from the immutable [`MatchConfig::loop_detection`]
@@ -8226,6 +8243,7 @@ impl GameState {
             debug_mode: false,
             debug_permitted: BTreeSet::new(),
             unbounded_resources: BTreeMap::new(),
+            unimplemented_oracle_ids: BTreeSet::new(),
             loop_detection: LoopDetectionMode::Off,
         }
     }
@@ -8842,6 +8860,37 @@ mod tests {
         assert!(
             loop_states_equal_modulo_resources(&a, &b),
             "the PR-0/PR-2 modulo path must exclude unbounded_resources"
+        );
+    }
+
+    /// Loop-equality guard for the telemetry accumulator: `unimplemented_oracle_ids`
+    /// is diagnostics/annotation state, NOT rules state for equality. Two states
+    /// identical except one has recorded an unimplemented-effect hit MUST compare
+    /// EQUAL through the loop comparators. Otherwise a populated live state would
+    /// stop matching the pre-hit ring snapshots and CR 104.4b / CR 732.2a loop
+    /// detection would yield false negatives.
+    ///
+    /// REVERT-PROBE: add `&& self.unimplemented_oracle_ids == other.unimplemented_oracle_ids`
+    /// to the manual `impl PartialEq for GameState` → both assertions below fail.
+    #[test]
+    fn unimplemented_oracle_ids_excluded_from_loop_equality() {
+        let a = GameState::new_two_player(7);
+        let mut b = a.clone();
+        b.unimplemented_oracle_ids
+            .insert("oracle-abc-123".to_string());
+        // Sanity: the populated field really does differ between the two states.
+        assert_ne!(
+            a.unimplemented_oracle_ids, b.unimplemented_oracle_ids,
+            "fixture must actually differ in unimplemented_oracle_ids"
+        );
+
+        assert!(
+            a == b,
+            "manual PartialEq must exclude unimplemented_oracle_ids (diagnostics state)"
+        );
+        assert!(
+            loop_states_equal(&a, &b),
+            "loop_states_equal (CR 104.4b/732.2a) must exclude unimplemented_oracle_ids"
         );
     }
 

--- a/lobby-worker/src/index.ts
+++ b/lobby-worker/src/index.ts
@@ -1,6 +1,7 @@
 import { LobbyDO } from "./lobby-do";
 import { handleImportDeck, type ImportDeckEnv } from "./import-deck";
 import { handleTurnCredentials, type TurnEnv } from "./turn";
+import { sanitizeTelemetryBatch, toDataPoint } from "./telemetry";
 
 // The DO class must be exported from the Worker entry so the runtime can
 // instantiate it for the binding declared in wrangler.toml.
@@ -8,6 +9,55 @@ export { LobbyDO };
 
 interface Env extends TurnEnv, ImportDeckEnv {
   LOBBY: DurableObjectNamespace;
+  // Analytics Engine binding for client telemetry. Optional so deploys without
+  // the binding keep working — ingest just drops the writes.
+  TELEMETRY?: AnalyticsEngineDataset;
+}
+
+/** Reject bodies larger than this outright (via Content-Length or read length).
+ *  The client batches ≤ 25 events with capped field strings, so a legitimate
+ *  batch is well under this. */
+const MAX_TELEMETRY_BYTES = 32 * 1024;
+
+const TELEMETRY_CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+/**
+ * Write-only, fire-and-forget telemetry ingest. NEVER returns a 5xx — a
+ * telemetry failure must not pollute Workers Metrics or surface to the client,
+ * so every path resolves to 204. Handles the `OPTIONS` preflight for the client
+ * fetch-fallback path.
+ */
+async function handleTelemetry(request: Request, env: Env): Promise<Response> {
+  const ok = () => new Response(null, { status: 204, headers: TELEMETRY_CORS_HEADERS });
+  try {
+    if (request.method === "OPTIONS" || request.method !== "POST") return ok();
+
+    const contentLength = Number(request.headers.get("content-length") ?? "0");
+    if (Number.isFinite(contentLength) && contentLength > MAX_TELEMETRY_BYTES) return ok();
+
+    const text = await request.text();
+    if (text.length > MAX_TELEMETRY_BYTES) return ok();
+
+    // Tolerate `text/plain` (the client sends a bare string to skip the CORS
+    // preflight); parse defensively.
+    let body: unknown = null;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = null;
+    }
+
+    for (const event of sanitizeTelemetryBatch(body)) {
+      env.TELEMETRY?.writeDataPoint(toDataPoint(event));
+    }
+  } catch {
+    // Swallow — ingest is best-effort and must never fail the request.
+  }
+  return ok();
 }
 
 export default {
@@ -24,6 +74,12 @@ export default {
     // hot deck costs one upstream call.
     if (url.pathname === "/import-deck") {
       return handleImportDeck(request, env, ctx);
+    }
+
+    // Client telemetry ingest (Analytics Engine). Routed BEFORE the DO
+    // catch-all so it never touches the lobby DO. Write-only + fire-and-forget.
+    if (url.pathname === "/telemetry") {
+      return handleTelemetry(request, env);
     }
 
     // Single global lobby: every other request routes to the one DO instance

--- a/lobby-worker/src/telemetry.ts
+++ b/lobby-worker/src/telemetry.ts
@@ -1,0 +1,142 @@
+// Telemetry ingest functional core for the lobby Worker.
+//
+// Same shape as `stats.ts`: pure functions with no I/O, unit-testable under
+// `node --test`. The Worker shell (`index.ts`) owns the request read, the
+// `env.TELEMETRY.writeDataPoint` calls, and `Response` construction; this
+// module owns the allow-listed event schema, envelope validation, and the
+// stable Analytics Engine column layout.
+//
+// The design mirrors how the lobby DO gates inbound frames: a per-event field
+// allow-list. Unknown events and unknown fields are dropped silently (never an
+// error) so a newer client can add events without a Worker deploy, and a
+// malformed body degrades to an empty batch rather than a 5xx.
+
+/** Max characters kept for any event-specific field string. Matches the client
+ *  enqueue cap; enforced again here because ingest cannot trust the client. */
+const MAX_FIELD_STR = 300;
+/** Max characters kept for a list field flattened to a comma-joined blob (e.g.
+ *  `unimplemented_oracle_ids`). Larger than {@link MAX_FIELD_STR} so the client's
+ *  20-id cap survives the join (20 UUID-ish ids ≈ 800 chars); still far under
+ *  AE's 16 KB per-point blob budget. */
+const MAX_LIST_BLOB = 1000;
+/** Max characters kept for an envelope string (version / hash / platform). */
+const MAX_ENVELOPE_STR = 64;
+/** Max events accepted from a single batch — the rest are dropped. */
+export const MAX_EVENTS_PER_BATCH = 25;
+
+/**
+ * Per-event allow-list. `blobs` are the event-specific string columns (in
+ * order); `doubles` are the numeric/boolean columns (in order). Only these five
+ * Tier 1 events are accepted. Array fields (e.g. `unimplemented_oracle_ids`) are
+ * flattened to a single comma-joined blob.
+ *
+ * Column layout for every point (documented so the AE schema is stable):
+ *   indexes: [event]
+ *   blobs:   [event, app_version, build_hash, platform, ...schema.blobs]
+ *   doubles: [...schema.doubles]
+ * AE hard limits respected by construction: ≤ 20 blobs, ≤ 20 doubles, exactly
+ * 1 index, ≤ 16 KB total blob bytes (guarded by the per-field string caps).
+ */
+export const EVENT_SCHEMAS: Record<string, { blobs: string[]; doubles: string[] }> = {
+  engine_panic: { blobs: ["reason", "panic", "game_mode"], doubles: ["fatal", "turn"] },
+  stuck_decision: { blobs: ["waiting_for_kind", "game_mode", "phase"], doubles: [] },
+  js_error: { blobs: ["name", "message", "top_frame", "source", "route"], doubles: [] },
+  chunk_reload: { blobs: ["reason", "chunk"], doubles: ["deferred"] },
+  game_end: {
+    blobs: ["result", "winner_kind", "game_mode", "unimplemented_oracle_ids"],
+    doubles: ["turn_count"],
+  },
+};
+
+/** A validated, column-resolved event ready to become an AE data point. */
+export interface SanitizedEvent {
+  event: string;
+  appVersion: string;
+  buildHash: string;
+  platform: string;
+  /** Event-specific string columns, in `EVENT_SCHEMAS[event].blobs` order. */
+  blobs: string[];
+  /** Event-specific numeric columns, in `EVENT_SCHEMAS[event].doubles` order. */
+  doubles: number[];
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+/** Coerce an arbitrary field value into a bounded blob string. Arrays are
+ *  comma-joined; missing/other values become "". */
+function toBlob(value: unknown): string {
+  if (typeof value === "string") return truncate(value, MAX_FIELD_STR);
+  if (Array.isArray(value)) {
+    return truncate(value.filter((v) => typeof v === "string").join(","), MAX_LIST_BLOB);
+  }
+  return "";
+}
+
+/** Coerce an arbitrary field value into a double. Booleans → 1/0; numbers pass
+ *  through (non-finite → 0); everything else → 0. */
+function toDouble(value: unknown): number {
+  if (typeof value === "boolean") return value ? 1 : 0;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return 0;
+}
+
+/** Read a string envelope field with the 64-char cap; "" when absent. */
+function envelopeString(source: Record<string, unknown>, key: string): string {
+  const value = source[key];
+  return typeof value === "string" ? truncate(value, MAX_ENVELOPE_STR) : "";
+}
+
+/**
+ * Validate and sanitize a raw request body into the accepted events. Returns
+ * `[]` for any malformed input (not an object, wrong schema version, missing
+ * events array). Drops unknown events, unknown fields, and events beyond
+ * {@link MAX_EVENTS_PER_BATCH}.
+ */
+export function sanitizeTelemetryBatch(body: unknown): SanitizedEvent[] {
+  if (!body || typeof body !== "object") return [];
+  const batch = body as Record<string, unknown>;
+  if (batch.schema !== 1) return [];
+  if (!Array.isArray(batch.events)) return [];
+
+  const appVersion = envelopeString(batch, "app_version");
+  const buildHash = envelopeString(batch, "build_hash");
+  const platform = envelopeString(batch, "platform");
+
+  const out: SanitizedEvent[] = [];
+  for (const raw of batch.events.slice(0, MAX_EVENTS_PER_BATCH)) {
+    if (!raw || typeof raw !== "object") continue;
+    const event = (raw as Record<string, unknown>).event;
+    if (typeof event !== "string") continue;
+    const schema = EVENT_SCHEMAS[event];
+    if (!schema) continue; // unknown event — dropped, not an error
+
+    const fields = raw as Record<string, unknown>;
+    out.push({
+      event,
+      appVersion,
+      buildHash,
+      platform,
+      blobs: schema.blobs.map((key) => toBlob(fields[key])),
+      doubles: schema.doubles.map((key) => toDouble(fields[key])),
+    });
+  }
+  return out;
+}
+
+/** Analytics Engine data point shape (mirrors `AnalyticsEngineDataPoint`). */
+export interface TelemetryDataPoint {
+  indexes: string[];
+  blobs: string[];
+  doubles: number[];
+}
+
+/** Project a sanitized event onto the stable AE column layout. */
+export function toDataPoint(e: SanitizedEvent): TelemetryDataPoint {
+  return {
+    indexes: [e.event],
+    blobs: [e.event, e.appVersion, e.buildHash, e.platform, ...e.blobs],
+    doubles: e.doubles,
+  };
+}

--- a/lobby-worker/test/telemetry.test.mjs
+++ b/lobby-worker/test/telemetry.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  EVENT_SCHEMAS,
+  MAX_EVENTS_PER_BATCH,
+  sanitizeTelemetryBatch,
+  toDataPoint,
+} from "../src/telemetry.ts";
+
+/** Minimal valid envelope helper. */
+function batch(events, overrides = {}) {
+  return {
+    schema: 1,
+    app_version: "0.42.1",
+    build_hash: "02b26c3",
+    platform: "web",
+    events,
+    ...overrides,
+  };
+}
+
+test("sanitizeTelemetryBatch accepts the five Tier 1 events with envelope fields", () => {
+  const out = sanitizeTelemetryBatch(
+    batch([
+      { event: "engine_panic", fatal: true, reason: "STATE_LOST", panic: "boom", game_mode: "ai", turn: 4 },
+      { event: "stuck_decision", waiting_for_kind: "Priority", game_mode: "ai", phase: "Upkeep" },
+      { event: "js_error", name: "TypeError", message: "x", top_frame: "at f", source: "boundary", route: "/game" },
+      { event: "chunk_reload", reason: "preload-error", deferred: false, chunk: "index-abc.js" },
+      { event: "game_end", result: "winner", winner_kind: "ai", game_mode: "ai", turn_count: 12, unimplemented_oracle_ids: ["a", "b"] },
+    ]),
+  );
+  assert.equal(out.length, 5);
+  for (const e of out) {
+    assert.equal(e.appVersion, "0.42.1");
+    assert.equal(e.buildHash, "02b26c3");
+    assert.equal(e.platform, "web");
+    assert.equal(e.blobs.length, EVENT_SCHEMAS[e.event].blobs.length);
+    assert.equal(e.doubles.length, EVENT_SCHEMAS[e.event].doubles.length);
+  }
+});
+
+test("toDataPoint prepends the envelope blobs and sets the single index", () => {
+  const [e] = sanitizeTelemetryBatch(
+    batch([{ event: "chunk_reload", reason: "preload-error", deferred: true, chunk: "c.js" }]),
+  );
+  const point = toDataPoint(e);
+  assert.deepEqual(point.indexes, ["chunk_reload"]);
+  // blobs: [event, app_version, build_hash, platform, ...schema.blobs]
+  assert.deepEqual(point.blobs, ["chunk_reload", "0.42.1", "02b26c3", "web", "preload-error", "c.js"]);
+  // deferred=true coerces to 1.
+  assert.deepEqual(point.doubles, [1]);
+  assert.equal(point.indexes.length, 1);
+  assert.ok(point.blobs.length <= 20);
+  assert.ok(point.doubles.length <= 20);
+});
+
+test("unknown events are dropped, not errors", () => {
+  const out = sanitizeTelemetryBatch(
+    batch([
+      { event: "not_a_real_event", foo: "bar" },
+      { event: "stuck_decision", waiting_for_kind: "Priority", game_mode: "ai", phase: "Draw" },
+    ]),
+  );
+  assert.equal(out.length, 1);
+  assert.equal(out[0].event, "stuck_decision");
+});
+
+test("unknown fields are dropped from a known event", () => {
+  const [e] = sanitizeTelemetryBatch(
+    batch([{ event: "stuck_decision", waiting_for_kind: "Priority", game_mode: "ai", phase: "Draw", secret: "leak" }]),
+  );
+  // Only schema blobs are projected; the extra field never appears.
+  assert.deepEqual(e.blobs, ["Priority", "ai", "Draw"]);
+});
+
+test("batch is truncated to the per-batch cap", () => {
+  const events = Array.from({ length: MAX_EVENTS_PER_BATCH + 10 }, () => ({
+    event: "js_error",
+    name: "E",
+    message: "m",
+    top_frame: "at f",
+    source: "window",
+    route: "/",
+  }));
+  const out = sanitizeTelemetryBatch(batch(events));
+  assert.equal(out.length, MAX_EVENTS_PER_BATCH);
+});
+
+test("malformed bodies yield an empty batch", () => {
+  assert.deepEqual(sanitizeTelemetryBatch(null), []);
+  assert.deepEqual(sanitizeTelemetryBatch("nope"), []);
+  assert.deepEqual(sanitizeTelemetryBatch(42), []);
+  assert.deepEqual(sanitizeTelemetryBatch({ schema: 2, events: [] }), []); // wrong schema
+  assert.deepEqual(sanitizeTelemetryBatch({ schema: 1 }), []); // no events array
+  assert.deepEqual(sanitizeTelemetryBatch({ schema: 1, events: "x" }), []);
+});
+
+test("field strings are capped at 300 and envelope strings at 64", () => {
+  const longField = "a".repeat(500);
+  const longEnvelope = "b".repeat(200);
+  const [e] = sanitizeTelemetryBatch(
+    batch([{ event: "engine_panic", fatal: false, reason: longField, panic: "p", game_mode: "ai", turn: 1 }], {
+      app_version: longEnvelope,
+    }),
+  );
+  assert.equal(e.blobs[0].length, 300); // reason capped
+  assert.equal(e.appVersion.length, 64); // envelope capped
+});
+
+test("the game_end oracle-id list survives the join at the client's 20-id cap", () => {
+  // 20 UUID-ish ids (36 chars each + commas ≈ 739 chars) must not be truncated:
+  // the list blob cap (1000) exceeds the joined length, so every id is retained.
+  const ids = Array.from({ length: 20 }, (_, i) => `oracle-${String(i).padStart(29, "0")}`);
+  const [e] = sanitizeTelemetryBatch(
+    batch([{ event: "game_end", result: "winner", winner_kind: "human", game_mode: "ai", turn_count: 3, unimplemented_oracle_ids: ids }]),
+  );
+  assert.equal(e.blobs[3], ids.join(","));
+  assert.equal(e.blobs[3].split(",").length, 20);
+});
+
+test("booleans and numbers coerce; missing/other values default", () => {
+  const [e] = sanitizeTelemetryBatch(
+    batch([{ event: "engine_panic", fatal: true, reason: "r", panic: "p", game_mode: "ai" }]),
+  );
+  // fatal=true → 1; turn missing → 0.
+  assert.deepEqual(e.doubles, [1, 0]);
+
+  const [drawn] = sanitizeTelemetryBatch(
+    batch([{ event: "game_end", result: "draw", winner_kind: null, game_mode: "ai", turn_count: 7, unimplemented_oracle_ids: ["x", 5, "y"] }]),
+  );
+  // winner_kind null → ""; array keeps only strings, comma-joined.
+  assert.deepEqual(drawn.blobs, ["draw", "", "ai", "x,y"]);
+  assert.deepEqual(drawn.doubles, [7]);
+});

--- a/lobby-worker/wrangler.toml
+++ b/lobby-worker/wrangler.toml
@@ -28,6 +28,16 @@ class_name = "LobbyDO"
 tag = "v1"
 new_sqlite_classes = ["LobbyDO"]
 
+# Analytics Engine dataset for client telemetry (`POST /telemetry`). Write-only,
+# high-cardinality event store queried out-of-band via the SQL-over-HTTP API.
+# AE is available on the Workers Free plan and is currently UNBILLED; Cloudflare
+# has said pricing will be announced in advance, so a future billing change here
+# is expected, not a surprise. The binding is optional in the Worker (`TELEMETRY?`)
+# so a deploy without this stanza still serves the lobby — ingest just no-ops.
+[[analytics_engine_datasets]]
+binding = "TELEMETRY"
+dataset = "phase_telemetry"
+
 # Workers Logs — persistent logs in the dashboard Observability tab. We keep this
 # ON for our structured console.* output: relay-mint failures surface via
 # `console.error({event:"turn_mint_failed"})` in turn.ts (the always-on Workers


### PR DESCRIPTION
Implements the Tier 1 slice of docs/telemetry-proposal.md:

- Engine: GameState.unimplemented_oracle_ids accumulates oracle ids (name
  fallback for tokens) when Effect::Unimplemented resolves; excluded from
  the CR 104.4b loop-equality family per the unbounded_resources precedent,
  with accumulator + loop-exclusion tests. Flows to all clients through the
  existing full-GameState serialization.
- Client: services/telemetry.ts (batched sendBeacon/keepalive-fetch, gated
  by __TELEMETRY_URL__ define + telemetryEnabled preference, session caps,
  identity-free) + telemetryEvents.ts wiring engine_panic, stuck_decision,
  js_error, chunk_reload, game_end; new React ErrorBoundary; settings
  toggle; i18n keys in all 7 locales.
- Worker: POST /telemetry on the lobby worker -> Analytics Engine dataset
  (allow-listed event schemas, 25-event/32KB caps, 204-always, CORS),
  optional TELEMETRY binding in wrangler.toml; node --test coverage.
- CI: TELEMETRY_URL define wired into staging deploy and release builds.

winner_kind is null for online games (AI seats are server-hosted and not
client-identifiable); local hotseat correctly reports human.
