### PR TITLE
feat(telemetry): card reports and usage events (Tier 2)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, useSearchParams } from "react-router";
 
 import { AppShell } from "./components/chrome/AppShell";
 import { AppToast } from "./components/chrome/AppToast";
+import { RouteTelemetry } from "./components/chrome/RouteTelemetry";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { HostControlTile } from "./components/chrome/HostControlTile";
 import { EngineLostModal } from "./components/modal/EngineLostModal";
@@ -98,6 +99,7 @@ function AppContent() {
 
   return (
     <div className="min-h-screen bg-gray-950 text-white">
+      <RouteTelemetry />
       {showSplash && (
         <SplashScreen progress={progress} onComplete={handleSplashComplete} label={loadLabel} />
       )}

--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -14,6 +14,7 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { ManaCostPips } from "../mana/ManaCostPips.tsx";
 import { RichLabel } from "../mana/RichLabel.tsx";
+import { ReportCardButton, type CardReportContext } from "./ReportCardButton.tsx";
 import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
 import { computePTDisplay, formatCounterType, formatTypeLine, toRoman } from "../../viewmodel/cardProps.ts";
 import {
@@ -127,6 +128,10 @@ function CardPreviewInner({
   const obj = useGameStore((s) =>
     inspectedObjectId != null ? s.gameState?.objects[inspectedObjectId] ?? null : null,
   );
+  // `card_report` context needs a live game: `obj == null` (deck builder) has no
+  // zone and a possibly-stale `gameMode`, and `gameId == null` means no game at
+  // all — a report in either case would pollute `game_mode`, so skip the button.
+  const gameId = useGameStore((s) => s.gameId);
 
   // Auto-derive back face name from " // " separator when not explicitly provided
   // (e.g., deck builder passes "Delver of Secrets // Insectile Aberration" as cardName)
@@ -318,6 +323,26 @@ function CardPreviewInner({
     viewportWidth,
   ]);
 
+  // Identity + parse counts for the "report this card" button, carrying the
+  // DISPLAYED face (back face under Ctrl) so the report matches what the player
+  // sees. Undefined outside a live game (`obj == null` or `gameId == null`), so
+  // the button never renders in the deck builder. On mobile `showOtherFace` is
+  // always false, so this resolves to the front face there.
+  const reportItems = showOtherFace && backParseDetails ? backParseDetails : frontParseDetails;
+  const reportContext: CardReportContext | undefined =
+    obj != null && gameId !== null
+      ? {
+          oracleId:
+            (showOtherFace ? obj.back_face?.printed_ref?.oracle_id : obj.printed_ref?.oracle_id) ?? "",
+          faceName:
+            (showOtherFace ? obj.back_face?.printed_ref?.face_name : obj.printed_ref?.face_name) ?? "",
+          name: showOtherFace ? (obj.back_face?.printed_ref?.face_name ?? backFaceName ?? obj.name) : obj.name,
+          zone: obj.zone,
+          supported: (reportItems ?? []).filter((item) => item.supported).length,
+          total: (reportItems ?? []).length,
+        }
+      : undefined;
+
   // Mobile overlay mode: centered with backdrop
   if (isMobile) {
     return (
@@ -329,6 +354,7 @@ function CardPreviewInner({
         onDismiss={onDismiss ?? dismissPreview}
         sourcePrinting={sourcePrinting}
         layout={mobileLayout ?? "modal"}
+        report={reportContext}
       />
     );
   }
@@ -371,6 +397,7 @@ function CardPreviewInner({
           localizedTypeLine={showOtherFace ? engineBackFace?.localized_type_line : engineFrontFace?.localized_type_line}
           parseDetails={showOtherFace && backParseDetails ? backParseDetails : frontParseDetails}
           maxHeight={viewportHeight - margin * 2}
+          report={reportContext}
         />
       ) : (
         <CardImagePreview
@@ -405,6 +432,7 @@ function MobilePreviewOverlay({
   onDismiss,
   sourcePrinting,
   layout = "modal",
+  report,
 }: {
   cardName: string;
   backFaceName: string | null;
@@ -413,6 +441,9 @@ function MobilePreviewOverlay({
   onDismiss: () => void;
   sourcePrinting?: SourcePrinting;
   layout?: "modal" | "compact";
+  /** In-game report context; absent in the deck builder. Only the full modal
+   *  layout hosts the button — the compact peek dismisses on any tap. */
+  report?: CardReportContext;
 }) {
   const { t } = useTranslation("game");
   const { src, isRotated, isFlip } = useCardImage(cardName, {
@@ -509,6 +540,11 @@ function MobilePreviewOverlay({
             >
               ⟳ {t("preview.flip")}
             </button>
+          )}
+          {report && (
+            <div className="absolute right-3 top-3 rounded-full border border-white/20 bg-black/70 px-3 py-1.5 shadow-lg backdrop-blur">
+              <ReportCardButton key={report.oracleId || report.name} {...report} />
+            </div>
           )}
         </div>
       )}
@@ -777,9 +813,12 @@ interface ParsedAbilitiesPanelProps {
   localizedTypeLine?: string | null;
   parseDetails: ParsedItem[] | null;
   maxHeight?: number;
+  /** In-game report context for the displayed face; absent in the deck builder
+   *  (no live game), where the report button is not shown. */
+  report?: CardReportContext;
 }
 
-function ParsedAbilitiesPanel({ name, cardTypes, keywords, localizedTypeLine, parseDetails, maxHeight }: ParsedAbilitiesPanelProps) {
+function ParsedAbilitiesPanel({ name, cardTypes, keywords, localizedTypeLine, parseDetails, maxHeight, report }: ParsedAbilitiesPanelProps) {
   const { t } = useTranslation("game");
   const items = parseDetails ?? [];
   const rulings = useCardRulings(name);
@@ -800,6 +839,11 @@ function ParsedAbilitiesPanel({ name, cardTypes, keywords, localizedTypeLine, pa
           <div className="text-[10px] text-gray-500 mt-0.5">{typeLine}</div>
         )}
         <SupportSummary items={items} />
+        {report && (
+          <div className="mt-1 flex justify-end">
+            <ReportCardButton key={report.oracleId || report.name} {...report} />
+          </div>
+        )}
       </div>
       <div className="px-2 py-2 space-y-0.5">
         {items.length === 0 && (

--- a/client/src/components/card/ReportCardButton.tsx
+++ b/client/src/components/card/ReportCardButton.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { Zone } from "../../adapter/types.ts";
+import { trackEvent } from "../../services/telemetry.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
+
+/** Cards reported this page-load, keyed by `oracle_id ?? name`, so a card
+ *  already reported renders its sent state when re-opened. This is UI-level
+ *  dedup; the event-level session cap lives in telemetry.ts
+ *  (`PER_EVENT_CAPS.card_report`). */
+const reportedThisSession = new Set<string>();
+
+/** Identity + parse-coverage context for a single reportable card face. Built
+ *  at the CardPreview call site from the live `GameObject` and the parse tree
+ *  the panel already holds (counts are not recomputed here). */
+export interface CardReportContext {
+  /** `""` for tokens/emblems (no `printed_ref`); `name` is the dedup fallback. */
+  oracleId: string;
+  faceName: string;
+  name: string;
+  zone: Zone;
+  /** Supported / total parsed items for the displayed face. */
+  supported: number;
+  total: number;
+}
+
+/**
+ * One-click "report this card" affordance. A single click sends a `card_report`
+ * telemetry event — no modal, no confirm step, no free text. The existing
+ * GitHub-issue and Discord report flows are untouched; this is the
+ * low-friction, identity-free counter. Renders nothing in `spectate` mode.
+ *
+ * Callers pass `key={oracleId || name}` so switching cards remounts the button
+ * and re-derives the sent state from {@link reportedThisSession}.
+ */
+export function ReportCardButton({ oracleId, faceName, name, zone, supported, total }: CardReportContext) {
+  const { t } = useTranslation("game");
+  const gameMode = useGameStore((s) => s.gameMode);
+  const turn = useGameStore((s) => s.gameState?.turn_number ?? null);
+  const dedupKey = oracleId || name;
+  const [sent, setSent] = useState(() => reportedThisSession.has(dedupKey));
+
+  if (gameMode === "spectate") return null;
+
+  const handleClick = () => {
+    if (sent) return;
+    reportedThisSession.add(dedupKey);
+    setSent(true);
+    trackEvent("card_report", {
+      oracle_id: oracleId,
+      face_name: faceName,
+      name,
+      zone,
+      game_mode: gameMode,
+      turn,
+      supported,
+      total,
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={sent}
+      className={
+        sent
+          ? "pointer-events-auto text-[11px] font-medium text-emerald-400"
+          : "pointer-events-auto text-[11px] text-indigo-300 hover:text-indigo-200"
+      }
+    >
+      {sent ? t("preview.reported") : t("preview.report")}
+    </button>
+  );
+}

--- a/client/src/components/chrome/RouteTelemetry.tsx
+++ b/client/src/components/chrome/RouteTelemetry.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router";
+
+import { coarseRoute } from "../../services/telemetryEvents";
+import { trackEvent } from "../../services/telemetry";
+
+/**
+ * Emits a `route_view` telemetry event on each navigation, keyed by the coarse
+ * route (`coarseRoute` strips ids/params, so a gameId never leaves the client).
+ * Consecutive repeats of the same coarse route are deduped — a param-only change
+ * within one area (e.g. two `/game/:id`s) is one bucket, not two views.
+ *
+ * Mounted once in `AppContent` inside the router but OUTSIDE the per-route
+ * `DevStrict` wrappers, so StrictMode's dev double-render can't double-emit.
+ * telemetryEvents.ts itself stays React-free; this is the one component that
+ * bridges the router to it.
+ */
+export function RouteTelemetry(): null {
+  const { pathname } = useLocation();
+  const lastRoute = useRef<string | null>(null);
+
+  useEffect(() => {
+    const route = coarseRoute(pathname);
+    if (route === lastRoute.current) return;
+    lastRoute.current = route;
+    trackEvent("route_view", { route });
+  }, [pathname]);
+
+  return null;
+}

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -16,6 +16,8 @@
     "holdCtrlFront": "Strg halten für Vorderseite",
     "holdCtrlFlip": "Strg halten zum Umdrehen",
     "flip": "Umdrehen",
+    "report": "Problem melden",
+    "reported": "Gemeldet ✓",
     "altParsedAbilities": "Alt: eingelesene Fähigkeiten",
     "debugId": "ID: {{id}}",
     "engineParse": "Engine-Parse",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -16,6 +16,8 @@
     "holdCtrlFront": "Hold Ctrl for front face",
     "holdCtrlFlip": "Hold Ctrl to flip",
     "flip": "Flip",
+    "report": "Report a problem",
+    "reported": "Reported ✓",
     "altParsedAbilities": "Alt: parsed abilities",
     "debugId": "ID: {{id}}",
     "engineParse": "Engine Parse",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -16,6 +16,8 @@
     "holdCtrlFront": "Mantén Ctrl para la cara frontal",
     "holdCtrlFlip": "Mantén Ctrl para girar",
     "flip": "Girar",
+    "report": "Informar de un problema",
+    "reported": "Informado ✓",
     "altParsedAbilities": "Alt: habilidades analizadas",
     "debugId": "ID: {{id}}",
     "engineParse": "Análisis del motor",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -16,6 +16,8 @@
     "holdCtrlFront": "Maintenez Ctrl pour la face avant",
     "holdCtrlFlip": "Maintenez Ctrl pour pivoter",
     "flip": "Pivoter",
+    "report": "Signaler un problème",
+    "reported": "Signalé ✓",
     "altParsedAbilities": "Alt : capacités analysées",
     "debugId": "ID : {{id}}",
     "engineParse": "Analyse du moteur",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -16,6 +16,8 @@
     "holdCtrlFront": "Tieni premuto Ctrl per il fronte",
     "holdCtrlFlip": "Tieni premuto Ctrl per girare",
     "flip": "Gira",
+    "report": "Segnala un problema",
+    "reported": "Segnalato ✓",
     "altParsedAbilities": "Alt: abilità analizzate",
     "debugId": "ID: {{id}}",
     "engineParse": "Analisi del motore",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -16,6 +16,8 @@
     "holdCtrlFront": "Przytrzymaj Ctrl, aby zobaczyć przednią stronę",
     "holdCtrlFlip": "Przytrzymaj Ctrl, aby odwrócić",
     "flip": "Odwróć",
+    "report": "Zgłoś problem",
+    "reported": "Zgłoszono ✓",
     "altParsedAbilities": "Alt: przeanalizowane zdolności",
     "debugId": "ID: {{id}}",
     "engineParse": "Analiza silnika",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -16,6 +16,8 @@
     "holdCtrlFront": "Segure Ctrl para a face dianteira",
     "holdCtrlFlip": "Segure Ctrl para virar",
     "flip": "Virar",
+    "report": "Relatar um problema",
+    "reported": "Relatado ✓",
     "altParsedAbilities": "Alt: habilidades processadas",
     "debugId": "ID: {{id}}",
     "engineParse": "Análise do Motor",

--- a/client/src/services/telemetry.ts
+++ b/client/src/services/telemetry.ts
@@ -25,11 +25,21 @@ const FLUSH_AT_COUNT = 20;
 /** Flush this long after the first event was queued, if the count trigger
  *  hasn't already fired. */
 const FLUSH_AFTER_MS = 10_000;
-/** Hard per-session cap on total events (abuse / runaway-loop backstop). */
+/** Hard per-session cap on total events (abuse / runaway-loop backstop). A
+ *  navigation-heavy session can spend up to half this budget on `route_view`s
+ *  before hitting the shared ceiling; that trade is accepted — the reserve
+ *  exists for crash events (`js_error`/`engine_panic`), which fire early rather
+ *  than late in a session. */
 const MAX_EVENTS_PER_SESSION = 100;
-/** Hard per-session cap on `js_error` events specifically — an error loop must
- *  not drown the batch. */
-const MAX_JS_ERRORS_PER_SESSION = 10;
+/** Hard per-session cap on specific event types — a loop of any one kind must
+ *  not drown the batch. Declarative so a new capped event is one entry, not a
+ *  new counter+constant pair. Events absent here are bounded only by
+ *  {@link MAX_EVENTS_PER_SESSION}. */
+const PER_EVENT_CAPS: Record<string, number> = {
+  js_error: 10,
+  card_report: 10,
+  route_view: 50,
+};
 
 /** A queued event: the caller's fields plus the event name and a client
  *  timestamp. Values are truncated (strings) at enqueue. */
@@ -48,7 +58,8 @@ const DISABLED = TELEMETRY_URL === "";
 const queue: QueuedEvent[] = [];
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
 let eventsThisSession = 0;
-let jsErrorsThisSession = 0;
+/** Per-event-type send counts this session, checked against {@link PER_EVENT_CAPS}. */
+const perEventCounts: Record<string, number> = {};
 
 /** Truncate a single string field to the session cap. Non-strings pass through
  *  untouched. */
@@ -74,7 +85,8 @@ export function trackEvent(name: string, fields: Record<string, unknown> = {}): 
     if (DISABLED) return;
     if (!usePreferencesStore.getState().telemetryEnabled) return;
     if (eventsThisSession >= MAX_EVENTS_PER_SESSION) return;
-    if (name === "js_error" && jsErrorsThisSession >= MAX_JS_ERRORS_PER_SESSION) return;
+    const cap = PER_EVENT_CAPS[name];
+    if (cap !== undefined && (perEventCounts[name] ?? 0) >= cap) return;
 
     const event: QueuedEvent = { event: name, ts: Date.now() };
     for (const [key, value] of Object.entries(fields)) {
@@ -83,7 +95,7 @@ export function trackEvent(name: string, fields: Record<string, unknown> = {}): 
 
     queue.push(event);
     eventsThisSession += 1;
-    if (name === "js_error") jsErrorsThisSession += 1;
+    perEventCounts[name] = (perEventCounts[name] ?? 0) + 1;
 
     if (queue.length >= FLUSH_AT_COUNT) {
       flushNow();

--- a/client/src/services/telemetryEvents.ts
+++ b/client/src/services/telemetryEvents.ts
@@ -16,10 +16,15 @@ import { useGameStore } from "../stores/gameStore";
 import { flushNow, installTelemetryLifecycle, trackEvent } from "./telemetry";
 
 /** Coarse route: the first path segment, so we bucket by area (deck / game /
- *  draft / menu) without capturing ids or query strings. */
-function coarseRoute(): string {
-  if (typeof window === "undefined") return "";
-  const segment = window.location.pathname.split("/").filter(Boolean)[0];
+ *  draft / menu) without capturing ids or query strings. The single route
+ *  vocabulary shared by `js_error.route`, `session_start`, and `route_view` —
+ *  every route-keyed dashboard query joins on this format. Defaults to the
+ *  current location; callers with a specific pathname (e.g. the route-change
+ *  component) pass it explicitly. */
+export function coarseRoute(pathname?: string): string {
+  if (pathname === undefined && typeof window === "undefined") return "";
+  const path = pathname ?? window.location.pathname;
+  const segment = path.split("/").filter(Boolean)[0];
   return segment ? `/${segment}` : "/";
 }
 
@@ -140,10 +145,54 @@ function installGameEndTracking(): void {
   );
 }
 
-/** Install all Tier 1 telemetry hooks. Idempotent-safe to call once at boot. */
+/**
+ * Emit `game_start` once per game when a new non-null `gameId` first has a
+ * non-null `gameState`. Mirrors `game_end`'s edge-trigger machinery
+ * (closure-scoped last-emitted gameId, spectate skip): counts are per-client
+ * sessions, not per game.
+ *
+ * Resume semantics: a mid-game reload re-emits `game_start` in the new session
+ * (the closure state resets on page load). This matches `game_end`'s existing
+ * per-client-session semantics — a resumed-and-finished game stays balanced
+ * because `game_end` re-emits in the same session too; only a reload-then-
+ * abandon skews starts-vs-ends, which is itself signal.
+ */
+function installGameStartTracking(): void {
+  let lastEmittedGameId: string | null = null;
+
+  useGameStore.subscribe(
+    (s) => s.gameState,
+    (gameState) => {
+      if (!gameState) return;
+      const { gameId, gameMode, aiSeatIds } = useGameStore.getState();
+      if (gameMode === "spectate") return;
+      if (gameId === null || gameId === lastEmittedGameId) return;
+      lastEmittedGameId = gameId;
+
+      trackEvent("game_start", {
+        game_mode: gameMode,
+        player_count: gameState.players.length,
+        ai_count: aiSeatIds.length,
+      });
+    },
+  );
+}
+
+/** Guards `session_start` to exactly one emit per page load, even if
+ *  `installTelemetry` is ever called twice (hot reload). */
+let sessionStarted = false;
+
+/** Install all telemetry hooks. Idempotent-safe to call once at boot. */
 export function installTelemetry(): void {
   installTelemetryLifecycle();
   installErrorListeners();
   installStuckDecisionTracking();
   installGameEndTracking();
+  installGameStartTracking();
+  // Once per page load: the session's opening route. Version/platform/build
+  // ride the batch envelope, so `route` is the only field.
+  if (!sessionStarted) {
+    sessionStarted = true;
+    trackEvent("session_start", { route: coarseRoute() });
+  }
 }

--- a/deploy/grafana/telemetry-dashboard.json
+++ b/deploy/grafana/telemetry-dashboard.json
@@ -1,0 +1,306 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_AE",
+      "label": "Cloudflare Analytics Engine",
+      "description": "Altinity ClickHouse datasource pointed at the Workers Analytics Engine SQL API",
+      "type": "datasource",
+      "pluginId": "vertamedia-clickhouse-datasource",
+      "pluginName": "Altinity plugin for ClickHouse"
+    }
+  ],
+  "title": "phase.rs Telemetry",
+  "uid": "phase-telemetry",
+  "tags": ["phase-rs", "telemetry"],
+  "timezone": "utc",
+  "time": { "from": "now-7d", "to": "now" },
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Events over time (by type)",
+      "gridPos": { "h": 9, "w": 16, "x": 0, "y": 0 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+          "query": "SELECT $timeSeries AS t, blob1 AS event, sum(_sample_interval) AS events FROM phase_telemetry WHERE $timeFilter GROUP BY t, event ORDER BY t",
+          "rawQuery": true,
+          "format": "time_series",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "round": "0s",
+          "extrapolate": false
+        }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 60, "stacking": { "mode": "normal" } } }, "overrides": [] }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Engine panics",
+      "gridPos": { "h": 3, "w": 4, "x": 16, "y": 0 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT sum(_sample_interval) AS n FROM phase_telemetry WHERE $timeFilter AND blob1 = 'engine_panic'",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ],
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 10 } ] } }, "overrides": [] }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "JS errors",
+      "gridPos": { "h": 3, "w": 4, "x": 20, "y": 0 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT sum(_sample_interval) AS n FROM phase_telemetry WHERE $timeFilter AND blob1 = 'js_error'",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ],
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 5 }, { "color": "red", "value": 50 } ] } }, "overrides": [] }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Games ended",
+      "gridPos": { "h": 3, "w": 4, "x": 16, "y": 3 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT sum(_sample_interval) AS n FROM phase_telemetry WHERE $timeFilter AND blob1 = 'game_end'",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Stuck decisions",
+      "gridPos": { "h": 3, "w": 4, "x": 20, "y": 3 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT sum(_sample_interval) AS n FROM phase_telemetry WHERE $timeFilter AND blob1 = 'stuck_decision'",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ],
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 1 } ] } }, "overrides": [] }
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Chunk reloads",
+      "gridPos": { "h": 3, "w": 8, "x": 16, "y": 6 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT sum(_sample_interval) AS n FROM phase_telemetry WHERE $timeFilter AND blob1 = 'chunk_reload'",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Recent errors (js_error + engine_panic)",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 9 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT timestamp, blob1 AS event, blob2 AS version, blob3 AS build, blob4 AS platform, blob6 AS message, blob7 AS detail, blob8 AS source FROM phase_telemetry WHERE $timeFilter AND blob1 IN ('js_error','engine_panic') ORDER BY timestamp DESC LIMIT 100",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "table",
+      "title": "Error signatures (grouped)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 19 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT blob1 AS event, blob6 AS message, blob3 AS build, sum(_sample_interval) AS occurrences FROM phase_telemetry WHERE $timeFilter AND blob1 IN ('js_error','engine_panic') GROUP BY event, message, build ORDER BY occurrences DESC LIMIT 50",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "table",
+      "title": "Game outcomes (mode x winner_kind, avg turns)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 19 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT blob7 AS game_mode, blob6 AS winner_kind, blob5 AS result, sum(_sample_interval) AS games, round(avg(double1), 1) AS avg_turns FROM phase_telemetry WHERE $timeFilter AND blob1 = 'game_end' GROUP BY game_mode, winner_kind, result ORDER BY games DESC",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "table",
+      "title": "Unimplemented-card demand (raw id lists from game_end)",
+      "description": "blob8 is a comma-joined oracle-id list per game. The AE SQL dialect has no arrayJoin, so per-card ranking needs client-side splitting (see scripts note in the setup guide) — this table surfaces the raw lists for eyeballing until volume justifies that.",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 27 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT timestamp, blob7 AS game_mode, blob8 AS unimplemented_oracle_ids FROM phase_telemetry WHERE $timeFilter AND blob1 = 'game_end' AND blob8 != '' ORDER BY timestamp DESC LIMIT 100",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Sessions per day",
+      "description": "session_start fires once per page load — an approximate session count (no install id, so distinct-user DAU is not derivable).",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT $timeSeries AS t, sum(_sample_interval) AS sessions FROM phase_telemetry WHERE $timeFilter AND blob1 = 'session_start' GROUP BY t ORDER BY t",
+          "rawQuery": true,
+          "format": "time_series",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "round": "0s",
+          "extrapolate": false
+        }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 60 } }, "overrides": [] }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Games started per day (by mode)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT $timeSeries AS t, blob5 AS game_mode, sum(_sample_interval) AS games FROM phase_telemetry WHERE $timeFilter AND blob1 = 'game_start' GROUP BY t, game_mode ORDER BY t",
+          "rawQuery": true,
+          "format": "time_series",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "round": "0s",
+          "extrapolate": false
+        }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 60, "stacking": { "mode": "normal" } } }, "overrides": [] }
+    },
+    {
+      "id": 13,
+      "type": "table",
+      "title": "Game completion (starts vs ends by mode)",
+      "description": "A mid-game reload re-emits game_start in the new client session; game_end re-emits too, so a resumed-and-finished game stays balanced. Only reload-then-abandon leaves starts > ends, which is itself signal.",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 43 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT mode, sum(if(event = 'game_start', n, 0)) AS starts, sum(if(event = 'game_end', n, 0)) AS ends FROM (SELECT blob5 AS mode, blob1 AS event, sum(_sample_interval) AS n FROM phase_telemetry WHERE $timeFilter AND blob1 = 'game_start' GROUP BY mode, event UNION ALL SELECT blob7 AS mode, blob1 AS event, sum(_sample_interval) AS n FROM phase_telemetry WHERE $timeFilter AND blob1 = 'game_end' GROUP BY mode, event) GROUP BY mode ORDER BY starts DESC",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "table",
+      "title": "Top reported cards",
+      "description": "Player 'report this card' clicks grouped by oracle_id + name. avg_supported / avg_total triage misparse-vs-known-gap: a low ratio means the parser is missing clauses the card claims, a full ratio (supported = total) points at a runtime/engine bug on an already-parsed card.",
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 43 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT blob5 AS oracle_id, blob7 AS name, sum(_sample_interval) AS reports, round(avg(double2), 1) AS avg_supported, round(avg(double3), 1) AS avg_total FROM phase_telemetry WHERE $timeFilter AND blob1 = 'card_report' GROUP BY oracle_id, name ORDER BY reports DESC LIMIT 50",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "table",
+      "title": "Route usage",
+      "description": "route_view counts per coarse route (ids/params stripped). Shares the route vocabulary of js_error.route and session_start.route.",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 51 },
+      "datasource": { "type": "vertamedia-clickhouse-datasource", "uid": "${DS_AE}" },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "SELECT blob5 AS route, sum(_sample_interval) AS views FROM phase_telemetry WHERE $timeFilter AND blob1 = 'route_view' GROUP BY route ORDER BY views DESC",
+          "rawQuery": true,
+          "format": "table",
+          "dateTimeType": "DATETIME",
+          "dateTimeColDataType": "timestamp",
+          "extrapolate": false
+        }
+      ]
+    }
+  ]
+}

--- a/lobby-worker/src/telemetry.ts
+++ b/lobby-worker/src/telemetry.ts
@@ -26,9 +26,10 @@ export const MAX_EVENTS_PER_BATCH = 25;
 
 /**
  * Per-event allow-list. `blobs` are the event-specific string columns (in
- * order); `doubles` are the numeric/boolean columns (in order). Only these five
- * Tier 1 events are accepted. Array fields (e.g. `unimplemented_oracle_ids`) are
- * flattened to a single comma-joined blob.
+ * order); `doubles` are the numeric/boolean columns (in order). Both the Tier 1
+ * crash/usage events and the Tier 2 report/usage events are accepted. Array
+ * fields (e.g. `unimplemented_oracle_ids`) are flattened to a single
+ * comma-joined blob.
  *
  * Column layout for every point (documented so the AE schema is stable):
  *   indexes: [event]
@@ -36,6 +37,10 @@ export const MAX_EVENTS_PER_BATCH = 25;
  *   doubles: [...schema.doubles]
  * AE hard limits respected by construction: ≤ 20 blobs, ≤ 20 doubles, exactly
  * 1 index, ≤ 16 KB total blob bytes (guarded by the per-field string caps).
+ *
+ * Note on `turn`/`turn_count`: `turn_number` is 1-based, and `toDouble` coerces
+ * a missing/null turn to 0 — so a `turn: 0` (or `turn_count: 0`) column means
+ * "unknown", never turn zero.
  */
 export const EVENT_SCHEMAS: Record<string, { blobs: string[]; doubles: string[] }> = {
   engine_panic: { blobs: ["reason", "panic", "game_mode"], doubles: ["fatal", "turn"] },
@@ -46,6 +51,13 @@ export const EVENT_SCHEMAS: Record<string, { blobs: string[]; doubles: string[] 
     blobs: ["result", "winner_kind", "game_mode", "unimplemented_oracle_ids"],
     doubles: ["turn_count"],
   },
+  card_report: {
+    blobs: ["oracle_id", "face_name", "name", "zone", "game_mode"],
+    doubles: ["turn", "supported", "total"],
+  },
+  session_start: { blobs: ["route"], doubles: [] },
+  game_start: { blobs: ["game_mode"], doubles: ["player_count", "ai_count"] },
+  route_view: { blobs: ["route"], doubles: [] },
 };
 
 /** A validated, column-resolved event ready to become an AE data point. */

--- a/lobby-worker/test/telemetry.test.mjs
+++ b/lobby-worker/test/telemetry.test.mjs
@@ -40,6 +40,41 @@ test("sanitizeTelemetryBatch accepts the five Tier 1 events with envelope fields
   }
 });
 
+test("sanitizeTelemetryBatch accepts the Tier 2 report/usage events with their columns", () => {
+  const out = sanitizeTelemetryBatch(
+    batch([
+      { event: "card_report", oracle_id: "abc", face_name: "Front", name: "Colossal Dreadmaw", zone: "Battlefield", game_mode: "ai", turn: 5, supported: 2, total: 3 },
+      { event: "session_start", route: "/game" },
+      { event: "game_start", game_mode: "ai", player_count: 2, ai_count: 1 },
+      { event: "route_view", route: "/deck-builder" },
+    ]),
+  );
+  assert.equal(out.length, 4);
+  for (const e of out) {
+    assert.equal(e.blobs.length, EVENT_SCHEMAS[e.event].blobs.length);
+    assert.equal(e.doubles.length, EVENT_SCHEMAS[e.event].doubles.length);
+  }
+  const [report, session, gameStart, route] = out;
+  // card_report columns land in documented order (blobs then doubles).
+  assert.deepEqual(report.blobs, ["abc", "Front", "Colossal Dreadmaw", "Battlefield", "ai"]);
+  assert.deepEqual(report.doubles, [5, 2, 3]);
+  assert.deepEqual(session.blobs, ["/game"]);
+  assert.deepEqual(session.doubles, []);
+  assert.deepEqual(gameStart.blobs, ["ai"]);
+  assert.deepEqual(gameStart.doubles, [2, 1]);
+  assert.deepEqual(route.blobs, ["/deck-builder"]);
+  assert.deepEqual(route.doubles, []);
+});
+
+test("unknown fields are dropped from a new Tier 2 event", () => {
+  const [e] = sanitizeTelemetryBatch(
+    batch([{ event: "card_report", oracle_id: "abc", face_name: "", name: "X", zone: "Hand", game_mode: "ai", turn: 1, supported: 1, total: 1, secret: "leak" }]),
+  );
+  // Only schema columns are projected; the extra field never appears.
+  assert.deepEqual(e.blobs, ["abc", "", "X", "Hand", "ai"]);
+  assert.deepEqual(e.doubles, [1, 1, 1]);
+});
+
 test("toDataPoint prepends the envelope blobs and sets the single index", () => {
   const [e] = sanitizeTelemetryBatch(
     batch([{ event: "chunk_reload", reason: "preload-error", deferred: true, chunk: "c.js" }]),


### PR DESCRIPTION
Player-facing "report this card" affordance plus usage telemetry, riding
the Tier 1 pipeline:

- card_report: single-click report button in the Alt parse panel sticky
  header and the mobile modal preview (spectate/deck-builder contexts
  excluded, back-face aware, per-card session dedup, no free text)
- session_start / game_start / route_view usage events; game_start
  reuses the game_end edge-trigger machinery, route_view mounts a tiny
  RouteTelemetry component inside BrowserRouter and dedupes repeats
- per-event session caps generalized into declarative PER_EVENT_CAPS
  (replaces the hardcoded js_error counter)
- lobby-worker: 4 new declarative EVENT_SCHEMAS entries + column-order
  and unknown-field-drop tests (50/50 passing)
- Grafana dashboard: sessions/day, games by mode, completion,
  top reported cards, route usage panels
- i18n keys added across all 7 locales

All events remain identity-free: no install id, no free text, no game
ids or player names in any payload.
