### PR TITLE
fix(parser): parse anaphoric perpetual effects

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6957,7 +6957,7 @@ fn try_parse_perpetual_become(tp: TextPair) -> Option<Effect> {
 
 /// Digital-only Alchemy: parse the base-P/T "perpetually" form —
 /// self-subject ("[~ / this creature / …] perpetually become(s)/has base power
-/// and toughness N/N"), referenced-object ("the duplicate perpetually has …"),
+/// and toughness N/N"), referenced-object ("the duplicate/it perpetually has …"),
 /// and prior-clause anaphor ("its base power and toughness perpetually
 /// become …") → [`Effect::ApplyPerpetual`] with
 /// [`PerpetualModification::SetBasePowerToughness`] (High Fae Prankster, Three
@@ -7002,6 +7002,29 @@ fn try_parse_perpetual_base_pt(tp: TextPair) -> Option<Effect> {
         });
     }
 
+    // Referenced object: "It perpetually has base power and toughness 1/1."
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("it perpetually ").parse(lower) {
+        let (rest, _) = alt((
+            tag::<_, _, OracleError<'_>>("becomes "),
+            tag::<_, _, OracleError<'_>>("become "),
+            tag::<_, _, OracleError<'_>>("has "),
+            tag::<_, _, OracleError<'_>>("have "),
+        ))
+        .parse(rest)
+        .ok()?;
+        let (rest, _) = tag::<_, _, OracleError<'_>>("base power and toughness ")
+            .parse(rest)
+            .ok()?;
+        let (power, toughness, _) = parse_base_pt_values(rest)?;
+        return Some(Effect::ApplyPerpetual {
+            target: TargetFilter::ParentTarget,
+            modification: crate::types::ability::PerpetualModification::SetBasePowerToughness {
+                power,
+                toughness,
+            },
+        });
+    }
+
     // Prior-clause anaphor: "Its base power and toughness perpetually become 2/2."
     if let Ok((rest, _)) =
         tag::<_, _, OracleError<'_>>("its base power and toughness perpetually ").parse(lower)
@@ -7025,10 +7048,6 @@ fn try_parse_perpetual_base_pt(tp: TextPair) -> Option<Effect> {
     }
 
     // Self-subject: "~ perpetually has base power and toughness 4/1."
-    // Only unambiguous self-subjects. The anaphoric "it " is intentionally
-    // excluded: after a prior object choice it refers to that object, not the
-    // source, so accepting it here would let a referenced-object perpetual clause
-    // parse as supported while mutating the wrong object.
     let after_subject = [
         "~ ",
         "this creature ",
@@ -7141,6 +7160,25 @@ fn try_parse_perpetual_modify_pt(tp: TextPair) -> Option<Effect> {
         });
     }
 
+    // Anaphoric back-reference: "it perpetually gets +1/+0".
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("it perpetually ").parse(lower) {
+        let (rest, _) = alt((
+            tag::<_, _, OracleError<'_>>("gets "),
+            tag::<_, _, OracleError<'_>>("get "),
+        ))
+        .parse(rest)
+        .ok()?;
+        let (rest, (power_delta, toughness_delta)) =
+            nom_primitives::parse_pt_modifier(rest).ok()?;
+        return tail_done(rest).then_some(Effect::ApplyPerpetual {
+            target: TargetFilter::ParentTarget,
+            modification: crate::types::ability::PerpetualModification::ModifyPowerToughness {
+                power_delta,
+                toughness_delta,
+            },
+        });
+    }
+
     let after_subject = [
         "~ ",
         "this creature ",
@@ -7183,6 +7221,8 @@ fn try_parse_perpetual_modify_pt(tp: TextPair) -> Option<Effect> {
 /// resolves against:
 /// - the anaphoric `"that <type> perpetually gains ..."` form back-references the
 ///   parent target ([`TargetFilter::ParentTarget`]);
+/// - the anaphoric `"it perpetually gains ..."` form also back-references the
+///   parent target;
 /// - the self forms (`~`, `this creature/artifact/…`) target the source itself
 ///   ([`TargetFilter::Any`], resolved to the source by the perpetual resolver).
 ///
@@ -7197,6 +7237,17 @@ fn parse_perpetual_self_subject(lower: &str) -> Option<(&str, TargetFilter)> {
         let (rest, _) = tag::<_, _, OracleError<'_>>("perpetually ")
             .parse(rest)
             .ok()?;
+        let (rest, _) = alt((
+            tag::<_, _, OracleError<'_>>("gains "),
+            tag::<_, _, OracleError<'_>>("gain "),
+        ))
+        .parse(rest)
+        .ok()?;
+        return Some((rest, TargetFilter::ParentTarget));
+    }
+
+    // Anaphoric back-reference: "it perpetually gains ...".
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("it perpetually ").parse(lower) {
         let (rest, _) = alt((
             tag::<_, _, OracleError<'_>>("gains "),
             tag::<_, _, OracleError<'_>>("gain "),

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -29634,8 +29634,7 @@ fn perpetual_parser_maps_self_base_pt() {
         }
     ));
 
-    // "become(s)" verb variant. (Uses an unambiguous self-subject; the
-    // anaphoric "it" form is intentionally not accepted.)
+    // "become(s)" verb variant with an unambiguous self-subject.
     let e = parse_effect("This creature perpetually becomes base power and toughness 2/2.");
     assert!(matches!(
         e,
@@ -29678,6 +29677,19 @@ fn perpetual_parser_maps_referenced_base_pt() {
             ..
         }
     ));
+
+    let e = parse_effect("It perpetually has base power and toughness 3/3.");
+    assert!(matches!(
+        e,
+        Effect::ApplyPerpetual {
+            target: TargetFilter::ParentTarget,
+            modification: PerpetualModification::SetBasePowerToughness {
+                power: 3,
+                toughness: 3,
+            },
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -29702,6 +29714,19 @@ fn perpetual_parser_maps_modify_pt() {
             target: TargetFilter::ParentTarget,
             modification: PerpetualModification::ModifyPowerToughness {
                 power_delta: 1,
+                toughness_delta: 0,
+            },
+            ..
+        }
+    ));
+
+    let e = parse_effect("it perpetually gets +3/+0.");
+    assert!(matches!(
+        e,
+        Effect::ApplyPerpetual {
+            target: TargetFilter::ParentTarget,
+            modification: PerpetualModification::ModifyPowerToughness {
+                power_delta: 3,
                 toughness_delta: 0,
             },
             ..
@@ -29758,6 +29783,16 @@ fn perpetual_parser_maps_grant_keywords() {
             modification: PerpetualModification::GrantKeywords { keywords },
             ..
         } if keywords == vec![Keyword::Flying]
+    ));
+
+    let e = parse_effect("it perpetually gains haste.");
+    assert!(matches!(
+        e,
+        Effect::ApplyPerpetual {
+            target: TargetFilter::ParentTarget,
+            modification: PerpetualModification::GrantKeywords { keywords },
+            ..
+        } if keywords == vec![Keyword::Haste]
     ));
 }
 
@@ -29941,6 +29976,112 @@ fn perpetual_modify_cost_anaphor_that_card() {
         ),
         "'that card' anaphor must map to ParentTarget Reduce generic(1), got {e:?}"
     );
+
+    let e = parse_effect("It perpetually gains \"This spell costs {1} less to cast.\"");
+    assert!(
+        matches!(
+            &e,
+            Effect::ApplyPerpetual {
+                target: TargetFilter::ParentTarget,
+                modification: PerpetualModification::ModifyCost {
+                    mode: CostModifyMode::Reduce,
+                    amount,
+                },
+            } if *amount == ManaCost::generic(1)
+        ),
+        "'it' anaphor must map to ParentTarget Reduce generic(1), got {e:?}"
+    );
+
+    let e = parse_effect("It perpetually gains \"This spell costs {2} more to cast.\"");
+    assert!(
+        matches!(
+            &e,
+            Effect::ApplyPerpetual {
+                target: TargetFilter::ParentTarget,
+                modification: PerpetualModification::ModifyCost {
+                    mode: CostModifyMode::Raise,
+                    amount,
+                },
+            } if *amount == ManaCost::generic(2)
+        ),
+        "'it' anaphor must map to ParentTarget Raise generic(2), got {e:?}"
+    );
+}
+
+#[test]
+fn perpetual_anaphor_after_chosen_card_targets_parent_target() {
+    use crate::types::ability::PerpetualModification;
+    use crate::types::mana::ManaCost;
+    use crate::types::statics::CostModifyMode;
+
+    let def = parse_effect_chain(
+        "Choose a nonland card in your hand. It perpetually gains \"This spell costs {1} less to cast.\"",
+        AbilityKind::Spell,
+    );
+    let sub = def
+        .sub_ability
+        .as_deref()
+        .expect("chosen card must feed perpetual sub-ability");
+    assert!(
+        matches!(
+            sub.effect.as_ref(),
+            Effect::ApplyPerpetual {
+                target: TargetFilter::ParentTarget,
+                modification: PerpetualModification::ModifyCost {
+                    mode: CostModifyMode::Reduce,
+                    amount,
+                },
+            } if *amount == ManaCost::generic(1)
+        ),
+        "chosen-card 'it' must map to ParentTarget ApplyPerpetual, got {:?}",
+        sub.effect
+    );
+
+    let def = parse_effect_chain(
+        "Choose a nonland card in your hand. It perpetually gains \"This spell costs {2} more to cast.\"",
+        AbilityKind::Spell,
+    );
+    let sub = def
+        .sub_ability
+        .as_deref()
+        .expect("chosen card must feed perpetual cost-increase sub-ability");
+    assert!(
+        matches!(
+            sub.effect.as_ref(),
+            Effect::ApplyPerpetual {
+                target: TargetFilter::ParentTarget,
+                modification: PerpetualModification::ModifyCost {
+                    mode: CostModifyMode::Raise,
+                    amount,
+                },
+            } if *amount == ManaCost::generic(2)
+        ),
+        "chosen-card 'it' must map to ParentTarget Raise generic(2), got {:?}",
+        sub.effect
+    );
+
+    let def = parse_effect_chain(
+        "Choose a creature card in your hand. It perpetually gets +3/+0.",
+        AbilityKind::Spell,
+    );
+    let sub = def
+        .sub_ability
+        .as_deref()
+        .expect("chosen card must feed perpetual P/T sub-ability");
+    assert!(
+        matches!(
+            sub.effect.as_ref(),
+            Effect::ApplyPerpetual {
+                target: TargetFilter::ParentTarget,
+                modification: PerpetualModification::ModifyPowerToughness {
+                    power_delta: 3,
+                    toughness_delta: 0,
+                },
+            }
+        ),
+        "chosen-card P/T 'it' must map to ParentTarget ApplyPerpetual, got {:?}",
+        sub.effect
+    );
 }
 
 /// Mass-hand arm: the EXACT real Oracle clauses (verified against
@@ -30060,8 +30201,7 @@ fn perpetual_mass_hand_cost_arm_parses_typed_hand_filter() {
 /// model and fall through (NOT ApplyPerpetual::ModifyCost):
 /// - Absorb Energy's "that share a card type with that spell" rider;
 /// - an `{X}` body the cost-body parser cannot interpret;
-/// - a trailing rider "…and draws a card";
-/// - the "It perpetually gains …" form (subject not in the mass-arm list).
+/// - a trailing rider "…and draws a card".
 #[test]
 fn perpetual_mass_hand_cost_arm_honest_red() {
     use crate::types::ability::PerpetualModification;
@@ -30099,13 +30239,6 @@ fn perpetual_mass_hand_cost_arm_honest_red() {
     assert!(
         !is_modify_cost(&e),
         "trailing rider must not parse as ModifyCost, got {e:?}"
-    );
-
-    // "It perpetually gains …" — the subject is not in the mass-arm class.
-    let e = parse_effect("It perpetually gains \"This spell costs {1} less to cast.\"");
-    assert!(
-        !is_modify_cost(&e),
-        "'It perpetually gains' is not a mass-hand subject, got {e:?}"
     );
 }
 

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -4621,7 +4621,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 19. Perpetual (Alchemy) duration mis-mapped to UntilEndOfTurn  (67 cards)
+### 19. Perpetual (Alchemy) duration mis-mapped to UntilEndOfTurn  (55 cards)
 
 **Signature.** 'perpetually' grant emitted with UntilEndOfTurn/null instead of a Perpetual duration; modification expires too soon.
 
@@ -4629,9 +4629,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 <details><summary>Cards</summary>
 
-- Bloodsprout Talisman
 - By Elspeth's Command
-- Chronicler of Worship
 - Cottontail Caretaker
 - Courtly Provocateur
 - Creeping Tar Pit
@@ -4640,9 +4638,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Edifice of Authority
 - Effluence Devourer
 - Emperor Apatzec Intli IV
-- Ethereal Escort
 - Garruk, Wrath of the Wilds
-- Geistchanneler
 - Gitrog, Horror of Zhava
 - Goblin Trapfinder
 - Grow Old Together
@@ -4657,27 +4653,19 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Karlach, Tiefling Spellrager
 - Karlach, Tiefling Zealot
 - Kemba's Outfitter
-- Kobold Warcaller
 - Legion of Clay (duration)
-- Leonin Sanctifier
 - Lizardfolk Librarians
 - Lobelia Sackville-Baggins
 - Loose in the Park
 - Lurking Spinecrawler
 - Mapping the Maze
 - Melt Through
-- Mentor of Evos Isle
 - Mischievous Lookout
 - Niambi, Beloved Protector
-- Nightclub Bouncer
 - Paths of Tuinvale
-- Plaguecrafter's Familiar
-- Prairie Survivalist
 - Pull of the Mist Moon
 - Puppet Raiser
 - Ravenous Pursuit
-- Reckless Ringleader
-- Sap Vitality
 - Scrutiny of the Guildpact
 - Shadow of the Enemy
 - Shattered Seraph


### PR DESCRIPTION
## Summary

Fixes the Root #19 perpetual misparse class where `It perpetually ...` clauses after a chosen/returned card parsed as temporary `GenericEffect`/`Pump` effects instead of `ApplyPerpetual` on the parent target.

This teaches the perpetual parser to bind the anaphoric `it` subject to `TargetFilter::ParentTarget` for:

- base power/toughness forms: `it perpetually has/becomes base power and toughness N/N`
- P/T modifiers: `it perpetually gets +N/+M`
- keyword grants and cast-cost modifications through the existing perpetual subject helper

## Backlog / Card Audit

Removed these 12 fully fixed cards from `docs/parser-misparse-backlog.md` Root #19 and updated the count from 67 to 55:

- Bloodsprout Talisman
- Chronicler of Worship
- Ethereal Escort
- Geistchanneler
- Kobold Warcaller
- Leonin Sanctifier
- Mentor of Evos Isle
- Nightclub Bouncer
- Plaguecrafter's Familiar
- Prairie Survivalist
- Reckless Ringleader
- Sap Vitality

Raw before/after parsed JSON diff for the Root #19 filter changed exactly 13 cards:

- the 12 cards above, all moving the `It perpetually ...` clause to `ApplyPerpetual { target: ParentTarget, ... }`
- Skyline Savior, intentionally: its `it perpetually gets +1/+1` clause now parses as perpetual, but the remaining `gains flying, and becomes an Angel...` rider is still temporary/unsupported, so the card stays in the backlog

`coverage-parse-diff` reported no support-signature changes for this PR.

## Validation

- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `git diff --check`
- `target/debug/card-data-validate /tmp/phase-root19-after.json`
- `target/debug/coverage-parse-diff /tmp/phase-root19-baseline.json /tmp/phase-root19-after.json --markdown /tmp/phase-root19-diff.md --json /tmp/phase-root19-diff.json`
- `env RUSTC_WRAPPER= RUSTC_WORKSPACE_WRAPPER= CARGO_BUILD_RUSTC_WRAPPER= CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER= SCCACHE_DISABLE=1 ZIG_GLOBAL_CACHE_DIR=/tmp/phase-zig-cache cargo test -p engine --features cli --lib perpetual_ -- --nocapture`