### PR TITLE
fix(parser): preserve single-graveyard target constraint

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1049,6 +1049,9 @@ export type TargetSelectionConstraint =
   | { type: "DifferentTargetPlayers" }
   // CR 115.1 + CR 601.2c: object targets must be controlled by different players.
   | { type: "DifferentObjectControllers" }
+  // CR 115.1 + CR 601.2c + CR 400.1: object targets must come from the same
+  // player-owned zone of the given kind.
+  | { type: "SameZoneOwner"; zone: Zone }
   // CR 202.3 + CR 601.2c: the chosen target set's combined mana value must satisfy
   // `comparator` against `value`. `value` is an engine `QuantityExpr` (internally
   // tagged); the frontend never evaluates it — legality is delivered via

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -1744,7 +1744,8 @@ fn legacy_target_constraint(c: &TargetSelectionConstraint) -> bool {
     match c {
         TargetSelectionConstraint::TotalManaValue { value, .. } => legacy_quantity_expr(value),
         TargetSelectionConstraint::DifferentTargetPlayers
-        | TargetSelectionConstraint::DifferentObjectControllers => false,
+        | TargetSelectionConstraint::DifferentObjectControllers
+        | TargetSelectionConstraint::SameZoneOwner { .. } => false,
     }
 }
 
@@ -3631,6 +3632,7 @@ fn rw_target_constraint(c: &TargetSelectionConstraint) -> RwProfile {
     match c {
         TargetSelectionConstraint::DifferentTargetPlayers => RwProfile::empty(),
         TargetSelectionConstraint::DifferentObjectControllers => RwProfile::empty(),
+        TargetSelectionConstraint::SameZoneOwner { zone: _ } => RwProfile::empty(),
         TargetSelectionConstraint::TotalManaValue {
             value,
             comparator: _,

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -313,6 +313,7 @@ fn scan_target_selection_constraint(c: &TargetSelectionConstraint) -> Axes {
     match c {
         TargetSelectionConstraint::DifferentTargetPlayers => Axes::NONE,
         TargetSelectionConstraint::DifferentObjectControllers => Axes::NONE,
+        TargetSelectionConstraint::SameZoneOwner { zone: _ } => Axes::NONE,
         TargetSelectionConstraint::TotalManaValue {
             value,
             comparator: _,

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -5604,6 +5604,35 @@ fn validate_target_constraints(
                     }
                 }
             }
+            TargetSelectionConstraint::SameZoneOwner { zone } => {
+                let Some(state) = state else {
+                    continue;
+                };
+                let mut zone_owner = None;
+                for target in targets {
+                    let TargetRef::Object(object_id) = target else {
+                        continue;
+                    };
+                    let object = state.objects.get(object_id).ok_or_else(|| {
+                        EngineError::InvalidAction("Selected object target is missing".into())
+                    })?;
+                    if object.zone != *zone {
+                        return Err(EngineError::InvalidAction(format!(
+                            "Selected object targets must be in {zone:?}"
+                        )));
+                    }
+                    match zone_owner {
+                        Some(owner) if owner != object.owner => {
+                            return Err(EngineError::InvalidAction(
+                                "Selected object targets must come from the same zone owner"
+                                    .to_string(),
+                            ));
+                        }
+                        Some(_) => {}
+                        None => zone_owner = Some(object.owner),
+                    }
+                }
+            }
             TargetSelectionConstraint::TotalManaValue { comparator, value } => {
                 let Some(state) = state else {
                     continue;
@@ -7799,6 +7828,126 @@ mod tests {
         assert!(!progress
             .current_legal_targets
             .contains(&TargetRef::Object(p0_b)));
+    }
+
+    #[test]
+    fn target_selection_filters_cards_outside_single_graveyard_owner() {
+        let mut state = GameState::new_two_player(42);
+        let p0_a = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "P0 A".to_string(),
+            Zone::Graveyard,
+        );
+        let p0_b = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "P0 B".to_string(),
+            Zone::Graveyard,
+        );
+        let p1_a = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "P1 A".to_string(),
+            Zone::Graveyard,
+        );
+        let p0_battlefield = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "P0 Battlefield".to_string(),
+            Zone::Battlefield,
+        );
+
+        let mut ability = ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: Some(Zone::Graveyard),
+                destination: Zone::Exile,
+                target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Card).properties(vec![
+                    FilterProp::InZone {
+                        zone: Zone::Graveyard,
+                    },
+                ])),
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+            Vec::new(),
+            ObjectId(100),
+            PlayerId(0),
+        );
+        ability.multi_target = Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 3 }));
+
+        let target_slots = build_target_slots(&state, &ability).expect("target slots");
+        let constraints = [TargetSelectionConstraint::SameZoneOwner {
+            zone: Zone::Graveyard,
+        }];
+        let progress =
+            begin_target_selection_for_ability(&state, &ability, &target_slots, &constraints)
+                .expect("selection starts");
+
+        let TargetSelectionAdvance::InProgress(progress) = choose_target_for_ability(
+            &state,
+            &ability,
+            &target_slots,
+            &constraints,
+            &progress,
+            Some(TargetRef::Object(p0_a)),
+        )
+        .expect("first target accepted") else {
+            panic!("expected second target prompt");
+        };
+
+        assert!(progress
+            .current_legal_targets
+            .contains(&TargetRef::Object(p0_b)));
+        assert!(!progress
+            .current_legal_targets
+            .contains(&TargetRef::Object(p1_a)));
+        assert!(!progress
+            .current_legal_targets
+            .contains(&TargetRef::Object(p0_battlefield)));
+
+        assert!(
+            validate_target_constraints(
+                Some(&state),
+                &[TargetRef::Object(p0_a), TargetRef::Object(p0_b)],
+                &constraints,
+                Some(&ability),
+            )
+            .is_ok(),
+            "same-owner graveyard pair must satisfy SameZoneOwner"
+        );
+        assert!(
+            validate_target_constraints(
+                Some(&state),
+                &[TargetRef::Object(p0_a), TargetRef::Object(p1_a)],
+                &constraints,
+                Some(&ability),
+            )
+            .is_err(),
+            "different graveyard owners must fail SameZoneOwner"
+        );
+        assert!(
+            validate_target_constraints(
+                Some(&state),
+                &[TargetRef::Object(p0_a), TargetRef::Object(p0_battlefield)],
+                &constraints,
+                Some(&ability),
+            )
+            .is_err(),
+            "objects outside the constrained zone must fail SameZoneOwner"
+        );
     }
 
     /// CR 202.3 + CR 601.2c: `validate_target_constraints` enforces the

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1817,6 +1817,9 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
         if parse_controlled_by_different_players_target_constraint(&clause_ir.source_text) {
             def = def.target_constraint(TargetSelectionConstraint::DifferentObjectControllers);
         }
+        if let Some(constraint) = parse_same_zone_owner_target_constraint(&clause_ir.source_text) {
+            def = def.target_constraint(constraint);
+        }
         if let Some(constraint) = parse_total_mana_value_target_constraint(&clause_ir.source_text) {
             def = def.target_constraint(constraint);
         }
@@ -5204,6 +5207,23 @@ fn parse_controlled_by_different_players_target_constraint(text: &str) -> bool {
         tag(CONTROLLED_BY_DIFFERENT_PLAYERS),
     );
     parser.parse(lower.as_str()).is_ok()
+}
+
+/// CR 115.1 + CR 601.2c + CR 400.1: Detect target-set constraints that require
+/// all chosen objects to come from one player's zone pile, currently the printed
+/// "from a single graveyard" class.
+fn parse_same_zone_owner_target_constraint(text: &str) -> Option<TargetSelectionConstraint> {
+    let lower = text.to_lowercase();
+    let mut parser = preceded(
+        take_until::<_, _, OracleError<'_>>("from a single graveyard"),
+        tag("from a single graveyard"),
+    );
+    parser
+        .parse(lower.as_str())
+        .ok()
+        .map(|_| TargetSelectionConstraint::SameZoneOwner {
+            zone: Zone::Graveyard,
+        })
 }
 
 /// CR 202.3 + CR 115.1: Detect a "with total mana value <N|X> or less" target-set

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -27274,6 +27274,68 @@ fn choose_two_target_creatures_controlled_by_different_players_sets_target_const
 }
 
 #[test]
+fn target_cards_from_single_graveyard_sets_same_zone_owner_constraint() {
+    let def = parse_effect_chain(
+        "Exile up to three target cards from a single graveyard.",
+        AbilityKind::Spell,
+    );
+
+    assert_eq!(
+        def.multi_target,
+        Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 3 }))
+    );
+    assert_eq!(
+        def.target_constraints,
+        vec![TargetSelectionConstraint::SameZoneOwner {
+            zone: Zone::Graveyard
+        }]
+    );
+    match &*def.effect {
+        Effect::ChangeZone {
+            origin,
+            destination,
+            target: TargetFilter::Typed(tf),
+            ..
+        } => {
+            assert_eq!(*origin, Some(Zone::Graveyard));
+            assert_eq!(*destination, Zone::Exile);
+            assert!(tf.type_filters.contains(&TypeFilter::Card));
+            assert!(tf.properties.contains(&FilterProp::InZone {
+                zone: Zone::Graveyard
+            }));
+        }
+        other => panic!("expected graveyard-card exile ChangeZone, got {other:?}"),
+    }
+}
+
+#[test]
+fn modal_single_graveyard_target_constraint_survives_mode_parsing() {
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        "Choose one —\n• Target opponent loses 1 life and you gain 1 life.\n• Exile up to three target cards from a single graveyard.\n• Target creature gains fear until end of turn.",
+        "Ebony Charm",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+
+    let exile_mode = parsed
+        .abilities
+        .iter()
+        .find(|ability| matches!(&*ability.effect, Effect::ChangeZone { .. }))
+        .expect("modal graveyard exile ability must parse");
+    assert_eq!(
+        exile_mode.target_constraints,
+        vec![TargetSelectionConstraint::SameZoneOwner {
+            zone: Zone::Graveyard
+        }]
+    );
+    assert_eq!(
+        exile_mode.multi_target,
+        Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 3 }))
+    );
+}
+
+#[test]
 fn effect_for_each_opponent_up_to_one_gain_control_has_optional_fanout_slots() {
     let def = parse_effect_chain(
         "For each opponent, gain control of up to one target creature that player controls.",

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2279,6 +2279,11 @@ pub enum TargetSelectionConstraint {
     DifferentTargetPlayers,
     /// CR 115.1 + CR 601.2c: Object targets must be controlled by different players.
     DifferentObjectControllers,
+    /// CR 115.1 + CR 601.2c + CR 400.1: Object targets must come from the same
+    /// player-owned zone of the given kind, e.g. "from a single graveyard".
+    SameZoneOwner {
+        zone: Zone,
+    },
     /// CR 202.3 + CR 601.2c: the chosen target set's combined mana value must
     /// satisfy `comparator` against `value`. `value` is a `QuantityExpr` (not
     /// `i32` like `SearchSelectionConstraint::TotalManaValue`) because the bound

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -5089,7 +5089,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 27. Cross-target group / shared-quality constraint dropped  (20 cards)
+### 27. Cross-target group / shared-quality constraint dropped  (16 cards)
 
 **Signature.** A multi-target group constraint ('from a single graveyard', 'with different names', same controller, parity) is not carried; the FilterProp/SharedQuality linkage is missing.
 
@@ -5098,10 +5098,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 <details><summary>Cards</summary>
 
 - Cannibalize
-- Carrion Beetles
-- Cease
 - Desecrate Reality
-- Ebony Charm
 - Echoing Courage
 - Echoing Decay
 - Echoing Echo
@@ -5112,7 +5109,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Rashmi, Eternities Crafter
 - Soundwave, Superior Captain
 - Thanos, the Mad Titan
-- Unlicensed Hearse
 - V.A.T.S.
 - Valor's Reach Tag Team
 - Void Winnower


### PR DESCRIPTION
## Summary

Fixes the Root #27 subcluster for `from a single graveyard` multi-target constraints.

The parser already recognized the target cards and the up-to count, but dropped the cross-target constraint that all selected cards must come from the same player's graveyard. This adds a typed `TargetSelectionConstraint::SameZoneOwner { zone }`, wires the Oracle lowerer to emit it for `from a single graveyard`, enforces it during target selection, and mirrors the serialized variant in the frontend adapter type.

## Backlog / Card Audit

Removed these 4 fully fixed cards from `docs/parser-misparse-backlog.md` Root #27 and updated the count from 20 to 16:

- Carrion Beetles
- Cease
- Ebony Charm
- Unlicensed Hearse

Raw before/after parsed JSON diff used this filter:

`Carrion Beetles|Cease|Ebony Charm|Unlicensed Hearse`

That export included 10 cards because of substring matches, and exactly 4 cards changed: the four listed above. Each change is the expected addition of:

```json
[{ "type": "SameZoneOwner", "zone": "Graveyard" }]
```

No substring-extra cards changed. `coverage-parse-diff` reported no support-signature changes.

## Validation

- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `git diff --check`
- `env RUSTC_WRAPPER= RUSTC_WORKSPACE_WRAPPER= CARGO_BUILD_RUSTC_WRAPPER= CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER= SCCACHE_DISABLE=1 ZIG_GLOBAL_CACHE_DIR=/tmp/phase-zig-cache cargo test -p engine --features cli --lib single_graveyard -- --nocapture`
- `env RUSTC_WRAPPER= RUSTC_WORKSPACE_WRAPPER= CARGO_BUILD_RUSTC_WRAPPER= CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER= SCCACHE_DISABLE=1 ZIG_GLOBAL_CACHE_DIR=/tmp/phase-zig-cache cargo run -p engine --features cli --bin card-data-validate -- /tmp/phase-root27-single-graveyard-after.json`
- `target/debug/coverage-parse-diff /tmp/phase-root27-single-graveyard-baseline.json /tmp/phase-root27-single-graveyard-after.json --markdown /tmp/phase-root27-single-graveyard-diff.md --json /tmp/phase-root27-single-graveyard-diff.json`

Not run locally: frontend type-check, because this shell has no usable Node/pnpm (`node` missing; `npm` reports WSL1 unsupported).