### PR TITLE
[codex] fix(parser): preserve named Kookus condition

### DIFF
--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1658,6 +1658,7 @@ fn parse_named_filter_terminator(input: &str) -> Result<(&str, ()), nom::Err<Ora
             (
                 tag(", "),
                 alt((
+                    tag("~ "),
                     tag("it "),
                     tag("they "),
                     tag("he "),
@@ -6780,6 +6781,12 @@ mod tests {
         // punctuation) when no clause boundary follows.
         let (name, _) = named_of("a creature named Bruna, the Fading Light");
         assert_eq!(name, "Bruna, the Fading Light");
+
+        // A comma followed by the normalized self-reference opens the next
+        // clause, not part of the literal name (Kookus class).
+        let (name, rest) = named_of("a creature named Keeper of Kookus, ~ deals 3 damage");
+        assert_eq!(name, "Keeper of Kookus");
+        assert_eq!(rest.trim_start_matches([',', ' ']), "~ deals 3 damage");
 
         // Period still ends the name.
         let (name, _) = named_of("a creature named Storm Crow.");

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -10,7 +10,8 @@ use crate::types::ability::{
     DamageModification, DamageSource, DelayedTriggerCondition, DiscardSelfScope, Duration, Effect,
     EffectScope, FilterProp, ManaContribution, ManaProduction, ManaSpendPermission, ObjectScope,
     PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
-    SharedQuality, TapStateChange, TargetFilter, TypeFilter, TypedFilter, ZoneRef,
+    SharedQuality, TapStateChange, TargetFilter, TriggerCondition, TypeFilter, TypedFilter,
+    ZoneRef,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::game_state::WaitingFor;
@@ -115,6 +116,73 @@ fn parse_damage_to_qualifier_player_planeswalker_or_battle() {
             )));
         }
         other => panic!("expected Or {{ Player, Planeswalker, Battle }}, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_kookus_named_creature_condition_preserves_literal_name_and_body() {
+    let parsed = parse_oracle_text(
+        "Trample\nAt the beginning of your upkeep, if you don't control a creature named Keeper of Kookus, this creature deals 3 damage to you and attacks this turn if able.\n{R}: This creature gets +1/+0 until end of turn.",
+        "Kookus",
+        &[],
+        &[],
+        &[],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|trigger| {
+            trigger
+                .description
+                .as_deref()
+                .is_some_and(|description| description.contains("Keeper of Kookus"))
+        })
+        .expect("Kookus upkeep trigger should parse");
+
+    let condition = trigger.condition.clone().expect("trigger condition");
+    match condition {
+        TriggerCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { filter },
+                },
+            comparator: Comparator::EQ,
+            rhs: QuantityExpr::Fixed { value: 0 },
+        } => match filter {
+            TargetFilter::Typed(TypedFilter { properties, .. }) => {
+                assert!(properties.iter().any(|prop| matches!(
+                    prop,
+                    FilterProp::Named { name } if name == "keeper of kookus"
+                )));
+            }
+            other => panic!("expected named creature filter, got {other:?}"),
+        },
+        other => panic!("expected no-Keeper condition, got {other:?}"),
+    }
+
+    let execute = trigger.execute.as_ref().expect("trigger body");
+    match execute.effect.as_ref() {
+        Effect::DealDamage {
+            amount: QuantityExpr::Fixed { value: 3 },
+            target: TargetFilter::Controller,
+            ..
+        } => {}
+        other => panic!("expected damage to controller, got {other:?}"),
+    }
+
+    let must_attack = execute
+        .sub_ability
+        .as_ref()
+        .expect("must-attack continuation");
+    match must_attack.effect.as_ref() {
+        Effect::GenericEffect {
+            static_abilities,
+            duration: Some(Duration::UntilEndOfTurn),
+            ..
+        } => assert!(static_abilities
+            .iter()
+            .any(|static_ability| static_ability.mode == StaticMode::MustAttack)),
+        other => panic!("expected must-attack continuation, got {other:?}"),
     }
 }
 

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1655,6 +1655,18 @@ fn unmask_card_name_keyword_action(text: String, originals: &[String]) -> String
 
 fn parse_card_named_literal_prefix(input: &str) -> OracleResult<'_, usize> {
     alt((
+        value("permanents named ".len(), tag("permanents named ")),
+        value("permanent named ".len(), tag("permanent named ")),
+        value("creatures named ".len(), tag("creatures named ")),
+        value("creature named ".len(), tag("creature named ")),
+        value("artifacts named ".len(), tag("artifacts named ")),
+        value("artifact named ".len(), tag("artifact named ")),
+        value("enchantments named ".len(), tag("enchantments named ")),
+        value("enchantment named ".len(), tag("enchantment named ")),
+        value("lands named ".len(), tag("lands named ")),
+        value("land named ".len(), tag("land named ")),
+        value("spells named ".len(), tag("spells named ")),
+        value("spell named ".len(), tag("spell named ")),
         value("cards named ".len(), tag("cards named ")),
         value("card named ".len(), tag("card named ")),
     ))
@@ -1827,10 +1839,11 @@ fn card_named_literal_span_len(lower: &str) -> usize {
         .unwrap_or(lower.len())
 }
 
-/// CR 201.2 / CR 201.5: the text after "card(s) named ..." is a literal card
-/// name, not a self-reference to the source card. Mask only that literal name
-/// span while `normalize_card_name_refs` runs so first-word fallback cannot
-/// rewrite cards like Emerald Collector's "Mox Emerald" into "Mox ~".
+/// CR 201.2 / CR 201.5: the text after "[object] named ..." is a literal name,
+/// not a self-reference to the source card. Mask only that literal name span
+/// while `normalize_card_name_refs` runs so first-word fallback cannot rewrite
+/// cards like Emerald Collector's "Mox Emerald" into "Mox ~" or Kookus's
+/// "Keeper of Kookus" into "Keeper of ~".
 fn mask_card_named_literal_spans(text: &str) -> (String, Vec<String>) {
     let lower = text.to_ascii_lowercase();
     let mut masked = String::with_capacity(text.len());
@@ -2358,6 +2371,17 @@ mod tests {
                 "Stomping Slabs",
             ),
             "If a card named Stomping Slabs was revealed this way, ~ deals 7 damage to any target."
+        );
+    }
+
+    #[test]
+    fn normalize_named_object_literal_preserves_embedded_source_name() {
+        assert_eq!(
+            normalize_card_name_refs(
+                "At the beginning of your upkeep, if you don't control a creature named Keeper of Kookus, this creature deals 3 damage to you.",
+                "Kookus",
+            ),
+            "At the beginning of your upkeep, if you don't control a creature named Keeper of Kookus, ~ deals 3 damage to you."
         );
     }
 

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -5148,7 +5148,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 30. Token/named-card name corrupted by normalization or overrun  (12 cards)
+### 30. Token/named-card name corrupted by normalization or overrun  (11 cards)
 
 **Signature.** A quoted/literal card name is rewritten by '~' self-reference normalization, an 'or'-list of names isn't split, a zone phrase is absorbed into the name, or trailing punctuation is left on a list option.
 
@@ -5159,7 +5159,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Dragonstorm Forecaster
 - Hecatomb
 - High Marshal Arguel
-- Kookus
 - Liu Bei, Lord of Shu
 - Sift Through Sands
 - Thran Golem


### PR DESCRIPTION
## Summary

Fixes the Root #30 Kookus subcluster in `docs/parser-misparse-backlog.md`.

Root cause: `normalize_card_name_refs` only masked `card(s) named ...` literal spans, so `creature named Keeper of Kookus` was allowed to self-reference-normalize the embedded source name to `Keeper of ~`. Then the named-filter terminator did not recognize the post-normalization `, ~ ...` clause boundary, so the trigger condition swallowed the trigger body into the `Named` filter.

Changes:
- Extend the existing named-literal mask to object/spell/permanent forms such as `creature named`, `permanent named`, `spell named`, etc.
- Treat `, ~ ...` as the same referential named-filter boundary class as `, it ...`.
- Add building-block tests and an end-to-end Kookus trigger regression.
- Remove Kookus from Root #30, reducing that bucket from 12 to 11 cards.

## Parsed-card diff audit

Baseline: `/tmp/phase-root30-baseline.json`
After: `/tmp/phase-root30-after.json`
Filter: `Dragonstorm Forecaster|Hecatomb|High Marshal Arguel|Kookus|Liu Bei, Lord of Shu|Sift Through Sands|Thran Golem|Thrasta, Tempest's Roar|Wrathful Raptors|Wrathful Red Dragon|Zenos yae Galvus|capital offense`

Raw changed card keys: exactly `kookus`.

Expected Kookus movement:
- `Named` filter changes from `keeper of ~, ~ deals 3 damage to you and attacks this turn if able` to `keeper of kookus`.
- The swallowed trigger body now parses as `DealDamage { amount: 3, target: Controller }` followed by the until-end-of-turn `MustAttack` continuation.

`coverage-parse-diff` reported no support-signature clusters (`oracle_changed: 0`).

## Validation

- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `git diff --check`
- `cargo test -p engine --features cli --lib normalize_named_object_literal_preserves_embedded_source_name -- --nocapture`
- `cargo test -p engine --features cli --lib named_filter_terminates_at_clause_boundary -- --nocapture`
- `cargo test -p engine --features cli --lib parse_kookus_named_creature_condition_preserves_literal_name_and_body -- --nocapture`
- `cargo run -p engine --features cli --bin oracle-gen -- data --filter "Dragonstorm Forecaster|Hecatomb|High Marshal Arguel|Kookus|Liu Bei, Lord of Shu|Sift Through Sands|Thran Golem|Thrasta, Tempest's Roar|Wrathful Raptors|Wrathful Red Dragon|Zenos yae Galvus|capital offense" --output /tmp/phase-root30-after.json`
- `cargo run -p engine --features cli --bin card-data-validate -- /tmp/phase-root30-after.json`
- `cargo run -p engine --features cli --bin coverage-parse-diff -- /tmp/phase-root30-baseline.json /tmp/phase-root30-after.json --markdown /tmp/phase-root30-parse-diff.md --json /tmp/phase-root30-parse-diff.json`

Tilt is not running locally (`No tilt apiserver found: tilt-default`), so direct cargo fallback was used.