### PR TITLE
fix(engine): recover from dangling pending-trigger cursor; classify stale actions; card-report follow-ups

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2394,6 +2394,17 @@ export const AdapterErrorCode = {
   BRACKET_ESTIMATION_UNSUPPORTED: "bracket-estimation/unsupported",
   /** Engine rejected game init because one or more decks are not bracket 5 at a cEDH table. */
   BRACKET_VIOLATION: "BRACKET_VIOLATION",
+  /**
+   * The engine's actor-authorization guards (`check_actor_authorization` /
+   * priority checks, CR 117 priority / CR 500 turn structure) rejected the
+   * action because the submitting seat is no longer the authorized submitter
+   * (`EngineError::WrongPlayer`) or no longer holds priority
+   * (`EngineError::NotYourPriority`). Both are the same benign race — a click
+   * lands in the same tick that priority/turn shifts — not a bug: the engine
+   * correctly refused a stale action. Dispatch treats it as a no-op rather
+   * than surfacing it as a crash.
+   */
+  STALE_ACTION: "STALE_ACTION",
 } as const;
 
 /**
@@ -2403,6 +2414,18 @@ export const AdapterErrorCode = {
  */
 export function isStateLostMessage(message: string): boolean {
   return message.startsWith("NOT_INITIALIZED:");
+}
+
+/**
+ * Detect the engine's actor-authorization rejections. `submit_action` in
+ * `engine-wasm/src/lib.rs` formats `EngineError::WrongPlayer` (Display: "Wrong
+ * player") and `EngineError::NotYourPriority` (Display: "Not your priority")
+ * as `Engine error: <display>`. Match the exact strings — these are the benign
+ * stale-action race (see `AdapterErrorCode.STALE_ACTION`), never a state-loss
+ * or panic.
+ */
+export function isStaleActionMessage(message: string): boolean {
+  return message === "Engine error: Wrong player" || message === "Engine error: Not your priority";
 }
 
 /**

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2138,6 +2138,18 @@ export interface GameState {
    */
   unimplemented_oracle_ids?: string[];
   /**
+   * Mirrors `engine::types::game_state::GameState::pending_trigger_abandons`.
+   * Descriptors (source name + dead stack-entry id) of push-first triggered
+   * abilities whose in-construction stack entry vanished before selection
+   * completed, forcing the engine to abandon construction. Diagnostics only —
+   * records recovery from an unidentified state-coherence defect (a dangling
+   * push-first construction cursor) that previously panicked and poisoned the
+   * WASM engine. Forwarded to the `game_end` telemetry event; an `Array` (not a
+   * set) because the raw occurrence count matters. Absent when empty (serde
+   * `skip_serializing_if`).
+   */
+  pending_trigger_abandons?: string[];
+  /**
    * Engine-authored derived projections, attached by adapters from the
    * wire-format `ClientGameState.derived` sibling field. Optional because
    * some wire paths (legacy cached state, older server builds) may not

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -11,7 +11,7 @@ import type {
   ViewerSnapshot,
   WaitingFor,
 } from "./types";
-import { AdapterError, AdapterErrorCode, isStateLostMessage } from "./types";
+import { AdapterError, AdapterErrorCode, isStaleActionMessage, isStateLostMessage } from "./types";
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 import { isBracketEstimate } from "../types/bracketEstimate";
 import { EngineWorkerClient } from "./engine-worker-client";
@@ -76,6 +76,11 @@ async function classifyEngineErrorAsync(
   // always narrow control flow through an awaited `Promise<never>`, so
   // making the throw explicit keeps the surrounding methods type-clean.
   const message = err instanceof Error ? err.message : String(err);
+  // Actor-authorization rejection (stale action after a priority/turn shift).
+  // Typed so dispatch can treat it as a benign no-op rather than a crash.
+  if (isStaleActionMessage(message)) {
+    return new AdapterError(AdapterErrorCode.STALE_ACTION, message, false);
+  }
   if (isStateLostMessage(message)) {
     let panic: string | null = null;
     try {

--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -128,10 +128,12 @@ function CardPreviewInner({
   const obj = useGameStore((s) =>
     inspectedObjectId != null ? s.gameState?.objects[inspectedObjectId] ?? null : null,
   );
-  // `card_report` context needs a live game: `obj == null` (deck builder) has no
-  // zone and a possibly-stale `gameMode`, and `gameId == null` means no game at
-  // all — a report in either case would pollute `game_mode`, so skip the button.
+  // `card_report` context needs a live, participating game: `obj == null` (deck
+  // builder) has no zone and a possibly-stale `gameMode`, `gameId == null` means
+  // no game at all, and spectators don't report — building no context in these
+  // cases keeps both the event and the button's wrapper elements out entirely.
   const gameId = useGameStore((s) => s.gameId);
+  const gameMode = useGameStore((s) => s.gameMode);
 
   // Auto-derive back face name from " // " separator when not explicitly provided
   // (e.g., deck builder passes "Delver of Secrets // Insectile Aberration" as cardName)
@@ -328,9 +330,12 @@ function CardPreviewInner({
   // sees. Undefined outside a live game (`obj == null` or `gameId == null`), so
   // the button never renders in the deck builder. On mobile `showOtherFace` is
   // always false, so this resolves to the front face there.
-  const reportItems = showOtherFace && backParseDetails ? backParseDetails : frontParseDetails;
+  // No front-face fallback for the counts: if the back face's parse details
+  // haven't loaded, 0/0 ("no parse data") is honest — front-face counts under a
+  // back-face identity would corrupt the misparse-vs-known-gap triage columns.
+  const reportItems = showOtherFace ? backParseDetails : frontParseDetails;
   const reportContext: CardReportContext | undefined =
-    obj != null && gameId !== null
+    obj != null && gameId !== null && gameMode !== "spectate"
       ? {
           oracleId:
             (showOtherFace ? obj.back_face?.printed_ref?.oracle_id : obj.printed_ref?.oracle_id) ?? "",

--- a/client/src/components/card/ReportCardButton.tsx
+++ b/client/src/components/card/ReportCardButton.tsx
@@ -29,7 +29,10 @@ export interface CardReportContext {
  * One-click "report this card" affordance. A single click sends a `card_report`
  * telemetry event — no modal, no confirm step, no free text. The existing
  * GitHub-issue and Discord report flows are untouched; this is the
- * low-friction, identity-free counter. Renders nothing in `spectate` mode.
+ * low-friction, identity-free counter. Callers only build a
+ * {@link CardReportContext} in a live, participating (non-spectate) game — the
+ * guard lives at the call site so the button's styled wrapper elements stay
+ * out of the DOM too, not just the button itself.
  *
  * Callers pass `key={oracleId || name}` so switching cards remounts the button
  * and re-derives the sent state from {@link reportedThisSession}.
@@ -40,8 +43,6 @@ export function ReportCardButton({ oracleId, faceName, name, zone, supported, to
   const turn = useGameStore((s) => s.gameState?.turn_number ?? null);
   const dedupKey = oracleId || name;
   const [sent, setSent] = useState(() => reportedThisSession.has(dedupKey));
-
-  if (gameMode === "spectate") return null;
 
   const handleClick = () => {
     if (sent) return;

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -145,6 +145,18 @@ function isEngineUnresponsive(err: unknown): boolean {
   return err instanceof AdapterError && err.code === AdapterErrorCode.ENGINE_UNRESPONSIVE;
 }
 
+/**
+ * A benign actor-authorization rejection: the click landed in the same tick
+ * that priority/turn shifted, so the engine correctly refused the now-stale
+ * action (CR 117 priority / CR 500 turn structure). Nothing mutated engine
+ * state, so dispatch treats it as a no-op rather than propagating an error to
+ * the many fire-and-forget UI `dispatchAction(...)` call sites (which would
+ * otherwise surface as an `unhandledrejection` and pollute crash telemetry).
+ */
+function isStaleAction(err: unknown): boolean {
+  return err instanceof AdapterError && err.code === AdapterErrorCode.STALE_ACTION;
+}
+
 async function processAction(action: GameAction, actor: number): Promise<void> {
   const { adapter, gameState } = useGameStore.getState();
   if (!adapter || !gameState) {
@@ -182,6 +194,13 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
   try {
     result = await adapter.submitAction(action, actor);
   } catch (err) {
+    // Stale click after a priority/turn shift: the engine's actor-auth guard
+    // correctly rejected it. Nothing changed engine-side, so drop it as a
+    // no-op instead of letting a benign race escape as an unhandled rejection.
+    if (isStaleAction(err)) {
+      debugLog(`processAction: stale action ${action.type} (actor-auth rejected) — ignoring`, "warn");
+      return;
+    }
     // Engine panic: re-running the same action against the same state is
     // guaranteed to re-panic (the previous "ai-getAction-retry" / similar
     // failure modes were caused by exactly this loop). Surface the captured

--- a/client/src/services/telemetryEvents.ts
+++ b/client/src/services/telemetryEvents.ts
@@ -137,6 +137,7 @@ function installGameEndTracking(): void {
         winner_kind: winnerKind,
         game_mode: gameMode,
         unimplemented_oracle_ids: (gameState?.unimplemented_oracle_ids ?? []).slice(0, 20),
+        pending_trigger_abandons: (gameState?.pending_trigger_abandons ?? []).slice(0, 20),
       });
       // Flush promptly so a game_end isn't stranded if the user leaves the
       // results screen before the batch timer fires.

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -4720,27 +4720,34 @@ fn apply_action(
                 // already on the stack (pushed at distribute-among pause time);
                 // mutate its ability with the distribution and clear
                 // `pending_trigger_entry` so the resolver may now fire it.
-                //
-                // Invariants (panic on violation — no recovery path):
-                // * `pending_trigger_entry` is `Some(_)` (push-first contract).
-                // * Entry id references a `TriggeredAbility` `StackEntry`.
                 pending_trigger.ability.distribution =
                     Some(distribution.iter().map(|(t, a)| (t.clone(), *a)).collect());
-                triggers::finalize_pending_trigger_entry(state, &pending_trigger.ability);
-                priority::clear_priority_passes(state);
-                // CR 113.2c + CR 603.2 + CR 603.3b: Drain siblings deferred
-                // behind this distribute-among trigger so each independent
-                // instance reaches the stack (issue #416).
-                debug_assert!(
-                    !triggers::is_pending_trigger_construction_active(state),
-                    "deferred-trigger drain entered with construction still active",
-                );
-                if let Some(waiting_for) =
-                    triggers::drain_deferred_trigger_queue(state, &mut events)
-                {
-                    waiting_for
-                } else {
+                if !triggers::finalize_pending_trigger_entry(state, &pending_trigger.ability) {
+                    // Unexpected dangling cursor: the entry is no longer on the
+                    // stack. Recover per CR 608.2b / CR 800.4a (a stack object
+                    // that has left the stack does not resolve) — record the
+                    // diagnostic, abandon, and return priority instead of
+                    // panicking (re-normalized next pass; CR 117.3b would give
+                    // the active player).
+                    triggers::abandon_ceased_pending_trigger(state, &pending_trigger.ability);
+                    priority::clear_priority_passes(state);
                     WaitingFor::Priority { player: p }
+                } else {
+                    priority::clear_priority_passes(state);
+                    // CR 113.2c + CR 603.2 + CR 603.3b: Drain siblings deferred
+                    // behind this distribute-among trigger so each independent
+                    // instance reaches the stack (issue #416).
+                    debug_assert!(
+                        !triggers::is_pending_trigger_construction_active(state),
+                        "deferred-trigger drain entered with construction still active",
+                    );
+                    if let Some(waiting_for) =
+                        triggers::drain_deferred_trigger_queue(state, &mut events)
+                    {
+                        waiting_for
+                    } else {
+                        WaitingFor::Priority { player: p }
+                    }
                 }
             } else {
                 // Resolution-time distribution continuation path.

--- a/crates/engine/src/game/engine_modes.rs
+++ b/crates/engine/src/game/engine_modes.rs
@@ -528,7 +528,16 @@ fn handle_triggered_mode_choice(
             // pause-time); mutate its ability with the resolved mode so the
             // target prompt operates on the chosen mode. `pending_trigger_entry`
             // stays set — construction continues through target selection.
-            triggers::mutate_pending_trigger_entry(state, &trigger.ability);
+            if !triggers::mutate_pending_trigger_entry(state, &trigger.ability) {
+                // Unexpected dangling cursor: the entry is gone before the target
+                // prompt could open. Recover per CR 608.2b / CR 800.4a (a stack
+                // object that has left the stack does not resolve) — record the
+                // diagnostic, abandon, return priority (re-normalized next pass;
+                // CR 117.3b would give the active player).
+                triggers::restore_trigger_event_context(state, mode_context_snapshot);
+                triggers::abandon_ceased_pending_trigger(state, &trigger.ability);
+                return Ok(WaitingFor::Priority { player });
+            }
             let description = trigger.description.clone();
             state.pending_trigger = Some(trigger);
             let pending_trigger = state
@@ -591,7 +600,16 @@ fn handle_triggered_mode_choice(
         // on the stack (pushed at modal pause-time); mutate its ability with
         // the resolved mode and clear `pending_trigger_entry` so the resolver
         // may fire this entry.
-        triggers::finalize_pending_trigger_entry(state, &trigger.ability);
+        if !triggers::finalize_pending_trigger_entry(state, &trigger.ability) {
+            // Unexpected dangling cursor: the entry is no longer on the stack.
+            // Recover per CR 608.2b / CR 800.4a (a stack object that has left the
+            // stack does not resolve) — record the diagnostic, abandon, and hand
+            // back priority instead of panicking (re-normalized next pass; CR
+            // 117.3b would give the active player).
+            triggers::abandon_ceased_pending_trigger(state, &trigger.ability);
+            priority::clear_priority_passes(state);
+            return Ok(WaitingFor::Priority { player });
+        }
         priority::clear_priority_passes(state);
         // CR 113.2c + CR 603.2 + CR 603.3b: Drain siblings deferred behind this
         // modal trigger so each independent instance reaches the stack

--- a/crates/engine/src/game/engine_stack.rs
+++ b/crates/engine/src/game/engine_stack.rs
@@ -53,7 +53,18 @@ pub(super) fn finalize_trigger_target_selection(
                 // on the stack with empty `distribution`; mutate the on-stack
                 // ability's targets (so they match what was just chosen) and
                 // keep `pending_trigger_entry` set until division completes.
-                triggers::mutate_pending_trigger_entry(state, &trigger.ability);
+                if !triggers::mutate_pending_trigger_entry(state, &trigger.ability) {
+                    // Unexpected dangling cursor: the entry is gone before the
+                    // division prompt could open. Recover per CR 608.2b / CR
+                    // 800.4a (a stack object that has left the stack does not
+                    // resolve) — record the diagnostic, abandon, hand back
+                    // priority. Matches the DistributeAmong-return convention
+                    // below; the next priority pass re-normalizes (CR 117.3b
+                    // would give the active player).
+                    triggers::abandon_ceased_pending_trigger(state, &trigger.ability);
+                    priority::clear_priority_passes(state);
+                    return WaitingFor::Priority { player: controller };
+                }
                 state.pending_trigger = Some(trigger);
                 priority::clear_priority_passes(state);
                 return WaitingFor::DistributeAmong {
@@ -70,7 +81,17 @@ pub(super) fn finalize_trigger_target_selection(
     // the stack (pushed by the pause-path that started selection); mutate its
     // ability with the resolved targets/distribution and clear
     // `pending_trigger_entry` so the resolver may now fire this entry.
-    triggers::finalize_pending_trigger_entry(state, &trigger.ability);
+    if !triggers::finalize_pending_trigger_entry(state, &trigger.ability) {
+        // Unexpected dangling cursor: the entry is no longer on the stack.
+        // Recover per CR 608.2b / CR 800.4a (a stack object that has left the
+        // stack does not resolve) — record the diagnostic, abandon the dead
+        // trigger, and hand control back rather than panic. Returns Priority for
+        // the controller (matching the DistributeAmong convention above); the
+        // next priority pass re-normalizes (CR 117.3b would give active player).
+        triggers::abandon_ceased_pending_trigger(state, &trigger.ability);
+        priority::clear_priority_passes(state);
+        return WaitingFor::Priority { player: controller };
+    }
 
     priority::clear_priority_passes(state);
     // CR 113.2c + CR 603.2 + CR 603.3b: After the active trigger is on the

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -4270,61 +4270,139 @@ pub(crate) fn is_pending_trigger_construction_active(state: &GameState) -> bool 
     state.pending_trigger_entry.is_some()
 }
 
+/// Abandon a push-first triggered ability whose in-construction stack entry
+/// vanished before mode/target/division selection completed — the construction
+/// cursor `pending_trigger_entry` is left dangling.
+///
+/// This should be UNREACHABLE: mode/target/division are chosen while the ability
+/// is put on the stack (CR 603.3d), before any player has priority, so it cannot
+/// be countered/removed mid-construction; and a controller leaving the game is
+/// already handled upstream (`elimination::do_eliminate` clears all three
+/// pending-trigger fields when the tracked entry is retained off the stack). If
+/// this fires, the entry left the stack via an UNEXPECTED / UNIDENTIFIED
+/// state-coherence defect, not a known rules-legal cause. The CRs below are
+/// cited only as the rules basis for the RECOVERY SEMANTICS, not the cause:
+///
+/// * CR 608.2b: a spell or ability that has left the stack does not resolve.
+/// * CR 800.4a: an object on the stack that ceases to exist is simply gone.
+///
+/// so a stack object that no longer exists can be neither mutated nor resolved.
+/// Recovery: record a distinguishable diagnostic (item recorded once per
+/// abandon, count preserved — see `GameState::pending_trigger_abandons`), drop
+/// the vanished entry's side-table rows, and clear every in-flight construction
+/// cursor coherently so the game continues (the caller surfaces `Priority`).
+/// `deferred_triggers` is intentionally left intact — sibling triggers stashed
+/// behind this one are still valid and drain at the next priority point.
+///
+/// Precondition: `pending_trigger_entry` is still `Some(_)` — `mutate_` never
+/// takes it, and `finalize_` only takes it on the assign-success path, so the
+/// dead entry id survives here for the diagnostic and side-table cleanup.
+pub(crate) fn abandon_ceased_pending_trigger(
+    state: &mut GameState,
+    source_ability: &ResolvedAbility,
+) {
+    if let Some(entry_id) = state.pending_trigger_entry {
+        // Distinguishable diagnostic: dead stack-entry id + the source's name so
+        // the telemetry `game_summary` can attribute the abandon to a card.
+        let source_name = state
+            .objects
+            .get(&source_ability.source_id)
+            .map(|obj| obj.name.clone())
+            .unwrap_or_else(|| "<unknown source>".to_string());
+        state
+            .pending_trigger_abandons
+            .push(format!("{source_name} (stack entry {})", entry_id.0));
+        // Recovery owns the side-table cleanup for the vanished entry (rather
+        // than leaving it to callers), mirroring how `resolve_top` prunes these
+        // per-entry tables when an entry leaves the stack.
+        state.stack_paid_facts.remove(&entry_id);
+        state.stack_trigger_event_batches.remove(&entry_id);
+    }
+    state.pending_trigger = None;
+    state.pending_trigger_entry = None;
+    state.pending_trigger_event_batch.clear();
+}
+
 /// CR 603.3c + CR 603.3d: Overwrite the in-construction stack entry's resolved
 /// ability with `source_ability`, leaving `pending_trigger_entry` untouched.
 /// Use for intermediate construction steps (e.g. a mode chosen while target
 /// selection is still outstanding) where the entry must remain non-resolvable.
 ///
-/// Invariants (panic on violation — the push-first contract guarantees them):
+/// Returns `false` if the entry is no longer on the stack — an unexpected
+/// dangling-cursor state (see [`abandon_ceased_pending_trigger`]); callers must
+/// then abandon construction rather than build a prompt for a dead entry.
+///
+/// Invariant (panic on violation — the push-first contract guarantees it):
 /// * `state.pending_trigger_entry` is `Some(_)`.
-/// * That id references a `TriggeredAbility` `StackEntry` in `state.stack`.
+#[must_use]
 pub(crate) fn mutate_pending_trigger_entry(
     state: &mut GameState,
     source_ability: &ResolvedAbility,
-) {
+) -> bool {
     let entry_id = state
         .pending_trigger_entry
         .expect("mutate_pending_trigger_entry: pending_trigger_entry must be set under the push-first contract");
-    assign_pending_trigger_entry_ability(state, entry_id, source_ability);
+    assign_pending_trigger_entry_ability(state, entry_id, source_ability)
 }
 
 /// CR 603.3c + CR 603.3d: Overwrite the in-construction stack entry's resolved
 /// ability with `source_ability` AND clear `pending_trigger_entry` —
 /// construction is complete, so the resolver is now free to fire this entry.
 ///
-/// Invariants (panic on violation — no recovery path):
-/// * `state.pending_trigger_entry` is `Some(_)` (every caller pushed under the
-///   push-first contract).
-/// * That id references a `TriggeredAbility` `StackEntry` in `state.stack`.
+/// Returns `false` if the entry is no longer on the stack — an unexpected
+/// dangling-cursor state (see [`abandon_ceased_pending_trigger`]); callers must
+/// then abandon construction rather than continue toward resolution of a dead
+/// entry. The cursor is taken ONLY on the success path, so on `false` it remains
+/// set for `abandon_ceased_pending_trigger` to read the dead entry id.
+///
+/// Invariant (panic on violation — every caller pushed under the push-first
+/// contract):
+/// * `state.pending_trigger_entry` is `Some(_)`.
+#[must_use]
 pub(crate) fn finalize_pending_trigger_entry(
     state: &mut GameState,
     source_ability: &ResolvedAbility,
-) {
+) -> bool {
     let entry_id = state
         .pending_trigger_entry
-        .take()
         .expect("finalize_pending_trigger_entry: pending_trigger_entry must be set under the push-first contract");
-    assign_pending_trigger_entry_ability(state, entry_id, source_ability);
+    if assign_pending_trigger_entry_ability(state, entry_id, source_ability) {
+        // Construction complete — release the cursor so the resolver may fire.
+        state.pending_trigger_entry = None;
+        true
+    } else {
+        // Leave the cursor set; `abandon_ceased_pending_trigger` reads it.
+        false
+    }
 }
 
 /// Locate the in-construction `TriggeredAbility` entry identified by `entry_id`
 /// (searching from the top of the stack down) and overwrite its resolved
 /// ability. Shared find-and-assign logic for `mutate`/`finalize` above.
+///
+/// Returns `false` when no stack entry carries `entry_id` — the triggered
+/// ability is unexpectedly no longer on the stack (dangling push-first cursor;
+/// see [`abandon_ceased_pending_trigger`]). Previously this `.expect()`-panicked,
+/// poisoning the WASM engine on the next submitted action.
+#[must_use]
 fn assign_pending_trigger_entry_ability(
     state: &mut GameState,
     entry_id: ObjectId,
     source_ability: &ResolvedAbility,
-) {
-    let entry = state
+) -> bool {
+    let Some(entry) = state
         .stack
         .iter_mut()
         .rev()
         .find(|entry| entry.id == entry_id)
-        .expect("pending_trigger_entry must reference a stack entry");
+    else {
+        return false;
+    };
     let ability = entry
         .ability_mut()
         .expect("pending_trigger_entry must reference a TriggeredAbility stack entry");
     *ability = source_ability.clone();
+    true
 }
 
 /// Outcome of dispatching one pending-trigger context through

--- a/crates/engine/src/game/triggers_push_first_contract_tests.rs
+++ b/crates/engine/src/game/triggers_push_first_contract_tests.rs
@@ -566,3 +566,122 @@ fn random_modal_trigger_resolves_without_prompting() {
         "random modal trigger entry must be resolver-eligible (cursor cleared)",
     );
 }
+
+/// SHAPE-level regression (manual surgery): drives the real dispatch pipeline to
+/// a genuine mid-construction pause, then manually removes the in-construction
+/// entry to model an unexpected dangling `pending_trigger_entry`. The real
+/// upstream producer of that dangling cursor is UNIDENTIFIED — the two known
+/// rules-legal causes were both proven unreachable (a controller leaving is
+/// handled upstream by `elimination::do_eliminate`; countering/removal
+/// mid-construction is impossible because modes/targets are chosen before anyone
+/// has priority, CR 603.3d) — so this test surgically injects the corrupt state
+/// rather than reproducing the producer. See the follow-up issue for the hunt.
+///
+/// The recovery (`triggers::abandon_ceased_pending_trigger`, CR 608.2b / CR
+/// 800.4a recovery semantics) must NOT panic in
+/// `assign_pending_trigger_entry_ability`; it must record a distinguishable
+/// diagnostic, clean the vanished entry's side tables, clear all pending-trigger
+/// state, and hand control back to the game via `Priority`.
+///
+/// Reverting the recovery path makes this test panic with
+/// `pending_trigger_entry must reference a stack entry` — the exact live
+/// production crash (`submitAction-panic`, WASM-poisoning).
+#[test]
+fn ceased_in_construction_trigger_recovers_without_panic_on_completion() {
+    let mut state = setup();
+    state.active_player = PlayerId(0);
+    state.priority_player = PlayerId(0);
+
+    // Two legal opponent creatures so target choice cannot auto-resolve — the
+    // trigger genuinely pauses mid-construction via the real dispatch pipeline.
+    let target1 = make_creature(&mut state, PlayerId(1), "Opp 1");
+    let _target2 = make_creature(&mut state, PlayerId(1), "Opp 2");
+    let source = make_source_with_trigger(&mut state);
+
+    process_triggers(
+        &mut state,
+        &[zone_changed_event(source, Zone::Hand, Zone::Battlefield)],
+    );
+
+    let entry_id = state
+        .pending_trigger_entry
+        .expect("push-first: trigger entry is in construction on the stack");
+    let wf = crate::game::engine::begin_pending_trigger_target_selection(&mut state)
+        .expect("begin target selection")
+        .expect("target prompt required (two legal targets)");
+    state.waiting_for = wf;
+
+    // Manual surgery: drop ONLY the entry from the stack, modelling an unexpected
+    // dangling cursor. Seed BOTH per-entry side tables so the assertions that the
+    // recovery owns their cleanup (not the test) are non-vacuous — the recovery,
+    // not this test, must prune them.
+    state.stack.retain(|e| e.id != entry_id);
+    state
+        .stack_trigger_event_batches
+        .insert(entry_id, Vec::new());
+    state.stack_paid_facts.insert(
+        entry_id,
+        crate::types::game_state::StackPaidSnapshot::default(),
+    );
+    assert!(
+        state.stack_trigger_event_batches.contains_key(&entry_id)
+            && state.stack_paid_facts.contains_key(&entry_id),
+        "reach-guard: both side-table rows seeded before recovery runs",
+    );
+
+    // Submitting the choice for the now-dead trigger must recover, not panic.
+    let result = crate::game::engine::apply_as_current(
+        &mut state,
+        GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(target1)),
+        },
+    )
+    .expect("completion of a ceased trigger recovers");
+
+    assert!(
+        state.pending_trigger_entry.is_none(),
+        "ceased trigger must clear the construction cursor",
+    );
+    assert!(
+        state.pending_trigger.is_none(),
+        "ceased trigger must clear the stashed pending_trigger",
+    );
+    // (c) the trigger event batch is cleared as part of the coherent cleanup.
+    assert!(
+        state.pending_trigger_event_batch.is_empty(),
+        "ceased trigger must clear pending_trigger_event_batch",
+    );
+    // (b) the completion hands control back to the game via Priority.
+    assert!(
+        matches!(result.waiting_for, WaitingFor::Priority { .. }),
+        "ceased trigger recovery must return Priority, got {:?}",
+        result.waiting_for,
+    );
+    // (a) the abandon is recorded distinguishably for telemetry (count matters).
+    assert_eq!(
+        state.pending_trigger_abandons.len(),
+        1,
+        "the abandon must be recorded exactly once for telemetry",
+    );
+    // Descriptor must carry BOTH the source name and the dead stack-entry id.
+    assert!(
+        state.pending_trigger_abandons[0].contains("Test Source"),
+        "diagnostic must name the source, got {:?}",
+        state.pending_trigger_abandons,
+    );
+    assert!(
+        state.pending_trigger_abandons[0].contains(&format!("(stack entry {})", entry_id.0)),
+        "diagnostic must carry the dead stack-entry id, got {:?}",
+        state.pending_trigger_abandons,
+    );
+    // Item 5 hygiene: the recovery — not the test — owns per-entry side-table
+    // cleanup for the vanished entry.
+    assert!(
+        !state.stack_trigger_event_batches.contains_key(&entry_id),
+        "recovery must prune the dead entry's stack_trigger_event_batches row",
+    );
+    assert!(
+        !state.stack_paid_facts.contains_key(&entry_id),
+        "recovery must prune the dead entry's stack_paid_facts row",
+    );
+}

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6462,6 +6462,28 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub unimplemented_oracle_ids: BTreeSet<String>,
 
+    /// Descriptors (source name + dead stack-entry id) of push-first triggered
+    /// abilities whose in-construction stack entry vanished before mode/target/
+    /// division selection completed, forcing the engine to abandon construction
+    /// (`triggers::abandon_ceased_pending_trigger`). This records recovery from
+    /// an UNIDENTIFIED state-coherence defect: the push-first construction cursor
+    /// (`pending_trigger_entry`) was left dangling by some upstream path, so the
+    /// completion action could not find its entry. Diagnostics only — game-scoped,
+    /// this is the telemetry `game_summary` surface for the (previously
+    /// engine-panicking) recovery. A `Vec`, not a set: the raw occurrence COUNT
+    /// matters — ~6 hits/night in production before the panic was made
+    /// recoverable — so repeated abandons must not be deduplicated away.
+    ///
+    /// INTENTIONALLY EXCLUDED from `PartialEq`, `normalize_for_loop`, and
+    /// `loop_fingerprint` (same family as `unimplemented_oracle_ids` /
+    /// `unbounded_resources`): this is diagnostics/annotation state, not rules
+    /// state for equality. CR 104.4b / CR 732.2a loop detection compares two
+    /// states reached at different times; a populated live state must still
+    /// compare equal to snapshots taken before the abandon, or loop detection
+    /// yields false negatives.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pending_trigger_abandons: Vec<String>,
+
     /// CR 732.2a: per-game runtime gate for the live combo (infinite-loop) detector.
     /// Default `Off` = exact pre-combo-detector behavior. This is the hot-path flag the
     /// detector gates read; it is PROJECTED from the immutable [`MatchConfig::loop_detection`]
@@ -8244,6 +8266,7 @@ impl GameState {
             debug_permitted: BTreeSet::new(),
             unbounded_resources: BTreeMap::new(),
             unimplemented_oracle_ids: BTreeSet::new(),
+            pending_trigger_abandons: Vec::new(),
             loop_detection: LoopDetectionMode::Off,
         }
     }
@@ -8891,6 +8914,38 @@ mod tests {
         assert!(
             loop_states_equal(&a, &b),
             "loop_states_equal (CR 104.4b/732.2a) must exclude unimplemented_oracle_ids"
+        );
+    }
+
+    /// Loop-equality guard for the telemetry accumulator: `pending_trigger_abandons`
+    /// is diagnostics/annotation state (same family as `unimplemented_oracle_ids`),
+    /// NOT rules state for equality. Two states identical except one has recorded a
+    /// push-first construction abandon MUST compare EQUAL through the loop
+    /// comparators, or a populated live state would stop matching the pre-abandon
+    /// ring snapshots and CR 104.4b / CR 732.2a loop detection would yield false
+    /// negatives.
+    ///
+    /// REVERT-PROBE: add `&& self.pending_trigger_abandons == other.pending_trigger_abandons`
+    /// to the manual `impl PartialEq for GameState` → both assertions below fail.
+    #[test]
+    fn pending_trigger_abandons_excluded_from_loop_equality() {
+        let a = GameState::new_two_player(7);
+        let mut b = a.clone();
+        b.pending_trigger_abandons
+            .push("Test Source (stack entry 42)".to_string());
+        // Sanity: the populated field really does differ between the two states.
+        assert_ne!(
+            a.pending_trigger_abandons, b.pending_trigger_abandons,
+            "fixture must actually differ in pending_trigger_abandons"
+        );
+
+        assert!(
+            a == b,
+            "manual PartialEq must exclude pending_trigger_abandons (diagnostics state)"
+        );
+        assert!(
+            loop_states_equal(&a, &b),
+            "loop_states_equal (CR 104.4b/732.2a) must exclude pending_trigger_abandons"
         );
     }
 

--- a/lobby-worker/src/telemetry.ts
+++ b/lobby-worker/src/telemetry.ts
@@ -48,7 +48,13 @@ export const EVENT_SCHEMAS: Record<string, { blobs: string[]; doubles: string[] 
   js_error: { blobs: ["name", "message", "top_frame", "source", "route"], doubles: [] },
   chunk_reload: { blobs: ["reason", "chunk"], doubles: ["deferred"] },
   game_end: {
-    blobs: ["result", "winner_kind", "game_mode", "unimplemented_oracle_ids"],
+    blobs: [
+      "result",
+      "winner_kind",
+      "game_mode",
+      "unimplemented_oracle_ids",
+      "pending_trigger_abandons",
+    ],
     doubles: ["turn_count"],
   },
   card_report: {

--- a/lobby-worker/test/telemetry.test.mjs
+++ b/lobby-worker/test/telemetry.test.mjs
@@ -164,7 +164,27 @@ test("booleans and numbers coerce; missing/other values default", () => {
   const [drawn] = sanitizeTelemetryBatch(
     batch([{ event: "game_end", result: "draw", winner_kind: null, game_mode: "ai", turn_count: 7, unimplemented_oracle_ids: ["x", 5, "y"] }]),
   );
-  // winner_kind null → ""; array keeps only strings, comma-joined.
-  assert.deepEqual(drawn.blobs, ["draw", "", "ai", "x,y"]);
+  // winner_kind null → ""; array keeps only strings, comma-joined;
+  // pending_trigger_abandons absent → "".
+  assert.deepEqual(drawn.blobs, ["draw", "", "ai", "x,y", ""]);
   assert.deepEqual(drawn.doubles, [7]);
+});
+
+test("the game_end pending_trigger_abandons list survives the join at the client's 20-item cap", () => {
+  // Mirrors the unimplemented_oracle_ids blob: the abandon descriptors are
+  // comma-joined into the 5th game_end blob and kept up to the list cap.
+  const abandons = Array.from(
+    { length: 20 },
+    (_, i) => `Test Source (stack entry ${i})`,
+  );
+  const [e] = sanitizeTelemetryBatch(
+    batch([{ event: "game_end", result: "winner", winner_kind: "human", game_mode: "ai", turn_count: 3, pending_trigger_abandons: abandons }]),
+  );
+  assert.equal(e.blobs[4], abandons.join(","));
+  assert.equal(e.blobs[4].split(",").length, 20);
+  // Non-strings are dropped, strings comma-joined (same treatment as oracle ids).
+  const [mixed] = sanitizeTelemetryBatch(
+    batch([{ event: "game_end", result: "draw", winner_kind: null, game_mode: "ai", turn_count: 1, pending_trigger_abandons: ["a", 5, "b"] }]),
+  );
+  assert.equal(mixed.blobs[4], "a,b");
 });


### PR DESCRIPTION
Three fixes from tonight's telemetry triage (all reviewed via the implement/review loop):

## 1. Engine: dangling pending-trigger cursor recovery (`engine_panic`, ~6/night)
Live telemetry showed `pending_trigger_entry must reference a stack entry` panics poisoning the WASM engine. `finalize_pending_trigger_entry` now peeks the push-first construction cursor and takes it only on success; on a miss, `abandon_ceased_pending_trigger` clears the cursor + sidecar tables and returns priority. CR 608.2b / CR 800.4a are cited as the rules basis for the recovery semantics only — both rules-legal removal causes are excluded (`do_eliminate` clears the cursor upstream on leave-game; removal pre-priority is impossible per CR 603.3d), so every recovery fingerprints an unidentified coherence defect. Each abandon records a `pending_trigger_abandons` diagnostic on `GameState` (mirrors the `unimplemented_oracle_ids` pattern, excluded from loop equality/fingerprint) surfaced end-to-end via the `game_end` telemetry event. Producer hunt: #5118.

⚠️ **Deploy note: the lobby worker must be redeployed before this client build reaches users** — it adds a `game_end` schema blob and the worker silently drops unknown fields.

## 2. Client: stale-action rejections swallowed (`js_error`, 28 hits in first hours)
`Engine error: Wrong player` / `Not your priority` are benign races between UI intent and engine actor-auth (CR 117 / CR 500). Both now classify as a non-fatal `STALE_ACTION` code and are dropped in `processAction` with a debug log.

## 3. Client: card-report follow-ups from #5113 Gemini review
Honest 0/0 counts when back-face parse details aren't loaded (no front-face fallback), and the spectate guard lives solely at `CardReportContext` creation so wrapper pills stay out of the DOM.