### PR TITLE
fix(deck): stop corrupting card names that literally contain "//" (#4790)

### DIFF
--- a/client/src/services/__tests__/deckParser.test.ts
+++ b/client/src/services/__tests__/deckParser.test.ts
@@ -282,6 +282,37 @@ Deck
     ]);
   });
 
+  it('normalizes multi-part single-slash split names to canonical " // "', () => {
+    const result = parseMtgaDeck('1 Who / What / When / Where / Why');
+    expect(result.main).toEqual([
+      { count: 1, name: 'Who // What // When // Where // Why' },
+    ]);
+  });
+
+  it('preserves a printed name that literally contains "//" (issue #4790)', () => {
+    // "SP//dr, Piloted by Peni" is a single-faced card whose real name contains
+    // "//" with no surrounding spaces. Splitting it into "SP // dr, ..." breaks
+    // the engine's exact-name lookup, so the card is left unrecognized.
+    const result = parseMtgaDeck('1 SP//dr, Piloted by Peni');
+    expect(result.main).toEqual([
+      { count: 1, name: 'SP//dr, Piloted by Peni' },
+    ]);
+  });
+
+  it('leaves an already-canonical split name unchanged', () => {
+    const result = parseMtgaDeck('1 Fire // Ice');
+    expect(result.main).toEqual([
+      { count: 1, name: 'Fire // Ice' },
+    ]);
+  });
+
+  it('canonicalizes irregular spacing around a "//" separator', () => {
+    // A "//" with whitespace on either side is a separator; collapse the
+    // spacing to canonical " // " (but a glued "//" like SP//dr is left alone).
+    expect(parseMtgaDeck('1 Fire// Ice').main).toEqual([{ count: 1, name: 'Fire // Ice' }]);
+    expect(parseMtgaDeck('1 Wear //Tear').main).toEqual([{ count: 1, name: 'Wear // Tear' }]);
+  });
+
   it('preserves an explicit sideboard header instead of promoting commander heuristically', () => {
     const content = `Deck
 1 Sol Ring

--- a/client/src/services/__tests__/deckParser.test.ts
+++ b/client/src/services/__tests__/deckParser.test.ts
@@ -313,6 +313,34 @@ Deck
     expect(parseMtgaDeck('1 Wear //Tear').main).toEqual([{ count: 1, name: 'Wear // Tear' }]);
   });
 
+  it('keeps real double-faced card names intact (spaced and one-sided spacing)', () => {
+    // These are genuine DFCs whose two faces are separated by "//". Real
+    // importers (Moxfield/Archidekt/MTGA) emit the canonical spaced form, which
+    // must pass through unchanged; one-sided spacing is repaired to canonical.
+    expect(parseMtgaDeck('1 Peter Parker // The Amazing Spider-Man').main).toEqual([
+      { count: 1, name: 'Peter Parker // The Amazing Spider-Man' },
+    ]);
+    expect(parseMtgaDeck('1 Witch Enchanter // Witch-blessed Meadow').main).toEqual([
+      { count: 1, name: 'Witch Enchanter // Witch-blessed Meadow' },
+    ]);
+    expect(parseMtgaDeck('1 Peter Parker //The Amazing Spider-Man').main).toEqual([
+      { count: 1, name: 'Peter Parker // The Amazing Spider-Man' },
+    ]);
+  });
+
+  it('leaves a glued double-faced name glued (engine resolves it via the front face)', () => {
+    // A fully glued "A//B" is syntactically indistinguishable from a printed
+    // name like "SP//dr", so the parser leaves it verbatim. The engine's
+    // lookup_key splits on bare "//" and resolves it to the front face, so the
+    // deck still loads.
+    expect(parseMtgaDeck('1 Peter Parker//The Amazing Spider-Man').main).toEqual([
+      { count: 1, name: 'Peter Parker//The Amazing Spider-Man' },
+    ]);
+    expect(parseMtgaDeck('1 Witch Enchanter//Witch-blessed Meadow').main).toEqual([
+      { count: 1, name: 'Witch Enchanter//Witch-blessed Meadow' },
+    ]);
+  });
+
   it('preserves an explicit sideboard header instead of promoting commander heuristically', () => {
     const content = `Deck
 1 Sol Ring

--- a/client/src/services/deckParser.ts
+++ b/client/src/services/deckParser.ts
@@ -168,14 +168,28 @@ function parseDeckEntryLine(line: string): LineParseResult | null {
 
 function normalizeCardName(name: string): string {
   const trimmed = name.trim();
-  if (!trimmed.includes("/")) return trimmed;
 
-  const slashParts = trimmed.split("/").map((part) => part.trim()).filter(Boolean);
-  if (slashParts.length === 2) {
-    return `${slashParts[0]} // ${slashParts[1]}`;
+  // The canonical MTG split/DFC separator is " // " (double slash, spaced).
+  // Whitespace adjacent to a "//" is the tell that it's a separator: normalize
+  // irregular spacing ("Fire// Ice", "Wear //Tear") to the canonical " // ".
+  // A "//" with NO adjacent whitespace is part of a printed name — e.g.
+  // "SP//dr, Piloted by Peni" — and must be left verbatim, or the engine's
+  // exact-name lookup (keyed on the real "//"-glued name) fails to resolve it.
+  if (trimmed.includes("//")) {
+    return /\s\/\/|\/\/\s/.test(trimmed)
+      ? trimmed.replace(/\s*\/\/+\s*/g, " // ")
+      : trimmed;
   }
 
-  return trimmed.replace(/\s*\/{2,}\s*/g, " // ");
+  // Single-slash exporter forms upgrade to canonical. Split on each "/" so both
+  // two-part ("Revival/Revenge") and multi-part
+  // ("Who / What / When / Where / Why") split cards collapse to " // " joins.
+  if (!trimmed.includes("/")) return trimmed;
+  return trimmed
+    .split("/")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join(" // ");
 }
 
 function normalizeEntries(entries: DeckEntry[]): DeckEntry[] {

--- a/crates/engine/src/database/card_db.rs
+++ b/crates/engine/src/database/card_db.rs
@@ -772,6 +772,55 @@ mod tests {
     }
 
     #[test]
+    fn single_face_name_containing_double_slash_resolves_to_itself() {
+        // "SP//dr, Piloted by Peni" is a single-faced card whose printed name
+        // literally contains "//". lookup_key must match the exact name before
+        // falling back to its "//"-split, so the card is not mistaken for a
+        // "front // back" combined name (issue #4790).
+        let mut map = HashMap::new();
+        map.insert(
+            "sp//dr, piloted by peni".to_string(),
+            test_face("SP//dr, Piloted by Peni"),
+        );
+        let json = serde_json::to_string(&map).unwrap();
+
+        let db = CardDatabase::from_json_str(&json).unwrap();
+
+        assert_eq!(
+            db.get_face_by_name("SP//dr, Piloted by Peni")
+                .map(|face| face.name.as_str()),
+            Some("SP//dr, Piloted by Peni")
+        );
+    }
+
+    #[test]
+    fn glued_combined_face_name_resolves_front_face() {
+        // A hand-typed glued combined name ("Front//Back", no spaces) resolves to
+        // the front face via lookup_key's bare-"//" split, identically to the
+        // canonical spaced form — so a deck listing a DFC either way still loads.
+        let mut map = HashMap::new();
+        map.insert("peter parker".to_string(), test_face("Peter Parker"));
+        map.insert(
+            "the amazing spider-man".to_string(),
+            test_face("The Amazing Spider-Man"),
+        );
+        let json = serde_json::to_string(&map).unwrap();
+
+        let db = CardDatabase::from_json_str(&json).unwrap();
+
+        assert_eq!(
+            db.get_face_by_name("Peter Parker//The Amazing Spider-Man")
+                .map(|face| face.name.as_str()),
+            Some("Peter Parker")
+        );
+        assert_eq!(
+            db.get_face_by_name("Peter Parker // The Amazing Spider-Man")
+                .map(|face| face.name.as_str()),
+            Some("Peter Parker")
+        );
+    }
+
+    #[test]
     fn name_lookup_resolves_card_names_without_leading_the() {
         let mut map = serde_json::Map::new();
         map.insert(


### PR DESCRIPTION
## Summary

Fixes #4790 — cards whose printed name literally contains `//` (e.g. **SP//dr, Piloted by Peni**) were unrecognized when added to a deck, both on import and manual add.

The client deck parser's `normalizeCardName` treated every `/` as a split-card separator, so `"SP//dr".split("/").filter(Boolean)` collapsed to two parts and the name was rewritten to `"SP // dr, Piloted by Peni"`. The engine keys the card under its real `//`-glued name, so the spaced form matched nothing. This bit both entry points because `repairParsedDeck` → `normalizeCardName` runs on import **and** on every deck load from storage.

## Fix

Treat whitespace adjacent to `//` as the separator signal:

- `//` **with** adjacent whitespace is a separator → normalize spacing to canonical `" // "` (`"Fire// Ice"`, `"Wear //Tear"` → `"… // …"`).
- `//` **glued** with no adjacent whitespace is part of a printed name → left verbatim (`"SP//dr, Piloted by Peni"`).
- Single-slash exporter forms still upgrade to canonical (`"Revival/Revenge"`, `"Who / What / When / Where / Why"`).

Genuine glued split names (`"Fire//Ice"`) are rare and still resolve through the engine's front-face `//` split, so preserving the real card name is the correct trade-off.

## Verification

- **Frontend** `deckParser` (vitest): **73 passed**; `tsc -b --noEmit` clean. New tests cover the `SP//dr` name, irregular `//` spacing, multi-part single-slash, already-canonical names, and real DFCs (`Peter Parker // The Amazing Spider-Man`, `Witch Enchanter // Witch-blessed Meadow`) in spaced and glued forms.
- **Engine** `database::card_db` (`cargo test -p engine`): **19 passed**. Added two regression tests proving `SP//dr, Piloted by Peni` resolves to itself (not mis-split) and a glued combined DFC name resolves to its front face.

## Note

A card entered as a **fully glued** combined name by hand (`"Peter Parker//The Amazing Spider-Man"`) still loads (engine resolves it to the front face) but its deck-builder thumbnail falls back to a text tile, since card-data keys multi-face cards by their spaced display name + front-face name. Real importers emit the spaced form and manual add uses the front-face name, so this only affects the rare hand-typed-glued case. Happy to add a front-face fallback to the display lookup (`scryfall.ts`) if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
