### PR TITLE
fix(cards): resolve glued combined multi-face names in image lookup

### DIFF
--- a/client/src/services/__tests__/scryfall.test.ts
+++ b/client/src/services/__tests__/scryfall.test.ts
@@ -218,6 +218,84 @@ describe("fetchCardData", () => {
   });
 });
 
+describe("fetchCardData — combined multi-face names", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // A two-face card keyed the way the export does it: by front-face name and by
+  // the spaced display name, but NOT by the glued combined form.
+  function makeDfcDataMap(): Response {
+    const dfc = {
+      oracle_id: "peter-oracle",
+      face_names: ["peter parker", "the amazing spider-man"],
+      faces: [
+        { normal: "https://img.example/peter-front.jpg", art_crop: "https://img.example/peter-front-art.jpg" },
+        { normal: "https://img.example/peter-back.jpg", art_crop: "https://img.example/peter-back-art.jpg" },
+      ],
+      layout: "transform",
+      name: "Peter Parker // The Amazing Spider-Man",
+      mana_cost: "{1}{W}",
+      cmc: 2,
+      type_line: "Legendary Creature — Human Hero",
+      colors: ["W"],
+      color_identity: ["W"],
+      keywords: [],
+    };
+    const map: Record<string, unknown> = {
+      "peter parker": dfc,
+      "peter parker // the amazing spider-man": dfc,
+      // A single-faced card whose own printed name contains "//" (issue #4790).
+      "sp//dr, piloted by peni": {
+        oracle_id: "spdr-oracle",
+        face_names: ["sp//dr, piloted by peni"],
+        faces: [{ normal: "https://img.example/spdr.jpg", art_crop: "https://img.example/spdr-art.jpg" }],
+        name: "SP//dr, Piloted by Peni",
+        mana_cost: "{3}{W}{U}",
+        cmc: 5,
+        type_line: "Legendary Artifact Creature — Spider Hero",
+        colors: ["W", "U"],
+        color_identity: ["W", "U"],
+        keywords: [],
+      },
+    };
+    return new Response(JSON.stringify(map), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("resolves a hand-typed glued double-faced name via the front face", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce(makeDfcDataMap());
+
+    const { fetchCardData } = await loadScryfallModule();
+    const card = await fetchCardData("Peter Parker//The Amazing Spider-Man");
+
+    expect(card.name).toBe("Peter Parker // The Amazing Spider-Man");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves the canonical spaced double-faced name directly", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce(makeDfcDataMap());
+
+    const { fetchCardData } = await loadScryfallModule();
+    const card = await fetchCardData("Peter Parker // The Amazing Spider-Man");
+
+    expect(card.name).toBe("Peter Parker // The Amazing Spider-Man");
+  });
+
+  it("does not mis-split a single-faced card whose name contains \"//\" (issue #4790)", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce(makeDfcDataMap());
+
+    const { fetchCardData } = await loadScryfallModule();
+    const card = await fetchCardData("SP//dr, Piloted by Peni");
+
+    // Its own name is a primary key, so the exact match wins before any split.
+    expect(card.name).toBe("SP//dr, Piloted by Peni");
+    expect(card.type_line).toContain("Spider Hero");
+  });
+});
+
 describe("fetchCardImageUrl", () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/client/src/services/scryfall.ts
+++ b/client/src/services/scryfall.ts
@@ -377,7 +377,23 @@ function resolveNameLookupKey(name: string): string {
   if (!scryfallDataResolved) return normalized;
   if (scryfallDataResolved[normalized]) return normalized;
   const folded = foldDiacritics(normalized);
-  return scryfallFoldedNameIndex?.get(folded) ?? normalized;
+  const foldedHit = scryfallFoldedNameIndex?.get(folded);
+  if (foldedHit) return foldedHit;
+  // A combined multi-face name ("Front // Back", or a hand-typed glued
+  // "Front//Back") is not itself an export key — multi-face cards are keyed by
+  // oracle id, spaced display name, and front-face name. When the combined form
+  // misses, fall back to the front face so the card still resolves to its
+  // entry. A single card whose own name contains "//" (e.g. "SP//dr, Piloted by
+  // Peni") is a primary key and already returned above, so it never splits here.
+  if (normalized.includes("//")) {
+    const frontFace = normalized.split("//")[0].trim();
+    if (frontFace && frontFace !== normalized) {
+      if (scryfallDataResolved[frontFace]) return frontFace;
+      const frontFolded = scryfallFoldedNameIndex?.get(foldDiacritics(frontFace));
+      if (frontFolded) return frontFolded;
+    }
+  }
+  return normalized;
 }
 
 function lookupEntryByName(name: string): ScryfallDataEntry | undefined {


### PR DESCRIPTION
## Summary

Makes the deck-builder image/type lookup resolve **glued combined multi-face names** (`"Front//Back"`, no spaces) so they render their art instead of a text-tile fallback.

`fetchCardData` (via `resolveNameLookupKey` in `scryfall.ts`) does a direct key lookup into the local card-data map. That map keys multi-face cards by **oracle id**, **spaced display name** (`"front // back"`), and **front-face name** — never the glued form. So a card entered as a hand-typed glued combined name missed every key and threw `"Card not in local data"`, falling back to a text tile. (The engine still resolved the card via its own `//` split, so the deck loaded — only the thumbnail was lost.)

## Fix

Add a front-face fallback to `resolveNameLookupKey`: when a `//` name isn't a direct or diacritic-folded key, split on `//` and resolve the **front face**, which the export always indexes. This mirrors the engine's `card_db` `lookup_key` behavior, so the display layer and the engine agree.

A single-faced card whose own printed name contains `//` (e.g. **SP//dr, Piloted by Peni**) is itself a primary key and hits the exact-match path first, so it is never mis-split.

## Verification

`scryfall` (vitest): the three new tests pass —
- a glued combined name (`"Peter Parker//The Amazing Spider-Man"`) resolves to the card entry via the front face;
- the canonical spaced form still resolves directly;
- a single-faced `//`-in-name card (`"SP//dr, Piloted by Peni"`) resolves to itself, not mis-split.

`tsc -b --noEmit` is clean. (Two unrelated pre-existing tests in this file shell out to `gen-scryfall-*.sh` and need `jq`/`bash`, absent in my local env — they don't touch this code path.)

## Relationship to #4790

Independent of, but complementary to, the [#4790 deck-parser fix](https://github.com/phase-rs/phase/pull/5124). That PR stops corrupting `//`-in-name cards during parsing; this PR hardens the *display* layer so any glued combined name (from old saved decks, unusual paste sources, or a future import source) shows its art. Neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
