### PR TITLE
fix: require bearer auth for unauthenticated /admin/drafts endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Docker uses environment variables for the common options:
 | `PHASE_LOBBY_ONLY` | `--lobby-only` | false | Matchmaking broker mode |
 | `PHASE_LOG_JSON` | `--log-json` | false | Emit JSON logs |
 | `PHASE_LOG_DIR` | `--log-dir` | stdout | Write logs to files |
+| `PHASE_ADMIN_TOKEN` | — | unset | Bearer token for `/admin/*` endpoints (environment variable only; no CLI flag). Unset ⇒ admin routes disabled (404). Send as `Authorization: Bearer <token>`. |
 
 You can also pass server flags after the image name:
 

--- a/crates/phase-server/Cargo.toml
+++ b/crates/phase-server/Cargo.toml
@@ -40,4 +40,3 @@ ngrok = ["dep:ngrok"]
 futures-util = "0.3"
 tempfile = "3"
 tokio-tungstenite = "0.29"
-tower = { version = "0.5", features = ["util"] }

--- a/crates/phase-server/Cargo.toml
+++ b/crates/phase-server/Cargo.toml
@@ -40,3 +40,4 @@ ngrok = ["dep:ngrok"]
 futures-util = "0.3"
 tempfile = "3"
 tokio-tungstenite = "0.29"
+tower = { version = "0.5", features = ["util"] }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7177,9 +7177,7 @@ mod admin_auth_tests {
         app.with_state(app_state)
     }
 
-    async fn spawn_admin_test_server(
-        app: Router,
-    ) -> (String, tokio::task::JoinHandle<()>) {
+    async fn spawn_admin_test_server(app: Router) -> (String, tokio::task::JoinHandle<()>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind test server");

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1158,25 +1158,7 @@ async fn main() {
         None => info!("admin HTTP endpoints disabled (set PHASE_ADMIN_TOKEN to enable)"),
     }
     if let Some(token) = admin_token.as_deref().filter(|t| !t.is_empty()) {
-        let auth_layer = |expected: Arc<str>| {
-            from_fn(move |request: Request, next: Next| {
-                let expected = expected.clone();
-                async move { require_admin_auth(expected, request, next).await }
-            })
-        };
-        let list_auth = auth_layer(Arc::from(token));
-        let detail_auth = auth_layer(Arc::from(token));
-        app = app
-            .route(
-                "/admin/drafts",
-                get(admin::admin_list_drafts).route_layer(list_auth),
-            )
-            .route(
-                "/admin/drafts/{code}",
-                get(admin::admin_get_draft)
-                    .delete(admin::admin_delete_draft)
-                    .route_layer(detail_auth),
-            );
+        app = mount_admin_routes(app, token);
     }
 
     let app = app.layer(cors).with_state(AppState {
@@ -1297,6 +1279,28 @@ fn admin_token_from_env() -> Option<String> {
         .ok()
         .map(|t| t.trim().to_string())
         .filter(|t| !t.is_empty())
+}
+
+/// Mount bearer-guarded `/admin/*` routes on a router that will receive `AppState`.
+fn mount_admin_routes(mut app: Router<AppState>, admin_token: &str) -> Router<AppState> {
+    let auth_layer = |expected: Arc<str>| {
+        from_fn(move |request: Request, next: Next| {
+            let expected = expected.clone();
+            async move { require_admin_auth(expected, request, next).await }
+        })
+    };
+    let list_auth = auth_layer(Arc::from(admin_token));
+    let detail_auth = auth_layer(Arc::from(admin_token));
+    app.route(
+        "/admin/drafts",
+        get(admin::admin_list_drafts).route_layer(list_auth),
+    )
+    .route(
+        "/admin/drafts/{code}",
+        get(admin::admin_get_draft)
+            .delete(admin::admin_delete_draft)
+            .route_layer(detail_auth),
+    )
 }
 
 /// Decide whether an `Authorization` header value authorizes an admin request.
@@ -7126,9 +7130,64 @@ mod issue_4548_deadlock_tests {
 
 #[cfg(test)]
 mod admin_auth_tests {
-    use super::{admin_request_authorized, tokens_match};
+    use std::sync::atomic::AtomicU32;
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::Router;
+    use lobby_broker::Broker;
+    use server_core::draft_session::DraftSessionManager;
+    use server_core::session::SessionManager;
+    use tokio::sync::Mutex;
+    use tower::ServiceExt;
+
+    use super::{
+        admin_request_authorized, draft_pools, mount_admin_routes, persistence, tokens_match,
+        AppState, ServerMode,
+    };
 
     const TOKEN: &str = "s3cr3t-admin-token";
+
+    fn test_app_state(temp_dir: &tempfile::TempDir) -> AppState {
+        let game_db_path = temp_dir.path().join("games.db");
+        let game_db = Arc::new(persistence::GameDb::open(&game_db_path).expect("game db"));
+        AppState {
+            sessions: Arc::new(Mutex::new(SessionManager::new())),
+            draft_sessions: Arc::new(Mutex::new(DraftSessionManager::new())),
+            draft_pools: Arc::new(draft_pools::DraftPools::default()),
+            connections: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            db: Arc::new(engine::database::CardDatabase::default()),
+            lobby: Arc::new(Mutex::new(Broker::new())),
+            lobby_subscribers: Arc::new(Mutex::new(Vec::new())),
+            player_count: Arc::new(AtomicU32::new(0)),
+            game_db,
+            draft_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            game_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            mode: ServerMode::Full,
+            public_url: None,
+        }
+    }
+
+    fn test_admin_router(app_state: AppState, admin_token: Option<&str>) -> Router<AppState> {
+        let mut app = Router::new();
+        if let Some(token) = admin_token.filter(|t| !t.is_empty()) {
+            app = mount_admin_routes(app, token);
+        }
+        app.with_state(app_state)
+    }
+
+    async fn get_admin_drafts(app: Router<AppState>, auth: Option<&str>) -> StatusCode {
+        let mut builder = Request::builder().method("GET").uri("/admin/drafts");
+        if let Some(value) = auth {
+            builder = builder.header(http::header::AUTHORIZATION, value);
+        }
+        let response = app
+            .oneshot(builder.body(Body::empty()).unwrap())
+            .await
+            .expect("router response");
+        response.status()
+    }
 
     #[test]
     fn tokens_match_is_exact() {
@@ -7163,5 +7222,39 @@ mod admin_auth_tests {
         let basic = format!("Basic {TOKEN}");
         assert!(!admin_request_authorized(Some(&basic), TOKEN));
         assert!(!admin_request_authorized(Some(TOKEN), TOKEN));
+    }
+
+    #[tokio::test]
+    async fn admin_routes_absent_without_token() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app = test_admin_router(test_app_state(&temp_dir), None);
+        assert_eq!(get_admin_drafts(app, None).await, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn admin_routes_reject_missing_bearer() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app = test_admin_router(test_app_state(&temp_dir), Some(TOKEN));
+        assert_eq!(get_admin_drafts(app, None).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_routes_reject_wrong_bearer() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app = test_admin_router(test_app_state(&temp_dir), Some(TOKEN));
+        assert_eq!(
+            get_admin_drafts(app, Some("Bearer wrong-token")).await,
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_routes_accept_valid_bearer() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app = test_admin_router(test_app_state(&temp_dir), Some(TOKEN));
+        assert_eq!(
+            get_admin_drafts(app, Some(&format!("Bearer {TOKEN}"))).await,
+            StatusCode::OK
+        );
     }
 }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7134,6 +7134,7 @@ mod admin_auth_tests {
     use std::sync::Arc;
 
     use axum::http::StatusCode;
+    use axum::routing::get;
     use axum::Router;
     use lobby_broker::Broker;
     use server_core::draft_session::DraftSessionManager;

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1285,21 +1285,25 @@ where
     S: Clone + Send + Sync + 'static,
 {
     if let Some(token) = admin_token.filter(|t| !t.is_empty()) {
-        let expected: Arc<str> = Arc::from(token);
-        let admin_routes = Router::new()
-            .route("/admin/drafts", get(admin::admin_list_drafts))
+        let auth_layer = |expected: Arc<str>| {
+            from_fn(move |request: Request, next: Next| {
+                let expected = expected.clone();
+                async move { require_admin_auth(expected, request, next).await }
+            })
+        };
+        let list_auth = auth_layer(Arc::from(token));
+        let detail_auth = auth_layer(Arc::from(token));
+        app = app
+            .route(
+                "/admin/drafts",
+                get(admin::admin_list_drafts).route_layer(list_auth),
+            )
             .route(
                 "/admin/drafts/{code}",
-                get(admin::admin_get_draft).delete(admin::admin_delete_draft),
-            )
-            .route_layer(from_fn({
-                let expected = expected.clone();
-                move |request: Request, next: Next| {
-                    let expected = expected.clone();
-                    async move { require_admin_auth(expected, request, next).await }
-                }
-            }));
-        app = app.merge(admin_routes);
+                get(admin::admin_get_draft)
+                    .delete(admin::admin_delete_draft)
+                    .route_layer(detail_auth),
+            );
     }
     app
 }
@@ -7131,64 +7135,9 @@ mod issue_4548_deadlock_tests {
 
 #[cfg(test)]
 mod admin_auth_tests {
-    use std::sync::atomic::AtomicU32;
-    use std::sync::Arc;
-
-    use axum::body::Body;
-    use axum::http::{Request, StatusCode};
-    use axum::Router;
-    use lobby_broker::Broker;
-    use server_core::draft_session::DraftSessionManager;
-    use server_core::session::SessionManager;
-    use tokio::sync::Mutex;
-    use tower::ServiceExt;
-
-    use super::{
-        admin_request_authorized, draft_pools, merge_admin_routes, persistence, tokens_match,
-        AppState, ServerMode,
-    };
+    use super::{admin_request_authorized, tokens_match};
 
     const TOKEN: &str = "s3cr3t-admin-token";
-
-    fn test_app_state(temp_dir: &tempfile::TempDir) -> AppState {
-        let game_db_path = temp_dir.path().join("games.db");
-        let game_db = Arc::new(persistence::GameDb::open(&game_db_path).expect("game db"));
-        AppState {
-            sessions: Arc::new(Mutex::new(SessionManager::new())),
-            draft_sessions: Arc::new(Mutex::new(DraftSessionManager::new())),
-            draft_pools: Arc::new(draft_pools::DraftPools::default()),
-            connections: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            db: Arc::new(engine::database::CardDatabase::default()),
-            lobby: Arc::new(Mutex::new(Broker::new())),
-            lobby_subscribers: Arc::new(Mutex::new(Vec::new())),
-            player_count: Arc::new(AtomicU32::new(0)),
-            game_db,
-            draft_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            game_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            mode: ServerMode::Full,
-            public_url: None,
-        }
-    }
-
-    fn test_admin_app(admin_token: Option<&str>) -> (Router<AppState>, tempfile::TempDir) {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
-        let app =
-            merge_admin_routes(Router::new(), admin_token).with_state(test_app_state(&temp_dir));
-        (app, temp_dir)
-    }
-
-    async fn get_admin_drafts(app: Router<AppState>, auth: Option<&str>) -> StatusCode {
-        let mut service = app.into_service();
-        let mut builder = Request::builder().method("GET").uri("/admin/drafts");
-        if let Some(value) = auth {
-            builder = builder.header(http::header::AUTHORIZATION, value);
-        }
-        let response = service
-            .oneshot(builder.body(Body::empty()).unwrap())
-            .await
-            .expect("router response");
-        response.status()
-    }
 
     #[test]
     fn tokens_match_is_exact() {
@@ -7223,35 +7172,5 @@ mod admin_auth_tests {
         let basic = format!("Basic {TOKEN}");
         assert!(!admin_request_authorized(Some(&basic), TOKEN));
         assert!(!admin_request_authorized(Some(TOKEN), TOKEN));
-    }
-
-    #[tokio::test]
-    async fn admin_routes_absent_without_token() {
-        let (app, _temp) = test_admin_app(None);
-        assert_eq!(get_admin_drafts(app, None).await, StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn admin_routes_reject_missing_bearer() {
-        let (app, _temp) = test_admin_app(Some(TOKEN));
-        assert_eq!(get_admin_drafts(app, None).await, StatusCode::UNAUTHORIZED);
-    }
-
-    #[tokio::test]
-    async fn admin_routes_reject_wrong_bearer() {
-        let (app, _temp) = test_admin_app(Some(TOKEN));
-        assert_eq!(
-            get_admin_drafts(app, Some("Bearer wrong-token")).await,
-            StatusCode::UNAUTHORIZED
-        );
-    }
-
-    #[tokio::test]
-    async fn admin_routes_accept_valid_bearer() {
-        let (app, _temp) = test_admin_app(Some(TOKEN));
-        assert_eq!(
-            get_admin_drafts(app, Some(&format!("Bearer {TOKEN}"))).await,
-            StatusCode::OK
-        );
     }
 }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1280,7 +1280,10 @@ fn admin_token_from_env() -> Option<String> {
 }
 
 /// Mount `/admin/*` routes when `admin_token` is present, guarded by bearer auth.
-fn merge_admin_routes<S>(mut app: Router<S>, admin_token: Option<&str>) -> Router<S> {
+fn merge_admin_routes<S>(mut app: Router<S>, admin_token: Option<&str>) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
     if let Some(token) = admin_token.filter(|t| !t.is_empty()) {
         let expected: Arc<str> = Arc::from(token);
         let admin_routes = Router::new()
@@ -7148,8 +7151,9 @@ mod admin_auth_tests {
     const TOKEN: &str = "s3cr3t-admin-token";
 
     fn test_app_state(temp_dir: &tempfile::TempDir) -> AppState {
+        let game_db_path = temp_dir.path().join("games.db");
         let game_db =
-            Arc::new(persistence::GameDb::open(temp_dir.path().join("games.db")).expect("game db"));
+            Arc::new(persistence::GameDb::open(&game_db_path).expect("game db"));
         AppState {
             sessions: Arc::new(Mutex::new(SessionManager::new())),
             draft_sessions: Arc::new(Mutex::new(DraftSessionManager::new())),
@@ -7174,12 +7178,13 @@ mod admin_auth_tests {
         (app, temp_dir)
     }
 
-    async fn get_admin_drafts(app: &mut Router<AppState>, auth: Option<&str>) -> StatusCode {
+    async fn get_admin_drafts(app: Router<AppState>, auth: Option<&str>) -> StatusCode {
+        let mut service = app.into_service();
         let mut builder = Request::builder().method("GET").uri("/admin/drafts");
         if let Some(value) = auth {
             builder = builder.header(http::header::AUTHORIZATION, value);
         }
-        let response = app
+        let response = service
             .oneshot(builder.body(Body::empty()).unwrap())
             .await
             .expect("router response");
@@ -7223,36 +7228,33 @@ mod admin_auth_tests {
 
     #[tokio::test]
     async fn admin_routes_absent_without_token() {
-        let (mut app, _temp) = test_admin_app(None);
-        assert_eq!(
-            get_admin_drafts(&mut app, None).await,
-            StatusCode::NOT_FOUND
-        );
+        let (app, _temp) = test_admin_app(None);
+        assert_eq!(get_admin_drafts(app, None).await, StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
     async fn admin_routes_reject_missing_bearer() {
-        let (mut app, _temp) = test_admin_app(Some(TOKEN));
+        let (app, _temp) = test_admin_app(Some(TOKEN));
         assert_eq!(
-            get_admin_drafts(&mut app, None).await,
+            get_admin_drafts(app, None).await,
             StatusCode::UNAUTHORIZED
         );
     }
 
     #[tokio::test]
     async fn admin_routes_reject_wrong_bearer() {
-        let (mut app, _temp) = test_admin_app(Some(TOKEN));
+        let (app, _temp) = test_admin_app(Some(TOKEN));
         assert_eq!(
-            get_admin_drafts(&mut app, Some("Bearer wrong-token")).await,
+            get_admin_drafts(app, Some("Bearer wrong-token")).await,
             StatusCode::UNAUTHORIZED
         );
     }
 
     #[tokio::test]
     async fn admin_routes_accept_valid_bearer() {
-        let (mut app, _temp) = test_admin_app(Some(TOKEN));
+        let (app, _temp) = test_admin_app(Some(TOKEN));
         assert_eq!(
-            get_admin_drafts(&mut app, Some(&format!("Bearer {TOKEN}"))).await,
+            get_admin_drafts(app, Some(&format!("Bearer {TOKEN}"))).await,
             StatusCode::OK
         );
     }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7169,19 +7169,17 @@ mod admin_auth_tests {
         }
     }
 
-    fn test_admin_router(app_state: AppState, admin_token: Option<&str>) {
-        let mut app = Router::new();
-        if let Some(token) = admin_token.filter(|t| !t.is_empty()) {
-            app = mount_admin_routes(app, token);
-        }
-        app.with_state(app_state)
-    }
-
     async fn spawn_admin_http_test(
         admin_token: Option<&str>,
     ) -> (String, tokio::task::JoinHandle<()>, tempfile::TempDir) {
         let temp_dir = tempfile::tempdir().expect("temp dir");
-        let app = test_admin_router(test_app_state(&temp_dir), admin_token);
+        let app_state = test_app_state(&temp_dir);
+        // Mirror production: establish Router<AppState> before mounting admin routes.
+        let mut app = Router::new().route("/ws", get(super::ws_handler));
+        if let Some(token) = admin_token.filter(|t| !t.is_empty()) {
+            app = mount_admin_routes(app, token);
+        }
+        let app = app.with_state(app_state);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind test server");

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -10,8 +10,9 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use axum::extract::ws::{Message, WebSocket};
-use axum::extract::{State, WebSocketUpgrade};
-use axum::response::IntoResponse;
+use axum::extract::{Request, State, WebSocketUpgrade};
+use axum::middleware::{from_fn_with_state, Next};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Router;
 use clap::Parser;
@@ -1137,21 +1138,28 @@ async fn main() {
         info!(public_url = %url, "advertising public URL for join-code sharing");
     }
 
-    let app = Router::new()
+    // Public, client-facing HTTP surface. `/p2p-draft-backup*` is part of the
+    // normal P2P draft flow; only the administrative `/admin/*` routes are gated.
+    let mut app = Router::new()
         .route("/ws", get(ws_handler))
         .route("/health", get(health))
-        .route("/admin/drafts", get(admin::admin_list_drafts))
-        .route(
-            "/admin/drafts/{code}",
-            get(admin::admin_get_draft).delete(admin::admin_delete_draft),
-        )
         .route("/p2p-draft-backup", post(admin::p2p_backup_store))
         .route(
             "/p2p-draft-backup/{code}",
             get(admin::p2p_backup_get).delete(admin::p2p_backup_delete),
-        )
-        .layer(cors)
-        .with_state(AppState {
+        );
+
+    // Administrative endpoints are destructive and information-disclosing, and
+    // reachable through the same reverse proxy as `/ws` (see deploy nginx).
+    // Mount them only when PHASE_ADMIN_TOKEN is set; otherwise absent (404).
+    let admin_token = admin_token_from_env();
+    match admin_token.as_deref() {
+        Some(_) => info!("admin HTTP endpoints enabled (bearer-token authenticated)"),
+        None => info!("admin HTTP endpoints disabled (set PHASE_ADMIN_TOKEN to enable)"),
+    }
+    app = merge_admin_routes(app, admin_token.as_deref());
+
+    let app = app.layer(cors).with_state(AppState {
             sessions: state,
             draft_sessions,
             draft_pools,
@@ -1247,6 +1255,78 @@ async fn shutdown_signal() {
 
 async fn health() -> &'static str {
     "ok"
+}
+
+/// Constant-time byte comparison so admin-token validation does not leak the
+/// expected token through response timing.
+fn tokens_match(presented: &[u8], expected: &[u8]) -> bool {
+    if presented.len() != expected.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (a, b) in presented.iter().zip(expected.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
+/// Load the admin bearer token from the environment. Intentionally not a CLI
+/// flag — command-line secrets leak via process listings and shell history.
+fn admin_token_from_env() -> Option<String> {
+    std::env::var("PHASE_ADMIN_TOKEN")
+        .ok()
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+}
+
+/// Mount `/admin/*` routes when `admin_token` is present, guarded by bearer auth.
+fn merge_admin_routes<S>(mut app: Router<S>, admin_token: Option<&str>) -> Router<S> {
+    if let Some(token) = admin_token.filter(|t| !t.is_empty()) {
+        let expected: Arc<str> = Arc::from(token);
+        let admin_routes = Router::new()
+            .route("/admin/drafts", get(admin::admin_list_drafts))
+            .route(
+                "/admin/drafts/{code}",
+                get(admin::admin_get_draft).delete(admin::admin_delete_draft),
+            )
+            .layer(from_fn_with_state(expected, require_admin_auth));
+        app = app.merge(admin_routes);
+    }
+    app
+}
+
+/// Decide whether an `Authorization` header value authorizes an admin request.
+/// Scheme must be `Bearer` (case-insensitive per RFC 9110); credential must
+/// match `expected` in constant time.
+fn admin_request_authorized(auth_header: Option<&str>, expected: &str) -> bool {
+    let Some(value) = auth_header.map(str::trim) else {
+        return false;
+    };
+    let Some((scheme, credentials)) = value.split_once(' ') else {
+        return false;
+    };
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return false;
+    }
+    tokens_match(credentials.trim().as_bytes(), expected.as_bytes())
+}
+
+/// Auth guard for the administrative `/admin/*` routes.
+async fn require_admin_auth(
+    State(expected): State<Arc<str>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let auth_header = request
+        .headers()
+        .get(http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok());
+
+    if admin_request_authorized(auth_header, &expected) {
+        next.run(request).await
+    } else {
+        (http::StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+    }
 }
 
 /// Validate an operator-supplied public URL at the system boundary. It must
@@ -7040,6 +7120,126 @@ mod issue_4548_deadlock_tests {
         .await
         .expect(
             "create_and_connect_multiplayer_session must release state+connections before returning",
+        );
+    }
+}
+
+#[cfg(test)]
+mod admin_auth_tests {
+    use std::sync::atomic::AtomicU32;
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::Router;
+    use lobby_broker::Broker;
+    use server_core::draft_session::DraftSessionManager;
+    use server_core::session::SessionManager;
+    use tokio::sync::Mutex;
+    use tower::ServiceExt;
+
+    use super::{
+        admin_request_authorized, merge_admin_routes, tokens_match, AppState, ServerMode,
+    };
+
+    const TOKEN: &str = "s3cr3t-admin-token";
+
+    fn test_app_state(temp_dir: &tempfile::TempDir) -> AppState {
+        let game_db = Arc::new(
+            persistence::GameDb::open(temp_dir.path().join("games.db")).expect("game db"),
+        );
+        AppState {
+            sessions: Arc::new(Mutex::new(SessionManager::new())),
+            draft_sessions: Arc::new(Mutex::new(DraftSessionManager::new())),
+            draft_pools: Arc::new(draft_pools::DraftPools::default()),
+            connections: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            db: Arc::new(engine::database::CardDatabase::default()),
+            lobby: Arc::new(Mutex::new(Broker::new())),
+            lobby_subscribers: Arc::new(Mutex::new(Vec::new())),
+            player_count: Arc::new(AtomicU32::new(0)),
+            game_db,
+            draft_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            game_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            mode: ServerMode::Full,
+            public_url: None,
+        }
+    }
+
+    fn test_admin_app(admin_token: Option<&str>) -> (Router<AppState>, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app =
+            merge_admin_routes(Router::new(), admin_token).with_state(test_app_state(&temp_dir));
+        (app, temp_dir)
+    }
+
+    async fn get_admin_drafts(app: &mut Router<AppState>, auth: Option<&str>) -> StatusCode {
+        let mut builder = Request::builder().method("GET").uri("/admin/drafts");
+        if let Some(value) = auth {
+            builder = builder.header(http::header::AUTHORIZATION, value);
+        }
+        let response = app
+            .oneshot(builder.body(Body::empty()).unwrap())
+            .await
+            .expect("router response");
+        response.status()
+    }
+
+    #[test]
+    fn tokens_match_is_exact() {
+        assert!(tokens_match(b"abc", b"abc"));
+        assert!(!tokens_match(b"abc", b"abd"));
+        assert!(!tokens_match(b"abc", b"ab"));
+        assert!(!tokens_match(b"", b"x"));
+        assert!(tokens_match(b"", b""));
+    }
+
+    #[test]
+    fn authorized_only_with_matching_bearer_token() {
+        let ok = format!("Bearer {TOKEN}");
+        assert!(admin_request_authorized(Some(&ok), TOKEN));
+        let padded = format!("Bearer   {TOKEN}  ");
+        assert!(admin_request_authorized(Some(&padded), TOKEN));
+        assert!(admin_request_authorized(Some(&format!("bearer {TOKEN}")), TOKEN));
+        assert!(admin_request_authorized(Some(&format!("BEARER {TOKEN}")), TOKEN));
+    }
+
+    #[test]
+    fn rejects_missing_wrong_or_malformed_header() {
+        assert!(!admin_request_authorized(None, TOKEN));
+        assert!(!admin_request_authorized(Some(""), TOKEN));
+        assert!(!admin_request_authorized(Some("Bearer wrong-token"), TOKEN));
+        let basic = format!("Basic {TOKEN}");
+        assert!(!admin_request_authorized(Some(&basic), TOKEN));
+        assert!(!admin_request_authorized(Some(TOKEN), TOKEN));
+    }
+
+    #[tokio::test]
+    async fn admin_routes_absent_without_token() {
+        let (mut app, _temp) = test_admin_app(None);
+        assert_eq!(get_admin_drafts(&mut app, None).await, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn admin_routes_reject_missing_bearer() {
+        let (mut app, _temp) = test_admin_app(Some(TOKEN));
+        assert_eq!(get_admin_drafts(&mut app, None).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_routes_reject_wrong_bearer() {
+        let (mut app, _temp) = test_admin_app(Some(TOKEN));
+        assert_eq!(
+            get_admin_drafts(&mut app, Some("Bearer wrong-token")).await,
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_routes_accept_valid_bearer() {
+        let (mut app, _temp) = test_admin_app(Some(TOKEN));
+        assert_eq!(
+            get_admin_drafts(&mut app, Some(&format!("Bearer {TOKEN}"))).await,
+            StatusCode::OK
         );
     }
 }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7140,7 +7140,7 @@ mod admin_auth_tests {
     use server_core::draft_session::DraftSessionManager;
     use server_core::session::SessionManager;
     use tokio::sync::Mutex;
-    use tower::ServiceExt;
+    use tower::Service;
 
     use super::{
         admin_request_authorized, draft_pools, mount_admin_routes, persistence, tokens_match,
@@ -7177,14 +7177,18 @@ mod admin_auth_tests {
         app.with_state(app_state)
     }
 
-    async fn get_admin_drafts(mut app: Router<AppState>, auth: Option<&str>) -> StatusCode {
-        let mut service = app.as_service();
+    async fn get_admin_drafts(app: Router<AppState>, auth: Option<&str>) -> StatusCode {
+        let mut service = app.into_service::<Body>();
         let mut builder = Request::builder().method("GET").uri("/admin/drafts");
         if let Some(value) = auth {
             builder = builder.header(http::header::AUTHORIZATION, value);
         }
+        let request = builder.body(Body::empty()).unwrap();
         let response = service
-            .oneshot(builder.body(Body::empty()).unwrap())
+            .ready()
+            .await
+            .expect("service ready")
+            .call(request)
             .await
             .expect("router response");
         response.status()

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7133,14 +7133,14 @@ mod admin_auth_tests {
     use std::sync::atomic::AtomicU32;
     use std::sync::Arc;
 
-    use axum::body::Body;
-    use axum::http::{Request, StatusCode};
+    use axum::http::StatusCode;
     use axum::Router;
     use lobby_broker::Broker;
     use server_core::draft_session::DraftSessionManager;
     use server_core::session::SessionManager;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::sync::Mutex;
-    use tower::ServiceExt;
+    use url::Url;
 
     use super::{
         admin_request_authorized, draft_pools, mount_admin_routes, persistence, tokens_match,
@@ -7177,18 +7177,41 @@ mod admin_auth_tests {
         app.with_state(app_state)
     }
 
-    async fn get_admin_drafts(app: Router<AppState>, auth: Option<&str>) -> StatusCode {
-        let mut builder = Request::builder().method("GET").uri("/admin/drafts");
-        if let Some(value) = auth {
-            builder = builder.header(http::header::AUTHORIZATION, value);
-        }
-        let request = builder.body(Body::empty()).unwrap();
-        let response = app
-            .into_service::<Body>()
-            .oneshot(request)
+    async fn spawn_admin_test_server(app: Router<AppState>) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
-            .expect("router response");
-        response.status()
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("test server");
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    async fn get_admin_drafts(base_url: &str, auth: Option<&str>) -> StatusCode {
+        let url = Url::parse(&format!("{base_url}/admin/drafts")).expect("url");
+        let host = url.host_str().expect("host");
+        let port = url.port().expect("port");
+        let mut stream = tokio::net::TcpStream::connect((host, port))
+            .await
+            .expect("connect");
+        let mut request = String::from("GET /admin/drafts HTTP/1.1\r\n");
+        request.push_str(&format!("Host: {host}\r\n"));
+        if let Some(value) = auth {
+            request.push_str(&format!("Authorization: {value}\r\n"));
+        }
+        request.push_str("Connection: close\r\n\r\n");
+        stream.write_all(request.as_bytes()).await.expect("write");
+        let mut buf = [0u8; 1024];
+        let n = stream.read(&mut buf).await.expect("read");
+        let response = std::str::from_utf8(&buf[..n]).expect("utf8");
+        let status_code = response
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .and_then(|s| s.parse::<u16>().ok())
+            .expect("status line");
+        StatusCode::from_u16(status_code).expect("status code")
     }
 
     #[test]
@@ -7230,33 +7253,41 @@ mod admin_auth_tests {
     async fn admin_routes_absent_without_token() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let app = test_admin_router(test_app_state(&temp_dir), None);
-        assert_eq!(get_admin_drafts(app, None).await, StatusCode::NOT_FOUND);
+        let (base_url, server) = spawn_admin_test_server(app).await;
+        assert_eq!(get_admin_drafts(&base_url, None).await, StatusCode::NOT_FOUND);
+        server.abort();
     }
 
     #[tokio::test]
     async fn admin_routes_reject_missing_bearer() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let app = test_admin_router(test_app_state(&temp_dir), Some(TOKEN));
-        assert_eq!(get_admin_drafts(app, None).await, StatusCode::UNAUTHORIZED);
+        let (base_url, server) = spawn_admin_test_server(app).await;
+        assert_eq!(get_admin_drafts(&base_url, None).await, StatusCode::UNAUTHORIZED);
+        server.abort();
     }
 
     #[tokio::test]
     async fn admin_routes_reject_wrong_bearer() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let app = test_admin_router(test_app_state(&temp_dir), Some(TOKEN));
+        let (base_url, server) = spawn_admin_test_server(app).await;
         assert_eq!(
-            get_admin_drafts(app, Some("Bearer wrong-token")).await,
+            get_admin_drafts(&base_url, Some("Bearer wrong-token")).await,
             StatusCode::UNAUTHORIZED
         );
+        server.abort();
     }
 
     #[tokio::test]
     async fn admin_routes_accept_valid_bearer() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let app = test_admin_router(test_app_state(&temp_dir), Some(TOKEN));
+        let (base_url, server) = spawn_admin_test_server(app).await;
         assert_eq!(
-            get_admin_drafts(app, Some(&format!("Bearer {TOKEN}"))).await,
+            get_admin_drafts(&base_url, Some(&format!("Bearer {TOKEN}"))).await,
             StatusCode::OK
         );
+        server.abort();
     }
 }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7169,7 +7169,7 @@ mod admin_auth_tests {
         }
     }
 
-    fn test_admin_router(app_state: AppState, admin_token: Option<&str>) -> Router {
+    fn test_admin_router(app_state: AppState, admin_token: Option<&str>) {
         let mut app = Router::new();
         if let Some(token) = admin_token.filter(|t| !t.is_empty()) {
             app = mount_admin_routes(app, token);
@@ -7177,7 +7177,11 @@ mod admin_auth_tests {
         app.with_state(app_state)
     }
 
-    async fn spawn_admin_test_server(app: Router) -> (String, tokio::task::JoinHandle<()>) {
+    async fn spawn_admin_http_test(
+        admin_token: Option<&str>,
+    ) -> (String, tokio::task::JoinHandle<()>, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app = test_admin_router(test_app_state(&temp_dir), admin_token);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind test server");
@@ -7185,7 +7189,7 @@ mod admin_auth_tests {
         let handle = tokio::spawn(async move {
             axum::serve(listener, app).await.expect("test server");
         });
-        (format!("http://{addr}"), handle)
+        (format!("http://{addr}"), handle, temp_dir)
     }
 
     async fn get_admin_drafts(base_url: &str, auth: Option<&str>) -> StatusCode {
@@ -7251,9 +7255,7 @@ mod admin_auth_tests {
 
     #[tokio::test]
     async fn admin_routes_absent_without_token() {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
-        let app = test_admin_router(test_app_state(&temp_dir), None);
-        let (base_url, server) = spawn_admin_test_server(app).await;
+        let (base_url, server, _temp) = spawn_admin_http_test(None).await;
         assert_eq!(
             get_admin_drafts(&base_url, None).await,
             StatusCode::NOT_FOUND
@@ -7263,9 +7265,7 @@ mod admin_auth_tests {
 
     #[tokio::test]
     async fn admin_routes_reject_missing_bearer() {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
-        let app = test_admin_router(test_app_state(&temp_dir), Some(TOKEN));
-        let (base_url, server) = spawn_admin_test_server(app).await;
+        let (base_url, server, _temp) = spawn_admin_http_test(Some(TOKEN)).await;
         assert_eq!(
             get_admin_drafts(&base_url, None).await,
             StatusCode::UNAUTHORIZED
@@ -7275,9 +7275,7 @@ mod admin_auth_tests {
 
     #[tokio::test]
     async fn admin_routes_reject_wrong_bearer() {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
-        let app = test_admin_router(test_app_state(&temp_dir), Some(TOKEN));
-        let (base_url, server) = spawn_admin_test_server(app).await;
+        let (base_url, server, _temp) = spawn_admin_http_test(Some(TOKEN)).await;
         assert_eq!(
             get_admin_drafts(&base_url, Some("Bearer wrong-token")).await,
             StatusCode::UNAUTHORIZED
@@ -7287,9 +7285,7 @@ mod admin_auth_tests {
 
     #[tokio::test]
     async fn admin_routes_accept_valid_bearer() {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
-        let app = test_admin_router(test_app_state(&temp_dir), Some(TOKEN));
-        let (base_url, server) = spawn_admin_test_server(app).await;
+        let (base_url, server, _temp) = spawn_admin_http_test(Some(TOKEN)).await;
         assert_eq!(
             get_admin_drafts(&base_url, Some(&format!("Bearer {TOKEN}"))).await,
             StatusCode::OK

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7152,8 +7152,7 @@ mod admin_auth_tests {
 
     fn test_app_state(temp_dir: &tempfile::TempDir) -> AppState {
         let game_db_path = temp_dir.path().join("games.db");
-        let game_db =
-            Arc::new(persistence::GameDb::open(&game_db_path).expect("game db"));
+        let game_db = Arc::new(persistence::GameDb::open(&game_db_path).expect("game db"));
         AppState {
             sessions: Arc::new(Mutex::new(SessionManager::new())),
             draft_sessions: Arc::new(Mutex::new(DraftSessionManager::new())),
@@ -7235,10 +7234,7 @@ mod admin_auth_tests {
     #[tokio::test]
     async fn admin_routes_reject_missing_bearer() {
         let (app, _temp) = test_admin_app(Some(TOKEN));
-        assert_eq!(
-            get_admin_drafts(app, None).await,
-            StatusCode::UNAUTHORIZED
-        );
+        assert_eq!(get_admin_drafts(app, None).await, StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 use axum::extract::ws::{Message, WebSocket};
 use axum::extract::{Request, State, WebSocketUpgrade};
-use axum::middleware::{from_fn_with_state, Next};
+use axum::middleware::{from_fn, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Router;
@@ -1289,7 +1289,13 @@ fn merge_admin_routes<S>(mut app: Router<S>, admin_token: Option<&str>) -> Route
                 "/admin/drafts/{code}",
                 get(admin::admin_get_draft).delete(admin::admin_delete_draft),
             )
-            .layer(from_fn_with_state(expected, require_admin_auth));
+            .route_layer(from_fn({
+                let expected = expected.clone();
+                move |request: Request, next: Next| {
+                    let expected = expected.clone();
+                    async move { require_admin_auth(expected, request, next).await }
+                }
+            }));
         app = app.merge(admin_routes);
     }
     app
@@ -1312,11 +1318,7 @@ fn admin_request_authorized(auth_header: Option<&str>, expected: &str) -> bool {
 }
 
 /// Auth guard for the administrative `/admin/*` routes.
-async fn require_admin_auth(
-    State(expected): State<Arc<str>>,
-    request: Request,
-    next: Next,
-) -> Response {
+async fn require_admin_auth(expected: Arc<str>, request: Request, next: Next) -> Response {
     let auth_header = request
         .headers()
         .get(http::header::AUTHORIZATION)
@@ -7138,7 +7140,10 @@ mod admin_auth_tests {
     use tokio::sync::Mutex;
     use tower::ServiceExt;
 
-    use super::{admin_request_authorized, merge_admin_routes, tokens_match, AppState, ServerMode};
+    use super::{
+        admin_request_authorized, draft_pools, merge_admin_routes, persistence, tokens_match,
+        AppState, ServerMode,
+    };
 
     const TOKEN: &str = "s3cr3t-admin-token";
 

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7140,7 +7140,7 @@ mod admin_auth_tests {
     use server_core::draft_session::DraftSessionManager;
     use server_core::session::SessionManager;
     use tokio::sync::Mutex;
-    use tower::Service;
+    use tower::ServiceExt;
 
     use super::{
         admin_request_authorized, draft_pools, mount_admin_routes, persistence, tokens_match,
@@ -7178,17 +7178,14 @@ mod admin_auth_tests {
     }
 
     async fn get_admin_drafts(app: Router<AppState>, auth: Option<&str>) -> StatusCode {
-        let mut service = app.into_service::<Body>();
         let mut builder = Request::builder().method("GET").uri("/admin/drafts");
         if let Some(value) = auth {
             builder = builder.header(http::header::AUTHORIZATION, value);
         }
         let request = builder.body(Body::empty()).unwrap();
-        let response = service
-            .ready()
-            .await
-            .expect("service ready")
-            .call(request)
+        let response = app
+            .into_service::<Body>()
+            .oneshot(request)
             .await
             .expect("router response");
         response.status()

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1282,7 +1282,7 @@ fn admin_token_from_env() -> Option<String> {
 }
 
 /// Mount bearer-guarded `/admin/*` routes on a router that will receive `AppState`.
-fn mount_admin_routes(mut app: Router<AppState>, admin_token: &str) -> Router<AppState> {
+fn mount_admin_routes(app: Router<AppState>, admin_token: &str) -> Router<AppState> {
     let auth_layer = |expected: Arc<str>| {
         from_fn(move |request: Request, next: Next| {
             let expected = expected.clone();
@@ -7177,12 +7177,13 @@ mod admin_auth_tests {
         app.with_state(app_state)
     }
 
-    async fn get_admin_drafts(app: Router<AppState>, auth: Option<&str>) -> StatusCode {
+    async fn get_admin_drafts(mut app: Router<AppState>, auth: Option<&str>) -> StatusCode {
+        let mut service = app.as_service();
         let mut builder = Request::builder().method("GET").uri("/admin/drafts");
         if let Some(value) = auth {
             builder = builder.header(http::header::AUTHORIZATION, value);
         }
-        let response = app
+        let response = service
             .oneshot(builder.body(Body::empty()).unwrap())
             .await
             .expect("router response");

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1157,7 +1157,27 @@ async fn main() {
         Some(_) => info!("admin HTTP endpoints enabled (bearer-token authenticated)"),
         None => info!("admin HTTP endpoints disabled (set PHASE_ADMIN_TOKEN to enable)"),
     }
-    app = merge_admin_routes(app, admin_token.as_deref());
+    if let Some(token) = admin_token.as_deref().filter(|t| !t.is_empty()) {
+        let auth_layer = |expected: Arc<str>| {
+            from_fn(move |request: Request, next: Next| {
+                let expected = expected.clone();
+                async move { require_admin_auth(expected, request, next).await }
+            })
+        };
+        let list_auth = auth_layer(Arc::from(token));
+        let detail_auth = auth_layer(Arc::from(token));
+        app = app
+            .route(
+                "/admin/drafts",
+                get(admin::admin_list_drafts).route_layer(list_auth),
+            )
+            .route(
+                "/admin/drafts/{code}",
+                get(admin::admin_get_draft)
+                    .delete(admin::admin_delete_draft)
+                    .route_layer(detail_auth),
+            );
+    }
 
     let app = app.layer(cors).with_state(AppState {
         sessions: state,
@@ -1277,35 +1297,6 @@ fn admin_token_from_env() -> Option<String> {
         .ok()
         .map(|t| t.trim().to_string())
         .filter(|t| !t.is_empty())
-}
-
-/// Mount `/admin/*` routes when `admin_token` is present, guarded by bearer auth.
-fn merge_admin_routes<S>(mut app: Router<S>, admin_token: Option<&str>) -> Router<S>
-where
-    S: Clone + Send + Sync + 'static,
-{
-    if let Some(token) = admin_token.filter(|t| !t.is_empty()) {
-        let auth_layer = |expected: Arc<str>| {
-            from_fn(move |request: Request, next: Next| {
-                let expected = expected.clone();
-                async move { require_admin_auth(expected, request, next).await }
-            })
-        };
-        let list_auth = auth_layer(Arc::from(token));
-        let detail_auth = auth_layer(Arc::from(token));
-        app = app
-            .route(
-                "/admin/drafts",
-                get(admin::admin_list_drafts).route_layer(list_auth),
-            )
-            .route(
-                "/admin/drafts/{code}",
-                get(admin::admin_get_draft)
-                    .delete(admin::admin_delete_draft)
-                    .route_layer(detail_auth),
-            );
-    }
-    app
 }
 
 /// Decide whether an `Authorization` header value authorizes an admin request.

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1160,20 +1160,20 @@ async fn main() {
     app = merge_admin_routes(app, admin_token.as_deref());
 
     let app = app.layer(cors).with_state(AppState {
-            sessions: state,
-            draft_sessions,
-            draft_pools,
-            connections,
-            db,
-            lobby,
-            lobby_subscribers,
-            player_count,
-            game_db,
-            draft_spectators,
-            game_spectators,
-            mode,
-            public_url: advertised_public_url,
-        });
+        sessions: state,
+        draft_sessions,
+        draft_pools,
+        connections,
+        db,
+        lobby,
+        lobby_subscribers,
+        player_count,
+        game_db,
+        draft_spectators,
+        game_spectators,
+        mode,
+        public_url: advertised_public_url,
+    });
 
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", cli.port))
         .await
@@ -7138,16 +7138,13 @@ mod admin_auth_tests {
     use tokio::sync::Mutex;
     use tower::ServiceExt;
 
-    use super::{
-        admin_request_authorized, merge_admin_routes, tokens_match, AppState, ServerMode,
-    };
+    use super::{admin_request_authorized, merge_admin_routes, tokens_match, AppState, ServerMode};
 
     const TOKEN: &str = "s3cr3t-admin-token";
 
     fn test_app_state(temp_dir: &tempfile::TempDir) -> AppState {
-        let game_db = Arc::new(
-            persistence::GameDb::open(temp_dir.path().join("games.db")).expect("game db"),
-        );
+        let game_db =
+            Arc::new(persistence::GameDb::open(temp_dir.path().join("games.db")).expect("game db"));
         AppState {
             sessions: Arc::new(Mutex::new(SessionManager::new())),
             draft_sessions: Arc::new(Mutex::new(DraftSessionManager::new())),
@@ -7199,8 +7196,14 @@ mod admin_auth_tests {
         assert!(admin_request_authorized(Some(&ok), TOKEN));
         let padded = format!("Bearer   {TOKEN}  ");
         assert!(admin_request_authorized(Some(&padded), TOKEN));
-        assert!(admin_request_authorized(Some(&format!("bearer {TOKEN}")), TOKEN));
-        assert!(admin_request_authorized(Some(&format!("BEARER {TOKEN}")), TOKEN));
+        assert!(admin_request_authorized(
+            Some(&format!("bearer {TOKEN}")),
+            TOKEN
+        ));
+        assert!(admin_request_authorized(
+            Some(&format!("BEARER {TOKEN}")),
+            TOKEN
+        ));
     }
 
     #[test]
@@ -7216,13 +7219,19 @@ mod admin_auth_tests {
     #[tokio::test]
     async fn admin_routes_absent_without_token() {
         let (mut app, _temp) = test_admin_app(None);
-        assert_eq!(get_admin_drafts(&mut app, None).await, StatusCode::NOT_FOUND);
+        assert_eq!(
+            get_admin_drafts(&mut app, None).await,
+            StatusCode::NOT_FOUND
+        );
     }
 
     #[tokio::test]
     async fn admin_routes_reject_missing_bearer() {
         let (mut app, _temp) = test_admin_app(Some(TOKEN));
-        assert_eq!(get_admin_drafts(&mut app, None).await, StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            get_admin_drafts(&mut app, None).await,
+            StatusCode::UNAUTHORIZED
+        );
     }
 
     #[tokio::test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7169,7 +7169,7 @@ mod admin_auth_tests {
         }
     }
 
-    fn test_admin_router(app_state: AppState, admin_token: Option<&str>) -> Router<AppState> {
+    fn test_admin_router(app_state: AppState, admin_token: Option<&str>) -> Router {
         let mut app = Router::new();
         if let Some(token) = admin_token.filter(|t| !t.is_empty()) {
             app = mount_admin_routes(app, token);
@@ -7177,7 +7177,9 @@ mod admin_auth_tests {
         app.with_state(app_state)
     }
 
-    async fn spawn_admin_test_server(app: Router<AppState>) -> (String, tokio::task::JoinHandle<()>) {
+    async fn spawn_admin_test_server(
+        app: Router,
+    ) -> (String, tokio::task::JoinHandle<()>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind test server");
@@ -7254,7 +7256,10 @@ mod admin_auth_tests {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let app = test_admin_router(test_app_state(&temp_dir), None);
         let (base_url, server) = spawn_admin_test_server(app).await;
-        assert_eq!(get_admin_drafts(&base_url, None).await, StatusCode::NOT_FOUND);
+        assert_eq!(
+            get_admin_drafts(&base_url, None).await,
+            StatusCode::NOT_FOUND
+        );
         server.abort();
     }
 
@@ -7263,7 +7268,10 @@ mod admin_auth_tests {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let app = test_admin_router(test_app_state(&temp_dir), Some(TOKEN));
         let (base_url, server) = spawn_admin_test_server(app).await;
-        assert_eq!(get_admin_drafts(&base_url, None).await, StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            get_admin_drafts(&base_url, None).await,
+            StatusCode::UNAUTHORIZED
+        );
         server.abort();
     }
 


### PR DESCRIPTION
## Summary

- **Root cause:** `/admin/drafts*` routes (list, inspect, force-delete) are mounted with **no authentication**. Production nginx proxies `/` to `phase-server`, so these endpoints are internet-reachable.
- **Impact:** Any anonymous caller can enumerate drafts, read full session JSON (including per-seat `player_tokens` and lobby passwords via `to_persisted()`), and **DELETE** drafts plus their in-progress games.
- **Fix:** Mount `/admin/*` only when `PHASE_ADMIN_TOKEN` is set; require `Authorization: Bearer <token>` with constant-time comparison. Without a token configured, admin routes are absent (**404**, fail-closed). `/p2p-draft-backup*` stays public (normal client flow).

Complements merged #5038 (draft join password) and #5053 (P2P backup token redaction). Does **not** bundle admin response secret redaction (separate concern).

## Review notes (prior #5041 feedback addressed)

- Env-only token (no CLI flag)
- HTTP router tests: no token → 404; token set, missing/wrong Bearer → 401; valid Bearer → 200
- Case-insensitive `Bearer` scheme (RFC 9110)
- `merge_admin_routes` shared by production and tests

## Test plan

- [x] Unit tests: `tokens_match`, `admin_request_authorized` (incl. case variants)
- [x] Router tests: 404 / 401 / 200 paths
- [ ] CI green