### PR TITLE
fix(parser): gate a conditional draw on "if that creature has a +1/+1 counter" (Oblivion's Hunger)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2199,6 +2199,19 @@ fn parse_counter_threshold(text: &str) -> Option<(Comparator, i32, CounterType, 
         return Some((Comparator::EQ, 0, counter_type, consumed));
     }
 
+    // CR 122.1 + CR 122.1a: an indefinite "a [type] counter" means one or more (>= 1).
+    // Placed before the numeric branch, whose `parse_number` fails fast on the
+    // article "a"/"an" (Oblivion's Hunger: "a +1/+1 counter on it").
+    if let Ok((rest, _)) = nom_primitives::parse_article(text) {
+        if let Ok((after_type, counter_type)) = nom_primitives::parse_counter_type_typed(rest) {
+            let after_type = after_type.trim_start();
+            if let Some(after_on) = parse_counter_on_suffix(after_type) {
+                let consumed = original_len - after_on.len();
+                return Some((Comparator::GE, 1, counter_type, consumed));
+            }
+        }
+    }
+
     let (rest, threshold) = nom_primitives::parse_number.parse(text).ok()?;
     let rest = rest.trim_start();
     type E<'a> = OracleError<'a>;
@@ -2222,11 +2235,12 @@ fn build_counter_condition(
     comparator: Comparator,
     threshold: i32,
     counter_type: CounterType,
+    scope: ObjectScope,
 ) -> AbilityCondition {
     AbilityCondition::QuantityCheck {
         lhs: QuantityExpr::Ref {
             qty: QuantityRef::CountersOn {
-                scope: ObjectScope::Source,
+                scope,
                 counter_type: Some(counter_type),
             },
         },
@@ -2235,33 +2249,70 @@ fn build_counter_condition(
     }
 }
 
-pub(super) fn strip_counter_conditional(text: &str) -> (Option<AbilityCondition>, String) {
+pub(super) fn strip_counter_conditional(
+    text: &str,
+    in_trigger: bool,
+) -> (Option<AbilityCondition>, String) {
     let lower = text.to_lowercase();
     let tp = TextPair::new(text, &lower);
 
+    // Leading form: "if it has [N] [type] counter[s] on it, [effect]". The
+    // subject here is ALWAYS the source ("it"); the demonstrative "that
+    // creature"/"that permanent"/"that card" is deliberately NOT offered in the
+    // leading position. A sentence-initial "If that creature has … counter …,
+    // [source] deals N … instead" belongs to the target-gated *replacement*
+    // class (Bring Low, Strider, Urdnan), whose honest counter/P-T gating is
+    // deferred to the inert `strip_target_keyword_instead` rider (see the CR
+    // 122.1b note there). Offering the demonstrative here would GATE OUT that
+    // deferral and over-accept those cards into a false-green additive
+    // `DealDamage` sibling (the "instead" is a replacement, not additive).
+    // CR 115.1's demonstrative-as-target is honored only in the trailing form
+    // below, where the leading-space needle can't collide with that class.
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("if it has ").parse(lower.as_str()) {
         if let Some((comparator, threshold, counter_type, consumed)) = parse_counter_threshold(rest)
         {
             let after = rest[consumed..].trim_start();
+            // allow-noncombinator: comma cleanup on the already-parsed remainder (the condition is parsed; not dispatch)
             let after = after.strip_prefix(',').unwrap_or(after).trim_start();
             let offset = text.len() - after.len();
             return (
-                Some(build_counter_condition(comparator, threshold, counter_type)),
+                Some(build_counter_condition(
+                    comparator,
+                    threshold,
+                    counter_type,
+                    ObjectScope::Source,
+                )),
                 text[offset..].to_string(),
             );
         }
     }
 
-    if let Some((before, after)) = tp.rsplit_around(" if it has ") {
-        if let Some((comparator, threshold, counter_type, consumed)) =
-            parse_counter_threshold(after.lower)
-        {
-            let remaining = after.lower[consumed..].trim();
-            if remaining.is_empty() || remaining == "." {
-                return (
-                    Some(build_counter_condition(comparator, threshold, counter_type)),
-                    before.original.trim_end_matches('.').trim().to_string(),
-                );
+    // Trailing form: "[effect] if {subject} has [N] [type] counter[s] on it".
+    // "it" is always offered; the demonstrative "that creature"/"that permanent"/
+    // "that card" only in non-trigger context (CR 115.1: the spell's target).
+    let mut subjects: Vec<(&str, ObjectScope)> = vec![(" if it has ", ObjectScope::Source)];
+    if !in_trigger {
+        subjects.push((" if that creature has ", ObjectScope::Target));
+        subjects.push((" if that permanent has ", ObjectScope::Target));
+        subjects.push((" if that card has ", ObjectScope::Target));
+    }
+    for (needle, scope) in subjects {
+        if let Some((before, after)) = tp.rsplit_around(needle) {
+            if let Some((comparator, threshold, counter_type, consumed)) =
+                parse_counter_threshold(after.lower)
+            {
+                let remaining = after.lower[consumed..].trim();
+                if remaining.is_empty() || remaining == "." {
+                    return (
+                        Some(build_counter_condition(
+                            comparator,
+                            threshold,
+                            counter_type,
+                            scope,
+                        )),
+                        before.original.trim_end_matches('.').trim().to_string(),
+                    );
+                }
             }
         }
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22387,7 +22387,7 @@ pub(crate) fn parse_effect_chain_ir(
         // on the text output from strip_if_you_do_conditional. For compound
         // "when you do, if it has N counters" patterns, WhenYouDo is always true for
         // non-optional parents (CR 603.12), so the QuantityCheck is the meaningful gate.
-        let (counter_cond, text) = strip_counter_conditional(&text);
+        let (counter_cond, text) = strip_counter_conditional(&text, ctx.in_trigger);
         // CR 202.3 + CR 608.2c: Mana value threshold condition — same priority as counter_cond.
         let (mv_cond, text) = strip_mana_value_conditional(&text);
         // CR 608.2c: Spell-target superlative gate — "if it has the least/greatest

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -11929,6 +11929,126 @@ fn strip_counter_conditional_no_ice_counters() {
     );
 }
 
+/// SHAPE C1 — the indefinite-article arm: "a +1/+1 counter on it" means
+/// one or more (CR 122.1 + CR 122.1a). The "it" subject keeps the source scope.
+#[test]
+fn strip_counter_conditional_article_it_source() {
+    use crate::parser::oracle_effect::parse_effect_chain;
+    use crate::types::ability::{
+        AbilityCondition, AbilityKind, Comparator, Effect, QuantityExpr, QuantityRef,
+    };
+
+    let def = parse_effect_chain(
+        "draw a card if it has a +1/+1 counter on it",
+        AbilityKind::Spell,
+    );
+    assert!(
+        matches!(
+            &def.condition,
+            Some(AbilityCondition::QuantityCheck {
+                lhs: QuantityExpr::Ref { qty: QuantityRef::CountersOn { scope: ObjectScope::Source, counter_type: Some(counter_type) } },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
+            }) if *counter_type == crate::types::counter::CounterType::Plus1Plus1
+        ),
+        "Expected QuantityCheck(P1P1 >= 1, Source), got {:?}",
+        def.condition,
+    );
+    // Reach-guard (CR: the effect must actually be the draw, never Unimplemented).
+    assert!(
+        matches!(&*def.effect, Effect::Draw { .. }),
+        "Expected Draw effect, got {:?}",
+        def.effect,
+    );
+    assert!(
+        !matches!(&*def.effect, Effect::Unimplemented { .. }),
+        "Draw clause must not be Unimplemented, got {:?}",
+        def.effect,
+    );
+}
+
+/// SHAPE C2 — the demonstrative arm in NON-trigger context: "that creature" is
+/// the spell's target (CR 115.1), so the scope is `Target`, not `Source`. This is
+/// Oblivion's Hunger clause 2. `parse_effect_chain` parses in spell (non-trigger)
+/// context, so the demonstrative is recognized.
+#[test]
+fn strip_counter_conditional_demonstrative_target_non_trigger() {
+    use crate::parser::oracle_effect::parse_effect_chain;
+    use crate::types::ability::{
+        AbilityCondition, AbilityKind, Comparator, Effect, QuantityExpr, QuantityRef,
+    };
+
+    let def = parse_effect_chain(
+        "draw a card if that creature has a +1/+1 counter on it",
+        AbilityKind::Spell,
+    );
+    assert!(
+        matches!(
+            &def.condition,
+            Some(AbilityCondition::QuantityCheck {
+                lhs: QuantityExpr::Ref { qty: QuantityRef::CountersOn { scope: ObjectScope::Target, counter_type: Some(counter_type) } },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
+            }) if *counter_type == crate::types::counter::CounterType::Plus1Plus1
+        ),
+        "Expected QuantityCheck(P1P1 >= 1, Target), got {:?}",
+        def.condition,
+    );
+    // Reach-guard: draw effect reached, zero Unimplemented.
+    assert!(
+        matches!(&*def.effect, Effect::Draw { .. }),
+        "Expected Draw effect, got {:?}",
+        def.effect,
+    );
+    assert!(
+        !matches!(&*def.effect, Effect::Unimplemented { .. }),
+        "Draw clause must not be Unimplemented, got {:?}",
+        def.effect,
+    );
+}
+
+/// SHAPE C3 — GUARD: a LEADING demonstrative "if that creature has … counter …,
+/// [source] deals N … instead" (Bring Low's verbatim clause 2) must NOT be
+/// captured by the counter-conditional as an additive `QuantityCheck`-gated
+/// `DealDamage`. The leading demonstrative is deliberately withheld from
+/// `strip_counter_conditional` (offered only in the trailing form), so
+/// `strip_counter_conditional` returns no condition here and this
+/// replacement-class clause stays on the same inert deferral path as upstream
+/// `main` (CR 608.2e). Discriminating: under the pre-fix over-acceptance the
+/// leading demonstrative matched and the condition became
+/// `QuantityCheck(Target, GE 1)`, with the "instead" replacement wrongly lowered
+/// as an additive 5-damage sibling (target with a counter → 3+5=8 instead of the
+/// correct 5). This test fails under that regression (condition would be
+/// `Some(QuantityCheck)`) and passes only on the deferred path (condition `None`,
+/// exactly as upstream produces for this isolated clause).
+#[test]
+fn strip_counter_conditional_leading_demonstrative_instead_deferred() {
+    use crate::parser::oracle_effect::parse_effect_chain;
+    use crate::types::ability::{AbilityCondition, AbilityKind};
+
+    let def = parse_effect_chain(
+        "If that creature has a +1/+1 counter on it, Bring Low deals 5 damage to it instead.",
+        AbilityKind::Spell,
+    );
+    // Must NOT be captured as a counter-gated additive QuantityCheck (the
+    // pre-fix false-green). This is the discriminating assertion.
+    assert!(
+        !matches!(&def.condition, Some(AbilityCondition::QuantityCheck { .. })),
+        "Leading 'if that creature has a +1/+1 counter … instead' must NOT parse to a \
+         QuantityCheck-gated additive DealDamage; got {:?}",
+        def.condition,
+    );
+    // Upstream parity: the counter-conditional does not recognize this leading
+    // demonstrative at all, so no counter condition is attached — the clause is
+    // left as an honest deferred gap, identical to upstream `main`.
+    assert!(
+        def.condition.is_none(),
+        "Leading demonstrative 'instead' clause must stay a deferred gap (no counter \
+         condition), matching upstream main; got {:?}",
+        def.condition,
+    );
+}
+
 #[test]
 fn earthbender_ascension_landfall_chain() {
     use crate::parser::oracle_effect::parse_effect_chain;

--- a/crates/engine/tests/oblivions_hunger_conditional_draw.rs
+++ b/crates/engine/tests/oblivions_hunger_conditional_draw.rs
@@ -1,0 +1,84 @@
+//! Regression coverage for Oblivion's Hunger — the conditional draw
+//! ("Draw a card **if that creature has a +1/+1 counter on it**") whose
+//! condition was previously SWALLOWED, so the draw fired unconditionally
+//! (coverage gap `Swallow:Condition_If`).
+//!
+//! The demonstrative "that creature" denotes the spell's TARGET object
+//! (CR 115.1), so the counter check must resolve against the targeted creature
+//! (`ObjectScope::Target`), not the spell (`ObjectScope::Source`). The parser fix
+//! recognizes the demonstrative subject in non-trigger context and threads the
+//! `Target` scope into the `QuantityCheck`; everything downstream (the
+//! `CountersOn { scope: Target }` resolution via `object_id_for_scope`) already
+//! ships.
+//!
+//! CARD TEXT: the Oracle string below is Oblivion's Hunger's verbatim Oracle
+//! text — an instant, "Target creature you control gains indestructible until
+//! end of turn. Draw a card if that creature has a +1/+1 counter on it."
+
+use engine::game::scenario::GameScenario;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+
+/// Oblivion's Hunger — verbatim Oracle text.
+const ORACLE: &str = "Target creature you control gains indestructible until end of turn. \
+Draw a card if that creature has a +1/+1 counter on it.";
+
+/// Setup A — POSITIVE REACH-GUARD. The targeted creature HAS a +1/+1 counter, so
+/// the conditional draw fires (CR 121.1: draw a card; CR 115.1: "that creature"
+/// is the target). Proves the draw path is genuinely reached when the condition
+/// holds — the non-vacuous sibling for the revert-failing negative below.
+#[test]
+fn oblivions_hunger_draws_when_target_has_counter() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Seed a card so the draw has something to pull (CR 121.1).
+    scenario.with_library_top(P0, &["Filler A", "Filler B"]);
+
+    let creature = scenario
+        .add_creature(P0, "Counter Bearer", 2, 2)
+        .with_plus_counters(1)
+        .id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Oblivion's Hunger", true, ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(spell).target_objects(&[creature]).resolve();
+
+    // CR 115.1 + CR 121.1: target has a +1/+1 counter → the conditional draw fires.
+    outcome.assert_hand_drawn(P0, 1);
+}
+
+/// Setup B — REVERT-FAILING NEGATIVE. The targeted creature has NO counter, while
+/// a DIFFERENT P0 creature DOES (a decoy). Because "that creature" is the TARGET
+/// (CR 115.1), the counter check evaluates against the bare target and the draw
+/// must NOT fire. Before the fix the condition was swallowed and the draw was
+/// unconditional (drew 1) — this assertion flips to a failure when the fix is
+/// reverted. The decoy makes it discriminating: a naive "any creature has a
+/// counter" reading would still draw here.
+#[test]
+fn oblivions_hunger_no_draw_when_target_lacks_counter() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Filler A", "Filler B"]);
+
+    // Decoy: a P0 creature WITH a +1/+1 counter that is NOT the spell's target.
+    scenario
+        .add_creature(P0, "Decoy Counter Bearer", 2, 2)
+        .with_plus_counters(1);
+    // The actual target: a bare creature with no counter.
+    let bare = scenario.add_creature(P0, "Bare Creature", 2, 2).id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Oblivion's Hunger", true, ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(spell).target_objects(&[bare]).resolve();
+
+    // CR 115.1: the condition binds to the TARGET (no counter) — not the decoy —
+    // so the draw is suppressed. Reverting the parser fix (condition swallowed →
+    // unconditional draw) makes this assertion fail.
+    outcome.assert_hand_drawn(P0, 0);
+}


### PR DESCRIPTION
## Summary
Fixes **Oblivion's Hunger** — `Target creature you control gains indestructible until end of turn. Draw a card if that creature has a +1/+1 counter on it.` The trailing "if that creature has …" condition was swallowed, so the draw fired **unconditionally** (coverage gap `Swallow:Condition_If`).

The fix widens the existing counter-conditional combinator on two axes, reusing downstream machinery that already exists and resolves at runtime (`AbilityCondition::QuantityCheck` / `QuantityRef::CountersOn` / `ObjectScope`):

- **`parse_counter_threshold`** — accept the indefinite-article form "a/an [type] counter on it" as `>= 1` (CR 122.1 / 122.1a), placed before the numeric branch (which fails-fast on "a").
- **`strip_counter_conditional`** (trailing form only) — recognize the demonstrative subject "that creature/permanent/card" and bind it to `ObjectScope::Target` (CR 115.1), gated to non-trigger context.

**Deliberate narrowing (guarded):** the demonstrative is withheld from the *leading* form ("If that creature has …, X **instead**"). Matching it there would gate out the intentional `strip_target_keyword_instead` deferral for the "deals N … instead" replacement class (**Bring Low / Strider / Urdnan**) and mis-model the replacement as additive damage. Those cards stay on their honest deferral exactly as on `main`; a regression test pins that parity.

**Scope:** Oblivion's Hunger flips to supported. **Marcus, Mutant Mayor** (same phrase in a *trigger*, plus an "If it doesn't, put a +1/+1 counter on it" else-branch that touches the shared "Otherwise" handler) is a deliberate follow-up — it remains an honest, unchanged coverage gap here rather than a risky same-PR change.

## Files changed
- `crates/engine/src/parser/oracle_effect/conditions.rs`
- `crates/engine/src/parser/oracle_effect/mod.rs` (one-line call-site thread of `ctx.in_trigger`)
- `crates/engine/src/parser/oracle_tests.rs`
- `crates/engine/tests/oblivions_hunger_conditional_draw.rs`

## CR references
- `CR 122.1` / `CR 122.1a` — a counter marker; the indefinite "a [type] counter" means one or more (`>= 1`)
- `CR 115.1` — "that creature" = the spell's target object

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high
Tier: Frontier

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (exit 0)
- `cargo clippy -p engine --all-targets -- -D warnings` — clean
- `cargo test -p engine` — **17463 passed / 0 failed**
- `./scripts/gen-card-data.sh` + `cargo coverage` — **Oblivion's Hunger**: `supported: true`, `gap_count: 0` (flipped). **Bring Low / Strider / Urdnan / Marcus, Mutant Mayor**: unchanged vs `main` (still their honest deferrals).
- `cargo semantic-audit` — Oblivion's Hunger: 0 findings; Bring Low: not newly flagged.

Tests added:
- `strip_counter_conditional_article_it_source` (SHAPE) — "if it has a +1/+1 counter on it" → `QuantityCheck { CountersOn{Source, P1P1}, GE, 1 }`, with `Effect::Draw` + no-`Unimplemented` reach-guards.
- `strip_counter_conditional_demonstrative_target_non_trigger` (SHAPE) — Oblivion's trailing clause → `CountersOn { scope: Target }`.
- `strip_counter_conditional_leading_demonstrative_instead_deferred` (guard) — Bring Low's leading "If that creature has … deals 5 … instead" stays `condition: None` (upstream parity); fails under the pre-fix over-acceptance.
- `oblivions_hunger_conditional_draw.rs` — **discriminating runtime, revert-failing**: target **with** a +1/+1 counter → draws 1; target **without** (while a *different* controlled creature holds a decoy counter) → draws 0. Reverting the fix makes the draw unconditional (draws 1) → the `0` assertion fails.

## Gate A
`./scripts/check-parser-combinators.sh` — exit 0, no violations.

## Anchored on
- `crates/engine/src/parser/oracle_effect/conditions.rs` `strip_counter_conditional` / `parse_counter_threshold` / `build_counter_condition` — the existing counter-conditional combinator this PR widens (same combinator family; superset for the trailing form, leading form byte-identical to `main`).
- `crates/engine/src/parser/oracle_effect/conditions.rs` `parse_target_demonstrative_subject` — the established demonstrative-subject recognizer reused for the trailing "that creature" arm.
- `crates/engine/src/parser/oracle_tests.rs` existing `strip_counter_conditional_*` tests — the sibling test pattern the new SHAPE/guard tests mirror.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
