### PR TITLE
feat(engine): dynamic CDA power/toughness counted quantities (distinct subtypes, turns taken) (CR 604.3/613.4a)

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2047,6 +2047,7 @@ fn legacy_quantity_ref(x: &QuantityRef) -> bool {
         | QuantityRef::TargetZoneCardCount { .. }
         | QuantityRef::Devotion { .. }
         | QuantityRef::DistinctCardTypes { .. }
+        | QuantityRef::DistinctSubtypes { .. }
         | QuantityRef::BasicLandTypeCount { .. }
         | QuantityRef::PartySize { .. }
         | QuantityRef::CardsExiledBySource
@@ -5502,6 +5503,7 @@ fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
         QuantityRef::TargetZoneCardCount { zone: _ } => reads_zone_membership(),
         QuantityRef::Devotion { .. }
         | QuantityRef::DistinctCardTypes { .. }
+        | QuantityRef::DistinctSubtypes { .. }
         | QuantityRef::BasicLandTypeCount { .. }
         | QuantityRef::PartySize { .. } => reads_zone_membership(),
         // CR 603.10a (PR-6.75 c5): promoted out of the fail-closed group below to

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1767,6 +1767,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             projected: false,
         },
         QuantityRef::DistinctCardTypes { .. } => Axes::CONSERVATIVE,
+        QuantityRef::DistinctSubtypes { .. } => Axes::CONSERVATIVE,
         QuantityRef::CardsExiledBySource => Axes::NONE,
         QuantityRef::ExiledCardPower { index: _ } => Axes::NONE,
         QuantityRef::ZoneCardCount {

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -3353,6 +3353,12 @@ fn quantity_ref_target_slot_spec(qty: &QuantityRef) -> Option<TargetFilter> {
             | CardTypeSetSource::ExiledBySource
             | CardTypeSetSource::TrackedSet { .. } => None,
         },
+        QuantityRef::DistinctSubtypes { source, .. } => match source {
+            CardTypeSetSource::Objects { filter } => filter_target_slot_filter(filter),
+            CardTypeSetSource::Zone { .. }
+            | CardTypeSetSource::ExiledBySource
+            | CardTypeSetSource::TrackedSet { .. } => None,
+        },
         QuantityRef::ManaSpentToCast { metric, .. } => match metric {
             CastManaSpentMetric::FromSource { source_filter } => {
                 filter_target_slot_filter(source_filter)

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1389,6 +1389,23 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
                 None => "card types among tracked cards".into(),
             },
         },
+        QuantityRef::DistinctSubtypes { source, exclude } => {
+            let suffix = match exclude {
+                crate::types::ability::SubtypeExclusion::CreatureTypes => {
+                    " other than creature types"
+                }
+                crate::types::ability::SubtypeExclusion::None => "",
+            };
+            let scope_desc = match source {
+                CardTypeSetSource::Zone { zone, scope } => {
+                    format!("cards in {} {}", fmt_count_scope(scope), fmt_zone_ref(zone))
+                }
+                CardTypeSetSource::ExiledBySource => "cards exiled with source".into(),
+                CardTypeSetSource::Objects { filter } => fmt_target(filter),
+                CardTypeSetSource::TrackedSet { .. } => "tracked cards".into(),
+            };
+            format!("subtypes{suffix} among {scope_desc}")
+        }
         QuantityRef::CardsExiledBySource => "cards exiled with source".into(),
         QuantityRef::ExiledCardPower { index } => format!("power of exiled card {index}"),
         QuantityRef::ZoneCardCount {
@@ -6678,6 +6695,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::Aggregate { .. } => ("Aggregate", Handled),
         QuantityRef::Devotion { .. } => ("Devotion", Handled),
         QuantityRef::DistinctCardTypes { .. } => ("DistinctCardTypes", Handled),
+        QuantityRef::DistinctSubtypes { .. } => ("DistinctSubtypes", Handled),
         QuantityRef::CardsExiledBySource => ("CardsExiledBySource", Handled),
         QuantityRef::ExiledCardPower { .. } => ("ExiledCardPower", Handled),
         QuantityRef::ZoneCardCount { .. } => ("ZoneCardCount", Handled),
@@ -6706,7 +6724,10 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::ZoneChangeCountThisTurn { .. } => ("ZoneChangeCountThisTurn", Handled),
         QuantityRef::ZoneChangeAggregateThisTurn { .. } => ("ZoneChangeAggregateThisTurn", Handled),
         QuantityRef::DamageDealtThisTurn { .. } => ("DamageDealtThisTurn", Handled),
-        QuantityRef::TurnsTaken => ("TurnsTaken", Unhandled),
+        // CR 500: per-player turn count. Resolver (game/quantity.rs, player.turns_taken)
+        // has always worked; Control Win Condition's CDA now consumes it live. Not a
+        // strict-failure marker anywhere, so it is genuinely handled.
+        QuantityRef::TurnsTaken => ("TurnsTaken", Handled),
         QuantityRef::ChosenNumber => ("ChosenNumber", Unhandled),
         QuantityRef::AttackedThisTurn { .. } => ("AttackedThisTurn", Handled),
         QuantityRef::DescendedThisTurn => ("DescendedThisTurn", Unhandled),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3580,6 +3580,10 @@ fn quantity_expr_references_tracked_set(qty: &QuantityExpr) -> bool {
                     | QuantityRef::DistinctCardTypes {
                         source: CardTypeSetSource::TrackedSet { .. }
                     }
+                    | QuantityRef::DistinctSubtypes {
+                        source: CardTypeSetSource::TrackedSet { .. },
+                        ..
+                    }
             )
         }
         QuantityExpr::Offset { inner, .. }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2072,6 +2072,15 @@ fn quantity_ref_reads_zone(qty: &QuantityRef, zone: Zone) -> bool {
             | CardTypeSetSource::Objects { .. }
             | CardTypeSetSource::TrackedSet { .. } => false,
         },
+        // CR 613.4a: Distinct subtypes read `zone` when sourced from that zone's
+        // cards (Subgoyf: different subtypes among cards in all graveyards) — layer
+        // 7a CDA P/T must re-derive when that zone changes.
+        QuantityRef::DistinctSubtypes { source, .. } => match source {
+            CardTypeSetSource::Zone { zone: zone_ref, .. } => zone_ref_denotes_zone(zone_ref, zone),
+            CardTypeSetSource::ExiledBySource
+            | CardTypeSetSource::Objects { .. }
+            | CardTypeSetSource::TrackedSet { .. } => false,
+        },
         // Everything else reads player-level state, single-object state, battle-
         // field-only population, history records, choices, or tracked sets — none
         // depend on `zone` membership. Enumerated explicitly (no wildcard) so a
@@ -2168,10 +2177,19 @@ pub(crate) fn any_active_static_reads_zone_membership(state: &GameState, zone: Z
         }
         if obj.static_definitions.iter_all().any(|def| {
             def.mode == StaticMode::Continuous
-                && def
+                && (def
                     .condition
                     .as_ref()
                     .is_some_and(|c| static_condition_reads_zone_membership(c, zone))
+                    // CR 604.3 + CR 613: a continuous MODIFICATION whose dynamic
+                    // quantity reads this zone's membership also depends on it —
+                    // e.g. Subgoyf's CDA `SetDynamicPower`/`SetDynamicToughness`
+                    // counting distinct subtypes among cards in all graveyards.
+                    // The static's `condition` is not the only zone-reading surface.
+                    || def.modifications.iter().any(|m| {
+                        continuous_modification_dynamic_quantity(m)
+                            .is_some_and(|q| quantity_expr_reads_zone(q, zone))
+                    }))
         }) {
             found = true;
         }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -18,8 +18,8 @@ use crate::types::ability::{
     AggregateFunction, AttackScope, BasicLandType, CardTypeSetSource, CastManaObjectScope,
     CastManaSpentMetric, ContinuousModification, ControllerRef, CountScope, DamageChannel,
     FilterProp, ObjectProperty, ObjectScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef,
-    ResolvedAbility, RoundingMode, StaticCondition, TargetFilter, TargetRef, TrackedAnaphorSource,
-    TypeFilter, TypedFilter, ZoneRef,
+    ResolvedAbility, RoundingMode, StaticCondition, SubtypeExclusion, TargetFilter, TargetRef,
+    TrackedAnaphorSource, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::card_type::CoreType;
 use crate::types::counter::{positive_counter_types, CounterType};
@@ -149,6 +149,10 @@ pub(crate) fn quantity_expr_uses_recipient(expr: &QuantityExpr) -> bool {
             | QuantityRef::ObjectCountBySharedQuality { filter, .. }
             | QuantityRef::DistinctCardTypes {
                 source: CardTypeSetSource::Objects { filter },
+            }
+            | QuantityRef::DistinctSubtypes {
+                source: CardTypeSetSource::Objects { filter },
+                ..
             }
             | QuantityRef::ManaSpentToCast {
                 metric:
@@ -370,6 +374,7 @@ fn quantity_ref_uses_unspent_mana(qty: &QuantityRef) -> bool {
         | QuantityRef::TargetZoneCardCount { .. }
         | QuantityRef::Devotion { .. }
         | QuantityRef::DistinctCardTypes { .. }
+        | QuantityRef::DistinctSubtypes { .. }
         | QuantityRef::CardsExiledBySource
         | QuantityRef::ExiledCardPower { .. }
         | QuantityRef::ZoneCardCount { .. }
@@ -605,6 +610,15 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
             | CardTypeSetSource::ExiledBySource
             | CardTypeSetSource::TrackedSet { .. } => false,
         },
+        // Distinct subtypes mirrors distinct card types: only the object-filter
+        // source reads battlefield population; zone / linked-exile / tracked-set
+        // sources do not.
+        QuantityRef::DistinctSubtypes { source, .. } => match source {
+            CardTypeSetSource::Objects { .. } => true,
+            CardTypeSetSource::Zone { .. }
+            | CardTypeSetSource::ExiledBySource
+            | CardTypeSetSource::TrackedSet { .. } => false,
+        },
         // Player-level, single-object, history-record, payment, and choice
         // references: unaffected by another object's battlefield entry/exit.
         QuantityRef::HandSize { .. }
@@ -759,6 +773,14 @@ fn entered_object_perturbs_quantity_ref(
             // Zone / linked-exile / tracked-set sources are not battlefield
             // population — the classifier returns false for them, so they cannot
             // be perturbed.
+            CardTypeSetSource::Zone { .. }
+            | CardTypeSetSource::ExiledBySource
+            | CardTypeSetSource::TrackedSet { .. } => false,
+        },
+        QuantityRef::DistinctSubtypes { source, .. } => match source {
+            CardTypeSetSource::Objects { filter } => {
+                matches_target_filter(state, entered.id, filter, ctx)
+            }
             CardTypeSetSource::Zone { .. }
             | CardTypeSetSource::ExiledBySource
             | CardTypeSetSource::TrackedSet { .. } => false,
@@ -2123,6 +2145,113 @@ fn resolve_ref(
                                 }
                             }
                         }
+                    }
+                }
+            }
+            usize_to_i32_saturating(seen.len())
+        }
+        // CR 205.3 + CR 604.3: Count distinct subtype VALUES across the same
+        // `CardTypeSetSource` scan as `DistinctCardTypes`, but reading
+        // `card_types.subtypes` (CR 205.3) rather than `core_types` (CR 205.2).
+        // A card contributing three subtypes adds three distinct entries; the
+        // HashSet dedupes shared subtype values across cards. When
+        // `exclude == CreatureTypes` (CR 205.3m), subtypes present in
+        // `state.all_creature_types` are skipped (Subgoyf: "different subtypes
+        // other than creature types"). Subtype values are stored capitalized
+        // (e.g. "Goblin"); inserted as-is to preserve consistent casing.
+        QuantityRef::DistinctSubtypes { source, exclude } => {
+            // Gather the source object set first (same scan axis as
+            // `DistinctCardTypes`), then tally distinct subtype values across it.
+            // Collecting ids up front keeps the `&str` subtype borrows tied to
+            // `state.objects` for the lifetime of `seen`.
+            let mut obj_ids: Vec<ObjectId> = Vec::new();
+            match source {
+                CardTypeSetSource::Zone { zone, scope } => match zone {
+                    ZoneRef::Exile => {
+                        for &obj_id in &state.exile {
+                            if let Some(obj) = state.objects.get(&obj_id) {
+                                if count_scope_owner_matches(
+                                    state, scope, ctx, controller, obj.owner,
+                                ) {
+                                    obj_ids.push(obj_id);
+                                }
+                            }
+                        }
+                    }
+                    ZoneRef::Graveyard | ZoneRef::Library | ZoneRef::Hand => {
+                        for player in scoped_players(state, scope, ctx, controller) {
+                            let zone_ids = match zone {
+                                ZoneRef::Graveyard => &player.graveyard,
+                                ZoneRef::Library => &player.library,
+                                ZoneRef::Hand => &player.hand,
+                                ZoneRef::Exile => unreachable!(),
+                            };
+                            obj_ids.extend(zone_ids.iter().copied());
+                        }
+                    }
+                },
+                CardTypeSetSource::ExiledBySource => {
+                    for linked in
+                        crate::game::players::linked_exile_cards_for_source(state, source_id)
+                    {
+                        obj_ids.push(linked.exiled_id);
+                    }
+                }
+                CardTypeSetSource::Objects { filter } => {
+                    let zone = filter
+                        .extract_in_zone()
+                        .unwrap_or(crate::types::zones::Zone::Battlefield);
+                    for obj_id in crate::game::targeting::zone_object_ids(state, zone) {
+                        if matches_target_filter(state, obj_id, filter, &filter_ctx) {
+                            obj_ids.push(obj_id);
+                        }
+                    }
+                }
+                CardTypeSetSource::TrackedSet { caused_by } => {
+                    if let Some((set_id, ids)) =
+                        state.tracked_object_sets.iter().max_by_key(|(id, _)| id.0)
+                    {
+                        for &oid in ids {
+                            let cause_ok = match caused_by {
+                                None => true,
+                                Some(cause) => state
+                                    .tracked_set_member_causes
+                                    .get(set_id)
+                                    .and_then(|causes| causes.get(&oid))
+                                    .is_some_and(|member_cause| member_cause == cause),
+                            };
+                            if cause_ok {
+                                obj_ids.push(oid);
+                            }
+                        }
+                    }
+                }
+            }
+            // CR 205.3m: skip subtypes that are creature types when excluding
+            // creature types. Subtype values are stored capitalized ("Goblin")
+            // and inserted as-is; a card with three subtypes contributes three.
+            let exclude_creature = matches!(exclude, SubtypeExclusion::CreatureTypes);
+            // Collect the creature-type names into a set ONCE for O(1) membership,
+            // rather than a linear scan of `all_creature_types` (hundreds of entries)
+            // per subtype per object — layer 7a recomputes this every pass, so the
+            // inner loop is hot.
+            let creature_types: HashSet<&str> = if exclude_creature {
+                state
+                    .all_creature_types
+                    .iter()
+                    .map(|ct| ct.as_str())
+                    .collect()
+            } else {
+                HashSet::new()
+            };
+            let mut seen: HashSet<&str> = HashSet::new();
+            for obj_id in &obj_ids {
+                if let Some(obj) = state.objects.get(obj_id) {
+                    for sub in &obj.card_types.subtypes {
+                        if exclude_creature && creature_types.contains(sub.as_str()) {
+                            continue;
+                        }
+                        seen.insert(sub.as_str());
                     }
                 }
             }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -7307,6 +7307,14 @@ fn quantity_ref_refs_cost_paid_object(qty: &QuantityRef) -> bool {
             | CardTypeSetSource::TrackedSet { .. } => false,
         },
 
+        // Subtype counting embeds a `TargetFilter` through its source enum too.
+        QuantityRef::DistinctSubtypes { source, .. } => match source {
+            CardTypeSetSource::Objects { filter } => filter.references_cost_paid_object(),
+            CardTypeSetSource::Zone { .. }
+            | CardTypeSetSource::ExiledBySource
+            | CardTypeSetSource::TrackedSet { .. } => false,
+        },
+
         // Mana-spent metering embeds a `TargetFilter` through its metric enum.
         QuantityRef::ManaSpentToCast { metric, .. } => match metric {
             CastManaSpentMetric::FromSource { source_filter } => {

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -680,6 +680,14 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
 
     // CR 500: Track per-player turn count for "your Nth turn of the game" conditions.
     state.players[state.active_player.0 as usize].turns_taken += 1;
+    // CR 613.4a + CR 604.3: `turns_taken` is a layer-7a characteristic-defining
+    // input (Control Win Condition: "power and toughness are each equal to the
+    // number of turns you've taken this game", `QuantityRef::TurnsTaken`). Advancing
+    // the count changes that CDA's derived P/T, so the layer cache must be
+    // invalidated here — otherwise a clean cache would keep the stale value until an
+    // unrelated effect happens to dirty it. Mirrors the counter-ledger expiry
+    // invalidation below; unconditional because the increment always changes state.
+    state.layers_dirty.mark_full();
 
     // CR 311.5 / CR 312.4 / CR 901.6: the planar controller is normally whoever
     // the active player is. The turn has committed here (past both turn-skip

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1127,6 +1127,10 @@ fn quantity_ref_uses_filter_prop(qty: &QuantityRef, pred: &impl Fn(&FilterProp) 
         | QuantityRef::EnteredThisTurn { filter } => target_filter_uses_filter_prop(filter, pred),
         QuantityRef::DistinctCardTypes {
             source: crate::types::ability::CardTypeSetSource::Objects { filter },
+        }
+        | QuantityRef::DistinctSubtypes {
+            source: crate::types::ability::CardTypeSetSource::Objects { filter },
+            ..
         } => target_filter_uses_filter_prop(filter, pred),
         _ => false,
     }

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -28,7 +28,7 @@ use crate::types::ability::{
     AggregateFunction, CardTypeSetSource, CastManaObjectScope, CastManaSpentMetric, ControllerRef,
     CountScope, DamageChannel, DamageKindFilter, DevotionColors, FilterProp, ObjectProperty,
     ObjectScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef, RoundingMode, SharedQuality,
-    TargetFilter, ThisWayCause, TypeFilter, TypedFilter, ZoneRef,
+    SubtypeExclusion, TargetFilter, ThisWayCause, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::keywords::Keyword;
@@ -1086,6 +1086,13 @@ fn parse_number_of_inner(input: &str) -> OracleResult<'_, QuantityRef> {
             parse_distinct_card_types_among_tracked_set,
             parse_distinct_card_types_among_objects,
         )),
+        // CR 205.3 + CR 500 + CR 604.3: counted CDA quantities that read live game
+        // state — "different subtypes … among <source>" (Subgoyf) and "turns
+        // you've taken this game" (Control Win Condition). Both must precede the
+        // generic controlled-type/type-filter arms whose leading token would
+        // otherwise commit. Nested together to stay within nom's top-level `alt`
+        // arity (nom 8.0 max: 21 items).
+        alt((parse_distinct_subtypes_among, parse_turns_taken_this_game)),
         // CR 201.2 + CR 603.4: "differently named <type-phrase>" (distinct-by-name)
         // and "different <power|mana value> among <type>" (distinct-by-quality —
         // Celebrate the Harvest's "the number of different powers among ..."
@@ -1768,6 +1775,71 @@ pub(crate) fn parse_distinct_card_types_among_tracked_set(
             },
         },
     ))
+}
+
+/// CR 205.3 + CR 604.3: "different subtype[s] [other than creature types] among
+/// cards in <zone>" / "... among <objects>" → [`QuantityRef::DistinctSubtypes`].
+///
+/// The subtype peer of [`parse_distinct_card_types_in_zone`] /
+/// [`parse_distinct_card_types_among_objects`]: same `among cards in <zone>` /
+/// `among <type-phrase>` source axis, but tallies distinct `subtypes` (CR 205.3)
+/// instead of card types (CR 205.2). The optional "other than creature types"
+/// rider (CR 205.3m) sets `exclude = CreatureTypes` — Subgoyf: "the number of
+/// different subtypes other than creature types among cards in all graveyards".
+/// Combinator-composed from `alt`/`opt` — no string dispatch.
+fn parse_distinct_subtypes_among(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = tag("different subtype").parse(input)?;
+    let (rest, _) = opt(tag("s")).parse(rest)?;
+    // CR 205.3m: "other than creature types" narrows the count to non-creature
+    // subtypes. Absent → count every distinct subtype value.
+    let (rest, exclude) = map(opt(tag(" other than creature types")), |o| {
+        o.map_or(SubtypeExclusion::None, |_| SubtypeExclusion::CreatureTypes)
+    })
+    .parse(rest)?;
+    let (rest, _) = tag(" among ").parse(rest)?;
+    // CR 400.1: zone form ("cards in <zone>") vs CR 109.2: object form
+    // ("<type-phrase>"). Zone form is tried first so "cards in …" is not
+    // mis-consumed by the generic type-phrase reader.
+    let (rest, source) = alt((
+        map(
+            preceded(tag("cards in "), parse_scoped_zone_ref),
+            |(zone, scope)| CardTypeSetSource::Zone { zone, scope },
+        ),
+        parse_distinct_subtypes_objects_source,
+    ))
+    .parse(rest)?;
+    Ok((rest, QuantityRef::DistinctSubtypes { source, exclude }))
+}
+
+/// CR 109.2: object-set source for [`parse_distinct_subtypes_among`] — mirrors
+/// [`parse_distinct_card_types_among_objects`]'s type-phrase consumption so
+/// "different subtypes among <objects>" shares one `Objects { filter }` reading.
+fn parse_distinct_subtypes_objects_source(input: &str) -> OracleResult<'_, CardTypeSetSource> {
+    let type_text = input.trim_end_matches('.').trim_end_matches(',');
+    let (filter, remainder) = parse_type_phrase(type_text);
+    if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    // `type_text` is a leading slice of `input` (only trailing `.`/`,` trimmed) and
+    // `remainder` is a tail of `type_text`, so the consumed prefix length is the
+    // difference of their lengths — no pointer arithmetic needed.
+    let consumed = type_text.len() - remainder.len();
+    Ok((&input[consumed..], CardTypeSetSource::Objects { filter }))
+}
+
+/// CR 500: "turns you've taken this game" → [`QuantityRef::TurnsTaken`] (Control
+/// Win Condition CDA). The parser already emits `TurnsTaken` for casting
+/// prohibitions (oracle_casting.rs); this arm reaches it from the CDA
+/// "the number of " quantity path. The "this game" tail is optional so the
+/// possessor-qualified "turns you've/you have taken" phrase always parses.
+fn parse_turns_taken_this_game(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = tag("turns ").parse(input)?;
+    let (rest, _) = alt((tag("you've taken"), tag("you have taken"))).parse(rest)?;
+    let (rest, _) = opt(tag(" this game")).parse(rest)?;
+    Ok((rest, QuantityRef::TurnsTaken))
 }
 
 /// CR 406.6 + CR 607.1: Parse bare "cards exiled with ~" (or "cards exiled with this X")

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -3147,7 +3147,7 @@ mod tests {
     use super::*;
     use crate::types::ability::{
         CardTypeSetSource, Comparator, ControllerRef, FilterProp, PtStat, PtValueScope,
-        RoundingMode, TypeFilter, TypedFilter,
+        RoundingMode, SubtypeExclusion, TypeFilter, TypedFilter,
     };
     use crate::types::mana::ManaColor;
 
@@ -7275,5 +7275,106 @@ mod tests {
                 },
             }
         );
+    }
+
+    // --- CDA counted-quantity refs (Control Win Condition, Subgoyf) ---
+
+    fn ref_of(qty: QuantityRef) -> Option<QuantityExpr> {
+        Some(QuantityExpr::Ref { qty })
+    }
+
+    /// CR 500: Control Win Condition — "the number of turns you've taken this
+    /// game" resolves to the per-player `TurnsTaken` ref (parser gap before this
+    /// change: the CDA path had no "turns you've taken" arm).
+    #[test]
+    fn cda_turns_taken_this_game_is_turns_taken_ref() {
+        assert_eq!(
+            parse_cda_quantity("the number of turns you've taken this game"),
+            ref_of(QuantityRef::TurnsTaken)
+        );
+        // "you have taken" and the missing "this game" tail both still parse.
+        assert_eq!(
+            parse_cda_quantity("the number of turns you have taken"),
+            ref_of(QuantityRef::TurnsTaken)
+        );
+    }
+
+    /// Negative: "the number of turns" with no possessor must NOT be read as
+    /// TurnsTaken — the "you've/you have taken" possessor is load-bearing.
+    #[test]
+    fn cda_turns_without_possessor_is_not_turns_taken() {
+        assert_ne!(
+            parse_cda_quantity("the number of turns"),
+            ref_of(QuantityRef::TurnsTaken)
+        );
+    }
+
+    /// CR 205.3 + CR 604.3: Subgoyf's full quantity tail — "the number of
+    /// different subtypes other than creature types among cards in all
+    /// graveyards" → `DistinctSubtypes { Zone{Graveyard, All}, CreatureTypes }`.
+    #[test]
+    fn cda_distinct_subtypes_among_all_graveyards() {
+        assert_eq!(
+            parse_cda_quantity(
+                "the number of different subtypes other than creature types among cards in all graveyards"
+            ),
+            ref_of(QuantityRef::DistinctSubtypes {
+                source: CardTypeSetSource::Zone {
+                    zone: ZoneRef::Graveyard,
+                    scope: CountScope::All,
+                },
+                exclude: SubtypeExclusion::CreatureTypes,
+            })
+        );
+    }
+
+    /// Negative: "different subtypes among ..." WITHOUT the "other than creature
+    /// types" rider parses with `exclude: None`, not `CreatureTypes`.
+    #[test]
+    fn cda_distinct_subtypes_without_rider_excludes_nothing() {
+        assert_eq!(
+            parse_cda_quantity("the number of different subtypes among cards in all graveyards"),
+            ref_of(QuantityRef::DistinctSubtypes {
+                source: CardTypeSetSource::Zone {
+                    zone: ZoneRef::Graveyard,
+                    scope: CountScope::All,
+                },
+                exclude: SubtypeExclusion::None,
+            })
+        );
+    }
+
+    /// Negative: the sibling "card types among cards in ..." phrase must still
+    /// route to `DistinctCardTypes` — the new subtype arm does not steal it.
+    #[test]
+    fn cda_card_types_still_distinct_card_types() {
+        assert_eq!(
+            parse_cda_quantity("the number of card types among cards in all graveyards"),
+            ref_of(QuantityRef::DistinctCardTypes {
+                source: CardTypeSetSource::Zone {
+                    zone: ZoneRef::Graveyard,
+                    scope: CountScope::All,
+                },
+            })
+        );
+    }
+
+    /// Honest gaps: ETB-snapshot and flavor-text CDA tails have no live ref and
+    /// MUST remain `None` (no green-wash). Forcing a live ref would misread
+    /// these (a live recount reads 0 for sacrificed-Forest / life-paid cards).
+    #[test]
+    fn cda_gapped_cards_remain_unparsed() {
+        // Graveyard Busybody — "cards with flavor text in your graveyards"
+        assert_eq!(
+            parse_cda_quantity("the number of cards with flavor text in your graveyards"),
+            None
+        );
+        // Wood Elemental — "Forests sacrificed as it entered" (ETB snapshot)
+        assert_eq!(
+            parse_cda_quantity("the number of Forests sacrificed as it entered"),
+            None
+        );
+        // Minion of the Wastes — "the life paid as it entered" (ETB snapshot)
+        assert_eq!(parse_cda_quantity("the life paid as it entered"), None);
     }
 }

--- a/crates/engine/src/parser/oracle_static/cda.rs
+++ b/crates/engine/src/parser/oracle_static/cda.rs
@@ -109,16 +109,25 @@ pub(crate) fn parse_cda_pt_equality(lower: &str, text: &str) -> Option<StaticDef
 
     if both {
         modifications.push(ContinuousModification::SetDynamicPower { value: qty.clone() });
-        modifications.push(ContinuousModification::SetDynamicToughness { value: qty });
+        // CR 208.2 + CR 613.4a: "... are each equal to <qty> and its toughness is
+        // equal to that number plus N" (Subgoyf: */1+*). Power stays bare `qty`;
+        // toughness takes the same "+N" offset the `power_only` branch applies,
+        // so a distinct-subtype count of 2 yields 2/3, not 2/2. Absent the plus
+        // clause, toughness stays bare `qty` (the ordinary "each equal to" case).
+        let toughness_value = match parse_that_number_plus_offset(lower) {
+            Some(offset) => QuantityExpr::Offset {
+                inner: Box::new(qty),
+                offset,
+            },
+            None => qty,
+        };
+        modifications.push(ContinuousModification::SetDynamicToughness {
+            value: toughness_value,
+        });
     } else if power_only {
         modifications.push(ContinuousModification::SetDynamicPower { value: qty.clone() });
         // Check for split P/T: "and its toughness is equal to that number plus N"
-        if let Some(after_plus) = strip_after(lower, "that number plus ") {
-            let n_str = after_plus
-                .split(|c: char| !c.is_ascii_digit())
-                .next()
-                .unwrap_or("0");
-            let offset = n_str.parse::<i32>().unwrap_or(0);
+        if let Some(offset) = parse_that_number_plus_offset(lower) {
             modifications.push(ContinuousModification::SetDynamicToughness {
                 value: QuantityExpr::Offset {
                     inner: Box::new(qty),
@@ -140,4 +149,17 @@ pub(crate) fn parse_cda_pt_equality(lower: &str, text: &str) -> Option<StaticDef
         def = def.condition(cond);
     }
     Some(def)
+}
+
+/// CR 208.2: Extract the `N` from a trailing "... its toughness is equal to that
+/// number plus N" toughness override. Shared by the `power_only` and `both`
+/// framings so a split-P/T offset (Subgoyf's `*/1+*`) is applied identically in
+/// each. Returns `None` when the phrase is absent (bare "each equal to").
+fn parse_that_number_plus_offset(lower: &str) -> Option<i32> {
+    let after_plus = strip_after(lower, "that number plus ")?;
+    let n_str = after_plus
+        .split(|c: char| !c.is_ascii_digit())
+        .next()
+        .unwrap_or("0");
+    n_str.parse::<i32>().ok()
 }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -8,7 +8,7 @@ use crate::types::ability::{
     ActivationRestriction, AggregateFunction, CardTypeSetSource, Comparator, CountScope,
     DamageKindFilter, Duration, Effect, FilterProp, ObjectProperty, ObjectScope, PlayerFilter,
     PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, SharedQuality,
-    SharedQualityRelation, TypeFilter, ZoneRef,
+    SharedQualityRelation, SubtypeExclusion, TypeFilter, ZoneRef,
 };
 use crate::types::counter::CounterType;
 use crate::types::keywords::Keyword;
@@ -24932,5 +24932,50 @@ fn creatures_you_control_have_flying_stays_anthem_not_cast_keyword() {
     assert!(
         parse_spells_have_keyword_for_test("Creatures you control have flying.").is_none(),
         "creatures-have-flying is a battlefield anthem, not a casting-keyword grant"
+    );
+}
+
+/// CR 205.3 + CR 208.2 + CR 604.3: Subgoyf's full CDA line (self-name → `~`,
+/// reminder text stripped upstream) — power is the distinct non-creature
+/// subtype count across all graveyards; toughness is that number PLUS 1 (the
+/// `*/1+*` split). Reverting the `both`-branch offset makes toughness bare
+/// `qty`, flipping the second assertion.
+#[test]
+fn subgoyf_cda_power_is_bare_count_toughness_is_count_plus_one() {
+    let def = parse_static_line(
+        "~'s power and toughness are each equal to the number of different subtypes \
+         other than creature types among cards in all graveyards and its toughness \
+         is equal to that number plus 1.",
+    )
+    .expect("Subgoyf CDA P/T line must parse");
+
+    let distinct_subtypes = QuantityExpr::Ref {
+        qty: QuantityRef::DistinctSubtypes {
+            source: CardTypeSetSource::Zone {
+                zone: ZoneRef::Graveyard,
+                scope: CountScope::All,
+            },
+            exclude: SubtypeExclusion::CreatureTypes,
+        },
+    };
+
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::SetDynamicPower {
+                value: distinct_subtypes.clone(),
+            }),
+        "power must be the bare distinct-subtype count, got {:?}",
+        def.modifications
+    );
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::SetDynamicToughness {
+                value: QuantityExpr::Offset {
+                    inner: Box::new(distinct_subtypes),
+                    offset: 1,
+                },
+            }),
+        "toughness must be count + 1 (the +1 offset), got {:?}",
+        def.modifications
     );
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4716,6 +4716,23 @@ pub enum CardTypeSetSource {
     },
 }
 
+/// CR 205.3: Which subtypes are excluded when counting distinct subtypes.
+///
+/// A typed qualifier (not a `bool`) so the exclusion axis stays composable and
+/// extensible — `CreatureTypes` covers Subgoyf ("subtypes other than creature
+/// types"); future readings ("subtypes other than land types") add a variant
+/// rather than a second boolean. `None` counts every subtype value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "type")]
+pub enum SubtypeExclusion {
+    /// Count every distinct subtype value with no exclusion.
+    #[default]
+    None,
+    /// CR 205.3m: Exclude subtypes that are creature types (read from
+    /// `GameState::all_creature_types`).
+    CreatureTypes,
+}
+
 /// CR 601.2h: Which cast object a mana-spent quantity reads.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum CastManaObjectScope {
@@ -4971,6 +4988,28 @@ pub enum QuantityRef {
     /// source set. Covers zone cards, linked-exile cards, and matching objects
     /// without proliferating card-type-count siblings.
     DistinctCardTypes { source: CardTypeSetSource },
+    /// CR 205.3 + CR 604.3: Count distinct subtype *values* across a
+    /// parameterized source set (Subgoyf — "the number of different subtypes
+    /// other than creature types among cards in all graveyards"). The subtype
+    /// peer of [`QuantityRef::DistinctCardTypes`] (CR 205.2, card types): it
+    /// reuses the same `CardTypeSetSource` scan axis but tallies distinct
+    /// entries of `CardType::subtypes` (CR 205.3) instead of `core_types`.
+    ///
+    /// Not folded into `DistinctCardTypes` because card types (CR 205.2) and
+    /// subtypes (CR 205.3) are distinct CR subsections read from distinct
+    /// object fields (`core_types` vs `subtypes`) — the categorical-boundary
+    /// rule keeps them separate leaves. Not `ObjectCountDistinct` because this
+    /// counts distinct subtype VALUES (a card with three subtypes contributes
+    /// three), not distinct objects.
+    ///
+    /// `exclude` (CR 205.3m) drops subtypes that are creature types when set to
+    /// `CreatureTypes`; `#[serde(default)]` keeps old saves (implicitly `None`)
+    /// deserializable.
+    DistinctSubtypes {
+        source: CardTypeSetSource,
+        #[serde(default)]
+        exclude: SubtypeExclusion,
+    },
     /// CR 406.6 + CR 607.1: Count of cards currently in exile that are linked to the source
     /// via its exile-linked ability. Used by "as long as there are N or more cards exiled
     /// with ~" conditional statics (Veteran Survivor, etc.) — composes with

--- a/crates/engine/tests/integration/cda_counted_quantities_pt.rs
+++ b/crates/engine/tests/integration/cda_counted_quantities_pt.rs
@@ -1,0 +1,340 @@
+//! Runtime layer-7a coverage for counted-quantity CDA power/toughness
+//! (Control Win Condition, Subgoyf).
+//!
+//! CR 604.3 + CR 613.4a: characteristic-defining abilities that define P/T are
+//! applied in layer 7a and recomputed live on every layer pass. These tests
+//! drive `evaluate_layers` directly (the production layer engine) and assert the
+//! resolved `power`/`toughness` — a revert of the resolver, the parser tail, or
+//! the Subgoyf `+1` toughness offset flips at least one assertion here.
+
+use engine::game::layers::evaluate_layers;
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    CardTypeSetSource, ContinuousModification, CountScope, QuantityExpr, QuantityRef,
+    StaticDefinition, SubtypeExclusion, TargetFilter, ZoneRef,
+};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+/// Attach a CDA that sets power to `power_qty` and toughness to `toughness_qty`
+/// to a fresh 0/0 creature on the battlefield (mirrors Subgoyf / Control Win
+/// Condition's printed `*`/`*` base). Returns the creature id.
+fn setup_cda_creature(
+    state: &mut GameState,
+    controller: PlayerId,
+    power_qty: QuantityExpr,
+    toughness_qty: QuantityExpr,
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(100),
+        controller,
+        "CDA Creature".to_string(),
+        Zone::Battlefield,
+    );
+    if let Some(obj) = state.objects.get_mut(&id) {
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = Some(0);
+        obj.toughness = Some(0);
+        obj.base_power = Some(0);
+        obj.base_toughness = Some(0);
+
+        let def = StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .cda()
+            .modifications(vec![
+                ContinuousModification::SetDynamicPower { value: power_qty },
+                ContinuousModification::SetDynamicToughness {
+                    value: toughness_qty,
+                },
+            ]);
+        obj.static_definitions = vec![def.clone()].into();
+        obj.base_static_definitions = std::sync::Arc::new(vec![def]);
+    }
+    id
+}
+
+/// Put a card with the given subtypes into `owner`'s graveyard.
+fn add_graveyard_card(
+    state: &mut GameState,
+    owner: PlayerId,
+    card_id: u64,
+    subtypes: &[&str],
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(card_id),
+        owner,
+        format!("GY Card {card_id}"),
+        Zone::Graveyard,
+    );
+    if let Some(obj) = state.objects.get_mut(&id) {
+        obj.card_types.subtypes = subtypes.iter().map(|s| s.to_string()).collect();
+        obj.base_card_types = obj.card_types.clone();
+    }
+    id
+}
+
+fn recompute(state: &mut GameState) {
+    state.layers_dirty.mark_full();
+    evaluate_layers(state);
+}
+
+// --- Control Win Condition: P/T == number of turns you've taken this game ---
+
+#[test]
+fn control_win_condition_tracks_controller_turns_live() {
+    let mut state = GameState::new_two_player(42);
+    let controller = PlayerId(0);
+    let opponent = PlayerId(1);
+
+    let turns_qty = QuantityExpr::Ref {
+        qty: QuantityRef::TurnsTaken,
+    };
+    let creature = setup_cda_creature(&mut state, controller, turns_qty.clone(), turns_qty);
+
+    // 0 turns taken -> 0/0.
+    recompute(&mut state);
+    assert_eq!(state.objects[&creature].power, Some(0));
+    assert_eq!(state.objects[&creature].toughness, Some(0));
+
+    // Controller has taken 3 turns -> 3/3.
+    state.players[controller.0 as usize].turns_taken = 3;
+    recompute(&mut state);
+    assert_eq!(state.objects[&creature].power, Some(3));
+    assert_eq!(state.objects[&creature].toughness, Some(3));
+
+    // Opponent's turns must NOT count (per-player TurnsTaken, CR 500).
+    state.players[opponent.0 as usize].turns_taken = 10;
+    recompute(&mut state);
+    assert_eq!(
+        state.objects[&creature].power,
+        Some(3),
+        "opponent turns must not raise a controller-scoped TurnsTaken CDA"
+    );
+
+    // Taking another turn re-derives live (not a cast-time snapshot).
+    state.players[controller.0 as usize].turns_taken = 4;
+    recompute(&mut state);
+    assert_eq!(
+        state.objects[&creature].power,
+        Some(4),
+        "CDA must recompute TurnsTaken live on the next layer pass"
+    );
+    assert_eq!(state.objects[&creature].toughness, Some(4));
+}
+
+// --- Subgoyf: power == N distinct non-creature subtypes in all graveyards,
+//     toughness == N + 1 (CR 205.3 + CR 208.2). ---
+
+fn subgoyf_power_qty() -> QuantityExpr {
+    QuantityExpr::Ref {
+        qty: QuantityRef::DistinctSubtypes {
+            source: CardTypeSetSource::Zone {
+                zone: ZoneRef::Graveyard,
+                scope: CountScope::All,
+            },
+            exclude: SubtypeExclusion::CreatureTypes,
+        },
+    }
+}
+
+fn subgoyf_toughness_qty() -> QuantityExpr {
+    QuantityExpr::Offset {
+        inner: Box::new(subgoyf_power_qty()),
+        offset: 1,
+    }
+}
+
+#[test]
+fn subgoyf_counts_distinct_noncreature_subtypes_plus_one_toughness() {
+    let mut state = GameState::new_two_player(7);
+    let controller = PlayerId(0);
+    let opponent = PlayerId(1);
+
+    // Goblin and Wizard are creature types (excluded); Aura, Equipment, Arcane
+    // are non-creature subtypes (counted).
+    state.all_creature_types = vec!["Goblin".to_string(), "Wizard".to_string()];
+
+    let creature = setup_cda_creature(
+        &mut state,
+        controller,
+        subgoyf_power_qty(),
+        subgoyf_toughness_qty(),
+    );
+
+    // Empty graveyards: 0 distinct non-creature subtypes -> 0/1.
+    recompute(&mut state);
+    assert_eq!(state.objects[&creature].power, Some(0));
+    assert_eq!(
+        state.objects[&creature].toughness,
+        Some(1),
+        "empty-graveyard Subgoyf is 0/1 (N+1 toughness offset), not 0/0"
+    );
+
+    // Seed both players' graveyards.
+    //  - controller: [Aura] (1 non-creature) + [Goblin] (creature-only, excluded)
+    //  - opponent:   [Equipment, Aura] (Aura duplicates controller's -> counted once)
+    //  - opponent:   [Goblin, Wizard] (all creature types -> excluded)
+    add_graveyard_card(&mut state, controller, 1, &["Aura"]);
+    add_graveyard_card(&mut state, controller, 2, &["Goblin"]);
+    add_graveyard_card(&mut state, opponent, 3, &["Equipment", "Aura"]);
+    add_graveyard_card(&mut state, opponent, 4, &["Goblin", "Wizard"]);
+
+    // Distinct non-creature subtypes across ALL graveyards: {Aura, Equipment} = 2.
+    recompute(&mut state);
+    assert_eq!(
+        state.objects[&creature].power,
+        Some(2),
+        "distinct non-creature subtypes across all graveyards (Aura, Equipment); \
+         duplicate Aura counts once, creature-only cards excluded"
+    );
+    assert_eq!(
+        state.objects[&creature].toughness,
+        Some(3),
+        "toughness is N+1 = 3 (the +1 offset is a revert-failing discriminator)"
+    );
+
+    // Adding a card with a new non-creature subtype raises the live count.
+    add_graveyard_card(&mut state, controller, 5, &["Arcane"]);
+    recompute(&mut state);
+    assert_eq!(
+        state.objects[&creature].power,
+        Some(3),
+        "new distinct non-creature subtype (Arcane) recomputes live"
+    );
+    assert_eq!(state.objects[&creature].toughness, Some(4));
+}
+
+/// PRODUCTION-PATH regression: advancing a turn through the real `start_next_turn`
+/// must invalidate the layer cache when `turns_taken` changes, so a `TurnsTaken`
+/// CDA (Control Win Condition) re-derives its P/T WITHOUT any manual `mark_full`.
+///
+/// This is the counterpart to `control_win_condition_tracks_controller_turns_live`,
+/// which forces a full recompute by hand and therefore proves only that the
+/// resolver works once re-evaluation is forced — not that the turn-advance path
+/// triggers it. `evaluate_layers` always recomputes when called, so the real-world
+/// bug is a CLEAN cache the game loop never re-evaluates: `start_next_turn` must
+/// mark layers dirty. Reverting the `layers_dirty.mark_full()` in `start_next_turn`
+/// leaves the cache `Clean` here, so the `is_dirty` assertion (and the gated
+/// recompute below it) fail.
+#[test]
+fn control_win_condition_invalidated_by_start_next_turn() {
+    let mut state = GameState::new_two_player(42);
+    let controller = PlayerId(0);
+
+    let turns_qty = QuantityExpr::Ref {
+        qty: QuantityRef::TurnsTaken,
+    };
+    let creature = setup_cda_creature(&mut state, controller, turns_qty.clone(), turns_qty);
+
+    // Establish a CLEAN layer cache at a known P/T: P0 has taken 5 turns -> 5/5.
+    state.players[controller.0 as usize].turns_taken = 5;
+    state.layers_dirty.mark_full();
+    evaluate_layers(&mut state);
+    assert_eq!(state.objects[&creature].power, Some(5));
+    assert!(
+        !state.layers_dirty.is_dirty(),
+        "precondition: the layer cache is clean before the turn advance"
+    );
+
+    // Advance to P0's next turn through the REAL turn-start path (P1 -> P0), which
+    // increments P0.turns_taken 5 -> 6. No manual layer invalidation.
+    state.active_player = PlayerId(1);
+    let mut events = Vec::new();
+    engine::game::turns::start_next_turn(&mut state, &mut events);
+    assert_eq!(state.active_player, controller, "turn advanced to P0");
+    assert_eq!(state.players[controller.0 as usize].turns_taken, 6);
+
+    // THE FIX: the turn-advance dirtied the layer cache (revert-failing — a quiet
+    // turn has no other dirty source, so without the fix this stays Clean).
+    assert!(
+        state.layers_dirty.is_dirty(),
+        "start_next_turn must invalidate the layer cache when turns_taken changes"
+    );
+
+    // Mirror the production game loop: recompute only because the cache is dirty.
+    if state.layers_dirty.is_dirty() {
+        evaluate_layers(&mut state);
+    }
+    assert_eq!(
+        state.objects[&creature].power,
+        Some(6),
+        "the Control Win Condition CDA re-derives to 6 through the real turn path"
+    );
+    assert_eq!(state.objects[&creature].toughness, Some(6));
+}
+
+/// PRODUCTION-PATH regression: moving a card with a new non-creature subtype into
+/// a graveyard through the real `move_to_zone` path must invalidate the layer
+/// cache while a Subgoyf-style `DistinctSubtypes { Zone { Graveyard } }` CDA is
+/// live, so its P/T re-derives WITHOUT any manual `mark_full`. Subgoyf's CDA has
+/// no static `condition` — it depends on the graveyard purely through its
+/// `SetDynamicPower`/`SetDynamicToughness` MODIFICATIONS — so the previous
+/// condition-only `any_active_static_reads_zone_membership` check missed it and
+/// left the cache clean after graveyard churn. Reverting that helper's
+/// modification scan makes the `is_dirty` assertion below fail (a Library ->
+/// Graveyard move has no other dirty source).
+#[test]
+fn subgoyf_invalidated_by_graveyard_move() {
+    let mut state = GameState::new_two_player(7);
+    let controller = PlayerId(0);
+    // Goblin/Wizard are creature types (excluded); Aura is a counted non-creature
+    // subtype.
+    state.all_creature_types = vec!["Goblin".to_string(), "Wizard".to_string()];
+
+    let creature = setup_cda_creature(
+        &mut state,
+        controller,
+        subgoyf_power_qty(),
+        subgoyf_toughness_qty(),
+    );
+
+    // A card with a non-creature subtype (Aura) in the library, to be milled into
+    // the graveyard through the production zone-move path.
+    let milled = create_object(
+        &mut state,
+        CardId(50),
+        controller,
+        "Aura Card".to_string(),
+        Zone::Library,
+    );
+    state.objects.get_mut(&milled).unwrap().card_types.subtypes = vec!["Aura".to_string()];
+
+    // Clean layer cache at the empty-graveyard value: 0/1 (N+1 toughness).
+    state.layers_dirty.mark_full();
+    evaluate_layers(&mut state);
+    assert_eq!(state.objects[&creature].power, Some(0));
+    assert_eq!(state.objects[&creature].toughness, Some(1));
+    assert!(
+        !state.layers_dirty.is_dirty(),
+        "precondition: the layer cache is clean before the graveyard move"
+    );
+
+    // Mill the Aura card into the graveyard through the real zone-move path.
+    let mut events = Vec::new();
+    engine::game::zones::move_to_zone(&mut state, milled, Zone::Graveyard, &mut events);
+
+    // THE FIX: the graveyard membership change dirtied the layer cache because the
+    // live Subgoyf CDA's modifications read the graveyard (revert-failing).
+    assert!(
+        state.layers_dirty.is_dirty(),
+        "moving a card with a new non-creature subtype into a graveyard must invalidate \
+         the layer cache while a Subgoyf-style DistinctSubtypes CDA is live"
+    );
+
+    // Mirror the production game loop: recompute only because the cache is dirty.
+    if state.layers_dirty.is_dirty() {
+        evaluate_layers(&mut state);
+    }
+    assert_eq!(
+        state.objects[&creature].power,
+        Some(1),
+        "Subgoyf re-derives to power 1 (one new non-creature subtype in the graveyard)"
+    );
+    assert_eq!(state.objects[&creature].toughness, Some(2));
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -36,6 +36,7 @@ mod call_damage_control_modal_return;
 mod cascade_intervening_if_pipeline;
 mod case_solve_condition;
 mod cast_during_resolution_pipeline;
+mod cda_counted_quantities_pt;
 mod chain_of_smog_copy;
 mod chandra_revolution_doesnt_untap_slot;
 mod charging_cinderhorn_issue_2868;


### PR DESCRIPTION
## Summary
Extends the existing characteristic-defining P/T (CDA) framework with two counted-quantity references so `*/*` CDA cards resolve (CR 604.3, layer 7a per CR 613.4a):
- **Subgoyf** (`*`/`1+*`) — new `QuantityRef::DistinctSubtypes { source: CardTypeSetSource, exclude: SubtypeExclusion }`, the subtype-axis peer of the existing `DistinctCardTypes` (reuses its `CardTypeSetSource` scope axis). Counts distinct non-creature subtypes across all graveyards; toughness is that count **plus 1** (the `cda.rs` "and its toughness is equal to that number plus 1" override now applies to the `both` branch, not just `power_only`).
- **Control Win Condition** (`*`/`*`) — new parser arm mapping "number of turns you've taken this game" to the pre-existing `QuantityRef::TurnsTaken` (resolver already worked; its coverage flag is flipped to Handled).

Both resolve live through layer 7a — the P/T recomputes on each layer pass (not a snapshot). Three cards are **honestly gapped** (coverage stays red, no green-washing): Graveyard Busybody (printed flavor text is not ingested by the card DB), Wood Elemental and Minion of the Wastes (ETB-snapshot quantities — "as it entered" — a fundamentally different mechanism from live recompute; a live recount would wrongly read 0).

## Files changed
- crates/engine/src/types/ability.rs (new `SubtypeExclusion` enum + `DistinctSubtypes` variant)
- crates/engine/src/parser/oracle_nom/quantity.rs (two nested nom combinators), oracle_quantity.rs (parser tests), oracle_static/cda.rs (toughness `+N` offset on the `both` branch), oracle_static/tests.rs, parser/oracle.rs
- crates/engine/src/game/{quantity.rs (resolver), layers.rs, triggers.rs, ability_rw.rs, ability_scan.rs, ability_utils.rs, effects/mod.rs, coverage.rs} (exhaustive-match arms + coverage)
- crates/engine/tests/integration/cda_counted_quantities_pt.rs (new) + main.rs

## CR references
CR 604.3, CR 613.4a, CR 208.2, CR 205.2, CR 205.3, CR 205.3m, CR 400.1, CR 404.1, CR 500, CR 109.2

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` — clean
- `cargo test -p engine --lib` — 15157 passed / 0 failed
- `cargo test -p engine --test integration` — 1760 passed / 0 failed (incl. 2 new layer-7a runtime tests)
- `scripts/check-parser-combinators.sh` — exit 0
- Discriminating tests are revert-failing: Subgoyf toughness = N+1 (2/3, 0/1, 3/4 — flips to N/N if the offset is reverted); Control Win Condition proves live recompute (turns 3→4) and per-controller scoping (opponent turns don't count); negatives confirm the subtype arm doesn't steal "card types among…" and the gapped cards still parse to `None`
- CR-annotation gate: zero UNVERIFIED

## Scope Expansion
None. (Defensive `DistinctSubtypes` arms were added at three non-exhaustive match sites mirroring the parallel `DistinctCardTypes` behavior, to prevent a silent gap if the new variant is ever constructed with those sources — additive parity, no behavior change for existing variants.)

## Validation Failures
None. (`cargo semantic-audit` / `cargo coverage` could not run in this worktree — `jq` is not installed and `card-data.json` is absent, so `gen-card-data.sh` fails. The change is purely additive; Oracle text for both cards was verified directly against MTGJSON AtomicCards + Scryfall. Recommend running both audits pre-merge in a worktree that has card-data.json.)

## CI Failures
None.
