### PR TITLE
fix: redact nested draftSessionJson secrets in P2P backup snapshots

### DIFF
--- a/crates/server-core/src/p2p_backup_guard.rs
+++ b/crates/server-core/src/p2p_backup_guard.rs
@@ -19,6 +19,11 @@
 //! be persisted or echoed on the unauthenticated HTTP backup surface — the host
 //! keeps credentials in local IndexedDB; the server backup is for draft progress
 //! recovery only.
+//!
+//! The host also embeds a full `draftSessionJson` blob (exported `DraftSession`).
+//! That nested payload can carry `config.rng_seed` and unopened `packs_by_seat`,
+//! which must be stripped before SQLite persistence or `GET` echo — merged #5053
+//! only removed top-level seat tokens.
 
 use lobby_broker::validation::{validate_token, MAX_TOKEN_LEN};
 use serde_json::{Map, Value};
@@ -55,11 +60,17 @@ pub fn guard_p2p_backup(host_peer_id: &str, snapshot_json: &str) -> Result<(), S
 /// HTTP response. These are session credentials, not recoverable draft state.
 const P2P_BACKUP_SECRET_KEYS: &[&str] = &["seatTokens", "kickedTokens"];
 
+/// Host snapshot field carrying a serialized [`draft_core::types::DraftSession`].
+const DRAFT_SESSION_JSON_KEY: &str = "draftSessionJson";
+
+/// Nested draft session fields that must not be stored or echoed on the backup API.
+const NESTED_DRAFT_SECRET_KEYS: &[&str] = &["packs_by_seat"];
+
 /// Remove session credentials from a host backup snapshot JSON blob.
 ///
 /// The backup row is keyed only by the 6-character draft code and is readable by
 /// any caller of `GET /p2p-draft-backup/{code}`, so stored snapshots must not
-/// contain per-seat tokens.
+/// contain per-seat tokens or competitive secrets embedded in `draftSessionJson`.
 pub fn redact_p2p_backup_snapshot_secrets(snapshot_json: &str) -> Result<String, String> {
     let mut value: Value = serde_json::from_str(snapshot_json)
         .map_err(|_| "snapshot_json must be a JSON object".to_string())?;
@@ -73,6 +84,36 @@ pub fn redact_p2p_backup_snapshot_secrets(snapshot_json: &str) -> Result<String,
 fn redact_secret_keys(obj: &mut Map<String, Value>) {
     for key in P2P_BACKUP_SECRET_KEYS {
         obj.remove(*key);
+    }
+    redact_nested_draft_session_json(obj);
+}
+
+fn redact_nested_draft_session_json(obj: &mut Map<String, Value>) {
+    let Some(Value::String(nested_raw)) = obj.get(DRAFT_SESSION_JSON_KEY) else {
+        return;
+    };
+    let nested_raw = nested_raw.clone();
+    let Ok(mut nested) = serde_json::from_str::<Value>(&nested_raw) else {
+        return;
+    };
+    let Some(nested_obj) = nested.as_object_mut() else {
+        return;
+    };
+    redact_draft_session_object(nested_obj);
+    if let Ok(serialized) = serde_json::to_string(&nested) {
+        obj.insert(
+            DRAFT_SESSION_JSON_KEY.to_string(),
+            Value::String(serialized),
+        );
+    }
+}
+
+fn redact_draft_session_object(session: &mut Map<String, Value>) {
+    for key in NESTED_DRAFT_SECRET_KEYS {
+        session.remove(*key);
+    }
+    if let Some(Value::Object(config)) = session.get_mut("config") {
+        config.insert("rng_seed".to_string(), Value::Number(0.into()));
     }
 }
 
@@ -160,6 +201,31 @@ mod tests {
         assert!(parsed.get("kickedTokens").is_none());
         assert_eq!(parsed["draftCode"], "ABC123");
         assert_eq!(parsed["draftStarted"], true);
+    }
+
+    #[test]
+    fn redact_p2p_backup_snapshot_secrets_strips_nested_draft_session_secrets() {
+        let nested = serde_json::json!({
+            "draft_code": "ABC123",
+            "config": { "rng_seed": 42, "pod_size": 8 },
+            "packs_by_seat": [[{"card_id": "secret-pack"}]],
+            "status": "Drafting"
+        });
+        let raw = serde_json::json!({
+            "draftCode": "ABC123",
+            "draftSessionJson": nested.to_string(),
+            "seatTokens": { "0": "host-secret" },
+            "draftStarted": true
+        });
+        let redacted =
+            redact_p2p_backup_snapshot_secrets(&raw.to_string()).expect("valid snapshot");
+        let parsed: Value = serde_json::from_str(&redacted).unwrap();
+        assert!(parsed.get("seatTokens").is_none());
+        let nested_out: Value =
+            serde_json::from_str(parsed["draftSessionJson"].as_str().unwrap()).unwrap();
+        assert_eq!(nested_out["config"]["rng_seed"], 0);
+        assert!(nested_out.get("packs_by_seat").is_none());
+        assert_eq!(nested_out["status"], "Drafting");
     }
 
     #[test]

--- a/crates/server-core/src/p2p_backup_guard.rs
+++ b/crates/server-core/src/p2p_backup_guard.rs
@@ -89,11 +89,10 @@ fn redact_secret_keys(obj: &mut Map<String, Value>) {
 }
 
 fn redact_nested_draft_session_json(obj: &mut Map<String, Value>) {
-    let Some(Value::String(nested_raw)) = obj.get(DRAFT_SESSION_JSON_KEY) else {
+    let Some(nested_raw) = obj.get(DRAFT_SESSION_JSON_KEY).and_then(|v| v.as_str()) else {
         return;
     };
-    let nested_raw = nested_raw.clone();
-    let Ok(mut nested) = serde_json::from_str::<Value>(&nested_raw) else {
+    let Ok(mut nested) = serde_json::from_str::<Value>(nested_raw) else {
         return;
     };
     let Some(nested_obj) = nested.as_object_mut() else {


### PR DESCRIPTION
## Summary

Extends `redact_p2p_backup_snapshot_secrets` so nested `draftSessionJson` (serialized `DraftSession`) is stripped of competitive secrets before SQLite persistence and unauthenticated `GET /p2p-draft-backup/{code}` echo. #5053 only removed top-level `seatTokens`/`kickedTokens`; nested `config.rng_seed` and `packs_by_seat` still leaked.

## Files changed

- `crates/server-core/src/p2p_backup_guard.rs` — nested `draftSessionJson` parse/redact/rewrite; unit test

## CR references

None (server-core backup redaction boundary, not engine/parser rules).

## Track

Non-developer

## LLM

Model: claude-sonnet-4-6
Thinking: high

Tier: Standard

## Gate A

```
$ ./scripts/check-parser-combinators.sh
(no parser diff — gate clean, exit 0)
```

## Anchored on

- `crates/server-core/src/p2p_backup_guard.rs:56` — existing `P2P_BACKUP_SECRET_KEYS` top-level key removal in `redact_secret_keys`
- `crates/server-core/src/p2p_backup_guard.rs:63` — existing `redact_p2p_backup_snapshot_secrets` parse → mutate object → re-serialize seam used before persistence/GET echo

## Implementation method (required)

- [x] **Not** `/engine-implementer` — server-core P2P backup redaction only; no `crates/engine/` parser or rules behavior changes.

> Security fix on the unauthenticated HTTP backup surface. Extends the existing `redact_p2p_backup_snapshot_secrets` helper rather than adding a parallel redaction path.

## Verification

**Head:** `bedf56e1f83279c66e306a6d6e29a61f72fda15d`

**CI workflow run (head `bedf56e1f`):** https://github.com/phase-rs/phase/actions/runs/28737292057

| Check | Result | Job link |
|-------|--------|----------|
| Rust lint (fmt, clippy, parser gate) | pass | https://github.com/phase-rs/phase/actions/runs/28737292057/job/85213662697 |
| Rust tests (shard 1/2) | pass | https://github.com/phase-rs/phase/actions/runs/28737292057/job/85213662689 |
| Rust tests (shard 2/2) | pass | https://github.com/phase-rs/phase/actions/runs/28737292057/job/85213662686 |
| Rust (fmt, clippy, test, coverage-gate) | pass | https://github.com/phase-rs/phase/actions/runs/28737292057/job/85214628208 |
| Frontend (lint, type-check, test) | pass | https://github.com/phase-rs/phase/actions/runs/28737292057/job/85213662688 |
| WASM compile check | pass | https://github.com/phase-rs/phase/actions/runs/28737292057/job/85213662694 |
| Tauri compile check | pass | https://github.com/phase-rs/phase/actions/runs/28737292057/job/85213662692 |
| Card data (generate, validate, coverage) | pass | https://github.com/phase-rs/phase/actions/runs/28737292057/job/85213662690 |
| Lobby worker (pnpm test) | pass | https://github.com/phase-rs/phase/actions/runs/28737292057/job/85213662691 |

The nested-redaction unit test runs in the Rust test shards above (`server-core::p2p_backup_guard` — `redact_p2p_backup_snapshot_secrets_strips_nested_draft_session_secrets`).

**Unit test assertions** (would fail if nested redaction were removed):

Input: top-level `seatTokens` + nested `draftSessionJson` with `config.rng_seed = 42`, `packs_by_seat = [[{card_id: secret-pack}]]`, `status = Drafting`.

After `redact_p2p_backup_snapshot_secrets`:

1. top-level `seatTokens` removed
2. nested `config.rng_seed` == `0`
3. nested `packs_by_seat` absent
4. nested `status` still `Drafting`

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.
