### PR TITLE
feat(parser): "Lands you control are the chosen type in addition to their other types" (Realmwright)

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -523,6 +523,11 @@ pub(crate) fn parse_static_line_inner(
     if let Some(def) = parse_arcane_adaptation_chosen_type_static(&tp, &text) {
         return Some(def);
     }
+    // CR 305.6 + CR 607.2d: land-axis counterpart — "Lands you control are the
+    // chosen type in addition to their other types" (Realmwright).
+    if let Some(def) = parse_chosen_land_type_static(&tp, &text) {
+        return Some(def);
+    }
     // CR 514.2: "Damage isn't removed from [subject] during cleanup steps."
     if let Some(def) = parse_damage_not_removed_during_cleanup(&tp, &text) {
         return Some(def);

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -16729,6 +16729,55 @@ fn parse_arcane_adaptation_adds_chosen_creature_type() {
     );
 }
 
+// CR 305.6 + CR 205.1b: land-axis counterpart of Arcane Adaptation. Realmwright's
+// "Lands you control are the chosen type in addition to their other types" adds the
+// chosen BASIC LAND TYPE additively (single AddChosenSubtype{BasicLandType}, no
+// wipe) to lands the source's controller controls — mirroring the creature path's
+// AddChosenSubtype{CreatureType}.
+#[test]
+fn parse_chosen_land_type_adds_chosen_basic_land_type() {
+    let def = parse_static_line(
+        "Lands you control are the chosen type in addition to their other types.",
+    )
+    .unwrap();
+    assert_eq!(
+        &def.modifications,
+        &vec![ContinuousModification::AddChosenSubtype {
+            kind: ChosenSubtypeKind::BasicLandType,
+        }],
+        "additive land form must be a single AddChosenSubtype{{BasicLandType}}: {:?}",
+        def.modifications
+    );
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(
+                tf.controller,
+                Some(ControllerRef::You),
+                "affected must be you-control: {tf:?}"
+            );
+            assert!(
+                tf.type_filters
+                    .iter()
+                    .any(|t| matches!(t, TypeFilter::Land)),
+                "affected must be lands (not creatures): {tf:?}"
+            );
+        }
+        other => panic!("expected Typed land filter, got {other:?}"),
+    }
+    // The bare-creature form must NOT be claimed by the land handler.
+    assert!(
+        parse_static_line(
+            "Creatures you control are the chosen type in addition to their other types."
+        )
+        .unwrap()
+        .modifications
+        .contains(&ContinuousModification::AddChosenSubtype {
+            kind: ChosenSubtypeKind::CreatureType,
+        }),
+        "creature form must still route to the creature-type handler"
+    );
+}
+
 // CR 205.1a + CR 607.2d: full Conspiracy oracle. The battlefield SET static must be
 // present (composed RemoveAllSubtypes + AddChosenSubtype) AND the non-battlefield
 // "the same is true for ..." tail must surface as an Unimplemented residual (the

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -147,6 +147,49 @@ pub(crate) fn parse_arcane_adaptation_chosen_type_static(
     )
 }
 
+/// CR 305.6 + CR 607.2d + CR 613.1d (Layer 4): "Lands you control are the chosen
+/// [land] type in addition to their other types" — the basic-land-type axis
+/// sibling of [`parse_arcane_adaptation_chosen_type_static`] (which parameterizes
+/// the CR 205.3g creature-subtype axis). Realmwright ("As ~ enters, choose a
+/// basic land type. Lands you control are the chosen type in addition to their
+/// other types.") is the type specimen. Additive only (CR 205.1b): the chosen
+/// basic land type is added while each affected land RETAINS its existing
+/// subtypes. Reuses the existing `AddChosenSubtype { kind: BasicLandType }`
+/// runtime (game/layers.rs), the land-axis counterpart of the creature path's
+/// `kind: CreatureType` — no new variant, no new runtime.
+pub(crate) fn parse_chosen_land_type_static(
+    tp: &TextPair<'_>,
+    description: &str,
+) -> Option<StaticDefinition> {
+    nom_on_lower(
+        tp.original,
+        tp.lower,
+        parse_chosen_land_type_static_sentence,
+    )?;
+    Some(
+        StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(
+                TypedFilter::land().controller(ControllerRef::You),
+            ))
+            .modifications(vec![ContinuousModification::AddChosenSubtype {
+                kind: ChosenSubtypeKind::BasicLandType,
+            }])
+            .description(description.to_string()),
+    )
+}
+
+/// nom body for [`parse_chosen_land_type_static`]: "lands you control are the
+/// chosen [land ]type in addition to their other types[.]", consumed to `eof`
+/// so a partial prefix can never mis-claim a longer line.
+fn parse_chosen_land_type_static_sentence(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = tag("lands you control are the chosen ").parse(input)?;
+    let (input, _) = opt(tag("land ")).parse(input)?;
+    let (input, _) = tag("type in addition to their other types").parse(input)?;
+    let (input, _) = opt(tag(".")).parse(input)?;
+    eof.parse(input)?;
+    Ok((input, ()))
+}
+
 fn parse_chosen_creature_type_static_sentence_with_scope(
     input: &str,
 ) -> OracleResult<'_, (ChosenCreatureTypeStaticScope, ChosenCreatureTypeApplication)> {


### PR DESCRIPTION
Realmwright ("As ~ enters, choose a basic land type. Lands you control are the chosen type in addition to their other types.") produced **no static** — the existing chosen-type-in-addition handler `parse_arcane_adaptation_chosen_type_static` covers only the **creature-subtype** axis (Creatures / Vehicle you control).

This adds the **basic-land-type axis sibling** `parse_chosen_land_type_static` in `oracle_static/type_change.rs`, emitting the existing `AddChosenSubtype { kind: BasicLandType }` runtime (already applied in `game/layers.rs`) scoped to lands you control. Additive only (CR 205.1b): each land retains its existing subtypes.

**No new variant, no new runtime** — the land axis mirrors the creature path's `kind: CreatureType`. Per the categorical-boundary rule, basic land types (CR 305.6) are a distinct CR section from creature subtypes (CR 205.3g), so a sibling handler is the correct shape rather than parameterizing the creature-specific scope enum.

CR 305.6 (basic land types) + CR 607.2d (chosen link) + CR 613.1d (Layer 4) + CR 205.1b (in-addition retain) — all verified against `docs/MagicCompRules.txt`.

Verified: new `parse_chosen_land_type_adds_chosen_basic_land_type` test (asserts `AddChosenSubtype{BasicLandType}` on lands-you-control, and that the creature form still routes to the creature handler); full `chosen_type` suite 35/35 green; parser-combinator gate + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)