### PR TITLE
feat(parser): attached-permanent type SWAP "isn't a X and is a Y in addition to its other types" (Luxior)

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1055,6 +1055,16 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
+    // CR 613.1d (Layer 4) + CR 205.1b: "[Enchanted|Equipped] <subject> isn't a
+    // <type> and is a <type> in addition to its other types" — attached-permanent
+    // type SWAP (Luxior: equipped planeswalker loses Planeswalker, gains
+    // Creature). Placed after `parse_enchanted_is_type` (whose "is a" copula
+    // parse rejects the "isn't a ..." lead) and before the generic
+    // enchanted/equipped predicate arms so the type-removal clause is preserved.
+    if let Some(def) = parse_attached_isnt_and_is_type(&tp, &text) {
+        return Some(def);
+    }
+
     // --- "Enchanted creature gets +N/+M" or "has {keyword}" ---
     if let Some(rest) = nom_tag_tp(&tp, "enchanted creature ") {
         let filter =

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -713,6 +713,16 @@ pub(crate) fn attached_subject_filter<'a>(tp: &TextPair<'a>) -> Option<(TargetFi
             rest.original,
         ));
     }
+    // An Equipment that can attach to a non-creature permanent (e.g. Luxior,
+    // Giada's Gift equips a planeswalker) addresses the "equipped permanent" —
+    // the widest attached-Equipment subject. Mirrors the "enchanted permanent"
+    // arm above with `EquippedBy`.
+    if let Some(rest) = nom_tag_tp(tp, "equipped permanent ") {
+        return Some((
+            TargetFilter::Typed(TypedFilter::permanent().properties(vec![FilterProp::EquippedBy])),
+            rest.original,
+        ));
+    }
     None
 }
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5677,6 +5677,41 @@ fn static_type_removal_with_nondevotion_condition() {
     assert!(def.condition.is_some(), "condition must be extracted");
 }
 
+// CR 613.1d (Layer 4) + CR 205.1b/205.2: Luxior — attached-permanent type SWAP.
+// "Equipped permanent isn't a planeswalker and is a creature in addition to its
+// other types" (Luxior, Giada's Gift; Luxior and Shadowspear) removes the
+// Planeswalker card type (RemoveType) and additively grants Creature (AddType),
+// scoped to the equipped permanent — turning an equipped planeswalker into a
+// creature while it keeps its other types.
+#[test]
+fn parse_luxior_equipped_permanent_type_swap() {
+    let def = parse_static_line(
+        "Equipped permanent isn't a planeswalker and is a creature in addition to its other types.",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(
+        def.modifications,
+        vec![
+            ContinuousModification::RemoveType {
+                core_type: CoreType::Planeswalker,
+            },
+            ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            },
+        ],
+        "must remove Planeswalker then additively add Creature: {:?}",
+        def.modifications
+    );
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => assert!(
+            tf.properties.contains(&FilterProp::EquippedBy),
+            "affected must be the equipped permanent: {tf:?}"
+        ),
+        other => panic!("expected Typed EquippedBy filter, got {other:?}"),
+    }
+}
+
 #[test]
 fn static_can_attack_despite_defender_self_unconditional() {
     // CR 702.3b: bare ~ subject, no condition.

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -887,6 +887,98 @@ pub(crate) fn parse_enchanted_is_type(
     None
 }
 
+/// CR 613.1d (Layer 4) + CR 205.1b + CR 205.2: Parse an attached-permanent
+/// type-SWAP static of the form
+/// "[Enchanted|Equipped] <subject> isn't a[n] <core type> and is a[n] <core
+/// type> in addition to its other types."
+///
+/// Luxior, Giada's Gift and Luxior and Shadowspear are the type specimens
+/// ("Equipped permanent isn't a planeswalker and is a creature in addition to
+/// its other types."): the Equipment removes the equipped permanent's
+/// Planeswalker card type while adding the Creature card type, turning an
+/// equipped planeswalker into a creature. The two clauses decompose into two
+/// independent Layer-4 modifications. The "isn't a[n] <T>" clause becomes
+/// `RemoveType { core_type: <T> }` (CR 613.1d type removal — the permanent loses
+/// the named card type). The "is a[n] <T> in addition to its other types" clause
+/// becomes `AddType { core_type: <T> }` (CR 205.1b / CR 205.2 additive grant —
+/// the permanent keeps its other card types and gains <T>).
+///
+/// Both reuse the existing `RemoveType` / `AddType` runtime (`game/layers.rs`)
+/// applied at Layer 4 — no new engine variant, no new runtime. The subject is
+/// the shared `attached_subject_filter` building block (Enchanted/Equipped
+/// creature/permanent/land), extended here to accept the "equipped permanent"
+/// prefix that Equipment reconfigured onto a non-creature permanent needs. The
+/// body is consumed to `eof`, so a partial prefix can never mis-claim a longer
+/// or differently-shaped line.
+pub(crate) fn parse_attached_isnt_and_is_type(
+    tp: &TextPair<'_>,
+    description: &str,
+) -> Option<StaticDefinition> {
+    let (affected, predicate) = parse_attached_type_change_subject(tp)?;
+    let predicate_lower = predicate.trim().to_lowercase();
+    let (_, modifications) = parse_isnt_and_is_additive_type_body(&predicate_lower).ok()?;
+    Some(
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(modifications)
+            .description(description.to_string()),
+    )
+}
+
+/// Resolve the attached subject of [`parse_attached_isnt_and_is_type`] into its
+/// `EnchantedBy` / `EquippedBy` `TargetFilter`, returning the original-cased
+/// predicate remainder. Delegates the Aura/Equipment subjects the shared
+/// `attached_subject_filter` already recognizes (enchanted creature/permanent/
+/// land, equipped creature) and adds the "equipped permanent" prefix that a
+/// reconfigured Equipment attached to a non-creature permanent uses (Luxior).
+fn parse_attached_type_change_subject<'a>(tp: &TextPair<'a>) -> Option<(TargetFilter, &'a str)> {
+    if let Some(result) = attached_subject_filter(tp) {
+        return Some(result);
+    }
+    let rest = nom_tag_tp(tp, "equipped permanent ")?;
+    Some((
+        TargetFilter::Typed(TypedFilter::permanent().properties(vec![FilterProp::EquippedBy])),
+        rest.original,
+    ))
+}
+
+/// nom body for [`parse_attached_isnt_and_is_type`]: "isn't a[n] <core type> and
+/// is a[n] <core type> in addition to its other types[.]", consumed to `eof`.
+/// CR 613.1d: the leading clause removes a card type; CR 205.1b / CR 205.2: the
+/// trailing "in addition to its other types" clause adds a card type additively.
+fn parse_isnt_and_is_additive_type_body(
+    input: &str,
+) -> OracleResult<'_, Vec<ContinuousModification>> {
+    let (input, _) = alt((tag("isn't an "), tag("isn't a "))).parse(input)?;
+    let (input, removed) = parse_core_type_word(input)?;
+    let (input, _) = alt((tag(" and is an "), tag(" and is a "))).parse(input)?;
+    let (input, added) = parse_core_type_word(input)?;
+    let (input, _) = tag(" in addition to its other types").parse(input)?;
+    let (input, _) = opt(tag(".")).parse(input)?;
+    let (input, _) = eof.parse(input)?;
+    Ok((
+        input,
+        vec![
+            ContinuousModification::RemoveType { core_type: removed },
+            ContinuousModification::AddType { core_type: added },
+        ],
+    ))
+}
+
+/// CR 205.2: Map a singular core-type word to its [`CoreType`]. Longest tokens
+/// have no shared prefixes here, so left-to-right `alt` ordering is unambiguous.
+fn parse_core_type_word(input: &str) -> OracleResult<'_, CoreType> {
+    alt((
+        value(CoreType::Artifact, tag("artifact")),
+        value(CoreType::Battle, tag("battle")),
+        value(CoreType::Creature, tag("creature")),
+        value(CoreType::Enchantment, tag("enchantment")),
+        value(CoreType::Planeswalker, tag("planeswalker")),
+        value(CoreType::Land, tag("land")),
+    ))
+    .parse(input)
+}
+
 /// CR 205.1a + CR 205.2 + CR 205.3 + CR 613.1c: Scan text for a "becomes a
 /// [subtype]* [core-type]+ in addition to its other types" descriptor and
 /// decompose it into typed `ContinuousModification`s.

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -906,15 +906,15 @@ pub(crate) fn parse_enchanted_is_type(
 /// Both reuse the existing `RemoveType` / `AddType` runtime (`game/layers.rs`)
 /// applied at Layer 4 — no new engine variant, no new runtime. The subject is
 /// the shared `attached_subject_filter` building block (Enchanted/Equipped
-/// creature/permanent/land), extended here to accept the "equipped permanent"
-/// prefix that Equipment reconfigured onto a non-creature permanent needs. The
-/// body is consumed to `eof`, so a partial prefix can never mis-claim a longer
-/// or differently-shaped line.
+/// creature/permanent/land), which owns every attached-subject prefix including
+/// the "equipped permanent" case a Luxior-style Equipment attached to a
+/// non-creature permanent uses. The body is consumed to `eof`, so a partial
+/// prefix can never mis-claim a longer or differently-shaped line.
 pub(crate) fn parse_attached_isnt_and_is_type(
     tp: &TextPair<'_>,
     description: &str,
 ) -> Option<StaticDefinition> {
-    let (affected, predicate) = parse_attached_type_change_subject(tp)?;
+    let (affected, predicate) = attached_subject_filter(tp)?;
     let predicate_lower = predicate.trim().to_lowercase();
     let (_, modifications) = parse_isnt_and_is_additive_type_body(&predicate_lower).ok()?;
     Some(
@@ -923,23 +923,6 @@ pub(crate) fn parse_attached_isnt_and_is_type(
             .modifications(modifications)
             .description(description.to_string()),
     )
-}
-
-/// Resolve the attached subject of [`parse_attached_isnt_and_is_type`] into its
-/// `EnchantedBy` / `EquippedBy` `TargetFilter`, returning the original-cased
-/// predicate remainder. Delegates the Aura/Equipment subjects the shared
-/// `attached_subject_filter` already recognizes (enchanted creature/permanent/
-/// land, equipped creature) and adds the "equipped permanent" prefix that a
-/// reconfigured Equipment attached to a non-creature permanent uses (Luxior).
-fn parse_attached_type_change_subject<'a>(tp: &TextPair<'a>) -> Option<(TargetFilter, &'a str)> {
-    if let Some(result) = attached_subject_filter(tp) {
-        return Some(result);
-    }
-    let rest = nom_tag_tp(tp, "equipped permanent ")?;
-    Some((
-        TargetFilter::Typed(TypedFilter::permanent().properties(vec![FilterProp::EquippedBy])),
-        rest.original,
-    ))
 }
 
 /// nom body for [`parse_attached_isnt_and_is_type`]: "isn't a[n] <core type> and


### PR DESCRIPTION
## Summary
Adds parser support for the attached-permanent **type-swap** static ability `"[Equipped|Enchanted] permanent isn't a <T> and is a <T> in addition to its other types"` (Luxior, Giada's Gift / Luxior and Shadowspear). The existing enchanted/equipped is-type handlers rejected the `"isn't a … and is a …"` lead and produced **no static**, so the type swap was silently dropped. Decomposes the line into two Layer-4 modifications — `RemoveType` (the leading `"isn't a <T>"`) + `AddType` (the trailing `"is a <T> in addition to its other types"`) — reusing the shared `attached_subject_filter` building block (extended to the `"equipped permanent"` prefix). No new variant, no new runtime.

## Files changed
- `crates/engine/src/parser/oracle_static/type_change.rs`
- `crates/engine/src/parser/oracle_static/dispatch.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`

## CR references
- `CR 613.1d` — Layer 4 (type-changing) continuous effect; the leading clause removes a card type
- `CR 205.1b` / `CR 205.2` — additive card-type grant ("in addition to its other types")

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
Verified against CI on this head (commit `724e5bb36`) — all required gates green:
- `Rust lint (fmt, clippy, parser gate)` — ✅ SUCCESS (fmt clean, `clippy -D warnings` clean, parser-combinator gate clean)
- `Rust tests (shard 1/2 + 2/2)` — ✅ SUCCESS (includes the new `parse_luxior_equipped_permanent_type_swap` test; full `oracle_static` suite 944/944)
- `Card data (generate, validate, coverage)` — ✅ SUCCESS
- `WASM compile check` / `Tauri compile check` / `Frontend (lint, type-check, test)` / `Lobby worker` — ✅ SUCCESS

Card-level blast radius (from the `coverage-parse-diff` sticky, baseline `main 8d46028b9589`) — exactly the 2 intended cards, no collateral:
- **added** `Continuous (affects=equipped by self permanent, mods=remove type planeswalker, add type creature)` — Luxior, Giada's Gift · Luxior and Shadowspear
- **removed** the prior mis-structured `static_structure` on those same 2 cards

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
