### PR TITLE
feat(parser): compound bare-color cost-mod subject "<color> spells and <color> spells cost less" (Prophecy Familiar cycle)

### DIFF
--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -44,6 +44,20 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
         .parse(base)
         .map_or(base, |(rest, _)| rest);
 
+    // CR 105.1 + CR 601.2f: Compound BARE-color subject — "<color> spells and
+    // <color> spells" (the Prophecy Familiar cycle: Nightscape / Stormscape /
+    // Sunscape / Thornscape / Thunderscape Familiar). The single-subject path
+    // below maps a lone bare color via `parse_named_color`, and
+    // `parse_type_phrase` decomposes compounds whose operands carry a type noun
+    // ("Angel spells and Human spells", "red creature spells and green creature
+    // spells"). A two-BARE-color compound falls through both and yields
+    // `None` — which silently drops the color restriction and reduces EVERY
+    // spell. Recognize it here and emit the same `Or` of `HasColor` typed
+    // filters the noun-bearing compounds already produce.
+    if let Some(filter) = parse_cost_mod_compound_color_subject(base) {
+        return Some(filter);
+    }
+
     let that_split: Result<(&str, (&str, &str)), nom::Err<OracleError<'_>>> = all_consuming(alt((
         (
             take_until(" that's "),
@@ -124,6 +138,45 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
         )),
     };
     filter.map(remap_cost_mod_imprint_exile_reference)
+}
+
+/// CR 105.1 + CR 601.2f: Decompose a compound BARE-color cost-mod subject —
+/// "<color>[ spells] and <color>[ spells]" — into an `Or` of `HasColor` typed
+/// filters. Each operand is a color name (`nom_primitives::parse_color`)
+/// optionally trailed by the spell noun; operands are joined by " and ".
+///
+/// The Prophecy Familiar cycle (Nightscape Familiar "Blue spells and red
+/// spells you cast cost {1} less to cast", plus Stormscape / Sunscape /
+/// Thornscape / Thunderscape Familiar) is the exemplar class. Requires two or
+/// more colors and full consumption, so a lone bare color ("Red spells …") and
+/// a noun-bearing operand ("red creature spells and …") both decline here and
+/// fall through to the single-subject path and `parse_type_phrase` respectively.
+fn parse_cost_mod_compound_color_subject(base: &str) -> Option<TargetFilter> {
+    // Operand: a bare color name, optionally followed by the spell noun. The
+    // trailing " spell[s]" is present on every operand except the last (the
+    // caller strips one trailing " spells" before this runs).
+    fn color_operand(input: &str) -> OracleResult<'_, ManaColor> {
+        let (input, color) = nom_primitives::parse_color(input)?;
+        let (input, _) = opt(alt((tag(" spells"), tag(" spell")))).parse(input)?;
+        Ok((input, color))
+    }
+
+    let (rest, colors) = separated_list1(tag::<_, _, OracleError<'_>>(" and "), color_operand)
+        .parse(base.trim())
+        .ok()?;
+    if !rest.trim().is_empty() || colors.len() < 2 {
+        return None;
+    }
+
+    let filters = colors
+        .into_iter()
+        .map(|color| {
+            TargetFilter::Typed(
+                TypedFilter::card().properties(vec![FilterProp::HasColor { color }]),
+            )
+        })
+        .collect();
+    Some(TargetFilter::Or { filters })
 }
 
 /// CR 607.2a + CR 607.3: Cost-mod lines such as Semblance Anvil reference

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -4525,6 +4525,54 @@ fn static_creature_spells_cost_less() {
     }
 }
 
+// CR 105.1 + CR 601.2f: Prophecy Familiar cycle (Nightscape / Stormscape /
+// Sunscape / Thornscape / Thunderscape Familiar) — "<color> spells and <color>
+// spells you cast cost {1} less to cast." A two-BARE-color compound subject must
+// narrow the reduction to an `Or` of `HasColor` filters, NOT silently drop the
+// color restriction (which would cheapen every spell).
+#[test]
+fn static_compound_bare_color_spells_cost_less_narrows_to_or_of_colors() {
+    let def =
+        parse_static_line("Blue spells and red spells you cast cost {1} less to cast.").unwrap();
+    assert!(matches!(
+        def.mode,
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
+            amount: ManaCost::Cost { generic: 1, .. },
+            ..
+        }
+    ));
+    if let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        ref spell_filter,
+        ..
+    } = def.mode
+    {
+        let filter = spell_filter
+            .as_ref()
+            .expect("compound color must set a spell_filter");
+        match filter {
+            TargetFilter::Or { filters } => {
+                let colors: Vec<_> = filters
+                    .iter()
+                    .filter_map(|f| match f {
+                        TargetFilter::Typed(tf) => tf.properties.iter().find_map(|p| match p {
+                            FilterProp::HasColor { color } => Some(*color),
+                            _ => None,
+                        }),
+                        _ => None,
+                    })
+                    .collect();
+                assert!(
+                    colors.contains(&ManaColor::Blue) && colors.contains(&ManaColor::Red),
+                    "must narrow to Blue OR Red HasColor filters: {filters:?}"
+                );
+            }
+            other => panic!("expected Or of HasColor filters, got {other:?}"),
+        }
+    }
+}
+
 #[test]
 fn static_spells_of_chosen_type_cost_less_carries_chosen_card_type() {
     // Issue #930 — Cloud Key / Umori / Stenn:


### PR DESCRIPTION
## Summary
Adds parser support for **compound bare-color** cost-modification subjects — `"<color>[ spells] and <color>[ spells] cost {N} less to cast"` — used by the Prophecy Familiar cycle (Nightscape, Stormscape, Sunscape, Thornscape, Thunderscape Familiar). The two-bare-color compound subject fell through both the single-bare-color path and `parse_type_phrase` (which only decomposes compounds whose operands carry a type noun), so the subject resolved to `None` and the color restriction was **silently dropped** — cheapening *every* spell instead of only the two colors. This is a rules bug, not just a coverage miss. Decomposes the subject into the same `Or` of `HasColor` typed filters the noun-bearing compounds already produce. No new variant, no new runtime.

## Files changed
- `crates/engine/src/parser/oracle_static/static_helpers.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`

## CR references
- `CR 105.1` — the five colors (the bare-color operands)
- `CR 601.2f` — cost modification applied while casting the affected spells

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
**Card-level before/after** (full `parse_oracle_text` pipeline, Nightscape Familiar, run on both refs):

| ref | `ModifyCost.spell_filter` | effect |
|-----|---------------------------|--------|
| baseline `main` 8d46028b9 | `None` | reduces **every** spell you cast (color restriction dropped — the bug) |
| this head c95971e2c | `Some(Or{ Typed{Card, HasColor Blue}, Typed{Card, HasColor Red} })` | reduces **only blue/red** spells you cast (correct) |

> Note: the `coverage-parse-diff` sticky reports "No card-parse changes" here — a **false negative**. Its per-card signature captures the `ModifyCost` mode + `affected` filter but not the contents of `spell_filter`, the field this PR populates. The card data genuinely changes (table above); the diff tool just can't see inside `spell_filter`. See the pinned comment for the full parse dumps.

CI on this head — all green:
- `Rust lint (fmt, clippy, parser gate)` — ✅ SUCCESS (fmt, `clippy -D warnings`, parser-combinator gate)
- `Rust tests (shard 1/2 + 2/2)` — ✅ SUCCESS; includes `static_compound_bare_color_spells_cost_less_narrows_to_or_of_colors` asserting the `Or{HasColor Blue, HasColor Red}` spell_filter
- `Card data (generate, validate, coverage)` — ✅ SUCCESS
- `WASM` / `Tauri` / `Frontend` / `Lobby worker` — ✅ SUCCESS

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

