### PR TITLE
feat(engine): count opponents dealt any damage this turn (Furious Spinesplitter, You've Been Caught Stealing)

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2127,7 +2127,7 @@ fn legacy_player_filter(x: &PlayerFilter) -> bool {
         PlayerFilter::AllExcept { exclude } => legacy_player_filter(exclude),
         PlayerFilter::OpponentLostLife
         | PlayerFilter::OpponentGainedLife
-        | PlayerFilter::OpponentDealtCombatDamage { .. }
+        | PlayerFilter::OpponentDealtDamage { .. }
         | PlayerFilter::OpponentOtherThanTriggering
         | PlayerFilter::OpponentOfTriggeringPlayer
         | PlayerFilter::OpponentOfTriggeringPlayerNotAttacked
@@ -6079,7 +6079,7 @@ fn rw_player_filter(x: &PlayerFilter) -> RwProfile {
         PlayerFilter::OpponentLostLife | PlayerFilter::OpponentGainedLife => {
             reads_player_of(StateKind::JournalLife)
         }
-        PlayerFilter::OpponentDealtCombatDamage { source: _ } => {
+        PlayerFilter::OpponentDealtDamage { source: _, kind: _ } => {
             reads_player_of(StateKind::JournalLife)
         }
         // D5 carrier.

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -3025,7 +3025,10 @@ fn scan_player_filter(x: &PlayerFilter) -> Axes {
             projected: true,
         },
         PlayerFilter::HasLostTheGame => Axes::NONE,
-        PlayerFilter::OpponentDealtCombatDamage { source } => {
+        // `kind` is a static damage-kind selector (combat/noncombat/any) — not an
+        // event-context, sibling, or projected-growth resource — so it carries no
+        // axis; only the optional `source` sub-filter contributes.
+        PlayerFilter::OpponentDealtDamage { kind: _, source } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1653,7 +1653,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
 }
 
 fn fmt_player_filter(pf: &PlayerFilter) -> String {
-    use crate::types::ability::PlayerRelation;
+    use crate::types::ability::{DamageKindFilter, PlayerRelation};
     match pf {
         PlayerFilter::Controller => "you",
         PlayerFilter::Opponent => "each opponent",
@@ -1661,9 +1661,14 @@ fn fmt_player_filter(pf: &PlayerFilter) -> String {
         PlayerFilter::OpponentLostLife => "each opponent who lost life this turn",
         PlayerFilter::OpponentGainedLife => "each opponent who gained life this turn",
         PlayerFilter::HasLostTheGame => "each player who has lost the game",
-        PlayerFilter::OpponentDealtCombatDamage { .. } => {
-            "each opponent who was dealt combat damage this turn"
-        }
+        // CR 120.2a/120.2b: human string reflects the damage-kind selector.
+        PlayerFilter::OpponentDealtDamage { kind, .. } => match kind {
+            DamageKindFilter::CombatOnly => "each opponent who was dealt combat damage this turn",
+            DamageKindFilter::NoncombatOnly => {
+                "each opponent who was dealt noncombat damage this turn"
+            }
+            DamageKindFilter::Any => "each opponent who was dealt damage this turn",
+        },
         PlayerFilter::OpponentAttacked { subject, scope } => match (subject, scope) {
             (AttackSubject::You, AttackScope::ThisTurn) => "each opponent you attacked this turn",
             (AttackSubject::Source, AttackScope::ThisTurn) => {
@@ -6753,7 +6758,7 @@ fn player_filter_feature(scope: &PlayerFilter) -> (&'static str, FeatureSupport)
         PlayerFilter::OpponentLostLife => ("OpponentLostLife", Handled),
         PlayerFilter::OpponentGainedLife => ("OpponentGainedLife", Handled),
         PlayerFilter::HasLostTheGame => ("HasLostTheGame", Handled),
-        PlayerFilter::OpponentDealtCombatDamage { .. } => ("OpponentDealtCombatDamage", Handled),
+        PlayerFilter::OpponentDealtDamage { .. } => ("OpponentDealtDamage", Handled),
         PlayerFilter::OpponentAttacked { .. } => ("OpponentAttacked", Handled),
         PlayerFilter::OpponentAttackingEnchantedPlayer => {
             ("OpponentAttackingEnchantedPlayer", Handled)

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -1658,14 +1658,16 @@ fn collect_matching_players(
                     // CR 506.2 + CR 508.6: Count-only filter (Suppressor Skyguard);
                     // it has no live damage-recipient meaning.
                     PlayerFilter::OpponentOfTriggeringPlayerNotAttacked => false,
-                    // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
-                    // who was dealt combat damage this turn, optionally
-                    // restricted to a matching source.
-                    PlayerFilter::OpponentDealtCombatDamage { ref source } => {
-                        crate::game::quantity::opponent_dealt_combat_damage_matches(
+                    // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i +
+                    // CR 120.2a/120.2b: Each opponent who was dealt damage of the
+                    // given kind this turn, optionally restricted to a matching
+                    // source.
+                    PlayerFilter::OpponentDealtDamage { kind, ref source } => {
+                        crate::game::quantity::opponent_dealt_damage_matches(
                             state,
                             p.id,
                             source_controller,
+                            kind,
                             source,
                             source_id,
                         )
@@ -1891,14 +1893,16 @@ pub fn resolve_each_player(
                     // CR 506.2 + CR 508.6: Count-only filter (Suppressor Skyguard);
                     // it has no live damage-recipient meaning.
                     PlayerFilter::OpponentOfTriggeringPlayerNotAttacked => false,
-                    // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
-                    // who was dealt combat damage this turn, optionally
-                    // restricted to a matching source.
-                    PlayerFilter::OpponentDealtCombatDamage { source } => {
-                        crate::game::quantity::opponent_dealt_combat_damage_matches(
+                    // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i +
+                    // CR 120.2a/120.2b: Each opponent who was dealt damage of the
+                    // given kind this turn, optionally restricted to a matching
+                    // source.
+                    PlayerFilter::OpponentDealtDamage { kind, source } => {
+                        crate::game::quantity::opponent_dealt_damage_matches(
                             state,
                             p.id,
                             ability.controller,
+                            *kind,
                             source,
                             ability.source_id,
                         )

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -354,12 +354,13 @@ pub(crate) fn matches_player_scope(
                     // intervening-if); it has no live effect-recipient meaning, so
                     // no player ever matches it as an effect target.
                     PlayerFilter::OpponentOfTriggeringPlayerNotAttacked => false,
-                    // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
-                    // who was dealt combat damage this turn, optionally
-                    // restricted to a matching source.
-                    PlayerFilter::OpponentDealtCombatDamage { source } => {
-                        crate::game::quantity::opponent_dealt_combat_damage_matches(
-                            state, p.id, controller, source, source_id,
+                    // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i +
+                    // CR 120.2a/120.2b: Each opponent who was dealt damage of the
+                    // given kind this turn, optionally restricted to a matching
+                    // source.
+                    PlayerFilter::OpponentDealtDamage { kind, source } => {
+                        crate::game::quantity::opponent_dealt_damage_matches(
+                            state, p.id, controller, *kind, source, source_id,
                         )
                     }
                     // CR 508.6: opponent the subject attacked within scope.
@@ -8570,7 +8571,7 @@ fn scoped_player_matches_filter(
         // game/triggers.rs:3703-3723).
         PlayerFilter::DefendingPlayer
         | PlayerFilter::HasLostTheGame
-        | PlayerFilter::OpponentDealtCombatDamage { .. }
+        | PlayerFilter::OpponentDealtDamage { .. }
         | PlayerFilter::OpponentAttacked { .. }
         | PlayerFilter::OpponentAttackingEnchantedPlayer
         | PlayerFilter::HighestSpeed

--- a/crates/engine/src/game/effects/speed_effects.rs
+++ b/crates/engine/src/game/effects/speed_effects.rs
@@ -54,16 +54,16 @@ pub(crate) fn players_for_filter(
         // CR 506.2 + CR 508.6: Count-only filter (Suppressor Skyguard); it has
         // no live speed-effect recipient meaning.
         PlayerFilter::OpponentOfTriggeringPlayerNotAttacked => Vec::new(),
-        // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent who was
-        // dealt combat damage this turn, optionally restricted to a matching
-        // source.
-        PlayerFilter::OpponentDealtCombatDamage { source } => state
+        // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i + CR 120.2a/120.2b: Each
+        // opponent who was dealt damage of the given kind this turn, optionally
+        // restricted to a matching source.
+        PlayerFilter::OpponentDealtDamage { kind, source } => state
             .players
             .iter()
             .filter(|player| !player.is_eliminated)
             .filter(|player| {
-                crate::game::quantity::opponent_dealt_combat_damage_matches(
-                    state, player.id, controller, source, source_id,
+                crate::game::quantity::opponent_dealt_damage_matches(
+                    state, player.id, controller, *kind, source, source_id,
                 )
             })
             .map(|player| player.id)

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -4632,19 +4632,20 @@ pub(crate) fn compute_party_size(state: &GameState, player: PlayerId) -> i32 {
     best as i32
 }
 
-/// CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Single authority for
-/// `PlayerFilter::OpponentDealtCombatDamage` matching. `player` was dealt combat
-/// damage this turn (relative to `controller`'s opponents) when a
-/// `damage_dealt_this_turn` record targets it with `is_combat = true` AND its
-/// source matches `source`. `source = None` accepts any source (Tymna the
-/// Weaver); otherwise (CR 120.9) the record's CR 608.2i look-back source
-/// snapshot is matched against the filter (`TargetFilter::Any` matching every
-/// source via the matcher), so the source's qualities are evaluated as of
-/// damage time.
-pub(crate) fn opponent_dealt_combat_damage_matches(
+/// CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i + CR 120.2a/120.2b: Single
+/// authority for `PlayerFilter::OpponentDealtDamage` matching. `player` was
+/// dealt damage this turn (relative to `controller`'s opponents) when a
+/// `damage_dealt_this_turn` record targets it, its combat status matches `kind`
+/// (CR 120.2a combat / CR 120.2b noncombat / `Any` = either), AND its source
+/// matches `source`. `source = None` accepts any source (Tymna the Weaver);
+/// otherwise (CR 120.9) the record's CR 608.2i look-back source snapshot is
+/// matched against the filter (`TargetFilter::Any` matching every source via the
+/// matcher), so the source's qualities are evaluated as of damage time.
+pub(crate) fn opponent_dealt_damage_matches(
     state: &GameState,
     player: PlayerId,
     controller: PlayerId,
+    kind: crate::types::ability::DamageKindFilter,
     source: &Option<Box<TargetFilter>>,
     ability_source_id: ObjectId,
 ) -> bool {
@@ -4653,7 +4654,7 @@ pub(crate) fn opponent_dealt_combat_damage_matches(
     }
     let ctx = FilterContext::from_source_with_controller(ability_source_id, controller);
     state.damage_dealt_this_turn.iter().any(|r| {
-        r.is_combat
+        damage_record_matches_kind(r, kind)
             && matches!(r.target, TargetRef::Player(pid) if pid == player)
             && match source {
                 None => true,
@@ -4719,12 +4720,13 @@ pub(crate) fn resolve_player_count(
                         }
                         // Handled by the early return above; unreachable here.
                         PlayerFilter::HasLostTheGame => false,
-                        // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each
-                        // opponent who was dealt combat damage this turn,
-                        // optionally restricted to a matching source.
-                        PlayerFilter::OpponentDealtCombatDamage { source } => {
-                            opponent_dealt_combat_damage_matches(
-                                state, p.id, controller, source, source_id,
+                        // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i +
+                        // CR 120.2a/120.2b: Each opponent who was dealt damage of
+                        // the given kind this turn, optionally restricted to a
+                        // matching source.
+                        PlayerFilter::OpponentDealtDamage { kind, source } => {
+                            opponent_dealt_damage_matches(
+                                state, p.id, controller, *kind, source, source_id,
                             )
                         }
                         // CR 508.6: opponent the subject attacked within scope.
@@ -8409,7 +8411,7 @@ mod tests {
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 0);
     }
 
-    /// CR 120.1 + CR 510.1: Resolving `PlayerCount { OpponentDealtCombatDamage }`
+    /// CR 120.1 + CR 510.1: Resolving `PlayerCount { OpponentDealtDamage }`
     /// against `damage_dealt_this_turn` records counts only opponents whose
     /// player target appears in the ledger with `is_combat = true`. Mirrors
     /// the partner-quality "for each opponent that was dealt combat damage
@@ -8453,11 +8455,110 @@ mod tests {
 
         let expr = QuantityExpr::Ref {
             qty: QuantityRef::PlayerCount {
-                filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
+                filter: PlayerFilter::OpponentDealtDamage {
+                    kind: DamageKindFilter::CombatOnly,
+                    source: None,
+                },
             },
         };
         // Controller = player 0: only player 1 satisfies (combat + opponent).
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 1);
+    }
+
+    /// CR 120.2a/120.2b: The `kind` axis discriminates on the SAME ledger.
+    /// One opponent (P1) was dealt combat damage, a different opponent (P2)
+    /// noncombat damage. `Any` counts both (2); `CombatOnly` counts only P1 (1);
+    /// `NoncombatOnly` counts only P2 (1). This is the non-vacuous test that
+    /// fails on any single-kind regression: pre-fix combat-only would return 1
+    /// for the `Any` case, and a broadened-to-Any resolver would return 2 for
+    /// the `CombatOnly`/`NoncombatOnly` cases.
+    #[test]
+    fn resolve_quantity_player_count_opponent_dealt_damage_kind_discriminates() {
+        use crate::types::ability::DamageKindFilter;
+        use crate::types::format::FormatConfig;
+
+        let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+        // P1: combat damage.
+        state.damage_dealt_this_turn.push_back(DamageRecord {
+            source_id: ObjectId(99),
+            source_controller: PlayerId(0),
+            target: TargetRef::Player(PlayerId(1)),
+            target_controller: PlayerId(1),
+            amount: 4,
+            is_combat: true,
+            ..Default::default()
+        });
+        // P2: noncombat damage.
+        state.damage_dealt_this_turn.push_back(DamageRecord {
+            source_id: ObjectId(99),
+            source_controller: PlayerId(0),
+            target: TargetRef::Player(PlayerId(2)),
+            target_controller: PlayerId(2),
+            amount: 2,
+            is_combat: false,
+            ..Default::default()
+        });
+
+        let count = |kind: DamageKindFilter| {
+            resolve_quantity(
+                &state,
+                &QuantityExpr::Ref {
+                    qty: QuantityRef::PlayerCount {
+                        filter: PlayerFilter::OpponentDealtDamage { kind, source: None },
+                    },
+                },
+                PlayerId(0),
+                ObjectId(1),
+            )
+        };
+
+        assert_eq!(count(DamageKindFilter::Any), 2, "Any counts both opponents");
+        assert_eq!(
+            count(DamageKindFilter::CombatOnly),
+            1,
+            "CombatOnly counts only the combat-damaged opponent (P1)"
+        );
+        assert_eq!(
+            count(DamageKindFilter::NoncombatOnly),
+            1,
+            "NoncombatOnly counts only the noncombat-damaged opponent (P2)"
+        );
+    }
+
+    /// Serde back-compat: legacy data serialized the combat-only variant as
+    /// `{"type":"OpponentDealtCombatDamage"}` with no `kind` field. The
+    /// `#[serde(alias)]` routes the old tag and the `#[serde(default =
+    /// "damage_kind_combat_only")]` fills `kind = CombatOnly` — NOT the
+    /// `DamageKindFilter::Any` type-default, which would broaden the filter and
+    /// misresolve reloaded games. The current tag round-trips through `Any`.
+    #[test]
+    fn opponent_dealt_damage_serde_legacy_and_roundtrip() {
+        use crate::types::ability::DamageKindFilter;
+
+        // Legacy tag, absent `kind` → CombatOnly (NOT Any).
+        let legacy: PlayerFilter =
+            serde_json::from_str(r#"{"type":"OpponentDealtCombatDamage"}"#).unwrap();
+        assert_eq!(
+            legacy,
+            PlayerFilter::OpponentDealtDamage {
+                kind: DamageKindFilter::CombatOnly,
+                source: None
+            }
+        );
+
+        // Current tag with explicit `kind: Any` round-trips.
+        let any: PlayerFilter =
+            serde_json::from_str(r#"{"type":"OpponentDealtDamage","kind":"Any"}"#).unwrap();
+        assert_eq!(
+            any,
+            PlayerFilter::OpponentDealtDamage {
+                kind: DamageKindFilter::Any,
+                source: None
+            }
+        );
+        let reser = serde_json::to_string(&any).unwrap();
+        let back: PlayerFilter = serde_json::from_str(&reser).unwrap();
+        assert_eq!(any, back);
     }
 
     /// CR 120.1 + CR 510.1: With no combat damage dealt this turn, the
@@ -8468,13 +8569,16 @@ mod tests {
         let state = GameState::new_two_player(42);
         let expr = QuantityExpr::Ref {
             qty: QuantityRef::PlayerCount {
-                filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
+                filter: PlayerFilter::OpponentDealtDamage {
+                    kind: DamageKindFilter::CombatOnly,
+                    source: None,
+                },
             },
         };
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 0);
     }
 
-    /// CR 608.2i (the whole point): a source-restricted `OpponentDealtCombatDamage`
+    /// CR 608.2i (the whole point): a source-restricted `OpponentDealtDamage`
     /// must match against the record's damage-time source snapshot, NOT the live
     /// object. Record combat damage from a Dragon to an opponent, then remove
     /// the live Dragon from the battlefield. A resolve-now model would see no
@@ -8511,7 +8615,8 @@ mod tests {
             TargetFilter::Typed(TypedFilter::default().subtype("Dragon".to_string()));
         let expr = QuantityExpr::Ref {
             qty: QuantityRef::PlayerCount {
-                filter: PlayerFilter::OpponentDealtCombatDamage {
+                filter: PlayerFilter::OpponentDealtDamage {
+                    kind: DamageKindFilter::CombatOnly,
                     source: Some(Box::new(dragon_filter)),
                 },
             },
@@ -8551,7 +8656,8 @@ mod tests {
                 &state,
                 &QuantityExpr::Ref {
                     qty: QuantityRef::PlayerCount {
-                        filter: PlayerFilter::OpponentDealtCombatDamage {
+                        filter: PlayerFilter::OpponentDealtDamage {
+                            kind: DamageKindFilter::CombatOnly,
                             source: Some(Box::new(source)),
                         },
                     },

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -4227,7 +4227,7 @@ fn evaluate_replacement_condition(
             state.damage_dealt_this_turn.iter().any(|record| {
                 // CR 608.2i + CR 608.2h: match the damage source against its
                 // damage-time snapshot (look-back), consistent with
-                // DamageDealtThisTurn / OpponentDealtCombatDamage.
+                // DamageDealtThisTurn / OpponentDealtDamage.
                 record.target == TargetRef::Object(affected_id)
                     && matches_target_filter_on_damage_record_source(state, record, source, &ctx)
             })

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -6373,7 +6373,7 @@ pub(crate) fn check_trigger_condition(
         // CR 603.4 + CR 120.1: "if any of that damage was dealt by a [filter]"
         // evaluates the triggering damage source as it was when the damage was
         // dealt. Reuse the same DamageRecord snapshot matcher as
-        // PlayerFilter::OpponentDealtCombatDamage so later type changes or zone
+        // PlayerFilter::OpponentDealtDamage so later type changes or zone
         // moves do not change what "that damage was dealt by" refers to.
         TriggerCondition::EventDamageSourceMatchesFilter { filter } => trigger_event
             .and_then(|event| match event {
@@ -6531,9 +6531,9 @@ pub(crate) fn check_trigger_condition(
             | PlayerFilter::OpponentLostLife
             | PlayerFilter::OpponentGainedLife
             | PlayerFilter::HasLostTheGame
-            // CR 120.1 + CR 510.1: a set-valued combat-damaged-this-turn
-            // predicate has no single-player "whose turn" semantic.
-            | PlayerFilter::OpponentDealtCombatDamage { .. }
+            // CR 120.1 + CR 510.1: a set-valued damaged-this-turn predicate has
+            // no single-player "whose turn" semantic.
+            | PlayerFilter::OpponentDealtDamage { .. }
             // CR 508.6: a set-valued attacked-this-turn predicate has no
             // single-player "whose turn" semantic.
             | PlayerFilter::OpponentAttacked { .. }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11695,10 +11695,20 @@ fn try_parse_for_each_effect(text: &str, ctx: &mut ParseContext) -> Option<Parse
     //
     // The base may carry a subject ("You create a Treasure token …" — You've Been
     // Caught Stealing). Try the raw base first (preserves subject-bearing forms
-    // like "each player creates …" that `try_parse_token` handles directly), then
-    // fall back to the subject-stripped imperative, mirroring the numeric arm
-    // above, so a leading "you " no longer strands the for-each quantity.
-    let token_stripped_storage = subject::strip_subject_clause(base_no_duration);
+    // like "each player creates …" that `try_parse_token` handles directly with
+    // the correct owner), then fall back to the subject-stripped imperative so a
+    // leading "you " no longer strands the for-each quantity.
+    //
+    // CR 109.5 + CR 111.11: the stripped fallback is CONTROLLER-only. This arm
+    // early-returns from `try_parse_for_each_effect` and so never runs the
+    // subject→owner rebinding used by the numeric/targeted arms, and
+    // `try_parse_token` defaults `Effect::Token.owner` to
+    // `TargetFilter::Controller`. Stripping a non-controller subject here
+    // ("each player", "target opponent", "its controller", …) would silently
+    // create the token under the SOURCE controller instead of the named player
+    // (maintainer CHANGES_REQUESTED on #5144). Such forms must fall through to
+    // unsupported rather than be mis-owned; only "you"/"you may" is safe to strip.
+    let token_stripped_storage = subject::strip_controller_subject_clause(base_no_duration);
     let token_effect =
         if let Some(effect) = token::try_parse_token(base_tp.lower, base_tp.original, ctx) {
             Some(effect)

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11692,7 +11692,23 @@ fn try_parse_for_each_effect(text: &str, ctx: &mut ParseContext) -> Option<Parse
     // CR 111.11: "create [token description] for each X" → Token with dynamic count.
     // Delegates to try_parse_token, which handles token description parsing (name, P/T,
     // types, colors, keywords). Replace the embedded count with the for-each quantity.
-    if let Some(effect) = token::try_parse_token(base_tp.lower, base_tp.original, ctx) {
+    //
+    // The base may carry a subject ("You create a Treasure token …" — You've Been
+    // Caught Stealing). Try the raw base first (preserves subject-bearing forms
+    // like "each player creates …" that `try_parse_token` handles directly), then
+    // fall back to the subject-stripped imperative, mirroring the numeric arm
+    // above, so a leading "you " no longer strands the for-each quantity.
+    let token_stripped_storage = subject::strip_subject_clause(base_no_duration);
+    let token_effect =
+        if let Some(effect) = token::try_parse_token(base_tp.lower, base_tp.original, ctx) {
+            Some(effect)
+        } else if let Some(stripped) = token_stripped_storage.as_deref() {
+            let stripped_lower = stripped.to_lowercase();
+            token::try_parse_token(&stripped_lower, stripped, ctx)
+        } else {
+            None
+        };
+    if let Some(effect) = token_effect {
         let effect = match effect {
             Effect::Token {
                 name,

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -5157,6 +5157,44 @@ pub(super) fn strip_subject_clause(text: &str) -> Option<String> {
     Some(deconjugate_verb(predicate))
 }
 
+/// Strip a leading *controller* subject ("you may " / "you ") from `text`,
+/// returning the imperative remainder in original case; `None` for every other
+/// leading subject.
+///
+/// This is the controller-only counterpart to [`strip_subject_clause`]. It
+/// exists for the token "create … for each X" fallback in
+/// `oracle_effect/mod.rs`, which delegates to `token::try_parse_token`. That
+/// path defaults `Effect::Token.owner` to `TargetFilter::Controller`
+/// (CR 109.5: an unqualified "you" is the controller of the source) and — via
+/// the early return in `try_parse_for_each_effect` — does NOT run the
+/// subject→owner rebinding that the numeric/targeted for-each arms use. So
+/// stripping a *non-controller* subject there ("each player", "each opponent",
+/// "target player/opponent", "its controller", "that player", …) would
+/// silently mis-own the created token to the source controller
+/// (CR 111.11: a token is created under a specific player's control). Only the
+/// controller subject may be stripped in that fallback; any other leading
+/// subject returns `None` so the clause honestly falls through to unsupported.
+pub(super) fn strip_controller_subject_clause(text: &str) -> Option<String> {
+    let lower = text.to_lowercase();
+    // Longest-match first: "you may " before the bare "you " so the optional
+    // permission word is consumed rather than stranded on the remainder.
+    let ((), remainder) = nom_on_lower(text, &lower, |i| {
+        value(
+            (),
+            alt((
+                tag::<_, _, OracleError<'_>>("you may "),
+                tag::<_, _, OracleError<'_>>("you "),
+            )),
+        )
+        .parse(i)
+    })?;
+    let remainder = remainder.trim();
+    if remainder.is_empty() {
+        return None;
+    }
+    Some(remainder.to_string())
+}
+
 /// Strip third-person 's' from the first word: "discards a card" → "discard a card".
 pub(super) fn deconjugate_verb(text: &str) -> String {
     let text = text.trim();

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -6977,15 +6977,9 @@ fn for_each_token_non_controller_subject_not_misowned_via_fallback() {
         &mut ParseContext::default(),
     );
     assert!(
-        !matches!(
-            clause.as_ref().map(|c| &c.effect),
-            Some(Effect::Token {
-                owner: TargetFilter::Controller,
-                ..
-            })
-        ),
-        "non-controller 'each player creates … for each' must not be accepted as \
-         a Controller-owned token via the subject-stripped fallback, got {clause:?}"
+        clause.is_none(),
+        "non-controller 'each player creates … for each' must DECLINE (return None) at \
+         the controller-only fallback — not merely avoid Controller ownership; got {clause:?}"
     );
 }
 
@@ -6998,15 +6992,9 @@ fn for_each_token_target_opponent_subject_not_misowned_via_fallback() {
         &mut ParseContext::default(),
     );
     assert!(
-        !matches!(
-            clause.as_ref().map(|c| &c.effect),
-            Some(Effect::Token {
-                owner: TargetFilter::Controller,
-                ..
-            })
-        ),
-        "non-controller 'target opponent creates … for each' must not be accepted \
-         as a Controller-owned token via the subject-stripped fallback, got {clause:?}"
+        clause.is_none(),
+        "non-controller 'target opponent creates … for each' must DECLINE (return None) at \
+         the controller-only fallback — not merely avoid Controller ownership; got {clause:?}"
     );
 }
 

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -6947,6 +6947,97 @@ fn for_each_token_count_replaced() {
     );
 }
 
+/// CR 109.5 + CR 111.11: a NON-controller token "create … for each X" creator
+/// must NOT be accepted as a `Controller`-owned token via the subject-stripped
+/// fallback inside the token for-each arm.
+///
+/// This targets `try_parse_for_each_effect` DIRECTLY — not `parse_effect` — on
+/// purpose. The token for-each arm early-returns and so never runs the
+/// subject→owner rebinding; `try_parse_token` defaults `owner` to `Controller`.
+/// Under the pre-fix broad `strip_subject_clause`, the leading "each player "
+/// was stripped, `try_parse_token` accepted the bare imperative, and the arm
+/// returned `Effect::Token { owner: Controller, count: Ref }` — silently
+/// creating the tokens for the SOURCE controller instead of each player. The
+/// fix restricts the fallback to a controller ("you"/"you may") subject, so
+/// this arm must now DECLINE (return `None`) for a non-controller subject.
+///
+/// Why the arm and not `parse_effect`: at the full-pipeline level "each player
+/// creates …" is ALSO mis-owned to `Controller` by a SEPARATE, out-of-scope
+/// path (`thread_for_each_subject` has no `Effect::Token` arm, so it strips the
+/// subject and fails to rebind the owner). That path is unchanged by this fix,
+/// so a `parse_effect` assertion would not isolate — or discriminate — the
+/// fallback this change actually narrows. Calling the arm directly does.
+///
+/// Discriminating: this assertion FAILS under the pre-fix code (the arm returns
+/// `owner: Controller`) and PASSES after (the arm returns `None`).
+#[test]
+fn for_each_token_non_controller_subject_not_misowned_via_fallback() {
+    let clause = try_parse_for_each_effect(
+        "each player creates a Treasure token for each creature they control",
+        &mut ParseContext::default(),
+    );
+    assert!(
+        !matches!(
+            clause.as_ref().map(|c| &c.effect),
+            Some(Effect::Token {
+                owner: TargetFilter::Controller,
+                ..
+            })
+        ),
+        "non-controller 'each player creates … for each' must not be accepted as \
+         a Controller-owned token via the subject-stripped fallback, got {clause:?}"
+    );
+}
+
+/// Companion for the "target opponent" non-controller creator — same hazard,
+/// different subject form. The arm must decline rather than mis-own to Controller.
+#[test]
+fn for_each_token_target_opponent_subject_not_misowned_via_fallback() {
+    let clause = try_parse_for_each_effect(
+        "target opponent creates a Treasure token for each artifact they control",
+        &mut ParseContext::default(),
+    );
+    assert!(
+        !matches!(
+            clause.as_ref().map(|c| &c.effect),
+            Some(Effect::Token {
+                owner: TargetFilter::Controller,
+                ..
+            })
+        ),
+        "non-controller 'target opponent creates … for each' must not be accepted \
+         as a Controller-owned token via the subject-stripped fallback, got {clause:?}"
+    );
+}
+
+/// Positive companion: the intended controller form ("You create …") STILL
+/// parses through the arm's controller-only fallback to a `Controller`-owned
+/// dynamic-count Token. This is the case the fallback exists to support
+/// (You've Been Caught Stealing; Cavern-Hoard Dragon; Covetous Elegy; Yes Man,
+/// Personal Securitron; Wreck Hunter) — it proves the narrowing did not break
+/// the fix it was tightening.
+#[test]
+fn for_each_token_controller_subject_still_controller_owned() {
+    let clause = try_parse_for_each_effect(
+        "you create a Treasure token for each creature you control",
+        &mut ParseContext::default(),
+    )
+    .expect("controller 'you create … for each' should parse via the arm");
+    assert!(
+        matches!(
+            clause.effect,
+            Effect::Token {
+                owner: TargetFilter::Controller,
+                count: QuantityExpr::Ref { .. },
+                ..
+            }
+        ),
+        "controller 'you create … for each' must stay a Controller-owned \
+         dynamic Token, got {:?}",
+        clause.effect
+    );
+}
+
 /// CR 701.9 + CR 603.4: "draw a card for each card you've discarded this
 /// turn" must produce a dynamic Draw count referencing the controller's
 /// per-turn discard tally, not a dropped `Fixed(1)`.

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -38,9 +38,9 @@ use crate::parser::oracle_target::{parse_target, parse_type_phrase, parse_type_p
 use crate::parser::oracle_util::merge_or_filters;
 use crate::types::ability::{
     AggregateFunction, AttackScope, AttackSubject, Comparator, ControllerRef, CountScope,
-    DevotionColors, FilterProp, ObjectProperty, ObjectScope, PlayerFilter, PlayerRelation,
-    PlayerScope, QuantityExpr, QuantityRef, RoundingMode, TargetFilter, ThisWayCause,
-    TrackedAnaphorSource, TypeFilter, TypedFilter, ZoneRef,
+    DamageKindFilter, DevotionColors, FilterProp, ObjectProperty, ObjectScope, PlayerFilter,
+    PlayerRelation, PlayerScope, QuantityExpr, QuantityRef, RoundingMode, TargetFilter,
+    ThisWayCause, TrackedAnaphorSource, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::counter::CounterType;
 use crate::types::events::PlayerActionKind;
@@ -464,14 +464,15 @@ pub(crate) fn parse_quantity_ref_with_context(
                 filter: PlayerFilter::Opponent,
             });
         }
-        // CR 120.1 + CR 510.1: "opponents that were dealt combat damage
-        // [this turn]". The trailing " this turn" suffix is optional because
-        // upstream callers may strip durations before this parser sees the
-        // phrase. PlayerCount{OpponentDealtCombatDamage} is inherently scoped
-        // to this turn through `state.damage_dealt_this_turn`.
-        if let Ok((_, source)) = parse_opponent_dealt_combat_damage_clause(rest) {
+        // CR 120.1 + CR 510.1 + CR 120.2a/120.2b: "opponents that were dealt
+        // [combat|noncombat] damage [this turn]". The trailing " this turn"
+        // suffix is optional because upstream callers may strip durations before
+        // this parser sees the phrase. PlayerCount{OpponentDealtDamage} is
+        // inherently scoped to this turn through `state.damage_dealt_this_turn`.
+        if let Ok((_, (kind, source))) = parse_opponent_dealt_damage_clause(rest) {
             return Some(QuantityRef::PlayerCount {
-                filter: PlayerFilter::OpponentDealtCombatDamage {
+                filter: PlayerFilter::OpponentDealtDamage {
+                    kind,
                     source: source.map(Box::new),
                 },
             });
@@ -1274,23 +1275,35 @@ fn parse_counters_removed_phrase(input: &str) -> nom::IResult<&str, (), OracleEr
     Ok((input, ()))
 }
 
-/// CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Parse "[your] opponents who were
-/// dealt combat damage [by <source>] [this turn]" into the optional source
-/// filter. Returns `Ok((_, None))` for the unfiltered class (Tymna the Weaver,
-/// Moonshae Pixie) and `Ok((_, Some(f)))` for a `by <source>` restriction
-/// (Estinien Varlineau: "by ~ or a Dragon" → `Or[SelfRef, Typed{Dragon}]`).
-/// `Err` means the clause did not match. The whole clause must be consumed
-/// (explicit `eof`) so trailing unrecognized text doesn't silently drop.
-fn parse_opponent_dealt_combat_damage_clause(
+/// CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i + CR 120.2a/120.2b: Parse "[your]
+/// opponents who were dealt [combat|noncombat] damage [by <source>] [this turn]"
+/// into the `(DamageKindFilter, Option<TargetFilter>)` pair. The damage-kind
+/// axis is parameterized: "combat damage" → `CombatOnly` (Tymna the Weaver),
+/// "noncombat damage" → `NoncombatOnly`, bare "damage" → `Any` (Furious
+/// Spinesplitter, You've Been Caught Stealing). Source `None` = unfiltered;
+/// `Some(f)` = a `by <source>` restriction (Estinien Varlineau: "by ~ or a
+/// Dragon" → `Or[SelfRef, Typed{Dragon}]`). `Err` means the clause did not
+/// match. The whole clause must be consumed (explicit `eof`) so trailing
+/// unrecognized text doesn't silently drop.
+fn parse_opponent_dealt_damage_clause(
     input: &str,
-) -> OracleResult<'_, Option<TargetFilter>> {
+) -> OracleResult<'_, (DamageKindFilter, Option<TargetFilter>)> {
     let (input, _) = opt(tag("your ")).parse(input)?;
     let (input, _) = alt((tag("opponents"), tag("opponent"))).parse(input)?;
     let (input, _) = tag(" ").parse(input)?;
     let (input, _) = alt((tag("that"), tag("who"))).parse(input)?;
     let (input, _) = tag(" ").parse(input)?;
     let (input, _) = alt((tag("were"), tag("was"))).parse(input)?;
-    let (input, _) = tag(" dealt combat damage").parse(input)?;
+    let (input, _) = tag(" dealt ").parse(input)?;
+    // CR 120.2a/120.2b: the damage-kind literal. Order matters — the
+    // combat/noncombat qualifiers precede the bare "damage" so they win; the
+    // three literals start with c/n/d, so no prefix collision.
+    let (input, kind) = alt((
+        value(DamageKindFilter::CombatOnly, tag("combat damage")),
+        value(DamageKindFilter::NoncombatOnly, tag("noncombat damage")),
+        value(DamageKindFilter::Any, tag("damage")),
+    ))
+    .parse(input)?;
     // CR 120.9: optional "by <source>" restriction. The source phrase is
     // isolated from the optional trailing " this turn" with a combinator
     // (`take_until` / `eof`), then parsed via the `parse_target` + " or " +
@@ -1298,7 +1311,7 @@ fn parse_opponent_dealt_combat_damage_clause(
     let (input, source) = opt(preceded(tag(" by "), parse_damage_source_chain)).parse(input)?;
     let (input, _) = opt(tag(" this turn")).parse(input)?;
     let (input, _) = eof.parse(input)?;
-    Ok((input, source))
+    Ok((input, (kind, source)))
 }
 
 /// CR 120.9 + CR 608.2i: Parse a damage-source phrase ("~", "a Dragon", "~ or a
@@ -2824,13 +2837,14 @@ fn parse_for_each_clause_with_they_controller(
         return Some(qty);
     }
 
-    // CR 120.1 + CR 510.1: "opponent that was dealt combat damage this turn"
-    // / "opponent who was dealt combat damage this turn". Mirrors the
-    // lost-life / gained-life arms above, but consumes the full clause instead
-    // of doing substring dispatch.
-    if let Ok((_, source)) = parse_opponent_dealt_combat_damage_clause(clause) {
+    // CR 120.1 + CR 510.1 + CR 120.2a/120.2b: "opponent that was dealt
+    // [combat|noncombat] damage this turn" / "opponent who was dealt ... damage
+    // this turn". Mirrors the lost-life / gained-life arms above, but consumes
+    // the full clause instead of doing substring dispatch.
+    if let Ok((_, (kind, source))) = parse_opponent_dealt_damage_clause(clause) {
         return Some(QuantityRef::PlayerCount {
-            filter: PlayerFilter::OpponentDealtCombatDamage {
+            filter: PlayerFilter::OpponentDealtDamage {
+                kind,
                 source: source.map(Box::new),
             },
         });
@@ -3608,9 +3622,56 @@ mod tests {
             assert_eq!(
                 parse_for_each_clause(phrase),
                 Some(QuantityRef::PlayerCount {
-                    filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
+                    filter: PlayerFilter::OpponentDealtDamage {
+                        kind: DamageKindFilter::CombatOnly,
+                        source: None
+                    },
                 }),
-                "phrase {phrase:?} must consume as OpponentDealtCombatDamage"
+                "phrase {phrase:?} must consume as OpponentDealtDamage{{CombatOnly}}"
+            );
+        }
+    }
+
+    #[test]
+    fn for_each_opponent_dealt_any_damage_is_player_count_any() {
+        // CR 120.2a/120.2b: bare "damage" (no combat/noncombat qualifier) →
+        // DamageKindFilter::Any. Furious Spinesplitter, You've Been Caught
+        // Stealing. Positive reach-guard: the phrase resolves to a PlayerCount
+        // over the OpponentDealtDamage filter (not None / a Fixed fall-through).
+        for phrase in [
+            "opponent that was dealt damage this turn",
+            "opponent who was dealt damage this turn",
+            "opponents who were dealt damage",
+        ] {
+            assert_eq!(
+                parse_for_each_clause(phrase),
+                Some(QuantityRef::PlayerCount {
+                    filter: PlayerFilter::OpponentDealtDamage {
+                        kind: DamageKindFilter::Any,
+                        source: None
+                    },
+                }),
+                "phrase {phrase:?} must consume as OpponentDealtDamage{{Any}}"
+            );
+        }
+    }
+
+    #[test]
+    fn for_each_opponent_dealt_noncombat_damage_is_player_count_noncombat() {
+        // CR 120.2b: "noncombat damage" qualifier → DamageKindFilter::NoncombatOnly.
+        for phrase in [
+            "opponent that was dealt noncombat damage this turn",
+            "opponents who were dealt noncombat damage",
+        ] {
+            assert_eq!(
+                parse_for_each_clause(phrase),
+                Some(QuantityRef::PlayerCount {
+                    filter: PlayerFilter::OpponentDealtDamage {
+                        kind: DamageKindFilter::NoncombatOnly,
+                        source: None
+                    },
+                }),
+                "phrase {phrase:?} must consume as OpponentDealtDamage{{NoncombatOnly}}"
             );
         }
     }
@@ -4398,7 +4459,7 @@ mod tests {
 
     /// CR 120.1 + CR 510.1: Tymna the Weaver — "the number of opponents that
     /// were dealt combat damage this turn" must route to the dedicated
-    /// `PlayerCount { OpponentDealtCombatDamage }` and NOT fall through into
+    /// `PlayerCount { OpponentDealtDamage }` and NOT fall through into
     /// the generic type-phrase fallback that produces an empty `ObjectCount`
     /// (the latter matched every battlefield object and drained the deck).
     #[test]
@@ -4410,14 +4471,17 @@ mod tests {
             qty,
             QuantityExpr::Ref {
                 qty: QuantityRef::PlayerCount {
-                    filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
+                    filter: PlayerFilter::OpponentDealtDamage {
+                        kind: DamageKindFilter::CombatOnly,
+                        source: None
+                    },
                 }
             }
         );
     }
 
     /// Symmetric singular form ("opponent that was dealt combat damage this
-    /// turn") must hit the same `PlayerFilter::OpponentDealtCombatDamage` arm.
+    /// turn") must hit the same `PlayerFilter::OpponentDealtDamage` arm.
     #[test]
     fn cda_quantity_opponent_singular_dealt_combat_damage() {
         let qty =
@@ -4427,7 +4491,10 @@ mod tests {
             qty,
             QuantityExpr::Ref {
                 qty: QuantityRef::PlayerCount {
-                    filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
+                    filter: PlayerFilter::OpponentDealtDamage {
+                        kind: DamageKindFilter::CombatOnly,
+                        source: None
+                    },
                 }
             }
         );
@@ -4436,11 +4503,11 @@ mod tests {
     /// CR 120.1 + CR 510.1: Upstream `strip_trailing_duration` removes the
     /// "this turn" suffix before the draw-count parser path reaches
     /// `parse_quantity_ref`. The phrase must still resolve to
-    /// `PlayerFilter::OpponentDealtCombatDamage` without the suffix —
+    /// `PlayerFilter::OpponentDealtDamage` without the suffix —
     /// otherwise cards like Moonshae Pixie ("draw cards equal to the number
     /// of opponents who were dealt combat damage this turn") regress to
     /// `Effect::Unimplemented`. The "this turn" tail is informational at
-    /// this layer: `PlayerCount{OpponentDealtCombatDamage}` already queries
+    /// this layer: `PlayerCount{OpponentDealtDamage}` already queries
     /// `state.damage_dealt_this_turn`.
     #[test]
     fn cda_quantity_opponents_dealt_combat_damage_strip_suffix() {
@@ -4456,10 +4523,13 @@ mod tests {
                 qty,
                 QuantityExpr::Ref {
                     qty: QuantityRef::PlayerCount {
-                        filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
+                        filter: PlayerFilter::OpponentDealtDamage {
+                            kind: DamageKindFilter::CombatOnly,
+                            source: None
+                        },
                     }
                 },
-                "phrase {phrase:?} must route to OpponentDealtCombatDamage",
+                "phrase {phrase:?} must route to OpponentDealtDamage",
             );
         }
     }
@@ -4480,7 +4550,8 @@ mod tests {
         assert_eq!(
             qty,
             QuantityRef::PlayerCount {
-                filter: PlayerFilter::OpponentDealtCombatDamage {
+                filter: PlayerFilter::OpponentDealtDamage {
+                    kind: DamageKindFilter::CombatOnly,
                     source: Some(Box::new(TargetFilter::Or {
                         filters: vec![
                             TargetFilter::SelfRef,
@@ -4505,7 +4576,8 @@ mod tests {
         assert_eq!(
             qty,
             QuantityRef::PlayerCount {
-                filter: PlayerFilter::OpponentDealtCombatDamage {
+                filter: PlayerFilter::OpponentDealtDamage {
+                    kind: DamageKindFilter::CombatOnly,
                     source: Some(Box::new(TargetFilter::SelfRef)),
                 },
             }
@@ -4525,9 +4597,12 @@ mod tests {
             assert_eq!(
                 parse_quantity_ref(phrase),
                 Some(QuantityRef::PlayerCount {
-                    filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
+                    filter: PlayerFilter::OpponentDealtDamage {
+                        kind: DamageKindFilter::CombatOnly,
+                        source: None
+                    },
                 }),
-                "phrase {phrase:?} must parse to unfiltered OpponentDealtCombatDamage"
+                "phrase {phrase:?} must parse to unfiltered OpponentDealtDamage"
             );
         }
     }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -4418,7 +4418,7 @@ fn try_extract_zone_change_object_filter_condition(
 /// ("Whenever your opponents are dealt combat damage, if any of that damage
 /// was dealt by a Warrior, ..."). The source phrase reuses the same
 /// `parse_target` + " or " + `merge_or_filters` chain as the
-/// `OpponentDealtCombatDamage { source }` PlayerFilter so a `~ or a Dragon`
+/// `OpponentDealtDamage { source }` PlayerFilter so a `~ or a Dragon`
 /// style disjunction composes uniformly.
 fn try_extract_event_damage_source_condition(
     lower: &str,
@@ -4454,7 +4454,7 @@ fn try_extract_event_damage_source_condition(
 /// CR 120.1 + CR 608.2i: Fold a "X or Y or ..." damage-source phrase into a
 /// single `TargetFilter` via `parse_target` + `merge_or_filters`. Mirrors
 /// `parse_source_chain_phrase` in `oracle_quantity.rs` (the
-/// `OpponentDealtCombatDamage { source }` builder) so source-restriction
+/// `OpponentDealtDamage { source }` builder) so source-restriction
 /// parsing stays consistent across the quantity and trigger-condition layers.
 fn parse_event_damage_source_chain(phrase: &str) -> TargetFilter {
     let (first, rest) = super::oracle_target::parse_target(phrase.trim());

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -15219,7 +15219,7 @@ fn trigger_postcombat_main_phase() {
 /// must bind `X` from the trailing "where X is …" clause across BOTH the
 /// "pay X life" cost AND the "draw X cards" sub-ability. The bound
 /// expression must resolve to
-/// `PlayerCount { OpponentDealtCombatDamage }`, not to an empty-shaped
+/// `PlayerCount { OpponentDealtDamage }`, not to an empty-shaped
 /// `ObjectCount` (which previously matched every battlefield permanent
 /// and made Tymna draw all 12 of the player's permanents instead of 1).
 #[test]
@@ -15239,7 +15239,10 @@ fn trigger_tymna_the_weaver_pays_and_draws_bound_x() {
 
     let bound_qty = QuantityExpr::Ref {
         qty: QuantityRef::PlayerCount {
-            filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
+            filter: PlayerFilter::OpponentDealtDamage {
+                kind: DamageKindFilter::CombatOnly,
+                source: None,
+            },
         },
     };
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -3190,7 +3190,7 @@ fn detect_duration_this_turn(
         // intervening-if condition consumes the "this turn" scope (Avatar Aang).
         "BendTypesThisTurn",
         "OpponentLostLife",
-        "OpponentDealtCombatDamage",
+        "OpponentDealtDamage",
         // CR 611.3: a condition slot serialized as the typed `Unrecognized`
         // marker means the parser routed the "as long as ... this turn" clause
         // INTO a condition slot (and explicitly recorded that it could not

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3044,6 +3044,16 @@ fn is_total_damage_channel(channel: &DamageChannel) -> bool {
     matches!(channel, DamageChannel::Total)
 }
 
+/// CR 120.2a: Back-compat serde default for `PlayerFilter::OpponentDealtDamage`'s
+/// `kind` field. Legacy data serialized before the field existed encoded the
+/// former `OpponentDealtCombatDamage` variant (combat-only semantics), so an
+/// absent `kind` must deserialize to `CombatOnly` — NOT `DamageKindFilter`'s own
+/// `Any` default, which would silently broaden the filter to noncombat damage
+/// too and misresolve reloaded games/scenarios.
+fn damage_kind_combat_only() -> DamageKindFilter {
+    DamageKindFilter::CombatOnly
+}
+
 /// CR 120.6 + CR 120.10: Compatibility deserializer for the `channel` field that
 /// replaced the former `excess_only: bool` on `QuantityRef::DamageDealtThisTurn`
 /// (and `AbilityCondition::PreviousEffectAmount`). Accepts both the current
@@ -5612,15 +5622,23 @@ pub enum PlayerFilter {
     /// player who has lost the game".
     HasLostTheGame,
     /// CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent who was dealt
-    /// combat damage this turn, optionally restricted to damage from a source
-    /// matching `source`. Resolved against `state.damage_dealt_this_turn`
-    /// records whose `is_combat = true` and `target = Player(p.id)`. `source =
-    /// None` counts any combat-damage source (Tymna the Weaver); `source =
-    /// Some(f)` (CR 120.9) counts only opponents dealt combat damage by a source
-    /// matching `f` — matched against each record's CR 608.2i look-back source
-    /// snapshot, so the source's qualities are checked as they were at damage
-    /// time (Estinien Varlineau: "by ~ or a Dragon").
-    OpponentDealtCombatDamage {
+    /// damage this turn matching `kind`, optionally restricted to damage from a
+    /// source matching `source`. Resolved against `state.damage_dealt_this_turn`
+    /// records whose `target = Player(p.id)` and whose combat status matches
+    /// `kind` (CR 120.2a combat / CR 120.2b noncombat / `Any` = either).
+    /// `kind = CombatOnly` + `source = None` counts any combat-damage source
+    /// (Tymna the Weaver); `kind = Any` counts any damage combat or noncombat
+    /// (Furious Spinesplitter, You've Been Caught Stealing); `source = Some(f)`
+    /// (CR 120.9) further restricts to opponents dealt matching damage by a
+    /// source matching `f` — matched against each record's CR 608.2i look-back
+    /// source snapshot, so the source's qualities are checked as they were at
+    /// damage time (Estinien Varlineau: "by ~ or a Dragon").
+    #[serde(alias = "OpponentDealtCombatDamage")]
+    OpponentDealtDamage {
+        /// CR 120.2a/120.2b: which damage kind counts. Defaults to `CombatOnly`
+        /// on absence for back-compat with the pre-rename combat-only variant.
+        #[serde(default = "damage_kind_combat_only")]
+        kind: DamageKindFilter,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<Box<TargetFilter>>,
     },

--- a/crates/engine/tests/furious_spinesplitter_any_damage.rs
+++ b/crates/engine/tests/furious_spinesplitter_any_damage.rs
@@ -1,0 +1,102 @@
+//! Furious Spinesplitter — end-step trigger: "put a +1/+1 counter on this
+//! creature for each opponent who was dealt damage this turn."
+//!
+//! Discriminating runtime coverage for the `PlayerFilter::OpponentDealtDamage`
+//! parameterization (gap Swallow:DynamicQty). The quantity is "each opponent
+//! who was dealt **damage** this turn" — ANY damage, combat OR noncombat
+//! (CR 120.2a/120.2b, `DamageKindFilter::Any`).
+//!
+//! REVERT-FAILING / non-vacuous: three players (P0 controls Spinesplitter, P1 +
+//! P2 opponents). P0 deals NONCOMBAT damage (Shock) to BOTH opponents, then the
+//! end-step trigger resolves. Correct count is 2 counters (one per any-damaged
+//! opponent). A pre-fix swallow (`Fixed 1`) yields 1 counter → the `== 2`
+//! assertion fails; a `CombatOnly` regression yields 0 (Shock is noncombat) →
+//! fails. Only `Any` yields 2.
+//!
+//! A positive shape reach-guard confirms the trigger parsed to
+//! `PlayerCount { OpponentDealtDamage { kind: Any } }` with no `Unimplemented`.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::parse_oracle_text;
+use engine::types::counter::CounterType;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::ObjectId;
+
+const P2: PlayerId = PlayerId(2);
+
+const SPINESPLITTER_ORACLE: &str = "Trample\nAt the beginning of your end step, put a +1/+1 counter on this creature for each opponent who was dealt damage this turn.";
+
+const SHOCK_ORACLE: &str = "Shock deals 2 damage to any target.";
+
+fn plus1_counters(state: &engine::types::game_state::GameState, id: ObjectId) -> u32 {
+    state
+        .objects
+        .get(&id)
+        .and_then(|o| o.counters.get(&CounterType::Plus1Plus1).copied())
+        .unwrap_or(0)
+}
+
+#[test]
+fn furious_spinesplitter_counters_per_any_damaged_opponent() {
+    // Shape reach-guard (positive): the end-step trigger must parse to the
+    // ANY-damage player count, no swallowed/unimplemented clause.
+    // Trample is supplied as an MTGJSON keyword (as in production), so the
+    // keyword line is extracted rather than left as a bare-word effect.
+    let parsed = parse_oracle_text(
+        SPINESPLITTER_ORACLE,
+        "Furious Spinesplitter",
+        &["Trample".to_string()],
+        &[],
+        &[],
+    );
+    let dbg = format!("{parsed:#?}");
+    assert!(
+        dbg.contains("OpponentDealtDamage") && dbg.contains("Any"),
+        "trigger must parse to PlayerCount {{ OpponentDealtDamage {{ kind: Any }} }}; got {dbg}"
+    );
+    assert!(
+        !dbg.contains("Unimplemented"),
+        "no clause of Furious Spinesplitter may fall through to Unimplemented; got {dbg}"
+    );
+
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    // Post-combat main so advancing to the end step does not cross the combat
+    // declaration steps (which would stall the phase driver at DeclareAttackers).
+    scenario.at_phase(Phase::PostCombatMain);
+    scenario.with_mana_pool(
+        P0,
+        (0..8)
+            .map(|_| ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![]))
+            .collect(),
+    );
+    // Verbatim Oracle (keyword Trample extracted from the keyword line).
+    let spinesplitter = scenario
+        .add_creature_from_oracle(P0, "Furious Spinesplitter", 3, 3, SPINESPLITTER_ORACLE)
+        .id();
+    let shock1 = scenario
+        .add_spell_to_hand_from_oracle(P0, "Shock", true, SHOCK_ORACLE)
+        .id();
+    let shock2 = scenario
+        .add_spell_to_hand_from_oracle(P0, "Shock", true, SHOCK_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // NONCOMBAT damage to BOTH opponents (CR 120.2b) through the real pipeline.
+    runner.cast(shock1).target_player(P1).resolve();
+    runner.cast(shock2).target_player(P2).resolve();
+
+    // Advance to P0's end step and resolve the triggered ability.
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+
+    // CR 120.1 + CR 120.2a/120.2b: both opponents were dealt (noncombat) damage
+    // this turn → 2 +1/+1 counters. Fixed-1 revert → 1; CombatOnly revert → 0.
+    assert_eq!(
+        plus1_counters(runner.state(), spinesplitter),
+        2,
+        "Spinesplitter must gain one +1/+1 counter per any-damaged opponent (2)"
+    );
+}

--- a/crates/engine/tests/you_have_been_caught_stealing_any_damage.rs
+++ b/crates/engine/tests/you_have_been_caught_stealing_any_damage.rs
@@ -1,0 +1,97 @@
+//! You've Been Caught Stealing — Bribe mode: "You create a Treasure token for
+//! each opponent who was dealt damage this turn."
+//!
+//! Discriminating runtime coverage for the `PlayerFilter::OpponentDealtDamage`
+//! parameterization (gap Swallow:DynamicQty). The Bribe quantity is
+//! "each opponent who was dealt **damage** this turn" — ANY damage, combat OR
+//! noncombat (CR 120.2a/120.2b, `DamageKindFilter::Any`).
+//!
+//! REVERT-FAILING / non-vacuous: three players (P0 caster, P1 + P2 opponents).
+//! P0 deals NONCOMBAT damage (Shock) to BOTH opponents, then casts YBCS choosing
+//! Bribe. The correct count is 2 Treasures (one per any-damaged opponent). A
+//! pre-fix swallow (`Fixed 1`) yields 1 Treasure → the `== 2` assertion fails; a
+//! `CombatOnly` regression yields 0 (Shock is noncombat) → fails. Only `Any`
+//! yields 2.
+//!
+//! A positive shape reach-guard confirms the Bribe mode parsed to
+//! `PlayerCount { OpponentDealtDamage { kind: Any } }` with no `Unimplemented`,
+//! so the runtime count is not passing for the wrong reason.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::parse_oracle_text;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::ObjectId;
+
+const P2: PlayerId = PlayerId(2);
+
+const YBCS_ORACLE: &str = "Choose one —\n\u{2022} Threaten the Merchant — Each creature blocks this turn if able.\n\u{2022} Bribe the Guards — You create a Treasure token for each opponent who was dealt damage this turn. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")";
+
+const SHOCK_ORACLE: &str = "Shock deals 2 damage to any target.";
+
+/// Count battlefield Treasure tokens owned by `owner`.
+fn treasure_count(state: &engine::types::game_state::GameState, owner: PlayerId) -> usize {
+    state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .filter(|o| o.is_token && o.name == "Treasure" && o.owner == owner)
+        .count()
+}
+
+#[test]
+fn ybcs_bribe_creates_one_treasure_per_any_damaged_opponent() {
+    // Shape reach-guard (positive): the Bribe mode must parse to the ANY-damage
+    // player count, with no swallowed/unimplemented clause — otherwise the
+    // runtime `== 2` below could pass for the wrong reason.
+    let parsed = parse_oracle_text(YBCS_ORACLE, "You've Been Caught Stealing", &[], &[], &[]);
+    let dbg = format!("{parsed:#?}");
+    assert!(
+        dbg.contains("OpponentDealtDamage") && dbg.contains("Any"),
+        "Bribe mode must parse to PlayerCount {{ OpponentDealtDamage {{ kind: Any }} }}; got {dbg}"
+    );
+    assert!(
+        !dbg.contains("Unimplemented"),
+        "no clause of YBCS may fall through to Unimplemented; got {dbg}"
+    );
+
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    // Generous pool; oracle-parsed spells carry no mana cost, so this is simply
+    // unused if a cast needs no payment.
+    scenario.with_mana_pool(
+        P0,
+        (0..12)
+            .map(|_| ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![]))
+            .collect(),
+    );
+    let shock1 = scenario
+        .add_spell_to_hand_from_oracle(P0, "Shock", true, SHOCK_ORACLE)
+        .id();
+    let shock2 = scenario
+        .add_spell_to_hand_from_oracle(P0, "Shock", true, SHOCK_ORACLE)
+        .id();
+    let ybcs = scenario
+        .add_spell_to_hand_from_oracle(P0, "You've Been Caught Stealing", true, YBCS_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // NONCOMBAT damage to BOTH opponents (CR 120.2b), through the real pipeline
+    // so each records a `damage_dealt_this_turn` entry with target = Player.
+    runner.cast(shock1).target_player(P1).resolve();
+    runner.cast(shock2).target_player(P2).resolve();
+
+    // Bribe the Guards is the second mode (index 1).
+    let outcome = runner.cast(ybcs).modes(&[1]).resolve();
+    let state = outcome.state();
+
+    // CR 120.1 + CR 120.2a/120.2b: both opponents were dealt (noncombat) damage
+    // this turn → 2 Treasure tokens. Fixed-1 revert → 1; CombatOnly revert → 0.
+    assert_eq!(
+        treasure_count(state, P0),
+        2,
+        "Bribe must create one Treasure per any-damaged opponent (2)"
+    );
+}


### PR DESCRIPTION
## Summary
Supports **"for each opponent who was dealt damage this turn"** (ANY damage — combat OR noncombat) on **Furious Spinesplitter** and **You've Been Caught Stealing**. The quantity was swallowed → `Fixed 1`; only the combat form ("dealt combat damage this turn", Tymna the Weaver) was supported.

**Parameterize, don't proliferate** (per `CLAUDE.md`) — reuse the existing typed axis, no new variant/bool:
- Rename `PlayerFilter::OpponentDealtCombatDamage { source }` → `OpponentDealtDamage { kind: DamageKindFilter, source }`, where `DamageKindFilter` is the pre-existing `{ Any, CombatOnly, NoncombatOnly }` enum already threaded through the `DamageDealtThisTurn` resolver. A `#[serde(alias)]` + a `CombatOnly` default preserve legacy data (a bare `OpponentDealtCombatDamage` meant combat-only, not `Any`).
- Parser: `"dealt {combat|noncombat|} damage this turn"` → the matching kind via a nom `alt`; `"dealt combat damage"` still → `CombatOnly` (Tymna unchanged).
- Resolver: delegate the `is_combat` decision to the existing `damage_record_matches_kind`. Noncombat player damage is already recorded in `state.damage_dealt_this_turn` (`is_combat = false`), so **no new tracking infrastructure**.

## Files changed
- `crates/engine/src/types/ability.rs` (variant parameterization + serde back-compat)
- `crates/engine/src/parser/oracle_quantity.rs` (kind-aware clause combinator)
- `crates/engine/src/parser/oracle_effect/mod.rs` (token-for-each subject-strip fallback — see Scope Expansion)
- `crates/engine/src/game/quantity.rs` (resolver via `damage_record_matches_kind`)
- `crates/engine/src/game/{effects/mod.rs, effects/deal_damage.rs, effects/speed_effects.rs, ability_scan.rs, ability_rw.rs, triggers.rs, coverage.rs, replacement.rs}` (rename threaded through exhaustive matches / doc)
- `crates/engine/src/parser/{oracle_trigger.rs, oracle_trigger_tests.rs, swallow_check.rs}`
- `crates/engine/tests/furious_spinesplitter_any_damage.rs`, `crates/engine/tests/you_have_been_caught_stealing_any_damage.rs` (new)

## CR references
- `CR 120.1` — dealing damage
- `CR 120.2a` — combat damage; `CR 120.2b` — noncombat damage (the new `kind` axis)
- `CR 510.1` — combat damage step; `CR 120.9` — "damage dealt by a source" restriction

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high
Tier: Frontier

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (exit 0)
- `cargo check -p engine --all-targets` — clean (exhaustive `PlayerFilter` matches all threaded)
- `cargo clippy -p engine --all-targets -- -D warnings` — clean
- `cargo test -p engine` — 0 failures (incl. updated + new parser/resolver/serde tests and both new runtime tests)
- `./scripts/gen-card-data.sh` + `cargo coverage` — **Furious Spinesplitter** & **You've Been Caught Stealing**: `supported: true`, `gap_count: 0`; **Tymna the Weaver**: unchanged (`kind: CombatOnly`)
- `cargo semantic-audit` — 0 findings for all three cards

Tests:
- Parser (oracle_quantity.rs) — `Any` and `NoncombatOnly` forms → `PlayerCount { OpponentDealtDamage { kind } }`; combat form still `CombatOnly`.
- Resolver (game/quantity.rs) — one combat + one noncombat damaged opponent in the ledger: `Any` → 2, `CombatOnly` → 1, `NoncombatOnly` → 1 (kind-discriminating). Legacy-JSON test: `{"type":"OpponentDealtCombatDamage"}` (no `kind`) → `CombatOnly`; round-trip.
- Runtime, **revert-failing** (3 players, both opponents dealt *noncombat* Shock):
  - `you_have_been_caught_stealing_any_damage.rs` — Bribe mode (`modes(&[1])`) → **2 Treasure tokens**. Pre-fix `Fixed 1` → 1; `CombatOnly` → 0. Reach-guard: parse = `OpponentDealtDamage{Any}`, no `Unimplemented`.
  - `furious_spinesplitter_any_damage.rs` — end-step trigger → **2 `+1/+1` counters** (read via `runner.state().objects[...].counters`). Same revert-failing/reach-guard pattern.

## Gate A
`./scripts/check-parser-combinators.sh` — exit 0, no violations.

## Anchored on
- `crates/engine/src/types/ability.rs` — `DamageKindFilter` (existing `{Any,CombatOnly,NoncombatOnly}`) reused as the `kind` axis, mirroring its use in the `DamageDealtThisTurn` resolver.
- `crates/engine/src/game/quantity.rs` `damage_record_matches_kind` — the existing per-record kind gate the resolver now delegates to (was a hardcoded `r.is_combat`).
- `crates/engine/src/parser/oracle_effect/mod.rs` — the token-for-each arm's new raw-then-subject-stripped ordering mirrors the pre-existing numeric-for-each arm directly above it.

## Scope Expansion
The enum parameterization alone did not flip **You've Been Caught Stealing**: the token "for each" arm (`try_parse_for_each_effect` → `try_parse_token`, `oracle_effect/mod.rs`) fed the raw subject-bearing base `"You create a Treasure token"` to `try_parse_token`, which returned `None`, stranding the correctly-parsed for-each quantity (this also swallowed the *combat* token form). Fixed by having the token arm try the raw base first, then fall back to a subject-stripped base — mirroring the numeric arm directly above. Verified additive: swept `card-data.json` for every `create … token for each …` card; multi-player subjects (`each player/opponent creates …`) are handled by `player_scope` upstream and never reach this fallback, distributive `its controller creates …` routes elsewhere, and the only newly-captured forms are singular `you create …` (owner = controller, correct). No card changes owner/scope.

## Validation Failures
None.

## CI Failures
None.
