### PR TITLE
fix: gate discard triggers on madness intervening-if (closes #5143)

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -1808,6 +1808,7 @@ fn legacy_trigger_condition(x: &TriggerCondition) -> bool {
         | TriggerCondition::ZoneChangeObjectMatchesFilter { .. }
         | TriggerCondition::ZoneChangeObjectIsTapped
         | TriggerCondition::EventDamageSourceMatchesFilter { .. }
+        | TriggerCondition::EventObjectMatchesFilter { .. }
         | TriggerCondition::DamagedPlayerIsEventSourceOwner
         | TriggerCondition::TriggeringSpellTargetsFilter { .. }
         | TriggerCondition::ManaColorSpent { .. }
@@ -5572,6 +5573,7 @@ fn rw_trigger_condition(x: &TriggerCondition) -> RwProfile {
         TriggerCondition::ZoneChangeObjectMatchesFilter { .. }
         | TriggerCondition::ZoneChangeObjectIsTapped
         | TriggerCondition::EventDamageSourceMatchesFilter { .. }
+        | TriggerCondition::EventObjectMatchesFilter { .. }
         | TriggerCondition::DamagedPlayerIsEventSourceOwner
         | TriggerCondition::TriggeringSpellTargetsFilter { .. } => reads_event_live(),
         TriggerCondition::ManaColorSpent { .. } | TriggerCondition::ManaSpentCondition { .. } => {

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -2688,6 +2688,15 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
+        TriggerCondition::EventObjectMatchesFilter { filter } => {
+            let mut acc = Axes {
+                event: true,
+                sibling: false,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
         TriggerCondition::DamagedPlayerIsEventSourceOwner => Axes {
             event: true,
             sibling: false,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3556,6 +3556,9 @@ fn fmt_trigger_condition(cond: &crate::types::ability::TriggerCondition) -> Stri
         TC::EventDamageSourceMatchesFilter { filter } => {
             format!("damage source is {}", fmt_target(filter))
         }
+        TC::EventObjectMatchesFilter { filter } => {
+            format!("event object is {}", fmt_target(filter))
+        }
         TC::DamagedPlayerIsEventSourceOwner => "damaged player is the source's owner".into(),
         TC::ChosenLabelIs { label } => format!("chosen label is {label}"),
         TC::AttackersDeclaredCount {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -6375,14 +6375,11 @@ pub(crate) fn check_trigger_condition(
                 if super::filter::matches_target_filter(state, object_id, filter, &ctx) {
                     return true;
                 }
-                state
-                    .lki_cache
-                    .get(&object_id)
-                    .is_some_and(|lki| {
-                        super::filter::matches_target_filter_on_lki_snapshot(
-                            state, object_id, lki, filter, &ctx,
-                        )
-                    })
+                state.lki_cache.get(&object_id).is_some_and(|lki| {
+                    super::filter::matches_target_filter_on_lki_snapshot(
+                        state, object_id, lki, filter, &ctx,
+                    )
+                })
             }),
         // CR 120.1 + CR 108.3: "deals combat damage to its owner" — the damaged
         // player must be the owner of the object that dealt the damage (CR 120.1:

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -6362,6 +6362,28 @@ pub(crate) fn check_trigger_condition(
                 _ => None,
             })
             .is_some(),
+        // CR 603.4 + CR 701.9a: Intervening-if on the triggering event's object
+        // (e.g. the discarded card). The object may already have left the hand,
+        // so fall back to LKI when the live object no longer matches.
+        TriggerCondition::EventObjectMatchesFilter { filter } => trigger_event
+            .and_then(crate::game::targeting::extract_source_from_event)
+            .is_some_and(|object_id| {
+                let ctx = FilterContext::from_source_with_controller(
+                    source_id.unwrap_or(ObjectId(0)),
+                    controller,
+                );
+                if super::filter::matches_target_filter(state, object_id, filter, &ctx) {
+                    return true;
+                }
+                state
+                    .lki_cache
+                    .get(&object_id)
+                    .is_some_and(|lki| {
+                        super::filter::matches_target_filter_on_lki_snapshot(
+                            state, object_id, lki, filter, &ctx,
+                        )
+                    })
+            }),
         // CR 120.1 + CR 108.3: "deals combat damage to its owner" — the damaged
         // player must be the owner of the object that dealt the damage (CR 120.1:
         // the object that deals damage is the source of that damage). Two event
@@ -7718,6 +7740,64 @@ pub mod tests {
         assert!(
             !check_trigger_constraint(&state, &def, source, 0, PlayerId(0), &no_cause),
             "a discard with no recorded cause must NOT satisfy the constraint"
+        );
+    }
+
+    /// Issue #5143 — Anje Falkenrath: intervening-if "if it has madness" must
+    /// read the discarded card, not fire for every discard.
+    #[test]
+    fn event_object_madness_intervening_if_gates_discard_trigger() {
+        use crate::types::ability::{FilterProp, TriggerCondition};
+        use crate::types::keywords::{Keyword, KeywordKind};
+        use crate::types::mana::ManaCost;
+
+        let mut state = setup();
+        let anje = make_creature(&mut state, PlayerId(0), "Anje Falkenrath", 1, 3);
+        let madness_card = make_creature(&mut state, PlayerId(0), "Basking Rootwalla", 1, 1);
+        let normal_card = make_creature(&mut state, PlayerId(0), "Grizzly Bears", 2, 2);
+
+        if let Some(obj) = state.objects.get_mut(&madness_card) {
+            obj.keywords.push(Keyword::Madness(ManaCost::default()));
+        }
+
+        let condition = TriggerCondition::EventObjectMatchesFilter {
+            filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
+                FilterProp::HasKeywordKind {
+                    value: KeywordKind::Madness,
+                },
+            ])),
+        };
+
+        let madness_discard = GameEvent::Discarded {
+            player_id: PlayerId(0),
+            object_id: madness_card,
+            source_id: None,
+        };
+        assert!(
+            check_trigger_condition(
+                &state,
+                &condition,
+                PlayerId(0),
+                Some(anje),
+                Some(&madness_discard),
+            ),
+            "madness discard must satisfy the intervening-if"
+        );
+
+        let normal_discard = GameEvent::Discarded {
+            player_id: PlayerId(0),
+            object_id: normal_card,
+            source_id: None,
+        };
+        assert!(
+            !check_trigger_condition(
+                &state,
+                &condition,
+                PlayerId(0),
+                Some(anje),
+                Some(&normal_discard),
+            ),
+            "non-madness discard must NOT satisfy the intervening-if"
         );
     }
 

--- a/crates/engine/src/parser/oracle_nom/primitives.rs
+++ b/crates/engine/src/parser/oracle_nom/primitives.rs
@@ -707,6 +707,7 @@ pub fn parse_alt_cost_keyword_name_to_kind(input: &str) -> OracleResult<'_, Keyw
         value(KeywordKind::Mutate, tag("mutate")),
         value(KeywordKind::Bestow, tag("bestow")),
         value(KeywordKind::Harmonize, tag("harmonize")),
+        value(KeywordKind::Madness, tag("madness")),
     ))
     .parse(input)
 }
@@ -1837,6 +1838,7 @@ mod tests {
             ("mutate ability", KeywordKind::Mutate),
             ("bestow ability", KeywordKind::Bestow),
             ("harmonize ability", KeywordKind::Harmonize),
+            ("madness", KeywordKind::Madness),
         ];
         for (input, expected) in cases {
             let (_, kind) = parse_alt_cost_keyword_name_to_kind(input).unwrap();

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3892,12 +3892,12 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
         );
     }
 
-    // CR 603.4 + CR 701.9a + CR 702.35a: "if it has madness" — intervening-if on
-    // discard triggers whose subject is the discarded card (Anje Falkenrath).
-    // MUST precede the zone-change-object "if it " arms below, which would
-    // otherwise mis-route this predicate.
+    // CR 603.4 + CR 701.9a + CR 702.35a: "if it has <alt-cost keyword>" —
+    // intervening-if on discard triggers whose subject is the discarded card
+    // (Anje Falkenrath: "if it has madness"). MUST precede the zone-change-
+    // object "if it " arms below, which would otherwise mis-route this predicate.
     if let Some((before, condition, rest)) =
-        scan_preceded(&lower, parse_discarded_card_has_madness_intervening_if)
+        scan_preceded(&lower, parse_event_object_has_alt_cost_keyword_intervening_if)
     {
         let pos = before.len();
         let clause_len = lower.len() - before.len() - rest.len();
@@ -4349,18 +4349,18 @@ fn parse_zone_change_object_token_contraction_intervening_if(
     Ok((rest, zone_change_object_token_condition(true)))
 }
 
-/// CR 603.4 + CR 701.9a + CR 702.35a: "if it has madness" on discard triggers.
-fn parse_discarded_card_has_madness_intervening_if(
+/// CR 603.4 + CR 701.9a + CR 702.35a: "if it has <alt-cost keyword>" on
+/// event-object intervening-ifs (e.g. discard triggers: "if it has madness").
+fn parse_event_object_has_alt_cost_keyword_intervening_if(
     input: &str,
 ) -> OracleResult<'_, TriggerCondition> {
-    let (rest, _) = tag("if it has madness").parse(input)?;
+    let (rest, _) = tag("if it has ").parse(input)?;
+    let (rest, keyword) = nom_primitives::parse_alt_cost_keyword_name_to_kind.parse(rest)?;
     Ok((
         rest,
         TriggerCondition::EventObjectMatchesFilter {
             filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
-                FilterProp::HasKeywordKind {
-                    value: KeywordKind::Madness,
-                },
+                FilterProp::HasKeywordKind { value: keyword },
             ])),
         },
     ))

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -49,7 +49,6 @@ use crate::types::ability::{
 use crate::types::card_type::{is_land_subtype, CoreType};
 use crate::types::counter::CounterType;
 use crate::types::events::{ClashResult, PlayerActionKind};
-use crate::types::keywords::KeywordKind;
 use crate::types::mana::{ManaColor, ManaType};
 use crate::types::phase::Phase;
 use crate::types::triggers::{AttackTargetFilter, TriggerMode};
@@ -3892,10 +3891,10 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
         );
     }
 
-    // CR 603.4 + CR 701.9a + CR 702.35a: "if it has <alt-cost keyword>" —
-    // intervening-if on discard triggers whose subject is the discarded card
-    // (Anje Falkenrath: "if it has madness"). MUST precede the zone-change-
-    // object "if it " arms below, which would otherwise mis-route this predicate.
+    // CR 603.4 + CR 701.9a + CR 702.35a: "if it has <alt-cost keyword>" — intervening-if
+    // on discard triggers whose subject is the discarded card (Anje Falkenrath: "if it has
+    // madness"). MUST precede the zone-change-object "if it " arms below, which would
+    // otherwise mis-route this predicate.
     if let Some((before, condition, rest)) =
         scan_preceded(&lower, parse_event_object_has_alt_cost_keyword_intervening_if)
     {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -4349,6 +4349,16 @@ fn parse_zone_change_object_token_contraction_intervening_if(
     Ok((rest, zone_change_object_token_condition(true)))
 }
 
+/// CR 603.4 + CR 701.9a + CR 702.35a: Build an event-object intervening-if
+/// filter for a named alt-cost keyword on the triggering object.
+fn event_object_has_alt_cost_keyword_condition(keyword: KeywordKind) -> TriggerCondition {
+    TriggerCondition::EventObjectMatchesFilter {
+        filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
+            FilterProp::HasKeywordKind { value: keyword },
+        ])),
+    }
+}
+
 /// CR 603.4 + CR 701.9a + CR 702.35a: "if it has <alt-cost keyword>" on
 /// event-object intervening-ifs (e.g. discard triggers: "if it has madness").
 fn parse_event_object_has_alt_cost_keyword_intervening_if(
@@ -4356,14 +4366,7 @@ fn parse_event_object_has_alt_cost_keyword_intervening_if(
 ) -> OracleResult<'_, TriggerCondition> {
     let (rest, _) = tag("if it has ").parse(input)?;
     let (rest, keyword) = nom_primitives::parse_alt_cost_keyword_name_to_kind.parse(rest)?;
-    Ok((
-        rest,
-        TriggerCondition::EventObjectMatchesFilter {
-            filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
-                FilterProp::HasKeywordKind { value: keyword },
-            ])),
-        },
-    ))
+    Ok((rest, event_object_has_alt_cost_keyword_condition(keyword)))
 }
 
 /// CR 603.4 + CR 603.6a + CR 208.1: Entering-object intervening-if comparing the

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -46,6 +46,7 @@ use crate::types::ability::{
     TapCreaturesRequirement, TargetFilter, TriggerCondition, TriggerConstraint, TriggerDefinition,
     TypeFilter, TypedFilter, UnlessPayModifier, ZoneChangeClause,
 };
+use crate::types::card_type::{is_land_subtype, CoreType};
 use crate::types::counter::CounterType;
 use crate::types::events::{ClashResult, PlayerActionKind};
 use crate::types::keywords::KeywordKind;

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3896,16 +3896,14 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
     // discard triggers whose subject is the discarded card (Anje Falkenrath).
     // MUST precede the zone-change-object "if it " arms below, which would
     // otherwise mis-route this predicate.
-    if let Some(pos) = tp.find("if it has madness") {
+    if let Some((before, condition, rest)) =
+        scan_preceded(&lower, parse_discarded_card_has_madness_intervening_if)
+    {
+        let pos = before.len();
+        let clause_len = lower.len() - before.len() - rest.len();
         return (
-            strip_condition_clause(text, pos, "if it has madness".len()),
-            Some(TriggerCondition::EventObjectMatchesFilter {
-                filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
-                    FilterProp::HasKeywordKind {
-                        value: KeywordKind::Madness,
-                    },
-                ])),
-            }),
+            strip_condition_clause(text, pos, clause_len),
+            Some(condition),
         );
     }
 
@@ -4349,6 +4347,23 @@ fn parse_zone_change_object_token_contraction_intervening_if(
     let (rest, _) = tag("if it's not a ").parse(input)?;
     let (rest, _) = tag("token").parse(rest)?;
     Ok((rest, zone_change_object_token_condition(true)))
+}
+
+/// CR 603.4 + CR 701.9a + CR 702.35a: "if it has madness" on discard triggers.
+fn parse_discarded_card_has_madness_intervening_if(
+    input: &str,
+) -> OracleResult<'_, TriggerCondition> {
+    let (rest, _) = tag("if it has madness").parse(input)?;
+    Ok((
+        rest,
+        TriggerCondition::EventObjectMatchesFilter {
+            filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
+                FilterProp::HasKeywordKind {
+                    value: KeywordKind::Madness,
+                },
+            ])),
+        },
+    ))
 }
 
 /// CR 603.4 + CR 603.6a + CR 208.1: Entering-object intervening-if comparing the

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3895,9 +3895,10 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
     // on discard triggers whose subject is the discarded card (Anje Falkenrath: "if it has
     // madness"). MUST precede the zone-change-object "if it " arms below, which would
     // otherwise mis-route this predicate.
-    if let Some((before, condition, rest)) =
-        scan_preceded(&lower, parse_event_object_has_alt_cost_keyword_intervening_if)
-    {
+    if let Some((before, condition, rest)) = scan_preceded(
+        &lower,
+        parse_event_object_has_alt_cost_keyword_intervening_if,
+    ) {
         let pos = before.len();
         let clause_len = lower.len() - before.len() - rest.len();
         return (

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -4353,9 +4353,9 @@ fn parse_zone_change_object_token_contraction_intervening_if(
 /// filter for a named alt-cost keyword on the triggering object.
 fn event_object_has_alt_cost_keyword_condition(keyword: KeywordKind) -> TriggerCondition {
     TriggerCondition::EventObjectMatchesFilter {
-        filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
-            FilterProp::HasKeywordKind { value: keyword },
-        ])),
+        filter: TargetFilter::Typed(
+            TypedFilter::card().properties(vec![FilterProp::HasKeywordKind { value: keyword }]),
+        ),
     }
 }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -49,6 +49,7 @@ use crate::types::ability::{
 use crate::types::card_type::{is_land_subtype, CoreType};
 use crate::types::counter::CounterType;
 use crate::types::events::{ClashResult, PlayerActionKind};
+use crate::types::keywords::KeywordKind;
 use crate::types::mana::{ManaColor, ManaType};
 use crate::types::phase::Phase;
 use crate::types::triggers::{AttackTargetFilter, TriggerMode};

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -46,7 +46,7 @@ use crate::types::ability::{
     TapCreaturesRequirement, TargetFilter, TriggerCondition, TriggerConstraint, TriggerDefinition,
     TypeFilter, TypedFilter, UnlessPayModifier, ZoneChangeClause,
 };
-use crate::types::card_type::{is_land_subtype, CoreType};
+use crate::types::keywords::KeywordKind;
 use crate::types::counter::CounterType;
 use crate::types::events::{ClashResult, PlayerActionKind};
 use crate::types::mana::{ManaColor, ManaType};
@@ -3887,6 +3887,23 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
                     controller: None,
                     owner: None,
                 }),
+            }),
+        );
+    }
+
+    // CR 603.4 + CR 701.9a + CR 702.35a: "if it has madness" — intervening-if on
+    // discard triggers whose subject is the discarded card (Anje Falkenrath).
+    // MUST precede the zone-change-object "if it " arms below, which would
+    // otherwise mis-route this predicate.
+    if let Some(pos) = tp.find("if it has madness") {
+        return (
+            strip_condition_clause(text, pos, "if it has madness".len()),
+            Some(TriggerCondition::EventObjectMatchesFilter {
+                filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
+                    FilterProp::HasKeywordKind {
+                        value: KeywordKind::Madness,
+                    },
+                ])),
             }),
         );
     }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -46,9 +46,9 @@ use crate::types::ability::{
     TapCreaturesRequirement, TargetFilter, TriggerCondition, TriggerConstraint, TriggerDefinition,
     TypeFilter, TypedFilter, UnlessPayModifier, ZoneChangeClause,
 };
-use crate::types::keywords::KeywordKind;
 use crate::types::counter::CounterType;
 use crate::types::events::{ClashResult, PlayerActionKind};
+use crate::types::keywords::KeywordKind;
 use crate::types::mana::{ManaColor, ManaType};
 use crate::types::phase::Phase;
 use crate::types::triggers::{AttackTargetFilter, TriggerMode};

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -7283,6 +7283,40 @@ fn trigger_intervening_if_opponent_discarded_this_turn() {
     );
 }
 
+/// Issue #5143 — Anje Falkenrath: "Whenever you discard a card, if it has
+/// madness, untap Anje Falkenrath." The madness intervening-if must gate on
+/// the discarded card, not fire on every discard.
+#[test]
+fn trigger_intervening_if_discarded_card_has_madness() {
+    use crate::types::ability::FilterProp;
+    use crate::types::keywords::KeywordKind;
+
+    let def = parse_trigger_line(
+        "Whenever you discard a card, if it has madness, untap Anje Falkenrath.",
+        "Anje Falkenrath",
+    );
+    assert_eq!(def.mode, TriggerMode::Discarded);
+    let Some(TriggerCondition::EventObjectMatchesFilter { filter }) = &def.condition else {
+        panic!(
+            "expected EventObjectMatchesFilter intervening-if, got {:?}",
+            def.condition
+        );
+    };
+    let TargetFilter::Typed(tf) = filter else {
+        panic!("expected typed madness filter, got {filter:?}");
+    };
+    assert!(
+        tf.properties.iter().any(|prop| matches!(
+            prop,
+            FilterProp::HasKeywordKind {
+                value: KeywordKind::Madness
+            }
+        )),
+        "expected madness keyword filter, got {:?}",
+        tf.properties
+    );
+}
+
 /// Issue #551 — The Raven Man: "At the beginning of each end step, if a
 /// player discarded a card this turn, create a 1/1 black Bird ...". The
 /// "a player" (any player) intervening-if must be hoisted as an all-players

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -16217,6 +16217,14 @@ pub enum TriggerCondition {
     /// Checked at both fire-time and resolution-time per CR 603.4.
     EventDamageSourceMatchesFilter { filter: TargetFilter },
 
+    /// CR 603.4 + CR 701.9a: Intervening-if whose subject is the object named
+    /// by the triggering event (e.g. the discarded card on `GameEvent::Discarded`),
+    /// not the permanent that owns the ability. Distinct from
+    /// `ZoneChangeObjectMatchesFilter` (zone-change subjects) and
+    /// `SourceMatchesFilter` (the ability's own permanent). Used by discard
+    /// riders such as "if it has madness" (Anje Falkenrath).
+    EventObjectMatchesFilter { filter: TargetFilter },
+
     /// CR 120.1 + CR 108.3 + CR 603.4: Intervening-if predicate that holds when
     /// the player dealt the triggering damage is the OWNER of the object that
     /// dealt it ("deals combat damage to its owner"). Reads the triggering

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -231,6 +231,8 @@ pub enum KeywordKind {
     Escape,
     Morph,
     Megamorph,
+    /// CR 702.35a: Madness — see `Keyword::Madness`.
+    Madness,
     /// CR 702.187: Mayhem — see `Keyword::Mayhem`.
     Mayhem,
     Suspend,
@@ -1159,6 +1161,7 @@ impl Keyword {
             Keyword::Escape(_) => KeywordKind::Escape,
             Keyword::Morph(_) => KeywordKind::Morph,
             Keyword::Megamorph(_) => KeywordKind::Megamorph,
+            Keyword::Madness(_) => KeywordKind::Madness,
             Keyword::Mayhem(_) => KeywordKind::Mayhem,
             Keyword::Suspend { .. } => KeywordKind::Suspend,
             Keyword::Blitz(_) => KeywordKind::Blitz,
@@ -1244,7 +1247,6 @@ impl Keyword {
             | Keyword::Ingest
             | Keyword::LevelUp(_)
             | Keyword::LivingMetal
-            | Keyword::Madness(_)
             | Keyword::Melee
             | Keyword::Mentor
             | Keyword::Mobilize(_)

--- a/crates/mtgish-import/src/convert/condition.rs
+++ b/crates/mtgish-import/src/convert/condition.rs
@@ -1170,6 +1170,13 @@ pub struct TriggerCondExt {
 /// engine variants in a separate round).
 pub fn convert_trigger_with_etb_filter(c: &Condition) -> ConvResult<TriggerCondExt> {
     match c {
+        // CR 603.4 + CR 701.9a: "if the discarded card [passes predicate]" on a
+        // discard trigger — lower onto `valid_card` so `match_discarded` gates
+        // the event object (Anje Falkenrath's madness rider).
+        Condition::DiscardedCardPassesFilter(cards) => Ok(TriggerCondExt {
+            condition: None,
+            valid_card: Some(crate::convert::filter::cards_to_filter(cards)?),
+        }),
         Condition::EnteringPermanentPassesFilter(pred) => {
             // Try the event-object condition path first; fall through to the
             // legacy valid_card route only for predicates that still cannot be

--- a/crates/mtgish-import/src/convert/filter.rs
+++ b/crates/mtgish-import/src/convert/filter.rs
@@ -1923,6 +1923,9 @@ fn has_ability_filter(check: &CheckHasable) -> ConvResult<TargetFilter> {
         C::AnyFlashback => FilterProp::HasKeywordKind {
             value: KeywordKind::Flashback,
         },
+        C::AnyMadness => FilterProp::HasKeywordKind {
+            value: KeywordKind::Madness,
+        },
         C::AnySuspend => FilterProp::HasKeywordKind {
             value: KeywordKind::Suspend,
         },

--- a/crates/mtgish-import/src/convert/trigger.rs
+++ b/crates/mtgish-import/src/convert/trigger.rs
@@ -362,16 +362,11 @@ pub fn convert(t: &Trigger) -> ConvResult<TriggerDefinition> {
             });
         }
 
-        // CR 701.9: Discard triggers — "when [players] discards [cards]". Engine
-        // TriggerDefinition::Discarded has no valid_player or discarded-card
-        // filter axis today, so dropping the player/card constraints fires the
-        // trigger on every discard regardless of who/what. Strict-fail until
-        // engine extends.
-        Trigger::WhenAPlayerDiscardsACard(_players, _cards) => {
-            return Err(ConversionGap::EnginePrerequisiteMissing {
-                engine_type: "TriggerDefinition",
-                needed_variant: "Discarded with valid_player + discarded-card filter".into(),
-            });
+        // CR 701.9: Discard triggers — "when [players] discards [cards]".
+        // `valid_target` carries the player axis; `valid_card` optionally
+        // constrains the discarded card (type/keyword predicates).
+        Trigger::WhenAPlayerDiscardsACard(players, cards) => {
+            discard_trigger(players, cards, "Trigger::WhenAPlayerDiscardsACard")?
         }
         // CR 702.29 + CR 603: Cycling triggers — "whenever [a player] cycles a
         // card". Engine `TriggerMode::Cycled` fires per cycle event; the
@@ -845,6 +840,64 @@ fn cycled_trigger(
             return Err(ConversionGap::EnginePrerequisiteMissing {
                 engine_type: "TriggerDefinition",
                 needed_variant: format!("{idiom} with cycled-card filter: CardsInHand::{other:?}"),
+            });
+        }
+    }
+    Ok(def)
+}
+
+/// CR 701.9 + CR 603: Build a `Discarded` trigger with the player axis on
+/// `valid_target` and optional discarded-card predicates on `valid_card`.
+fn discard_trigger(
+    players: &Players,
+    cards: &CardsInHand,
+    idiom: &'static str,
+) -> ConvResult<TriggerDefinition> {
+    let mut def = TriggerDefinition::new(TriggerMode::Discarded);
+    if !matches!(players, Players::AnyPlayer) {
+        let controller = players_to_controller(players)?;
+        def.valid_target = Some(TargetFilter::Typed(
+            TypedFilter::default().controller(controller),
+        ));
+    }
+    match cards {
+        CardsInHand::AnyCard => {}
+        CardsInHand::SingleCardInHand(crate::schema::types::CardInHand::ThisCardInHand) => {
+            def.valid_card = Some(TargetFilter::SelfRef);
+        }
+        other => {
+            return Err(ConversionGap::EnginePrerequisiteMissing {
+                engine_type: "TriggerDefinition",
+                needed_variant: format!("{idiom} with discarded-card filter: CardsInHand::{other:?}"),
+            });
+        }
+    }
+    Ok(def)
+}
+
+/// CR 701.9 + CR 603: Build a `Discarded` trigger with the player axis on
+/// `valid_target` and optional discarded-card predicates on `valid_card`.
+fn discard_trigger(
+    players: &Players,
+    cards: &CardsInHand,
+    idiom: &'static str,
+) -> ConvResult<TriggerDefinition> {
+    let mut def = TriggerDefinition::new(TriggerMode::Discarded);
+    if !matches!(players, Players::AnyPlayer) {
+        let controller = players_to_controller(players)?;
+        def.valid_target = Some(TargetFilter::Typed(
+            TypedFilter::default().controller(controller),
+        ));
+    }
+    match cards {
+        CardsInHand::AnyCard => {}
+        CardsInHand::SingleCardInHand(crate::schema::types::CardInHand::ThisCardInHand) => {
+            def.valid_card = Some(TargetFilter::SelfRef);
+        }
+        other => {
+            return Err(ConversionGap::EnginePrerequisiteMissing {
+                engine_type: "TriggerDefinition",
+                needed_variant: format!("{idiom} with discarded-card filter: CardsInHand::{other:?}"),
             });
         }
     }

--- a/crates/mtgish-import/src/convert/trigger.rs
+++ b/crates/mtgish-import/src/convert/trigger.rs
@@ -868,36 +868,9 @@ fn discard_trigger(
         other => {
             return Err(ConversionGap::EnginePrerequisiteMissing {
                 engine_type: "TriggerDefinition",
-                needed_variant: format!("{idiom} with discarded-card filter: CardsInHand::{other:?}"),
-            });
-        }
-    }
-    Ok(def)
-}
-
-/// CR 701.9 + CR 603: Build a `Discarded` trigger with the player axis on
-/// `valid_target` and optional discarded-card predicates on `valid_card`.
-fn discard_trigger(
-    players: &Players,
-    cards: &CardsInHand,
-    idiom: &'static str,
-) -> ConvResult<TriggerDefinition> {
-    let mut def = TriggerDefinition::new(TriggerMode::Discarded);
-    if !matches!(players, Players::AnyPlayer) {
-        let controller = players_to_controller(players)?;
-        def.valid_target = Some(TargetFilter::Typed(
-            TypedFilter::default().controller(controller),
-        ));
-    }
-    match cards {
-        CardsInHand::AnyCard => {}
-        CardsInHand::SingleCardInHand(crate::schema::types::CardInHand::ThisCardInHand) => {
-            def.valid_card = Some(TargetFilter::SelfRef);
-        }
-        other => {
-            return Err(ConversionGap::EnginePrerequisiteMissing {
-                engine_type: "TriggerDefinition",
-                needed_variant: format!("{idiom} with discarded-card filter: CardsInHand::{other:?}"),
+                needed_variant: format!(
+                    "{idiom} with discarded-card filter: CardsInHand::{other:?}"
+                ),
             });
         }
     }


### PR DESCRIPTION
## Summary
- Fix Anje Falkenrath (and similar cards) firing their discard untap rider on every discard by hoisting the "if it has madness" intervening-if instead of dropping it.
- Add `TriggerCondition::EventObjectMatchesFilter` plus `KeywordKind::Madness` so event-object predicates can gate on off-zone keyword grants.
- Wire mtgish discard triggers (`WhenAPlayerDiscardsACard`, `DiscardedCardPassesFilter`) for the mtgish card-data path.

Closes #5143.

## Test plan
- [x] Parser regression: `trigger_intervening_if_discarded_card_has_madness`
- [x] Engine unit test: `event_object_madness_intervening_if_gates_discard_trigger`
- [ ] CI green on Rust lint + test shards
