### PR TITLE
feat(client): add player-facing card-report picker dialog

### DIFF
--- a/client/src/components/board/BoardContextMenu.tsx
+++ b/client/src/components/board/BoardContextMenu.tsx
@@ -9,6 +9,9 @@ interface BoardContextMenuProps {
   onCustomizeLayout: () => void;
   onToggleGameLog: () => void;
   onToggleDebugLog: () => void;
+  /** Open the "Report a card problem" picker. Rendered only when provided
+   *  (live, participating games). */
+  onReportCard?: () => void;
 }
 
 export function BoardContextMenu({
@@ -19,6 +22,7 @@ export function BoardContextMenu({
   onCustomizeLayout,
   onToggleGameLog,
   onToggleDebugLog,
+  onReportCard,
 }: BoardContextMenuProps) {
   const { t } = useTranslation("game");
   const ref = useRef<HTMLDivElement | null>(null);
@@ -93,6 +97,15 @@ export function BoardContextMenu({
           onClose();
         }}
       />
+      {onReportCard && (
+        <MenuItem
+          label={t("board.reportCard")}
+          onClick={() => {
+            onReportCard();
+            onClose();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/components/card/CardReportDialog.tsx
+++ b/client/src/components/card/CardReportDialog.tsx
@@ -1,0 +1,260 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { GameObject, PlayerId, Zone } from "../../adapter/types.ts";
+import { type CardReportContext, useCardReport } from "../../hooks/useCardReport.ts";
+import { useCardParseDetails } from "../../hooks/useEngineCardData.ts";
+import { usePlayerId } from "../../hooks/usePlayerId.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
+import { useUiStore } from "../../stores/uiStore.ts";
+import { isObjectReportableToViewer } from "../../viewmodel/gameStateView.ts";
+import { ModalPanelShell } from "../ui/ModalPanelShell.tsx";
+
+// Most-relevant-first zone ordering. `Library` is intentionally absent — the
+// visibility helper hides library cards, and top-of-library reveals are out of
+// scope (plan §5).
+const ZONE_ORDER: Zone[] = ["Stack", "Battlefield", "Hand", "Graveyard", "Exile", "Command"];
+
+/** A representative object plus how many copies it stands in for. Duplicate
+ *  copies sharing the report dedup key (`oracle_id || name`) — e.g. several
+ *  instances of the same token — collapse into one entry. */
+interface ZoneEntry {
+  obj: GameObject;
+  count: number;
+}
+
+interface ZoneGroup {
+  zone: Zone;
+  entries: ZoneEntry[];
+}
+
+/** The seat whose ownership the zone chip labels: controller for the shared
+ *  public zones, otherwise the owner. Display-only — visibility is already gated
+ *  by `isObjectReportableToViewer`. */
+function labelSeatForZone(obj: GameObject): PlayerId {
+  return obj.zone === "Battlefield" || obj.zone === "Stack" ? obj.controller : obj.owner;
+}
+
+interface ReportIdentity {
+  oracleId: string;
+  faceName: string;
+  /** Displayed + reported name, and the key used for parse lookup. */
+  name: string;
+  isEmblem: boolean;
+}
+
+/**
+ * The card identity a row displays, reports, and dedups on. For normal objects
+ * that's the printed card; for emblems it's the SOURCE card. CR 114.5: an emblem
+ * isn't represented by a card and the engine names every emblem literally
+ * "Emblem" (`create_emblem.rs`), so keying on `obj.name` would collapse all
+ * emblems into one meaningless row and fail the parse lookup. Instead we key on
+ * `emblem_source` — the planeswalker whose ultimate made it — which carries a
+ * real name (and usually a real `oracle_id`) that resolves for parse coverage.
+ * `oracleId` stays empty for emblems so their reports don't merge with reports
+ * of the source card itself.
+ */
+function reportIdentity(obj: GameObject): ReportIdentity {
+  if (obj.is_emblem) {
+    const source = obj.emblem_source;
+    return { oracleId: "", faceName: "", name: source?.name ?? obj.name, isEmblem: true };
+  }
+  return {
+    oracleId: obj.printed_ref?.oracle_id ?? "",
+    faceName: obj.printed_ref?.face_name ?? "",
+    name: obj.name,
+    isEmblem: false,
+  };
+}
+
+/** Dedup / ✓-state key — identical to `useCardReport`'s (`oracleId || name`). */
+function reportKey(identity: ReportIdentity): string {
+  return identity.oracleId || identity.name;
+}
+
+/**
+ * Player-facing "Report a card problem" picker. Lists the current game's cards
+ * grouped by zone, each row carrying a live parse-coverage fraction and a
+ * one-click report action, so the player picks the offending card from a stable
+ * list instead of chasing the hover preview. Reads engine-provided state only
+ * (objects + reveal sets + parse details) and formats it — no game logic.
+ */
+export function CardReportDialog() {
+  const { t } = useTranslation("game");
+  const open = useUiStore((s) => s.cardReportDialogOpen);
+  const close = useUiStore((s) => s.closeCardReportDialog);
+  const gameState = useGameStore((s) => s.gameState);
+  const viewerId = usePlayerId();
+  const [search, setSearch] = useState("");
+
+  const groups = useMemo<ZoneGroup[]>(() => {
+    if (!gameState) return [];
+    const query = search.trim().toLowerCase();
+    const byZone = new Map<Zone, GameObject[]>();
+    for (const obj of Object.values(gameState.objects)) {
+      if (!ZONE_ORDER.includes(obj.zone)) continue; // excludes Library
+      if (!isObjectReportableToViewer(gameState, obj, viewerId)) continue;
+      // Basic lands are vanilla (CR 305.6) — nothing to parse or misbehave — and
+      // usually the most numerous cards on the board, so they're pure noise in a
+      // problem report. The `Basic` supertype marks every basic land generally
+      // (incl. Snow-Covered), so this never name-matches the five basics.
+      if (obj.card_types.supertypes.includes("Basic")) continue;
+      // Drop objects with nothing to key a report on. Kept: printed cards, tokens
+      // (reported with an empty oracle_id), and emblems (reported under their
+      // source card via `reportIdentity`).
+      if (!obj.printed_ref && obj.display_source !== "Token" && !obj.is_emblem) continue;
+      if (query && !reportIdentity(obj).name.toLowerCase().includes(query)) continue;
+      const list = byZone.get(obj.zone) ?? [];
+      list.push(obj);
+      byZone.set(obj.zone, list);
+    }
+    return ZONE_ORDER.flatMap((zone) => {
+      const list = byZone.get(zone);
+      if (!list || list.length === 0) return [];
+      list.sort((a, b) => reportIdentity(a).name.localeCompare(reportIdentity(b).name));
+      // Collapse duplicates sharing the report dedup key (`oracleId || name`) —
+      // e.g. several copies of the same token, or emblems from the same source —
+      // into one representative row with a count. Keyed identically to the report
+      // dedup, so one row maps 1:1 to one telemetry event. Insertion order
+      // preserves the name sort above.
+      const byKey = new Map<string, ZoneEntry>();
+      for (const obj of list) {
+        const key = reportKey(reportIdentity(obj));
+        const entry = byKey.get(key);
+        if (entry) entry.count += 1;
+        else byKey.set(key, { obj, count: 1 });
+      }
+      return [{ zone, entries: [...byKey.values()] }];
+    });
+  }, [gameState, viewerId, search]);
+
+  return (
+    <ModalPanelShell
+      open={open}
+      title={t("cardReport.title")}
+      subtitle={t("cardReport.subtitle")}
+      onClose={close}
+      maxWidthClassName="max-w-lg"
+    >
+      <div className="flex flex-col gap-3 px-4 py-4 lg:px-6">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={t("cardReport.search")}
+          className="w-full rounded-[12px] border border-white/10 bg-black/20 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-indigo-400/50 focus:outline-none"
+        />
+
+        {groups.length === 0 ? (
+          <p className="py-8 text-center text-sm text-slate-400">{t("cardReport.empty")}</p>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {groups.map((group) => (
+              <section key={group.zone} className="flex flex-col gap-1.5">
+                <h3 className="text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  {t(`cardReport.zone.${group.zone}`)}
+                </h3>
+                <ul className="flex flex-col gap-1">
+                  {group.entries.map((entry) => (
+                    <CardReportRow
+                      key={entry.obj.id}
+                      obj={entry.obj}
+                      count={entry.count}
+                      viewerId={viewerId}
+                    />
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </ModalPanelShell>
+  );
+}
+
+/** One picker row. Fetches its own parse details (Rules of Hooks: one hook per
+ *  rendered row, so this must be a component, not a `.map` callback body) and
+ *  gates the report action until the parse resolves, so a transient `0/0`
+ *  fraction can never be sent. */
+function CardReportRow({
+  obj,
+  count,
+  viewerId,
+}: {
+  obj: GameObject;
+  count: number;
+  viewerId: PlayerId;
+}) {
+  const { t } = useTranslation("game");
+  const identity = reportIdentity(obj);
+  // Parse coverage keys on the identity name (the source card for emblems), so
+  // an emblem gets its source's real, loadable parse fraction rather than the
+  // engine's synthetic "Emblem" name, which resolves to nothing.
+  const parseItems = useCardParseDetails(identity.name);
+  const isOwn = labelSeatForZone(obj) === viewerId;
+
+  const loaded = parseItems != null;
+  const supported = (parseItems ?? []).filter((item) => item.supported).length;
+  const total = (parseItems ?? []).length;
+  const allSupported = total > 0 && supported === total;
+
+  const context: CardReportContext = {
+    oracleId: identity.oracleId,
+    faceName: identity.faceName,
+    name: identity.name,
+    zone: obj.zone,
+    supported,
+    total,
+  };
+  const { sent, report } = useCardReport(context);
+  const disabled = sent || !loaded;
+
+  return (
+    <li className="flex items-center gap-3 rounded-[10px] border border-white/8 bg-white/[0.03] px-3 py-2">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-1.5">
+          <span className="truncate text-sm font-medium text-white">{identity.name}</span>
+          {identity.isEmblem && (
+            <span className="shrink-0 rounded-[4px] bg-amber-400/15 px-1.5 text-[9px] font-semibold uppercase tracking-[0.1em] text-amber-300">
+              {t("cardReport.emblemTag")}
+            </span>
+          )}
+          {count > 1 && (
+            <span className="shrink-0 text-[11px] font-medium tabular-nums text-slate-500">
+              ×{count}
+            </span>
+          )}
+        </div>
+        <div className="mt-0.5 text-[0.62rem] uppercase tracking-[0.12em] text-slate-500">
+          {t(isOwn ? "cardReport.ownTag" : "cardReport.opponentTag")}
+        </div>
+      </div>
+
+      {loaded && total > 0 && (
+        <span
+          className={`shrink-0 text-[11px] font-medium tabular-nums ${
+            allSupported ? "text-emerald-400" : "text-amber-400"
+          }`}
+        >
+          {supported}/{total}
+        </span>
+      )}
+
+      <button
+        type="button"
+        onClick={report}
+        disabled={disabled}
+        className={
+          sent
+            ? "shrink-0 text-[11px] font-medium text-emerald-400"
+            : loaded
+              ? "shrink-0 text-[11px] text-indigo-300 hover:text-indigo-200"
+              : "shrink-0 text-[11px] text-slate-600"
+        }
+      >
+        {sent ? t("preview.reported") : t("preview.report")}
+      </button>
+    </li>
+  );
+}

--- a/client/src/components/card/ReportCardButton.tsx
+++ b/client/src/components/card/ReportCardButton.tsx
@@ -1,29 +1,11 @@
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { Zone } from "../../adapter/types.ts";
-import { trackEvent } from "../../services/telemetry.ts";
-import { useGameStore } from "../../stores/gameStore.ts";
+import { type CardReportContext, useCardReport } from "../../hooks/useCardReport.ts";
 
-/** Cards reported this page-load, keyed by `oracle_id ?? name`, so a card
- *  already reported renders its sent state when re-opened. This is UI-level
- *  dedup; the event-level session cap lives in telemetry.ts
- *  (`PER_EVENT_CAPS.card_report`). */
-const reportedThisSession = new Set<string>();
-
-/** Identity + parse-coverage context for a single reportable card face. Built
- *  at the CardPreview call site from the live `GameObject` and the parse tree
- *  the panel already holds (counts are not recomputed here). */
-export interface CardReportContext {
-  /** `""` for tokens/emblems (no `printed_ref`); `name` is the dedup fallback. */
-  oracleId: string;
-  faceName: string;
-  name: string;
-  zone: Zone;
-  /** Supported / total parsed items for the displayed face. */
-  supported: number;
-  total: number;
-}
+// Re-exported for back-compat with existing importers (CardPreview.tsx). The
+// type's single source of truth is the hook module; keeping the re-export here
+// avoids churning every call site.
+export type { CardReportContext };
 
 /**
  * One-click "report this card" affordance. A single click sends a `card_report`
@@ -34,36 +16,17 @@ export interface CardReportContext {
  * guard lives at the call site so the button's styled wrapper elements stay
  * out of the DOM too, not just the button itself.
  *
- * Callers pass `key={oracleId || name}` so switching cards remounts the button
- * and re-derives the sent state from {@link reportedThisSession}.
+ * Dedup/sent state is owned by {@link useCardReport}'s reactive store, so the
+ * button, the picker rows, and the mobile pill share one authority.
  */
-export function ReportCardButton({ oracleId, faceName, name, zone, supported, total }: CardReportContext) {
+export function ReportCardButton(props: CardReportContext) {
   const { t } = useTranslation("game");
-  const gameMode = useGameStore((s) => s.gameMode);
-  const turn = useGameStore((s) => s.gameState?.turn_number ?? null);
-  const dedupKey = oracleId || name;
-  const [sent, setSent] = useState(() => reportedThisSession.has(dedupKey));
-
-  const handleClick = () => {
-    if (sent) return;
-    reportedThisSession.add(dedupKey);
-    setSent(true);
-    trackEvent("card_report", {
-      oracle_id: oracleId,
-      face_name: faceName,
-      name,
-      zone,
-      game_mode: gameMode,
-      turn,
-      supported,
-      total,
-    });
-  };
+  const { sent, report } = useCardReport(props);
 
   return (
     <button
       type="button"
-      onClick={handleClick}
+      onClick={report}
       disabled={sent}
       className={
         sent

--- a/client/src/components/chrome/GameMenu.tsx
+++ b/client/src/components/chrome/GameMenu.tsx
@@ -30,6 +30,10 @@ interface GameMenuProps {
    *  multiplayer sandbox). */
   showSandboxTools?: boolean;
   onSandboxToolsClick?: () => void;
+  /** Show the always-visible "Report a card problem" flag button. Gated by the
+   *  caller to live, participating (non-spectate) games. */
+  showReportCard?: boolean;
+  onReportCardClick?: () => void;
 }
 
 export function GameMenu({
@@ -46,6 +50,8 @@ export function GameMenu({
   onRequestTakeback,
   showSandboxTools,
   onSandboxToolsClick,
+  showReportCard,
+  onReportCardClick,
 }: GameMenuProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -132,6 +138,28 @@ export function GameMenu({
               <path d="M8 2.5v4.2L4 14.2a1.6 1.6 0 0 0 1.45 2.3h9.1A1.6 1.6 0 0 0 16 14.2L12 6.7V2.5" />
               <path d="M7 2.5h6" />
               <path d="M6.3 11.5h7.4" />
+            </svg>
+          </button>
+        )}
+        {showReportCard && onReportCardClick && (
+          <button
+            onClick={onReportCardClick}
+            className="flex h-7 w-7 items-center justify-center rounded-md bg-white/6 text-gray-400 transition-colors hover:bg-white/10 hover:text-gray-200"
+            aria-label={t("gameMenu.reportCard")}
+            title={t("gameMenu.reportCard")}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-4 w-4"
+            >
+              <path d="M4 2.5v15" />
+              <path d="M4 3.5h9.5l-1.6 3 1.6 3H4" />
             </svg>
           </button>
         )}

--- a/client/src/hooks/useCardReport.ts
+++ b/client/src/hooks/useCardReport.ts
@@ -1,0 +1,73 @@
+import { create } from "zustand";
+
+import type { Zone } from "../adapter/types.ts";
+import { trackEvent } from "../services/telemetry.ts";
+import { useGameStore } from "../stores/gameStore.ts";
+
+/** Identity + parse-coverage context for a single reportable card face. Built
+ *  at each call site (CardPreview, the picker rows, the mobile pill) from the
+ *  live `GameObject` and the parse tree already held — counts are not recomputed
+ *  here. */
+export interface CardReportContext {
+  /** `""` for tokens/emblems (no `printed_ref`); `name` is the dedup fallback. */
+  oracleId: string;
+  faceName: string;
+  name: string;
+  zone: Zone;
+  /** Supported / total parsed items for the displayed face. */
+  supported: number;
+  total: number;
+}
+
+/**
+ * Session (page-load)-scoped set of reported dedup keys (`oracle_id ?? name`).
+ * Reactive so every mounted surface sharing a dedup key flips to its sent (✓)
+ * state together, and the click-time guard in {@link useCardReport} makes
+ * `report()` idempotent even across simultaneously-mounted duplicate rows in the
+ * picker. This is the single UI-level dedup authority for every report call site;
+ * the event-level session cap lives in telemetry.ts (`PER_EVENT_CAPS.card_report`).
+ */
+const useReportedCardsStore = create<{
+  keys: Record<string, true>;
+  mark: (key: string) => void;
+}>()((set) => ({
+  keys: {},
+  mark: (key) => set((s) => (s.keys[key] ? s : { keys: { ...s.keys, [key]: true } })),
+}));
+
+/**
+ * Shared "report this card" send logic. A single `report()` call sends one
+ * `card_report` telemetry event — no modal, no confirm step, no free text. The
+ * returned `sent` reflects the reactive dedup store, so re-opening a surface for
+ * an already-reported card shows its sent state, and multiple rows sharing a
+ * dedup key flip together.
+ *
+ * The event shape is fixed (Grafana columns): blobs `oracle_id`, `face_name`,
+ * `name`, `zone`, `game_mode`; doubles `turn`, `supported`, `total`.
+ */
+export function useCardReport(ctx: CardReportContext): { sent: boolean; report: () => void } {
+  const dedupKey = ctx.oracleId || ctx.name;
+  const sent = useReportedCardsStore((s) => Boolean(s.keys[dedupKey]));
+  const mark = useReportedCardsStore((s) => s.mark);
+  const gameMode = useGameStore((s) => s.gameMode);
+  const turn = useGameStore((s) => s.gameState?.turn_number ?? null);
+
+  const report = () => {
+    // Click-time guard (not just mount-init) — idempotent across duplicate rows
+    // that share a dedup key and are mounted at once (4-ofs, same-named tokens).
+    if (useReportedCardsStore.getState().keys[dedupKey]) return;
+    mark(dedupKey);
+    trackEvent("card_report", {
+      oracle_id: ctx.oracleId,
+      face_name: ctx.faceName,
+      name: ctx.name,
+      zone: ctx.zone,
+      game_mode: gameMode,
+      turn,
+      supported: ctx.supported,
+      total: ctx.total,
+    });
+  };
+
+  return { sent, report };
+}

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -35,6 +35,7 @@
     "off": "Aus"
   },
   "gameMenu": {
+    "reportCard": "Karte melden",
     "menu": "Spielmenü",
     "sandboxTools": "Sandbox-Werkzeuge",
     "sandboxToolsTitle": "Sandbox-Werkzeuge — beliebigen Spielzustand einrichten (`)",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -82,7 +82,25 @@
     "autoPassing": "Automatisch bis zum Endschritt abgeben...",
     "resolvingStack": "Stapel wird aufgelöst..."
   },
+  "cardReport": {
+    "title": "Kartenproblem melden",
+    "subtitle": "Wähle die Karte, die nicht richtig funktioniert.",
+    "search": "Karten suchen…",
+    "empty": "Keine meldbaren Karten sichtbar.",
+    "zone": {
+      "Stack": "Stapel",
+      "Battlefield": "Schlachtfeld",
+      "Hand": "Hand",
+      "Graveyard": "Friedhof",
+      "Exile": "Exil",
+      "Command": "Kommandozone"
+    },
+    "ownTag": "Du",
+    "opponentTag": "Gegner",
+    "emblemTag": "Emblem"
+  },
   "board": {
+    "reportCard": "Kartenproblem melden",
     "regroupCreatures": "Doppelte Kreaturengruppen neu gruppieren",
     "changeBackground": "Hintergrund ändern…",
     "customizeLayout": "Layout anpassen…",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -35,6 +35,7 @@
     "off": "Off"
   },
   "gameMenu": {
+    "reportCard": "Report a card",
     "menu": "Game menu",
     "sandboxTools": "Sandbox Tools",
     "sandboxToolsTitle": "Sandbox Tools — set up any board state (`)",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -82,7 +82,25 @@
     "autoPassing": "Auto-Passing to End Step...",
     "resolvingStack": "Resolving Stack..."
   },
+  "cardReport": {
+    "title": "Report a card problem",
+    "subtitle": "Pick the card that isn't working correctly.",
+    "search": "Search cards…",
+    "empty": "No reportable cards in view.",
+    "zone": {
+      "Stack": "Stack",
+      "Battlefield": "Battlefield",
+      "Hand": "Hand",
+      "Graveyard": "Graveyard",
+      "Exile": "Exile",
+      "Command": "Command"
+    },
+    "ownTag": "You",
+    "opponentTag": "Opponent",
+    "emblemTag": "Emblem"
+  },
   "board": {
+    "reportCard": "Report a card problem",
     "regroupCreatures": "Regroup duplicate creature groups",
     "changeBackground": "Change background…",
     "customizeLayout": "Customize layout…",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -35,6 +35,7 @@
     "off": "Desactivado"
   },
   "gameMenu": {
+    "reportCard": "Informar de una carta",
     "menu": "Menú de la partida",
     "sandboxTools": "Herramientas de sandbox",
     "sandboxToolsTitle": "Herramientas de sandbox — configura cualquier estado del tablero (`)",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -82,7 +82,25 @@
     "autoPassing": "Pasando automáticamente al paso final...",
     "resolvingStack": "Resolviendo la pila..."
   },
+  "cardReport": {
+    "title": "Informar de un problema con una carta",
+    "subtitle": "Elige la carta que no funciona correctamente.",
+    "search": "Buscar cartas…",
+    "empty": "No hay cartas para informar a la vista.",
+    "zone": {
+      "Stack": "Pila",
+      "Battlefield": "Campo de batalla",
+      "Hand": "Mano",
+      "Graveyard": "Cementerio",
+      "Exile": "Exilio",
+      "Command": "Zona de mando"
+    },
+    "ownTag": "Tú",
+    "opponentTag": "Oponente",
+    "emblemTag": "Emblema"
+  },
   "board": {
+    "reportCard": "Informar de un problema con una carta",
     "regroupCreatures": "Reagrupar grupos de criaturas duplicadas",
     "changeBackground": "Cambiar fondo…",
     "customizeLayout": "Personalizar diseño…",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -35,6 +35,7 @@
     "off": "Désactivé"
   },
   "gameMenu": {
+    "reportCard": "Signaler une carte",
     "menu": "Menu de la partie",
     "sandboxTools": "Outils bac à sable",
     "sandboxToolsTitle": "Outils bac à sable — configurez n'importe quel état du plateau (`)",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -82,7 +82,25 @@
     "autoPassing": "Passage automatique jusqu'à l'étape de fin...",
     "resolvingStack": "Résolution de la pile..."
   },
+  "cardReport": {
+    "title": "Signaler un problème de carte",
+    "subtitle": "Choisissez la carte qui ne fonctionne pas correctement.",
+    "search": "Rechercher des cartes…",
+    "empty": "Aucune carte à signaler visible.",
+    "zone": {
+      "Stack": "Pile",
+      "Battlefield": "Champ de bataille",
+      "Hand": "Main",
+      "Graveyard": "Cimetière",
+      "Exile": "Exil",
+      "Command": "Zone de commandement"
+    },
+    "ownTag": "Vous",
+    "opponentTag": "Adversaire",
+    "emblemTag": "Emblème"
+  },
   "board": {
+    "reportCard": "Signaler un problème de carte",
     "regroupCreatures": "Regrouper les groupes de créatures en double",
     "changeBackground": "Changer l'arrière-plan…",
     "customizeLayout": "Personnaliser la disposition…",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -35,6 +35,7 @@
     "off": "Disattivato"
   },
   "gameMenu": {
+    "reportCard": "Segnala una carta",
     "menu": "Menu di gioco",
     "sandboxTools": "Strumenti Sandbox",
     "sandboxToolsTitle": "Strumenti Sandbox — imposta qualsiasi stato del campo (`)",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -82,7 +82,25 @@
     "autoPassing": "Passaggio automatico fino al passo finale...",
     "resolvingStack": "Risoluzione della pila..."
   },
+  "cardReport": {
+    "title": "Segnala un problema con una carta",
+    "subtitle": "Scegli la carta che non funziona correttamente.",
+    "search": "Cerca carte…",
+    "empty": "Nessuna carta segnalabile in vista.",
+    "zone": {
+      "Stack": "Pila",
+      "Battlefield": "Campo di battaglia",
+      "Hand": "Mano",
+      "Graveyard": "Cimitero",
+      "Exile": "Esilio",
+      "Command": "Zona di comando"
+    },
+    "ownTag": "Tu",
+    "opponentTag": "Avversario",
+    "emblemTag": "Emblema"
+  },
   "board": {
+    "reportCard": "Segnala un problema con una carta",
     "regroupCreatures": "Raggruppa i gruppi di creature duplicate",
     "changeBackground": "Cambia sfondo…",
     "customizeLayout": "Personalizza layout…",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -35,6 +35,7 @@
     "off": "Wył."
   },
   "gameMenu": {
+    "reportCard": "Zgłoś kartę",
     "menu": "Menu gry",
     "sandboxTools": "Narzędzia piaskownicy",
     "sandboxToolsTitle": "Narzędzia piaskownicy — skonfiguruj dowolny stan pola bitwy (`)",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -82,7 +82,25 @@
     "autoPassing": "Automatyczne przekazywanie do kroku końcowego...",
     "resolvingStack": "Rozpatrywanie stosu..."
   },
+  "cardReport": {
+    "title": "Zgłoś problem z kartą",
+    "subtitle": "Wybierz kartę, która nie działa poprawnie.",
+    "search": "Szukaj kart…",
+    "empty": "Brak widocznych kart do zgłoszenia.",
+    "zone": {
+      "Stack": "Stos",
+      "Battlefield": "Pole bitwy",
+      "Hand": "Ręka",
+      "Graveyard": "Cmentarz",
+      "Exile": "Wygnanie",
+      "Command": "Strefa dowodzenia"
+    },
+    "ownTag": "Ty",
+    "opponentTag": "Przeciwnik",
+    "emblemTag": "Emblemat"
+  },
   "board": {
+    "reportCard": "Zgłoś problem z kartą",
     "regroupCreatures": "Pogrupuj zduplikowane grupy stworów",
     "changeBackground": "Zmień tło…",
     "customizeLayout": "Dostosuj układ…",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -35,6 +35,7 @@
     "off": "Desligado"
   },
   "gameMenu": {
+    "reportCard": "Relatar uma carta",
     "menu": "Menu do jogo",
     "sandboxTools": "Ferramentas de Sandbox",
     "sandboxToolsTitle": "Ferramentas de Sandbox — configure qualquer estado de tabuleiro (`)",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -82,7 +82,25 @@
     "autoPassing": "Passando Automaticamente até a Etapa Final...",
     "resolvingStack": "Resolvendo a Pilha..."
   },
+  "cardReport": {
+    "title": "Relatar um problema com uma carta",
+    "subtitle": "Escolha a carta que não está funcionando corretamente.",
+    "search": "Buscar cartas…",
+    "empty": "Nenhuma carta relatável à vista.",
+    "zone": {
+      "Stack": "Pilha",
+      "Battlefield": "Campo de batalha",
+      "Hand": "Mão",
+      "Graveyard": "Cemitério",
+      "Exile": "Exílio",
+      "Command": "Zona de comando"
+    },
+    "ownTag": "Você",
+    "opponentTag": "Oponente",
+    "emblemTag": "Emblema"
+  },
   "board": {
+    "reportCard": "Relatar um problema com uma carta",
     "regroupCreatures": "Reagrupar grupos de criaturas duplicadas",
     "changeBackground": "Alterar plano de fundo…",
     "customizeLayout": "Personalizar layout…",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -37,6 +37,7 @@ import { BlockRequirementBadges } from "../components/combat/BlockRequirementBad
 import { GameBoard } from "../components/board/GameBoard.tsx";
 import { CardImage } from "../components/card/CardImage.tsx";
 import { GameCardPreview } from "../components/card/GameCardPreview.tsx";
+import { CardReportDialog } from "../components/card/CardReportDialog.tsx";
 import { ActionButton } from "../components/board/ActionButton.tsx";
 import { FullControlToggle } from "../components/controls/FullControlToggle.tsx";
 import { CombatPhaseIndicator } from "../components/controls/PhaseStopBar.tsx";
@@ -833,6 +834,8 @@ function GamePageContent({
   const playerId = usePlayerId();
   const perspectivePlayerId = usePerspectivePlayerId();
   const isSpectatorMode = useSpectatorMode();
+  // Card-report picker is valid in a live, participating game (never spectate).
+  const canReportCard = gameState != null && !isSpectatorMode;
   const canActForWaitingState = useCanActForWaitingState();
   const helpSheetOpen = useUiStore((s) => s.helpSheetOpen);
   const setHelpSheetOpen = useUiStore((s) => s.setHelpSheetOpen);
@@ -1422,8 +1425,11 @@ function GamePageContent({
         onRequestTakeback={isOnlineMode ? handleRequestTakeback : undefined}
         showSandboxTools={mode === "ai" || mode === "local" || isSandboxGame}
         onSandboxToolsClick={() => useUiStore.getState().openSandboxTools()}
+        showReportCard={canReportCard}
+        onReportCardClick={() => useUiStore.getState().openCardReportDialog()}
       />
       <HelpSheet />
+      <CardReportDialog />
 
       {/* Connection failure toast */}
       {isOnlineMode && (
@@ -1571,6 +1577,9 @@ function GamePageContent({
           onCustomizeLayout={() => useUiStore.getState().setFlexEditMode(true)}
           onToggleGameLog={() => useUiStore.getState().toggleLogPanel()}
           onToggleDebugLog={() => useUiStore.getState().toggleDebugPanel()}
+          onReportCard={
+            canReportCard ? () => useUiStore.getState().openCardReportDialog() : undefined
+          }
         />
       )}
 

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -169,6 +169,9 @@ interface UiStoreState {
    *  any zone via the standard debug context menu. `null` when closed. */
   debugLibraryViewer: { playerId: number } | null;
   helpSheetOpen: boolean;
+  /** Whether the "Report a card problem" picker dialog is open. A plain boolean
+   *  open-flag, mirroring the sandbox-tools / help-sheet open patterns. */
+  cardReportDialogOpen: boolean;
   /** Object currently being "previewed" by a debug-panel control (e.g. an
    *  ObjectSelect dropdown option under the cursor). Drives a distinct,
    *  always-obvious highlight on the board permanent / player avatar that is
@@ -245,6 +248,8 @@ interface UiStoreActions {
   closeDebugLibraryViewer: () => void;
   setHelpSheetOpen: (open: boolean) => void;
   toggleHelpSheet: () => void;
+  openCardReportDialog: () => void;
+  closeCardReportDialog: () => void;
   /** Set or clear the debug-panel preview highlight for an object. */
   setDebugHighlightedObjectId: (id: ObjectId | null) => void;
   /** Set or clear the debug-panel preview highlight for a player. */
@@ -293,6 +298,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   debugContextMenu: null,
   debugLibraryViewer: null,
   helpSheetOpen: false,
+  cardReportDialogOpen: false,
   debugHighlightedObjectId: null,
   debugHighlightedPlayerId: null,
   logPanelOpen: false,
@@ -550,6 +556,8 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   closeDebugLibraryViewer: () => set({ debugLibraryViewer: null }),
   setHelpSheetOpen: (open) => set({ helpSheetOpen: open }),
   toggleHelpSheet: () => set((state) => ({ helpSheetOpen: !state.helpSheetOpen })),
+  openCardReportDialog: () => set({ cardReportDialogOpen: true }),
+  closeCardReportDialog: () => set({ cardReportDialogOpen: false }),
   setLogPanelOpen: (open) => set({ logPanelOpen: open }),
   toggleLogPanel: () => set((state) => ({ logPanelOpen: !state.logPanelOpen })),
   setFlexEditMode: (active) => set({ flexEditMode: active }),

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -178,6 +178,46 @@ export function isFaceDownExileCardVisibleToViewer(
   );
 }
 
+/**
+ * Whether `viewerId` may see the identity of `obj` for the card-report picker.
+ *
+ * Composes the engine-mirroring reveal-set helpers above; NEVER infers
+ * visibility from `name !== HIDDEN_CARD_NAME`. In single-player the client
+ * renders the raw, unredacted state (the `showAiHand` debug toggle depends on
+ * it), so hidden-zone objects carry their real names and a name check would leak
+ * every opponent card. Conservative: hides on any doubt, never leaks.
+ */
+export function isObjectReportableToViewer(
+  gameState: GameState | null,
+  obj: GameObject,
+  viewerId: PlayerId,
+): boolean {
+  if (!gameState) return false;
+  // CR 701.20b: a publicly revealed card is visible to every player.
+  const revealed = gameState.revealed_cards?.includes(obj.id) ?? false;
+  switch (obj.zone) {
+    case "Stack":
+    case "Battlefield":
+      // Public zones; a face-down (morph/manifest) permanent hides its identity
+      // from non-owners unless it has been publicly revealed.
+      return !obj.face_down || obj.owner === viewerId || revealed;
+    case "Graveyard":
+    case "Command":
+      return true; // public, face-up
+    case "Exile":
+      return !obj.face_down || isFaceDownExileCardVisibleToViewer(gameState, obj, viewerId);
+    case "Hand":
+      // Own hand, or a card revealed to everyone (mirror OpponentHand's gate).
+      return (
+        obj.owner === viewerId ||
+        revealed ||
+        (gameState.public_revealed_cards?.includes(obj.id) ?? false)
+      );
+    case "Library":
+      return false; // hidden; rare face-up-top reveals are out of scope
+  }
+}
+
 export function getWaitingForObjectChoiceIds(
   waitingFor: WaitingFor | null | undefined,
 ): ObjectId[] {


### PR DESCRIPTION
The card_report telemetry affordance was only reachable via the Alt-hover
parse panel (desktop) or the mobile tap modal, so desktop players could
neither discover nor click it. Add a persistent "Report a card problem"
entry point (flag icon in the GameMenu strip + a board context-menu row)
that opens a picker dialog listing the current game's cards grouped by zone,
each row carrying a live parse-coverage fraction and a one-click report.

- Visibility mirrors the engine reveal sets via a new
  isObjectReportableToViewer helper (never the card name), so single-player
  raw state cannot leak opponent hidden-zone cards.
- Dedup + report send is a single reactive authority (useCardReport) with a
  click-time idempotency guard, shared by the picker, the Alt-panel button,
  and the mobile pill.
- Duplicate copies sharing the report key collapse per-zone into one row
  with a count; basic lands are filtered out (vanilla, pure noise).
- Emblems are reported under their source card (the engine names every
  emblem "Emblem"; the identity is emblem_source), tagged in the row.
- No engine/worker/telemetry-schema change; event shape is unchanged.
- i18n across all 7 locales.
