### PR TITLE
feat(client): polish card-report picker dialog

### DIFF
--- a/client/src/components/card/CardReportDialog.tsx
+++ b/client/src/components/card/CardReportDialog.tsx
@@ -5,7 +5,9 @@ import type { GameObject, PlayerId, Zone } from "../../adapter/types.ts";
 import { type CardReportContext, useCardReport } from "../../hooks/useCardReport.ts";
 import { useCardParseDetails } from "../../hooks/useEngineCardData.ts";
 import { usePlayerId } from "../../hooks/usePlayerId.ts";
+import { getSeatColor, useSeatColor } from "../../hooks/useSeatColor.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
+import { getPlayerDisplayName } from "../../stores/multiplayerStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { isObjectReportableToViewer } from "../../viewmodel/gameStateView.ts";
 import { ModalPanelShell } from "../ui/ModalPanelShell.tsx";
@@ -85,11 +87,15 @@ export function CardReportDialog() {
   const close = useUiStore((s) => s.closeCardReportDialog);
   const gameState = useGameStore((s) => s.gameState);
   const viewerId = usePlayerId();
+  const seatOrder = gameState?.seat_order;
   const [search, setSearch] = useState("");
+  // null = show every seat's cards; otherwise restrict to one seat's cards.
+  const [playerFilter, setPlayerFilter] = useState<PlayerId | null>(null);
 
-  const groups = useMemo<ZoneGroup[]>(() => {
-    if (!gameState) return [];
+  const { groups, seats } = useMemo(() => {
+    if (!gameState) return { groups: [] as ZoneGroup[], seats: [] as PlayerId[] };
     const query = search.trim().toLowerCase();
+    const seatSet = new Set<PlayerId>();
     const byZone = new Map<Zone, GameObject[]>();
     for (const obj of Object.values(gameState.objects)) {
       if (!ZONE_ORDER.includes(obj.zone)) continue; // excludes Library
@@ -103,12 +109,18 @@ export function CardReportDialog() {
       // (reported with an empty oracle_id), and emblems (reported under their
       // source card via `reportIdentity`).
       if (!obj.printed_ref && obj.display_source !== "Token" && !obj.is_emblem) continue;
+      // Record the owning/controlling seat for the filter chips BEFORE applying
+      // the active player/search filters, so selecting one player never removes
+      // the chips for the others.
+      const seat = labelSeatForZone(obj);
+      seatSet.add(seat);
+      if (playerFilter != null && seat !== playerFilter) continue;
       if (query && !reportIdentity(obj).name.toLowerCase().includes(query)) continue;
       const list = byZone.get(obj.zone) ?? [];
       list.push(obj);
       byZone.set(obj.zone, list);
     }
-    return ZONE_ORDER.flatMap((zone) => {
+    const groups = ZONE_ORDER.flatMap((zone) => {
       const list = byZone.get(zone);
       if (!list || list.length === 0) return [];
       list.sort((a, b) => reportIdentity(a).name.localeCompare(reportIdentity(b).name));
@@ -126,7 +138,12 @@ export function CardReportDialog() {
       }
       return [{ zone, entries: [...byKey.values()] }];
     });
-  }, [gameState, viewerId, search]);
+    // Chips ordered by seat_order so they read the same as board seating.
+    const seats = [...seatSet].sort(
+      (a, b) => (seatOrder?.indexOf(a) ?? 0) - (seatOrder?.indexOf(b) ?? 0),
+    );
+    return { groups, seats };
+  }, [gameState, viewerId, search, playerFilter, seatOrder]);
 
   return (
     <ModalPanelShell
@@ -135,8 +152,10 @@ export function CardReportDialog() {
       subtitle={t("cardReport.subtitle")}
       onClose={close}
       maxWidthClassName="max-w-lg"
+      bodyClassName="flex flex-col"
     >
-      <div className="flex flex-col gap-3 px-4 py-4 lg:px-6">
+      {/* Pinned controls: the search + player filter stay put while the list scrolls. */}
+      <div className="flex shrink-0 flex-col gap-2.5 px-4 pt-4 pb-3 lg:px-6">
         <input
           type="text"
           value={search}
@@ -144,7 +163,28 @@ export function CardReportDialog() {
           placeholder={t("cardReport.search")}
           className="w-full rounded-[12px] border border-white/10 bg-black/20 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-indigo-400/50 focus:outline-none"
         />
+        {seats.length > 1 && (
+          <div className="flex flex-wrap gap-1.5">
+            <PlayerFilterChip
+              active={playerFilter === null}
+              label={t("cardReport.allPlayers")}
+              onClick={() => setPlayerFilter(null)}
+            />
+            {seats.map((seat) => (
+              <PlayerFilterChip
+                key={seat}
+                active={playerFilter === seat}
+                label={getPlayerDisplayName(seat, viewerId)}
+                color={getSeatColor(seat, seatOrder)}
+                onClick={() => setPlayerFilter((cur) => (cur === seat ? null : seat))}
+              />
+            ))}
+          </div>
+        )}
+      </div>
 
+      {/* Scrollable card list. */}
+      <div className="thin-scrollbar min-h-0 flex-1 overflow-y-auto px-4 pb-4 lg:px-6">
         {groups.length === 0 ? (
           <p className="py-8 text-center text-sm text-slate-400">{t("cardReport.empty")}</p>
         ) : (
@@ -173,10 +213,47 @@ export function CardReportDialog() {
   );
 }
 
+/** A quick per-player filter pill. Reuses the seat color dot from the HUD so a
+ *  chip reads as the same player as their board nameplate. The "All" chip has no
+ *  `color`. */
+function PlayerFilterChip({
+  active,
+  label,
+  color,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  color?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition ${
+        active
+          ? "border-white/25 bg-white/12 text-white"
+          : "border-white/10 bg-black/20 text-slate-400 hover:bg-white/6 hover:text-slate-200"
+      }`}
+    >
+      {color && (
+        <span
+          aria-hidden
+          className="h-2 w-2 shrink-0 rounded-full"
+          style={{ backgroundColor: color }}
+        />
+      )}
+      <span className="max-w-[8rem] truncate">{label}</span>
+    </button>
+  );
+}
+
 /** One picker row. Fetches its own parse details (Rules of Hooks: one hook per
  *  rendered row, so this must be a component, not a `.map` callback body) and
  *  gates the report action until the parse resolves, so a transient `0/0`
- *  fraction can never be sent. */
+ *  fraction can never be sent. The whole row is a tap target; tapping opens an
+ *  inline Cancel/Report confirm, and once reported the row locks. */
 function CardReportRow({
   obj,
   count,
@@ -187,12 +264,19 @@ function CardReportRow({
   viewerId: PlayerId;
 }) {
   const { t } = useTranslation("game");
+  const [confirming, setConfirming] = useState(false);
   const identity = reportIdentity(obj);
   // Parse coverage keys on the identity name (the source card for emblems), so
   // an emblem gets its source's real, loadable parse fraction rather than the
   // engine's synthetic "Emblem" name, which resolves to nothing.
   const parseItems = useCardParseDetails(identity.name);
-  const isOwn = labelSeatForZone(obj) === viewerId;
+  // Label the card with the seat that owns/controls it (per `labelSeatForZone`),
+  // resolved to the same display name + seat color the HUD nameplates use, so the
+  // picker agrees with the board instead of showing a generic "opponent".
+  // `viewerId` gives the local seat the "You" treatment via `getPlayerDisplayName`.
+  const seatId = labelSeatForZone(obj);
+  const seatColor = useSeatColor(seatId);
+  const seatName = getPlayerDisplayName(seatId, viewerId);
 
   const loaded = parseItems != null;
   const supported = (parseItems ?? []).filter((item) => item.supported).length;
@@ -208,52 +292,110 @@ function CardReportRow({
     total,
   };
   const { sent, report } = useCardReport(context);
-  const disabled = sent || !loaded;
 
-  return (
-    <li className="flex items-center gap-3 rounded-[10px] border border-white/8 bg-white/[0.03] px-3 py-2">
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline gap-1.5">
-          <span className="truncate text-sm font-medium text-white">{identity.name}</span>
-          {identity.isEmblem && (
-            <span className="shrink-0 rounded-[4px] bg-amber-400/15 px-1.5 text-[9px] font-semibold uppercase tracking-[0.1em] text-amber-300">
-              {t("cardReport.emblemTag")}
-            </span>
-          )}
-          {count > 1 && (
-            <span className="shrink-0 text-[11px] font-medium tabular-nums text-slate-500">
-              ×{count}
-            </span>
-          )}
-        </div>
-        <div className="mt-0.5 text-[0.62rem] uppercase tracking-[0.12em] text-slate-500">
-          {t(isOwn ? "cardReport.ownTag" : "cardReport.opponentTag")}
-        </div>
+  // Card name + owning seat — shared across the row's three states.
+  const info = (
+    <div className="min-w-0 flex-1 text-left">
+      <div className="flex items-baseline gap-1.5">
+        <span className="truncate text-sm font-medium text-white">{identity.name}</span>
+        {identity.isEmblem && (
+          <span className="shrink-0 rounded-[4px] bg-amber-400/15 px-1.5 text-[9px] font-semibold uppercase tracking-[0.1em] text-amber-300">
+            {t("cardReport.emblemTag")}
+          </span>
+        )}
+        {count > 1 && (
+          <span className="shrink-0 text-[11px] font-medium tabular-nums text-slate-500">
+            ×{count}
+          </span>
+        )}
       </div>
-
-      {loaded && total > 0 && (
+      <div className="mt-0.5 flex items-center gap-1">
         <span
-          className={`shrink-0 text-[11px] font-medium tabular-nums ${
-            allSupported ? "text-emerald-400" : "text-amber-400"
-          }`}
-        >
-          {supported}/{total}
+          aria-hidden
+          className="h-1.5 w-1.5 shrink-0 rounded-full"
+          style={{ backgroundColor: seatColor }}
+        />
+        <span className="truncate text-[0.65rem] font-medium" style={{ color: seatColor }}>
+          {seatName}
         </span>
-      )}
+      </div>
+    </div>
+  );
 
+  // Already reported this session — the dedup key is spent, so lock the row.
+  if (sent) {
+    return (
+      <li className="flex items-center gap-3 rounded-[10px] border border-emerald-400/25 bg-emerald-400/[0.06] px-3 py-2">
+        {info}
+        <span className="shrink-0 text-[11px] font-medium text-emerald-400">
+          {t("preview.reported")}
+        </span>
+      </li>
+    );
+  }
+
+  // Second tap: an explicit confirm so a stray tap can't fire a report.
+  if (confirming) {
+    return (
+      <li className="flex items-center gap-3 rounded-[10px] border border-red-400/30 bg-red-500/[0.07] px-3 py-2">
+        {info}
+        <div className="flex shrink-0 items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            className="rounded-[8px] px-2.5 py-1 text-[11px] font-medium text-slate-400 transition hover:text-slate-200"
+          >
+            {t("cardReport.cancel")}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              report();
+              setConfirming(false);
+            }}
+            className="rounded-[8px] bg-red-500/90 px-2.5 py-1 text-[11px] font-semibold text-white transition hover:bg-red-500"
+          >
+            {t("preview.report")}
+          </button>
+        </div>
+      </li>
+    );
+  }
+
+  // Default: the whole row is one tap target. Disabled until parse details load
+  // so a transient 0/0 fraction can never be sent.
+  return (
+    <li>
       <button
         type="button"
-        onClick={report}
-        disabled={disabled}
-        className={
-          sent
-            ? "shrink-0 text-[11px] font-medium text-emerald-400"
-            : loaded
-              ? "shrink-0 text-[11px] text-indigo-300 hover:text-indigo-200"
-              : "shrink-0 text-[11px] text-slate-600"
-        }
+        disabled={!loaded}
+        onClick={() => setConfirming(true)}
+        className="flex w-full items-center gap-3 rounded-[10px] border border-white/8 bg-white/[0.03] px-3 py-2 transition hover:border-white/15 hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-50"
       >
-        {sent ? t("preview.reported") : t("preview.report")}
+        {info}
+        {loaded && total > 0 && (
+          <span
+            className={`shrink-0 text-[11px] font-medium tabular-nums ${
+              allSupported ? "text-emerald-400" : "text-amber-400"
+            }`}
+          >
+            {supported}/{total}
+          </span>
+        )}
+        <svg
+          aria-hidden
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-3.5 w-3.5 shrink-0 text-slate-500"
+        >
+          <path d="M4 2.5v15" />
+          <path d="M4 3.5h9.5l-1.6 3 1.6 3H4" />
+        </svg>
       </button>
     </li>
   );

--- a/client/src/components/chrome/GameMenu.tsx
+++ b/client/src/components/chrome/GameMenu.tsx
@@ -174,7 +174,7 @@ export function GameMenu({
         {showReportCard && onReportCardClick && (
           <button
             onClick={onReportCardClick}
-            className="flex h-7 w-7 items-center justify-center rounded-md bg-white/6 text-gray-400 transition-colors hover:bg-white/10 hover:text-gray-200"
+            className="flex h-7 w-7 items-center justify-center rounded-md bg-red-500/12 text-red-400 transition-colors hover:bg-red-500/20 hover:text-red-300"
             aria-label={t("gameMenu.reportCard")}
             title={t("gameMenu.reportCard")}
           >

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -95,7 +95,9 @@
       "Exile": "Exil",
       "Command": "Kommandozone"
     },
-    "emblemTag": "Emblem"
+    "emblemTag": "Emblem",
+    "allPlayers": "Alle",
+    "cancel": "Abbrechen"
   },
   "board": {
     "reportCard": "Kartenproblem melden",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -95,7 +95,9 @@
       "Exile": "Exile",
       "Command": "Command"
     },
-    "emblemTag": "Emblem"
+    "emblemTag": "Emblem",
+    "allPlayers": "All",
+    "cancel": "Cancel"
   },
   "board": {
     "reportCard": "Report a card problem",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -95,7 +95,9 @@
       "Exile": "Exilio",
       "Command": "Zona de mando"
     },
-    "emblemTag": "Emblema"
+    "emblemTag": "Emblema",
+    "allPlayers": "Todos",
+    "cancel": "Cancelar"
   },
   "board": {
     "reportCard": "Informar de un problema con una carta",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -95,7 +95,9 @@
       "Exile": "Exil",
       "Command": "Zone de commandement"
     },
-    "emblemTag": "Emblème"
+    "emblemTag": "Emblème",
+    "allPlayers": "Tous",
+    "cancel": "Annuler"
   },
   "board": {
     "reportCard": "Signaler un problème de carte",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -95,7 +95,9 @@
       "Exile": "Esilio",
       "Command": "Zona di comando"
     },
-    "emblemTag": "Emblema"
+    "emblemTag": "Emblema",
+    "allPlayers": "Tutti",
+    "cancel": "Annulla"
   },
   "board": {
     "reportCard": "Segnala un problema con una carta",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -95,7 +95,9 @@
       "Exile": "Wygnanie",
       "Command": "Strefa dowodzenia"
     },
-    "emblemTag": "Emblemat"
+    "emblemTag": "Emblemat",
+    "allPlayers": "Wszyscy",
+    "cancel": "Anuluj"
   },
   "board": {
     "reportCard": "Zgłoś problem z kartą",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -95,7 +95,9 @@
       "Exile": "Exílio",
       "Command": "Zona de comando"
     },
-    "emblemTag": "Emblema"
+    "emblemTag": "Emblema",
+    "allPlayers": "Todos",
+    "cancel": "Cancelar"
   },
   "board": {
     "reportCard": "Relatar um problema com uma carta",


### PR DESCRIPTION
- Label each card with its owning seat as a color-highlighted player name
  (reusing the HUD seat palette + getPlayerDisplayName) instead of a generic
  "You"/"Opponent" tag; retire the now-unused ownTag/opponentTag i18n keys.
- Add an instant per-player filter: seat-colored chips above the list narrow
  it to one player's cards (chips derived before the filter so they never
  self-hide).
- Pin the search + filter controls and scroll only the card list.
- Replace the persistent per-row "Report" text with a full-row tap target
  that opens an inline Cancel/Report confirm; lock the row once reported.
- Recolor the top-left report flag button red.
