### PR TITLE
fix: re-prompt behold creature type on spell re-cast (closes #5051)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -9588,6 +9588,11 @@ fn announce_spell_on_stack(
     prepared: &PreparedSpellCast,
     events: &mut Vec<GameEvent>,
 ) {
+    // CR 400.7: A new cast announcement is a new casting event — discard any
+    // stale behold creature-type choice left on the spell object from a prior
+    // resolution (#5051; cancel rewind uses the same clear in handle_cancel_cast).
+    clear_cast_scoped_creature_type_choice(state, prepared.object_id);
+
     stack::push_to_stack(
         state,
         StackEntry {
@@ -14285,6 +14290,17 @@ pub fn handle_activate_ability(
 /// reversion is needed — the object is already in its origin zone.
 /// Activated-ability casts never placed an object on the stack during target
 /// selection, so no stack rollback is needed for them.
+/// CR 400.7 + CR 601.2: Cast-scoped behold creature-type choices must not
+/// survive across casting events. A resolved spell that later re-enters the
+/// cast pipeline (flashback, retrace, hand re-cast, etc.) is a new object for
+/// game purposes and must re-prompt (#5051).
+fn clear_cast_scoped_creature_type_choice(state: &mut GameState, object_id: ObjectId) {
+    if let Some(obj) = state.objects.get_mut(&object_id) {
+        obj.chosen_attributes
+            .retain(|a| !matches!(a, crate::types::ability::ChosenAttribute::CreatureType(_)));
+    }
+}
+
 pub fn handle_cancel_cast(
     state: &mut GameState,
     pending: &PendingCast,
@@ -14301,10 +14317,7 @@ pub fn handle_cancel_cast(
     // (`casting_costs::pay_additional_cost_with_source`) would skip the type
     // prompt on the next cast attempt and silently reuse the stale type — so
     // remove it here and let a re-cast re-prompt from a clean slate.
-    if let Some(obj) = state.objects.get_mut(&pending.object_id) {
-        obj.chosen_attributes
-            .retain(|a| !matches!(a, crate::types::ability::ChosenAttribute::CreatureType(_)));
-    }
+    clear_cast_scoped_creature_type_choice(state, pending.object_id);
 
     let convoked_creatures = if pending.convoked_creatures.is_empty() {
         state

--- a/crates/engine/tests/celestial_reunion_behold_choose_type.rs
+++ b/crates/engine/tests/celestial_reunion_behold_choose_type.rs
@@ -23,7 +23,8 @@ use engine::game::scenario::{GameScenario, P0, P1};
 use engine::game::zones::create_object;
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
-use engine::types::game_state::WaitingFor;
+use engine::types::keywords::{FlashbackCost, Keyword};
+use engine::types::game_state::{CastingVariant, WaitingFor};
 use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
@@ -456,6 +457,83 @@ fn cancel_after_type_choice_rewinds_and_recast_reprompts() {
     assert!(
         saw_cost_type_choice,
         "REVERT-PROOF (b): re-cast must re-present CostTypeChoice, not skip to behold with the stale type"
+    );
+}
+
+/// Issue #5051: after a resolved behold pre-cost spell sits in the graveyard with
+/// a stale `ChosenAttribute::CreatureType`, a later cast from that zone must
+/// re-prompt for the type (CR 400.7 — new object, no memory of prior choices).
+#[test]
+fn resolve_then_flashback_recast_reprompts_creature_type() {
+    let mut s = setup();
+    let card_id = s.runner.state().objects[&s.spell].card_id;
+    drive(&mut s, true, "Elf", Some(s.lib_elf));
+
+    assert_eq!(
+        zone_of(&s, s.spell),
+        Zone::Graveyard,
+        "resolved sorcery must be in the graveyard"
+    );
+    assert!(
+        s.runner.state().objects[&s.spell]
+            .chosen_attributes
+            .iter()
+            .any(|a| matches!(
+                a,
+                engine::types::ability::ChosenAttribute::CreatureType(t) if t == "Elf"
+            )),
+        "precondition: the prior cast left the chosen creature type on the spell object"
+    );
+
+    s.runner
+        .state_mut()
+        .objects
+        .get_mut(&s.spell)
+        .unwrap()
+        .keywords
+        .push(Keyword::Flashback(FlashbackCost::Mana(ManaCost::generic(2))));
+
+    add_mana(&mut s.runner, 4);
+    s.runner
+        .act(GameAction::CastSpell {
+            object_id: s.spell,
+            card_id,
+            targets: vec![],
+            payment_mode: engine::types::game_state::CastPaymentMode::Auto,
+        })
+        .expect("flashback cast accepted");
+
+    let mut saw_cost_type_choice = false;
+    for _ in 0..16 {
+        match s.runner.state().waiting_for.clone() {
+            WaitingFor::CastingVariantChoice { options, .. } => {
+                let index = options
+                    .iter()
+                    .position(|o| o.variant == CastingVariant::Flashback)
+                    .expect("flashback casting variant");
+                s.runner
+                    .act(GameAction::ChooseCastingVariant { index })
+                    .unwrap();
+            }
+            WaitingFor::ChooseXValue { .. } => {
+                s.runner.act(GameAction::ChooseX { value: 3 }).unwrap();
+            }
+            WaitingFor::OptionalCostChoice { .. } => {
+                s.runner
+                    .act(GameAction::DecideOptionalCost { pay: true })
+                    .unwrap();
+            }
+            WaitingFor::CostTypeChoice { .. } => {
+                saw_cost_type_choice = true;
+                break;
+            }
+            WaitingFor::PayCost { .. } => break,
+            other => panic!("unexpected prompt on flashback re-cast: {other:?}"),
+        }
+    }
+    assert!(
+        saw_cost_type_choice,
+        "re-cast from graveyard must re-present CostTypeChoice, not reuse the stale Elf type (#5051)"
     );
 }
 

--- a/crates/engine/tests/celestial_reunion_behold_choose_type.rs
+++ b/crates/engine/tests/celestial_reunion_behold_choose_type.rs
@@ -486,9 +486,7 @@ fn resolve_then_flashback_recast_reprompts_creature_type() {
         "precondition: the prior cast left the chosen creature type on the spell object"
     );
 
-    let flashback = Keyword::Flashback(FlashbackCost::Mana(ManaCost::generic(
-        2,
-    )));
+    let flashback = Keyword::Flashback(FlashbackCost::Mana(ManaCost::generic(2)));
     {
         let obj = s.runner.state_mut().objects.get_mut(&s.spell).unwrap();
         obj.base_keywords.push(flashback.clone());

--- a/crates/engine/tests/celestial_reunion_behold_choose_type.rs
+++ b/crates/engine/tests/celestial_reunion_behold_choose_type.rs
@@ -23,9 +23,9 @@ use engine::game::scenario::{GameScenario, P0, P1};
 use engine::game::zones::create_object;
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
-use engine::types::keywords::{FlashbackCost, Keyword};
 use engine::types::game_state::{CastingVariant, WaitingFor};
 use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::keywords::{FlashbackCost, Keyword};
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
@@ -491,7 +491,9 @@ fn resolve_then_flashback_recast_reprompts_creature_type() {
         .get_mut(&s.spell)
         .unwrap()
         .keywords
-        .push(Keyword::Flashback(FlashbackCost::Mana(ManaCost::generic(2))));
+        .push(Keyword::Flashback(FlashbackCost::Mana(ManaCost::generic(
+            2,
+        ))));
 
     add_mana(&mut s.runner, 4);
     s.runner

--- a/crates/engine/tests/celestial_reunion_behold_choose_type.rs
+++ b/crates/engine/tests/celestial_reunion_behold_choose_type.rs
@@ -467,7 +467,8 @@ fn cancel_after_type_choice_rewinds_and_recast_reprompts() {
 fn resolve_then_flashback_recast_reprompts_creature_type() {
     let mut s = setup();
     let card_id = s.runner.state().objects[&s.spell].card_id;
-    drive(&mut s, true, "Elf", Some(s.lib_elf));
+    let lib_elf = s.lib_elf;
+    drive(&mut s, true, "Elf", Some(lib_elf));
 
     assert_eq!(
         zone_of(&s, s.spell),

--- a/crates/engine/tests/celestial_reunion_behold_choose_type.rs
+++ b/crates/engine/tests/celestial_reunion_behold_choose_type.rs
@@ -486,15 +486,14 @@ fn resolve_then_flashback_recast_reprompts_creature_type() {
         "precondition: the prior cast left the chosen creature type on the spell object"
     );
 
-    s.runner
-        .state_mut()
-        .objects
-        .get_mut(&s.spell)
-        .unwrap()
-        .keywords
-        .push(Keyword::Flashback(FlashbackCost::Mana(ManaCost::generic(
-            2,
-        ))));
+    let flashback = Keyword::Flashback(FlashbackCost::Mana(ManaCost::generic(
+        2,
+    )));
+    {
+        let obj = s.runner.state_mut().objects.get_mut(&s.spell).unwrap();
+        obj.base_keywords.push(flashback.clone());
+        obj.keywords.push(flashback);
+    }
 
     add_mana(&mut s.runner, 4);
     s.runner


### PR DESCRIPTION
## Summary
- Clear cast-scoped `ChosenAttribute::CreatureType` at spell stack announcement (CR 400.7 / new casting event).
- Reuse the same helper for cancel-rewind path (`handle_cancel_cast`).
- Add regression test: resolve Celestial Reunion with behold type choice, then flashback re-cast from graveyard must re-present `CostTypeChoice`.

Closes #5051.

## Test plan
- [x] `resolve_then_flashback_recast_reprompts_creature_type` in `celestial_reunion_behold_choose_type.rs`
- [ ] CI green (rustfmt/clippy/tests)
