### PR TITLE
feat(client): add report-card nudge and debug-menu entry point

### DIFF
--- a/client/src/components/chrome/DebugPanel.tsx
+++ b/client/src/components/chrome/DebugPanel.tsx
@@ -161,6 +161,14 @@ export function DebugPanel() {
       });
   }, [gameState]);
 
+  // Same destination as the top-left report flag. Close this panel first — it
+  // renders at z-[9999], above the report dialog's z-50 overlay, so leaving it
+  // open would hide the dialog behind it.
+  const handleReportCard = useCallback(() => {
+    useUiStore.getState().toggleDebugPanel();
+    useUiStore.getState().openCardReportDialog();
+  }, []);
+
   const scrollToBottom = useCallback(() => {
     consoleEndRef.current?.scrollIntoView({ behavior: "smooth" });
     setNewMessageCount(0);
@@ -296,6 +304,35 @@ export function DebugPanel() {
           </button>
         ))}
       </div>
+
+      {/* Report a card — always visible regardless of tab; mirrors the
+          top-left report flag so players can flag a mis-rendered/misbehaving
+          card from here too. */}
+      <section className="border-b border-gray-700 px-3 py-2">
+        <p className="mb-1 text-xs text-gray-500">
+          See a card rendering or behaving wrong? Flag it so we can fix it.
+        </p>
+        <button
+          onClick={handleReportCard}
+          disabled={!gameState}
+          className="flex w-full items-center justify-center gap-1.5 rounded bg-red-600/90 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-3.5 w-3.5"
+          >
+            <path d="M4 2.5v15" />
+            <path d="M4 3.5h9.5l-1.6 3 1.6 3H4" />
+          </svg>
+          Report a Card Problem
+        </button>
+      </section>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         {activeTab === "actions" ? (

--- a/client/src/components/help/ReportCardNudge.tsx
+++ b/client/src/components/help/ReportCardNudge.tsx
@@ -1,0 +1,50 @@
+import { Trans, useTranslation } from "react-i18next";
+
+import { usePreferencesStore } from "../../stores/preferencesStore.ts";
+import { useUiStore } from "../../stores/uiStore.ts";
+
+/**
+ * First-run nudge that points out the card-report affordance (the red flag in
+ * the top-left game menu). Lets a player flag a card that renders or behaves
+ * wrong so the parser/engine gap gets telemetry. Mirrors {@link SandboxToolsNudge}:
+ * one-time, dismissible, persisted via `preferencesStore.dismissedReportCardNudge`,
+ * and sequenced after the sandbox nudge so the first-run hints never stack.
+ */
+export function ReportCardNudge() {
+  const { t } = useTranslation();
+  const openCardReportDialog = useUiStore((s) => s.openCardReportDialog);
+  const setDismissed = usePreferencesStore((s) => s.setDismissedReportCardNudge);
+
+  return (
+    <div className="max-w-[min(24rem,calc(100vw-1.25rem))] rounded-[18px] border border-rose-400/25 bg-slate-950/86 p-3 text-sm text-slate-100 shadow-[0_24px_64px_rgba(15,23,42,0.55)] backdrop-blur-xl">
+      <p className="leading-5">
+        <Trans
+          i18nKey="help.reportCardNudge.message"
+          t={t}
+          components={{
+            flag: <span className="font-semibold text-rose-300" />,
+          }}
+        />
+      </p>
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          className="rounded-lg px-3 py-1.5 text-xs font-semibold text-slate-400 transition hover:bg-white/8 hover:text-slate-200"
+        >
+          {t("help.reportCardNudge.dismiss")}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setDismissed(true);
+            openCardReportDialog();
+          }}
+          className="rounded-lg bg-rose-500 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-rose-400"
+        >
+          {t("help.reportCardNudge.open")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -211,6 +211,11 @@
       "message": "Richte mit den <tools>Sandbox-Werkzeugen</tools> einen beliebigen Spielzustand ein — füge Karten und Spielsteine hinzu, ändere Leben und Marken, kopiere bleibende Karten oder springe zwischen Phasen. Öffne sie jederzeit mit der Taste <key>`</key>.",
       "dismiss": "Schließen",
       "open": "Sandbox-Werkzeuge öffnen"
+    },
+    "reportCardNudge": {
+      "message": "Wird eine Karte falsch dargestellt oder gespielt? Tippe oben links auf die <flag>Melden-Flagge</flag>, um sie zu melden, damit wir sie beheben können.",
+      "dismiss": "Schließen",
+      "open": "Karte melden"
     }
   },
   "splash": {

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -211,6 +211,11 @@
       "message": "Set up any board state with <tools>Sandbox Tools</tools> — add cards and tokens, change life and counters, copy permanents, or jump phases. Open it anytime with the <key>`</key> key.",
       "dismiss": "Dismiss",
       "open": "Open Sandbox Tools"
+    },
+    "reportCardNudge": {
+      "message": "See a card render or play wrong? Tap the <flag>report flag</flag> in the top-left to flag it so we can fix it.",
+      "dismiss": "Dismiss",
+      "open": "Report a Card"
     }
   },
   "splash": {

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -211,6 +211,11 @@
       "message": "Configura cualquier estado del tablero con <tools>Herramientas de sandbox</tools> — añade cartas y fichas, cambia vidas y contadores, copia permanentes o salta fases. Ábrelo en cualquier momento con la tecla <key>`</key>.",
       "dismiss": "Descartar",
       "open": "Abrir Herramientas de sandbox"
+    },
+    "reportCardNudge": {
+      "message": "¿Una carta se muestra o juega mal? Toca la <flag>bandera de reporte</flag> arriba a la izquierda para reportarla y poder corregirla.",
+      "dismiss": "Descartar",
+      "open": "Reportar carta"
     }
   },
   "splash": {

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -211,6 +211,11 @@
       "message": "Configurez n'importe quel état du plateau avec les <tools>Outils bac à sable</tools> — ajoutez des cartes et des jetons, modifiez les points de vie et les marqueurs, copiez des permanents ou changez de phase. Ouvrez-les à tout moment avec la touche <key>`</key>.",
       "dismiss": "Ignorer",
       "open": "Ouvrir les outils bac à sable"
+    },
+    "reportCardNudge": {
+      "message": "Une carte s'affiche ou se joue mal ? Touchez le <flag>drapeau de signalement</flag> en haut à gauche pour la signaler afin que nous la corrigions.",
+      "dismiss": "Ignorer",
+      "open": "Signaler une carte"
     }
   },
   "splash": {

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -211,6 +211,11 @@
       "message": "Imposta qualsiasi stato del campo con <tools>Strumenti Sandbox</tools> — aggiungi carte e pedine, cambia punti vita e segnalini, copia permanenti o salta le fasi. Aprilo in qualsiasi momento con il tasto <key>`</key>.",
       "dismiss": "Ignora",
       "open": "Apri Strumenti Sandbox"
+    },
+    "reportCardNudge": {
+      "message": "Una carta viene mostrata o giocata in modo errato? Tocca la <flag>bandierina di segnalazione</flag> in alto a sinistra per segnalarla così possiamo correggerla.",
+      "dismiss": "Ignora",
+      "open": "Segnala una carta"
     }
   },
   "splash": {

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -211,6 +211,11 @@
       "message": "Skonfiguruj dowolny stan pola bitwy za pomocą <tools>Narzędzi piaskownicy</tools> — dodawaj karty i żetony, zmieniaj życie i znaczniki, kopiuj trwałe permanenty lub przeskakuj fazy. Otwórz je w dowolnej chwili klawiszem <key>`</key>.",
       "dismiss": "Odrzuć",
       "open": "Otwórz Narzędzia piaskownicy"
+    },
+    "reportCardNudge": {
+      "message": "Karta wyświetla się lub działa źle? Dotknij <flag>flagi zgłoszenia</flag> w lewym górnym rogu, aby ją zgłosić, a my ją naprawimy.",
+      "dismiss": "Odrzuć",
+      "open": "Zgłoś kartę"
     }
   },
   "splash": {

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -211,6 +211,11 @@
       "message": "Configure qualquer estado de tabuleiro com as <tools>Ferramentas de Sandbox</tools> — adicione cartas e fichas, altere vidas e marcadores, copie permanentes ou avance fases. Abra a qualquer momento com a tecla <key>`</key>.",
       "dismiss": "Dispensar",
       "open": "Abrir Ferramentas de Sandbox"
+    },
+    "reportCardNudge": {
+      "message": "Uma carta é exibida ou jogada de forma errada? Toque na <flag>bandeira de reporte</flag> no canto superior esquerdo para reportá-la e podermos corrigi-la.",
+      "dismiss": "Dispensar",
+      "open": "Reportar carta"
     }
   },
   "splash": {

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -46,6 +46,7 @@ import { MobileHandDrawer } from "../components/hand/MobileHandDrawer.tsx";
 import { HandBadge } from "../components/hand/HandBadge.tsx";
 import { PlayerHand } from "../components/hand/PlayerHand.tsx";
 import { FlowHelpNudge } from "../components/help/FlowHelpNudge.tsx";
+import { ReportCardNudge } from "../components/help/ReportCardNudge.tsx";
 import { SandboxToolsNudge } from "../components/help/SandboxToolsNudge.tsx";
 import { HelpSheet } from "../components/help/HelpSheet.tsx";
 import { GameLogPanel } from "../components/log/GameLogPanel.tsx";
@@ -841,6 +842,8 @@ function GamePageContent({
   const setHelpSheetOpen = useUiStore((s) => s.setHelpSheetOpen);
   const dismissedFlowHelpNudge = usePreferencesStore((s) => s.dismissedFlowHelpNudge);
   const dismissedSandboxToolsNudge = usePreferencesStore((s) => s.dismissedSandboxToolsNudge);
+  const dismissedReportCardNudge = usePreferencesStore((s) => s.dismissedReportCardNudge);
+  const cardReportDialogOpen = useUiStore((s) => s.cardReportDialogOpen);
   const multiplayerBoardLayout = usePreferencesStore((s) => s.multiplayerBoardLayout);
   const setMultiplayerBoardLayout = usePreferencesStore((s) => s.setMultiplayerBoardLayout);
   const debugPanelOpen = useUiStore((s) => s.debugPanelOpen);
@@ -1176,6 +1179,31 @@ function GamePageContent({
     canActForWaitingState &&
     stackLength === 0;
 
+  // Last in the first-run hint chain (requires the sandbox nudge dismissed first)
+  // so the three hints never stack. Same calm-moment guards, plus: gated on the
+  // report affordance being available and hidden once the dialog is already open.
+  const showReportCardNudge =
+    !dismissedReportCardNudge &&
+    dismissedSandboxToolsNudge &&
+    canReportCard &&
+    !cardReportDialogOpen &&
+    !debugPanelOpen &&
+    !helpSheetOpen &&
+    (mode === "ai" || mode === "local") &&
+    viewingZone == null &&
+    preferencesOpen == null &&
+    boardContextMenu == null &&
+    !showCardDataMissing &&
+    resumeResetReason == null &&
+    !showConcedeDialog &&
+    disconnectChoice == null &&
+    pauseReason == null &&
+    reconnectState.status === "idle" &&
+    waitingFor?.type === "Priority" &&
+    waitingFor.data.player === playerId &&
+    canActForWaitingState &&
+    stackLength === 0;
+
   return (
     <div
       ref={containerRef}
@@ -1390,6 +1418,7 @@ function GamePageContent({
         >
           {showFlowHelpNudge && <FlowHelpNudge />}
           {showSandboxToolsNudge && <SandboxToolsNudge />}
+          {showReportCardNudge && <ReportCardNudge />}
           <div className="hidden max-lg:landscape:block lg:block">
             <CombatPhaseIndicator />
           </div>

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -306,6 +306,7 @@ function buildDefaultPreferences(): PreferencesState {
     lastPlayerCount: 2,
     dismissedFlowHelpNudge: false,
     dismissedSandboxToolsNudge: false,
+    dismissedReportCardNudge: false,
     artChain: [] as ArtChainEntry[],
     artOverrides: {} as Record<string, CardArtOverride>,
     flexLayout: defaultFlexLayout(),
@@ -396,6 +397,7 @@ interface PreferencesState {
   lastPlayerCount: number;
   dismissedFlowHelpNudge: boolean;
   dismissedSandboxToolsNudge: boolean;
+  dismissedReportCardNudge: boolean;
   artChain: ArtChainEntry[];
   artOverrides: Record<string, CardArtOverride>;
   /** Persisted board layout (grid bands + per-widget offsets + active preset).
@@ -468,6 +470,7 @@ interface PreferencesActions {
   setLastPlayerCount: (count: number) => void;
   setDismissedFlowHelpNudge: (dismissed: boolean) => void;
   setDismissedSandboxToolsNudge: (dismissed: boolean) => void;
+  setDismissedReportCardNudge: (dismissed: boolean) => void;
   addArtChainEntry: (entry: ArtChainEntry) => void;
   removeArtChainEntry: (index: number) => void;
   moveArtChainEntry: (fromIndex: number, toIndex: number) => void;
@@ -650,6 +653,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       setLastPlayerCount: (count) => set({ lastPlayerCount: count }),
       setDismissedFlowHelpNudge: (dismissed) => set({ dismissedFlowHelpNudge: dismissed }),
       setDismissedSandboxToolsNudge: (dismissed) => set({ dismissedSandboxToolsNudge: dismissed }),
+      setDismissedReportCardNudge: (dismissed) => set({ dismissedReportCardNudge: dismissed }),
       addArtChainEntry: (entry) =>
         set((state) => {
           const isDuplicate = state.artChain.some((e) =>
@@ -760,7 +764,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
     }),
     {
       name: "phase-preferences",
-      version: 23,
+      version: 24,
       // v0 → v1: flat aiDifficulty + aiDeckName become aiSeats[0].
       // v1 → v2: discrete animationSpeed/combatPacing enums become numeric
       //          animationSpeedMultiplier/combatPacingMultiplier.
@@ -808,6 +812,9 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       // v22 → v23: phaseStops gained a turn-direction scope; each legacy bare
       //          Phase string maps to a scoped stop defaulting to "AllTurns"
       //          (fire on every turn = the old behavior).
+      // v23 → v24: Add dismissedReportCardNudge; legacy stores default to `false`
+      //          (nudge not yet dismissed) via the shallow merge — no explicit
+      //          migration block needed (see telemetryEnabled precedent).
       migrate: (persisted: unknown, version: number) => {
         if (!persisted || typeof persisted !== "object") return persisted;
         let migrated = persisted as Record<string, unknown>;


### PR DESCRIPTION
Introduce a one-time, dismissible nudge that points players at the
top-left report-card flag, persisted via a new dismissedReportCardNudge
preference (store v23 -> v24, additive default). It is chained after the
sandbox-tools nudge so the first-run hints never stack, and gated on the
report affordance being available.

Also add an always-visible 'Report a Card Problem' entry point to the
debug panel that opens the same dialog (closing the panel first so its
z-[9999] layer does not hide the z-50 dialog).

New i18n keys (help.reportCardNudge) across all 7 locales.
