### PR TITLE
fix: gate attacks-alone triggers on zero co-attackers (closes #5159)

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8162,7 +8162,7 @@ fn strip_attack_unblocked_qualifier(after: &str) -> (bool, &str) {
 /// text ("attacks alone", Exalted / Sharon Carter class). Encoded as
 /// `Not(MinCoAttackers { minimum: 1 })` — zero same-controller co-attackers.
 fn strip_attack_alone_qualifier(after: &str) -> (bool, &str) {
-    if let Ok((rest, ())) = tag::<_, _, OracleError<'_>>(" alone").parse(after) {
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(" alone").parse(after) {
         (true, rest)
     } else {
         (false, after)

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8529,6 +8529,7 @@ fn try_parse_event(
             def.valid_target = Some(TargetFilter::Controller);
         }
         if attacks_alone {
+            // CR 506.5: attacks alone — zero same-controller co-attackers.
             def.condition = Some(TriggerCondition::Not {
                 condition: Box::new(TriggerCondition::MinCoAttackers {
                     minimum: 1,

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8158,6 +8158,17 @@ fn strip_attack_unblocked_qualifier(after: &str) -> (bool, &str) {
     (false, after)
 }
 
+/// CR 506.5: Strip a trailing " alone" qualifier from attack trigger event
+/// text ("attacks alone", Exalted / Sharon Carter class). Encoded as
+/// `Not(MinCoAttackers { minimum: 1 })` — zero same-controller co-attackers.
+fn strip_attack_alone_qualifier(after: &str) -> (bool, &str) {
+    if let Ok((rest, ())) = tag::<_, _, OracleError<'_>>(" alone").parse(after) {
+        (true, rest)
+    } else {
+        (false, after)
+    }
+}
+
 /// Try to parse an event verb and build a TriggerDefinition from subject + event.
 fn try_parse_event(
     subject: &TargetFilter,
@@ -8450,6 +8461,7 @@ fn try_parse_event(
         });
     if let Some(after) = attacks_result {
         let (attacks_and_unblocked, after) = strip_attack_unblocked_qualifier(after);
+        let (attacks_alone, after) = strip_attack_alone_qualifier(after);
         // CR 508.3a: Detect attack target qualifier ("attacks a planeswalker" etc.)
         fn parse_attack_target(input: &str) -> OracleResult<'_, AttackTargetFilter> {
             alt((
@@ -8515,6 +8527,14 @@ fn try_parse_event(
         ) && tag::<_, _, OracleError<'_>>(" you").parse(after).is_ok()
         {
             def.valid_target = Some(TargetFilter::Controller);
+        }
+        if attacks_alone {
+            def.condition = Some(TriggerCondition::Not {
+                condition: Box::new(TriggerCondition::MinCoAttackers {
+                    minimum: 1,
+                    filter: None,
+                }),
+            });
         }
         let mode = def.mode.clone();
         return Some((mode, def));

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -12760,9 +12760,17 @@ fn trigger_samurai_or_warrior_attacks_alone() {
         "Whenever a Samurai or Warrior you control attacks alone, draw a card.",
         "Raiyuu, Storm's Edge",
     );
-    // Now that parse_type_phrase recognizes subtypes ("Samurai", "Warrior"),
-    // the trigger parser correctly identifies this as an Attacks trigger.
     assert!(matches!(def.mode, TriggerMode::Attacks));
+    assert_eq!(
+        def.condition,
+        Some(TriggerCondition::Not {
+            condition: Box::new(TriggerCondition::MinCoAttackers {
+                minimum: 1,
+                filter: None,
+            }),
+        }),
+        "attacks alone must gate on zero co-attackers (CR 506.5)"
+    );
 }
 
 #[test]

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -1777,7 +1777,16 @@ fn trigger_first_combat_phase_followup_condition() {
             "Whenever a Samurai or Warrior you control attacks alone, untap it. If it's the first combat phase of the turn, there is an additional combat phase after this phase.",
             "A-Raiyuu, Storm's Edge",
         );
-    assert!(def.condition.is_none());
+    assert_eq!(
+        def.condition,
+        Some(TriggerCondition::Not {
+            condition: Box::new(TriggerCondition::MinCoAttackers {
+                minimum: 1,
+                filter: None,
+            }),
+        }),
+        "attacks alone gates the main trigger; first-combat-phase is on the follow-up"
+    );
     let followup = def
         .execute
         .as_ref()

--- a/crates/engine/tests/integration/issue_5159_attacks_alone_investigate.rs
+++ b/crates/engine/tests/integration/issue_5159_attacks_alone_investigate.rs
@@ -1,0 +1,65 @@
+//! Issue #5159: "Whenever a creature you control attacks alone, investigate"
+//! (Agent 13, Sharon Carter) must fire only when exactly one creature attacks.
+//!
+//! https://github.com/phase-rs/phase/issues/5159
+
+use engine::types::phase::Phase;
+
+use super::rules::run_combat;
+use super::{GameScenario, P0};
+
+const ORACLE: &str = "Whenever a creature you control attacks alone, investigate.";
+
+fn count_clues_on_battlefield(runner: &engine::game::scenario::GameRunner) -> usize {
+    runner
+        .state()
+        .battlefield
+        .iter()
+        .filter(|id| {
+            runner
+                .state()
+                .objects
+                .get(id)
+                .is_some_and(|obj| obj.name.eq_ignore_ascii_case("Clue"))
+        })
+        .count()
+}
+
+#[test]
+fn issue_5159_solo_attack_investigates_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let agent = scenario
+        .add_creature_from_oracle(P0, "Agent 13, Sharon Carter", 2, 2, ORACLE)
+        .id();
+    let mut runner = scenario.build();
+
+    run_combat(&mut runner, vec![agent], vec![]);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        count_clues_on_battlefield(&runner),
+        1,
+        "solo attack must investigate exactly once"
+    );
+}
+
+#[test]
+fn issue_5159_multi_attack_does_not_investigate() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let agent = scenario
+        .add_creature_from_oracle(P0, "Agent 13, Sharon Carter", 2, 2, ORACLE)
+        .id();
+    let other = scenario.add_creature(P0, "Grizzly Bear", 2, 2).id();
+    let mut runner = scenario.build();
+
+    run_combat(&mut runner, vec![agent, other], vec![]);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        count_clues_on_battlefield(&runner),
+        0,
+        "multi-creature attack must not trigger attacks-alone investigate"
+    );
+}

--- a/crates/engine/tests/integration/issue_5159_attacks_alone_investigate.rs
+++ b/crates/engine/tests/integration/issue_5159_attacks_alone_investigate.rs
@@ -5,8 +5,7 @@
 
 use engine::types::phase::Phase;
 
-use super::rules::run_combat;
-use super::{GameScenario, P0};
+use super::rules::{run_combat, GameScenario, P0};
 
 const ORACLE: &str = "Whenever a creature you control attacks alone, investigate.";
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -422,6 +422,7 @@ mod issue_4836_mindskinner;
 mod issue_4921_skullscorch_unless_deal_damage;
 mod issue_4962_volo_guide_to_monsters;
 mod issue_5145_violent_eruption_choose_target_distribution;
+mod issue_5159_attacks_alone_investigate;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;

--- a/crates/mtgish-import/src/convert/trigger.rs
+++ b/crates/mtgish-import/src/convert/trigger.rs
@@ -8,7 +8,7 @@
 
 use engine::types::ability::{CounterTriggerFilter, DamageKindFilter, TriggerConstraint};
 use engine::types::triggers::{AttackTargetFilter, TriggerMode};
-use engine::types::{Phase, TargetFilter, TriggerDefinition, TypedFilter, Zone};
+use engine::types::{Phase, TargetFilter, TriggerCondition, TriggerDefinition, TypedFilter, Zone};
 
 use crate::convert::filter::{
     cards_in_graveyard_to_filter, cards_to_filter, convert as convert_permanents,
@@ -567,12 +567,18 @@ pub fn convert(t: &Trigger) -> ConvResult<TriggerDefinition> {
             TriggerDefinition::new(TriggerMode::YouAttack)
         }
 
-        // CR 508.3a: "Whenever [a creature] attacks alone" — same firing axis
-        // as a regular attack trigger; the "alone" qualifier (single-attacker
-        // batch) has no engine field today. Mirrors native parser at
-        // oracle_trigger.rs:8273 (collapses to `TriggerMode::Attacks`).
+        // CR 506.5: "Whenever [a creature] attacks alone" — same firing axis
+        // as a regular attack trigger; zero same-controller co-attackers via
+        // `Not(MinCoAttackers { minimum: 1 })`.
         Trigger::WhenACreatureAttacksAlone(filter) => {
-            TriggerDefinition::new(TriggerMode::Attacks).valid_card(convert_permanents(filter)?)
+            TriggerDefinition::new(TriggerMode::Attacks)
+                .valid_card(convert_permanents(filter)?)
+                .condition(TriggerCondition::Not {
+                    condition: Box::new(TriggerCondition::MinCoAttackers {
+                        minimum: 1,
+                        filter: None,
+                    }),
+                })
         }
 
         // CR 509.1h: "Whenever [a creature] blocks [a creature]" — fires for


### PR DESCRIPTION
## Summary
- Parse `"attacks alone"` on attack triggers into `TriggerCondition::MinCoAttackers { minimum: 0 }` (CR 508.3a — zero co-attackers).
- Wire the same condition through mtgish-import `WhenACreatureAttacksAlone`.
- Add integration tests for Agent 13, Sharon Carter: solo attack investigates once; multi-creature attack does not.

Closes #5159.

## Test plan
- [x] `trigger_samurai_or_warrior_attacks_alone` parser unit test
- [x] `issue_5159_solo_attack_investigates_once`
- [x] `issue_5159_multi_attack_does_not_investigate`
- [ ] CI green
