### PR TITLE
feat(client): report-picker art thumbnails, zone filter, and debug i18n

### DIFF
--- a/client/src/components/card/CardReportDialog.tsx
+++ b/client/src/components/card/CardReportDialog.tsx
@@ -2,10 +2,13 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GameObject, PlayerId, Zone } from "../../adapter/types.ts";
+import { useCardHover } from "../../hooks/useCardHover.ts";
+import { useCardImage } from "../../hooks/useCardImage.ts";
 import { type CardReportContext, useCardReport } from "../../hooks/useCardReport.ts";
 import { useCardParseDetails } from "../../hooks/useEngineCardData.ts";
 import { usePlayerId } from "../../hooks/usePlayerId.ts";
 import { getSeatColor, useSeatColor } from "../../hooks/useSeatColor.ts";
+import { cardImageLookup, tokenFiltersForObject } from "../../services/cardImageLookup.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { getPlayerDisplayName } from "../../stores/multiplayerStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
@@ -91,11 +94,16 @@ export function CardReportDialog() {
   const [search, setSearch] = useState("");
   // null = show every seat's cards; otherwise restrict to one seat's cards.
   const [playerFilter, setPlayerFilter] = useState<PlayerId | null>(null);
+  // null = show every zone's cards; otherwise restrict to one zone.
+  const [zoneFilter, setZoneFilter] = useState<Zone | null>(null);
 
-  const { groups, seats } = useMemo(() => {
-    if (!gameState) return { groups: [] as ZoneGroup[], seats: [] as PlayerId[] };
+  const { groups, seats, zones } = useMemo(() => {
+    if (!gameState) {
+      return { groups: [] as ZoneGroup[], seats: [] as PlayerId[], zones: [] as Zone[] };
+    }
     const query = search.trim().toLowerCase();
     const seatSet = new Set<PlayerId>();
+    const zoneSet = new Set<Zone>();
     const byZone = new Map<Zone, GameObject[]>();
     for (const obj of Object.values(gameState.objects)) {
       if (!ZONE_ORDER.includes(obj.zone)) continue; // excludes Library
@@ -109,12 +117,14 @@ export function CardReportDialog() {
       // (reported with an empty oracle_id), and emblems (reported under their
       // source card via `reportIdentity`).
       if (!obj.printed_ref && obj.display_source !== "Token" && !obj.is_emblem) continue;
-      // Record the owning/controlling seat for the filter chips BEFORE applying
-      // the active player/search filters, so selecting one player never removes
-      // the chips for the others.
+      // Record the owning/controlling seat and the zone for the filter chips
+      // BEFORE applying the active player/zone/search filters, so selecting one
+      // filter never removes the chips for the others.
       const seat = labelSeatForZone(obj);
       seatSet.add(seat);
+      zoneSet.add(obj.zone);
       if (playerFilter != null && seat !== playerFilter) continue;
+      if (zoneFilter != null && obj.zone !== zoneFilter) continue;
       if (query && !reportIdentity(obj).name.toLowerCase().includes(query)) continue;
       const list = byZone.get(obj.zone) ?? [];
       list.push(obj);
@@ -142,8 +152,10 @@ export function CardReportDialog() {
     const seats = [...seatSet].sort(
       (a, b) => (seatOrder?.indexOf(a) ?? 0) - (seatOrder?.indexOf(b) ?? 0),
     );
-    return { groups, seats };
-  }, [gameState, viewerId, search, playerFilter, seatOrder]);
+    // Zone chips ordered by ZONE_ORDER so they read the same as the list sections.
+    const zones = ZONE_ORDER.filter((zone) => zoneSet.has(zone));
+    return { groups, seats, zones };
+  }, [gameState, viewerId, search, playerFilter, zoneFilter, seatOrder]);
 
   return (
     <ModalPanelShell
@@ -154,7 +166,7 @@ export function CardReportDialog() {
       maxWidthClassName="max-w-lg"
       bodyClassName="flex flex-col"
     >
-      {/* Pinned controls: the search + player filter stay put while the list scrolls. */}
+      {/* Pinned controls: the search + player/zone filters stay put while the list scrolls. */}
       <div className="flex shrink-0 flex-col gap-2.5 px-4 pt-4 pb-3 lg:px-6">
         <input
           type="text"
@@ -165,18 +177,35 @@ export function CardReportDialog() {
         />
         {seats.length > 1 && (
           <div className="flex flex-wrap gap-1.5">
-            <PlayerFilterChip
+            <FilterChip
               active={playerFilter === null}
               label={t("cardReport.allPlayers")}
               onClick={() => setPlayerFilter(null)}
             />
             {seats.map((seat) => (
-              <PlayerFilterChip
+              <FilterChip
                 key={seat}
                 active={playerFilter === seat}
                 label={getPlayerDisplayName(seat, viewerId)}
                 color={getSeatColor(seat, seatOrder)}
                 onClick={() => setPlayerFilter((cur) => (cur === seat ? null : seat))}
+              />
+            ))}
+          </div>
+        )}
+        {zones.length > 1 && (
+          <div className="flex flex-wrap gap-1.5">
+            <FilterChip
+              active={zoneFilter === null}
+              label={t("cardReport.allZones")}
+              onClick={() => setZoneFilter(null)}
+            />
+            {zones.map((zone) => (
+              <FilterChip
+                key={zone}
+                active={zoneFilter === zone}
+                label={t(`cardReport.zone.${zone}`)}
+                onClick={() => setZoneFilter((cur) => (cur === zone ? null : zone))}
               />
             ))}
           </div>
@@ -213,10 +242,11 @@ export function CardReportDialog() {
   );
 }
 
-/** A quick per-player filter pill. Reuses the seat color dot from the HUD so a
- *  chip reads as the same player as their board nameplate. The "All" chip has no
- *  `color`. */
-function PlayerFilterChip({
+/** A quick filter pill, shared by the player and zone filter rows. When `color`
+ *  is given (player chips) it shows the seat color dot from the HUD so the chip
+ *  reads as the same player as their board nameplate; the "All" chips and the
+ *  zone chips omit `color`. */
+function FilterChip({
   active,
   label,
   color,
@@ -277,6 +307,22 @@ function CardReportRow({
   const seatId = labelSeatForZone(obj);
   const seatColor = useSeatColor(seatId);
   const seatName = getPlayerDisplayName(seatId, viewerId);
+  // Tiny art thumbnail + shared hover/long-press preview, driven off the real
+  // game object so hovering the icon opens the same full card preview overlay the
+  // board uses (display only). `cardImageLookup` already resolves emblems (via
+  // emblem_source), tokens, MDFCs, and transformed faces, so no special-casing.
+  const { handlers: hoverHandlers, firedRef } = useCardHover(obj.id);
+  const imageLookup = cardImageLookup(obj);
+  const isToken = obj.display_source === "Token";
+  const { src: artSrc } = useCardImage(imageLookup.name, {
+    size: "art_crop",
+    faceIndex: imageLookup.faceIndex,
+    isToken,
+    tokenFilters: isToken ? tokenFiltersForObject(obj) : undefined,
+    tokenImageRef: isToken ? obj.token_image_ref : undefined,
+    oracleId: imageLookup.oracleId,
+    faceName: imageLookup.faceName,
+  });
 
   const loaded = parseItems != null;
   const supported = (parseItems ?? []).filter((item) => item.supported).length;
@@ -292,6 +338,19 @@ function CardReportRow({
     total,
   };
   const { sent, report } = useCardReport(context);
+
+  // Tiny art icon; hovering it (or long-pressing on touch) opens the full
+  // preview. Shared across the row's three states, like `info`.
+  const thumb = (
+    <span
+      {...hoverHandlers}
+      className="relative block h-9 w-9 shrink-0 overflow-hidden rounded-[6px] border border-white/10 bg-black/30"
+    >
+      {artSrc && (
+        <img src={artSrc} alt="" draggable={false} className="h-full w-full object-cover" />
+      )}
+    </span>
+  );
 
   // Card name + owning seat — shared across the row's three states.
   const info = (
@@ -326,6 +385,7 @@ function CardReportRow({
   if (sent) {
     return (
       <li className="flex items-center gap-3 rounded-[10px] border border-emerald-400/25 bg-emerald-400/[0.06] px-3 py-2">
+        {thumb}
         {info}
         <span className="shrink-0 text-[11px] font-medium text-emerald-400">
           {t("preview.reported")}
@@ -338,6 +398,7 @@ function CardReportRow({
   if (confirming) {
     return (
       <li className="flex items-center gap-3 rounded-[10px] border border-red-400/30 bg-red-500/[0.07] px-3 py-2">
+        {thumb}
         {info}
         <div className="flex shrink-0 items-center gap-1.5">
           <button
@@ -369,9 +430,14 @@ function CardReportRow({
       <button
         type="button"
         disabled={!loaded}
-        onClick={() => setConfirming(true)}
+        onClick={() => {
+          // Suppress the tap that trails a touch long-press (which just opened
+          // the sticky preview), so previewing the art never fires a report.
+          if (!firedRef.current) setConfirming(true);
+        }}
         className="flex w-full items-center gap-3 rounded-[10px] border border-white/8 bg-white/[0.03] px-3 py-2 transition hover:border-white/15 hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-50"
       >
+        {thumb}
         {info}
         {loaded && total > 0 && (
           <span

--- a/client/src/components/chrome/DebugPanel.tsx
+++ b/client/src/components/chrome/DebugPanel.tsx
@@ -1,6 +1,7 @@
 import { strToU8, zipSync } from "fflate";
 import type { ChangeEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { GameState } from "../../adapter/types";
 import { audioManager } from "../../audio/AudioManager";
@@ -57,6 +58,7 @@ function patchConsole(): void {
 patchConsole();
 
 export function DebugPanel() {
+  const { t } = useTranslation();
   const open = useUiStore((s) => s.debugPanelOpen);
   const turnCheckpoints = useGameStore((s) => s.turnCheckpoints);
   const gameState = useGameStore((s) => s.gameState);
@@ -310,7 +312,7 @@ export function DebugPanel() {
           card from here too. */}
       <section className="border-b border-gray-700 px-3 py-2">
         <p className="mb-1 text-xs text-gray-500">
-          See a card rendering or behaving wrong? Flag it so we can fix it.
+          {t("help.reportCardNudge.debugPrompt")}
         </p>
         <button
           onClick={handleReportCard}
@@ -330,7 +332,7 @@ export function DebugPanel() {
             <path d="M4 2.5v15" />
             <path d="M4 3.5h9.5l-1.6 3 1.6 3H4" />
           </svg>
-          Report a Card Problem
+          {t("help.reportCardNudge.open")}
         </button>
       </section>
 

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -215,7 +215,8 @@
     "reportCardNudge": {
       "message": "Wird eine Karte falsch dargestellt oder gespielt? Tippe oben links auf die <flag>Melden-Flagge</flag>, um sie zu melden, damit wir sie beheben können.",
       "dismiss": "Schließen",
-      "open": "Karte melden"
+      "open": "Karte melden",
+      "debugPrompt": "Wird eine Karte falsch dargestellt oder gespielt? Melde sie, damit wir sie beheben können."
     }
   },
   "splash": {

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -97,6 +97,7 @@
     },
     "emblemTag": "Emblem",
     "allPlayers": "Alle",
+    "allZones": "Alle Zonen",
     "cancel": "Abbrechen"
   },
   "board": {

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -215,7 +215,8 @@
     "reportCardNudge": {
       "message": "See a card render or play wrong? Tap the <flag>report flag</flag> in the top-left to flag it so we can fix it.",
       "dismiss": "Dismiss",
-      "open": "Report a Card"
+      "open": "Report a Card",
+      "debugPrompt": "See a card render or play wrong? Flag it so we can fix it."
     }
   },
   "splash": {

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -97,6 +97,7 @@
     },
     "emblemTag": "Emblem",
     "allPlayers": "All",
+    "allZones": "All zones",
     "cancel": "Cancel"
   },
   "board": {

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -215,7 +215,8 @@
     "reportCardNudge": {
       "message": "¿Una carta se muestra o juega mal? Toca la <flag>bandera de reporte</flag> arriba a la izquierda para reportarla y poder corregirla.",
       "dismiss": "Descartar",
-      "open": "Reportar carta"
+      "open": "Reportar carta",
+      "debugPrompt": "¿Una carta se muestra o juega mal? Repórtala para que podamos corregirla."
     }
   },
   "splash": {

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -97,6 +97,7 @@
     },
     "emblemTag": "Emblema",
     "allPlayers": "Todos",
+    "allZones": "Todas las zonas",
     "cancel": "Cancelar"
   },
   "board": {

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -215,7 +215,8 @@
     "reportCardNudge": {
       "message": "Une carte s'affiche ou se joue mal ? Touchez le <flag>drapeau de signalement</flag> en haut à gauche pour la signaler afin que nous la corrigions.",
       "dismiss": "Ignorer",
-      "open": "Signaler une carte"
+      "open": "Signaler une carte",
+      "debugPrompt": "Une carte s'affiche ou se joue mal ? Signalez-la pour que nous la corrigions."
     }
   },
   "splash": {

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -97,6 +97,7 @@
     },
     "emblemTag": "Emblème",
     "allPlayers": "Tous",
+    "allZones": "Toutes les zones",
     "cancel": "Annuler"
   },
   "board": {

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -215,7 +215,8 @@
     "reportCardNudge": {
       "message": "Una carta viene mostrata o giocata in modo errato? Tocca la <flag>bandierina di segnalazione</flag> in alto a sinistra per segnalarla così possiamo correggerla.",
       "dismiss": "Ignora",
-      "open": "Segnala una carta"
+      "open": "Segnala una carta",
+      "debugPrompt": "Una carta viene mostrata o giocata in modo errato? Segnalala così possiamo correggerla."
     }
   },
   "splash": {

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -97,6 +97,7 @@
     },
     "emblemTag": "Emblema",
     "allPlayers": "Tutti",
+    "allZones": "Tutte le zone",
     "cancel": "Annulla"
   },
   "board": {

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -215,7 +215,8 @@
     "reportCardNudge": {
       "message": "Karta wyświetla się lub działa źle? Dotknij <flag>flagi zgłoszenia</flag> w lewym górnym rogu, aby ją zgłosić, a my ją naprawimy.",
       "dismiss": "Odrzuć",
-      "open": "Zgłoś kartę"
+      "open": "Zgłoś kartę",
+      "debugPrompt": "Karta wyświetla się lub działa źle? Zgłoś ją, a my ją naprawimy."
     }
   },
   "splash": {

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -97,6 +97,7 @@
     },
     "emblemTag": "Emblemat",
     "allPlayers": "Wszyscy",
+    "allZones": "Wszystkie strefy",
     "cancel": "Anuluj"
   },
   "board": {

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -215,7 +215,8 @@
     "reportCardNudge": {
       "message": "Uma carta é exibida ou jogada de forma errada? Toque na <flag>bandeira de reporte</flag> no canto superior esquerdo para reportá-la e podermos corrigi-la.",
       "dismiss": "Dispensar",
-      "open": "Reportar carta"
+      "open": "Reportar carta",
+      "debugPrompt": "Uma carta é exibida ou jogada de forma errada? Reporte-a para podermos corrigi-la."
     }
   },
   "splash": {

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -97,6 +97,7 @@
     },
     "emblemTag": "Emblema",
     "allPlayers": "Todos",
+    "allZones": "Todas as zonas",
     "cancel": "Cancelar"
   },
   "board": {


### PR DESCRIPTION
Card-report picker polish, all composed from existing building blocks:

- Per-row art thumbnail (art_crop via cardImageLookup + useCardImage) that
  opens the board's full card preview on hover / touch long-press through
  useCardHover; the row's tap-to-confirm is gated on firedRef so previewing
  never fires a report. cardImageLookup already handles emblems, tokens,
  MDFCs, and transformed faces, so no special-casing.
- Zone filter chips mirroring the player filter: zones recorded before any
  filter is applied so a selection never hides the other chips; the shared
  chip is generalized from PlayerFilterChip to FilterChip. New cardReport.
  allZones key across all 7 locales.
- Debug panel's player-facing 'report a card' section now uses i18n
  (help.reportCardNudge.debugPrompt + reused open) instead of hardcoded
  English. New debugPrompt key across all 7 locales.
