### PR TITLE
feat: discoverable priority-yield auto-pass UX (CR 117.3d)

### DIFF
--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -15,7 +15,6 @@ import { useBlockRequirements } from "../combat/useBlockRequirements.ts";
 import { gameButtonClass } from "../ui/buttonStyles.ts";
 import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
 import { AttackTargetPicker } from "../controls/AttackTargetPicker.tsx";
-import { PriorityYieldList } from "./PriorityYieldList.tsx";
 
 type ActionButtonMode =
   | "combat-attackers"
@@ -487,9 +486,6 @@ export function ActionButton() {
           </button>
         )}
       </div>
-
-      {/* CR 117.3d: the viewer's standing priority yields, with revoke controls. */}
-      <PriorityYieldList />
 
       {showTargetPicker && (
         <AttackTargetPicker

--- a/client/src/components/board/PriorityYieldList.tsx
+++ b/client/src/components/board/PriorityYieldList.tsx
@@ -2,12 +2,18 @@ import { useTranslation } from "react-i18next";
 
 import { dispatchAction } from "../../game/dispatch.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
+import { PopoverMenu } from "../menu/PopoverMenu.tsx";
+import { YieldMuteIcon } from "../stack/YieldMuteIcon.tsx";
 
 /**
- * CR 117.3d: Compact list of the viewer's standing priority yields, with a
- * per-row revoke and a clear-all. Purely a display + dispatch surface — the
- * engine owns the yield state (redacted per-viewer in `priority_yields`), and
- * each revoke echoes the stored `YieldTarget` verbatim.
+ * CR 117.3d: the viewer's standing priority yields. Presented as a single
+ * fixed-footprint summary chip ("Auto-passing ×N") that opens a portaled
+ * PopoverMenu holding the scrollable, per-row revoke list plus a clear-all.
+ * Collapsing the list into a chip keeps the action rail's height constant no
+ * matter how many yields accumulate (an inline list grew unbounded and pushed
+ * the surrounding layout). Purely a display + dispatch surface — the engine
+ * owns the yield state (redacted per-viewer in `priority_yields`), and each
+ * revoke echoes the stored `YieldTarget` verbatim.
  */
 export function PriorityYieldList() {
   const { t } = useTranslation("game");
@@ -17,44 +23,75 @@ export function PriorityYieldList() {
   if (!yields || yields.length === 0) return null;
 
   return (
-    <div className="rounded-lg bg-gray-900/90 p-2 text-[11px] ring-1 ring-white/10">
-      <div className="mb-1 flex items-center justify-between">
-        <span className="font-semibold text-purple-200">{t("priorityYield.listHeader")}</span>
+    <PopoverMenu
+      ariaLabel={t("priorityYield.listHeader")}
+      menuWidthPx={240}
+      renderTrigger={({ ref, open, toggle }) => (
         <button
-          className="rounded px-1.5 py-0.5 text-amber-200 hover:bg-white/10"
-          onClick={() => dispatchAction({ type: "SetPriorityYield", data: { op: { type: "ClearAll" } } })}
+          ref={ref}
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          onClick={toggle}
+          className={`pointer-events-auto flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold shadow-sm ring-1 transition-colors ${
+            open
+              ? "bg-amber-400 text-black ring-amber-300"
+              : "bg-amber-500/90 text-black ring-amber-300/80 hover:bg-amber-400"
+          }`}
         >
-          {t("priorityYield.clearAll")}
+          <YieldMuteIcon muted className="h-3.5 w-3.5 shrink-0" />
+          <span>{t("priorityYield.menuButtonShortActive")}</span>
+          <span className="rounded-full bg-black/25 px-1.5 leading-tight">{yields.length}</span>
         </button>
-      </div>
-      <ul className="flex flex-col gap-0.5">
-        {yields.map((y) => {
-          const key =
-            "ThisObject" in y.target
-              ? `${y.player}-obj-${y.target.ThisObject.source_id}-${y.target.ThisObject.incarnation}`
-              : `${y.player}-all-${y.target.AllCopies.card_id}`;
-          const label =
-            "ThisObject" in y.target
-              ? objects?.[y.target.ThisObject.source_id]?.name ?? t("priorityYield.yieldThis")
-              : t("priorityYield.yieldAllCopies");
-          return (
-            <li key={key} className="flex items-center justify-between gap-2">
-              <span className="truncate text-gray-200">{label}</span>
-              <button
-                className="shrink-0 rounded px-1.5 py-0.5 text-amber-200 hover:bg-white/10"
-                onClick={() =>
-                  dispatchAction({
-                    type: "SetPriorityYield",
-                    data: { op: { type: "Remove", data: { target: y.target } } },
-                  })
-                }
-              >
-                {t("priorityYield.revoke")}
-              </button>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
+      )}
+    >
+      {(close) => (
+        <>
+          <div className="flex items-center justify-between px-3 pb-1.5 pt-1">
+            <span className="text-sm font-bold text-white">{t("priorityYield.listHeader")}</span>
+            <button
+              type="button"
+              className="rounded px-1.5 py-0.5 text-xs font-semibold text-amber-200 transition-colors hover:bg-white/10"
+              onClick={() => {
+                dispatchAction({ type: "SetPriorityYield", data: { op: { type: "ClearAll" } } });
+                close();
+              }}
+            >
+              {t("priorityYield.clearAll")}
+            </button>
+          </div>
+          <div className="mx-2 mb-1 border-t border-white/10" />
+          <ul className="flex flex-col">
+            {yields.map((y) => {
+              const key =
+                "ThisObject" in y.target
+                  ? `${y.player}-obj-${y.target.ThisObject.source_id}-${y.target.ThisObject.incarnation}`
+                  : `${y.player}-all-${y.target.AllCopies.card_id}`;
+              const label =
+                "ThisObject" in y.target
+                  ? objects?.[y.target.ThisObject.source_id]?.name ?? t("priorityYield.yieldThis")
+                  : t("priorityYield.yieldAllCopies");
+              return (
+                <li key={key} className="flex items-center justify-between gap-2 px-3 py-1.5">
+                  <span className="truncate text-sm text-gray-200">{label}</span>
+                  <button
+                    type="button"
+                    className="shrink-0 rounded px-1.5 py-0.5 text-xs font-semibold text-amber-200 transition-colors hover:bg-white/10"
+                    onClick={() =>
+                      dispatchAction({
+                        type: "SetPriorityYield",
+                        data: { op: { type: "Remove", data: { target: y.target } } },
+                      })
+                    }
+                  >
+                    {t("priorityYield.revoke")}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </PopoverMenu>
   );
 }

--- a/client/src/components/board/__tests__/PriorityYieldList.test.tsx
+++ b/client/src/components/board/__tests__/PriorityYieldList.test.tsx
@@ -1,0 +1,91 @@
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { PriorityYieldList } from "../PriorityYieldList.tsx";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { buildGameObject, buildObjectMap } from "../../../test/factories/gameObjectFactory.ts";
+import { buildGameState } from "../../../test/factories/gameStateFactory.ts";
+
+const { dispatchActionMock } = vi.hoisted(() => ({ dispatchActionMock: vi.fn() }));
+vi.mock("../../../game/dispatch.ts", () => ({ dispatchAction: dispatchActionMock }));
+
+function seed(yieldCount: number) {
+  const gameState = buildGameState({
+    objects: buildObjectMap(
+      buildGameObject({ id: 50, card_id: 9, name: "Bloodghast", zone: "Battlefield" }),
+    ),
+    priority_yields: Array.from({ length: yieldCount }, (_, i) => ({
+      player: 0,
+      target: { AllCopies: { card_id: 100 + i } },
+    })),
+  });
+  act(() => {
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+  });
+}
+
+describe("PriorityYieldList", () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+    dispatchActionMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing when the viewer holds no yields", () => {
+    seed(0);
+    const { container } = render(<PriorityYieldList />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("collapses standing yields into a single fixed-footprint chip that shows the count", () => {
+    seed(3);
+    render(<PriorityYieldList />);
+
+    // Fixed footprint: one chip regardless of yield count. The list rows and the
+    // clear-all live behind it, not inline, so the action rail height is constant.
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.queryByText("Clear all")).not.toBeInTheDocument();
+    expect(screen.queryByText("Revoke")).not.toBeInTheDocument();
+  });
+
+  it("reveals the revocable list only after the chip is opened", () => {
+    seed(2);
+    render(<PriorityYieldList />);
+
+    fireEvent.click(screen.getByRole("button", { name: /auto-passing/i }));
+
+    expect(screen.getByText("Clear all")).toBeInTheDocument();
+    expect(screen.getAllByText("Revoke")).toHaveLength(2);
+  });
+
+  it("dispatches a scoped Remove when a row's Revoke is chosen", () => {
+    seed(1);
+    render(<PriorityYieldList />);
+
+    fireEvent.click(screen.getByRole("button", { name: /auto-passing/i }));
+    fireEvent.click(screen.getByText("Revoke"));
+
+    expect(dispatchActionMock).toHaveBeenCalledWith({
+      type: "SetPriorityYield",
+      data: { op: { type: "Remove", data: { target: { AllCopies: { card_id: 100 } } } } },
+    });
+  });
+
+  it("dispatches ClearAll and closes the popover when Clear all is chosen", () => {
+    seed(2);
+    render(<PriorityYieldList />);
+
+    fireEvent.click(screen.getByRole("button", { name: /auto-passing/i }));
+    fireEvent.click(screen.getByText("Clear all"));
+
+    expect(dispatchActionMock).toHaveBeenCalledWith({
+      type: "SetPriorityYield",
+      data: { op: { type: "ClearAll" } },
+    });
+    expect(screen.queryByText("Clear all")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/controls/FullControlToggle.tsx
+++ b/client/src/components/controls/FullControlToggle.tsx
@@ -20,13 +20,19 @@ export function FullControlToggle({ className }: { className?: string } = {}) {
     <button
       onClick={toggleFullControl}
       aria-describedby={tooltipId}
+      // Toggle semantics + descriptive state live in ARIA so the visible label
+      // can stay a compact "Control" (the long "Full Control On/Off" text
+      // dominated the action row); on-state is conveyed by the amber styling and
+      // the tooltip elaborates.
+      aria-pressed={fullControl}
+      aria-label={fullControl ? t("fullControl.on") : t("fullControl.off")}
       className={`group relative flex items-center justify-center rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] backdrop-blur-xl transition-all duration-200 lg:px-3.5 lg:py-1.5 lg:text-[11px] ${
         fullControl
           ? "border-amber-300/35 bg-amber-500/18 text-amber-100 shadow-[0_10px_24px_rgba(245,158,11,0.2)]"
           : "border-white/10 bg-slate-950/64 text-slate-300 hover:border-white/20 hover:text-white"
       } ${className ?? ""}`}
     >
-      {fullControl ? t("fullControl.on") : t("fullControl.off")}
+      {t("fullControl.label")}
       <GameplayTooltip id={tooltipId}>
         {t("fullControl.tooltip")}
       </GameplayTooltip>

--- a/client/src/components/menu/PopoverMenu.tsx
+++ b/client/src/components/menu/PopoverMenu.tsx
@@ -4,7 +4,9 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type MouseEvent,
   type ReactNode,
+  type RefObject,
 } from "react";
 import { createPortal } from "react-dom";
 
@@ -19,12 +21,28 @@ interface PopoverMenuStyle {
   maxHeight: number;
 }
 
+interface PopoverMenuTriggerArgs {
+  /** Attach to the trigger element — drives positioning + Escape refocus. */
+  ref: RefObject<HTMLButtonElement | null>;
+  open: boolean;
+  /** Toggle the menu; stops propagation so a card/list-row click doesn't fire. */
+  toggle: (event: MouseEvent) => void;
+}
+
 interface PopoverMenuProps {
   ariaLabel: string;
   /** Menu panel width in px — the menu is wider than the kebab trigger. */
   menuWidthPx?: number;
-  /** Extra classes on the kebab trigger button. */
+  /** Extra classes on the default kebab trigger button (ignored when
+   *  `renderTrigger` is supplied). */
   triggerClassName?: string;
+  /** Custom trigger in place of the default kebab (⋯). The returned element
+   *  MUST attach `ref` and call `toggle`. Used by the stack yield control to
+   *  keep its labeled pill while reusing this portaled-popover authority. */
+  renderTrigger?: (args: PopoverMenuTriggerArgs) => ReactNode;
+  /** Notified when the menu opens/closes — e.g. to dismiss a hover preview
+   *  that would otherwise sit behind the portaled menu. */
+  onOpenChange?: (open: boolean) => void;
   /** Render the menu items; call `close` after an action runs. */
   children: (close: () => void) => ReactNode;
 }
@@ -40,6 +58,8 @@ export function PopoverMenu({
   ariaLabel,
   menuWidthPx = 224,
   triggerClassName,
+  renderTrigger,
+  onOpenChange,
   children,
 }: PopoverMenuProps) {
   const [open, setOpen] = useState(false);
@@ -52,7 +72,23 @@ export function PopoverMenu({
     maxHeight: 320,
   });
 
-  const close = useCallback(() => setOpen(false), []);
+  // Single authority for open transitions so `onOpenChange` fires on every
+  // path (toggle, outside-click, Escape) — never as a bare `setOpen`.
+  const changeOpen = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      onOpenChange?.(next);
+    },
+    [onOpenChange],
+  );
+  const close = useCallback(() => changeOpen(false), [changeOpen]);
+  const toggle = useCallback(
+    (event: MouseEvent) => {
+      event.stopPropagation();
+      changeOpen(!open);
+    },
+    [changeOpen, open],
+  );
 
   const position = useCallback(() => {
     const trigger = triggerRef.current;
@@ -107,25 +143,26 @@ export function PopoverMenu({
 
   return (
     <>
-      <button
-        ref={triggerRef}
-        type="button"
-        aria-haspopup="menu"
-        aria-expanded={open}
-        aria-label={ariaLabel}
-        onClick={(event) => {
-          event.stopPropagation();
-          setOpen((prev) => !prev);
-        }}
-        className={
-          triggerClassName ??
-          "flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-black/35 text-gray-400 transition-colors hover:bg-white/15 hover:text-white"
-        }
-      >
-        <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="h-4 w-4">
-          <path d="M8 4a1.25 1.25 0 1 0 0-2.5A1.25 1.25 0 0 0 8 4Zm0 5.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5ZM9.25 13.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z" />
-        </svg>
-      </button>
+      {renderTrigger ? (
+        renderTrigger({ ref: triggerRef, open, toggle })
+      ) : (
+        <button
+          ref={triggerRef}
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label={ariaLabel}
+          onClick={toggle}
+          className={
+            triggerClassName ??
+            "flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-black/35 text-gray-400 transition-colors hover:bg-white/15 hover:text-white"
+          }
+        >
+          <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="h-4 w-4">
+            <path d="M8 4a1.25 1.25 0 1 0 0-2.5A1.25 1.25 0 0 0 8 4Zm0 5.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5ZM9.25 13.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z" />
+          </svg>
+        </button>
+      )}
 
       {open &&
         createPortal(
@@ -133,6 +170,15 @@ export function PopoverMenu({
             ref={menuRef}
             role="menu"
             aria-label={ariaLabel}
+            // Seal the whole pointer/click family so a menu interaction never
+            // leaks through the React tree to whatever ancestor rendered this
+            // menu. The portal escapes the DOM subtree, but React synthetic
+            // events still bubble up the component tree — without this, a
+            // pointerdown on an option reaches the host's handlers (e.g. a
+            // card's long-press → card preview) even though the click alone
+            // was already stopped. Bubble-phase only; the outside-click
+            // dismissal listens in the capture phase, so it is unaffected.
+            onPointerDown={(event) => event.stopPropagation()}
             onClick={(event) => event.stopPropagation()}
             style={{
               top: style.top,

--- a/client/src/components/menu/__tests__/PopoverMenu.test.tsx
+++ b/client/src/components/menu/__tests__/PopoverMenu.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { PopoverMenu } from "../PopoverMenu.tsx";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PopoverMenu", () => {
+  it("does not leak menu-item pointer/click events to the ancestor that rendered it", () => {
+    // The menu portals to <body>, but React synthetic events bubble through the
+    // *component* tree — so without sealing them, an interaction inside the menu
+    // reaches the host's handlers (in the stack, a card's long-press →
+    // card preview). This reproduces that leak path with spy handlers on the
+    // ancestor that wraps the menu.
+    const ancestorPointerDown = vi.fn();
+    const ancestorClick = vi.fn();
+
+    render(
+      <div onPointerDown={ancestorPointerDown} onClick={ancestorClick}>
+        <PopoverMenu ariaLabel="Actions">
+          {(close) => (
+            <button type="button" role="menuitem" onClick={() => close()}>
+              Do the thing
+            </button>
+          )}
+        </PopoverMenu>
+      </div>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+    const item = screen.getByRole("menuitem", { name: "Do the thing" });
+
+    fireEvent.pointerDown(item);
+    fireEvent.click(item);
+
+    // The item's own onClick ran (menu closed), but neither event reached the
+    // ancestor — the whole pointer/click family is sealed at the menu panel.
+    expect(ancestorPointerDown).not.toHaveBeenCalled();
+    expect(ancestorClick).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menuitem", { name: "Do the thing" })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -183,7 +183,7 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
       data-card-hover
       className="relative cursor-pointer"
       onClick={handleClick}
-      onMouseEnter={isMobile ? undefined : () => {
+      onMouseEnter={isMobile || yieldMenuOpen ? undefined : () => {
         inspectObject(entry.source_id);
         onHoverChange?.(true);
       }}
@@ -315,18 +315,30 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
           aria-label={matchingYield ? t("priorityYield.menuButtonActive") : t("priorityYield.menuButton")}
           aria-pressed={matchingYield != null}
           title={matchingYield ? t("priorityYield.menuButtonActive") : t("priorityYield.menuButton")}
-          className={`absolute right-1 top-1/2 z-30 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full shadow-md ring-1 transition-colors ${
+          className={`absolute right-1 top-1/2 z-30 flex -translate-y-1/2 items-center gap-1 rounded-full px-2 py-1 text-[9px] font-bold shadow-lg ring-2 transition-colors ${
             matchingYield
-              ? "bg-amber-500/90 text-black ring-amber-200"
-              : "bg-gray-900/85 text-purple-100 ring-white/25 hover:bg-gray-800"
+              ? "bg-amber-400 text-black ring-amber-200"
+              : "bg-indigo-600 text-white ring-white/80 hover:bg-indigo-500"
           }`}
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
-            setYieldMenuOpen((open) => !open);
+            const opening = !yieldMenuOpen;
+            setYieldMenuOpen(opening);
+            // Opening the menu drops any hover/sticky card preview so the options
+            // aren't rendered on top of the previewed card; the hover handler is
+            // gated off (above) while the menu stays open so it can't re-arm.
+            if (opening) {
+              inspectObject(null);
+              setPreviewSticky(false);
+              onHoverChange?.(false);
+            }
           }}
         >
           <YieldMuteIcon muted={matchingYield != null} />
+          <span className="whitespace-nowrap">
+            {matchingYield ? t("priorityYield.menuButtonShortActive") : t("priorityYield.menuButtonShort")}
+          </span>
         </button>
       )}
 
@@ -412,7 +424,7 @@ function YieldMuteIcon({ muted }: { muted: boolean }) {
   return (
     <svg
       viewBox="0 0 24 24"
-      className="h-4 w-4"
+      className="h-3.5 w-3.5 shrink-0"
       fill="none"
       stroke="currentColor"
       strokeWidth={2}

--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -54,17 +54,15 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
 
   const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
   const priorityYields = useGameStore((s) => s.gameState?.priority_yields);
-  // CR 117.3d: long-press on a triggered ability opens the yield menu (a
-  // pre-commitment to pass priority for that trigger class); other entries keep
-  // the inspect-and-pin behavior.
+  // CR 117.3d: a triggered ability can be pre-committed to auto-pass priority via
+  // the always-visible yield button rendered below (the menu it opens dispatches
+  // SetPriorityYield). Long-press stays uniformly bound to inspect-and-pin for
+  // every entry, so it never competes with the mobile card-preview gesture and
+  // the yield control doesn't depend on a hidden, undiscoverable gesture.
   const [yieldMenuOpen, setYieldMenuOpen] = useState(false);
   const { handlers: longPressHandlers, firedRef: longPressFired } = useLongPress(() => {
-    if (entry.kind.type === "TriggeredAbility") {
-      setYieldMenuOpen(true);
-    } else {
-      inspectObject(entry.source_id);
-      setPreviewSticky(true);
-    }
+    inspectObject(entry.source_id);
+    setPreviewSticky(true);
   });
 
   const sourceObj = objects?.[entry.source_id];
@@ -306,10 +304,36 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
         </div>
       )}
 
-      {/* CR 117.3d: priority-yield context menu (triggered abilities only).
-          Long-press opens it; each option dispatches a SetPriorityYield action.
-          The frontend only names the source + scope (Add) or echoes a stored
-          YieldTarget (Revoke) — no game state is computed here. */}
+      {/* CR 117.3d: always-visible yield affordance (triggered abilities only) so
+          the auto-pass control is discoverable, replacing the former hidden
+          long-press. Amber = a yield already stands for this trigger; tap toggles
+          the options menu below. Center-right edge is the one card zone clear of
+          the status badges (top), chip row, and ability overlay (bottom). */}
+      {isTriggered && (
+        <button
+          type="button"
+          aria-label={matchingYield ? t("priorityYield.menuButtonActive") : t("priorityYield.menuButton")}
+          aria-pressed={matchingYield != null}
+          title={matchingYield ? t("priorityYield.menuButtonActive") : t("priorityYield.menuButton")}
+          className={`absolute right-1 top-1/2 z-30 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full shadow-md ring-1 transition-colors ${
+            matchingYield
+              ? "bg-amber-500/90 text-black ring-amber-200"
+              : "bg-gray-900/85 text-purple-100 ring-white/25 hover:bg-gray-800"
+          }`}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            setYieldMenuOpen((open) => !open);
+          }}
+        >
+          <YieldMuteIcon muted={matchingYield != null} />
+        </button>
+      )}
+
+      {/* CR 117.3d: priority-yield context menu (triggered abilities only), opened
+          by the yield button above. Each option dispatches a SetPriorityYield
+          action; the frontend only names the source + scope (Add) or echoes a
+          stored YieldTarget (Revoke) — no game state is computed here. */}
       {yieldMenuOpen && isTriggered && (
         <>
           <div
@@ -378,6 +402,38 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
         {controllerInitial}
       </span>
     </motion.div>
+  );
+}
+
+// Bell (will stop for this trigger) vs. bell-off (auto-passing / muted). An SVG
+// glyph is theme-aware via `currentColor` and crisp at badge size, unlike an
+// emoji whose rendering varies by platform. Paths adapted from Lucide (MIT).
+function YieldMuteIcon({ muted }: { muted: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {muted ? (
+        <>
+          <path d="M8.7 3A6 6 0 0 1 18 8c0 2.6.5 4.4 1.1 5.7" />
+          <path d="M17 17H3s3-2 3-9a4.8 4.8 0 0 1 .3-1.7" />
+          <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+          <line x1="2" y1="2" x2="22" y2="22" />
+        </>
+      ) : (
+        <>
+          <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+          <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+        </>
+      )}
+    </svg>
   );
 }
 

--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties } from "react";
-import { useState } from "react";
 
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
@@ -16,6 +15,8 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { renderDescription } from "../../utils/description.ts";
 import { ManaCostPips } from "../mana/ManaCostPips.tsx";
+import { PopoverMenu } from "../menu/PopoverMenu.tsx";
+import { YieldMuteIcon } from "./YieldMuteIcon.tsx";
 import { RichLabel } from "../mana/RichLabel.tsx";
 import type { StackEntry as StackEntryType, StackEntryDisplay, StackPaidFactView } from "../../adapter/types.ts";
 
@@ -55,11 +56,10 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
   const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
   const priorityYields = useGameStore((s) => s.gameState?.priority_yields);
   // CR 117.3d: a triggered ability can be pre-committed to auto-pass priority via
-  // the always-visible yield button rendered below (the menu it opens dispatches
-  // SetPriorityYield). Long-press stays uniformly bound to inspect-and-pin for
-  // every entry, so it never competes with the mobile card-preview gesture and
-  // the yield control doesn't depend on a hidden, undiscoverable gesture.
-  const [yieldMenuOpen, setYieldMenuOpen] = useState(false);
+  // the always-visible yield pill rendered below (the menu it opens dispatches
+  // SetPriorityYield through PopoverMenu). Long-press stays uniformly bound to
+  // inspect-and-pin for every entry, so it never competes with the mobile
+  // card-preview gesture and the yield control isn't a hidden gesture.
   const { handlers: longPressHandlers, firedRef: longPressFired } = useLongPress(() => {
     inspectObject(entry.source_id);
     setPreviewSticky(true);
@@ -183,7 +183,7 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
       data-card-hover
       className="relative cursor-pointer"
       onClick={handleClick}
-      onMouseEnter={isMobile || yieldMenuOpen ? undefined : () => {
+      onMouseEnter={isMobile ? undefined : () => {
         inspectObject(entry.source_id);
         onHoverChange?.(true);
       }}
@@ -304,102 +304,137 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
         </div>
       )}
 
-      {/* CR 117.3d: always-visible yield affordance (triggered abilities only) so
-          the auto-pass control is discoverable, replacing the former hidden
-          long-press. Amber = a yield already stands for this trigger; tap toggles
-          the options menu below. Center-right edge is the one card zone clear of
-          the status badges (top), chip row, and ability overlay (bottom). */}
+      {/* CR 117.3d: discoverable auto-pass (yield) control on triggered abilities.
+          A quiet icon-button (hover-expands to its label; amber when a yield
+          stands) is the trigger; the options menu renders through
+          PopoverMenu — portaled to <body>, so it escapes the stack panel's
+          clipping/transform context, paints above the target-arc overlay, and
+          dismisses on outside-click/Escape (the bespoke in-card menu did none of
+          these). Each option dispatches SetPriorityYield; the frontend only names
+          the source + scope (Add) or echoes a stored YieldTarget (Remove). */}
       {isTriggered && (
-        <button
-          type="button"
-          aria-label={matchingYield ? t("priorityYield.menuButtonActive") : t("priorityYield.menuButton")}
-          aria-pressed={matchingYield != null}
-          title={matchingYield ? t("priorityYield.menuButtonActive") : t("priorityYield.menuButton")}
-          className={`absolute right-1 top-1/2 z-30 flex -translate-y-1/2 items-center gap-1 rounded-full px-2 py-1 text-[9px] font-bold shadow-lg ring-2 transition-colors ${
-            matchingYield
-              ? "bg-amber-400 text-black ring-amber-200"
-              : "bg-indigo-600 text-white ring-white/80 hover:bg-indigo-500"
-          }`}
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={(e) => {
-            e.stopPropagation();
-            const opening = !yieldMenuOpen;
-            setYieldMenuOpen(opening);
-            // Opening the menu drops any hover/sticky card preview so the options
-            // aren't rendered on top of the previewed card; the hover handler is
-            // gated off (above) while the menu stays open so it can't re-arm.
-            if (opening) {
+        <PopoverMenu
+          ariaLabel={matchingYield ? t("priorityYield.menuButtonActive") : t("priorityYield.menuButton")}
+          menuWidthPx={248}
+          onOpenChange={(menuOpen) => {
+            // Drop any hover/sticky card preview when the menu opens so it isn't
+            // left lingering on screen while the player reads the options.
+            if (menuOpen) {
               inspectObject(null);
               setPreviewSticky(false);
               onHoverChange?.(false);
             }
           }}
-        >
-          <YieldMuteIcon muted={matchingYield != null} />
-          <span className="whitespace-nowrap">
-            {matchingYield ? t("priorityYield.menuButtonShortActive") : t("priorityYield.menuButtonShort")}
-          </span>
-        </button>
-      )}
-
-      {/* CR 117.3d: priority-yield context menu (triggered abilities only), opened
-          by the yield button above. Each option dispatches a SetPriorityYield
-          action; the frontend only names the source + scope (Add) or echoes a
-          stored YieldTarget (Revoke) — no game state is computed here. */}
-      {yieldMenuOpen && isTriggered && (
-        <>
-          <div
-            className="fixed inset-0 z-40"
-            onClick={(e) => {
-              e.stopPropagation();
-              setYieldMenuOpen(false);
-            }}
-          />
-          <div
-            className="absolute inset-x-1 top-1 z-50 flex flex-col gap-0.5 rounded-lg bg-gray-900/98 p-1 text-[10px] shadow-xl ring-1 ring-white/15"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button
-              className="flex min-h-[44px] items-center rounded px-2 py-1 text-left font-semibold text-purple-200 hover:bg-white/10"
-              onClick={() => {
-                dispatchAction({
-                  type: "SetPriorityYield",
-                  data: { op: { type: "Add", data: { source_id: entry.source_id, scope: "ThisObject" } } },
-                });
-                setYieldMenuOpen(false);
-              }}
-            >
-              {t("priorityYield.yieldThis")}
-            </button>
-            <button
-              className="flex min-h-[44px] items-center rounded px-2 py-1 text-left font-semibold text-purple-200 hover:bg-white/10"
-              title={t("priorityYield.allCopiesHint")}
-              onClick={() => {
-                dispatchAction({
-                  type: "SetPriorityYield",
-                  data: { op: { type: "Add", data: { source_id: entry.source_id, scope: "AllCopies" } } },
-                });
-                setYieldMenuOpen(false);
-              }}
-            >
-              {t("priorityYield.yieldAllCopies")}
-            </button>
-            {matchingYield && (
+          renderTrigger={({ ref, open, toggle }) => {
+            // A yield already standing is meaningful *state*, so the active chip
+            // is loud (amber) and always shows its label. An available-but-unused
+            // control is tertiary chrome: a quiet icon that only unfurls its
+            // "Auto-pass" label on hover/focus (progressive disclosure), so it
+            // never out-shouts the card at rest.
+            const active = matchingYield != null;
+            return (
               <button
-                className="flex min-h-[44px] items-center rounded px-2 py-1 text-left font-semibold text-amber-200 hover:bg-white/10"
+                ref={ref}
+                type="button"
+                aria-haspopup="menu"
+                aria-expanded={open}
+                aria-label={active ? t("priorityYield.menuButtonActive") : t("priorityYield.menuButton")}
+                aria-pressed={active}
+                title={active ? t("priorityYield.menuButtonActive") : t("priorityYield.menuButton")}
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={toggle}
+                className={`group absolute right-1 top-1/2 z-30 flex -translate-y-1/2 items-center rounded-full p-2 shadow-md ring-1 backdrop-blur-sm transition-colors ${
+                  active
+                    ? "bg-amber-500/95 text-black ring-amber-300"
+                    : open
+                      ? "bg-black/70 text-white ring-white/40"
+                      : "bg-black/45 text-white/85 ring-white/25 hover:bg-black/70 hover:text-white hover:ring-white/40"
+                }`}
+              >
+                <YieldMuteIcon muted={active} />
+                <span
+                  className={`overflow-hidden whitespace-nowrap text-[10px] font-semibold leading-none transition-all duration-150 ${
+                    active
+                      ? "ml-1 max-w-[6rem] opacity-100"
+                      : "ml-0 max-w-0 opacity-0 group-hover:ml-1 group-hover:max-w-[6rem] group-hover:opacity-100 group-focus-visible:ml-1 group-focus-visible:max-w-[6rem] group-focus-visible:opacity-100"
+                  }`}
+                >
+                  {active ? t("priorityYield.menuButtonShortActive") : t("priorityYield.menuButtonShort")}
+                </span>
+              </button>
+            );
+          }}
+        >
+          {(close) => (
+            <>
+              {/* Explanatory header — the "full context" of what this control does,
+                  so the scope options below read as a refinement, not a mystery. */}
+              <div className="px-3 pb-2 pt-1.5">
+                <div className="flex items-center gap-1.5 text-sm font-bold text-white">
+                  <YieldMuteIcon muted={false} />
+                  {t("priorityYield.menuHeader")}
+                </div>
+                <p className="mt-1 text-xs font-normal leading-snug text-gray-400">
+                  {t("priorityYield.menuExplainer")}
+                </p>
+              </div>
+              <div className="mx-2 mb-1 border-t border-white/10" />
+              <button
+                role="menuitem"
+                type="button"
+                className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left transition-colors hover:bg-white/10"
                 onClick={() => {
                   dispatchAction({
                     type: "SetPriorityYield",
-                    data: { op: { type: "Remove", data: { target: matchingYield.target } } },
+                    data: { op: { type: "Add", data: { source_id: entry.source_id, scope: "ThisObject" } } },
                   });
-                  setYieldMenuOpen(false);
+                  close();
                 }}
               >
-                {t("priorityYield.revoke")}
+                <span className="text-sm font-semibold text-purple-200">{t("priorityYield.yieldThis")}</span>
+                <span className="text-xs font-normal leading-tight text-gray-400">
+                  {t("priorityYield.yieldThisHint", { source: sourceName })}
+                </span>
               </button>
-            )}
-          </div>
-        </>
+              <button
+                role="menuitem"
+                type="button"
+                className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left transition-colors hover:bg-white/10"
+                onClick={() => {
+                  dispatchAction({
+                    type: "SetPriorityYield",
+                    data: { op: { type: "Add", data: { source_id: entry.source_id, scope: "AllCopies" } } },
+                  });
+                  close();
+                }}
+              >
+                <span className="text-sm font-semibold text-purple-200">{t("priorityYield.yieldAllCopies")}</span>
+                <span className="text-xs font-normal leading-tight text-gray-400">
+                  {t("priorityYield.allCopiesHint", { source: sourceName })}
+                </span>
+              </button>
+              {matchingYield && (
+                <button
+                  role="menuitem"
+                  type="button"
+                  className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left transition-colors hover:bg-white/10"
+                  onClick={() => {
+                    dispatchAction({
+                      type: "SetPriorityYield",
+                      data: { op: { type: "Remove", data: { target: matchingYield.target } } },
+                    });
+                    close();
+                  }}
+                >
+                  <span className="text-sm font-semibold text-amber-200">{t("priorityYield.revoke")}</span>
+                  <span className="text-xs font-normal leading-tight text-gray-400">
+                    {t("priorityYield.revokeHint")}
+                  </span>
+                </button>
+              )}
+            </>
+          )}
+        </PopoverMenu>
       )}
 
       {/* Controller seat avatar — colored initial anchors identity to every surface
@@ -420,35 +455,6 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
 // Bell (will stop for this trigger) vs. bell-off (auto-passing / muted). An SVG
 // glyph is theme-aware via `currentColor` and crisp at badge size, unlike an
 // emoji whose rendering varies by platform. Paths adapted from Lucide (MIT).
-function YieldMuteIcon({ muted }: { muted: boolean }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      className="h-3.5 w-3.5 shrink-0"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      {muted ? (
-        <>
-          <path d="M8.7 3A6 6 0 0 1 18 8c0 2.6.5 4.4 1.1 5.7" />
-          <path d="M17 17H3s3-2 3-9a4.8 4.8 0 0 1 .3-1.7" />
-          <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
-          <line x1="2" y1="2" x2="22" y2="22" />
-        </>
-      ) : (
-        <>
-          <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
-          <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
-        </>
-      )}
-    </svg>
-  );
-}
-
 function formatPaidFact(fact: StackPaidFactView, t: TFunction<"game">): string {
   switch (fact.type) {
     case "XValue":

--- a/client/src/components/stack/YieldMuteIcon.tsx
+++ b/client/src/components/stack/YieldMuteIcon.tsx
@@ -1,0 +1,34 @@
+/**
+ * Bell / bell-off glyph shared by the priority-yield surfaces (the per-trigger
+ * control on a stack entry and the standing-yields summary chip). `muted` draws
+ * the struck-through bell — the "auto-passing / silenced" state. Kept in one
+ * place so both surfaces stay visually identical (CR 117.3d yields).
+ */
+export function YieldMuteIcon({ muted, className = "h-3.5 w-3.5 shrink-0" }: { muted: boolean; className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {muted ? (
+        <>
+          <path d="M8.7 3A6 6 0 0 1 18 8c0 2.6.5 4.4 1.1 5.7" />
+          <path d="M17 17H3s3-2 3-9a4.8 4.8 0 0 1 .3-1.7" />
+          <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+          <line x1="2" y1="2" x2="22" y2="22" />
+        </>
+      ) : (
+        <>
+          <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+          <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+        </>
+      )}
+    </svg>
+  );
+}

--- a/client/src/components/stack/__tests__/StackEntry.test.tsx
+++ b/client/src/components/stack/__tests__/StackEntry.test.tsx
@@ -106,7 +106,6 @@ describe("StackEntry", () => {
     // CR 400.7 + CR 704.5d: a ceased token is gone from `objects`, so the entry
     // has no live source object to read a card_id from — the menu must match the
     // standing AllCopies yield via the engine-stamped `source_card_id` instead.
-    vi.useFakeTimers();
     const entry: StackEntryType = buildStackEntry({
       id: 77,
       source_id: 42,
@@ -130,18 +129,75 @@ describe("StackEntry", () => {
       useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
     });
 
-    const { container } = render(
+    render(
       <StackEntry entry={entry} index={0} isTop isPending cardSize={{ width: 120, height: 168 }} />,
     );
 
-    // Long-press the entry to open the priority-yield menu.
-    const root = container.querySelector('[data-stack-entry="77"]')!;
-    act(() => {
-      fireEvent.pointerDown(root, { isPrimary: true, button: 0, pointerId: 1 });
-      vi.advanceTimersByTime(500);
-    });
+    // The always-visible yield button opens the menu on a plain tap — no hidden
+    // long-press. Its label reflects the standing yield ("Auto-passing…").
+    fireEvent.click(screen.getByRole("button", { name: /auto-pass/i }));
 
     expect(screen.getByText("Revoke")).toBeInTheDocument();
-    vi.useRealTimers();
+  });
+
+  it("shows a discoverable yield button on a triggered ability and opens the menu on tap", () => {
+    const entry: StackEntryType = buildStackEntry({
+      id: 88,
+      source_id: 50,
+      controller: 0,
+      kind: {
+        type: "TriggeredAbility",
+        data: {
+          source_id: 50,
+          ability: { targets: [], source_card_id: 9 },
+          source_name: "Bloodghast",
+        },
+      },
+    });
+    const gameState = createGameState({
+      objects: buildObjectMap(
+        buildGameObject({ id: 50, card_id: 9, name: "Bloodghast", zone: "Stack" }),
+      ),
+      stack: [entry],
+    });
+
+    act(() => {
+      useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+    });
+
+    render(<StackEntry entry={entry} index={0} isTop cardSize={{ width: 120, height: 168 }} />);
+
+    // Discoverable: the control is present with no hidden gesture, and the menu
+    // stays closed until the button is tapped.
+    const button = screen.getByRole("button", { name: /auto-pass/i });
+    expect(screen.queryByText("Yield this")).not.toBeInTheDocument();
+
+    fireEvent.click(button);
+
+    expect(screen.getByText("Yield this")).toBeInTheDocument();
+    expect(screen.getByText("Yield all copies")).toBeInTheDocument();
+  });
+
+  it("does not render the yield button on a spell entry", () => {
+    const entry: StackEntryType = buildStackEntry({
+      id: 99,
+      source_id: 60,
+      controller: 0,
+      kind: { type: "Spell", data: { card_id: 3, actual_mana_spent: 0 } },
+    });
+    const gameState = createGameState({
+      objects: buildObjectMap(
+        buildGameObject({ id: 60, card_id: 3, name: "Lightning Bolt", zone: "Stack" }),
+      ),
+      stack: [entry],
+    });
+
+    act(() => {
+      useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+    });
+
+    render(<StackEntry entry={entry} index={0} isTop cardSize={{ width: 120, height: 168 }} />);
+
+    expect(screen.queryByRole("button", { name: /auto-pass/i })).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/stack/__tests__/StackEntry.test.tsx
+++ b/client/src/components/stack/__tests__/StackEntry.test.tsx
@@ -17,6 +17,9 @@ vi.mock("../../../hooks/useCardImage.ts", () => ({
   useCardImage: () => ({ src: "/test-card.png", isLoading: false }),
 }));
 
+const { dispatchActionMock } = vi.hoisted(() => ({ dispatchActionMock: vi.fn() }));
+vi.mock("../../../game/dispatch.ts", () => ({ dispatchAction: dispatchActionMock }));
+
 function createGameState(overrides: Partial<GameState> = {}): GameState {
   return buildGameState({
     next_object_id: 100,
@@ -28,6 +31,7 @@ function createGameState(overrides: Partial<GameState> = {}): GameState {
 describe("StackEntry", () => {
   beforeEach(() => {
     useGameStore.getState().reset();
+    dispatchActionMock.mockClear();
   });
 
   afterEach(() => {
@@ -170,12 +174,61 @@ describe("StackEntry", () => {
     // Discoverable: the control is present with no hidden gesture, and the menu
     // stays closed until the button is tapped.
     const button = screen.getByRole("button", { name: /auto-pass/i });
-    expect(screen.queryByText("Yield this")).not.toBeInTheDocument();
+    expect(screen.queryByText("Only this one")).not.toBeInTheDocument();
 
     fireEvent.click(button);
 
-    expect(screen.getByText("Yield this")).toBeInTheDocument();
-    expect(screen.getByText("Yield all copies")).toBeInTheDocument();
+    expect(screen.getByText("Only this one")).toBeInTheDocument();
+    expect(screen.getByText("All copies")).toBeInTheDocument();
+  });
+
+  it("dispatches a scoped SetPriorityYield when a menu option is chosen", () => {
+    const entry: StackEntryType = buildStackEntry({
+      id: 88,
+      source_id: 50,
+      controller: 0,
+      kind: {
+        type: "TriggeredAbility",
+        data: {
+          source_id: 50,
+          ability: { targets: [], source_card_id: 9 },
+          source_name: "Bloodghast",
+        },
+      },
+    });
+    const gameState = createGameState({
+      objects: buildObjectMap(
+        buildGameObject({ id: 50, card_id: 9, name: "Bloodghast", zone: "Stack" }),
+      ),
+      stack: [entry],
+    });
+
+    act(() => {
+      useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+    });
+
+    render(<StackEntry entry={entry} index={0} isTop cardSize={{ width: 120, height: 168 }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /auto-pass/i }));
+
+    // Realistic pointer sequence: pointerdown fires PopoverMenu's window-level
+    // outside-click listener BEFORE the click. If that listener wrongly treats a
+    // menu-internal press as "outside" and closes the menu, the option unmounts
+    // and its onClick never runs — the exact "pressing does nothing" symptom.
+    const option = screen.getByText("All copies");
+    fireEvent.pointerDown(option);
+    expect(screen.getByText("All copies")).toBeInTheDocument(); // menu stayed open
+    fireEvent.click(option);
+
+    expect(dispatchActionMock).toHaveBeenCalledWith({
+      type: "SetPriorityYield",
+      data: { op: { type: "Add", data: { source_id: 50, scope: "AllCopies" } } },
+    });
+
+    // Observable behavior, not just that the handler ran: choosing an option
+    // dismisses the menu. (The dispatch firing is necessary but not sufficient —
+    // "the menu stays open" is a distinct, user-visible failure.)
+    expect(screen.queryByText("All copies")).not.toBeInTheDocument();
   });
 
   it("does not render the yield button on a spell entry", () => {

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -269,6 +269,7 @@
     "confirmDistribute_other": "{{count}} Angreifer erklären"
   },
   "fullControl": {
+    "label": "Kontrolle",
     "on": "Volle Kontrolle An",
     "off": "Volle Kontrolle Aus",
     "tooltip": "Prioritätsfenster halten, anstatt ruhige Stellen automatisch abgeben zu lassen. Tastenkürzel: F."
@@ -588,11 +589,15 @@
   },
   "priorityYield": {
     "listHeader": "Prioritätsverzichte",
-    "yieldThis": "Diesen überspringen",
-    "yieldAllCopies": "Alle Kopien überspringen",
+    "menuHeader": "Diesen Auslöser automatisch überspringen",
+    "menuExplainer": "Überspringt die Nachfrage, bei der das Spiel jedes Mal anhält, wenn dieser Auslöser auf den Stapel gelegt wird. Auf andere Dinge kannst du weiterhin reagieren.",
+    "yieldThis": "Nur dieses",
+    "yieldThisHint": "Nur dieses {{source}} – nicht andere Kopien",
+    "yieldAllCopies": "Alle Kopien",
+    "allCopiesHint": "Jedes {{source}}, auch neue",
     "revoke": "Widerrufen",
+    "revokeHint": "Wieder für diesen Auslöser anhalten",
     "clearAll": "Alle löschen",
-    "allCopiesHint": "Empfohlen für Spielstein-Auslöser",
     "menuButton": "Diesen Auslöser automatisch überspringen",
     "menuButtonActive": "Wird automatisch übersprungen – ändern oder widerrufen",
     "menuButtonShort": "Auto-Pass",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -592,7 +592,9 @@
     "yieldAllCopies": "Alle Kopien überspringen",
     "revoke": "Widerrufen",
     "clearAll": "Alle löschen",
-    "allCopiesHint": "Empfohlen für Spielstein-Auslöser"
+    "allCopiesHint": "Empfohlen für Spielstein-Auslöser",
+    "menuButton": "Diesen Auslöser automatisch überspringen",
+    "menuButtonActive": "Wird automatisch übersprungen – ändern oder widerrufen"
   },
   "targeting": {
     "choosePermanentToCopy": "Wähle eine bleibende Karte zum Kopieren",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -594,7 +594,9 @@
     "clearAll": "Alle löschen",
     "allCopiesHint": "Empfohlen für Spielstein-Auslöser",
     "menuButton": "Diesen Auslöser automatisch überspringen",
-    "menuButtonActive": "Wird automatisch übersprungen – ändern oder widerrufen"
+    "menuButtonActive": "Wird automatisch übersprungen – ändern oder widerrufen",
+    "menuButtonShort": "Auto-Pass",
+    "menuButtonShortActive": "Übersprungen"
   },
   "targeting": {
     "choosePermanentToCopy": "Wähle eine bleibende Karte zum Kopieren",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -301,6 +301,7 @@
     "confirmDistribute_other": "Declare {{count}} Attackers"
   },
   "fullControl": {
+    "label": "Control",
     "on": "Full Control On",
     "off": "Full Control Off",
     "tooltip": "Hold priority windows instead of letting quiet spots auto-pass. Shortcut: F."
@@ -620,11 +621,15 @@
   },
   "priorityYield": {
     "listHeader": "Priority yields",
-    "yieldThis": "Yield this",
-    "yieldAllCopies": "Yield all copies",
+    "menuHeader": "Auto-pass this trigger",
+    "menuExplainer": "Skip the prompt where the game stops to ask you to act each time this trigger is put on the stack. You can still respond to other things.",
+    "yieldThis": "Only this one",
+    "yieldThisHint": "Just this {{source}} — not other copies",
+    "yieldAllCopies": "All copies",
+    "allCopiesHint": "Every {{source}}, including new ones",
     "revoke": "Revoke",
+    "revokeHint": "Go back to stopping for this trigger",
     "clearAll": "Clear all",
-    "allCopiesHint": "Recommended for token triggers",
     "menuButton": "Auto-pass this trigger",
     "menuButtonActive": "Auto-passing — change or revoke",
     "menuButtonShort": "Auto-pass",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -624,7 +624,9 @@
     "yieldAllCopies": "Yield all copies",
     "revoke": "Revoke",
     "clearAll": "Clear all",
-    "allCopiesHint": "Recommended for token triggers"
+    "allCopiesHint": "Recommended for token triggers",
+    "menuButton": "Auto-pass this trigger",
+    "menuButtonActive": "Auto-passing — change or revoke"
   },
   "targeting": {
     "choosePermanentToCopy": "Choose a permanent to copy",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -626,7 +626,9 @@
     "clearAll": "Clear all",
     "allCopiesHint": "Recommended for token triggers",
     "menuButton": "Auto-pass this trigger",
-    "menuButtonActive": "Auto-passing — change or revoke"
+    "menuButtonActive": "Auto-passing — change or revoke",
+    "menuButtonShort": "Auto-pass",
+    "menuButtonShortActive": "Auto-passing"
   },
   "targeting": {
     "choosePermanentToCopy": "Choose a permanent to copy",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -594,7 +594,9 @@
     "clearAll": "Borrar todo",
     "allCopiesHint": "Recomendado para disparos de fichas",
     "menuButton": "Pasar automáticamente este disparo",
-    "menuButtonActive": "Pasando automáticamente: cambiar o revocar"
+    "menuButtonActive": "Pasando automáticamente: cambiar o revocar",
+    "menuButtonShort": "Auto-pasar",
+    "menuButtonShortActive": "Pasando"
   },
   "targeting": {
     "choosePermanentToCopy": "Elige un permanente para copiar",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -269,6 +269,7 @@
     "confirmDistribute_other": "Declarar {{count}} atacantes"
   },
   "fullControl": {
+    "label": "Control",
     "on": "Control total activado",
     "off": "Control total desactivado",
     "tooltip": "Mantén las ventanas de prioridad en lugar de dejar que los momentos tranquilos pasen automáticamente. Atajo: F."
@@ -588,11 +589,15 @@
   },
   "priorityYield": {
     "listHeader": "Cesiones de prioridad",
-    "yieldThis": "Ceder este",
-    "yieldAllCopies": "Ceder todas las copias",
+    "menuHeader": "Pasar automáticamente este disparo",
+    "menuExplainer": "Omite la pausa en la que el juego se detiene para preguntarte cada vez que este disparo se pone en la pila. Aún puedes responder a otras cosas.",
+    "yieldThis": "Solo este",
+    "yieldThisHint": "Solo este {{source}}, no otras copias",
+    "yieldAllCopies": "Todas las copias",
+    "allCopiesHint": "Cada {{source}}, incluidas las nuevas",
     "revoke": "Revocar",
+    "revokeHint": "Volver a detenerse en este disparo",
     "clearAll": "Borrar todo",
-    "allCopiesHint": "Recomendado para disparos de fichas",
     "menuButton": "Pasar automáticamente este disparo",
     "menuButtonActive": "Pasando automáticamente: cambiar o revocar",
     "menuButtonShort": "Auto-pasar",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -592,7 +592,9 @@
     "yieldAllCopies": "Ceder todas las copias",
     "revoke": "Revocar",
     "clearAll": "Borrar todo",
-    "allCopiesHint": "Recomendado para disparos de fichas"
+    "allCopiesHint": "Recomendado para disparos de fichas",
+    "menuButton": "Pasar automáticamente este disparo",
+    "menuButtonActive": "Pasando automáticamente: cambiar o revocar"
   },
   "targeting": {
     "choosePermanentToCopy": "Elige un permanente para copiar",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -594,7 +594,9 @@
     "clearAll": "Tout effacer",
     "allCopiesHint": "Recommandé pour les capacités de jetons",
     "menuButton": "Passer automatiquement ce déclencheur",
-    "menuButtonActive": "Passage automatique – modifier ou révoquer"
+    "menuButtonActive": "Passage automatique – modifier ou révoquer",
+    "menuButtonShort": "Auto-passer",
+    "menuButtonShortActive": "Passage auto"
   },
   "targeting": {
     "choosePermanentToCopy": "Choisissez un permanent à copier",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -592,7 +592,9 @@
     "yieldAllCopies": "Passer toutes les copies",
     "revoke": "Révoquer",
     "clearAll": "Tout effacer",
-    "allCopiesHint": "Recommandé pour les capacités de jetons"
+    "allCopiesHint": "Recommandé pour les capacités de jetons",
+    "menuButton": "Passer automatiquement ce déclencheur",
+    "menuButtonActive": "Passage automatique – modifier ou révoquer"
   },
   "targeting": {
     "choosePermanentToCopy": "Choisissez un permanent à copier",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -269,6 +269,7 @@
     "confirmDistribute_other": "Déclarer {{count}} attaquants"
   },
   "fullControl": {
+    "label": "Contrôle",
     "on": "Contrôle total activé",
     "off": "Contrôle total désactivé",
     "tooltip": "Conservez les fenêtres de priorité au lieu de laisser les moments calmes passer automatiquement. Raccourci : F."
@@ -588,11 +589,15 @@
   },
   "priorityYield": {
     "listHeader": "Renoncements de priorité",
-    "yieldThis": "Passer celui-ci",
-    "yieldAllCopies": "Passer toutes les copies",
+    "menuHeader": "Passer automatiquement ce déclencheur",
+    "menuExplainer": "Ignore la pause où le jeu s'arrête pour vous demander d'agir chaque fois que ce déclencheur est mis sur la pile. Vous pouvez toujours répondre à autre chose.",
+    "yieldThis": "Celui-ci uniquement",
+    "yieldThisHint": "Uniquement ce {{source}}, pas les autres copies",
+    "yieldAllCopies": "Toutes les copies",
+    "allCopiesHint": "Chaque {{source}}, y compris les nouvelles",
     "revoke": "Révoquer",
+    "revokeHint": "Se remettre à s'arrêter pour ce déclencheur",
     "clearAll": "Tout effacer",
-    "allCopiesHint": "Recommandé pour les capacités de jetons",
     "menuButton": "Passer automatiquement ce déclencheur",
     "menuButtonActive": "Passage automatique – modifier ou révoquer",
     "menuButtonShort": "Auto-passer",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -594,7 +594,9 @@
     "clearAll": "Cancella tutto",
     "allCopiesHint": "Consigliato per le pedine",
     "menuButton": "Salta automaticamente questo innesco",
-    "menuButtonActive": "Salto automatico: modifica o revoca"
+    "menuButtonActive": "Salto automatico: modifica o revoca",
+    "menuButtonShort": "Auto-salta",
+    "menuButtonShortActive": "Saltando"
   },
   "targeting": {
     "choosePermanentToCopy": "Scegli un permanente da copiare",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -269,6 +269,7 @@
     "confirmDistribute_other": "Dichiara {{count}} attaccanti"
   },
   "fullControl": {
+    "label": "Controllo",
     "on": "Controllo totale attivo",
     "off": "Controllo totale disattivato",
     "tooltip": "Mantieni le finestre di priorità invece di lasciare che i punti tranquilli passino automaticamente. Scorciatoia: F."
@@ -588,11 +589,15 @@
   },
   "priorityYield": {
     "listHeader": "Rinunce di priorità",
-    "yieldThis": "Rinuncia a questo",
-    "yieldAllCopies": "Rinuncia a tutte le copie",
+    "menuHeader": "Salta automaticamente questo innesco",
+    "menuExplainer": "Salta la pausa in cui il gioco si ferma per chiederti di agire ogni volta che questo innesco va sulla pila. Puoi comunque rispondere ad altre cose.",
+    "yieldThis": "Solo questo",
+    "yieldThisHint": "Solo questo {{source}}, non le altre copie",
+    "yieldAllCopies": "Tutte le copie",
+    "allCopiesHint": "Ogni {{source}}, comprese quelle nuove",
     "revoke": "Revoca",
+    "revokeHint": "Torna a fermarti per questo innesco",
     "clearAll": "Cancella tutto",
-    "allCopiesHint": "Consigliato per le pedine",
     "menuButton": "Salta automaticamente questo innesco",
     "menuButtonActive": "Salto automatico: modifica o revoca",
     "menuButtonShort": "Auto-salta",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -592,7 +592,9 @@
     "yieldAllCopies": "Rinuncia a tutte le copie",
     "revoke": "Revoca",
     "clearAll": "Cancella tutto",
-    "allCopiesHint": "Consigliato per le pedine"
+    "allCopiesHint": "Consigliato per le pedine",
+    "menuButton": "Salta automaticamente questo innesco",
+    "menuButtonActive": "Salto automatico: modifica o revoca"
   },
   "targeting": {
     "choosePermanentToCopy": "Scegli un permanente da copiare",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -592,7 +592,9 @@
     "yieldAllCopies": "Zrezygnuj ze wszystkich kopii",
     "revoke": "Cofnij",
     "clearAll": "Wyczyść wszystko",
-    "allCopiesHint": "Zalecane dla żetonów"
+    "allCopiesHint": "Zalecane dla żetonów",
+    "menuButton": "Automatycznie pomijaj ten wyzwalacz",
+    "menuButtonActive": "Automatyczne pomijanie — zmień lub cofnij"
   },
   "targeting": {
     "choosePermanentToCopy": "Wybierz trwałego do skopiowania",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -594,7 +594,9 @@
     "clearAll": "Wyczyść wszystko",
     "allCopiesHint": "Zalecane dla żetonów",
     "menuButton": "Automatycznie pomijaj ten wyzwalacz",
-    "menuButtonActive": "Automatyczne pomijanie — zmień lub cofnij"
+    "menuButtonActive": "Automatyczne pomijanie — zmień lub cofnij",
+    "menuButtonShort": "Auto-pomiń",
+    "menuButtonShortActive": "Pomijanie"
   },
   "targeting": {
     "choosePermanentToCopy": "Wybierz trwałego do skopiowania",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -269,6 +269,7 @@
     "confirmDistribute_other": "Zadeklaruj {{count}} atakujących"
   },
   "fullControl": {
+    "label": "Kontrola",
     "on": "Pełna kontrola włączona",
     "off": "Pełna kontrola wyłączona",
     "tooltip": "Zatrzymuj okna priorytetu zamiast pozwalać na automatyczne przekazywanie w spokojnych momentach. Skrót: F."
@@ -588,11 +589,15 @@
   },
   "priorityYield": {
     "listHeader": "Rezygnacje z priorytetu",
-    "yieldThis": "Zrezygnuj z tego",
-    "yieldAllCopies": "Zrezygnuj ze wszystkich kopii",
+    "menuHeader": "Automatycznie pomijaj ten wyzwalacz",
+    "menuExplainer": "Pomija moment, w którym gra zatrzymuje się i pyta o akcję za każdym razem, gdy ten wyzwalacz trafia na stos. Nadal możesz reagować na inne rzeczy.",
+    "yieldThis": "Tylko ten",
+    "yieldThisHint": "Tylko ten {{source}} — nie inne kopie",
+    "yieldAllCopies": "Wszystkie kopie",
+    "allCopiesHint": "Każdy {{source}}, także nowe",
     "revoke": "Cofnij",
+    "revokeHint": "Znów zatrzymuj się na tym wyzwalaczu",
     "clearAll": "Wyczyść wszystko",
-    "allCopiesHint": "Zalecane dla żetonów",
     "menuButton": "Automatycznie pomijaj ten wyzwalacz",
     "menuButtonActive": "Automatyczne pomijanie — zmień lub cofnij",
     "menuButtonShort": "Auto-pomiń",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -592,7 +592,9 @@
     "yieldAllCopies": "Ceder todas as cópias",
     "revoke": "Revogar",
     "clearAll": "Limpar tudo",
-    "allCopiesHint": "Recomendado para gatilhos de fichas"
+    "allCopiesHint": "Recomendado para gatilhos de fichas",
+    "menuButton": "Passar automaticamente este gatilho",
+    "menuButtonActive": "Passando automaticamente — alterar ou revogar"
   },
   "targeting": {
     "choosePermanentToCopy": "Escolha um permanente para copiar",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -594,7 +594,9 @@
     "clearAll": "Limpar tudo",
     "allCopiesHint": "Recomendado para gatilhos de fichas",
     "menuButton": "Passar automaticamente este gatilho",
-    "menuButtonActive": "Passando automaticamente — alterar ou revogar"
+    "menuButtonActive": "Passando automaticamente — alterar ou revogar",
+    "menuButtonShort": "Auto-passar",
+    "menuButtonShortActive": "Passando"
   },
   "targeting": {
     "choosePermanentToCopy": "Escolha um permanente para copiar",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -269,6 +269,7 @@
     "confirmDistribute_other": "Declarar {{count}} Atacantes"
   },
   "fullControl": {
+    "label": "Controle",
     "on": "Controle Total Ativado",
     "off": "Controle Total Desativado",
     "tooltip": "Mantenha as janelas de prioridade em vez de deixar pontos tranquilos passarem automaticamente. Atalho: F."
@@ -588,11 +589,15 @@
   },
   "priorityYield": {
     "listHeader": "Cessões de prioridade",
-    "yieldThis": "Ceder este",
-    "yieldAllCopies": "Ceder todas as cópias",
+    "menuHeader": "Passar automaticamente este gatilho",
+    "menuExplainer": "Pula a pausa em que o jogo para para perguntar a você toda vez que este gatilho é colocado na pilha. Você ainda pode responder a outras coisas.",
+    "yieldThis": "Apenas este",
+    "yieldThisHint": "Apenas este {{source}}, não outras cópias",
+    "yieldAllCopies": "Todas as cópias",
+    "allCopiesHint": "Cada {{source}}, incluindo as novas",
     "revoke": "Revogar",
+    "revokeHint": "Voltar a parar neste gatilho",
     "clearAll": "Limpar tudo",
-    "allCopiesHint": "Recomendado para gatilhos de fichas",
     "menuButton": "Passar automaticamente este gatilho",
     "menuButtonActive": "Passando automaticamente — alterar ou revogar",
     "menuButtonShort": "Auto-passar",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -41,6 +41,7 @@ import { CardReportDialog } from "../components/card/CardReportDialog.tsx";
 import { ActionButton } from "../components/board/ActionButton.tsx";
 import { FullControlToggle } from "../components/controls/FullControlToggle.tsx";
 import { CombatPhaseIndicator } from "../components/controls/PhaseStopBar.tsx";
+import { PriorityYieldList } from "../components/board/PriorityYieldList.tsx";
 import { OpponentHand } from "../components/hand/OpponentHand.tsx";
 import { MobileHandDrawer } from "../components/hand/MobileHandDrawer.tsx";
 import { HandBadge } from "../components/hand/HandBadge.tsx";
@@ -1409,7 +1410,10 @@ function GamePageContent({
               <CombatPhaseIndicator />
               <HandBadge className="w-full" />
             </div>
-            <FullControlToggle className="w-full" />
+            <div className="flex items-center gap-1.5">
+              <PriorityYieldList />
+              <FullControlToggle className="w-full" />
+            </div>
           </div>
         )}
         <div
@@ -1432,6 +1436,9 @@ function GamePageContent({
               <div className="hidden flex-row items-center gap-1.5 max-lg:landscape:flex lg:flex">
                 <TurnStatusLine />
                 <HandBadge />
+                {/* CR 117.3d: standing priority-yield summary chip, beside the
+                    Full Control toggle (self-hides when no yields stand). */}
+                <PriorityYieldList />
                 <FullControlToggle />
               </div>
               <ActionButton />

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -11,7 +11,7 @@ use crate::game::casting;
 use crate::game::layers;
 use crate::game::mana_abilities;
 use crate::game::mana_sources;
-use crate::types::ability::{AbilityKind, CounterCostSelection};
+use crate::types::ability::{AbilityKind, CounterCostSelection, TriggerDefinition};
 use crate::types::actions::GameAction;
 use crate::types::card_type::CoreType;
 use crate::types::game_state::{CastOfferKind, GameState, PayCostKind, WaitingFor};
@@ -19,6 +19,7 @@ use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaCost;
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
 
 pub use candidates::{
     candidate_actions, candidate_actions_broad, candidate_actions_exact,
@@ -735,27 +736,27 @@ fn activate_ability_is_meaningful_priority(
     })
 }
 
-/// True when `actions` contains a priority action that materially changes the
-/// game beyond passing or producing standalone mana.
-///
-/// Sacrifice-for-mana activations are omitted from the flat `legal_actions`
-/// list (they live in `legal_actions_by_object` only) but remain meaningful
-/// priority decisions, so during `WaitingFor::Priority` this also scans
-/// `activatable_object_mana_actions`.
-pub fn has_meaningful_priority_action(state: &GameState, actions: &[GameAction]) -> bool {
-    if actions.iter().any(|action| match action {
+/// The flat-list half of [`has_meaningful_priority_action`]: any non-pass,
+/// non-standalone-mana priority action in the caller-supplied `actions` list
+/// (or a sacrifice-for-mana injected into the flat list by a test/probe).
+/// Extracted so the auto-pass gate and the CR 732.5 loop-shortcut firewall
+/// classifier consume the SAME primitive and cannot drift.
+fn flat_actions_have_meaningful_priority(state: &GameState, actions: &[GameAction]) -> bool {
+    actions.iter().any(|action| match action {
         GameAction::PassPriority => false,
         GameAction::ActivateAbility {
             source_id,
             ability_index,
         } => activate_ability_is_meaningful_priority(state, *source_id, *ability_index),
         _ => true,
-    }) {
-        return true;
-    }
+    })
+}
 
-    // Issue #544: sacrifice-for-mana abilities (KCI, Phyrexian Altar, etc.) are
-    // excluded from the flat legal-actions list but must still block auto-pass.
+/// Issue #544: sacrifice-for-mana abilities (KCI, Phyrexian Altar, etc.) are
+/// grouped-only (absent from the flat `legal_actions` list) but remain a real
+/// board-changing action. Structural, state-driven scan — no downstream-use
+/// judgement here (that belongs to the auto-pass gate, not the loop firewall).
+fn has_activatable_sacrifice_for_mana(state: &GameState) -> bool {
     matches!(state.waiting_for, WaitingFor::Priority { .. })
         && activatable_object_mana_actions(state).iter().any(|action| {
             matches!(
@@ -766,6 +767,20 @@ pub fn has_meaningful_priority_action(state: &GameState, actions: &[GameAction])
                 } if activate_ability_is_meaningful_priority(state, *source_id, *ability_index)
             )
         })
+}
+
+/// True when `actions` contains a priority action that materially changes the
+/// game beyond passing or producing standalone mana.
+///
+/// Sacrifice-for-mana activations are omitted from the flat `legal_actions`
+/// list (they live in `legal_actions_by_object` only) but remain meaningful
+/// priority decisions, so during `WaitingFor::Priority` this also scans
+/// `activatable_object_mana_actions`. Recomposed from the two building blocks
+/// above so the auto-pass gate reuses the identical primitives — behavior is
+/// byte-identical to the previous inline form (loop-firewall safe).
+pub fn has_meaningful_priority_action(state: &GameState, actions: &[GameAction]) -> bool {
+    flat_actions_have_meaningful_priority(state, actions)
+        || has_activatable_sacrifice_for_mana(state)
 }
 
 fn auto_passes_initial_priority_by_default(state: &GameState) -> bool {
@@ -780,6 +795,78 @@ fn has_feasibly_castable_spell(state: &GameState, player: PlayerId) -> bool {
     crate::game::casting::spell_objects_available_to_cast(state, player)
         .iter()
         .any(|&object_id| crate::game::casting::can_cast_object_now(state, player, object_id))
+}
+
+/// CR 605.3a + CR 603.6 + CR 117.1d: A sacrifice-for-mana activation blocks
+/// frontend auto-pass ONLY when the sacrifice or its mana enables a concrete
+/// follow-up. Case (1) — a feasibly castable spell — is already resolved by the
+/// castability rungs above `auto_pass_recommended`'s sac branch (both count
+/// sac-for-mana mana via `feasible_mana_capacity`), so it is structurally
+/// `false` here and intentionally NOT re-checked (hot-path perf — re-calling
+/// `has_feasibly_castable_spell` would repeat the whole hand sweep). This gate
+/// covers the two remaining downstream channels:
+///   (2) a mana-costed non-mana activated ability the produced mana could feed, and
+///   (3) a leaves-the-battlefield / dies / sacrifice trigger (CR 603.6c) where the
+///       sacrifice itself is the payoff (aristocrats / altars).
+/// Both are conservative presence checks (hold on presence, not on proven net
+/// benefit) — they err toward HOLDING (today's behavior), so no real play is
+/// ever silently auto-passed. This is a live query over current game state; it
+/// snapshots nothing.
+fn sacrifice_for_mana_enables_followup(state: &GameState, player: PlayerId) -> bool {
+    state.battlefield.iter().any(|id| {
+        let Some(obj) = state.objects.get(id) else {
+            return false;
+        };
+        if obj.controller != player {
+            return false;
+        }
+        // Case (2): a non-mana activated ability with a mana component in its
+        // cost — the produced mana could pay it (CR 602.2: activating an ability
+        // is putting it on the stack and paying its costs).
+        let case2 = obj.abilities.iter().any(|ability| {
+            ability.kind == AbilityKind::Activated
+                && !mana_abilities::is_mana_ability(ability)
+                && mana_abilities::mana_sub_cost_of(&ability.cost).is_some()
+        });
+        // Case (3): a trigger that fires when a controlled permanent leaves the
+        // battlefield — the sacrifice is itself the payoff (CR 603.6c).
+        let case3 = obj
+            .trigger_definitions
+            .iter_all()
+            .any(trigger_fires_on_leaving_battlefield);
+        case2 || case3
+    })
+}
+
+/// CR 603.6c + CR 701.21: True when this trigger fires on a permanent moving off
+/// the battlefield (leaves / dies / sacrificed / destroyed). Bounded structural
+/// predicate over `TriggerMode` plus the zone-change source constraint.
+fn trigger_fires_on_leaving_battlefield(trigger: &TriggerDefinition) -> bool {
+    use crate::types::triggers::TriggerMode::*;
+    match trigger.mode {
+        // CR 603.6c / CR 701.21 / CR 701.8: direct leaves-the-battlefield,
+        // sacrifice, and destroy triggers always fire on a battlefield exit.
+        LeavesBattlefield | Sacrificed | SacrificedOnce | Destroyed => true,
+        // A general zone-change trigger is a battlefield-exit payoff only when
+        // its source-zone constraint admits the battlefield. `matches_from`
+        // answers "would an object leaving the battlefield satisfy this origin?"
+        // — correctly rejecting `NotEquals(Battlefield)` ("from anywhere other
+        // than the battlefield") while admitting `Any` / `Equals(Battlefield)` /
+        // `OneOf([.. Battlefield ..])` and the disjunctive `zone_change_clauses`
+        // shape (Syr Konrad: the leaves-battlefield event lives only in a clause,
+        // not the scalar `origin`/`origin_zones`).
+        ChangesZone | ChangesZoneAll => {
+            trigger.origin == Some(Zone::Battlefield)
+                || trigger.origin_zones.contains(&Zone::Battlefield)
+                || trigger
+                    .zone_change_clauses
+                    .iter()
+                    .any(|clause| clause.origin.matches_from(&Some(Zone::Battlefield)))
+        }
+        // All other modes (enters, cast, damage, attack, tap, counters, life, …)
+        // are NOT battlefield-exit events — a sacrifice does not feed them.
+        _ => false,
+    }
 }
 
 /// Determines whether the frontend should auto-pass the current priority window.
@@ -872,7 +959,19 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
         return false;
     }
 
-    if !has_meaningful_priority_action(state, actions) {
+    // A genuinely meaningful non-mana priority action always holds. A
+    // sacrifice-for-mana ability (issue #544) holds ONLY when the sacrifice or
+    // its mana enables a concrete downstream follow-up — case (1) a feasibly
+    // castable spell is already resolved by the castability rungs above, so
+    // cases (2) mana-costed activated ability and (3) leaves-battlefield trigger
+    // are checked here (CR 605.3a + CR 603.6). A bare sac-for-mana source with
+    // no downstream use is not a meaningful priority window — let auto-pass fire.
+    // Short-circuit order preserves perf: the followup scan runs only when the
+    // flat list is not already meaningful AND a sac-for-mana source is present.
+    let holds = flat_actions_have_meaningful_priority(state, actions)
+        || (has_activatable_sacrifice_for_mana(state)
+            && sacrifice_for_mana_enables_followup(state, player));
+    if !holds {
         return true;
     }
 
@@ -2486,12 +2585,16 @@ mod tests {
         );
     }
 
-    // Issue #544: Krark-Clan Ironworks ("Sacrifice an artifact: Add {C}{C}") is
-    // a mana ability whose cost sacrifices a permanent. Even though it is a mana
-    // ability, the sacrifice is a meaningful priority decision (CR 605.3a +
-    // 603.6), so auto-pass must NOT fire when it is the only available action.
+    // Issue #544 (narrowed): Krark-Clan Ironworks ("Sacrifice an artifact: Add
+    // {C}{C}") is a mana ability whose cost sacrifices a permanent. It remains a
+    // meaningful priority decision for the CR 732.5 loop firewall (the classifier
+    // `has_meaningful_priority_action` still returns true — the sacrifice is a
+    // board change). But with a BARE board (no castable spell, no mana-costed
+    // activated ability, no leaves-battlefield trigger) the sacrifice enables no
+    // concrete follow-up, so the frontend auto-pass recommendation now fires.
+    // Classifier and recommendation deliberately DISAGREE for this bare case.
     #[test]
-    fn auto_pass_does_not_skip_sacrifice_for_mana_ability() {
+    fn auto_pass_fires_for_bare_sac_for_mana_own_turn() {
         use crate::game::zones::create_object;
         use crate::types::ability::{
             AbilityCost, AbilityDefinition, AbilityKind, Effect, ManaContribution, ManaProduction,
@@ -2551,13 +2654,13 @@ mod tests {
                 ability_index: 0,
             },
         ];
+        // Classifier reach-guard: the sac-for-mana is still a meaningful
+        // priority decision for the loop firewall (CR 605.3a + 603.6) — this
+        // assertion is UNCHANGED and proves the classifier and the auto-pass
+        // recommendation deliberately disagree for the bare case below.
         assert!(
             super::has_meaningful_priority_action(&state, &actions),
             "A sacrifice-for-mana ability is a meaningful priority decision (CR 605.3a + 603.6)"
-        );
-        assert!(
-            !super::auto_pass_recommended(&state, &actions),
-            "Auto-pass must not fire when only a sacrifice-for-mana ability is available (#544)"
         );
 
         // Production path: flat `legal_actions` omits mana abilities, so the
@@ -2582,10 +2685,14 @@ mod tests {
             ),
             "KCI activation must appear in legal_actions_by_object"
         );
+        // NARROWED (this task): with a bare board the grouped sac-for-mana
+        // enables no downstream follow-up, so auto-pass now FIRES even though the
+        // classifier above still counts it as meaningful. This is the flipped
+        // assertion — it fails if the narrowing is reverted.
         assert!(
-            !super::auto_pass_recommended(&state, &flat),
-            "Issue #544: auto-pass must not fire from flat legal_actions alone \
-             when grouped sacrifice-for-mana is available"
+            super::auto_pass_recommended(&state, &flat),
+            "Bare sac-for-mana with no downstream castable spell / mana-costed \
+             ability / leaves-battlefield trigger → auto-pass fires"
         );
     }
 
@@ -2676,12 +2783,14 @@ mod tests {
         );
     }
 
-    /// Issue #4388 (ladder preservation): a meaningful sac-for-mana ability
-    /// (Krark-Clan Ironworks, issue #544) still holds priority on an opponent's
-    /// turn even with an empty hand — the narrowed mana rung must not swallow
-    /// the `has_meaningful_priority_action` rung below it (CR 605.3a + 603.6).
+    /// Issue #4388 / #544 (narrowed): on an opponent's turn a BARE sac-for-mana
+    /// ability (Krark-Clan Ironworks) with an empty hand and no downstream
+    /// follow-up enables nothing — the frontend auto-pass recommendation fires.
+    /// The classifier `has_meaningful_priority_action` still returns true (the
+    /// loop firewall must keep counting the sacrifice as a board change, CR
+    /// 605.3a + 603.6), so the two deliberately disagree for this bare case.
     #[test]
-    fn auto_pass_holds_priority_for_meaningful_ability_on_opponents_turn() {
+    fn auto_pass_fires_for_bare_sac_for_mana_opponents_turn() {
         use crate::game::zones::create_object;
         use crate::types::ability::TypeFilter;
 
@@ -2752,17 +2861,562 @@ mod tests {
             ),
             "KCI activation must appear in legal_actions_by_object"
         );
-        // Reach-guard: even with the sac-for-mana omitted from the flat list, the
-        // classifier still returns true via its internal-scan branch, so this test
-        // truly reaches the `has_meaningful_priority_action` rung (CR 605.3a + 603.6).
+        // Reach-guard (UNCHANGED): even with the sac-for-mana omitted from the
+        // flat list, the classifier still returns true via its internal-scan
+        // branch, so this test truly reaches the auto-pass sac rung and does not
+        // pass vacuously (CR 605.3a + 603.6).
         assert!(
             super::has_meaningful_priority_action(&state, &flat),
             "precondition: sac-for-mana is a meaningful priority decision reached via the internal scan"
         );
+        // NARROWED (this task): bare sac-for-mana on the opponent's turn with an
+        // empty hand and no downstream follow-up → auto-pass FIRES. Flipped
+        // assertion — fails if the narrowing is reverted.
+        assert!(
+            super::auto_pass_recommended(&state, &flat),
+            "bare sac-for-mana on opponent's turn with no downstream follow-up → auto-pass fires; \
+             classifier stays meaningful for the loop firewall, so the two deliberately disagree"
+        );
+    }
+
+    /// Sacrifice-for-mana source (KCI-proven cost shape): an artifact whose only
+    /// ability is a mana ability whose cost sacrifices an artifact — self-
+    /// satisfiable, so a lone source classifies as `ManaSourcePenalty::Sacrifices`
+    /// and is activatable. Colorless mana models the Eldrazi-Spawn/altar class.
+    fn add_sac_for_mana_source(state: &mut GameState, controller: PlayerId) -> ObjectId {
+        use crate::types::ability::{TypeFilter, TypedFilter};
+        let id = create_object(
+            state,
+            CardId(700),
+            controller,
+            "Sacrifice-for-Mana Altar".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        Arc::make_mut(&mut obj.abilities).push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Colorless {
+                        count: QuantityExpr::Fixed { value: 1 },
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Sacrifice(SacrificeCost::count(
+                TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact)),
+                1,
+            ))),
+        );
+        id
+    }
+
+    /// V1 (repro fix): on an OPPONENT's turn, a lone sacrifice-for-mana source
+    /// with nothing castable in hand and an opponent trigger on the stack must
+    /// recommend auto-pass — the sacrifice/its mana enables no concrete follow-up
+    /// (CR 605.3a + CR 603.6 + CR 117.1d). Before the fix `auto_pass_recommended`
+    /// returned `false` (unconditional sac hold), forcing a pointless stop.
+    #[test]
+    fn auto_pass_fires_for_bare_sac_for_mana_on_opponents_turn_repro() {
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(1);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        // P0 controls the lone sac-for-mana source; P0's hand is empty.
+        add_sac_for_mana_source(&mut state, PlayerId(0));
+
+        // Opponent (P1) spell on top of the stack — its controller != P0, so the
+        // own-stack auto-pass shortcut (`top.controller == player`) cannot be the
+        // path that fires. This isolates the narrowed sac rung as the cause.
+        let opp_spell = create_object(
+            &mut state,
+            CardId(900),
+            PlayerId(1),
+            "Opponent Spell".to_string(),
+            Zone::Stack,
+        );
+        state.stack.push_back(StackEntry {
+            id: opp_spell,
+            source_id: opp_spell,
+            controller: PlayerId(1),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(900),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+
+        let flat = super::flat_priority_actions(&state);
+
+        // Reach-guards (non-vacuous): the sac source is genuinely activatable AND
+        // the classifier counts it meaningful, so we truly reach the sac rung.
+        assert!(
+            super::has_activatable_sacrifice_for_mana(&state),
+            "precondition: the sac-for-mana ability is activatable"
+        );
+        assert!(
+            super::has_meaningful_priority_action(&state, &flat),
+            "precondition: the classifier reaches the sac rung (loop firewall intact)"
+        );
+        // Sibling guard: the top of stack belongs to the opponent.
+        assert_ne!(
+            state.stack.back().unwrap().controller,
+            PlayerId(0),
+            "top of stack is the opponent's, so the own-stack shortcut is not under test"
+        );
+        // Nothing castable — the produced mana would feed no spell (case 1 false).
+        assert!(
+            !super::has_feasibly_castable_spell(&state, PlayerId(0)),
+            "precondition: empty hand, nothing feasibly castable"
+        );
+
+        // Flipped-on-revert assertion: fails if the narrowing is reverted.
+        assert!(
+            super::auto_pass_recommended(&state, &flat),
+            "bare sac-for-mana on opponent's turn with no downstream follow-up → auto-pass fires"
+        );
+    }
+
+    /// V3 (#544 case 1 preserved): a sac-for-mana source PLUS a feasibly castable
+    /// instant on an opponent's turn holds — the mana can pay the spell (CR 117.1d
+    /// + CR 601.2g). Hold flows through the castability rung above the sac rung.
+    #[test]
+    fn sac_for_mana_holds_with_downstream_castable_spell() {
+        use crate::game::scenario::{GameScenario, P0, P1};
+        use crate::types::mana::ManaCostShard;
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.add_basic_land(P0, ManaColor::Green);
+        scenario
+            .add_spell_to_hand_from_oracle(P0, "Test Bolt", true, "Draw a card.")
+            .with_mana_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Green],
+                generic: 0,
+            });
+        let mut runner = scenario.build();
+        add_sac_for_mana_source(runner.state_mut(), P0);
+        {
+            let state = runner.state_mut();
+            state.active_player = P1;
+            state.priority_player = P0;
+            state.waiting_for = WaitingFor::Priority { player: P0 };
+        }
+
+        // Positive reach-guard: the {G} instant is genuinely castable, so the HOLD
+        // cannot pass vacuously.
+        assert!(
+            super::has_feasibly_castable_spell(runner.state(), P0),
+            "precondition: the {{G}} instant is feasibly castable"
+        );
+        assert!(
+            !super::auto_pass_recommended(
+                runner.state(),
+                &super::flat_priority_actions(runner.state())
+            ),
+            "sac-for-mana + castable spell → hold (case 1 via castability rung)"
+        );
+
+        // Negative sibling — same board minus the hand spell: a lone sac-for-mana
+        // with nothing castable auto-passes.
+        let mut bare = GameScenario::new();
+        bare.at_phase(Phase::PreCombatMain);
+        bare.add_basic_land(P0, ManaColor::Green);
+        let mut bare_runner = bare.build();
+        add_sac_for_mana_source(bare_runner.state_mut(), P0);
+        {
+            let state = bare_runner.state_mut();
+            state.active_player = P1;
+            state.priority_player = P0;
+            state.waiting_for = WaitingFor::Priority { player: P0 };
+        }
+        assert!(
+            !super::has_feasibly_castable_spell(bare_runner.state(), P0),
+            "precondition (negative): no castable spell on the bare board"
+        );
+        assert!(
+            super::auto_pass_recommended(
+                bare_runner.state(),
+                &super::flat_priority_actions(bare_runner.state())
+            ),
+            "negative sibling: sac-for-mana with nothing castable → auto-pass fires"
+        );
+    }
+
+    /// V4 (#544 case 2): a sac-for-mana source PLUS a mana-costed non-mana
+    /// activated ability holds — the produced mana could feed the ability
+    /// (CR 605.3a + CR 603.6). The ability is present but unaffordable-now (no
+    /// floating mana), so it is absent from the flat list — proving the hold
+    /// flows through the case-2 followup gate, not the flat meaningful-action path.
+    #[test]
+    fn sac_for_mana_holds_with_downstream_mana_costed_activated_ability() {
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(1);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        add_sac_for_mana_source(&mut state, PlayerId(0));
+
+        // Separate permanent with "{1}: Draw a card" — a non-mana activated
+        // ability with a mana component in its cost.
+        let engine = create_object(
+            &mut state,
+            CardId(710),
+            PlayerId(0),
+            "Mana-Costed Engine".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&engine).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Draw {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        target: TargetFilter::Controller,
+                    },
+                )
+                .cost(AbilityCost::Mana {
+                    cost: ManaCost::generic(1),
+                }),
+            );
+        }
+
+        let flat = super::flat_priority_actions(&state);
+        // Reach-guard: the flat list carries no meaningful action (the {1} ability
+        // is unaffordable now), so the hold MUST come from the case-2 gate.
+        assert!(
+            !super::flat_actions_have_meaningful_priority(&state, &flat),
+            "precondition: the mana-costed ability is unaffordable-now, absent from the flat list"
+        );
+        assert!(
+            super::has_activatable_sacrifice_for_mana(&state),
+            "precondition: the sac-for-mana source is activatable (we reach the sac rung)"
+        );
+        assert!(
+            super::sacrifice_for_mana_enables_followup(&state, PlayerId(0)),
+            "precondition: case 2 fires on the mana-costed activated ability"
+        );
         assert!(
             !super::auto_pass_recommended(&state, &flat),
-            "meaningful sac-for-mana ability on opponent's turn → hold via the internal scan; \
-             empty hand must not auto-pass (#4388 ladder preservation)"
+            "sac-for-mana + mana-costed activated ability → hold (case 2)"
+        );
+
+        // Negative sibling: replace the mana cost with a bare {T} cost (no mana
+        // component) and tap the permanent so it stays out of the flat list. Case
+        // 2 requires a mana-consuming cost, so it no longer fires → auto-pass.
+        {
+            let obj = state.objects.get_mut(&engine).unwrap();
+            obj.tapped = true;
+            Arc::make_mut(&mut obj.abilities).clear();
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Draw {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        target: TargetFilter::Controller,
+                    },
+                )
+                .cost(AbilityCost::Tap),
+            );
+        }
+        let flat = super::flat_priority_actions(&state);
+        assert!(
+            !super::flat_actions_have_meaningful_priority(&state, &flat),
+            "precondition (negative): the tapped {{T}} ability is absent from the flat list"
+        );
+        assert!(
+            !super::sacrifice_for_mana_enables_followup(&state, PlayerId(0)),
+            "negative: a non-mana ({{T}}) cost does not satisfy case 2"
+        );
+        assert!(
+            super::auto_pass_recommended(&state, &flat),
+            "negative sibling: no mana-component ability → case 2 fails → auto-pass fires"
+        );
+    }
+
+    /// V5 (#544 case 3, aristocrat): a sac-for-mana source PLUS a
+    /// leaves-the-battlefield trigger on a SEPARATE controlled permanent (Blood
+    /// Artist shape: `ChangesZone` origin battlefield → graveyard) holds — the
+    /// sacrifice is itself the payoff (CR 603.6c). Multi-authority: the trigger
+    /// lives on a different permanent, proving the scan sweeps all permanents.
+    #[test]
+    fn sac_for_mana_holds_with_beneficial_death_trigger() {
+        use crate::types::ability::TriggerDefinition;
+        use crate::types::triggers::TriggerMode;
+
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(1);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        let sac = add_sac_for_mana_source(&mut state, PlayerId(0));
+
+        // Separate Blood-Artist-shaped permanent: "whenever a creature dies" =
+        // ChangesZone from battlefield to graveyard.
+        let blood_artist = create_object(
+            &mut state,
+            CardId(720),
+            PlayerId(0),
+            "Blood Artist".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&blood_artist).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.trigger_definitions.push(
+                TriggerDefinition::new(TriggerMode::ChangesZone)
+                    .origin(Zone::Battlefield)
+                    .destination(Zone::Graveyard),
+            );
+        }
+
+        let flat = super::flat_priority_actions(&state);
+        assert_ne!(
+            sac, blood_artist,
+            "the trigger lives on a separate permanent from the sac source"
+        );
+        assert!(
+            !super::flat_actions_have_meaningful_priority(&state, &flat),
+            "precondition: no flat meaningful action; the hold must come from case 3"
+        );
+        assert!(
+            super::has_activatable_sacrifice_for_mana(&state),
+            "precondition: the sac-for-mana source is activatable"
+        );
+        assert!(
+            super::sacrifice_for_mana_enables_followup(&state, PlayerId(0)),
+            "precondition: case 3 fires on the separate leaves-battlefield trigger"
+        );
+        assert!(
+            !super::auto_pass_recommended(&state, &flat),
+            "sac-for-mana + leaves-battlefield trigger → hold (case 3)"
+        );
+    }
+
+    /// V5b (disjunctive-clause LTB): a Syr-Konrad-shaped trigger whose
+    /// leaves-the-battlefield event lives ONLY in a `zone_change_clauses` clause
+    /// (not the scalar `origin`/`origin_zones`) must ALSO hold — the case-3 scan
+    /// consults the clause origins. Preserves the "always errs toward holding"
+    /// invariant for disjunctive dies/leaves triggers.
+    #[test]
+    fn sac_for_mana_holds_with_disjunctive_leaves_battlefield_clause_trigger() {
+        use crate::types::ability::{OriginConstraint, TriggerDefinition, ZoneChangeClause};
+        use crate::types::triggers::TriggerMode;
+
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(1);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        add_sac_for_mana_source(&mut state, PlayerId(0));
+
+        let konrad = create_object(
+            &mut state,
+            CardId(730),
+            PlayerId(0),
+            "Syr Konrad, the Grim".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&konrad).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            // Disjunctive trigger: scalar origin is None; the battlefield-exit
+            // event lives only in a clause.
+            obj.trigger_definitions.push(
+                TriggerDefinition::new(TriggerMode::ChangesZone).zone_change_clauses(vec![
+                    ZoneChangeClause {
+                        origin: OriginConstraint::Equals(Zone::Battlefield),
+                        destination: None,
+                        destination_constraint: OriginConstraint::Any,
+                        valid_card: None,
+                    },
+                    ZoneChangeClause {
+                        origin: OriginConstraint::NotEquals(Zone::Battlefield),
+                        destination: Some(Zone::Graveyard),
+                        destination_constraint: OriginConstraint::Any,
+                        valid_card: None,
+                    },
+                ]),
+            );
+        }
+
+        let flat = super::flat_priority_actions(&state);
+        assert!(
+            super::sacrifice_for_mana_enables_followup(&state, PlayerId(0)),
+            "precondition: case 3 fires on the disjunctive battlefield-exit clause"
+        );
+        assert!(
+            !super::auto_pass_recommended(&state, &flat),
+            "sac-for-mana + disjunctive leaves-battlefield clause trigger → hold (case 3)"
+        );
+    }
+
+    /// V6 (case 3 negative): a sac-for-mana source PLUS only an enters-battlefield
+    /// / spell-cast trigger enables nothing when the permanent is sacrificed, so
+    /// auto-pass fires. Boundary: `ChangesZone` with a non-battlefield origin and
+    /// `SpellCast` must NOT match `trigger_fires_on_leaving_battlefield`.
+    #[test]
+    fn sac_for_mana_auto_passes_with_only_non_leaving_trigger() {
+        use crate::types::ability::TriggerDefinition;
+        use crate::types::triggers::TriggerMode;
+
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(1);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        add_sac_for_mana_source(&mut state, PlayerId(0));
+
+        let etb = create_object(
+            &mut state,
+            CardId(740),
+            PlayerId(0),
+            "Enters-Trigger Permanent".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&etb).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            // Enters-the-battlefield: ChangesZone from library → battlefield.
+            obj.trigger_definitions.push(
+                TriggerDefinition::new(TriggerMode::ChangesZone)
+                    .origin(Zone::Library)
+                    .destination(Zone::Battlefield),
+            );
+            // A spell-cast trigger is likewise not a battlefield-exit payoff.
+            obj.trigger_definitions
+                .push(TriggerDefinition::new(TriggerMode::SpellCast));
+        }
+
+        let flat = super::flat_priority_actions(&state);
+        assert!(
+            super::has_activatable_sacrifice_for_mana(&state),
+            "precondition: the sac-for-mana source is activatable (we reach the sac rung)"
+        );
+        assert!(
+            !super::sacrifice_for_mana_enables_followup(&state, PlayerId(0)),
+            "precondition: neither the enters nor the spell-cast trigger satisfies case 3"
+        );
+        assert!(
+            super::auto_pass_recommended(&state, &flat),
+            "sac-for-mana with only non-leaving triggers → auto-pass fires"
+        );
+    }
+
+    /// V6b (predicate boundary): direct unit coverage of
+    /// `trigger_fires_on_leaving_battlefield`, pinning the `OriginConstraint`
+    /// semantics for the disjunctive-clause arm (CR 603.6c).
+    #[test]
+    fn trigger_fires_on_leaving_battlefield_predicate_boundary() {
+        use crate::types::ability::{OriginConstraint, TriggerDefinition, ZoneChangeClause};
+        use crate::types::triggers::TriggerMode;
+
+        // Direct battlefield-exit modes always fire.
+        for mode in [
+            TriggerMode::LeavesBattlefield,
+            TriggerMode::Sacrificed,
+            TriggerMode::SacrificedOnce,
+            TriggerMode::Destroyed,
+        ] {
+            assert!(
+                super::trigger_fires_on_leaving_battlefield(&TriggerDefinition::new(mode.clone())),
+                "{mode:?} is a battlefield-exit event"
+            );
+        }
+        // ChangesZone with a scalar battlefield origin fires.
+        assert!(super::trigger_fires_on_leaving_battlefield(
+            &TriggerDefinition::new(TriggerMode::ChangesZone).origin(Zone::Battlefield)
+        ));
+        // Disjunctive clause whose origin includes the battlefield fires.
+        assert!(super::trigger_fires_on_leaving_battlefield(
+            &TriggerDefinition::new(TriggerMode::ChangesZone).zone_change_clauses(vec![
+                ZoneChangeClause {
+                    origin: OriginConstraint::Equals(Zone::Battlefield),
+                    destination: None,
+                    destination_constraint: OriginConstraint::Any,
+                    valid_card: None,
+                },
+            ])
+        ));
+        // "from anywhere other than the battlefield" does NOT fire.
+        assert!(!super::trigger_fires_on_leaving_battlefield(
+            &TriggerDefinition::new(TriggerMode::ChangesZone).zone_change_clauses(vec![
+                ZoneChangeClause {
+                    origin: OriginConstraint::NotEquals(Zone::Battlefield),
+                    destination: Some(Zone::Graveyard),
+                    destination_constraint: OriginConstraint::Any,
+                    valid_card: None,
+                },
+            ])
+        ));
+        // Enters-battlefield (origin Library) and SpellCast do NOT fire.
+        assert!(!super::trigger_fires_on_leaving_battlefield(
+            &TriggerDefinition::new(TriggerMode::ChangesZone).origin(Zone::Library)
+        ));
+        assert!(!super::trigger_fires_on_leaving_battlefield(
+            &TriggerDefinition::new(TriggerMode::SpellCast)
+        ));
+    }
+
+    /// V7 (Mana Leak / Daze non-interference): `auto_pass_recommended` must never
+    /// suppress a non-`Priority` decision prompt. A "counter unless you pay {1}"
+    /// surfaces as `WaitingFor::UnlessPayment` (CR 118.12a), and even with a
+    /// sac-for-mana `{C}` source on the payer's board the recommendation returns
+    /// `false` — the guard that early-returns for non-`Priority` states
+    /// (mod.rs `_ => return false`) makes this safe.
+    #[test]
+    fn unless_pay_surfaces_pay_cost_prompt_despite_sac_for_mana_autopass() {
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(1);
+        state.priority_player = PlayerId(0);
+
+        let sac = add_sac_for_mana_source(&mut state, PlayerId(0));
+
+        // Mana-Leak-shaped prompt: P0 must pay {1} or the effect happens.
+        state.waiting_for = WaitingFor::UnlessPayment {
+            player: PlayerId(0),
+            cost: AbilityCost::Mana {
+                cost: ManaCost::generic(1),
+            },
+            pending_effect: Box::new(empty_effect(sac)),
+            trigger_event: None,
+            effect_description: Some("counter target spell".to_string()),
+            remaining: vec![],
+        };
+
+        // Reach-guard: the waiting state is genuinely non-`Priority`.
+        assert!(
+            matches!(state.waiting_for, WaitingFor::UnlessPayment { .. }),
+            "precondition: the prompt is UnlessPayment (PayCost class), not Priority"
+        );
+        // Non-interference: auto-pass never fires for a non-`Priority` prompt.
+        assert!(
+            !super::auto_pass_recommended(&state, &[]),
+            "auto-pass must not suppress an unless-pay prompt despite a sac-for-mana source"
         );
     }
 

--- a/crates/engine/tests/integration/issue_544_krark_clan_ironworks_auto_pass.rs
+++ b/crates/engine/tests/integration/issue_544_krark_clan_ironworks_auto_pass.rs
@@ -7,7 +7,9 @@
 //! still consult activatable sacrifice mana sources so the client does not
 //! auto-pass when the player may want to sac for triggers or mana.
 
-use engine::ai_support::{auto_pass_recommended, legal_actions_full};
+use engine::ai_support::{
+    auto_pass_recommended, has_meaningful_priority_action, legal_actions_full,
+};
 use engine::game::apply_as_current;
 use engine::game::zones::create_object;
 use engine::types::ability::{
@@ -88,10 +90,15 @@ fn add_artifact_creature(
     id
 }
 
-// CR 605.3a + CR 603.6: Sacrificing a permanent for mana is a meaningful
-// priority decision — the player may want ETB/dies triggers or graveyard value.
+// CR 605.3a + CR 603.6 (narrowed): Sacrificing a permanent for mana stays a
+// meaningful priority decision for the CR 732.5 loop firewall (the classifier
+// `has_meaningful_priority_action` still returns true). But on a BARE board —
+// vanilla artifact fodder with no death-trigger payoff, nothing castable, no
+// mana-costed activated ability — the sacrifice enables no concrete follow-up,
+// so the frontend auto-pass recommendation now fires. Classifier and
+// recommendation deliberately DISAGREE for this bare case.
 #[test]
-fn auto_pass_blocked_when_kci_sacrifice_mana_is_only_action() {
+fn auto_pass_fires_for_bare_kci_sacrifice_mana() {
     let mut state = GameState::new_two_player(42);
     priority_main_phase(&mut state, P0);
 
@@ -114,9 +121,18 @@ fn auto_pass_blocked_when_kci_sacrifice_mana_is_only_action() {
         !flat.contains(&kci_activation),
         "precondition: sacrifice mana stays out of flat legal_actions during priority"
     );
+    // Classifier reach-guard (UNCHANGED): proves we truly reach the sac rung and
+    // the loop firewall still counts the sacrifice as meaningful (CR 605.3a +
+    // 603.6) — so this test is non-vacuous and the disagreement below is real.
     assert!(
-        !auto_pass_recommended(&state, &flat),
-        "Issue #544: must not auto-pass when KCI sacrifice-for-mana is available"
+        has_meaningful_priority_action(&state, &flat),
+        "classifier still counts sacrifice-for-mana as meaningful (loop firewall intact)"
+    );
+    // Flipped-on-revert assertion: with a bare board the sacrifice enables no
+    // downstream follow-up, so auto-pass now fires.
+    assert!(
+        auto_pass_recommended(&state, &flat),
+        "bare KCI sacrifice-for-mana with no downstream follow-up → auto-pass fires"
     );
 }
 


### PR DESCRIPTION
## Summary

Priority-yield ("auto-pass") UX for **CR 117.3d**, building on the engine mechanism from #5132. Four commits:

1. **feat(client): discoverable tap affordance for priority yields** — the yield control was reachable only by long-pressing a triggered stack entry (undiscoverable, and it collided with the mobile card-preview long-press). Replaced with an always-visible tap button on triggered-ability entries; long-press is restored to a single uniform meaning (inspect-and-pin).

2. **fix(engine): auto-pass past bare sacrifice-for-mana with no downstream use (CR 117.1d)** — `auto_pass_recommended` held priority at every window whenever the player controlled a sac-for-mana permanent (Eldrazi Spawn, Krark-Clan Ironworks, Phyrexian Altar), even when the mana could pay for nothing and the sacrifice triggered nothing (endless priority on an opponent's turn with an uncastable hand). The #544 hold is narrowed to block auto-pass only when the sacrifice/mana enables a concrete follow-up: a feasibly castable spell, a mana-costed non-mana activated ability, or a leaves-battlefield/dies/sacrifice trigger. `has_meaningful_priority_action` is kept byte-identical (extracted + recomposed) because the CR 732.5 loop-shortcut firewall depends on it still counting a sacrifice as a board change. **This is the auto-pass/AI-adjacent change — see the commit body for the full case analysis and the V7 `Counter unless pay {1}` regression note.**

3. **fix(stack): make yield affordance discoverable and dismiss preview on open** — polish on the tap affordance; dismisses the card preview when the yield menu opens.

4. **fix(client): make priority-yield menu options work and collapse standing yields into a compact chip** — the core interaction fix: `PopoverMenu` now seals `onPointerDown` (not just `onClick`) on its portal container, so a menu interaction no longer leaks through the React tree to the card's `useLongPress` (which was firing the card preview and leaving the menu open — the "options do nothing" bug). Standing yields collapse into one fixed-footprint amber "Auto-passing N" chip that opens the revocable list; `FullControlToggle` shortened to "Control" (ARIA preserves toggle semantics) on the same row.

## Testing

- `PopoverMenu` regression test (fails without the pointer-event seal), `PriorityYieldList` (5 cases), updated `StackEntry` tests, i18n parity across all 7 locales.
- Tilt `check-frontend` green (tsc + eslint).

## Notes

Two interleaved report-card commits on local `main` are intentionally **excluded** — they ship via their own `ship/report-card-nudge` and `ship/report-picker-polish` branches.
