### PR TITLE
fix(client): guard getArcPath against coincident endpoints

### DIFF
--- a/client/src/components/targeting/__tests__/arcPath.test.ts
+++ b/client/src/components/targeting/__tests__/arcPath.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { getArcPath } from "../arcPath";
+
+describe("getArcPath", () => {
+  it("draws a quadratic arc between two distinct points with a finite control point", () => {
+    const d = getArcPath({ x: 0, y: 0 }, { x: 100, y: 0 });
+    expect(d.startsWith("M 0 0 Q ")).toBe(true);
+    expect(d.endsWith("100 0")).toBe(true);
+    // Every coordinate in the path must be a finite number (no NaN/Infinity).
+    for (const n of d.match(/-?\d+(?:\.\d+)?|NaN|Infinity/g) ?? []) {
+      expect(Number.isFinite(Number(n))).toBe(true);
+    }
+  });
+
+  it("does not emit NaN when the endpoints are coincident (dist === 0)", () => {
+    // A self-target or two anchors overlapping mid-layout gives from === to. The
+    // perpendicular unit vector -dy/dist is 0/0 = NaN without a guard, which would
+    // produce an invalid SVG `d` like "M 100 100 Q NaN NaN 100 100".
+    const d = getArcPath({ x: 100, y: 100 }, { x: 100, y: 100 });
+    expect(d).not.toContain("NaN");
+    expect(d).toBe("M 100 100 L 100 100");
+  });
+});

--- a/client/src/components/targeting/arcPath.ts
+++ b/client/src/components/targeting/arcPath.ts
@@ -9,6 +9,13 @@ export function getArcPath(from: Point, to: Point): string {
   const dx = to.x - from.x;
   const dy = to.y - from.y;
   const dist = Math.sqrt(dx * dx + dy * dy);
+  // Coincident endpoints (a self-target, or two anchors overlapping mid-layout):
+  // the perpendicular unit vector `-dy/dist` is 0/0 = NaN, which propagates into
+  // the control point (NaN * 0 is still NaN) and yields an invalid `d` attribute.
+  // There is no arc to draw, so emit a degenerate line instead.
+  if (dist === 0) {
+    return `M ${from.x} ${from.y} L ${to.x} ${to.y}`;
+  }
   // Perpendicular offset for curve — proportional to distance
   const offset = Math.min(80, dist * 0.3);
   const nx = -dy / dist;


### PR DESCRIPTION
## Problem

`getArcPath` (`client/src/components/targeting/arcPath.ts`) computes a perpendicular curve offset by dividing by `dist = Math.sqrt(dx*dx + dy*dy)` with no guard:

```ts
const nx = -dy / dist;   // dist === 0  ->  0/0 = NaN
const ny = dx / dist;
```

When `from` and `to` are the **same point** — a self-referential source/target, or two anchor rects that overlap transiently during layout — `dist === 0`, so `-dy/dist` is `NaN`. The zero offset does not save it (`NaN * 0` is still `NaN`), so the result is `"M x y Q NaN NaN x y"`. That `d` is fed straight into an SVG `<path>` in `StackTargetArcs.tsx`; an invalid `d` makes the arc silently vanish and logs SVG parse warnings.

## Fix

When `dist === 0` there is no arc to draw, so return a degenerate line (`M .. L ..`) before the division.

## Test

`client/src/components/targeting/__tests__/arcPath.test.ts` — asserts a normal arc has only finite coordinates, and that coincident endpoints produce no `NaN`.