### PR TITLE
fix(client): expand shorthand hex in hexToRgb instead of a NaN channel

### DIFF
--- a/client/src/components/animation/__tests__/hexToRgb.test.ts
+++ b/client/src/components/animation/__tests__/hexToRgb.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { hexToRgb } from "../particleEffects";
+
+describe("hexToRgb", () => {
+  it("parses a 6-digit hex color", () => {
+    expect(hexToRgb("#ff8800")).toEqual({ r: 255, g: 136, b: 0 });
+    expect(hexToRgb("00ff00")).toEqual({ r: 0, g: 255, b: 0 }); // tolerant of a missing '#'
+  });
+
+  it("expands 3-digit shorthand instead of producing a NaN channel", () => {
+    // Without expansion, the blue channel is parseInt("", 16) === NaN, yielding a
+    // corrupt rgb(...) color. `#fff` must expand to `ffffff`.
+    const c = hexToRgb("#fff");
+    expect(Number.isNaN(c.b)).toBe(false);
+    expect(c).toEqual({ r: 255, g: 255, b: 255 });
+    expect(hexToRgb("#0af")).toEqual({ r: 0, g: 170, b: 255 });
+  });
+});

--- a/client/src/components/animation/particleEffects.ts
+++ b/client/src/components/animation/particleEffects.ts
@@ -44,7 +44,12 @@ export function lerpColor(a: RGB, b: RGB, t: number): RGB {
 }
 
 export function hexToRgb(hex: string): RGB {
-  const h = hex.replace("#", "");
+  // Expand CSS 3-digit shorthand (`#fff` -> `ffffff`) first. Without this the
+  // blue channel reads `h.substring(4, 6)` === "" -> parseInt("", 16) === NaN,
+  // producing a corrupt `rgb(r,g,NaN)` color that renders nothing.
+  const h = hex
+    .replace("#", "")
+    .replace(/^([0-9a-f])([0-9a-f])([0-9a-f])$/i, "$1$1$2$2$3$3");
   return {
     r: parseInt(h.substring(0, 2), 16),
     g: parseInt(h.substring(2, 4), 16),


### PR DESCRIPTION
## Problem

`hexToRgb` (`client/src/components/animation/particleEffects.ts`) reads fixed byte offsets off the hex string:

```ts
const h = hex.replace("#", "");
return { r: parseInt(h.substring(0,2),16), g: parseInt(h.substring(2,4),16), b: parseInt(h.substring(4,6),16) };
```

For a CSS-legal 3-digit shorthand like `#fff`, `h` is `"fff"`, so the blue channel reads `h.substring(4, 6)` === `""` -> `parseInt("", 16)` === `NaN`. The result is a corrupt `rgb(r, g, NaN)` color string, which renders nothing.

## Fix

Expand 3-digit shorthand to its 6-digit form (`#fff` -> `ffffff`) before parsing.

## Test

`client/src/components/animation/__tests__/hexToRgb.test.ts` — covers 6-digit parsing and asserts shorthand produces no `NaN` channel.