### PR TITLE
fix(client): require a positive integer count for feed deck entries

### DIFF
--- a/client/src/services/__tests__/feedService.test.ts
+++ b/client/src/services/__tests__/feedService.test.ts
@@ -445,3 +445,24 @@ describe("getFeedDecksByFeed", () => {
     );
   });
 });
+
+describe("validateFeed — a deck entry count must be a positive integer", () => {
+  const feedWithMainCount = (count: unknown) => ({
+    ...VALID_FEED,
+    decks: [
+      { ...VALID_FEED.decks[0], main: [{ count, name: "Lightning Bolt" }] },
+      VALID_FEED.decks[1],
+    ],
+  });
+
+  it("accepts a positive integer count", () => {
+    expect(validateFeed(feedWithMainCount(3))).not.toBeNull();
+  });
+
+  it.each([0, -1, 2.5, NaN])(
+    "rejects a non-positive / fractional / NaN count from untrusted feed JSON: %s",
+    (count) => {
+      expect(validateFeed(feedWithMainCount(count))).toBeNull();
+    },
+  );
+});

--- a/client/src/services/feedService.ts
+++ b/client/src/services/feedService.ts
@@ -30,7 +30,16 @@ function isNonEmptyString(v: unknown): v is string {
 }
 
 function isValidDeckEntry(v: unknown): boolean {
-  return isObject(v) && typeof v.count === "number" && isNonEmptyString(v.name);
+  // `count` must be a positive integer. `typeof v.count === "number"` alone
+  // admits 0, negatives, fractional, and NaN from untrusted feed JSON — which
+  // then flow into card-total counters and copy-expansion (a 2.5 becomes 3
+  // copies while the displayed total shows 2.5; a 0 becomes a phantom row).
+  return (
+    isObject(v) &&
+    Number.isInteger(v.count) &&
+    (v.count as number) > 0 &&
+    isNonEmptyString(v.name)
+  );
 }
 
 function isValidFeedDeck(v: unknown): v is FeedDeck {


### PR DESCRIPTION
## Problem

`isValidDeckEntry` (`client/src/services/feedService.ts`) validates deck entries coming from **subscribed-feed JSON** (untrusted), but the numeric check is:

```ts
return isObject(v) && typeof v.count === "number" && isNonEmptyString(v.name);
```

`typeof v.count === "number"` admits `0`, negatives, fractional values, and `NaN`. Such an entry passes `validateFeed` and is persisted; it then flows into the card-total counters and copy-expansion (`expandParsedDeck` loops `for (let i=0;i<entry.count;i++)`), so a `2.5` count expands to 3 copies while the displayed total reads `2.5`, and a `0`/negative count becomes a permanent phantom row.

## Fix

Require `Number.isInteger(v.count) && v.count > 0`.

## Test

`client/src/services/__tests__/feedService.test.ts` — `validateFeed` accepts a positive integer count and rejects `0`, `-1`, `2.5`, and `NaN`.