### PR TITLE
fix(client): parse a port-less bracketed IPv6 host in parseJoinCode

### DIFF
--- a/client/src/services/__tests__/serverDetection.test.ts
+++ b/client/src/services/__tests__/serverDetection.test.ts
@@ -165,3 +165,19 @@ describe("mixedContentBlockReason", () => {
     expect(mixedContentBlockReason("wss://play.example.com/ws")).toBeNull();
   });
 });
+
+describe("parseJoinCode — bracketed IPv6 host", () => {
+  it("does not corrupt a bracketed IPv6 host that has no port", () => {
+    // `[::1]` ends in `]`; its last colon is inside the address. Splitting there
+    // produced a broken host `[:` and a malformed `wss://[::1/ws`.
+    const r = parseJoinCode("ABC123@[::1]");
+    expect(r.code).toBe("ABC123");
+    expect(r.serverAddress).toBe("wss://[::1]/ws");
+  });
+
+  it("still splits a bracketed IPv6 host that DOES carry a port", () => {
+    expect(parseJoinCode("ABC123@[::1]:9000").serverAddress).toBe(
+      "wss://[::1]:9000/ws",
+    );
+  });
+});

--- a/client/src/services/serverDetection.ts
+++ b/client/src/services/serverDetection.ts
@@ -133,8 +133,15 @@ export function parseJoinCode(input: string): { code: string; serverAddress?: st
   }
 
   // Split host:port on the last colon so a host:port pair splits correctly.
+  // A bracketed IPv6 literal with no port (e.g. `[::1]`) ends in `]`, and its
+  // last colon is INSIDE the address — splitting there yields a broken host like
+  // `[:`. When the host is a bracketed literal with no trailing `:port`, there
+  // is no port to split off.
   const colonIndex = hostPort.lastIndexOf(":");
-  const hasPort = colonIndex !== -1 && colonIndex < hostPort.length - 1;
+  const hasPort =
+    colonIndex !== -1 &&
+    colonIndex < hostPort.length - 1 &&
+    !hostPort.endsWith("]");
   const host = hasPort ? hostPort.slice(0, colonIndex) : hostPort;
 
   const isLocal = host === "localhost" || host === "127.0.0.1";


### PR DESCRIPTION
## Problem

`parseJoinCode` (`client/src/services/serverDetection.ts`) splits `host:port` on the **last** colon:

```ts
const colonIndex = hostPort.lastIndexOf(":");
const hasPort = colonIndex !== -1 && colonIndex < hostPort.length - 1;
const host = hasPort ? hostPort.slice(0, colonIndex) : hostPort;
```

For a bracketed IPv6 literal with no port (`[::1]`), that last colon is **inside** the address, so `host` becomes `"[:"` and the join code `ABC123@[::1]` resolves to a malformed, unconnectable `wss://[::1/ws`.

## Fix

A bracketed host with no port ends in `]`, so add `!hostPort.endsWith("]")` to the `hasPort` check. A bracketed host that *does* carry a port (`[::1]:9000`) does not end in `]`, so it still splits correctly.

## Test

`client/src/services/__tests__/serverDetection.test.ts` — `[::1]` resolves to `wss://[::1]/ws`, and `[::1]:9000` still splits to `wss://[::1]:9000/ws`.