### PR TITLE
fix(client): render blank for a missing/invalid class level in toRoman

### DIFF
--- a/client/src/viewmodel/__tests__/cardProps.test.ts
+++ b/client/src/viewmodel/__tests__/cardProps.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { GameObject } from "../../adapter/types";
-import { toCardProps } from "../cardProps";
+import { toCardProps, toRoman } from "../cardProps";
 
 function makeGameObject(overrides: Partial<GameObject> = {}): GameObject {
   return {
@@ -165,5 +165,24 @@ describe("toCardProps", () => {
     expect(props.attachmentIds).toEqual([10, 11]);
     expect(props.keywords).toEqual(["Flying", "Trample"]);
     expect(props.colorIdentity).toEqual(["White", "Blue"]);
+  });
+});
+
+describe("toRoman", () => {
+  it("converts 1-5 to Roman numerals", () => {
+    expect(["", "I", "II", "III", "IV", "V"].map((_, i) => toRoman(i))).toEqual([
+      "", "I", "II", "III", "IV", "V",
+    ]);
+  });
+
+  it("renders blank (never the literal 'undefined'/'NaN') for a missing/invalid level", () => {
+    expect(toRoman(undefined as unknown as number)).toBe("");
+    expect(toRoman(NaN)).toBe("");
+    expect(toRoman(0)).toBe("");
+    expect(toRoman(-1)).toBe("");
+  });
+
+  it("falls back to the arabic numeral for a Class level beyond V", () => {
+    expect(toRoman(6)).toBe("6");
   });
 });

--- a/client/src/viewmodel/cardProps.ts
+++ b/client/src/viewmodel/cardProps.ts
@@ -3,8 +3,14 @@ import { isChangeling } from "./keywordProps";
 
 const ROMAN = ["", "I", "II", "III", "IV", "V"] as const;
 export const FACE_DOWN_CARD_NAME = "Face-down card";
-/** Convert a small integer (1–5) to a Roman numeral string. */
-export function toRoman(n: number): string { return ROMAN[n] ?? String(n); }
+/** Convert a small integer (1–5) to a Roman numeral string. Values outside the
+ *  table fall back to the arabic numeral for a positive integer, or "" for a
+ *  non-positive / non-integer input — so a missing/NaN class level renders blank
+ *  rather than the literal string "undefined"/"NaN" (`ROMAN[undefined]` is
+ *  `undefined`, and the old `?? String(n)` stringified it onto the card badge). */
+export function toRoman(n: number): string {
+  return ROMAN[n] ?? (Number.isInteger(n) && n > 0 ? String(n) : "");
+}
 
 export interface CardViewProps {
   id: ObjectId;


### PR DESCRIPTION
## Problem

`toRoman` (`client/src/viewmodel/cardProps.ts`) renders a Class level:

```ts
const ROMAN = ["", "I", "II", "III", "IV", "V"];
export function toRoman(n: number): string { return ROMAN[n] ?? String(n); }
```

`ROMAN[undefined]` and `ROMAN[NaN]` are `undefined`, so the `?? String(n)` fallback stringifies them — a missing/NaN `class_level` renders the literal `"undefined"` / `"NaN"` on the card badge (called as `toRoman(obj.class_level)` in three card renderers).

## Fix

Fall back to the arabic numeral only for a positive integer, otherwise `""`, so an out-of-range or missing level renders blank instead of a garbage string (a Class level beyond V still shows its number).

## Test

`client/src/viewmodel/__tests__/cardProps.test.ts` — 1–5 map to Roman numerals; `undefined`/`NaN`/`0`/`-1` render `""`; `6` renders `"6"`.