### PR TITLE
fix(client): guard zero-duration ParticleSystem effects against a NaN leak

### DIFF
--- a/client/src/components/animation/__tests__/particleSystem.test.ts
+++ b/client/src/components/animation/__tests__/particleSystem.test.ts
@@ -19,4 +19,24 @@ describe("ParticleSystem", () => {
 
     expect(updates).toBe(0);
   });
+
+  it("removes a zero-duration effect instead of leaking it forever", () => {
+    // duration 0 makes elapsed/duration NaN at elapsed 0; NaN >= 1 is false, so
+    // the effect would never complete — it leaks and keeps the rAF loop alive.
+    const system = new ParticleSystem();
+    let completed = false;
+    const effect: ActiveEffect = {
+      startTime: 0,
+      duration: 0,
+      update() {},
+      onComplete() {
+        completed = true;
+      },
+    };
+    system.addEffect(effect);
+    system["updateEffects"](0);
+
+    expect(system["effects"].length).toBe(0);
+    expect(completed).toBe(true);
+  });
 });

--- a/client/src/components/animation/particleSystem.ts
+++ b/client/src/components/animation/particleSystem.ts
@@ -257,7 +257,13 @@ export class ParticleSystem {
       const effect = this.effects[i];
       const elapsed = now - effect.startTime;
       if (elapsed < 0) continue;
-      const t = Math.min(Math.max(elapsed / effect.duration, 0), 1);
+      // A zero (or non-positive) duration makes `elapsed / duration` NaN at
+      // elapsed 0; NaN >= 1 is false, so the effect is never completed/removed —
+      // it leaks and keeps the rAF loop alive forever. Treat it as instantly done.
+      const t =
+        effect.duration > 0
+          ? Math.min(Math.max(elapsed / effect.duration, 0), 1)
+          : 1;
       effect.update(t, this);
       if (t >= 1) {
         effect.onComplete?.(this);
@@ -304,7 +310,11 @@ export class ParticleSystem {
       if (effect.draw) {
         const elapsed = _now - effect.startTime;
         if (elapsed < 0) continue;
-        const t = Math.min(Math.max(elapsed / effect.duration, 0), 1);
+        // Guard a zero/non-positive duration (NaN progress) — see updateEffects.
+        const t =
+          effect.duration > 0
+            ? Math.min(Math.max(elapsed / effect.duration, 0), 1)
+            : 1;
         effect.draw(t, ctx);
       }
     }


### PR DESCRIPTION
## Problem

`ParticleSystem.updateEffects` and `draw` (`client/src/components/animation/particleSystem.ts`) compute an effect's progress as:

```ts
const t = Math.min(Math.max(elapsed / effect.duration, 0), 1);
```

When an effect is added with `duration: 0`, the first frame has `elapsed === 0`, so `t = 0 / 0 = NaN`. `NaN >= 1` is `false`, so the effect is **never** completed or removed — it leaks, keeps the `requestAnimationFrame` loop alive forever (battery/CPU drain), and feeds `NaN` into every `draw`. This is reachable from the pure emitters (`emitProjectile`/`emitDamageFlurry` with a 0 duration).

## Fix

Treat a non-positive duration as instantly complete (`t = 1`) at both sites, so the effect runs once and is removed.

## Test

`client/src/components/animation/__tests__/particleSystem.test.ts` — a zero-duration effect is removed after one `updateEffects` tick and its `onComplete` fires.