### PR TITLE
fix(client): count wire-format mana shard variant names in dominant color

### DIFF
--- a/client/src/viewmodel/__tests__/dominantColor.test.ts
+++ b/client/src/viewmodel/__tests__/dominantColor.test.ts
@@ -134,6 +134,50 @@ describe("getDominantManaColor", () => {
 
     expect(result).toBe("Blue");
   });
+
+  it("counts wire-format shard variant names emitted by the adapter", () => {
+    // The engine sends full variant names ("White", "WhiteBlue", …), not the
+    // abbreviated forms ("W", "W/U"). These must still be counted.
+    const objects: Record<string, GameObject> = {
+      "1": makeGameObject({
+        id: 1,
+        name: "Serra Angel",
+        card_types: { supertypes: [], core_types: ["Creature"], subtypes: ["Angel"] },
+        mana_cost: { type: "Cost", shards: ["White", "White"], generic: 3 },
+      }),
+      "2": makeGameObject({
+        id: 2,
+        name: "Lightning Bolt",
+        card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
+        mana_cost: { type: "Cost", shards: ["Red"], generic: 0 },
+      }),
+    };
+
+    const result = getDominantManaColor([1, 2], objects, 0);
+
+    expect(result).toBe("White");
+  });
+
+  it("counts both halves of a hybrid shard variant name", () => {
+    const objects: Record<string, GameObject> = {
+      "1": makeGameObject({
+        id: 1,
+        name: "Hybrid Spell",
+        card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
+        mana_cost: { type: "Cost", shards: ["WhiteBlue"], generic: 0 },
+      }),
+      "2": makeGameObject({
+        id: 2,
+        name: "Blue Spell",
+        card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
+        mana_cost: { type: "Cost", shards: ["Blue"], generic: 0 },
+      }),
+    };
+
+    const result = getDominantManaColor([1, 2], objects, 0);
+
+    expect(result).toBe("Blue");
+  });
 });
 
 describe("getDeckDominantColor", () => {

--- a/client/src/viewmodel/dominantColor.ts
+++ b/client/src/viewmodel/dominantColor.ts
@@ -1,4 +1,5 @@
 import type { GameObject, ManaColor, PlayerId } from "../adapter/types";
+import { SHARD_ABBREVIATION } from "./costLabel";
 
 const LAND_SUBTYPE_TO_COLOR: Record<string, ManaColor> = {
   Plains: "White",
@@ -35,10 +36,15 @@ function countColors(
         if (color) colorCounts.set(color, (colorCounts.get(color) ?? 0) + 1);
       }
     } else if (obj.mana_cost.type === "Cost") {
-      // Non-land permanents: count colored mana shards
+      // Non-land permanents: count colored mana shards. `shards` holds the
+      // wire-format variant names ("White", "WhiteBlue", …); normalize them to
+      // the abbreviated form ("W", "W/U", …) before splitting hybrids so each
+      // colored half is counted. The `?? shard` fallback keeps already-abbreviated
+      // inputs working.
       for (const shard of obj.mana_cost.shards) {
+        const abbreviation = SHARD_ABBREVIATION[shard] ?? shard;
         // Handle hybrid shards like "W/U" — count both halves
-        for (const part of shard.split("/")) {
+        for (const part of abbreviation.split("/")) {
           const color = SHARD_TO_COLOR[part];
           if (color) colorCounts.set(color, (colorCounts.get(color) ?? 0) + 1);
         }


### PR DESCRIPTION
## Problem

`getDominantManaColor` / `getDeckDominantColor` (`client/src/viewmodel/dominantColor.ts`) tint a deck by its dominant mana color. `countColors` looked up each shard in `SHARD_TO_COLOR`, a table keyed by abbreviations (`"W"`, `"U"`, …). But `ManaCost.shards` on the wire are the Rust variant **names** — `"White"`, `"WhiteBlue"`, … (see `SHARD_ABBREVIATION` in `costLabel.ts`, and fixtures like `shards: ["White","Blue"]`). So `SHARD_TO_COLOR["White"]` is `undefined`: every colored spell contributed **nothing** to the count, and the tint was driven by lands alone.

## Fix

Normalize each shard through `SHARD_ABBREVIATION` (`"White"→"W"`, `"WhiteBlue"→"W/U"`) before splitting hybrids. A `?? shard` fallback keeps already-abbreviated inputs working, so nothing that previously counted stops counting.

## Tests

Adds two cases to the existing `dominantColor` suite using the real wire-format variant names: a mono-color spell (`["White","White"]`) and a hybrid (`["WhiteBlue"]`). Both fail before the fix (dominant color comes back `null`) and pass after. The whole file stays green (the pre-existing abbreviated-form tests still pass via the fallback).

Self-contained: only `dominantColor.ts` + its test; no engine/Rust/protocol changes.

Model: claude-opus-4-8
