### PR TITLE
fix(client): guard zero-length arc against a NaN targeting path

### DIFF
--- a/client/src/components/targeting/__tests__/arcPath.test.ts
+++ b/client/src/components/targeting/__tests__/arcPath.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { getArcPath } from "../arcPath";
+
+describe("getArcPath", () => {
+  it("produces a valid path for a zero-length arrow (from === to)", () => {
+    // When the source and target anchors coincide, `dist` is 0; without a guard
+    // the perpendicular normal is `0/0 = NaN` and the path is unrenderable.
+    const path = getArcPath({ x: 100, y: 100 }, { x: 100, y: 100 });
+
+    expect(path).not.toContain("NaN");
+    expect(path).toBe("M 100 100 Q 100 100 100 100");
+  });
+
+  it("builds a curved path with finite control points for a normal arrow", () => {
+    const path = getArcPath({ x: 0, y: 0 }, { x: 100, y: 0 });
+
+    expect(path).not.toContain("NaN");
+    expect(path.startsWith("M 0 0 Q ")).toBe(true);
+    expect(path.endsWith(" 100 0")).toBe(true);
+    // Every coordinate emitted must be a finite number.
+    const numbers = path.match(/-?\d+(\.\d+)?/g)?.map(Number) ?? [];
+    expect(numbers.every((n) => Number.isFinite(n))).toBe(true);
+  });
+});

--- a/client/src/components/targeting/arcPath.ts
+++ b/client/src/components/targeting/arcPath.ts
@@ -8,7 +8,11 @@ export function getArcPath(from: Point, to: Point): string {
   const my = (from.y + to.y) / 2;
   const dx = to.x - from.x;
   const dy = to.y - from.y;
-  const dist = Math.sqrt(dx * dx + dy * dy);
+  // Guard the degenerate `from === to` case: without `|| 1`, `dist` is 0 and
+  // the perpendicular normal (`-dy/dist`, `dx/dist`) becomes `0/0 = NaN`,
+  // producing a malformed `M … Q NaN NaN …` path that renders nothing. (The
+  // sibling arc helper in `useAttackerArrowPositions` guards this the same way.)
+  const dist = Math.sqrt(dx * dx + dy * dy) || 1;
   // Perpendicular offset for curve — proportional to distance
   const offset = Math.min(80, dist * 0.3);
   const nx = -dy / dist;


### PR DESCRIPTION
## Problem

`getArcPath` (`client/src/components/targeting/arcPath.ts`) computes a perpendicular offset for the targeting arc by dividing by the arrow length:

```
const dist = Math.sqrt(dx * dx + dy * dy);
const nx = -dy / dist;
const ny = dx / dist;
```

There is no zero guard. When the source and target anchors coincide (`from === to` — a self-target, or a transient pre-layout frame where both anchors resolve to the same point), `dist` is `0` and `nx`/`ny` become `0/0 = NaN`. The result is a malformed path — `"M 100 100 Q NaN NaN 100 100"` — and the SVG arrow renders nothing.

The sibling arc helper in `hooks/useAttackerArrowPositions.ts` already guards this exact case with `|| 1`; this copy dropped it.

## Fix

`const dist = Math.sqrt(dx * dx + dy * dy) || 1;` — a zero length falls back to `1`, yielding a valid (degenerate) path `"M 100 100 Q 100 100 100 100"`.

## Tests

Adds `arcPath.test.ts`: the zero-length case asserts the path contains no `NaN` and equals the degenerate path (fails before the fix); a normal case asserts every emitted coordinate is finite.

Self-contained: only `arcPath.ts` + a new test; no engine/Rust/protocol changes.

Model: claude-opus-4-8
