### PR TITLE
fix(client): expand shorthand hex in hexToRgb to avoid a NaN channel

### DIFF
--- a/client/src/components/animation/__tests__/particleEffects.test.ts
+++ b/client/src/components/animation/__tests__/particleEffects.test.ts
@@ -5,7 +5,11 @@ import {
   DAMAGE_FLURRY_TRAIL_PARTICLE_MAX,
 } from "../../../animation/types";
 import type { ActiveEffect, ParticleSystem } from "../particleSystem";
-import { damageFlurryProjectileCount, emitDamageFlurry } from "../particleEffects";
+import {
+  damageFlurryProjectileCount,
+  emitDamageFlurry,
+  hexToRgb,
+} from "../particleEffects";
 
 describe("particleEffects", () => {
   it("caps damage flurry projectile count for huge combat batches", () => {
@@ -59,5 +63,19 @@ describe("particleEffects", () => {
 
     expect(lastProjectile.startTime + lastProjectile.duration).toBe(impactEffect.startTime);
     expect(impactEffect.startTime).toBe(projectileEffects[0].startTime + impactDelay);
+  });
+
+  describe("hexToRgb", () => {
+    it("expands CSS shorthand hex without producing a NaN channel", () => {
+      // #fff must expand to #ffffff; otherwise substring(4,6) is "" and the
+      // blue channel is parseInt("", 16) === NaN.
+      expect(hexToRgb("#fff")).toEqual({ r: 255, g: 255, b: 255 });
+      expect(hexToRgb("#f00")).toEqual({ r: 255, g: 0, b: 0 });
+    });
+
+    it("parses full 6-digit hex", () => {
+      expect(hexToRgb("#ff8000")).toEqual({ r: 255, g: 128, b: 0 });
+      expect(hexToRgb("3498db")).toEqual({ r: 52, g: 152, b: 219 });
+    });
   });
 });

--- a/client/src/components/animation/particleEffects.ts
+++ b/client/src/components/animation/particleEffects.ts
@@ -44,7 +44,13 @@ export function lerpColor(a: RGB, b: RGB, t: number): RGB {
 }
 
 export function hexToRgb(hex: string): RGB {
-  const h = hex.replace("#", "");
+  let h = hex.replace("#", "");
+  // Expand CSS shorthand hex (#fff -> #ffffff). Without this, `substring(4, 6)`
+  // is "" for a 3-digit value and `parseInt("", 16)` is NaN, so the blue channel
+  // comes back NaN and the color renders as `rgb(255, 255, NaN)` (nothing).
+  if (h.length === 3) {
+    h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  }
   return {
     r: parseInt(h.substring(0, 2), 16),
     g: parseInt(h.substring(2, 4), 16),


### PR DESCRIPTION
## Problem

`hexToRgb` (`client/src/components/animation/particleEffects.ts`) parses a hex color at fixed offsets:

```
r: parseInt(h.substring(0, 2), 16),
g: parseInt(h.substring(2, 4), 16),
b: parseInt(h.substring(4, 6), 16),
```

For a CSS-legal 3-digit shorthand like `#fff`, `substring(4, 6)` is `""` and `parseInt("", 16)` is `NaN`. The function returns `{ r: 255, g: 255, b: NaN }`, which serializes to `rgb(255, 255, NaN)` — an invalid color that renders nothing. The pure-function contract (`string -> RGB`) is broken for a whole class of valid inputs.

## Fix

Expand shorthand to the 6-digit form (`#fff -> #ffffff`) before slicing.

## Tests

Adds a `hexToRgb` block to the existing `particleEffects` suite: `#fff`/`#f00` must expand with no `NaN` channel (fails before the fix — blue is `NaN`), and full 6-digit inputs still parse correctly.

Self-contained: only `particleEffects.ts` + its test; no engine/Rust/protocol changes.

Model: claude-opus-4-8
