### PR TITLE
fix(client): fall back to defaults when preset storage is corrupt

### DIFF
--- a/client/src/services/__tests__/presets.test.ts
+++ b/client/src/services/__tests__/presets.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { deletePreset, loadPresets, savePreset } from "../presets";
+
+const STORAGE_KEY = "phase-game-presets";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("loadPresets", () => {
+  it("returns the defaults when storage is empty", () => {
+    const presets = loadPresets();
+    expect(presets.length).toBeGreaterThan(0);
+    expect(presets.some((p) => p.id.startsWith("default-"))).toBe(true);
+  });
+
+  it("falls back to the defaults on corrupt storage instead of throwing", () => {
+    localStorage.setItem(STORAGE_KEY, "{oops");
+    expect(() => loadPresets()).not.toThrow();
+    expect(loadPresets()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: expect.stringMatching(/^default-/) }),
+      ]),
+    );
+  });
+
+  it("does not let corrupt storage crash savePreset/deletePreset", () => {
+    localStorage.setItem(STORAGE_KEY, "not json");
+    expect(() =>
+      savePreset({
+        id: "custom-1",
+        name: "My Preset",
+        format: "Standard",
+        formatConfig: {},
+        deckId: null,
+        aiDifficulty: "Medium",
+        playerCount: 2,
+      }),
+    ).not.toThrow();
+    expect(() => deletePreset("custom-1")).not.toThrow();
+  });
+
+  it("returns saved presets when storage holds a valid non-empty array", () => {
+    savePreset({
+      id: "custom-2",
+      name: "Saved",
+      format: "Commander",
+      formatConfig: {},
+      deckId: null,
+      aiDifficulty: "Hard",
+      playerCount: 4,
+    });
+    const presets = loadPresets();
+    expect(presets.some((p) => p.id === "custom-2")).toBe(true);
+  });
+});

--- a/client/src/services/presets.ts
+++ b/client/src/services/presets.ts
@@ -36,8 +36,16 @@ const DEFAULT_PRESETS: GamePreset[] = [
 export function loadPresets(): GamePreset[] {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) return DEFAULT_PRESETS;
-  const saved = JSON.parse(raw) as GamePreset[];
-  return saved.length > 0 ? saved : DEFAULT_PRESETS;
+  // Corrupt/partial storage must not throw — every sibling loader falls back to
+  // a default. Without this guard, a malformed value crashes loadPresets and,
+  // through it, savePreset/deletePreset (both call it first), taking down the
+  // game-setup preset UI.
+  try {
+    const saved = JSON.parse(raw) as GamePreset[];
+    return saved.length > 0 ? saved : DEFAULT_PRESETS;
+  } catch {
+    return DEFAULT_PRESETS;
+  }
 }
 
 export function savePreset(preset: GamePreset): void {


### PR DESCRIPTION
## Problem

`loadPresets` (`client/src/services/presets.ts`) is the only localStorage loader in the module that calls `JSON.parse` without a try/catch:

```
const saved = JSON.parse(raw) as GamePreset[];
return saved.length > 0 ? saved : DEFAULT_PRESETS;
```

Every sibling loader (`loadActiveGame`, `loadWsSession`, `loadActiveQuickDraft`, …) wraps the parse and returns a fallback. So a corrupt/partial `phase-game-presets` value (e.g. a write interrupted mid-flush, or an older schema) throws a `SyntaxError`. And because `savePreset` and `deletePreset` both call `loadPresets()` first, **all three** throw — the game-setup preset UI crashes rather than recovering.

## Fix

Wrap the parse in try/catch and fall back to `DEFAULT_PRESETS`, matching the other loaders.

## Tests

Adds `presets.test.ts`: corrupt storage (`"{oops"`) makes `loadPresets` / `savePreset` / `deletePreset` throw before the fix and return/no-throw after; empty storage yields the defaults; valid storage round-trips a saved preset.

Self-contained: only `presets.ts` + a new test; no engine/Rust/protocol changes.

Model: claude-opus-4-8
