### PR TITLE
fix(client): include deckFolders in the backup digest and diff

### DIFF
--- a/client/src/services/cloudSync/__tests__/backupDiff.test.ts
+++ b/client/src/services/cloudSync/__tests__/backupDiff.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import type { PhaseBackup } from "../../backup";
+import { computeBackupDigest, summarizeBackupDiff } from "../backupDiff";
+
+function makeBackup(over: Partial<PhaseBackup> = {}): PhaseBackup {
+  return {
+    version: 1,
+    exportedAt: "2024-01-01T00:00:00.000Z",
+    preferences: null,
+    decks: {},
+    deckMetadata: null,
+    deckFolders: null,
+    activeDeck: null,
+    feedSubscriptions: null,
+    feedDeckOrigins: null,
+    ...over,
+  };
+}
+
+describe("computeBackupDigest", () => {
+  it("ignores the volatile exportedAt timestamp", async () => {
+    const a = makeBackup({ exportedAt: "2024-01-01T00:00:00.000Z" });
+    const b = makeBackup({ exportedAt: "2025-06-06T12:00:00.000Z" });
+    expect(await computeBackupDigest(a)).toBe(await computeBackupDigest(b));
+  });
+
+  it("changes when deckFolders changes", async () => {
+    const a = makeBackup({ deckFolders: '["A"]' });
+    const b = makeBackup({ deckFolders: '["A","B"]' });
+    expect(await computeBackupDigest(a)).not.toBe(await computeBackupDigest(b));
+  });
+
+  it("treats an omitted deckFolders the same as null", async () => {
+    const withNull = makeBackup({ deckFolders: null });
+    const omitted = makeBackup();
+    delete (omitted as { deckFolders?: string | null }).deckFolders;
+    expect(await computeBackupDigest(withNull)).toBe(
+      await computeBackupDigest(omitted),
+    );
+  });
+});
+
+describe("summarizeBackupDiff", () => {
+  it("flags a deckFolders-only change via otherChanged", () => {
+    const local = makeBackup({ deckFolders: '["A"]' });
+    const remote = makeBackup({ deckFolders: '["A","B"]' });
+    expect(summarizeBackupDiff(local, remote).otherChanged).toBe(true);
+  });
+
+  it("reports no otherChanged when folders match", () => {
+    const local = makeBackup({ deckFolders: '["A"]' });
+    const remote = makeBackup({ deckFolders: '["A"]' });
+    expect(summarizeBackupDiff(local, remote).otherChanged).toBe(false);
+  });
+});

--- a/client/src/services/cloudSync/backupDiff.ts
+++ b/client/src/services/cloudSync/backupDiff.ts
@@ -25,6 +25,12 @@ function canonicalPayload(b: PhaseBackup): string {
     preferences: b.preferences,
     decks: sortedDecks,
     deckMetadata: b.deckMetadata,
+    // `deckFolders` is a persisted payload field (`buildBackup` always writes
+    // it; `applyBackup` restores it). Omitting it from the digest made a
+    // folder reorganization hash-equal to the old state, so the reconciler
+    // suppressed the "conflict" and the change never propagated. `?? null`
+    // keeps pre-folders backups (which omit the field) digest-stable.
+    deckFolders: b.deckFolders ?? null,
     activeDeck: b.activeDeck,
     feedSubscriptions: b.feedSubscriptions,
     feedDeckOrigins: b.feedDeckOrigins,
@@ -82,6 +88,7 @@ export function summarizeBackupDiff(
     feedsChanged: local.feedSubscriptions !== remote.feedSubscriptions,
     otherChanged:
       local.deckMetadata !== remote.deckMetadata ||
+      (local.deckFolders ?? null) !== (remote.deckFolders ?? null) ||
       local.activeDeck !== remote.activeDeck ||
       local.feedDeckOrigins !== remote.feedDeckOrigins,
   };


### PR DESCRIPTION
## Problem

`canonicalPayload` (`client/src/services/cloudSync/backupDiff.ts`) is the basis for `computeBackupDigest`, which the sync reconciler uses to decide whether two backups are equal. Its doc says it "hashes everything except the volatile `exportedAt` timestamp" — but it never reads `deckFolders`.

`deckFolders` is a real persisted payload field: `buildBackup` always writes it (`deckFolders: localStorage.getItem(DECK_FOLDERS_KEY)`) and `applyBackup` restores it; the interface even documents it as "always present on write." Because the digest omitted it, two backups differing **only** in `deckFolders` (a folder rename/reorder) produced the same hash, so the reconciler treated them as identical and the folder change never propagated. `summarizeBackupDiff.otherChanged` had the same omission, so even a forced diff wouldn't surface it.

## Fix

Add `deckFolders: b.deckFolders ?? null` to `canonicalPayload`, and `(local.deckFolders ?? null) !== (remote.deckFolders ?? null)` to `otherChanged`. The `?? null` normalization keeps pre-folders backups (which omit the field) digest-stable.

## Tests

Adds `backupDiff.test.ts`: a `deckFolders`-only difference now changes the digest and sets `otherChanged` (both fail before the fix); `exportedAt` is still ignored; and an omitted `deckFolders` hashes identically to an explicit `null`.

Self-contained: only `backupDiff.ts` + a new test; no engine/Rust/protocol changes.

Model: claude-opus-4-8
