### PR TITLE
fix(client): enforce colorless color identity for colorless commanders

### DIFF
--- a/client/src/components/deck-builder/__tests__/commanderUtils.test.ts
+++ b/client/src/components/deck-builder/__tests__/commanderUtils.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import type { ScryfallCard } from "../../../services/scryfall";
+import { getColorIdentityViolations } from "../commanderUtils";
+
+function card(colorIdentity: string[]): ScryfallCard {
+  return { color_identity: colorIdentity } as ScryfallCard;
+}
+
+describe("getColorIdentityViolations", () => {
+  it("flags off-color cards for a genuinely colorless commander (CR 903.5c)", () => {
+    const cache = new Map<string, ScryfallCard>([
+      ["Kozilek, Butcher of Truth", card([])],
+      ["Lightning Bolt", card(["R"])],
+      ["Wastes", card([])],
+    ]);
+    const deck = [
+      { name: "Lightning Bolt", count: 1 },
+      { name: "Wastes", count: 1 },
+    ];
+
+    const violations = getColorIdentityViolations(
+      deck,
+      ["Kozilek, Butcher of Truth"],
+      cache,
+    );
+
+    expect(violations).toEqual(["Lightning Bolt"]);
+  });
+
+  it("does not flag on-identity cards for a colored commander", () => {
+    const cache = new Map<string, ScryfallCard>([
+      ["Krenko, Mob Boss", card(["R"])],
+      ["Lightning Bolt", card(["R"])],
+      ["Counterspell", card(["U"])],
+    ]);
+    const deck = [
+      { name: "Lightning Bolt", count: 1 },
+      { name: "Counterspell", count: 1 },
+    ];
+
+    expect(
+      getColorIdentityViolations(deck, ["Krenko, Mob Boss"], cache),
+    ).toEqual(["Counterspell"]);
+  });
+
+  it("returns no violations while commander data is still loading", () => {
+    // Commander not in cache — an empty identity must NOT flag every colored card.
+    const cache = new Map<string, ScryfallCard>([
+      ["Lightning Bolt", card(["R"])],
+    ]);
+    const deck = [{ name: "Lightning Bolt", count: 1 }];
+
+    expect(
+      getColorIdentityViolations(deck, ["Kozilek, Butcher of Truth"], cache),
+    ).toEqual([]);
+  });
+});

--- a/client/src/components/deck-builder/commanderUtils.ts
+++ b/client/src/components/deck-builder/commanderUtils.ts
@@ -25,7 +25,11 @@ export function getCombinedColorIdentity(
 }
 
 function isInColorIdentity(card: ScryfallCard, identity: string[]): boolean {
-  if (identity.length === 0) return true;
+  // A card is legal iff every color in its identity is within the commander's.
+  // For a colorless commander (`identity` empty), only colorless cards pass —
+  // `[].every(...)` is `true`, a colored card's `.every(...)` is `false` — which
+  // is exactly CR 903.5c. (Callers must only invoke this once commander data is
+  // loaded; an empty identity from a cache miss would otherwise flag everything.)
   const identitySet = new Set(identity);
   return card.color_identity.every((c) => identitySet.has(c));
 }
@@ -36,6 +40,9 @@ export function getColorIdentityViolations(
   cardDataCache: Map<string, ScryfallCard>,
 ): string[] {
   if (commanders.length === 0) return [];
+  // Don't compute violations until every commander's data has loaded — a cache
+  // miss yields an empty identity that would wrongly flag every colored card.
+  if (!commanders.every((name) => cardDataCache.has(name))) return [];
   const identity = getCombinedColorIdentity(commanders, cardDataCache);
   const violations: string[] = [];
   for (const entry of deck) {


### PR DESCRIPTION
## Problem

`isInColorIdentity` (`client/src/components/deck-builder/commanderUtils.ts`) began with `if (identity.length === 0) return true;`. For a **genuinely colorless** commander (e.g. Kozilek, Butcher of Truth — color identity `[]`), the combined identity is empty, so every card was treated as legal. A red card like Lightning Bolt passed the color-identity check, but CR 903.5c permits only colorless cards in a colorless commander's deck.

The subtlety (and why a naive fix is wrong): that same empty-identity short-circuit also absorbed the "commander card data hasn't loaded yet" case — a cache miss yields an empty identity too. Dropping the short-circuit outright would flag **every** colored card in the deck during the async card-data load window (false positives on a fresh open).

## Fix

- Remove the `identity.length === 0 -> true` short-circuit from `isInColorIdentity`; `card.color_identity.every(c => set.has(c))` already does the right thing — `[].every()` is `true` (colorless card legal), a colored card is `false` (violation).
- Move the loading guard to `getColorIdentityViolations`: return `[]` until **every** commander's data is cached, so a cache miss can't masquerade as "colorless commander."

Behavior for colored commanders and for the loading window is unchanged; only the genuinely-colorless-commander case is corrected.

## Tests

Adds `commanderUtils.test.ts`: a colorless commander (Kozilek) now flags an off-color card and allows a colorless one (fails before the fix — no violation reported); a colored commander still flags only off-color cards; and an unloaded commander yields no violations (no false positives mid-load).

Self-contained: only `commanderUtils.ts` + a new test; no engine/Rust/protocol changes.

Model: claude-opus-4-8
