### PR TITLE
fix(client): include sideboard in the bracket-estimate cache key

### DIFF
--- a/client/src/hooks/__tests__/bracketDeckKey.test.ts
+++ b/client/src/hooks/__tests__/bracketDeckKey.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBracketDeckKey } from "../bracketDeckKey";
+
+const deck = (
+  main: [string, number][],
+  sideboard: [string, number][] = [],
+) => ({
+  main: main.map(([name, count]) => ({ name, count })),
+  sideboard: sideboard.map(([name, count]) => ({ name, count })),
+});
+
+describe("buildBracketDeckKey", () => {
+  it("changes when only the sideboard differs", () => {
+    const commanders = ["Krenko, Mob Boss"];
+    const a = buildBracketDeckKey(commanders, deck([["Lightning Bolt", 1]], [["Pyroblast", 1]]));
+    const b = buildBracketDeckKey(commanders, deck([["Lightning Bolt", 1]], [["Pyroblast", 2]]));
+    expect(a).not.toBe(b);
+  });
+
+  it("is stable for identical decks", () => {
+    const commanders = ["Krenko, Mob Boss"];
+    const a = buildBracketDeckKey(commanders, deck([["Lightning Bolt", 1]], [["Pyroblast", 1]]));
+    const b = buildBracketDeckKey(commanders, deck([["Lightning Bolt", 1]], [["Pyroblast", 1]]));
+    expect(a).toBe(b);
+  });
+
+  it("is order-independent within main and sideboard", () => {
+    const commanders = ["Krenko, Mob Boss"];
+    const a = buildBracketDeckKey(
+      commanders,
+      deck(
+        [["Lightning Bolt", 1], ["Shock", 2]],
+        [["Pyroblast", 1], ["Red Elemental Blast", 1]],
+      ),
+    );
+    const b = buildBracketDeckKey(
+      commanders,
+      deck(
+        [["Shock", 2], ["Lightning Bolt", 1]],
+        [["Red Elemental Blast", 1], ["Pyroblast", 1]],
+      ),
+    );
+    expect(a).toBe(b);
+  });
+
+  it("changes when the main deck differs", () => {
+    const commanders = ["Krenko, Mob Boss"];
+    const a = buildBracketDeckKey(commanders, deck([["Lightning Bolt", 1]]));
+    const b = buildBracketDeckKey(commanders, deck([["Lightning Bolt", 2]]));
+    expect(a).not.toBe(b);
+  });
+
+  it("distinguishes a main-deck card from a sideboard card of the same name", () => {
+    const commanders = ["Krenko, Mob Boss"];
+    const a = buildBracketDeckKey(commanders, deck([["Pyroblast", 1]], []));
+    const b = buildBracketDeckKey(commanders, deck([], [["Pyroblast", 1]]));
+    expect(a).not.toBe(b);
+  });
+});

--- a/client/src/hooks/bracketDeckKey.ts
+++ b/client/src/hooks/bracketDeckKey.ts
@@ -1,0 +1,27 @@
+/** Minimal deck shape the bracket-estimate key depends on. */
+export interface BracketKeyEntry {
+  name: string;
+  count: number;
+}
+export interface BracketKeyDeck {
+  main: BracketKeyEntry[];
+  sideboard: BracketKeyEntry[];
+}
+
+/**
+ * Content key for a bracket-estimate request. Two decks produce the same key
+ * iff they would produce the same estimate, so the hook can cache/short-circuit
+ * on it. It must therefore cover **everything** the estimate depends on —
+ * commanders, main, AND sideboard (the request sends the sideboard too). The
+ * parts are sorted so object-identity / ordering churn does not change the key.
+ */
+export function buildBracketDeckKey(
+  commanders: string[],
+  deck: BracketKeyDeck,
+): string {
+  const parts: string[] = [...commanders.map((c) => `c:${c.toLowerCase()}`)];
+  for (const e of deck.main) parts.push(`m:${e.count}x${e.name.toLowerCase()}`);
+  for (const e of deck.sideboard) parts.push(`s:${e.count}x${e.name.toLowerCase()}`);
+  parts.sort();
+  return parts.join("|");
+}

--- a/client/src/hooks/useBracketEstimate.ts
+++ b/client/src/hooks/useBracketEstimate.ts
@@ -5,6 +5,7 @@ import type { EngineAdapter, GameFormat } from "../adapter/types";
 import type { BracketEstimate } from "../types/bracket";
 import { isCommanderFamilyFormat } from "../types/bracket";
 import type { ParsedDeck } from "../services/deckParser";
+import { buildBracketDeckKey } from "./bracketDeckKey";
 
 const DEBOUNCE_MS = 200;
 
@@ -86,13 +87,7 @@ export function useBracketEstimate({
 
   const eligible = isCommanderFamilyFormat(format) && commanders.length > 0;
 
-  const deckKey = (() => {
-    if (!eligible) return null;
-    const parts: string[] = [...commanders.map((c) => `c:${c.toLowerCase()}`)];
-    for (const e of deck.main) parts.push(`m:${e.count}x${e.name.toLowerCase()}`);
-    parts.sort();
-    return parts.join("|");
-  })();
+  const deckKey = eligible ? buildBracketDeckKey(commanders, deck) : null;
 
   useEffect(() => {
     if (!eligible || !deckKey) {


### PR DESCRIPTION
## Problem

`useBracketEstimate` (`client/src/hooks/useBracketEstimate.ts`) derives a `deckKey` used both as the effect's short-circuit guard (`if (deckKey === storedKeyRef.current) return;`) and as the module cache key. But it was built from **commanders + `deck.main` only**:

```
const parts = [...commanders.map(...)];
for (const e of deck.main) parts.push(`m:${e.count}x${e.name...}`);
```

The estimate request itself, however, sends the sideboard too:

```
sideboard: deck.sideboard.flatMap((e) => Array(e.count).fill(e.name)),
```

So two decks identical in commanders + main but differing only in `sideboard` produced the **same** `deckKey`. The effect short-circuits and the cache returns the previous deck's estimate — a sideboard edit silently shows a stale bracket. The effect's own dependency comment even claimed sideboard "content is fully captured by `deckKey`", which was false.

## Fix

Extract the key into a pure, unit-tested `buildBracketDeckKey` (`client/src/hooks/bracketDeckKey.ts`) that folds in the sideboard as well (`s:` parts). This makes the dependency comment true and keeps the sorted, order-independent behavior. Extraction is what lets the key be tested without standing up the debounced async hook.

## Tests

Adds `bracketDeckKey.test.ts`: a sideboard-only difference now changes the key (fails before the fix — keys are equal); identical decks stay equal; ordering within main/sideboard doesn't matter; a main-deck change and a same-name main-vs-sideboard placement both change the key.

Self-contained: only `useBracketEstimate.ts`, a new pure helper, and its test; no engine/Rust/protocol changes.

Model: claude-opus-4-8
