### PR TITLE
fix(client): accept lowercase set codes in MTGA deck lines

### DIFF
--- a/client/src/services/__tests__/deckParser.test.ts
+++ b/client/src/services/__tests__/deckParser.test.ts
@@ -52,6 +52,34 @@ Deck
     ]);
   });
 
+  it('parses MTGA printing lines with a lowercase (Scryfall-style) set code', () => {
+    // Several exporters emit lowercase set codes. The set/number must be parsed
+    // out as a sourcePrinting, not swallowed into the card name.
+    const result = detectAndParseDeck('1 Lightning Bolt (2xm) 123');
+
+    expect(result.main).toEqual([
+      {
+        count: 1,
+        name: 'Lightning Bolt',
+        sourcePrinting: { setCode: '2xm', collectorNumber: '123' },
+      },
+    ]);
+  });
+
+  it('parses lowercase and uppercase set codes to the same result', () => {
+    const lower = detectAndParseDeck('2 Counterspell (mh2) 267').main;
+    const upper = detectAndParseDeck('2 Counterspell (MH2) 267').main;
+
+    expect(lower).toEqual(upper);
+    expect(lower).toEqual([
+      {
+        count: 2,
+        name: 'Counterspell',
+        sourcePrinting: { setCode: 'mh2', collectorNumber: '267' },
+      },
+    ]);
+  });
+
   it('parses [Main] and [Sideboard] sections', () => {
     const content = `[Main]
 4 Lightning Bolt

--- a/client/src/services/deckParser.ts
+++ b/client/src/services/deckParser.ts
@@ -142,7 +142,11 @@ function parseDeckEntryLine(line: string): LineParseResult | null {
   // trailing-group allowance in MTGA_LINE_PATTERN so a detected MTGA line is
   // never demoted to the simple matcher (which would swallow the set/number
   // into the card name).
-  const mtgaMatch = remainder.match(/^(\d+)x?\s+(.+?)\s+\(([A-Z0-9]*)\)\s+(\S+)(?:\s+.*)?$/);
+  // The set code may be lowercase (Scryfall-style, e.g. `(2xm) 123`); several
+  // exporters emit it that way. `setCode.toLowerCase()` below already normalizes
+  // case, so widening the char class only keeps the line from being demoted to
+  // the simple matcher (which would swallow the set/number into the card name).
+  const mtgaMatch = remainder.match(/^(\d+)x?\s+(.+?)\s+\(([A-Za-z0-9]*)\)\s+(\S+)(?:\s+.*)?$/);
   if (mtgaMatch) {
     const setCode = mtgaMatch[3];
     const collectorNumber = mtgaMatch[4];
@@ -439,7 +443,7 @@ export function parseDeckFile(content: string): ParsedDeck {
 
 // MTGA format detection: count + name + (set) + collector#, with optional
 // trailing Archidekt category annotation (e.g. "[Commander {top}]").
-const MTGA_LINE_PATTERN = /^\d+x?\s+.+\s+\([A-Z0-9]*\)\s+\S+(\s+\S.*)?$/;
+const MTGA_LINE_PATTERN = /^\d+x?\s+.+\s+\([A-Za-z0-9]*\)\s+\S+(\s+\S.*)?$/;
 
 /**
  * Parse an MTGA text format deck.


### PR DESCRIPTION
## Problem

`parseDeckEntryLine` matches MTGA-style printing lines (`<count> <name> (<set>) <collector#>`) with:

```
/^(\d+)x?\s+(.+?)\s+\(([A-Z0-9]*)\)\s+(\S+)(?:\s+.*)?$/
```

The set-code group is `[A-Z0-9]*` — **uppercase only**. `MTGA_LINE_PATTERN` (used for format detection) has the same restriction. A decklist line whose set code is lowercase (Scryfall-style — e.g. `2xm`, `mh2`, `m21`, `fdn`, which several exporters emit) fails the MTGA match, falls through to the simple `(\d+)x?\s+(.+)` matcher, and the set code + collector number get **swallowed into the card name**:

```
"1 Lightning Bolt (2xm) 123"  ->  { count: 1, name: "Lightning Bolt (2xm) 123" }   // no sourcePrinting; name won't resolve
```

## Fix

Widen the set-code class to `[A-Za-z0-9]*` in both the parse regex and `MTGA_LINE_PATTERN`. `setCode.toLowerCase()` already normalizes case downstream, so a lowercase code yields exactly the same `sourcePrinting` an uppercase one would. Card names never contain a parenthesized `(...) <token>` run, so widening the class can't misclassify a real name line.

## Tests

Adds two cases to the existing `deckParser` suite: a lowercase set code (`(2xm) 123`) now parses to `{ name: "Lightning Bolt", sourcePrinting: { setCode: "2xm", collectorNumber: "123" } }` (fails before — the name is garbled and there's no printing), and lowercase vs uppercase set codes produce identical results. The full existing 73-test suite still passes.

Self-contained: only `deckParser.ts` + its test; no engine/Rust/protocol changes.

Model: claude-opus-4-8
