### PR TITLE
fix(engine): make the "before attackers declared" window phase-based (CR 508.1/508.2)

### DIFF
--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1770,13 +1770,17 @@ pub(crate) fn is_sorcery_speed_window(
 }
 
 fn is_before_attackers_declared(state: &crate::types::game_state::GameState) -> bool {
-    // CR 723: compare the active player against the semantic priority *seat*, not
-    // `priority_player` (the authorized submitter). Under turn-control these
-    // diverge, so the raw field would never equal `active_player` during a
-    // controlled turn and wrongly close this window. Behavior is identical
-    // without turn-control, where the seat and submitter are the same player.
-    super::turn_control::priority_seat(state) == state.active_player
-        && matches!(state.phase, Phase::PreCombatMain | Phase::BeginCombat)
+    // CR 508.1 + CR 508.2: attackers are declared as the first turn-based action
+    // of the declare-attackers step, BEFORE any player receives priority. So
+    // "before attackers are declared" is a pure PHASE property — we are strictly
+    // before that step — independent of which player currently holds priority.
+    // This is deliberately not priority-gated: a non-active player casting an
+    // instant during the active player's pre-combat (Siren's Call, Master
+    // Warcraft) is correctly inside the window, and turn-control (CR 723) can't
+    // affect a check that never reads priority. Turn-qualified cards (the
+    // `DuringYourTurn` activations) remain pinned to the active player by their
+    // own restriction, which is AND-composed with this one.
+    matches!(state.phase, Phase::PreCombatMain | Phase::BeginCombat)
 }
 
 fn is_before_combat_damage(phase: Phase) -> bool {
@@ -3870,5 +3874,103 @@ mod tests {
         // proving the assertion above is not vacuous.
         assert!(place_blocking(&mut state, blocker, normally_blocked));
         assert!(is_source_blocked(&state, normally_blocked));
+    }
+
+    // CR 508.1 + CR 508.2: "before attackers are declared" is a phase property,
+    // independent of which player holds priority — so a NON-active player casting
+    // an instant during the active player's pre-combat (Master Warcraft, Siren's
+    // Call) is inside the window. Fails on revert of the phase-only fix (the old
+    // `priority_seat == active_player` clause rejected the non-active seat).
+    #[test]
+    fn before_attackers_window_admits_non_active_caster() {
+        let mut state = crate::types::game_state::GameState::new_two_player(42);
+        let active = PlayerId(0);
+        let non_active = PlayerId(1);
+        let src = ObjectId(10);
+        let restr = [CastingRestriction::BeforeAttackersDeclared];
+
+        for phase in [Phase::PreCombatMain, Phase::BeginCombat] {
+            state.active_player = active;
+            state.phase = phase;
+            // The non-active player holds priority to cast the instant — exactly
+            // the state the old priority_seat clause wrongly rejected.
+            state.priority_player = non_active;
+            state.waiting_for = WaitingFor::Priority { player: non_active };
+
+            assert!(
+                check_casting_restrictions(&state, non_active, src, &restr).is_ok(),
+                "non-active player must be inside the before-attackers window in {phase:?}"
+            );
+            // Reach-guard: the active player is also inside the window, so the
+            // assertion above is not vacuously true.
+            assert!(
+                check_casting_restrictions(&state, active, src, &restr).is_ok(),
+                "active player must also be inside the window in {phase:?}"
+            );
+        }
+    }
+
+    // CR 508.1/508.2: the window is strictly before the declare-attackers step;
+    // it must be closed once attackers are (or could have been) declared.
+    #[test]
+    fn before_attackers_window_closes_at_and_after_declaration() {
+        let mut state = crate::types::game_state::GameState::new_two_player(42);
+        let p = PlayerId(0);
+        let src = ObjectId(10);
+        let restr = [CastingRestriction::BeforeAttackersDeclared];
+        state.active_player = p;
+        state.priority_player = p;
+        state.waiting_for = WaitingFor::Priority { player: p };
+
+        for phase in [
+            Phase::DeclareAttackers,
+            Phase::DeclareBlockers,
+            Phase::PostCombatMain,
+        ] {
+            state.phase = phase;
+            assert!(
+                check_casting_restrictions(&state, p, src, &restr).is_err(),
+                "the window must be closed in {phase:?} (attackers already declared)"
+            );
+        }
+        // Reach-guard: open before declaration.
+        state.phase = Phase::BeginCombat;
+        assert!(check_casting_restrictions(&state, p, src, &restr).is_ok());
+    }
+
+    // Non-regression: `[DuringYourTurn, BeforeAttackersDeclared]` cards (King's
+    // Assassin and the Portal Three Kingdoms tap-ability cycle) must stay pinned
+    // to the active player. Widening the before-attackers window to phase-only
+    // must NOT let a non-active player activate them — DuringYourTurn (AND-composed)
+    // still gates, across the whole widened window (both PreCombatMain and BeginCombat).
+    #[test]
+    fn during_your_turn_before_attackers_stays_active_player_gated() {
+        let mut state = crate::types::game_state::GameState::new_two_player(42);
+        let controller = PlayerId(0);
+        let opponent = PlayerId(1);
+        let src = ObjectId(10);
+        let restr = [
+            ActivationRestriction::DuringYourTurn,
+            ActivationRestriction::BeforeAttackersDeclared,
+        ];
+
+        for phase in [Phase::PreCombatMain, Phase::BeginCombat] {
+            // Controller's OWN turn: legal.
+            state.active_player = controller;
+            state.phase = phase;
+            state.priority_player = controller;
+            state.waiting_for = WaitingFor::Priority { player: controller };
+            assert!(
+                check_activation_restrictions(&state, controller, src, 0, &restr).is_ok(),
+                "own turn {phase:?} must be legal"
+            );
+            // Opponent's turn: illegal (DuringYourTurn fails) — proves phase-only
+            // did not widen these cards to opponents' turns.
+            state.active_player = opponent;
+            assert!(
+                check_activation_restrictions(&state, controller, src, 0, &restr).is_err(),
+                "opponent's turn {phase:?} must be illegal (DuringYourTurn gate)"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

`is_before_attackers_declared` (the shared predicate behind the `BeforeAttackersDeclared` casting **and** activation restrictions) gated the window on `priority_seat(state) == state.active_player`. That clause is only ever satisfiable by the active player, so it wrongly closed the "before attackers are declared" window for **non-active** actors.

Per **CR 508.1** ("First, the active player declares attackers. This turn-based action doesn't use the stack") + **CR 508.2** ("Second, the active player gets priority"), attackers are declared as a turn-based action *before any player receives priority*. So "before attackers are declared" is a pure **phase** property — the `PreCombatMain | BeginCombat` run-up — independent of who currently holds priority. This PR drops the priority-seat clause and keeps the phase check.

### What was broken (and is now fixed)
- **Master Warcraft** — "Cast this spell only before attackers are declared." A non-active player could never cast it during another player's combat.
- **Siren's Call** — "…only during an opponent's turn, before attackers are declared." Its two casting restrictions were *mutually exclusive* under the old clause (`DuringOpponentsTurn` needs `active_player != caster`, but the window needed the caster's seat == active player) → **entirely uncastable front-door**.

### Why it's safe
26 of the 28 `BeforeAttackersDeclared` cards are `[DuringYourTurn, BeforeAttackersDeclared]` (Portal Three Kingdoms tap-ability cycle, King's Assassin, etc.). Restrictions are AND-composed, and `DuringYourTurn => active_player == player` independently pins those to the active player — so a phase-only window cannot widen them. The only two `BeforeAttackersDeclared`-without-`DuringYourTurn` cards (Master Warcraft, Siren's Call) are exactly the intended beneficiaries. No existing test exercises the old priority-gated behavior; turn-control (CR 723) can't affect a check that never reads priority.

## Anchored on
- crates/engine/src/game/restrictions.rs — `is_before_combat_damage` / `is_sorcery_speed_window`: sibling timing predicates that key on `state.phase` (phase-based window pattern).
- crates/engine/src/game/restrictions.rs — `ActivationRestriction::DuringYourTurn => state.active_player == player`: the AND-composed active-player gate that keeps the 26 turn-qualified cards pinned.

## Test Plan
Three runtime restriction-check tests drive the production entry points (`check_casting_restrictions` / `check_activation_restrictions`):
- `before_attackers_window_admits_non_active_caster` — a non-active player is inside the window in both PreCombatMain and BeginCombat (with an active-player reach-guard). **Fail-on-revert measured:** restoring the priority-seat clause makes only this test fail.
- `before_attackers_window_closes_at_and_after_declaration` — window closed at DeclareAttackers/DeclareBlockers/PostCombatMain, open at BeginCombat (reach-guard).
- `during_your_turn_before_attackers_stays_active_player_gated` — `[DuringYourTurn, BeforeAttackersDeclared]` stays legal on the controller's own turn / illegal on an opponent's turn, across both phases (non-regression).

## Verification (Non-developer track; Tilt down → direct cargo)
- `cargo test -p engine` — 196 test binaries, 0 failures
- CI-parity clippy (`--workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings`) — exit 0
- `cargo check -p engine-wasm --target wasm32-unknown-unknown` — exit 0
- `cargo fmt --all` — clean
- Gate A (`./scripts/check-parser-combinators.sh`) — exit 0 (no parser change)

Model: claude-opus-4-8
Thinking: high
Tier: Frontier
Track: Non-developer (card-data.json integration deferred to CI per docs/AI-CONTRIBUTOR.md §2)
