### PR TITLE
Add Wretched Banquet

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -7613,6 +7613,62 @@ mod tests {
         );
     }
 
+    /// CR 608.2c: Wretched Banquet's spell-target gate carries a redundant
+    /// "or is tied for least power" tail before "among <filter>". In the
+    /// spell-target superlative form the target is itself part of the aggregate
+    /// population, so the comparison is already non-strict (LE for "least") and
+    /// the tail adds nothing — it must be consumed, not swallowed. The trailing
+    /// "on the battlefield" zone qualifier is folded into the aggregate filter.
+    #[test]
+    fn strip_superlative_target_conditional_least_power_or_tied_for_least() {
+        use crate::types::ability::{AggregateFunction, ObjectProperty};
+
+        let (condition, body) = strip_superlative_target_conditional(
+            "Destroy target creature if it has the least power or is tied for least power among creatures on the battlefield.",
+        );
+        assert_eq!(body, "Destroy target creature");
+        let Some(AbilityCondition::QuantityCheck {
+            lhs,
+            comparator,
+            rhs,
+        }) = condition
+        else {
+            panic!("expected QuantityCheck, got {condition:?}");
+        };
+        // "least ... or is tied for least" stays a non-strict comparison.
+        assert_eq!(comparator, Comparator::LE);
+        assert_eq!(
+            lhs,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Power {
+                    scope: ObjectScope::Target,
+                }
+            }
+        );
+        let QuantityExpr::Ref {
+            qty:
+                QuantityRef::Aggregate {
+                    function,
+                    property,
+                    filter,
+                },
+        } = rhs
+        else {
+            panic!("expected Aggregate rhs, got {rhs:?}");
+        };
+        assert_eq!(function, AggregateFunction::Min);
+        assert_eq!(property, ObjectProperty::Power);
+        // The "on the battlefield" qualifier rides the aggregate population.
+        assert!(
+            matches!(&filter, TargetFilter::Typed(tf)
+            if tf.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::InZone { zone: Zone::Battlefield }
+            ))),
+            "aggregate filter should be creatures on the battlefield, got {filter:?}"
+        );
+    }
+
     #[test]
     fn strip_superlative_target_conditional_plural_subject() {
         use crate::types::ability::{AggregateFunction, ObjectProperty};

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -2389,6 +2389,17 @@ pub(crate) fn parse_spell_target_has_superlative(
     let (rest, aggregate) = parse_superlative_adjective(input)?;
     let (rest, _) = tag::<_, _, OracleError<'_>>(" ").parse(rest)?;
     let (rest, property) = parse_property_keyword(rest)?;
+    // CR 608.2c: consume an optional "or is tied for <same superlative> <same
+    // property>" tail (Wretched Banquet: "the least power or is tied for least
+    // power among creatures on the battlefield"). In this spell-target form the
+    // aggregate population INCLUDES the target itself, so the Min/Max comparison
+    // below already uses LE/GE (ties allowed) -- the tail is redundant text,
+    // discarded here so the shared "among <filter>" clause still parses. The
+    // trigger-anchored `parse_subject_has_superlative_form` instead READS this
+    // tail's comparator to relax its strict GT/LT, because it excludes the
+    // trigger object from the population. Agreement of the tail's superlative and
+    // property with the leading clause is enforced by the shared combinator.
+    let (rest, _) = parse_optional_tied_for_tail(rest, aggregate, property)?;
     let (rest, _) = tag::<_, _, OracleError<'_>>(" among ").parse(rest)?;
     let (filter, remainder) = parse_type_phrase(rest);
     if matches!(filter, TargetFilter::Any) {


### PR DESCRIPTION
Adds support for **Wretched Banquet** (`Destroy target creature if it has the least power or is tied for least power among creatures on the battlefield.`).

## The gap
The spell-target superlative gate (`parse_spell_target_has_superlative`) parsed `<superlative> <property>` and then expected ` among <filter>`. Wretched Banquet inserts a redundant `or is tied for least power` tail before ` among `, so parsing failed there and the card was unsupported.

## The fix
Reuse the existing `parse_optional_tied_for_tail` combinator (already used by the trigger-anchored superlative form) in the spell-target path. It consumes an optional `or is tied for <same superlative> <same property>` tail, **enforcing that the tail's superlative and property agree with the leading clause** (mismatched text errors out rather than being swallowed). In the spell-target form the target is part of the aggregate population, so the comparison is already non-strict (`LE` for "least") and the tail is purely redundant — it is consumed and discarded.

The change is **strictly additive**: without the tail, the combinator returns the input unchanged (identical to prior behaviour); with the tail, cards that previously failed at ` among ` now parse. It cannot regress any card.

## Verification
- New test `strip_superlative_target_conditional_least_power_or_tied_for_least` (CR 608.2c) — passes.
- Full engine lib suite: **15350 passed, 0 failed** (no regressions).
- `cargo fmt --check`, parser-combinator gate, and `clippy -D warnings` all clean.
- Coverage: `supported_cards` 31395 / 35397 (88.7%); Wretched Banquet now parses with populated abilities.
