### PR TITLE
feat(parser): turn-window CDA — leading timing condition + constant P/T form (Angry Mob)

### DIFF
--- a/crates/engine/src/parser/oracle_static/cda.rs
+++ b/crates/engine/src/parser/oracle_static/cda.rs
@@ -11,14 +11,68 @@ use super::support::*;
 ///   and its toughness is equal to that number plus 1."
 /// - "~'s toughness is equal to the number of cards in your hand."
 pub(crate) fn parse_cda_pt_equality(lower: &str, text: &str) -> Option<StaticDefinition> {
+    // CR 611.3 + CR 613.7c: peel a leading turn-window timing condition so a CDA
+    // scoped to "During your turn," / "During turns other than yours," carries
+    // that condition (Angry Mob), mirroring the base-P/T-set path. Such a card's
+    // two clauses are split into separate sentences upstream by
+    // `parse_multi_sentence_statics`, so each clause reaches here independently.
+    let (lower, text, timing_condition) =
+        if let Some(rest) = nom_tag_lower(lower, lower, "during your turn, ") {
+            (
+                rest,
+                &text[text.len() - rest.len()..],
+                Some(StaticCondition::DuringYourTurn),
+            )
+        } else if let Some(rest) = nom_tag_lower(lower, lower, "during turns other than yours, ") {
+            (
+                rest,
+                &text[text.len() - rest.len()..],
+                Some(StaticCondition::Not {
+                    condition: Box::new(StaticCondition::DuringYourTurn),
+                }),
+            )
+        } else {
+            (lower, text, None)
+        };
+
     // Detect framing
     let both = nom_primitives::scan_contains(lower, "power and toughness are each equal to");
     let power_only = !both && nom_primitives::scan_contains(lower, "power is equal to");
     let toughness_only =
         !both && !power_only && nom_primitives::scan_contains(lower, "toughness is equal to");
+    // CR 613.4c: constant characteristic-defining P/T — "~'s power and toughness
+    // are each N" (Angry Mob's off-turn clause "... are each 2"): a fixed base
+    // value, not a dynamic quantity. Guarded by `!both` so the dynamic "are each
+    // equal to" framing (which also contains "are each ") keeps priority.
+    let both_const = !both
+        && !power_only
+        && !toughness_only
+        && nom_primitives::scan_contains(lower, "power and toughness are each ");
 
-    if !both && !power_only && !toughness_only {
+    if !both && !power_only && !toughness_only && !both_const {
         return None;
+    }
+
+    if both_const {
+        let after = strip_after(lower, "power and toughness are each ")?;
+        let digits: String = after
+            .trim_start()
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
+        let value = digits.parse::<i32>().ok()?;
+        let mut def = StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![
+                ContinuousModification::SetPower { value },
+                ContinuousModification::SetToughness { value },
+            ])
+            .cda()
+            .description(text.to_string());
+        if let Some(cond) = timing_condition {
+            def = def.condition(cond);
+        }
+        return Some(def);
     }
 
     // Extract the quantity text after "equal to "
@@ -72,11 +126,13 @@ pub(crate) fn parse_cda_pt_equality(lower: &str, text: &str) -> Option<StaticDef
         modifications.push(ContinuousModification::SetDynamicToughness { value: qty });
     }
 
-    Some(
-        StaticDefinition::continuous()
-            .affected(TargetFilter::SelfRef)
-            .modifications(modifications)
-            .cda()
-            .description(text.to_string()),
-    )
+    let mut def = StaticDefinition::continuous()
+        .affected(TargetFilter::SelfRef)
+        .modifications(modifications)
+        .cda()
+        .description(text.to_string());
+    if let Some(cond) = timing_condition {
+        def = def.condition(cond);
+    }
+    Some(def)
 }

--- a/crates/engine/src/parser/oracle_static/cda.rs
+++ b/crates/engine/src/parser/oracle_static/cda.rs
@@ -11,39 +11,44 @@ use super::support::*;
 ///   and its toughness is equal to that number plus 1."
 /// - "~'s toughness is equal to the number of cards in your hand."
 pub(crate) fn parse_cda_pt_equality(lower: &str, text: &str) -> Option<StaticDefinition> {
-    // CR 611.3 + CR 613.7c: peel a leading turn-window timing condition so a CDA
+    // CR 611.3a + CR 604.3: peel a leading turn-window timing condition so a CDA
     // scoped to "During your turn," / "During turns other than yours," carries
-    // that condition (Angry Mob), mirroring the base-P/T-set path. Such a card's
-    // two clauses are split into separate sentences upstream by
-    // `parse_multi_sentence_statics`, so each clause reaches here independently.
-    let (lower, text, timing_condition) =
-        if let Some(rest) = nom_tag_lower(lower, lower, "during your turn, ") {
-            (
-                rest,
-                &text[text.len() - rest.len()..],
-                Some(StaticCondition::DuringYourTurn),
-            )
-        } else if let Some(rest) = nom_tag_lower(lower, lower, "during turns other than yours, ") {
-            (
-                rest,
-                &text[text.len() - rest.len()..],
-                Some(StaticCondition::Not {
-                    condition: Box::new(StaticCondition::DuringYourTurn),
-                }),
-            )
-        } else {
-            (lower, text, None)
-        };
+    // that condition (Angry Mob). A continuous effect from a static ability
+    // applies at any moment to whatever its text indicates (CR 611.3a), so the
+    // turn window becomes a `StaticCondition`. Such a card's two clauses are split
+    // into separate sentences upstream by `parse_multi_sentence_statics`, so each
+    // clause reaches here independently. `nom_tag_tp` slices the original and
+    // lowercased text in lockstep (no manual byte-offset arithmetic).
+    let tp = TextPair::new(text, lower);
+    let (lower, text, timing_condition) = if let Some(rest) = nom_tag_tp(&tp, "during your turn, ")
+    {
+        (
+            rest.lower,
+            rest.original,
+            Some(StaticCondition::DuringYourTurn),
+        )
+    } else if let Some(rest) = nom_tag_tp(&tp, "during turns other than yours, ") {
+        (
+            rest.lower,
+            rest.original,
+            Some(StaticCondition::Not {
+                condition: Box::new(StaticCondition::DuringYourTurn),
+            }),
+        )
+    } else {
+        (lower, text, None)
+    };
 
     // Detect framing
     let both = nom_primitives::scan_contains(lower, "power and toughness are each equal to");
     let power_only = !both && nom_primitives::scan_contains(lower, "power is equal to");
     let toughness_only =
         !both && !power_only && nom_primitives::scan_contains(lower, "toughness is equal to");
-    // CR 613.4c: constant characteristic-defining P/T — "~'s power and toughness
-    // are each N" (Angry Mob's off-turn clause "... are each 2"): a fixed base
-    // value, not a dynamic quantity. Guarded by `!both` so the dynamic "are each
-    // equal to" framing (which also contains "are each ") keeps priority.
+    // CR 604.3 + CR 613.4a (Layer 7a): constant characteristic-defining P/T —
+    // "~'s power and toughness are each N" (Angry Mob's off-turn clause "... are
+    // each 2") is a CDA that defines P/T as a fixed value, not a dynamic quantity.
+    // Guarded by `!both` so the dynamic "are each equal to" framing (which also
+    // contains "are each ") keeps priority.
     let both_const = !both
         && !power_only
         && !toughness_only

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -75,7 +75,7 @@ fn compound_subject_keyword_static_splits_serras_emissary() {
     );
 }
 
-// CR 611.3 + CR 613.4c/613.7c: Angry Mob — a two-clause turn-window CDA. "During
+// CR 611.3a + CR 604.3 + CR 613.4a: Angry Mob — a two-clause turn-window CDA. "During
 // your turn, ~'s power and toughness are each equal to 2 plus the number of
 // Swamps your opponents control. During turns other than yours, ~'s power and
 // toughness are each 2." Splits into two CDA statics: the on-turn clause is a

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -99,12 +99,33 @@ fn static_angry_mob_two_clause_turn_window_cda() {
         "on-turn clause must be a CDA"
     );
     assert_eq!(on_turn.condition, Some(StaticCondition::DuringYourTurn));
-    assert!(
-        on_turn
-            .modifications
-            .iter()
-            .any(|m| matches!(m, ContinuousModification::SetDynamicPower { .. })),
-        "on-turn clause must set dynamic power: {:?}",
+    // Prove the full quantity, not just that *some* dynamic power exists: both
+    // power AND toughness must be set to `2 + <opponent Swamp count>`. Asserting
+    // the entire modification vector by value means the test fails if the offset,
+    // the counted subtype, the controller scope, or the toughness clause regress.
+    let opponent_swamps = QuantityExpr::Ref {
+        qty: QuantityRef::ObjectCount {
+            filter: TargetFilter::Typed(
+                TypedFilter::new(TypeFilter::Subtype("Swamp".to_string()))
+                    .controller(ControllerRef::Opponent),
+            ),
+        },
+    };
+    let two_plus_opponent_swamps = QuantityExpr::Offset {
+        inner: Box::new(opponent_swamps),
+        offset: 2,
+    };
+    assert_eq!(
+        on_turn.modifications,
+        vec![
+            ContinuousModification::SetDynamicPower {
+                value: two_plus_opponent_swamps.clone(),
+            },
+            ContinuousModification::SetDynamicToughness {
+                value: two_plus_opponent_swamps,
+            },
+        ],
+        "on-turn CDA must set BOTH power and toughness to (2 + opponent Swamp count): {:?}",
         on_turn.modifications
     );
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -75,6 +75,63 @@ fn compound_subject_keyword_static_splits_serras_emissary() {
     );
 }
 
+// CR 611.3 + CR 613.4c/613.7c: Angry Mob — a two-clause turn-window CDA. "During
+// your turn, ~'s power and toughness are each equal to 2 plus the number of
+// Swamps your opponents control. During turns other than yours, ~'s power and
+// toughness are each 2." Splits into two CDA statics: the on-turn clause is a
+// dynamic P/T (2 + count) gated on DuringYourTurn; the off-turn clause is a
+// constant 2/2 gated on Not{DuringYourTurn}.
+#[test]
+fn static_angry_mob_two_clause_turn_window_cda() {
+    let defs = parse_static_line_multi(
+        "During your turn, Angry Mob's power and toughness are each equal to 2 plus the number of Swamps your opponents control. During turns other than yours, Angry Mob's power and toughness are each 2.",
+    );
+    assert_eq!(
+        defs.len(),
+        2,
+        "expected two turn-window CDA statics, got {defs:?}"
+    );
+
+    // On-turn: dynamic P/T (Offset over opponent Swamp count), gated DuringYourTurn.
+    let on_turn = &defs[0];
+    assert!(
+        on_turn.characteristic_defining,
+        "on-turn clause must be a CDA"
+    );
+    assert_eq!(on_turn.condition, Some(StaticCondition::DuringYourTurn));
+    assert!(
+        on_turn
+            .modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetDynamicPower { .. })),
+        "on-turn clause must set dynamic power: {:?}",
+        on_turn.modifications
+    );
+
+    // Off-turn: constant 2/2, gated Not{DuringYourTurn}.
+    let off_turn = &defs[1];
+    assert!(
+        off_turn.characteristic_defining,
+        "off-turn clause must be a CDA"
+    );
+    assert_eq!(
+        off_turn.condition,
+        Some(StaticCondition::Not {
+            condition: Box::new(StaticCondition::DuringYourTurn),
+        })
+    );
+    assert!(
+        off_turn
+            .modifications
+            .contains(&ContinuousModification::SetPower { value: 2 })
+            && off_turn
+                .modifications
+                .contains(&ContinuousModification::SetToughness { value: 2 }),
+        "off-turn clause must set constant 2/2: {:?}",
+        off_turn.modifications
+    );
+}
+
 #[test]
 fn static_ignore_hexproof_and_ward_suppression_pair() {
     // Nowhere to Run's static line: hexproof-bypass + ward-suppression. The


### PR DESCRIPTION
Angry Mob ("During your turn, ~'s power and toughness are each equal to 2 plus the number of Swamps your opponents control. During turns other than yours, ~'s power and toughness are each 2.") **dropped entirely** — the CDA-equality handler ignored a leading turn-window timing condition and had no `"are each N"` constant form, so the off-turn clause never parsed and the multi-sentence splitter (`parse_multi_sentence_statics`) failed its "every segment yields a static" guard.

Extends `parse_cda_pt_equality` (test-free `oracle_static/cda.rs`) with two additions:
1. **Peel a leading timing condition** — `"During your turn,"` → `StaticCondition::DuringYourTurn`, `"During turns other than yours,"` → `Not{DuringYourTurn}` (via `nom_tag_lower`, mirroring the base-P/T-set path). The CDA-equality form now carries the condition consistently with the base-P/T form.
2. **Constant CDA P/T** — `"~'s power and toughness are each N"` → `SetPower{N}` + `SetToughness{N}` (guarded by `!both` so the dynamic `"equal to"` framing keeps priority).

With both clauses parsing, the existing multi-sentence splitter emits the two turn-gated CDA statics automatically:
- on-turn → dynamic P/T `Offset{ObjectCount(Swamp, opponents), +2}`, gated `DuringYourTurn`
- off-turn → constant `2/2`, gated `Not{DuringYourTurn}`

**No new variant, no new runtime.** CR 611.3 + CR 613.4c + CR 613.7c.

Verified: new `static_angry_mob_two_clause_turn_window_cda` test (asserts both CDA statics, conditions, dynamic vs constant); full oracle_static suite **957/957** green (no CDA regressions); parser-combinator gate + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)