### PR TITLE
fix(parser): terminate card-name filter at a locative zone — "named X in your graveyard" count misparse (CR 201.2)

### DIFF
--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1714,6 +1714,31 @@ fn parse_named_filter_origin_zone_terminator(
     Ok((&input[consumed..], ()))
 }
 
+/// CR 201.2 + CR 400.1: A locative zone constraint ("in your graveyard", "in
+/// all graveyards", "on the battlefield") scopes *where the named objects are
+/// counted/filtered*; it is outside the literal card name. Unlike the
+/// "from <zone>" move-origin suffix (`parse_named_filter_origin_zone_terminator`,
+/// which the caller consumes as a move source and leaves in the remainder), an
+/// "in"/"on" locative both terminates the name and is re-attached as an
+/// `InZone`/`InAnyZone` filter prop by the caller. Requires a real zone after
+/// the "in"/"on" preposition so a name-internal "in"/"on" stays whole. Covers
+/// the "cards named X in your graveyard / in all graveyards" count class
+/// (Frantic Inventory, Accumulated Knowledge, Take Inventory, Undead Servant,
+/// Goblin Gathering, Galvanic Bombardment, Ancestral Anger) and "creatures
+/// named X on the battlefield" (Plague Rats).
+fn parse_named_filter_locative_zone_terminator(
+    input: &str,
+) -> Result<(&str, ()), nom::Err<OracleError<'_>>> {
+    alt((tag::<_, _, OracleError<'_>>(" in "), tag(" on "))).parse(input)?;
+    let Some((_, _, consumed)) = parse_zone_suffix(input) else {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    };
+    Ok((&input[consumed..], ()))
+}
+
 fn parse_named_filter_terminator(input: &str) -> Result<(&str, ()), nom::Err<OracleError<'_>>> {
     alt((
         // Controller-scope suffixes (CR 109.4). Longest-match-first.
@@ -1730,6 +1755,10 @@ fn parse_named_filter_terminator(input: &str) -> Result<(&str, ()), nom::Err<Ora
         // card name ("card named X from your graveyard"). Require a real zone
         // suffix after "from" so names like "Extract from Darkness" stay whole.
         parse_named_filter_origin_zone_terminator,
+        // CR 201.2 + CR 400.1: locative "in <zone>"/"on the battlefield" count
+        // scope ("cards named X in your graveyard") — reattached as InZone by
+        // the caller. Requires a real zone so name-internal "in"/"on" is kept.
+        parse_named_filter_locative_zone_terminator,
         // Copular / state predicates opening a relative clause.
         value((), tag(" is ")),
         value((), tag(" are ")),
@@ -2934,6 +2963,28 @@ pub fn parse_type_phrase_with_ctx<'a>(
                 name: orig_name.to_string(),
             });
             pos += named_offset + "named ".len() + name_end;
+
+            // CR 201.2 + CR 400.1: Re-run the zone-suffix pass now that the name
+            // is consumed, so a trailing locative constraint ("named X in your
+            // graveyard", "named X in all graveyards", "named X on the
+            // battlefield") attaches as an `InZone`/`InAnyZone` filter prop —
+            // parity with the non-named "creature card in your graveyard" path.
+            // The primary `parse_zone_suffix` pass above ran before the name was
+            // consumed and could not see it. Scoped to "in"/"on" locatives so
+            // "from <zone>" move-origins stay in the remainder for the caller
+            // (CR 115.2 target zones, return-from-graveyard move sources).
+            let after_named = lower[pos..].trim_start();
+            let is_locative =
+                alt((tag::<_, _, OracleError<'_>>("in "), tag("on "))).parse(after_named);
+            if is_locative.is_ok() {
+                if let Some((zone_props, zone_ctrl, consumed)) = parse_zone_suffix(&lower[pos..]) {
+                    properties.extend(zone_props);
+                    pos += consumed;
+                    if controller.is_none() {
+                        controller = zone_ctrl;
+                    }
+                }
+            }
         }
     }
 
@@ -7001,6 +7052,87 @@ mod tests {
         // Period still ends the name.
         let (name, _) = named_of("a creature named Storm Crow.");
         assert_eq!(name, "Storm Crow");
+    }
+
+    /// CR 201.2 + CR 400.1: A locative "in <zone>" / "on the battlefield" count
+    /// scope is NOT part of the card name — it must terminate the name and
+    /// re-attach as an `InZone`/`InAnyZone` filter prop. Regression guard for
+    /// the "cards named X in your graveyard" misparse (Frantic Inventory,
+    /// Accumulated Knowledge, Plague Rats, Undead Servant, ...), where the zone
+    /// was swallowed into the name — producing `Named { name: "Frantic
+    /// Inventory in your graveyard" }`, a name no card ever has, so the count
+    /// always resolved to 0.
+    #[test]
+    fn named_filter_terminates_at_locative_zone() {
+        fn named_and_props(text: &str) -> (String, Vec<FilterProp>, Option<ControllerRef>, String) {
+            let (filter, rest) = parse_type_phrase(text);
+            let tf = typed_leg(&filter)
+                .unwrap_or_else(|| panic!("expected a Typed filter in {filter:?}"));
+            let name = tf
+                .properties
+                .iter()
+                .find_map(|p| match p {
+                    FilterProp::Named { name } => Some(name.clone()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| panic!("expected a Named property in {filter:?}"));
+            (
+                name,
+                tf.properties.clone(),
+                tf.controller.clone(),
+                rest.to_string(),
+            )
+        }
+
+        // "in your graveyard": name terminates, InZone Graveyard + You attached,
+        // remainder fully consumed.
+        let (name, props, ctrl, rest) =
+            named_and_props("cards named Frantic Inventory in your graveyard");
+        assert_eq!(name, "Frantic Inventory");
+        assert!(
+            props
+                .iter()
+                .any(|p| matches!(p, FilterProp::InZone { zone } if *zone == Zone::Graveyard)),
+            "expected InZone Graveyard, got {props:?}"
+        );
+        assert_eq!(ctrl, Some(ControllerRef::You));
+        assert_eq!(rest, "");
+
+        // "in all graveyards": name terminates, InZone Graveyard, no controller
+        // restriction (counts every player's graveyard).
+        let (name, props, ctrl, rest) =
+            named_and_props("cards named Accumulated Knowledge in all graveyards");
+        assert_eq!(name, "Accumulated Knowledge");
+        assert!(
+            props
+                .iter()
+                .any(|p| matches!(p, FilterProp::InZone { zone } if *zone == Zone::Graveyard)),
+            "expected InZone Graveyard, got {props:?}"
+        );
+        assert_eq!(ctrl, None);
+        assert_eq!(rest, "");
+
+        // "on the battlefield": name terminates, remainder consumed.
+        let (name, _props, _ctrl, rest) =
+            named_and_props("creatures named Plague Rats on the battlefield");
+        assert_eq!(name, "Plague Rats");
+        assert_eq!(rest, "");
+
+        // "from <zone>" move-origin is unchanged: the name still terminates at
+        // "Deathpact Angel" but the "from" suffix stays in the remainder for the
+        // caller (no InZone attached here).
+        let (name, props, _ctrl, rest) =
+            named_and_props("card named Deathpact Angel from your graveyard");
+        assert_eq!(name, "Deathpact Angel");
+        assert!(
+            !props.iter().any(|p| matches!(p, FilterProp::InZone { .. })),
+            "'from' origin-zone must not attach InZone here, got {props:?}"
+        );
+        assert_eq!(rest, " from your graveyard");
+
+        // A "from" inside a real card name is still preserved.
+        let (name, _props, _ctrl, _rest) = named_and_props("a card named Extract from Darkness");
+        assert_eq!(name, "Extract from Darkness");
     }
 
     fn is_stack_spell_leg(filter: &TargetFilter) -> bool {

--- a/crates/engine/tests/frantic_inventory_graveyard_count.rs
+++ b/crates/engine/tests/frantic_inventory_graveyard_count.rs
@@ -1,0 +1,63 @@
+//! Regression coverage for the "cards named X in your graveyard" count misparse.
+//!
+//! Frantic Inventory reads "Draw a card, then draw cards equal to the number of
+//! cards named Frantic Inventory in your graveyard." The locative zone phrase
+//! ("in your graveyard") was previously SWALLOWED into the card-name filter,
+//! producing `Named { name: "Frantic Inventory in your graveyard" }` — a name no
+//! object ever has — with no `InZone` constraint, so the `ObjectCount` fell back
+//! to the battlefield and always resolved to 0. The second draw therefore never
+//! fired, regardless of how many copies sat in the graveyard.
+//!
+//! The parser fix terminates the card name at the "in <zone>" locative (CR 201.2)
+//! and re-attaches it as `InZone { Graveyard }` + controller You (CR 400.1), so
+//! the count is over graveyard copies named "Frantic Inventory".
+//!
+//! This is a whole-class fix (Accumulated Knowledge "in all graveyards", Plague
+//! Rats "on the battlefield", Undead Servant, Goblin Gathering, Galvanic
+//! Bombardment, Ancestral Anger, Compound Fracture, Growth Cycle, Take
+//! Inventory); Frantic Inventory is the runtime exemplar because the misparse
+//! directly changes how many cards it draws.
+
+use engine::game::scenario::GameScenario;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+
+/// Frantic Inventory — verbatim Oracle text.
+const ORACLE: &str =
+    "Draw a card, then draw cards equal to the number of cards named Frantic Inventory \
+in your graveyard.";
+
+/// Two copies of Frantic Inventory sit in the graveyard alongside an unrelated
+/// card. CR 121.1: the first draw always happens; the second draw is
+/// `number of cards named Frantic Inventory in your graveyard` = 2 (the decoy
+/// "Scrap Note" is excluded by the name filter). Total = 1 + 2 = 3.
+///
+/// REVERT-FAILING: before the fix the count resolved to 0 (name never matched,
+/// no zone constraint), so only the first card was drawn — this assertion flips
+/// to `assert_hand_drawn(P0, 1)`-vs-3 failure when the parser fix is reverted.
+#[test]
+fn frantic_inventory_draws_one_plus_named_graveyard_copies() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // CR 121.1: seed the library so all three draws have something to pull.
+    scenario.with_library_top(P0, &["Filler A", "Filler B", "Filler C", "Filler D"]);
+
+    // Two graveyard copies named "Frantic Inventory" (counted) + one decoy with a
+    // different name (excluded by the Named filter — proves the count is by name,
+    // not "every card in the graveyard").
+    scenario.add_spell_to_graveyard(P0, "Frantic Inventory", false);
+    scenario.add_spell_to_graveyard(P0, "Frantic Inventory", false);
+    scenario.add_spell_to_graveyard(P0, "Scrap Note", false);
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Frantic Inventory", false, ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(spell).resolve();
+
+    // CR 121.1: 1 (first draw) + 2 (graveyard copies named "Frantic Inventory").
+    outcome.assert_hand_drawn(P0, 3);
+}


### PR DESCRIPTION
Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Summary
CR 201.2 + CR 400.1: a **misparse** in the "cards named X **in `<zone>`**" count class. The locative zone phrase was swallowed into the card **name**: `"the number of cards named Frantic Inventory in your graveyard"` parsed to `Named { name: "Frantic Inventory in your graveyard" }` — a name **no object ever has** — with no `InZone` constraint, so the `ObjectCount` fell back to the battlefield and **always resolved to 0**. These cards are marked "supported" (no `Unimplemented`) but silently misresolve: **Frantic Inventory** drew only its first card regardless of graveyard copies; the whole class was affected (Accumulated Knowledge, Take Inventory, Undead Servant, Goblin Gathering, Galvanic Bombardment, Ancestral Anger, Plague Rats "on the battlefield", …).

**Fix (parser-only):** terminate the card-name filter at a locative `" in <zone>"` / `" on the battlefield"` (requiring a *real* zone after the preposition, so name-internal words and `Extract from Darkness` stay whole) and re-attach it as an `InZone`/`InAnyZone` filter prop + controller — parity with the non-named `"card in your graveyard"` path. Distinct from the `"from <zone>"` move-origin suffix, which stays in the remainder for the caller (CR 115.2 return-from-graveyard sources). The count/draw engine already resolves the corrected AST — no engine change.

## Files changed
- crates/engine/src/parser/oracle_target.rs (locative terminator + name-consumed zone-suffix re-run + parser test)
- crates/engine/tests/frantic_inventory_graveyard_count.rs (new — runtime cast test)

## CR references
- `CR 201.2` — a card's name is set by its name line; a locative clause is not part of the name.
- `CR 400.1` — zones; the locative scopes *where* named objects are counted.
- `CR 121.1` — Frantic Inventory's draw count.

## Gate A
```
$ ./scripts/check-parser-combinators.sh
[exit 0 — no violations]
```
Also ran the authoritative check on my changes only — `git diff origin/main...HEAD -- 'crates/engine/src/parser/**' | grep '^+' | grep -E '<FORBIDDEN_METHODS>'` — which printed **nothing**. The new terminator is combinator-only (`alt`/`tag` + the shared `parse_zone_suffix`); the name-consumed re-run gates on an `alt((tag("in "),tag("on ")))` locative probe, not string dispatch.

## Anchored on
- crates/engine/src/parser/oracle_target.rs:1704 — `parse_named_filter_origin_zone_terminator` (the sibling `"from <zone>"` name terminator); the new `parse_named_filter_locative_zone_terminator` mirrors its structure (zone-after-preposition guard) but is re-attached as a filter prop rather than left as a move source.
- crates/engine/src/parser/oracle_target.rs:6623 — `parse_zone_suffix`, the shared zone→(`InZone` props, controller) extractor reused verbatim by both the terminator and the name-consumed re-run, so named and non-named `"… in your graveyard"` filters lower identically.

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
Developer track (Tilt not running → cargo directly with the repo `CC` linker):
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — exit 0; authoritative `git diff origin/main...HEAD` combinator grep — **empty**
- `cargo clippy -p engine --tests -- -D warnings` — clean
- `cargo test -p engine --lib -- parser::` — **7439 pass / 0 fail**; new parser test `named_filter_terminates_at_locative_zone` covers "in your graveyard" (InZone+You), "in all graveyards" (InZone, no controller), "on the battlefield", the unchanged `"from <zone>"` move-origin, and name-internal `Extract from Darkness`
- **Runtime cast test** (fail-on-revert): `frantic_inventory_draws_one_plus_named_graveyard_copies` — 2 graveyard copies + 1 decoy → draws **1+2=3** (reverting the fix drops the count to 0 → draws 1)
- Regenerated card-data (oracle-gen rebuilt with the fix): Frantic Inventory now parses `Named{"frantic inventory"}` + `InZone{Graveyard}`; total `Unimplemented` count did not increase (no new gaps / no over-match regression).

## Scope Expansion
None.
