### PR TITLE
fix(parser): strip ability-word prefix on subject-anchored statics (CR 207.2c)

### DIFF
--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -1642,6 +1642,9 @@ pub(super) const ABILITY_WORD_NAMES: &[&str] = &[
     "pack tactics",
     "paradox",
     "parley",
+    // Warhammer 40,000 Commander (40K) flavor ability words — no rules meaning.
+    "proclamator hailer",
+    "protector",
     "radiance",
     "raid",
     "rally",

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -1642,7 +1642,7 @@ pub(super) const ABILITY_WORD_NAMES: &[&str] = &[
     "pack tactics",
     "paradox",
     "parley",
-    // Warhammer 40,000 Commander (40K) flavor ability words — no rules meaning.
+    // CR 207.2c: Warhammer 40,000 Commander (40K) flavor ability words — no rules meaning.
     "proclamator hailer",
     "protector",
     "radiance",

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1077,7 +1077,34 @@ pub(crate) fn parse_tiered_enters_with_additional_counters_pattern(
     parse_tiered_enters_with_additional_counters_parts(&tp).map(|(_, pattern)| pattern)
 }
 
+/// CR 207.2c: An ability word is italicized flavor text with no rules meaning
+/// (e.g. `Chroma`, `Metalcraft`, `Fateful hour`, and the set-specific `Protector`
+/// / `Proclamator Hailer`). The subject-anchored static parsers match their
+/// subject at the *start* of the line, so a leading ability-word label like
+/// `"Chroma — Each creature you control gets ..."` prevents them from firing and
+/// the whole static silently drops. When the ordinary dispatch classifies
+/// nothing, strip a *recognized* ability-word label — whitelist-gated through the
+/// shared `is_known_ability_word` authority, exactly as the token-grant path in
+/// `keyword_grant.rs` does — and re-enter the dispatch once on the body.
+///
+/// This is a strict fallback: any line the dispatch already parses is returned
+/// untouched, so no existing coverage can regress. The stripped body carries no
+/// further label, so `strip_ability_word_with_name` yields `None` on the retry
+/// and the recursion terminates after a single hop.
 pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition> {
+    let defs = parse_static_line_multi_dispatch(text);
+    if !defs.is_empty() {
+        return defs;
+    }
+    if let Some((ability_word, body)) = super::oracle_modal::strip_ability_word_with_name(text) {
+        if super::oracle_modal::is_known_ability_word(&ability_word) {
+            return parse_static_line_multi_dispatch(&body);
+        }
+    }
+    defs
+}
+
+fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
     let stripped = strip_reminder_text(text);
     let lower = stripped.to_lowercase();
     let tp = TextPair::new(&stripped, &lower);

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -17,6 +17,55 @@ use crate::types::statics::{AdditionalCostTaxAction, CrewAction, CrewContributio
 
 /// CR 702.16 + CR 609.6: Serra's Emissary's compound-subject keyword grant
 /// "You and creatures you control have protection from the chosen card
+/// CR 207.2c: an ability word is italic flavor with no rules meaning. A leading
+/// ability-word label on a subject-anchored static must be stripped so the static
+/// still parses; a leading label that is NOT a recognized ability word must be
+/// left intact so the fallback can't mis-strip a real subject.
+#[test]
+fn ability_word_prefix_is_stripped_from_subject_anchored_statics() {
+    // Whitelisted ability words (already known) whose statics only dropped
+    // because the static dispatch never stripped the flavor label.
+    assert_eq!(
+        parse_static_line_multi(
+            "Chroma — Each creature you control gets +1/+1 for each white mana symbol in its mana cost."
+        )
+        .len(),
+        1,
+        "Light from Within: Chroma prefix must be stripped"
+    );
+    assert_eq!(
+        parse_static_line_multi(
+            "Fateful hour — As long as you have 5 or less life, other creatures you control get +1/+4."
+        )
+        .len(),
+        1,
+        "Gavony Ironwright: Fateful hour prefix must be stripped"
+    );
+    // Set-specific 40K flavor words newly added to the whitelist.
+    assert_eq!(
+        parse_static_line_multi("Protector — Other artifact creatures you control have hexproof.")
+            .len(),
+        1,
+        "Cryptothrall: Protector prefix must be stripped"
+    );
+    assert_eq!(
+        parse_static_line_multi(
+            "Proclamator Hailer — Each creature you control gets +1/+1 for each +1/+1 counter on it."
+        )
+        .len(),
+        1,
+        "Clamavus: Proclamator Hailer prefix must be stripped"
+    );
+    // Safety: a capitalized em-dash label that is NOT a recognized ability word
+    // must never be stripped — the fallback stays whitelist-gated.
+    assert_eq!(
+        parse_static_line_multi("Vigilant Sentry — Other creatures you control have vigilance.")
+            .len(),
+        0,
+        "unknown em-dash label must not be stripped"
+    );
+}
+
 /// type." must decompose into exactly TWO `StaticDefinition`s:
 ///   - object-half: `Continuous` / `AddKeyword(Protection(ChosenCardType))`
 ///     with a controller-You creatures filter;

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15,8 +15,6 @@ use crate::types::keywords::Keyword;
 use crate::types::mana::ManaCost;
 use crate::types::statics::{AdditionalCostTaxAction, CrewAction, CrewContributionKind};
 
-/// CR 702.16 + CR 609.6: Serra's Emissary's compound-subject keyword grant
-/// "You and creatures you control have protection from the chosen card
 /// CR 207.2c: an ability word is italic flavor with no rules meaning. A leading
 /// ability-word label on a subject-anchored static must be stripped so the static
 /// still parses; a leading label that is NOT a recognized ability word must be
@@ -127,6 +125,8 @@ fn ability_word_prefix_is_stripped_from_subject_anchored_statics() {
     );
 }
 
+/// CR 702.16 + CR 609.6: Serra's Emissary's compound-subject keyword grant
+/// "You and creatures you control have protection from the chosen card
 /// type." must decompose into exactly TWO `StaticDefinition`s:
 ///   - object-half: `Continuous` / `AddKeyword(Protection(ChosenCardType))`
 ///     with a controller-You creatures filter;

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -23,39 +23,100 @@ use crate::types::statics::{AdditionalCostTaxAction, CrewAction, CrewContributio
 /// left intact so the fallback can't mis-strip a real subject.
 #[test]
 fn ability_word_prefix_is_stripped_from_subject_anchored_statics() {
-    // Whitelisted ability words (already known) whose statics only dropped
-    // because the static dispatch never stripped the flavor label.
-    assert_eq!(
-        parse_static_line_multi(
-            "Chroma — Each creature you control gets +1/+1 for each white mana symbol in its mana cost."
-        )
-        .len(),
-        1,
-        "Light from Within: Chroma prefix must be stripped"
+    use crate::types::mana::ManaColor;
+
+    // Light from Within (Chroma, whitelisted): the stripped body must produce the
+    // same static it would without the label — creatures-you-control gaining a
+    // dynamic +N/+N equal to the white pips in each recipient's own mana cost.
+    let chroma = parse_static_line_multi(
+        "Chroma — Each creature you control gets +1/+1 for each white mana symbol in its mana cost.",
+    );
+    assert_eq!(chroma.len(), 1, "Chroma prefix must be stripped");
+    let def = &chroma[0];
+    assert!(
+        matches!(&def.affected, Some(TargetFilter::Typed(tf))
+            if tf.type_filters == vec![TypeFilter::Creature]
+                && tf.controller == Some(ControllerRef::You)
+                && tf.properties.is_empty()),
+        "Chroma affected must be creatures you control: {:?}",
+        def.affected
+    );
+    assert!(def.condition.is_none(), "Chroma carries no condition");
+    assert!(
+        matches!(&def.modifications[..],
+            [
+                ContinuousModification::AddDynamicPower { value: p },
+                ContinuousModification::AddDynamicToughness { value: t },
+            ]
+            if matches!(p, QuantityExpr::Ref { qty: QuantityRef::ManaSymbolsInManaCost { color: Some(ManaColor::White), .. } })
+                && p == t),
+        "Chroma must add dynamic P/T = white pips in mana cost: {:?}",
+        def.modifications
+    );
+
+    // Gavony Ironwright (Fateful hour, whitelisted): a life<=5 gate on an
+    // "other creatures you control" +1/+4 pump.
+    let fateful = parse_static_line_multi(
+        "Fateful hour — As long as you have 5 or less life, other creatures you control get +1/+4.",
+    );
+    assert_eq!(fateful.len(), 1, "Fateful hour prefix must be stripped");
+    let def = &fateful[0];
+    assert!(
+        matches!(&def.affected, Some(TargetFilter::Typed(tf))
+            if tf.type_filters == vec![TypeFilter::Creature]
+                && tf.controller == Some(ControllerRef::You)
+                && tf.properties.contains(&FilterProp::Another)),
+        "Fateful hour affected must be OTHER creatures you control: {:?}",
+        def.affected
+    );
+    assert!(
+        matches!(&def.condition, Some(StaticCondition::QuantityComparison { comparator: Comparator::LE, rhs, .. })
+            if matches!(rhs, QuantityExpr::Fixed { value: 5 })),
+        "Fateful hour must gate on your life <= 5: {:?}",
+        def.condition
+    );
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::AddPower { value: 1 })
+            && def
+                .modifications
+                .contains(&ContinuousModification::AddToughness { value: 4 }),
+        "Fateful hour must pump +1/+4: {:?}",
+        def.modifications
+    );
+
+    // Cryptothrall (Protector, newly whitelisted 40K word): an "Other artifact
+    // creatures you control" hexproof grant.
+    let protector =
+        parse_static_line_multi("Protector — Other artifact creatures you control have hexproof.");
+    assert_eq!(protector.len(), 1, "Protector prefix must be stripped");
+    let def = &protector[0];
+    assert!(
+        matches!(&def.affected, Some(TargetFilter::Typed(tf))
+            if tf.type_filters == vec![TypeFilter::Creature, TypeFilter::Artifact]
+                && tf.controller == Some(ControllerRef::You)
+                && tf.properties.contains(&FilterProp::Another)),
+        "Protector affected must be OTHER artifact creatures you control: {:?}",
+        def.affected
     );
     assert_eq!(
-        parse_static_line_multi(
-            "Fateful hour — As long as you have 5 or less life, other creatures you control get +1/+4."
-        )
-        .len(),
-        1,
-        "Gavony Ironwright: Fateful hour prefix must be stripped"
+        def.modifications,
+        vec![ContinuousModification::AddKeyword {
+            keyword: Keyword::Hexproof
+        }],
+        "Protector must grant hexproof"
     );
-    // Set-specific 40K flavor words newly added to the whitelist.
-    assert_eq!(
-        parse_static_line_multi("Protector — Other artifact creatures you control have hexproof.")
-            .len(),
-        1,
-        "Cryptothrall: Protector prefix must be stripped"
-    );
+
+    // Clamavus (Proclamator Hailer, newly whitelisted 40K word): still parses.
     assert_eq!(
         parse_static_line_multi(
             "Proclamator Hailer — Each creature you control gets +1/+1 for each +1/+1 counter on it."
         )
         .len(),
         1,
-        "Clamavus: Proclamator Hailer prefix must be stripped"
+        "Proclamator Hailer prefix must be stripped"
     );
+
     // Safety: a capitalized em-dash label that is NOT a recognized ability word
     // must never be stripped — the fallback stays whitelist-gated.
     assert_eq!(


### PR DESCRIPTION
## Summary
Fixes a **class** of static abilities that silently drop when their Oracle line carries a leading **ability-word label** (CR 207.2c — ability words are italic flavor with no rules meaning).

The subject-anchored static parsers match their subject at the *start* of the line, so a label like `Chroma — ` / `Fateful hour — ` / `Protector — ` prevents the subject match and the whole static is lost — leaving the permanent strictly off its printed rules. (`Threshold — `/`Metalcraft — ` self-pumps slipped through only because their scanner matches mid-line.)

`parse_static_line_multi_inner` now retries the dispatch after stripping a **recognized** ability-word label — whitelist-gated through the shared `is_known_ability_word` authority, exactly as the token-grant path in `keyword_grant.rs` already does. It is a **strict fallback**: any line the ordinary dispatch already parses is returned untouched (zero regression), and the stripped body carries no further label so the retry recurses at most once.

Recovered cards (and every future known-ability-word subject-anchored static):
- **Light from Within** — `Chroma — Each creature you control gets +1/+1 for each white mana symbol in its mana cost.`
- **Gavony Ironwright** — `Fateful hour — As long as you have 5 or less life, other creatures you control get +1/+4.`
- **Echo of Dusk** — `Descend 4 — As long as there are four or more permanent cards in your graveyard, ~ gets +1/+1 and has lifelink.`
- **Cryptothrall** — `Protector — Other artifact creatures you control have hexproof.`
- **Clamavus** — `Proclamator Hailer — Each creature you control gets +1/+1 for each +1/+1 counter on it.`

## Files changed
- `crates/engine/src/parser/oracle_static/shared.rs`
- `crates/engine/src/parser/oracle_modal.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`

## Anchored on
- `crates/engine/src/parser/oracle_static/keyword_grant.rs:1768` — the token-granted-ability path already strips an em-dash label with `strip_ability_word_with_name` and gates it on `is_known_ability_word` before re-dispatching the body; this change applies the identical, whitelist-gated pattern to the static-line dispatch.
- `crates/engine/src/parser/oracle_modal.rs:1602` — `ABILITY_WORD_NAMES` (CR 207.2c) is the single source of recognized ability words; the two 40K flavor words are added here so the gate accepts them.

## Gate A
```

```
(exit 0)

## CR references
- `CR 207.2c` — ability words are italicized flavor text with no rules meaning (verified against `docs/MagicCompRules.txt`).

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (Gate A above)
- `cargo test -p engine --lib parser::oracle_static` — 1008 pass / 0 fail
- `cargo test -p engine --lib parser::oracle_modal` — 53 pass / 0 fail
- New regression test `ability_word_prefix_is_stripped_from_subject_anchored_statics` — passes, incl. a safety case asserting an **unknown** em-dash label is NOT stripped (whitelist gate holds).

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)