### PR TITLE
fix(parser): strip "additional" from "N additional <type> counters" so the counter type is canonical (CR 122.1)

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -3473,6 +3473,12 @@ fn parse_enters_with_counters(
     let (mut count_expr, rest) =
         parse_count_expr(after_prefix).unwrap_or((QuantityExpr::Fixed { value: 1 }, after_prefix));
     rewrite_variable_x_to_cost_x_paid(&mut count_expr);
+    // CR 122.1: "N additional <type> counters" — the count word precedes
+    // "additional", so the leading-`additional` strip above (which only fires
+    // when no count word is present, e.g. "an additional +1/+1 counter") misses
+    // it. Strip it here so "additional" doesn't leak into the counter-type slice
+    // (`Generic("additional +1/+1")` instead of the canonical `Plus1Plus1`).
+    let rest = strip_additional_counter_qualifier(rest);
     // Next word(s) before "counter" are the counter type
     let (_, (counter_type_raw, after_counter)) =
         nom_primitives::split_once_on(rest, "counter").ok()?;
@@ -3751,6 +3757,22 @@ fn parse_for_each_convoked_creature_clause(
     ))
 }
 
+/// CR 122.1 + CR 614.1c: Strip an optional "additional " qualifier that follows
+/// the count word in "N additional <type> counter(s)". The word "additional" is
+/// not part of the counter TYPE — it only signals that the counters stack on top
+/// of any the object already enters with, which the engine models by this being a
+/// distinct `PutCounter` replacement. Callers slice the counter type out of the
+/// text after `parse_count_expr` consumes the count, so the leading-`additional`
+/// strip in `parse_enters_with_counters` (which only fires on the count-less
+/// "an additional +1/+1 counter" form) never reaches this position; without this
+/// strip, "additional" leaks into the type (a bogus `Generic("additional +1/+1")`
+/// instead of the canonical `Plus1Plus1`).
+fn strip_additional_counter_qualifier(input: &str) -> &str {
+    tag::<_, _, OracleError<'_>>("additional ")
+        .parse(input)
+        .map_or(input, |(rest, _)| rest)
+}
+
 fn parse_enters_counter_entries(after_with: &str) -> Option<Vec<(CounterType, QuantityExpr)>> {
     let mut remaining = after_with;
     let mut entries = Vec::new();
@@ -3758,6 +3780,9 @@ fn parse_enters_counter_entries(after_with: &str) -> Option<Vec<(CounterType, Qu
     loop {
         let (mut count_expr, rest) = parse_count_expr(remaining)?;
         rewrite_variable_x_to_cost_x_paid(&mut count_expr);
+        // CR 122.1: strip the "additional" qualifier that follows the count word
+        // ("two additional +1/+1 counters") so it doesn't leak into the type.
+        let rest = strip_additional_counter_qualifier(rest);
 
         let (at_counter, counter_type_raw) = take_until::<_, _, OracleError<'_>>(" counter")
             .parse(rest)

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -19054,3 +19054,75 @@ fn curse_of_vitality_rider_clones_gain_life_across_attacking_opponents() {
         "no Unimplemented residual may survive: {execute:#?}"
     );
 }
+
+/// CR 122.1 + CR 614.1c: "enters with N additional +1/+1 counters on it" must
+/// parse the counter TYPE as the canonical `Plus1Plus1`, not leak the "additional"
+/// qualifier into a bogus `Generic("additional +1/+1")`. The qualifier follows the
+/// count word ("two additional …"), so it is stripped after the count is parsed.
+/// Fail-on-revert: before the fix these all produced `Generic("additional +1/+1")`
+/// / `Generic("additional time")`, which matches no real counter at runtime.
+#[test]
+fn enters_with_n_additional_counters_parses_canonical_type() {
+    fn enters_counter(text: &str, name: &str, types: &[&str]) -> (CounterType, QuantityExpr) {
+        let t: Vec<String> = types.iter().map(|s| s.to_string()).collect();
+        let parsed = parse_oracle_text(text, name, &[], &t, &[]);
+        let rep = parsed
+            .replacements
+            .iter()
+            .find(|r| {
+                r.execute
+                    .as_ref()
+                    .is_some_and(|e| matches!(e.effect.as_ref(), Effect::PutCounter { .. }))
+            })
+            .unwrap_or_else(|| panic!("{name}: no PutCounter replacement: {parsed:?}"));
+        let Effect::PutCounter {
+            counter_type,
+            count,
+            ..
+        } = rep.execute.as_ref().unwrap().effect.as_ref()
+        else {
+            unreachable!()
+        };
+        (counter_type.clone(), count.clone())
+    }
+
+    // "that creature enters with two additional +1/+1 counters on it" (Necromantic Summons)
+    let (ct, count) = enters_counter(
+        "Put target creature card from a graveyard onto the battlefield under your control.\n\
+         Spell mastery — If there are two or more instant and/or sorcery cards in your graveyard, \
+         that creature enters with two additional +1/+1 counters on it.",
+        "Necromantic Summons",
+        &["Sorcery"],
+    );
+    assert_eq!(ct, CounterType::Plus1Plus1, "Necromantic Summons type");
+    assert_eq!(count, QuantityExpr::Fixed { value: 2 }, "count");
+
+    // "it enters with two additional +1/+1 counters on it" (Heroic Return)
+    let (ct, _) = enters_counter(
+        "Return target creature card from your graveyard to the battlefield. \
+         If a Hero enters this way, it enters with two additional +1/+1 counters on it.",
+        "Heroic Return",
+        &["Sorcery"],
+    );
+    assert_eq!(ct, CounterType::Plus1Plus1, "Heroic Return type");
+
+    // "it enters with three additional +1/+1 counters on it" (Turntimber Symbiosis)
+    let (ct, count) = enters_counter(
+        "Look at the top seven cards of your library. You may put a creature card from among them \
+         onto the battlefield. If that card has mana value 3 or less, it enters with three \
+         additional +1/+1 counters on it. Put the rest on the bottom of your library in a random order.",
+        "Turntimber Symbiosis",
+        &["Sorcery"],
+    );
+    assert_eq!(ct, CounterType::Plus1Plus1, "Turntimber Symbiosis type");
+    assert_eq!(count, QuantityExpr::Fixed { value: 3 }, "count");
+
+    // Non-P/T counter class: "it enters with three additional time counters on it" (Ravaging Riftwurm)
+    let (ct, count) = enters_counter(
+        "If this creature was kicked, it enters with three additional time counters on it.",
+        "Ravaging Riftwurm",
+        &["Creature"],
+    );
+    assert_eq!(ct, CounterType::Time, "Ravaging Riftwurm type");
+    assert_eq!(count, QuantityExpr::Fixed { value: 3 }, "count");
+}


### PR DESCRIPTION
Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Summary
CR 122.1 + CR 614.1c: a **misparse** in the "enters with **N additional `<type>`** counters" class. `parse_enters_with_counters` consumed the count word ("two") but then sliced the counter TYPE out of the remaining `"additional +1/+1 counters on it"` — so **"additional" leaked into the counter type**, producing `Effect::PutCounter { counter_type: Generic("additional +1/+1"), count: 2 }`. That's a counter of a type **no real counter has**: the permanent entered with two counters of a nonexistent kind and **never actually gained +2/+2**.

**Affected (5, marked "supported" but silently wrong):** Necromantic Summons, Heroic Return, Turntimber Symbiosis, Curator Beastie (`+1/+1`), and **Ravaging Riftwurm** (`Generic("additional time")` instead of `CounterType::Time` — which breaks its Vanishing count).

**Fix (parser-only):** the existing leading-`additional` strip handles the *count-less* form ("**an additional** +1/+1 counter") but not the "**N** additional …" form, where the count word precedes "additional". Add a small nom helper (`tag("additional ")`) and apply it to the remainder **after** `parse_count_expr` consumes the count, at both counter-type slice sites (the single-entry path and the `parse_enters_counter_entries` loop). "additional" is a stacking qualifier, not part of the type (CR 614.12 — the engine models additivity by this being a distinct `PutCounter` replacement), so stripping it yields the canonical `CounterType`. The engine already resolves `Plus1Plus1`/`Time` correctly — no engine change.

## Files changed
- crates/engine/src/parser/oracle_replacement.rs (strip helper + application at both slice sites)
- crates/engine/src/parser/oracle_tests.rs (fail-on-revert parse test)

## CR references
- `CR 122.1` — counters (a counter has a kind).
- `CR 614.1c` + `CR 614.12` — "enters with additional counters" replacement; "additional" signals stacking, not a counter kind.

## Gate A
```
$ ./scripts/check-parser-combinators.sh
[exit 0 — no violations]
```
Also ran the authoritative check on my parser diff — combinator grep on `git diff -- 'crates/engine/src/parser/**'` — printed **nothing**. The new `strip_additional_counter_qualifier` is combinator-only (`tag("additional ")` + `map_or`), reusing the same idiom as the existing leading-`additional` strip.

## Anchored on
- crates/engine/src/parser/oracle_replacement.rs:3360 — the existing leading-`additional` strip in `parse_enters_with_counters` (`alt((tag("an additional "), tag("additional ")))`); the new `strip_additional_counter_qualifier` mirrors that exact `tag`-based qualifier-strip idiom, applied at the post-count position the leading strip never reaches.
- crates/engine/src/parser/oracle_replacement.rs:3776 — `parse_enters_counter_entries`, the multi-entry loop that slices each counter type after `parse_count_expr`; the strip is applied there too so multi-entry "N additional …" clauses lower identically.

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
Developer track (Tilt not running → cargo directly with the repo `CC` linker):
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — exit 0; parser-diff combinator grep — **empty**
- `cargo clippy -p engine --tests -- -D warnings` — clean
- `cargo test -p engine --lib -- parser::` — **7544 pass / 0 fail**; new fail-on-revert test `enters_with_n_additional_counters_parses_canonical_type` asserts the SEMANTIC `counter_type` value (`Plus1Plus1` for the four +1/+1 cards, `Time` for Ravaging Riftwurm) — reverting the strip flips it to `Generic("additional +1/+1")` and fails
- Rebuilt oracle-gen (with the fix) + regenerated card-data: the 5 target cards now parse the canonical type; total `Unimplemented` count unchanged (3583→3583, no new gaps); a global diff of every `PutCounter.counter_type` across all 34.6k cards shows **exactly the 5 target cards changed, nothing else** (no over-match — non-"additional" enters-with-counter cards like Kalonian Hydra, Avatar of the Resolute, Renata, Spark Double are byte-identical to baseline)

## Scope Expansion
None.
