### PR TITLE
fix(parser): cycle the whole hand to the library bottom for Teferi’s Puzzle Box

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -1194,6 +1194,17 @@ pub fn resolve_all(
             ability,
             &TargetFilter::ParentTargetOwner,
         ),
+        // CR 603.2b + CR 102.1: "At the beginning of each player's draw step,
+        // that player puts the cards in their hand on the bottom of their
+        // library" (Teferi's Puzzle Box). The per-player trigger binds "that
+        // player" to `ScopedPlayer` (the active player whose step it is), so the
+        // whole-hand move must scan that player's hand, not the source
+        // controller's.
+        TargetFilter::ScopedPlayer => crate::game::targeting::resolve_effect_player_ref(
+            state,
+            ability,
+            &TargetFilter::ScopedPlayer,
+        ),
         _ => None,
     };
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5778,6 +5778,19 @@ pub(super) fn parse_put_ast(
         }
     }
 
+    // CR 401.4 + CR 608.2c: "put the cards {in|from} <possessive> hand on the
+    // bottom/top [of <possessive> library] [in any order]" — whole-hand library
+    // reposition (Teferi's Puzzle Box). The "the cards {in|from} <possessive>
+    // hand" guard keeps single-card "put that card on the bottom" and "put the
+    // rest on the bottom" out of this branch (they lack the hand-origin phrase),
+    // so those still route to the positional `BottomOfLibrary`/`TopOfLibrary`
+    // forms below.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("put ").parse(lower) {
+        if let Some(position) = parse_hand_to_library_position(rest) {
+            return Some(PutImperativeAst::HandToLibraryPosition { position });
+        }
+    }
+
     let has_mass_zone_origin = (nom_primitives::scan_contains(lower, "all")
         || nom_primitives::scan_contains(lower, "each"))
         && nom_primitives::scan_contains(lower, "from");
@@ -6108,6 +6121,26 @@ pub(super) fn lower_put_ast(ast: PutImperativeAst) -> Effect {
             profile,
             enters_under,
         },
+        // CR 401.4 + CR 608.2c: "put the cards in their hand on the bottom of
+        // their library in any order" (Teferi's Puzzle Box) moves the mover's
+        // whole hand to the named library position at once. Mirrors the
+        // hand→library field set of `change_zone_all_to_library_effect`, but
+        // pins `library_position` and OMITS that helper's trailing `Shuffle`
+        // sub-ability — a shuffle would scatter the cards the effect just placed
+        // on the bottom/top. `target: Controller` is rebound to the acting
+        // player ("that player") by `inject_subject_target` when the enclosing
+        // subject-predicate clause carries a player subject.
+        PutImperativeAst::HandToLibraryPosition { position } => Effect::ChangeZoneAll {
+            origin: Some(Zone::Hand),
+            destination: Zone::Library,
+            target: TargetFilter::Controller,
+            enters_under: None,
+            enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+            enter_with_counters: vec![],
+            face_down_profile: None,
+            library_position: Some(position),
+            random_order: false,
+        },
     }
 }
 
@@ -6344,6 +6377,54 @@ fn parse_mass_zones_to_library(lower: &str) -> Option<Vec<Zone>> {
     let (rest, _) = parse_possessive_determiner(rest).ok()?;
     let (_rest, _) = tag::<_, _, OracleError<'_>>(" library").parse(rest).ok()?;
     Some(origins)
+}
+
+/// Parse "the cards {in|from} {possessive} hand on the bottom/top [of
+/// {possessive} library] [in any order]" and return the target library position.
+///
+/// CR 401.4 + CR 608.2c: The whole-hand reposition of Teferi's Puzzle Box —
+/// "that player puts the cards in their hand on the bottom of their library in
+/// any order". Modeled on `parse_mass_zones_to_library`'s combinator style; the
+/// optional " of {possessive} library" and "in any order" tail is matched to be
+/// consumed but the trailing remainder is discarded (the position is the whole
+/// payload). The leading "the cards {in|from} {possessive} hand" guard is what
+/// keeps single-card "put that card on the bottom" and "put the rest on the
+/// bottom" from routing here.
+fn parse_hand_to_library_position(rest: &str) -> Option<LibraryPosition> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("the cards ")
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("in "),
+        tag::<_, _, OracleError<'_>>("from "),
+    ))
+    .parse(rest)
+    .ok()?;
+    let (rest, _) = parse_possessive_determiner(rest).ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" hand").parse(rest).ok()?;
+    let (rest, position) = alt((
+        value(
+            LibraryPosition::Bottom,
+            tag::<_, _, OracleError<'_>>(" on the bottom"),
+        ),
+        value(LibraryPosition::Top, tag(" on top")),
+    ))
+    .parse(rest)
+    .ok()?;
+    // Optional " of {possessive} library" and "in any order" tail — matched to
+    // consume when present, but not required. Only "in any order" appears in this
+    // class (CR 401.4 owner arrangement); bottom-of-library order is gameplay-inert
+    // so it is not modeled as an interactive choice.
+    let (rest, _) = opt(preceded(
+        tag::<_, _, OracleError<'_>>(" of "),
+        (parse_possessive_determiner, tag(" library")),
+    ))
+    .parse(rest)
+    .ok()?;
+    let (_rest, _) = opt(tag::<_, _, OracleError<'_>>(" in any order"))
+        .parse(rest)
+        .ok()?;
+    Some(position)
 }
 
 pub(super) fn parse_shuffle_ast(text: &str, lower: &str) -> Option<ShuffleImperativeAst> {
@@ -12545,6 +12626,78 @@ mod tests {
                 .iter()
                 .any(|ability| matches!(&*ability.effect, Effect::CastFromZone { .. })),
             "Wish must not parse to a permanent-targeting CastFromZone"
+        );
+    }
+
+    /// SHAPE (issue #4241): Teferi's Puzzle Box's verbatim Oracle text parses to
+    /// a per-player draw-step trigger whose execute effect is a whole-hand
+    /// `ChangeZoneAll { origin: Hand, destination: Library, library_position:
+    /// Some(Bottom) }` with a `Draw` sub-ability ("then draws that many cards"),
+    /// NOT a no-op `PutAtLibraryPosition`/`Unimplemented`. The zero-Unimplemented
+    /// sweep is the positive reach-guard that keeps the shape assertion from
+    /// passing vacuously (card-test foot-gun #6).
+    #[test]
+    fn puzzle_box_hand_to_bottom_then_draw_shape() {
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "At the beginning of each player's draw step, that player puts the cards \
+             in their hand on the bottom of their library in any order, then draws \
+             that many cards.",
+            "Teferi's Puzzle Box",
+            &[],
+            &["Artifact".to_string()],
+            &[],
+        );
+
+        // Positive reach-guard: nothing anywhere fell to Unimplemented.
+        fn walk<'a>(ability: &'a AbilityDefinition, out: &mut Vec<&'a Effect>) {
+            out.push(&ability.effect);
+            if let Some(sub) = &ability.sub_ability {
+                walk(sub, out);
+            }
+        }
+        let mut effects: Vec<&Effect> = Vec::new();
+        for ability in &parsed.abilities {
+            walk(ability, &mut effects);
+        }
+        for trigger in &parsed.triggers {
+            if let Some(exec) = &trigger.execute {
+                walk(exec, &mut effects);
+            }
+        }
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::Unimplemented { .. })),
+            "no clause may fall to Unimplemented; got {effects:?}"
+        );
+
+        let trigger = parsed
+            .triggers
+            .iter()
+            .find(|t| t.execute.is_some())
+            .expect("Puzzle Box yields a triggered ability");
+        let exec = trigger.execute.as_ref().unwrap();
+
+        match &*exec.effect {
+            Effect::ChangeZoneAll {
+                origin: Some(Zone::Hand),
+                destination: Zone::Library,
+                library_position: Some(LibraryPosition::Bottom),
+                ..
+            } => {}
+            other => panic!(
+                "execute must be a hand->library ChangeZoneAll placed on the bottom, got {other:?}"
+            ),
+        }
+
+        let draw_sub = exec
+            .sub_ability
+            .as_ref()
+            .expect("the hand-cycle must chain a 'draw that many' sub-ability");
+        assert!(
+            matches!(&*draw_sub.effect, Effect::Draw { .. }),
+            "the sub-ability must be a Draw, got {:?}",
+            draw_sub.effect
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -16837,11 +16837,15 @@ fn apply_anchor_subject(effect: &mut Effect, anchor: &TargetFilter) {
         Effect::ChangeZoneAll { target, .. } if *target == TargetFilter::Controller => {
             *target = anchor.clone();
         }
-        // CR 608.2c + CR 121.1: "That player shuffles, then draws a card for
-        // each card exiled from their hand this way" (The End, Deadly Cover-Up,
-        // Test of Talents) — the trailing Draw defaults its target to the caster
-        // (`Controller`) but must draw for the SEARCHED player carried on the
-        // anchor. Mirrors the `Shuffle` arm above (same caster-default set).
+        // CR 608.2c: a trailing "…, then draws …" continuation is a separate
+        // chunk with no subject of its own, so it defaults its target to the
+        // caster (`Controller`); inherit the earlier player anchor so the acting
+        // player — not the source's controller — draws. Covers "That player
+        // shuffles, then draws a card for each card exiled from their hand this
+        // way" (The End, Deadly Cover-Up, Test of Talents; CR 121.1) and "that
+        // player puts the cards in their hand on the bottom of their library …,
+        // then draws that many cards" (Teferi's Puzzle Box, #4241; CR 102.1).
+        // Mirrors the `Shuffle` arm above (same caster-default set).
         Effect::Draw { target, .. }
             if matches!(
                 *target,

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1344,6 +1344,17 @@ pub(crate) enum PutImperativeAst {
         profile: Option<FaceDownProfile>,
         enters_under: Option<ControllerRef>,
     },
+    /// CR 401.4 + CR 608.2c: "put the cards {in|from} <possessive> hand on the
+    /// bottom/top of <possessive> library [in any order]" — the whole-hand
+    /// reposition (Teferi's Puzzle Box). The mover's entire hand moves to the
+    /// named library `position` at once; CR 401.4 lets the owner arrange the
+    /// simultaneously-placed cards in any order. Lowered to
+    /// `Effect::ChangeZoneAll { origin: Hand, destination: Library,
+    /// library_position: Some(position) }` with NO trailing shuffle — a shuffle
+    /// would scatter the cards the effect just placed on the bottom/top.
+    HandToLibraryPosition {
+        position: LibraryPosition,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/crates/engine/tests/teferis_puzzle_box_4241.rs
+++ b/crates/engine/tests/teferis_puzzle_box_4241.rs
@@ -1,0 +1,213 @@
+//! Reproduction for issue #4241 — Teferi's Puzzle Box.
+//!
+//! "At the beginning of each player's draw step, that player puts the cards in
+//! their hand on the bottom of their library in any order, then draws that many
+//! cards." (CR 603.2 per-player beginning-of-step trigger.)
+//!
+//! https://github.com/phase-rs/phase/issues/4241
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const PUZZLE_BOX_ORACLE: &str = "At the beginning of each player's draw step, \
+    that player puts the cards in their hand on the bottom of their library in any order, \
+    then draws that many cards.";
+
+fn at_untap(runner: &mut GameRunner, active: PlayerId) {
+    let s = runner.state_mut();
+    s.turn_number = 2;
+    s.phase = Phase::Untap;
+    s.active_player = active;
+    s.priority_player = active;
+    s.waiting_for = WaitingFor::Priority { player: active };
+}
+
+fn hand_names(runner: &GameRunner, p: PlayerId) -> Vec<String> {
+    let state = runner.state();
+    state.players[p.0 as usize]
+        .hand
+        .iter()
+        .filter_map(|id| state.objects.get(id).map(|o| o.name.clone()))
+        .collect()
+}
+
+#[test]
+fn puzzle_box_active_player_cycles_hand_and_draws_that_many() {
+    let mut scenario = GameScenario::new();
+    scenario
+        .add_creature_from_oracle(P0, "Teferi's Puzzle Box", 0, 0, PUZZLE_BOX_ORACLE)
+        .as_artifact();
+    scenario.with_cards_in_hand(P0, &["Hand A", "Hand B", "Hand C"]);
+    scenario.with_library_top(
+        P0,
+        &[
+            "Lib 1", "Lib 2", "Lib 3", "Lib 4", "Lib 5", "Lib 6", "Lib 7", "Lib 8",
+        ],
+    );
+
+    let mut runner = scenario.build();
+    at_untap(&mut runner, P0);
+    runner.advance_to_phase(Phase::Draw);
+    runner.advance_until_stack_empty();
+
+    let hand = hand_names(&runner, P0);
+    eprintln!("post-draw-step hand = {hand:?}");
+
+    // The whole hand must have been cycled to the bottom of the library and an
+    // equal number of fresh cards drawn — no original hand card should remain.
+    assert!(
+        !hand.iter().any(|n| n.starts_with("Hand ")),
+        "original hand cards must be on the bottom after Puzzle Box resolves, got {hand:?}"
+    );
+}
+
+/// CR 603.2b + CR 102.1: the trigger fires on *each* player's draw step, and
+/// "that player" is the active player of that step — not the Box's controller.
+/// P0 controls the Box; on P1's draw step, P1's hand is cycled and P1 draws that
+/// many, while P0's hand is untouched. This exercises the `ScopedPlayer` routing
+/// in `ChangeZoneAll::resolve_all` (the whole-hand move keys off the scoped
+/// player, not `ability.controller`).
+#[test]
+fn puzzle_box_opponent_draw_step_cycles_that_players_hand() {
+    let mut scenario = GameScenario::new();
+    scenario
+        .add_creature_from_oracle(P0, "Teferi's Puzzle Box", 0, 0, PUZZLE_BOX_ORACLE)
+        .as_artifact();
+    scenario.with_cards_in_hand(P1, &["P1 Hand A", "P1 Hand B"]);
+    scenario.with_cards_in_hand(P0, &["P0 Keep X", "P0 Keep Y"]);
+    scenario.with_library_top(
+        P1,
+        &[
+            "Lib 1", "Lib 2", "Lib 3", "Lib 4", "Lib 5", "Lib 6", "Lib 7", "Lib 8",
+        ],
+    );
+
+    let mut runner = scenario.build();
+    // P1 is the active player whose draw step runs.
+    at_untap(&mut runner, P1);
+    runner.advance_to_phase(Phase::Draw);
+    runner.advance_until_stack_empty();
+
+    let p1_hand = hand_names(&runner, P1);
+    let p0_hand = hand_names(&runner, P0);
+
+    // P1's original hand was cycled to the bottom; only fresh library cards
+    // remain. The non-empty guard proves P1 (not P0) is the player who redrew —
+    // an empty P1 hand would pass the `all(...)` check vacuously (card-test
+    // foot-gun #6).
+    assert!(
+        !p1_hand.is_empty(),
+        "P1 must have redrawn fresh cards, not been left empty-handed, got {p1_hand:?}"
+    );
+    assert!(
+        !p1_hand.iter().any(|n| n.starts_with("P1 Hand ")),
+        "P1's original hand must be on the bottom after Puzzle Box resolves, got {p1_hand:?}"
+    );
+    assert!(
+        p1_hand.iter().all(|n| n.starts_with("Lib ")),
+        "P1's post-trigger hand must be freshly drawn library cards, got {p1_hand:?}"
+    );
+
+    // P0 controls the Box but is NOT the active player, so P0's hand is untouched.
+    assert_eq!(
+        p0_hand,
+        vec!["P0 Keep X".to_string(), "P0 Keep Y".to_string()],
+        "the Box's controller keeps their hand when a different player's draw step fires"
+    );
+}
+
+/// CR 401.4 + CR 608.2c: an empty starting hand is a legal no-op — the whole-hand
+/// move of zero non-turn-based cards plus the CR 504.1 mandatory draw-step draw
+/// must not panic. The active player draws exactly one card for the step (the
+/// turn-based draw), the trigger cycles that single card and redraws one, so the
+/// hand settles at exactly one card.
+#[test]
+fn puzzle_box_empty_hand_is_legal_noop() {
+    let mut scenario = GameScenario::new();
+    scenario
+        .add_creature_from_oracle(P0, "Teferi's Puzzle Box", 0, 0, PUZZLE_BOX_ORACLE)
+        .as_artifact();
+    // No cards in hand.
+    scenario.with_library_top(
+        P0,
+        &[
+            "Lib 1", "Lib 2", "Lib 3", "Lib 4", "Lib 5", "Lib 6", "Lib 7", "Lib 8",
+        ],
+    );
+
+    let mut runner = scenario.build();
+    at_untap(&mut runner, P0);
+    runner.advance_to_phase(Phase::Draw);
+    runner.advance_until_stack_empty();
+
+    let hand = hand_names(&runner, P0);
+    assert_eq!(
+        hand.len(),
+        1,
+        "empty-hand active player ends the draw step holding only the turn-based draw, got {hand:?}"
+    );
+    assert!(
+        hand.iter().all(|n| n.starts_with("Lib ")),
+        "the surviving card must be a library draw, got {hand:?}"
+    );
+}
+
+/// CR 608.2c: "draws that many cards" draws a count equal to the hand size the
+/// trigger cycled — never `Fixed(1)` and never `0`. Setup: three distinct named
+/// hand cards plus the CR 504.1 mandatory draw-step draw (which adds `Lib 1`
+/// before the trigger resolves), so the trigger cycles four cards and draws four
+/// fresh library cards (`Lib 2`..`Lib 5`). The count therefore tracks hand size,
+/// not a hardcoded 1 or 0.
+#[test]
+fn puzzle_box_draw_count_equals_hand_size() {
+    let mut scenario = GameScenario::new();
+    scenario
+        .add_creature_from_oracle(P0, "Teferi's Puzzle Box", 0, 0, PUZZLE_BOX_ORACLE)
+        .as_artifact();
+    scenario.with_cards_in_hand(P0, &["Name One", "Name Two", "Name Three"]);
+    scenario.with_library_top(
+        P0,
+        &[
+            "Lib 1", "Lib 2", "Lib 3", "Lib 4", "Lib 5", "Lib 6", "Lib 7", "Lib 8",
+        ],
+    );
+
+    let mut runner = scenario.build();
+    at_untap(&mut runner, P0);
+
+    // After the draw step's turn-based draw (CR 504.1) but before the trigger
+    // resolves, the hand holds the three named cards plus one library card.
+    runner.advance_to_phase(Phase::Draw);
+    let pre_trigger = hand_names(&runner, P0);
+    assert_eq!(
+        pre_trigger.len(),
+        4,
+        "three named + one turn-based draw before the trigger, got {pre_trigger:?}"
+    );
+
+    runner.advance_until_stack_empty();
+    let hand = hand_names(&runner, P0);
+
+    // The trigger drew a card for every card it cycled: hand size is preserved,
+    // every named card is gone, and every surviving card is a fresh library draw.
+    assert_eq!(
+        hand.len(),
+        pre_trigger.len(),
+        "the trigger draws exactly as many cards as it cycled (hand size), got {hand:?}"
+    );
+    assert_eq!(
+        hand.len(),
+        4,
+        "hand-size-driven draw of four (not Fixed(1) or 0), got {hand:?}"
+    );
+    assert!(
+        !hand.iter().any(|n| n.starts_with("Name ")),
+        "the named hand cards must have been cycled to the bottom, got {hand:?}"
+    );
+    assert!(
+        hand.iter().all(|n| n.starts_with("Lib ")),
+        "every surviving card is a fresh library draw, got {hand:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #4241 — Teferi's Puzzle Box did nothing on the draw step. "At the beginning of each player's draw step, that player puts the cards in their hand on the bottom of their library in any order, then draws that many cards" parsed but into a no-op AST: the whole-hand origin collapsed to `PutAtLibraryPosition { count: Fixed(1) }` (no hand moved), the "that many" count was never captured (draw of 0), and the draw targeted the Box's controller instead of the scoped player.

The fix reroutes the whole-hand→library-position surface form to the existing `Effect::ChangeZoneAll` mover — the same building block Whirlpool Drake's "shuffle the cards from your hand into your library, then draw that many" already uses — with `library_position: Some(Bottom)` and no shuffle. That mover already stamps `last_effect_count`, which the `EventContextAmount` "draws that many" reads, and the existing subject-injection path binds "that player" (the scoped player) to both the move and the draw. No new engine surface.

Model: claude-opus-4-8
Tier: Frontier
Thinking: high

## Implementation method (required)

- [x] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)

## Anchored on

The change is Whirlpool Drake ("shuffle the cards from your hand into your library, then draw that many cards") re-pointed at a positional library placement instead of a shuffle. Each new piece mirrors an existing analog:

- `crates/engine/src/parser/oracle_effect/imperative.rs` — `parse_mass_zones_to_library`: the nom-combinator whole-hand-origin recognizer whose combinator style the new `parse_hand_to_library_position` copies.
- `crates/engine/src/parser/oracle_effect/imperative.rs` — `lower_change_zone_all_to_library`: the `Effect::ChangeZoneAll { origin: Hand, destination: Library }` field-set the new lowering reuses (with `library_position: Some(pos)` and no shuffle sub).
- `crates/engine/src/parser/oracle_effect/mod.rs` — the `Effect::Shuffle` arm of `apply_anchor_subject`: the new `Effect::Draw` arm matches the identical `{Controller, Player, ParentTargetController}` set and is disarmed by the same `chunk_declares_caster_subject` guard.
- `crates/engine/src/game/effects/change_zone.rs` — the `ParentTargetController`/`ParentTargetOwner` arms of `resolve_all`'s `player_scope` match, which the new `ScopedPlayer` arm mirrors (delegating to `resolve_effect_player_ref`).

## Gate A

`scripts/check-parser-combinators.sh` passes on the staged diff (exit 0, no violations). The one new parser detector `parse_hand_to_library_position` is built entirely from `nom` combinators (`tag`/`alt`/`value`/`opt`/`preceded`/`parse_possessive_determiner`), with no string-method dispatch, match-arm string literals, chained `if let Ok = tag(...)` blocks, verbatim-sentence equality, or hand-built `Effect::Unimplemented`.

## CR references

All verified against the current Comprehensive Rules:
- **CR 401.4** — "If an effect puts two or more cards in a specific position in a library at the same time, the owner of those cards may arrange them in any order." (the "in any order" whole-hand placement).
- **CR 608.2c** — later text modifies earlier ("…, then draws that many cards" anaphora over the just-moved count).
- **CR 603.2b** — "at the beginning of" phase/step triggers (the per-player draw-step trigger).
- **CR 102.1** — the active player is whose turn it is (binds "that player" to the scoped/active player).

## Verification

Built and tested with cargo (this contributor box has no Tilt):

```
tests/teferis_puzzle_box_4241.rs .... 4 passed; 0 failed
engine --lib ...................... 14555 passed; 0 failed
engine --test integration ......... 1712 passed; 0 failed
```

- New regression tests (`crates/engine/tests/teferis_puzzle_box_4241.rs`): the controller's own draw step; an opponent's draw step (P0's Box cycles **P1's** hand and P1 draws that many while **P0's hand is untouched** — proves the `ScopedPlayer` binding on both the move and the draw); an empty-hand no-op; and draw-count == hand-size (never `Fixed(1)`/0). All drive real trigger firing + resolution through the scenario runner, not a resolver shortcut. Plus a parser SHAPE unit test with a zero-`Unimplemented` reach-guard.
- Regression-ran the whole lib + integration suites: Whirlpool hand→library shuffle, Jace snapshots, Sanwell rest-on-bottom (#3267), and Blinkmoth Urn (#2900) all still pass — the shared `parse_put_ast` dispatch change is tightly guarded (requires "the cards {in|from} <possessive> hand … on the bottom/top"), so single-card and "put the rest" forms are untouched.
