### PR TITLE
fix(parser): order generic subtype-count after Coven/same-name conditions

### DIFF
--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -438,9 +438,6 @@ fn parse_you_control_condition(text: &str) -> Option<ParsedCondition> {
     if let Some(subtypes) = parse_you_control_land_subtypes(text) {
         return Some(ParsedCondition::YouControlLandSubtypeAny { subtypes });
     }
-    if let Some((count, subtype)) = parse_you_control_subtype_count(text) {
-        return Some(ParsedCondition::YouControlSubtypeCountAtLeast { subtype, count });
-    }
     if let Some(count) = parse_numeric_threshold(
         text,
         "creatures you control have total power ",
@@ -464,6 +461,16 @@ fn parse_you_control_condition(text: &str) -> Option<ParsedCondition> {
     }
     if let Some(count) = parse_numeric_threshold(text, "you control ", " or more snow permanents") {
         return Some(ParsedCondition::YouControlSnowPermanentCountAtLeast { count });
+    }
+    // The generic bare-subtype catch-all must run AFTER the specific "creatures with
+    // different powers" / "lands with the same name" / "snow permanents" suffix arms
+    // above. Otherwise it greedily consumes those qualifier phrases via its bare
+    // `" or more "` split and dumps the whole phrase into a stringly-typed subtype
+    // (e.g. subtype "creatures with different power"), shadowing the dedicated
+    // YouControlDifferentPowerCreatureCountAtLeast / YouControlLandsWithSameNameAtLeast
+    // variants so those cards never reach the correct parse.
+    if let Some((count, subtype)) = parse_you_control_subtype_count(text) {
+        return Some(ParsedCondition::YouControlSubtypeCountAtLeast { subtype, count });
     }
     // "you control N or more [color] permanents" / "you control N or more [core type]s"
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("you control ").parse(text) {
@@ -1353,6 +1360,46 @@ mod tests {
                 filter: None,
             }),
             "numeric attacker threshold must stay filter: None"
+        );
+    }
+
+    /// CR 207.2c: The "creatures with different powers" (Coven) and "lands with the
+    /// same name" qualifier phrases have dedicated typed condition variants. The
+    /// generic bare-subtype count catch-all must not shadow them by swallowing the
+    /// whole phrase into a stringly-typed subtype. This is a fail-on-revert guard:
+    /// reordering the generic arm back above the specific arms makes these produce
+    /// `YouControlSubtypeCountAtLeast { subtype: "creatures with different power"/… }`.
+    #[test]
+    fn qualifier_phrase_conditions_beat_generic_subtype_count() {
+        // Coven activation/cast restriction (Dawnhart Mentor, Ambitious Farmhand,
+        // Candletrap, Sungold Sentinel).
+        assert_eq!(
+            parse_restriction_condition(
+                "you control three or more creatures with different powers"
+            ),
+            Some(ParsedCondition::YouControlDifferentPowerCreatureCountAtLeast { count: 3 }),
+            "Coven 'different powers' must map to the dedicated variant, not a subtype dump"
+        );
+        // Endless Atlas / Sceptre of Eternal Glory.
+        assert_eq!(
+            parse_restriction_condition("you control three or more lands with the same name"),
+            Some(ParsedCondition::YouControlLandsWithSameNameAtLeast { count: 3 }),
+            "'lands with the same name' must map to the dedicated variant"
+        );
+        // Regression guard: a genuine bare subtype still flows to the generic arm.
+        assert_eq!(
+            parse_restriction_condition("you control five or more vampires"),
+            Some(ParsedCondition::YouControlSubtypeCountAtLeast {
+                subtype: "vampire".to_string(),
+                count: 5,
+            }),
+            "bare subtype threshold must still reach the generic subtype-count arm"
+        );
+        // Regression guard: snow permanents keep their own variant.
+        assert_eq!(
+            parse_restriction_condition("you control two or more snow permanents"),
+            Some(ParsedCondition::YouControlSnowPermanentCountAtLeast { count: 2 }),
+            "snow-permanent threshold must keep its dedicated variant"
         );
     }
 


### PR DESCRIPTION
Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Summary

In `parse_you_control_condition`, the generic `you control N or more <subtype>` catch-all (`parse_you_control_subtype_count`) ran **before** the dedicated qualifier-phrase arms. Its bare `" or more "` split greedily consumed the qualifier phrase and dumped the entire tail into a stringly-typed subtype:

| Oracle text | Before (wrong) | After (correct) |
|---|---|---|
| `…three or more creatures with different powers` | `YouControlSubtypeCountAtLeast{ subtype: "creatures with different power" }` | `YouControlDifferentPowerCreatureCountAtLeast{ count: 3 }` |
| `…three or more lands with the same name` | `YouControlSubtypeCountAtLeast{ subtype: "lands with the same name" }` | `YouControlLandsWithSameNameAtLeast{ count: 3 }` |

No permanent has the subtype `"creatures with different power"` or `"lands with the same name"`, so the runtime count is **always 0** — the Coven (CR 702.152) and same-name conditions can never become true. Dawnhart Mentor's Coven bonus, Candletrap's Coven activation restriction, Endless Atlas's card draw, etc. silently never fire.

The fix moves the generic catch-all **below** the dedicated `YouControlDifferentPowerCreatureCountAtLeast` / `YouControlLandsWithSameNameAtLeast` arms (which already existed in the same function) so the specific typed parse wins. Parser-only; the target variants and their runtime handlers already ship.

**Cards fixed (6):** Ambitious Farmhand, Candletrap, Dawnhart Mentor, Sungold Sentinel (Coven); Endless Atlas, Sceptre of Eternal Glory (same name).

## Gate A

`./scripts/check-parser-combinators.sh` — clean. The change introduces **no** new string-matching primitives; it only reorders three existing `if let` arms. Three-dot diff of `crates/engine/src/parser/**` against `origin/main` grepped for forbidden methods (`.contains("`, `.split_once(`, `.strip_suffix(`, `.starts_with("`, `.find("`, …): **no matches**.

## Anchored on

- `crates/engine/src/parser/oracle_condition.rs:455` — dedicated `YouControlDifferentPowerCreatureCountAtLeast` arm (and `:460` for `YouControlLandsWithSameNameAtLeast`) that the generic catch-all was shadowing.
- `crates/engine/src/parser/oracle_condition.rs:472` — the relocated `parse_you_control_subtype_count` generic arm, now ordered after the specific arms.

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --tests -- -D warnings` — clean.
- `cargo test -p engine --lib -- parser::` — **7550 passed / 0 failed**, including the new fail-on-revert guard `qualifier_phrase_conditions_beat_generic_subtype_count` (reordering the generic arm back on top makes it fail).
- **Blast-radius proof:** rebuilt `oracle-gen` with the fix and regenerated `card-data.json` (35,397 cards) vs the clean-main baseline — **exactly 6 cards changed**, all listed above, each moving from the stringly-typed subtype dump to the correct dedicated variant. Zero collateral, zero over-match.

## Scope Expansion

None.
