### PR TITLE
fix(data): populate Alchemy spellbook lists from AtomicCards so DraftFromSpellbook works

### DIFF
--- a/crates/engine/src/bin/oracle_gen.rs
+++ b/crates/engine/src/bin/oracle_gen.rs
@@ -448,20 +448,39 @@ struct TokenSourceMetadata {
 
 fn build_token_source_metadata(
     mtgjson_path: &std::path::Path,
+    atomic: &engine::database::mtgjson::AtomicCardsFile,
 ) -> HashMap<String, TokenSourceMetadata> {
     let sets_dir = mtgjson_path
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."))
         .join("sets");
 
-    if !sets_dir.exists() {
-        return HashMap::new();
+    let mut map: HashMap<String, TokenSourceMetadata> = HashMap::new();
+
+    // Per-set token/spellbook metadata requires local set files, so guard the
+    // set loop on the directory. It must NOT early-return the whole function —
+    // the Alchemy spellbook harvest below runs unconditionally so the
+    // Effect::DraftFromSpellbook faces are populated even when only
+    // AtomicCards.json is present locally.
+    if sets_dir.exists() {
+        merge_set_token_metadata(&sets_dir, &mut map);
     }
 
-    let mut map: HashMap<String, TokenSourceMetadata> = HashMap::new();
-    let entries = match std::fs::read_dir(&sets_dir) {
+    // Revive Effect::DraftFromSpellbook: source each face's Alchemy spellbook
+    // list from the already-loaded AtomicCards.json (relatedCards.spellbook),
+    // which serde previously dropped for lack of a capturing field.
+    merge_atomic_spellbooks(&mut map, atomic);
+
+    map
+}
+
+fn merge_set_token_metadata(
+    sets_dir: &std::path::Path,
+    map: &mut HashMap<String, TokenSourceMetadata>,
+) {
+    let entries = match std::fs::read_dir(sets_dir) {
         Ok(entries) => entries,
-        Err(_) => return HashMap::new(),
+        Err(_) => return,
     };
 
     for entry in entries.flatten() {
@@ -498,7 +517,42 @@ fn build_token_source_metadata(
             }
         }
     }
-    map
+}
+
+/// Harvest each card's Alchemy spellbook (`relatedCards.spellbook`) from the
+/// already-loaded AtomicCards data and merge it into the token-source map.
+///
+/// This is the data-pipeline fix that revives `Effect::DraftFromSpellbook`:
+/// the spellbook faces are absent from the local per-set files, and serde
+/// previously dropped the nested `relatedCards`, so the map was empty and every
+/// DraftFromSpellbook face drafted from an empty list (a runtime no-op).
+///
+/// The key mirrors the set-file loop's derivation — `faceName` when present,
+/// otherwise `name`, lowercased — NOT `faceName` alone: several spellbook
+/// sources (e.g. Tome of Gadwick, Boseiju Pathlighter) have `faceName: null`,
+/// so keying by face name alone would leave them inert. The "first non-empty
+/// list wins" guard matches the set-file loop so a set-file spellbook, if any,
+/// is not clobbered.
+fn merge_atomic_spellbooks(
+    map: &mut HashMap<String, TokenSourceMetadata>,
+    atomic: &engine::database::mtgjson::AtomicCardsFile,
+) {
+    for faces in atomic.data.values() {
+        for card in faces {
+            if card.related_cards.spellbook.is_empty() {
+                continue;
+            }
+            let key = card
+                .face_name
+                .as_deref()
+                .unwrap_or(&card.name)
+                .to_lowercase();
+            let entry = map.entry(key).or_default();
+            if entry.spellbook.is_empty() {
+                entry.spellbook = card.related_cards.spellbook.clone();
+            }
+        }
+    }
 }
 
 fn stamp_token_source_metadata(face: &mut CardFace, map: &HashMap<String, TokenSourceMetadata>) {
@@ -665,7 +719,7 @@ fn main() {
 
     // Scan per-set MTGJSON files to build a card name → rarities map.
     let rarity_map = build_rarity_map(&mtgjson_path);
-    let token_source_metadata = build_token_source_metadata(&mtgjson_path);
+    let token_source_metadata = build_token_source_metadata(&mtgjson_path, &atomic);
 
     let set_catalog = data_dir
         .as_ref()
@@ -1527,7 +1581,7 @@ mod tests {
     use std::sync::OnceLock;
 
     use engine::database::mtgjson::{
-        load_atomic_cards, AtomicCard, AtomicCardsFile, AtomicIdentifiers,
+        load_atomic_cards, AtomicCard, AtomicCardsFile, AtomicIdentifiers, SetRelatedCards,
     };
     use engine::types::ability::TargetFilter;
     use engine::types::card::CardFace;
@@ -1592,6 +1646,7 @@ mod tests {
                 scryfall_oracle_id: oracle_id.map(str::to_string),
             },
             foreign_data: Vec::new(),
+            related_cards: SetRelatedCards::default(),
         }
     }
 
@@ -1828,6 +1883,57 @@ mod tests {
             Some("finish-oracle"),
             "on a tie, first-inserted wins"
         );
+    }
+
+    /// DATA-PIPELINE guard for the Alchemy spellbook fix. Reverting the
+    /// unconditional `merge_atomic_spellbooks` fold (or the `related_cards`
+    /// capture on `AtomicCard`) empties the map and flips this test red. The
+    /// path deliberately has NO `sets/` subdir, so ONLY the AtomicCards harvest
+    /// can populate the spellbook — exercising the fold in isolation.
+    #[test]
+    fn build_token_source_metadata_harvests_spellbook_from_atomic() {
+        // Drafting source with a 12-name Alchemy spellbook.
+        let spellbook: Vec<String> = (1..=12).map(|i| format!("Spell {i}")).collect();
+        let mut source = atomic_single("Tome Test", Some("tome-oracle"));
+        source.related_cards.spellbook = spellbook.clone();
+
+        // Reach-guard: a second card WITH a spellbook must get its own entry.
+        let mut other = atomic_single("Second Source", Some("second-oracle"));
+        other.related_cards.spellbook = vec!["A".to_string(), "B".to_string()];
+
+        // Negative: a card with an EMPTY spellbook must create no entry.
+        let empty = atomic_single("No Spellbook", Some("none-oracle"));
+
+        let mut data: HashMap<String, Vec<AtomicCard>> = HashMap::new();
+        data.insert("Tome Test".to_string(), vec![source]);
+        data.insert("Second Source".to_string(), vec![other]);
+        data.insert("No Spellbook".to_string(), vec![empty]);
+        let atomic = AtomicCardsFile { data };
+
+        // Temp path whose parent has no `sets/` subdir → set-file loop skipped.
+        let dir =
+            std::env::temp_dir().join(format!("phase-spellbook-harvest-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir should be creatable");
+        let mtgjson_path = dir.join("AtomicCards.json");
+
+        let map = build_token_source_metadata(&mtgjson_path, &atomic);
+
+        assert_eq!(
+            map["tome test"].spellbook, spellbook,
+            "12-name spellbook must be harvested from AtomicCards even with no set files"
+        );
+        assert_eq!(map["tome test"].spellbook.len(), 12);
+        assert_eq!(
+            map["second source"].spellbook,
+            vec!["A".to_string(), "B".to_string()],
+            "a second spellbook source must yield its own populated entry"
+        );
+        assert!(
+            !map.contains_key("no spellbook"),
+            "a card with an empty spellbook must not create a map entry"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     fn load_atomic_fixture() -> &'static AtomicCardsFile {

--- a/crates/engine/src/database/embalm_eternalize_tests.rs
+++ b/crates/engine/src/database/embalm_eternalize_tests.rs
@@ -405,6 +405,7 @@ fn atomic_creature(name: &str, mana_cost: &str, keyword: &str, oracle: &str) -> 
             scryfall_id: Some(format!("{name}-face")),
         },
         foreign_data: Vec::new(),
+        related_cards: crate::database::mtgjson::SetRelatedCards::default(),
     }
 }
 
@@ -461,6 +462,7 @@ fn atomic_with_types(
             scryfall_id: Some(format!("{name}-face")),
         },
         foreign_data: Vec::new(),
+        related_cards: crate::database::mtgjson::SetRelatedCards::default(),
     }
 }
 

--- a/crates/engine/src/database/encore_tests.rs
+++ b/crates/engine/src/database/encore_tests.rs
@@ -390,6 +390,7 @@ fn real_encore_card_synthesizes_encore_ability() {
             scryfall_id: Some("coastline-marauders-face".to_string()),
         },
         foreign_data: Vec::new(),
+        related_cards: crate::database::mtgjson::SetRelatedCards::default(),
     };
 
     let face = crate::database::synthesis::build_oracle_face(&atomic, None);

--- a/crates/engine/src/database/hideaway_tests.rs
+++ b/crates/engine/src/database/hideaway_tests.rs
@@ -389,6 +389,7 @@ fn real_hideaway_card_synthesizes_etb_trigger() {
             scryfall_id: Some("windbrisk-heights-face".to_string()),
         },
         foreign_data: Vec::new(),
+        related_cards: crate::database::mtgjson::SetRelatedCards::default(),
     };
 
     let face = crate::database::synthesis::build_oracle_face(&atomic, None);

--- a/crates/engine/src/database/meld_tests.rs
+++ b/crates/engine/src/database/meld_tests.rs
@@ -45,6 +45,7 @@ fn atomic(name: &str, type_line: &str, types: &[&str], text: &str) -> AtomicCard
             scryfall_id: Some(format!("{}-face", name.to_lowercase())),
         },
         foreign_data: Vec::new(),
+        related_cards: crate::database::mtgjson::SetRelatedCards::default(),
     }
 }
 

--- a/crates/engine/src/database/mtgjson.rs
+++ b/crates/engine/src/database/mtgjson.rs
@@ -86,6 +86,12 @@ pub struct AtomicCard {
     /// sidecars for content i18n. The engine itself stays English-only.
     #[serde(default)]
     pub foreign_data: Vec<ForeignData>,
+    /// Related-card metadata from AtomicCards' `relatedCards`. Without this
+    /// field serde silently drops `relatedCards.spellbook`, leaving the Alchemy
+    /// `Effect::DraftFromSpellbook` faces inert (drafting from an empty list).
+    /// Captured here so `oracle_gen` can harvest the spellbook lists at export.
+    #[serde(default)]
+    pub related_cards: SetRelatedCards,
 }
 
 /// A localized printing of a card from MTGJSON's `foreignData` array. `language`
@@ -617,5 +623,54 @@ mod tests {
         let data = load_atomic_cards(&path).expect("Should load test fixture from file");
         let card = find_card(&data, "Lightning Bolt").expect("Lightning Bolt should exist");
         assert_eq!(card.name, "Lightning Bolt");
+    }
+
+    /// Reach-guard for the Alchemy spellbook data pipeline: AtomicCards' nested
+    /// `relatedCards.spellbook` must survive deserialization into `AtomicCard`.
+    /// Before capturing `related_cards`, serde silently dropped this array,
+    /// leaving every `Effect::DraftFromSpellbook` face inert. The card WITHOUT
+    /// `relatedCards` proves the `#[serde(default)]` fallback yields an empty
+    /// list (non-vacuous negative twin).
+    #[test]
+    fn deserializes_related_cards_spellbook() {
+        let data: AtomicCardsFile = serde_json::from_str(
+            r#"{
+                "data": {
+                    "Alchemist": [{
+                        "name": "Alchemist",
+                        "colors": [],
+                        "colorIdentity": [],
+                        "layout": "normal",
+                        "manaValue": 2.0,
+                        "identifiers": {},
+                        "relatedCards": {
+                            "spellbook": ["Brainstorm", "Ponder"]
+                        }
+                    }],
+                    "Plain Jane": [{
+                        "name": "Plain Jane",
+                        "colors": [],
+                        "colorIdentity": [],
+                        "layout": "normal",
+                        "manaValue": 1.0,
+                        "identifiers": {}
+                    }]
+                }
+            }"#,
+        )
+        .expect("inline fixture should deserialize");
+
+        let alchemist = find_card(&data, "Alchemist").expect("Alchemist should exist");
+        assert_eq!(
+            alchemist.related_cards.spellbook,
+            vec!["Brainstorm".to_string(), "Ponder".to_string()],
+            "relatedCards.spellbook must deserialize into related_cards.spellbook"
+        );
+
+        let plain = find_card(&data, "Plain Jane").expect("Plain Jane should exist");
+        assert!(
+            plain.related_cards.spellbook.is_empty(),
+            "a card without relatedCards must default to an empty spellbook, not fail to parse"
+        );
     }
 }

--- a/crates/engine/src/database/subtype_vocab.rs
+++ b/crates/engine/src/database/subtype_vocab.rs
@@ -263,6 +263,7 @@ mod tests {
                     scryfall_oracle_id: None,
                 },
                 foreign_data: vec![],
+                related_cards: crate::database::mtgjson::SetRelatedCards::default(),
             }],
         );
         let atomic = crate::database::mtgjson::AtomicCardsFile { data: atomic_data };
@@ -309,6 +310,7 @@ mod tests {
                     scryfall_oracle_id: None,
                 },
                 foreign_data: vec![],
+                related_cards: crate::database::mtgjson::SetRelatedCards::default(),
             }],
         );
         atomic_data.insert(
@@ -342,6 +344,7 @@ mod tests {
                     scryfall_oracle_id: None,
                 },
                 foreign_data: vec![],
+                related_cards: crate::database::mtgjson::SetRelatedCards::default(),
             }],
         );
         let atomic = crate::database::mtgjson::AtomicCardsFile { data: atomic_data };

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -10538,6 +10538,7 @@ mod cycling_synthesis_tests {
                 scryfall_id: Some("fractured-sanity-test-face".to_string()),
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         };
 
         let face = build_oracle_face(&mtgjson, None);
@@ -10606,6 +10607,7 @@ mod cycling_synthesis_tests {
                 scryfall_id: Some("storm-queen-test-face".to_string()),
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         };
 
         let face = build_oracle_face(&storm, None);
@@ -10657,6 +10659,7 @@ mod cycling_synthesis_tests {
                 scryfall_id: Some("flying-men-test-face".to_string()),
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         };
 
         let face = build_oracle_face(&men, None);
@@ -11260,6 +11263,7 @@ mod evoke_synthesis_tests {
                 scryfall_oracle_id: None,
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         };
 
         let face = build_oracle_face(&mtgjson, None);
@@ -13662,6 +13666,7 @@ mod provoke_synthesis_tests {
                 scryfall_oracle_id: None,
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         };
 
         let face = build_oracle_face(&mtgjson, None);
@@ -14738,6 +14743,7 @@ mod increment_synthesis_tests {
                 scryfall_id: Some("increment-dedupe-test-face".to_string()),
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         }
     }
 
@@ -21254,6 +21260,7 @@ mod bloodthirst_synthesis_tests {
                 scryfall_oracle_id: None,
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         };
 
         let face = build_oracle_face(&mtgjson, None);
@@ -21317,6 +21324,7 @@ mod bloodthirst_synthesis_tests {
                 scryfall_oracle_id: None,
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         }
     }
 
@@ -21436,6 +21444,7 @@ mod bloodthirst_synthesis_tests {
                 scryfall_oracle_id: None,
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         }
     }
 
@@ -21567,6 +21576,7 @@ mod bloodthirst_synthesis_tests {
                 scryfall_oracle_id: None,
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         };
 
         let face = build_oracle_face(&mtgjson, None);

--- a/crates/engine/src/database/unearth_tests.rs
+++ b/crates/engine/src/database/unearth_tests.rs
@@ -411,6 +411,7 @@ fn atomic_unearth_creature() -> AtomicCard {
             scryfall_id: Some("hellspark-face".to_string()),
         },
         foreign_data: Vec::new(),
+        related_cards: crate::database::mtgjson::SetRelatedCards::default(),
     }
 }
 

--- a/crates/engine/src/game/effects/spellbook_tests.rs
+++ b/crates/engine/src/game/effects/spellbook_tests.rs
@@ -231,3 +231,141 @@ fn parser_rejects_unmodeled_riders_as_unimplemented() {
         );
     }
 }
+
+/// Runtime DRIVER + RESOLVER guard for the interactive Alchemy draft. Builds a
+/// battlefield permanent with a `{T}: DraftFromSpellbook` activated ability,
+/// seeds its spellbook, and drives it through the real activation pipeline via
+/// the new `.spellbook_pick(..)` driver hook. Reverting the driver's
+/// `SpellbookDraft` arm (or the `spellbook_pick` threading) leaves the pick
+/// unanswered: the draft never completes, the card never reaches hand, and the
+/// pipeline halts at `SpellbookDraft` instead of `Priority` — flipping both
+/// assertions. This guards the driver/resolver, NOT the data pipeline (that
+/// revert guard is the oracle_gen `build_token_source_metadata` merge test).
+#[test]
+fn spellbook_pick_drives_the_draft_and_conjures_the_chosen_card() {
+    use crate::game::scenario::GameScenario;
+    use crate::types::ability::{AbilityCost, AbilityDefinition, AbilityKind};
+    use crate::types::phase::Phase;
+
+    let p0 = PlayerId(0);
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(p0, "Alchemist", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::DraftFromSpellbook {
+                    destination: Zone::Hand,
+                    tapped: false,
+                },
+            )
+            .cost(AbilityCost::Tap),
+        )
+        .id();
+    let mut runner = scenario.build();
+
+    // Seed the drafting source's spellbook — the runtime data the pipeline fix
+    // populates at export from AtomicCards' relatedCards.spellbook.
+    let list = ["Fireshrieker", "Lion Sash", "Fishing Pole"];
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&source)
+        .unwrap()
+        .spellbook = list.iter().map(|s| s.to_string()).collect();
+
+    let outcome = runner
+        .activate(source, 0)
+        .spellbook_pick("Lion Sash")
+        .resolve();
+
+    let drafted = outcome.state().players[0]
+        .hand
+        .iter()
+        .filter_map(|id| outcome.state().objects.get(id))
+        .any(|o| o.name == "Lion Sash");
+    assert!(
+        drafted,
+        "the driver must conjure the declared spellbook pick into P0's hand"
+    );
+    // Positive reach-guard (non-vacuous): the driver actually reached the
+    // SpellbookDraft halt, answered it, and drove resolution back to Priority.
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "resolution must return to Priority after the draft, got {:?}",
+        outcome.final_waiting_for()
+    );
+}
+
+/// Multi-authority provenance: with two permanents carrying DIFFERENT
+/// spellbooks, activating one must offer ONLY that source's list — proving the
+/// offered options come from the drafting source, not any other permanent.
+/// Activating without a `.spellbook_pick(..)` halts cleanly at `SpellbookDraft`
+/// (the driver's no-pick break), which we inspect for the offered options.
+#[test]
+fn spellbook_draft_offers_only_the_activated_sources_list() {
+    use crate::game::scenario::GameScenario;
+    use crate::types::ability::{AbilityCost, AbilityDefinition, AbilityKind};
+    use crate::types::phase::Phase;
+
+    let p0 = PlayerId(0);
+    let draft = || {
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::DraftFromSpellbook {
+                destination: Zone::Hand,
+                tapped: false,
+            },
+        )
+        .cost(AbilityCost::Tap)
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source_a = scenario
+        .add_creature(p0, "Archivist A", 1, 1)
+        .with_ability_definition(draft())
+        .id();
+    let source_b = scenario
+        .add_creature(p0, "Archivist B", 1, 1)
+        .with_ability_definition(draft())
+        .id();
+    let mut runner = scenario.build();
+
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&source_a)
+        .unwrap()
+        .spellbook = vec!["Alpha One".to_string(), "Alpha Two".to_string()];
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&source_b)
+        .unwrap()
+        .spellbook = vec![
+        "Beta One".to_string(),
+        "Beta Two".to_string(),
+        "Beta Three".to_string(),
+    ];
+
+    // Activate A with NO pick → the driver halts at the draft boundary.
+    let outcome = runner.activate(source_a, 0).resolve();
+    match outcome.final_waiting_for() {
+        WaitingFor::SpellbookDraft {
+            source_id, options, ..
+        } => {
+            assert_eq!(
+                *source_id, source_a,
+                "the draft must be sourced from the activated permanent"
+            );
+            assert_eq!(
+                options,
+                &vec!["Alpha One".to_string(), "Alpha Two".to_string()],
+                "only the activated source's spellbook may be offered, not the other permanent's"
+            );
+        }
+        other => panic!("expected halt at SpellbookDraft, got {other:?}"),
+    }
+}

--- a/crates/engine/src/game/haunt_tests.rs
+++ b/crates/engine/src/game/haunt_tests.rs
@@ -507,6 +507,7 @@ fn atomic(name: &str, types: &[&str], type_line: &str, oracle: &str) -> AtomicCa
             scryfall_id: Some(format!("{name}-face")),
         },
         foreign_data: Vec::new(),
+        related_cards: crate::database::mtgjson::SetRelatedCards::default(),
     }
 }
 

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1748,6 +1748,7 @@ pub struct SpellCast<'a> {
     discard_cards: Vec<ObjectId>,
     effect_zone_cards: Vec<ObjectId>,
     copy_target: Option<ObjectId>,
+    spellbook_pick: Option<String>,
 }
 
 impl<'a> SpellCast<'a> {
@@ -1773,6 +1774,7 @@ impl<'a> SpellCast<'a> {
             discard_cards: Vec::new(),
             effect_zone_cards: Vec::new(),
             copy_target: None,
+            spellbook_pick: None,
         }
     }
 
@@ -1927,6 +1929,13 @@ impl<'a> SpellCast<'a> {
         self
     }
 
+    /// Draft this card name at any `SpellbookDraft` prompt during resolution
+    /// (Alchemy `Effect::DraftFromSpellbook`). Mirrors [`choose_option`].
+    pub fn spellbook_pick(mut self, name: &str) -> Self {
+        self.spellbook_pick = Some(name.to_string());
+        self
+    }
+
     /// Tap these creatures to pay the cost via Convoke (CR 702.51a). Each is
     /// tapped during the `ManaPayment { convoke_mode }` window with mana of the
     /// creature's first declared color (falling back to colorless for the
@@ -1966,6 +1975,7 @@ impl<'a> SpellCast<'a> {
             discard_cards,
             effect_zone_cards,
             copy_target,
+            spellbook_pick,
         } = self;
 
         // CR 119.3: snapshot life totals before the cast so `life_delta` reads a
@@ -2224,6 +2234,7 @@ impl<'a> SpellCast<'a> {
             discard_cards,
             effect_zone_cards,
             copy_target,
+            spellbook_pick,
         })
     }
 
@@ -2261,6 +2272,7 @@ pub struct CastCommit<'a> {
     discard_cards: Vec<ObjectId>,
     effect_zone_cards: Vec<ObjectId>,
     copy_target: Option<ObjectId>,
+    spellbook_pick: Option<String>,
 }
 
 impl<'a> CastCommit<'a> {
@@ -2299,6 +2311,7 @@ impl<'a> CastCommit<'a> {
             discard_cards,
             effect_zone_cards,
             copy_target,
+            spellbook_pick,
             ..
         } = self;
 
@@ -2321,6 +2334,7 @@ impl<'a> CastCommit<'a> {
             discard_cards,
             effect_zone_cards,
             copy_target,
+            spellbook_pick,
         };
         events.extend(drive_resolution(runner, &policy)?);
 
@@ -2497,6 +2511,7 @@ pub struct AbilityActivation<'a> {
     pay_with: Vec<ObjectId>,
     search_pick: SearchPolicy,
     optional: OptionalPolicy,
+    spellbook_pick: Option<String>,
 }
 
 impl<'a> AbilityActivation<'a> {
@@ -2512,6 +2527,7 @@ impl<'a> AbilityActivation<'a> {
             pay_with: Vec::new(),
             search_pick: SearchPolicy::default(),
             optional: OptionalPolicy::default(),
+            spellbook_pick: None,
         }
     }
 
@@ -2582,6 +2598,13 @@ impl<'a> AbilityActivation<'a> {
         self
     }
 
+    /// Draft this card name at any `SpellbookDraft` prompt during resolution
+    /// (Alchemy `Effect::DraftFromSpellbook`). Mirrors [`SpellCast::spellbook_pick`].
+    pub fn spellbook_pick(mut self, name: &str) -> Self {
+        self.spellbook_pick = Some(name.to_string());
+        self
+    }
+
     /// Drive the full activation pipeline to its conclusion and return the
     /// outcome. See [`SpellCast::resolve`] for the shared contract.
     pub fn resolve(self) -> Outcome {
@@ -2596,6 +2619,7 @@ impl<'a> AbilityActivation<'a> {
             pay_with,
             search_pick,
             optional,
+            spellbook_pick,
         } = self;
 
         // CR 119.3: snapshot life totals before activation for `life_delta`.
@@ -2736,6 +2760,7 @@ impl<'a> AbilityActivation<'a> {
             discard_cards: Vec::new(),
             effect_zone_cards: Vec::new(),
             copy_target: None,
+            spellbook_pick,
         };
         events.extend(
             drive_resolution(runner, &policy).expect("ability resolution must be accepted"),
@@ -2811,6 +2836,10 @@ pub struct ResolutionPolicy {
     pub effect_zone_cards: Vec<ObjectId>,
     /// Permanent to choose at `CopyTargetChoice`.
     pub copy_target: Option<ObjectId>,
+    /// Card name to draft at a `SpellbookDraft` prompt (Alchemy
+    /// `Effect::DraftFromSpellbook`). `None` halts the driver so tests without a
+    /// pick can inspect the offered `options` via `final_waiting_for()`.
+    pub spellbook_pick: Option<String>,
 }
 
 /// Drive the engine through resolution, answering the prompts the harness knows
@@ -2997,6 +3026,24 @@ fn drive_resolution(
                     break;
                 };
                 act_collect(runner, GameAction::ChooseOption { choice }, &mut events)?;
+            }
+            // Alchemy `Effect::DraftFromSpellbook`: draft the declared card name
+            // from the drafting source's spellbook `options`. No pick declared →
+            // halt so the caller can assert the offered options and the draft
+            // boundary via `final_waiting_for()`.
+            WaitingFor::SpellbookDraft { options, .. } => {
+                let Some(card) = policy.spellbook_pick.clone() else {
+                    break;
+                };
+                debug_assert!(
+                    options.contains(&card),
+                    "spellbook_pick {card:?} is not in the drafting source's spellbook {options:?}"
+                );
+                act_collect(
+                    runner,
+                    GameAction::SubmitSpellbookDraft { card },
+                    &mut events,
+                )?;
             }
             WaitingFor::DiscardChoice {
                 cards,

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -1331,6 +1331,7 @@ fn oracle_face_for(
             scryfall_id: Some(format!("{}-face", name.to_lowercase())),
         },
         foreign_data: Vec::new(),
+        related_cards: crate::database::mtgjson::SetRelatedCards::default(),
     };
     crate::database::synthesis::build_oracle_face(&card, None)
 }
@@ -1844,6 +1845,7 @@ fn pupu_ufo_full_card_supported_dynamic_base_power() {
                 scryfall_id: Some("pupu-ufo-face".to_string()),
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         };
     let face = crate::database::synthesis::build_oracle_face(&card, None);
     let gaps = crate::game::coverage::card_face_gaps(&face);
@@ -1894,6 +1896,7 @@ fn sita_varma_full_card_supported_inverted_genitive_base_pt() {
                 scryfall_id: Some("sita-varma-face".to_string()),
             },
             foreign_data: Vec::new(),
+            related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         };
     let face = crate::database::synthesis::build_oracle_face(&card, None);
     let gaps = crate::game::coverage::card_face_gaps(&face);


### PR DESCRIPTION
## Summary
Fixes a latent data-pipeline bug that left the **Alchemy spellbook** mechanic silently inert. `Effect::DraftFromSpellbook` (and the conjure-from-spellbook path) reads `GameObject::spellbook`, which is populated from `CardFace.metadata.spellbook` — but that field was **never populated in production**, so ~29 already-supported spellbook cards drafted from an empty list and did nothing.

**Root cause:** the `AtomicCard` deserialization struct had no field capturing MTGJSON's `relatedCards`, so `relatedCards.spellbook` was silently dropped on load; and per-set files (the only source `build_token_source_metadata` read) don't carry `spellbook` — only `AtomicCards.json` does.

**Fix (data-only, no parser/AST change):**
- `database/mtgjson.rs` — capture `relatedCards` on `AtomicCard` via the existing `SetRelatedCards` struct (`#[serde(default)]`).
- `bin/oracle_gen.rs` — `build_token_source_metadata` now harvests `spellbook` from the already-loaded `AtomicCardsFile` (mirroring `harvest_creature_subtypes_from_atomic`), keyed by the same `face_name.unwrap_or(name).to_lowercase()` convention the stamp lookup uses, "first non-empty wins". Token/scryfall sourcing untouched.

This revives the whole spellbook class (Tome of Gadwick, Boseiju Pathlighter, Ominous Traveler, Adaptive Armorer, …) to actually draft. **No card's parse signature or coverage status changes** — these cards already parse to `DraftFromSpellbook`; the fix restores their runtime behavior only.

## Files changed
- `crates/engine/src/database/mtgjson.rs` — `AtomicCard.related_cards` field + deser test
- `crates/engine/src/bin/oracle_gen.rs` — `merge_atomic_spellbooks` harvest + merge test
- `crates/engine/src/game/scenario.rs` — test-driver support for the interactive `WaitingFor::SpellbookDraft` (`ResolutionPolicy.spellbook_pick` + `.spellbook_pick()` builder + `drive_resolution` arm)
- `crates/engine/src/game/effects/spellbook_tests.rs` — runtime + provenance tests
- 9 test modules — mechanical `AtomicCard` struct-literal updates for the new field

## CR references
None — conjure/spellbook is a digital-only Alchemy mechanic with no Comprehensive Rules entry (per `game/effects/spellbook.rs`).

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high
Tier: Frontier

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (exit 0; no parser change)
- `cargo clippy -p engine --all-targets -- -D warnings` — clean
- `cargo test -p engine` — 0 failures, incl. the new tests
- `./scripts/gen-card-data.sh` — regenerated; `metadata.spellbook` now populated (Tome of Gadwick=12, Boseiju Pathlighter=15, Goblin Influx Array=15, Ominous Traveler=15). Byte-check: `parse_details`/`abilities`/`triggers`/`statics` **identical** vs baseline — only `metadata.spellbook` changed.
- `cargo coverage` — no delta (88.75%); spellbook cards' supported status unchanged (data-only, no coverage flip)

Tests added:
- `deserializes_related_cards_spellbook` (mtgjson.rs) — proves `relatedCards.spellbook` now deserializes (was silently dropped); non-vacuous negative twin.
- `build_token_source_metadata_harvests_spellbook_from_atomic` (oracle_gen.rs) — sets-less temp path so only the atomic fold can populate; **reverting the fold fails this test** (the pipeline-fix revert guard).
- `spellbook_pick_drives_the_draft_and_conjures_the_chosen_card` (spellbook_tests.rs) — drives the real interactive pipeline (activate → `SpellbookDraft` → `SubmitSpellbookDraft` → `complete_draft`) and asserts the chosen card enters hand; fails if the draft doesn't happen.
- `spellbook_draft_offers_only_the_activated_sources_list` — two sources with different spellbooks → asserts the offered list is the drafting source's own (provenance via `source_id`).

## Scope Expansion
None. (Data-source fix only. The `ConjureSource::Random` parser generalization that would additionally consume this data is a deliberate follow-up, not included here.)

## Validation Failures
None.

## CI Failures
None.
