### PR TITLE
fix(parser): classify each-object damage continuation as mass damage (DamageAll)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -14625,6 +14625,58 @@ fn parse_bare_damage_continuation<'a>(
             "",
         ));
     }
+    // CR 120.2b + CR 120.3: A chained continuation whose recipient is an
+    // "each <object>" scope — e.g. "... and 1 damage to each creature your
+    // opponents control" — is uniform mass damage to every matching permanent,
+    // not a single targeted hit. The primary segment already classifies this in
+    // `try_parse_damage_with_remainder`; the bare-continuation path must do the
+    // same or it emits a single-target `DealDamage` that would (illegally)
+    // require one legal target and mark damage on only one creature. Affects the
+    // second segment of Dagger Caster, Seismic Wave, Wildfire Howl (gift half),
+    // The Fall of Kroog, and Radiating Lightning. Excluded via `each of ` guard:
+    // the "each of up to N target(s)" distribute form (Drakuseth), which is a
+    // targeted multi-hit owned by the primary distribute path, not mass damage.
+    if tag::<_, _, OracleError<'_>>("each ")
+        .parse(after_to)
+        .is_ok()
+        && tag::<_, _, OracleError<'_>>("each of ")
+            .parse(after_to)
+            .is_err()
+    {
+        // "each player" / "each opponent" / "each foe" → per-player damage,
+        // which may vary per recipient (`DamageEachPlayer`, CR 120.3a).
+        if let Some(player_filter) = lower::parse_damage_each_player_scope(after_to) {
+            return Some((
+                Effect::DamageEachPlayer {
+                    amount,
+                    player_filter,
+                },
+                "",
+            ));
+        }
+        // "each <object filter>" → uniform mass object damage (`DamageAll`). A
+        // trailing "and each <player>" composite scope is lifted into
+        // `player_filter`, mirroring the primary each-branch classification.
+        let (target, rem) = parse_target_with_ctx(after_to, ctx);
+        let (target, rem) = refine_damage_target_remainder(target, rem);
+        let rem = trim_dangling_target_word(rem);
+        let trimmed_rem = rem.trim_start_matches([',', ' ']);
+        let trimmed_rem_lower = trimmed_rem.to_lowercase();
+        let player_filter = tag::<_, _, OracleError<'_>>("and ")
+            .parse(trimmed_rem_lower.as_str())
+            .ok()
+            .and_then(|(after_and, _)| lower::parse_damage_each_player_scope(after_and));
+        let rem_out = if player_filter.is_some() { "" } else { rem };
+        return Some((
+            Effect::DamageAll {
+                amount,
+                target,
+                player_filter,
+                damage_source: None,
+            },
+            rem_out,
+        ));
+    }
     let (target, rem) = parse_target_with_ctx(after_to, ctx);
     let (target, rem) = refine_damage_target_remainder(target, rem);
     let rem = trim_dangling_target_word(rem);

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -3317,7 +3317,11 @@ fn dagger_caster_each_opponent_chain_emits_damage_each_player() {
             ),
         }
     // Sub-ability: the second "1 damage to each creature your opponents
-    // control" segment chains as a mass-damage effect at opponents' creatures.
+    // control" segment is uniform mass damage to every matching creature, so it
+    // MUST chain as `DamageAll{Typed{Creature, Opponent}}` — NOT a single-target
+    // `DealDamage`, which would illegally require one legal target and mark
+    // damage on only one creature (CR 120.3). Fail-on-revert of the bare-damage
+    // continuation each-object mass classification.
     let sub = def
         .sub_ability
         .as_ref()
@@ -3325,23 +3329,64 @@ fn dagger_caster_each_opponent_chain_emits_damage_each_player() {
     match &*sub.effect {
         Effect::DamageAll {
             amount: QuantityExpr::Fixed { value: 1 },
-            target,
+            target: TargetFilter::Typed(tf),
+            player_filter: None,
             ..
-        } => match target {
-            TargetFilter::Typed(tf) => {
-                assert_eq!(tf.controller, Some(ControllerRef::Opponent));
-                assert!(tf
-                    .type_filters
-                    .iter()
-                    .any(|t| matches!(t, TypeFilter::Creature)));
+        } => {
+            assert_eq!(tf.controller, Some(ControllerRef::Opponent));
+            assert!(tf
+                .type_filters
+                .iter()
+                .any(|t| matches!(t, TypeFilter::Creature)));
+        }
+        other => {
+            panic!("expected DamageAll{{Typed{{Creature, Opponent}}}} sub_ability, got {other:?}")
+        }
+    }
+}
+
+/// CR 120.2b + CR 120.3: The bare-damage continuation classifier must treat an
+/// "each <object>" recipient as uniform mass damage (`DamageAll`), the same as
+/// the primary segment does. Seismic Wave — "deals 2 damage to any target and 1
+/// damage to each nonartifact creature target opponent controls" — chains the
+/// object half as `DamageAll` over the whole nonartifact-creature set of the
+/// targeted opponent, never a single-target `DealDamage`. Building-block guard
+/// for the whole "... and N damage to each <object>" chain class.
+#[test]
+fn bare_damage_continuation_each_object_is_mass_damage() {
+    let def = parse_effect_chain(
+        "~ deals 2 damage to any target and 1 damage to each nonartifact creature target opponent controls",
+        AbilityKind::Spell,
+    );
+    // Primary: the "any target" half stays a single-target DealDamage(2).
+    assert!(
+        matches!(
+            &*def.effect,
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 2 },
+                ..
             }
-            other => panic!("expected Typed{{Creature, Opponent}} sub-target, got {other:?}"),
-        },
-        Effect::DealDamage {
+        ),
+        "primary must stay single-target DealDamage(2), got {:?}",
+        def.effect
+    );
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("expected chained mass-damage sub_ability for the each-object segment");
+    match &*sub.effect {
+        Effect::DamageAll {
             amount: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Typed(tf),
             ..
-        } => {}
-        other => panic!("expected DamageAll/DealDamage(1) sub_ability, got {other:?}"),
+        } => {
+            assert_eq!(tf.controller, Some(ControllerRef::TargetOpponent));
+            assert!(tf
+                .type_filters
+                .iter()
+                .any(|t| matches!(t, TypeFilter::Creature)));
+        }
+        other => panic!("expected DamageAll over the nonartifact-creature set, got {other:?}"),
     }
 }
 


### PR DESCRIPTION
Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Summary

A chained damage line whose **second** conjunct deals damage to `each <object>` — e.g. `"deals N damage to <recipient> and M damage to each creature your opponents control"` — is uniform **mass** damage to every matching permanent, not a single targeted hit.

The primary damage segment already classifies `each <object>` recipients into `DamageAll` / `DamageEachPlayer` (`try_parse_damage_with_remainder`), but the verbless bare-continuation path (`parse_bare_damage_continuation`) unconditionally emitted a single-target `Effect::DealDamage`. That is doubly wrong at runtime: it would require **one legal target** and mark damage on only **one** creature instead of the whole set.

| Card | second segment | before (wrong) | after (correct) |
|---|---|---|---|
| Dagger Caster | `1 damage to each creature your opponents control` | `DealDamage{1, Typed[Creature, Opponent]}` | `DamageAll{1, Typed[Creature, Opponent]}` |
| Seismic Wave | `1 damage to each nonartifact creature target opponent controls` | single-target `DealDamage(1)` | `DamageAll{1, …, TargetOpponent}` |

The fix adds an `"each "` classification branch (nom `tag()` combinators) before the generic `DealDamage` fallthrough:
- `each player / opponent / foe` → `DamageEachPlayer` (per-player, CR 120.3a)
- `each <object>` → `DamageAll`, lifting a trailing `and each <player>` composite scope into `player_filter`, mirroring the primary each-branch.

It is guarded with an `"each of "` negative so the `each of up to N target(s)` **targeted-distribute** form (Drakuseth), owned by the primary distribute path, is untouched. Parser-only; `DamageAll` / `DamageEachPlayer` and their runtime handlers already ship.

**Cards fixed (5):** Dagger Caster, Radiating Lightning, Seismic Wave, The Fall of Kroog, Wildfire Howl.

## Gate A

`./scripts/check-parser-combinators.sh` — clean. The new branch uses only nom combinators (`tag().parse()`) for dispatch and reuses existing building blocks (`parse_damage_each_player_scope`, `parse_target_with_ctx`, `refine_damage_target_remainder`, `trim_dangling_target_word`). Three-dot diff of `crates/engine/src/parser/**` against `origin/main` grepped for forbidden methods (`.contains("`, `.split_once(`, `.starts_with("`, `.strip_suffix(`, …): **no matches**.

## Anchored on

- `crates/engine/src/parser/oracle_effect/mod.rs:14628` — the new `each <object>`/`each <player>` classification branch inside `parse_bare_damage_continuation` (fn at `:14556`).
- `crates/engine/src/parser/oracle_effect/mod.rs` `try_parse_damage_with_remainder` — the primary-segment each-branch this mirrors, so both damage-line positions classify `each <object>` identically.

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --tests -- -D warnings` — clean.
- `cargo test -p engine --lib -- parser::` — **7560 passed / 0 failed**, including two fail-on-revert tests: `dagger_caster_each_opponent_chain_emits_damage_each_player` (tightened — now requires `DamageAll{Typed[Creature,Opponent], player_filter:None}`, the lenient `DealDamage` fallback removed) and the new class-level `bare_damage_continuation_each_object_is_mass_damage` (Seismic Wave — primary stays `DealDamage(2)`, object half becomes `DamageAll` over `TargetOpponent`'s creatures).
- CR annotations verified against `docs/MagicCompRules.txt` (120.2b, 120.3, 120.3a).
- **Blast-radius proof:** rebuilt `oracle-gen` with the fix and regenerated `card-data.json` vs the clean-main baseline — **exactly 5 cards changed**, all the same `DealDamage → DamageAll` correction on the each-object continuation, amount/type-filter/controller preserved. Drakuseth (`each of up to` distribute, guarded) and the complex-controller chains (Chandra's Fury, Fear Fire Foes!) are untouched. Zero collateral; total unimplemented count unchanged.

## Scope Expansion

None.
