### PR TITLE
feat(parser): parse "for each <type> you control with <keyword>" counts

### DIFF
--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -6749,6 +6749,83 @@ fn for_each_pump_self_ref() {
     );
 }
 
+/// CR 109.4 + CR 702 (issue #5018): PRODUCTION-PATH proof that a real card's
+/// Oracle line flows through `parse_effect` all the way into the new
+/// controller-scoped keyword `for each` arm — not just the quantity helper in
+/// isolation. Aven Gagglemaster / Aerial Assault ("you gain N life for each
+/// creature you control with flying") must lower to a `GainLife` whose amount
+/// is the controller-scoped (`ControllerRef::You`, CR 109.4) count of creatures
+/// with the flying keyword (CR 702). Before the new arm, the bare "you control"
+/// clause stranded " with flying", the for-each clause failed full consumption,
+/// and this dynamic amount was dropped.
+#[test]
+fn for_each_gain_life_controlled_creature_with_keyword_production_path() {
+    let e = parse_effect("You gain 1 life for each creature you control with flying.");
+    match e {
+        Effect::GainLife { amount, .. } => match amount {
+            QuantityExpr::Ref {
+                qty:
+                    QuantityRef::ObjectCount {
+                        filter: TargetFilter::Typed(tf),
+                    },
+            } => {
+                assert_eq!(
+                    tf.controller,
+                    Some(ControllerRef::You),
+                    "life-gain count must be scoped to the source's controller, got {tf:?}"
+                );
+                assert!(
+                    tf.properties.contains(&FilterProp::WithKeyword {
+                        value: Keyword::Flying
+                    }),
+                    "life-gain count must gate on the flying keyword, got {tf:?}"
+                );
+            }
+            other => panic!("expected controller-scoped ObjectCount amount, got {other:?}"),
+        },
+        other => panic!("expected GainLife, got {other:?}"),
+    }
+}
+
+/// CR 109.4 + CR 702 (issue #5018): PRODUCTION-PATH proof for the headline card
+/// Skycat Sovereign ("gets +1/+1 for each other creature you control with
+/// flying") — a static pump through `parse_effect`. The `other` self-exclusion
+/// (`FilterProp::Another`) AND the keyword predicate must both survive the full
+/// production lowering, and the count stays scoped to the source's controller.
+#[test]
+fn for_each_pump_other_controlled_creature_with_keyword_production_path() {
+    let e = parse_effect("~ gets +1/+1 for each other creature you control with flying");
+    match e {
+        Effect::Pump {
+            power:
+                PtValue::Quantity(QuantityExpr::Ref {
+                    qty:
+                        QuantityRef::ObjectCount {
+                            filter: TargetFilter::Typed(tf),
+                        },
+                }),
+            ..
+        } => {
+            assert_eq!(
+                tf.controller,
+                Some(ControllerRef::You),
+                "pump count must be scoped to the source's controller, got {tf:?}"
+            );
+            assert!(
+                tf.properties.contains(&FilterProp::Another),
+                "\"other creature\" must exclude the source via Another, got {tf:?}"
+            );
+            assert!(
+                tf.properties.contains(&FilterProp::WithKeyword {
+                    value: Keyword::Flying
+                }),
+                "pump count must gate on the flying keyword, got {tf:?}"
+            );
+        }
+        other => panic!("expected Pump with dynamic controller-scoped ObjectCount, got {other:?}"),
+    }
+}
+
 /// CR 115.1a/c + CR 701.21a + CR 608.2c: "Target opponent sacrifices a
 /// creature ... for each <dynamic>" (Urborg Justice). The "for each" path
 /// intercepts before the fixed-count `inject_subject_target` Sacrifice arm,

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -4348,8 +4348,8 @@ fn parse_for_each_controlled_type_with_keyword(input: &str) -> OracleResult<'_, 
     let (rest, _) = tag(" you").parse(rest)?;
     let (rest, _) = opt(tag(" already")).parse(rest)?;
     let (rest, _) = tag(" control with ").parse(rest)?;
-    let (rest, keyword_name) = parse_keyword_name(rest)?;
-    let keyword: Keyword = keyword_name.parse().unwrap();
+    let (rest, keyword) =
+        map_res(parse_keyword_name, |s: &str| s.parse::<Keyword>()).parse(rest)?;
 
     let mut properties = Vec::new();
     if has_other.is_some() {

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -3219,6 +3219,13 @@ fn parse_for_each_clause_ref_with_they_controller(
         // unconsumed remainder (Armorcraft Judge, High Sentinels of Arashin,
         // Inspiring Call).
         parse_for_each_controlled_type_with_counter,
+        // CR 109.4 + CR 702: "[other] <type> you control with <keyword>" — a
+        // controller-scoped count gated on a keyword-presence predicate. Must
+        // precede `parse_for_each_controlled_type`, whose bare " you control"
+        // match would otherwise strand the trailing " with <keyword>" clause as
+        // an unconsumed remainder, dropping the quantity (Skycat Sovereign, Aven
+        // Gagglemaster, Aerial Assault, Alert Heedbonder, Overgrown Battlement).
+        parse_for_each_controlled_type_with_keyword,
         parse_for_each_controlled_type,
         // CR 201.2: "for each [other] <type> named <CardName> you control"
         // (Seven Dwarves). The `named X` qualifier sits between the type word
@@ -4310,6 +4317,58 @@ fn parse_for_each_controlled_type_with_counter(input: &str) -> OracleResult<'_, 
     ))
 }
 
+/// CR 109.4 + CR 702: Parse "[other] <type> you [already] control with
+/// <keyword>" in a "for each" clause -> a controller-scoped
+/// (`ControllerRef::You`) population count of the source controller's
+/// permanents of the given type that have the named keyword ability (CR 702),
+/// with an optional "other"/"another" exclusion of the source object.
+///
+/// The controller-scoped ("you control") sibling of
+/// `parse_for_each_battlefield_type_with_keyword` (the any-controller "on the
+/// battlefield with <keyword>" form): both compose `parse_type_filter_word`
+/// with `parse_keyword_name` + `FilterProp::WithKeyword` over the whole
+/// evergreen keyword table, but this arm binds the count to the source's
+/// controller (CR 109.4 — only battlefield/stack objects have a controller).
+/// The controller phrase mirrors `parse_for_each_controlled_type_with_counter`
+/// (the counter-predicate cousin), tolerating the "already" adverb.
+///
+/// Must precede the bare `parse_for_each_controlled_type` arm: that arm matches
+/// "<type> you control" and strands " with <keyword>" as an unconsumed
+/// remainder, which fails the "for each" full-consumption requirement and
+/// silently drops the whole quantity (and its dependent P/T pump, life-gain, or
+/// mana amount). Backs the class: Skycat Sovereign ("for each other creature
+/// you control with flying"), Aven Gagglemaster, Aerial Assault, Alert
+/// Heedbonder, and Overgrown Battlement.
+fn parse_for_each_controlled_type_with_keyword(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, has_other) =
+        opt(alt((value((), tag("other ")), value((), tag("another "))))).parse(input)?;
+    let (rest, tf) = parse_type_filter_word(rest)?;
+    // Mirror the bare `parse_for_each_controlled_type` controller phrase,
+    // tolerating the "already" adverb ("<type> you already control with …").
+    let (rest, _) = tag(" you").parse(rest)?;
+    let (rest, _) = opt(tag(" already")).parse(rest)?;
+    let (rest, _) = tag(" control with ").parse(rest)?;
+    let (rest, keyword_name) = parse_keyword_name(rest)?;
+    let keyword: Keyword = keyword_name.parse().unwrap();
+
+    let mut properties = Vec::new();
+    if has_other.is_some() {
+        properties.push(FilterProp::Another);
+    }
+    properties.push(FilterProp::WithKeyword { value: keyword });
+
+    Ok((
+        rest,
+        QuantityRef::ObjectCount {
+            filter: TargetFilter::Typed(TypedFilter {
+                type_filters: vec![tf],
+                controller: Some(ControllerRef::You),
+                properties,
+            }),
+        },
+    ))
+}
+
 fn parse_for_each_controlled_type(input: &str) -> OracleResult<'_, QuantityRef> {
     // CR 109.4: Only objects on the stack or on the battlefield have a
     // controller, so a "you control" count is over battlefield permanents
@@ -4841,6 +4900,60 @@ mod tests {
                     filter: TargetFilter::Typed(tf),
                 } => {
                     assert_eq!(tf.controller, None, "{clause:?}: counts every controller");
+                    assert_eq!(
+                        tf.properties.contains(&FilterProp::Another),
+                        other,
+                        "{clause:?}: Another presence must match the other/another prefix"
+                    );
+                    assert!(
+                        tf.properties
+                            .contains(&FilterProp::WithKeyword { value: kw }),
+                        "{clause:?}: must gate on the named keyword"
+                    );
+                }
+                other => panic!("{clause:?}: expected ObjectCount, got {other:?}"),
+            }
+        }
+    }
+
+    /// CR 109.4 + CR 702: controller-scoped ("you control") sibling of
+    /// `parse_for_each_battlefield_type_with_keyword_global_count`. Backs the
+    /// class dropped before this arm existed (issue #5018): Skycat Sovereign
+    /// ("for each other creature you control with flying"), Aven Gagglemaster /
+    /// Aerial Assault (flying life-gain), Alert Heedbonder (vigilance), and
+    /// Overgrown Battlement (defender mana). The controller must be `Some(You)`
+    /// — the discriminator from the any-controller battlefield form.
+    #[test]
+    fn parse_for_each_controlled_type_with_keyword_scoped_count() {
+        for (clause, other, kw) in [
+            (
+                "other creature you control with flying",
+                true,
+                Keyword::Flying,
+            ),
+            ("creature you control with flying", false, Keyword::Flying),
+            (
+                "creature you control with vigilance",
+                false,
+                Keyword::Vigilance,
+            ),
+            (
+                "another creature you already control with defender",
+                true,
+                Keyword::Defender,
+            ),
+        ] {
+            let (rest, q) = parse_for_each_clause_ref(clause).unwrap();
+            assert_eq!(rest, "", "{clause:?} should fully consume");
+            match q {
+                QuantityRef::ObjectCount {
+                    filter: TargetFilter::Typed(tf),
+                } => {
+                    assert_eq!(
+                        tf.controller,
+                        Some(ControllerRef::You),
+                        "{clause:?}: 'you control' binds the count to the source controller"
+                    );
                     assert_eq!(
                         tf.properties.contains(&FilterProp::Another),
                         other,


### PR DESCRIPTION
## Summary

Closes #5018

Adds `parse_for_each_controlled_type_with_keyword` to the "for each" quantity dispatch — the **controller-scoped** counterpart to the existing any-controller `parse_for_each_battlefield_type_with_keyword`.

The `for each` grammar could parse `<type> on the battlefield with <keyword>` (any controller) and `<type> you control with a <kind> counter on it` (controller-scoped, counter predicate), but had **no** arm for `<type> you control with <keyword>`. The bare `parse_for_each_controlled_type` arm matched `creature you control` and stranded ` with flying` as an unconsumed remainder; because the `for each` clause requires full consumption, the whole quantity — and the effect depending on it — was silently dropped.

## Cards fixed (class, not one card)

| Card | Oracle text | Effect that was dropped |
|------|-------------|-------------------------|
| **Skycat Sovereign** | "…+1/+1 **for each other creature you control with flying**." | dynamic P/T pump |
| **Aven Gagglemaster** | "…you gain 2 life **for each creature you control with flying**." | life-gain amount |
| **Aerial Assault** | "You gain 1 life **for each creature you control with flying**." | life-gain amount |
| **Alert Heedbonder** | "…you gain 1 life **for each creature you control with vigilance**." | life-gain amount |
| **Overgrown Battlement** | "{T}: Add {G} **for each creature you control with defender**." | mana amount |

## Root cause

The `for each` dispatch (`crates/engine/src/parser/oracle_nom/quantity.rs`) already had a combinator for the **any-controller** form (`parse_for_each_battlefield_type_with_keyword`, `<type> on the battlefield with <keyword>`) and a controller-scoped **counter** form (`parse_for_each_controlled_type_with_counter`), but **no** controller-scoped **keyword** form. The bare `parse_for_each_controlled_type` arm consumed `<type> you control` and left ` with <keyword>` unconsumed, so the clause failed full-consumption and the dependent effect was silently dropped — exactly the failure mode the battlefield-wide sibling already fixed, but for the `you control` scope.

## Implementation

The new combinator composes only existing building blocks:

- `parse_type_filter_word` for the type head,
- the shared controller phrase (mirroring `parse_for_each_controlled_type_with_counter`, tolerating the `already` adverb in "you already control"),
- `parse_keyword_name` + `FilterProp::WithKeyword`, generalized over the whole evergreen keyword table.

The optional `other`/`another` prefix lowers to `FilterProp::Another` (Skycat's "other creature you control"). The count binds to the source controller via `ControllerRef::You` (**CR 109.4** — only battlefield/stack objects have a controller), which is the discriminator from the any-controller battlefield form. **No new enum variants and no engine/runtime changes** — the `FilterProp::WithKeyword` runtime evaluation path already backs the battlefield sibling.

It is registered immediately **before** the bare `parse_for_each_controlled_type` arm so the keyword suffix is consumed before the shorter ` you control` tag can match.

## Tests

`parse_for_each_controlled_type_with_keyword_scoped_count` exercises the class across the keyword table (flying / vigilance / defender), the `other`/`another` self-exclusion, and the `already` adverb, asserting full consumption and `controller == Some(You)` (the discriminator vs. the any-controller battlefield form).

## CR annotations

- **CR 109.4** — only objects on the battlefield/stack have a controller (verified in `docs/MagicCompRules.txt`).
- **CR 702** — Keyword Abilities (the `with <keyword>` predicate; verified).
