### PR TITLE
fix(parser): decompose supertype in 'you control a <supertype> <type>' restrictions

### DIFF
--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -463,6 +463,29 @@ fn parse_you_control_condition(text: &str) -> Option<ParsedCondition> {
     if let Some(count) = parse_numeric_threshold(text, "you control ", " or more snow permanents") {
         return Some(ParsedCondition::YouControlSnowPermanentCountAtLeast { count });
     }
+    // CR 205.4a: A counted "you control N or more <supertype> <type>s" restriction
+    // (two or more basic lands, two or more legendary creatures) must decompose the
+    // supertype into a `HasSupertype` object-count the same way the singular arm
+    // does — otherwise the bare-subtype catch-all below dumps "basic land" /
+    // "legendary creature" into a non-existent subtype and the restriction can never
+    // be satisfied. Runs before `parse_you_control_subtype_count`; the
+    // `parse_supertype_prefix` gate inside the helper keeps ordinary subtype counts
+    // ("two or more vampires") on the subtype path.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("you control ").parse(text) {
+        if let Ok((type_text, count_text)) = terminated(
+            take_until::<_, _, OracleError<'_>>(" or more "),
+            tag(" or more "),
+        )
+        .parse(rest)
+        {
+            if let Some(count) = parse_count_word(count_text) {
+                let singular = type_text.trim().trim_end_matches('.').trim_end_matches('s');
+                if let Some(cond) = parse_you_control_supertype_count(singular, count) {
+                    return Some(cond);
+                }
+            }
+        }
+    }
     // The generic bare-subtype catch-all must run AFTER the specific "creatures with
     // different powers" / "lands with the same name" / "snow permanents" suffix arms
     // above. Otherwise it greedily consumes those qualifier phrases via its bare
@@ -569,21 +592,8 @@ fn parse_you_control_condition(text: &str) -> Option<ParsedCondition> {
         // `parse_type_phrase` — the same combinator that decomposes "basic land
         // card" into `Land` + `HasSupertype Basic` — and count matching permanents
         // you control via the generic `ObjectCount >= 1` presence check.
-        if nom_target::parse_supertype_prefix(rest).is_ok() {
-            let (filter, remainder) = parse_type_phrase(rest);
-            if remainder.trim().is_empty() {
-                if let TargetFilter::Typed(typed) = filter {
-                    return Some(ParsedCondition::QuantityComparison {
-                        lhs: QuantityExpr::Ref {
-                            qty: QuantityRef::ObjectCount {
-                                filter: TargetFilter::Typed(typed.controller(ControllerRef::You)),
-                            },
-                        },
-                        comparator: Comparator::GE,
-                        rhs: QuantityExpr::Fixed { value: 1 },
-                    });
-                }
-            }
+        if let Some(cond) = parse_you_control_supertype_count(rest, 1) {
+            return Some(cond);
         }
         if let Some(core_type) = parse_core_type_word(rest) {
             return Some(ParsedCondition::YouControlCoreTypeCountAtLeast {
@@ -1259,6 +1269,37 @@ fn parse_you_control_subtype_count(text: &str) -> Option<(usize, String)> {
     Some((minimum, subtype))
 }
 
+/// CR 205.4a + CR 205.4g: Decompose a `<supertype> <type>` phrase (snow land,
+/// basic land, legendary creature, …) into a `HasSupertype` object-count
+/// presence condition — count the matching permanents you control and compare
+/// `>= count`. Shared by the singular "you control a snow land" arm and the
+/// plural "you control N or more basic lands" arm so a supertype adjective never
+/// falls through to the stringly-typed subtype dump (which yields a non-existent
+/// subtype like "basic land", leaving the restriction permanently unsatisfiable).
+/// Gated on `parse_supertype_prefix` so genuine bare-subtype counts
+/// ("two or more vampires") are untouched and still reach the subtype path.
+fn parse_you_control_supertype_count(type_phrase: &str, count: usize) -> Option<ParsedCondition> {
+    nom_target::parse_supertype_prefix(type_phrase).ok()?;
+    let (filter, remainder) = parse_type_phrase(type_phrase);
+    if !remainder.trim().is_empty() {
+        return None;
+    }
+    let TargetFilter::Typed(typed) = filter else {
+        return None;
+    };
+    Some(ParsedCondition::QuantityComparison {
+        lhs: QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(typed.controller(ControllerRef::You)),
+            },
+        },
+        comparator: Comparator::GE,
+        rhs: QuantityExpr::Fixed {
+            value: count as i32,
+        },
+    })
+}
+
 /// CR 601.3d + CR 608.2c: Parse `"it targets a <type_phrase>"` (or `"it targets <type_phrase>"`)
 /// into a `ParsedCondition::SpellTargetsFilter` whose filter is derived from
 /// `parse_type_phrase`. The pronoun `it` refers to the spell being cast — this
@@ -1490,7 +1531,12 @@ mod tests {
     fn you_control_supertype_permanent_decomposes_to_filter() {
         use crate::types::card_type::Supertype;
 
-        fn assert_snow_filter(text: &str, expect_type: TypeFilter) {
+        fn assert_supertype_filter(
+            text: &str,
+            expect_type: TypeFilter,
+            expect_supertype: Supertype,
+            expect_count: i32,
+        ) {
             match parse_restriction_condition(text) {
                 Some(ParsedCondition::QuantityComparison {
                     lhs:
@@ -1498,44 +1544,80 @@ mod tests {
                             qty: QuantityRef::ObjectCount { filter },
                         },
                     comparator: Comparator::GE,
-                    rhs: QuantityExpr::Fixed { value: 1 },
-                }) => match filter {
-                    TargetFilter::Typed(tf) => {
-                        assert_eq!(
-                            tf.controller,
-                            Some(ControllerRef::You),
-                            "{text}: must be scoped to permanents you control"
-                        );
-                        assert!(
-                            tf.properties.iter().any(|p| matches!(
-                                p,
-                                FilterProp::HasSupertype {
-                                    value: Supertype::Snow
-                                }
-                            )),
-                            "{text}: must carry HasSupertype(Snow), got {:?}",
-                            tf.properties
-                        );
-                        assert!(
-                            tf.type_filters.contains(&expect_type),
-                            "{text}: type_filters {:?} must contain {expect_type:?}",
-                            tf.type_filters
-                        );
+                    rhs: QuantityExpr::Fixed { value },
+                }) => {
+                    assert_eq!(value, expect_count, "{text}: count must be {expect_count}");
+                    match filter {
+                        TargetFilter::Typed(tf) => {
+                            assert_eq!(
+                                tf.controller,
+                                Some(ControllerRef::You),
+                                "{text}: must be scoped to permanents you control"
+                            );
+                            assert!(
+                                tf.properties.iter().any(|p| matches!(
+                                    p,
+                                    FilterProp::HasSupertype { value } if *value == expect_supertype
+                                )),
+                                "{text}: must carry HasSupertype({expect_supertype:?}), got {:?}",
+                                tf.properties
+                            );
+                            assert!(
+                                tf.type_filters.contains(&expect_type),
+                                "{text}: type_filters {:?} must contain {expect_type:?}",
+                                tf.type_filters
+                            );
+                        }
+                        other => panic!("{text}: expected a Typed filter, got {other:?}"),
                     }
-                    other => panic!("{text}: expected a Typed filter, got {other:?}"),
-                },
+                }
                 other => {
-                    panic!("{text}: expected QuantityComparison(ObjectCount >= 1), got {other:?}")
+                    panic!("{text}: expected QuantityComparison(ObjectCount >= N), got {other:?}")
                 }
             }
         }
 
-        // Blizzard: supertype Snow + core type Land.
-        assert_snow_filter("you control a snow land", TypeFilter::Land);
-        // Goblin Ski Patrol: supertype Snow + subtype Mountain (basic land type).
-        assert_snow_filter(
+        // Singular "you control a <supertype> <type>" (count 1):
+        // Blizzard — supertype Snow + core type Land.
+        assert_supertype_filter(
+            "you control a snow land",
+            TypeFilter::Land,
+            Supertype::Snow,
+            1,
+        );
+        // Goblin Ski Patrol — supertype Snow + subtype Mountain (basic land type).
+        assert_supertype_filter(
             "you control a snow mountain",
             TypeFilter::Subtype("Mountain".to_string()),
+            Supertype::Snow,
+            1,
+        );
+
+        // Plural/count "you control N or more <supertype> <type>s" (Matt's sibling
+        // gap): must decompose the same way with the parsed count, NOT dump
+        // "basic land" / "legendary creature" into a stringly subtype.
+        assert_supertype_filter(
+            "you control two or more basic lands",
+            TypeFilter::Land,
+            Supertype::Basic,
+            2,
+        );
+        assert_supertype_filter(
+            "you control two or more legendary creatures",
+            TypeFilter::Creature,
+            Supertype::Legendary,
+            2,
+        );
+
+        // Regression guard: an ordinary bare subtype count keeps the subtype path
+        // (no supertype prefix → must NOT become an ObjectCount comparison).
+        assert_eq!(
+            parse_restriction_condition("you control two or more vampires"),
+            Some(ParsedCondition::YouControlSubtypeCountAtLeast {
+                subtype: "vampire".to_string(),
+                count: 2,
+            }),
+            "bare subtype count must stay on the subtype path"
         );
     }
 

--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -10,6 +10,7 @@ use nom::Parser;
 
 use super::oracle_nom::condition as nom_condition;
 use super::oracle_nom::primitives as nom_primitives;
+use super::oracle_nom::target as nom_target;
 use super::oracle_target::parse_type_phrase;
 use crate::types::ability::{
     Comparator, ControllerRef, FilterProp, ParsedCondition, PlayerFilter, PlayerScope,
@@ -558,6 +559,32 @@ fn parse_you_control_condition(text: &str) -> Option<ParsedCondition> {
     ))
     .parse(text)
     {
+        // CR 205.4a: A supertype adjective ("snow", "basic", "legendary", "world")
+        // in "you control a <supertype> <type>" must decompose into a
+        // `HasSupertype` filter property plus the core type / subtype — it must NOT
+        // be dumped whole into a stringly-typed `subtype`. No permanent has the
+        // subtype "snow land" or "snow mountain", so the bare-subtype parse below
+        // makes the restriction permanently unsatisfiable (Blizzard could never be
+        // cast; Goblin Ski Patrol's ability could never activate). Reuse
+        // `parse_type_phrase` — the same combinator that decomposes "basic land
+        // card" into `Land` + `HasSupertype Basic` — and count matching permanents
+        // you control via the generic `ObjectCount >= 1` presence check.
+        if nom_target::parse_supertype_prefix(rest).is_ok() {
+            let (filter, remainder) = parse_type_phrase(rest);
+            if remainder.trim().is_empty() {
+                if let TargetFilter::Typed(typed) = filter {
+                    return Some(ParsedCondition::QuantityComparison {
+                        lhs: QuantityExpr::Ref {
+                            qty: QuantityRef::ObjectCount {
+                                filter: TargetFilter::Typed(typed.controller(ControllerRef::You)),
+                            },
+                        },
+                        comparator: Comparator::GE,
+                        rhs: QuantityExpr::Fixed { value: 1 },
+                    });
+                }
+            }
+        }
         if let Some(core_type) = parse_core_type_word(rest) {
             return Some(ParsedCondition::YouControlCoreTypeCountAtLeast {
                 core_type,
@@ -1449,6 +1476,67 @@ mod tests {
             ),
             other => panic!("expected QuantityComparison(ObjectCount >= 3), got {other:?}"),
         }
+    }
+
+    /// CR 205.4a + CR 205.4g: A supertype adjective in a "you control a
+    /// <supertype> <type>" restriction (Blizzard — "Cast this spell only if you
+    /// control a snow land"; Goblin Ski Patrol — "only if you control a snow
+    /// Mountain") must decompose into a `HasSupertype` filter property plus the
+    /// core type / subtype and count via `ObjectCount >= 1`. It must NOT dump
+    /// "snow land" / "snow mountain" into a stringly-typed
+    /// `YouControlSubtypeCountAtLeast` — no permanent has such a subtype, so that
+    /// parse leaves the restriction permanently unsatisfiable.
+    #[test]
+    fn you_control_supertype_permanent_decomposes_to_filter() {
+        use crate::types::card_type::Supertype;
+
+        fn assert_snow_filter(text: &str, expect_type: TypeFilter) {
+            match parse_restriction_condition(text) {
+                Some(ParsedCondition::QuantityComparison {
+                    lhs:
+                        QuantityExpr::Ref {
+                            qty: QuantityRef::ObjectCount { filter },
+                        },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: 1 },
+                }) => match filter {
+                    TargetFilter::Typed(tf) => {
+                        assert_eq!(
+                            tf.controller,
+                            Some(ControllerRef::You),
+                            "{text}: must be scoped to permanents you control"
+                        );
+                        assert!(
+                            tf.properties.iter().any(|p| matches!(
+                                p,
+                                FilterProp::HasSupertype {
+                                    value: Supertype::Snow
+                                }
+                            )),
+                            "{text}: must carry HasSupertype(Snow), got {:?}",
+                            tf.properties
+                        );
+                        assert!(
+                            tf.type_filters.contains(&expect_type),
+                            "{text}: type_filters {:?} must contain {expect_type:?}",
+                            tf.type_filters
+                        );
+                    }
+                    other => panic!("{text}: expected a Typed filter, got {other:?}"),
+                },
+                other => {
+                    panic!("{text}: expected QuantityComparison(ObjectCount >= 1), got {other:?}")
+                }
+            }
+        }
+
+        // Blizzard: supertype Snow + core type Land.
+        assert_snow_filter("you control a snow land", TypeFilter::Land);
+        // Goblin Ski Patrol: supertype Snow + subtype Mountain (basic land type).
+        assert_snow_filter(
+            "you control a snow mountain",
+            TypeFilter::Subtype("Mountain".to_string()),
+        );
     }
 
     #[test]


### PR DESCRIPTION
Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Summary

A cast/activation restriction of the form `you control a <supertype> <type>` fell through to the stringly-typed subtype catch-all in `parse_you_control_condition`, dumping the whole phrase into a non-existent subtype:

| Card | Oracle | before (wrong) | after (correct) |
|---|---|---|---|
| Blizzard | `Cast this spell only if you control a snow land` | `YouControlSubtypeCountAtLeast{ subtype:"snow land" }` | `QuantityComparison{ ObjectCount[Land, You, HasSupertype(Snow)] ≥ 1 }` |
| Goblin Ski Patrol | `Activate only … if you control a snow Mountain` | `YouControlSubtypeCountAtLeast{ subtype:"snow mountain" }` | `QuantityComparison{ ObjectCount[Subtype(Mountain), You, HasSupertype(Snow)] ≥ 1 }` |

No permanent has a subtype literally named `"snow land"` / `"snow mountain"`, so the restriction is **permanently unsatisfiable** — Blizzard can never be cast and Goblin Ski Patrol's ability can never activate. Both cards are currently unplayable.

The fix adds a supertype-prefix branch (gated on `nom_target::parse_supertype_prefix`) that reuses the existing `parse_type_phrase` combinator — the same one that decomposes `"basic land card"` into `Land` + `HasSupertype(Basic)` — to build a proper `TargetFilter`, scopes it to controller `You`, and emits the established `QuantityComparison` / `ObjectCount ≥ 1` presence building block (identical shape to the shipped Mox Opal / Confront the Assault restriction path). Parser-only; the `ObjectCount`-based restriction is already engine-resolved.

**Scope:** a general supertype-decomposition fix (any supertype × any type). Two cards currently match the pattern — both listed above — and both are presently broken; the mechanism auto-covers any future `you control a <supertype> <type>` restriction.

## Gate A

`./scripts/check-parser-combinators.sh` — clean. The new branch dispatches via the `parse_supertype_prefix` nom combinator and reuses `parse_type_phrase`; no string-matching primitives introduced. Three-dot diff of `crates/engine/src/parser/**` against `origin/main` grepped for forbidden methods (`.contains("`, `.split_once(`, `.starts_with("`, `.strip_suffix(`, …): **no matches**.

## Anchored on

- `crates/engine/src/parser/oracle_condition.rs:562` — the new supertype-prefix decomposition branch in `parse_you_control_condition`, placed before the `parse_core_type_word` / bare-subtype catch-all it was falling through.
- `crates/engine/src/parser/oracle_nom/target.rs:115` — `parse_supertype_prefix`, the existing combinator the branch gates on; decomposition delegates to `parse_type_phrase` (`oracle_target.rs`), reusing the canonical `<supertype> <type>` grammar rather than string-matching.

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --tests -- -D warnings` — clean.
- `cargo test -p engine --lib -- parser::` — **7567 passed / 0 failed**, including the new fail-on-revert test `you_control_supertype_permanent_decomposes_to_filter` (asserts both "snow land" → `TypeFilter::Land` and "snow mountain" → `TypeFilter::Subtype("Mountain")` produce `ObjectCount ≥ 1` with `controller: You` + `HasSupertype(Snow)`; the old parse returned `YouControlSubtypeCountAtLeast`, so reverting fails it).
- CR annotations verified against `docs/MagicCompRules.txt` (205.4a supertype list; 205.4g snow permanent).
- **Blast-radius proof:** rebuilt `oracle-gen` with the fix and regenerated `card-data.json` (35,397 faces) vs the clean-main baseline — **exactly 2 cards changed** (Blizzard, Goblin Ski Patrol), each from the unsatisfiable subtype dump to the correct Snow-supertype filter. Zero collateral, no over-match.

## Scope Expansion

None.
