### PR TITLE
feat(parser+engine): enforce "cast only during combat after blockers are declared"

### DIFF
--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1056,6 +1056,16 @@ fn casting_restriction_applies(
         CastingRestriction::BeforeBlockersDeclared => {
             matches!(state.phase, Phase::BeginCombat | Phase::DeclareAttackers)
         }
+        // CR 509.1 + CR 510.1 + CR 511.1: "after blockers are declared" opens
+        // once the declare-blockers turn-based action has placed blockers and
+        // stays open through combat damage and end of combat — the exact
+        // complement of BeforeBlockersDeclared within the combat phase (CR
+        // 506.1). ANDed with the separately-emitted DuringCombat, the effective
+        // legal window is exactly these three steps.
+        CastingRestriction::AfterBlockersDeclared => matches!(
+            state.phase,
+            Phase::DeclareBlockers | Phase::CombatDamage | Phase::EndCombat
+        ),
         CastingRestriction::BeforeCombatDamage => is_before_combat_damage(state.phase),
         CastingRestriction::AfterCombat => matches!(
             state.phase,

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -4156,6 +4156,74 @@ mod tests {
         assert!(check_casting_restrictions(&state, p, src, &restr).is_ok());
     }
 
+    // CR 509.1 + CR 510.1 + CR 511.1: "cast only during combat after blockers are
+    // declared" opens once the declare-blockers turn-based action has placed
+    // blockers and stays open through combat damage and end of combat — the exact
+    // complement of the BeforeBlockersDeclared window. Drives the real CR 601.3
+    // enforcement (`check_casting_restrictions`), not just parser shape: the spell
+    // must be REJECTED before blockers are declared (Begin Combat / Declare
+    // Attackers, and outside combat) and ALLOWED from the declare-blockers step
+    // onward. Backs Aleatory, Chaotic Strike, Curtain of Light, Flash Foliage.
+    #[test]
+    fn after_blockers_declared_window_rejects_pre_blockers_and_admits_post_blockers() {
+        let mut state = crate::types::game_state::GameState::new_two_player(42);
+        let p = PlayerId(0);
+        let src = ObjectId(10);
+        state.active_player = p;
+        state.priority_player = p;
+        state.waiting_for = WaitingFor::Priority { player: p };
+
+        // The lone new restriction: closed before blockers are declared (and
+        // outside combat entirely), open from the declare-blockers step onward.
+        let after = [CastingRestriction::AfterBlockersDeclared];
+        for phase in [
+            Phase::PreCombatMain,
+            Phase::BeginCombat,
+            Phase::DeclareAttackers,
+        ] {
+            state.phase = phase;
+            assert!(
+                check_casting_restrictions(&state, p, src, &after).is_err(),
+                "the after-blockers window must be closed in {phase:?} (blockers not yet declared)"
+            );
+        }
+        for phase in [
+            Phase::DeclareBlockers,
+            Phase::CombatDamage,
+            Phase::EndCombat,
+        ] {
+            state.phase = phase;
+            assert!(
+                check_casting_restrictions(&state, p, src, &after).is_ok(),
+                "the after-blockers window must be open in {phase:?} (blockers declared)"
+            );
+        }
+
+        // The full restriction set the parser emits for these cards
+        // (`DuringCombat` AND `AfterBlockersDeclared`): the effective legal window
+        // is exactly the declare-blockers, combat-damage, and end-of-combat steps.
+        let combined = [
+            CastingRestriction::DuringCombat,
+            CastingRestriction::AfterBlockersDeclared,
+        ];
+        for (phase, allowed) in [
+            (Phase::PreCombatMain, false),
+            (Phase::BeginCombat, false),
+            (Phase::DeclareAttackers, false),
+            (Phase::DeclareBlockers, true),
+            (Phase::CombatDamage, true),
+            (Phase::EndCombat, true),
+            (Phase::PostCombatMain, false),
+        ] {
+            state.phase = phase;
+            assert_eq!(
+                check_casting_restrictions(&state, p, src, &combined).is_ok(),
+                allowed,
+                "combined DuringCombat+AfterBlockersDeclared legality wrong in {phase:?}"
+            );
+        }
+    }
+
     // Non-regression: `[DuringYourTurn, BeforeAttackersDeclared]` cards (King's
     // Assassin and the Portal Three Kingdoms tap-ability cycle) must stay pinned
     // to the active player. Widening the before-attackers window to phase-only

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1059,8 +1059,8 @@ fn casting_restriction_applies(
         // CR 509.1 + CR 510.1 + CR 511.1: "after blockers are declared" opens
         // once the declare-blockers turn-based action has placed blockers and
         // stays open through combat damage and end of combat — the exact
-        // complement of BeforeBlockersDeclared within the combat phase (CR
-        // 506.1). ANDed with the separately-emitted DuringCombat, the effective
+        // complement of BeforeBlockersDeclared within the combat phase (CR 506.1).
+        // ANDed with the separately-emitted DuringCombat, the effective
         // legal window is exactly these three steps.
         CastingRestriction::AfterBlockersDeclared => matches!(
             state.phase,

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -611,6 +611,7 @@ fn parse_timing_restriction(
     alt((
         preceded(tag("during "), parse_during_phrase),
         preceded(tag("before "), parse_before_phrase),
+        preceded(tag("after "), parse_after_phrase),
         preceded(
             tag("on "),
             alt((
@@ -618,7 +619,6 @@ fn parse_timing_restriction(
                 value(CastingRestriction::DuringYourTurn, tag("your turn")),
             )),
         ),
-        value(CastingRestriction::AfterCombat, tag("after combat")),
         value(CastingRestriction::AsSorcery, tag("as a sorcery")),
     ))
     .parse(input)
@@ -708,6 +708,24 @@ fn parse_before_phrase(input: &str) -> nom::IResult<&str, CastingRestriction, Or
             CastingRestriction::BeforeCombatDamage,
             alt((tag("the combat damage step"), tag("combat damage"))),
         ),
+    ))
+    .parse(input)
+}
+
+/// Sub-dispatch for "after [rest]" — blockers declared, combat. Mirror of
+/// `parse_before_phrase`: `after blockers are declared` opens the post-blockers
+/// combat window (CR 509.1/510.1/511.1), while `after combat` (folded in from
+/// the former standalone leaf) is the post-combat-phase window. Backs the class
+/// printing "Cast this spell only during combat after blockers are declared."
+/// (Aleatory, Chaotic Strike, Curtain of Light, Flash Foliage) alongside the
+/// separately-scanned `DuringCombat`.
+fn parse_after_phrase(input: &str) -> nom::IResult<&str, CastingRestriction, OracleError<'_>> {
+    alt((
+        value(
+            CastingRestriction::AfterBlockersDeclared,
+            tag("blockers are declared"),
+        ),
+        value(CastingRestriction::AfterCombat, tag("combat")),
     ))
     .parse(input)
 }
@@ -939,6 +957,34 @@ mod tests {
         assert!(restrictions.contains(&CastingRestriction::DuringCombat));
         assert!(restrictions.contains(&CastingRestriction::DuringYourTurn));
         assert!(restrictions.contains(&CastingRestriction::BeforeBlockersDeclared));
+    }
+
+    /// CR 509.1 + CR 510.1 + CR 511.1: the "after blockers are declared" window
+    /// used to be dropped — `during combat` matched and stranded the remainder,
+    /// leaving the spell castable during all of combat. The line must now emit
+    /// both `DuringCombat` and `AfterBlockersDeclared` (and NOT the opposite
+    /// `BeforeBlockersDeclared` window). Backs Aleatory, Chaotic Strike, Curtain
+    /// of Light, and Flash Foliage, which all print this exact line.
+    #[test]
+    fn spell_cast_restriction_handles_combat_after_blockers() {
+        let restrictions = parse_casting_restriction_line(
+            "Cast this spell only during combat after blockers are declared.",
+        )
+        .expect("restrictions should parse");
+        assert!(restrictions.contains(&CastingRestriction::DuringCombat));
+        assert!(restrictions.contains(&CastingRestriction::AfterBlockersDeclared));
+        assert!(!restrictions.contains(&CastingRestriction::BeforeBlockersDeclared));
+    }
+
+    /// Regression: folding the former standalone `after combat` leaf into the
+    /// `after` prefix sub-dispatch (`parse_after_phrase`) must preserve the
+    /// post-combat-phase window.
+    #[test]
+    fn spell_cast_restriction_after_combat_still_parses() {
+        let restrictions =
+            parse_casting_restriction_line("Cast this spell only after combat on your turn.")
+                .expect("restrictions should parse");
+        assert!(restrictions.contains(&CastingRestriction::AfterCombat));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -714,7 +714,7 @@ fn parse_before_phrase(input: &str) -> nom::IResult<&str, CastingRestriction, Or
 
 /// Sub-dispatch for "after [rest]" — blockers declared, combat. Mirror of
 /// `parse_before_phrase`: `after blockers are declared` opens the post-blockers
-/// combat window (CR 509.1/510.1/511.1), while `after combat` (folded in from
+/// combat window (CR 509.1, CR 510.1, and CR 511.1), while `after combat` (folded in from
 /// the former standalone leaf) is the post-combat-phase window. Backs the class
 /// printing "Cast this spell only during combat after blockers are declared."
 /// (Aleatory, Chaotic Strike, Curtain of Light, Flash Foliage) alongside the

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -15076,9 +15076,17 @@ pub enum CastingRestriction {
     DeclareBlockersStep,
     BeforeAttackersDeclared,
     BeforeBlockersDeclared,
+    /// CR 509.1 + CR 510.1 + CR 511.1: "only during combat after blockers are
+    /// declared" — the window that opens once the declare-blockers turn-based
+    /// action has placed blockers and stays open through combat damage and end
+    /// of combat. The exact complement of `BeforeBlockersDeclared` within the
+    /// combat phase (CR 506.1); enforced in `restrictions.rs`.
+    AfterBlockersDeclared,
     BeforeCombatDamage,
     AfterCombat,
-    RequiresCondition { condition: Option<ParsedCondition> },
+    RequiresCondition {
+        condition: Option<ParsedCondition>,
+    },
 }
 
 /// CR 602.2b + CR 601.2f: Self-referential cost reduction on an activated ability.


### PR DESCRIPTION
## Summary

Closes #4996

Spells printing **"Cast this spell only during combat after blockers are declared."** silently lost the `after blockers are declared` qualifier. The timing scanner matched `during combat` and stranded the remainder, so these spells became castable during **all** of combat (including begin-combat and declare-attackers) — strictly more permissive than the printed rules text (CR 601.3 timing violation).

## Cards fixed (a class, not a one-off)

All four print the exact line `Cast this spell only during combat after blockers are declared.`:

- **Aleatory**
- **Chaotic Strike**
- **Curtain of Light**
- **Flash Foliage**

## Root cause

`parse_timing_restriction` in `parser/oracle_casting.rs` dispatched `during …` / `before …` / `on …` by prefix, with a `before` sub-dispatch (`parse_before_phrase`) — but only a lone `after combat` leaf for `after`. For `during combat after blockers are declared`, `during combat` emitted `DuringCombat` and no branch matched the stranded `after blockers are declared`, so it was dropped.

## Fix (mirror the existing `before` handling)

- **`types/ability.rs`** — add `CastingRestriction::AfterBlockersDeclared`, the exact complement of `BeforeBlockersDeclared` within the combat phase (CR 506.1).
- **`parser/oracle_casting.rs`** — add an `after` prefix sub-dispatch (`parse_after_phrase`) mirroring `parse_before_phrase`, recognizing `blockers are declared` → `AfterBlockersDeclared` and folding in the former `after combat` → `AfterCombat` leaf.
- **`game/restrictions.rs`** — enforce the window as `Phase::DeclareBlockers | Phase::CombatDamage | Phase::EndCombat` (CR 509.1 / 510.1 / 511.1). ANDed with the separately-emitted `DuringCombat`, the effective legal window is exactly those three steps.

Blast radius is contained: `CastingRestriction` has a single exhaustive match (`casting_restriction_applies`); serialization is derived; no frontend switch references the enum.

## Tests

- `spell_cast_restriction_handles_combat_after_blockers` — the class line now emits both `DuringCombat` and `AfterBlockersDeclared`, and **not** the opposite `BeforeBlockersDeclared` window (revert-failing: before this change only `DuringCombat` was emitted).
- `spell_cast_restriction_after_combat_still_parses` — regression guard that folding the `after combat` leaf into the sub-dispatch preserves `AfterCombat`.

## Follow-up (honest scope note)

The activated-ability sibling **Trap Runner** (`Activate only during combat after blockers are declared.`) is the same window on the `ActivationRestriction` axis, which currently lacks even a `BeforeBlockersDeclared` analog. That's a separate, larger change (new `ActivationRestriction` variant + its own parser/enforcement path) and is intentionally out of scope here.

## CR annotations

CR 506.1 (combat phase steps), CR 509.1 (declare blockers), CR 510.1 (combat damage), CR 511.1 (end of combat), CR 601.3 (timing) — all verified in `docs/MagicCompRules.txt`.
