### PR TITLE
fix(parser): strip leading universal quantifier (all/each/every) in parse_type_phrase

### DIFF
--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1927,25 +1927,37 @@ pub fn parse_type_phrase_with_ctx<'a>(
     ))
     .parse(&lower[pos..])
     {
-        if starts_with_type_phrase_lead(rest) {
+        // Strip the quantifier when a type-phrase lead follows directly OR through
+        // an "other"/"another" exclusion ("each other creature", "all other
+        // nonland permanents"); in the latter case only the quantifier is consumed
+        // here and the handler below adds `FilterProp::Another`.
+        let after_other = alt((tag::<_, _, OracleError<'_>>("other "), tag("another ")))
+            .parse(rest)
+            .map(|(r, _)| r)
+            .ok();
+        if starts_with_type_phrase_lead(rest)
+            || after_other.is_some_and(starts_with_type_phrase_lead)
+        {
             pos = lower.len() - rest.len();
         }
     }
 
     // Handle "other"/"another" prefix: "other creatures", "another creature",
-    // "other nonland permanents", "another target creature"
+    // "other nonland permanents", "another target creature". Reads from the
+    // current `pos` (not the raw trimmed head) so it composes with a universal
+    // quantifier already stripped above ("all other creatures" → Another + type).
     if tag::<_, _, OracleError<'_>>("other ")
-        .parse(lower_trimmed)
+        .parse(&lower[pos..])
         .is_ok()
     {
         properties.push(FilterProp::Another);
-        pos = offset + "other ".len();
+        pos += "other ".len();
     } else if tag::<_, _, OracleError<'_>>("another ")
-        .parse(lower_trimmed)
+        .parse(&lower[pos..])
         .is_ok()
     {
         properties.push(FilterProp::Another);
-        pos = offset + "another ".len();
+        pos += "another ".len();
     }
     // "another target [type]" — strip "target " after "another " so the type is reachable.
     if properties.contains(&FilterProp::Another) {
@@ -13725,6 +13737,40 @@ mod tests {
             assert!(
                 !tf.properties.contains(&FilterProp::Another),
                 "unexpected Another for '{text}': {:?}",
+                tf.properties
+            );
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+        }
+
+        // "all/each/every OTHER <type>" must strip the quantifier AND still carry
+        // the type plus `FilterProp::Another` (source excluded) — the quantifier
+        // must not leave the "other" exclusion stranded. Covers "each other
+        // creature" / "all other creatures" (review-flagged gap).
+        for text in [
+            "each other creature you control",
+            "all other creatures you control",
+        ] {
+            let (filter, rest) = parse_type_phrase(text);
+            assert!(rest.trim().is_empty(), "remainder for '{text}': '{rest}'");
+            let TargetFilter::Typed(tf) = &filter else {
+                panic!("Expected Typed filter for '{text}', got {filter:?}");
+            };
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Creature),
+                "expected Creature for '{text}', got {:?}",
+                tf.type_filters
+            );
+            assert!(
+                !tf.type_filters
+                    .iter()
+                    .any(|t| matches!(t, TypeFilter::Subtype(s) if s.contains(' '))),
+                "quantifier/other leaked into subtype for '{text}': {:?}",
+                tf.type_filters
+            );
+            // "other" excludes the source → Another IS present here.
+            assert!(
+                tf.properties.contains(&FilterProp::Another),
+                "expected Another for '{text}': {:?}",
                 tf.properties
             );
             assert_eq!(tf.controller, Some(ControllerRef::You));

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1911,6 +1911,27 @@ pub fn parse_type_phrase_with_ctx<'a>(
         }
     }
 
+    // CR 109.2: A description that includes a card type or subtype means
+    // permanents of that type/subtype on the battlefield. A leading universal
+    // quantifier — "all", "each", or "every" — ranges over every such object,
+    // source included, so it is a semantic no-op on the filter and adds NO
+    // FilterProp::Another (unlike "other"/"another" below, which exclude the
+    // source). Strip it so a subject like "Each Vehicle you control" / "All Cats
+    // you control" reaches the type word instead of leaking the quantifier into
+    // the subtype string (e.g. Subtype("Each Vehicle")). Guarded on a following
+    // type-phrase lead so a bare quantifier without a type word is left intact.
+    if let Ok((rest, _)) = alt((
+        tag::<_, _, OracleError<'_>>("all "),
+        tag("each "),
+        tag("every "),
+    ))
+    .parse(&lower[pos..])
+    {
+        if starts_with_type_phrase_lead(rest) {
+            pos = lower.len() - rest.len();
+        }
+    }
+
     // Handle "other"/"another" prefix: "other creatures", "another creature",
     // "other nonland permanents", "another target creature"
     if tag::<_, _, OracleError<'_>>("other ")
@@ -13660,6 +13681,53 @@ mod tests {
             assert_eq!(tf.controller, Some(ControllerRef::You));
         } else {
             panic!("Expected Typed filter, got {filter:?}");
+        }
+    }
+
+    /// CR 109.2: A leading universal quantifier ("all"/"each"/"every") ranging
+    /// over a type/subtype subject must be stripped to reach the type word — it
+    /// must NOT leak into the subtype string (e.g. Subtype("Each Vehicle")) and
+    /// must NOT add `FilterProp::Another` (it selects the source too, unlike
+    /// "other"). Consumers of `parse_type_phrase` that exercise this: the
+    /// "sacrifice all <type> you control" additional/activation cost filters
+    /// (Soulblast — creatures; Kaervek's Spite — permanents; Tomb of Urami —
+    /// lands) and the "Whenever all <type> you control attack" trigger
+    /// `valid_card` (Mob Mentality — non-Wall creatures). Before this fix those
+    /// filters were left empty/untyped (matching every object) or the trigger
+    /// failed to classify.
+    #[test]
+    fn parse_type_phrase_universal_quantifier_stripped_no_leak() {
+        for (text, subtype) in [
+            ("each Vehicle you control", "Vehicle"),
+            ("all Cats you control", "Cat"),
+            ("every Skeleton you control", "Skeleton"),
+        ] {
+            let (filter, rest) = parse_type_phrase(text);
+            assert!(rest.trim().is_empty(), "remainder for '{text}': '{rest}'");
+            let TargetFilter::Typed(tf) = &filter else {
+                panic!("Expected Typed filter for '{text}', got {filter:?}");
+            };
+            assert!(
+                tf.type_filters
+                    .contains(&TypeFilter::Subtype(subtype.to_string())),
+                "expected Subtype(\"{subtype}\") for '{text}', got {:?}",
+                tf.type_filters
+            );
+            // The quantifier must NOT survive inside the subtype string.
+            assert!(
+                !tf.type_filters
+                    .iter()
+                    .any(|t| matches!(t, TypeFilter::Subtype(s) if s.contains(' '))),
+                "quantifier leaked into subtype for '{text}': {:?}",
+                tf.type_filters
+            );
+            // Universal quantifiers select the source too — no Another exclusion.
+            assert!(
+                !tf.properties.contains(&FilterProp::Another),
+                "unexpected Another for '{text}': {:?}",
+                tf.properties
+            );
+            assert_eq!(tf.controller, Some(ControllerRef::You));
         }
     }
 


### PR DESCRIPTION
Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Summary

`parse_type_phrase_with_ctx` stripped leading `a`/`an` and `other`/`another`, but never the **universal quantifiers** `all` / `each` / `every`. The quantifier leaked into the type filter, leaving it empty/untyped:

| Card | Oracle | before (wrong) | after (correct) |
|---|---|---|---|
| Soulblast | `sacrifice all creatures you control` | cost filter `type_filters: [], controller: null` — **matches every object in play, including opponents'** | `[Creature], You` |
| Kaervek's Spite | `sacrifice all permanents you control` | `[], null` | `[Permanent], You` |
| Tomb of Urami | `Sacrifice all lands you control` | `[], null` | `[Land], You` |
| Mob Mentality | `Whenever all non-Wall creatures you control attack` | trigger mode `Unknown` (unclassified) | `Attacks`, `valid_card` = `Creature` + `Non(Subtype "Wall")`, controller `You` |

The Soulblast case is the most severe — an empty, uncontrolled sacrifice-cost filter matches **every** object on the battlefield rather than your own creatures.

The fix adds a nom `alt((tag("all "), tag("each "), tag("every ")))` strip in `parse_type_phrase_with_ctx`, guarded by the existing `starts_with_type_phrase_lead` (only strips when a real type word follows), advancing `pos` with **no** `FilterProp` added. Per CR 109.2 a universal quantifier ranges over every matching permanent, source included — so unlike `other`/`another` (which add `FilterProp::Another`) it is a semantic no-op on the filter. This is the central building-block fix: it corrects every `parse_type_phrase` consumer (targets, cost filters, trigger `valid_card`) at once.

## Gate A

`./scripts/check-parser-combinators.sh` — clean. Dispatch is nom `tag`/`alt`; the guard reuses the existing `starts_with_type_phrase_lead` helper. Three-dot diff of `crates/engine/src/parser/**` against `origin/main` grepped for forbidden methods (`.contains("`, `.split_once(`, `.starts_with("`, …): **no matches**.

## Anchored on

- `crates/engine/src/parser/oracle_target.rs:1914` — the new universal-quantifier strip in `parse_type_phrase_with_ctx`, placed before the `other`/`another` handling (which it deliberately does *not* mimic — no `Another`).
- `crates/engine/src/parser/oracle_target.rs:3291` — `starts_with_type_phrase_lead`, the existing guard so a bare quantifier without a following type word is left intact.

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --tests -- -D warnings` — clean.
- `cargo test -p engine --lib -- parser::` — **7568 passed / 0 failed**, including the new fail-on-revert test `parse_type_phrase_universal_quantifier_stripped_no_leak` (asserts `each/all/every <subtype> you control` → the bare `Subtype`, no space-containing subtype leak, no `Another`, controller `You`).
- CR annotation verified against `docs/MagicCompRules.txt` (109.2).
- **Blast-radius proof:** rebuilt `oracle-gen` with the fix and regenerated `card-data.json` (35,397 faces) vs the no-fix baseline — **exactly 4 cards changed** (Kaervek's Spite, Mob Mentality, Soulblast, Tomb of Urami), each a genuine correction. Zero collateral.

## Scope Expansion

None.

## Known adjacent (separate root cause, deliberately not in this PR)

A handful of static-anthem cards show the same *surface* symptom — a `Subtype("Each Vehicle")` / `Subtype("All Cats")` leak — e.g. Depala, Rin and Seri, Skeletal Swarming, Brightcap Badger (`"Each Vehicle you control gets …"` / `"All Cats you control are …"`). Those do **not** flow through `parse_type_phrase`; they hit a different root cause in the static-anthem / type-change subsystem (conditional-pump / type-change sub-parsers that bypass the `parse_continuous_subject_filter` quantifier strip). Fixing them means touching that broader subsystem across multiple sub-paths, so I kept this change surgical to the `parse_type_phrase` building block (verified zero-regression, 4-card delta) rather than bundle an unrelated subsystem change. Happy to follow up on the anthem path in a separate PR.
