### PR TITLE
feat(parser): compound-subject animation static — Life and Limb (CR 611.3)

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1516,6 +1516,16 @@ pub(crate) fn parse_static_line_inner(
         }
     }
 
+    // CR 611.3 + CR 613.1 + CR 613.4b: "All <X> and all <Y> are <predicate>" —
+    // a compound-subject animation where one predicate applies to every object
+    // matching either subject (Life and Limb). Must precede parse_land_animation
+    // (which splits on "are" and would claim only the first subject with an
+    // incomplete predicate); the " and all " conjunction + Or-subject guard keep
+    // single-subject animation lines falling through to parse_land_animation.
+    if let Some(def) = parse_compound_all_subjects_type_change(&tp, &text) {
+        return Some(def);
+    }
+
     // CR 613.1d + CR 613.4b: "[Subject] lands are [P/T] creatures that are still
     // lands" — continuous land animation (Living Plane, Nature's Revolt). Must
     // come before parse_land_type_change: both split on "are", but the land

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -3350,43 +3350,94 @@ fn static_bare_compound_tribal_subject_verdeloth() {
         .contains(&ContinuousModification::AddToughness { value: 1 }));
 }
 
-// #5147 regression on Life and Limb's ACTUAL static text. Its subject "All
-// Forests and all Saprolings" has "Forests" as a LAND subtype; the ungated bare
-// tribal-compound helper reinterpreted it as `Or{creature Forest, creature
-// Saproling}`, silently adding wrong out-of-scope support. With the
-// creature-term gate the helper declines this non-creature subject, so the
-// unsupported compound type-change strict-fails (no static) — the same shape as
-// baseline main — rather than over-claiming. Assert BOTH: Forest is never
-// reinterpreted as a creature-anthem branch, AND the line strict-fails.
+// Life and Limb — dual-subject reciprocal animation on its ACTUAL static text.
+// The subject "All Forests and all Saprolings" mixes a LAND subtype (Forest)
+// with a CREATURE subtype (Saproling); the predicate "1/1 green Saproling
+// creatures and Forest lands in addition to their other types" animates every
+// object in either subject into a 1/1 green creature that is also a land while
+// keeping its other types (CR 611.3 + CR 613.4b + CR 205.1b).
+//
+// Supersedes the earlier #5147 strict-fail guard: that test asserted the line
+// produced NO static, because the only handler that touched it was the ungated
+// bare tribal-compound helper, which mis-read Forest as `creature Forest`.
+// `parse_compound_all_subjects_type_change` now supports the line correctly, so
+// the assertions flip to the positive parse — while still guarding the original
+// intent that the Forest conjunct is a LAND subtype, never a creature subject.
 #[test]
-fn life_and_limb_real_text_not_over_claimed_as_creature_forest() {
+fn life_and_limb_real_text_dual_subject_animation() {
+    use crate::types::card_type::CoreType;
+    use crate::types::mana::ManaColor;
+
     let line = "All Forests and all Saprolings are 1/1 green Saproling creatures \
                 and Forest lands in addition to their other types.";
-    // No produced static may treat the land subtype Forest as a creature subject.
-    for def in parse_static_line_multi(line) {
-        if let Some(TargetFilter::Or { ref filters }) = def.affected {
-            assert!(
-                !filters.iter().any(|f| matches!(
-                    f,
-                    TargetFilter::Typed(tf)
-                        if tf.type_filters.iter().any(|t| matches!(
-                            t, TypeFilter::Subtype(s) if s == "Forest"
-                        ))
-                )),
-                "Life and Limb must not reinterpret land subtype Forest as a \
-                 creature-anthem branch: {def:?}"
-            );
-        }
-    }
-    // The bare-compound creature helper must decline this non-creature subject,
-    // so the unsupported compound type-change produces no bogus static (strict
-    // failure) — matching baseline main. This is the discriminating check: the
-    // ungated helper produced a spurious `creature Forest` static here.
-    assert!(
-        parse_static_line_multi(line).is_empty(),
-        "unsupported compound type-change must strict-fail, not over-claim: {:?}",
-        parse_static_line_multi(line)
+    let defs = parse_static_line_multi(line);
+    assert_eq!(
+        defs.len(),
+        1,
+        "Life and Limb is one compound static: {defs:?}"
     );
+    let def = &defs[0];
+
+    let Some(TargetFilter::Or { filters }) = def.affected.as_ref() else {
+        panic!(
+            "affected must be an Or of the two subjects: {:?}",
+            def.affected
+        );
+    };
+    assert_eq!(filters.len(), 2, "one disjunct per subject: {filters:?}");
+    // Forest conjunct: a LAND with subtype Forest.
+    assert!(
+        filters.iter().any(|f| matches!(f, TargetFilter::Typed(tf)
+            if tf.type_filters.contains(&TypeFilter::Land)
+                && tf.type_filters.iter().any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Forest")))),
+        "Forest conjunct must be a LAND subtype: {:?}",
+        def.affected
+    );
+    // Original #5147 intent preserved: Forest is NEVER a creature subject.
+    assert!(
+        !filters.iter().any(|f| matches!(f, TargetFilter::Typed(tf)
+            if tf.type_filters.contains(&TypeFilter::Creature)
+                && tf.type_filters.iter().any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Forest")))),
+        "Forest must never be reinterpreted as a creature subject: {:?}",
+        def.affected
+    );
+    // Saproling conjunct: a CREATURE with subtype Saproling.
+    assert!(
+        filters.iter().any(|f| matches!(f, TargetFilter::Typed(tf)
+            if tf.type_filters.contains(&TypeFilter::Creature)
+                && tf.type_filters.iter().any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Saproling")))),
+        "Saproling conjunct must be a creature subtype: {:?}",
+        def.affected
+    );
+
+    // Uniform modification set shared by both subjects: base 1/1 (layer 7b), set
+    // green (layer 5), additive Creature+Saproling and Land+Forest (layer 4).
+    use ContinuousModification as CM;
+    for expected in [
+        CM::SetPower { value: 1 },
+        CM::SetToughness { value: 1 },
+        CM::SetColor {
+            colors: vec![ManaColor::Green],
+        },
+        CM::AddType {
+            core_type: CoreType::Creature,
+        },
+        CM::AddSubtype {
+            subtype: "Saproling".to_string(),
+        },
+        CM::AddType {
+            core_type: CoreType::Land,
+        },
+        CM::AddSubtype {
+            subtype: "Forest".to_string(),
+        },
+    ] {
+        assert!(
+            def.modifications.contains(&expected),
+            "missing {expected:?} in {:?}",
+            def.modifications
+        );
+    }
 }
 
 #[test]

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -3440,6 +3440,32 @@ fn life_and_limb_real_text_dual_subject_animation() {
     }
 }
 
+// CR 205.1a vs CR 205.1b: the compound-subject animation handler applies strictly
+// ADDITIVE type semantics, so it must decline a compound predicate that lacks the
+// "in addition to their/its other types" marker — a bare "are <P/T> <type>
+// creatures" compound is a type REPLACEMENT and must not be reinterpreted as
+// additive (which would keep the objects' other types instead of replacing them).
+#[test]
+fn compound_subject_animation_declines_non_additive_replacement_predicate() {
+    // No "in addition to their other types" marker → replacement semantics →
+    // this additive handler must not claim it.
+    assert!(
+        parse_static_line_multi("All Elves and all Goblins are 2/2 Zombie creatures.").is_empty(),
+        "non-additive compound animation must not be additive-claimed"
+    );
+    // The additive form (Life and Limb) is still claimed — guards against the
+    // gate being over-broad.
+    assert_eq!(
+        parse_static_line_multi(
+            "All Forests and all Saprolings are 1/1 green Saproling creatures and \
+             Forest lands in addition to their other types."
+        )
+        .len(),
+        1,
+        "additive compound animation must still parse"
+    );
+}
+
 #[test]
 fn static_opponent_controlled_compound_subject_shares_continuous_predicate() {
     let def = parse_static_line(

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1920,9 +1920,21 @@ pub(crate) fn parse_compound_all_subjects_type_change(
     let affected = parse_compound_all_subjects_filter(subject_tp.original)?;
 
     let predicate = predicate_tp.original.trim().trim_end_matches('.').trim();
+    let predicate_lower = predicate.to_lowercase();
     // Claim only creature-animation predicates; a bare additive type line
     // ("All Forests and all Saprolings are Plains") is owned elsewhere.
-    if !nom_primitives::scan_contains(&predicate.to_lowercase(), "creature") {
+    if !nom_primitives::scan_contains(&predicate_lower, "creature") {
+        return None;
+    }
+    // CR 205.1b: this handler applies strictly ADDITIVE type/subtype semantics
+    // (`AddType` / `AddSubtype`), so it must only claim predicates that carry the
+    // "in addition to {their|its} other types" marker. A compound predicate
+    // without it ("All X and all Y are Zombies") is a type REPLACEMENT (CR 205.1a
+    // `SetCardTypes`) that must fall through to a replacement-semantics handler
+    // rather than be silently reinterpreted as additive.
+    if !nom_primitives::scan_contains(&predicate_lower, "in addition to their other")
+        && !nom_primitives::scan_contains(&predicate_lower, "in addition to its other")
+    {
         return None;
     }
     let spec = super::oracle_effect::animation::parse_animation_spec(

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1889,6 +1889,110 @@ pub(crate) fn parse_land_animation(tp: &TextPair<'_>, text: &str) -> Option<Stat
     )
 }
 
+/// CR 611.3 + CR 613.1 + CR 613.4b + CR 205.1b: "All `<X>` and all `<Y>` are
+/// `<predicate>`" — a compound-subject continuous animation/type-change where a
+/// single predicate applies uniformly to every object matching either subject.
+///
+/// Life and Limb is the canonical member: "All Forests and all Saprolings are
+/// 1/1 green Saproling creatures and Forest lands in addition to their other
+/// types." Neither single-subject parser is complete for this predicate — the
+/// animation path drops the trailing additive "and `<type>` lands", and the
+/// creature-subtype path drops the base P/T — so the compound line is dispatched
+/// here. The subjects distribute into an `Or` filter (CR 611.3: the same
+/// continuous effect applies to every object in the affected set), and the
+/// compound predicate is parsed once into a uniform modification set that both
+/// subjects share.
+///
+/// The predicate reuses the two tested predicate parsers: `parse_animation_spec`
+/// supplies the base P/T (CR 613.4b, layer 7b), the set color (CR 105.2, layer
+/// 5) and the leading type/subtype grants; `parse_additive_type_clause_modifications`
+/// supplies the additive type/subtype nouns the animation parser stops short of
+/// at the internal " and " (CR 205.1b, layer 4). Only additive `AddType` /
+/// `AddSubtype` grants are merged in — the animation spec's set color takes
+/// precedence over the additive parser's additive color.
+pub(crate) fn parse_compound_all_subjects_type_change(
+    tp: &TextPair<'_>,
+    text: &str,
+) -> Option<StaticDefinition> {
+    let (subject_tp, predicate_tp) = tp.split_around(" are ")?;
+    // Require a genuine "all <X> and all <Y>" conjunction so single-subject
+    // "all <X> are ..." lines fall through to their dedicated dispatchers.
+    let affected = parse_compound_all_subjects_filter(subject_tp.original)?;
+
+    let predicate = predicate_tp.original.trim().trim_end_matches('.').trim();
+    // Claim only creature-animation predicates; a bare additive type line
+    // ("All Forests and all Saprolings are Plains") is owned elsewhere.
+    if !nom_primitives::scan_contains(&predicate.to_lowercase(), "creature") {
+        return None;
+    }
+    let spec = super::oracle_effect::animation::parse_animation_spec(
+        predicate,
+        &mut ParseContext::default(),
+    )?;
+    let mut modifications = super::oracle_effect::animation::animation_modifications(&spec);
+    if modifications.is_empty() {
+        return None;
+    }
+    // Merge the additive type/subtype grants past the animation parser's
+    // internal " and " stop (the "and <type> lands in addition to their other
+    // types" tail). The animation spec already set base P/T and color.
+    if let Some(additive) = parse_additive_type_clause_modifications(&format!("~ are {predicate}"))
+    {
+        for modification in additive {
+            let is_type_grant = matches!(
+                modification,
+                ContinuousModification::AddType { .. } | ContinuousModification::AddSubtype { .. }
+            );
+            if is_type_grant && !modifications.contains(&modification) {
+                modifications.push(modification);
+            }
+        }
+    }
+
+    Some(
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(modifications)
+            .description(text.to_string()),
+    )
+}
+
+/// Parse "all `<X>` and all `<Y>`[ and all `<Z>`…]" into an `Or` of per-subject
+/// filters. Peels conjuncts on the " and all " seam (so every conjunct after the
+/// first is an `all `-quantified subject) and parses each through the shared
+/// subject parser. Requires 2+ conjuncts, all of which resolve to a filter;
+/// returns None otherwise so single-subject lines fall through to their
+/// dedicated dispatchers. The mandatory second `all ` quantifier is what
+/// distinguishes this compound animation subject from an incidental " and "
+/// inside a lone subject phrase.
+fn parse_compound_all_subjects_filter(subject: &str) -> Option<TargetFilter> {
+    let lower = subject.to_lowercase();
+    let mut filters: Vec<TargetFilter> = Vec::new();
+    let mut remaining: &str = lower.as_str();
+    // Each " and all " seam ends one conjunct and drops the next conjunct's
+    // `all ` quantifier; the shared parser strips a leading `all ` itself, so the
+    // leading conjunct's own quantifier is harmless.
+    while let Ok((_, (conjunct, rest))) = nom_primitives::split_once_on(remaining, " and all ") {
+        filters.push(parse_compound_subject_conjunct(conjunct.trim())?);
+        remaining = rest;
+    }
+    filters.push(parse_compound_subject_conjunct(remaining.trim())?);
+    if filters.len() < 2 {
+        return None;
+    }
+    Some(TargetFilter::Or { filters })
+}
+
+/// Resolve one conjunct of a compound animation subject to a filter. A basic
+/// land-type conjunct ("Forests") must resolve to a `Land` + subtype filter
+/// (CR 305.6), so try the land-type-change subject parser first; the shared
+/// subject parser (which defaults a bare subtype to a *creature* subtype)
+/// handles the creature-subtype conjuncts ("Saprolings").
+fn parse_compound_subject_conjunct(conjunct: &str) -> Option<TargetFilter> {
+    parse_land_type_change_subject(conjunct)
+        .or_else(|| super::shared::parse_continuous_subject_filter(conjunct))
+}
+
 /// Parse the subject of a land type-change line into a TargetFilter.
 pub(crate) fn parse_land_type_change_subject(subject: &str) -> Option<TargetFilter> {
     match subject.to_lowercase().as_str() {


### PR DESCRIPTION
## Summary
Adds engine support for **Life and Limb** — the dual-subject reciprocal land/creature animation — and the compound-subject animation *class* it represents.

Its printed static, `All Forests and all Saprolings are 1/1 green Saproling creatures and Forest lands in addition to their other types.`, silently dropped: no handler recognized the compound `all <X> and all <Y>` subject, and neither single-subject path is complete for the predicate — the land-animation path drops the trailing additive `and <type> lands`, and the creature-subtype path drops the base P/T. So the whole static (a board-defining continuous effect) was lost.

`parse_compound_all_subjects_type_change` (dispatched before `parse_land_animation`) distributes the subjects into an `Or` filter (CR 611.3 — the same continuous effect applies to every object in the affected set) and parses the compound predicate once into a uniform modification set that both subjects share:
- affected = `Or([ Land+Subtype("Forest"), Creature+Subtype("Saproling") ])` — the Forest conjunct resolves to a **land** subtype (CR 305.6), never a creature.
- mods = `[SetPower 1, SetToughness 1, SetColor([Green]), AddType Creature, AddSubtype "Saproling", AddType Land, AddSubtype "Forest"]` — base 1/1 (CR 613.4b, layer 7b), set green (CR 105.2, layer 5), additive types (CR 205.1b, layer 4).

The predicate reuses the two tested predicate parsers: `parse_animation_spec` (base P/T + set color + leading types) merged with `parse_additive_type_clause_modifications` (the additive type/subtype nouns past the animation parser's internal ` and `). The subject conjuncts reuse `parse_land_type_change_subject` (land subtypes) with a `parse_continuous_subject_filter` fallback (creature subtypes). No new runtime — every modification is an existing layer-system `ContinuousModification`.

## Files changed
- `crates/engine/src/parser/oracle_static/type_change.rs`
- `crates/engine/src/parser/oracle_static/dispatch.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`

## Anchored on
- `crates/engine/src/parser/oracle_static/type_change.rs` `parse_land_animation` — the single-subject sibling; the new handler mirrors its animation-spec reuse and is dispatched immediately before it, guarded by the ` and all ` conjunction so single-subject lines fall through unchanged.
- `crates/engine/src/parser/oracle_static/type_change.rs` `parse_additive_type_clause_modifications` — reused verbatim to supply the additive type/subtype grants the animation spec stops short of.

## Gate A
```

```
(exit 0)

## CR references
- `CR 611.3` — a continuous static effect applies to every object its text indicates (the Or-distributed affected set).
- `CR 613.4b` — layer 7b, setting base power/toughness.
- `CR 205.1b` — additive type/subtype grants ("in addition to its other types").
- `CR 105.2` — a "becomes [color]" effect sets the object's colors.
- `CR 305.6` — Forest is a basic land type (the Forest conjunct resolves to a land subtype).

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (Gate A above)
- `cargo test -p engine --lib parser::oracle_static` — 1008 pass / 0 fail
- Updated the prior #5147 strict-fail guard (`life_and_limb_real_text_dual_subject_animation`) to assert the full correct parse — Or(Land+Forest, Creature+Saproling) and the 7 uniform modifications — while preserving its original intent that Forest is never a creature subject. Verified single-subject animations (Living Plane / Nature's Revolt / Kormus Bell) still route through `parse_land_animation` unchanged.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)