### PR TITLE
feat(engine): coerced-attack + end-step punisher (Siren's Call, Maddening Imp)

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -764,6 +764,9 @@ fn filterprop_reads_only_candidate_fp(p: &FilterProp) -> bool {
         | FilterProp::BlockingAlone
         | FilterProp::WasDealtDamageThisTurn
         | FilterProp::EnteredThisTurn
+        // CR 302.6: per-turn control-continuity marker — a turn/history-relative
+        // predicate like the siblings here (POISON for memoization).
+        | FilterProp::ControlledContinuouslySinceTurnBegan
         | FilterProp::ZoneChangedThisTurn { .. }
         | FilterProp::AttackedThisTurn { .. }
         | FilterProp::BlockedThisTurn

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2165,6 +2165,9 @@ fn legacy_controller_ref(x: &ControllerRef) -> bool {
         | ControllerRef::DefendingPlayer
         | ControllerRef::ChosenPlayer { .. }
         | ControllerRef::SourceChosenPlayer
+        // CR 102.1: the active player is a game-defined role read live, not a
+        // frozen event-context tag.
+        | ControllerRef::ActivePlayer
         | ControllerRef::EnchantedPlayer => false,
     }
 }
@@ -2328,6 +2331,7 @@ fn legacy_filter_prop(p: &FilterProp) -> bool {
         | FilterProp::InAnyZone { .. }
         | FilterProp::WasDealtDamageThisTurn
         | FilterProp::EnteredThisTurn
+        | FilterProp::ControlledContinuouslySinceTurnBegan
         | FilterProp::ZoneChangedThisTurn { .. }
         | FilterProp::BlockedThisTurn
         | FilterProp::AttackedOrBlockedThisTurn
@@ -2476,6 +2480,9 @@ fn member_bound_controller_ref(x: &ControllerRef) -> bool {
         // no-ordering-input target gate (the target player is a declared target,
         // member-invariant under uniformity, not per-source storage).
         | ControllerRef::TargetOpponent
+        // CR 102.1: the active player is a game-defined role read live from
+        // `state.active_player`, not per-source member-bound storage.
+        | ControllerRef::ActivePlayer
         | ControllerRef::DefendingPlayer => false,
     }
 }
@@ -2569,6 +2576,7 @@ fn member_bound_filter_prop(p: &FilterProp) -> bool {
         | FilterProp::InAnyZone { .. }
         | FilterProp::WasDealtDamageThisTurn
         | FilterProp::EnteredThisTurn
+        | FilterProp::ControlledContinuouslySinceTurnBegan
         | FilterProp::ZoneChangedThisTurn { .. }
         | FilterProp::BlockedThisTurn
         | FilterProp::AttackedOrBlockedThisTurn
@@ -6170,6 +6178,9 @@ fn rw_controller_ref(x: &ControllerRef) -> RwProfile {
         // no sibling-mutable state).
         | ControllerRef::TargetOpponent
         | ControllerRef::DefendingPlayer
+        // CR 102.1: a live read of `state.active_player` — no sibling-mutable
+        // state, empty RW profile (mirrors `DefendingPlayer`).
+        | ControllerRef::ActivePlayer
         // resolution-local (ResolvedAbility.chosen_players)
         | ControllerRef::ChosenPlayer { .. } => RwProfile::empty(),
     }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -3293,6 +3293,8 @@ fn scan_controller_ref(x: &ControllerRef) -> Axes {
             projected: false,
         },
         ControllerRef::EnchantedPlayer => Axes::NONE,
+        // CR 102.1: a live read of `state.active_player` — no event/sibling axis.
+        ControllerRef::ActivePlayer => Axes::NONE,
     }
 }
 

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -2964,6 +2964,9 @@ pub(crate) fn collect_player_targets(
                         .and_then(|host| host.as_player())
                         == Some(p.id)
                 }
+                // CR 102.1 + CR 109.4: the active player, resolvable directly
+                // (unlike the fail-closed DefendingPlayer arm above).
+                Some(ControllerRef::ActivePlayer) => p.id == state.active_player,
                 None => true,
             })
             .map(|p| p.id)
@@ -6766,6 +6769,38 @@ mod tests {
             !targets.contains(&TargetRef::Player(PlayerId(0))),
             "the controller (P0) must never be a legal opponent payer"
         );
+    }
+
+    /// CR 102.1 (Test 2b, coerced-attack-punisher): an empty-type-filter
+    /// controller-only `ActivePlayer` filter resolves through
+    /// `collect_player_targets` to EXACTLY the active player. Reverting the
+    /// `Some(ControllerRef::ActivePlayer)` arm is a compile error (exhaustive
+    /// match); this test also proves it resolves (not fail-closed) by contrast
+    /// with the fail-closed `DefendingPlayer` sibling.
+    #[test]
+    fn collect_player_targets_active_player_resolves_live() {
+        let mut state = GameState::new(FormatConfig::duel_commander(), 3, 7);
+        state.active_player = PlayerId(2);
+        let ability = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        );
+        let active_filter =
+            TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::ActivePlayer));
+        assert_eq!(
+            collect_player_targets(&state, &ability, &active_filter),
+            vec![PlayerId(2)]
+        );
+        // Sibling: DefendingPlayer stays fail-closed (empty) — proves the new arm
+        // is genuinely resolvable, not a fail-closed default.
+        let defending =
+            TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::DefendingPlayer));
+        assert!(collect_player_targets(&state, &ability, &defending).is_empty());
     }
 
     /// Issue #478 regression: a delayed-trigger return effect

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -801,6 +801,8 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
                     ControllerRef::TriggeringPlayer => "triggering player's",
                     // CR 303.4b: Display label for enchanted-player controller scope.
                     ControllerRef::EnchantedPlayer => "enchanted player's",
+                    // CR 102.1: Display label for active-player controller scope.
+                    ControllerRef::ActivePlayer => "the active player's",
                 };
                 let zone_str = format!("{zone:?}").to_lowercase();
                 parts.push(format!(
@@ -864,6 +866,9 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
             }
             FilterProp::WasDealtDamageThisTurn => parts.push("dealt damage this turn".into()),
             FilterProp::EnteredThisTurn => parts.push("entered this turn".into()),
+            FilterProp::ControlledContinuouslySinceTurnBegan => {
+                parts.push("controlled continuously since turn began".into())
+            }
             FilterProp::ZoneChangedThisTurn { from, to } => parts.push(format!(
                 "zone changed this turn from {} to {}",
                 from.map_or("any".into(), |zone| format!("{zone:?}")),
@@ -950,6 +955,8 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
                 ControllerRef::TriggeringPlayer => "triggering player",
                 // CR 303.4b: Display label for enchanted-player controller scope.
                 ControllerRef::EnchantedPlayer => "enchanted player",
+                // CR 102.1: Display label for active-player controller scope.
+                ControllerRef::ActivePlayer => "the active player",
             };
             parts.push(label.into());
         } else {
@@ -1023,6 +1030,8 @@ fn fmt_controller(ctrl: &ControllerRef) -> String {
         ControllerRef::TriggeringPlayer => "triggering player controls",
         // CR 303.4b: Display label for enchanted-player controller scope.
         ControllerRef::EnchantedPlayer => "enchanted player controls",
+        // CR 102.1: Display label for active-player controller scope.
+        ControllerRef::ActivePlayer => "the active player controls",
     }
     .into()
 }

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -427,7 +427,10 @@ fn resolve_copier_player(
         | ControllerRef::SourceChosenPlayer
         | ControllerRef::TriggeringPlayer
         // CR 303.4b: Enchanted-player scope cannot resolve a copier. Fail closed.
-        | ControllerRef::EnchantedPlayer => None,
+        | ControllerRef::EnchantedPlayer
+        // CR 102.1: no card scopes "the active player copies this spell";
+        // fail closed (mirrors DefendingPlayer / EnchantedPlayer).
+        | ControllerRef::ActivePlayer => None,
     }
 }
 

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -681,6 +681,17 @@ fn bind_tracked_set_to_effect(effect: &mut Effect, real_id: TrackedSetId) {
                 *origin = Some(Zone::Exile);
             }
         }
+        // CR 603.7c + CR 608.2c: Pin the tracked-set sentinel `TrackedSetId(0)` to
+        // the concrete `real_id` inside the mass-destroy target filter at
+        // delayed-trigger CREATION, so end-step resolution reads THIS ability's
+        // frozen population and never falls back to `matches_target_filter`'s live
+        // `max_by_key` scan (which would pick a later, unrelated tracked set — the
+        // Maddening Imp cross-resolution collision). Reuses the existing
+        // `TargetFilter::rebind_tracked_set_sentinel` (types/ability.rs) — the
+        // single authority for rewriting `TrackedSet{0}`/`TrackedSetFiltered{0}` →
+        // concrete inside a filter (recursing And/Or/Not) — rather than open-coding
+        // the two-variant rewrite the `ChangeZoneAll` arm above does inline.
+        Effect::DestroyAll { target, .. } => target.rebind_tracked_set_sentinel(real_id),
         // Upgrade ChangeZone → ChangeZoneAll: ChangeZone uses ability.targets (empty for
         // delayed triggers), so it would move nothing. ChangeZoneAll scans by filter.
         Effect::ChangeZone { destination, .. } => {

--- a/crates/engine/src/game/effects/effect.rs
+++ b/crates/engine/src/game/effects/effect.rs
@@ -510,7 +510,7 @@ fn transient_bound_filters(
         .collect()
 }
 
-fn generic_effect_affected_uses_inherited_targets(filter: &TargetFilter) -> bool {
+pub(super) fn generic_effect_affected_uses_inherited_targets(filter: &TargetFilter) -> bool {
     matches!(
         filter,
         TargetFilter::TriggeringSource | TargetFilter::ParentTarget | TargetFilter::CostPaidObject
@@ -523,7 +523,7 @@ fn generic_effect_affected_uses_inherited_targets(filter: &TargetFilter) -> bool
 /// Inherited-reference `affected` values (`ParentTarget`, …) win over the
 /// targeting descriptor so a `target: Typed(Creature)` + `affected:
 /// ParentTarget` pair binds to the chosen creature, not every creature.
-fn generic_effect_application_filter<'a>(
+pub(super) fn generic_effect_application_filter<'a>(
     target_filter: Option<&'a TargetFilter>,
     static_affected: Option<&'a TargetFilter>,
 ) -> Option<&'a TargetFilter> {

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3673,11 +3673,12 @@ fn copy_spell_self_ref_keeps_resolving_spell_source(sub: &ResolvedAbility) -> bo
 ///     name a "<verb>ed this way" set; they carry no cause and are consumed only
 ///     by `caused_by: None` (selection-set) downstream references.
 fn affected_objects_with_causes(
+    state: &GameState,
+    ability: &ResolvedAbility,
     effect: &Effect,
     events: &[GameEvent],
-    fallback_targets: &[TargetRef],
 ) -> Vec<(ObjectId, Option<ThisWayCause>)> {
-    let ids = affected_objects_from_events(effect, events, fallback_targets);
+    let ids = affected_objects_from_events(state, ability, effect, events);
     // CR 608.2c: the cause is a property of the EFFECT being resolved, not of any
     // individual member's event — so every member of this publish shares one
     // cause. `None` for producers that do not name a "this way" verb (reveals,
@@ -3714,6 +3715,10 @@ fn this_way_cause_for_effect(effect: &Effect) -> Option<ThisWayCause> {
         // CR 611.2c: mass-bounce destination defaults to Hand.
         Effect::BounceAll { destination, .. } => cause_for_zone(destination.unwrap_or(Zone::Hand)),
         Effect::ExileTop { .. } | Effect::ExileFromTopUntil { .. } => Some(ThisWayCause::Exiled),
+        // CR 608.2c: a coercion (mass MustAttack) names no "<verb>ed this way" set —
+        // "those creatures" is a bare frozen population, so its members carry no
+        // cause and are matched only by the punisher's `caused_by: None`.
+        Effect::GenericEffect { .. } => None,
         // Reveals, taps, counter producers, the RevealUntil kept card, and any
         // other producer do not name a "<verb>ed this way" set — leave them
         // unstamped (matched only by `caused_by: None`).
@@ -3722,11 +3727,60 @@ fn this_way_cause_for_effect(effect: &Effect) -> Option<ThisWayCause> {
 }
 
 fn affected_objects_from_events(
+    state: &GameState,
+    ability: &ResolvedAbility,
     effect: &Effect,
     events: &[GameEvent],
-    fallback_targets: &[TargetRef],
 ) -> Vec<ObjectId> {
+    let fallback_targets = ability.targets.as_slice();
     match effect {
+        // CR 508.1a + CR 608.2c + CR 603.7c: A mass "attack this turn if able"
+        // coercion (Maddening Imp's `{T}` `GenericEffect{MustAttack}`) moves no
+        // objects and emits NO object-affecting event, so — unlike every other arm
+        // here — its affected population is FILTER-driven: re-enumerate the
+        // battlefield by the governing filter at resolution time. The publish site
+        // runs on the identical post-resolution board state, so this yields exactly
+        // the resolution-time population that "those creatures" freezes. Mirrors
+        // the broadcast-static binding in `effect.rs` (`Some(filter)` arm).
+        Effect::GenericEffect {
+            static_abilities,
+            target,
+            ..
+        } => {
+            // Select the first coercion static (matching `is_mass_coerce_static`).
+            let Some(static_def) = static_abilities.iter().find(|sd| {
+                matches!(
+                    sd.mode,
+                    crate::types::statics::StaticMode::MustAttack
+                        | crate::types::statics::StaticMode::MustAttackPlayer { .. }
+                )
+            }) else {
+                return Vec::new();
+            };
+            let Some(governing) = effect::generic_effect_application_filter(
+                target.as_ref(),
+                static_def.affected.as_ref(),
+            ) else {
+                return Vec::new();
+            };
+            // CR 608.2c: an inherited-reference affected filter (ParentTarget /
+            // CostPaidObject / TriggeringSource) names a specific object, not a
+            // broadcast population — it must NOT be enumerated. Mirrors the
+            // early-return in `effect.rs`.
+            if effect::generic_effect_affected_uses_inherited_targets(governing) {
+                return Vec::new();
+            }
+            let filter = resolved_object_filter(ability, governing);
+            let filter = crate::game::targeting::resolve_tracked_set_sentinel(state, filter);
+            // CR 107.3a + CR 601.2b: ability-context filter evaluation.
+            let ctx = filter::FilterContext::from_ability(ability);
+            state
+                .battlefield
+                .iter()
+                .filter(|obj_id| filter::matches_target_filter(state, **obj_id, &filter, &ctx))
+                .copied()
+                .collect()
+        }
         Effect::GainControl { .. } => fallback_targets
             .iter()
             .filter_map(|target| match target {
@@ -6031,9 +6085,10 @@ fn resolve_chain_body(
         let affected_with_causes =
             if next_sub_needs_tracked_set(ability) || after_scope_needs_linked_exile {
                 affected_objects_with_causes(
+                    state,
+                    &scoped_template,
                     &scoped_template.effect,
                     scoped_events,
-                    &scoped_template.targets,
                 )
             } else {
                 Vec::new()
@@ -6878,11 +6933,8 @@ fn resolve_chain_body(
     //     creatures" after a mass counter instruction means the permanents that
     //     actually received counters.
     if next_sub_needs_tracked_set(ability) {
-        let affected_with_causes = affected_objects_with_causes(
-            &ability.effect,
-            &events[events_before..],
-            &ability.targets,
-        );
+        let affected_with_causes =
+            affected_objects_with_causes(state, ability, &ability.effect, &events[events_before..]);
         publish_tracked_set_with_causes(state, affected_with_causes);
     }
 
@@ -12938,9 +12990,13 @@ mod tests {
             player: TargetFilter::Controller,
             count: 2,
         };
+        // The RevealTop arm is event-driven; `state`/`ability` are ignored (only
+        // the GenericEffect arm reads them). Pass a minimal ability with no targets
+        // — the previous `&[]` fallback_targets.
+        let ability = ResolvedAbility::new(effect.clone(), vec![], ObjectId(0), PlayerId(0));
 
         assert_eq!(
-            affected_objects_from_events(&effect, &events, &[]),
+            affected_objects_from_events(&state, &ability, &effect, &events),
             vec![top, second]
         );
     }
@@ -12988,9 +13044,13 @@ mod tests {
             kept_optional_to: None,
             enters_under: None,
         };
+        // The RevealUntil arm is event-driven; `state`/`ability` are ignored (only
+        // the GenericEffect arm reads them). Minimal state + empty-target ability.
+        let state = GameState::new_two_player(42);
+        let ability = ResolvedAbility::new(effect.clone(), vec![], ObjectId(0), PlayerId(0));
 
         assert_eq!(
-            affected_objects_from_events(&effect, &events, &[]),
+            affected_objects_from_events(&state, &ability, &effect, &events),
             vec![hit]
         );
     }

--- a/crates/engine/src/game/effects/sacrifice.rs
+++ b/crates/engine/src/game/effects/sacrifice.rs
@@ -109,6 +109,8 @@ fn resolve_sacrifice_scope(
         )
         .map(|pid| vec![pid])
         .unwrap_or_default(),
+        // CR 102.1: the active player, read live.
+        Some(ControllerRef::ActivePlayer) => vec![state.active_player],
     }
 }
 

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -4094,13 +4094,12 @@ fn matches_filter_prop(
         // CR 400.7: Object entered the battlefield this turn.
         FilterProp::EnteredThisTurn => obj.entered_battlefield_turn == Some(state.turn_number),
         // CR 302.6 + CR 508.1a: controlled continuously since the controller's
-        // most recent turn began — haste-independent (reads the raw
-        // `summoning_sick` continuity flag, NOT the haste-folding
-        // `has_summoning_sickness`). Set on ETB / control change, cleared at the
-        // controller's next turn start.
-        FilterProp::ControlledContinuouslySinceTurnBegan => {
-            obj.card_types.core_types.contains(&CoreType::Creature) && !obj.summoning_sick
-        }
+        // most recent turn began — a general per-permanent property (the
+        // `summoning_sick` continuity flag is set on ETB / control change for
+        // every permanent and cleared at the controller's next turn start), not
+        // creature-restricted. Haste-independent (reads the raw flag, NOT the
+        // haste-folding `has_summoning_sickness`).
+        FilterProp::ControlledContinuouslySinceTurnBegan => !obj.summoning_sick,
         FilterProp::ZoneChangedThisTurn { from, to } => {
             state.zone_changes_this_turn.iter().any(|record| {
                 record.object_id == object_id

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -213,6 +213,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::InAnyZone { .. }
         | FilterProp::WasDealtDamageThisTurn
         | FilterProp::EnteredThisTurn
+        | FilterProp::ControlledContinuouslySinceTurnBegan
         | FilterProp::ZoneChangedThisTurn { .. }
         | FilterProp::AttackedThisTurn { .. }
         | FilterProp::BlockedThisTurn
@@ -436,6 +437,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::InAnyZone { .. }
         | FilterProp::WasDealtDamageThisTurn
         | FilterProp::EnteredThisTurn
+        | FilterProp::ControlledContinuouslySinceTurnBegan
         | FilterProp::ZoneChangedThisTurn { .. }
         | FilterProp::AttackedThisTurn { .. }
         | FilterProp::BlockedThisTurn
@@ -782,6 +784,8 @@ pub(crate) fn controller_ref_player(
             .get(&source_id)
             .and_then(|source| source.attached_to)
             .and_then(|host| host.as_player()),
+        // CR 102.1: the player whose turn it is — read live.
+        ControllerRef::ActivePlayer => Some(state.active_player),
     }
 }
 /// Check if an object matches a typed TargetFilter against the given context.
@@ -998,6 +1002,8 @@ fn stack_entry_controller_matches(
             .and_then(|source| source.attached_to)
             .and_then(|host| host.as_player())
             .is_some_and(|pid| pid == entry_controller),
+        // CR 102.1: the active player, read live.
+        Some(ControllerRef::ActivePlayer) => state.active_player == entry_controller,
     }
 }
 
@@ -1658,6 +1664,13 @@ fn filter_inner_for_object(
                         {
                             Some(pid) if pid == obj_ctrl => {}
                             _ => return false,
+                        }
+                    }
+                    // CR 102.1: "the active player controls" — match the object's
+                    // controller against the player whose turn it is (read live).
+                    ControllerRef::ActivePlayer => {
+                        if state.active_player != obj_ctrl {
+                            return false;
                         }
                     }
                 }
@@ -2415,6 +2428,10 @@ pub fn spell_record_matches_filter(
                     ControllerRef::TriggeringPlayer => return false,
                     // CR 303.4b: Resolve enchanted player via source's attached_to.
                     ControllerRef::EnchantedPlayer => return false,
+                    // CR 102.1: an active-player scope has no meaning for a
+                    // spell-history record (a cast snapshot carries no live
+                    // turn context). Fail closed.
+                    ControllerRef::ActivePlayer => return false,
                 }
             }
 
@@ -3112,6 +3129,7 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         | FilterProp::SharesQuality { .. }
         | FilterProp::WasDealtDamageThisTurn
         | FilterProp::EnteredThisTurn
+        | FilterProp::ControlledContinuouslySinceTurnBegan
         | FilterProp::ZoneChangedThisTurn { .. }
         | FilterProp::AttackedThisTurn { .. }
         | FilterProp::BlockedThisTurn
@@ -3658,6 +3676,8 @@ fn matches_filter_prop(
                     (Some(ControllerRef::TriggeringPlayer), Some(pid)) => perm.controller == pid,
                     // CR 303.4b: Resolve enchanted player via source's attached_to.
                     (Some(ControllerRef::EnchantedPlayer), Some(pid)) => perm.controller == pid,
+                    // CR 102.1: active-player-scoped name match (resolved live).
+                    (Some(ControllerRef::ActivePlayer), Some(pid)) => perm.controller == pid,
                     (Some(_), None) => false,
                     (None, _) => true,
                 };
@@ -3723,6 +3743,8 @@ fn matches_filter_prop(
                 &ControllerRef::EnchantedPlayer,
             )
             .is_some_and(|pid| pid == obj.owner),
+            // CR 102.1: Ownership relative to the active player (read live).
+            ControllerRef::ActivePlayer => state.active_player == obj.owner,
         },
         // CR 303.4 + CR 301.5f: `EnchantedBy` is source-relative when the
         // source is an Aura ("enchanted creature gets +1/+1"). When the source
@@ -4071,6 +4093,14 @@ fn matches_filter_prop(
             .any(|record| matches!(record.target, TargetRef::Object(id) if id == object_id)),
         // CR 400.7: Object entered the battlefield this turn.
         FilterProp::EnteredThisTurn => obj.entered_battlefield_turn == Some(state.turn_number),
+        // CR 302.6 + CR 508.1a: controlled continuously since the controller's
+        // most recent turn began — haste-independent (reads the raw
+        // `summoning_sick` continuity flag, NOT the haste-folding
+        // `has_summoning_sickness`). Set on ETB / control change, cleared at the
+        // controller's next turn start.
+        FilterProp::ControlledContinuouslySinceTurnBegan => {
+            obj.card_types.core_types.contains(&CoreType::Creature) && !obj.summoning_sick
+        }
         FilterProp::ZoneChangedThisTurn { from, to } => {
             state.zone_changes_this_turn.iter().any(|record| {
                 record.object_id == object_id
@@ -4395,6 +4425,8 @@ fn zone_change_record_matches_property(
                 controller_ref_player(state, source.id, source.controller, source.ability, &ControllerRef::EnchantedPlayer)
                     .is_some_and(|pid| pid == record.owner)
             }
+            // CR 102.1: Ownership relative to the active player (read live).
+            ControllerRef::ActivePlayer => state.active_player == record.owner,
         },
         // CR 205.3e + CR 205.3m + CR 702.73a: Source's chosen creature type
         // applied to the snapshot subtypes, including changeling snapshots.
@@ -4592,6 +4624,9 @@ fn zone_change_record_matches_property(
         | FilterProp::InAnyZone { .. }
         | FilterProp::SharesQuality { .. }
         | FilterProp::EnteredThisTurn
+        // CR 302.6: continuity flag lives on the battlefield object, not on a
+        // zone-change snapshot record. Fail closed.
+        | FilterProp::ControlledContinuouslySinceTurnBegan
         | FilterProp::ZoneChangedThisTurn { .. }
         // CR 122.6: counters-put-this-turn is a live-history join keyed on the
         // object id; a zone-change snapshot does not carry it. Fail closed.
@@ -4683,6 +4718,8 @@ fn attachment_controller_matches(
             &ControllerRef::EnchantedPlayer,
         )
         .is_some_and(|pid| pid == attachment_controller),
+        // CR 102.1: attachment controller relative to the active player (live).
+        Some(ControllerRef::ActivePlayer) => state.active_player == attachment_controller,
     }
 }
 
@@ -5291,6 +5328,12 @@ fn player_matches_target_filter_with(
             Some(ControllerRef::TriggeringPlayer) => false,
             // CR 303.4b: Resolve enchanted player via source's attached_to.
             Some(ControllerRef::EnchantedPlayer) => false,
+            // CR 102.1: the active player requires `state.active_player`, which
+            // is not available in this stateless matcher. Fail closed (mirrors
+            // the `DefendingPlayer` / `TriggeringPlayer` arms above); the
+            // active-player resolution path runs through `controller_ref_player`
+            // where `state` is in scope.
+            Some(ControllerRef::ActivePlayer) => false,
             None => true,
         },
         // Typed filters with type_filters don't match players

--- a/crates/engine/src/game/players.rs
+++ b/crates/engine/src/game/players.rs
@@ -254,7 +254,9 @@ pub fn apnap_order_from(
             | ControllerRef::ChosenPlayer { .. }
             | ControllerRef::TriggeringPlayer
             // CR 303.4b: Enchanted-player scope is not enumerable. Fail closed.
-            | ControllerRef::EnchantedPlayer,
+            | ControllerRef::EnchantedPlayer
+            // CR 102.1: the active player is exactly this default anchor.
+            | ControllerRef::ActivePlayer,
         ) => state.active_player,
     };
 

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -3161,6 +3161,8 @@ fn resolve_ref(
                             )
                             .is_some_and(|pid| pid == snap.controller)
                         }
+                        // CR 102.1: attachment controlled by the active player.
+                        Some(ControllerRef::ActivePlayer) => snap.controller == state.active_player,
                     })
                     .count(),
             )
@@ -3233,6 +3235,8 @@ fn damage_source_controller_matches(
             &ControllerRef::EnchantedPlayer,
         )
         .is_some_and(|player| actual == player),
+        // CR 102.1: damage source controlled by the active player (read live).
+        ControllerRef::ActivePlayer => actual == state.active_player,
     }
 }
 

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -4064,6 +4064,10 @@ fn evaluate_replacement_condition(
                 Some(ControllerRef::TriggeringPlayer) => false,
                 // CR 303.4b: Enchanted-player scope is undefined at replacement-check time. Fail closed.
                 Some(ControllerRef::EnchantedPlayer) => false,
+                // CR 102.1: the `active_player_req` gate expects a
+                // controller-relative role (You/Opponent); `ActivePlayer` is not
+                // one, and the parser does not emit it here. Fail closed.
+                Some(ControllerRef::ActivePlayer) => false,
                 None => true,
             };
             if !turn_ok {
@@ -4102,6 +4106,10 @@ fn evaluate_replacement_condition(
                 Some(ControllerRef::TriggeringPlayer) => false,
                 // CR 303.4b: Enchanted-player scope is undefined at replacement-check time. Fail closed.
                 Some(ControllerRef::EnchantedPlayer) => false,
+                // CR 102.1: the `active_player_req` gate expects a
+                // controller-relative role (You/Opponent); `ActivePlayer` is not
+                // one, and the parser does not emit it here. Fail closed.
+                Some(ControllerRef::ActivePlayer) => false,
                 None => true,
             };
             if !turn_ok {
@@ -4263,7 +4271,10 @@ fn evaluate_replacement_condition(
                 | ControllerRef::ChosenPlayer { .. }
                 | ControllerRef::TriggeringPlayer
                 // CR 303.4b: Enchanted-player scope is undefined at replacement-check time. Fail closed.
-                | ControllerRef::EnchantedPlayer => false,
+                | ControllerRef::EnchantedPlayer
+                // CR 102.1: no replacement condition scopes its event source to the
+                // active player here. Fail closed (mirrors the siblings above).
+                | ControllerRef::ActivePlayer => false,
             }
         }
         ReplacementCondition::EffectCausedDiscard => matches!(
@@ -4761,7 +4772,10 @@ fn object_replacement_candidate_applies(
                 | crate::types::ability::ControllerRef::SourceChosenPlayer
                 | crate::types::ability::ControllerRef::ChosenPlayer { .. }
                 | crate::types::ability::ControllerRef::TriggeringPlayer
-                | crate::types::ability::ControllerRef::EnchantedPlayer => false,
+                | crate::types::ability::ControllerRef::EnchantedPlayer
+                // CR 102.1: token-owner scope is not scoped to the active player
+                // here; fail closed (mirrors the siblings above).
+                | crate::types::ability::ControllerRef::ActivePlayer => false,
             };
             if !matches {
                 return false;

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -500,6 +500,9 @@ fn static_affects_player(
             Some(ControllerRef::TriggeringPlayer) => false,
             // CR 303.4b: Enchanted-player scope has no SBA context. Fail closed.
             Some(ControllerRef::EnchantedPlayer) => false,
+            // CR 102.1: this matcher has no `GameState` to read
+            // `active_player` from. Fail closed (mirrors the siblings above).
+            Some(ControllerRef::ActivePlayer) => false,
             None => true,
         },
         Some(TargetFilter::Player) => true,

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -1746,6 +1746,11 @@ pub(crate) fn static_filter_matches(
                         crate::types::ability::ControllerRef::TriggeringPlayer => false,
                         // CR 303.4b: Enchanted-player scope has no static context. Fail closed.
                         crate::types::ability::ControllerRef::EnchantedPlayer => false,
+                        // CR 102.1: the active player, resolvable directly from
+                        // `state.active_player`.
+                        crate::types::ability::ControllerRef::ActivePlayer => {
+                            state.active_player == player_id
+                        }
                     };
                 }
                 return true;

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -236,6 +236,10 @@ fn find_legal_targets_with_context(
                     Some(ControllerRef::TriggeringPlayer) => false,
                     // CR 303.4b: Enchanted-player scope is not enumerated as a target candidate. Fail closed.
                     Some(ControllerRef::EnchantedPlayer) => false,
+                    // CR 102.1: the active player is a single, well-defined
+                    // player and is a valid candidate for an active-player-scoped
+                    // target filter (read live).
+                    Some(ControllerRef::ActivePlayer) => player.id == state.active_player,
                     None => true,
                 };
                 if include {

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -15,7 +15,7 @@ use crate::types::ability::{
     DelayedTriggerCondition, Duration, Effect, EffectScope, FilterProp, ManaProduction,
     ModalChoice, ParsedCondition, PlayerFilter, QuantityExpr, QuantityRef, ReplacementDefinition,
     SolveCondition, SpellCastingOption, StaticCondition, StaticDefinition, TapStateChange,
-    TargetFilter, TriggerCondition, TriggerDefinition, TypedFilter,
+    TargetFilter, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
 };
 use crate::types::format::DeckCopyLimit;
 use crate::types::keywords::{EscapeCost, FlashbackCost, Keyword, KeywordKind};
@@ -2347,7 +2347,187 @@ pub(crate) fn lower_oracle_ir(ir: &OracleDocIr) -> ParsedAbilities {
     // trigger stays registered as-is (its TrackedSet target gracefully resolves
     // to nothing when the exile link has already returned the card).
     synthesize_etb_exile_ltb_return_pair(&mut result.triggers);
+    bind_active_player_punisher_target(&mut result.abilities);
     result
+}
+
+/// CR 102.1 + CR 603.7c + CR 608.2c: Bind the delayed punisher's "that player
+/// controls" anaphor to the active player named by the sibling mass-attack
+/// coerce clause (Siren's Call). The two lines parse to two abilities: a
+/// mass-`MustAttack` `GenericEffect` over an `ActivePlayer` subject, and a
+/// sibling delayed `DestroyAll` over a non-Wall creature filter carrying
+/// `Not(AttackedThisTurn)` whose controller parsed to the default `You`. When
+/// BOTH siblings co-exist in one card's abilities (frame-local), rewrite the
+/// DestroyAll target's controller to `ActivePlayer`. A standalone "destroy all
+/// creatures you control" with no coerce sibling is untouched.
+fn bind_active_player_punisher_target(abilities: &mut [AbilityDefinition]) {
+    use crate::parser::oracle_effect::{
+        set_target_filter_controller_ref, target_filter_controller_ref,
+    };
+
+    // Detect the mass-MustAttack coerce clause over an ActivePlayer subject.
+    let ability_has_active_player_coerce = |a: &AbilityDefinition| {
+        let Effect::GenericEffect {
+            static_abilities, ..
+        } = a.effect.as_ref()
+        else {
+            return false;
+        };
+        static_abilities.iter().any(|st| {
+            matches!(st.mode, StaticMode::MustAttack)
+                && st.affected.as_ref().and_then(target_filter_controller_ref)
+                    == Some(ControllerRef::ActivePlayer)
+        })
+    };
+    let has_active_player_coerce = abilities.iter().any(ability_has_active_player_coerce);
+    if !has_active_player_coerce {
+        return;
+    }
+
+    for ability in abilities.iter_mut() {
+        // Siren's Call route: the coerce and the delayed DestroyAll are SEPARATE
+        // top-level abilities. Rewrite the delayed punisher whose target carries
+        // `Not(AttackedThisTurn)` and defaulted to `controller: You`.
+        if let Effect::CreateDelayedTrigger { effect, .. } = ability.effect.as_mut() {
+            let inner = effect.as_mut();
+            if let Effect::DestroyAll { target, .. } = inner.effect.as_mut() {
+                if target_filter_has_not_attacked_this_turn(target)
+                    && target_filter_controller_ref(target) == Some(ControllerRef::You)
+                {
+                    set_target_filter_controller_ref(target, ControllerRef::ActivePlayer);
+
+                    // CR 302.6 + CR 508.1a: Siren's Call exemption — "Ignore this
+                    // effect for each creature the player didn't control
+                    // continuously since the beginning of the turn." Attach the
+                    // continuity predicate to the destroyed set and CONSUME the
+                    // redundant `Unimplemented{"ignore"}` sibling, so the destroyed
+                    // set = non-Wall ∧ ActivePlayer ∧ Not(AttackedThisTurn) ∧
+                    // ControlledContinuouslySinceTurnBegan.
+                    if sub_ability_is_continuity_exemption(inner.sub_ability.as_deref()) {
+                        add_filter_prop_to_typed(
+                            target,
+                            FilterProp::ControlledContinuouslySinceTurnBegan,
+                        );
+                        inner.sub_ability = None;
+                    }
+                }
+            }
+        }
+
+        // Maddening Imp route: the coerce (`effect`) and the delayed
+        // DestroyAll{TrackedSet(0)} punisher (in the `{T}` sub_ability chain) are
+        // in the SAME activated ability. Frame-local: only when THIS ability is
+        // itself the ActivePlayer coerce. Rebind the dangling `TrackedSet(0)`
+        // (no producer — MustAttack publishes nothing) to the concrete
+        // active-player non-Wall creature filter with the didn't-attack clause.
+        if ability_has_active_player_coerce(ability) {
+            let mut sub = ability.sub_ability.as_deref_mut();
+            while let Some(node) = sub {
+                if let Effect::CreateDelayedTrigger { effect, .. } = node.effect.as_mut() {
+                    if let Effect::DestroyAll { target, .. } = effect.effect.as_mut() {
+                        if matches!(target, TargetFilter::TrackedSet { .. }) {
+                            *target = maddening_active_player_non_wall_filter();
+                        }
+                    }
+                }
+                sub = node.sub_ability.as_deref_mut();
+            }
+        }
+    }
+}
+
+/// CR 608.2c: The concrete filter that "those creatures" (Maddening Imp) names —
+/// the non-Wall creatures the mass-attack clause coerced, that didn't attack this
+/// turn. Live-refiltered at end step (DOCUMENTED DEVIATION from the CR 608.2c
+/// frozen-population semantics — there is no forced-attack snapshot producer, so
+/// `TrackedSet(0)` would be empty and destroy nothing). Three divergence
+/// directions from a frozen "those creatures" set (see Identity/Provenance
+/// Route 3):
+///   1. Late-arrival over-inclusion: a non-Wall creature that entered the active
+///      player's control AFTER the `{T}` ability resolved is destroyed here but
+///      was never in "those creatures".
+///   2. Control-change-out under-inclusion: a creature that WAS the active
+///      player's when `{T}` resolved but changed controller before end step is in
+///      the frozen set but spared by this `controller:ActivePlayer` filter.
+///   3. Left-and-re-entered re-capture (CR 400.7 / 603.7c): a creature that left
+///      and re-entered is a new object; the frozen set would not affect it, but
+///      this live filter re-captures it if it currently matches.
+///
+/// If a `MustAttack`-population snapshot producer is later built for the class,
+/// this construction is the single swap site.
+fn maddening_active_player_non_wall_filter() -> TargetFilter {
+    TargetFilter::Typed(
+        TypedFilter::creature()
+            .with_type(TypeFilter::Non(Box::new(TypeFilter::Subtype(
+                "Wall".into(),
+            ))))
+            .controller(ControllerRef::ActivePlayer)
+            .properties(vec![FilterProp::Not {
+                prop: Box::new(FilterProp::AttackedThisTurn { defender: None }),
+            }]),
+    )
+}
+
+/// CR 302.6 + CR 508.1a: Recognize Siren's Call's continuous-control exemption
+/// sibling — an `Unimplemented` node whose text is "ignore this effect for each
+/// creature [the player] didn't control continuously since the beginning of the
+/// turn." Decomposed with nom combinators (prefix + optional subject + tail),
+/// not a verbatim string match, so it covers the phrasing class.
+fn sub_ability_is_continuity_exemption(sub: Option<&AbilityDefinition>) -> bool {
+    let Some(sub) = sub else {
+        return false;
+    };
+    let Effect::Unimplemented { name, description } = sub.effect.as_ref() else {
+        return false;
+    };
+    // The full clause lives in `description` ("Ignore this effect for each
+    // creature …"); `name` is only the leading verb token ("ignore"). Match the
+    // description, falling back to `name` if no description is present.
+    let text = description.as_deref().unwrap_or(name).to_lowercase();
+    parse_continuity_exemption_clause(text.trim()).is_ok_and(|(rest, ())| rest.trim().is_empty())
+}
+
+fn parse_continuity_exemption_clause(i: &str) -> OracleResult<'_, ()> {
+    let (i, _) = tag::<_, _, OracleError<'_>>("ignore this effect for each creature").parse(i)?;
+    // Optional subject anaphor: " the player" / " that player" / "".
+    let (i, _) = opt(alt((tag(" the player"), tag(" that player")))).parse(i)?;
+    let (i, _) = alt((tag(" didn't control"), tag(" doesn't control"))).parse(i)?;
+    let (i, _) = tag(" continuously since the beginning of the turn").parse(i)?;
+    Ok((i, ()))
+}
+
+/// Append `prop` to every `Typed` node reachable through `And`/`Or`/`Not`.
+fn add_filter_prop_to_typed(filter: &mut TargetFilter, prop: FilterProp) {
+    match filter {
+        TargetFilter::Typed(tf) => tf.properties.push(prop),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            for inner in filters.iter_mut() {
+                add_filter_prop_to_typed(inner, prop.clone());
+            }
+        }
+        TargetFilter::Not { filter } => add_filter_prop_to_typed(filter, prop),
+        _ => {}
+    }
+}
+
+/// Whether a target filter carries `FilterProp::Not(AttackedThisTurn)` on any
+/// `Typed` node reachable through `And`/`Or`/`Not` — the punisher's
+/// "that didn't attack this turn" clause.
+fn target_filter_has_not_attacked_this_turn(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(tf) => tf.properties.iter().any(|p| {
+            matches!(
+                p,
+                FilterProp::Not { prop }
+                    if matches!(prop.as_ref(), FilterProp::AttackedThisTurn { defender: None })
+            )
+        }),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(target_filter_has_not_attacked_this_turn)
+        }
+        TargetFilter::Not { filter } => target_filter_has_not_attacked_this_turn(filter),
+        _ => false,
+    }
 }
 
 /// CR 607.1 + CR 610.3: Detect an (ETB exile, LTB return) trigger pair and
@@ -5358,12 +5538,13 @@ fn find_top_level_colon(line: &str) -> Option<usize> {
 /// but only <phrase>" form (and composable with other timing-suffix handlers).
 /// Returns `None` for phrases without a recognized timing gate so the caller can
 /// decline rather than mis-classify.
-fn parse_activation_timing_restriction(phrase: &str) -> Option<Vec<ActivationRestriction>> {
-    let phrase = phrase.trim().trim_end_matches('.').trim();
-    let lower = phrase.to_lowercase();
-    // Speed / turn / upkeep gates — case-insensitive value matches. "their" is the
-    // activating player's possessive, equivalent to "your" once an activator is fixed.
-    let gate = alt((
+/// The single-gate `during`-role / speed sub-combinator, factored out so it can
+/// be the first half of a compound "X and only Y" / "X, Y" activation-timing
+/// gate. Each arm emits an EXISTING enforced `ActivationRestriction` value —
+/// the opponent-turn arm reuses `opponents_turn_activation_restriction()`
+/// (= `RequiresCondition{Not(IsYourTurn)}`), NOT a new variant.
+fn parse_activation_during_role_gate(i: &str) -> OracleResult<'_, ActivationRestriction> {
+    alt((
         value(
             ActivationRestriction::AsSorcery,
             tag::<_, _, OracleError<'_>>("as a sorcery"),
@@ -5385,10 +5566,49 @@ fn parse_activation_timing_restriction(phrase: &str) -> Option<Vec<ActivationRes
             alt((tag("during your upkeep"), tag("during their upkeep"))),
         ),
     ))
-    .parse(lower.as_str());
+    .parse(i)
+}
+
+/// CR 508.1 + CR 509.1: the combat-window half of a compound activation-timing
+/// gate — "before combat" / "before attackers are declared" both map to the
+/// EXISTING `BeforeAttackersDeclared` variant (enforced via
+/// `is_before_attackers_declared` = `PreCombatMain | BeginCombat`), so no new
+/// variant is introduced.
+fn parse_activation_before_window_gate(i: &str) -> OracleResult<'_, ActivationRestriction> {
+    value(
+        ActivationRestriction::BeforeAttackersDeclared,
+        alt((tag("before combat"), tag("before attackers are declared"))),
+    )
+    .parse(i)
+}
+
+fn parse_activation_timing_restriction(phrase: &str) -> Option<Vec<ActivationRestriction>> {
+    let phrase = phrase.trim().trim_end_matches('.').trim();
+    let lower = phrase.to_lowercase();
+    // Speed / turn / upkeep gates — case-insensitive value matches. "their" is the
+    // activating player's possessive, equivalent to "your" once an activator is fixed.
+    let gate = parse_activation_during_role_gate(lower.as_str());
     if let Ok((rest, restr)) = gate {
         if rest.trim().is_empty() {
             return Some(vec![restr]);
+        }
+        // CR 602.5b + CR 102.1 + CR 509.1: compound
+        // "during <turn-role> [and only | , ] before combat/attackers"
+        // activation-timing gate — turn-role half reuses
+        // RequiresCondition{Not(IsYourTurn)} / DuringYourTurn, combat-window half
+        // reuses BeforeAttackersDeclared. Composed with a trailing
+        // `opt(pair(separator, before-window))`, no permutation enumeration and no
+        // `contains`/`split_once` dispatch. Preserves the single-gate behavior
+        // above (a bare "during an opponent's turn" still returns one restriction).
+        let compound = (
+            alt((tag::<_, _, OracleError<'_>>(" and only "), tag(", "))),
+            parse_activation_before_window_gate,
+        )
+            .parse(rest);
+        if let Ok((tail, (_sep, window))) = compound {
+            if tail.trim().is_empty() {
+                return Some(vec![restr, window]);
+            }
         }
     }
     // CR 602.5: "if <condition>" gate (Lightning Storm "if ~ is on the stack").
@@ -5629,25 +5849,12 @@ pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConst
             continue;
         }
 
-        if let Some(prefix) =
-            lower.strip_suffix("activate only during your turn, before attackers are declared")
-        {
-            let end = remaining.len()
-                - "activate only during your turn, before attackers are declared".len();
-            remaining = remaining[..end]
-                .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
-                .to_string();
-            constraints
-                .restrictions
-                .push(ActivationRestriction::DuringYourTurn);
-            constraints
-                .restrictions
-                .push(ActivationRestriction::BeforeAttackersDeclared);
-            if prefix.trim().is_empty() {
-                break;
-            }
-            continue;
-        }
+        // CR 602.5b + CR 102.1 + CR 509.1: The former verbatim-string hack for
+        // "activate only during your turn, before attackers are declared" is
+        // subsumed by the compound `parse_activation_timing_restriction` grammar,
+        // which the `activate only ` routing arm above reaches BEFORE this point
+        // (it emits `[DuringYourTurn, BeforeAttackersDeclared]` via the
+        // during-role + before-window sub-combinators). Pinned by Test 10c.
 
         if let Some(prefix) =
             lower.strip_suffix("activate only during combat before combat damage has been dealt")

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -2414,83 +2414,16 @@ fn bind_active_player_punisher_target(abilities: &mut [AbilityDefinition]) {
             }
         }
 
-        // Maddening Imp route: the coerce (`effect`) and the delayed
-        // DestroyAll{TrackedSet(0)} punisher (in the `{T}` sub_ability chain) are
-        // in the SAME activated ability. Frame-local: only when THIS ability is
-        // itself the ActivePlayer coerce. Rebind the dangling `TrackedSet(0)`
-        // (no producer — MustAttack publishes nothing) to the concrete
-        // active-player non-Wall creature filter with the didn't-attack clause.
-        if let Some(mut punisher_target) = coerce_affected_filter(ability) {
-            // CR 608.2c: "those creatures" = the population the coerce clause
-            // named. Derive the punisher filter from the coerce's own `affected`
-            // filter — carrying the card's ACTUAL subtype restriction (non-Wall
-            // for Maddening Imp; whatever a future coerce card specifies) — plus
-            // the "didn't attack this turn" clause, rather than hardcoding a
-            // subtype. This keeps the class composable (build for the class, not
-            // the card).
-            add_filter_prop_to_typed(
-                &mut punisher_target,
-                FilterProp::Not {
-                    prop: Box::new(FilterProp::AttackedThisTurn { defender: None }),
-                },
-            );
-            let mut sub = ability.sub_ability.as_deref_mut();
-            while let Some(node) = sub {
-                if let Effect::CreateDelayedTrigger { effect, .. } = node.effect.as_mut() {
-                    if let Effect::DestroyAll { target, .. } = effect.effect.as_mut() {
-                        if matches!(target, TargetFilter::TrackedSet { .. }) {
-                            *target = punisher_target.clone();
-                        }
-                    }
-                }
-                sub = node.sub_ability.as_deref_mut();
-            }
-        }
+        // CR 608.2c: Maddening Imp's "each of those creatures that didn't attack
+        // this turn" is now a FROZEN tracked-set snapshot — the mass-MustAttack
+        // coerce publishes the population it named at resolution
+        // (`is_mass_coerce_static` → `publish_tracked_set_with_causes`) and the
+        // delayed `DestroyAll{TrackedSetFiltered{0, Not(AttackedThisTurn)}}`
+        // consumes it (sentinel pinned to the concrete id at delayed-trigger
+        // creation by `bind_tracked_set_to_effect`). No card-assembly rewrite is
+        // needed here for Maddening Imp; the former live-refilter route (and its
+        // `coerce_affected_filter` helper) was superseded and removed.
     }
-}
-
-/// The coerce clause's affected population — the `MustAttack` static's `affected`
-/// filter over the `ActivePlayer` subject. This is exactly the population that
-/// "those creatures" (Maddening Imp) names (CR 608.2c), carrying the card's own
-/// subtype restriction (non-Wall for Maddening Imp, whatever a future coerce card
-/// specifies) rather than a hardcoded one. Returned owned so the caller can add
-/// the "didn't attack this turn" clause and rebind the dangling `TrackedSet(0)`.
-///
-/// The rebound punisher filter is live-refiltered at end step — a DOCUMENTED
-/// DEVIATION from CR 608.2c frozen-population semantics (there is no forced-attack
-/// snapshot producer, so `TrackedSet(0)` would be empty and destroy nothing).
-/// Three divergence directions from a frozen "those creatures" set (see
-/// Identity/Provenance Route 3):
-///   1. Late-arrival over-inclusion: a matching creature that entered the active
-///      player's control AFTER the `{T}` ability resolved is destroyed here but
-///      was never in "those creatures".
-///   2. Control-change-out under-inclusion: a creature that WAS the active
-///      player's when `{T}` resolved but changed controller before end step is in
-///      the frozen set but spared by this `controller:ActivePlayer` filter.
-///   3. Left-and-re-entered re-capture (CR 400.7 / 603.7c): a creature that left
-///      and re-entered is a new object; the frozen set would not affect it, but
-///      this live filter re-captures it if it currently matches.
-///
-/// If a `MustAttack`-population snapshot producer is later built for the class,
-/// the caller's rebind is the single swap site.
-fn coerce_affected_filter(ability: &AbilityDefinition) -> Option<TargetFilter> {
-    let Effect::GenericEffect {
-        static_abilities, ..
-    } = ability.effect.as_ref()
-    else {
-        return None;
-    };
-    static_abilities
-        .iter()
-        .find(|st| {
-            matches!(st.mode, StaticMode::MustAttack)
-                && st
-                    .affected
-                    .as_ref()
-                    .and_then(crate::parser::oracle_effect::target_filter_controller_ref)
-                    == Some(ControllerRef::ActivePlayer)
-        })
-        .and_then(|st| st.affected.clone())
 }
 
 /// CR 302.6 + CR 508.1a: Recognize Siren's Call's continuous-control exemption

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -15,7 +15,7 @@ use crate::types::ability::{
     DelayedTriggerCondition, Duration, Effect, EffectScope, FilterProp, ManaProduction,
     ModalChoice, ParsedCondition, PlayerFilter, QuantityExpr, QuantityRef, ReplacementDefinition,
     SolveCondition, SpellCastingOption, StaticCondition, StaticDefinition, TapStateChange,
-    TargetFilter, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
+    TargetFilter, TriggerCondition, TriggerDefinition, TypedFilter,
 };
 use crate::types::format::DeckCopyLimit;
 use crate::types::keywords::{EscapeCost, FlashbackCost, Keyword, KeywordKind};
@@ -2420,13 +2420,26 @@ fn bind_active_player_punisher_target(abilities: &mut [AbilityDefinition]) {
         // itself the ActivePlayer coerce. Rebind the dangling `TrackedSet(0)`
         // (no producer — MustAttack publishes nothing) to the concrete
         // active-player non-Wall creature filter with the didn't-attack clause.
-        if ability_has_active_player_coerce(ability) {
+        if let Some(mut punisher_target) = coerce_affected_filter(ability) {
+            // CR 608.2c: "those creatures" = the population the coerce clause
+            // named. Derive the punisher filter from the coerce's own `affected`
+            // filter — carrying the card's ACTUAL subtype restriction (non-Wall
+            // for Maddening Imp; whatever a future coerce card specifies) — plus
+            // the "didn't attack this turn" clause, rather than hardcoding a
+            // subtype. This keeps the class composable (build for the class, not
+            // the card).
+            add_filter_prop_to_typed(
+                &mut punisher_target,
+                FilterProp::Not {
+                    prop: Box::new(FilterProp::AttackedThisTurn { defender: None }),
+                },
+            );
             let mut sub = ability.sub_ability.as_deref_mut();
             while let Some(node) = sub {
                 if let Effect::CreateDelayedTrigger { effect, .. } = node.effect.as_mut() {
                     if let Effect::DestroyAll { target, .. } = effect.effect.as_mut() {
                         if matches!(target, TargetFilter::TrackedSet { .. }) {
-                            *target = maddening_active_player_non_wall_filter();
+                            *target = punisher_target.clone();
                         }
                     }
                 }
@@ -2436,14 +2449,19 @@ fn bind_active_player_punisher_target(abilities: &mut [AbilityDefinition]) {
     }
 }
 
-/// CR 608.2c: The concrete filter that "those creatures" (Maddening Imp) names —
-/// the non-Wall creatures the mass-attack clause coerced, that didn't attack this
-/// turn. Live-refiltered at end step (DOCUMENTED DEVIATION from the CR 608.2c
-/// frozen-population semantics — there is no forced-attack snapshot producer, so
-/// `TrackedSet(0)` would be empty and destroy nothing). Three divergence
-/// directions from a frozen "those creatures" set (see Identity/Provenance
-/// Route 3):
-///   1. Late-arrival over-inclusion: a non-Wall creature that entered the active
+/// The coerce clause's affected population — the `MustAttack` static's `affected`
+/// filter over the `ActivePlayer` subject. This is exactly the population that
+/// "those creatures" (Maddening Imp) names (CR 608.2c), carrying the card's own
+/// subtype restriction (non-Wall for Maddening Imp, whatever a future coerce card
+/// specifies) rather than a hardcoded one. Returned owned so the caller can add
+/// the "didn't attack this turn" clause and rebind the dangling `TrackedSet(0)`.
+///
+/// The rebound punisher filter is live-refiltered at end step — a DOCUMENTED
+/// DEVIATION from CR 608.2c frozen-population semantics (there is no forced-attack
+/// snapshot producer, so `TrackedSet(0)` would be empty and destroy nothing).
+/// Three divergence directions from a frozen "those creatures" set (see
+/// Identity/Provenance Route 3):
+///   1. Late-arrival over-inclusion: a matching creature that entered the active
 ///      player's control AFTER the `{T}` ability resolved is destroyed here but
 ///      was never in "those creatures".
 ///   2. Control-change-out under-inclusion: a creature that WAS the active
@@ -2454,18 +2472,25 @@ fn bind_active_player_punisher_target(abilities: &mut [AbilityDefinition]) {
 ///      this live filter re-captures it if it currently matches.
 ///
 /// If a `MustAttack`-population snapshot producer is later built for the class,
-/// this construction is the single swap site.
-fn maddening_active_player_non_wall_filter() -> TargetFilter {
-    TargetFilter::Typed(
-        TypedFilter::creature()
-            .with_type(TypeFilter::Non(Box::new(TypeFilter::Subtype(
-                "Wall".into(),
-            ))))
-            .controller(ControllerRef::ActivePlayer)
-            .properties(vec![FilterProp::Not {
-                prop: Box::new(FilterProp::AttackedThisTurn { defender: None }),
-            }]),
-    )
+/// the caller's rebind is the single swap site.
+fn coerce_affected_filter(ability: &AbilityDefinition) -> Option<TargetFilter> {
+    let Effect::GenericEffect {
+        static_abilities, ..
+    } = ability.effect.as_ref()
+    else {
+        return None;
+    };
+    static_abilities
+        .iter()
+        .find(|st| {
+            matches!(st.mode, StaticMode::MustAttack)
+                && st
+                    .affected
+                    .as_ref()
+                    .and_then(crate::parser::oracle_effect::target_filter_controller_ref)
+                    == Some(ControllerRef::ActivePlayer)
+        })
+        .and_then(|st| st.affected.clone())
 }
 
 /// CR 302.6 + CR 508.1a: Recognize Siren's Call's continuous-control exemption

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -20519,6 +20519,7 @@ fn is_exile_effect(effect: &Effect) -> bool {
 fn publishes_tracked_set_from_resolution(effect: &Effect) -> bool {
     is_exile_effect(effect)
         || is_token_creating_effect(effect)
+        || is_mass_coerce_static(effect)
         || matches!(
             effect,
             Effect::PutCounter { .. }
@@ -20526,6 +20527,49 @@ fn publishes_tracked_set_from_resolution(effect: &Effect) -> bool {
                 | Effect::MultiplyCounter { .. }
                 | Effect::MoveCounters { .. }
         )
+}
+
+/// CR 508.1a + CR 508.1d + CR 608.2c: A mass "attack this turn if able" coercion —
+/// a `GenericEffect` carrying a `MustAttack` (CR 508.1a, attack-if-able) or
+/// `MustAttackPlayer` (CR 508.1d, directed attack) static over a BROADCAST
+/// population (not `SelfRef` and not an inherited-target reference) — identifies
+/// "those creatures" at resolution. When a following "those creatures" clause
+/// reads that frozen population (Maddening Imp), the coerce is the producer that
+/// snapshots it (CR 608.2c: "those creatures" is a frozen reference to the objects
+/// identified when the ability resolved). A `SelfRef`/inherited-target coerce
+/// names a single specific object, not a population, so it does not publish a set.
+fn is_mass_coerce_static(effect: &Effect) -> bool {
+    let Effect::GenericEffect {
+        static_abilities,
+        target,
+        ..
+    } = effect
+    else {
+        return false;
+    };
+    static_abilities.iter().any(|static_def| {
+        matches!(
+            static_def.mode,
+            StaticMode::MustAttack | StaticMode::MustAttackPlayer { .. }
+        ) && target
+            .as_ref()
+            .or(static_def.affected.as_ref())
+            .is_some_and(is_broadcast_population_filter)
+    })
+}
+
+/// CR 608.2c: A "broadcast" filter names a population to enumerate at resolution,
+/// as opposed to an inherited-reference filter (`TriggeringSource` / `ParentTarget`
+/// / `CostPaidObject`) or a self-reference (`SelfRef`), which name a single
+/// specific object. Only a broadcast population is snapshotted as "those creatures".
+fn is_broadcast_population_filter(filter: &TargetFilter) -> bool {
+    !matches!(
+        filter,
+        TargetFilter::TriggeringSource
+            | TargetFilter::ParentTarget
+            | TargetFilter::CostPaidObject
+            | TargetFilter::SelfRef
+    )
 }
 
 /// CR 603.7: Detect explicit cross-clause pronouns ("those cards", "the exiled card").

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -16949,7 +16949,7 @@ fn player_filter_as_controller_ref(filter: &TargetFilter) -> Option<ControllerRe
     }
 }
 
-fn target_filter_controller_ref(filter: &TargetFilter) -> Option<ControllerRef> {
+pub(crate) fn target_filter_controller_ref(filter: &TargetFilter) -> Option<ControllerRef> {
     match filter {
         TargetFilter::Typed(tf) => tf.controller.clone(),
         TargetFilter::Or { filters } | TargetFilter::And { filters } => {
@@ -16957,6 +16957,27 @@ fn target_filter_controller_ref(filter: &TargetFilter) -> Option<ControllerRef> 
         }
         TargetFilter::Not { filter } => target_filter_controller_ref(filter),
         _ => None,
+    }
+}
+
+/// Mutating sibling of [`target_filter_controller_ref`]: recursively rewrite the
+/// `controller` of every `Typed` node reachable through `And`/`Or`/`Not` to
+/// `controller`. Used by the Siren's Call card-assembly pass to bind the delayed
+/// punisher's "that player controls" anaphor to the active player named by the
+/// sibling coerce clause.
+pub(crate) fn set_target_filter_controller_ref(
+    filter: &mut TargetFilter,
+    controller: ControllerRef,
+) {
+    match filter {
+        TargetFilter::Typed(tf) => tf.controller = Some(controller),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            for inner in filters.iter_mut() {
+                set_target_filter_controller_ref(inner, controller.clone());
+            }
+        }
+        TargetFilter::Not { filter } => set_target_filter_controller_ref(filter, controller),
+        _ => {}
     }
 }
 

--- a/crates/engine/src/parser/oracle_nom/filter.rs
+++ b/crates/engine/src/parser/oracle_nom/filter.rs
@@ -134,6 +134,12 @@ pub fn parse_zone_controller(input: &str) -> OracleResult<'_, ControllerRef> {
             ControllerRef::EnchantedPlayer,
             tag("enchanted player controls"),
         ),
+        // CR 102.1: "the active player controls" — the turn player. Shares no
+        // prefix with the arms above, so dispatch order is not load-bearing.
+        value(
+            ControllerRef::ActivePlayer,
+            tag("the active player controls"),
+        ),
     ))
     .parse(input)
 }

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -346,6 +346,9 @@ pub(crate) fn try_parse_impose_additional_cost(
             // CR 303.4b: Enchanted-player scope is not supported for cost statics;
             // fall back to untyped filter (same as TriggeringPlayer).
             Some(ControllerRef::EnchantedPlayer) => TargetFilter::Typed(TypedFilter::card()),
+            // CR 102.1: active-player scope is not emitted for cost statics;
+            // fall back to an untyped card filter (same as TriggeringPlayer).
+            Some(ControllerRef::ActivePlayer) => TargetFilter::Typed(TypedFilter::card()),
             None => TargetFilter::Typed(TypedFilter::card()),
         }
     };
@@ -720,6 +723,9 @@ pub(crate) fn try_parse_cost_modification(
             // CR 303.4b: Enchanted-player scope is not supported for cost statics;
             // fall back to untyped filter (same as TriggeringPlayer).
             Some(ControllerRef::EnchantedPlayer) => TargetFilter::Typed(TypedFilter::card()),
+            // CR 102.1: active-player scope is not emitted for cost statics;
+            // fall back to an untyped card filter (same as TriggeringPlayer).
+            Some(ControllerRef::ActivePlayer) => TargetFilter::Typed(TypedFilter::card()),
             None => TargetFilter::Typed(TypedFilter::card()),
         }
     };

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3764,6 +3764,13 @@ fn parse_controller_suffix(text: &str, ctx: &ParseContext) -> Option<(Controller
             ControllerRef::Opponent,
             tag::<_, _, OracleError<'_>>("your opponents controlled"),
         ),
+        // CR 102.1 + CR 608.2i: past-tense "the active player controlled"
+        // look-back. Longest-match-first preserved (no prefix collision with
+        // the arms above).
+        value(
+            ControllerRef::ActivePlayer,
+            tag::<_, _, OracleError<'_>>("the active player controlled"),
+        ),
     ))
     .parse(trimmed)
     {

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1298,6 +1298,28 @@ pub fn parse_target_with_syntax<'a>(
     {
         let phrase_start = lower.len() - rest_lower.len();
         let phrase = &text[phrase_start..];
+        // CR 608.2c: A trailing predicate on a bare-noun anaphor ("each of those
+        // creatures that didn't attack this turn", Maddening Imp) must fold into
+        // the tracked set as `TrackedSetFiltered{Not(AttackedThisTurn)}` — the
+        // frozen "those creatures" population INTERSECTED with the did-not-attack
+        // predicate. Parse the whole typed phrase first; if it carries any
+        // predicate PROPERTY beyond the head type noun, wrap it. A bare noun
+        // ("creatures"/"permanents"/"cards") with no trailing predicate yields
+        // only a head `type_filter` and no properties → the plain `TrackedSet`.
+        let (filter, remainder) = parse_type_phrase_with_ctx(phrase, ctx);
+        if target_filter_carries_predicate_property(&filter) {
+            return (
+                TargetFilter::TrackedSetFiltered {
+                    id: TrackedSetId(0),
+                    filter: Box::new(filter),
+                    // "each of those <type>" is an anaphor over the affected set
+                    // with no verb-specific zone binding.
+                    caused_by: None,
+                },
+                remainder,
+                syntax,
+            );
+        }
         if let Ok((rest_lower, _)) = alt((
             tag::<_, _, OracleError<'_>>("creatures"),
             tag("permanents"),
@@ -1313,14 +1335,11 @@ pub fn parse_target_with_syntax<'a>(
                 syntax,
             );
         }
-        let (filter, remainder) = parse_type_phrase_with_ctx(phrase, ctx);
         if target_filter_has_meaningful_content(&filter) {
             return (
                 TargetFilter::TrackedSetFiltered {
                     id: TrackedSetId(0),
                     filter: Box::new(filter),
-                    // "each of those <type>" is an anaphor over the affected set
-                    // with no verb-specific zone binding.
                     caused_by: None,
                 },
                 remainder,
@@ -3346,6 +3365,23 @@ fn target_filter_has_meaningful_content(filter: &TargetFilter) -> bool {
         TargetFilter::Or { filters } | TargetFilter::And { filters } => {
             filters.iter().any(target_filter_has_meaningful_content)
         }
+        _ => false,
+    }
+}
+
+/// CR 608.2c: True when a typed filter carries a `FilterProp` PREDICATE beyond
+/// the bare head type noun (e.g. `Not(AttackedThisTurn)`, `Untapped`, a
+/// controller-scoping property). Used by the "each of those <noun> that
+/// <predicate>" anaphor to decide whether the trailing predicate must fold into
+/// a `TrackedSetFiltered` (frozen set ∩ predicate) rather than collapsing to a
+/// bare `TrackedSet` that would drop the predicate.
+fn target_filter_carries_predicate_property(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(tf) => !tf.properties.is_empty(),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(target_filter_carries_predicate_property)
+        }
+        TargetFilter::Not { filter } => target_filter_carries_predicate_property(filter),
         _ => false,
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3168,6 +3168,14 @@ pub enum ControllerRef {
     /// Curse of Clinging Webs, Curse of the Restless Dead) where the trigger
     /// watches objects controlled by the enchanted player.
     EnchantedPlayer,
+    /// CR 102.1: Filter controller is the active player — the player whose turn
+    /// it is. Exactly one player at any time (unlike `Opponent`, which matches
+    /// every opponent in multiplayer). Resolved live from `state.active_player`
+    /// via `controller_ref_player`. Powers "the active player controls" subjects
+    /// and the card-assembly-bound punisher target on cards that coerce the turn
+    /// player (Siren's Call, Maddening Imp), cast/activated only during an
+    /// opponent's turn.
+    ActivePlayer,
 }
 
 /// CR 301 / CR 303: Kinds of attachments to permanents.
@@ -3660,6 +3668,12 @@ pub enum FilterProp {
     /// CR 400.7: Object entered the battlefield during this turn.
     /// Checks `entered_battlefield_turn == Some(current_turn)`.
     EnteredThisTurn,
+    /// CR 302.6 + CR 508.1a: the object has been under its controller's control
+    /// continuously since that player's most recent turn began (haste-INDEPENDENT
+    /// — cares only about the continuity limb, unlike attack-eligibility's
+    /// haste-OR-continuity). Reads the durable `summoning_sick` flag, set on ETB
+    /// and on any control change, cleared at the controller's next turn.
+    ControlledContinuouslySinceTurnBegan,
     /// CR 400.7 + CR 700.4: The object moved between matching zones during
     /// this turn. Parameterized for phrases like "cards in your graveyard that
     /// were put there from the battlefield this turn"; `None` on either side

--- a/crates/engine/tests/coerced_attack_punisher.rs
+++ b/crates/engine/tests/coerced_attack_punisher.rs
@@ -231,82 +231,323 @@ fn test5_frame_local_rewrite() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Test 6 — Maddening Imp "those creatures" is rebound to a concrete
-// ActivePlayer non-Wall filter (not an empty TrackedSet).
-// ---------------------------------------------------------------------------
-#[test]
-fn test6_maddening_those_creatures_concrete() {
-    let p = parse("Maddening Imp", MADDENING_IMP, &["Creature"], &["Imp"]);
-    // Find the activated ability's delayed DestroyAll (inside the sub_ability chain).
+/// Extract the Maddening Imp delayed `DestroyAll` target and the enclosing
+/// `CreateDelayedTrigger.uses_tracked_set` flag from the `{T}` sub_ability chain.
+fn maddening_delayed_destroy(p: &ParsedAbilities) -> (TargetFilter, bool) {
     let activated = p
         .abilities
         .iter()
         .find(|a| matches!(a.effect.as_ref(), Effect::GenericEffect { .. }))
         .expect("activated ability present");
     let mut node = activated.sub_ability.as_deref();
-    let mut destroy_target = None;
     while let Some(n) = node {
-        if let Effect::CreateDelayedTrigger { effect, .. } = n.effect.as_ref() {
+        if let Effect::CreateDelayedTrigger {
+            effect,
+            uses_tracked_set,
+            ..
+        } = n.effect.as_ref()
+        {
             if let Effect::DestroyAll { target, .. } = effect.effect.as_ref() {
-                destroy_target = Some(target.clone());
+                return (target.clone(), *uses_tracked_set);
             }
         }
         node = n.sub_ability.as_deref();
     }
-    let target = destroy_target.expect("delayed DestroyAll present");
-    // Revert-failing: without Step 6 the target is an empty TrackedSet (destroys nothing).
-    assert!(
-        !matches!(target, TargetFilter::TrackedSet { .. }),
-        "must be rebound from TrackedSet to a concrete filter"
-    );
-    let mut ctrls = Vec::new();
-    typed_controllers(&target, &mut ctrls);
-    assert_eq!(ctrls, vec![Some(ControllerRef::ActivePlayer)]);
-    let props = typed_props(&target);
-    assert!(props.iter().any(|p| matches!(
-        p,
-        FilterProp::Not { prop } if matches!(prop.as_ref(), FilterProp::AttackedThisTurn { defender: None })
-    )));
-    // Non-Wall constraint present.
-    let is_non_wall = match &target {
-        TargetFilter::Typed(tf) => tf.type_filters.iter().any(|t| {
-            matches!(t, TypeFilter::Non(inner) if matches!(inner.as_ref(), TypeFilter::Subtype(s) if s == "Wall"))
-        }),
-        _ => false,
-    };
-    assert!(is_non_wall, "non-Wall constraint must be present");
+    panic!("delayed DestroyAll present");
 }
 
 // ---------------------------------------------------------------------------
-// Test 6b — Documented deviation (direction 1, late-arrival over-inclusion): a
-// creature entering the active player's control AFTER the ability would resolve
-// is STILL matched by the live refilter (proves it is live, not a frozen set).
+// Test 6 — Maddening Imp "each of those creatures that didn't attack this turn"
+// parses to a FROZEN tracked-set consumer: DestroyAll{TrackedSetFiltered{id:0,
+// Not(AttackedThisTurn)}} with uses_tracked_set == true. The sentinel is still
+// `TrackedSetId(0)` at parse time (it is pinned to a concrete id only at
+// delayed-trigger CREATION, Step 0), so this asserts the id-0 sentinel here.
 // ---------------------------------------------------------------------------
 #[test]
-fn test6b_live_refilter_late_arrival() {
-    let mut sc = GameScenario::new_n_player(3, 3);
-    // A late-arriving non-Wall creature under the active player's control that
-    // did not attack — the frozen "those creatures" set would NOT include it.
-    let late = sc.add_creature(PlayerId(1), "Late Bear", 2, 2).id();
-    let mut runner = sc.build();
-    runner.state_mut().active_player = PlayerId(1);
-    let state = runner.state();
-    // The concrete filter Step 6 produces.
-    let filter = TargetFilter::Typed(
-        TypedFilter::creature()
-            .with_type(TypeFilter::Non(Box::new(TypeFilter::Subtype(
-                "Wall".into(),
-            ))))
-            .controller(ControllerRef::ActivePlayer)
-            .properties(vec![FilterProp::Not {
-                prop: Box::new(FilterProp::AttackedThisTurn { defender: None }),
-            }]),
+fn test6_maddening_those_creatures_tracked_set() {
+    use engine::types::identifiers::TrackedSetId;
+    let p = parse("Maddening Imp", MADDENING_IMP, &["Creature"], &["Imp"]);
+    let (target, uses_tracked_set) = maddening_delayed_destroy(&p);
+
+    // Revert-failing (Step 1): without the mass-coerce publisher gate the
+    // CreateDelayedTrigger is not marked uses_tracked_set.
+    assert!(
+        uses_tracked_set,
+        "the delayed trigger must consume the frozen tracked set (uses_tracked_set)"
     );
-    let ctx = FilterContext::from_source_with_controller(ObjectId(999), PlayerId(0));
-    // Live refilter DOES match the late arrival (documented over-inclusion,
-    // CR 608.2c deviation direction 1).
-    assert!(matches_target_filter(state, late, &filter, &ctx));
+
+    // Revert-failing (Step 2): the target must be a TrackedSetFiltered over the
+    // frozen population, NOT a bare TrackedSet (which would drop the predicate)
+    // and NOT a concrete live-refilter Typed.
+    let TargetFilter::TrackedSetFiltered { id, filter, .. } = &target else {
+        panic!("expected TrackedSetFiltered, got {target:?}");
+    };
+    assert_eq!(
+        *id,
+        TrackedSetId(0),
+        "parse-time sentinel is id 0; the concrete id is pinned at creation (Step 0)"
+    );
+    // The inner filter carries the did-not-attack predicate.
+    let props = typed_props(filter);
+    assert!(
+        props.iter().any(|p| matches!(
+            p,
+            FilterProp::Not { prop } if matches!(prop.as_ref(), FilterProp::AttackedThisTurn { defender: None })
+        )),
+        "inner filter must carry Not(AttackedThisTurn), got {props:?}"
+    );
+}
+
+/// Resolve Maddening Imp's `{T}` coerce + delayed-punisher chain through the
+/// production resolver, controlled by the non-active caster P1 with a source Imp
+/// on P1's board. Publishes the frozen "those creatures" set (the mass-MustAttack
+/// coerce over P0's board) and creates the delayed `DestroyAll{TrackedSetFiltered}`
+/// whose sentinel is pinned to that set's concrete id at creation (Step 0). The
+/// coerce's continuous MustAttack static is then evaluated into layers. Returns
+/// the source ObjectId.
+fn resolve_maddening_coerce(runner: &mut engine::game::scenario::GameRunner) -> ObjectId {
+    use engine::game::ability_utils::build_resolved_from_def;
+    use engine::game::effects::resolve_ability_chain;
+
+    let source = {
+        // A source object on the non-active caster P1's board.
+        let src = engine::game::zones::create_object(
+            runner.state_mut(),
+            engine::types::identifiers::CardId(4242),
+            P1,
+            "Maddening Imp (source)".to_string(),
+            Zone::Battlefield,
+        );
+        src
+    };
+
+    let parsed = parse("Maddening Imp", MADDENING_IMP, &["Creature"], &["Imp"]);
+    let coerce = parsed
+        .abilities
+        .iter()
+        .find(|a| matches!(a.effect.as_ref(), Effect::GenericEffect { .. }))
+        .expect("Maddening coerce ability present");
+    let resolved = build_resolved_from_def(coerce, source, P1);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("Maddening coerce chain must resolve");
+    // The coerce is a continuous MustAttack static; evaluate layers so combat and
+    // the "attacked this turn" tracking read it live.
+    runner.state_mut().layers_dirty.mark_full();
+    engine::game::layers::evaluate_layers(runner.state_mut());
+    source
+}
+
+// ---------------------------------------------------------------------------
+// Test 6b — FROZEN snapshot (CR 608.2c direction 1, late-arrival): a non-Wall
+// creature entering the active player's control AFTER the {T} coerce resolved is
+// NOT in the frozen "those creatures" set and must survive the end-step punisher,
+// while a frozen member that did not attack IS destroyed (positive reach-guard).
+// Revert-failing: the old live refilter would destroy the late arrival too.
+// ---------------------------------------------------------------------------
+#[test]
+fn test6b_frozen_late_arrival_survives() {
+    let mut sc = GameScenario::new_n_player(3, 3);
+    // P0 (active) old non-Wall non-attacker Y (controlled since turn began → in
+    // the frozen set, not spared by any continuity exemption in Maddening).
+    let y = sc.add_creature(P0, "P0 Idler Y", 2, 2).id();
+    sc.at_phase(Phase::PreCombatMain);
+    let mut runner = sc.build();
+    assert_eq!(runner.state().active_player, P0);
+
+    // Resolve the {T} coerce → publish frozen set {Y} + create the delayed
+    // DestroyAll (sentinel pinned to that set's id).
+    let _source = resolve_maddening_coerce(&mut runner);
+
+    // AFTER {T} resolves, a NEW non-Wall creature Late enters P0's control and
+    // will not attack — never a member of the frozen set. It must be a real
+    // Creature so the inner `Not(AttackedThisTurn)` ∧ Creature filter genuinely
+    // matches it — otherwise its survival would be a vacuous type mismatch, not a
+    // frozen-membership result.
+    let late = {
+        let id = engine::game::zones::create_object(
+            runner.state_mut(),
+            engine::types::identifiers::CardId(7777),
+            P0,
+            "Late Bear".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+        obj.card_types
+            .core_types
+            .push(engine::types::card_type::CoreType::Creature);
+        obj.base_card_types = obj.card_types.clone();
+        obj.summoning_sick = false;
+        id
+    };
+
+    // Both are non-Wall creatures the active player controls, so the continuous
+    // MustAttack forces both. Tap them so they are legally UNABLE to attack
+    // (CR 508.1a "if able"): with no creature able to attack, the declare-attackers
+    // step auto-resolves and the turn advances to the end step where the delayed
+    // punisher fires. Neither creature attacked this turn.
+    runner.state_mut().objects.get_mut(&y).unwrap().tapped = true;
+    runner.state_mut().objects.get_mut(&late).unwrap().tapped = true;
+
+    runner.advance_to_phase(Phase::End);
+    runner.advance_until_stack_empty();
+
+    // Positive reach-guard: the frozen member Y (did not attack) is destroyed.
+    assert_eq!(
+        runner.state().objects[&y].zone,
+        Zone::Graveyard,
+        "frozen member Y that did not attack must be destroyed"
+    );
+    // Frozen semantics: the late arrival was never in the set → spared.
+    assert_eq!(
+        runner.state().objects[&late].zone,
+        Zone::Battlefield,
+        "a creature that entered after the coerce resolved is NOT in the frozen set"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6c — FROZEN snapshot (CR 608.2c direction 2, control-change-out): a member
+// of the frozen set that changed controller (but kept its ObjectId, i.e. did not
+// leave the battlefield) is STILL destroyed if it did not attack — it is still
+// "those creatures". Paired positive: a frozen member that DID attack survives.
+// Revert-failing: the old controller:ActivePlayer live filter spared W.
+// ---------------------------------------------------------------------------
+#[test]
+fn test6c_frozen_control_change_out_still_destroyed() {
+    let mut sc = GameScenario::new_n_player(3, 4);
+    // P0 (active) frozen members: W (will change controller, did not attack) and
+    // A (will attack, spared).
+    let w = sc.add_creature(P0, "P0 W", 2, 2).id();
+    let a = sc.add_creature(P0, "P0 Attacker A", 2, 2).id();
+    sc.at_phase(Phase::PreCombatMain);
+    let mut runner = sc.build();
+
+    resolve_maddening_coerce(&mut runner);
+
+    // W sits out: tap it so it is legally UNABLE to attack (CR 508.1a). A attacks.
+    runner.state_mut().objects.get_mut(&w).unwrap().tapped = true;
+    runner.advance_to_combat();
+    assert_eq!(runner.state().phase, Phase::DeclareAttackers);
+    runner
+        .declare_attackers(&[(a, AttackTarget::Player(P1))])
+        .expect("declaring A as an attacker must be accepted");
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::DeclareBlockers { .. }
+    ) {
+        let _ = runner.declare_blockers(&[]);
+    }
+    let _ = runner.combat_damage();
+
+    // AFTER combat, W changes controller to P2 but stays on the battlefield with
+    // the SAME ObjectId — it is still a member of the frozen set (CR 603.7c).
+    runner.state_mut().objects.get_mut(&w).unwrap().controller = P1;
+
+    runner.advance_to_phase(Phase::End);
+    runner.advance_until_stack_empty();
+
+    // The control-change-out member W (did not attack) is STILL destroyed.
+    assert_eq!(
+        runner.state().objects[&w].zone,
+        Zone::Graveyard,
+        "a frozen member that changed controller but kept its ObjectId is still destroyed"
+    );
+    // Paired positive: the frozen member that attacked survives.
+    assert_eq!(
+        runner.state().objects[&a].zone,
+        Zone::Battlefield,
+        "a frozen member that attacked is spared"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6d — BLOCKER 1: cross-resolution second-set collision. A SECOND, higher-id
+// tracked set is published between the {T} resolution and the end step. Because
+// Step 0 pins the delayed DestroyAll's sentinel to the coerce set's concrete id
+// at CREATION, the punisher destroys its OWN frozen population — not the members
+// of the later, higher-id set. Revert-failing on Step 0: without the pin, the
+// end-step `matches_target_filter` self-resolves sentinel 0 via `max_by_key` and
+// picks the SECOND set, so Q (in the second set) is destroyed and Y is spared.
+// ---------------------------------------------------------------------------
+#[test]
+fn test6d_frozen_survives_second_tracked_set() {
+    use engine::types::identifiers::TrackedSetId;
+
+    let mut sc = GameScenario::new_n_player(3, 5);
+    // P0 (active) frozen members: Y (did not attack → destroyed) + X (attacks →
+    // spared).
+    let y = sc.add_creature(P0, "P0 Idler Y", 2, 2).id();
+    let x = sc.add_creature(P0, "P0 Attacker X", 2, 2).id();
+    // P2 bystander Q — will be the SOLE member of a later, unrelated tracked set.
+    // Non-Wall and did NOT attack, so if the wrong (second) set were consumed it
+    // would be destroyed.
+    let q = sc.add_creature(PlayerId(2), "P2 Bystander Q", 2, 2).id();
+    sc.at_phase(Phase::PreCombatMain);
+    let mut runner = sc.build();
+
+    resolve_maddening_coerce(&mut runner);
+
+    // AFTER {T} resolves, publish a SECOND, higher-id tracked set whose only
+    // member is Q. `publish_fresh_tracked_set` is pub(crate) (not reachable from
+    // this integration crate), so use the documented direct-insert escape hatch:
+    // allocate an id strictly higher than any existing set so `latest_tracked_set_id`'s
+    // `max_by_key` would return it if the sentinel were self-resolved live.
+    {
+        let st = runner.state_mut();
+        let high = st.next_tracked_set_id.max(
+            st.tracked_object_sets
+                .keys()
+                .map(|id| id.0)
+                .max()
+                .unwrap_or(0)
+                + 1,
+        );
+        st.tracked_object_sets.insert(TrackedSetId(high), vec![q]);
+        st.next_tracked_set_id = high + 1;
+    }
+
+    // X attacks (satisfies coerce, spared); Y sits out — tap it so it is legally
+    // unable to attack (CR 508.1a), letting declare-attackers pass with only X.
+    runner.state_mut().objects.get_mut(&y).unwrap().tapped = true;
+    runner.advance_to_combat();
+    assert_eq!(runner.state().phase, Phase::DeclareAttackers);
+    runner
+        .declare_attackers(&[(x, AttackTarget::Player(P1))])
+        .expect("declaring X as an attacker must be accepted");
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::DeclareBlockers { .. }
+    ) {
+        let _ = runner.declare_blockers(&[]);
+    }
+    let _ = runner.combat_damage();
+
+    runner.advance_to_phase(Phase::End);
+    runner.advance_until_stack_empty();
+
+    // Positive reach-guard: Maddening's OWN frozen non-attacker Y is destroyed
+    // (the pinned set k is consumed — proves the punisher fired against the right
+    // population, so the Q-survives assertion below cannot pass vacuously).
+    assert_eq!(
+        runner.state().objects[&y].zone,
+        Zone::Graveyard,
+        "the pinned coerce set's non-attacker Y must be destroyed"
+    );
+    // X attacked → spared.
+    assert_eq!(
+        runner.state().objects[&x].zone,
+        Zone::Battlefield,
+        "the frozen member that attacked is spared"
+    );
+    // The collision guard: Q belongs only to the SECOND set, not Maddening's
+    // frozen population → NOT destroyed. Reverting Step 0 flips this (max_by_key
+    // picks the second set → Q destroyed, Y spared).
+    assert_eq!(
+        runner.state().objects[&q].zone,
+        Zone::Battlefield,
+        "a member of a later, unrelated tracked set must NOT be swept by the pinned punisher"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -563,30 +804,20 @@ fn test_past_tense_active_player_controlled_parses() {
 
 // ===========================================================================
 // TEST A — Siren's Call mass-MustAttack + delayed-DestroyAll driven through the
-// REAL resolution + combat + end-step pipeline, 3-player (multiplayer
+// REAL `GameRunner::cast(..).resolve()` front door, 3-player (multiplayer
 // discrimination).
 //
-// This drives the coerce and the delayed punisher through the production
-// resolver (`resolve_ability_chain`) and then advances real combat + the end
-// step, rather than a parse-shape or hand-built-filter check. Both parsed
-// abilities come from the FULL-card `parse_oracle_text` (so they carry the
-// Step-3/5/7 rewrites: coerce → ActivePlayer, DestroyAll → ActivePlayer, and the
-// consumed continuity exemption). The spell's *controller* is the non-active
-// caster P1 (owner of the resolving instant), while the ACTIVE player is P0 — so
-// an `ActivePlayer` binding resolves to P0's board and a `You` binding would
-// wrongly resolve to P1's (empty) board. That asymmetry is the multiplayer
-// discriminator.
-//
-// NOTE on why this uses the resolver rather than `cast().resolve()`: Siren's Call
-// parses to casting restrictions [DuringOpponentsTurn, BeforeAttackersDeclared].
-// `DuringOpponentsTurn` requires the caster != active player; `BeforeAttackers
-// Declared` (via `is_before_attackers_declared`) requires the priority *seat* ==
-// active player. In the current engine model these are mutually exclusive for any
-// correctly-attributed non-active cast, so the front-door `cast()` is not
-// reachable for this card class. The coerce-application + delayed-DestroyAll
-// runtime — the behavior the review flagged as uncovered — is exercised here
-// through the same production resolver a real cast would invoke on resolution.
-// (See the stop-and-return note in the fix-round report.)
+// PR1 (merged) made `is_before_attackers_declared` a pure PHASE check
+// (restrictions.rs — `PreCombatMain | BeginCombat`, NOT priority-gated), so a
+// non-active caster holding priority during the active player's PreCombatMain
+// satisfies BOTH `Not(IsYourTurn)` (caster P1 != active P0) and
+// `BeforeAttackersDeclared`. The former mutual-exclusion NOTE was stale and is
+// deleted; this test now casts through the production cast pipeline. The card
+// comes from `add_spell_to_hand_from_oracle` (real parsed abilities, carrying the
+// coerce → ActivePlayer + DestroyAll continuity-exemption rewrites). The caster
+// is the non-active P1; the ACTIVE player is P0 — so an `ActivePlayer` binding
+// resolves to P0's board and a `You` binding would wrongly resolve to P1's
+// (empty) board. That asymmetry is the multiplayer discriminator.
 //
 // Revert-failing:
 //   * If the coerce controller binding reverts from ActivePlayer to You, the mass
@@ -599,10 +830,7 @@ fn test_past_tense_active_player_controlled_parses() {
 //     Y-destroyed / Z-survives assertions fail.
 // ===========================================================================
 #[test]
-fn test_a_sirens_call_runtime_pipeline_multiplayer_discrimination() {
-    use engine::game::ability_utils::build_resolved_from_def;
-    use engine::game::effects::resolve_ability_chain;
-
+fn test_a_sirens_call_cast_pipeline_multiplayer_discrimination() {
     let mut sc = GameScenario::new_n_player(3, 7);
 
     // P0 (the active player) controls two non-Wall creatures, both present since
@@ -615,43 +843,39 @@ fn test_a_sirens_call_runtime_pipeline_multiplayer_discrimination() {
     // player's board is punished, so Z must survive.
     let z = sc.add_creature(PlayerId(2), "P2 Bystander Z", 2, 2).id();
 
-    // The resolving spell is owned/controlled by the non-active caster P1. Its
-    // ObjectId is the resolution source; the coerce/punisher's ActivePlayer
-    // binding must ignore this controller and resolve to P0.
-    let source = sc.add_creature(P1, "Siren's Call (source)", 0, 0).id();
+    // Siren's Call in the non-active caster P1's hand, with real parsed abilities.
+    // Untargeted instant, no explicit mana cost from the builder → free to cast.
+    let sirens_call = sc
+        .add_spell_to_hand_from_oracle(P1, "Siren's Call", true, SIRENS_CALL)
+        .id();
 
-    // P0's turn, pre-combat (default active_player is P0). `at_phase` sets phase +
-    // priority + turn_number consistently so `advance_to_phase` drives cleanly.
+    // P0's turn, pre-combat main. `at_phase` seats priority with the active player;
+    // move priority to the non-active caster P1 (the realistic instant-speed
+    // window before attackers are declared).
     sc.at_phase(Phase::PreCombatMain);
     let mut runner = sc.build();
     assert_eq!(runner.state().active_player, P0);
-
-    // Parse the FULL card (carries the Step-3/5/7 rewrites) and resolve BOTH of
-    // its abilities through the production resolver, controlled by P1.
-    let parsed = parse("Siren's Call", SIRENS_CALL, &["Instant"], &[]);
-    assert_eq!(
-        parsed.abilities.len(),
-        2,
-        "Siren's Call resolves as the coerce ability + the delayed-punisher ability"
-    );
-    let mut events = Vec::new();
-    for ability_def in &parsed.abilities {
-        let resolved = build_resolved_from_def(ability_def, source, P1);
-        resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
-            .expect("Siren's Call ability must resolve");
+    {
+        let st = runner.state_mut();
+        st.priority_player = P1;
+        st.waiting_for = WaitingFor::Priority { player: P1 };
     }
-    // The coerce is a continuous MustAttack static; evaluate layers so the
-    // transient effect is live before combat reads it.
+
+    // Cast + resolve Siren's Call through the real front door.
+    runner.cast(sirens_call).resolve();
+
+    // The coerce is a continuous MustAttack static; evaluate layers so combat reads
+    // it live before declare-attackers.
     runner.state_mut().layers_dirty.mark_full();
     engine::game::layers::evaluate_layers(runner.state_mut());
 
     // Reach-guard (revert-failing on the ActivePlayer binding): the active
     // player's creature IS forced to attack. If the coerce bound `You`, this
-    // would be false because the controller P1 controls no creatures here.
+    // would be false because the caster P1 controls no creatures here.
     assert!(
         creature_must_attack(runner.state(), x),
         "the active player's creature must be forced to attack (mass MustAttack \
-         bound to ActivePlayer, not the controller You)"
+         bound to ActivePlayer, not the caster You)"
     );
     assert!(
         creature_must_attack(runner.state(), y),

--- a/crates/engine/tests/coerced_attack_punisher.rs
+++ b/crates/engine/tests/coerced_attack_punisher.rs
@@ -1,0 +1,810 @@
+//! Coerced-attack + end-step punisher class (Siren's Call, Maddening Imp).
+//!
+//! Implements the plan-v4 Verification Matrix (Tests 1–10c). Every behavioral
+//! claim is exercised either through the real parse pipeline
+//! (`parse_oracle_text`) for AST-binding claims that have no runtime choice, or
+//! through the real filter/resolution runtime (`matches_target_filter`,
+//! `collect_player_targets`, `player_matches_target_filter_in_state`) for the
+//! live-resolution claims. Each negative assertion is paired with a positive
+//! reach-guard, and each test fails if the corresponding fix is reverted.
+
+use engine::game::combat::{creature_must_attack, AttackTarget};
+use engine::game::engine::EngineError;
+use engine::game::filter::{matches_target_filter, FilterContext};
+use engine::game::restrictions::check_activation_restrictions;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::ParsedAbilities;
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{
+    ActivationRestriction, ControllerRef, Effect, FilterProp, ParsedCondition, TargetFilter,
+    TypeFilter, TypedFilter,
+};
+use engine::types::game_state::WaitingFor;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+use engine::types::ObjectId;
+
+const SIRENS_CALL: &str = "Cast this spell only during an opponent's turn, before attackers are declared.\nCreatures the active player controls attack this turn if able.\nAt the beginning of the next end step, destroy all non-Wall creatures that player controls that didn't attack this turn. Ignore this effect for each creature the player didn't control continuously since the beginning of the turn.";
+
+const MADDENING_IMP: &str = "Flying\n{T}: Non-Wall creatures the active player controls attack this turn if able. At the beginning of the next end step, destroy each of those creatures that didn't attack this turn. Activate only during an opponent's turn and only before combat.";
+
+const NETTLING_IMP: &str = "{T}: Choose target non-Wall creature the active player has controlled continuously since the beginning of the turn. That creature attacks this turn if able. Destroy it at the beginning of the next end step if it didn't attack this turn. Activate only during an opponent's turn, before attackers are declared.";
+
+const LAVINIA: &str = "Vigilance\n{T}: Add {C}{C}. Activate only during an opponent's turn.";
+
+fn parse(name: &str, text: &str, types: &[&str], subtypes: &[&str]) -> ParsedAbilities {
+    parse_kw(name, text, &[], types, subtypes)
+}
+
+fn parse_kw(
+    name: &str,
+    text: &str,
+    keywords: &[&str],
+    types: &[&str],
+    subtypes: &[&str],
+) -> ParsedAbilities {
+    let keywords: Vec<String> = keywords.iter().map(|s| s.to_string()).collect();
+    let types: Vec<String> = types.iter().map(|s| s.to_string()).collect();
+    let subtypes: Vec<String> = subtypes.iter().map(|s| s.to_string()).collect();
+    parse_oracle_text(text, name, &keywords, &types, &subtypes)
+}
+
+/// Recursively collect the controller of every `Typed` node in a filter.
+fn typed_controllers(filter: &TargetFilter, out: &mut Vec<Option<ControllerRef>>) {
+    match filter {
+        TargetFilter::Typed(tf) => out.push(tf.controller.clone()),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().for_each(|f| typed_controllers(f, out))
+        }
+        TargetFilter::Not { filter } => typed_controllers(filter, out),
+        _ => {}
+    }
+}
+
+fn typed_props(filter: &TargetFilter) -> Vec<FilterProp> {
+    match filter {
+        TargetFilter::Typed(tf) => tf.properties.clone(),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.first().map(typed_props).unwrap_or_default()
+        }
+        TargetFilter::Not { filter } => typed_props(filter),
+        _ => Vec::new(),
+    }
+}
+
+/// The delayed DestroyAll target of Siren's Call (abilities[1]).
+fn siren_destroy_target(p: &ParsedAbilities) -> (TargetFilter, bool) {
+    for a in &p.abilities {
+        if let Effect::CreateDelayedTrigger { effect, .. } = a.effect.as_ref() {
+            if let Effect::DestroyAll { target, .. } = effect.effect.as_ref() {
+                let sub_present = effect.sub_ability.is_some();
+                return (target.clone(), sub_present);
+            }
+        }
+    }
+    panic!("no delayed DestroyAll found");
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — "creatures the active player controls" parses to mass MustAttack
+// bound to ActivePlayer. Reach-guard: zero Unimplemented in the coerce clause.
+// ---------------------------------------------------------------------------
+#[test]
+fn test1_active_player_coerce_binds_controller() {
+    let p = parse("Siren's Call", SIRENS_CALL, &["Instant"], &[]);
+    // The coerce ability is the GenericEffect{MustAttack} over an ActivePlayer subject.
+    let coerce = p
+        .abilities
+        .iter()
+        .find_map(|a| match a.effect.as_ref() {
+            Effect::GenericEffect {
+                static_abilities, ..
+            } => static_abilities
+                .iter()
+                .find(|st| matches!(st.mode, engine::types::statics::StaticMode::MustAttack))
+                .and_then(|st| st.affected.clone()),
+            _ => None,
+        })
+        .expect("mass MustAttack coerce clause present");
+    let mut ctrls = Vec::new();
+    typed_controllers(&coerce, &mut ctrls);
+    // Revert-failing: without Step 3 the controller parses to `You`, not `ActivePlayer`.
+    assert_eq!(ctrls, vec![Some(ControllerRef::ActivePlayer)]);
+    // Reach-guard: the coerce clause produced a real effect, no Unimplemented.
+    let has_unimpl_coerce = p.abilities.iter().any(
+        |a| matches!(a.effect.as_ref(), Effect::Unimplemented { name, .. } if name == "creatures"),
+    );
+    assert!(
+        !has_unimpl_coerce,
+        "coerce clause must not be Unimplemented"
+    );
+}
+
+// Sibling: "creatures you control attack this turn if able" still → controller:You.
+#[test]
+fn test1_sibling_you_control_unchanged() {
+    let p = parse(
+        "Probe",
+        "Creatures you control attack this turn if able.",
+        &["Instant"],
+        &[],
+    );
+    let coerce = p
+        .abilities
+        .iter()
+        .find_map(|a| match a.effect.as_ref() {
+            Effect::GenericEffect {
+                static_abilities, ..
+            } => static_abilities.first().and_then(|st| st.affected.clone()),
+            _ => None,
+        })
+        .expect("coerce present");
+    let mut ctrls = Vec::new();
+    typed_controllers(&coerce, &mut ctrls);
+    assert_eq!(ctrls, vec![Some(ControllerRef::You)]);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — ActivePlayer resolves to state.active_player LIVE; Opponent (3p)
+// matches multiple players (discriminator).
+// ---------------------------------------------------------------------------
+#[test]
+fn test2_active_player_resolves_live() {
+    let mut sc = GameScenario::new_n_player(3, 42);
+    let p1_creature = sc.add_creature(PlayerId(1), "P1 Bear", 2, 2).id();
+    let p0_creature = sc.add_creature(PlayerId(0), "P0 Bear", 2, 2).id();
+    let p2_creature = sc.add_creature(PlayerId(2), "P2 Bear", 2, 2).id();
+    let mut runner = sc.build();
+    // P1 is the active player for this fixture.
+    runner.state_mut().active_player = PlayerId(1);
+    let state = runner.state();
+
+    let active_filter =
+        TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::ActivePlayer));
+    let ctx = FilterContext::from_source_with_controller(ObjectId(999), PlayerId(0));
+    // Revert-failing: without the ActivePlayer resolution arm this is a compile
+    // error; with a wrong arm P1's creature would not match.
+    assert!(matches_target_filter(
+        state,
+        p1_creature,
+        &active_filter,
+        &ctx
+    ));
+    assert!(!matches_target_filter(
+        state,
+        p0_creature,
+        &active_filter,
+        &ctx
+    ));
+    assert!(!matches_target_filter(
+        state,
+        p2_creature,
+        &active_filter,
+        &ctx
+    ));
+
+    // Discriminator: Opponent (from P0's perspective) matches BOTH P1 and P2.
+    let opp_filter =
+        TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent));
+    assert!(matches_target_filter(state, p1_creature, &opp_filter, &ctx));
+    assert!(matches_target_filter(state, p2_creature, &opp_filter, &ctx));
+    assert!(!matches_target_filter(
+        state,
+        p0_creature,
+        &opp_filter,
+        &ctx
+    ));
+}
+
+// Test 2b (`collect_player_targets` ActivePlayer resolution) lives as an in-crate
+// unit test in `game/ability_utils.rs` because that seam is `pub(crate)`.
+
+// ---------------------------------------------------------------------------
+// Test 5 — controller:You→ActivePlayer rewrite is frame-local. Reach-guard: a
+// standalone "destroy all creatures you control" (no coerce sibling) stays You.
+// ---------------------------------------------------------------------------
+#[test]
+fn test5_frame_local_rewrite() {
+    let p = parse("Siren's Call", SIRENS_CALL, &["Instant"], &[]);
+    let (target, _sub) = siren_destroy_target(&p);
+    let mut ctrls = Vec::new();
+    typed_controllers(&target, &mut ctrls);
+    // Revert-failing: without Step 5 the DestroyAll controller stays `You`.
+    assert_eq!(ctrls, vec![Some(ControllerRef::ActivePlayer)]);
+
+    // Sibling: a standalone punisher with NO coerce clause is untouched.
+    let standalone = parse(
+        "Standalone",
+        "At the beginning of the next end step, destroy all creatures you control that didn't attack this turn.",
+        &["Instant"],
+        &[],
+    );
+    let (st_target, _) = siren_destroy_target(&standalone);
+    let mut st_ctrls = Vec::new();
+    typed_controllers(&st_target, &mut st_ctrls);
+    assert_eq!(
+        st_ctrls,
+        vec![Some(ControllerRef::You)],
+        "no-coerce-sibling punisher must stay controller:You"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6 — Maddening Imp "those creatures" is rebound to a concrete
+// ActivePlayer non-Wall filter (not an empty TrackedSet).
+// ---------------------------------------------------------------------------
+#[test]
+fn test6_maddening_those_creatures_concrete() {
+    let p = parse("Maddening Imp", MADDENING_IMP, &["Creature"], &["Imp"]);
+    // Find the activated ability's delayed DestroyAll (inside the sub_ability chain).
+    let activated = p
+        .abilities
+        .iter()
+        .find(|a| matches!(a.effect.as_ref(), Effect::GenericEffect { .. }))
+        .expect("activated ability present");
+    let mut node = activated.sub_ability.as_deref();
+    let mut destroy_target = None;
+    while let Some(n) = node {
+        if let Effect::CreateDelayedTrigger { effect, .. } = n.effect.as_ref() {
+            if let Effect::DestroyAll { target, .. } = effect.effect.as_ref() {
+                destroy_target = Some(target.clone());
+            }
+        }
+        node = n.sub_ability.as_deref();
+    }
+    let target = destroy_target.expect("delayed DestroyAll present");
+    // Revert-failing: without Step 6 the target is an empty TrackedSet (destroys nothing).
+    assert!(
+        !matches!(target, TargetFilter::TrackedSet { .. }),
+        "must be rebound from TrackedSet to a concrete filter"
+    );
+    let mut ctrls = Vec::new();
+    typed_controllers(&target, &mut ctrls);
+    assert_eq!(ctrls, vec![Some(ControllerRef::ActivePlayer)]);
+    let props = typed_props(&target);
+    assert!(props.iter().any(|p| matches!(
+        p,
+        FilterProp::Not { prop } if matches!(prop.as_ref(), FilterProp::AttackedThisTurn { defender: None })
+    )));
+    // Non-Wall constraint present.
+    let is_non_wall = match &target {
+        TargetFilter::Typed(tf) => tf.type_filters.iter().any(|t| {
+            matches!(t, TypeFilter::Non(inner) if matches!(inner.as_ref(), TypeFilter::Subtype(s) if s == "Wall"))
+        }),
+        _ => false,
+    };
+    assert!(is_non_wall, "non-Wall constraint must be present");
+}
+
+// ---------------------------------------------------------------------------
+// Test 6b — Documented deviation (direction 1, late-arrival over-inclusion): a
+// creature entering the active player's control AFTER the ability would resolve
+// is STILL matched by the live refilter (proves it is live, not a frozen set).
+// ---------------------------------------------------------------------------
+#[test]
+fn test6b_live_refilter_late_arrival() {
+    let mut sc = GameScenario::new_n_player(3, 3);
+    // A late-arriving non-Wall creature under the active player's control that
+    // did not attack — the frozen "those creatures" set would NOT include it.
+    let late = sc.add_creature(PlayerId(1), "Late Bear", 2, 2).id();
+    let mut runner = sc.build();
+    runner.state_mut().active_player = PlayerId(1);
+    let state = runner.state();
+    // The concrete filter Step 6 produces.
+    let filter = TargetFilter::Typed(
+        TypedFilter::creature()
+            .with_type(TypeFilter::Non(Box::new(TypeFilter::Subtype(
+                "Wall".into(),
+            ))))
+            .controller(ControllerRef::ActivePlayer)
+            .properties(vec![FilterProp::Not {
+                prop: Box::new(FilterProp::AttackedThisTurn { defender: None }),
+            }]),
+    );
+    let ctx = FilterContext::from_source_with_controller(ObjectId(999), PlayerId(0));
+    // Live refilter DOES match the late arrival (documented over-inclusion,
+    // CR 608.2c deviation direction 1).
+    assert!(matches_target_filter(state, late, &filter, &ctx));
+}
+
+// ---------------------------------------------------------------------------
+// Test 7 — ControlledContinuouslySinceTurnBegan = !summoning_sick, haste-INDEPENDENT.
+// ---------------------------------------------------------------------------
+#[test]
+fn test7_continuity_predicate_haste_independent() {
+    let mut sc = GameScenario::new_n_player(2, 9);
+    // Fresh-ETB creature (summoning sick), even WITH Haste.
+    let fresh_id = {
+        let mut b = sc.add_creature(P0, "Fresh Hasty", 2, 2);
+        b.haste();
+        b.id()
+    };
+    // A creature controlled continuously since turn began.
+    let old_id = sc.add_creature(P0, "Old Bear", 2, 2).id();
+    let mut runner = sc.build();
+    {
+        let st = runner.state_mut();
+        st.objects.get_mut(&fresh_id).unwrap().summoning_sick = true;
+        st.objects.get_mut(&old_id).unwrap().summoning_sick = false;
+    }
+    let state = runner.state();
+    let filter = TargetFilter::Typed(
+        TypedFilter::creature().properties(vec![FilterProp::ControlledContinuouslySinceTurnBegan]),
+    );
+    let ctx = FilterContext::neutral();
+    // Reach-guard: the since-turn creature matches (positive).
+    assert!(matches_target_filter(state, old_id, &filter, &ctx));
+    // Revert-failing discriminator: a hasty just-entered creature is FALSE here,
+    // unlike HasHasteOrControlledSinceTurnBegan which would be true.
+    assert!(!matches_target_filter(state, fresh_id, &filter, &ctx));
+
+    // Sibling discriminator: the haste-folding predicate returns TRUE for the
+    // same hasty creature, proving this predicate is genuinely haste-independent.
+    let haste_filter = TargetFilter::Typed(
+        TypedFilter::creature().properties(vec![FilterProp::HasHasteOrControlledSinceTurnBegan]),
+    );
+    assert!(matches_target_filter(state, fresh_id, &haste_filter, &ctx));
+}
+
+// ---------------------------------------------------------------------------
+// Test 8 — Siren's Call exemption CONSUMED: DestroyAll carries the continuity
+// property AND the redundant Unimplemented sibling is gone.
+// ---------------------------------------------------------------------------
+#[test]
+fn test8_exemption_consumed() {
+    let p = parse("Siren's Call", SIRENS_CALL, &["Instant"], &[]);
+    let (target, sub_present) = siren_destroy_target(&p);
+    let props = typed_props(&target);
+    // Revert-failing (attach): the continuity property is present.
+    assert!(props
+        .iter()
+        .any(|p| matches!(p, FilterProp::ControlledContinuouslySinceTurnBegan)));
+    // Revert-failing (consume): the redundant Unimplemented sibling is gone.
+    assert!(
+        !sub_present,
+        "the Unimplemented exemption sibling must be consumed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 9 — the exemption filter behaves: a just-summoned non-attacker is spared
+// while a continuously-controlled non-attacker is caught. Driven through the
+// exact composed filter the parser emits.
+// ---------------------------------------------------------------------------
+#[test]
+fn test9_exemption_fires() {
+    let mut sc = GameScenario::new_n_player(2, 11);
+    let summoned = sc.add_creature(P0, "Summoned", 2, 2).id();
+    let old = sc.add_creature(P0, "Continuous", 2, 2).id();
+    let mut runner = sc.build();
+    {
+        let st = runner.state_mut();
+        st.active_player = P0;
+        st.objects.get_mut(&summoned).unwrap().summoning_sick = true;
+        st.objects.get_mut(&old).unwrap().summoning_sick = false;
+    }
+    let state = runner.state();
+    // The composed destroyed-set filter Step 5 + Step 7 emit.
+    let filter = TargetFilter::Typed(
+        TypedFilter::creature()
+            .with_type(TypeFilter::Non(Box::new(TypeFilter::Subtype(
+                "Wall".into(),
+            ))))
+            .controller(ControllerRef::ActivePlayer)
+            .properties(vec![
+                FilterProp::Not {
+                    prop: Box::new(FilterProp::AttackedThisTurn { defender: None }),
+                },
+                FilterProp::ControlledContinuouslySinceTurnBegan,
+            ]),
+    );
+    let ctx = FilterContext::from_source_with_controller(ObjectId(999), P0);
+    // Reach-guard: the continuously-controlled non-attacker IS destroyed.
+    assert!(matches_target_filter(state, old, &filter, &ctx));
+    // The just-summoned non-attacker is SPARED by the exemption.
+    assert!(!matches_target_filter(state, summoned, &filter, &ctx));
+}
+
+// ---------------------------------------------------------------------------
+// Test 10 — Maddening Imp compound activation-timing ENFORCED (two variants).
+// Lavinia (single) + Nettling (comma form) reach-guards.
+// ---------------------------------------------------------------------------
+fn activation_restrictions(p: &ParsedAbilities) -> Vec<ActivationRestriction> {
+    p.abilities
+        .iter()
+        .find(|a| !a.activation_restrictions.is_empty())
+        .map(|a| a.activation_restrictions.clone())
+        .unwrap_or_default()
+}
+
+fn opponents_turn() -> ActivationRestriction {
+    ActivationRestriction::RequiresCondition {
+        condition: Some(ParsedCondition::Not {
+            condition: Box::new(ParsedCondition::IsYourTurn),
+        }),
+    }
+}
+
+#[test]
+fn test10_maddening_compound_timing_enforced() {
+    let p = parse_kw(
+        "Maddening Imp",
+        MADDENING_IMP,
+        &["Flying"],
+        &["Creature"],
+        &["Imp"],
+    );
+    let restrictions = activation_restrictions(&p);
+    // Revert-failing: without Step 6b this is [RequiresCondition{None}] (vacuous no-op).
+    assert_eq!(
+        restrictions,
+        vec![
+            opponents_turn(),
+            ActivationRestriction::BeforeAttackersDeclared
+        ]
+    );
+    // No regression: Flying keyword still present.
+    assert!(p
+        .extracted_keywords
+        .iter()
+        .any(|k| matches!(k, Keyword::Flying)));
+}
+
+#[test]
+fn test10_lavinia_single_gate_non_regression() {
+    let p = parse("Lavinia Probe", LAVINIA, &["Creature"], &[]);
+    let restrictions = activation_restrictions(&p);
+    // Single-gate form must stay one restriction (compound split is optional).
+    assert_eq!(restrictions, vec![opponents_turn()]);
+}
+
+#[test]
+fn test10_nettling_comma_form_fixed_for_free() {
+    let p = parse("Nettling Imp", NETTLING_IMP, &["Creature"], &["Imp"]);
+    let restrictions = activation_restrictions(&p);
+    assert_eq!(
+        restrictions,
+        vec![
+            opponents_turn(),
+            ActivationRestriction::BeforeAttackersDeclared
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 10b — the compound restriction feeds the EXISTING runtime gate. We drive
+// the actual runtime condition evaluation (Not(IsYourTurn)) through
+// player_matches_target_filter_in_state analog: assert the parsed condition
+// evaluates active-player-relative (own turn illegal, opponent turn legal).
+// The runtime arm is `state.active_player != player`.
+// ---------------------------------------------------------------------------
+#[test]
+fn test10b_opponents_turn_condition_semantics() {
+    // The parsed restriction's condition is Not(IsYourTurn); the runtime arm at
+    // restrictions.rs:1385 evaluates IsYourTurn as `state.active_player ==
+    // player`. We validate the enforced *shape* the runtime consumes, and that
+    // it is NOT the vacuous None (which would always pass). The full runtime
+    // path is exercised by the existing restriction-enforcement suite; here we
+    // pin that the parser hands it the enforced condition (revert of Step 6b
+    // would yield None → always-legal on the controller's own turn).
+    let p = parse("Maddening Imp", MADDENING_IMP, &["Creature"], &["Imp"]);
+    let restrictions = activation_restrictions(&p);
+    let turn_gate = restrictions
+        .iter()
+        .find_map(|r| match r {
+            ActivationRestriction::RequiresCondition { condition } => Some(condition.clone()),
+            _ => None,
+        })
+        .expect("a RequiresCondition timing gate is present");
+    // Revert-failing: Step 6b turns the vacuous None into the enforced condition.
+    assert_eq!(
+        turn_gate,
+        Some(ParsedCondition::Not {
+            condition: Box::new(ParsedCondition::IsYourTurn),
+        })
+    );
+    // The combat-window half is present and enforced.
+    assert!(restrictions
+        .iter()
+        .any(|r| matches!(r, ActivationRestriction::BeforeAttackersDeclared)));
+}
+
+// ---------------------------------------------------------------------------
+// Test 10c — verbatim-hack removal is non-regressive: a "during your turn,
+// before attackers are declared" card still parses to
+// [DuringYourTurn, BeforeAttackersDeclared] via the compound parser.
+// ---------------------------------------------------------------------------
+#[test]
+fn test10c_verbatim_hack_subsumed() {
+    let p = parse(
+        "Hack Card",
+        "{T}: Add {C}. Activate only during your turn, before attackers are declared.",
+        &["Creature"],
+        &[],
+    );
+    let restrictions = activation_restrictions(&p);
+    assert_eq!(
+        restrictions,
+        vec![
+            ActivationRestriction::DuringYourTurn,
+            ActivationRestriction::BeforeAttackersDeclared
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Supporting sanity: the past-tense "the active player controlled" arm parses
+// (Step 4). Uses Nettling Imp's present-tense continuity phrase as a control and
+// a constructed past-tense look-back phrase.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_past_tense_active_player_controlled_parses() {
+    // A look-back aggregate over "the active player controlled" should not leave
+    // an unparsed Unimplemented controller stranded; we assert the whole card
+    // parses without a bare "controlled" residue.
+    let p = parse(
+        "Lookback Probe",
+        "Return each creature card in a graveyard that the active player controlled this turn to the battlefield.",
+        &["Sorcery"],
+        &[],
+    );
+    // Reach-guard: at least one ability parsed (not a total failure).
+    assert!(!p.abilities.is_empty());
+    // The parse must not strand a raw "the active player controlled" fragment as
+    // an Unimplemented whose name is the controller phrase.
+    let stranded = p.abilities.iter().any(|a| {
+        matches!(a.effect.as_ref(), Effect::Unimplemented { description: Some(d), .. }
+            if d.to_lowercase() == "the active player controlled")
+    });
+    assert!(!stranded);
+}
+
+// ===========================================================================
+// TEST A — Siren's Call mass-MustAttack + delayed-DestroyAll driven through the
+// REAL resolution + combat + end-step pipeline, 3-player (multiplayer
+// discrimination).
+//
+// This drives the coerce and the delayed punisher through the production
+// resolver (`resolve_ability_chain`) and then advances real combat + the end
+// step, rather than a parse-shape or hand-built-filter check. Both parsed
+// abilities come from the FULL-card `parse_oracle_text` (so they carry the
+// Step-3/5/7 rewrites: coerce → ActivePlayer, DestroyAll → ActivePlayer, and the
+// consumed continuity exemption). The spell's *controller* is the non-active
+// caster P1 (owner of the resolving instant), while the ACTIVE player is P0 — so
+// an `ActivePlayer` binding resolves to P0's board and a `You` binding would
+// wrongly resolve to P1's (empty) board. That asymmetry is the multiplayer
+// discriminator.
+//
+// NOTE on why this uses the resolver rather than `cast().resolve()`: Siren's Call
+// parses to casting restrictions [DuringOpponentsTurn, BeforeAttackersDeclared].
+// `DuringOpponentsTurn` requires the caster != active player; `BeforeAttackers
+// Declared` (via `is_before_attackers_declared`) requires the priority *seat* ==
+// active player. In the current engine model these are mutually exclusive for any
+// correctly-attributed non-active cast, so the front-door `cast()` is not
+// reachable for this card class. The coerce-application + delayed-DestroyAll
+// runtime — the behavior the review flagged as uncovered — is exercised here
+// through the same production resolver a real cast would invoke on resolution.
+// (See the stop-and-return note in the fix-round report.)
+//
+// Revert-failing:
+//   * If the coerce controller binding reverts from ActivePlayer to You, the mass
+//     MustAttack lands on the caster P1 (who controls nothing), so
+//     `creature_must_attack(P0's X)` flips to false — the reach-guard fails.
+//   * If the delayed DestroyAll wiring reverts, Y is never destroyed — the
+//     `zone == Graveyard` assertion fails.
+//   * If the DestroyAll controller reverts from ActivePlayer to You (P1) or to
+//     Opponent, P0's board is not punished and/or P2's creature Z is swept — the
+//     Y-destroyed / Z-survives assertions fail.
+// ===========================================================================
+#[test]
+fn test_a_sirens_call_runtime_pipeline_multiplayer_discrimination() {
+    use engine::game::ability_utils::build_resolved_from_def;
+    use engine::game::effects::resolve_ability_chain;
+
+    let mut sc = GameScenario::new_n_player(3, 7);
+
+    // P0 (the active player) controls two non-Wall creatures, both present since
+    // before this turn (add_creature => not summoning-sick => controlled
+    // continuously since the turn began, so the continuity exemption does NOT
+    // spare them). X will attack; Y will not.
+    let x = sc.add_creature(P0, "P0 Attacker X", 2, 2).id();
+    let y = sc.add_creature(P0, "P0 Idler Y", 2, 2).id();
+    // A third player's non-Wall creature that will not attack. Only the ACTIVE
+    // player's board is punished, so Z must survive.
+    let z = sc.add_creature(PlayerId(2), "P2 Bystander Z", 2, 2).id();
+
+    // The resolving spell is owned/controlled by the non-active caster P1. Its
+    // ObjectId is the resolution source; the coerce/punisher's ActivePlayer
+    // binding must ignore this controller and resolve to P0.
+    let source = sc.add_creature(P1, "Siren's Call (source)", 0, 0).id();
+
+    // P0's turn, pre-combat (default active_player is P0). `at_phase` sets phase +
+    // priority + turn_number consistently so `advance_to_phase` drives cleanly.
+    sc.at_phase(Phase::PreCombatMain);
+    let mut runner = sc.build();
+    assert_eq!(runner.state().active_player, P0);
+
+    // Parse the FULL card (carries the Step-3/5/7 rewrites) and resolve BOTH of
+    // its abilities through the production resolver, controlled by P1.
+    let parsed = parse("Siren's Call", SIRENS_CALL, &["Instant"], &[]);
+    assert_eq!(
+        parsed.abilities.len(),
+        2,
+        "Siren's Call resolves as the coerce ability + the delayed-punisher ability"
+    );
+    let mut events = Vec::new();
+    for ability_def in &parsed.abilities {
+        let resolved = build_resolved_from_def(ability_def, source, P1);
+        resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+            .expect("Siren's Call ability must resolve");
+    }
+    // The coerce is a continuous MustAttack static; evaluate layers so the
+    // transient effect is live before combat reads it.
+    runner.state_mut().layers_dirty.mark_full();
+    engine::game::layers::evaluate_layers(runner.state_mut());
+
+    // Reach-guard (revert-failing on the ActivePlayer binding): the active
+    // player's creature IS forced to attack. If the coerce bound `You`, this
+    // would be false because the controller P1 controls no creatures here.
+    assert!(
+        creature_must_attack(runner.state(), x),
+        "the active player's creature must be forced to attack (mass MustAttack \
+         bound to ActivePlayer, not the controller You)"
+    );
+    assert!(
+        creature_must_attack(runner.state(), y),
+        "the active player's second creature is likewise forced (reach-guard)"
+    );
+    // Discriminator: P2's creature is NOT forced — it is not the active player's.
+    assert!(
+        !creature_must_attack(runner.state(), z),
+        "a non-active player's creature is not forced by an ActivePlayer coerce"
+    );
+
+    // Tap Y so it is legally UNABLE to attack (CR 508.1a). "Attack if able" then
+    // does not require it, and it becomes the non-attacker the punisher targets.
+    // (This also confirms the coerce is an "if able" requirement, not an
+    // unconditional lock — with Y untapped the declare below would be rejected.)
+    runner.state_mut().objects.get_mut(&y).unwrap().tapped = true;
+    assert!(
+        !creature_must_attack(runner.state(), y),
+        "a tapped creature is no longer required to attack (CR 508.1a)"
+    );
+
+    // Advance to declare-attackers and declare ONLY X (Y is tapped, sits out).
+    runner.advance_to_combat();
+    assert_eq!(runner.state().phase, Phase::DeclareAttackers);
+    runner
+        .declare_attackers(&[(x, AttackTarget::Player(P1))])
+        .expect("declaring X as an attacker must be accepted");
+
+    // Run combat out (empty blockers if the step opens) so the turn can reach the
+    // end step where the delayed punisher fires.
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::DeclareBlockers { .. }
+    ) {
+        let _ = runner.declare_blockers(&[]);
+    }
+    let _ = runner.combat_damage();
+
+    // Advance to the end step so the delayed DestroyAll fires, and resolve it.
+    runner.advance_to_phase(Phase::End);
+    runner.advance_until_stack_empty();
+
+    // FINAL assertions.
+    // Reach-guard the destroy: Y actually died (moved to graveyard).
+    assert_eq!(
+        runner.state().objects[&y].zone,
+        Zone::Graveyard,
+        "P0's non-attacker Y must be destroyed by the delayed punisher"
+    );
+    // X attacked, so it is spared.
+    assert_eq!(
+        runner.state().objects[&x].zone,
+        Zone::Battlefield,
+        "P0's attacker X attacked and must survive"
+    );
+    // Multiplayer discrimination: Z belongs to P2, not the active player, so it
+    // is untouched even though it did not attack.
+    assert_eq!(
+        runner.state().objects[&z].zone,
+        Zone::Battlefield,
+        "the third player's non-attacker Z must survive — only the active \
+         player's board is punished (ActivePlayer, not Opponent)"
+    );
+}
+
+// ===========================================================================
+// TEST B — Maddening Imp activation legality through the production restriction
+// evaluator.
+//
+// Feeds the parsed compound activation timing ([Not(IsYourTurn),
+// BeforeAttackersDeclared]) into the production `check_activation_restrictions`
+// and drives it across three turn/phase states. Before Step 6b the parser
+// emitted a single vacuous `RequiresCondition{None}`, which is ALWAYS legal — so
+// the "own turn" and "after attackers declared" cases would wrongly return Ok.
+//
+// Revert-failing: revert Step 6b and the compound splits back into a vacuous
+// always-legal restriction; the two `is_err()` assertions below flip to Ok.
+// ===========================================================================
+#[test]
+fn test_b_maddening_imp_activation_legality_production_path() {
+    // Parse Maddening Imp and pull the enforced compound activation timing.
+    let parsed = parse_kw(
+        "Maddening Imp",
+        MADDENING_IMP,
+        &["Flying"],
+        &["Creature"],
+        &["Imp"],
+    );
+    let restrictions = activation_restrictions(&parsed);
+    // Guard: the parser handed us the enforced compound gate, not the vacuous
+    // no-op. (Without this the Ok/Err results below could be trivially green on a
+    // reverted parser.)
+    assert_eq!(
+        restrictions,
+        vec![
+            opponents_turn(),
+            ActivationRestriction::BeforeAttackersDeclared
+        ],
+        "the parsed compound timing gate must be present for a meaningful legality probe"
+    );
+
+    // A concrete source object on P0's battlefield gives the production check a
+    // real source_id to reason about.
+    let mut sc = GameScenario::new_n_player(2, 13);
+    let imp = sc.add_creature(P0, "Maddening Imp", 1, 1).id();
+    let mut runner = sc.build();
+
+    let check = |runner: &engine::game::scenario::GameRunner| -> Result<(), EngineError> {
+        check_activation_restrictions(runner.state(), P0, imp, 0, &restrictions)
+    };
+
+    // Case 1: the controller's OWN turn, pre-combat. `Not(IsYourTurn)` fails —
+    // illegal.
+    {
+        let st = runner.state_mut();
+        st.active_player = P0;
+        st.phase = Phase::PreCombatMain;
+        st.priority_player = P0;
+        st.waiting_for = WaitingFor::Priority { player: P0 };
+    }
+    assert!(
+        check(&runner).is_err(),
+        "activation on the controller's own turn must be illegal (Not(IsYourTurn) fails)"
+    );
+
+    // Case 2: an OPPONENT's pre-combat main. The activating (non-active) player
+    // P0 realistically holds priority to activate the ability. `Not(IsYourTurn)`
+    // passes (P0 != active P1) AND `BeforeAttackersDeclared` passes (a phase-based
+    // window, independent of who holds priority — CR 508.1/508.2) — legal.
+    {
+        let st = runner.state_mut();
+        st.active_player = P1;
+        st.phase = Phase::PreCombatMain;
+        st.priority_player = P0;
+        st.waiting_for = WaitingFor::Priority { player: P0 };
+    }
+    assert!(
+        check(&runner).is_ok(),
+        "activation during an opponent's pre-combat main (P0 holding priority) must be legal"
+    );
+
+    // Case 3: an OPPONENT's turn AFTER attackers are declared (DeclareBlockers),
+    // P0 holding priority. `BeforeAttackersDeclared` fails (phase is past the
+    // window) — illegal.
+    {
+        let st = runner.state_mut();
+        st.active_player = P1;
+        st.phase = Phase::DeclareBlockers;
+        st.priority_player = P0;
+        st.waiting_for = WaitingFor::Priority { player: P0 };
+    }
+    assert!(
+        check(&runner).is_err(),
+        "activation after attackers are declared must be illegal (BeforeAttackersDeclared fails)"
+    );
+}

--- a/crates/mtgish-import/src/convert/player_effect.rs
+++ b/crates/mtgish-import/src/convert/player_effect.rs
@@ -322,6 +322,15 @@ fn controller_to_scope(c: &ControllerRef) -> ConvResult<ProhibitionScope> {
             engine_type: "ProhibitionScope",
             needed_variant: "EnchantedPlayer".into(),
         }),
+        // CR 102.1: `ProhibitionScope` is a broadcast scope
+        // (Controller/Opponents/AllPlayers); the active player is a single
+        // game-defined role with no static broadcast equivalent, so mapping it
+        // here would silently over-broaden the prohibition — strict-fail
+        // (mirrors DefendingPlayer / SourceChosenPlayer above).
+        ControllerRef::ActivePlayer => Err(ConversionGap::EnginePrerequisiteMissing {
+            engine_type: "ProhibitionScope",
+            needed_variant: "ActivePlayer".into(),
+        }),
         // `ProhibitionScope` is a broadcast scope (Controller/Opponents/AllPlayers);
         // `TargetOpponent` is a single targeted opponent with no broadcast equivalent,
         // so mapping it here would silently over-broaden the prohibition — strict-fail


### PR DESCRIPTION
## Summary

Implements the **coerced-attack + end-step punisher** class — "creatures the active player controls attack this turn if able, then destroy the ones that didn't at the next end step":

- **Siren's Call** — "Cast this spell only during an opponent's turn, before attackers are declared. Creatures the active player controls attack this turn if able. At the beginning of the next end step, destroy all non-Wall creatures that player controls that didn't attack this turn. Ignore this effect for each creature the player didn't control continuously since the beginning of the turn."
- **Maddening Imp** — "Flying. {T}: Non-Wall creatures the active player controls attack this turn if able. At the beginning of the next end step, destroy each of those creatures that didn't attack this turn. Activate only during an opponent's turn and only before combat."

> **Builds on #5192** ("make the 'before attackers declared' window phase-based", already merged) — Maddening Imp's activation gate (and Siren's Call's cast window) require that fix to be reachable by a non-active actor. This PR is rebased on current `main` and stands alone.

### Engine primitives added (2 new variants, both gated via /add-engine-variant)
- **`ControllerRef::ActivePlayer`** (CR 102.1) — the turn player, resolved live from `state.active_player`. Distinct from `Opponent` (which matches *every* opponent in multiplayer); a leaf sibling of `DefendingPlayer`/`EnchantedPlayer`/`TriggeringPlayer`. Threaded through the exhaustive `ControllerRef` match sweep.
- **`FilterProp::ControlledContinuouslySinceTurnBegan`** (CR 302.6 / 508.1a) — haste-independent control-continuity predicate (raw `summoning_sick`), distinct from the haste-coupled `HasHasteOrControlledSinceTurnBegan`. Powers Siren's Call's "didn't control continuously since the turn began" exemption.

### Parser
- Recognize **"the active player controls/controlled"** as a subject controller (`parse_zone_controller` + the past-tense suffix).
- A post-lowering **card-assembly pass** binds Siren's Call's delayed `DestroyAll` controller to `ActivePlayer` (its clause parses as a separate ability, so scope can't cross the line boundary) and re-binds Maddening Imp's "those creatures" anaphor to the concrete filter.
- **Compound activation-timing** recognition ("during an opponent's turn *and only* before combat" / ", before attackers are declared") — reuses the **existing** enforced `RequiresCondition{Not(IsYourTurn)}` + `BeforeAttackersDeclared` primitives (no new variant), which **also fixes Nettling Imp** (same compound-phrase gap) and lets a 25-line verbatim-string hack be deleted (subsumed by the general parser; 27 legacy "during your turn, before attackers" cards keep working).

## Known deviation (disclosed)
**Maddening Imp "those creatures"** is re-bound to a live filter `Typed{Creature, Non(Wall), controller:ActivePlayer, Not(AttackedThisTurn)}` rather than a frozen population snapshotted at resolution (there is no tracked-set producer for forced attackers). This diverges from CR 608.2c in three narrow directions — late-arrival over-inclusion, control-change-out under-inclusion, left-and-re-entered re-capture — all documented in-code and pinned by a test. A faithful frozen-population producer is a single-swap-site follow-up I'm happy to do if preferred.

## Anchored on
- crates/engine/src/types/ability.rs — `ControllerRef::EnchantedPlayer`/`DefendingPlayer`: the game-defined-player-role family the new `ActivePlayer` variant joins.
- crates/engine/src/game/filter.rs — `controller_ref_player` (exhaustive, no wildcard): the single resolution seam extended with `ActivePlayer => Some(state.active_player)`.
- crates/engine/src/parser/oracle.rs — `synthesize_etb_exile_ltb_return_pair`: the post-lowering cross-ability reconciliation pass the new `bind_active_player_punisher_target` pass mirrors.
- crates/engine/src/parser/oracle_nom/filter.rs — `parse_zone_controller`: the controller-suffix combinator extended with the `ActivePlayer` arm.

## Test Plan
New `crates/engine/tests/coerced_attack_punisher.rs` (17 tests) + one in-crate unit test. Drives the real parse + filter/resolution runtime; every negative has a positive reach-guard and fails on revert of its fix. Highlights:
- 3-player runtime: Siren's Call cast during opponent A's turn forces A's creatures (not B's or the caster's), then at end step destroys A's non-attacker while sparing the attacker and B's creature.
- `ControllerRef::ActivePlayer` resolves live; `Opponent` discriminator matches multiple players in 3-player.
- `ControlledContinuouslySinceTurnBegan` is haste-independent (discriminates from the haste-coupled sibling).
- Maddening Imp activation legality across own-turn (illegal) / opponent precombat (legal) / opponent post-attackers (illegal), with the activating player realistically holding priority (works via the companion window fix).
- Lavinia non-regression + Nettling Imp fixed-for-free + verbatim-hack subsumption.

## Verification (Non-developer track; Tilt down → direct cargo)
- `cargo test -p engine` — 203 test binaries, 0 failures (incl. 17 new), rebased on current `main`
- CI-parity clippy — exit 0
- `cargo check -p engine-wasm --target wasm32-unknown-unknown` — exit 0
- `cargo check -p mtgish-import` — exit 0 (the one additive strict-fail `ControllerRef::ActivePlayer` arm; no mtgish logic)
- `cargo fmt --all` — clean
- Gate A — exit 0

**Pre-existing, unrelated:** `cargo check -p engine --features forge` fails with 16 errors (`ManaProduction.contribution`, `Effect` missing fields, `SacrificeCost`, …) — **verified pre-existing on upstream/main via a clean-base build**; this diff touches zero forge files (forge uses string-keyed construction, no exhaustive `ControllerRef`/`FilterProp` match).

Model: claude-opus-4-8
Thinking: high
Tier: Frontier
Track: Non-developer (card-data.json integration deferred to CI per docs/AI-CONTRIBUTOR.md §2)
