### PR TITLE
feat(parser): support “enter tapped this turn” (Due Respect, Nahiri’s Lithoforming)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -5848,6 +5848,20 @@ pub(crate) fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedE
             }
             return attach_unless_slots(clause, None, unless_pay_deferred);
         }
+        // CR 614.1d + CR 514.2: "Permanents enter tapped this turn." / "Lands you
+        // control enter tapped this turn." — a turn-bound floating enters-tapped
+        // replacement (Due Respect, Nahiri's Lithoforming).
+        if let Some(effect) = try_parse_enter_tapped_set_this_turn(
+            TextPair::new(text, &original_lower),
+            ctx.card_name.as_deref().unwrap_or(""),
+        ) {
+            let mut clause = parsed_clause(effect);
+            peel_ctx.apply_optional(&mut clause.optional);
+            if clause.condition.is_none() {
+                clause.condition = peel_ctx.condition().cloned().or(unless_condition.clone());
+            }
+            return attach_unless_slots(clause, None, unless_pay_deferred);
+        }
     }
     let mut clause = parse_effect_clause_inner(&peeled_text, ctx);
     // Trial-parse fallback: peeling may have removed disambiguation signal
@@ -11041,6 +11055,57 @@ fn try_parse_additional_land_this_turn(tp: TextPair) -> Option<ParsedEffectClaus
     // later; it is not an optional choice to apply this continuous effect now.
     clause.optional = false;
     Some(clause)
+}
+
+/// CR 614.1d + CR 514.2 + CR 611.2a: Lift a turn-duration "enter tapped this
+/// turn" clause into a floating end-of-turn replacement. Covers Due Respect
+/// ("Permanents enter tapped this turn.") and Nahiri's Lithoforming ("Lands you
+/// control enter tapped this turn."), whose enter-tapped clause otherwise lands
+/// in `Effect::Unimplemented`.
+///
+/// The trailing "this turn" (CR 514.2) is stripped first to bind the effect's
+/// lifetime, and the bare body is handed to the replacement parser — the parser
+/// IS the detector, no string dispatch. Only the unconditional external
+/// "[type] enter tapped" class (Authority of the Consuls shape: `event ==
+/// ChangeZone`, `execute == SetTapState{Tap|Untap}` on SelfRef, CR 614.1d) is
+/// lifted; any other replacement shape returns `None` so the body falls through
+/// to the existing dispatch. The def is emitted as an
+/// `AddTargetReplacement { target: None }` (CR 611.2a: a resolution-fixed
+/// continuous effect) so the resolver installs it globally and anchors
+/// `source_controller` to `ability.controller` — required for Nahiri's
+/// controller-relative "Lands you control" `valid_card` filter.
+fn try_parse_enter_tapped_set_this_turn(tp: TextPair<'_>, card_name: &str) -> Option<Effect> {
+    // CR 514.2: the trailing "this turn" is the effect duration, not part of the
+    // replacement body. Fail closed on any other (or absent) trailing duration.
+    let (body, dur) = strip_trailing_duration(tp.original);
+    if dur != Some(Duration::UntilEndOfTurn) {
+        return None;
+    }
+    // The replacement parser is the detector: it recognizes "[type] enter
+    // tapped" and yields the ChangeZone def with a SelfRef tap execute.
+    let mut def = super::oracle_replacement::parse_replacement_line(body, card_name)?;
+    // Shape guard (CR 614.1d): only the enters-tapped external-replacement class
+    // is a valid turn-bound lift. Match through the `Option<Box<AbilityDefinition>>`
+    // wrapper to the execute's effect; a SelfRef tap/untap is exactly that class,
+    // and any other shape (zone redirects, counter riders, …) is out of scope.
+    let is_enter_tapped = def.event == ReplacementEvent::ChangeZone
+        && matches!(
+            def.execute.as_ref().map(|ability| &*ability.effect),
+            Some(Effect::SetTapState {
+                state: TapStateChange::Tap | TapStateChange::Untap,
+                ..
+            })
+        );
+    if !is_enter_tapped {
+        return None;
+    }
+    // CR 514.2: expire at this turn's cleanup. `source_controller` is left `None`
+    // here — the resolver anchors it to `ability.controller` at install time.
+    def.expiry = Some(RestrictionExpiry::EndOfTurn);
+    Some(Effect::AddTargetReplacement {
+        replacement: Box::new(def),
+        target: TargetFilter::None,
+    })
 }
 
 fn clause_is_additional_land_permission(clause: &ParsedEffectClause) -> bool {

--- a/crates/engine/tests/enters_tapped_this_turn.rs
+++ b/crates/engine/tests/enters_tapped_this_turn.rs
@@ -1,0 +1,368 @@
+//! "Permanents/Lands enter tapped this turn" — a turn-duration floating
+//! enters-tapped replacement (CR 614.1d + CR 514.2 + CR 611.2a).
+//!
+//! Cards under test (verbatim Oracle text):
+//!   - Due Respect (Instant): "Permanents enter tapped this turn.\nDraw a card."
+//!   - Nahiri's Lithoforming (Sorcery): "Sacrifice X lands. For each land
+//!     sacrificed this way, draw a card. You may play X additional lands this
+//!     turn. Lands you control enter tapped this turn."
+//!
+//! Both previously left the enter-tapped clause as `Effect::Unimplemented`.
+//! The fix lifts it to `Effect::AddTargetReplacement { target: None }` carrying
+//! a `ChangeZone` replacement whose `execute` is a SelfRef tap, `expiry` is
+//! end-of-turn, and whose `source_controller` is anchored to the resolving
+//! ability's controller at install time.
+//!
+//! Tests 1–2 assert parser SHAPE on the verbatim Oracle text. Tests R1–R3 drive
+//! the real replacement pipeline (production entry via cast / play-land /
+//! `replace_event`) and assert measured tap-state.
+
+use engine::game::replacement::{replace_event, ReplacementResult};
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{
+    ControllerRef, Effect, RestrictionExpiry, TapStateChange, TargetFilter, TypeFilter,
+};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::proposed_event::ProposedEvent;
+use engine::types::replacements::ReplacementEvent;
+use engine::types::zones::{EtbTapState, Zone};
+use engine::types::ObjectId;
+
+const P1: PlayerId = PlayerId(1);
+
+const DUE_RESPECT: &str = "Permanents enter tapped this turn.\nDraw a card.";
+const NAHIRI: &str = "Sacrifice X lands. For each land sacrificed this way, draw a card. \
+     You may play X additional lands this turn. Lands you control enter tapped this turn.";
+// The load-bearing clause of Nahiri's Lithoforming, cast standalone to install
+// the "Lands you control" floating replacement through the real cast pipeline
+// (the full X-cost land-sacrifice cast is hard to drive; the plan permits a
+// minimal install as long as the ENTRY runs through production).
+const LANDS_YOU_CONTROL: &str = "Lands you control enter tapped this turn.";
+
+// --- helpers ---------------------------------------------------------------
+
+/// Collect every `Effect` across all abilities' `sub_ability` chains.
+fn all_effects(parsed: &engine::parser::oracle::ParsedAbilities) -> Vec<&Effect> {
+    let mut out = Vec::new();
+    for ability in &parsed.abilities {
+        let mut cur = Some(ability);
+        while let Some(d) = cur {
+            out.push(&*d.effect);
+            cur = d.sub_ability.as_deref();
+        }
+    }
+    out
+}
+
+/// The single lifted enters-tapped replacement carried by the parsed abilities.
+/// Panics with a clear message if the `AddTargetReplacement { target: None }`
+/// shape is absent (positive reach-guard: proves the clause parsed).
+fn lifted_replacement(
+    parsed: &engine::parser::oracle::ParsedAbilities,
+) -> engine::types::ability::ReplacementDefinition {
+    for effect in all_effects(parsed) {
+        if let Effect::AddTargetReplacement {
+            replacement,
+            target,
+        } = effect
+        {
+            assert_eq!(
+                *target,
+                TargetFilter::None,
+                "the lift must use the no-per-target-binding mode (CR 611.2a)"
+            );
+            return (**replacement).clone();
+        }
+    }
+    panic!("expected an AddTargetReplacement in the parsed abilities, found none");
+}
+
+fn assert_no_unimplemented(parsed: &engine::parser::oracle::ParsedAbilities) {
+    for effect in all_effects(parsed) {
+        assert!(
+            !matches!(effect, Effect::Unimplemented { .. }),
+            "no clause may parse to Effect::Unimplemented, found {effect:?}"
+        );
+    }
+}
+
+/// Assert the carried replacement is the enters-tapped `ChangeZone` shape.
+fn assert_enter_tapped_shape(def: &engine::types::ability::ReplacementDefinition) {
+    // CR 614.1d: the event is a battlefield-entry replacement.
+    assert_eq!(
+        def.event,
+        ReplacementEvent::ChangeZone,
+        "event must be ChangeZone"
+    );
+    // The execute is a SelfRef single Tap (the enters-tapped modifier class).
+    let execute_effect = def
+        .execute
+        .as_ref()
+        .map(|ability| (*ability.effect).clone())
+        .expect("replacement must carry an execute effect");
+    assert!(
+        matches!(
+            execute_effect,
+            Effect::SetTapState {
+                state: TapStateChange::Tap,
+                ..
+            }
+        ),
+        "execute must be SetTapState{{Tap}}, got {execute_effect:?}"
+    );
+    // CR 514.2: expires at end of turn.
+    assert_eq!(
+        def.expiry,
+        Some(RestrictionExpiry::EndOfTurn),
+        "replacement must expire at end of turn"
+    );
+}
+
+/// Extract the `TypedFilter` from a `valid_card` filter.
+fn valid_typed(
+    def: &engine::types::ability::ReplacementDefinition,
+) -> engine::types::ability::TypedFilter {
+    match def.valid_card.clone() {
+        Some(TargetFilter::Typed(tf)) => tf,
+        other => panic!("expected valid_card = Typed(..), got {other:?}"),
+    }
+}
+
+// --- Test 1: parser SHAPE (Due Respect) ------------------------------------
+
+#[test]
+fn due_respect_parses_permanents_enter_tapped_shape() {
+    let parsed = parse_oracle_text(
+        DUE_RESPECT,
+        "Due Respect",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+
+    // Positive reach-guard: zero Unimplemented anywhere.
+    assert_no_unimplemented(&parsed);
+
+    let def = lifted_replacement(&parsed);
+    assert_enter_tapped_shape(&def);
+
+    // "Permanents" → Typed { [Permanent] }, no controller scope.
+    let tf = valid_typed(&def);
+    assert!(
+        matches!(tf.type_filters.as_slice(), [TypeFilter::Permanent]),
+        "valid_card must be Typed{{[Permanent]}}, got {:?}",
+        tf.type_filters
+    );
+    assert_eq!(tf.controller, None, "Due Respect's clause is uncontrolled");
+
+    // The "Draw a card." sub-clause must still be present.
+    assert!(
+        all_effects(&parsed)
+            .iter()
+            .any(|e| matches!(e, Effect::Draw { .. })),
+        "the Draw sub-effect must survive alongside the lifted replacement"
+    );
+}
+
+// --- Test 2: parser SHAPE (Nahiri's Lithoforming) --------------------------
+
+#[test]
+fn nahiris_lithoforming_parses_lands_you_control_shape() {
+    let parsed = parse_oracle_text(
+        NAHIRI,
+        "Nahiri's Lithoforming",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+
+    // Positive reach-guard: the entire chain now parses (no Unimplemented).
+    assert_no_unimplemented(&parsed);
+
+    let def = lifted_replacement(&parsed);
+    assert_enter_tapped_shape(&def);
+
+    // "Lands you control" → Typed { [Land], controller: You }.
+    let tf = valid_typed(&def);
+    assert!(
+        matches!(tf.type_filters.as_slice(), [TypeFilter::Land]),
+        "valid_card must be Typed{{[Land]}}, got {:?}",
+        tf.type_filters
+    );
+    assert_eq!(
+        tf.controller,
+        Some(ControllerRef::You),
+        "Nahiri's clause is scoped to lands YOU control"
+    );
+
+    // The other clauses are unchanged and still present.
+    let effects = all_effects(&parsed);
+    assert!(
+        effects
+            .iter()
+            .any(|e| matches!(e, Effect::Sacrifice { .. })),
+        "the Sacrifice clause must remain"
+    );
+    assert!(
+        effects.iter().any(|e| matches!(e, Effect::Draw { .. })),
+        "the per-land Draw clause must remain"
+    );
+    assert!(
+        effects
+            .iter()
+            .any(|e| matches!(e, Effect::CastFromZone { .. })),
+        "the play-additional-lands clause must remain"
+    );
+}
+
+// --- Runtime helpers -------------------------------------------------------
+
+fn zone_change_tap_state(runner: &mut GameRunner, object_id: ObjectId, from: Zone) -> EtbTapState {
+    let mut events = Vec::new();
+    let proposed = ProposedEvent::zone_change(object_id, from, Zone::Battlefield, None);
+    match replace_event(runner.state_mut(), proposed, &mut events) {
+        ReplacementResult::Execute(ProposedEvent::ZoneChange { enter_tapped, .. }) => enter_tapped,
+        other => panic!("expected an Execute(ZoneChange) result, got {other:?}"),
+    }
+}
+
+// --- Test R1: runtime — Due Respect taps later entries ---------------------
+
+#[test]
+fn r1_due_respect_taps_only_entries_after_resolution() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // A card for Due Respect's own "Draw a card".
+    scenario.add_spell_to_library_top(P0, "Filler", true);
+    // A creature already on the battlefield BEFORE Due Respect resolves.
+    let old_bear = scenario.add_creature(P0, "Old Bear", 2, 2).id();
+    // The creature that will ENTER after Due Respect resolves.
+    let new_bear = scenario.add_creature_to_hand(P0, "New Bear", 2, 2).id();
+    let due_respect = scenario
+        .add_spell_to_hand_from_oracle(P0, "Due Respect", true, DUE_RESPECT)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Cast + resolve Due Respect: installs the replacement and draws 1.
+    let outcome = runner.cast(due_respect).resolve();
+    outcome.assert_hand_drawn(P0, 1);
+
+    // A creature entering LATER this turn (production cast) enters tapped.
+    runner.cast(new_bear).resolve();
+    assert!(
+        runner.state().objects[&new_bear].tapped,
+        "a creature entering after Due Respect resolved must enter tapped"
+    );
+
+    // The creature that entered BEFORE the spell resolved is untouched.
+    assert!(
+        !runner.state().objects[&old_bear].tapped,
+        "a creature already on the battlefield must not be tapped retroactively"
+    );
+}
+
+// --- Test R2: runtime — expiry at cleanup ----------------------------------
+
+#[test]
+fn r2_due_respect_replacement_expires_at_cleanup() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_spell_to_library_top(P0, "Filler", true);
+    // A land in P0's hand whose proposed entry we probe next turn.
+    let probe_land = scenario.add_land_to_hand(P0, "Probe Land").id();
+    let due_respect = scenario
+        .add_spell_to_hand_from_oracle(P0, "Due Respect", true, DUE_RESPECT)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.cast(due_respect).resolve();
+
+    // Sanity: the floating replacement is installed this turn.
+    assert_eq!(
+        runner.state().pending_damage_replacements.len(),
+        1,
+        "Due Respect must install exactly one floating replacement this turn"
+    );
+
+    // Advance past this turn's cleanup (CR 514.2) into the next turn.
+    runner.advance_to_end_step();
+    runner.advance_to_phase(Phase::PreCombatMain);
+
+    // The floating store is empty after cleanup pruned the EndOfTurn expiry.
+    assert!(
+        runner.state().pending_damage_replacements.is_empty(),
+        "the end-of-turn replacement must be pruned at cleanup"
+    );
+
+    // A permanent proposed to enter now is UNTAPPED — the duration expired.
+    // (If expiry were not set, the surviving replacement would tap it.)
+    let tap_state = zone_change_tap_state(&mut runner, probe_land, Zone::Hand);
+    assert_eq!(
+        tap_state,
+        EtbTapState::Unspecified,
+        "after the replacement expires, a new entry must be untapped"
+    );
+}
+
+// --- Test R3: runtime — Nahiri multi-authority -----------------------------
+
+#[test]
+fn r3_nahiri_taps_your_lands_only() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Objects that will be proposed to enter through the replacement pipeline.
+    let my_land = scenario.add_land_to_hand(P0, "My Land").id();
+    let their_land = scenario.add_land_to_hand(P1, "Their Land").id();
+    let my_creature = scenario.add_creature_to_hand(P0, "My Bear", 2, 2).id();
+
+    // Install the "Lands you control enter tapped this turn" replacement through
+    // the real cast pipeline (P0 is the resolving controller / anchor).
+    let install = scenario
+        .add_spell_to_hand_from_oracle(P0, "Litho Clause", true, LANDS_YOU_CONTROL)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.cast(install).resolve();
+
+    // CR 109.4: the install anchors source_controller to P0 so the
+    // controller-relative "you control" filter can resolve for a floating def.
+    {
+        let pending = &runner.state().pending_damage_replacements;
+        assert_eq!(
+            pending.len(),
+            1,
+            "exactly one floating replacement installed"
+        );
+        assert_eq!(
+            pending[0].source_controller,
+            Some(P0),
+            "the resolver must anchor source_controller to the installing player"
+        );
+        assert_eq!(pending[0].event, ReplacementEvent::ChangeZone);
+        assert_eq!(pending[0].expiry, Some(RestrictionExpiry::EndOfTurn));
+    }
+
+    // Production entry (CR 614.1d) via the real replacement pipeline:
+    //   - P0's land matches [Land] + controller You  → enters TAPPED.
+    assert_eq!(
+        zone_change_tap_state(&mut runner, my_land, Zone::Hand),
+        EtbTapState::Tapped,
+        "a land YOU control must enter tapped"
+    );
+    //   - P1's land fails the controller:You gate      → enters UNTAPPED.
+    assert_eq!(
+        zone_change_tap_state(&mut runner, their_land, Zone::Hand),
+        EtbTapState::Unspecified,
+        "an opponent's land must not be tapped by 'Lands you control'"
+    );
+    //   - P0's creature fails the [Land] type gate      → enters UNTAPPED.
+    assert_eq!(
+        zone_change_tap_state(&mut runner, my_creature, Zone::Hand),
+        EtbTapState::Unspecified,
+        "a non-land you control must not be tapped by a Land-scoped replacement"
+    );
+}


### PR DESCRIPTION
## Summary

Implements the previously-unsupported "enter tapped this turn" replacement, so **Due Respect** ("Permanents enter tapped this turn. Draw a card.") and **Nahiri's Lithoforming** ("… Lands you control enter tapped this turn.") stop dropping that clause to `Effect::Unimplemented`.

The clause is a turn-duration floating replacement: on resolution it installs a global replacement that makes a filtered set of permanents enter the battlefield tapped, expiring at cleanup. It reuses the existing external "[objects] enter tapped" building block (the same `ReplacementDefinition{ event: ChangeZone, execute: SetTapState{Tap} }` shape that Authority of the Consuls already uses) — this is just its turn-scoped, spell-installed variant. **No new engine surface**: one new private parser function lifts the clause into the existing `Effect::AddTargetReplacement { target: None }` installer with an `EndOfTurn` expiry; the resolver, floating-replacement scan, controller-anchoring, and cleanup pruning are all unchanged.

Model: claude-opus-4-8
Tier: Frontier
Thinking: high

## Implementation method (required)

- [x] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)

## Anchored on
- `crates/engine/src/parser/oracle_effect/mod.rs` — `try_parse_global_damage_modification_replacement`: the sibling that wraps a `parse_replacement_line` def in `Effect::AddTargetReplacement { target: None, expiry: EndOfTurn }`; the new function mirrors its shape (different seam: the pre-peel "this turn" scan block, since the duration is trailing).
- `crates/engine/src/parser/oracle_replacement.rs` — `parse_external_enters_tapped` / `build_external_entry_replacement`: the existing `ChangeZone` + `SetTapState{SelfRef, Tap}` builder reused as the detector.
- The existing `scan_contains_phrase(&original_lower, "this turn")` arms (`try_parse_play_from_exile`, `try_parse_additional_land_this_turn`): the new arm copies their `peel_ctx` optional/condition handling and `attach_unless_slots` return.

## Gate A

`scripts/check-parser-combinators.sh` passes on the staged diff (no violations). The new detection delegates entirely to `strip_trailing_duration` + `parse_replacement_line` (nom end-to-end) plus a typed `matches!` shape guard — no string-method dispatch, match-arm string literals, chained `if let Ok = tag(...)`, verbatim-sentence equality, or hand-built `Effect::Unimplemented`.

## CR references
- **CR 614.1d** — "[Objects] enter [the battlefield] …" replacement effects (the external enters-tapped class; distinct from the self form in 614.1c).
- **CR 514.2** — "this turn" effects end during cleanup (the `EndOfTurn` expiry).
- **CR 611.2a** — a resolution-fixed continuous effect (`AddTargetReplacement { target: None }`, controller anchored at install).
- **CR 109.4** — controller-relative object references ("Lands you control").

## Verification

Built and tested with cargo (this contributor box has no Tilt):

```
tests/enters_tapped_this_turn.rs ... 5 passed; 0 failed
engine --lib parser::oracle_effect ... 2496 passed; 0 failed
```

- New tests (`crates/engine/tests/enters_tapped_this_turn.rs`, typed fixtures, real cast/resolve pipeline): parser SHAPE for both cards (with a zero-`Unimplemented` reach-guard); a permanent entering after Due Respect resolves enters tapped while one that entered before is unaffected; the replacement expires at cleanup (later-turn entries untapped); and the load-bearing **Nahiri multi-authority** test — P0's land enters tapped while P1's land and P0's non-land do not (proving the `source_controller` + "Lands you control" filter).
- Fail-closed: any duration other than end-of-turn, or any non-`ChangeZone`/`SetTapState` shape, returns `None` and the clause stays `Unimplemented` — coverage flips to supported only for what's genuinely handled.
