### PR TITLE
feat(engine): become-Equipment anthem + granted-equip runtime (Bram, Bludgeon Brawl) (CR 205.1a + 702.6)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -476,32 +476,39 @@ pub fn synthesize_basic_land_mana(face: &mut CardFace) {
 /// authority that sets both the display flag and pushes
 /// `ActivationRestriction::AsSorcery` so the runtime legality gate enforces
 /// timing at activation time.
+/// CR 702.6: Build the equip activated ability for a single `Keyword::Equip(cost)`
+/// — `{cost}: Attach this permanent to target creature you control`, activatable
+/// only as a sorcery. Returns `None` for any other keyword. Shared by card-load
+/// synthesis (`synthesize_equip`) and the battlefield runtime granted-keyword
+/// appender (`runtime_granted_equip_abilities`), so a printed and a statically
+/// granted equip keyword (Bram, Bludgeon Brawl) produce the identical ability.
+pub(crate) fn equip_ability_for_keyword(keyword: &Keyword) -> Option<AbilityDefinition> {
+    let Keyword::Equip(cost) = keyword else {
+        return None;
+    };
+    let mut def = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Attach {
+            attachment: TargetFilter::SelfRef,
+            target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+        },
+    )
+    .cost(AbilityCost::Mana { cost: cost.clone() })
+    // CR 702.6a: "Activate only as a sorcery."
+    .sorcery_speed();
+    // CR 702.6a: tag the synthesized ability as the Equip action so cost
+    // reductions and Equipment-source mana restrictions recognize it (matching
+    // the parser's `try_parse_equip` path).
+    def.ability_tag = Some(AbilityTag::Equip);
+    Some(def)
+}
+
 pub fn synthesize_equip(face: &mut CardFace) {
     let equip_abilities: Vec<AbilityDefinition> = face
         .keywords
         .iter()
-        .filter_map(|kw| {
-            if let Keyword::Equip(cost) = kw {
-                Some(
-                    AbilityDefinition::new(
-                        AbilityKind::Activated,
-                        Effect::Attach {
-                            attachment: TargetFilter::SelfRef,
-                            target: TargetFilter::Typed(
-                                TypedFilter::creature().controller(ControllerRef::You),
-                            ),
-                        },
-                    )
-                    .cost(AbilityCost::Mana { cost: cost.clone() })
-                    // CR 702.6a: "Activate only as a sorcery."
-                    .sorcery_speed(),
-                )
-            } else {
-                None
-            }
-        })
+        .filter_map(equip_ability_for_keyword)
         .collect();
-
     face.abilities.extend(equip_abilities);
 }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -75,6 +75,34 @@ fn runtime_granted_cycling_abilities(
         .collect()
 }
 
+/// CR 702.6: An `Equip` keyword granted at runtime by a static ability (Bram,
+/// Bludgeon Brawl's "… is an Equipment with equip {N} …") does not pass through
+/// card-load synthesis, so its equip activated ability must be synthesized live
+/// from the object's post-layer keyword set. `obj.keywords` is battlefield-
+/// authoritative (AddKeyword grants land there); printed equip keywords are
+/// excluded because card-load synthesis already turned them into an
+/// `obj.abilities` entry, so re-synthesizing them would double-offer equip.
+fn runtime_granted_equip_abilities(
+    state: &GameState,
+    source_id: ObjectId,
+) -> Vec<AbilityDefinition> {
+    let Some(obj) = state.objects.get(&source_id) else {
+        return Vec::new();
+    };
+    // CR 702.6: Equip functions only while its source is on the battlefield.
+    if obj.zone != Zone::Battlefield {
+        return Vec::new();
+    }
+    obj.keywords
+        .iter()
+        .filter(|keyword| {
+            matches!(keyword, Keyword::Equip(_))
+                && !obj.base_keywords.iter().any(|printed| printed == *keyword)
+        })
+        .filter_map(|keyword| crate::database::synthesis::equip_ability_for_keyword(keyword))
+        .collect()
+}
+
 /// CR 604.1 (seam 4: activated-ability-on-grant): synthesize graveyard activated
 /// abilities (Encore, Scavenge) for keywords granted to a graveyard card by a
 /// static. The `AddKeyword` layer seam installs only the keyword + triggers, so a
@@ -191,6 +219,10 @@ pub fn activated_ability_definitions(
             .chain(runtime_granted_top_of_library_plot_abilities(
                 state, source_id,
             ))
+            // CR 702.6: statically granted equip (Bram, Bludgeon Brawl) chained
+            // LAST — the identical append order is REQUIRED in
+            // `activation_ability_definition` so `ability_index` stays consistent.
+            .chain(runtime_granted_equip_abilities(state, source_id))
             .enumerate()
             .map(|(offset, ability)| (printed_len + offset, ability)),
     );
@@ -220,6 +252,7 @@ fn activation_ability_definition(
             .chain(runtime_granted_top_of_library_plot_abilities(
                 state, source_id,
             ))
+            .chain(runtime_granted_equip_abilities(state, source_id))
             .nth(offset)?
     };
     if let Some(ref cost) = ability.cost {

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -119,7 +119,20 @@ fn runtime_granted_equip_abilities(
                 unconsumed_printed.remove(index);
                 return None;
             }
-            crate::database::synthesis::equip_ability_for_keyword(keyword)
+            crate::database::synthesis::equip_ability_for_keyword(keyword).map(|mut ability| {
+                // CR 202.3 + CR 118.9: Bludgeon Brawl grants `equip {X}` where X
+                // is the artifact's mana value, so the keyword carries the
+                // `ManaCost::SelfManaValue` placeholder. Concretize it to the
+                // source's actual mana value HERE — otherwise the payment path
+                // treats `SelfManaValue` as `{0}` and the equip is effectively
+                // free.
+                if let Some(cost) = ability.cost.take() {
+                    ability.cost = Some(super::keywords::resolve_self_mana_in_ability_cost(
+                        state, source_id, &cost,
+                    ));
+                }
+                ability
+            })
         })
         .collect()
 }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -93,13 +93,34 @@ fn runtime_granted_equip_abilities(
     if obj.zone != Zone::Battlefield {
         return Vec::new();
     }
+    // CR 702.6a: a permanent may have more than one equip ability, and each is
+    // independently activatable. Card-load synthesis already turned every PRINTED
+    // Equip keyword into an `obj.abilities` entry, so subtract printed equips by
+    // OCCURRENCE (not value-wide membership): consume one printed instance per
+    // matching live keyword, and synthesize the rest. This keeps a granted
+    // Equip {1} offered even when the object also prints an identical Equip {1}.
+    let mut unconsumed_printed: Vec<&Keyword> = obj
+        .base_keywords
+        .iter()
+        .filter(|keyword| matches!(keyword, Keyword::Equip(_)))
+        .collect();
     obj.keywords
         .iter()
-        .filter(|keyword| {
-            matches!(keyword, Keyword::Equip(_))
-                && !obj.base_keywords.iter().any(|printed| printed == *keyword)
+        .filter_map(|keyword| {
+            if !matches!(keyword, Keyword::Equip(_)) {
+                return None;
+            }
+            if let Some(index) = unconsumed_printed
+                .iter()
+                .position(|printed| *printed == keyword)
+            {
+                // A printed equip already lives in `obj.abilities`; consume it so
+                // any additionally granted copies are still synthesized below.
+                unconsumed_printed.remove(index);
+                return None;
+            }
+            crate::database::synthesis::equip_ability_for_keyword(keyword)
         })
-        .filter_map(|keyword| crate::database::synthesis::equip_ability_for_keyword(keyword))
         .collect()
 }
 

--- a/crates/engine/src/game/engine_keyword_action_stack_tests.rs
+++ b/crates/engine/src/game/engine_keyword_action_stack_tests.rs
@@ -987,7 +987,7 @@ fn granted_equip_keyword_offers_functional_equip_ability() {
         "granted Equipment subtype missing"
     );
     assert!(
-        obj.keywords.iter().any(|k| matches!(k, Keyword::Equip(_))),
+        crate::game::keywords::has_keyword_kind(obj, crate::types::keywords::KeywordKind::Equip),
         "granted Equip keyword missing"
     );
 

--- a/crates/engine/src/game/engine_keyword_action_stack_tests.rs
+++ b/crates/engine/src/game/engine_keyword_action_stack_tests.rs
@@ -928,3 +928,86 @@ fn issue_3660_finalize_copy_retarget_stashes_offers_on_deferred_pause() {
         Some(remaining.as_slice()),
     );
 }
+
+/// CR 702.6: An Equip keyword granted at runtime by a static ability (Bram,
+/// Bludgeon Brawl: "… is an Equipment with equip {N} …") must produce a real,
+/// cost-bearing equip activated ability — offered and charged through the normal
+/// `ActivateAbility` path, exactly like a printed Equipment — rather than a
+/// keyword the runtime ignores.
+#[test]
+fn granted_equip_keyword_offers_functional_equip_ability() {
+    use crate::types::ability::{
+        AbilityCost, AbilityTag, ContinuousModification, Effect, StaticDefinition, TargetFilter,
+    };
+    use crate::types::keywords::Keyword;
+    use crate::types::mana::ManaCost;
+
+    let mut state = setup_main_phase();
+    // A Food artifact with NO printed equip keyword or ability.
+    let food = create_object(
+        &mut state,
+        CardId(1500),
+        PlayerId(0),
+        "Test Food".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&food).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.card_types.subtypes.push("Food".to_string());
+    }
+
+    // The Bram / Bludgeon Brawl grant on the object itself: become an Equipment
+    // and gain equip {1}.
+    let equip_cost = ManaCost::Cost {
+        shards: vec![],
+        generic: 1,
+    };
+    let def = StaticDefinition::continuous()
+        .affected(TargetFilter::SelfRef)
+        .modifications(vec![
+            ContinuousModification::AddSubtype {
+                subtype: "Equipment".to_string(),
+            },
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Equip(equip_cost),
+            },
+        ]);
+    {
+        let obj = state.objects.get_mut(&food).unwrap();
+        obj.static_definitions.push(def.clone());
+        std::sync::Arc::make_mut(&mut obj.base_static_definitions).push(def);
+    }
+    crate::game::layers::evaluate_layers(&mut state);
+
+    // Layer result: the object is now an Equipment carrying the Equip keyword.
+    let obj = state.objects.get(&food).unwrap();
+    assert!(
+        obj.card_types.subtypes.iter().any(|s| s == "Equipment"),
+        "granted Equipment subtype missing"
+    );
+    assert!(
+        obj.keywords.iter().any(|k| matches!(k, Keyword::Equip(_))),
+        "granted Equip keyword missing"
+    );
+
+    // The runtime now offers a synthesized, sorcery-speed, cost-bearing equip
+    // activated ability tagged `AbilityTag::Equip` — the SAME shape a printed
+    // Equipment gets, so it is offered + charged through the normal
+    // `ActivateAbility` path (not the cost-free `KeywordAction::Equip` path).
+    let abilities = crate::game::casting::activated_ability_definitions(&state, food);
+    let equip = abilities
+        .iter()
+        .find(|(_, ability)| ability.ability_tag == Some(AbilityTag::Equip))
+        .expect("granted equip must be offered as an activated ability");
+    assert!(
+        matches!(equip.1.effect.as_ref(), Effect::Attach { .. }),
+        "granted equip ability must attach: {:?}",
+        equip.1.effect
+    );
+    assert!(
+        matches!(equip.1.cost, Some(AbilityCost::Mana { .. })),
+        "granted equip ability must carry its mana cost: {:?}",
+        equip.1.cost
+    );
+}

--- a/crates/engine/src/game/engine_keyword_action_stack_tests.rs
+++ b/crates/engine/src/game/engine_keyword_action_stack_tests.rs
@@ -1079,3 +1079,53 @@ fn granted_equip_anthem_self_mana_value_reads_equipment_mana_value() {
         "+X/+0 must leave toughness unchanged"
     );
 }
+
+/// CR 702.6a: A permanent may have more than one equip ability, each independently
+/// activatable. An object that PRINTS `Equip {1}` (already synthesized into
+/// `obj.abilities` at card load) and is ALSO granted an identical `Equip {1}` at
+/// runtime must expose BOTH — the granted instance is subtracted by occurrence,
+/// not by value-wide membership.
+#[test]
+fn identical_printed_and_granted_equip_both_offered() {
+    use crate::types::keywords::Keyword;
+    use crate::types::mana::ManaCost;
+
+    let equip_one = Keyword::Equip(ManaCost::Cost {
+        shards: vec![],
+        generic: 1,
+    });
+    let mut state = setup_main_phase();
+    let gear = create_object(
+        &mut state,
+        CardId(1700),
+        PlayerId(0),
+        "Twin Equip".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&gear).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.card_types.subtypes.push("Equipment".to_string());
+        // Printed Equip {1}: lives in base_keywords AND (via card-load synthesis)
+        // as an activated ability.
+        obj.base_keywords.push(equip_one.clone());
+        std::sync::Arc::make_mut(&mut obj.abilities)
+            .push(crate::database::synthesis::equip_ability_for_keyword(&equip_one).unwrap());
+        // Post-layer keyword set carries BOTH the printed and a granted copy.
+        obj.keywords.push(equip_one.clone());
+        obj.keywords.push(equip_one.clone());
+    }
+
+    // Both equip abilities are offered: the printed one from obj.abilities and the
+    // granted one from the runtime appender.
+    let equip_count = crate::game::casting::activated_ability_definitions(&state, gear)
+        .iter()
+        .filter(|(_, ability)| {
+            ability.ability_tag == Some(crate::types::ability::AbilityTag::Equip)
+        })
+        .count();
+    assert_eq!(
+        equip_count, 2,
+        "printed + identical granted Equip must both be offered"
+    );
+}

--- a/crates/engine/src/game/engine_keyword_action_stack_tests.rs
+++ b/crates/engine/src/game/engine_keyword_action_stack_tests.rs
@@ -1129,3 +1129,62 @@ fn identical_printed_and_granted_equip_both_offered() {
         "printed + identical granted Equip must both be offered"
     );
 }
+
+/// CR 202.3 + CR 118.9: Bludgeon Brawl grants `equip {X}` where X is the
+/// artifact's mana value, carried as the `ManaCost::SelfManaValue` placeholder.
+/// The offered equip ability must present the CONCRETE mana value as its cost —
+/// otherwise the payment path treats `SelfManaValue` as `{0}` and equip is free.
+#[test]
+fn granted_equip_self_mana_value_cost_is_concretized_to_mana_value() {
+    use crate::types::ability::{
+        AbilityCost, AbilityTag, ContinuousModification, StaticDefinition, TargetFilter,
+    };
+    use crate::types::keywords::Keyword;
+    use crate::types::mana::ManaCost;
+
+    let mut state = setup_main_phase();
+    // An Equipment with mana value 4, granted equip {X}=its mana value.
+    let gear = create_object(
+        &mut state,
+        CardId(1800),
+        PlayerId(0),
+        "MV Gear".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&gear).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.card_types.subtypes.push("Equipment".to_string());
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![],
+            generic: 4,
+        };
+    }
+    let def = StaticDefinition::continuous()
+        .affected(TargetFilter::SelfRef)
+        .modifications(vec![ContinuousModification::AddKeyword {
+            keyword: Keyword::Equip(ManaCost::SelfManaValue),
+        }]);
+    {
+        let obj = state.objects.get_mut(&gear).unwrap();
+        obj.static_definitions.push(def.clone());
+        std::sync::Arc::make_mut(&mut obj.base_static_definitions).push(def);
+    }
+    crate::game::layers::evaluate_layers(&mut state);
+
+    // The offered equip cost is the concrete mana value (4), not the placeholder.
+    let abilities = crate::game::casting::activated_ability_definitions(&state, gear);
+    let equip = abilities
+        .iter()
+        .find(|(_, ability)| ability.ability_tag == Some(AbilityTag::Equip))
+        .expect("granted equip must be offered");
+    match &equip.1.cost {
+        Some(AbilityCost::Mana {
+            cost: ManaCost::Cost { generic, shards },
+        }) => {
+            assert_eq!(*generic, 4, "equip {{X}} must concretize to mana value 4");
+            assert!(shards.is_empty(), "no colored pips expected");
+        }
+        other => panic!("equip cost must be concrete Mana {{4}}, not a placeholder: {other:?}"),
+    }
+}

--- a/crates/engine/src/game/engine_keyword_action_stack_tests.rs
+++ b/crates/engine/src/game/engine_keyword_action_stack_tests.rs
@@ -1188,3 +1188,111 @@ fn granted_equip_self_mana_value_cost_is_concretized_to_mana_value() {
         other => panic!("equip cost must be concrete Mana {{4}}, not a placeholder: {other:?}"),
     }
 }
+
+/// CR 702.6 + CR 702.6a: end-to-end proof that a runtime-granted Equip keyword
+/// (Bram, Bludgeon Brawl) is not merely *offered* but fully *functional* through
+/// the normal `ActivateAbility` path — announced, its mana cost paid from the
+/// pool, a legal "creature you control" targeted, and resolved so the Equipment
+/// becomes attached. The shape-only tests above assert the offered ability's AST
+/// (cost + `Effect::Attach`); this drives the whole pipeline, so a regression in
+/// runtime-index selection, payment, targeting, or Attach resolution fails HERE
+/// even though those still pass.
+#[test]
+fn granted_equip_attaches_through_full_activation_pipeline() {
+    use crate::game::scenario::GameScenario;
+    use crate::types::ability::{
+        AbilityTag, ContinuousModification, StaticDefinition, TargetFilter,
+    };
+    use crate::types::keywords::Keyword;
+    use crate::types::mana::{ManaCost, ManaPipId, ManaType, ManaUnit};
+
+    let p0 = PlayerId(0);
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    // CR 702.6a: equip is a sorcery-speed activated ability — main phase, own
+    // turn, empty stack, priority to P0.
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // A creature P0 controls — the legal equip target.
+    let bear = scenario.add_creature(p0, "Bear", 2, 2).id();
+
+    // A noncreature Food artifact granted "Equipment with equip {1}" by a static
+    // on itself (Bram-shaped), mirroring the parser's `AddSubtype` + `AddKeyword`
+    // output.
+    let food = create_object(
+        &mut scenario.state,
+        CardId(1900),
+        p0,
+        "Test Food".to_string(),
+        Zone::Battlefield,
+    );
+    let equip_cost = ManaCost::Cost {
+        shards: vec![],
+        generic: 1,
+    };
+    let def = StaticDefinition::continuous()
+        .affected(TargetFilter::SelfRef)
+        .modifications(vec![
+            ContinuousModification::AddSubtype {
+                subtype: "Equipment".to_string(),
+            },
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Equip(equip_cost),
+            },
+        ]);
+    {
+        let obj = scenario.state.objects.get_mut(&food).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.card_types.subtypes.push("Food".to_string());
+        obj.static_definitions.push(def.clone());
+        std::sync::Arc::make_mut(&mut obj.base_static_definitions).push(def);
+    }
+    crate::game::layers::evaluate_layers(&mut scenario.state);
+
+    // Fund the {1} equip cost — the driver does not model source auto-tap, so the
+    // pool must cover the cost or `PassPriority` (finalize payment) errors.
+    scenario.with_mana_pool(
+        p0,
+        vec![ManaUnit {
+            color: ManaType::Colorless,
+            source_id: ObjectId(9998),
+            pip_id: ManaPipId(0),
+            supertype: None,
+            source_could_produce_two_or_more_colors: false,
+            restrictions: vec![],
+            grants: vec![],
+            expiry: None,
+        }],
+    );
+
+    // The granted equip is appended LAST in `activated_ability_definitions`;
+    // resolve its runtime index the same way the engine does.
+    let equip_index = crate::game::casting::activated_ability_definitions(&scenario.state, food)
+        .iter()
+        .position(|(_, ability)| ability.ability_tag == Some(AbilityTag::Equip))
+        .expect("granted equip must be offered as an activated ability");
+
+    let mut runner = scenario.build();
+    // Announce → pay {1} from the pool → target the creature → resolve.
+    let outcome = runner
+        .activate(food, equip_index)
+        .target_object(bear)
+        .resolve();
+
+    // CR 702.6a: equip attaches the Equipment to the chosen creature.
+    assert_eq!(
+        outcome.state().objects.get(&food).unwrap().attached_to,
+        Some(bear.into()),
+        "granted equip must attach the Equipment to the targeted creature through the \
+         normal ActivateAbility path"
+    );
+    assert!(
+        outcome
+            .state()
+            .objects
+            .get(&bear)
+            .unwrap()
+            .attachments
+            .contains(&food),
+        "the equipped creature must carry the Equipment"
+    );
+}

--- a/crates/engine/src/game/engine_keyword_action_stack_tests.rs
+++ b/crates/engine/src/game/engine_keyword_action_stack_tests.rs
@@ -1011,3 +1011,71 @@ fn granted_equip_keyword_offers_functional_equip_ability() {
         equip.1.cost
     );
 }
+
+/// CR 202.3: Bludgeon Brawl's granted anthem "Equipped creature gets +X/+0, where
+/// X is that artifact's mana value" binds X to the *Equipment's* mana value, not
+/// the equipped creature's. The parser lowers this to `AddDynamicPower {
+/// SelfManaValue }`; this test proves the layer system resolves `SelfManaValue`
+/// against the granting Equipment (the static's source), so a mana-value-3
+/// Equipment boosts a 2/2 to 5/2.
+#[test]
+fn granted_equip_anthem_self_mana_value_reads_equipment_mana_value() {
+    use crate::types::ability::{
+        ContinuousModification, FilterProp, QuantityExpr, QuantityRef, StaticDefinition,
+        TargetFilter, TypedFilter,
+    };
+    use crate::types::mana::ManaCost;
+
+    let mut state = setup_main_phase();
+    // An Equipment with mana value 3.
+    let gear = create_object(
+        &mut state,
+        CardId(1600),
+        PlayerId(0),
+        "Test Gear".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&gear).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.card_types.subtypes.push("Equipment".to_string());
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![],
+            generic: 3,
+        };
+    }
+    // A 2/2 creature, with the Equipment attached to it.
+    let bear = make_creature(&mut state, "Bear", 2);
+    state.objects.get_mut(&gear).unwrap().attached_to = Some(bear.into());
+
+    // Granted anthem on the Equipment: "Equipped creature gets +X/+0" where X is
+    // the Equipment's own mana value.
+    let anthem = StaticDefinition::continuous()
+        .affected(TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![FilterProp::EquippedBy]),
+        ))
+        .modifications(vec![ContinuousModification::AddDynamicPower {
+            value: QuantityExpr::Ref {
+                qty: QuantityRef::SelfManaValue,
+            },
+        }]);
+    {
+        let obj = state.objects.get_mut(&gear).unwrap();
+        obj.static_definitions.push(anthem.clone());
+        std::sync::Arc::make_mut(&mut obj.base_static_definitions).push(anthem);
+    }
+    crate::game::layers::evaluate_layers(&mut state);
+
+    // Power boosted by the EQUIPMENT's mana value (3): 2 + 3 = 5; +X/+0 leaves T.
+    let creature = state.objects.get(&bear).unwrap();
+    assert_eq!(
+        creature.power,
+        Some(5),
+        "granted anthem X must read the Equipment's mana value (2 + 3)"
+    );
+    assert_eq!(
+        creature.toughness,
+        Some(2),
+        "+X/+0 must leave toughness unchanged"
+    );
+}

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1055,6 +1055,12 @@ pub(crate) fn parse_static_line_inner(
     if let Some(def) = parse_enchanted_becomes_type_with_ability(&tp, &text) {
         return Some(def);
     }
+    // CR 205.1a + CR 702.6: "Each <subject> is an Equipment with equip {N} and
+    // "<ability>"" — the become-Equipment anthem (Bram, Bludgeon Brawl). Grants
+    // the Equipment subtype + Equip keyword + the quoted static ability.
+    if let Some(def) = parse_becomes_equipment_with_ability(&tp, &text) {
+        return Some(def);
+    }
     // CR 613.1d + CR 205.1a: "Enchanted [permanent-type] is a [type] [with base P/T N/N]
     // [in addition to its other types]" — type-changing aura effects.
     // Must come before the basic-land-type handler which is a subset of this pattern.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14950,6 +14950,31 @@ fn bludgeon_brawl_dynamic_equip_cost_and_anthem_bind_source_mana_value() {
     );
 }
 
+// The become-Equipment handler models exactly one trailing rider after the quoted
+// ability: the CR 202.3 "where X is that artifact's mana value" binding. Any other
+// rules-bearing tail must fail closed (return no static) rather than silently drop
+// the rider and export a permanent with missing behavior.
+#[test]
+fn becomes_equipment_rejects_unrecognized_trailing_rider() {
+    // Empty tail (Bram) and the recognized where-X binding (Bludgeon) still parse.
+    assert_eq!(
+        parse_static_line_multi(
+            "Each noncreature Food you control is an Equipment with equip {1} and \"Equipped creature gets +1/+1.\""
+        )
+        .len(),
+        1,
+        "fixed-cost form (empty tail) must still parse"
+    );
+    // An unrecognized rider after the closing quote must be declined.
+    assert!(
+        parse_static_line_multi(
+            "Each artifact you control is an Equipment with equip {1} and \"Equipped creature gets +1/+1,\" and it gains flying."
+        )
+        .is_empty(),
+        "an unrecognized trailing rider must fail closed, not be silently dropped"
+    );
+}
+
 // Issue #4770 sibling — Sugar Coat: "Enchanted permanent is a colorless Food
 // artifact with "..." and loses all other card types and abilities." Same class
 // as Imprisoned in the Moon but with a SUBTYPE (Food) before the core type. Must

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14853,6 +14853,60 @@ fn imprisoned_in_the_moon_becomes_colorless_land_with_granted_mana_ability() {
     }
 }
 
+// CR 205.1a + CR 702.6: Bram, Baguette Brawler / Bludgeon Brawl — "Each
+// <subject> is an Equipment with equip {N} and "Equipped creature gets +N/+M.""
+// Each matching permanent gains the Equipment subtype (replacing its artifact
+// subtypes), the Equip keyword with the printed cost, and the quoted anthem as a
+// granted static ability.
+#[test]
+fn becomes_equipment_with_equip_cost_and_granted_ability() {
+    use crate::types::keywords::Keyword;
+
+    let def = parse_static_line(
+        "Each noncreature Food you control is an Equipment with equip {1} and \"Equipped creature gets +1/+1.\"",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+
+    // Affected: noncreature Food you control.
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert!(
+                tf.type_filters
+                    .iter()
+                    .any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Food")),
+                "affected must be Food: {tf:?}"
+            );
+        }
+        other => panic!("expected Typed Food filter, got {other:?}"),
+    }
+
+    let mods = &def.modifications;
+    // Set the Equipment subtype (CR 205.1a: replace artifact subtypes first).
+    assert!(
+        mods.iter()
+            .any(|m| matches!(m, ContinuousModification::AddSubtype { subtype } if subtype == "Equipment")),
+        "must grant the Equipment subtype: {mods:?}"
+    );
+    // Grant the Equip keyword carrying the printed {1} cost.
+    assert!(
+        mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Equip(_)
+            }
+        )),
+        "must grant the Equip keyword: {mods:?}"
+    );
+    // Grant the quoted "Equipped creature gets +1/+1" anthem as a static ability.
+    assert!(
+        mods.iter()
+            .any(|m| matches!(m, ContinuousModification::GrantStaticAbility { .. })),
+        "must grant the quoted equipped-creature anthem: {mods:?}"
+    );
+}
+
 // Issue #4770 sibling — Sugar Coat: "Enchanted permanent is a colorless Food
 // artifact with "..." and loses all other card types and abilities." Same class
 // as Imprisoned in the Moon but with a SUBTYPE (Food) before the core type. Must

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14973,6 +14973,15 @@ fn becomes_equipment_rejects_unrecognized_trailing_rider() {
         .is_empty(),
         "an unrecognized trailing rider must fail closed, not be silently dropped"
     );
+    // A rider AFTER the recognized mana-value binding must also fail closed — the
+    // binding is matched exactly (full consumption), not by substring.
+    assert!(
+        parse_static_line_multi(
+            "Each noncreature artifact is an Equipment with equip {X} and \"Equipped creature gets +X/+0,\" where X is that artifact's mana value, and it gains flying."
+        )
+        .is_empty(),
+        "extra rules text after the mana-value binding must fail closed"
+    );
 }
 
 // Issue #4770 sibling — Sugar Coat: "Enchanted permanent is a colorless Food

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14907,6 +14907,49 @@ fn becomes_equipment_with_equip_cost_and_granted_ability() {
     );
 }
 
+// CR 202.3: Bludgeon Brawl — the dynamic-mana-value member of the become-Equipment
+// class. "equip {X} … where X is that artifact's mana value" binds X to the
+// Equipment's own mana value for BOTH the equip cost and the granted anthem, so
+// the cost lowers to Equip(SelfManaValue) and the anthem's "+X/+0" is rebound
+// from the default cost-X reference to SelfManaValue.
+#[test]
+fn bludgeon_brawl_dynamic_equip_cost_and_anthem_bind_source_mana_value() {
+    use crate::types::keywords::Keyword;
+    use crate::types::mana::ManaCost;
+
+    let def = parse_static_line(
+        "Each noncreature, non-Equipment artifact is an Equipment with equip {X} and \"Equipped creature gets +X/+0,\" where X is that artifact's mana value.",
+    )
+    .unwrap();
+    let mods = &def.modifications;
+
+    // Equip cost bound to the Equipment's own mana value.
+    assert!(
+        mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Equip(ManaCost::SelfManaValue)
+            }
+        )),
+        "equip {{X}} must lower to Equip(SelfManaValue): {mods:?}"
+    );
+    // The granted anthem's dynamic power reads the source's mana value (rebound
+    // from the default cost-X reference).
+    let anthem_ok = mods.iter().any(|m| {
+        matches!(m, ContinuousModification::GrantStaticAbility { definition }
+        if definition.modifications.iter().any(|inner| matches!(
+            inner,
+            ContinuousModification::AddDynamicPower {
+                value: QuantityExpr::Ref { qty: QuantityRef::SelfManaValue }
+            }
+        )))
+    });
+    assert!(
+        anthem_ok,
+        "granted anthem must add dynamic power = SelfManaValue: {mods:?}"
+    );
+}
+
 // Issue #4770 sibling — Sugar Coat: "Enchanted permanent is a colorless Food
 // artifact with "..." and loses all other card types and abilities." Same class
 // as Imprisoned in the Moon but with a SUBTYPE (Food) before the core type. Must

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -696,19 +696,46 @@ pub(crate) fn parse_becomes_equipment_with_ability(
     let (subject_tp, rest_tp) = tp.split_around(" is an equipment with equip ")?;
     let affected = super::shared::parse_continuous_subject_filter(subject_tp.original)?;
 
-    // rest: `{N} and "<quoted ability>"[.]` — the equip cost precedes ` and "`.
+    // rest: `{cost} and "<quoted ability>"[, where X is <…> mana value][.]`. The
+    // equip cost precedes ` and "`; the quoted ability is bounded by its closing
+    // quote, and any trailing `, where X is …` binding follows it.
     let (cost_tp, ability_tp) = rest_tp.split_around(" and \"")?;
-    let (cost_rest, equip_cost) = nom_primitives::parse_mana_cost(cost_tp.lower.trim()).ok()?;
-    if !cost_rest.trim().is_empty() {
-        return None;
-    }
+    let (quoted_body_tp, tail_tp) = ability_tp.split_around("\"")?;
+    let tail_lower = tail_tp.lower.trim().trim_start_matches([',', '.']).trim();
 
-    // Re-add the opening quote the split consumed and delegate to the shared
-    // quoted-ability authority (original case preserves any {symbols}).
-    let quoted = format!("\"{}", ability_tp.original.trim());
-    let grant_modifications = parse_quoted_ability_modifications(&quoted);
+    // CR 202.3: Bludgeon Brawl binds X to "that artifact's mana value" — the
+    // Equipment's own mana value — used for BOTH the equip cost ({X}) and the
+    // granted anthem ("gets +X/+0"). Match only the unambiguous "artifact's mana
+    // value" (the source): a bare "its" could refer to the equipped creature.
+    let dynamic_self_mana_value = nom_primitives::scan_contains(tail_lower, "where x is ")
+        && nom_primitives::scan_contains(tail_lower, "artifact's mana value");
+
+    // Equip cost: a bare `{X}` bound to the source's mana value lowers to
+    // `ManaCost::SelfManaValue` (concretized at activation like a graveyard-grant
+    // "encore {X}, where X is its mana value"); otherwise a fixed mana cost.
+    let cost_text = cost_tp.lower.trim();
+    let equip_cost = if cost_text == "{x}" && dynamic_self_mana_value {
+        ManaCost::SelfManaValue
+    } else {
+        let (cost_rest, cost) = nom_primitives::parse_mana_cost(cost_text).ok()?;
+        if !cost_rest.trim().is_empty() {
+            return None;
+        }
+        cost
+    };
+
+    // Re-wrap the quoted body and delegate to the shared quoted-ability authority
+    // (original case preserves any {symbols}).
+    let quoted = format!("\"{}\"", quoted_body_tp.original.trim());
+    let mut grant_modifications = parse_quoted_ability_modifications(&quoted);
     if grant_modifications.is_empty() {
         return None;
+    }
+    // CR 202.3: the standalone anthem parser reads "gets +X/+0" as the cost-X
+    // paid; for a CONTINUOUS grant bound to the Equipment's mana value, rebind
+    // that reference to `SelfManaValue` so it reads the source's mana value.
+    if dynamic_self_mana_value {
+        rebind_cost_x_to_self_mana_value(&mut grant_modifications);
     }
 
     // CR 205.1a: Equipment is an artifact subtype; setting it replaces the
@@ -732,6 +759,36 @@ pub(crate) fn parse_becomes_equipment_with_ability(
             .modifications(modifications)
             .description(description.to_string()),
     )
+}
+
+/// CR 202.3: Rebind a granted anthem's `CostXPaid` power/toughness reference to
+/// the source object's mana value (`SelfManaValue`). Used when a become-Equipment
+/// grant binds X to "that artifact's mana value" (Bludgeon Brawl): the standalone
+/// anthem parser reads the bare "gets +X/+0" as the cost-X paid, but for a
+/// continuous grant X is a fixed characteristic of the granting Equipment.
+/// Recurses into the granted `StaticDefinition` carried by `GrantStaticAbility`.
+fn rebind_cost_x_to_self_mana_value(modifications: &mut [ContinuousModification]) {
+    for modification in modifications.iter_mut() {
+        match modification {
+            ContinuousModification::GrantStaticAbility { definition } => {
+                rebind_cost_x_to_self_mana_value(&mut definition.modifications);
+            }
+            ContinuousModification::AddDynamicPower { value }
+            | ContinuousModification::AddDynamicToughness { value } => {
+                if matches!(
+                    value,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::CostXPaid
+                    }
+                ) {
+                    *value = QuantityExpr::Ref {
+                        qty: QuantityRef::SelfManaValue,
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 /// CR 205.3: the subtype set correlated with a core card type. Used to wipe an

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -682,6 +682,58 @@ pub(crate) fn parse_enchanted_becomes_type_with_ability(
     )
 }
 
+/// CR 205.1a + CR 301.5c + CR 702.6: "Each `<subject>` is an Equipment with equip
+/// `{N}` and \"`<quoted ability>`\"" — the become-Equipment anthem (Bram,
+/// Baguette Brawler; Bludgeon Brawl). Each matching permanent gains the Equipment
+/// artifact subtype (CR 301.5c — replacing its other artifact subtypes, CR
+/// 205.1a), the Equip keyword with the printed cost (CR 702.6), and the quoted
+/// static ability (typically an "Equipped creature gets +N/+0" anthem, granted
+/// via the shared quoted-ability authority).
+pub(crate) fn parse_becomes_equipment_with_ability(
+    tp: &TextPair<'_>,
+    description: &str,
+) -> Option<StaticDefinition> {
+    let (subject_tp, rest_tp) = tp.split_around(" is an equipment with equip ")?;
+    let affected = super::shared::parse_continuous_subject_filter(subject_tp.original)?;
+
+    // rest: `{N} and "<quoted ability>"[.]` — the equip cost precedes ` and "`.
+    let (cost_tp, ability_tp) = rest_tp.split_around(" and \"")?;
+    let (cost_rest, equip_cost) = nom_primitives::parse_mana_cost(cost_tp.lower.trim()).ok()?;
+    if !cost_rest.trim().is_empty() {
+        return None;
+    }
+
+    // Re-add the opening quote the split consumed and delegate to the shared
+    // quoted-ability authority (original case preserves any {symbols}).
+    let quoted = format!("\"{}", ability_tp.original.trim());
+    let grant_modifications = parse_quoted_ability_modifications(&quoted);
+    if grant_modifications.is_empty() {
+        return None;
+    }
+
+    // CR 205.1a: Equipment is an artifact subtype; setting it replaces the
+    // object's existing artifact subtypes (Bram's Food → Equipment), so wipe the
+    // artifact subtype set before granting Equipment.
+    let mut modifications = Vec::new();
+    if let Some(set) = core_type_subtype_set(CoreType::Artifact) {
+        modifications.push(ContinuousModification::RemoveAllSubtypes { set });
+    }
+    modifications.push(ContinuousModification::AddSubtype {
+        subtype: "Equipment".to_string(),
+    });
+    modifications.push(ContinuousModification::AddKeyword {
+        keyword: Keyword::Equip(equip_cost),
+    });
+    modifications.extend(grant_modifications);
+
+    Some(
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(modifications)
+            .description(description.to_string()),
+    )
+}
+
 /// CR 205.3: the subtype set correlated with a core card type. Used to wipe an
 /// object's existing subtypes of that set before a set-replacement `AddSubtype`
 /// (CR 205.1a). Returns `None` for core types that have no subtype set of

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -701,21 +701,28 @@ pub(crate) fn parse_becomes_equipment_with_ability(
     // quote, and any trailing `, where X is …` binding follows it.
     let (cost_tp, ability_tp) = rest_tp.split_around(" and \"")?;
     let (quoted_body_tp, tail_tp) = ability_tp.split_around("\"")?;
-    let tail_lower = tail_tp.lower.trim().trim_start_matches([',', '.']).trim();
+    // Punctuation cleanup on the post-quote chunk (a leading comma from the
+    // split, a trailing period) before matching the binding.
+    let tail_core = tail_tp.lower.trim().trim_matches([',', '.']).trim();
 
     // CR 202.3: Bludgeon Brawl binds X to "that artifact's mana value" — the
     // Equipment's own mana value — used for BOTH the equip cost ({X}) and the
-    // granted anthem ("gets +X/+0"). Match only the unambiguous "artifact's mana
-    // value" (the source): a bare "its" could refer to the equipped creature.
-    let dynamic_self_mana_value = nom_primitives::scan_contains(tail_lower, "where x is ")
-        && nom_primitives::scan_contains(tail_lower, "artifact's mana value");
+    // granted anthem ("gets +X/+0"). Match the binding EXACTLY with full
+    // consumption ("that artifact's mana value" — the unambiguous source; a bare
+    // "its" could refer to the equipped creature), so extra rules text after the
+    // binding is not accepted.
+    let dynamic_self_mana_value = all_consuming(tag::<_, _, OracleError<'_>>(
+        "where x is that artifact's mana value",
+    ))
+    .parse(tail_core)
+    .is_ok();
 
-    // Fail closed on an unrecognized trailing rider: the only text this handler
-    // models after the quoted ability is the CR 202.3 "where X is that
-    // artifact's mana value" binding. Any other rules-bearing tail must NOT be
-    // silently dropped — decline so the line is reported unsupported rather than
-    // exported with missing behavior.
-    if !tail_lower.is_empty() && !dynamic_self_mana_value {
+    // Fail closed on any unrecognized tail: the only text this handler models
+    // after the quoted ability is that exact binding. A non-empty tail that is
+    // not exactly the binding — whether the binding is absent OR followed by an
+    // extra rider ("…artifact's mana value, and it gains flying") — carries
+    // unmodeled rules text and must NOT be silently dropped.
+    if !tail_core.is_empty() && !dynamic_self_mana_value {
         return None;
     }
 

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -682,13 +682,13 @@ pub(crate) fn parse_enchanted_becomes_type_with_ability(
     )
 }
 
-/// CR 205.1a + CR 301.5c + CR 702.6: "Each `<subject>` is an Equipment with equip
+/// CR 205.1a + CR 702.6: "Each `<subject>` is an Equipment with equip
 /// `{N}` and \"`<quoted ability>`\"" — the become-Equipment anthem (Bram,
 /// Baguette Brawler; Bludgeon Brawl). Each matching permanent gains the Equipment
-/// artifact subtype (CR 301.5c — replacing its other artifact subtypes, CR
-/// 205.1a), the Equip keyword with the printed cost (CR 702.6), and the quoted
-/// static ability (typically an "Equipped creature gets +N/+0" anthem, granted
-/// via the shared quoted-ability authority).
+/// artifact subtype (CR 205.1a — setting an artifact subtype replaces the
+/// object's other artifact subtypes), the Equip keyword with the printed cost
+/// (CR 702.6), and the quoted static ability (typically an "Equipped creature
+/// gets +N/+0" anthem, granted via the shared quoted-ability authority).
 pub(crate) fn parse_becomes_equipment_with_ability(
     tp: &TextPair<'_>,
     description: &str,

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -710,6 +710,15 @@ pub(crate) fn parse_becomes_equipment_with_ability(
     let dynamic_self_mana_value = nom_primitives::scan_contains(tail_lower, "where x is ")
         && nom_primitives::scan_contains(tail_lower, "artifact's mana value");
 
+    // Fail closed on an unrecognized trailing rider: the only text this handler
+    // models after the quoted ability is the CR 202.3 "where X is that
+    // artifact's mana value" binding. Any other rules-bearing tail must NOT be
+    // silently dropped — decline so the line is reported unsupported rather than
+    // exported with missing behavior.
+    if !tail_lower.is_empty() && !dynamic_self_mana_value {
+        return None;
+    }
+
     // Equip cost: a bare `{X}` bound to the source's mana value lowers to
     // `ManaCost::SelfManaValue` (concretized at activation like a graveyard-grant
     // "encore {X}, where X is its mana value"); otherwise a fixed mana cost.


### PR DESCRIPTION
## Summary
Adds engine support for the **become-Equipment anthem** — Bram, Baguette Brawler ("Each noncreature Food you control is an Equipment with equip {1} and \"Equipped creature gets +1/+1.\"") and Bludgeon Brawl ("Each noncreature, non-Equipment artifact is an Equipment with equip {X} and \"Equipped creature gets +X/+0,\" where X is that artifact's mana value.").

The whole static dropped: no handler recognized "Each `<subject>` is an Equipment with equip `{N}` and \"`<ability>`\"". This ships **both halves** — parser *and* the runtime that makes a statically granted Equip keyword actually function.

### Parser (`type_change.rs`)
`parse_becomes_equipment_with_ability` (dispatched next to the sibling Imprisoned `parse_enchanted_becomes_type_with_ability`) parses the subject, equip cost, and quoted ability into:
- `RemoveAllSubtypes{Artifact}` + `AddSubtype{Equipment}` — CR 205.1a (Equipment is an artifact subtype; setting it replaces the object's other artifact subtypes, e.g. Bram's Food → Equipment),
- `AddKeyword{Equip(cost)}` — CR 702.6,
- `GrantStaticAbility{...}` — the quoted "Equipped creature gets +N/+M" anthem, via the shared quoted-ability authority.

Reuses `parse_continuous_subject_filter`, `nom_primitives::parse_mana_cost`, and `parse_quoted_ability_modifications`.

### Runtime (`synthesis.rs`, `casting.rs`)
Card-load synthesis turns a **printed** Equip keyword into an activated `Effect::Attach` ability, but a **granted** Equip keyword never runs that conversion — so without runtime support the object would get the Equipment subtype and keyword but no equip ability (parses-but-doesn't-function). Fixed by:
- extracting `synthesis::equip_ability_for_keyword` (shared by `synthesize_equip` and the new runtime path; also sets `AbilityTag::Equip`, fixing a prior synthesis omission),
- adding `casting::runtime_granted_equip_abilities` — mirrors the existing cycling runtime-grant appender: reads the object's post-layer battlefield keywords, excludes printed equip (already in `obj.abilities`), and synthesizes the equip ability for each granted `Keyword::Equip`,
- chaining it LAST into both `activated_ability_definitions` and `activation_ability_definition` (index-consistent).

Granted equip is now offered and charged through the **normal `ActivateAbility` path**, sharing all printed-equip machinery.

### Dynamic mana value (Bludgeon Brawl)
Bludgeon Brawl binds X to "that artifact's mana value" (CR 202.3) — the Equipment's own mana value — for **both** the equip cost and the granted anthem. The handler lowers `equip {X}` to `Equip(SelfManaValue)` (concretized at activation, like a graveyard-grant `encore {X}, where X is its mana value`) and rebinds the anthem's `+X/+0` from the parser's default cost-X reference to `SelfManaValue`. The runtime resolves `SelfManaValue` against the granting Equipment (the static's source, not the equipped creature) — proven by a runtime test where a mana-value-3 Equipment boosts a 2/2 to 5/2.

## Files changed
- `crates/engine/src/parser/oracle_static/type_change.rs`
- `crates/engine/src/parser/oracle_static/dispatch.rs`
- `crates/engine/src/database/synthesis.rs`
- `crates/engine/src/game/casting.rs`
- `crates/engine/src/game/engine_keyword_action_stack_tests.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`

## Anchored on
- `crates/engine/src/parser/oracle_static/type_change.rs` `parse_enchanted_becomes_type_with_ability` — the sibling become-type-with-granted-ability handler; same compose pattern (type identity + `GrantAbility`), dispatched immediately after it.
- `crates/engine/src/game/casting.rs` `runtime_granted_cycling_abilities` — the runtime keyword-grant appender template the new `runtime_granted_equip_abilities` mirrors exactly.

## Gate A
```
```
(check-parser-combinators.sh — clean, exit 0)

## CR references
- `CR 205.1a` — setting an artifact subtype (Equipment) replaces the object's other artifact subtypes.
- `CR 702.6 / CR 702.6a` — Equip is an activated ability, "{cost}: Attach to target creature you control," activatable only as a sorcery.

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (Gate A)
- `cargo test -p engine --lib parser::oracle_static` — 1014 pass / 0 fail
- `cargo test -p engine --lib database::synthesis` — 399 pass / 0 fail
- `cargo test -p engine --lib equip` — 146 pass / 0 fail; `game::layers` — 206 pass / 0 fail
- Parser tests: `becomes_equipment_with_equip_cost_and_granted_ability` (Bram fixed-cost — affected filter + Equipment subtype + Equip keyword + granted anthem) and `bludgeon_brawl_dynamic_equip_cost_and_anthem_bind_source_mana_value` (Bludgeon — `Equip(SelfManaValue)` + anthem rebound to `SelfManaValue`).
- Runtime tests: `granted_equip_keyword_offers_functional_equip_ability` (a granted Equip keyword yields a cost-bearing, `AbilityTag::Equip`, `Effect::Attach` ability through `activated_ability_definitions`) and `granted_equip_anthem_self_mana_value_reads_equipment_mana_value` (the granted anthem's `SelfManaValue` resolves against the Equipment: MV-3 Equipment → 2/2 becomes 5/2).

## Scope Expansion
Adds runtime support so a statically granted Equip keyword synthesizes a functional equip activated ability (`synthesis::equip_ability_for_keyword` + `casting::runtime_granted_equip_abilities`), reusing the printed-equip path. Required because the parser alone would produce a non-functional "Equipment" — see the Runtime section.

## Validation Failures
None.

## CI Failures
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)