### PR TITLE
fix: require host_peer_id to delete P2P draft backups

### DIFF
--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -1421,9 +1421,11 @@ export class P2PDraftHost {
   private async cleanupServerBackup(): Promise<void> {
     if (!this.backupEndpoint || !this.draftCode) return;
     try {
-      await fetch(`${this.backupEndpoint}/p2p-draft-backup/${this.draftCode}`, {
-        method: "DELETE",
-      });
+      const params = new URLSearchParams({ host_peer_id: this.hostPeer.id });
+      await fetch(
+        `${this.backupEndpoint}/p2p-draft-backup/${this.draftCode}?${params}`,
+        { method: "DELETE" },
+      );
     } catch {
       // Best-effort cleanup
     }

--- a/crates/phase-server/src/admin.rs
+++ b/crates/phase-server/src/admin.rs
@@ -1,4 +1,4 @@
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
@@ -8,6 +8,7 @@ use tracing::{info, warn};
 
 use server_core::{
     guard_p2p_backup, guard_p2p_backup_overwrite, redact_p2p_backup_snapshot_secrets,
+    validate_p2p_backup_host_peer_id,
 };
 
 use crate::AppState;
@@ -161,14 +162,45 @@ pub async fn p2p_backup_get(
     }
 }
 
+/// Query params for `DELETE /p2p-draft-backup/:code`.
+#[derive(Deserialize)]
+pub struct P2pBackupDeleteQuery {
+    pub host_peer_id: String,
+}
+
 /// DELETE /p2p-draft-backup/:code — Remove a P2P draft backup.
+///
+/// Requires `host_peer_id` to match the row owner (same contract as POST
+/// overwrite) so knowing the 6-char draft code alone cannot grief-delete a
+/// recovery snapshot.
 pub async fn p2p_backup_delete(
     State(app_state): State<AppState>,
     Path(code): Path<String>,
+    Query(query): Query<P2pBackupDeleteQuery>,
 ) -> impl IntoResponse {
     if !is_valid_draft_code(&code) {
         return (StatusCode::BAD_REQUEST, "Invalid draft code").into_response();
     }
-    let _ = app_state.game_db.delete_p2p_backup(&code);
-    (StatusCode::OK, "Deleted").into_response()
+    if let Err(reason) = validate_p2p_backup_host_peer_id(&query.host_peer_id) {
+        return (StatusCode::BAD_REQUEST, reason).into_response();
+    }
+    match app_state.game_db.load_p2p_backup(&code) {
+        Ok(Some((existing_peer, _, _))) => {
+            if let Err(reason) = guard_p2p_backup_overwrite(&existing_peer, &query.host_peer_id) {
+                return (StatusCode::FORBIDDEN, reason).into_response();
+            }
+            match app_state.game_db.delete_p2p_backup(&code) {
+                Ok(()) => (StatusCode::OK, "Deleted").into_response(),
+                Err(e) => {
+                    warn!(error = %e, "P2P backup delete failed");
+                    (StatusCode::INTERNAL_SERVER_ERROR, "Delete failed").into_response()
+                }
+            }
+        }
+        Ok(None) => (StatusCode::NOT_FOUND, "No backup found").into_response(),
+        Err(e) => {
+            warn!(error = %e, "P2P backup load failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "Load failed").into_response()
+        }
+    }
 }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7299,7 +7299,7 @@ mod p2p_backup_delete_tests {
     use std::sync::Arc;
 
     use axum::http::StatusCode;
-    use axum::routing::{delete, get, post};
+    use axum::routing::{get, post};
     use axum::Router;
     use lobby_broker::Broker;
     use server_core::draft_session::DraftSessionManager;

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7394,8 +7394,12 @@ mod p2p_backup_delete_tests {
         let (base_url, server) = spawn_p2p_backup_http_test(app_state).await;
 
         assert_eq!(
-            request_status(&base_url, "DELETE", &format!("/p2p-draft-backup/{DRAFT_CODE}"))
-                .await,
+            request_status(
+                &base_url,
+                "DELETE",
+                &format!("/p2p-draft-backup/{DRAFT_CODE}")
+            )
+            .await,
             StatusCode::BAD_REQUEST,
         );
         assert!(
@@ -7417,9 +7421,7 @@ mod p2p_backup_delete_tests {
             request_status(
                 &base_url,
                 "DELETE",
-                &format!(
-                    "/p2p-draft-backup/{DRAFT_CODE}?host_peer_id={OTHER_PEER}"
-                ),
+                &format!("/p2p-draft-backup/{DRAFT_CODE}?host_peer_id={OTHER_PEER}"),
             )
             .await,
             StatusCode::FORBIDDEN,

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7292,3 +7292,166 @@ mod admin_auth_tests {
         server.abort();
     }
 }
+
+#[cfg(test)]
+mod p2p_backup_delete_tests {
+    use std::sync::atomic::AtomicU32;
+    use std::sync::Arc;
+
+    use axum::http::StatusCode;
+    use axum::routing::{delete, get, post};
+    use axum::Router;
+    use lobby_broker::Broker;
+    use server_core::draft_session::DraftSessionManager;
+    use server_core::session::SessionManager;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::sync::Mutex;
+    use url::Url;
+
+    use super::{admin, draft_pools, persistence, AppState, ServerMode};
+
+    const DRAFT_CODE: &str = "BACK01";
+    const HOST_PEER: &str = "peer-host-owner";
+    const OTHER_PEER: &str = "peer-not-owner";
+    const SNAPSHOT: &str = r#"{"status":"Drafting"}"#;
+
+    fn test_app_state(temp_dir: &tempfile::TempDir) -> AppState {
+        let game_db_path = temp_dir.path().join("games.db");
+        let game_db = Arc::new(persistence::GameDb::open(&game_db_path).expect("game db"));
+        AppState {
+            sessions: Arc::new(Mutex::new(SessionManager::new())),
+            draft_sessions: Arc::new(Mutex::new(DraftSessionManager::new())),
+            draft_pools: Arc::new(draft_pools::DraftPools::default()),
+            connections: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            db: Arc::new(engine::database::CardDatabase::default()),
+            lobby: Arc::new(Mutex::new(Broker::new())),
+            lobby_subscribers: Arc::new(Mutex::new(Vec::new())),
+            player_count: Arc::new(AtomicU32::new(0)),
+            game_db,
+            draft_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            game_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            mode: ServerMode::Full,
+            public_url: None,
+        }
+    }
+
+    async fn spawn_p2p_backup_http_test(
+        app_state: AppState,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new()
+            .route("/p2p-draft-backup", post(admin::p2p_backup_store))
+            .route(
+                "/p2p-draft-backup/{code}",
+                get(admin::p2p_backup_get).delete(admin::p2p_backup_delete),
+            )
+            .with_state(app_state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("test server");
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    async fn request_status(base_url: &str, method: &str, path: &str) -> StatusCode {
+        let url = Url::parse(&format!("{base_url}{path}")).expect("url");
+        let host = url.host_str().expect("host");
+        let port = url.port().expect("port");
+        let mut stream = tokio::net::TcpStream::connect((host, port))
+            .await
+            .expect("connect");
+        let mut request = format!("{method} {path} HTTP/1.1\r\n");
+        request.push_str(&format!("Host: {host}\r\n"));
+        request.push_str("Connection: close\r\n\r\n");
+        stream.write_all(request.as_bytes()).await.expect("write");
+        let mut buf = [0u8; 1024];
+        let n = stream.read(&mut buf).await.expect("read");
+        let response = std::str::from_utf8(&buf[..n]).expect("utf8");
+        let status_code = response
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .and_then(|s| s.parse::<u16>().ok())
+            .expect("status line");
+        StatusCode::from_u16(status_code).expect("status code")
+    }
+
+    fn seed_backup(app_state: &AppState) {
+        app_state
+            .game_db
+            .save_p2p_backup(DRAFT_CODE, HOST_PEER, SNAPSHOT)
+            .expect("seed backup");
+    }
+
+    #[tokio::test]
+    async fn delete_rejects_missing_host_peer_id_and_preserves_row() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app_state = test_app_state(&temp_dir);
+        seed_backup(&app_state);
+        let game_db = Arc::clone(&app_state.game_db);
+        let (base_url, server) = spawn_p2p_backup_http_test(app_state).await;
+
+        assert_eq!(
+            request_status(&base_url, "DELETE", &format!("/p2p-draft-backup/{DRAFT_CODE}"))
+                .await,
+            StatusCode::BAD_REQUEST,
+        );
+        assert!(
+            game_db.load_p2p_backup(DRAFT_CODE).expect("load").is_some(),
+            "backup must survive DELETE without host_peer_id"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn delete_rejects_mismatched_host_peer_id_and_preserves_row() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app_state = test_app_state(&temp_dir);
+        seed_backup(&app_state);
+        let game_db = Arc::clone(&app_state.game_db);
+        let (base_url, server) = spawn_p2p_backup_http_test(app_state).await;
+
+        assert_eq!(
+            request_status(
+                &base_url,
+                "DELETE",
+                &format!(
+                    "/p2p-draft-backup/{DRAFT_CODE}?host_peer_id={OTHER_PEER}"
+                ),
+            )
+            .await,
+            StatusCode::FORBIDDEN,
+        );
+        assert!(
+            game_db.load_p2p_backup(DRAFT_CODE).expect("load").is_some(),
+            "backup must survive DELETE with wrong host_peer_id"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn delete_accepts_matching_host_peer_id() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app_state = test_app_state(&temp_dir);
+        seed_backup(&app_state);
+        let game_db = Arc::clone(&app_state.game_db);
+        let (base_url, server) = spawn_p2p_backup_http_test(app_state).await;
+
+        assert_eq!(
+            request_status(
+                &base_url,
+                "DELETE",
+                &format!("/p2p-draft-backup/{DRAFT_CODE}?host_peer_id={HOST_PEER}"),
+            )
+            .await,
+            StatusCode::OK,
+        );
+        assert!(
+            game_db.load_p2p_backup(DRAFT_CODE).expect("load").is_none(),
+            "backup must be removed after authorized DELETE"
+        );
+        server.abort();
+    }
+}

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -52,7 +52,7 @@ pub use lobby::LobbyManager;
 pub use lobby_subscriber_wire_guard::{guard_lobby_subscriber_capacity, MAX_LOBBY_SUBSCRIBERS};
 pub use p2p_backup_guard::{
     guard_p2p_backup, guard_p2p_backup_overwrite, redact_p2p_backup_snapshot_secrets,
-    MAX_P2P_SNAPSHOT_LEN,
+    validate_p2p_backup_host_peer_id, MAX_P2P_SNAPSHOT_LEN,
 };
 pub use persist::{restored_draft_lobby_register_request, PersistedLobbyMeta, PersistedSession};
 pub use protocol::{

--- a/crates/server-core/src/p2p_backup_guard.rs
+++ b/crates/server-core/src/p2p_backup_guard.rs
@@ -35,16 +35,23 @@ use serde_json::{Map, Value};
 /// snapshots a real client produces.
 pub const MAX_P2P_SNAPSHOT_LEN: usize = 1024 * 1024;
 
+/// Validate a `host_peer_id` on any P2P draft-backup HTTP surface (POST store,
+/// DELETE cleanup). Reuses the same [`validate_token`] bound the WebSocket lobby
+/// path applies to the host peer id.
+pub fn validate_p2p_backup_host_peer_id(host_peer_id: &str) -> Result<(), String> {
+    if host_peer_id.trim().is_empty() {
+        return Err("host_peer_id must not be empty".to_string());
+    }
+    validate_token("host_peer_id", host_peer_id, MAX_TOKEN_LEN)
+}
+
 /// Validate the free-form body fields of a `POST /p2p-draft-backup` request
 /// before persistence. `host_peer_id` reuses the same [`validate_token`] bound
 /// (`MAX_TOKEN_LEN`, plus control-character rejection) the WebSocket lobby path
 /// applies to the host peer id; `snapshot_json` is an opaque serialized blob, so
 /// it is required and bounded by byte length only.
 pub fn guard_p2p_backup(host_peer_id: &str, snapshot_json: &str) -> Result<(), String> {
-    if host_peer_id.trim().is_empty() {
-        return Err("host_peer_id must not be empty".to_string());
-    }
-    validate_token("host_peer_id", host_peer_id, MAX_TOKEN_LEN)?;
+    validate_p2p_backup_host_peer_id(host_peer_id)?;
     if snapshot_json.trim().is_empty() {
         return Err("snapshot_json must not be empty".to_string());
     }
@@ -132,7 +139,7 @@ pub fn guard_p2p_backup_overwrite(
 mod tests {
     use super::{
         guard_p2p_backup, guard_p2p_backup_overwrite, redact_p2p_backup_snapshot_secrets,
-        MAX_P2P_SNAPSHOT_LEN,
+        validate_p2p_backup_host_peer_id, MAX_P2P_SNAPSHOT_LEN,
     };
     use lobby_broker::validation::MAX_TOKEN_LEN;
     use serde_json::Value;
@@ -237,5 +244,11 @@ mod tests {
     fn guard_p2p_backup_overwrite_rejects_peer_mismatch() {
         assert!(guard_p2p_backup_overwrite("peer-a", "peer-b").is_err());
         assert!(guard_p2p_backup_overwrite("peer-a", "peer-a").is_ok());
+    }
+
+    #[test]
+    fn validate_p2p_backup_host_peer_id_rejects_blank() {
+        let err = validate_p2p_backup_host_peer_id("  ").unwrap_err();
+        assert!(err.contains("host_peer_id"));
     }
 }


### PR DESCRIPTION
## Summary

**Root cause:** `DELETE /p2p-draft-backup/{code}` only validated the 6-character draft code. Anyone who learned or guessed a code could wipe another host'\''s recovery snapshot. POST already enforced `host_peer_id` ownership on overwrite via `guard_p2p_backup_overwrite`, but DELETE had no equivalent check.

**Fix:** Require a `host_peer_id` query parameter on DELETE, validate its shape with `validate_p2p_backup_host_peer_id`, load the stored row, and reject with 403 unless the peer id matches the backup owner. The P2P draft host client now passes its peer id on cleanup.

**Impact:** Prevents grief-deletion of P2P draft recovery snapshots without the host peer id. Backward-incompatible for any non-client callers that DELETE without `host_peer_id` (intentional — those callers were unauthenticated).

## Risk / tradeoffs

- Old DELETE calls without `host_peer_id` now receive 400. Only the phase client uses this endpoint today.
- GET remains unauthenticated (draft progress recovery); secrets are already redacted per #5053.

## Test plan

- [x] `validate_p2p_backup_host_peer_id` unit test in `server-core`
- [ ] CI `cargo nextest` + `phase-server` compile