### PR TITLE
fix(parser): bare 'it's a <type>' replaces card types per CR 205.1a (Arixmethes, #5213)

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -5583,6 +5583,49 @@ mod tests {
             .contains(&CoreType::Creature));
     }
 
+    /// CR 205.1a (issue #5213): Arixmethes, Slumbering Isle — a `SetCardTypes([Land])`
+    /// replacement on a Legendary Creature Kraken removes the Creature card type
+    /// AND the correlated Kraken creature subtype, leaving a Legendary Land — never
+    /// the impossible "Creature Land" the additive `AddType` produced.
+    #[test]
+    fn set_card_types_land_strips_creature_and_creature_subtype() {
+        use crate::types::card_type::Supertype;
+
+        let mut state = setup();
+        let arixmethes = make_creature(&mut state, "Arixmethes", 12, 12, PlayerId(0));
+        {
+            let obj = state.objects.get_mut(&arixmethes).unwrap();
+            obj.card_types.subtypes.push("Kraken".to_string());
+            obj.card_types.supertypes.push(Supertype::Legendary);
+            obj.base_card_types = obj.card_types.clone();
+            let def = StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::SetCardTypes {
+                    core_types: vec![CoreType::Land],
+                }]);
+            obj.static_definitions.push(def.clone());
+            std::sync::Arc::make_mut(&mut obj.base_static_definitions).push(def);
+        }
+
+        evaluate_layers(&mut state);
+
+        let obj = state.objects.get(&arixmethes).unwrap();
+        assert_eq!(
+            obj.card_types.core_types,
+            vec![CoreType::Land],
+            "must be only a Land (Creature removed)"
+        );
+        assert!(
+            !obj.card_types.subtypes.iter().any(|s| s == "Kraken"),
+            "correlated Kraken creature subtype must be removed: {:?}",
+            obj.card_types.subtypes
+        );
+        assert!(
+            obj.card_types.supertypes.contains(&Supertype::Legendary),
+            "Legendary supertype must be retained"
+        );
+    }
+
     /// Places a battlefield commander object with the given owner/controller.
     fn make_commander(state: &mut GameState, owner: PlayerId, controller: PlayerId) -> ObjectId {
         let id = make_creature(state, "Test Commander", 3, 3, owner);

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14316,6 +14316,62 @@ fn omo_nonland_creature_counter_subject_is_all_creature_types() {
     }
 }
 
+// CR 205.1a (issue #5213): Arixmethes, Slumbering Isle — "As long as ~ has a
+// slumber counter on it, it's a land. (It's not a creature.)". A bare "it's a
+// [non-creature type]" with no CR 205.1b retention marker REPLACES the object's
+// card types, so the Kraken stops being a creature while it slumbers. The
+// modification must be a REPLACING `SetCardTypes`, not an additive `AddType`
+// (which left the impossible "Creature Land"). Creature animations, "artifact
+// creature" forms, and "in addition to its other types" stay additive.
+#[test]
+fn arixmethes_bare_is_a_land_replaces_card_types() {
+    use crate::types::card_type::CoreType;
+
+    let def = parse_static_line(
+        "As long as ~ has a slumber counter on it, it's a land. (It's not a creature.)",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(
+        def.modifications,
+        vec![ContinuousModification::SetCardTypes {
+            core_types: vec![CoreType::Land],
+        }],
+        "bare 'it's a land' must REPLACE card types (remove Creature), not add: {:?}",
+        def.modifications
+    );
+    // The slumber-counter condition is preserved.
+    assert!(
+        matches!(
+            def.condition,
+            Some(StaticCondition::HasCounters { minimum: 1, .. })
+        ),
+        "must gate on having a slumber counter: {:?}",
+        def.condition
+    );
+
+    // Retention forms remain ADDITIVE.
+    let additive = parse_static_line("~ is a land in addition to its other types.").unwrap();
+    assert_eq!(
+        additive.modifications,
+        vec![ContinuousModification::AddType {
+            core_type: CoreType::Land,
+        }],
+        "'in addition to its other types' must stay additive: {:?}",
+        additive.modifications
+    );
+    // An artifact-creature compound retains its prior types (CR 205.1b).
+    let artifact_creature = parse_static_line("~ is an artifact creature.").unwrap();
+    assert!(
+        artifact_creature
+            .modifications
+            .iter()
+            .all(|m| matches!(m, ContinuousModification::AddType { .. })),
+        "'artifact creature' must stay additive: {:?}",
+        artifact_creature.modifications
+    );
+}
+
 // --- CantCastDuring: turn/phase-scoped casting prohibitions ---
 
 #[test]

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1369,6 +1369,13 @@ pub(crate) fn parse_pronoun_becomes_type_static(
         return None;
     }
 
+    // CR 205.1a: an effect that sets an object's card type replaces its existing
+    // card types unless it retains them (CR 205.1b). A pure non-creature
+    // card-type change with no retention marker therefore REPLACES — Arixmethes,
+    // Slumbering Isle's "it's a land. (It's not a creature.)" must stop the
+    // Kraken from being a creature, not leave it a "Creature Land" (issue #5213).
+    let modifications = maybe_replace_card_types(modifications, body.lower);
+
     // STEP D — attach the condition(s). The leading "during your turn, " timing
     // peel (STEP A.0) and the trailing " as long as <cond>" peel (STEP A) are
     // independent; either, both, or neither may be present.
@@ -1401,6 +1408,48 @@ pub(crate) fn parse_pronoun_becomes_type_static(
         def = def.condition(condition);
     }
     Some(def)
+}
+
+/// CR 205.1a / CR 205.1b: Decide whether a self type-change is a REPLACEMENT or
+/// an additive grant. A set of `AddType` modifications is replaced by a single
+/// `SetCardTypes` (which removes the object's prior card types, CR 205.1a) only
+/// when ALL of these hold:
+///   - every modification is an `AddType` (a pure card-type change — no P/T,
+///     subtype, keyword, color, or supertype, which would signal an animation
+///     that retains its card type),
+///   - none of the added types is `Creature` (creature forms retain via CR
+///     205.1b's "artifact creature" rule and P/T-bearing animations),
+///   - the body carries no CR 205.1b retention marker ("in addition to" /
+///     "still a[n]").
+///
+/// Otherwise the additive modifications are returned unchanged. This makes
+/// Arixmethes' "it's a land" strip the Creature type while leaving creature
+/// animations (Gideon Blackblade, Midnight Mangler, Circle of the Moon Druid)
+/// on their additive path.
+fn maybe_replace_card_types(
+    modifications: Vec<ContinuousModification>,
+    body_lower: &str,
+) -> Vec<ContinuousModification> {
+    if nom_primitives::scan_contains(body_lower, "in addition to")
+        || nom_primitives::scan_contains(body_lower, "still a")
+    {
+        return modifications;
+    }
+    let mut core_types = Vec::new();
+    for modification in &modifications {
+        match modification {
+            ContinuousModification::AddType { core_type } if *core_type != CoreType::Creature => {
+                core_types.push(*core_type);
+            }
+            // Anything else (P/T, subtype, keyword, an added Creature type, …)
+            // keeps the additive form.
+            _ => return modifications,
+        }
+    }
+    if core_types.is_empty() {
+        return modifications;
+    }
+    vec![ContinuousModification::SetCardTypes { core_types }]
 }
 
 /// CR 205.2 + CR 613.1d + CR 613.4b + CR 611.3a: "Each noncreature <T> [you control]


### PR DESCRIPTION
Closes #5213

## Summary
Fixes **Arixmethes, Slumbering Isle** (issue #5213): while it has a slumber counter it should become just a **Land**, but the engine showed the impossible "Legendary Creature Land — Kraken" — the Creature type was never removed.

Its static reads `As long as Arixmethes has a slumber counter on it, it's a land. (It's not a creature.)`. The parser emitted an **additive** `AddType{Land}`, so the Kraken stayed a creature. Per **CR 205.1a**, an effect that *sets* a card type **replaces** the object's existing card types unless it retains them (CR 205.1b: "in addition to its other types" / "still a"). A bare "it's a land" therefore replaces.

## Fix
`parse_pronoun_becomes_type_static` now runs its computed modifications through `maybe_replace_card_types`, which converts them to a single replacing `SetCardTypes` **only** when all of:
- every modification is an `AddType` (a pure card-type change — no P/T, subtype, keyword, color, or supertype),
- none of the added types is `Creature` (creature forms retain via the CR 205.1b "artifact creature" rule and their P/T),
- the body carries no CR 205.1b retention marker (`in addition to` / `still a`).

So `it's a land` → `SetCardTypes{[Land]}` (replaces, removing Creature), while creature animations (Gideon Blackblade, Midnight Mangler, Circle of the Moon Druid) and `in addition to its other types` forms stay additive. No new runtime: the existing `SetCardTypes` layer application (`game/layers.rs`) sets the core types and drops the correlated `Kraken` creature subtype, leaving a **Legendary Land**.

## Files changed
- `crates/engine/src/parser/oracle_static/type_change.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`
- `crates/engine/src/game/layers.rs`

## Anchored on
- `crates/engine/src/parser/oracle_static/type_change.rs` `parse_attached_isnt_and_is_type` / the Imprisoned `parse_enchanted_becomes_type_with_ability` — existing handlers that already model type REPLACEMENT via `SetCardTypes` / `RemoveType`; this reuses `SetCardTypes` for the self "it's a [type]" form.
- `crates/engine/src/game/layers.rs:4886` `ContinuousModification::SetCardTypes` — the existing replacement runtime that sets core types and retains only correlated subtypes.

## CR references
- `CR 205.1a` — an effect that sets an object's card type replaces its existing card types; correlated subtypes of a removed card type are also removed.
- `CR 205.1b` — retention only when the effect says "in addition to its other types", "still a [type]", or is an "artifact creature" form.

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (exit 0)
- `./scripts/check-engine-authorities.sh` — clean (exit 0)
- `cargo test -p engine --lib parser::oracle_static` — 1014 pass / 0 fail
- Parser test `arixmethes_bare_is_a_land_replaces_card_types` (asserts `SetCardTypes{[Land]}` + the slumber-counter condition, and that `in addition to` / `artifact creature` stay additive).
- Runtime test `set_card_types_land_strips_creature_and_creature_subtype` (a Legendary Creature Kraken under `SetCardTypes([Land])` becomes a Legendary Land: Creature removed, Kraken subtype dropped, Legendary retained).

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)