### PR TITLE
fix(tokens): role tokens grant their abilities and resolve face art

### DIFF
--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -2567,8 +2567,14 @@ fn wicked_role_spec() -> RoleSpec {
 ///
 /// All Role tokens share the `Role` subtype, so dispatch must be by display
 /// name — subtype alone cannot distinguish the seven variants.
+///
+/// CR 111.10: a Role token's printed name is "<Role> Role" (e.g. "Monster Role"),
+/// which is exactly what the parser/token creation assigns as the display name.
+/// Strip that trailing " Role" before matching so real tokens dispatch correctly;
+/// the bare role word ("Monster") is also accepted for internal/test callers.
 fn predefined_role_token_spec(name: &str) -> Option<RoleSpec> {
-    match name {
+    let role = name.strip_suffix(" Role").unwrap_or(name);
+    match role {
         "Cursed" => Some(RoleSpec::statics_only(cursed_role_statics())),
         "Monster" => Some(RoleSpec::statics_only(monster_role_statics())),
         "Royal" => Some(RoleSpec::statics_only(royal_role_statics())),
@@ -4366,6 +4372,144 @@ mod tests {
         assert!(
             obj.trigger_definitions.is_empty(),
             "catalog injection must not double-grant predefined Royal Role statics"
+        );
+    }
+
+    /// CR 111.10k: A Role token created by a real card ("Create a Monster Role
+    /// token …") is named "Monster Role" — the parser's `known_role_token_identity`
+    /// produces the full "<Role> Role" name, which is the printed token name. The
+    /// predefined-ability dispatch MUST recognize that full name; matching only the
+    /// bare "Monster" left the token with no +1/+1-and-trample static. Regression
+    /// for Role tokens (Monstrous Rage, Royal Treatment, …) granting nothing.
+    #[test]
+    fn predefined_monster_role_full_name_grants_role_static() {
+        use crate::types::proposed_event::TokenCharacteristics;
+        use std::collections::HashSet;
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Monstrous Rage".to_string(),
+            Zone::Battlefield,
+        );
+        let spec = TokenSpec {
+            characteristics: TokenCharacteristics {
+                // The name the parser actually produces for "a Monster Role token".
+                display_name: "Monster Role".to_string(),
+                power: None,
+                toughness: None,
+                core_types: vec![CoreType::Enchantment],
+                subtypes: vec!["Aura".to_string(), "Role".to_string()],
+                supertypes: vec![],
+                colors: vec![],
+                keywords: vec![],
+            },
+            script_name: "Monster Role".to_string(),
+            static_abilities: vec![],
+            enter_with_counters: vec![],
+            tapped: false,
+            enters_attacking: false,
+            sacrifice_at: None,
+            source_id: source,
+            controller: PlayerId(0),
+            attach_to: None,
+        };
+        let event = ProposedEvent::CreateToken {
+            owner: PlayerId(0),
+            spec: Box::new(spec),
+            copy: None,
+            enter_tapped: crate::types::proposed_event::EtbTapState::Unspecified,
+            count: 1,
+            applied: HashSet::new(),
+        };
+        let mut events = vec![];
+        apply_create_token_after_replacement(&mut state, event, &mut events);
+
+        let role_id = state.last_created_token_ids[0];
+        let obj = &state.objects[&role_id];
+        assert_eq!(
+            obj.static_definitions.len(),
+            1,
+            "Monster Role must carry its enchanted-creature +1/+1-and-trample static"
+        );
+    }
+
+    /// CR 111.3: A Role token is one face of a two-Role DFC ("Monster // Sorcerer"),
+    /// so its source card links to BOTH face presets — the single-preset fast path
+    /// in `find_exact_token_ref` is skipped and art resolves via body match. The
+    /// token is named "Monster Role" but the face preset is "Monster", so the name
+    /// comparison must reconcile the trailing " Role"; otherwise the token gets no
+    /// image ref and renders with no art (reported for Monstrous Rage). The match
+    /// must also select the correct face (Monster, not Sorcerer).
+    #[test]
+    fn dfc_monster_role_resolves_the_monster_face_art() {
+        use crate::types::card::PrintedCardRef;
+        use crate::types::proposed_event::TokenCharacteristics;
+        use std::collections::HashSet;
+
+        // Monster face of the "Monster // Sorcerer" DFC (WOE), and the Sorcerer face.
+        const MONSTER_PRESET: &str = "246f948c-eea9-5f6a-8d19-f8c11c51de94";
+        const SORCERER_PRESET: &str = "dd6f5274-9bb4-5acc-9855-55815f497831";
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Monstrous Rage".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.printed_ref = Some(PrintedCardRef {
+                oracle_id: "646a2371-54c0-4492-ac2f-20f109d6108c".to_string(),
+                face_name: "Monstrous Rage".to_string(),
+            });
+            obj.source_related_token_ids =
+                vec![MONSTER_PRESET.to_string(), SORCERER_PRESET.to_string()];
+        }
+        let spec = TokenSpec {
+            characteristics: TokenCharacteristics {
+                display_name: "Monster Role".to_string(),
+                power: None,
+                toughness: None,
+                core_types: vec![CoreType::Enchantment],
+                subtypes: vec!["Aura".to_string(), "Role".to_string()],
+                supertypes: vec![],
+                colors: vec![],
+                keywords: vec![],
+            },
+            script_name: "Monster Role".to_string(),
+            static_abilities: vec![],
+            enter_with_counters: vec![],
+            tapped: false,
+            enters_attacking: false,
+            sacrifice_at: None,
+            source_id: source,
+            controller: PlayerId(0),
+            attach_to: None,
+        };
+        let event = ProposedEvent::CreateToken {
+            owner: PlayerId(0),
+            spec: Box::new(spec),
+            copy: None,
+            enter_tapped: crate::types::proposed_event::EtbTapState::Unspecified,
+            count: 1,
+            applied: HashSet::new(),
+        };
+        let mut events = vec![];
+        apply_create_token_after_replacement(&mut state, event, &mut events);
+
+        let role_id = state.last_created_token_ids[0];
+        let image_ref = state.objects[&role_id]
+            .token_image_ref
+            .clone()
+            .expect("DFC Monster Role must resolve an image ref, not render artless");
+        assert_eq!(
+            image_ref.preset_id, MONSTER_PRESET,
+            "must resolve the Monster face preset, not the Sorcerer face"
         );
     }
 

--- a/crates/engine/src/game/token_presets.rs
+++ b/crates/engine/src/game/token_presets.rs
@@ -375,12 +375,25 @@ fn find_token_ref_with_mode(
     first.token_image_ref.clone()
 }
 
+/// CR 111.10: The engine names a Role token "<Role> Role" (e.g. "Monster Role",
+/// the parser/token-creation convention), but catalog presets — generated from
+/// MTGJSON — name the same token by its bare role word ("Monster"). Reconcile the
+/// trailing " Role" so a "Monster Role" token body matches its "Monster" face
+/// preset. Without this a DFC Role token ("Monster // Sorcerer"), whose source
+/// card links to BOTH face presets and so skips the single-preset fast path,
+/// never resolves an image ref and renders with no art. Non-Role names have no
+/// " Role" suffix and are unaffected; the accompanying subtype/type comparison
+/// still prevents a Role body from matching a non-Role preset.
+fn role_normalized_display_name(name: &str) -> &str {
+    name.strip_suffix(" Role").unwrap_or(name)
+}
+
 fn token_body_matches(a: &TokenCharacteristics, b: &TokenCharacteristics) -> bool {
     token_body_identity_matches(a, b) && a.power == b.power && a.toughness == b.toughness
 }
 
 fn token_body_identity_matches(a: &TokenCharacteristics, b: &TokenCharacteristics) -> bool {
-    a.display_name == b.display_name
+    role_normalized_display_name(&a.display_name) == role_normalized_display_name(&b.display_name)
         && sorted_debug(&a.core_types) == sorted_debug(&b.core_types)
         && sorted_strings(&a.subtypes) == sorted_strings(&b.subtypes)
         && sorted_debug(&a.supertypes) == sorted_debug(&b.supertypes)

--- a/crates/engine/tests/std_small_parser_a_batch.rs
+++ b/crates/engine/tests/std_small_parser_a_batch.rs
@@ -287,6 +287,26 @@ fn royal_treatment_creates_role_token_attached_to_target() {
         Some(target),
         "the Royal Role token must enter attached to the targeted creature (CR 303.7)"
     );
+
+    // CR 111.10m: the Role must actually BUFF the enchanted creature, not merely
+    // attach. Pre-fix the predefined dispatch matched only the bare "Royal", so a
+    // token named "Royal Role" carried no static and the 2/2 target stayed 2/2
+    // with no ward — the reported "Roles do nothing" bug. After layers apply the
+    // Role's enchanted-creature static, the 2/2 target must be a 3/3 with ward.
+    engine::game::layers::evaluate_layers(runner.state_mut());
+    let buffed = &runner.state().objects[&target];
+    assert_eq!(
+        (buffed.power, buffed.toughness),
+        (Some(3), Some(3)),
+        "Royal Role must grant the enchanted creature +1/+1 (2/2 -> 3/3)"
+    );
+    assert!(
+        buffed
+            .keywords
+            .iter()
+            .any(|k| matches!(k, engine::types::keywords::Keyword::Ward(_))),
+        "Royal Role must grant the enchanted creature ward"
+    );
 }
 
 // ===========================================================================


### PR DESCRIPTION
Role tokens (Monster Role from Monstrous Rage, Royal Role from Royal
Treatment, ...) granted none of their effects and rendered with no art.
Both stem from the same naming mismatch: the parser names the token by
its full "<Role> Role" printed name (e.g. "Monster Role"), but the
consumers keyed off the bare role word ("Monster") used by the
MTGJSON-derived catalog presets.

- No effects: predefined_role_token_spec matched only "Monster", so a
  token named "Monster Role" dispatched to None and carried no static --
  no +1/+1, no trample/ward. Strip the trailing " Role" before matching.

- No art: a Role token is one face of a two-Role DFC ("Monster //
  Sorcerer"), so its source card links to BOTH face presets. That skips
  find_exact_token_ref's single-preset fast path and falls to a body
  match, where "Monster Role" != the preset's "Monster" left the token
  with no image ref. Reconcile the " Role" suffix in token_body_matches
  so the correct face (Monster, not Sorcerer) resolves.

Existing tests masked the bug (bare "Royal" name; the end-to-end section
19 test only checked attach, not the buff). Add reproduction tests for
both, and harden that test to assert the enchanted creature is actually
buffed (Royal Treatment: 2/2 -> 3/3 with ward).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
