### PR TITLE
fix(parser): "it's a land" replaces card types so Arixmethes loses Creature (#5213)

### DIFF
--- a/crates/engine/src/parser/oracle_static/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_static/snapshot_tests.rs
@@ -1112,3 +1112,42 @@ fn neutral_plural_pronoun_they_becomes_creature_static() {
         "expected AddKeyword(Vigilance) in {mods:?}"
     );
 }
+
+/// SHAPE — CR 205.1a (issue #5213): Arixmethes, Slumbering Isle —
+/// "As long as ~ has a slumber counter on it, it's a land." While it has a
+/// slumber counter it is JUST a land, NOT a land creature. The parser must emit
+/// a core-type *replacement* (`SetCardTypes { core_types: [Land] }`, which
+/// removes Creature at runtime), NOT an additive `AddType { Land }` (which would
+/// keep Creature and yield a land creature). Parsed through the real entry point
+/// (`parse_static_line` → `parse_conditional_static` peels the "as long as"
+/// condition → `parse_pronoun_becomes_type_static`), matching production.
+#[test]
+fn arixmethes_it_is_a_land_replaces_core_types() {
+    let text = "As long as ~ has a slumber counter on it, it's a land.";
+    let def = parse_static_line(text)
+        .unwrap_or_else(|| panic!("Arixmethes land static must parse; text = {text:?}"));
+    let mods = &def.modifications;
+
+    // Reach-guard: the static parsed to a non-empty modification set.
+    assert!(!mods.is_empty(), "expected a non-empty modification set");
+    // The fix: replacement, not additive.
+    assert_eq!(
+        mods,
+        &vec![ContinuousModification::SetCardTypes {
+            core_types: vec![CoreType::Land],
+        }],
+        "expected SetCardTypes([Land]) (replacement, removes Creature), got {mods:?}"
+    );
+    // Discriminator vs. the pre-fix behavior: no additive AddType survives.
+    assert!(
+        !mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::AddType { .. })),
+        "must NOT emit additive AddType for 'it's a land'; got {mods:?}"
+    );
+    assert!(
+        matches!(def.affected, Some(TargetFilter::SelfRef)),
+        "affected must be SelfRef, got {:?}",
+        def.affected
+    );
+}

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1342,10 +1342,11 @@ pub(crate) fn parse_pronoun_becomes_type_static(
     // fixed P/T (CR 613.4b), dynamic P/T-by-mana-value, types (CR 613.1d),
     // subtypes (CR 205.3), and keyword tails (CR 613.1g) in one composable pass.
     let body_text = body.original.trim().trim_end_matches('.');
-    let modifications = if let Some(spec) = super::oracle_effect::animation::parse_animation_spec(
-        body_text,
-        &mut ParseContext::default(),
-    ) {
+    let mut modifications = if let Some(spec) =
+        super::oracle_effect::animation::parse_animation_spec(
+            body_text,
+            &mut ParseContext::default(),
+        ) {
         super::oracle_effect::animation::animation_modifications(&spec)
     } else {
         // Fallback: type-token parse + mana-value dynamic P/T. Handles edge
@@ -1364,6 +1365,14 @@ pub(crate) fn parse_pronoun_becomes_type_static(
         }
         mods
     };
+
+    // STEP C.1 — CR 205.1a: "it's a land" replaces the card's core types
+    // (removes Creature). Scoped to Land here; the general planeswalker/creature
+    // replace is deferred (removing Planeswalker exposes the loyalty-gate at
+    // game/planeswalker.rs, a separate fix). Runs on the MERGED modifications so
+    // the bare-"land" FALLBACK branch (which yields `AddType(Land)`) is covered
+    // as well as the spec branch. Any non-[Land] type-change is left additive.
+    convert_bare_land_animation_to_set_card_types(&body, &mut modifications);
 
     if modifications.is_empty() {
         return None;
@@ -1401,6 +1410,69 @@ pub(crate) fn parse_pronoun_becomes_type_static(
         def = def.condition(condition);
     }
     Some(def)
+}
+
+/// CR 205.1a: convert the bare "[pronoun]'s a land" animation to a core-type
+/// *replacement* (`SetCardTypes { core_types: [Land] }`) instead of an additive
+/// `AddType { Land }`. Setting the card type replaces the previous card types
+/// (removing Creature), so an "it's a land" object is JUST a land — never a land
+/// creature (Arixmethes, Slumbering Isle, issue #5213). The runtime layer at
+/// `game/layers.rs` (`SetCardTypes`) already replaces rather than adds.
+///
+/// NARROW BY DESIGN — fires ONLY when the sole type modification is a single
+/// `AddType { Land }` and the descriptor carries no retention / "in addition to"
+/// marker:
+///   - Retention ("... that's still a creature") and additive "in addition to
+///     its other types" (Awakened Skyclave) forms are CR 205.1b — they RETAIN
+///     prior types and must stay additive. Excluded via `split_type_retention_clause`
+///     and the `" in addition to"` guard (mirroring the bare replacement path).
+///   - Any creature/artifact/planeswalker/subtype type-change is left additive
+///     and untouched, so Grand Master of Flowers / Kaito / Gideon / Animate
+///     Artifact keep `AddType` (converting them would remove Planeswalker and
+///     break the loyalty-gate at `game/planeswalker.rs` — a separate follow-up).
+///   - Non-type modifications (P/T, keywords) are preserved.
+fn convert_bare_land_animation_to_set_card_types(
+    body: &TextPair<'_>,
+    modifications: &mut [ContinuousModification],
+) {
+    let descriptor = body.lower.trim().trim_end_matches('.').trim();
+
+    // CR 205.1b retention — "... that's still a [type]" keeps prior types: additive.
+    if split_type_retention_clause(descriptor).is_some() {
+        return;
+    }
+    // CR 205.1b "in addition to its other types" (Awakened Skyclave): additive.
+    if take_until::<_, _, OracleError<'_>>(" in addition to")
+        .parse(descriptor)
+        .is_ok()
+    {
+        return;
+    }
+
+    // The ONLY type modification must be a single `AddType { Land }`. Any other
+    // AddType core type, or any AddSubtype/AddSupertype, disqualifies the shape.
+    let mut land_index = None;
+    for (index, modification) in modifications.iter().enumerate() {
+        match modification {
+            ContinuousModification::AddType {
+                core_type: CoreType::Land,
+            } if land_index.is_none() => land_index = Some(index),
+            ContinuousModification::AddType { .. }
+            | ContinuousModification::AddSubtype { .. }
+            | ContinuousModification::AddSupertype { .. } => return,
+            // Non-type modifications (SetPower/SetToughness, keywords, ...) are
+            // preserved untouched.
+            _ => {}
+        }
+    }
+    let Some(index) = land_index else {
+        return;
+    };
+
+    // CR 205.1a: replace the core card-type set with just Land (removes Creature).
+    modifications[index] = ContinuousModification::SetCardTypes {
+        core_types: vec![CoreType::Land],
+    };
 }
 
 /// CR 205.2 + CR 613.1d + CR 613.4b + CR 611.3a: "Each noncreature <T> [you control]

--- a/crates/engine/tests/arixmethes_slumber_land_type_5213.rs
+++ b/crates/engine/tests/arixmethes_slumber_land_type_5213.rs
@@ -1,0 +1,155 @@
+//! Discriminating regression test for **issue #5213**: Arixmethes, Slumbering
+//! Isle must become JUST a land (never a land creature) while it has a slumber
+//! counter.
+//!
+//! Arixmethes' static:
+//!
+//! > As long as Arixmethes has a slumber counter on it, it's a land.
+//! > (It's not a creature.)
+//!
+//! Arixmethes is normally a "Legendary Creature — Kraken". CR 205.1a: setting an
+//! object's card type REPLACES its previous card types — so "it's a land" makes
+//! it just a Land and removes the Creature type. Before the fix the line parsed
+//! to an additive `AddType { Land }`, so at runtime Arixmethes kept the Creature
+//! type and became an (illegal) land creature.
+//!
+//! After the fix the static carries `SetCardTypes { core_types: [Land] }`, which
+//! the layer system (`game/layers.rs`) applies as a replacement: core types
+//! become exactly `[Land]`, the Creature type (and its Kraken subtype) drop, and
+//! the Legendary supertype is retained.
+//!
+//! CR 205.1a: setting card type(s) replaces the previous card types; correlated
+//!   subtypes drop unless they belong to a card type the object still has.
+//! CR 122.1: counters on a permanent (the slumber-counter gate).
+//! CR 613.3d (Layer 4): continuous type-changing static ability.
+
+use std::sync::Arc;
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::ContinuousModification;
+use engine::types::card_type::{CoreType, Supertype};
+use engine::types::counter::CounterType;
+use engine::types::phase::Phase;
+
+const ARIXMETHES_ORACLE: &str = "Arixmethes enters tapped with five slumber counters on it.\n\
+As long as Arixmethes has a slumber counter on it, it's a land. (It's not a creature.)\n\
+Whenever you cast a spell, you may remove a slumber counter from Arixmethes.\n\
+{T}: Add {G}{U}.";
+
+#[test]
+fn arixmethes_with_slumber_counter_is_just_a_land() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Build Arixmethes from his real Oracle text. Parsing of the land static
+    // happens here, at build time.
+    let arixmethes = scenario
+        .add_creature_from_oracle(P0, "Arixmethes, Slumbering Isle", 12, 12, ARIXMETHES_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Reshape the printed baseline into the real card: Legendary Creature —
+    // Kraken with 12/12 P/T. `GameScenario` exposes object mutation only after
+    // `build()` (mirroring the Gideon Blackblade test). The reshape touches only
+    // the type/P-T baseline, not `base_static_definitions` (already parsed).
+    {
+        let obj = runner.state_mut().objects.get_mut(&arixmethes).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.card_types.supertypes = vec![Supertype::Legendary];
+        obj.card_types.subtypes = vec!["Kraken".to_string()];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = Some(12);
+        obj.toughness = Some(12);
+        obj.base_power = Some(12);
+        obj.base_toughness = Some(12);
+    }
+
+    // ----- Reach-guard: the static parsed to a core-type REPLACEMENT, not an
+    // additive AddType (the #5213 fix). This is what makes the runtime assertions
+    // below discriminating: reverting to `AddType { Land }` fails right here, and
+    // also fails the "not a Creature" / "core == [Land]" checks. -----
+    let statics: &Arc<Vec<_>> = &runner.state().objects[&arixmethes].base_static_definitions;
+    let land_static = statics
+        .iter()
+        .find(|s| {
+            s.modifications
+                .contains(&ContinuousModification::SetCardTypes {
+                    core_types: vec![CoreType::Land],
+                })
+        })
+        .expect(
+            "Arixmethes' land static must carry SetCardTypes([Land]) (replacement), \
+             not additive AddType{Land} (#5213)",
+        );
+    assert!(
+        !land_static
+            .modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::AddType { .. })),
+        "the land static must not carry additive AddType; got {:?}",
+        land_static.modifications
+    );
+
+    // ----- With a slumber counter, Arixmethes is JUST a land. -----
+    // CR 122.1: add the slumber counter that satisfies the static's HasCounters gate.
+    {
+        let obj = runner.state_mut().objects.get_mut(&arixmethes).unwrap();
+        obj.counters
+            .insert(CounterType::Generic("slumber".to_string()), 1);
+    }
+    evaluate_layers(runner.state_mut());
+
+    let obj = &runner.state().objects[&arixmethes];
+    // CR 205.1a: core types are replaced by exactly [Land] — Creature is removed.
+    assert_eq!(
+        obj.card_types.core_types,
+        vec![CoreType::Land],
+        "with a slumber counter Arixmethes must be JUST a Land, got {:?}",
+        obj.card_types.core_types
+    );
+    assert!(
+        !obj.card_types.core_types.contains(&CoreType::Creature),
+        "Arixmethes must NOT be a Creature while a land (#5213), got {:?}",
+        obj.card_types.core_types
+    );
+    // CR 205.1a: the Kraken creature-subtype drops (no Creature type to hold it).
+    assert!(
+        !obj.card_types.subtypes.iter().any(|s| s == "Kraken"),
+        "Kraken subtype must drop when the Creature type is removed, got {:?}",
+        obj.card_types.subtypes
+    );
+    // The Legendary supertype is unaffected by a core-type replacement.
+    assert!(
+        obj.card_types.supertypes.contains(&Supertype::Legendary),
+        "Legendary supertype must be retained, got {:?}",
+        obj.card_types.supertypes
+    );
+
+    // ----- Remove the counter: the static no longer applies, Arixmethes reverts
+    // to a Legendary Creature — Kraken (the discriminator vs. an always-on fix). -----
+    {
+        let obj = runner.state_mut().objects.get_mut(&arixmethes).unwrap();
+        obj.counters
+            .remove(&CounterType::Generic("slumber".to_string()));
+    }
+    evaluate_layers(runner.state_mut());
+
+    let obj = &runner.state().objects[&arixmethes];
+    assert!(
+        obj.card_types.core_types.contains(&CoreType::Creature),
+        "without a slumber counter Arixmethes reverts to a Creature, got {:?}",
+        obj.card_types.core_types
+    );
+    assert!(
+        !obj.card_types.core_types.contains(&CoreType::Land),
+        "without a slumber counter Arixmethes is not a Land, got {:?}",
+        obj.card_types.core_types
+    );
+    assert!(
+        obj.card_types.subtypes.iter().any(|s| s == "Kraken"),
+        "Kraken subtype restored once the Creature type returns, got {:?}",
+        obj.card_types.subtypes
+    );
+}


### PR DESCRIPTION
## Summary
Fixes #5213. **Arixmethes, Slumbering Isle** — "As long as ~ has a slumber counter on it, it's a land." — parsed to an additive `AddType{Land}`, so at runtime it kept its Creature type and stayed a land **creature** while slumbering. Per **CR 205.1a**, a type-defining "it's a [type]" **replaces** the card's existing card types.

The fix emits `SetCardTypes{[Land]}` for the "it's a land" pronoun static (the runtime layer in `game/layers.rs` already replaces on `SetCardTypes`, so this is parser-only). It's scoped narrowly to the land case via a new `convert_bare_land_animation_to_set_card_types` that fires **only** when the sole type modification is a single `AddType{Land}`, and bails on:
- a retention clause ("…that's still a [type]"),
- "in addition to its other types" (Awakened Skyclave), and
- any creature / artifact / planeswalker / subtype change.

**Deliberately out of scope (deferred):** the broader CR 205.1a fix for creature/planeswalker animations (Grand Master of Flowers, Kaito). Converting those to `SetCardTypes{[Creature]}` would remove the Planeswalker type and — given the loyalty-activation gate at `game/planeswalker.rs` — **break their loyalty abilities** (their rulings say loyalty stays activatable while a creature). That needs a paired engine fix (correct the loyalty gate to CR 606.3 "a permanent") and belongs in a separate change. Grand Master / Kaito / Gideon / Animate Artifact and the she/they pronoun fixtures are provably untouched — their regression snapshots pass **unedited**.

## Files changed
- `crates/engine/src/parser/oracle_static/type_change.rs` — the narrow land-only conversion
- `crates/engine/src/parser/oracle_static/snapshot_tests.rs` — SHAPE test
- `crates/engine/tests/arixmethes_slumber_land_type_5213.rs` — revert-failing runtime test

## CR references
- `CR 205.1a` — a type-defining effect replaces the card's existing card types
- `CR 205.1b` — retention ("that's still a [type]") / "in addition to" exceptions stay additive

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high
Tier: Frontier

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (exit 0)
- `cargo clippy -p engine --all-targets -- -D warnings` — clean
- `cargo test -p engine` — 0 failures
- Regenerated card-data: Arixmethes' static now emits `SetCardTypes{[Land]}`; Grand Master of Flowers / Kaito / Animate Artifact / Awakened Skyclave unchanged (still additive)

Tests:
- `arixmethes_it_is_a_land_replaces_core_types` (SHAPE) — the "it's a land" static → `[SetCardTypes{[Land]}]`, `affected: SelfRef` (not `AddType`).
- `arixmethes_with_slumber_counter_is_just_a_land` (runtime, **revert-failing**) — with a slumber counter, `evaluate_layers` gives `core_types == [Land]`, NOT a Creature (Kraken subtype dropped, Legendary retained); remove the last counter → the Kraken creature returns. Under the pre-fix `AddType{Land}` the types would be `[Creature, Land]` → the assertions fail.
- **Regression guards (pass unedited):** `pronoun_becomes_type_static_dynamic_pt_by_mana_value` (Animate Artifact, artifact-creature stays additive), `grand_master_of_flowers_becomes_777_dragon_god_creature`, `gendered_pronoun_she_becomes_creature_static`, `neutral_plural_pronoun_they_becomes_creature_static`, and `gideon_blackblade_turn_conditional_creature_1155` (retention) — proving the conversion does not over-broaden.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
