### PR TITLE
fix(engine): resolve mulligan bottoming at each player's declare point (CR 103.5b)

### DIFF
--- a/.claude/skills/add-interactive-effect/SKILL.md
+++ b/.claude/skills/add-interactive-effect/SKILL.md
@@ -357,8 +357,7 @@ For interactive replacements, you need to:
 
 | Effect | WaitingFor | Complexity |
 |--------|-----------|------------|
-| **Mulligan** | `MulliganDecision { player }` | Simple — keep/mulligan |
-| **MulliganBottom** | `MulliganBottomCards { player, count }` | Simple — cards to bottom |
+| **Mulligan** | `MulliganDecision { player }` | Simple — keep/mulligan (bottoming is a `MulliganDecisionPhase::BottomCards` sub-phase of the same variant) |
 | **Sideboard** | `BetweenGamesSideboard { player, ... }` | Medium — sideboard swaps |
 | **PlayDraw** | `BetweenGamesChoosePlayDraw { player }` | Simple — play/draw choice |
 | **GameOver** | `GameOver { winners }` | Terminal state |

--- a/.claude/skills/add-interactive-effect/SKILL.md
+++ b/.claude/skills/add-interactive-effect/SKILL.md
@@ -357,7 +357,8 @@ For interactive replacements, you need to:
 
 | Effect | WaitingFor | Complexity |
 |--------|-----------|------------|
-| **Mulligan** | `MulliganDecision { player }` | Simple — keep/mulligan (bottoming is a `MulliganDecisionPhase::BottomCards` sub-phase of the same variant) |
+| **Mulligan** | `MulliganDecision { player }` | Simple — keep/mulligan |
+| **MulliganBottom** | `MulliganBottomCards { player, count }` | Simple — cards to bottom |
 | **Sideboard** | `BetweenGamesSideboard { player, ... }` | Medium — sideboard swaps |
 | **PlayDraw** | `BetweenGamesChoosePlayDraw { player }` | Simple — play/draw choice |
 | **GameOver** | `GameOver { winners }` | Terminal state |

--- a/client/src/adapter/__tests__/contract-fixtures.test.ts
+++ b/client/src/adapter/__tests__/contract-fixtures.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { GameAction, GameObject, GameState, WaitingFor } from "../types";
-import { WebSocketAdapter } from "../ws-adapter";
+import { PROTOCOL_VERSION, WebSocketAdapter } from "../ws-adapter";
 
 class MockWebSocket extends EventTarget {
   static OPEN = 1;
@@ -39,7 +39,7 @@ const SERVER_HELLO = JSON.stringify({
   data: {
     server_version: "0.0.0-test",
     build_commit: "testhash",
-    protocol_version: 12,
+    protocol_version: PROTOCOL_VERSION,
     mode: "Full",
   },
 });

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -527,8 +527,8 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
           type: "MulliganDecision",
           data: {
             pending: [
-              { player: 0, mulligan_count: 0 },
-              { player: 1, mulligan_count: 0 },
+              { player: 0, mulligan_count: 0, phase: { type: "Declare" } },
+              { player: 1, mulligan_count: 0, phase: { type: "Declare" } },
             ],
             free_first_mulligan: false,
           },

--- a/client/src/adapter/__tests__/server-draft-adapter.test.ts
+++ b/client/src/adapter/__tests__/server-draft-adapter.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ServerDraftAdapter } from "../server-draft-adapter";
+import { PROTOCOL_VERSION } from "../ws-adapter";
 import type { DraftPlayerView } from "../draft-adapter";
 import type { GameLogEntry, GameState } from "../types";
 
@@ -38,7 +39,7 @@ const SERVER_HELLO = JSON.stringify({
   data: {
     server_version: "0.0.0-test",
     build_commit: "testhash",
-    protocol_version: 12,
+    protocol_version: PROTOCOL_VERSION,
     mode: "Full",
   },
 });

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { WebSocketAdapter } from "../ws-adapter";
+import { PROTOCOL_VERSION, WebSocketAdapter } from "../ws-adapter";
 import type { GameState } from "../types";
 
 // Minimal mock WebSocket. Latest-constructed instance is exposed via
@@ -43,7 +43,7 @@ const SERVER_HELLO = JSON.stringify({
   data: {
     server_version: "0.0.0-test",
     build_commit: "testhash",
-    protocol_version: 12,
+    protocol_version: PROTOCOL_VERSION,
     mode: "Full",
   },
 });

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -187,7 +187,6 @@ function aiActorFromWaitingFor(
 ): PlayerId | null {
   if (
     waitingFor.type === "MulliganDecision" ||
-    waitingFor.type === "MulliganBottomCards" ||
     waitingFor.type === "OpeningHandBottomCards"
   ) {
     return (

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1211,19 +1211,28 @@ export type CastOfferKind =
       exile_instead_of_graveyard?: boolean;
     };
 
+// CR 103.5b: Which declare-point action a pending BottomCards obligation
+// completes once resolved. Field-flattened under `type` (no `data:` wrapper) to
+// mirror the Rust `#[serde(tag = "type")]` no-content shape — intentionally
+// different from MulliganChoice's TS shape (which nests under `data:`).
+export type PendingMulliganAction =
+  | { type: "Keep" }
+  | { type: "UseSerumPowder"; object_id: ObjectId };
+
+// CR 103.5 + 103.5b: Per-entry sub-state for the declare-point mulligan flow.
+export type MulliganDecisionPhase =
+  | { type: "Declare" }
+  | { type: "BottomCards"; count: number; then: PendingMulliganAction };
+
 export type WaitingFor =
   | { type: "Priority"; data: { player: PlayerId } }
   | { type: "ActivationCostOneOfChoice"; data: { player: PlayerId; costs: SerializedAbilityCost[]; pending_cast: PendingCast } }
   | {
       type: "MulliganDecision";
       data: {
-        pending: { player: PlayerId; mulligan_count: number }[];
+        pending: { player: PlayerId; mulligan_count: number; phase: MulliganDecisionPhase }[];
         free_first_mulligan: boolean;
       };
-    }
-  | {
-      type: "MulliganBottomCards";
-      data: { pending: { player: PlayerId; count: number }[] };
     }
   | {
       type: "OpeningHandBottomCards";

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -33,8 +33,12 @@ export interface DeckData {
  * Wire-protocol version the client speaks. Must match `PROTOCOL_VERSION` in
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
+ *
+ * 13 — WaitingFor::MulliganBottomCards removed; mulligan bottoming folded
+ *      into a MulliganDecisionPhase::BottomCards sub-phase on
+ *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 12;
+export const PROTOCOL_VERSION = 13;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/components/help/HelpSheet.tsx
+++ b/client/src/components/help/HelpSheet.tsx
@@ -71,15 +71,18 @@ function currentPromptSummary({
   if (waitingFor.type === "GameOver") return t("help.prompt.gameOver");
 
   if (waitingFor.type === "MulliganDecision") {
-    return waitingFor.data.pending.some((entry) => entry.player === playerId)
-      ? t("help.prompt.mulliganDecide")
+    const entry = waitingFor.data.pending.find((e) => e.player === playerId);
+    if (entry) {
+      return entry.phase.type === "BottomCards"
+        ? t("help.prompt.mulliganBottom")
+        : t("help.prompt.mulliganDecide");
+    }
+    const someoneBottoming = waitingFor.data.pending.some(
+      (e) => e.phase.type === "BottomCards",
+    );
+    return someoneBottoming
+      ? t("help.prompt.mulliganWaitBottom")
       : t("help.prompt.mulliganWaitDecide");
-  }
-
-  if (waitingFor.type === "MulliganBottomCards") {
-    return waitingFor.data.pending.some((entry) => entry.player === playerId)
-      ? t("help.prompt.mulliganBottom")
-      : t("help.prompt.mulliganWaitBottom");
   }
 
   if (waitingFor.type === "OpeningHandBottomCards") {

--- a/client/src/components/modal/DialogHost.tsx
+++ b/client/src/components/modal/DialogHost.tsx
@@ -26,7 +26,6 @@ const NON_DIALOG_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> = new Set<Wa
   "DeclareAttackers",
   "DeclareBlockers",
   "MulliganDecision",
-  "MulliganBottomCards",
   "OpeningHandBottomCards",
   "BetweenGamesSideboard",
   "BetweenGamesChoosePlayDraw",

--- a/client/src/game/__tests__/autoPass.test.ts
+++ b/client/src/game/__tests__/autoPass.test.ts
@@ -50,7 +50,7 @@ describe("shouldAutoPass", () => {
     const mulligan: WaitingFor = {
       type: "MulliganDecision",
       data: {
-        pending: [{ player: 0, mulligan_count: 0 }],
+        pending: [{ player: 0, mulligan_count: 0, phase: { type: "Declare" } }],
         free_first_mulligan: false,
       },
     };

--- a/client/src/game/__tests__/waitingForReason.test.ts
+++ b/client/src/game/__tests__/waitingForReason.test.ts
@@ -30,7 +30,7 @@ function wf(type: WaitingFor["type"]): WaitingFor {
     case "ManaPayment":
       return buildManaPaymentWaitingFor();
     case "MulliganDecision":
-      return { type, data: { pending: [{ player: 0, mulligan_count: 0 }], free_first_mulligan: false } };
+      return { type, data: { pending: [{ player: 0, mulligan_count: 0, phase: { type: "Declare" } }], free_first_mulligan: false } };
     case "OrderTriggers":
       return { type, data: { player: 0, triggers: [] } };
     case "Priority":

--- a/client/src/game/controllers/aiController.ts
+++ b/client/src/game/controllers/aiController.ts
@@ -92,7 +92,7 @@ export function createAIController(config: AIControllerConfig): AIController {
   /**
    * Stable identity key for a WaitingFor — type + player so Priority{0} ≠ Priority{1}.
    *
-   * For simultaneous-mulligan states (`MulliganDecision`, `MulliganBottomCards`,
+   * For simultaneous-mulligan states (`MulliganDecision`,
    * `OpeningHandBottomCards`)
    * `data.player` is undefined, so falling back to -1 would collapse every
    * pending seat to the same key. We instead key by the AI seat that the
@@ -116,7 +116,6 @@ export function createAIController(config: AIControllerConfig): AIController {
   }): number | null {
     if (
       wf.type !== "MulliganDecision" &&
-      wf.type !== "MulliganBottomCards" &&
       wf.type !== "OpeningHandBottomCards"
     ) {
       return null;
@@ -152,7 +151,6 @@ export function createAIController(config: AIControllerConfig): AIController {
       waitingPlayerId = mulliganPid;
     } else if (
       waitingFor.type === "MulliganDecision" ||
-      waitingFor.type === "MulliganBottomCards" ||
       waitingFor.type === "OpeningHandBottomCards"
     ) {
       // Local human is pending (or no AI players left in pending) — do nothing.
@@ -317,7 +315,6 @@ export function createAIController(config: AIControllerConfig): AIController {
     // engine returns (computation is near-instant after our optimizations).
     const isMulligan =
       waitingForType === "MulliganDecision" ||
-      waitingForType === "MulliganBottomCards" ||
       waitingForType === "OpeningHandBottomCards";
     // Collapse the humanization delay under stack pressure. The depth-based skip
     // gate (checkAndSchedule) only fires at Elevated depth, which a 0↔1 trigger

--- a/client/src/game/waitingForRegistry.ts
+++ b/client/src/game/waitingForRegistry.ts
@@ -169,7 +169,6 @@ export const HANDLED_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> =
     // Game lifecycle
     "GameOver",
     "MulliganDecision",
-    "MulliganBottomCards",
     "OpeningHandBottomCards",
     "BetweenGamesSideboard",
     "BetweenGamesChoosePlayDraw",
@@ -234,7 +233,6 @@ export function waitingForReason(
     case "UnlessPayment":
       return { key: "status.reason.payingCost" };
     case "MulliganDecision":
-    case "MulliganBottomCards":
     case "OpeningHandBottomCards":
       return { key: "status.reason.mulligan" };
     case "DiscardToHandSize":

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -53,8 +53,11 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *   3 — Planechase state and action payloads in game_setup/reconnect snapshots
  *   4 — Archenemy derived view and scheme deck payloads
  *   5 — CardPredicateGuessMade game event shape
+ *   6 — Mulligan bottoming folded into a MulliganDecisionPhase::BottomCards
+ *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
+ *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 5 as const;
+export const WIRE_PROTOCOL_VERSION = 6 as const;
 
 export type P2PMessage =
   | { type: "guest_deck"; deckData: unknown; displayName?: string; reservationToken?: string }

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1810,6 +1810,19 @@ function GamePageContent({
             (e) => e.player === playerId,
           );
           if (!entry) return null;
+          // CR 103.5b: bottoming is folded into the MulliganDecision variant as
+          // a per-entry BottomCards sub-phase resolved at this player's own
+          // declare point.
+          if (entry.phase.type === "BottomCards") {
+            return (
+              <MulliganBottomCardsPrompt
+                playerId={entry.player}
+                count={entry.phase.count}
+                openingHandBottom={false}
+                onChoose={handleBottomCards}
+              />
+            );
+          }
           return (
             <MulliganDecisionPrompt
               playerId={entry.player}
@@ -1833,8 +1846,7 @@ function GamePageContent({
           </div>
         )}
 
-      {(waitingFor?.type === "MulliganBottomCards" ||
-        waitingFor?.type === "OpeningHandBottomCards") &&
+      {waitingFor?.type === "OpeningHandBottomCards" &&
         (() => {
           const entry = waitingFor.data.pending.find(
             (e) => e.player === playerId,
@@ -1844,7 +1856,7 @@ function GamePageContent({
             <MulliganBottomCardsPrompt
               playerId={entry.player}
               count={entry.count}
-              openingHandBottom={waitingFor.type === "OpeningHandBottomCards"}
+              openingHandBottom
               onChoose={handleBottomCards}
             />
           );

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -11,7 +11,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { Trans, useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 
-import type { DeckCardCount, GameFormat, MatchConfig, SerializedAbilityCost } from "../adapter/types";
+import type { DeckCardCount, GameFormat, MatchConfig, ObjectId, SerializedAbilityCost } from "../adapter/types";
 import { useDraftStore } from "../stores/draftStore";
 import { loadActiveQuickDraft } from "../services/quickDraftPersistence";
 import type { DraftMatchResult } from "../services/quickDraftPersistence";
@@ -1819,6 +1819,11 @@ function GamePageContent({
                 playerId={entry.player}
                 count={entry.phase.count}
                 openingHandBottom={false}
+                excludedCardId={
+                  entry.phase.then.type === "UseSerumPowder"
+                    ? entry.phase.then.object_id
+                    : undefined
+                }
                 onChoose={handleBottomCards}
               />
             );
@@ -1969,6 +1974,10 @@ interface MulliganBottomCardsPromptProps {
   playerId: number;
   count: number;
   openingHandBottom?: boolean;
+  // CR 103.5b: when this bottom obligation completes into UseSerumPowder, the
+  // earmarked Powder object must stay in hand to be exiled by its own effect,
+  // so it is not selectable as a bottomed card (the engine rejects it too).
+  excludedCardId?: ObjectId;
   onChoose: (id: string) => void;
 }
 
@@ -2338,6 +2347,7 @@ function MulliganBottomCardsPrompt({
   playerId,
   count,
   openingHandBottom = false,
+  excludedCardId,
   onChoose,
 }: MulliganBottomCardsPromptProps) {
   const { t } = useTranslation("game");
@@ -2361,7 +2371,13 @@ function MulliganBottomCardsPrompt({
 
   if (!player || !objects) return null;
 
-  const handObjects = player.hand.map((id) => objects[id]).filter(Boolean);
+  // CR 103.5b: the earmarked Serum Powder object stays in hand to be exiled by
+  // its own effect, so it is excluded from the selectable bottom-cards set (the
+  // engine rejects any selection containing it).
+  const handObjects = player.hand
+    .filter((id) => id !== excludedCardId)
+    .map((id) => objects[id])
+    .filter(Boolean);
   const isReady = selectedCardIds.length === count;
 
   const handleConfirm = () => {

--- a/client/src/services/__tests__/openPhaseSocket.test.ts
+++ b/client/src/services/__tests__/openPhaseSocket.test.ts
@@ -5,6 +5,7 @@ import {
   openPhaseSocket,
   withReconnect,
 } from "../openPhaseSocket";
+import { PROTOCOL_VERSION } from "../../adapter/ws-adapter";
 
 class MockWebSocket extends EventTarget {
   static OPEN = 1;
@@ -44,7 +45,7 @@ function helloFrame(
     data: {
       server_version: "0.0.0-test",
       build_commit: "testhash",
-      protocol_version: 12,
+      protocol_version: PROTOCOL_VERSION,
       mode: "Full",
       ...overrides,
     },
@@ -64,7 +65,7 @@ describe("openPhaseSocket", () => {
 
     const socket = await promise;
     expect(socket.serverInfo.mode).toBe("Full");
-    expect(socket.serverInfo.protocolVersion).toBe(12);
+    expect(socket.serverInfo.protocolVersion).toBe(PROTOCOL_VERSION);
     expect(ws.send).toHaveBeenCalledWith(
       expect.stringContaining('"type":"ClientHello"'),
     );
@@ -82,7 +83,7 @@ describe("openPhaseSocket", () => {
   it("rejects the previous protocol version for Full servers", async () => {
     const promise = openPhaseSocket("ws://test");
     const ws = MockWebSocket.instances[0];
-    ws.deliverMessage(helloFrame({ protocol_version: 11 }));
+    ws.deliverMessage(helloFrame({ protocol_version: PROTOCOL_VERSION - 1 }));
 
     await expect(promise).rejects.toMatchObject({
       kind: "protocol_mismatch",
@@ -94,14 +95,14 @@ describe("openPhaseSocket", () => {
     const promise = openPhaseSocket("ws://test");
     const ws = MockWebSocket.instances[0];
     ws.deliverMessage(
-      helloFrame({ protocol_version: 11, mode: "LobbyOnly" }),
+      helloFrame({ protocol_version: PROTOCOL_VERSION - 1, mode: "LobbyOnly" }),
     );
 
     const socket = await promise;
     expect(socket.serverInfo.mode).toBe("LobbyOnly");
-    expect(socket.serverInfo.protocolVersion).toBe(11);
+    expect(socket.serverInfo.protocolVersion).toBe(PROTOCOL_VERSION - 1);
     expect(ws.send).toHaveBeenCalledWith(
-      expect.stringContaining('"protocol_version":11'),
+      expect.stringContaining(`"protocol_version":${PROTOCOL_VERSION - 1}`),
     );
   });
 

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -16,7 +16,8 @@ use crate::types::card_type::CoreType;
 use crate::types::counter::CounterMatch;
 use crate::types::game_state::{
     CastOfferKind, CastPaymentMode, ConvokeMode, CounterCostChoice, CounterMoveChoice,
-    CounterRemoveChoice, GameState, PayCostKind, TargetSelectionSlot, WaitingFor,
+    CounterRemoveChoice, GameState, MulliganDecisionPhase, PayCostKind, PendingMulliganAction,
+    TargetSelectionSlot, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaType;
@@ -686,44 +687,49 @@ pub fn candidate_actions_exact(state: &GameState) -> Vec<CandidateAction> {
         // candidate per Powder so the policy may pick that branch.
         WaitingFor::MulliganDecision { pending, .. } => pending
             .iter()
-            .flat_map(|entry| {
-                let mut actions = vec![
-                    candidate(
-                        GameAction::MulliganDecision {
-                            choice: MulliganChoice::Keep,
-                        },
-                        TacticalClass::Selection,
-                        Some(entry.player),
-                    ),
-                    candidate(
-                        GameAction::MulliganDecision {
-                            choice: MulliganChoice::Mulligan,
-                        },
-                        TacticalClass::Selection,
-                        Some(entry.player),
-                    ),
-                ];
-                for powder_id in serum_powders_in_hand(state, entry.player) {
-                    actions.push(candidate(
-                        GameAction::MulliganDecision {
-                            choice: MulliganChoice::UseSerumPowder {
-                                object_id: powder_id,
+            .flat_map(|entry| match &entry.phase {
+                MulliganDecisionPhase::Declare => {
+                    let mut actions = vec![
+                        candidate(
+                            GameAction::MulliganDecision {
+                                choice: MulliganChoice::Keep,
                             },
-                        },
-                        TacticalClass::Selection,
-                        Some(entry.player),
-                    ));
+                            TacticalClass::Selection,
+                            Some(entry.player),
+                        ),
+                        candidate(
+                            GameAction::MulliganDecision {
+                                choice: MulliganChoice::Mulligan,
+                            },
+                            TacticalClass::Selection,
+                            Some(entry.player),
+                        ),
+                    ];
+                    for powder_id in serum_powders_in_hand(state, entry.player) {
+                        actions.push(candidate(
+                            GameAction::MulliganDecision {
+                                choice: MulliganChoice::UseSerumPowder {
+                                    object_id: powder_id,
+                                },
+                            },
+                            TacticalClass::Selection,
+                            Some(entry.player),
+                        ));
+                    }
+                    actions
                 }
-                actions
+                MulliganDecisionPhase::BottomCards { count, then } => {
+                    let exclude = match then {
+                        PendingMulliganAction::UseSerumPowder { object_id } => Some(*object_id),
+                        PendingMulliganAction::Keep => None,
+                    };
+                    bottom_card_actions(state, entry.player, *count, exclude)
+                }
             })
-            .collect(),
-        WaitingFor::MulliganBottomCards { pending } => pending
-            .iter()
-            .flat_map(|entry| bottom_card_actions(state, entry.player, entry.count))
             .collect(),
         WaitingFor::OpeningHandBottomCards { pending, .. } => pending
             .iter()
-            .flat_map(|entry| bottom_card_actions(state, entry.player, entry.count))
+            .flat_map(|entry| bottom_card_actions(state, entry.player, entry.count, None))
             .collect(),
         _ => Vec::new(),
     }
@@ -2829,7 +2835,6 @@ pub fn candidate_actions_broad_with_probe(
         | WaitingFor::BetweenGamesChoosePlayDraw { .. }
         | WaitingFor::OrderTriggers { .. }
         | WaitingFor::MulliganDecision { .. }
-        | WaitingFor::MulliganBottomCards { .. }
         | WaitingFor::OpeningHandBottomCards { .. } => Vec::new(),
         // CR 702.xxx: Paradigm (Strixhaven) — enumerate each exiled paradigm
         // source as a cast candidate plus a pass option. Assign when WotC
@@ -4294,9 +4299,19 @@ fn serum_powders_in_hand(state: &GameState, player: PlayerId) -> Vec<ObjectId> {
         .collect()
 }
 
-fn bottom_card_actions(state: &GameState, player: PlayerId, count: u8) -> Vec<CandidateAction> {
+fn bottom_card_actions(
+    state: &GameState,
+    player: PlayerId,
+    count: u8,
+    exclude: Option<ObjectId>,
+) -> Vec<CandidateAction> {
     let p = &state.players[player.0 as usize];
-    let hand: Vec<_> = p.hand.iter().copied().collect();
+    let hand: Vec<_> = p
+        .hand
+        .iter()
+        .copied()
+        .filter(|id| Some(*id) != exclude)
+        .collect();
 
     if count == 0 || hand.is_empty() {
         return vec![candidate(

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -14,7 +14,9 @@ use crate::game::mana_sources;
 use crate::types::ability::{AbilityKind, CounterCostSelection, TriggerDefinition};
 use crate::types::actions::GameAction;
 use crate::types::card_type::CoreType;
-use crate::types::game_state::{CastOfferKind, GameState, PayCostKind, WaitingFor};
+use crate::types::game_state::{
+    CastOfferKind, GameState, MulliganDecisionPhase, PayCostKind, PendingMulliganAction, WaitingFor,
+};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaCost;
 use crate::types::phase::Phase;
@@ -381,8 +383,24 @@ fn cheap_reject_candidate(state: &GameState, action: &GameAction) -> bool {
         // count doesn't match the pending entry's owed bottom count. Because
         // the actor identity is carried via authorization upstream, this filter
         // only validates the count against any pending entry whose hand fits.
-        (WaitingFor::MulliganBottomCards { pending }, GameAction::SelectCards { cards })
-        | (WaitingFor::OpeningHandBottomCards { pending, .. }, GameAction::SelectCards { cards }) => {
+        (WaitingFor::MulliganDecision { pending, .. }, GameAction::SelectCards { cards }) => {
+            pending.iter().all(|entry| match &entry.phase {
+                MulliganDecisionPhase::Declare => true,
+                MulliganDecisionPhase::BottomCards { count, then } => {
+                    let excluded_hit = matches!(
+                        then,
+                        PendingMulliganAction::UseSerumPowder { object_id } if cards.contains(object_id)
+                    );
+                    excluded_hit
+                        || selection_mismatch(
+                            cards,
+                            &state.players[entry.player.0 as usize].hand,
+                            Some((*count).into()),
+                        )
+                }
+            })
+        }
+        (WaitingFor::OpeningHandBottomCards { pending, .. }, GameAction::SelectCards { cards }) => {
             pending.iter().all(|entry| {
                 selection_mismatch(
                     cards,
@@ -1192,7 +1210,7 @@ pub fn legal_actions_full(state: &GameState) -> LegalActionsFull {
 /// per guest; only the acting guest needs a populated legal-actions map.
 pub fn legal_actions_for_viewer(state: &GameState, viewer: PlayerId) -> LegalActionsFull {
     // CR 103.5: For simultaneous-decision states (MulliganDecision,
-    // MulliganBottomCards, OpeningHandBottomCards), every pending player has a
+    // OpeningHandBottomCards), every pending player has a
     // legal action set, so guests in a multiplayer mulligan can see and submit
     // their own decisions concurrently.
     //
@@ -1407,7 +1425,8 @@ mod tests {
     use crate::types::card_type::CoreType;
     use crate::types::game_state::{
         CastingVariant, ConvokeMode, DistributionUnit, GameState, MulliganDecisionEntry,
-        PendingCast, StackEntry, StackEntryKind, WaitingFor,
+        MulliganDecisionPhase, PendingCast, PendingMulliganAction, StackEntry, StackEntryKind,
+        WaitingFor,
     };
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::keywords::{Keyword, KeywordKind};
@@ -3903,6 +3922,7 @@ mod tests {
             pending: vec![MulliganDecisionEntry {
                 player: PlayerId(0),
                 mulligan_count: 0,
+                phase: MulliganDecisionPhase::Declare,
             }],
             free_first_mulligan: false,
         };
@@ -4121,22 +4141,25 @@ mod tests {
     }
 
     /// False-positive sweep (CR 103.5 / TL:R 906.6a): the simultaneous
-    /// bottom-cards classes (`MulliganBottomCards`, `OpeningHandBottomCards`)
-    /// always offer each pending player a `SelectCards` action, so the detector
-    /// must not fire. Both share the `MulliganBottomEntry` shape and the
-    /// `bottom_card_actions` generator, so one representative of each is covered
-    /// here. The pending player is given enough hand cards to satisfy the owed
-    /// bottom `count`.
+    /// bottom-cards flows (a `MulliganDecision` entry mid-`BottomCards`, and
+    /// `OpeningHandBottomCards`) always offer each pending player a
+    /// `SelectCards` action, so the detector must not fire. The pending player
+    /// is given enough hand cards to satisfy the owed bottom `count`.
     #[test]
     fn stuck_diagnostic_none_on_normal_bottom_cards() {
         use crate::types::game_state::{MulliganBottomEntry, OpeningHandBottomReason};
 
         for waiting_for in [
-            WaitingFor::MulliganBottomCards {
-                pending: vec![MulliganBottomEntry {
+            WaitingFor::MulliganDecision {
+                pending: vec![MulliganDecisionEntry {
                     player: PlayerId(0),
-                    count: 1,
+                    mulligan_count: 1,
+                    phase: MulliganDecisionPhase::BottomCards {
+                        count: 1,
+                        then: PendingMulliganAction::Keep,
+                    },
                 }],
+                free_first_mulligan: false,
             },
             WaitingFor::OpeningHandBottomCards {
                 pending: vec![MulliganBottomEntry {

--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -128,24 +128,17 @@ pub fn eliminate_players_simultaneously(
     }
 }
 
-/// CR 103.5 + CR 800.4a: Prune eliminated players from in-flight mulligan
-/// pending lists. If pruning empties the decision phase, transition to the
-/// bottoms phase (or finish mulligans). If it empties the bottoms phase,
-/// finish mulligans directly.
+/// CR 103.5 + CR 800.4a: Prune eliminated players from the in-flight
+/// mulligan pending list. If pruning empties it, finish the mulligan flow
+/// directly — bottoming is now resolved per-entry at the declare point, so
+/// there is no separate batch bottoms phase left to advance to.
 fn prune_mulligan_pending(state: &mut GameState, events: &mut Vec<GameEvent>) {
-    // CR 800.4a: Drop any final-mulligan-count entries for players who have
-    // been eliminated. Symmetric with the pending-list pruning below so
-    // enter_bottom_phase never sees stale entries for dead players.
     let alive: HashSet<PlayerId> = state
-        .final_mulligan_counts
+        .prepaid_mulligan_bottoms
         .keys()
-        .chain(state.prepaid_mulligan_bottoms.keys())
         .copied()
         .filter(|pid| players::is_alive(state, *pid))
         .collect();
-    state
-        .final_mulligan_counts
-        .retain(|pid, _| alive.contains(pid));
     state
         .prepaid_mulligan_bottoms
         .retain(|pid, _| alive.contains(pid));
@@ -155,30 +148,26 @@ fn prune_mulligan_pending(state: &mut GameState, events: &mut Vec<GameEvent>) {
             pending,
             free_first_mulligan,
         } => {
+            // CR 800.4a: A pruned player whose entry was mid-`BottomCards
+            // { then: UseSerumPowder { object_id } }` needs no special
+            // cleanup of `object_id` — that reference lives only inside this
+            // `MulliganDecisionEntry`. By the time this function runs,
+            // `eliminate_players_simultaneously` has already exiled every
+            // object the leaving player owned, including the Serum Powder
+            // itself. A plain is_alive-filtered removal of the whole entry
+            // is sufficient.
             let alive: Vec<_> = pending
                 .into_iter()
                 .filter(|e| players::is_alive(state, e.player))
                 .collect();
             if alive.is_empty() {
-                state.waiting_for = super::mulligan::enter_bottom_phase_public(state, events);
+                state.prepaid_mulligan_bottoms.clear();
+                state.waiting_for = super::mulligan::finish_mulligans_public(state, events);
             } else {
                 state.waiting_for = WaitingFor::MulliganDecision {
                     pending: alive,
                     free_first_mulligan,
                 };
-            }
-        }
-        WaitingFor::MulliganBottomCards { pending } => {
-            let alive: Vec<_> = pending
-                .into_iter()
-                .filter(|e| players::is_alive(state, e.player))
-                .collect();
-            if alive.is_empty() {
-                state.final_mulligan_counts.clear();
-                state.prepaid_mulligan_bottoms.clear();
-                state.waiting_for = super::mulligan::finish_mulligans_public(state, events);
-            } else {
-                state.waiting_for = WaitingFor::MulliganBottomCards { pending: alive };
             }
         }
         WaitingFor::OpeningHandBottomCards { pending, reason } => {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -462,7 +462,7 @@ fn check_actor_authorization(
         return Ok(());
     }
     // CR 103.5: For simultaneous-decision states (MulliganDecision,
-    // MulliganBottomCards, OpeningHandBottomCards), authorize against the full pending set so any
+    // OpeningHandBottomCards), authorize against the full pending set so any
     // pending player may submit in any order. Falls back to single-player
     // semantics for every other variant.
     let authorized = turn_control::authorized_submitters(state);
@@ -3339,16 +3339,16 @@ fn apply_action(
         (WaitingFor::MulliganDecision { .. }, GameAction::MulliganDecision { choice }) => {
             // CR 103.5 + 103.5b: `actor` is already authorized as a member of
             // `pending` by `check_actor_authorization`. The mulligan module
-            // resolves the per-player state update and either re-emits
-            // MulliganDecision (with the actor removed if they kept, retained
-            // with bumped count if they mulliganed, or retained with the
-            // same count if they used Serum Powder) or advances to the next
-            // phase when the pending set is empty.
+            // resolves the per-player state update, transitioning the actor's
+            // entry into `BottomCards` when a declare-point action still owes
+            // bottoms, or advancing the flow when the pending set is empty.
             mulligan::handle_mulligan_decision(state, actor, choice, &mut events)
                 .map_err(EngineError::InvalidAction)?
         }
-        (WaitingFor::MulliganBottomCards { .. }, GameAction::SelectCards { cards }) => {
+        (WaitingFor::MulliganDecision { .. }, GameAction::SelectCards { cards }) => {
             // CR 103.5: `actor` is already authorized as a member of `pending`.
+            // A `SelectCards` submission resolves that player's owed
+            // `BottomCards` sub-phase (rejected if their entry is in `Declare`).
             mulligan::handle_mulligan_bottom(state, actor, cards, &mut events)
                 .map_err(EngineError::InvalidAction)?
         }

--- a/crates/engine/src/game/mulligan.rs
+++ b/crates/engine/src/game/mulligan.rs
@@ -5,8 +5,8 @@ use crate::types::actions::MulliganChoice;
 use crate::types::events::GameEvent;
 use crate::types::format::GameFormat;
 use crate::types::game_state::{
-    GameState, MulliganBottomEntry, MulliganDecisionEntry, OpeningHandBottomReason,
-    PendingBeginGameAbility, WaitingFor,
+    GameState, MulliganBottomEntry, MulliganDecisionEntry, MulliganDecisionPhase,
+    OpeningHandBottomReason, PendingBeginGameAbility, PendingMulliganAction, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
@@ -66,7 +66,7 @@ pub fn kept_hand_size_after(mulligan_count: u8, free_first: bool) -> usize {
     STARTING_HAND_SIZE.saturating_sub(bottom_count_for(mulligan_count, free_first) as usize)
 }
 
-/// CR 103.4: Start the mulligan process — shuffle libraries and draw 7 for each player.
+/// CR 103.3 + CR 103.5: Start the mulligan process — shuffle libraries and draw 7 for each player.
 ///
 /// CR 103.5 + 103.5b: All players decide simultaneously. The returned
 /// `WaitingFor::MulliganDecision` carries every living player in seat order;
@@ -117,6 +117,7 @@ fn normal_mulligan_decision(state: &GameState) -> WaitingFor {
                 .get(&player)
                 .copied()
                 .unwrap_or(0),
+            phase: MulliganDecisionPhase::Declare,
         })
         .collect();
 
@@ -154,28 +155,28 @@ fn tiny_leaders_forced_mulligan_pending(state: &GameState) -> Vec<MulliganBottom
 
 /// CR 103.5 + 103.5b: Resolve one player's `MulliganDecision { choice }` action.
 ///
-/// - `Keep` removes the player from `pending`. The player has locked in their
-///   hand for the game; their bottom-cards selection is deferred to the second
-///   phase (CR 103.5 second sentence: "all players who decided to take
-///   mulligans do so at the same time" — bottoms happen after every player has
-///   kept).
+/// - `Keep` locks in the hand (CR 103.5). If the player still owes bottoms
+///   against the `prepaid_mulligan_bottoms` ledger, their entry transitions to
+///   `BottomCards { then: Keep }`; otherwise they are removed from `pending`.
 /// - `Mulligan` increments that player's `mulligan_count`, shuffles their hand
-///   back into their library, and redraws the starting hand size. The player
-///   remains in `pending` to decide again.
-/// - `UseSerumPowder { object_id }` (CR 103.5b + Serum Powder Oracle text)
-///   exiles **every** card from the player's hand — including the named Serum
-///   Powder itself — and redraws the same number of cards. The player's
-///   `mulligan_count` is *not* incremented (this is not a mulligan). The
-///   player remains in `pending` and may then keep, mulligan, or use another
-///   Serum Powder if their new hand contains one.
+///   back into their library, redraws the starting hand size, and RESETS that
+///   player's bottoms ledger to 0 (CR 103.5 — a fresh redraw invalidates prior
+///   credit). The player remains in `pending` to decide again. At the mulligan
+///   cap (CR 103.5 final sentence) the mulligan is treated as an implicit Keep
+///   at the new count.
+/// - `UseSerumPowder { object_id }` (CR 103.5b + Serum Powder Oracle text) is a
+///   declare-point action. If bottoms are still owed, the entry transitions to
+///   `BottomCards { then: UseSerumPowder { object_id } }` and the exile+redraw
+///   is deferred until that obligation resolves; otherwise the Powder's effect
+///   runs immediately. The player's `mulligan_count` is *not* incremented (this
+///   is not a mulligan) and the entry returns to `Declare` afterward.
 ///
-/// If `Mulligan` brings the player to the maximum mulligan count (CR 103.5
-/// final sentence: a player may not take a mulligan that would result in a
-/// zero-card hand), the player is force-removed from `pending` and will
-/// bottom every card in their hand.
+/// A decision is rejected if the player's entry is not in the `Declare` phase
+/// (they owe bottoms first).
 ///
-/// When `pending` becomes empty, advance to `MulliganBottomCards` (or, if no
-/// one owes bottoms, directly to `finish_mulligans`).
+/// When `pending` becomes empty, advance directly to `finish_mulligans` — each
+/// player's bottoms are resolved at their own declare point, so there is no
+/// separate batch bottoms phase.
 pub fn handle_mulligan_decision(
     state: &mut GameState,
     player: PlayerId,
@@ -195,61 +196,117 @@ pub fn handle_mulligan_decision(
         .iter()
         .position(|e| e.player == player)
         .ok_or_else(|| format!("Player {:?} is not in the mulligan pending set", player))?;
+
+    if !matches!(pending[idx].phase, MulliganDecisionPhase::Declare) {
+        return Err(format!(
+            "Player {:?} owes bottom cards before making another mulligan decision",
+            player
+        ));
+    }
     let current_count = pending[idx].mulligan_count;
 
     match choice {
         MulliganChoice::Keep => {
-            // Record the final mulligan_count for the bottoms phase. Track in
-            // state.final_mulligan_counts indexed by PlayerId — populated as
-            // each player locks in their hand.
-            record_final_count(state, player, current_count);
-            pending.remove(idx);
+            resolve_declare_point(
+                state,
+                &mut pending,
+                idx,
+                free_first,
+                PendingMulliganAction::Keep,
+                events,
+            )?;
         }
         MulliganChoice::Mulligan => {
             let new_count = current_count + 1;
             shuffle_hand_into_library(state, player, events);
             draw_n(state, player, STARTING_HAND_SIZE, events);
+            // CR 103.5: a fresh redraw makes any prior "already bottomed"
+            // credit meaningless — the obligation for the new count starts
+            // from scratch.
+            state.prepaid_mulligan_bottoms.insert(player, 0);
+            pending[idx].mulligan_count = new_count;
 
             if new_count >= max_mulligans_for(free_first) {
-                // CR 103.5 + 103.5c: A player may take mulligans until their
-                // opening hand would be zero cards. In free-first formats the
-                // first mulligan is uncounted, so the cap is one higher.
-                // Force-remove from pending; the bottoms phase will bottom
-                // every card in their hand.
-                record_final_count(state, player, new_count);
-                pending.remove(idx);
-            } else {
-                pending[idx].mulligan_count = new_count;
+                // CR 103.5 final sentence: this is the last legal mulligan.
+                // Treat it as an implicit Keep at the new count.
+                resolve_declare_point(
+                    state,
+                    &mut pending,
+                    idx,
+                    free_first,
+                    PendingMulliganAction::Keep,
+                    events,
+                )?;
             }
         }
         MulliganChoice::UseSerumPowder { object_id } => {
-            // CR 103.5b + Serum Powder Oracle text: validate the referenced
-            // object is in the actor's hand and is named "Serum Powder"
-            // (CR 201.2 — name match is exact), then exile the entire hand
-            // and redraw the same number of cards. Mulligan count unchanged.
-            handle_serum_powder(state, player, object_id, events)?;
-            // Player remains in `pending` with the same mulligan_count.
+            // CR 103.5b + Serum Powder Oracle text + CR 201.2: reject an
+            // invalid reference at declare time, before any owed-bottom
+            // sub-phase is created.
+            validate_serum_powder_reference(state, player, object_id)?;
+            resolve_declare_point(
+                state,
+                &mut pending,
+                idx,
+                free_first,
+                PendingMulliganAction::UseSerumPowder { object_id },
+                events,
+            )?;
         }
     }
 
     Ok(advance_after_decision(state, pending, free_first, events))
 }
 
-/// CR 103.5b + Serum Powder Oracle text: "Any time you could mulligan and this
-/// card is in your hand, you may exile all the cards from your hand, then draw
-/// that many cards."
-///
-/// Validates `serum_powder_id` is in `player`'s hand and is named "Serum
-/// Powder" (case-insensitive — CR 201.2 names are case-canonical but card data
-/// casing should still tolerate variation). Then moves every card in the
-/// hand — including the Serum Powder itself — to exile, and draws that many
-/// cards. Does not shuffle, does not change the library, does not increment
-/// the mulligan counter.
-fn handle_serum_powder(
+/// CR 103.5 + 103.5b: Shared declare-point resolution for `Keep` and
+/// `UseSerumPowder` (and the implicit-Keep at the mulligan cap). Computes the
+/// still-owed bottom count against the ledger and either completes the action
+/// immediately (owed == 0, calling `handle_serum_powder` right away for the
+/// UseSerumPowder case) or parks the entry in `BottomCards`.
+fn resolve_declare_point(
     state: &mut GameState,
+    pending: &mut Vec<MulliganDecisionEntry>,
+    idx: usize,
+    free_first: bool,
+    then: PendingMulliganAction,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), String> {
+    let player = pending[idx].player;
+    let mulligan_count = pending[idx].mulligan_count;
+    let prepaid = state
+        .prepaid_mulligan_bottoms
+        .get(&player)
+        .copied()
+        .unwrap_or(0);
+    let owed = bottom_count_for(mulligan_count, free_first).saturating_sub(prepaid);
+
+    if owed == 0 {
+        match then {
+            PendingMulliganAction::Keep => {
+                pending.remove(idx);
+            }
+            PendingMulliganAction::UseSerumPowder { object_id } => {
+                handle_serum_powder(state, player, object_id, events)?;
+                // Stays in `Declare`, same mulligan_count — Serum Powder is
+                // not a mulligan.
+            }
+        }
+    } else {
+        pending[idx].phase = MulliganDecisionPhase::BottomCards { count: owed, then };
+    }
+    Ok(())
+}
+
+/// CR 103.5b + Serum Powder Oracle text + CR 201.2: Validate that
+/// `serum_powder_id` is a legal Serum Powder activation for `player` — in
+/// their hand, and named "Serum Powder" (case-insensitive). Called at
+/// declare-time, before any owed-bottom `BottomCards` sub-phase is created, so
+/// an invalid reference is rejected immediately rather than after prompting
+/// for an unrelated bottom-cards selection.
+fn validate_serum_powder_reference(
+    state: &GameState,
     player: PlayerId,
     serum_powder_id: ObjectId,
-    events: &mut Vec<GameEvent>,
 ) -> Result<(), String> {
     let player_data = state
         .players
@@ -274,6 +331,30 @@ fn handle_serum_powder(
             serum_powder_id, referenced.name
         ));
     }
+    Ok(())
+}
+
+/// CR 103.5b + Serum Powder Oracle text: "Any time you could mulligan and this
+/// card is in your hand, you may exile all the cards from your hand, then draw
+/// that many cards."
+///
+/// Validates `serum_powder_id` is in `player`'s hand and is named "Serum
+/// Powder" (case-insensitive — CR 201.2 names are case-canonical but card data
+/// casing should still tolerate variation). Then moves every card in the
+/// hand — including the Serum Powder itself — to exile, and draws that many
+/// cards. Does not shuffle, does not change the library, does not increment
+/// the mulligan counter.
+fn handle_serum_powder(
+    state: &mut GameState,
+    player: PlayerId,
+    serum_powder_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), String> {
+    // Primary validation is delegated to `validate_serum_powder_reference`.
+    // This is called from a second call site (`handle_mulligan_bottom`'s `then`
+    // dispatch) as well as the declare-point fast path, so re-validating here
+    // is defense-in-depth against a caller that skips the declare-time check.
+    validate_serum_powder_reference(state, player, serum_powder_id)?;
 
     // CR 103.5b: Exile every card from the hand (including the Powder). The
     // exiled cards are gone for the rest of the game (per the official ruling
@@ -307,14 +388,10 @@ fn handle_serum_powder(
     Ok(())
 }
 
-/// CR 103.5: Stash the locked-in mulligan count for `player` so the bottoms
-/// phase knows how many cards they owe.
-fn record_final_count(state: &mut GameState, player: PlayerId, count: u8) {
-    state.final_mulligan_counts.insert(player, count);
-}
-
-/// CR 103.5: After updating `pending`, either re-emit `MulliganDecision` or
-/// transition to the bottom-cards phase (or finish entirely).
+/// CR 103.5: After updating `pending`, either re-emit `MulliganDecision` or,
+/// once every player is out of `pending`, finish the mulligan flow directly.
+/// Bottoming is resolved per-entry at each declare point, so there is no
+/// separate batch bottoms phase.
 fn advance_after_decision(
     state: &mut GameState,
     pending: Vec<MulliganDecisionEntry>,
@@ -327,53 +404,8 @@ fn advance_after_decision(
             free_first_mulligan: free_first,
         };
     }
-
-    // All players have locked in their hands. Build the bottoms-phase pending
-    // list from each player's final mulligan count.
-    enter_bottom_phase(state, events)
-}
-
-/// CR 103.5: Enter the bottoms phase. Each player who took at least one
-/// counted mulligan (after free-first discount) must put N cards on the
-/// bottom of their library. Players choose simultaneously.
-fn enter_bottom_phase(state: &mut GameState, events: &mut Vec<GameEvent>) -> WaitingFor {
-    let free_first = free_first_mulligan(state);
-    let pending: Vec<MulliganBottomEntry> = state
-        .seat_order
-        .iter()
-        .filter(|&&player_id| super::players::is_alive(state, player_id))
-        .filter_map(|&player_id| {
-            // CR 800.4a: A player who conceded during the decision phase is
-            // skipped — they cannot submit bottoms and would deadlock the game.
-            let count = state
-                .final_mulligan_counts
-                .get(&player_id)
-                .copied()
-                .unwrap_or(0);
-            let prepaid = state
-                .prepaid_mulligan_bottoms
-                .get(&player_id)
-                .copied()
-                .unwrap_or(0);
-            let bottom = bottom_count_for(count, free_first).saturating_sub(prepaid);
-            if bottom > 0 {
-                Some(MulliganBottomEntry {
-                    player: player_id,
-                    count: bottom,
-                })
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    if pending.is_empty() {
-        state.final_mulligan_counts.clear();
-        state.prepaid_mulligan_bottoms.clear();
-        finish_mulligans(state, events)
-    } else {
-        WaitingFor::MulliganBottomCards { pending }
-    }
+    state.prepaid_mulligan_bottoms.clear();
+    finish_mulligans(state, events)
 }
 
 /// TL:R 906.6a/e: Resolve a forced opening-hand bottom before any normal
@@ -423,26 +455,56 @@ pub fn handle_opening_hand_bottom(
     }
 }
 
-/// CR 103.5: Resolve one player's `SelectCards { cards }` during the bottoms
-/// phase. Validates the count and contents, moves cards to the bottom of the
-/// library, removes the player from `pending`. When `pending` is empty,
-/// advance to `finish_mulligans`.
+/// CR 103.5: Resolve one player's `SelectCards { cards }` while their entry is
+/// in the `BottomCards` sub-phase of `MulliganDecision`. Validates the count
+/// and hand-membership, rejects the earmarked Serum Powder object (if `then`
+/// is `UseSerumPowder`) from being selected as one of the bottomed cards —
+/// that object is committed to its own activation. Moves the selected cards to
+/// the bottom of the library, credits the ledger, then dispatches `then`.
 pub fn handle_mulligan_bottom(
     state: &mut GameState,
     player: PlayerId,
     cards: Vec<ObjectId>,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, String> {
-    let WaitingFor::MulliganBottomCards { pending } = &state.waiting_for else {
-        return Err("handle_mulligan_bottom called outside MulliganBottomCards".to_string());
+    let WaitingFor::MulliganDecision {
+        pending,
+        free_first_mulligan,
+    } = &state.waiting_for
+    else {
+        return Err("handle_mulligan_bottom called outside MulliganDecision".to_string());
     };
+    let free_first = *free_first_mulligan;
     let mut pending = pending.clone();
 
     let idx = pending
         .iter()
         .position(|e| e.player == player)
-        .ok_or_else(|| format!("Player {:?} is not in the bottoms pending set", player))?;
-    let expected_count = pending[idx].count;
+        .ok_or_else(|| format!("Player {:?} is not in the mulligan pending set", player))?;
+
+    let MulliganDecisionPhase::BottomCards {
+        count: expected_count,
+        then,
+    } = pending[idx].phase
+    else {
+        return Err(format!(
+            "Player {:?} has no owed bottom-cards obligation",
+            player
+        ));
+    };
+
+    // Engine invariant (no CR citation — not an explicit CR clause): the Serum
+    // Powder object earmarked by a pending `UseSerumPowder { object_id }`
+    // continuation cannot itself be selected as one of the bottomed cards; it
+    // is committed to its own activation.
+    if let PendingMulliganAction::UseSerumPowder { object_id } = then {
+        if cards.contains(&object_id) {
+            return Err(format!(
+                "Cannot bottom Serum Powder object {:?} — it is committed to its own activation",
+                object_id
+            ));
+        }
+    }
 
     validate_bottom_selection(state, player, &cards, expected_count)?;
 
@@ -455,15 +517,19 @@ pub fn handle_mulligan_bottom(
         crate::game::zone_pipeline::move_object(state, req, events);
     }
 
-    pending.remove(idx);
+    *state.prepaid_mulligan_bottoms.entry(player).or_insert(0) += expected_count;
 
-    if pending.is_empty() {
-        state.final_mulligan_counts.clear();
-        state.prepaid_mulligan_bottoms.clear();
-        Ok(finish_mulligans(state, events))
-    } else {
-        Ok(WaitingFor::MulliganBottomCards { pending })
+    match then {
+        PendingMulliganAction::Keep => {
+            pending.remove(idx);
+        }
+        PendingMulliganAction::UseSerumPowder { object_id } => {
+            handle_serum_powder(state, player, object_id, events)?;
+            pending[idx].phase = MulliganDecisionPhase::Declare;
+        }
     }
+
+    Ok(advance_after_decision(state, pending, free_first, events))
 }
 
 fn validate_bottom_selection(
@@ -549,15 +615,6 @@ pub fn resume_begin_game_abilities(
     state.resolving_begin_game_abilities = false;
     crate::game::planechase::reveal_starting_plane(state);
     turns::auto_advance(state, events)
-}
-
-/// CR 103.5 + CR 800.4a: Re-entry point for elimination cleanup — drives the
-/// flow to the bottoms phase as if the decision phase had ended naturally.
-pub(crate) fn enter_bottom_phase_public(
-    state: &mut GameState,
-    events: &mut Vec<GameEvent>,
-) -> WaitingFor {
-    enter_bottom_phase(state, events)
 }
 
 /// TL:R 906.6a: Re-entry point after pruning an opening-hand bottom prompt.
@@ -776,11 +833,17 @@ mod tests {
         }
     }
 
-    fn pending_bottom_for(wf: &WaitingFor, player: PlayerId) -> Option<u8> {
+    /// Test helper: read the `(count, then)` of a pending player's `BottomCards`
+    /// phase, if any.
+    fn bottom_phase_for(wf: &WaitingFor, player: PlayerId) -> Option<(u8, PendingMulliganAction)> {
         match wf {
-            WaitingFor::MulliganBottomCards { pending } => {
-                pending.iter().find(|e| e.player == player).map(|e| e.count)
-            }
+            WaitingFor::MulliganDecision { pending, .. } => pending
+                .iter()
+                .find(|e| e.player == player)
+                .and_then(|e| match e.phase {
+                    MulliganDecisionPhase::BottomCards { count, then } => Some((count, then)),
+                    MulliganDecisionPhase::Declare => None,
+                }),
             _ => None,
         }
     }
@@ -979,33 +1042,43 @@ mod tests {
         );
     }
 
+    /// CR 103.5 + 103.5b: `Keep` with an owed bottom enters `BottomCards`
+    /// immediately at declare time — independent of whether other players are
+    /// still deciding. This replaces the old batch model where bottoms were
+    /// deferred until every player had kept.
     #[test]
-    fn keep_after_mulligan_defers_bottoms_until_all_keep() {
+    fn keep_after_mulligan_enters_bottom_cards_immediately_independent_of_other_pending() {
         let mut state = setup_with_libraries(20);
         let mut events = Vec::new();
         state.waiting_for = start_mulligan(&mut state, &mut events);
 
-        // P0 mulligans once then keeps; P1 still pending → still decision phase.
         decide(&mut state, PlayerId(0), false, &mut events);
         let waiting = decide(&mut state, PlayerId(0), true, &mut events);
+
         assert!(
             matches!(waiting, WaitingFor::MulliganDecision { .. }),
-            "should still be decision phase while P1 is pending, got {:?}",
+            "still MulliganDecision (P1 hasn't acted), got {:?}",
             waiting
         );
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((1, PendingMulliganAction::Keep)),
+            "P0 should be in BottomCards immediately, before P1 has acted at all"
+        );
+        assert!(
+            pending_decision_players(&waiting).contains(&PlayerId(1)),
+            "P1 is still in Declare phase, untouched by P0's bottoming"
+        );
 
-        // P1 keeps → enters bottoms phase for P0 only.
+        let card_to_bottom = state.players[0].hand[0];
+        let waiting = bottom(&mut state, PlayerId(0), vec![card_to_bottom], &mut events).unwrap();
+        assert!(
+            !pending_decision_players(&waiting).contains(&PlayerId(0)),
+            "P0 is fully locked in and removed from pending"
+        );
+
         let waiting = decide(&mut state, PlayerId(1), true, &mut events);
-        assert_eq!(
-            pending_bottom_for(&waiting, PlayerId(0)),
-            Some(1),
-            "P0 owes 1 bottom card after 1 mulligan in 2-player Standard"
-        );
-        assert_eq!(
-            pending_bottom_for(&waiting, PlayerId(1)),
-            None,
-            "P1 owes nothing"
-        );
+        assert!(matches!(waiting, WaitingFor::Priority { .. }));
     }
 
     #[test]
@@ -1111,19 +1184,14 @@ mod tests {
         assert_eq!(decision_count_for(&waiting, PlayerId(3)), Some(1));
     }
 
-    /// CR 103.5: 4-player pod bottoms phase — three players owe bottoms,
-    /// they submit in non-seat order, all resolve concurrently.
+    /// Four players can independently reach and resolve BottomCards in any
+    /// order, none blocking another.
     #[test]
     fn four_player_concurrent_bottom_in_any_order() {
-        // Need a 4-player game without free-first-mulligan so all three mulligans
-        // produce bottoms. Multiplayer (≥3 seats) always grants free first per
-        // CR 103.5c, so a single mulligan is free. Take TWO mulligans per player
-        // to ensure each owes one bottom card.
         let mut state = setup_n_player_with_libraries(4, 30);
         let mut events = Vec::new();
         state.waiting_for = start_mulligan(&mut state, &mut events);
 
-        // P0, P2, P3 each mulligan twice then keep; P1 keeps immediately.
         for &pid in &[PlayerId(0), PlayerId(2), PlayerId(3)] {
             decide(&mut state, pid, false, &mut events);
             decide(&mut state, pid, false, &mut events);
@@ -1131,13 +1199,20 @@ mod tests {
         }
         let waiting = decide(&mut state, PlayerId(1), true, &mut events);
 
-        // Bottoms phase: P0/P2/P3 each owe 1 (2 mulligans - 1 free).
-        assert_eq!(pending_bottom_for(&waiting, PlayerId(0)), Some(1));
-        assert_eq!(pending_bottom_for(&waiting, PlayerId(2)), Some(1));
-        assert_eq!(pending_bottom_for(&waiting, PlayerId(3)), Some(1));
-        assert_eq!(pending_bottom_for(&waiting, PlayerId(1)), None);
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((1, PendingMulliganAction::Keep))
+        );
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(2)),
+            Some((1, PendingMulliganAction::Keep))
+        );
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(3)),
+            Some((1, PendingMulliganAction::Keep))
+        );
+        assert_eq!(bottom_phase_for(&waiting, PlayerId(1)), None);
 
-        // Submit bottom cards in non-seat order.
         let card3 = state.players[3].hand[0];
         let card0 = state.players[0].hand[0];
         let card2 = state.players[2].hand[0];
@@ -1145,11 +1220,7 @@ mod tests {
         bottom(&mut state, PlayerId(0), vec![card0], &mut events).unwrap();
         let waiting = bottom(&mut state, PlayerId(2), vec![card2], &mut events).unwrap();
 
-        assert!(
-            matches!(waiting, WaitingFor::Priority { .. }),
-            "all bottoms submitted → game should start, got {:?}",
-            waiting
-        );
+        assert!(matches!(waiting, WaitingFor::Priority { .. }));
     }
 
     #[test]
@@ -1210,36 +1281,27 @@ mod tests {
         assert!(!state.resolving_begin_game_abilities);
     }
 
+    /// CR 103.5c: In multiplayer, the first mulligan is free (doesn't count
+    /// toward bottoms). After a single mulligan + Keep, nothing is owed.
     #[test]
     fn multiplayer_first_mulligan_is_free() {
         let mut state = setup_n_player_with_libraries(3, 30);
         let mut events = Vec::new();
         state.waiting_for = start_mulligan(&mut state, &mut events);
 
-        // CR 103.5c: First mulligan in multiplayer doesn't count.
         let waiting = decide(&mut state, PlayerId(0), false, &mut events);
-        assert_eq!(
-            decision_count_for(&waiting, PlayerId(0)),
-            Some(1),
-            "Mulligan count should increment to 1"
-        );
+        assert_eq!(decision_count_for(&waiting, PlayerId(0)), Some(1));
 
-        // Keep after first mulligan — drive into bottoms phase by keeping others too.
         decide(&mut state, PlayerId(0), true, &mut events);
         decide(&mut state, PlayerId(1), true, &mut events);
         let waiting = decide(&mut state, PlayerId(2), true, &mut events);
 
-        assert_eq!(
-            pending_bottom_for(&waiting, PlayerId(0)),
-            None,
-            "P0 had 1 free mulligan → owes 0 bottom cards"
-        );
-        assert!(
-            matches!(waiting, WaitingFor::Priority { .. }),
-            "with no bottoms owed, game should start immediately"
-        );
+        assert_eq!(bottom_phase_for(&waiting, PlayerId(0)), None);
+        assert!(matches!(waiting, WaitingFor::Priority { .. }));
     }
 
+    /// CR 103.5c: In multiplayer, the second mulligan is the first COUNTED one
+    /// — after 2 mulligans total (1 free), 1 card is owed at Keep.
     #[test]
     fn multiplayer_two_mulligans_bottoms_one() {
         let mut state = setup_n_player_with_libraries(3, 30);
@@ -1252,9 +1314,8 @@ mod tests {
         decide(&mut state, PlayerId(1), true, &mut events);
         let waiting = decide(&mut state, PlayerId(2), true, &mut events);
         assert_eq!(
-            pending_bottom_for(&waiting, PlayerId(0)),
-            Some(1),
-            "After 2 mulligans in multiplayer, P0 should bottom 1 card"
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((1, PendingMulliganAction::Keep))
         );
     }
 
@@ -1356,11 +1417,7 @@ mod tests {
         decide(&mut state, PlayerId(0), false, &mut events);
         decide(&mut state, PlayerId(0), true, &mut events);
         let waiting = decide(&mut state, PlayerId(1), true, &mut events);
-        assert_eq!(
-            pending_bottom_for(&waiting, PlayerId(0)),
-            None,
-            "Commander duel: first mulligan should be free — no MulliganBottomCards"
-        );
+        assert_eq!(bottom_phase_for(&waiting, PlayerId(0)), None);
     }
 
     /// CR 103.5c: A Brawl duel grants a free first mulligan.
@@ -1389,7 +1446,7 @@ mod tests {
         decide(&mut state, PlayerId(0), false, &mut events);
         decide(&mut state, PlayerId(0), true, &mut events);
         let waiting = decide(&mut state, PlayerId(1), true, &mut events);
-        assert_eq!(pending_bottom_for(&waiting, PlayerId(0)), None);
+        assert_eq!(bottom_phase_for(&waiting, PlayerId(0)), None);
     }
 
     /// CR 103.5c only applies to multiplayer (3+ players) and Brawl. A
@@ -1420,9 +1477,8 @@ mod tests {
         decide(&mut state, PlayerId(0), true, &mut events);
         let waiting = decide(&mut state, PlayerId(1), true, &mut events);
         assert_eq!(
-            pending_bottom_for(&waiting, PlayerId(0)),
-            Some(1),
-            "Standard duel: after 1 mulligan, should bottom 1 card"
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((1, PendingMulliganAction::Keep))
         );
     }
 
@@ -1622,31 +1678,35 @@ mod tests {
         assert_eq!(state.objects[&top_of_library].zone, Zone::Exile);
     }
 
-    /// CR 103.5 + 103.5c: In a non-free-first format (Standard duel), the 7th
-    /// `Mulligan` brings the player to a 0-card opening hand and must
-    /// force-remove them from `pending`. The 8th is never accepted because
-    /// they were already force-removed.
+    /// CR 103.5 + 103.5c: In a non-free-first format, the 7th `Mulligan` brings
+    /// the player to a 0-card opening hand and is treated as an implicit Keep at
+    /// that count — the entry transitions to `BottomCards` (still pending). A
+    /// further `MulliganDecision` submission is rejected.
     #[test]
     fn max_mulligans_standard_duel_caps_at_seven() {
         let mut state = setup_with_libraries(60);
         let mut events = Vec::new();
         state.waiting_for = start_mulligan(&mut state, &mut events);
 
-        // Seven mulligans in a row. The 7th hits the cap and force-removes P0.
         for _ in 0..7 {
             decide(&mut state, PlayerId(0), false, &mut events);
         }
+
         assert!(
-            !pending_decision_players(&state.waiting_for).contains(&PlayerId(0)),
-            "P0 should be force-removed after 7 mulligans in a non-free-first format"
+            pending_decision_players(&state.waiting_for).contains(&PlayerId(0)),
+            "P0 stays pending, now mid-BottomCards from the implicit Keep at the cap"
         );
         assert_eq!(
-            state.final_mulligan_counts.get(&PlayerId(0)).copied(),
+            decision_count_for(&state.waiting_for, PlayerId(0)),
             Some(7),
-            "P0's locked-in mulligan count should be 7"
+            "P0's mulligan_count should be 7"
+        );
+        assert_eq!(
+            bottom_phase_for(&state.waiting_for, PlayerId(0)),
+            Some((7, PendingMulliganAction::Keep)),
+            "P0 owes the full bottom_count_for(7, false) = 7, matching kept_hand_size_after(7,false) = 0"
         );
 
-        // 8th submission must be rejected — P0 is no longer in pending.
         let result = handle_mulligan_decision(
             &mut state,
             PlayerId(0),
@@ -1655,14 +1715,13 @@ mod tests {
         );
         assert!(
             result.is_err(),
-            "8th Mulligan must be rejected in non-free-first format"
+            "no MulliganDecision is legal while mid-BottomCards"
         );
     }
 
-    /// CR 103.5 + 103.5c: In a free-first format (Commander duel, Brawl, or
-    /// any multiplayer game), the player gets one uncounted mulligan, so the
-    /// 8th `Mulligan` submission is still permitted (bringing them to a
-    /// 1-card opening hand: 7→6→5→4→3→2→1). Only the 9th would hit the cap.
+    /// CR 103.5 + 103.5c: In a free-first format, the mulligan cap is 8
+    /// (`max_mulligans_for(true) = MAX_MULLIGANS + 1`). The 8th `Mulligan`
+    /// force-routes to an implicit Keep, owing `bottom_count_for(8, true) = 7`.
     #[test]
     fn max_mulligans_free_first_format_permits_eighth() {
         use crate::types::format::FormatConfig;
@@ -1684,7 +1743,6 @@ mod tests {
         let mut events = Vec::new();
         state.waiting_for = start_mulligan(&mut state, &mut events);
 
-        // 7 mulligans must keep P0 still in pending (free-first → cap is 8).
         for _ in 0..7 {
             decide(&mut state, PlayerId(0), false, &mut events);
         }
@@ -1692,22 +1750,20 @@ mod tests {
             pending_decision_players(&state.waiting_for).contains(&PlayerId(0)),
             "free-first format: P0 should still be pending after 7 mulligans"
         );
+        assert_eq!(decision_count_for(&state.waiting_for, PlayerId(0)), Some(7));
         assert_eq!(
-            decision_count_for(&state.waiting_for, PlayerId(0)),
-            Some(7),
-            "P0 mulligan_count should be 7"
+            bottom_phase_for(&state.waiting_for, PlayerId(0)),
+            None,
+            "still in Declare — the 7th mulligan does not hit the free-first cap of 8"
         );
 
-        // 8th mulligan is the cap-triggering submission in a free-first format.
-        decide(&mut state, PlayerId(0), false, &mut events);
-        assert!(
-            !pending_decision_players(&state.waiting_for).contains(&PlayerId(0)),
-            "8th mulligan force-removes in free-first format"
-        );
+        let waiting = decide(&mut state, PlayerId(0), false, &mut events);
+        assert_eq!(decision_count_for(&waiting, PlayerId(0)), Some(8));
         assert_eq!(
-            state.final_mulligan_counts.get(&PlayerId(0)).copied(),
-            Some(8),
-            "P0's locked-in mulligan count should be 8"
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((7, PendingMulliganAction::Keep)),
+            "8th mulligan force-routes to Keep, owing bottom_count_for(8, true) = 7 (kept_hand_size_after(8, true) = 0), got {:?}",
+            waiting
         );
     }
 
@@ -1755,33 +1811,27 @@ mod tests {
         assert_eq!(kept_hand_size_after(8, true), 0);
     }
 
-    /// CR 103.5 + CR 800.4a: A player who concedes during the mulligan
-    /// decision phase must not appear in the bottoms phase entry list, even
-    /// if they kept with a non-zero mulligan count beforehand. Tested in a
-    /// 3-player pod so the game does not end on concede.
+    /// CR 800.4a: A player who concedes while mid-`BottomCards { then: Keep }`
+    /// is pruned from `pending` and from `prepaid_mulligan_bottoms`. Remaining
+    /// players complete the flow normally.
     #[test]
     fn concede_during_mulligan_excludes_from_bottoms() {
         use crate::game::engine::apply;
         use crate::types::actions::GameAction;
 
-        // Multiplayer (3 seats) grants free-first per CR 103.5c — take TWO
-        // mulligans so P0's locked-in bottoms count is non-zero (2 - 1 = 1).
         let mut state = setup_n_player_with_libraries(3, 30);
         let mut events = Vec::new();
         state.waiting_for = start_mulligan(&mut state, &mut events);
 
-        // P0 mulligans twice then keeps (locks in mulligan_count = 2 → owes 1 bottom).
         decide(&mut state, PlayerId(0), false, &mut events);
         decide(&mut state, PlayerId(0), false, &mut events);
-        decide(&mut state, PlayerId(0), true, &mut events);
+        let waiting = decide(&mut state, PlayerId(0), true, &mut events);
         assert_eq!(
-            state.final_mulligan_counts.get(&PlayerId(0)).copied(),
-            Some(2),
-            "P0 should have a final mulligan count of 2 after keeping"
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((1, PendingMulliganAction::Keep)),
+            "P0 should owe 1 bottom card (2 mulligans, 1 free) before conceding"
         );
 
-        // P0 concedes before P1/P2 keep. Game does not end (2 living players
-        // remain). Elimination prunes pending and final_mulligan_counts.
         let _ = apply(
             &mut state,
             PlayerId(0),
@@ -1790,18 +1840,364 @@ mod tests {
             },
         )
         .expect("concede");
+
         assert!(
-            !state.final_mulligan_counts.contains_key(&PlayerId(0)),
-            "eliminated player should be pruned from final_mulligan_counts"
+            !pending_decision_players(&state.waiting_for).contains(&PlayerId(0)),
+            "conceded P0 must be pruned from pending, got {:?}",
+            state.waiting_for
+        );
+        assert!(
+            !state.prepaid_mulligan_bottoms.contains_key(&PlayerId(0)),
+            "conceded P0's prepaid ledger entry must be pruned"
         );
 
-        // P1 and P2 keep → bottoms phase should not include P0.
         decide(&mut state, PlayerId(1), true, &mut events);
         let waiting = decide(&mut state, PlayerId(2), true, &mut events);
+        assert!(
+            matches!(waiting, WaitingFor::Priority { .. }),
+            "remaining players should be able to complete the mulligan flow after P0's concession, got {:?}",
+            waiting
+        );
+    }
+
+    /// CR 103.5: Two mulligans then `Keep` bottoms the FULL cumulative count
+    /// (2), in a single resolution.
+    #[test]
+    fn mull_to_five_bottoms_full_cumulative_count_not_incremental_delta() {
+        let mut state = setup_with_libraries(20);
+        let mut events = Vec::new();
+        state.waiting_for = start_mulligan(&mut state, &mut events);
+
+        decide(&mut state, PlayerId(0), false, &mut events);
+        decide(&mut state, PlayerId(0), false, &mut events);
+        let waiting = decide(&mut state, PlayerId(0), true, &mut events);
+
         assert_eq!(
-            pending_bottom_for(&waiting, PlayerId(0)),
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((2, PendingMulliganAction::Keep)),
+            "P0 should owe the full cumulative count of 2, not an incremental delta, got {:?}",
+            waiting
+        );
+
+        let cards_to_bottom: Vec<ObjectId> =
+            state.players[0].hand.iter().take(2).copied().collect();
+        let waiting =
+            bottom(&mut state, PlayerId(0), cards_to_bottom, &mut events).expect("bottom");
+
+        assert_eq!(
+            state.players[0].hand.len(),
+            5,
+            "hand should land at kept_hand_size_after(2, false) = 5 in one resolution"
+        );
+        assert!(!pending_decision_players(&waiting).contains(&PlayerId(0)));
+    }
+
+    /// CR 103.5: HEADLINE TEST for the reset/accumulate discipline. Reaches a
+    /// 2-mulligan "mull to 5" checkpoint via `UseSerumPowder` (not `Keep`, since
+    /// `Keep` would lock the player out of further mulligans), takes a genuine
+    /// third `Mulligan`, then `Keep`s — asserts the owed amount is the FULL
+    /// cumulative count for mulligan_count=3 (3), not an incremental delta off
+    /// the count-2 payment already made (which would incorrectly yield 1).
+    #[test]
+    fn mull_to_five_then_third_mulligan_owes_full_amount_not_incremental_delta() {
+        let mut state = setup_with_libraries(40);
+        let mut events = Vec::new();
+        state.waiting_for = start_mulligan(&mut state, &mut events);
+
+        decide(&mut state, PlayerId(0), false, &mut events);
+        decide(&mut state, PlayerId(0), false, &mut events);
+
+        let powder_id = inject_serum_powder(&mut state, PlayerId(0), 0);
+
+        let waiting = use_serum_powder(&mut state, PlayerId(0), powder_id, &mut events)
+            .expect("use_serum_powder declare point");
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((2, PendingMulliganAction::UseSerumPowder { object_id: powder_id })),
+            "UseSerumPowder at count=2 should owe the full cumulative count of 2 before the Powder's own effect applies, got {:?}",
+            waiting
+        );
+
+        let hand_before_bottom: Vec<ObjectId> = state.players[0].hand.iter().copied().collect();
+        let cards_to_bottom: Vec<ObjectId> = hand_before_bottom
+            .iter()
+            .copied()
+            .filter(|&id| id != powder_id)
+            .take(2)
+            .collect();
+        let waiting = bottom(&mut state, PlayerId(0), cards_to_bottom, &mut events)
+            .expect("bottom resolves the owed BottomCards obligation");
+
+        assert_eq!(state.players[0].hand.len(), 5);
+        assert_eq!(state.objects[&powder_id].zone, Zone::Exile);
+        assert_eq!(
+            decision_count_for(&waiting, PlayerId(0)),
+            Some(2),
+            "Serum Powder use does not change mulligan_count"
+        );
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(0)),
             None,
-            "conceded P0 must not be in bottoms phase, got {:?}",
+            "back in Declare after the Powder's effect resolves"
+        );
+
+        let waiting = decide(&mut state, PlayerId(0), false, &mut events);
+        assert_eq!(decision_count_for(&waiting, PlayerId(0)), Some(3));
+        assert_eq!(state.players[0].hand.len(), STARTING_HAND_SIZE);
+
+        let waiting = decide(&mut state, PlayerId(0), true, &mut events);
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((3, PendingMulliganAction::Keep)),
+            "owed must be the full cumulative count for mulligan_count=3 (3), not an incremental delta off the count-2 payment already made — got {:?}",
+            waiting
+        );
+    }
+
+    /// CR 103.5 + 103.5b: `UseSerumPowder` with an owed bottom must NOT run its
+    /// exile+redraw effect until the `BottomCards` obligation is resolved.
+    #[test]
+    fn use_serum_powder_resolves_owed_bottom_before_exiling_hand() {
+        let mut state = setup_with_libraries(20);
+        let mut events = Vec::new();
+        state.waiting_for = start_mulligan(&mut state, &mut events);
+
+        decide(&mut state, PlayerId(0), false, &mut events);
+        let powder_id = inject_serum_powder(&mut state, PlayerId(0), 0);
+        let hand_before: Vec<ObjectId> = state.players[0].hand.iter().copied().collect();
+
+        let waiting = use_serum_powder(&mut state, PlayerId(0), powder_id, &mut events)
+            .expect("use_serum_powder declare point");
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((
+                1,
+                PendingMulliganAction::UseSerumPowder {
+                    object_id: powder_id
+                }
+            ))
+        );
+
+        assert_eq!(state.players[0].hand.len(), 7, "hand must still be 7 cards");
+        assert!(state.players[0].hand.contains(&powder_id));
+        for card_id in &hand_before {
+            assert_eq!(
+                state.objects[card_id].zone,
+                Zone::Hand,
+                "card {:?} must remain in hand until the bottom obligation resolves",
+                card_id
+            );
+        }
+
+        let card_to_bottom = *hand_before.iter().find(|&&id| id != powder_id).unwrap();
+        bottom(&mut state, PlayerId(0), vec![card_to_bottom], &mut events).expect("bottom");
+
+        assert_eq!(state.objects[&card_to_bottom].zone, Zone::Library);
+        assert_eq!(*state.players[0].library.back().unwrap(), card_to_bottom);
+        assert_eq!(state.objects[&powder_id].zone, Zone::Exile);
+        assert_eq!(state.players[0].hand.len(), 6);
+    }
+
+    /// Engine invariant (no CR citation — not an explicit CR clause): the
+    /// Serum Powder object earmarked by a pending `UseSerumPowder { object_id }`
+    /// continuation cannot be selected as one of the bottomed cards.
+    #[test]
+    fn use_serum_powder_cannot_bottom_the_earmarked_powder_itself() {
+        let mut state = setup_with_libraries(20);
+        let mut events = Vec::new();
+        state.waiting_for = start_mulligan(&mut state, &mut events);
+
+        decide(&mut state, PlayerId(0), false, &mut events);
+        let powder_id = inject_serum_powder(&mut state, PlayerId(0), 0);
+        let waiting = use_serum_powder(&mut state, PlayerId(0), powder_id, &mut events)
+            .expect("use_serum_powder declare point");
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((
+                1,
+                PendingMulliganAction::UseSerumPowder {
+                    object_id: powder_id
+                }
+            ))
+        );
+
+        let result = bottom(&mut state, PlayerId(0), vec![powder_id], &mut events);
+        assert!(
+            result.is_err(),
+            "bottoming the earmarked Powder itself must be rejected, got {:?}",
+            result
+        );
+        assert_eq!(
+            bottom_phase_for(&state.waiting_for, PlayerId(0)),
+            Some((
+                1,
+                PendingMulliganAction::UseSerumPowder {
+                    object_id: powder_id
+                }
+            ))
+        );
+        assert_eq!(state.players[0].hand.len(), 7);
+    }
+
+    /// CR 103.5 + 103.5b: HEADLINE TEST, the direct fix for the round-3
+    /// "double-charge" regression. First `UseSerumPowder` resolves an owed-1
+    /// bottom (`prepaid` becomes 1); a second, distinct Serum Powder found in
+    /// the redrawn hand is used at the SAME `mulligan_count` — asserts no
+    /// recharge occurs.
+    #[test]
+    fn use_serum_powder_twice_in_a_row_at_same_count_does_not_recharge() {
+        let mut state = setup_with_libraries(40);
+        let mut events = Vec::new();
+        state.waiting_for = start_mulligan(&mut state, &mut events);
+
+        decide(&mut state, PlayerId(0), false, &mut events);
+
+        let first_powder = inject_serum_powder(&mut state, PlayerId(0), 0);
+        let future_second_powder = state.players[0].library[0];
+        state.objects.get_mut(&future_second_powder).unwrap().name = SERUM_POWDER_NAME.to_string();
+
+        let waiting = use_serum_powder(&mut state, PlayerId(0), first_powder, &mut events)
+            .expect("first use_serum_powder declare point");
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((
+                1,
+                PendingMulliganAction::UseSerumPowder {
+                    object_id: first_powder
+                }
+            ))
+        );
+
+        let non_powder_card = *state.players[0]
+            .hand
+            .iter()
+            .find(|&&id| id != first_powder)
+            .unwrap();
+        bottom(&mut state, PlayerId(0), vec![non_powder_card], &mut events)
+            .expect("bottom resolves the first owed BottomCards obligation");
+
+        assert_eq!(state.prepaid_mulligan_bottoms.get(&PlayerId(0)), Some(&1));
+        assert_eq!(state.objects[&first_powder].zone, Zone::Exile);
+        assert_eq!(state.players[0].hand.len(), 6);
+        assert!(state.players[0].hand.contains(&future_second_powder));
+
+        let second_powder = future_second_powder;
+        let library_before_second_use = state.players[0].library.len();
+
+        let waiting = use_serum_powder(&mut state, PlayerId(0), second_powder, &mut events)
+            .expect("second use_serum_powder at the same count must succeed directly");
+
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(0)),
+            None,
+            "a second Serum Powder use at the same, already-paid mulligan_count must not recharge a BottomCards phase — got {:?}",
+            waiting
+        );
+        assert_eq!(
+            state.prepaid_mulligan_bottoms.get(&PlayerId(0)),
+            Some(&1),
+            "the ledger must remain unchanged by a zero-owed declare point"
+        );
+        assert_eq!(decision_count_for(&waiting, PlayerId(0)), Some(1));
+        assert_eq!(
+            state.players[0].library.len(),
+            library_before_second_use - 6,
+            "second Powder use should only draw 6 cards from the library, with no additional card silently bottomed"
+        );
+    }
+
+    /// CR 103.5: Documents the owed==0 fast path explicitly — `Keep` with
+    /// `mulligan_count = 0` never enters `BottomCards`.
+    #[test]
+    fn keep_with_zero_mulligans_resolves_immediately_no_bottom_phase() {
+        let mut state = setup_with_libraries(20);
+        let mut events = Vec::new();
+        state.waiting_for = start_mulligan(&mut state, &mut events);
+
+        let waiting = decide(&mut state, PlayerId(0), true, &mut events);
+
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(0)),
+            None,
+            "Keep with 0 mulligans must not enter BottomCards"
+        );
+        assert!(!pending_decision_players(&waiting).contains(&PlayerId(0)));
+        assert!(pending_decision_players(&waiting).contains(&PlayerId(1)));
+    }
+
+    /// Hostile-fixture coverage: a `SelectCards` submission while the player's
+    /// entry is still in `Declare` (nothing owed) must be rejected outright.
+    #[test]
+    fn select_cards_while_declare_phase_rejected() {
+        let mut state = setup_with_libraries(20);
+        let mut events = Vec::new();
+        state.waiting_for = start_mulligan(&mut state, &mut events);
+
+        assert_eq!(bottom_phase_for(&state.waiting_for, PlayerId(0)), None);
+
+        let some_card = state.players[0].hand[0];
+        let result = handle_mulligan_bottom(&mut state, PlayerId(0), vec![some_card], &mut events);
+        assert!(
+            result.is_err(),
+            "SelectCards must be rejected while the player's entry is in Declare phase (nothing owed), got {:?}",
+            result
+        );
+        assert_eq!(state.players[0].hand.len(), 7);
+        assert!(state.players[0].hand.contains(&some_card));
+    }
+
+    /// CR 800.4a: A player who concedes while mid-`BottomCards { then:
+    /// UseSerumPowder { object_id } }` (not just the simpler `then: Keep` case)
+    /// must be pruned cleanly, with no panic or dangling reference to the
+    /// earmarked Serum Powder object.
+    #[test]
+    fn concede_during_mulligan_use_serum_powder_bottoming_excludes_cleanly() {
+        use crate::game::engine::apply;
+        use crate::types::actions::GameAction;
+
+        let mut state = setup_n_player_with_libraries(3, 30);
+        let mut events = Vec::new();
+        state.waiting_for = start_mulligan(&mut state, &mut events);
+
+        decide(&mut state, PlayerId(0), false, &mut events);
+        decide(&mut state, PlayerId(0), false, &mut events);
+        let powder_id = inject_serum_powder(&mut state, PlayerId(0), 0);
+        let waiting = use_serum_powder(&mut state, PlayerId(0), powder_id, &mut events)
+            .expect("use_serum_powder declare point");
+        assert_eq!(
+            bottom_phase_for(&waiting, PlayerId(0)),
+            Some((
+                1,
+                PendingMulliganAction::UseSerumPowder {
+                    object_id: powder_id
+                }
+            ))
+        );
+
+        let result = apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::Concede {
+                player_id: PlayerId(0),
+            },
+        );
+        assert!(result.is_ok(), "concede must not panic, got {:?}", result);
+
+        assert!(
+            !pending_decision_players(&state.waiting_for).contains(&PlayerId(0)),
+            "conceded P0 must be pruned from pending regardless of their phase, got {:?}",
+            state.waiting_for
+        );
+        assert!(
+            !state.prepaid_mulligan_bottoms.contains_key(&PlayerId(0)),
+            "conceded P0's ledger row must be pruned"
+        );
+
+        decide(&mut state, PlayerId(1), true, &mut events);
+        let waiting = decide(&mut state, PlayerId(2), true, &mut events);
+        assert!(
+            matches!(waiting, WaitingFor::Priority { .. }),
+            "remaining players should complete the flow after P0's concession, got {:?}",
             waiting
         );
     }

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1478,7 +1478,6 @@ impl GameRunner {
         match &self.state.waiting_for {
             WaitingFor::Priority { .. } => "Priority",
             WaitingFor::MulliganDecision { .. } => "MulliganDecision",
-            WaitingFor::MulliganBottomCards { .. } => "MulliganBottomCards",
             WaitingFor::OpeningHandBottomCards { .. } => "OpeningHandBottomCards",
             WaitingFor::ManaPayment { .. } => "ManaPayment",
             WaitingFor::TargetSelection { .. } => "TargetSelection",

--- a/crates/engine/src/game/turn_control.rs
+++ b/crates/engine/src/game/turn_control.rs
@@ -73,7 +73,7 @@ pub fn authorized_submitter(state: &GameState) -> Option<PlayerId> {
 /// CR 103.5: Set-aware authorization. Returns every PlayerId who is currently
 /// allowed to submit an action for `state.waiting_for`. For single-player
 /// states this is a one-element Vec; for simultaneous-decision states
-/// (`MulliganDecision`, `MulliganBottomCards`, `OpeningHandBottomCards`) it is the full pending set.
+/// (`MulliganDecision`, `OpeningHandBottomCards`) it is the full pending set.
 /// Each entry is mapped through `authorized_submitter_for_player` so that
 /// turn-decision-controller effects (e.g., Mindslaver) still re-route the
 /// submitter correctly.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2657,12 +2657,42 @@ pub struct PendingBeginGameAbility {
     pub ability: ResolvedAbility,
 }
 
+/// CR 103.5b: Which declare-point action a pending `BottomCards` obligation
+/// will complete once resolved. `Keep` locks in the hand (CR 103.5); the
+/// player exits `pending`. `UseSerumPowder` runs the exile+redraw effect on
+/// the now-reduced hand and returns the entry to `Declare` (Serum Powder
+/// itself is not a mulligan — CR 103.5b + Serum Powder Oracle text).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum PendingMulliganAction {
+    Keep,
+    UseSerumPowder { object_id: ObjectId },
+}
+
+/// CR 103.5 + 103.5b: Per-entry sub-state for the declare-point mulligan
+/// flow. `Declare` is the default. `BottomCards` is entered the instant
+/// `Keep` or `UseSerumPowder` is declared with `count > 0` still owed
+/// against the per-player `prepaid_mulligan_bottoms` ledger; it must be
+/// resolved via `SelectCards` before the entry can advance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "type")]
+pub enum MulliganDecisionPhase {
+    #[default]
+    Declare,
+    BottomCards {
+        count: u8,
+        then: PendingMulliganAction,
+    },
+}
+
 /// CR 103.5: Per-player state during the simultaneous mulligan decision phase.
 /// One entry per player who has not yet declared "keep".
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MulliganDecisionEntry {
     pub player: PlayerId,
     pub mulligan_count: u8,
+    #[serde(default)]
+    pub phase: MulliganDecisionPhase,
 }
 
 /// CR 103.5: Per-player state during the simultaneous bottom-cards phase.
@@ -3122,14 +3152,18 @@ pub enum WaitingFor {
     },
     /// CR 103.5 + 103.5b: London mulligan — each un-kept player decides
     /// simultaneously. The `pending` list holds every player who has not yet
-    /// chosen `MulliganChoice::Keep`, each with their current mulligan count.
-    /// Players act in any order; `Keep` removes the actor from `pending`,
-    /// `Mulligan` increments their count and redraws but keeps them in
-    /// `pending`, and `UseSerumPowder { object_id }` (CR 103.5b) exiles the
-    /// hand and redraws the same number without incrementing the count, also
-    /// keeping the player in `pending`. When `pending` is empty the flow
-    /// advances to `MulliganBottomCards` (if anyone owes bottoms) or
-    /// `finish_mulligans`.
+    /// finished the flow, each with their current mulligan count and a
+    /// per-entry `phase` (`MulliganDecisionPhase`). Players act in any order.
+    /// In `Declare`, `Keep`/`Mulligan`/`UseSerumPowder` apply as usual;
+    /// `Mulligan` increments the count, redraws, and resets that player's
+    /// bottoms ledger. Bottoming is folded into this same variant: at a
+    /// declare point (`Keep` or `UseSerumPowder`), if any bottoms are still
+    /// owed against `prepaid_mulligan_bottoms`, the entry transitions to
+    /// `BottomCards { count, then }` and the player resolves it with
+    /// `SelectCards { cards }` — this happens at that player's own declare
+    /// point, independent of every other player (CR 103.5b). When `pending`
+    /// empties, the flow advances directly to `finish_mulligans`; there is no
+    /// separate batch bottoms phase.
     ///
     /// CR 103.5d + CR 805.3a + CR 810.2: shared-team-turn mulligans are
     /// represented in the same simultaneous-decision model; every player
@@ -3142,13 +3176,6 @@ pub enum WaitingFor {
         /// Surfaced so display layers can render "Free Mulligan" labelling
         /// without re-deriving format/seat rules.
         free_first_mulligan: bool,
-    },
-    /// CR 103.5: After all players have kept, each player who mulliganed at
-    /// least once (and is not on the free-first discount) must put N cards on
-    /// the bottom of their library, where N = `count`. All such players choose
-    /// simultaneously and submit `SelectCards { cards }` in any order.
-    MulliganBottomCards {
-        pending: Vec<MulliganBottomEntry>,
     },
     /// TL:R 906.6a/e: A player with more than one Tiny Leader performs a
     /// forced first mulligan before any player may make a normal mulligan
@@ -4938,7 +4965,6 @@ impl WaitingFor {
         match self {
             WaitingFor::Priority { .. } => "Priority",
             WaitingFor::MulliganDecision { .. } => "MulliganDecision",
-            WaitingFor::MulliganBottomCards { .. } => "MulliganBottomCards",
             WaitingFor::OpeningHandBottomCards { .. } => "OpeningHandBottomCards",
             WaitingFor::ManaPayment { .. } => "ManaPayment",
             WaitingFor::ChooseXValue { .. } => "ChooseXValue",
@@ -5057,19 +5083,12 @@ impl WaitingFor {
     /// Extract the player who must act, if any.
     ///
     /// CR 103.5: For simultaneous-decision states (`MulliganDecision`,
-    /// `MulliganBottomCards`, `OpeningHandBottomCards`) this returns `Some(p)` only when exactly one
+    /// `OpeningHandBottomCards`) this returns `Some(p)` only when exactly one
     /// player is pending, and `None` when multiple are pending — callers
     /// that need set semantics must use [`Self::acting_players`] instead.
     pub fn acting_player(&self) -> Option<PlayerId> {
         match self {
             WaitingFor::MulliganDecision { pending, .. } => {
-                if pending.len() == 1 {
-                    Some(pending[0].player)
-                } else {
-                    None
-                }
-            }
-            WaitingFor::MulliganBottomCards { pending } => {
                 if pending.len() == 1 {
                     Some(pending[0].player)
                 } else {
@@ -5216,9 +5235,6 @@ impl WaitingFor {
     pub fn acting_players(&self) -> Vec<PlayerId> {
         match self {
             WaitingFor::MulliganDecision { pending, .. } => {
-                pending.iter().map(|e| e.player).collect()
-            }
-            WaitingFor::MulliganBottomCards { pending } => {
                 pending.iter().map(|e| e.player).collect()
             }
             WaitingFor::OpeningHandBottomCards { pending, .. } => {
@@ -6825,17 +6841,20 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub lands_tapped_for_mana: HashMap<PlayerId, Vec<ObjectId>>,
 
-    /// CR 103.5: Per-player locked-in mulligan count, populated as each player
-    /// declares "keep" during the simultaneous decision phase. Read by the
-    /// bottoms-phase builder to compute how many cards each player must put
-    /// on the bottom of their library. Cleared when the mulligan flow finishes.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub final_mulligan_counts: HashMap<PlayerId, u8>,
-
-    /// TL:R 906.6a: Per-player bottoms already paid by a forced opening-hand
-    /// mulligan before the normal mulligan-decision step. Subtracted from the
-    /// later London bottom count so the forced bottom is not charged twice.
-    /// Cleared with `final_mulligan_counts` when the mulligan flow finishes.
+    /// CR 103.5 + 103.5b: Per-player ledger of bottom cards already put on the
+    /// bottom of the library toward the current mulligan obligation. This is
+    /// the single source of truth for "how many bottoms has this player
+    /// already paid at their current mulligan count". Discipline:
+    /// - Reset to 0 on every `MulliganChoice::Mulligan` — a fresh redraw
+    ///   invalidates any prior credit (the obligation for the new count starts
+    ///   from scratch, CR 103.5).
+    /// - Accumulated (never reset) across repeated `UseSerumPowder` uses at the
+    ///   same mulligan count, so cycling Serum Powder never double-charges an
+    ///   already-paid obligation (CR 103.5b + Serum Powder Oracle text).
+    /// - Also credited by the Tiny Leaders forced opening-hand bottom
+    ///   (TL:R 906.6a) so that first bottom is not charged twice.
+    ///
+    /// Cleared when the mulligan flow finishes (all players out of `pending`).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub prepaid_mulligan_bottoms: HashMap<PlayerId, u8>,
 
@@ -8583,7 +8602,6 @@ impl GameState {
             auto_pass: HashMap::new(),
             phase_stops: HashMap::new(),
             lands_tapped_for_mana: HashMap::new(),
-            final_mulligan_counts: HashMap::new(),
             prepaid_mulligan_bottoms: HashMap::new(),
             match_config: MatchConfig::default(),
             match_phase: MatchPhase::InGame,
@@ -10089,14 +10107,33 @@ mod tests {
             pending: vec![MulliganDecisionEntry {
                 player: PlayerId(0),
                 mulligan_count: 1,
+                phase: MulliganDecisionPhase::Declare,
             }],
             free_first_mulligan: false,
         }));
-        variants.push(Box::new(WaitingFor::MulliganBottomCards {
-            pending: vec![MulliganBottomEntry {
+        variants.push(Box::new(WaitingFor::MulliganDecision {
+            pending: vec![MulliganDecisionEntry {
                 player: PlayerId(0),
-                count: 2,
+                mulligan_count: 1,
+                phase: MulliganDecisionPhase::BottomCards {
+                    count: 1,
+                    then: PendingMulliganAction::Keep,
+                },
             }],
+            free_first_mulligan: false,
+        }));
+        variants.push(Box::new(WaitingFor::MulliganDecision {
+            pending: vec![MulliganDecisionEntry {
+                player: PlayerId(0),
+                mulligan_count: 2,
+                phase: MulliganDecisionPhase::BottomCards {
+                    count: 2,
+                    then: PendingMulliganAction::UseSerumPowder {
+                        object_id: ObjectId(7),
+                    },
+                },
+            }],
+            free_first_mulligan: false,
         }));
         variants.push(Box::new(WaitingFor::OpeningHandBottomCards {
             pending: vec![MulliganBottomEntry {
@@ -10371,7 +10408,7 @@ mod tests {
             mana_reduction: ManaCost::zero(),
             pending_cast: dummy_pending(),
         }));
-        assert_eq!(variants.len(), 33);
+        assert_eq!(variants.len(), 34);
     }
 
     #[test]

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -30,7 +30,12 @@ use serde::{Deserialize, Serialize};
 /// (clients see "Invalid message: unknown variant") rather than at the
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
-pub const PROTOCOL_VERSION: u32 = 12;
+///
+/// 13 — `WaitingFor::MulliganBottomCards` removed from the full-game state
+///      payload; mulligan bottoming folded into a
+///      `MulliganDecisionPhase::BottomCards` sub-phase on
+///      `WaitingFor::MulliganDecision`.
+pub const PROTOCOL_VERSION: u32 = 13;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake. Lobby traffic has a one-version rollout window; full game servers

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -12,7 +12,8 @@ use engine::types::ability::TargetRef;
 use engine::types::card::CardFace;
 use engine::types::counter::CounterType;
 use engine::types::game_state::{
-    GameState, ManaChoice, ManaChoicePrompt, StackEntryKind, WaitingFor,
+    GameState, ManaChoice, ManaChoicePrompt, MulliganDecisionPhase, PendingMulliganAction,
+    StackEntryKind, WaitingFor,
 };
 use engine::types::mana::{ManaColor as EngineManaColor, ManaCost, ManaCostShard, ManaType};
 use engine::types::phase::Phase;
@@ -418,6 +419,9 @@ pub enum PromptOutput {
     MulliganDecision {
         keep: bool,
     },
+    MulliganUseSerumPowder {
+        card_id: String,
+    },
     MulliganPutBackDecision {
         card_ids: Vec<String>,
     },
@@ -664,6 +668,7 @@ pub struct MulliganInput {
 )]
 pub enum MulliganOutput {
     MulliganDecision { keep: bool },
+    MulliganUseSerumPowder { card_id: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -672,6 +677,12 @@ pub struct MulliganPutBackInput {
     pub hand_card_ids: Vec<String>,
     pub cards: Vec<CardDto>,
     pub count: usize,
+    /// The earmarked Serum Powder object committed to a pending
+    /// `UseSerumPowder` continuation, if any — the client must not offer it
+    /// as selectable in the bottom-cards picker. `None` for both `Keep`
+    /// resolutions and the (unrelated) `OpeningHandBottomCards` phase.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub excluded_card_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1206,14 +1217,34 @@ fn build_prompt_input(
         })),
         WaitingFor::MulliganDecision { pending, .. } => {
             let entry = pending_entry_for_viewer(&prepared.state, prepared.viewer, pending)?;
-            let hand = &prepared.state.players[player_index(&prepared.state, entry.player)?].hand;
-            Ok(PromptInput::Mulligan(MulliganInput {
-                hand_card_ids: hand.iter().copied().map(encode_object_id).collect(),
-                mulligan_count: u32::from(entry.mulligan_count),
-            }))
+            match &entry.phase {
+                MulliganDecisionPhase::Declare => {
+                    let hand =
+                        &prepared.state.players[player_index(&prepared.state, entry.player)?].hand;
+                    Ok(PromptInput::Mulligan(MulliganInput {
+                        hand_card_ids: hand.iter().copied().map(encode_object_id).collect(),
+                        mulligan_count: u32::from(entry.mulligan_count),
+                    }))
+                }
+                MulliganDecisionPhase::BottomCards { count, then } => {
+                    let cards = CardBuildContext { card_lookup };
+                    let hand =
+                        &prepared.state.players[player_index(&prepared.state, entry.player)?].hand;
+                    Ok(PromptInput::MulliganPutBack(MulliganPutBackInput {
+                        hand_card_ids: hand.iter().copied().map(encode_object_id).collect(),
+                        cards: objects_from_ids(&prepared.state, hand, &cards)?,
+                        count: usize::from(*count),
+                        excluded_card_id: match then {
+                            PendingMulliganAction::Keep => None,
+                            PendingMulliganAction::UseSerumPowder { object_id } => {
+                                Some(encode_object_id(*object_id))
+                            }
+                        },
+                    }))
+                }
+            }
         }
-        WaitingFor::MulliganBottomCards { pending }
-        | WaitingFor::OpeningHandBottomCards { pending, .. } => {
+        WaitingFor::OpeningHandBottomCards { pending, .. } => {
             let entry = pending_bottom_entry_for_viewer(&prepared.state, prepared.viewer, pending)?;
             let cards = CardBuildContext { card_lookup };
             let hand = &prepared.state.players[player_index(&prepared.state, entry.player)?].hand;
@@ -1221,6 +1252,7 @@ fn build_prompt_input(
                 hand_card_ids: hand.iter().copied().map(encode_object_id).collect(),
                 cards: objects_from_ids(&prepared.state, hand, &cards)?,
                 count: usize::from(entry.count),
+                excluded_card_id: None,
             }))
         }
         WaitingFor::DeclareAttackers {
@@ -1419,7 +1451,7 @@ pub fn translate_response(
             viewer: context.deciding_player,
         });
     }
-    if !response_output_matches_waiting(&response.output, &state.waiting_for) {
+    if !response_output_matches_waiting(&response.output, state, context.deciding_player) {
         return Err(AdapterError::IllegalResponseForPrompt {
             response_kind: response_output_type(&response.output),
         });
@@ -1453,6 +1485,11 @@ pub fn translate_response(
                 engine::types::actions::MulliganChoice::Keep
             } else {
                 engine::types::actions::MulliganChoice::Mulligan
+            },
+        }),
+        PromptOutput::MulliganUseSerumPowder { card_id } => Ok(GameAction::MulliganDecision {
+            choice: engine::types::actions::MulliganChoice::UseSerumPowder {
+                object_id: parse_object_id(&card_id)?,
             },
         }),
         PromptOutput::MulliganPutBackDecision { card_ids } => Ok(GameAction::SelectCards {
@@ -2373,7 +2410,12 @@ fn choose_mana_color_input(choice: &ManaChoicePrompt) -> Result<ChooseColorInput
     }
 }
 
-fn response_output_matches_waiting(output: &PromptOutput, waiting_for: &WaitingFor) -> bool {
+fn response_output_matches_waiting(
+    output: &PromptOutput,
+    state: &GameState,
+    viewer: PlayerId,
+) -> bool {
+    let waiting_for = &state.waiting_for;
     match output {
         PromptOutput::Pass { .. }
         | PromptOutput::Concede
@@ -2387,13 +2429,31 @@ fn response_output_matches_waiting(output: &PromptOutput, waiting_for: &WaitingF
         PromptOutput::Pay { .. } | PromptOutput::PayLife | PromptOutput::Cancel => {
             matches!(waiting_for, WaitingFor::ManaPayment { .. })
         }
-        PromptOutput::MulliganDecision { .. } => {
-            matches!(waiting_for, WaitingFor::MulliganDecision { .. })
+        // A declare-point response (keep/mulligan or use Serum Powder) is only
+        // legal while the viewer's own entry is in the `Declare` phase.
+        PromptOutput::MulliganDecision { .. } | PromptOutput::MulliganUseSerumPowder { .. } => {
+            match waiting_for {
+                WaitingFor::MulliganDecision { pending, .. } => {
+                    pending_entry_for_viewer(state, viewer, pending)
+                        .is_ok_and(|entry| matches!(entry.phase, MulliganDecisionPhase::Declare))
+                }
+                _ => false,
+            }
         }
-        PromptOutput::MulliganPutBackDecision { .. } => matches!(
-            waiting_for,
-            WaitingFor::MulliganBottomCards { .. } | WaitingFor::OpeningHandBottomCards { .. }
-        ),
+        // A bottom-cards selection is legal while the viewer's own entry is in
+        // the `BottomCards` sub-phase, or during the unrelated
+        // `OpeningHandBottomCards` phase.
+        PromptOutput::MulliganPutBackDecision { .. } => match waiting_for {
+            WaitingFor::MulliganDecision { pending, .. } => {
+                pending_entry_for_viewer(state, viewer, pending).is_ok_and(|entry| {
+                    matches!(entry.phase, MulliganDecisionPhase::BottomCards { .. })
+                })
+            }
+            WaitingFor::OpeningHandBottomCards { pending, .. } => {
+                pending_bottom_entry_for_viewer(state, viewer, pending).is_ok()
+            }
+            _ => false,
+        },
         PromptOutput::DeclareAttackers { .. } => {
             matches!(waiting_for, WaitingFor::DeclareAttackers { .. })
         }
@@ -2439,6 +2499,7 @@ fn response_output_type(output: &PromptOutput) -> &'static str {
         PromptOutput::PayLife => "payLife",
         PromptOutput::Cancel => "cancel",
         PromptOutput::MulliganDecision { .. } => "mulliganDecision",
+        PromptOutput::MulliganUseSerumPowder { .. } => "mulliganUseSerumPowder",
         PromptOutput::MulliganPutBackDecision { .. } => "mulliganPutBackDecision",
         PromptOutput::DeclareAttackers { .. } => "declareAttackers",
         PromptOutput::DeclareBlockers { .. } => "declareBlockers",
@@ -2812,7 +2873,6 @@ fn waiting_for_type(waiting_for: &WaitingFor) -> &'static str {
     match waiting_for {
         WaitingFor::Priority { .. } => "Priority",
         WaitingFor::MulliganDecision { .. } => "MulliganDecision",
-        WaitingFor::MulliganBottomCards { .. } => "MulliganBottomCards",
         WaitingFor::OpeningHandBottomCards { .. } => "OpeningHandBottomCards",
         WaitingFor::ManaPayment { .. } => "ManaPayment",
         WaitingFor::ChooseXValue { .. } => "ChooseXValue",
@@ -2850,8 +2910,8 @@ mod tests {
     use engine::game::zones::create_object;
     use engine::types::ability::{Effect, ResolvedAbility, TargetFilter};
     use engine::types::game_state::{
-        MulliganBottomEntry, MulliganDecisionEntry, PendingCast, TargetSelectionProgress,
-        TargetSelectionSlot,
+        MulliganDecisionEntry, MulliganDecisionPhase, PendingCast, PendingMulliganAction,
+        TargetSelectionProgress, TargetSelectionSlot,
     };
     use engine::types::identifiers::CardId;
     use pretty_assertions::assert_eq;
@@ -3097,6 +3157,7 @@ mod tests {
             pending: vec![MulliganDecisionEntry {
                 player: PlayerId(0),
                 mulligan_count: 0,
+                phase: MulliganDecisionPhase::Declare,
             }],
             free_first_mulligan: false,
         };
@@ -3164,6 +3225,52 @@ mod tests {
             Err(AdapterError::IllegalResponseForPrompt {
                 response_kind: "mulliganDecision"
             })
+        ));
+    }
+
+    /// Round-trip (CR 103.5b): a `MulliganUseSerumPowder` response submitted
+    /// while the viewer's entry is in the `Declare` phase translates to
+    /// `MulliganChoice::UseSerumPowder` carrying the referenced object id.
+    #[test]
+    fn mulligan_use_serum_powder_response_translates() {
+        let context = PromptContext {
+            prompt_id: 1,
+            deciding_player: PlayerId(0),
+            action_table: Vec::new(),
+        };
+        let mut state = GameState::new_two_player(7);
+        let powder = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Serum Powder".to_string(),
+            Zone::Hand,
+        );
+        state.waiting_for = WaitingFor::MulliganDecision {
+            pending: vec![MulliganDecisionEntry {
+                player: PlayerId(0),
+                mulligan_count: 0,
+                phase: MulliganDecisionPhase::Declare,
+            }],
+            free_first_mulligan: false,
+        };
+
+        let action = translate_response(
+            PromptResponse {
+                prompt_id: 1,
+                output: PromptOutput::MulliganUseSerumPowder {
+                    card_id: encode_object_id(powder),
+                },
+            },
+            &context,
+            &state,
+        )
+        .unwrap();
+        assert!(matches!(
+            action,
+            GameAction::MulliganDecision {
+                choice: engine::types::actions::MulliganChoice::UseSerumPowder { object_id },
+            } if object_id == powder
         ));
     }
 
@@ -3442,17 +3549,23 @@ mod tests {
                     pending: vec![MulliganDecisionEntry {
                         player: PlayerId(0),
                         mulligan_count: 1,
+                        phase: MulliganDecisionPhase::Declare,
                     }],
                     free_first_mulligan: false,
                 },
             ),
             (
                 "mulliganPutBack",
-                WaitingFor::MulliganBottomCards {
-                    pending: vec![MulliganBottomEntry {
+                WaitingFor::MulliganDecision {
+                    pending: vec![MulliganDecisionEntry {
                         player: PlayerId(0),
-                        count: 1,
+                        mulligan_count: 1,
+                        phase: MulliganDecisionPhase::BottomCards {
+                            count: 1,
+                            then: PendingMulliganAction::Keep,
+                        },
                     }],
+                    free_first_mulligan: false,
                 },
             ),
             (
@@ -3583,6 +3696,7 @@ mod protocol_wire_tests {
                     hand_card_ids: vec!["card-1".to_string()],
                     cards: vec![card()],
                     count: 1,
+                    excluded_card_id: None,
                 }),
             ),
             (

--- a/crates/phase-ai/src/decision_kind.rs
+++ b/crates/phase-ai/src/decision_kind.rs
@@ -17,9 +17,9 @@ use engine::types::game_state::CastPaymentMode;
 /// Classify a decision into the bucket the policy registry uses for routing.
 pub fn classify(waiting_for: &WaitingFor, action: &GameAction) -> DecisionKind {
     match waiting_for {
-        WaitingFor::MulliganDecision { .. }
-        | WaitingFor::MulliganBottomCards { .. }
-        | WaitingFor::OpeningHandBottomCards { .. } => DecisionKind::Mulligan,
+        WaitingFor::MulliganDecision { .. } | WaitingFor::OpeningHandBottomCards { .. } => {
+            DecisionKind::Mulligan
+        }
         WaitingFor::ManaPayment { .. } | WaitingFor::PhyrexianPayment { .. } => {
             DecisionKind::ManaPayment
         }
@@ -212,6 +212,7 @@ mod tests {
                     pending: vec![engine::types::game_state::MulliganDecisionEntry {
                         player: PlayerId(0),
                         mulligan_count: 0,
+                        phase: engine::types::game_state::MulliganDecisionPhase::Declare,
                     }],
                     free_first_mulligan: false,
                 },

--- a/crates/phase-ai/src/projection.rs
+++ b/crates/phase-ai/src/projection.rs
@@ -287,7 +287,6 @@ fn resolve_choice(
     // Impossible-mid-game gates.
     match &state.waiting_for {
         WaitingFor::MulliganDecision { .. }
-        | WaitingFor::MulliganBottomCards { .. }
         | WaitingFor::OpeningHandBottomCards { .. }
         | WaitingFor::BetweenGamesSideboard { .. }
         | WaitingFor::BetweenGamesChoosePlayDraw { .. } => {

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -11,7 +11,8 @@ use engine::types::ability::{
 use engine::types::actions::{AlternativeCastDecision, GameAction, MulliganChoice};
 use engine::types::card_type::CoreType;
 use engine::types::game_state::{
-    CastOfferKind, CostResume, GameState, ManaChoice, ManaChoicePrompt, WaitingFor,
+    CastOfferKind, CostResume, GameState, ManaChoice, ManaChoicePrompt, MulliganDecisionPhase,
+    PendingMulliganAction, WaitingFor,
 };
 use engine::types::identifiers::ObjectId;
 use engine::types::phase::Phase;
@@ -135,11 +136,6 @@ pub fn choose_action_with_session(
     // bridge doesn't fabricate an action that would fail authorization.
     match &state.waiting_for {
         WaitingFor::MulliganDecision { pending, .. }
-            if !pending.iter().any(|e| e.player == ai_player) =>
-        {
-            return None;
-        }
-        WaitingFor::MulliganBottomCards { pending }
             if !pending.iter().any(|e| e.player == ai_player) =>
         {
             return None;
@@ -967,21 +963,29 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
             order: (0..triggers.len()).collect(),
         }),
 
-        // CR 103.5 + 103.5b: Mulligan default = keep, unless the AI has a
-        // Serum Powder in hand, in which case use it first (auto-heuristic —
-        // see `first_serum_powder_in_hand`).
+        // CR 103.5 + 103.5b: Mulligan default. In `Declare`, keep unless the AI
+        // has a Serum Powder in hand, in which case use it first (auto-heuristic
+        // — see `first_serum_powder_in_hand`). In `BottomCards`, submit an empty
+        // `SelectCards` as the deadlock-safe escape hatch.
         WaitingFor::MulliganDecision { pending, .. } => {
             let entry = pending.first()?;
-            Some(match first_serum_powder_in_hand(state, entry.player) {
-                Some(object_id) => GameAction::MulliganDecision {
-                    choice: MulliganChoice::UseSerumPowder { object_id },
-                },
-                None => GameAction::MulliganDecision {
-                    choice: MulliganChoice::Keep,
-                },
-            })
+            match &entry.phase {
+                MulliganDecisionPhase::Declare => {
+                    Some(match first_serum_powder_in_hand(state, entry.player) {
+                        Some(object_id) => GameAction::MulliganDecision {
+                            choice: MulliganChoice::UseSerumPowder { object_id },
+                        },
+                        None => GameAction::MulliganDecision {
+                            choice: MulliganChoice::Keep,
+                        },
+                    })
+                }
+                MulliganDecisionPhase::BottomCards { .. } => {
+                    Some(GameAction::SelectCards { cards: Vec::new() })
+                }
+            }
         }
-        WaitingFor::MulliganBottomCards { .. } | WaitingFor::OpeningHandBottomCards { .. } => {
+        WaitingFor::OpeningHandBottomCards { .. } => {
             Some(GameAction::SelectCards { cards: Vec::new() })
         }
 
@@ -2133,48 +2137,65 @@ pub(crate) fn deterministic_choice(
             .get(&player)
             .unwrap_or(&default_features);
         let plan = ctx.session.plan.get(&player).unwrap_or(&default_plan);
-        let hand: Vec<_> = state.players[player.0 as usize]
-            .hand
-            .iter()
-            .copied()
-            .collect();
-        let turn_order = crate::policies::mulligan::turn_order_for(state, player);
-        let decision = crate::policies::mulligan::MulliganRegistry::default().evaluate_hand(
-            &hand,
-            state,
-            features,
-            plan,
-            turn_order,
-            mulligan_count,
-        );
-        // CR 103.5b + Serum Powder Oracle text: if the AI would mulligan and
-        // it has a Serum Powder in hand, prefer the Powder — it's a strictly
-        // better action than a mulligan (no bottoming, no mulligan count
-        // increment). When the registry says keep, take the keep — don't burn
-        // a Powder on a hand the policies already endorsed.
-        let choice = if decision.keep {
-            MulliganChoice::Keep
-        } else if let Some(object_id) = first_serum_powder_in_hand(state, player) {
-            MulliganChoice::UseSerumPowder { object_id }
-        } else {
-            MulliganChoice::Mulligan
-        };
-        return Some(GameAction::MulliganDecision { choice });
+
+        match &entry.phase {
+            // CR 103.5: This player's entry owes bottoms at their own declare
+            // point. Bottom the N least valuable cards, using the cached plan
+            // to preserve expected land count and structurally detected payoff
+            // cards. The earmarked Serum Powder (if `then` is `UseSerumPowder`)
+            // is excluded from the selection pool — it's committed to its own
+            // activation.
+            MulliganDecisionPhase::BottomCards { count, then } => {
+                let exclude = match then {
+                    PendingMulliganAction::UseSerumPowder { object_id } => Some(*object_id),
+                    PendingMulliganAction::Keep => None,
+                };
+                let to_bottom = plan_aware_bottom_cards(
+                    state,
+                    player,
+                    *count as usize,
+                    features,
+                    plan,
+                    exclude,
+                );
+                return Some(GameAction::SelectCards { cards: to_bottom });
+            }
+            MulliganDecisionPhase::Declare => {
+                let hand: Vec<_> = state.players[player.0 as usize]
+                    .hand
+                    .iter()
+                    .copied()
+                    .collect();
+                let turn_order = crate::policies::mulligan::turn_order_for(state, player);
+                let decision = crate::policies::mulligan::MulliganRegistry::default()
+                    .evaluate_hand(&hand, state, features, plan, turn_order, mulligan_count);
+                // CR 103.5b + Serum Powder Oracle text: if the AI would mulligan
+                // and it has a Serum Powder in hand, prefer the Powder — it's a
+                // strictly better action than a mulligan (no mulligan count
+                // increment). When the registry says keep, take the keep — don't
+                // burn a Powder on a hand the policies already endorsed.
+                let choice = if decision.keep {
+                    MulliganChoice::Keep
+                } else if let Some(object_id) = first_serum_powder_in_hand(state, player) {
+                    MulliganChoice::UseSerumPowder { object_id }
+                } else {
+                    MulliganChoice::Mulligan
+                };
+                return Some(GameAction::MulliganDecision { choice });
+            }
+        }
     }
 
-    // CR 103.5 + TL:R 906.6: Mulligan / opening-hand bottoming. Each pending
-    // player owes a distinct `count`, and several players can be pending at
-    // once (simultaneous bottoming). The AI controller must scope to
-    // `ai_player`'s own entry: the shared candidate pool mixes every pending
-    // player's combos, and `validate_candidates` simulates them as the first
-    // authorized submitter (seat order) rather than `ai_player` — so without
-    // this branch the AI can pick a selection sized for a different player and
-    // the engine rejects it ("Expected N cards to bottom, got M"). Bottom the
-    // N least valuable cards, using the cached plan to preserve expected land
-    // count and structurally detected payoff cards.
-    if let WaitingFor::MulliganBottomCards { pending }
-    | WaitingFor::OpeningHandBottomCards { pending, .. } = &state.waiting_for
-    {
+    // TL:R 906.6: Opening-hand forced bottoming. Each pending player owes a
+    // distinct `count`, and several players can be pending at once. The AI
+    // controller must scope to `ai_player`'s own entry: the shared candidate
+    // pool mixes every pending player's combos, and `validate_candidates`
+    // simulates them as the first authorized submitter (seat order) rather than
+    // `ai_player` — so without this branch the AI can pick a selection sized for
+    // a different player and the engine rejects it. Bottom the N least valuable
+    // cards, using the cached plan to preserve expected land count and
+    // structurally detected payoff cards.
+    if let WaitingFor::OpeningHandBottomCards { pending, .. } = &state.waiting_for {
         let entry = pending.iter().find(|e| e.player == ai_player)?;
         let count = entry.count as usize;
         let owned_ctx;
@@ -2193,7 +2214,7 @@ pub(crate) fn deterministic_choice(
             .get(&ai_player)
             .unwrap_or(&default_features);
         let plan = ctx.session.plan.get(&ai_player).unwrap_or(&default_plan);
-        let to_bottom = plan_aware_bottom_cards(state, ai_player, count, features, plan);
+        let to_bottom = plan_aware_bottom_cards(state, ai_player, count, features, plan, None);
         return Some(GameAction::SelectCards { cards: to_bottom });
     }
 
@@ -2710,7 +2731,11 @@ fn plan_aware_bottom_cards(
     count: usize,
     features: &DeckFeatures,
     plan: &PlanSnapshot,
+    exclude: Option<ObjectId>,
 ) -> Vec<ObjectId> {
+    // The full hand — including any earmarked-Serum-Powder `exclude` object —
+    // drives the hand-size and land-target arithmetic, because the earmarked
+    // card is still physically in hand until its effect runs.
     let hand: Vec<_> = state.players[player.0 as usize]
         .hand
         .iter()
@@ -2730,7 +2755,8 @@ fn plan_aware_bottom_cards(
     let mut surplus_lands = land_count.saturating_sub(land_target);
     let mut scored = Vec::with_capacity(hand.len());
 
-    for id in hand {
+    // Only the candidate selection POOL excludes the earmarked object.
+    for id in hand.into_iter().filter(|id| Some(*id) != exclude) {
         let score = state.objects.get(&id).map_or(0.0, |obj| {
             if is_plan_payoff_name(features, &obj.name) {
                 25.0 + evaluate_card_value(state, id)
@@ -5074,17 +5100,26 @@ mod tests {
         let mut state = make_state();
         let vanilla = two_player_bottom_fixture(&mut state, 4, 3);
 
-        state.waiting_for = WaitingFor::MulliganBottomCards {
+        state.waiting_for = WaitingFor::MulliganDecision {
             pending: vec![
-                engine::types::game_state::MulliganBottomEntry {
+                engine::types::game_state::MulliganDecisionEntry {
                     player: PlayerId(0),
-                    count: 1,
+                    mulligan_count: 1,
+                    phase: MulliganDecisionPhase::BottomCards {
+                        count: 1,
+                        then: PendingMulliganAction::Keep,
+                    },
                 },
-                engine::types::game_state::MulliganBottomEntry {
+                engine::types::game_state::MulliganDecisionEntry {
                     player: PlayerId(1),
-                    count: 3,
+                    mulligan_count: 3,
+                    phase: MulliganDecisionPhase::BottomCards {
+                        count: 3,
+                        then: PendingMulliganAction::Keep,
+                    },
                 },
             ],
+            free_first_mulligan: false,
         };
 
         let config = create_config(AiDifficulty::VeryHard, Platform::Native);
@@ -5106,10 +5141,10 @@ mod tests {
         }
     }
 
-    /// The fix's `|`-combined arm must hold for `OpeningHandBottomCards`
-    /// (TL:R 906.6 Tiny Leaders forced bottom), not just `MulliganBottomCards`:
-    /// the AI must still scope to its own owed count when a second player is
-    /// pending. Guards against a future refactor silently dropping one variant.
+    /// The AI must scope to its own owed count for the `OpeningHandBottomCards`
+    /// path (TL:R 906.6 Tiny Leaders forced bottom), not just the folded
+    /// `MulliganDecision` bottoming, when a second player is pending. Guards
+    /// against a future refactor silently dropping one variant.
     #[test]
     fn ai_opening_hand_bottom_scopes_to_own_count_via_choose_action() {
         let mut state = make_state();
@@ -5159,8 +5194,14 @@ mod tests {
 
         let mut plan = PlanSnapshot::default();
         plan.expected_lands[2] = 3;
-        let bottoms =
-            plan_aware_bottom_cards(&state, PlayerId(1), 2, &DeckFeatures::default(), &plan);
+        let bottoms = plan_aware_bottom_cards(
+            &state,
+            PlayerId(1),
+            2,
+            &DeckFeatures::default(),
+            &plan,
+            None,
+        );
         let land_set: std::collections::HashSet<_> = lands.iter().copied().collect();
 
         assert_eq!(bottoms.len(), 2);
@@ -5185,8 +5226,14 @@ mod tests {
             ..Default::default()
         };
 
-        let bottoms =
-            plan_aware_bottom_cards(&state, PlayerId(1), 1, &features, &PlanSnapshot::default());
+        let bottoms = plan_aware_bottom_cards(
+            &state,
+            PlayerId(1),
+            1,
+            &features,
+            &PlanSnapshot::default(),
+            None,
+        );
 
         assert_ne!(bottoms, vec![payoff]);
         assert!(

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -1806,8 +1806,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_12() {
-        assert_eq!(PROTOCOL_VERSION, 12);
+    fn protocol_version_is_13() {
+        assert_eq!(PROTOCOL_VERSION, 13);
     }
 
     #[test]

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -90,7 +90,7 @@ pub fn acting_players(state: &GameState) -> Vec<PlayerId> {
 /// CR 103.5: True iff `player` is one of the actors permitted to submit an
 /// action for the current WaitingFor. Replaces the
 /// `acting_player(state) == Some(player)` idiom at multiplayer routing sites
-/// so the simultaneous-decision states (MulliganDecision, MulliganBottomCards,
+/// so the simultaneous-decision states (MulliganDecision,
 /// OpeningHandBottomCards)
 /// route legal actions to every pending player, not just the first.
 pub fn is_acting(state: &GameState, player: PlayerId) -> bool {
@@ -2300,6 +2300,7 @@ mod tests {
             pending: vec![engine::types::game_state::MulliganDecisionEntry {
                 player: ai_pid,
                 mulligan_count: 0,
+                phase: engine::types::game_state::MulliganDecisionPhase::Declare,
             }],
             free_first_mulligan: true,
         };


### PR DESCRIPTION
## Summary

- Serum Powder's "any time you could mulligan" ability surfaced a deeper bug: the engine deferred **all** bottom-cards resolution (CR 103.5's "puts a number of cards equal to the number of times that player has taken a mulligan on the bottom of their library") to a single batch phase that only ran once *every* player at the table had finished mulliganing. Per CR 103.5b, each player's bottoming obligation must resolve at **their own** declare point (choosing to keep, or invoking a "you could mulligan" action), independent of other players.
- Folds bottoming into a per-player `MulliganDecisionPhase::BottomCards { count, then }` sub-phase on each `MulliganDecisionEntry`, driven by the existing `prepaid_mulligan_bottoms` ledger. The ledger resets to 0 on every real `Mulligan` (a fresh redraw invalidates prior bottoming credit, CR 103.5) but accumulates — never resets — across repeated `UseSerumPowder` activations at the same mulligan count, so cycling Serum Powder never double-charges an already-paid obligation.
- Deletes `WaitingFor::MulliganBottomCards`, `state.final_mulligan_counts`, `record_final_count`, and `enter_bottom_phase`/`_public` — bottoming is now resolved per-entry, so there's no separate batch phase to advance to.
- Threads the new `phase` field through engine dispatch, elimination pruning, AI candidate-generation/reject/search paths, a manabrew-compat prompt DTO extension (new `MulliganUseSerumPowder` output variant + `excluded_card_id` on the put-back input, with `response_output_matches_waiting` made phase-aware), and the frontend `WaitingFor` union, help sheet, and prompt rendering.
- Follow-up commit excludes the earmarked Serum Powder object from the in-repo web client's bottom-cards picker (the engine already rejected selecting it, but the UI let a player try and hit a confusing dead-end).

## CR references

CR 103.3 (pre-mulligan shuffle), CR 103.5 (core bottom-count rule), CR 103.5b (declare-point timing for "any time you could mulligan" actions), CR 103.5c (free-first-mulligan discount), CR 800.4a (elimination pruning), CR 201.2 (Serum Powder name-match). `start_mulligan`'s doc comment previously cited CR 103.4 (starting life total, unrelated) — corrected.

## Test plan

- [x] Two headline regression tests directly pin the ledger arithmetic: `mull_to_five_then_third_mulligan_owes_full_amount_not_incremental_delta` (proves a new mulligan resets stale bottoming credit rather than plateauing) and `use_serum_powder_twice_in_a_row_at_same_count_does_not_recharge` (proves repeated Serum Powder use at an unchanged mulligan count doesn't double-charge).
- [x] Full `cargo test -p engine --lib` (15582 passed), `cargo test -p manabrew-compat`, `cargo test -p phase-ai`, `cargo test -p server-core` all green.
- [x] `cargo clippy -D warnings` clean on all touched crates; `cargo fmt --all --check` clean.
- [x] `pnpm run type-check` / `pnpm lint` clean on all touched frontend files.
- [x] `cargo engine-inventory` confirms the two new types (`MulliganDecisionPhase`, `PendingMulliganAction`) have no sibling-cluster collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)