### PR TITLE
feat(parser): compound-subject replacement animation static (CR 205.1a / CR 611.3)

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1526,6 +1526,14 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
+    // CR 611.3 + CR 205.1a + CR 613.4b: non-additive compound-subject animation
+    // ("All Elves and all Goblins are 2/2 Zombie creatures") — replacement
+    // subtype semantics via animation_modifications_with_replacement. Must follow
+    // the additive compound handler so the CR 205.1b gate stays authoritative.
+    if let Some(def) = parse_compound_all_subjects_type_replacement(&tp, &text) {
+        return Some(def);
+    }
+
     // CR 613.1d + CR 613.4b: "[Subject] lands are [P/T] creatures that are still
     // lands" — continuous land animation (Living Plane, Nature's Revolt). Must
     // come before parse_land_type_change: both split on "are", but the land

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -3440,21 +3440,61 @@ fn life_and_limb_real_text_dual_subject_animation() {
     }
 }
 
-// CR 205.1a vs CR 205.1b: the compound-subject animation handler applies strictly
-// ADDITIVE type semantics, so it must decline a compound predicate that lacks the
-// "in addition to their/its other types" marker — a bare "are <P/T> <type>
-// creatures" compound is a type REPLACEMENT and must not be reinterpreted as
-// additive (which would keep the objects' other types instead of replacing them).
+// CR 205.1a vs CR 205.1b: compound-subject animation splits across two handlers.
+// Additive predicates ("in addition to their other types") route to
+// `parse_compound_all_subjects_type_change`; bare "are <P/T> <type> creatures"
+// compounds route to `parse_compound_all_subjects_type_replacement` with subtype
+// replacement semantics (RemoveAllSubtypes + AddSubtype).
 #[test]
-fn compound_subject_animation_declines_non_additive_replacement_predicate() {
-    // No "in addition to their other types" marker → replacement semantics →
-    // this additive handler must not claim it.
+fn compound_subject_animation_replacement_predicate() {
+    use crate::types::card_type::{CoreType, SubtypeSet};
+
+    let line = "All Elves and all Goblins are 2/2 Zombie creatures.";
+    let defs = parse_static_line_multi(line);
+    assert_eq!(defs.len(), 1, "one compound static: {defs:?}");
+    let def = &defs[0];
+
+    let Some(TargetFilter::Or { filters }) = def.affected.as_ref() else {
+        panic!("affected must be Or of both subjects: {:?}", def.affected);
+    };
+    assert_eq!(filters.len(), 2, "one disjunct per subject: {filters:?}");
     assert!(
-        parse_static_line_multi("All Elves and all Goblins are 2/2 Zombie creatures.").is_empty(),
-        "non-additive compound animation must not be additive-claimed"
+        filters.iter().any(|f| matches!(f, TargetFilter::Typed(tf)
+            if tf.type_filters.contains(&TypeFilter::Creature)
+                && tf.type_filters.iter().any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Elf")))),
+        "Elf conjunct must be creature subtype Elf: {:?}",
+        def.affected
     );
-    // The additive form (Life and Limb) is still claimed — guards against the
-    // gate being over-broad.
+    assert!(
+        filters.iter().any(|f| matches!(f, TargetFilter::Typed(tf)
+            if tf.type_filters.contains(&TypeFilter::Creature)
+                && tf.type_filters.iter().any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Goblin")))),
+        "Goblin conjunct must be creature subtype Goblin: {:?}",
+        def.affected
+    );
+
+    use ContinuousModification as CM;
+    for expected in [
+        CM::SetPower { value: 2 },
+        CM::SetToughness { value: 2 },
+        CM::RemoveAllSubtypes {
+            set: SubtypeSet::Creature,
+        },
+        CM::AddType {
+            core_type: CoreType::Creature,
+        },
+        CM::AddSubtype {
+            subtype: "Zombie".to_string(),
+        },
+    ] {
+        assert!(
+            def.modifications.contains(&expected),
+            "missing {expected:?} in {:?}",
+            def.modifications
+        );
+    }
+
+    // The additive form (Life and Limb) still routes to the additive handler.
     assert_eq!(
         parse_static_line_multi(
             "All Forests and all Saprolings are 1/1 green Saproling creatures and \

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -2036,14 +2036,8 @@ pub(crate) fn parse_compound_all_subjects_type_replacement(
     let affected = parse_compound_all_subjects_filter(subject_tp.original)?;
 
     let predicate = predicate_tp.original.trim().trim_end_matches('.').trim();
-    let predicate_lower = predicate.to_lowercase();
-    if !nom_primitives::scan_contains(&predicate_lower, "creature") {
-        return None;
-    }
     // CR 205.1b: additive predicates are owned by the additive compound handler.
-    if nom_primitives::scan_contains(&predicate_lower, "in addition to their other")
-        || nom_primitives::scan_contains(&predicate_lower, "in addition to its other")
-    {
+    if super::oracle_effect::animation::has_in_addition_to_other_types(predicate) {
         return None;
     }
 
@@ -2053,7 +2047,16 @@ pub(crate) fn parse_compound_all_subjects_type_replacement(
     )?;
     let modifications =
         super::oracle_effect::animation::animation_modifications_with_replacement(&spec, false);
-    if modifications.is_empty() {
+    if modifications.is_empty()
+        || !modifications.iter().any(|modification| {
+            matches!(
+                modification,
+                ContinuousModification::AddType {
+                    core_type: CoreType::Creature
+                }
+            )
+        })
+    {
         return None;
     }
 

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -2018,6 +2018,53 @@ pub(crate) fn parse_compound_all_subjects_type_change(
     )
 }
 
+/// CR 611.3 + CR 613.1 + CR 613.4b + CR 205.1a: "All `<X>` and all `<Y>` are
+/// `<predicate>`" — a compound-subject continuous animation where a single
+/// replacement predicate applies uniformly to every object matching either
+/// subject, without the CR 205.1b additive marker.
+///
+/// Sibling of [`parse_compound_all_subjects_type_change`]: a bare
+/// "are `<P/T>` `<type>` creatures" compound replaces creature subtypes (CR
+/// 205.1a) rather than retaining them additively. The subjects distribute into
+/// an `Or` filter and the predicate is parsed once via `parse_animation_spec` +
+/// `animation_modifications_with_replacement`.
+pub(crate) fn parse_compound_all_subjects_type_replacement(
+    tp: &TextPair<'_>,
+    text: &str,
+) -> Option<StaticDefinition> {
+    let (subject_tp, predicate_tp) = tp.split_around(" are ")?;
+    let affected = parse_compound_all_subjects_filter(subject_tp.original)?;
+
+    let predicate = predicate_tp.original.trim().trim_end_matches('.').trim();
+    let predicate_lower = predicate.to_lowercase();
+    if !nom_primitives::scan_contains(&predicate_lower, "creature") {
+        return None;
+    }
+    // CR 205.1b: additive predicates are owned by the additive compound handler.
+    if nom_primitives::scan_contains(&predicate_lower, "in addition to their other")
+        || nom_primitives::scan_contains(&predicate_lower, "in addition to its other")
+    {
+        return None;
+    }
+
+    let spec = super::oracle_effect::animation::parse_animation_spec(
+        predicate,
+        &mut ParseContext::default(),
+    )?;
+    let modifications =
+        super::oracle_effect::animation::animation_modifications_with_replacement(&spec, false);
+    if modifications.is_empty() {
+        return None;
+    }
+
+    Some(
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(modifications)
+            .description(text.to_string()),
+    )
+}
+
 /// Parse "all `<X>` and all `<Y>`[ and all `<Z>`…]" into an `Or` of per-subject
 /// filters. Peels conjuncts on the " and all " seam (so every conjunct after the
 /// first is an `all `-quantified subject) and parses each through the shared


### PR DESCRIPTION
## Summary

Completes the compound-subject animation class started in #5219 by adding the **replacement-semantics** sibling handler. PR #5219 gated its additive handler on the CR 205.1b marker (`in addition to their other types`); bare compounds like `All Elves and all Goblins are 2/2 Zombie creatures` previously fell through with no static.

`parse_compound_all_subjects_type_replacement` mirrors the #5219 structure:
- Reuses `parse_compound_all_subjects_filter` for `Or` subject distribution (CR 611.3)
- Parses the shared predicate once via `parse_animation_spec` + `animation_modifications_with_replacement(&spec, false)` (CR 205.1a subtype replacement, CR 613.4b base P/T)
- Dispatched immediately after the additive compound handler, before `parse_land_animation`

Closes #5235

## Files changed

- `crates/engine/src/parser/oracle_static/type_change.rs`
- `crates/engine/src/parser/oracle_static/dispatch.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo check -p engine` — clean
- [ ] `cargo test -p engine --lib parser::oracle_static` — blocked locally by Windows linker (`link.exe` missing operand); CI should verify
- [x] Updated regression: `compound_subject_animation_replacement_predicate` asserts `Or(Elf, Goblin)` + replacement mods; Life and Limb additive line still parses