### PR TITLE
feat(parser): compound-subject land type-change static (CR 611.3 / CR 305.7)

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1534,6 +1534,14 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
+    // CR 611.3 + CR 305.7: "All <X> and all <Y> are <basic land type>" — compound-
+    // subject land type replacement/addition. Must follow the animation compound
+    // handlers (creature-gated) and precede parse_land_animation /
+    // parse_land_type_change, which only resolve single-subject land filters.
+    if let Some(def) = parse_compound_all_subjects_land_type_change(&tp, &text) {
+        return Some(def);
+    }
+
     // CR 613.1d + CR 613.4b: "[Subject] lands are [P/T] creatures that are still
     // lands" — continuous land animation (Living Plane, Nature's Revolt). Must
     // come before parse_land_type_change: both split on "are", but the land

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14076,6 +14076,70 @@ fn all_mountains_are_plains_conversion() {
     }
 }
 
+// CR 611.3 + CR 305.7: compound-subject land type-change — same structural class
+// as Life and Limb's compound animation handler, but the predicate is a basic
+// land type grant/replacement rather than creature animation.
+#[test]
+fn compound_subject_land_type_change_replacement_predicate() {
+    let line = "All Mountains and all Forests are Plains.";
+    let defs = parse_static_line_multi(line);
+    assert_eq!(defs.len(), 1, "one compound static: {defs:?}");
+    let def = &defs[0];
+
+    let Some(TargetFilter::Or { filters }) = def.affected.as_ref() else {
+        panic!("affected must be Or of both subjects: {:?}", def.affected);
+    };
+    assert_eq!(filters.len(), 2, "one disjunct per subject: {filters:?}");
+    assert!(
+        filters.iter().any(|f| matches!(f, TargetFilter::Typed(tf)
+            if tf.type_filters.contains(&TypeFilter::Land)
+                && tf.type_filters.iter().any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Mountain")))),
+        "Mountain conjunct must be a LAND subtype: {:?}",
+        def.affected
+    );
+    assert!(
+        filters.iter().any(|f| matches!(f, TargetFilter::Typed(tf)
+            if tf.type_filters.contains(&TypeFilter::Land)
+                && tf.type_filters.iter().any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Forest")))),
+        "Forest conjunct must be a LAND subtype: {:?}",
+        def.affected
+    );
+    assert!(matches!(
+        def.modifications.as_slice(),
+        [ContinuousModification::SetBasicLandType { land_type }]
+        if *land_type == BasicLandType::Plains
+    ));
+
+    // Single-subject sibling still routes through parse_land_type_change.
+    assert!(parse_static_line("All Mountains are Plains.").is_some());
+
+    // Animation compounds stay on the animation handler, not land type-change.
+    assert_eq!(
+        parse_static_line_multi(
+            "All Forests and all Saprolings are 1/1 green Saproling creatures and \
+             Forest lands in addition to their other types."
+        )
+        .len(),
+        1,
+        "animation compound must not be land-type-claimed"
+    );
+}
+
+#[test]
+fn compound_subject_land_type_change_additive_predicate() {
+    let def = parse_static_line(
+        "All Mountains and all Islands are Swamps in addition to their other land types.",
+    )
+    .unwrap();
+    assert!(matches!(def.affected, Some(TargetFilter::Or { .. })));
+    assert_eq!(
+        def.modifications,
+        vec![ContinuousModification::AddSubtype {
+            subtype: "Swamp".to_string(),
+        }]
+    );
+}
+
 #[test]
 fn each_land_is_a_swamp_in_addition_urborg() {
     let def =

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1805,6 +1805,52 @@ pub(crate) fn parse_subject_is_supertype(
     )
 }
 
+/// CR 305.7: Decompose the predicate of a land type-changing static into layer-4
+/// modifications — replacement (`SetBasicLandType`), additive (`AddSubtype`), or
+/// all-basic-types (`AddAllBasicLandTypes`). Shared by the single-subject and
+/// compound-subject land type-change handlers.
+fn parse_land_type_change_modifications(rest: &str) -> Option<Vec<ContinuousModification>> {
+    let lower_rest = rest.to_lowercase();
+
+    // "every basic land type in addition to their other types"
+    if nom_tag_lower(&lower_rest, &lower_rest, "every basic land type").is_some()
+        && nom_primitives::scan_contains(&lower_rest, "in addition to")
+    {
+        return Some(vec![ContinuousModification::AddAllBasicLandTypes]);
+    }
+
+    // "[Type] in addition to {its/their} other {land }types" → AddSubtype (additive)
+    if let Some(type_part) = strip_in_addition_suffix(&lower_rest) {
+        let basic_type = parse_basic_land_type_plural(type_part.trim())?;
+        return Some(vec![ContinuousModification::AddSubtype {
+            subtype: basic_type.as_subtype_str().to_string(),
+        }]);
+    }
+
+    // CR 305.7: Replacement semantics — "[Type]" or "[Types]" → SetBasicLandType
+    // Try multi-type list first: "Mountain, Forest, and Plains"
+    if let Some(types) = parse_basic_land_type_list(rest.trim()) {
+        if types.len() == 1 {
+            return Some(vec![ContinuousModification::SetBasicLandType {
+                land_type: types[0],
+            }]);
+        }
+        // CR 305.7: Multiple types — first SetBasicLandType clears old subtypes,
+        // subsequent AddSubtype entries add the remaining types.
+        let mut mods = vec![ContinuousModification::SetBasicLandType {
+            land_type: types[0],
+        }];
+        for &lt in &types[1..] {
+            mods.push(ContinuousModification::AddSubtype {
+                subtype: lt.as_subtype_str().to_string(),
+            });
+        }
+        return Some(mods);
+    }
+
+    None
+}
+
 /// CR 305.7: Parse "[Subject] lands are [type]" land type-changing static abilities.
 /// Handles replacement ("Nonbasic lands are Mountains"), additive ("Each land is a
 /// Swamp in addition to its other land types"), and all-basic-types ("Lands you control
@@ -1820,65 +1866,13 @@ pub(crate) fn parse_land_type_change(tp: &TextPair<'_>, text: &str) -> Option<St
 
     // Only proceed if subject is a land-type-change subject (avoids matching non-land patterns).
     let affected = parse_land_type_change_subject(subject)?;
-    let lower_rest = rest.to_lowercase();
-
-    // "every basic land type in addition to their other types"
-    if nom_tag_lower(&lower_rest, &lower_rest, "every basic land type").is_some()
-        && nom_primitives::scan_contains(&lower_rest, "in addition to")
-    {
-        return Some(
-            StaticDefinition::continuous()
-                .affected(affected)
-                .modifications(vec![ContinuousModification::AddAllBasicLandTypes])
-                .description(text.to_string()),
-        );
-    }
-
-    // "[Type] in addition to {its/their} other {land }types" → AddSubtype (additive)
-    if let Some(type_part) = strip_in_addition_suffix(&lower_rest) {
-        let basic_type = parse_basic_land_type_plural(type_part.trim())?;
-        return Some(
-            StaticDefinition::continuous()
-                .affected(affected)
-                .modifications(vec![ContinuousModification::AddSubtype {
-                    subtype: basic_type.as_subtype_str().to_string(),
-                }])
-                .description(text.to_string()),
-        );
-    }
-
-    // CR 305.7: Replacement semantics — "[Type]" or "[Types]" → SetBasicLandType
-    // Try multi-type list first: "Mountain, Forest, and Plains"
-    if let Some(types) = parse_basic_land_type_list(rest.trim()) {
-        if types.len() == 1 {
-            return Some(
-                StaticDefinition::continuous()
-                    .affected(affected)
-                    .modifications(vec![ContinuousModification::SetBasicLandType {
-                        land_type: types[0],
-                    }])
-                    .description(text.to_string()),
-            );
-        }
-        // CR 305.7: Multiple types — first SetBasicLandType clears old subtypes,
-        // subsequent AddSubtype entries add the remaining types.
-        let mut mods = vec![ContinuousModification::SetBasicLandType {
-            land_type: types[0],
-        }];
-        for &lt in &types[1..] {
-            mods.push(ContinuousModification::AddSubtype {
-                subtype: lt.as_subtype_str().to_string(),
-            });
-        }
-        return Some(
-            StaticDefinition::continuous()
-                .affected(affected)
-                .modifications(mods)
-                .description(text.to_string()),
-        );
-    }
-
-    None
+    let modifications = parse_land_type_change_modifications(rest)?;
+    Some(
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(modifications)
+            .description(text.to_string()),
+    )
 }
 
 /// CR 613.1d (Layer 4) + CR 613.4b (Layer 7b) + CR 205.1b: Parse a continuous
@@ -1970,8 +1964,9 @@ pub(crate) fn parse_compound_all_subjects_type_change(
 
     let predicate = predicate_tp.original.trim().trim_end_matches('.').trim();
     let predicate_lower = predicate.to_lowercase();
-    // Claim only creature-animation predicates; a bare additive type line
-    // ("All Forests and all Saprolings are Plains") is owned elsewhere.
+    // Claim only creature-animation predicates; bare land type-change compounds
+    // ("All Mountains and all Forests are Plains") are owned by
+    // `parse_compound_all_subjects_land_type_change`.
     if !nom_primitives::scan_contains(&predicate_lower, "creature") {
         return None;
     }
@@ -2060,6 +2055,38 @@ pub(crate) fn parse_compound_all_subjects_type_replacement(
         return None;
     }
 
+    Some(
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(modifications)
+            .description(text.to_string()),
+    )
+}
+
+/// CR 611.3 + CR 305.7 + CR 205.1b: "All `<X>` and all `<Y>` are `<land-type
+/// predicate>`" — a compound-subject land type-change where one predicate applies
+/// uniformly to every object matching either basic-land-subject conjunct.
+///
+/// Sibling of the compound animation handlers: `parse_land_type_change` only
+/// resolves single-subject land filters, so a line like "All Mountains and all
+/// Forests are Plains" would otherwise strict-fail. Subjects distribute into an
+/// `Or` filter via [`parse_compound_all_subjects_filter`]; the predicate is
+/// parsed once through [`parse_land_type_change_modifications`]. The `"creature"`
+/// guard keeps animation compounds on the animation dispatch path.
+pub(crate) fn parse_compound_all_subjects_land_type_change(
+    tp: &TextPair<'_>,
+    text: &str,
+) -> Option<StaticDefinition> {
+    let (subject_tp, predicate_tp) = tp.split_around(" are ")?;
+    let affected = parse_compound_all_subjects_filter(subject_tp.original)?;
+
+    let predicate = predicate_tp.original.trim().trim_end_matches('.').trim();
+    let predicate_lower = predicate.to_lowercase();
+    if nom_primitives::scan_contains(&predicate_lower, "creature") {
+        return None;
+    }
+
+    let modifications = parse_land_type_change_modifications(predicate)?;
     Some(
         StaticDefinition::continuous()
             .affected(affected)


### PR DESCRIPTION
## Summary

Mirrors the **structural pattern** from #5219 (compound-subject static dispatch) for the **land type-change** axis:

- `parse_compound_all_subjects_land_type_change` in `type_change.rs`
- Reuses `parse_compound_all_subjects_filter` for `Or` subject distribution (CR 611.3)
- Factors predicate parsing into `parse_land_type_change_modifications`, shared with `parse_land_type_change`
- Dispatched after compound animation handlers, before `parse_land_animation` / single-subject `parse_land_type_change`
- `"creature"` gate keeps animation compounds (Life and Limb) on the animation path

Closes #5294

## Files changed

- `crates/engine/src/parser/oracle_static/type_change.rs`
- `crates/engine/src/parser/oracle_static/dispatch.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo check -p engine` — clean
- [ ] `cargo test -p engine --lib parser::oracle_static` — blocked locally by Windows linker; CI should verify
- [x] Replacement compound `All Mountains and all Forests are Plains.` → `Or` + `SetBasicLandType`
- [x] Additive compound `… Swamps in addition to their other land types` → `AddSubtype`
- [x] Life and Limb animation compound still parses via animation handler
