### PR TITLE
refactor(parser): nom P/T remainder combinator in parse_enchanted_is_type (#5300 follow-up)

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1063,8 +1063,9 @@ pub(crate) fn parse_static_line_inner(
     }
     // CR 205.1a + CR 613.1d + CR 613.4b: Lignify-class — "Enchanted <subject> is a
     // <creature subtype> with base power and toughness N/N …" names only a
-    // creature subtype before the base-P/T seam. Must precede parse_enchanted_is_type,
-    // which requires at least one granted core card type (issue #5300).
+    // creature subtype before the base-P/T seam (no SetCardTypes — CR 205.1a
+    // subtype replacement leaves card types alone). Must precede
+    // parse_enchanted_is_type (issue #5300).
     if let Some(def) = parse_enchanted_is_creature_subtype_with_base_pt(&tp, &text) {
         return Some(def);
     }

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1061,6 +1061,13 @@ pub(crate) fn parse_static_line_inner(
     if let Some(def) = parse_becomes_equipment_with_ability(&tp, &text) {
         return Some(def);
     }
+    // CR 205.1a + CR 613.1d + CR 613.4b: Lignify-class — "Enchanted <subject> is a
+    // <creature subtype> with base power and toughness N/N …" names only a
+    // creature subtype before the base-P/T seam. Must precede parse_enchanted_is_type,
+    // which requires at least one granted core card type (issue #5300).
+    if let Some(def) = parse_enchanted_is_creature_subtype_with_base_pt(&tp, &text) {
+        return Some(def);
+    }
     // CR 613.1d + CR 205.1a: "Enchanted [permanent-type] is a [type] [with base P/T N/N]
     // [in addition to its other types]" — type-changing aura effects.
     // Must come before the basic-land-type handler which is a subset of this pattern.

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1061,14 +1061,6 @@ pub(crate) fn parse_static_line_inner(
     if let Some(def) = parse_becomes_equipment_with_ability(&tp, &text) {
         return Some(def);
     }
-    // CR 205.1a + CR 613.1d + CR 613.4b: Lignify-class — "Enchanted <subject> is a
-    // <creature subtype> with base power and toughness N/N …" names only a
-    // creature subtype before the base-P/T seam (no SetCardTypes — CR 205.1a
-    // subtype replacement leaves card types alone). Must precede
-    // parse_enchanted_is_type (issue #5300).
-    if let Some(def) = parse_enchanted_is_creature_subtype_with_base_pt(&tp, &text) {
-        return Some(def);
-    }
     // CR 613.1d + CR 205.1a: "Enchanted [permanent-type] is a [type] [with base P/T N/N]
     // [in addition to its other types]" — type-changing aura effects.
     // Must come before the basic-land-type handler which is a subset of this pattern.

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -6,7 +6,7 @@ use super::prelude::*;
 #[allow(unused_imports)]
 use super::support::*;
 use crate::types::ability::PlayerFilter;
-use nom::character::complete::{alphanumeric1, digit1, one_of};
+use nom::character::complete::{alphanumeric1, char, digit1, one_of};
 use nom::combinator::{all_consuming, not, opt, peek, recognize};
 use nom::sequence::{delimited, pair};
 
@@ -1529,6 +1529,26 @@ pub(crate) fn extract_lose_keyword_clause(text: &str) -> Option<&str> {
     }
 
     None
+}
+
+/// Parse a leading P/T pair from Oracle text, returning values and remainder.
+///
+/// CR 613.4b: Layer 7b base power/toughness literals after "with base power
+/// and toughness". Composes the signed [`nom_primitives::parse_pt_modifier`]
+/// path and an unsigned `N/N` path so trailing clause text (e.g. "and loses
+/// all abilities") is left in the nom remainder for downstream parsers.
+pub(crate) fn parse_pt_mod_with_remainder(input: &str) -> OracleResult<'_, (i32, i32)> {
+    let input = input.trim();
+    alt((
+        nom_primitives::parse_pt_modifier,
+        (
+            nom_primitives::parse_number,
+            char('/'),
+            nom_primitives::parse_number,
+        )
+            .map(|(power, _, toughness)| (power as i32, toughness as i32)),
+    ))
+    .parse(input)
 }
 
 /// Parse a P/T modifier like "+2/+3", "-1/-1", "+3/-2" from Oracle text.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15212,6 +15212,26 @@ fn pronoun_is_a_noncreature_type_replacement_is_not_land_specific() {
 // the base-P/T seam; must become a creature (SetCardTypes), wipe/replace the
 // creature subtype set, set base P/T, and strip abilities.
 #[test]
+fn parse_pt_mod_with_remainder_consumes_base_pt_and_returns_clause_tail() {
+    let (rest, (p, t)) = super::grammar::parse_pt_mod_with_remainder(
+        "0/4 and loses all abilities",
+    )
+    .expect("unsigned base P/T + trailing clause");
+    assert_eq!((p, t), (0, 4));
+    assert_eq!(rest.trim(), "and loses all abilities");
+
+    let (rest, (p, t)) =
+        super::grammar::parse_pt_mod_with_remainder("0/4.").expect("trailing period only");
+    assert_eq!((p, t), (0, 4));
+    assert_eq!(rest.trim(), ".");
+
+    let (rest, (p, t)) = super::grammar::parse_pt_mod_with_remainder("0/4")
+        .expect("bare base P/T with no tail");
+    assert_eq!((p, t), (0, 4));
+    assert!(rest.trim().is_empty());
+}
+
+#[test]
 fn lignify_creature_subtype_with_base_pt_and_loses_abilities() {
     let def = parse_static_line(
         "Enchanted creature is a Treefolk with base power and toughness 0/4 and loses all abilities.",

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15207,7 +15207,7 @@ fn pronoun_is_a_noncreature_type_replacement_is_not_land_specific() {
     );
 }
 
-// Issue #5300: combinator boundary for unsigned base P/T + trailing clause.
+// Follow-up to #5305: nom P/T remainder combinator for parse_enchanted_is_type.
 #[test]
 fn parse_pt_mod_with_remainder_consumes_base_pt_and_returns_clause_tail() {
     let (rest, (p, t)) = super::grammar::parse_pt_mod_with_remainder("0/4 and loses all abilities")
@@ -15224,123 +15224,6 @@ fn parse_pt_mod_with_remainder_consumes_base_pt_and_returns_clause_tail() {
         super::grammar::parse_pt_mod_with_remainder("0/4").expect("bare base P/T with no tail");
     assert_eq!((p, t), (0, 4));
     assert!(rest.trim().is_empty());
-}
-
-// Issue #5300: Lignify via dedicated dispatch arm — subtype + base P/T + ability
-// strip only (CR 205.1a: no SetCardTypes). Sibling of
-// `lignify_subtype_only_with_base_pt_type_change`.
-#[test]
-fn lignify_creature_subtype_with_base_pt_and_loses_abilities() {
-    let def = parse_static_line(
-        "Enchanted creature is a Treefolk with base power and toughness 0/4 and loses all abilities.",
-    )
-    .unwrap();
-    assert_eq!(def.mode, StaticMode::Continuous);
-    let mods = &def.modifications;
-    assert!(
-        !mods
-            .iter()
-            .any(|m| matches!(m, ContinuousModification::SetCardTypes { .. })),
-        "subtype-only Lignify must not emit SetCardTypes: {mods:?}"
-    );
-    assert!(
-        mods.contains(&ContinuousModification::AddSubtype {
-            subtype: "Treefolk".to_string(),
-        }),
-        "must gain Treefolk subtype: {mods:?}"
-    );
-    assert!(mods.contains(&ContinuousModification::SetPower { value: 0 }));
-    assert!(mods.contains(&ContinuousModification::SetToughness { value: 4 }));
-    assert!(mods.contains(&ContinuousModification::RemoveAllAbilities));
-    let wipe_idx = mods
-        .iter()
-        .position(|m| {
-            matches!(
-                m,
-                ContinuousModification::RemoveAllSubtypes {
-                    set: crate::types::card_type::SubtypeSet::Creature
-                }
-            )
-        })
-        .expect("must wipe creature subtypes before AddSubtype (CR 205.1a)");
-    let add_idx = mods
-        .iter()
-        .position(|m| {
-            matches!(
-                m,
-                ContinuousModification::AddSubtype { subtype } if subtype == "Treefolk"
-            )
-        })
-        .expect("must add Treefolk");
-    assert!(
-        wipe_idx < add_idx,
-        "RemoveAllSubtypes(Creature) must precede AddSubtype(Treefolk): {mods:?}"
-    );
-    match &def.affected {
-        Some(TargetFilter::Typed(tf)) => assert!(
-            tf.properties.contains(&FilterProp::EnchantedBy),
-            "affected must be enchanted creature: {tf:?}"
-        ),
-        other => panic!("expected Typed EnchantedBy filter, got {other:?}"),
-    }
-}
-
-// Issue #5300: trailing period on base P/T must not feed "." into clause parsing.
-#[test]
-fn lignify_trailing_dot_on_base_pt_does_not_parse_spurious_clause() {
-    let def =
-        parse_static_line("Enchanted creature is a Treefolk with base power and toughness 0/4.")
-            .unwrap();
-    assert!(
-        !def.modifications
-            .iter()
-            .any(|m| matches!(m, ContinuousModification::RemoveAllAbilities)),
-        "trailing dot must not synthesize a clause mod: {:?}",
-        def.modifications
-    );
-}
-
-// Issue #5300 sibling — Frogify-style leading ability-strip before the copula.
-#[test]
-fn lignify_prefix_loses_abilities_before_subtype_copula() {
-    let def = parse_static_line(
-        "Enchanted creature loses all abilities and is a Treefolk with base power and toughness 0/4.",
-    )
-    .unwrap();
-    let mods = &def.modifications;
-    assert!(mods.contains(&ContinuousModification::RemoveAllAbilities));
-    assert!(
-        !mods
-            .iter()
-            .any(|m| matches!(m, ContinuousModification::SetCardTypes { .. })),
-        "prefix-order sibling must still be subtype-only: {mods:?}"
-    );
-    assert!(
-        mods.contains(&ContinuousModification::AddSubtype {
-            subtype: "Treefolk".to_string(),
-        }),
-        "prefix-order sibling must still grant Treefolk: {mods:?}"
-    );
-}
-
-// Issue #5300 regression: multi-core-type enchanted-is-type lines stay on the
-// general handler, not the subtype-only arm.
-#[test]
-fn darksteel_mutation_not_claimed_by_subtype_only_handler() {
-    let def = parse_static_line(
-        "Enchanted creature is an Insect artifact creature with base power and \
-             toughness 0/1 and has indestructible, and it loses all other abilities, \
-             card types, and creature types.",
-    )
-    .unwrap();
-    assert!(
-        def.modifications
-            .contains(&ContinuousModification::AddKeyword {
-                keyword: Keyword::Indestructible,
-            }),
-        "general parse_enchanted_is_type path must preserve indestructible: {:?}",
-        def.modifications
-    );
 }
 
 // Issue #4770: Imprisoned in the Moon — "Enchanted permanent is a colorless land

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15207,6 +15207,103 @@ fn pronoun_is_a_noncreature_type_replacement_is_not_land_specific() {
     );
 }
 
+// Issue #5300: Lignify — "Enchanted creature is a Treefolk with base power and
+// toughness 0/4 and loses all abilities." Names only a creature subtype before
+// the base-P/T seam; must become a creature (SetCardTypes), wipe/replace the
+// creature subtype set, set base P/T, and strip abilities.
+#[test]
+fn lignify_creature_subtype_with_base_pt_and_loses_abilities() {
+    let def = parse_static_line(
+        "Enchanted creature is a Treefolk with base power and toughness 0/4 and loses all abilities.",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    let mods = &def.modifications;
+    assert!(
+        mods.contains(&ContinuousModification::SetCardTypes {
+            core_types: vec![crate::types::card_type::CoreType::Creature],
+        }),
+        "must become a creature: {mods:?}"
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddSubtype {
+            subtype: "Treefolk".to_string(),
+        }),
+        "must gain Treefolk subtype: {mods:?}"
+    );
+    assert!(mods.contains(&ContinuousModification::SetPower { value: 0 }));
+    assert!(mods.contains(&ContinuousModification::SetToughness { value: 4 }));
+    assert!(mods.contains(&ContinuousModification::RemoveAllAbilities));
+    let wipe_idx = mods
+        .iter()
+        .position(|m| {
+            matches!(
+                m,
+                ContinuousModification::RemoveAllSubtypes {
+                    set: crate::types::card_type::SubtypeSet::Creature
+                }
+            )
+        })
+        .expect("must wipe creature subtypes before AddSubtype (CR 205.1a)");
+    let add_idx = mods
+        .iter()
+        .position(|m| {
+            matches!(
+                m,
+                ContinuousModification::AddSubtype { subtype } if subtype == "Treefolk"
+            )
+        })
+        .expect("must add Treefolk");
+    assert!(
+        wipe_idx < add_idx,
+        "RemoveAllSubtypes(Creature) must precede AddSubtype(Treefolk): {mods:?}"
+    );
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => assert!(
+            tf.properties.contains(&FilterProp::EnchantedBy),
+            "affected must be enchanted creature: {tf:?}"
+        ),
+        other => panic!("expected Typed EnchantedBy filter, got {other:?}"),
+    }
+}
+
+// Issue #5300 sibling — Frogify-style leading ability-strip before the copula.
+#[test]
+fn lignify_prefix_loses_abilities_before_subtype_copula() {
+    let def = parse_static_line(
+        "Enchanted creature loses all abilities and is a Treefolk with base power and toughness 0/4.",
+    )
+    .unwrap();
+    let mods = &def.modifications;
+    assert!(mods.contains(&ContinuousModification::RemoveAllAbilities));
+    assert!(
+        mods.contains(&ContinuousModification::AddSubtype {
+            subtype: "Treefolk".to_string(),
+        }),
+        "prefix-order sibling must still grant Treefolk: {mods:?}"
+    );
+}
+
+// Issue #5300 regression: multi-core-type enchanted-is-type lines stay on the
+// general handler, not the subtype-only arm.
+#[test]
+fn darksteel_mutation_not_claimed_by_subtype_only_handler() {
+    let def = parse_static_line(
+        "Enchanted creature is an Insect artifact creature with base power and \
+             toughness 0/1 and has indestructible, and it loses all other abilities, \
+             card types, and creature types.",
+    )
+    .unwrap();
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::AddKeyword {
+                keyword: Keyword::Indestructible,
+            }),
+        "general parse_enchanted_is_type path must preserve indestructible: {:?}",
+        def.modifications
+    );
+}
+
 // Issue #4770: Imprisoned in the Moon — "Enchanted permanent is a colorless land
 // with "{T}: Add {C}" and loses all other card types and abilities." Must become
 // a colorless land (SetCardTypes + SetColor), lose its own abilities

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15213,10 +15213,8 @@ fn pronoun_is_a_noncreature_type_replacement_is_not_land_specific() {
 // creature subtype set, set base P/T, and strip abilities.
 #[test]
 fn parse_pt_mod_with_remainder_consumes_base_pt_and_returns_clause_tail() {
-    let (rest, (p, t)) = super::grammar::parse_pt_mod_with_remainder(
-        "0/4 and loses all abilities",
-    )
-    .expect("unsigned base P/T + trailing clause");
+    let (rest, (p, t)) = super::grammar::parse_pt_mod_with_remainder("0/4 and loses all abilities")
+        .expect("unsigned base P/T + trailing clause");
     assert_eq!((p, t), (0, 4));
     assert_eq!(rest.trim(), "and loses all abilities");
 
@@ -15225,8 +15223,8 @@ fn parse_pt_mod_with_remainder_consumes_base_pt_and_returns_clause_tail() {
     assert_eq!((p, t), (0, 4));
     assert_eq!(rest.trim(), ".");
 
-    let (rest, (p, t)) = super::grammar::parse_pt_mod_with_remainder("0/4")
-        .expect("bare base P/T with no tail");
+    let (rest, (p, t)) =
+        super::grammar::parse_pt_mod_with_remainder("0/4").expect("bare base P/T with no tail");
     assert_eq!((p, t), (0, 4));
     assert!(rest.trim().is_empty());
 }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15267,6 +15267,21 @@ fn lignify_creature_subtype_with_base_pt_and_loses_abilities() {
     }
 }
 
+// Issue #5300: trailing period on base P/T must not feed "." into clause parsing.
+#[test]
+fn lignify_trailing_dot_on_base_pt_does_not_parse_spurious_clause() {
+    let def =
+        parse_static_line("Enchanted creature is a Treefolk with base power and toughness 0/4.")
+            .unwrap();
+    assert!(
+        !def.modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::RemoveAllAbilities)),
+        "trailing dot must not synthesize a clause mod: {:?}",
+        def.modifications
+    );
+}
+
 // Issue #5300 sibling — Frogify-style leading ability-strip before the copula.
 #[test]
 fn lignify_prefix_loses_abilities_before_subtype_copula() {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15207,10 +15207,7 @@ fn pronoun_is_a_noncreature_type_replacement_is_not_land_specific() {
     );
 }
 
-// Issue #5300: Lignify — "Enchanted creature is a Treefolk with base power and
-// toughness 0/4 and loses all abilities." Names only a creature subtype before
-// the base-P/T seam; must become a creature (SetCardTypes), wipe/replace the
-// creature subtype set, set base P/T, and strip abilities.
+// Issue #5300: combinator boundary for unsigned base P/T + trailing clause.
 #[test]
 fn parse_pt_mod_with_remainder_consumes_base_pt_and_returns_clause_tail() {
     let (rest, (p, t)) = super::grammar::parse_pt_mod_with_remainder("0/4 and loses all abilities")
@@ -15229,6 +15226,9 @@ fn parse_pt_mod_with_remainder_consumes_base_pt_and_returns_clause_tail() {
     assert!(rest.trim().is_empty());
 }
 
+// Issue #5300: Lignify via dedicated dispatch arm — subtype + base P/T + ability
+// strip only (CR 205.1a: no SetCardTypes). Sibling of
+// `lignify_subtype_only_with_base_pt_type_change`.
 #[test]
 fn lignify_creature_subtype_with_base_pt_and_loses_abilities() {
     let def = parse_static_line(
@@ -15238,10 +15238,10 @@ fn lignify_creature_subtype_with_base_pt_and_loses_abilities() {
     assert_eq!(def.mode, StaticMode::Continuous);
     let mods = &def.modifications;
     assert!(
-        mods.contains(&ContinuousModification::SetCardTypes {
-            core_types: vec![crate::types::card_type::CoreType::Creature],
-        }),
-        "must become a creature: {mods:?}"
+        !mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetCardTypes { .. })),
+        "subtype-only Lignify must not emit SetCardTypes: {mods:?}"
     );
     assert!(
         mods.contains(&ContinuousModification::AddSubtype {
@@ -15309,6 +15309,12 @@ fn lignify_prefix_loses_abilities_before_subtype_copula() {
     .unwrap();
     let mods = &def.modifications;
     assert!(mods.contains(&ContinuousModification::RemoveAllAbilities));
+    assert!(
+        !mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetCardTypes { .. })),
+        "prefix-order sibling must still be subtype-only: {mods:?}"
+    );
     assert!(
         mods.contains(&ContinuousModification::AddSubtype {
             subtype: "Treefolk".to_string(),

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -551,12 +551,14 @@ pub(crate) fn try_parse_self_is_also_subtypes(
 /// Lignify-class — "Enchanted <subject> is a <creature subtype> with base power
 /// and toughness N/N [and loses all abilities]." The grammar names only a
 /// creature subtype (Treefolk, Wall, …) before the base-P/T seam — no explicit
-/// "creature" core-type word — so [`parse_enchanted_is_type`] declines with an
-/// empty `granted_core_types` list. Emits `SetCardTypes { Creature }` (CR 205.1a
-/// replacement), `RemoveAllSubtypes { Creature }` + `AddSubtype` (subtype set
-/// replacement), base P/T (CR 613.4b), and optional `RemoveAllAbilities` (CR
-/// 613.1f) from either the leading "loses all abilities and is a" prefix or the
-/// trailing "and loses all abilities" clause. No new variant, no new runtime.
+/// "creature" core-type word. CR 205.1a: setting a creature subtype replaces
+/// creature subtypes but does NOT set or overwrite card types, so this arm must
+/// NOT emit `SetCardTypes` (an enchanted Artifact/Land creature keeps
+/// Artifact/Land). Emits `RemoveAllSubtypes { Creature }` + `AddSubtype`
+/// (subtype set replacement), base P/T (CR 613.4b), and optional
+/// `RemoveAllAbilities` (CR 613.1f) from either the leading "loses all abilities
+/// and is a" prefix or the trailing "and loses all abilities" clause. No new
+/// variant, no new runtime.
 ///
 /// Dispatched AFTER [`parse_enchanted_becomes_type_with_ability`] and BEFORE
 /// [`parse_enchanted_is_type`], which owns multi-core-type phrases ("Insect
@@ -614,14 +616,11 @@ pub(crate) fn parse_enchanted_is_creature_subtype_with_base_pt(
         parse_continuous_modifications(remainder)
     };
 
-    // CR 205.1a: "is a Treefolk" replaces existing card types with Creature.
-    modifications.push(ContinuousModification::SetCardTypes {
-        core_types: vec![CoreType::Creature],
-    });
     // CR 613.4b: Layer 7b — "with base power and toughness N/N" sets base P/T.
     modifications.push(ContinuousModification::SetPower { value: p });
     modifications.push(ContinuousModification::SetToughness { value: t });
-    // CR 205.1a: new creature subtype(s) replace existing creature subtypes.
+    // CR 205.1a: new creature subtype(s) replace existing creature subtypes only —
+    // card types are unchanged (no SetCardTypes).
     modifications.push(ContinuousModification::RemoveAllSubtypes {
         set: SubtypeSet::Creature,
     });

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -609,7 +609,7 @@ pub(crate) fn parse_enchanted_is_creature_subtype_with_base_pt(
 
     let after_pt_trimmed = after_pt.original.trim().trim_end_matches('.');
     let (p, t) = parse_pt_mod(after_pt_trimmed)?;
-    let pt_part_lower = after_pt.lower.trim();
+    let pt_part_lower = after_pt.lower.trim().trim_end_matches('.');
     let slash_pos = pt_part_lower.find('/')?;
     let after_slash = &pt_part_lower[slash_pos + 1..];
     let t_end = after_slash
@@ -622,11 +622,14 @@ pub(crate) fn parse_enchanted_is_creature_subtype_with_base_pt(
         parse_continuous_modifications(remainder)
     };
 
+    // CR 205.1a: "is a Treefolk" replaces existing card types with Creature.
     modifications.push(ContinuousModification::SetCardTypes {
         core_types: vec![CoreType::Creature],
     });
+    // CR 613.4b: Layer 7b — "with base power and toughness N/N" sets base P/T.
     modifications.push(ContinuousModification::SetPower { value: p });
     modifications.push(ContinuousModification::SetToughness { value: t });
+    // CR 205.1a: new creature subtype(s) replace existing creature subtypes.
     modifications.push(ContinuousModification::RemoveAllSubtypes {
         set: SubtypeSet::Creature,
     });

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -547,98 +547,6 @@ pub(crate) fn try_parse_self_is_also_subtypes(
     )
 }
 
-/// CR 205.1a + CR 613.1d (Layer 4) + CR 613.4b (Layer 7b) + CR 613.1f (Layer 6):
-/// Lignify-class — "Enchanted <subject> is a <creature subtype> with base power
-/// and toughness N/N [and loses all abilities]." The grammar names only a
-/// creature subtype (Treefolk, Wall, …) before the base-P/T seam — no explicit
-/// "creature" core-type word. CR 205.1a: setting a creature subtype replaces
-/// creature subtypes but does NOT set or overwrite card types, so this arm must
-/// NOT emit `SetCardTypes` (an enchanted Artifact/Land creature keeps
-/// Artifact/Land). Emits `RemoveAllSubtypes { Creature }` + `AddSubtype`
-/// (subtype set replacement), base P/T (CR 613.4b), and optional
-/// `RemoveAllAbilities` (CR 613.1f) from either the leading "loses all abilities
-/// and is a" prefix or the trailing "and loses all abilities" clause. No new
-/// variant, no new runtime.
-///
-/// Dispatched AFTER [`parse_enchanted_becomes_type_with_ability`] and BEFORE
-/// [`parse_enchanted_is_type`], which owns multi-core-type phrases ("Insect
-/// artifact creature", "blue Frog creature", …). Closes #5300.
-pub(crate) fn parse_enchanted_is_creature_subtype_with_base_pt(
-    tp: &TextPair<'_>,
-    description: &str,
-) -> Option<StaticDefinition> {
-    let (before_pt, after_pt) = tp.split_around(" with base power and toughness ")?;
-
-    let before_rest = nom_tag_tp(&before_pt, "enchanted ")?;
-    let (r, perm_tf) = nom_target::parse_type_filter_word(before_rest.lower).ok()?;
-
-    let mut modifications = Vec::new();
-    type VE<'a> = OracleError<'a>;
-
-    let is_rest = if let Ok((r, _)) = alt((
-        tag::<_, _, VE>("loses all abilities and is a "),
-        tag::<_, _, VE>("loses all abilities and is an "),
-    ))
-    .parse(r.trim_start())
-    {
-        modifications.push(ContinuousModification::RemoveAllAbilities);
-        r
-    } else if let Ok((r, _)) =
-        alt((tag::<_, _, VE>("is a "), tag::<_, _, VE>("is an "))).parse(r.trim_start())
-    {
-        r
-    } else {
-        return None;
-    };
-
-    let is_rest = is_rest.trim_end_matches('.');
-
-    // Parse one or more creature subtypes; decline if a core-type word appears.
-    let mut r = is_rest.trim();
-    let mut subtypes: Vec<String> = Vec::new();
-    while let Some((canonical, consumed)) = parse_subtype(r) {
-        if core_type_from_additive_word(&canonical.to_lowercase()).is_some() {
-            return None;
-        }
-        subtypes.push(canonical);
-        r = r[consumed..].trim_start();
-    }
-    if subtypes.is_empty() || !r.trim().is_empty() {
-        return None;
-    }
-
-    let pt_tail = after_pt.lower.trim().trim_end_matches('.');
-    let (remainder, (p, t)) = parse_pt_mod_with_remainder(pt_tail).ok()?;
-    let remainder = remainder.trim().trim_end_matches('.').trim();
-    let clause_mods = if remainder.is_empty() {
-        Vec::new()
-    } else {
-        parse_continuous_modifications(remainder)
-    };
-
-    // CR 613.4b: Layer 7b — "with base power and toughness N/N" sets base P/T.
-    modifications.push(ContinuousModification::SetPower { value: p });
-    modifications.push(ContinuousModification::SetToughness { value: t });
-    // CR 205.1a: new creature subtype(s) replace existing creature subtypes only —
-    // card types are unchanged (no SetCardTypes).
-    modifications.push(ContinuousModification::RemoveAllSubtypes {
-        set: SubtypeSet::Creature,
-    });
-    modifications.extend(clause_mods);
-    for subtype in subtypes {
-        modifications.push(ContinuousModification::AddSubtype { subtype });
-    }
-
-    Some(
-        StaticDefinition::continuous()
-            .affected(TargetFilter::Typed(
-                TypedFilter::new(perm_tf).properties(vec![FilterProp::EnchantedBy]),
-            ))
-            .modifications(modifications)
-            .description(description.to_string()),
-    )
-}
-
 /// CR 205.1a + CR 613.1d (Layer 4) + CR 613.1f (Layer 6): Imprisoned-in-the-Moon
 /// class — an Aura that turns the enchanted permanent into a colorless permanent
 /// of a single card type (optionally with subtype[s]) carrying a granted ability
@@ -977,14 +885,9 @@ pub(crate) fn parse_enchanted_is_type(
             type_part.rsplit_once(" with base power and toughness ")
         // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
         {
-            if let Some((p, t)) = parse_pt_mod(pt_part) {
-                // Locate the end of the "N/N" token to capture the remainder.
-                let slash_pos = pt_part.find('/').unwrap_or(0);
-                let after_slash = &pt_part[slash_pos + 1..];
-                let t_end = after_slash
-                    .find(|c: char| c.is_whitespace() || c == '.' || c == ',')
-                    .unwrap_or(after_slash.len());
-                let remainder = after_slash[t_end..].trim();
+            let pt_tail = pt_part.trim().trim_end_matches('.');
+            if let Ok((remainder, (p, t))) = parse_pt_mod_with_remainder(pt_tail) {
+                let remainder = remainder.trim().trim_end_matches('.').trim();
                 let clause = (!remainder.is_empty()).then_some(remainder);
                 (before_pt.trim(), Some((p, t)), clause)
             } else {
@@ -996,15 +899,9 @@ pub(crate) fn parse_enchanted_is_type(
 
     // Parse "N/N [color] [type] [subtype]" patterns for Darksteel Mutation style
     // e.g., "0/1 green Insect creature"
-    let (type_part, inline_pt) = if let Some((p, t)) = parse_pt_mod(type_part) {
-        // parse_pt_mod trims and finds the slash — get remainder after P/T
-        let slash_pos = type_part.find('/').unwrap_or(0);
-        let after_slash = &type_part[slash_pos + 1..];
-        let t_end = after_slash
-            .find(|c: char| c.is_whitespace() || c == '.' || c == ',')
-            .unwrap_or(after_slash.len());
-        let rest = after_slash[t_end..].trim();
-        (rest, Some((p, t)))
+    let (type_part, inline_pt) = if let Ok((rest, (p, t))) = parse_pt_mod_with_remainder(type_part)
+    {
+        (rest.trim(), Some((p, t)))
     } else {
         (type_part, None)
     };

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -547,11 +547,104 @@ pub(crate) fn try_parse_self_is_also_subtypes(
     )
 }
 
-/// CR 613.1d + CR 205.1a: "Enchanted [permanent-type] is a/an [type] [with base P/T N/N]
-/// [in addition to its other types]"
+/// CR 205.1a + CR 613.1d (Layer 4) + CR 613.4b (Layer 7b) + CR 613.1f (Layer 6):
+/// Lignify-class — "Enchanted <subject> is a <creature subtype> with base power
+/// and toughness N/N [and loses all abilities]." The grammar names only a
+/// creature subtype (Treefolk, Wall, …) before the base-P/T seam — no explicit
+/// "creature" core-type word — so [`parse_enchanted_is_type`] declines with an
+/// empty `granted_core_types` list. Emits `SetCardTypes { Creature }` (CR 205.1a
+/// replacement), `RemoveAllSubtypes { Creature }` + `AddSubtype` (subtype set
+/// replacement), base P/T (CR 613.4b), and optional `RemoveAllAbilities` (CR
+/// 613.1f) from either the leading "loses all abilities and is a" prefix or the
+/// trailing "and loses all abilities" clause. No new variant, no new runtime.
 ///
-/// Handles type-changing aura effects like Ensoul Artifact, Imprisoned in the Moon,
-/// and Darksteel Mutation. Reuses nom type-word and P/T combinators.
+/// Dispatched AFTER [`parse_enchanted_becomes_type_with_ability`] and BEFORE
+/// [`parse_enchanted_is_type`], which owns multi-core-type phrases ("Insect
+/// artifact creature", "blue Frog creature", …). Closes #5300.
+pub(crate) fn parse_enchanted_is_creature_subtype_with_base_pt(
+    tp: &TextPair<'_>,
+    description: &str,
+) -> Option<StaticDefinition> {
+    use crate::types::card_type::{CoreType, SubtypeSet};
+
+    let (before_pt, after_pt) = tp.split_around(" with base power and toughness ")?;
+
+    let before_rest = nom_tag_tp(&before_pt, "enchanted ")?;
+    let (r, perm_tf) = nom_target::parse_type_filter_word(before_rest.lower).ok()?;
+
+    let mut modifications = Vec::new();
+    type VE<'a> = OracleError<'a>;
+
+    let is_rest = if let Ok((r, _)) = alt((
+        tag::<_, _, VE>("loses all abilities and is a "),
+        tag::<_, _, VE>("loses all abilities and is an "),
+    ))
+    .parse(r.trim_start())
+    {
+        modifications.push(ContinuousModification::RemoveAllAbilities);
+        r
+    } else if let Ok((r, _)) =
+        alt((tag::<_, _, VE>("is a "), tag::<_, _, VE>("is an "))).parse(r.trim_start())
+    {
+        r
+    } else {
+        return None;
+    };
+
+    let is_rest = is_rest.trim_end_matches('.');
+
+    // Parse one or more creature subtypes; decline if a core-type word appears.
+    let mut r = is_rest.trim();
+    let mut subtypes: Vec<String> = Vec::new();
+    while let Some((canonical, consumed)) = parse_subtype(r) {
+        if core_type_from_additive_word(&canonical.to_lowercase()).is_some() {
+            return None;
+        }
+        subtypes.push(canonical);
+        r = r[consumed..].trim_start();
+    }
+    if subtypes.is_empty() || !r.trim().is_empty() {
+        return None;
+    }
+
+    let after_pt_trimmed = after_pt.original.trim().trim_end_matches('.');
+    let (p, t) = parse_pt_mod(after_pt_trimmed)?;
+    let pt_part_lower = after_pt.lower.trim();
+    let slash_pos = pt_part_lower.find('/')?;
+    let after_slash = &pt_part_lower[slash_pos + 1..];
+    let t_end = after_slash
+        .find(|c: char| c.is_whitespace() || c == '.' || c == ',')
+        .unwrap_or(after_slash.len());
+    let remainder = after_slash[t_end..].trim();
+    let clause_mods = if remainder.is_empty() {
+        Vec::new()
+    } else {
+        parse_continuous_modifications(remainder)
+    };
+
+    modifications.push(ContinuousModification::SetCardTypes {
+        core_types: vec![CoreType::Creature],
+    });
+    modifications.push(ContinuousModification::SetPower { value: p });
+    modifications.push(ContinuousModification::SetToughness { value: t });
+    modifications.push(ContinuousModification::RemoveAllSubtypes {
+        set: SubtypeSet::Creature,
+    });
+    modifications.extend(clause_mods);
+    for subtype in subtypes {
+        modifications.push(ContinuousModification::AddSubtype { subtype });
+    }
+
+    Some(
+        StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(
+                TypedFilter::new(perm_tf).properties(vec![FilterProp::EnchantedBy]),
+            ))
+            .modifications(modifications)
+            .description(description.to_string()),
+    )
+}
+
 /// CR 205.1a + CR 613.1d (Layer 4) + CR 613.1f (Layer 6): Imprisoned-in-the-Moon
 /// class — an Aura that turns the enchanted permanent into a colorless permanent
 /// of a single card type (optionally with subtype[s]) carrying a granted ability
@@ -825,6 +918,11 @@ fn core_type_subtype_set(
     }
 }
 
+/// CR 613.1d + CR 205.1a: "Enchanted [permanent-type] is a/an [type] [with base P/T N/N]
+/// [in addition to its other types]"
+///
+/// Handles type-changing aura effects like Ensoul Artifact, Imprisoned in the Moon,
+/// and Darksteel Mutation. Reuses nom type-word and P/T combinators.
 pub(crate) fn parse_enchanted_is_type(
     tp: &TextPair,
     description: &str,

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -565,8 +565,6 @@ pub(crate) fn parse_enchanted_is_creature_subtype_with_base_pt(
     tp: &TextPair<'_>,
     description: &str,
 ) -> Option<StaticDefinition> {
-    use crate::types::card_type::{CoreType, SubtypeSet};
-
     let (before_pt, after_pt) = tp.split_around(" with base power and toughness ")?;
 
     let before_rest = nom_tag_tp(&before_pt, "enchanted ")?;
@@ -607,15 +605,9 @@ pub(crate) fn parse_enchanted_is_creature_subtype_with_base_pt(
         return None;
     }
 
-    let after_pt_trimmed = after_pt.original.trim().trim_end_matches('.');
-    let (p, t) = parse_pt_mod(after_pt_trimmed)?;
-    let pt_part_lower = after_pt.lower.trim().trim_end_matches('.');
-    let slash_pos = pt_part_lower.find('/')?;
-    let after_slash = &pt_part_lower[slash_pos + 1..];
-    let t_end = after_slash
-        .find(|c: char| c.is_whitespace() || c == '.' || c == ',')
-        .unwrap_or(after_slash.len());
-    let remainder = after_slash[t_end..].trim();
+    let pt_tail = after_pt.lower.trim().trim_end_matches('.');
+    let (remainder, (p, t)) = parse_pt_mod_with_remainder(pt_tail).ok()?;
+    let remainder = remainder.trim().trim_end_matches('.').trim();
     let clause_mods = if remainder.is_empty() {
         Vec::new()
     } else {


### PR DESCRIPTION
﻿## Summary

Follow-up to #5305: the Lignify-class subtype-only fix already merged on main via `parse_enchanted_is_type` (`subtype_only_creature_change`). This PR **does not** add a second dispatch arm.

Instead it lands `parse_pt_mod_with_remainder` — a nom combinator that consumes signed/unsigned `N/N` base P/T and returns the remainder — and wires it into `parse_enchanted_is_type`'s base-P/T and inline-P/T paths, replacing `find('/')` byte-slicing.

Relates to #5300. Supersedes the original dedicated-handler approach from this branch.

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline
- [x] **Not** `/engine-implementer` — parser refactor only; no new runtime or resolver work.

## CR references

- `CR 613.4b` — Layer 7b base P/T parsing (`parse_pt_mod_with_remainder`)

## Verification

**Scope vs main:** 3 files — `grammar.rs` (+combinator), `type_change.rs` (refactor `parse_enchanted_is_type` P/T tail), `tests.rs` (combinator unit test). No `dispatch.rs` delta.

**Lignify coverage:** Already on main via #5305 (`lignify_subtype_only_with_base_pt_type_change` at `tests.rs:14133`). This PR unique value is nom parser-boundary cleanup in the existing handler.

**Tests:**
- `parse_pt_mod_with_remainder_consumes_base_pt_and_returns_clause_tail` — combinator boundary
- `darksteel_mutation_full_modification_set` + `lignify_subtype_only_with_base_pt_type_change` on main — integration coverage

**Local:** `cargo fmt --all` — exit 0. **CI:** pending on push.

## Relationship to #5305

| | #5305 (merged) | This PR |
|---|---|---|
| Lignify parse | `parse_enchanted_is_type` subtype-only branch | unchanged |
| P/T remainder | `find('/')` byte-slicing | `parse_pt_mod_with_remainder` (nom) |
| Dispatch surface | no new arm | no new arm |
