### PR TITLE
docs(skill): fold stale MulliganBottomCards reference into MulliganDecision

### DIFF
--- a/.claude/skills/add-interactive-effect/SKILL.md
+++ b/.claude/skills/add-interactive-effect/SKILL.md
@@ -357,8 +357,7 @@ For interactive replacements, you need to:
 
 | Effect | WaitingFor | Complexity |
 |--------|-----------|------------|
-| **Mulligan** | `MulliganDecision { player }` | Simple — keep/mulligan |
-| **MulliganBottom** | `MulliganBottomCards { player, count }` | Simple — cards to bottom |
+| **Mulligan** | `MulliganDecision { player }` | Simple — keep/mulligan (bottoming is a `MulliganDecisionPhase::BottomCards` sub-phase of the same variant) |
 | **Sideboard** | `BetweenGamesSideboard { player, ... }` | Medium — sideboard swaps |
 | **PlayDraw** | `BetweenGamesChoosePlayDraw { player }` | Simple — play/draw choice |
 | **GameOver** | `GameOver { winners }` | Terminal state |


### PR DESCRIPTION
## Summary

- Split out from #5236 (mulligan bottoming per-declare-point fix), which removes `WaitingFor::MulliganBottomCards` — bottoming is now a `MulliganDecisionPhase::BottomCards` sub-phase of the existing `MulliganDecision` variant.
- `.claude/skills/add-interactive-effect/SKILL.md`'s reference table still had a separate `MulliganBottom` row pointing at the now-removed variant. Folds that note into the existing `Mulligan` row instead of leaving a stale second row.
- This is its own PR because `.claude/skills/**` is a hard-stop path for the PR review loop per `.agents/pr-review-policy.toml` and can't be bundled with engine-code PRs.

## Test plan

- [x] Doc-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)