### PR TITLE
fix(parser): Lignify-class subtype-only enchanted type-change with base P/T (#5300)

### DIFF
--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14133,9 +14133,9 @@ fn darksteel_mutation_full_modification_set() {
 /// CR 205.1a + CR 613.4b + CR 613.1f (issue #5300): Lignify-class subtype-only
 /// type-change auras — "Enchanted creature is a <creature subtype> with base
 /// power and toughness N/N and loses all abilities." The copula names only a
-/// creature SUBTYPE (no core card-type word), but a creature subtype makes the
-/// object a creature, so the Creature core type is implied and the full type
-/// replacement is emitted. Before the fix the "is a Treefolk" subtype was
+/// creature SUBTYPE (no core card-type word), Setting a creature subtype replaces
+/// the object's creature subtypes but does NOT set or overwrite its card types
+/// (CR 205.1a), so `SetCardTypes` must NOT be emitted. Before the fix the "is a Treefolk" subtype was
 /// silently dropped (only P/T + loses-abilities survived).
 #[test]
 fn lignify_subtype_only_with_base_pt_type_change() {
@@ -14146,11 +14146,14 @@ fn lignify_subtype_only_with_base_pt_type_change() {
     .unwrap();
     assert_eq!(def.mode, StaticMode::Continuous);
     let mods = &def.modifications;
+    // CR 205.1a: a subtype change does not affect card types — no SetCardTypes,
+    // so an enchanted Artifact/Land creature keeps Artifact/Land.
     assert!(
-        mods.contains(&ContinuousModification::SetCardTypes {
-            core_types: vec![CoreType::Creature],
-        }),
-        "creature subtype must imply SetCardTypes[Creature]: {mods:?}"
+        !mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetCardTypes { .. })),
+        "Lignify sets only the subtype; it must NOT emit SetCardTypes (which would \
+         strip other card types like Artifact/Land): {mods:?}"
     );
     assert!(
         mods.contains(&ContinuousModification::AddSubtype {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14130,6 +14130,53 @@ fn darksteel_mutation_full_modification_set() {
     );
 }
 
+/// CR 205.1a + CR 613.4b + CR 613.1f (issue #5300): Lignify-class subtype-only
+/// type-change auras — "Enchanted creature is a <creature subtype> with base
+/// power and toughness N/N and loses all abilities." The copula names only a
+/// creature SUBTYPE (no core card-type word), but a creature subtype makes the
+/// object a creature, so the Creature core type is implied and the full type
+/// replacement is emitted. Before the fix the "is a Treefolk" subtype was
+/// silently dropped (only P/T + loses-abilities survived).
+#[test]
+fn lignify_subtype_only_with_base_pt_type_change() {
+    use crate::types::card_type::SubtypeSet;
+    let def = parse_static_line(
+        "Enchanted creature is a Treefolk with base power and toughness 0/4 and loses all abilities.",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    let mods = &def.modifications;
+    assert!(
+        mods.contains(&ContinuousModification::SetCardTypes {
+            core_types: vec![CoreType::Creature],
+        }),
+        "creature subtype must imply SetCardTypes[Creature]: {mods:?}"
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddSubtype {
+            subtype: "Treefolk".to_string(),
+        }),
+        "the 'is a Treefolk' subtype must not be dropped: {mods:?}"
+    );
+    assert!(mods.contains(&ContinuousModification::RemoveAllSubtypes {
+        set: SubtypeSet::Creature,
+    }));
+    assert!(mods.contains(&ContinuousModification::SetPower { value: 0 }));
+    assert!(mods.contains(&ContinuousModification::SetToughness { value: 4 }));
+    assert!(mods.contains(&ContinuousModification::RemoveAllAbilities));
+    // CR 613.7 written-order: RemoveAllSubtypes must precede AddSubtype so the
+    // granted creature type survives the subtype wipe.
+    let pos = |m: &ContinuousModification| mods.iter().position(|x| x == m).unwrap();
+    assert!(
+        pos(&ContinuousModification::RemoveAllSubtypes {
+            set: SubtypeSet::Creature,
+        }) < pos(&ContinuousModification::AddSubtype {
+            subtype: "Treefolk".to_string(),
+        }),
+        "RemoveAllSubtypes must precede AddSubtype(Treefolk): {mods:?}"
+    );
+}
+
 #[test]
 fn enchanted_is_type_with_base_pt_preserves_trailing_keyword_clause() {
     // Building-block check: the trailing "and has <kw> ... loses all

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1045,22 +1045,24 @@ pub(crate) fn parse_enchanted_is_type(
         // "is a [land subtype]" ("Enchanted land is a Mountain") grants no
         // core type and is a basic-land-type change — defer to the dedicated
         // SetBasicLandType parser by returning None here.
-        if granted_core_types.is_empty() {
-            // CR 205.1a + CR 613.4b (issue #5300): the Lignify class names only a
-            // creature SUBTYPE in the copula — "Enchanted creature is a Treefolk
-            // with base power and toughness 0/4 and loses all abilities." No core
-            // card-type word appears, but a creature subtype makes the object a
-            // creature, so imply the Creature core type and let the emission below
-            // produce the full replacement (SetCardTypes + RemoveAllSubtypes +
-            // AddSubtype) instead of silently dropping the subtype. Gated on a base
-            // P/T (only creatures have one) so the basic-land subtype change
-            // ("Enchanted land is a Mountain", no P/T) still returns None here and
-            // defers to the SetBasicLandType handler.
-            if base_pt.is_some() && !granted_subtypes.is_empty() {
-                granted_core_types.push(CoreType::Creature);
-            } else {
-                return None;
-            }
+        // CR 205.1a + CR 613.4b (issue #5300): the Lignify class names only a
+        // creature SUBTYPE in the copula — "Enchanted creature is a Treefolk with
+        // base power and toughness 0/4 and loses all abilities." Setting a creature
+        // subtype replaces the object's creature subtypes but does NOT set or
+        // overwrite its card types (CR 205.1a: removing/replacing a subtype does not
+        // affect card types), so an enchanted Artifact/Land creature keeps
+        // Artifact/Land (Lignify on Gingerbrute → Artifact Creature — Treefolk;
+        // on Dryad Arbor → Land Creature — Forest Treefolk). We therefore do NOT
+        // synthesize a Creature core type — leaving `granted_core_types` empty so
+        // NO `SetCardTypes` is emitted — but still emit the subtype replacement
+        // (`RemoveAllSubtypes{Creature}` → `AddSubtype`) below. A base P/T is
+        // creature-only, disambiguating from the basic-land subtype change
+        // ("Enchanted land is a Mountain", no P/T → None, deferring to
+        // SetBasicLandType).
+        let subtype_only_creature_change =
+            granted_core_types.is_empty() && base_pt.is_some() && !granted_subtypes.is_empty();
+        if granted_core_types.is_empty() && !subtype_only_creature_change {
+            return None;
         }
 
         // Parse the trailing "and has <kw> ... and it loses all other ..."
@@ -1094,7 +1096,9 @@ pub(crate) fn parse_enchanted_is_type(
         // 1. Core types: replacement (SetCardTypes) when CR 205.1a applies (no
         //    "in addition" suffix) or the clause says "loses all other card
         //    types"; else additive AddType (CR 205.1b "in addition").
-        if needs_set_card_types {
+        // CR 205.1a (issue #5300): the subtype-only Lignify branch grants NO core
+        // type — emit no SetCardTypes so the object keeps its existing card types.
+        if needs_set_card_types && !granted_core_types.is_empty() {
             modifications.push(ContinuousModification::SetCardTypes {
                 core_types: granted_core_types.clone(),
             });
@@ -1132,7 +1136,7 @@ pub(crate) fn parse_enchanted_is_type(
         // already provides it (Darksteel Mutation explicitly says "loses all
         // other creature types" and its clause_mods contains the wipe).
         if !is_additive
-            && granted_core_types.contains(&CoreType::Creature)
+            && (granted_core_types.contains(&CoreType::Creature) || subtype_only_creature_change)
             && !granted_subtypes.is_empty()
             && !modifications
                 .iter()

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1046,7 +1046,21 @@ pub(crate) fn parse_enchanted_is_type(
         // core type and is a basic-land-type change — defer to the dedicated
         // SetBasicLandType parser by returning None here.
         if granted_core_types.is_empty() {
-            return None;
+            // CR 205.1a + CR 613.4b (issue #5300): the Lignify class names only a
+            // creature SUBTYPE in the copula — "Enchanted creature is a Treefolk
+            // with base power and toughness 0/4 and loses all abilities." No core
+            // card-type word appears, but a creature subtype makes the object a
+            // creature, so imply the Creature core type and let the emission below
+            // produce the full replacement (SetCardTypes + RemoveAllSubtypes +
+            // AddSubtype) instead of silently dropping the subtype. Gated on a base
+            // P/T (only creatures have one) so the basic-land subtype change
+            // ("Enchanted land is a Mountain", no P/T) still returns None here and
+            // defers to the SetBasicLandType handler.
+            if base_pt.is_some() && !granted_subtypes.is_empty() {
+                granted_core_types.push(CoreType::Creature);
+            } else {
+                return None;
+            }
         }
 
         // Parse the trailing "and has <kw> ... and it loses all other ..."


### PR DESCRIPTION
## Summary

Closes #5300.

Lignify-class auras — `"Enchanted creature is a <creature subtype> with base power and toughness N/N and loses all abilities."` — silently **dropped the subtype**. On HEAD the line parses to a static with `RemoveAllAbilities + SetPower + SetToughness` but **no** `SetCardTypes`/`AddSubtype`, so the enchanted creature never becomes the named type (e.g. Lignify's enchanted creature never becomes a **Treefolk**).

**Root cause** (per @jsdevninja's analysis): `parse_enchanted_is_type` routes the `is a <phrase>` copula through `classify_type`, which pushes a bare creature subtype (`Treefolk`) to `granted_subtypes` but leaves `granted_core_types` empty (no core card-type word). The `granted_core_types.is_empty() → return None` guard then bails, and the line falls through to a partial handler that keeps only the P/T + ability loss.

## Fix

A creature subtype makes the object a creature (CR 205.1a), and a **base P/T is creature-only**, so when the granted phrase is subtype-only **and** carries a base P/T, imply the `Creature` core type. The existing, tested emission then produces the full replacement in written order:

`SetCardTypes[Creature]` → `RemoveAllSubtypes{Creature}` → `AddSubtype(Treefolk)` → `SetPower(0)` → `SetToughness(4)` → `RemoveAllAbilities`

I took the **minimal in-place** route rather than a separate `parse_enchanted_is_creature_subtype_with_base_pt` handler (the issue's proposed structure): it reuses the already-tested Frogify/Darksteel emission (SetCardTypes / RemoveAllSubtypes-before-AddSubtype / trailing-clause) with zero duplication, and only adds a branch that fires when `granted_core_types` is empty — so the Frogify/Darksteel family (which name a core type) is never touched. The base-P/T gate keeps the basic-land subtype change (`"Enchanted land is a Mountain"`, no P/T) returning `None` here and deferring to the `SetBasicLandType` handler. No new engine variant, no new runtime.

## Test plan (from the issue)

- ✅ Lignify parses to `SetCardTypes(Creature) + RemoveAllSubtypes(Creature) + AddSubtype(Treefolk) + SetPower(0) + SetToughness(4) + RemoveAllAbilities` (with `RemoveAllSubtypes` before `AddSubtype`) — new test `lignify_subtype_only_with_base_pt_type_change`
- ✅ Prefix-order sibling (`"... loses all abilities and is a Treefolk with base power and toughness 0/4."`) parses (verified)
- ✅ Darksteel Mutation / Frogify still route through the core-type path (regression: `darksteel_mutation_full_modification_set` + full suite unchanged)
- ✅ `cargo fmt`, `scripts/check-parser-combinators.sh`, `scripts/check-engine-authorities.sh` pass; clippy clean; full engine lib suite **15,612 passed / 0 failed**