### PR TITLE
feat(parser): Lignify-class subtype-only type-change auras with base P/T (#5300)

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1055,6 +1055,15 @@ pub(crate) fn parse_static_line_inner(
     if let Some(def) = parse_enchanted_becomes_type_with_ability(&tp, &text) {
         return Some(def);
     }
+    // CR 205.1a + CR 613.1d (Layer 4) + CR 613.4b (Layer 7b): Lignify class —
+    // "Enchanted creature is a <creature subtype> with base power and toughness N/N
+    // and loses all abilities." The granted phrase names only a creature subtype
+    // (no core card-type word), so `parse_enchanted_is_type` strict-fails on it.
+    // Must precede `parse_enchanted_is_type`; it declines the moment a core-type
+    // word appears so the general handler keeps "Insect artifact creature" shapes.
+    if let Some(def) = parse_enchanted_is_creature_subtype_with_base_pt(&tp, &text) {
+        return Some(def);
+    }
     // CR 205.1a + CR 702.6: "Each <subject> is an Equipment with equip {N} and
     // "<ability>"" — the become-Equipment anthem (Bram, Bludgeon Brawl). Grants
     // the Equipment subtype + Equip keyword + the quoted static ability.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -16090,6 +16090,143 @@ fn enchanted_creature_is_blue_frog() {
 }
 
 #[test]
+fn lignify_subtype_only_base_pt() {
+    // Lignify — CR 205.1a: "is a Treefolk" sets the creature subtype (replaces
+    // existing creature subtypes) but does NOT touch card types; CR 613.4b: base
+    // P/T 0/4; CR 613.1f: "loses all abilities". The granted phrase names only a
+    // creature subtype (no core-type word), so this is the subtype-only sibling of
+    // the Frogify/Darksteel Mutation family.
+    use crate::types::card_type::{CoreType, SubtypeSet};
+    let def = parse_static_line(
+        "Enchanted creature is a Treefolk with base power and toughness 0/4 and loses all abilities.",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    let mods = &def.modifications;
+
+    // CR 205.1a: card types are untouched — no SetCardTypes / AddType.
+    assert!(
+        !mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::SetCardTypes { .. } | ContinuousModification::AddType { .. }
+        )),
+        "subtype-only 'is a Treefolk' must not change card types (CR 205.1a): {mods:?}"
+    );
+    assert!(
+        mods.contains(&ContinuousModification::RemoveAllSubtypes {
+            set: SubtypeSet::Creature,
+        }),
+        "must wipe existing creature subtypes: {mods:?}"
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddSubtype {
+            subtype: "Treefolk".to_string(),
+        }),
+        "must grant Treefolk: {mods:?}"
+    );
+    assert!(mods.contains(&ContinuousModification::SetPower { value: 0 }));
+    assert!(mods.contains(&ContinuousModification::SetToughness { value: 4 }));
+    assert!(mods.contains(&ContinuousModification::RemoveAllAbilities));
+    // No spurious CoreType leaks into an AddType.
+    assert!(!mods
+        .iter()
+        .any(|m| matches!(m, ContinuousModification::AddType { core_type } if *core_type == CoreType::Creature)));
+
+    // CR 613.7 same-layer written order: RemoveAllSubtypes precedes AddSubtype.
+    let pos = |m: &ContinuousModification| mods.iter().position(|x| x == m).unwrap();
+    assert!(
+        pos(&ContinuousModification::RemoveAllSubtypes {
+            set: SubtypeSet::Creature,
+        }) < pos(&ContinuousModification::AddSubtype {
+            subtype: "Treefolk".to_string(),
+        }),
+        "RemoveAllSubtypes must precede AddSubtype(Treefolk): {mods:?}"
+    );
+}
+
+#[test]
+fn lignify_class_prefix_order_loses_abilities() {
+    // Prefix-order sibling: "loses all abilities and is a <subtype> ...". Must emit
+    // exactly one RemoveAllAbilities (not duplicated by the trailing-clause path).
+    use crate::types::card_type::SubtypeSet;
+    let def = parse_static_line(
+        "Enchanted creature loses all abilities and is a Treefolk with base power and toughness 0/4.",
+    )
+    .unwrap();
+    let mods = &def.modifications;
+    assert_eq!(
+        mods.iter()
+            .filter(|m| matches!(m, ContinuousModification::RemoveAllAbilities))
+            .count(),
+        1,
+        "exactly one RemoveAllAbilities: {mods:?}"
+    );
+    assert!(mods.contains(&ContinuousModification::RemoveAllSubtypes {
+        set: SubtypeSet::Creature,
+    }));
+    assert!(mods.contains(&ContinuousModification::AddSubtype {
+        subtype: "Treefolk".to_string(),
+    }));
+    assert!(mods.contains(&ContinuousModification::SetPower { value: 0 }));
+    assert!(mods.contains(&ContinuousModification::SetToughness { value: 4 }));
+    assert!(
+        !mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::SetCardTypes { .. } | ContinuousModification::AddType { .. }
+        )),
+        "no card-type change (CR 205.1a): {mods:?}"
+    );
+}
+
+#[test]
+fn lignify_class_leading_color_subtype() {
+    // Real Frogify oracle shape — "is a blue Frog with base power and toughness
+    // 1/1". Optional leading color → CR 613.1e SetColor; subtype-only → no
+    // SetCardTypes.
+    use crate::types::mana::ManaColor;
+    let def = parse_static_line(
+        "Enchanted creature loses all abilities and is a blue Frog with base power and toughness 1/1.",
+    )
+    .unwrap();
+    let mods = &def.modifications;
+    assert!(mods.contains(&ContinuousModification::SetColor {
+        colors: vec![ManaColor::Blue],
+    }));
+    assert!(mods.contains(&ContinuousModification::AddSubtype {
+        subtype: "Frog".to_string(),
+    }));
+    assert!(mods.contains(&ContinuousModification::SetPower { value: 1 }));
+    assert!(mods.contains(&ContinuousModification::SetToughness { value: 1 }));
+    assert!(mods.contains(&ContinuousModification::RemoveAllAbilities));
+    assert!(
+        !mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetCardTypes { .. })),
+        "subtype-only must not set card types (CR 205.1a): {mods:?}"
+    );
+}
+
+#[test]
+fn lignify_class_declines_core_type_phrase() {
+    // Regression / handoff: a granted phrase that names a core card-type word
+    // ("Insect artifact creature") must NOT be claimed by the subtype-only handler
+    // — it belongs to parse_enchanted_is_type, which sets the card types.
+    let def = parse_static_line(
+        "Enchanted creature is an Insect artifact creature with base power and toughness 2/2.",
+    )
+    .unwrap();
+    let mods = &def.modifications;
+    assert!(
+        mods.iter()
+            .any(|m| matches!(m, ContinuousModification::SetCardTypes { .. })),
+        "core-type phrase must route to the general handler (SetCardTypes): {mods:?}"
+    );
+    assert!(mods.contains(&ContinuousModification::AddSubtype {
+        subtype: "Insect".to_string(),
+    }));
+}
+
+#[test]
 fn enchanted_creature_is_blue_creature_no_subtype() {
     // CR 205.1a: no new creature subtype granted → no Oracle instruction to wipe existing subtypes.
     let def = parse_static_line("Enchanted creature is a blue creature.").unwrap();

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -825,6 +825,100 @@ fn core_type_subtype_set(
     }
 }
 
+/// Typed result of [`parse_lignify_sentence`] — the decomposed grammar axes of a
+/// Lignify-class aura line, before they are mapped to `ContinuousModification`s.
+struct LignifyParse<'a> {
+    /// The enchanted permanent's type (the affected object). Always a creature in
+    /// practice (base P/T only applies to creatures), but carried generically.
+    perm_tf: TypeFilter,
+    /// `true` when the copula was preceded by "loses all abilities and" (the
+    /// prefix-order ability wipe, CR 613.1f).
+    loses_abilities_prefix: bool,
+    /// Optional leading color word (Frogify's "blue"), CR 613.1e.
+    color: Option<crate::types::mana::ManaColor>,
+    /// The granted creature subtype word(s) (`Treefolk`, `Wall`, …), canonicalized.
+    subtypes: Vec<String>,
+    /// Base power / toughness (CR 613.4b).
+    power: i32,
+    toughness: i32,
+    /// Everything after the "N/N" token — the free-form trailing clause (e.g.
+    /// "and loses all abilities" / "in addition to its other types"), handed to
+    /// `parse_continuous_modifications` and scanned for the additive marker.
+    trailing: &'a str,
+}
+
+/// nom combinator: one creature subtype word. Delegates to the shared
+/// `parse_type_filter_word` and accepts ONLY a `TypeFilter::Subtype` — a core
+/// card-type word (creature/artifact/enchantment/land/planeswalker) fails here,
+/// which is what makes the Lignify handler decline "Insect artifact creature"
+/// phrases and leave them to `parse_enchanted_is_type`.
+fn parse_creature_subtype_word(input: &str) -> OracleResult<'_, String> {
+    let (rest, tf) = nom_target::parse_type_filter_word(input)?;
+    match tf {
+        TypeFilter::Subtype(sub) => Ok((rest, sub)),
+        _ => Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        ))),
+    }
+}
+
+/// nom combinator: an unsigned base power/toughness pair, e.g. "0/4" (CR 613.4b).
+/// Uses `parse_number_or_x` (X→0 per the P/T convention) rather than
+/// `parse_pt_modifier`, which requires a signed `+`/`-` and would reject a base
+/// value.
+fn parse_base_pt(input: &str) -> OracleResult<'_, (i32, i32)> {
+    let (input, power) = nom_primitives::parse_number_or_x(input)?;
+    let (input, _) = nom::character::complete::char('/').parse(input)?;
+    let (input, toughness) = nom_primitives::parse_number_or_x(input)?;
+    Ok((input, (power as i32, toughness as i32)))
+}
+
+/// nom sentence combinator for the Lignify class. Operates on the already
+/// lowercased line and composes existing atomic combinators along independent
+/// axes:
+///
+/// ```text
+/// "enchanted " <subject type> ("loses all abilities and ")? ("is a "|"is an ")
+///     <color>? <creature subtype>+ "with base power and toughness " <P>/<T> <rest>
+/// ```
+///
+/// It declines (nom error) the moment a core card-type word appears where a
+/// creature subtype is expected — see [`parse_creature_subtype_word`].
+fn parse_lignify_sentence(input: &str) -> OracleResult<'_, LignifyParse<'_>> {
+    use nom::character::complete::{multispace0, multispace1};
+
+    let (input, _) = tag("enchanted ").parse(input)?;
+    let (input, perm_tf) = nom_target::parse_type_filter_word(input)?;
+    let (input, _) = multispace0.parse(input)?;
+    // CR 613.1f (Layer 6): optional prefix-order ability wipe.
+    let (input, loses_prefix) = opt(tag("loses all abilities and ")).parse(input)?;
+    let (input, _) = alt((tag("is a "), tag("is an "))).parse(input)?;
+    // CR 613.1e (Layer 5): optional leading color.
+    let (input, color) = opt(terminated(nom_primitives::parse_color, multispace1)).parse(input)?;
+    // CR 205.1a (Layer 4): one or more granted creature subtypes (core types decline).
+    let (input, subtypes) =
+        nom::multi::many1(terminated(parse_creature_subtype_word, multispace0)).parse(input)?;
+    // The base-P/T seam is what distinguishes this class from a bare
+    // color/subtype-only "is a [subtype]" aura owned elsewhere.
+    let (input, _) = tag("with base power and toughness ").parse(input)?;
+    let (input, (power, toughness)) = parse_base_pt.parse(input)?;
+    let (trailing, _) = multispace0.parse(input)?;
+
+    Ok((
+        "",
+        LignifyParse {
+            perm_tf,
+            loses_abilities_prefix: loses_prefix.is_some(),
+            color,
+            subtypes,
+            power,
+            toughness,
+            trailing,
+        },
+    ))
+}
+
 /// CR 205.1a + CR 613.1d (Layer 4) + CR 613.4b (Layer 7b): Parse a Lignify-class
 /// type-changing aura whose granted phrase names ONLY a creature subtype (no core
 /// card-type word) followed by a base-P/T seam:
@@ -837,7 +931,9 @@ fn core_type_subtype_set(
 /// grammar names only a creature subtype (`Treefolk`, `Wall`, `Frog`, …) its
 /// `granted_core_types` list stays empty and it returns `None`, so this shape
 /// strict-fails to `Unimplemented` even though the runtime already supports every
-/// emitted modification. This handler owns that uncovered sibling.
+/// emitted modification. This handler owns that uncovered sibling. The grammar is
+/// parsed entirely by [`parse_lignify_sentence`]; this wrapper only maps the typed
+/// axes to `ContinuousModification`s in written (mod-index) order.
 ///
 /// CR 205.1a is the load-bearing distinction from the general handler: "when an
 /// effect sets one or more of an object's subtypes, the new subtype(s) replaces
@@ -853,118 +949,47 @@ fn core_type_subtype_set(
 /// the Oracle text. This is the intentional deviation from issue #5300's proposed
 /// `SetCardTypes{Creature}`.
 ///
-/// A core-type word anywhere in the granted phrase (`Insect artifact creature`)
-/// makes this decline so `parse_enchanted_is_type` keeps ownership. Optional
-/// leading color (`blue Frog`) maps to Layer-5 `SetColor` (CR 613.1e); "loses all
-/// abilities" in either written position maps to Layer-6 `RemoveAllAbilities`
-/// (CR 613.1f). Must dispatch before `parse_enchanted_is_type`.
+/// Must dispatch before `parse_enchanted_is_type`.
 pub(crate) fn parse_enchanted_is_creature_subtype_with_base_pt(
     tp: &TextPair<'_>,
     description: &str,
 ) -> Option<StaticDefinition> {
     use crate::types::card_type::SubtypeSet;
 
-    type VE<'a> = OracleError<'a>;
-
-    // "enchanted <subject-type> " — the enchanted permanent is the affected object.
-    let rest_tp = nom_tag_tp(tp, "enchanted ")?;
-    let (after_type, perm_tf) = nom_target::parse_type_filter_word(rest_tp.lower).ok()?;
-    let after_type_lower = after_type.trim_start();
-
-    let mut modifications: Vec<ContinuousModification> = Vec::new();
-
-    // Leading "loses all abilities and is a[n]" (prefix order) or plain "is a[n]".
-    // CR 613.1f (Layer 6): the prefix "loses all abilities" is ability removal.
-    let is_rest_lower = if let Ok((r, _)) = alt((
-        tag::<_, _, VE>("loses all abilities and is a "),
-        tag::<_, _, VE>("loses all abilities and is an "),
-    ))
-    .parse(after_type_lower)
-    {
-        modifications.push(ContinuousModification::RemoveAllAbilities);
-        r
-    } else if let Ok((r, _)) =
-        alt((tag::<_, _, VE>("is a "), tag::<_, _, VE>("is an "))).parse(after_type_lower)
-    {
-        r
-    } else {
-        return None;
-    };
-
-    let is_rest_lower = is_rest_lower.trim_end_matches('.').trim();
+    let (_, parsed) = parse_lignify_sentence(tp.lower).ok()?;
+    let LignifyParse {
+        perm_tf,
+        loses_abilities_prefix,
+        color,
+        subtypes,
+        power,
+        toughness,
+        trailing,
+    } = parsed;
 
     // CR 205.1b: "in addition to its other types" retains prior subtypes (additive);
     // its absence means CR 205.1a applies and the new creature subtype replaces the
-    // existing ones.
-    let (type_part, is_additive) =
-        match is_rest_lower.strip_suffix(" in addition to its other types") {
-            Some(before) => (before.trim(), true),
-            None => (is_rest_lower, false),
-        };
+    // existing ones. The marker rides the trailing clause, after the base P/T.
+    let is_additive = nom_primitives::scan_contains(trailing, "in addition to its other types");
 
-    // The base-P/T seam is REQUIRED for this class — it is what distinguishes a
-    // Lignify aura from a bare color/subtype-only "is a [subtype]" aura owned
-    // elsewhere. Its absence declines.
-    let (type_part, pt_part) = type_part.split_once(" with base power and toughness ")?;
-    let pt_part = pt_part.trim_start();
-    let (base_p, base_t) = parse_pt_mod(pt_part)?;
+    let mut modifications: Vec<ContinuousModification> = Vec::new();
 
-    // Capture any trailing clause after the "N/N" token (e.g. "and loses all
-    // abilities") so it is not dropped — fed to `parse_continuous_modifications`
-    // below, exactly as `parse_enchanted_is_type` treats its own remainder.
-    let slash_pos = pt_part.find('/')?;
-    let after_slash = &pt_part[slash_pos + 1..];
-    let t_end = after_slash
-        .find(|c: char| c.is_whitespace() || c == '.' || c == ',')
-        .unwrap_or(after_slash.len());
-    let trailing_clause = after_slash[t_end..].trim().trim_end_matches('.').trim();
-
-    let mut type_part = type_part.trim();
-
-    // Optional leading color (Frogify: "is a blue Frog …").
-    // CR 613.1e (Layer 5): a set color replaces prior colors (non-additive);
-    // "in addition" makes it additive.
-    let opt_color = match nom_primitives::parse_color(type_part) {
-        Ok((rest, color)) => {
-            type_part = rest.trim();
-            Some(color)
-        }
-        Err(_) => None,
-    };
-
-    // The remaining phrase must be creature subtype(s) ONLY. A core card-type word
-    // (creature/artifact/enchantment/land/planeswalker) disqualifies this class so
-    // `parse_enchanted_is_type` keeps ownership of "Insect artifact creature"-style
-    // phrases. Any unrecognized leftover also declines (never over-claim).
-    let mut granted_subtypes: Vec<String> = Vec::new();
-    let mut scan = type_part;
-    while !scan.is_empty() {
-        let (rest, tf) = nom_target::parse_type_filter_word(scan).ok()?;
-        match tf {
-            TypeFilter::Subtype(sub) => granted_subtypes.push(sub),
-            _ => return None,
-        }
-        scan = rest.trim_start();
-    }
-    if granted_subtypes.is_empty() {
-        return None;
+    // CR 613.1f (Layer 6): prefix-order "loses all abilities".
+    if loses_abilities_prefix {
+        modifications.push(ContinuousModification::RemoveAllAbilities);
     }
 
     // Trailing-clause modifications (e.g. "and loses all abilities" → Layer-6
-    // RemoveAllAbilities). Dedup against mods already emitted from the prefix so a
-    // card can't yield two RemoveAllAbilities.
-    let clause_mods: Vec<ContinuousModification> = if trailing_clause.is_empty() {
-        Vec::new()
-    } else {
-        parse_continuous_modifications(trailing_clause)
-            .into_iter()
-            .filter(|m| !modifications.contains(m))
-            .collect()
-    };
+    // RemoveAllAbilities, "and has flying" → AddKeyword). Dedup against mods
+    // already emitted from the prefix so a card can't yield two RemoveAllAbilities.
+    let clause_mods: Vec<ContinuousModification> = parse_continuous_modifications(trailing)
+        .into_iter()
+        .filter(|m| !modifications.contains(m))
+        .collect();
 
     // --- Assemble modifications in written (mod_index) order ---
     // CR 613.1e (Layer 5): color replacement / additive grant.
-    if let Some(color) = opt_color {
+    if let Some(color) = color {
         if is_additive {
             modifications.push(ContinuousModification::AddColor { color });
         } else {
@@ -975,8 +1000,8 @@ pub(crate) fn parse_enchanted_is_creature_subtype_with_base_pt(
     }
 
     // CR 613.4b (Layer 7b): base power and toughness.
-    modifications.push(ContinuousModification::SetPower { value: base_p });
-    modifications.push(ContinuousModification::SetToughness { value: base_t });
+    modifications.push(ContinuousModification::SetPower { value: power });
+    modifications.push(ContinuousModification::SetToughness { value: toughness });
 
     // CR 205.1a (Layer 4): setting a creature subtype replaces the object's
     // existing creature subtypes. Inject the wipe only when non-additive, and only
@@ -998,7 +1023,7 @@ pub(crate) fn parse_enchanted_is_creature_subtype_with_base_pt(
     modifications.extend(clause_mods);
 
     // CR 205.1a (Layer 4): grant the new creature subtype(s) after the wipe.
-    for sub in granted_subtypes {
+    for sub in subtypes {
         modifications.push(ContinuousModification::AddSubtype { subtype: sub });
     }
 

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -825,6 +825,194 @@ fn core_type_subtype_set(
     }
 }
 
+/// CR 205.1a + CR 613.1d (Layer 4) + CR 613.4b (Layer 7b): Parse a Lignify-class
+/// type-changing aura whose granted phrase names ONLY a creature subtype (no core
+/// card-type word) followed by a base-P/T seam:
+///
+/// > "Enchanted creature is a Treefolk with base power and toughness 0/4 and loses
+/// > all abilities."
+///
+/// `parse_enchanted_is_type` requires at least one core card-type word in the
+/// granted phrase (`Insect artifact creature`, `blue Frog creature`, …); when the
+/// grammar names only a creature subtype (`Treefolk`, `Wall`, `Frog`, …) its
+/// `granted_core_types` list stays empty and it returns `None`, so this shape
+/// strict-fails to `Unimplemented` even though the runtime already supports every
+/// emitted modification. This handler owns that uncovered sibling.
+///
+/// CR 205.1a is the load-bearing distinction from the general handler: "when an
+/// effect sets one or more of an object's subtypes, the new subtype(s) replaces
+/// any existing subtypes from the appropriate set … Removing an object's subtype
+/// doesn't affect its card types at all." So "is a Treefolk" replaces the
+/// creature subtypes (`RemoveAllSubtypes{Creature}` + `AddSubtype`) but MUST NOT
+/// touch card types. This handler therefore deliberately does **not** emit
+/// `SetCardTypes` — doing so would wrongly strip Artifact/Enchantment from a
+/// multi-type creature (Lignify on an Ornithopter keeps its Artifact card type;
+/// Gatherer ruling: "It retains any other types and colors it may have had, but
+/// its subtypes are overwritten."). The enchanted permanent is already a creature
+/// (the aura's enchant restriction), so no card-type modification is authorized by
+/// the Oracle text. This is the intentional deviation from issue #5300's proposed
+/// `SetCardTypes{Creature}`.
+///
+/// A core-type word anywhere in the granted phrase (`Insect artifact creature`)
+/// makes this decline so `parse_enchanted_is_type` keeps ownership. Optional
+/// leading color (`blue Frog`) maps to Layer-5 `SetColor` (CR 613.1e); "loses all
+/// abilities" in either written position maps to Layer-6 `RemoveAllAbilities`
+/// (CR 613.1f). Must dispatch before `parse_enchanted_is_type`.
+pub(crate) fn parse_enchanted_is_creature_subtype_with_base_pt(
+    tp: &TextPair<'_>,
+    description: &str,
+) -> Option<StaticDefinition> {
+    use crate::types::card_type::SubtypeSet;
+
+    type VE<'a> = OracleError<'a>;
+
+    // "enchanted <subject-type> " — the enchanted permanent is the affected object.
+    let rest_tp = nom_tag_tp(tp, "enchanted ")?;
+    let (after_type, perm_tf) = nom_target::parse_type_filter_word(rest_tp.lower).ok()?;
+    let after_type_lower = after_type.trim_start();
+
+    let mut modifications: Vec<ContinuousModification> = Vec::new();
+
+    // Leading "loses all abilities and is a[n]" (prefix order) or plain "is a[n]".
+    // CR 613.1f (Layer 6): the prefix "loses all abilities" is ability removal.
+    let is_rest_lower = if let Ok((r, _)) = alt((
+        tag::<_, _, VE>("loses all abilities and is a "),
+        tag::<_, _, VE>("loses all abilities and is an "),
+    ))
+    .parse(after_type_lower)
+    {
+        modifications.push(ContinuousModification::RemoveAllAbilities);
+        r
+    } else if let Ok((r, _)) =
+        alt((tag::<_, _, VE>("is a "), tag::<_, _, VE>("is an "))).parse(after_type_lower)
+    {
+        r
+    } else {
+        return None;
+    };
+
+    let is_rest_lower = is_rest_lower.trim_end_matches('.').trim();
+
+    // CR 205.1b: "in addition to its other types" retains prior subtypes (additive);
+    // its absence means CR 205.1a applies and the new creature subtype replaces the
+    // existing ones.
+    let (type_part, is_additive) =
+        match is_rest_lower.strip_suffix(" in addition to its other types") {
+            Some(before) => (before.trim(), true),
+            None => (is_rest_lower, false),
+        };
+
+    // The base-P/T seam is REQUIRED for this class — it is what distinguishes a
+    // Lignify aura from a bare color/subtype-only "is a [subtype]" aura owned
+    // elsewhere. Its absence declines.
+    let (type_part, pt_part) = type_part.split_once(" with base power and toughness ")?;
+    let pt_part = pt_part.trim_start();
+    let (base_p, base_t) = parse_pt_mod(pt_part)?;
+
+    // Capture any trailing clause after the "N/N" token (e.g. "and loses all
+    // abilities") so it is not dropped — fed to `parse_continuous_modifications`
+    // below, exactly as `parse_enchanted_is_type` treats its own remainder.
+    let slash_pos = pt_part.find('/')?;
+    let after_slash = &pt_part[slash_pos + 1..];
+    let t_end = after_slash
+        .find(|c: char| c.is_whitespace() || c == '.' || c == ',')
+        .unwrap_or(after_slash.len());
+    let trailing_clause = after_slash[t_end..].trim().trim_end_matches('.').trim();
+
+    let mut type_part = type_part.trim();
+
+    // Optional leading color (Frogify: "is a blue Frog …").
+    // CR 613.1e (Layer 5): a set color replaces prior colors (non-additive);
+    // "in addition" makes it additive.
+    let opt_color = match nom_primitives::parse_color(type_part) {
+        Ok((rest, color)) => {
+            type_part = rest.trim();
+            Some(color)
+        }
+        Err(_) => None,
+    };
+
+    // The remaining phrase must be creature subtype(s) ONLY. A core card-type word
+    // (creature/artifact/enchantment/land/planeswalker) disqualifies this class so
+    // `parse_enchanted_is_type` keeps ownership of "Insect artifact creature"-style
+    // phrases. Any unrecognized leftover also declines (never over-claim).
+    let mut granted_subtypes: Vec<String> = Vec::new();
+    let mut scan = type_part;
+    while !scan.is_empty() {
+        let (rest, tf) = nom_target::parse_type_filter_word(scan).ok()?;
+        match tf {
+            TypeFilter::Subtype(sub) => granted_subtypes.push(sub),
+            _ => return None,
+        }
+        scan = rest.trim_start();
+    }
+    if granted_subtypes.is_empty() {
+        return None;
+    }
+
+    // Trailing-clause modifications (e.g. "and loses all abilities" → Layer-6
+    // RemoveAllAbilities). Dedup against mods already emitted from the prefix so a
+    // card can't yield two RemoveAllAbilities.
+    let clause_mods: Vec<ContinuousModification> = if trailing_clause.is_empty() {
+        Vec::new()
+    } else {
+        parse_continuous_modifications(trailing_clause)
+            .into_iter()
+            .filter(|m| !modifications.contains(m))
+            .collect()
+    };
+
+    // --- Assemble modifications in written (mod_index) order ---
+    // CR 613.1e (Layer 5): color replacement / additive grant.
+    if let Some(color) = opt_color {
+        if is_additive {
+            modifications.push(ContinuousModification::AddColor { color });
+        } else {
+            modifications.push(ContinuousModification::SetColor {
+                colors: vec![color],
+            });
+        }
+    }
+
+    // CR 613.4b (Layer 7b): base power and toughness.
+    modifications.push(ContinuousModification::SetPower { value: base_p });
+    modifications.push(ContinuousModification::SetToughness { value: base_t });
+
+    // CR 205.1a (Layer 4): setting a creature subtype replaces the object's
+    // existing creature subtypes. Inject the wipe only when non-additive, and only
+    // when the trailing clause did not already provide one. RemoveAllSubtypes MUST
+    // precede AddSubtype (CR 613.7 same-layer written order) so the granted subtype
+    // survives the wipe.
+    if !is_additive
+        && !modifications
+            .iter()
+            .chain(clause_mods.iter())
+            .any(|m| matches!(m, ContinuousModification::RemoveAllSubtypes { .. }))
+    {
+        modifications.push(ContinuousModification::RemoveAllSubtypes {
+            set: SubtypeSet::Creature,
+        });
+    }
+
+    // Trailing-clause mods (RemoveAllAbilities, …) before the AddSubtype emissions.
+    modifications.extend(clause_mods);
+
+    // CR 205.1a (Layer 4): grant the new creature subtype(s) after the wipe.
+    for sub in granted_subtypes {
+        modifications.push(ContinuousModification::AddSubtype { subtype: sub });
+    }
+
+    let affected =
+        TargetFilter::Typed(TypedFilter::new(perm_tf).properties(vec![FilterProp::EnchantedBy]));
+
+    Some(
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(modifications)
+            .description(description.to_string()),
+    )
+}
+
 pub(crate) fn parse_enchanted_is_type(
     tp: &TextPair,
     description: &str,


### PR DESCRIPTION
## Summary

Adds parser support for the **Lignify class** of type-changing auras —
`"Enchanted creature is a <creature subtype> with base power and toughness N/N and loses all abilities."`
(Lignify, Frogify, and ~13 similar auras). These strict-failed to `Unimplemented` because `parse_enchanted_is_type` requires at least one **core card-type word** in the granted phrase; a phrase that names only a creature subtype (`Treefolk`, `Wall`, `Frog`) left `granted_core_types` empty and returned `None`, even though the runtime already supports every emitted modification.

Fixes #5300

## Implementation method (required)

- [x] **Not** `/engine-implementer` — explain why below

> Self-contained, additive single-handler parser change that directly implements the maintainer-authored plan in #5300. No new engine variant and no new runtime — it only composes existing `ContinuousModification`s. It was implemented against the issue's spec, verified line-by-line against CR 205.1a / 613.x, and covered by new parser unit tests. One deliberate, documented deviation from the issue's proposal is called out below.

## Deviation from the issue's proposed approach

The issue proposes emitting `SetCardTypes { Creature }`. That is **rules-incorrect** for the class and is intentionally omitted. Per **CR 205.1a**: *"when an effect sets one or more of an object's subtypes, the new subtype(s) replaces any existing subtypes from the appropriate set … Removing an object's subtype doesn't affect its card types at all."* Lignify says `"is a Treefolk"` (a creature **subtype**) and `"loses all abilities"` — it never says *"loses all other card types."* Emitting `SetCardTypes { Creature }` would wrongly strip `Artifact`/`Enchantment` from a multi-type creature (e.g. Lignify on an Ornithopter must keep its Artifact card type; Gatherer ruling: *"It retains any other types and colors it may have had, but its subtypes are overwritten."*). The enchanted permanent is already a creature (the aura's enchant restriction), so no card-type modification is authorized by the Oracle text.

The new handler therefore emits, in written (mod-index) order:

| Modification | Rule | Layer |
|---|---|---|
| optional `SetColor` (Frogify's `blue`) | CR 613.1e | 5 |
| `SetPower` / `SetToughness` | CR 613.4b | 7b |
| `RemoveAllSubtypes { Creature }` (non-additive only) | CR 205.1a | 4 |
| `RemoveAllAbilities` (`loses all abilities`, either position) | CR 613.1f | 6 |
| `AddSubtype` (after the subtype wipe) | CR 205.1a | 4 |

It is dispatched **before** `parse_enchanted_is_type` and **declines** the moment a core-type word appears in the granted phrase, so `"Insect artifact creature"`-style phrases stay on the general handler.

## CR references

- CR 205.1a — setting a creature subtype replaces existing creature subtypes; does not affect card types
- CR 205.1b — `in addition to its other types` retains prior subtypes (additive)
- CR 613.1d (Layer 4) — type/subtype-changing continuous effect
- CR 613.1e (Layer 5) — color-setting continuous effect
- CR 613.1f (Layer 6) — ability removal
- CR 613.4b (Layer 7b) — base power and toughness

## Verification

- `cargo fmt --all` — clean
- New parser unit tests in `parser::oracle_static::tests`:
  - `lignify_subtype_only_base_pt` — Treefolk specimen; asserts no `SetCardTypes`/`AddType`, correct subtype wipe/grant, base P/T, ability loss, and `RemoveAllSubtypes` precedes `AddSubtype`.
  - `lignify_class_prefix_order_loses_abilities` — `"loses all abilities and is a ..."`; asserts exactly one `RemoveAllAbilities`.
  - `lignify_class_leading_color_subtype` — real Frogify shape `"is a blue Frog ..."`; asserts `SetColor(Blue)` + subtype, no `SetCardTypes`.
  - `lignify_class_declines_core_type_phrase` — regression: `"Insect artifact creature ..."` still routes to the general handler (`SetCardTypes` present).
- Existing `enchanted_creature_is_blue_frog` (core-type `"1/1 blue Frog creature"`) regression preserved — the new handler declines it (no base-P/T seam) and it stays on `parse_enchanted_is_type`.
