### PR TITLE
feat(engine): K'rrik Phyrexian pause for activated ability mana costs…

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -14371,7 +14371,7 @@ fn quantity_ref_is_board_state_relative(qty: &QuantityRef) -> bool {
 /// without routing through `enter_payment_step`. Removal-first and `{X}` detours
 /// already hoist mana through `finalize_mana_payment`, which shares this pause
 /// helper — this path covers bare mana + non-removal residual tails only.
-fn try_pause_activation_phyrexian_payment(
+pub(super) fn try_pause_activation_phyrexian_payment(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
@@ -15082,20 +15082,6 @@ pub fn handle_activate_ability(
                 events,
             );
         }
-
-        // CR 107.4f + GH #600: K'rrik/Phyrexian per-shard consent for activated
-        // mana legs that would otherwise be paid inline after target auto-select.
-        if let Some(waiting) = try_pause_activation_phyrexian_payment(
-            state,
-            player,
-            source_id,
-            ability_index,
-            &resolved,
-            cost,
-            events,
-        ) {
-            return Ok(waiting);
-        }
     }
 
     let target_slots = build_target_slots(state, &resolved)?;
@@ -15119,6 +15105,17 @@ pub fn handle_activate_ability(
                     ));
                 }
                 stamp_self_ref_discard_cost_paid_object(state, source_id, &mut resolved, cost);
+                if let Some(waiting) = try_pause_activation_phyrexian_payment(
+                    state,
+                    player,
+                    source_id,
+                    ability_index,
+                    &resolved,
+                    cost,
+                    events,
+                ) {
+                    return Ok(waiting);
+                }
                 if let PaymentOutcome::Paused { remaining_cost } = pay_ability_cost_for_activation(
                     state,
                     player,
@@ -15225,6 +15222,17 @@ pub fn handle_activate_ability(
             ));
         }
         stamp_self_ref_discard_cost_paid_object(state, source_id, &mut resolved, cost);
+        if let Some(waiting) = try_pause_activation_phyrexian_payment(
+            state,
+            player,
+            source_id,
+            ability_index,
+            &resolved,
+            cost,
+            events,
+        ) {
+            return Ok(waiting);
+        }
         if let PaymentOutcome::Paused { remaining_cost } = pay_ability_cost_for_activation(
             state,
             player,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -14366,6 +14366,53 @@ fn quantity_ref_is_board_state_relative(qty: &QuantityRef) -> bool {
     }
 }
 
+/// CR 107.4f + GH #600: Pause for K'rrik/Phyrexian per-shard consent when an
+/// activated ability's mana leg would otherwise be paid inline (e.g. `{B},{T}: …`)
+/// without routing through `enter_payment_step`. Removal-first and `{X}` detours
+/// already hoist mana through `finalize_mana_payment`, which shares this pause
+/// helper — this path covers bare mana + non-removal residual tails only.
+fn try_pause_activation_phyrexian_payment(
+    state: &mut GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    ability_index: usize,
+    resolved: &ResolvedAbility,
+    cost: &AbilityCost,
+    events: &mut Vec<GameEvent>,
+) -> Option<WaitingFor> {
+    if find_non_self_battlefield_removal_cost(cost).is_some() {
+        return None;
+    }
+    let (mana_cost, remaining) = casting_costs::extract_mana_leg(cost)?;
+    let excluded_sources = remaining
+        .as_ref()
+        .map(|tail| ability_mana_payment_excluded_sources(tail, source_id))
+        .unwrap_or_default();
+    let (source_types, source_subtypes) = activation_source_types(state, source_id);
+    let activation_ctx = PaymentContext::Activation {
+        source_types: &source_types,
+        source_subtypes: &source_subtypes,
+        ability_tag: activation_ability_tag(state, source_id, ability_index),
+    };
+    let waiting = casting_costs::maybe_pause_for_phyrexian_choice(
+        state,
+        player,
+        source_id,
+        &mana_cost,
+        events,
+        Some(&activation_ctx),
+        &excluded_sources,
+    )?;
+    let mut pending = PendingCast::new(source_id, CardId(0), resolved.clone(), mana_cost);
+    pending.activation_cost = remaining;
+    pending.activation_ability_index = Some(ability_index);
+    if pending.activation_cost.is_some() {
+        pending.activation_residual = ActivationResidual::ManaLeg;
+    }
+    state.pending_cast = Some(Box::new(pending));
+    Some(waiting)
+}
+
 /// CR 602.2: To activate an ability is to put it onto the stack and pay its costs.
 /// CR 602.2a: Only an object's controller can activate its activated ability unless
 /// the object specifically says otherwise.
@@ -15034,6 +15081,20 @@ pub fn handle_activate_ability(
                 Some(ConvokeMode::Waterbend),
                 events,
             );
+        }
+
+        // CR 107.4f + GH #600: K'rrik/Phyrexian per-shard consent for activated
+        // mana legs that would otherwise be paid inline after target auto-select.
+        if let Some(waiting) = try_pause_activation_phyrexian_payment(
+            state,
+            player,
+            source_id,
+            ability_index,
+            &resolved,
+            cost,
+            events,
+        ) {
+            return Ok(waiting);
         }
     }
 

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -525,6 +525,21 @@ fn pay_activation_costs_after_target_selection(
     }
 
     if let Some(ref activation_cost) = pending.activation_cost {
+        // CR 107.4f + GH #600: Target-first activations store the full cost in
+        // `activation_cost` with `pending.cost = NoCost`; route through the same
+        // Phyrexian pause helper as the no-target activation path.
+        if let Some(waiting) = super::casting::try_pause_activation_phyrexian_payment(
+            state,
+            player,
+            pending.object_id,
+            ability_index,
+            &assigned_ability,
+            activation_cost,
+            events,
+        ) {
+            return Ok(Some(waiting));
+        }
+
         if let Some((count, zone, filter)) = super::casting::find_non_self_exile(activation_cost) {
             let narrow_zone = ExileCostSourceZone::try_from_zone(zone)
                 .expect("find_non_self_exile restricts zone to Hand or Graveyard");

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -28667,9 +28667,9 @@ fn sneak_cast_requires_source_in_hand() {
 // may pay 2 life rather than pay that mana." Engine wires the static
 // through `PayLifeAsColoredMana { color: Black }` → `LifePaymentColors` →
 // `effective_shard_requirement` promotion → existing Phyrexian pause/
-// payment infrastructure. These tests cover the spell-cast side only.
-// Activated-ability mana costs are deferred to GH #600 (require
-// `pending_activation` pause/resume primitive not yet built).
+// payment infrastructure. Spell-cast and activated-ability mana legs share the
+// same Phyrexian pause/resume path via `pending_cast` + `SubmitPhyrexianChoices`
+// (GH #595 spell casts, GH #600 activated abilities).
 mod krrik_life_for_color {
     use super::*;
 
@@ -29018,6 +29018,131 @@ mod krrik_life_for_color {
             !can_cast_object_now(&state, PlayerId(0), spell),
             "CR 119.8: CantLoseLife must forbid the K'rrik life-substitution branch"
         );
+    }
+
+    /// Build a creature on the battlefield with `{B}, {T}: draw a card`.
+    fn create_creature_with_black_tap_activated(
+        state: &mut GameState,
+        player: PlayerId,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(0x6001),
+            player,
+            "Krrik Activation Test Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        Arc::make_mut(&mut obj.abilities).push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost {
+                            shards: vec![ManaCostShard::Black],
+                            generic: 0,
+                        },
+                    },
+                    AbilityCost::Tap,
+                ],
+            }),
+        );
+        id
+    }
+
+    /// CR 107.4f + GH #600: K'rrik life-for-{B} on activated ability mana costs.
+    /// With 0 black mana and ample life, activating `{B}, {T}: draw` pauses at
+    /// `PhyrexianPayment` (`LifeOnly`); confirming deducts 2 life and puts the
+    /// ability on the stack.
+    #[test]
+    fn krrik_offers_life_payment_for_black_activation_cost() {
+        use crate::game::engine::apply_as_current;
+        use crate::types::actions::GameAction;
+        use crate::types::game_state::{ShardChoice, ShardOptions};
+
+        let mut state = setup_game_at_main_phase();
+        add_krrik_static(&mut state, PlayerId(0));
+        state.players[0].life = 20;
+        let creature = create_creature_with_black_tap_activated(&mut state, PlayerId(0));
+        assert!(
+            can_activate_ability_now(&state, PlayerId(0), creature, 0),
+            "CR 107.4f: K'rrik must make {{B}} activation affordable with life only"
+        );
+
+        let life_before = state.players[0].life;
+        let activate = GameAction::ActivateAbility {
+            source_id: creature,
+            ability_index: 0,
+        };
+        let result = apply_as_current(&mut state, activate)
+            .expect("CR 107.4f: {{B}} activation announcement must succeed");
+        match &result.waiting_for {
+            WaitingFor::PhyrexianPayment { shards, .. } => {
+                assert_eq!(shards.len(), 1);
+                assert!(
+                    matches!(shards[0].options, ShardOptions::LifeOnly),
+                    "CR 107.4f: with no black mana, K'rrik-promoted activation shard is LifeOnly"
+                );
+            }
+            other => panic!("expected PhyrexianPayment (LifeOnly), got {other:?}"),
+        }
+        assert_eq!(
+            state.players[0].life, life_before,
+            "CR 601.2h: life must not be deducted before the activator confirms"
+        );
+
+        let submit = GameAction::SubmitPhyrexianChoices {
+            choices: vec![ShardChoice::PayLife],
+        };
+        apply_as_current(&mut state, submit).expect("CR 107.4f: PayLife submit");
+
+        assert_eq!(
+            state.players[0].life,
+            life_before - 2,
+            "CR 118.3b: K'rrik life payment must deduct exactly 2 life"
+        );
+        assert!(
+            state.stack.iter().any(|entry| entry.source_id == creature),
+            "CR 602.2: successful activation must push the ability onto the stack"
+        );
+        assert!(
+            state.objects.get(&creature).unwrap().tapped,
+            "CR 602.2: residual {{T}} cost must be paid after mana"
+        );
+    }
+
+    /// CR 107.4f + GH #600: When both black mana and life routes are viable for
+    /// an activated `{B}` mana leg, the engine pauses with `ManaOrLife`.
+    #[test]
+    fn krrik_pauses_activation_when_mana_and_life_both_viable() {
+        use crate::types::game_state::ShardOptions;
+
+        let mut state = setup_game_at_main_phase();
+        add_krrik_static(&mut state, PlayerId(0));
+        state.players[0].life = 20;
+        add_mana(&mut state, PlayerId(0), ManaType::Black, 1);
+        let creature = create_creature_with_black_tap_activated(&mut state, PlayerId(0));
+
+        let mut events = Vec::new();
+        let waiting = handle_activate_ability(&mut state, PlayerId(0), creature, 0, &mut events)
+            .expect("CR 107.4f: activation must be legal");
+        match waiting {
+            WaitingFor::PhyrexianPayment { shards, .. } => {
+                assert_eq!(shards.len(), 1);
+                assert!(
+                    matches!(shards[0].options, ShardOptions::ManaOrLife),
+                    "CR 107.4f: with both mana and life viable, surface ManaOrLife"
+                );
+            }
+            other => panic!("expected PhyrexianPayment ManaOrLife, got {other:?}"),
+        }
     }
 }
 

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -29057,6 +29057,134 @@ mod krrik_life_for_color {
         id
     }
 
+    /// Build a creature on the battlefield with `{B}, {T}: deal 1 damage to
+    /// target creature`.
+    fn create_creature_with_black_tap_targeted_damage(
+        state: &mut GameState,
+        player: PlayerId,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(0x6002),
+            player,
+            "Krrik Targeted Activation Test Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        Arc::make_mut(&mut obj.abilities).push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::DealDamage {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+                    damage_source: None,
+                    excess: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost {
+                            shards: vec![ManaCostShard::Black],
+                            generic: 0,
+                        },
+                    },
+                    AbilityCost::Tap,
+                ],
+            }),
+        );
+        id
+    }
+
+    /// CR 107.4f + GH #600: Target-first activations (`{B}, {T}: deal 1 damage
+    /// to target creature`) must pause at `PhyrexianPayment` after target
+    /// selection, not silently auto-pay life during `pay_activation_costs_after_target_selection`.
+    #[test]
+    fn krrik_offers_life_payment_for_targeted_black_activation_cost() {
+        use crate::game::engine::apply_as_current;
+        use crate::types::actions::GameAction;
+        use crate::types::game_state::{ShardChoice, ShardOptions};
+
+        let mut state = setup_game_at_main_phase();
+        add_krrik_static(&mut state, PlayerId(0));
+        state.players[0].life = 20;
+        let activator = create_creature_with_black_tap_targeted_damage(&mut state, PlayerId(0));
+        let target_creature = create_object(
+            &mut state,
+            CardId(0x6003),
+            PlayerId(1),
+            "Target Bear".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&target_creature)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let life_before = state.players[0].life;
+        apply_as_current(
+            &mut state,
+            GameAction::ActivateAbility {
+                source_id: activator,
+                ability_index: 0,
+            },
+        )
+        .expect("CR 107.4f: targeted activation announcement must succeed");
+        assert!(
+            matches!(state.waiting_for, WaitingFor::TargetSelection { .. }),
+            "targeted {{B}}, {{T}} activation must open TargetSelection before payment"
+        );
+
+        apply_as_current(
+            &mut state,
+            GameAction::ChooseTarget {
+                target: Some(TargetRef::Object(target_creature)),
+            },
+        )
+        .expect("target creature must be selectable");
+
+        match &state.waiting_for {
+            WaitingFor::PhyrexianPayment { shards, .. } => {
+                assert_eq!(shards.len(), 1);
+                assert!(
+                    matches!(shards[0].options, ShardOptions::LifeOnly),
+                    "CR 107.4f: after target selection, K'rrik-promoted shard is LifeOnly"
+                );
+            }
+            other => panic!("expected PhyrexianPayment after target selection, got {other:?}"),
+        }
+        assert_eq!(
+            state.players[0].life, life_before,
+            "CR 601.2h: life must not be deducted before the activator confirms"
+        );
+
+        apply_as_current(
+            &mut state,
+            GameAction::SubmitPhyrexianChoices {
+                choices: vec![ShardChoice::PayLife],
+            },
+        )
+        .expect("CR 107.4f: PayLife submit");
+
+        assert_eq!(
+            state.players[0].life,
+            life_before - 2,
+            "CR 118.3b: K'rrik life payment must deduct exactly 2 life"
+        );
+        assert!(
+            state.stack.iter().any(|entry| entry.source_id == activator),
+            "CR 602.2: successful targeted activation must push the ability onto the stack"
+        );
+        assert!(
+            state.objects.get(&activator).unwrap().tapped,
+            "CR 602.2: residual {{T}} cost must be paid after mana"
+        );
+    }
+
     /// CR 107.4f + GH #600: K'rrik life-for-{B} on activated ability mana costs.
     /// With 0 black mana and ample life, activating `{B}, {T}: draw` pauses at
     /// `PhyrexianPayment` (`LifeOnly`); confirming deducts 2 life and puts the

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1729,10 +1729,9 @@ pub enum StaticMode {
     /// Yawgmoth (color = Black). `ManaColor` parameterization admits future
     /// printings for any other single color without enum proliferation.
     ///
-    /// **Scope note**: this static currently affects spell-cast mana costs only.
-    /// Activated-ability mana costs are covered by the same 2024-06-07 K'rrik
-    /// ruling but require a `pending_activation` pause/resume primitive not yet
-    /// built. Deferred to GH issue #600.
+    /// **Scope note**: wired through spell-cast and activated-ability mana payment
+    /// via `effective_shard_requirement` promotion and the shared Phyrexian pause
+    /// infrastructure (`maybe_pause_for_phyrexian_choice`).
     PayLifeAsColoredMana {
         color: ManaColor,
     },


### PR DESCRIPTION
## Summary

Fixes [issue #600](https://github.com/phase-rs/phase/issues/600), the follow-up to [#595](https://github.com/phase-rs/phase/issues/595). Spell casts with K'rrik's **"For each {B} in a cost, you may pay 2 life rather than pay that mana"** static already paused at `WaitingFor::PhyrexianPayment`; activated abilities with `{B}` in the activation cost did not, because many activations paid mana inline via `pay_ability_cost_for_activation` instead of routing through `enter_payment_step` / `finalize_mana_payment`.

This PR adds a targeted detour in `handle_activate_ability` that reuses the existing spell-side pause/resume infrastructure (`pending_cast`, `SubmitPhyrexianChoices`, `finalize_mana_payment_with_phyrexian_choices`) — no new `PendingActivation` struct was required.

## Root cause

Activation cost detours for `{X}` mana, removal-first mana legs (`{B}, Sacrifice …`), and waterbend already hoist mana through `enter_payment_step`, where `finalize_mana_payment` calls `maybe_pause_for_phyrexian_choice`. Simple costs like `{B}, {T}: …` fell through to the inline payment path at the end of `handle_activate_ability`, skipping the Phyrexian consent UI entirely.

## Approach

`try_pause_activation_phyrexian_payment`:

1. Skips costs already handled by the removal-first detour (`find_non_self_battlefield_removal_cost`).
2. Extracts the mana leg via `extract_mana_leg`.
3. Calls `maybe_pause_for_phyrexian_choice` with `PaymentContext::Activation`.
4. On pause, stashes `PendingCast` with `activation_ability_index`, the residual tail in `activation_cost`, and `ActivationResidual::ManaLeg` when non-mana costs (e.g. `{T}`) remain.
5. Resume via existing `SubmitPhyrexianChoices` → `finalize_mana_payment_with_phyrexian_choices` → `push_activated_ability_to_stack`.

Frontend (`ManaPaymentUI`) and AI (`SubmitPhyrexianChoices` validation) already handle `PhyrexianPayment` for activations via the shared `pending_cast` wiring.

## Changes

| File | Change |
|------|--------|
| `crates/engine/src/game/casting.rs` | `try_pause_activation_phyrexian_payment` helper; detour hook before inline cost payment |
| `crates/engine/src/game/casting_tests.rs` | Two activation tests in `krrik_life_for_color`; updated module comment |
| `crates/engine/src/types/statics.rs` | `PayLifeAsColoredMana` scope note — activated abilities now covered |

## Tests

| Test | Asserts |
|------|---------|
| `krrik_offers_life_payment_for_black_activation_cost` | `{B}, {T}: draw` with K'rrik, 0 black mana, ≥2 life → `PhyrexianPayment` (`LifeOnly`); `PayLife` → −2 life, ability on stack, source tapped |
| `krrik_pauses_activation_when_mana_and_life_both_viable` | Same activation with 1 black mana → `PhyrexianPayment` (`ManaOrLife`) |

All existing `krrik_life_for_color` spell-cast tests remain green (9/9).

## Acceptance criteria (from issue)

- [x] Creature with `{B}` in activation cost, K'rrik on battlefield, 0 black mana, ≥2 life — activation is legal
- [x] Activating surfaces `WaitingFor::PhyrexianPayment` offering life-for-{B} substitution
- [x] Choosing life payment deducts 2 life and resolves the activated ability normally

## CR references

- CR 107.4f — Phyrexian mana / life-for-color payment semantics
- CR 118.3b — paying life as a cost
- CR 601.2h — mana payment step; caster may refuse via `CancelCast`
- CR 602.2 — activated ability activation (announce → pay → stack)

## Test plan

- [x] `cargo test -p engine --lib 'game::casting::tests::krrik_life_for_color'`
- [x] `cargo fmt --all`
- [x] `cargo clippy -p engine -- -D warnings`
- [ ] `test-engine` Tilt resource green (if applicable)
- [ ] Manual: K'rrik + Bloodghast / Vampire Hexmage — activate `{B}` ability with empty pool, confirm Phyrexian UI, ability resolves

## Suggested git metadata

- **Branch:** `fix/issue-600-krrik-activation-phyrexian`
- **Commit:** `fix(engine): K'rrik Phyrexian pause for activated ability mana costs (#600)`

## Closes

Fixes https://github.com/phase-rs/phase/issues/600
