### PR TITLE
fix(parser): scope enchanted-player cast triggers to the enchanted player (#5288)

### DIFF
--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -8946,6 +8946,66 @@ fn spell_temporal_whenever_line_builds_delayed_trigger() {
 }
 
 #[test]
+fn enchanted_player_cast_trigger_scopes_caster_to_enchanted_player() {
+    // CR 702.5a + CR 603.2: Maddening Hex — "Whenever enchanted player casts a
+    // noncreature spell, ..." must fire ONLY for the enchanted player's casts.
+    // Before the fix the caster filter stayed unset (any player), so the trigger
+    // over-fired on every player's noncreature spell (issue #5288). The enchanted
+    // player is the Aura's attached player, so the caster scopes to `AttachedTo`.
+    let r = parse(
+        "Enchant player\n\
+         Whenever enchanted player casts a noncreature spell, you draw a card.",
+        "Maddening Hex Test",
+        &[],
+        &["Enchantment"],
+        &["Aura"],
+    );
+    let trigger = r
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::SpellCast)
+        .expect("expected a SpellCast trigger");
+    assert_eq!(
+        trigger.valid_target,
+        Some(TargetFilter::AttachedTo),
+        "enchanted-player cast trigger must scope the caster to the enchanted player: {:?}",
+        trigger.valid_target
+    );
+    // The noncreature-spell restriction is preserved on the spell object.
+    assert!(
+        trigger.valid_card.is_some(),
+        "noncreature spell restriction must remain set"
+    );
+}
+
+#[test]
+fn opponent_cast_trigger_still_scopes_to_opponent_not_attached_to() {
+    // Regression for the enchanted-player fix: an "an opponent casts ..." cast
+    // trigger must keep its opponent-controller caster scope and NOT collapse to
+    // AttachedTo.
+    let r = parse(
+        "Whenever an opponent casts a noncreature spell, you draw a card.",
+        "Opponent Cast Test",
+        &[],
+        &["Enchantment"],
+        &[],
+    );
+    let trigger = r
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::SpellCast)
+        .expect("expected a SpellCast trigger");
+    assert_eq!(
+        trigger.valid_target,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::Opponent)
+        )),
+        "opponent cast trigger must stay opponent-scoped: {:?}",
+        trigger.valid_target
+    );
+}
+
+#[test]
 fn full_throttle_parses_additional_combats_and_delayed_combat_trigger() {
     let r = parse(
             "After this main phase, there are two additional combat phases.\nAt the beginning of each combat this turn, untap all creatures that attacked this turn.",

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -8947,8 +8947,9 @@ fn spell_temporal_whenever_line_builds_delayed_trigger() {
 
 #[test]
 fn enchanted_player_cast_trigger_scopes_caster_to_enchanted_player() {
-    // CR 702.5a + CR 603.2: Maddening Hex — "Whenever enchanted player casts a
-    // noncreature spell, ..." must fire ONLY for the enchanted player's casts.
+    // CR 303.4m + CR 702.5a: Maddening Hex — "Whenever enchanted player casts a
+    // noncreature spell, ..." must fire ONLY for the enchanted player's casts
+    // ("enchanted player" = the Aura's attached player, CR 303.4m).
     // Before the fix the caster filter stayed unset (any player), so the trigger
     // over-fired on every player's noncreature spell (issue #5288). The enchanted
     // player is the Aura's attached player, so the caster scopes to `AttachedTo`.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -12310,13 +12310,15 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
                     TypedFilter::default().controller(ControllerRef::Opponent),
                 ));
             } else if scan_contains(who, "enchanted player") {
-                // CR 702.5a + CR 603.2: "Whenever enchanted player casts a
-                // [quality] spell" (Maddening Hex) scopes the caster to the player
-                // this Aura enchants. Enchant player (CR 702.5a) guarantees the
-                // source is attached to a player, so `AttachedTo` — which
-                // `player_matches_filter` resolves to the source's attached player
-                // — fires the trigger only for that player's casts, not every
-                // player's. Without this the caster filter stays unset (any player).
+                // CR 303.4m + CR 702.5a: "enchanted player" refers to whatever
+                // player this Aura is attached to (CR 303.4m); Enchant player
+                // (CR 702.5a) guarantees the source is attached to a player. So
+                // "Whenever enchanted player casts a [quality] spell" (Maddening
+                // Hex) scopes the caster to the enchanted player. `AttachedTo` —
+                // which `player_matches_filter` resolves to the source's attached
+                // player — fires the trigger only for that player's casts, not
+                // every player's. Without this the caster filter stays unset (any
+                // player).
                 def.valid_target = Some(TargetFilter::AttachedTo);
             }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -12309,6 +12309,15 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
                 def.valid_target = Some(TargetFilter::Typed(
                     TypedFilter::default().controller(ControllerRef::Opponent),
                 ));
+            } else if scan_contains(who, "enchanted player") {
+                // CR 702.5a + CR 603.2: "Whenever enchanted player casts a
+                // [quality] spell" (Maddening Hex) scopes the caster to the player
+                // this Aura enchants. Enchant player (CR 702.5a) guarantees the
+                // source is attached to a player, so `AttachedTo` — which
+                // `player_matches_filter` resolves to the source's attached player
+                // — fires the trigger only for that player's casts, not every
+                // player's. Without this the caster filter stays unset (any player).
+                def.valid_target = Some(TargetFilter::AttachedTo);
             }
 
             // Parse the spell quality generically (e.g., "creature spell", "multicolored spell")

--- a/crates/engine/tests/integration/curse_spell_cast_triggers.rs
+++ b/crates/engine/tests/integration/curse_spell_cast_triggers.rs
@@ -18,7 +18,8 @@ use engine::game::effects::attach::attach_to_player;
 use engine::game::layers::evaluate_layers;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::game::trigger_index::reindex_object_triggers;
-use engine::types::game_state::WaitingFor;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaType, ManaUnit};
 use engine::types::phase::Phase;
@@ -158,9 +159,6 @@ fn curse_of_echoes_fires_on_instant_cast() {
 /// We manually drive the cast and verify the trigger appears on the stack.
 #[test]
 fn maddening_hex_fires_on_noncreature_spell_cast() {
-    use engine::types::actions::GameAction;
-    use engine::types::game_state::CastPaymentMode;
-
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
@@ -224,5 +222,57 @@ fn maddening_hex_fires_on_noncreature_spell_cast() {
     assert!(
         trigger_on_stack || at_trigger_target,
         "Maddening Hex must trigger when enchanted player casts a noncreature spell"
+    );
+}
+
+/// Maddening Hex must not trigger for a matching spell cast by anyone other
+/// than the enchanted player.
+#[test]
+fn maddening_hex_does_not_fire_for_non_enchanted_player_spell_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let curse_id = {
+        let mut builder =
+            scenario.add_creature_from_oracle(P0, "Maddening Hex", 0, 0, MADDENING_HEX);
+        builder.as_enchantment();
+        builder.with_subtypes(vec!["Aura", "Curse"]);
+        builder.id()
+    };
+
+    let spell_id = scenario.add_spell_to_hand(P0, "Explore", false).id();
+    scenario.with_mana_pool(P0, vec![mana(ManaType::Green), mana(ManaType::Colorless)]);
+
+    for _ in 0..10 {
+        scenario.add_card_to_library_top(P0, "Plains");
+        scenario.add_card_to_library_top(P1, "Island");
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    attach_to_player(runner.state_mut(), curse_id, P1);
+    evaluate_layers(runner.state_mut());
+    reindex_object_triggers(runner.state_mut(), curse_id);
+
+    let card_id = runner.state().objects[&spell_id].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell_id,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("CastSpell must succeed");
+
+    assert!(
+        runner
+            .state()
+            .stack
+            .iter()
+            .all(|entry| entry.source_id != curse_id),
+        "Maddening Hex must not trigger for a spell cast by the non-enchanted player"
     );
 }


### PR DESCRIPTION
## Summary

[[Maddening Hex]] — `"Whenever enchanted player casts a noncreature spell, roll a d6. This Aura deals damage to that player equal to the result. …"` — fired for **every** player's noncreature spell instead of only the **enchanted** player's.

Root cause: in the generic `"<subject> casts a <quality> spell"` trigger parser (`oracle_trigger.rs`), the caster filter (`valid_target`) is only set when the subject names an *opponent*. An `"enchanted player"` subject left `valid_target` unset, and `match_spell_cast` treats an unset caster filter as "any player" — so the trigger over-fired.

Fixes #5288

## Fix

Recognize the `"enchanted player"` caster subject and scope it to `TargetFilter::AttachedTo`. **Enchant player** (CR 702.5a) guarantees the Aura is attached to a player, and `player_matches_filter` already resolves `AttachedTo` to the source's attached player, so the trigger fires only for that player's casts. This is the same representation the parser already emits for `"enchanted creature/land/permanent"` subjects (`parse_attached_to_prefix`). **No new engine variant, no runtime change** — it reuses the existing, tested `AttachedTo` caster-matching path.

## Implementation method (required)

- [x] **Not** `/engine-implementer` — explain why below

> Surgical one-branch parser fix (an `else if` in the existing caster-subject determination) that reuses an existing runtime path — no new engine variant, no new runtime, no state-machine change. Verified against the CR and covered by two new parser unit tests.

## CR references

- CR 702.5a — Enchant [object or player]: the Aura's attach restriction guarantees the source is attached to the enchanted player
- CR 603.2 — triggered abilities: the trigger event is scoped to the enchanted player's spell casts

## Verification

- `cargo fmt --all` — clean
- `scripts/check-parser-combinators.sh` — clean (no new non-combinator dispatch)
- New parser unit tests in `parser::oracle_tests`:
  - `enchanted_player_cast_trigger_scopes_caster_to_enchanted_player` — asserts `valid_target == AttachedTo` and the noncreature restriction is preserved.
  - `opponent_cast_trigger_still_scopes_to_opponent_not_attached_to` — regression: an opponent-cast trigger keeps its opponent-controller scope.
- Full `parser::oracle_tests` lib suite green (no regressions).

## Scope note

This fixes the reported over-firing (the trigger's caster scope). The card's random-reattach clause (`"Then attach this Aura to another one of your opponents chosen at random"`) is orthogonal to the caster-scoping bug and is not part of this change.
