### PR TITLE
fix(engine): apply Ad Nauseam's repeat-loop reveal/hand/life-loss immediately per iteration

### DIFF
--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -965,6 +965,20 @@ pub(super) fn handle_resolution_choice(
             GameAction::DecideOptionalEffect { accept },
         ) => {
             if accept {
+                // CR 608.2c + CR 107.1c (issue #1032): reset to `Priority`
+                // BEFORE re-entering the chain, mirroring the `decline`
+                // branch's `finish_with_continuation` reset below and
+                // `handle_optional_effect_choice`'s `set_active_priority`
+                // reset (engine_payment_choices.rs). Without this,
+                // `state.waiting_for` is still the just-answered
+                // `RepeatDecision`, which `waits_for_resolution_choice`
+                // (effects/mod.rs) matches — the ChangeZone/LoseLife
+                // sub-chain following this iteration's RevealTop is then
+                // wrongly deferred into `pending_continuation` (accumulating
+                // there via `append_to_sub_chain`) instead of resolving
+                // immediately, and only drains in one batch when the
+                // controller eventually declines.
+                set_priority(state, player);
                 // Re-resolve one more process pass. `ability` retains
                 // `repeat_until: Some(ControllerChoice)`, so this hits the
                 // `repeat_until` dispatch, runs `resolve_chain_body` once, and

--- a/crates/engine/tests/integration/ad_nauseam_repeat.rs
+++ b/crates/engine/tests/integration/ad_nauseam_repeat.rs
@@ -1,0 +1,252 @@
+//! Runtime regression for the Ad Nauseam repeat-loop batching bug
+//! (phase-rs/phase#1032) — "Reveal the top card of your library and put that
+//! card into your hand. You lose life equal to its mana value. You may repeat
+//! this process any number of times." (CR 107.1c + CR 608.2c).
+//!
+//! Ad Nauseam parses to a ROOT spell ability whose chain is
+//! `RevealTop -> ChangeZone(top card into hand) -> LoseLife(its mana value)`,
+//! stamped with `repeat_until: Some(ControllerChoice)`. Each iteration prompts
+//! the controller via `WaitingFor::RepeatDecision`; on accept the process runs
+//! again, on decline the loop ends.
+//!
+//! Discriminating assertion (the bug): before the fix, on `accept` the handler
+//! re-entered `resolve_ability_chain` WITHOUT first resetting
+//! `state.waiting_for` away from the just-answered `RepeatDecision`. That stale
+//! value made `waits_for_resolution_choice` wrongly defer each iteration's
+//! `ChangeZone`/`LoseLife` sub-chain into `pending_continuation` (accumulating
+//! via `append_to_sub_chain`) instead of applying it immediately — so every
+//! accepted iteration's card-to-hand and life-loss only landed in one batch
+//! when the controller eventually declined. Final totals are identical either
+//! way (3 cards, -6 life); only the BETWEEN-accepts checkpoints diverge, so we
+//! assert per-iteration state, not just the final aggregate.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::parse_oracle_text;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const AD_NAUSEAM_ORACLE: &str = "Reveal the top card of your library and put that card into your hand. You lose life equal to its mana value. You may repeat this process any number of times.";
+
+/// Parse Ad Nauseam's spell ability, asserting the parsed ROOT ability carries
+/// the `ControllerChoice` repeat continuation (the "any number of times" loop).
+fn ad_nauseam_def() -> engine::types::ability::AbilityDefinition {
+    let parsed = parse_oracle_text(
+        AD_NAUSEAM_ORACLE,
+        "Ad Nauseam",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    let def = parsed
+        .abilities
+        .first()
+        .expect("Ad Nauseam parses to a spell ability")
+        .clone();
+    assert!(
+        matches!(
+            def.repeat_until,
+            Some(engine::types::ability::RepeatContinuation::ControllerChoice)
+        ),
+        "precondition: parsed ability carries a ControllerChoice repeat, got {:?}",
+        def.repeat_until
+    );
+    def
+}
+
+/// Add the Ad Nauseam spell object to the stack as the ability source.
+fn add_source(runner: &mut GameRunner) -> ObjectId {
+    let card_id = CardId(runner.state().next_object_id);
+    create_object(
+        runner.state_mut(),
+        card_id,
+        P0,
+        "Ad Nauseam".to_string(),
+        Zone::Stack,
+    )
+}
+
+/// Add a card with mana value `mv` to the TOP-of-library position that reflects
+/// insertion order (`library[0]` = top, `zones.rs` convention). Cards are added
+/// top-to-bottom by call order.
+fn add_library_card(runner: &mut GameRunner, name: &str, mv: u32) -> ObjectId {
+    let card_id = CardId(runner.state().next_object_id);
+    let id = create_object(
+        runner.state_mut(),
+        card_id,
+        P0,
+        name.to_string(),
+        Zone::Library,
+    );
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    obj.mana_cost = ManaCost::generic(mv);
+    id
+}
+
+fn hand_size(runner: &GameRunner) -> usize {
+    runner.state().players[P0.0 as usize].hand.len()
+}
+
+fn life(runner: &GameRunner) -> i32 {
+    runner.state().players[P0.0 as usize].life
+}
+
+fn hand_contains(runner: &GameRunner, id: ObjectId) -> bool {
+    runner.state().players[P0.0 as usize].hand.contains(&id)
+}
+
+fn awaiting_repeat(runner: &GameRunner) -> bool {
+    matches!(
+        runner.state().waiting_for,
+        WaitingFor::RepeatDecision { .. }
+    )
+}
+
+#[test]
+fn ad_nauseam_applies_hand_and_life_loss_immediately_per_iteration() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut runner = scenario.build();
+
+    // Top-to-bottom: A(mv 2), B(mv 3), C(mv 1).
+    let card_a = add_library_card(&mut runner, "Card A", 2);
+    let card_b = add_library_card(&mut runner, "Card B", 3);
+    let card_c = add_library_card(&mut runner, "Card C", 1);
+
+    let start_life = life(&runner);
+    let start_hand = hand_size(&runner);
+
+    let def = ad_nauseam_def();
+    let source = add_source(&mut runner);
+    let ability = build_resolved_from_def(&def, source, P0);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0).unwrap();
+
+    // Initial pass: A into hand, lose 2 life, prompted to repeat.
+    assert!(
+        awaiting_repeat(&runner),
+        "initial pass must prompt to repeat"
+    );
+    assert_eq!(hand_size(&runner), start_hand + 1, "A revealed into hand");
+    assert!(hand_contains(&runner, card_a), "card A is the one in hand");
+    assert_eq!(
+        life(&runner),
+        start_life - 2,
+        "lose life = A's mana value 2"
+    );
+
+    // First accept reveals B. THE CHECKPOINT THAT FAILS ON UNFIXED CODE:
+    // buggy code defers B's move-to-hand + life-loss into pending_continuation,
+    // so hand/life would still read start+1 / start-2 here.
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("first accept resolves");
+    assert!(
+        awaiting_repeat(&runner),
+        "still prompting after first accept"
+    );
+    assert_eq!(
+        hand_size(&runner),
+        start_hand + 2,
+        "B must land in hand IMMEDIATELY on accept, not batch-deferred to decline"
+    );
+    assert!(hand_contains(&runner, card_b), "card B now in hand");
+    assert_eq!(
+        life(&runner),
+        start_life - 5,
+        "life must drop by B's mana value 3 IMMEDIATELY on accept (total -5)"
+    );
+
+    // Second accept reveals C.
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("second accept resolves");
+    assert!(
+        awaiting_repeat(&runner),
+        "still prompting after second accept"
+    );
+    assert_eq!(hand_size(&runner), start_hand + 3, "C now in hand");
+    assert!(hand_contains(&runner, card_c), "card C now in hand");
+    assert_eq!(
+        life(&runner),
+        start_life - 6,
+        "life -6 total after C's mv 1"
+    );
+
+    // Decline: loop ends, no further change.
+    let hand_before_decline = hand_size(&runner);
+    let life_before_decline = life(&runner);
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: false })
+        .expect("decline ends the loop");
+    assert!(
+        !awaiting_repeat(&runner),
+        "declining ends the repeat loop — no longer prompting"
+    );
+    assert_eq!(
+        hand_size(&runner),
+        hand_before_decline,
+        "decline applies nothing new — everything already landed per-iteration"
+    );
+    assert_eq!(
+        life(&runner),
+        life_before_decline,
+        "decline applies no further life loss — nothing was batch-deferred"
+    );
+}
+
+#[test]
+fn ad_nauseam_decline_immediately_stops_after_mandatory_pass() {
+    // CR 107.1c: "any number of times" includes zero repeats — declining right
+    // after the mandatory first pass ends the loop with exactly one card in hand
+    // and one life-loss applied. Sibling/negative case.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut runner = scenario.build();
+
+    let only_card = add_library_card(&mut runner, "Solo Card", 4);
+    let start_life = life(&runner);
+    let start_hand = hand_size(&runner);
+
+    let def = ad_nauseam_def();
+    let source = add_source(&mut runner);
+    let ability = build_resolved_from_def(&def, source, P0);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0).unwrap();
+
+    assert!(awaiting_repeat(&runner), "initial pass prompts to repeat");
+    assert_eq!(hand_size(&runner), start_hand + 1, "the one card into hand");
+    assert!(hand_contains(&runner, only_card), "the card is in hand");
+    assert_eq!(
+        life(&runner),
+        start_life - 4,
+        "lose life = its mana value 4"
+    );
+
+    // Decline immediately — zero repeats.
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: false })
+        .expect("immediate decline ends the loop");
+    assert!(
+        !awaiting_repeat(&runner),
+        "declining after the mandatory pass ends the loop"
+    );
+    assert_eq!(
+        hand_size(&runner),
+        start_hand + 1,
+        "no further card enters hand after decline"
+    );
+    assert_eq!(
+        life(&runner),
+        start_life - 4,
+        "no further life loss after decline"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1,5 +1,6 @@
 mod abigale_integration;
 mod abundance_optional_draw_replacement;
+mod ad_nauseam_repeat;
 mod adapter_contract_fixtures;
 mod advanced_reconstruction_regression;
 mod ajani_nacatl_pariah_transform;


### PR DESCRIPTION
## Summary

- Fixes #1032 — Ad Nauseam's "reveal top card, put into hand, lose life, you may repeat this process" loop silently deferred each accepted iteration's card-to-hand move and life loss instead of applying it immediately, only draining everything in one batch when the controller finally declined.
- Root cause: the `RepeatDecision` accept handler (`engine_resolution_choices.rs`) re-entered `resolve_ability_chain` without resetting `state.waiting_for` away from the just-answered `RepeatDecision` prompt. The stale value fooled `waits_for_resolution_choice` into deferring that iteration's `ChangeZone`/`LoseLife` sub-chain into `pending_continuation` instead of running it, and deferred pairs accumulated (not clobbered) until decline drained them all at once.
- Fix is a one-line `set_priority(state, player)` reset, mirroring the sibling `decline` branch (already does this via `finish_with_continuation`) and the analogous `OptionalEffectChoice` resume handler (`engine_payment_choices.rs`), both of which already reset priority before re-entering resolution. CR 107.1c + CR 608.2c annotated and verified against `docs/MagicCompRules.txt`.
- Class-level fix: covers every `RepeatContinuation::ControllerChoice` card whose per-iteration body has more than one instruction (a `sub_ability`), not just Ad Nauseam — the existing single-leaf-effect unit test never exercised this path, which is why it went uncaught.

## Test plan

- [x] New integration test `ad_nauseam_repeat.rs`: discriminating assertion checks hand size/life total *between* each accepted repeat (not just final aggregate — final totals are identical whether the bug is present or not, since life loss is additive regardless of timing). Confirmed this test fails on the unfixed code (`left: 1, right: 2`) and passes with the fix.
- [x] Sibling repeat-mechanism tests (`another_round_repeat`, `sin_spiras_punishment_repeat`, `claim_jumper_repeat`) unaffected, 9/9 pass.
- [x] Existing lib unit tests (`repeat_until_controller_choice_prompts_each_iteration`, `repeat_until_paused_resume_resets_prompt_after_inner_choice`, `token_choice_seed_survives_pending_repeat_until_drain`) unaffected, 3/3 pass.
- [x] `cargo fmt --all` clean.
- [x] `cargo clippy -p engine --all-targets -- -D warnings` zero warnings.
- [x] Went through two rounds of plan review and one implementation review before merge (all clean; one non-blocking informational note about theoretical edge-case coverage, judged low-risk by architectural equivalence to already-tested sibling repeat variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)