### PR TITLE
fix(parser): scope enchanted-creature's-controller phase triggers (#5275)

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -659,6 +659,22 @@ fn player_matches_filter(
                 .and_then(|host| host.as_player())
                 == Some(player_id)
         }
+        // CR 303.4e + CR 109.4: "enchanted [permanent]'s controller" — for an Aura
+        // phase trigger the scoped player is the CONTROLLER of the permanent the
+        // source is attached to (per CR 303.4e this may differ from the Aura's own
+        // controller). Resolves the attached object's current controller; a source
+        // attached to a player (not an object) or unattached never matches, so the
+        // trigger stays inert until the Aura is on a creature.
+        TargetFilter::ParentTargetController => {
+            state
+                .objects
+                .get(&source_id)
+                .and_then(|source| source.attached_to)
+                .and_then(|host| host.as_object())
+                .and_then(|obj_id| state.objects.get(&obj_id))
+                .map(|obj| obj.controller)
+                == Some(player_id)
+        }
         _ => true,
     }
 }

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -9007,6 +9007,65 @@ fn opponent_cast_trigger_still_scopes_to_opponent_not_attached_to() {
 }
 
 #[test]
+fn super_intelligence_upkeep_scoped_to_enchanted_creature_controller() {
+    // CR 303.4e + CR 109.4 + CR 503.1: Super Intelligence — "At the beginning of
+    // the upkeep of enchanted creature's controller, that player draws a card."
+    // must fire ONLY on the enchanted creature's controller's upkeep, not every
+    // player's. Before the fix the phase trigger had no player scope and behaved
+    // like a Howling Mine for all players (issue #5275).
+    let r = parse(
+        "Enchant creature\n\
+         At the beginning of the upkeep of enchanted creature's controller, that player draws a card.",
+        "Super Intelligence",
+        &[],
+        &["Enchantment"],
+        &["Aura"],
+    );
+    let trigger = r
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::Phase)
+        .expect("expected a Phase trigger");
+    assert_eq!(trigger.phase, Some(Phase::Upkeep));
+    assert_eq!(
+        trigger.valid_target,
+        Some(TargetFilter::ParentTargetController),
+        "upkeep trigger must scope to the enchanted creature's controller: {:?}",
+        trigger.valid_target
+    );
+    // The card's draw effect must still parse (no Unimplemented fallback).
+    let dbg = format!("{:?}", r.triggers);
+    assert!(
+        !dbg.contains("Unimplemented"),
+        "Super Intelligence trigger must fully parse: {dbg}"
+    );
+}
+
+#[test]
+fn each_player_upkeep_phase_trigger_stays_unscoped() {
+    // Regression: a genuine "each player's upkeep" Howling-Mine trigger must keep
+    // firing on every player's upkeep (no valid_target), unaffected by the
+    // enchanted-creature's-controller scoping.
+    let r = parse(
+        "At the beginning of each player's upkeep, that player draws a card.",
+        "Howling Mine Test",
+        &[],
+        &["Artifact"],
+        &[],
+    );
+    let trigger = r
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::Phase)
+        .expect("expected a Phase trigger");
+    assert_eq!(
+        trigger.valid_target, None,
+        "each-player's-upkeep must remain unscoped: {:?}",
+        trigger.valid_target
+    );
+}
+
+#[test]
 fn full_throttle_parses_additional_combats_and_delayed_combat_trigger() {
     let r = parse(
             "After this main phase, there are two additional combat phases.\nAt the beginning of each combat this turn, untap all creatures that attacked this turn.",

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -11579,6 +11579,21 @@ fn try_parse_phase_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefinitio
     if scan_contains(phase_text, "enchanted player's") {
         def.valid_target = Some(TargetFilter::AttachedTo);
     }
+    // CR 303.4e + CR 109.4 + CR 503.1: "the upkeep of enchanted creature's
+    // controller" (Super Intelligence) / "enchanted permanent's controller" —
+    // the turn-owner scope is the controller of the permanent this Aura is
+    // attached to, which per CR 303.4e may differ from the Aura's controller.
+    // `ParentTargetController` resolves to the attached permanent's controller
+    // for Aura phase triggers. Without this scope the phase trigger has no
+    // player constraint and fires on EVERY player's phase — a Howling-Mine
+    // over-fire (issue #5275).
+    else if scan_contains(phase_text, "enchanted creature's controller")
+        || scan_contains(phase_text, "enchanted creature\u{2019}s controller")
+        || scan_contains(phase_text, "enchanted permanent's controller")
+        || scan_contains(phase_text, "enchanted permanent\u{2019}s controller")
+    {
+        def.valid_target = Some(TargetFilter::ParentTargetController);
+    }
     if scan_contains(phase_text, "chosen player's")
         || scan_contains(phase_text, "chosen player\u{2019}s ")
         || scan_contains(phase_text, "chosen players ")

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -11523,6 +11523,22 @@ fn build_controlled_subtype_filters(
 // Category parsers
 // ---------------------------------------------------------------------------
 
+/// CR 303.4e: nom combinator for the "enchanted [creature|permanent]'s controller"
+/// possessive that scopes an Aura phase trigger to the controller of the permanent
+/// the source is attached to. Composed along its grammar axes — the fixed
+/// `enchanted ` lead, the object-kind alternation (`creature`/`permanent`), the
+/// possessive apostrophe (ASCII `'s` or curly `’s`), and the `controller` head —
+/// rather than enumerating the cartesian product of literals, so a new object-kind
+/// sibling is a single `alt()` arm. Matched at any word boundary by the caller
+/// because the phrase trails the phase noun ("the upkeep of …").
+fn parse_enchanted_controller_phrase(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = tag("enchanted ").parse(input)?;
+    let (input, _) = alt((tag("creature"), tag("permanent"))).parse(input)?;
+    let (input, _) = alt((tag("'s"), tag("\u{2019}s"))).parse(input)?;
+    let (input, _) = tag(" controller").parse(input)?;
+    Ok((input, ()))
+}
+
 /// Parse phase triggers: "At the beginning of your upkeep/end step/combat/draw step"
 fn try_parse_phase_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefinition)> {
     // CR 511.2: "at end of combat" triggers as the end of combat step begins.
@@ -11586,11 +11602,11 @@ fn try_parse_phase_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefinitio
     // `ParentTargetController` resolves to the attached permanent's controller
     // for Aura phase triggers. Without this scope the phase trigger has no
     // player constraint and fires on EVERY player's phase — a Howling-Mine
-    // over-fire (issue #5275).
-    else if scan_contains(phase_text, "enchanted creature's controller")
-        || scan_contains(phase_text, "enchanted creature\u{2019}s controller")
-        || scan_contains(phase_text, "enchanted permanent's controller")
-        || scan_contains(phase_text, "enchanted permanent\u{2019}s controller")
+    // over-fire (issue #5275). The phrase is composed along its axes
+    // (`enchanted` + object kind + possessive) and matched at any word boundary
+    // (it trails the phase noun, e.g. "the upkeep of …").
+    else if nom_primitives::scan_at_word_boundaries(phase_text, parse_enchanted_controller_phrase)
+        .is_some()
     {
         def.valid_target = Some(TargetFilter::ParentTargetController);
     }


### PR DESCRIPTION
## Summary

[[Super Intelligence]] — `"Enchant creature\nAt the beginning of the upkeep of enchanted creature's controller, that player draws a card."` — behaved like a **Howling Mine**, giving the extra card on *every* player's upkeep instead of only the **enchanted creature's controller's** upkeep.

Root cause: `try_parse_phase_trigger` scopes `"enchanted player's <phase>"` (player-enchant Auras) to `AttachedTo`, but had no handling for the creature-enchant `"the <phase> of enchanted creature's controller"` form. That left `valid_target` unset, and `match_phase` treats an unset player scope as "any active player" — so the trigger fired on every upkeep.

Fixes #5275

## Fix

Two small, localized changes — **no new engine variant**:

1. **Parser** (`try_parse_phase_trigger`): recognize `"enchanted creature's controller"` / `"enchanted permanent's controller"` (ASCII + `’`) in the phase text and set `valid_target = TargetFilter::ParentTargetController`, mirroring the existing `"enchanted player's"` → `AttachedTo` arm.
2. **Matcher** (`player_matches_filter`, trigger side): add a `ParentTargetController` arm that resolves to the **controller of the permanent the source Aura is attached to** and compares it to the active player.

Per **CR 303.4e**, the Aura's controller and the enchanted permanent's controller need not be the same, so this can't reuse the source-controller turn constraint (`OnlyDuringYourTurn`). `ParentTargetController`'s documented resolution already covers "the AttachedTo host on source for Aura phase triggers," so it's the intended representation here; no trigger currently used it as `valid_target`, so the new matcher arm is additive.

## CR references

- CR 303.4e — an Aura's controller is separate from the enchanted object's controller; the two need not be the same
- CR 109.4 — controller of an object (the enchanted permanent's current controller)
- CR 503.1 — the upkeep step

## Verification

- `cargo fmt --all` — clean
- `scripts/check-parser-combinators.sh` — clean
- New parser unit tests in `parser::oracle::tests`:
  - `super_intelligence_upkeep_scoped_to_enchanted_creature_controller` — asserts `phase == Upkeep`, `valid_target == ParentTargetController`, and the card fully parses (no `Unimplemented`).
  - `each_player_upkeep_phase_trigger_stays_unscoped` — regression: a genuine "each player's upkeep" Howling-Mine trigger keeps `valid_target == None` (fires every turn).
- Full `parser::oracle::tests` suite green.

## Scope note

The `"enchanted player's <phase>"` player-enchant path (`AttachedTo`) is unchanged; the new arm is `else if`, so player-enchant Auras are unaffected. The existing Aggression card (`"the end step of enchanted creature's controller"`) now also gains correct turn-owner scoping as a member of the same class.
