### PR TITLE
feat(engine): loyalty-ability activation cost modifiers (Eidolon of Obstruction)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -14696,7 +14696,17 @@ pub fn handle_activate_ability(
         // both fall through to the unchanged paths. SelfRef removal is excluded by
         // the walkers. `{X}`-mana removals were already caught by the X detour
         // above, so any mana leg seen here is non-X (mutually exclusive residuals).
-        if find_non_self_battlefield_removal_cost(cost).is_some() {
+        //
+        // CR 118.7 + CR 606.4: A loyalty ability taxed by a cost-raise static
+        // (Eidolon of Obstruction) reaches here as `Composite { Loyalty, Mana }`
+        // via `handle_activate_loyalty`'s delegation. It must ALSO hoist the mana
+        // leg to `enter_payment_step` and defer the loyalty counter cost as the
+        // `ManaLeg` residual — otherwise the composite falls through to
+        // `pay_ability_cost`, which pays the loyalty counters and then fails on the
+        // unaffordable mana, leaving the planeswalker with a free loyalty change.
+        if find_non_self_battlefield_removal_cost(cost).is_some()
+            || crate::types::ability::is_loyalty_ability_cost(cost)
+        {
             if let Some((mana_cost, remaining)) = casting_costs::extract_mana_leg(cost) {
                 let mut pending_leg = PendingCast::new(source_id, CardId(0), resolved, mana_cost);
                 pending_leg.activation_cost = remaining;
@@ -15618,6 +15628,29 @@ fn added_generic_mana_cost(amount: u32) -> AbilityCost {
             generic: amount,
         },
     }
+}
+
+/// CR 118.7 + CR 601.2f + CR 606.1: True when an active cost-modifier static
+/// (Eidolon of Obstruction) adds a mana component to an otherwise mana-free
+/// loyalty ability. Such an ability can no longer use the loyalty fast path
+/// (`handle_activate_loyalty`, which pays only loyalty counters and never mana);
+/// the caller routes it through the general activated-ability flow instead,
+/// which prompts for the added mana, pays the loyalty counters, records the
+/// CR 606.3 activation, and enforces the once-per-turn gate. A bare `Loyalty`
+/// cost that stays bare after applying every modifier is untaxed and keeps the
+/// fast path (zero behavior change for the common case).
+pub(crate) fn loyalty_ability_gains_mana_tax(
+    state: &GameState,
+    ability_def: &AbilityDefinition,
+    player: PlayerId,
+    source_id: ObjectId,
+) -> bool {
+    if !matches!(ability_def.cost, Some(AbilityCost::Loyalty { .. })) {
+        return false;
+    }
+    let mut probe = ability_def.clone();
+    apply_cost_reduction(state, &mut probe, player, source_id);
+    !matches!(probe.cost, Some(AbilityCost::Loyalty { .. }))
 }
 
 /// CR 601.2f: Apply self-referential cost reduction to an ability definition's cost.

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -15575,15 +15575,49 @@ fn increase_generic_in_cost(cost: &mut AbilityCost, amount: u32) {
         } => {
             *generic = generic.saturating_add(amount);
         }
+        // A pre-resolution placeholder mana cost (`NoCost`, `SelfManaCost`, …) or a
+        // `ManaDynamic` cost carries no concrete generic component to grow here; it
+        // is concretized on its own path, so leave it untouched.
+        AbilityCost::Mana { .. } | AbilityCost::ManaDynamic { .. } => {}
         AbilityCost::Composite { costs } => {
-            if let Some(sub) = costs
-                .iter_mut()
-                .find(|c| matches!(c, AbilityCost::Mana { .. }))
-            {
+            if let Some(sub) = costs.iter_mut().find(|c| {
+                matches!(
+                    c,
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost { .. }
+                    }
+                )
+            }) {
                 increase_generic_in_cost(sub, amount);
+            } else {
+                // CR 118.7: no concrete mana component to grow — add one so the
+                // increase still applies (e.g. a Composite of only `{T}`/sacrifice).
+                costs.push(added_generic_mana_cost(amount));
             }
         }
-        _ => {} // Non-mana costs unaffected
+        // CR 118.7 + CR 606.1: A non-mana cost (a loyalty ability's `Loyalty` cost,
+        // a bare `{T}` / sacrifice / pay-life cost) has no generic mana to grow, so
+        // a raise must ADD a generic-mana component. Wrap the existing cost in a
+        // `Composite` with the added `{amount}` — this is what makes Eidolon of
+        // Obstruction actually tax an opponent's loyalty ability by {1}.
+        _ => {
+            let existing = std::mem::replace(cost, AbilityCost::Composite { costs: Vec::new() });
+            if let AbilityCost::Composite { costs } = cost {
+                costs.push(existing);
+                costs.push(added_generic_mana_cost(amount));
+            }
+        }
+    }
+}
+
+/// CR 118.7: A `{amount}` generic-mana `AbilityCost`, used to add a mana component
+/// to an ability whose printed cost has none when a cost-raise static applies.
+fn added_generic_mana_cost(amount: u32) -> AbilityCost {
+    AbilityCost::Mana {
+        cost: ManaCost::Cost {
+            shards: Vec::new(),
+            generic: amount,
+        },
     }
 }
 
@@ -15664,6 +15698,14 @@ fn apply_static_activated_ability_cost_reduction(
     // abilities" / "that aren't mana abilities" — Suppression Field, Zirda) can
     // skip a mana ability's cost.
     let ability_is_mana = super::mana_abilities::is_mana_ability(ability_def);
+    // CR 606.1: Loyalty abilities are activated abilities identified by their
+    // `AbilityCost::Loyalty` cost, not by an `AbilityTag`. A `ReduceAbilityCost`
+    // static keyed on `keyword == "loyalty"` (Eidolon of Obstruction) matches
+    // exactly this class, so classify it here before the mutable cost borrow.
+    let ability_is_loyalty = ability_def
+        .cost
+        .as_ref()
+        .is_some_and(crate::types::ability::is_loyalty_ability_cost);
 
     let Some(cost) = ability_def.cost.as_mut() else {
         return;
@@ -15682,7 +15724,13 @@ fn apply_static_activated_ability_cost_reduction(
         else {
             continue;
         };
-        if (keyword != "activated" && Some(keyword.as_str()) != active_keyword) || *amount == 0 {
+        // CR 601.2f + CR 606.1: match the "activated" blanket arm, a tag-keyed
+        // keyword (power-up, exhaust, …), or the "loyalty" arm against a loyalty
+        // ability's cost.
+        let keyword_matches = keyword == "activated"
+            || Some(keyword.as_str()) == active_keyword
+            || (keyword == "loyalty" && ability_is_loyalty);
+        if !keyword_matches || *amount == 0 {
             continue;
         }
         // CR 605.1a: a mana ability bypasses a "unless they're mana abilities"

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -15602,10 +15602,9 @@ fn increase_generic_in_cost(cost: &mut AbilityCost, amount: u32) {
         // Obstruction actually tax an opponent's loyalty ability by {1}.
         _ => {
             let existing = std::mem::replace(cost, AbilityCost::Composite { costs: Vec::new() });
-            if let AbilityCost::Composite { costs } = cost {
-                costs.push(existing);
-                costs.push(added_generic_mana_cost(amount));
-            }
+            *cost = AbilityCost::Composite {
+                costs: vec![existing, added_generic_mana_cost(amount)],
+            };
         }
     }
 }
@@ -15698,18 +15697,16 @@ fn apply_static_activated_ability_cost_reduction(
     // abilities" / "that aren't mana abilities" — Suppression Field, Zirda) can
     // skip a mana ability's cost.
     let ability_is_mana = super::mana_abilities::is_mana_ability(ability_def);
-    // CR 606.1: Loyalty abilities are activated abilities identified by their
-    // `AbilityCost::Loyalty` cost, not by an `AbilityTag`. A `ReduceAbilityCost`
-    // static keyed on `keyword == "loyalty"` (Eidolon of Obstruction) matches
-    // exactly this class, so classify it here before the mutable cost borrow.
-    let ability_is_loyalty = ability_def
-        .cost
-        .as_ref()
-        .is_some_and(crate::types::ability::is_loyalty_ability_cost);
 
     let Some(cost) = ability_def.cost.as_mut() else {
         return;
     };
+    // CR 606.1: Loyalty abilities are activated abilities identified by their
+    // `AbilityCost::Loyalty` cost, not by an `AbilityTag`. A `ReduceAbilityCost`
+    // static keyed on `keyword == "loyalty"` (Eidolon of Obstruction) matches
+    // exactly this class. Classified on the unwrapped cost (a `&mut` reborrows to
+    // `&`) before the loop mutates it.
+    let ability_is_loyalty = crate::types::ability::is_loyalty_ability_cost(cost);
 
     for (static_source, def) in super::functioning_abilities::battlefield_active_statics(state) {
         let StaticMode::ReduceAbilityCost {

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -14698,15 +14698,18 @@ pub fn handle_activate_ability(
         // above, so any mana leg seen here is non-X (mutually exclusive residuals).
         //
         // CR 118.7 + CR 606.4: A loyalty ability taxed by a cost-raise static
-        // (Eidolon of Obstruction) reaches here as `Composite { Loyalty, Mana }`
-        // via `handle_activate_loyalty`'s delegation. It must ALSO hoist the mana
-        // leg to `enter_payment_step` and defer the loyalty counter cost as the
-        // `ManaLeg` residual — otherwise the composite falls through to
-        // `pay_ability_cost`, which pays the loyalty counters and then fails on the
-        // unaffordable mana, leaving the planeswalker with a free loyalty change.
-        if find_non_self_battlefield_removal_cost(cost).is_some()
-            || crate::types::ability::is_loyalty_ability_cost(cost)
-        {
+        // (Eidolon of Obstruction) reaches here as `Composite { Mana, Loyalty }`
+        // via `handle_activate_loyalty`'s delegation. A NON-TARGETED taxed loyalty
+        // ability hoists the mana leg to `enter_payment_step` and defers the
+        // loyalty counter cost as the `ManaLeg` residual, so mana is paid before
+        // the loyalty counters (no free loyalty on an unaffordable/cancelled mana
+        // payment). A TARGETED taxed loyalty ability is deliberately NOT hoisted
+        // here — it must fall through to the general target-first path below
+        // (CR 601.2c: targets are chosen before costs are paid), where the
+        // mana-first `Composite` ordering keeps the post-target payment atomic.
+        let loyalty_no_targets = crate::types::ability::is_loyalty_ability_cost(cost)
+            && build_target_slots(state, &resolved)?.is_empty();
+        if find_non_self_battlefield_removal_cost(cost).is_some() || loyalty_no_targets {
             if let Some((mana_cost, remaining)) = casting_costs::extract_mana_leg(cost) {
                 let mut pending_leg = PendingCast::new(source_id, CardId(0), resolved, mana_cost);
                 pending_leg.activation_cost = remaining;
@@ -15600,9 +15603,11 @@ fn increase_generic_in_cost(cost: &mut AbilityCost, amount: u32) {
             }) {
                 increase_generic_in_cost(sub, amount);
             } else {
-                // CR 118.7: no concrete mana component to grow — add one so the
-                // increase still applies (e.g. a Composite of only `{T}`/sacrifice).
-                costs.push(added_generic_mana_cost(amount));
+                // CR 118.7 + CR 601.2h: no concrete mana component to grow — add
+                // one so the increase still applies (e.g. a Composite of only
+                // `{T}`/sacrifice). Inserted at the FRONT so it is paid before the
+                // non-mana components (see the `_` arm rationale).
+                costs.insert(0, added_generic_mana_cost(amount));
             }
         }
         // CR 118.7 + CR 606.1: A non-mana cost (a loyalty ability's `Loyalty` cost,
@@ -15610,10 +15615,16 @@ fn increase_generic_in_cost(cost: &mut AbilityCost, amount: u32) {
         // a raise must ADD a generic-mana component. Wrap the existing cost in a
         // `Composite` with the added `{amount}` — this is what makes Eidolon of
         // Obstruction actually tax an opponent's loyalty ability by {1}.
+        //
+        // CR 601.2h: the added mana leg is placed FIRST so any payment path that
+        // pays a `Composite` in order settles the mana before the non-mana cost.
+        // This keeps payment atomic: an unaffordable mana leg fails/pauses before
+        // the loyalty counters (or other non-mana cost) are ever committed, so a
+        // cancelled payment never leaves a free loyalty change behind.
         _ => {
             let existing = std::mem::replace(cost, AbilityCost::Composite { costs: Vec::new() });
             *cost = AbilityCost::Composite {
-                costs: vec![existing, added_generic_mana_cost(amount)],
+                costs: vec![added_generic_mana_cost(amount), existing],
             };
         }
     }

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -38759,6 +38759,171 @@ fn skyseer_increases_chosen_name_activated_ability_cost() {
     );
 }
 
+/// CR 606.1 + CR 118.7 + CR 601.2f: Eidolon of Obstruction — "Loyalty abilities
+/// of planeswalkers your opponents control cost {1} more to activate." Loyalty
+/// abilities are activated abilities (CR 606.1) whose printed cost is a bare
+/// `Loyalty` cost with no mana component, so the raise must ADD a generic-mana
+/// component (CR 118.7) rather than grow a nonexistent one. The generalized
+/// "Activated/Loyalty abilities of [subject]" parser emits
+/// `ReduceAbilityCost { keyword: "loyalty" }`, and the runtime gate matches it
+/// against an ability whose cost `is_loyalty_ability_cost`.
+///
+/// Drives the production seam `apply_cost_reduction`. Discriminating assertions:
+///   - An opponent's planeswalker loyalty ability gains a {1} generic component.
+///     Reverting the `increase_generic_in_cost` non-mana arm leaves the bare
+///     `Loyalty` cost untouched, so this reads {0} and fails.
+///   - The controller's OWN planeswalker loyalty ability is untaxed (the
+///     `controller: Opponent` affected filter excludes it).
+///   - A non-loyalty (mana-cost) activated ability on the opponent's
+///     planeswalker is untaxed — the "loyalty" keyword requires a loyalty cost.
+///     Reverting the gate's `keyword == "loyalty"` arm would leave the first
+///     assertion at {0}.
+#[test]
+fn eidolon_of_obstruction_taxes_opponent_loyalty_ability() {
+    use crate::types::ability::{
+        AbilityCost, Effect, StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
+    };
+    use crate::types::card_type::CoreType;
+    use crate::types::identifiers::CardId;
+    use crate::types::mana::ManaCost;
+    use crate::types::statics::{CostModifyMode, StaticMode};
+
+    let mut state = GameState::new_two_player(7);
+
+    // Eidolon of Obstruction (controlled by P0) carries the parsed Raise static
+    // keyed on "loyalty", affecting planeswalkers P0's opponents control.
+    let eidolon = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Eidolon of Obstruction".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&eidolon).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Raise,
+            keyword: "loyalty".to_string(),
+            amount: 1,
+            minimum_mana: None,
+            dynamic_count: None,
+            exemption: crate::types::statics::ActivationExemption::None,
+            activator: None,
+        })
+        .affected(TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
+        ))]
+        .into();
+    }
+
+    // Opponent's planeswalker (P1) and the controller's own planeswalker (P0).
+    let opp_pw = create_object(
+        &mut state,
+        CardId(2),
+        PlayerId(1),
+        "Opponent Walker".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&opp_pw)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Planeswalker);
+    let own_pw = create_object(
+        &mut state,
+        CardId(3),
+        PlayerId(0),
+        "Own Walker".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&own_pw)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Planeswalker);
+
+    let make_loyalty_def = || {
+        let mut def = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Unimplemented {
+                name: "loyalty".to_string(),
+                description: None,
+            },
+        );
+        def.cost = Some(AbilityCost::Loyalty { amount: 1 });
+        def
+    };
+    let make_mana_def = || {
+        let mut def = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Unimplemented {
+                name: "mana".to_string(),
+                description: None,
+            },
+        );
+        def.cost = Some(AbilityCost::Mana {
+            cost: ManaCost::Cost {
+                shards: vec![],
+                generic: 3,
+            },
+        });
+        def
+    };
+    // Sum the generic mana across a (possibly composite) cost.
+    let added_generic = |def: &AbilityDefinition| -> u32 {
+        match def.cost.as_ref().unwrap() {
+            AbilityCost::Composite { costs } => costs
+                .iter()
+                .filter_map(|c| match c {
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost { generic, .. },
+                    } => Some(*generic),
+                    _ => None,
+                })
+                .sum(),
+            AbilityCost::Loyalty { .. } => 0,
+            AbilityCost::Mana {
+                cost: ManaCost::Cost { generic, .. },
+            } => *generic,
+            other => panic!("unexpected cost {other:?}"),
+        }
+    };
+
+    // Opponent's loyalty ability: the bare Loyalty cost gains a {1} component.
+    let mut def_opp = make_loyalty_def();
+    apply_cost_reduction(&state, &mut def_opp, PlayerId(1), opp_pw);
+    assert_eq!(
+        added_generic(&def_opp),
+        1,
+        "an opponent's loyalty ability must be taxed {{1}}"
+    );
+
+    // Controller's OWN loyalty ability: untaxed (opponent-scoped affected filter).
+    let mut def_own = make_loyalty_def();
+    apply_cost_reduction(&state, &mut def_own, PlayerId(0), own_pw);
+    assert_eq!(
+        added_generic(&def_own),
+        0,
+        "the controller's own loyalty ability must not be taxed"
+    );
+
+    // A non-loyalty (mana-cost) activated ability on the opponent's planeswalker:
+    // untaxed — the loyalty-keyed static requires a loyalty cost.
+    let mut def_mana = make_mana_def();
+    apply_cost_reduction(&state, &mut def_mana, PlayerId(1), opp_pw);
+    assert_eq!(
+        added_generic(&def_mana),
+        3,
+        "the loyalty-keyed static must not tax a non-loyalty ability"
+    );
+}
+
 /// CR 601.2f + CR 208.1 + CR 113.7: Agatha of the Vile Cauldron — "Activated
 /// abilities of creatures you control cost {X} less to activate, where X is
 /// ~'s power. ... can't reduce ... less than one mana." The reduction is

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -33276,6 +33276,75 @@ mod loyalty_gate {
         );
     }
 
+    /// CR 606.3 + CR 606.1 + CR 118.7: A loyalty ability whose activation cost was
+    /// raised by a static (Eidolon of Obstruction) carries its `Loyalty` cost
+    /// inside a `Composite`. The DIRECT `GameAction::ActivateAbility` guard in
+    /// `handle_activate_ability` classifies the already tax-mutated cost with
+    /// `is_loyalty_ability_cost`, so that predicate must keep recognizing the
+    /// taxed composite — otherwise a second taxed loyalty activation in the same
+    /// turn bypasses the per-permanent CR 606.3 gate (candidate generation still
+    /// blocks through its pre-tax path). Reverting the `Composite` arm of
+    /// `is_loyalty_ability_cost` makes the guard skip and this activation succeed.
+    #[test]
+    fn direct_activation_of_taxed_loyalty_ability_second_time_denied() {
+        use crate::types::ability::{StaticDefinition, TargetFilter, TypeFilter, TypedFilter};
+        use crate::types::statics::{ActivationExemption, CostModifyMode, StaticMode};
+
+        let mut state = setup_game_at_main_phase();
+        // P0's planeswalker with a single loyalty ability.
+        let pw = add_planeswalker(
+            &mut state,
+            PlayerId(0),
+            "Taxed Walker",
+            4,
+            vec![make_loyalty_ability(1)],
+        );
+        // P1's Eidolon of Obstruction taxes loyalty abilities of planeswalkers
+        // P1's opponents (P0) control.
+        let eidolon_card_id = CardId(state.next_object_id);
+        let eidolon = create_object(
+            &mut state,
+            eidolon_card_id,
+            PlayerId(1),
+            "Eidolon of Obstruction".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&eidolon).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Raise,
+                keyword: "loyalty".to_string(),
+                amount: 1,
+                minimum_mana: None,
+                dynamic_count: None,
+                exemption: ActivationExemption::None,
+                activator: None,
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
+            ))]
+            .into();
+        }
+
+        // Simulate P0 having already activated a loyalty ability of this PW this turn.
+        state
+            .objects
+            .get_mut(&pw)
+            .unwrap()
+            .loyalty_activations_this_turn = 1;
+
+        // CR 606.3: the direct activation must be rejected even though the tax
+        // wrapped the loyalty cost in a `Composite`.
+        let mut events = Vec::new();
+        let result = handle_activate_ability(&mut state, PlayerId(0), pw, 0, &mut events);
+        assert!(
+            matches!(result, Err(EngineError::ActionNotAllowed(ref m)) if m.contains("loyalty")),
+            "a taxed loyalty ability must still hit the CR 606.3 once-per-turn guard, got {result:?}"
+        );
+    }
+
     /// CR 606.3: The per-permanent gate resets at the start of the controller's
     /// turn (verified via `loyalty_activation_resets_at_turn_start` in
     /// `planeswalker.rs`). Reproducing the reset effect here ensures the

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -33345,6 +33345,110 @@ mod loyalty_gate {
         );
     }
 
+    /// CR 118.7 + CR 606.1 + CR 606.4: Production regression for the real
+    /// `GameAction::ActivateAbility` path (`handle_activate_loyalty`, engine.rs).
+    /// Without Eidolon, a fixed loyalty ability uses the mana-free fast path and
+    /// never enters a mana-payment step. With Eidolon taxing it {1}, the fast
+    /// path defers to the general activated-ability flow, which gates the
+    /// activation behind paying the added mana — so an opponent who lacks the {1}
+    /// cannot activate it for free. Reverting the `handle_activate_loyalty`
+    /// delegation makes the taxed case resolve without a mana step and this fails.
+    #[test]
+    fn eidolon_forces_mana_payment_for_real_loyalty_activation() {
+        use crate::types::ability::{StaticDefinition, TargetFilter, TypeFilter, TypedFilter};
+        use crate::types::statics::{ActivationExemption, CostModifyMode, StaticMode};
+
+        fn build(with_eidolon: bool) -> (GameState, ObjectId) {
+            let mut state = setup_game_at_main_phase();
+            let pw = add_planeswalker(
+                &mut state,
+                PlayerId(0),
+                "Loyal Walker",
+                4,
+                vec![make_loyalty_ability(1)],
+            );
+            if with_eidolon {
+                let cid = CardId(state.next_object_id);
+                let eidolon = create_object(
+                    &mut state,
+                    cid,
+                    PlayerId(1),
+                    "Eidolon of Obstruction".to_string(),
+                    Zone::Battlefield,
+                );
+                let obj = state.objects.get_mut(&eidolon).unwrap();
+                obj.card_types.core_types.push(CoreType::Enchantment);
+                obj.card_types.core_types.push(CoreType::Creature);
+                obj.static_definitions =
+                    vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                        mode: CostModifyMode::Raise,
+                        keyword: "loyalty".to_string(),
+                        amount: 1,
+                        minimum_mana: None,
+                        dynamic_count: None,
+                        exemption: ActivationExemption::None,
+                        activator: None,
+                    })
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::new(TypeFilter::Planeswalker)
+                            .controller(ControllerRef::Opponent),
+                    ))]
+                    .into();
+            }
+            (state, pw)
+        }
+
+        // Control: untaxed loyalty activation never requires mana.
+        let (mut s0, pw0) = build(false);
+        let mut ev0 = Vec::new();
+        let r0 = crate::game::planeswalker::handle_activate_loyalty(
+            &mut s0,
+            PlayerId(0),
+            pw0,
+            0,
+            &mut ev0,
+        )
+        .expect("untaxed loyalty activation must proceed");
+        assert!(
+            !matches!(r0, WaitingFor::ManaPayment { .. }),
+            "an untaxed loyalty ability must not require mana, got {r0:?}"
+        );
+
+        // Under Eidolon, the real activation path routes through the general
+        // activated-ability flow and gates on the added {1}: the mana leg is paid
+        // FIRST (CR 601.2g) with the loyalty counter cost deferred as the residual.
+        // A manaless player therefore either stops at a mana-payment step or is
+        // refused — but NEVER gains a free loyalty change (the pre-fix bug: the
+        // composite paid the loyalty counters, then failed on the unaffordable
+        // mana). The unchanged loyalty is the load-bearing assertion.
+        let (mut s1, pw1) = build(true);
+        let loyalty_before = s1.objects.get(&pw1).unwrap().loyalty;
+        let mut ev1 = Vec::new();
+        let r1 = crate::game::planeswalker::handle_activate_loyalty(
+            &mut s1,
+            PlayerId(0),
+            pw1,
+            0,
+            &mut ev1,
+        );
+        match &r1 {
+            Ok(wf) => assert!(
+                matches!(wf, WaitingFor::ManaPayment { .. }),
+                "a taxed loyalty activation must stop at the mana-payment step, got {wf:?}"
+            ),
+            Err(EngineError::ActionNotAllowed(m)) => assert!(
+                m.to_lowercase().contains("mana"),
+                "a taxed loyalty refusal must be about the unpayable mana, got {m}"
+            ),
+            other => panic!("unexpected activation result {other:?}"),
+        }
+        assert_eq!(
+            s1.objects.get(&pw1).unwrap().loyalty,
+            loyalty_before,
+            "the loyalty counter must not change until the taxed {{1}} is paid"
+        );
+    }
+
     /// CR 606.3: The per-permanent gate resets at the start of the controller's
     /// turn (verified via `loyalty_activation_resets_at_turn_start` in
     /// `planeswalker.rs`). Reproducing the reset effect here ensures the

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -33449,6 +33449,118 @@ mod loyalty_gate {
         );
     }
 
+    /// CR 601.2c + CR 118.7: A TARGETED loyalty ability taxed by Eidolon must
+    /// still choose targets before paying costs. The taxed composite is deferred
+    /// (not hoisted) for targeted abilities, so activation falls through to the
+    /// general target-first path: it stops at target selection with the loyalty
+    /// counter (and the added {1}) still unpaid. The unchanged loyalty while
+    /// waiting for targets is the load-bearing assertion — the pre-fix delegation
+    /// hoisted the mana leg and paid before target selection.
+    #[test]
+    fn eidolon_taxed_targeted_loyalty_selects_targets_before_paying() {
+        use crate::types::ability::{
+            ActivationRestriction, Effect, StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
+        };
+        use crate::types::mana::ManaType;
+        use crate::types::statics::{ActivationExemption, CostModifyMode, StaticMode};
+
+        let mut state = setup_game_at_main_phase();
+
+        // A targeted [-1] loyalty ability: deal 1 damage to target creature.
+        let mut targeted = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+                damage_source: None,
+                excess: None,
+            },
+        )
+        .cost(AbilityCost::Loyalty { amount: -1 });
+        targeted
+            .activation_restrictions
+            .push(ActivationRestriction::AsSorcery);
+        targeted
+            .activation_restrictions
+            .push(ActivationRestriction::OnlyOnceEachTurn);
+        let pw = add_planeswalker(
+            &mut state,
+            PlayerId(0),
+            "Targeting Walker",
+            4,
+            vec![targeted],
+        );
+
+        // Two opposing creatures so target selection is interactive (not auto).
+        for (cid, name) in [(9001u64, "Creature A"), (9002u64, "Creature B")] {
+            let c = create_object(
+                &mut state,
+                CardId(cid),
+                PlayerId(1),
+                name.to_string(),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&c)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+
+        // Eidolon (P1) taxes P0's planeswalker loyalty abilities {1}.
+        let cid = CardId(state.next_object_id);
+        let eidolon = create_object(
+            &mut state,
+            cid,
+            PlayerId(1),
+            "Eidolon of Obstruction".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&eidolon).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Raise,
+                keyword: "loyalty".to_string(),
+                amount: 1,
+                minimum_mana: None,
+                dynamic_count: None,
+                exemption: ActivationExemption::None,
+                activator: None,
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
+            ))]
+            .into();
+        }
+
+        // Give P0 the {1} so activation reaches target selection rather than being
+        // refused for unpayable mana.
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+
+        let loyalty_before = state.objects.get(&pw).unwrap().loyalty;
+        let waiting = crate::game::planeswalker::handle_activate_loyalty(
+            &mut state,
+            PlayerId(0),
+            pw,
+            0,
+            &mut Vec::new(),
+        )
+        .expect("taxed targeted loyalty activation must proceed to target selection");
+        assert!(
+            matches!(waiting, WaitingFor::TargetSelection { .. }),
+            "a taxed targeted loyalty ability must ask for targets first, got {waiting:?}"
+        );
+        assert_eq!(
+            state.objects.get(&pw).unwrap().loyalty,
+            loyalty_before,
+            "loyalty must be unchanged while waiting for target selection"
+        );
+    }
+
     /// CR 606.3: The per-permanent gate resets at the start of the controller's
     /// turn (verified via `loyalty_activation_resets_at_turn_start` in
     /// `planeswalker.rs`). Reproducing the reset effect here ensures the

--- a/crates/engine/src/game/planeswalker.rs
+++ b/crates/engine/src/game/planeswalker.rs
@@ -179,31 +179,56 @@ pub fn handle_activate_loyalty(
         ));
     }
 
-    let obj = state
-        .objects
-        .get(&pw_id)
-        .ok_or_else(|| EngineError::InvalidAction("Planeswalker not found".to_string()))?;
-
-    if ability_index >= obj.abilities.len() {
-        return Err(EngineError::InvalidAction(
-            "Invalid ability index".to_string(),
-        ));
-    }
-
-    let ability_def = &obj.abilities[ability_index];
-    let loyalty_cost = parse_loyalty_cost(ability_def);
-    let current_loyalty = obj.loyalty.unwrap_or(0) as i32;
+    // Extract the loyalty cost + counters and clone the definition so the
+    // immutable object borrow ends before any `&mut state` path below (the
+    // tax-delegation branch calls `handle_activate_ability`).
+    let (loyalty_cost, current_loyalty, ability_def) = {
+        let obj = state
+            .objects
+            .get(&pw_id)
+            .ok_or_else(|| EngineError::InvalidAction("Planeswalker not found".to_string()))?;
+        if ability_index >= obj.abilities.len() {
+            return Err(EngineError::InvalidAction(
+                "Invalid ability index".to_string(),
+            ));
+        }
+        let ability_def = &obj.abilities[ability_index];
+        (
+            parse_loyalty_cost(ability_def),
+            obj.loyalty.unwrap_or(0) as i32,
+            ability_def.clone(),
+        )
+    };
 
     // CR 606.6: A loyalty ability with a negative loyalty cost can't be activated unless the
-    // permanent has at least that many loyalty counters on it.
+    // permanent has at least that many loyalty counters on it. Checked here for
+    // BOTH the fast path and the tax-delegation branch below, so a `[−N]` ability
+    // the planeswalker can't afford is refused before either path proceeds.
     if loyalty_cost < 0 && current_loyalty + loyalty_cost < 0 {
         return Err(EngineError::ActionNotAllowed(
             "Not enough loyalty to activate ability".to_string(),
         ));
     }
 
+    // CR 118.7 + CR 601.2f + CR 606.1: When a cost-raise static (Eidolon of
+    // Obstruction) adds a mana component to this loyalty ability, the mana-free
+    // loyalty fast path can't pay it. Defer to the general activated-ability
+    // flow, which applies the tax (`apply_cost_reduction`), prompts for the added
+    // mana, pays the loyalty counters, records the CR 606.3 activation, and
+    // re-enforces the once-per-turn gate. Untaxed loyalty abilities fall through
+    // to the unchanged fast path.
+    if super::casting::loyalty_ability_gains_mana_tax(state, &ability_def, player, pw_id) {
+        return super::casting::handle_activate_ability(
+            state,
+            player,
+            pw_id,
+            ability_index,
+            events,
+        );
+    }
+
     // Build a ResolvedAbility for the stack from the typed definition
-    let resolved = build_pw_resolved(ability_def, pw_id, player);
+    let resolved = build_pw_resolved(&ability_def, pw_id, player);
 
     // CR 602.2b + CR 601.2c: Targets are announced before costs are paid.
     // If this ability requires targets, prompt for selection first.

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2767,16 +2767,25 @@ pub(crate) fn parse_static_line_inner(
         );
     }
 
-    // --- "Activated abilities of [filter] cost {N} less/more to activate" ---
+    // --- "Activated/Loyalty abilities of [filter] cost {N} less/more to activate" ---
     // CR 602.1 + CR 601.2f + CR 118.7: Generic activated-ability cost modifier,
     // directional. Reduce (Training Grounds: "Activated abilities of creatures you
     // control cost {2} less to activate") and Raise (Skyseer's Chariot: "Activated
     // abilities of sources with the chosen name cost {2} more to activate").
+    // CR 606.1: Loyalty abilities are activated abilities, so the same shape covers
+    // "Loyalty abilities of planeswalkers your opponents control cost {1} more to
+    // activate" (Eidolon of Obstruction) — the leading noun is the only axis that
+    // varies, so it is a single `alt` that sets the matched `keyword` tag; the
+    // runtime gate matches `keyword == "loyalty"` against a loyalty ability's cost.
     // Combinator: prefix → subject → " cost {N} " → direction. The subject is
     // either the chosen-name source phrase (→ HasChosenName) or a type phrase.
-    if let Some(((amount_n, is_x, mode, subject_filter, dynamic_count), _)) =
+    if let Some(((amount_n, is_x, mode, subject_filter, dynamic_count, keyword), _)) =
         nom_on_lower(tp.original, tp.lower, |i| {
-            let (i, _) = tag("activated abilities of ").parse(i)?;
+            let (i, keyword) = alt((
+                value("activated", tag("activated abilities of ")),
+                value("loyalty", tag("loyalty abilities of ")),
+            ))
+            .parse(i)?;
             let (i, subject) = take_until(" cost ").parse(i)?;
             let (i, _) = tag(" cost ").parse(i)?;
             // CR 107.3 + CR 601.2f: the amount is a fixed `{N}` (Training Grounds)
@@ -2802,7 +2811,14 @@ pub(crate) fn parse_static_line_inner(
             let (i, dynamic_count) = opt(parse_where_x_is_self_stat).parse(i)?;
             Ok((
                 i,
-                (amount_n, is_x, mode, subject.to_string(), dynamic_count),
+                (
+                    amount_n,
+                    is_x,
+                    mode,
+                    subject.to_string(),
+                    dynamic_count,
+                    keyword,
+                ),
             ))
         })
     {
@@ -2827,13 +2843,13 @@ pub(crate) fn parse_static_line_inner(
             return Some(
                 StaticDefinition::new(StaticMode::ReduceAbilityCost {
                     mode,
-                    keyword: "activated".to_string(),
+                    keyword: keyword.to_string(),
                     amount,
                     minimum_mana,
                     dynamic_count,
                     exemption: ActivationExemption::None,
-                    // Source-scoped ("Activated abilities of <filter>"): scope is
-                    // the `affected` filter below; no activator gate.
+                    // Source-scoped ("Activated/Loyalty abilities of <filter>"):
+                    // scope is the `affected` filter below; no activator gate.
                     activator: None,
                 })
                 .affected(affected)

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -18356,6 +18356,35 @@ fn static_activated_ability_cost_increase_chosen_name() {
 }
 
 #[test]
+fn static_loyalty_ability_cost_increase_eidolon_of_obstruction() {
+    // CR 606.1: Loyalty abilities are activated abilities, so Eidolon of
+    // Obstruction's "Loyalty abilities of planeswalkers your opponents control
+    // cost {1} more to activate" shares the "<Activated/Loyalty> abilities of
+    // [subject]" grammar, emitting `ReduceAbilityCost { keyword: "loyalty" }` so
+    // the runtime gate can target loyalty-cost abilities specifically.
+    let def = parse_static_line(
+        "Loyalty abilities of planeswalkers your opponents control cost {1} more to activate.",
+    )
+    .expect("Eidolon loyalty cost-increase static must parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Raise,
+            keyword: "loyalty".to_string(),
+            amount: 1,
+            minimum_mana: None,
+            dynamic_count: None,
+            exemption: ActivationExemption::None,
+            activator: None,
+        }
+    );
+    assert!(
+        def.affected.is_some(),
+        "Eidolon must scope the increase to opponents' planeswalkers"
+    );
+}
+
+#[test]
 fn static_activated_ability_cost_generic_reduce_vs_raise_discriminates() {
     // CR 118.7: the same grammar with only the direction word changed must yield
     // opposite `CostModifyMode`s. Pins reduce ≠ increase at the parser layer.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7233,6 +7233,12 @@ pub fn is_loyalty_ability_cost(cost: &AbilityCost) -> bool {
                 && target.is_none()
                 && matches!(selection, CounterCostSelection::SingleObject)
         }
+        // CR 606.1 + CR 118.7: A loyalty ability whose activation cost has been
+        // raised by a static (Eidolon of Obstruction) carries its loyalty cost
+        // inside a `Composite` alongside the added mana. It is still a loyalty
+        // ability, so the CR 606.3 once-per-turn gate and loyalty-activation
+        // tracking must keep recognizing it after the tax.
+        AbilityCost::Composite { costs } => costs.iter().any(is_loyalty_ability_cost),
         _ => false,
     }
 }


### PR DESCRIPTION
## What

Makes **Eidolon of Obstruction** — "Loyalty abilities of planeswalkers your opponents control cost {1} more to activate" — parse and function end to end. It previously dropped the static to `Effect::Unimplemented`, so opponents' loyalty abilities were never taxed.

Loyalty abilities are activated abilities (CR 606.1), so a "cost {N} more/less to activate" static targets them like any other activated ability. Three composed pieces:

- **Parser** (`oracle_static/dispatch.rs`): the existing "Activated abilities of [subject] cost {N} …" static (Training Grounds / Skyseer's Chariot) is parameterized on its leading noun so it also accepts "Loyalty abilities of [subject]", emitting `ReduceAbilityCost { keyword: "loyalty" }`. Only the noun axis varies, so it's one `alt` — not a new handler.
- **Runtime gate** (`casting.rs`): `apply_static_activated_ability_cost_reduction` matches a `keyword == "loyalty"` static against an ability whose cost `is_loyalty_ability_cost` (loyalty abilities are identified by their `AbilityCost::Loyalty` cost, not an `AbilityTag`).
- **Cost application** (`casting.rs`, CR 118.7): a loyalty ability's printed cost has no mana component, so `increase_generic_in_cost` now **adds** a generic-mana component (wrapping in a `Composite`) instead of no-oping. This also fixes the latent gap where a cost-raise static silently failed to tax any activated ability whose cost is `{T}`/sacrifice-only.

## Tests

- Parser test pins the `keyword: "loyalty"` mode for Eidolon's line.
- Runtime test drives the production seam `apply_cost_reduction` and asserts an opponent's loyalty ability gains `{1}`, while the controller's own loyalty ability (opponent-scoped filter) and a non-loyalty ability (keyword mismatch) are untaxed.

Verified locally: `cargo fmt`, full `engine` lib test suite (15,625 passed / 0 failed), and `clippy -p engine --lib -D warnings` clean.

## CR references
CR 606.1 (loyalty abilities are activated abilities) · CR 601.2f + CR 118.7 (cost modification adds generic mana).