### PR TITLE
feat(engine): auto-pass priority-window overhaul (G1/G2/G3/G5/G6)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1698,8 +1698,17 @@ export type DebugAction =
 export type YieldScope = "ThisObject" | "AllCopies";
 
 export type YieldTarget =
-  | { ThisObject: { source_id: ObjectId; incarnation: number } }
-  | { AllCopies: { card_id: CardId } };
+  | {
+      ThisObject: {
+        source_id: ObjectId;
+        // `null` for synthetic/delayed triggers that never latched an incarnation.
+        incarnation: number | null;
+        // Absent/`null` = source-level wildcard (legacy/coarse yields); a value
+        // scopes the yield to one of a source's distinct triggers.
+        trigger_description?: string | null;
+      };
+    }
+  | { AllCopies: { card_id: CardId; trigger_description?: string | null } };
 
 export type PriorityYieldOp =
   | { type: "Add"; data: { source_id: ObjectId; scope: YieldScope } }

--- a/client/src/components/board/PriorityYieldList.tsx
+++ b/client/src/components/board/PriorityYieldList.tsx
@@ -63,10 +63,12 @@ export function PriorityYieldList() {
           <div className="mx-2 mb-1 border-t border-white/10" />
           <ul className="flex flex-col">
             {yields.map((y) => {
+              // Include trigger_description so two per-trigger yields on the same
+              // source/card (same id + incarnation) don't collide on the React key.
               const key =
                 "ThisObject" in y.target
-                  ? `${y.player}-obj-${y.target.ThisObject.source_id}-${y.target.ThisObject.incarnation}`
-                  : `${y.player}-all-${y.target.AllCopies.card_id}`;
+                  ? `${y.player}-obj-${y.target.ThisObject.source_id}-${y.target.ThisObject.incarnation}-${y.target.ThisObject.trigger_description ?? ""}`
+                  : `${y.player}-all-${y.target.AllCopies.card_id}-${y.target.AllCopies.trigger_description ?? ""}`;
               const label =
                 "ThisObject" in y.target
                   ? objects?.[y.target.ThisObject.source_id]?.name ?? t("priorityYield.yieldThis")

--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -107,11 +107,21 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
   // CR 117.3d: a stored yield the viewer already holds for this entry, so the
   // menu can surface a Revoke that echoes the exact engine-owned YieldTarget
   // (the frontend never constructs an incarnation or card_id itself).
-  const matchingYield = priorityYields?.find((y) =>
-    "ThisObject" in y.target
-      ? y.target.ThisObject.source_id === entry.source_id
-      : yieldCardId !== undefined && y.target.AllCopies.card_id === yieldCardId,
-  );
+  // The per-trigger `description` this entry carries — the G5 discriminator.
+  const entryDescription =
+    entry.kind.type === "TriggeredAbility" ? entry.kind.data.description ?? undefined : undefined;
+  const matchingYield = priorityYields?.find((y) => {
+    // Mirror the engine's None-wildcard rule (game_state.rs `is_priority_yielded`):
+    // an absent/null `trigger_description` matches ANY entry description (coarse/
+    // legacy yields), while a value matches only that exact trigger. A strict-only
+    // compare would wrongly hide the Revoke pill for legacy yields still held.
+    const stored = "ThisObject" in y.target ? y.target.ThisObject : y.target.AllCopies;
+    const descMatches =
+      stored.trigger_description == null || stored.trigger_description === entryDescription;
+    return "ThisObject" in y.target
+      ? y.target.ThisObject.source_id === entry.source_id && descMatches
+      : yieldCardId !== undefined && y.target.AllCopies.card_id === yieldCardId && descMatches;
+  });
   // Triggered abilities show "Triggered — From <source>" so the player can
   // tell which permanent owns the trigger without hovering the card image.
   // Activated abilities don't carry a pre-resolved source name (different

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -770,6 +770,34 @@ fn flat_actions_have_meaningful_priority(state: &GameState, actions: &[GameActio
     })
 }
 
+/// G2 upkeep/draw gate: like [`flat_actions_have_meaningful_priority`] but a
+/// merely-castable spell (`CastSpell`) does NOT count. Per the locked design
+/// decision, a castable instant at your own upkeep/draw keeps auto-passing
+/// (MTGA parity — see the existing
+/// `auto_passes_initial_upkeep_and_draw_priority_with_instant_speed_actions`
+/// regression); only a genuine non-cast action (a meaningful activated ability,
+/// morph flip, and other non-cast special actions) holds the initial
+/// upkeep/draw window open. Kept SEPARATE from
+/// `flat_actions_have_meaningful_priority` because that primitive is wired into
+/// the CR 732.5 loop-detection firewall (`has_meaningful_priority_action`) and
+/// must stay byte-identical. Delegates to the same
+/// `activate_ability_is_meaningful_priority` classifier — the only added logic
+/// is the explicit `CastSpell => false` arm.
+fn flat_actions_have_meaningful_noncast_priority(
+    state: &GameState,
+    actions: &[GameAction],
+) -> bool {
+    actions.iter().any(|action| match action {
+        GameAction::PassPriority => false,
+        GameAction::CastSpell { .. } => false,
+        GameAction::ActivateAbility {
+            source_id,
+            ability_index,
+        } => activate_ability_is_meaningful_priority(state, *source_id, *ability_index),
+        _ => true,
+    })
+}
+
 /// Issue #544: sacrifice-for-mana abilities (KCI, Phyrexian Altar, etc.) are
 /// grouped-only (absent from the flat `legal_actions` list) but remain a real
 /// board-changing action. Structural, state-driven scan — no downstream-use
@@ -1067,6 +1095,21 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
         return true;
     }
 
+    // Rung 4 — MTGA-style: auto-pass when the player's own spell/ability is on
+    // top of the stack. The player almost never wants to respond to their own
+    // spell — let it resolve. Hoisted above the castability holds (G3): accepted
+    // MTGA parity means an own object on top outranks "you could still cast
+    // something", including the case where the top object is your own triggered
+    // ability (own triggers lose their implicit stop). Kept BELOW the CR 117.3d
+    // yield rung so an explicit yield still wins, and disjoint from the G1 rung
+    // below (that requires an empty stack; this requires a non-empty one).
+    // Full control mode (checked by the frontend) overrides this.
+    if let Some(top) = state.stack.back() {
+        if top.controller == player {
+            return true;
+        }
+    }
+
     // Rung 5 — G1 (CR 605.1b + CR 603.3): hold priority when tapping one of the
     // player's own currently-activatable mana sources would fire a *beneficial*
     // non-mana tap trigger (opponent-scoped damage/life-loss or controller-scoped
@@ -1118,14 +1161,31 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
         }
     }
 
-    // Own-turn upkeep/draw fast path. This MUST stay above the own-turn
-    // castability rung so a routine own upkeep/draw window short-circuits here
-    // BEFORE any hand sweep (perf; preserves today's behavior). The rung above
-    // is gated on `active_player != player` and the rung below on
-    // `active_player == player`, so the two are mutually exclusive:
-    // `has_feasibly_castable_spell` runs at most once per call, and zero times
-    // on your own upkeep/draw.
-    if auto_passes_initial_priority_by_default(state) {
+    // Own-turn upkeep/draw fast path (G2, gated). This MUST stay above the
+    // own-turn castability rung so a routine own upkeep/draw window
+    // short-circuits here BEFORE any hand sweep (perf; preserves today's
+    // behavior). The rung above is gated on `active_player != player` and the
+    // rung below on `active_player == player`, so the two are mutually
+    // exclusive: `has_feasibly_castable_spell` runs at most once per call, and
+    // zero times on your own upkeep/draw.
+    //
+    // Gated (G2) so it fast-passes ONLY a genuinely empty window:
+    //  - `active_player == player`: the "own upkeep/draw" intent this rung
+    //    claims. On an OPPONENT's upkeep/draw the meaningful-action holds below
+    //    must still apply, so this fast path must not fire there.
+    //  - `!flat_actions_have_meaningful_noncast_priority`: a meaningful NON-cast
+    //    flat action (a meaningful activated ability, morph flip, other special
+    //    actions) at your own upkeep/draw is a real decision — hold for it. A
+    //    merely-castable instant (`CastSpell`) deliberately does NOT hold here
+    //    (MTGA parity — see the noncast predicate's doc and the
+    //    `auto_passes_initial_upkeep_and_draw_priority_with_instant_speed_actions`
+    //    regression). The distinct noncast predicate is used (not
+    //    `flat_actions_have_meaningful_priority`) precisely so casts pass while
+    //    the CR 732.5 loop-firewall primitive stays byte-identical.
+    if state.active_player == player
+        && auto_passes_initial_priority_by_default(state)
+        && !flat_actions_have_meaningful_noncast_priority(state, actions)
+    {
         return true;
     }
 
@@ -1157,15 +1217,6 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
     };
     if !holds {
         return true;
-    }
-
-    // MTGA-style: auto-pass when own spell/ability is on top of the stack.
-    // The player almost never wants to respond to their own spell — let it resolve.
-    // Full control mode (checked by the frontend) overrides this.
-    if let Some(top) = state.stack.back() {
-        if top.controller == player {
-            return true;
-        }
     }
 
     false
@@ -4838,6 +4889,408 @@ mod tests {
         assert!(
             super::auto_pass_recommended(&state, &[GameAction::PassPriority]),
             "player 1's phase stop must not gate player 0's auto-pass"
+        );
+    }
+
+    /// Creates a battlefield permanent controlled by P0 carrying a single
+    /// non-mana activated ability, so `ActivateAbility { source_id, 0 }` is a
+    /// meaningful flat priority action for the auto-pass classifier.
+    fn create_nonmana_activated_source(state: &mut GameState) -> ObjectId {
+        let src = create_object(
+            state,
+            CardId(2),
+            PlayerId(0),
+            "Pinger".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&src).unwrap();
+        Arc::make_mut(&mut obj.abilities).push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Tap),
+        );
+        src
+    }
+
+    /// G3 (hoist): on your own turn, with your own spell on top of the stack AND
+    /// a feasibly castable instant in hand, auto-pass fires — the hoisted own-top
+    /// rung now outranks the own-turn castability HOLD. Before the hoist the
+    /// rung-9 castability check returned `false` (HOLD); reverting the hoist flips
+    /// this assertion back to `false`.
+    #[test]
+    fn auto_pass_true_for_own_spell_on_top_despite_castable_instant() {
+        use crate::game::scenario::{GameScenario, P0};
+        use crate::types::mana::ManaCostShard;
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.add_basic_land(P0, ManaColor::Green);
+        scenario
+            .add_spell_to_hand_from_oracle(P0, "Test Bolt", true, "Draw a card.")
+            .with_mana_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Green],
+                generic: 0,
+            });
+
+        let mut runner = scenario.build();
+        {
+            let state = runner.state_mut();
+            state.active_player = P0;
+            state.priority_player = P0;
+            state.waiting_for = WaitingFor::Priority { player: P0 };
+            state.stack.push_back(StackEntry {
+                id: ObjectId(900),
+                source_id: ObjectId(901),
+                controller: P0,
+                kind: StackEntryKind::Spell {
+                    card_id: CardId(1),
+                    ability: None,
+                    casting_variant: CastingVariant::Normal,
+                    actual_mana_spent: 0,
+                },
+            });
+        }
+
+        // Reach-guard: the {G} instant is genuinely castable, so absent the hoist
+        // the own-turn castability rung would HOLD (return false). This is exactly
+        // the false-HOLD the hoist fixes — the assertion below cannot pass
+        // vacuously.
+        assert!(
+            super::has_feasibly_castable_spell(runner.state(), P0, None),
+            "precondition: the {{G}} instant is feasibly castable — the castability rung would otherwise hold"
+        );
+        assert!(
+            super::auto_pass_recommended(
+                runner.state(),
+                &super::flat_priority_actions(runner.state())
+            ),
+            "G3 hoist: own spell on top outranks the castability hold → auto-pass fires"
+        );
+    }
+
+    /// G3 (MTGA parity): on an OPPONENT's turn, your own instant just cast and on
+    /// top of the stack auto-passes even though you still hold another castable
+    /// instant — the hoisted own-top rung outranks the opponent-turn castability
+    /// HOLD. Reverting the hoist flips this to `false` (rung-7 castability holds).
+    #[test]
+    fn auto_pass_true_for_own_instant_on_top_opponents_turn() {
+        use crate::game::scenario::{GameScenario, P0, P1};
+        use crate::types::mana::ManaCostShard;
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.add_basic_land(P0, ManaColor::Green);
+        scenario
+            .add_spell_to_hand_from_oracle(P0, "Test Bolt", true, "Draw a card.")
+            .with_mana_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Green],
+                generic: 0,
+            });
+
+        let mut runner = scenario.build();
+        {
+            let state = runner.state_mut();
+            state.active_player = P1;
+            state.priority_player = P0;
+            state.waiting_for = WaitingFor::Priority { player: P0 };
+            // Your own instant already on the stack (controller P0).
+            state.stack.push_back(StackEntry {
+                id: ObjectId(900),
+                source_id: ObjectId(901),
+                controller: P0,
+                kind: StackEntryKind::Spell {
+                    card_id: CardId(1),
+                    ability: None,
+                    casting_variant: CastingVariant::Normal,
+                    actual_mana_spent: 0,
+                },
+            });
+        }
+
+        // Reach-guard: another castable instant remains in hand, so rung-7
+        // opponent-turn castability WOULD hold absent the hoist.
+        assert!(
+            super::has_feasibly_castable_spell(runner.state(), P0, None),
+            "precondition: a second {{G}} instant is feasibly castable"
+        );
+        assert!(
+            super::auto_pass_recommended(
+                runner.state(),
+                &super::flat_priority_actions(runner.state())
+            ),
+            "G3 hoist (MTGA parity): own instant on top auto-passes even on the opponent's turn"
+        );
+    }
+
+    /// G3 negative (reach-guarded): an OPPONENT's spell on top of the stack must
+    /// still HOLD when you have a castable instant — the hoisted own-top rung only
+    /// fires for objects YOU control, never for an opponent's. The castable-spell
+    /// precondition proves the hold routes through the castability rung.
+    #[test]
+    fn auto_pass_false_for_opponent_spell_on_top_with_castable_instant() {
+        use crate::game::scenario::{GameScenario, P0, P1};
+        use crate::types::mana::ManaCostShard;
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.add_basic_land(P0, ManaColor::Green);
+        scenario
+            .add_spell_to_hand_from_oracle(P0, "Test Bolt", true, "Draw a card.")
+            .with_mana_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Green],
+                generic: 0,
+            });
+
+        let mut runner = scenario.build();
+        {
+            let state = runner.state_mut();
+            state.active_player = P1;
+            state.priority_player = P0;
+            state.waiting_for = WaitingFor::Priority { player: P0 };
+            // OPPONENT's spell on top (controller P1).
+            state.stack.push_back(StackEntry {
+                id: ObjectId(900),
+                source_id: ObjectId(901),
+                controller: P1,
+                kind: StackEntryKind::Spell {
+                    card_id: CardId(1),
+                    ability: None,
+                    casting_variant: CastingVariant::Normal,
+                    actual_mana_spent: 0,
+                },
+            });
+        }
+
+        // Reach-guard: the instant is feasibly castable, so the `false` below is
+        // the castability HOLD firing — proving the hoisted own-top rung did NOT
+        // fire for an opponent-controlled top-of-stack object.
+        assert!(
+            super::has_feasibly_castable_spell(runner.state(), P0, None),
+            "precondition: the {{G}} instant is feasibly castable"
+        );
+        assert!(
+            !super::auto_pass_recommended(
+                runner.state(),
+                &super::flat_priority_actions(runner.state())
+            ),
+            "opponent spell on top → still hold to respond (own-top rung must not fire for opponent objects)"
+        );
+    }
+
+    /// G3 negative (reach-guarded): an opponent's spell on top plus a meaningful
+    /// flat action HOLDS. The reach-guard proves that, absent the meaningful
+    /// action, the same state auto-passes — so the hold is the meaningful action,
+    /// and the hoisted own-top rung correctly did not fire for the opponent spell.
+    #[test]
+    fn auto_pass_false_for_opponent_spell_on_top_with_meaningful_action() {
+        let mut state = setup_priority();
+        state.phase = Phase::PreCombatMain;
+        state.stack.push_back(StackEntry {
+            id: ObjectId(600),
+            source_id: ObjectId(601),
+            controller: PlayerId(1),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(1),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+        let src = create_nonmana_activated_source(&mut state);
+        let actions = vec![
+            GameAction::PassPriority,
+            GameAction::ActivateAbility {
+                source_id: src,
+                ability_index: 0,
+            },
+        ];
+
+        // Reach-guard: with only PassPriority the window auto-passes (the own-top
+        // rung does not fire for the opponent's spell), so the hold below is
+        // attributable to the meaningful action, not an upstream short-circuit.
+        assert!(
+            super::auto_pass_recommended(&state, &[GameAction::PassPriority]),
+            "reach-guard: opponent spell on top with no meaningful action → auto-pass"
+        );
+        assert!(
+            !super::auto_pass_recommended(&state, &actions),
+            "opponent spell on top + meaningful action → hold"
+        );
+    }
+
+    /// G3 (hoist, meaningful-ability variant): on your own turn with your own
+    /// spell on top of the stack AND a meaningful non-mana activated ability
+    /// available, auto-pass fires — the hoisted own-top rung (Rung 4) outranks
+    /// the meaningful-action hold below (accepted MTGA parity). The reach-guard
+    /// (same state/actions, EMPTY stack) proves the ability genuinely HOLDS the
+    /// window absent an own-top entry, so the flip is non-vacuous: it is the
+    /// presence of the own object on top that turns the hold into a pass. This
+    /// covers the own-top rung for the meaningful-activated-ability input class
+    /// (the existing `..._despite_castable_instant` / `..._own_instant_on_top_*`
+    /// tests cover the rung-order-vs-castability delta); deleting or making the
+    /// own-top rung unreachable for this input flips the main assertion to false.
+    #[test]
+    fn auto_pass_true_for_own_spell_on_top_despite_meaningful_ability() {
+        let mut state = setup_priority();
+        state.phase = Phase::PreCombatMain;
+        let src = create_nonmana_activated_source(&mut state);
+        let actions = vec![
+            GameAction::PassPriority,
+            GameAction::ActivateAbility {
+                source_id: src,
+                ability_index: 0,
+            },
+        ];
+
+        // Reach-guard: with an EMPTY stack the meaningful activated ability
+        // genuinely HOLDS the window (the meaningful-action hold) — auto-pass does
+        // NOT fire. This proves the flip below is caused by the own-top entry, not
+        // an upstream short-circuit.
+        assert!(
+            !super::auto_pass_recommended(&state, &actions),
+            "reach-guard: own turn + meaningful activated ability, empty stack → hold"
+        );
+
+        // Own spell on top of the stack: the hoisted own-top rung (Rung 4) flips
+        // that hold to a PASS, outranking the meaningful-action hold below.
+        state.stack.push_back(StackEntry {
+            id: ObjectId(900),
+            source_id: ObjectId(901),
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(1),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+        assert!(
+            super::auto_pass_recommended(&state, &actions),
+            "G3 hoist: own spell on top outranks the meaningful-action hold → auto-pass fires"
+        );
+    }
+
+    /// G2 (gate): a meaningful NON-cast flat action at your OWN upkeep now HOLDS
+    /// instead of fast-passing, while a merely-castable instant keeps auto-passing
+    /// (MTGA parity). Before the gate the bare
+    /// `auto_passes_initial_priority_by_default` fast path returned `true`
+    /// unconditionally; the `!flat_actions_have_meaningful_noncast_priority` gate
+    /// flips the activated-ability case to `false`. The `CastSpell` control
+    /// assertion proves the noncast predicate's `CastSpell => false` arm — it
+    /// flips to `false` if the gate is (wrongly) switched to the broad
+    /// `flat_actions_have_meaningful_priority` primitive.
+    #[test]
+    fn auto_pass_false_for_meaningful_noncast_action_on_own_upkeep() {
+        let mut state = setup_priority();
+        state.phase = Phase::Upkeep;
+        let src = create_nonmana_activated_source(&mut state);
+        let hold_actions = vec![
+            GameAction::PassPriority,
+            GameAction::ActivateAbility {
+                source_id: src,
+                ability_index: 0,
+            },
+        ];
+        let cast_actions = vec![
+            GameAction::PassPriority,
+            GameAction::CastSpell {
+                object_id: ObjectId(10),
+                card_id: CardId(10),
+                targets: Vec::new(),
+                payment_mode: crate::types::game_state::CastPaymentMode::Auto,
+            },
+        ];
+
+        // Reach-guard: absent any meaningful action this own-upkeep window
+        // fast-passes through the gated rung — proving the window really is the
+        // gated fast path and the meaningful action is what now holds it.
+        assert!(
+            super::auto_pass_recommended(&state, &[GameAction::PassPriority]),
+            "reach-guard: empty own-upkeep window fast-passes via the gated rung"
+        );
+        // Control: a merely-castable instant does NOT hold the upkeep window
+        // (MTGA parity) — the noncast predicate excludes `CastSpell`.
+        assert!(
+            super::auto_pass_recommended(&state, &cast_actions),
+            "G2: a merely-castable instant at own upkeep keeps auto-passing (CastSpell excluded)"
+        );
+        // Gap fix: a meaningful non-mana activated ability HOLDS.
+        assert!(
+            !super::auto_pass_recommended(&state, &hold_actions),
+            "G2: a meaningful non-cast action at own upkeep now HOLDS instead of fast-passing"
+        );
+    }
+
+    /// G2 (gate, negative route-guard, REV3): a bare own upkeep whose only flat
+    /// action is Pass — with a standalone (grouped-only) mana source on the
+    /// battlefield — still fast-passes, and does so THROUGH the gated fast path.
+    /// The route-guards prove both gate predicates hold and no meaningful non-cast
+    /// action is present, so the `true` is the gate's.
+    #[test]
+    fn auto_pass_true_for_bare_own_upkeep_via_gated_fast_path() {
+        let mut state = setup_priority();
+        state.phase = Phase::Upkeep;
+        // A standalone mana source: activatable mana, but grouped-only (NOT in the
+        // flat priority list) — mirrors production.
+        let land = create_land(&mut state, "Forest", &["Forest"]);
+        add_fixed_mana_ability(&mut state, land, ManaColor::Green);
+        let actions = vec![GameAction::PassPriority];
+
+        // Route-guards: the gate window is live, the flat list carries no
+        // meaningful non-cast action, and a standalone mana source IS activatable
+        // (grouped-only). Together these prove the gated fast path is the rung
+        // that returns true.
+        assert!(
+            super::auto_passes_initial_priority_by_default(&state),
+            "route-guard: empty-stack own upkeep is the fast-path window"
+        );
+        assert!(
+            !super::flat_actions_have_meaningful_noncast_priority(&state, &actions),
+            "route-guard: the flat list carries no meaningful non-cast action"
+        );
+        assert!(
+            !super::activatable_object_mana_actions(&state).is_empty(),
+            "route-guard: a standalone mana source IS activatable (grouped-only)"
+        );
+        assert!(
+            super::auto_pass_recommended(&state, &actions),
+            "G2: bare own upkeep with only a standalone mana source fast-passes via the gate"
+        );
+    }
+
+    /// G2 (active_player gate, REV2): a meaningful non-cast flat action on the
+    /// OPPONENT's upkeep now HOLDS. The pre-Stage-2 bare fast path fast-passed any
+    /// upkeep/draw window regardless of whose turn it was; gating on
+    /// `active_player == player` flips this to `false`. The reach-guard proves the
+    /// meaningful action is the discriminator.
+    #[test]
+    fn auto_pass_false_for_meaningful_action_on_opponents_upkeep() {
+        let mut state = setup_priority();
+        state.active_player = PlayerId(1);
+        state.phase = Phase::Upkeep;
+        let src = create_nonmana_activated_source(&mut state);
+        let actions = vec![
+            GameAction::PassPriority,
+            GameAction::ActivateAbility {
+                source_id: src,
+                ability_index: 0,
+            },
+        ];
+
+        // Reach-guard: with only PassPriority the opponent's upkeep window still
+        // auto-passes, proving the meaningful action is what holds below.
+        assert!(
+            super::auto_pass_recommended(&state, &[GameAction::PassPriority]),
+            "reach-guard: opponent's upkeep with no meaningful action → auto-pass"
+        );
+        assert!(
+            !super::auto_pass_recommended(&state, &actions),
+            "G2 active_player: a meaningful action on the OPPONENT's upkeep now HOLDS"
         );
     }
 }

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -4784,6 +4784,7 @@ mod tests {
             PlayerId(0),
             crate::types::game_state::YieldTarget::AllCopies {
                 card_id: CardId(77),
+                trigger_description: None,
             },
         );
         assert!(

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -776,15 +776,28 @@ fn flat_actions_have_meaningful_priority(state: &GameState, actions: &[GameActio
 /// judgement here (that belongs to the auto-pass gate, not the loop firewall).
 fn has_activatable_sacrifice_for_mana(state: &GameState) -> bool {
     matches!(state.waiting_for, WaitingFor::Priority { .. })
-        && activatable_object_mana_actions(state).iter().any(|action| {
-            matches!(
-                action,
-                GameAction::ActivateAbility {
-                    source_id,
-                    ability_index,
-                } if activate_ability_is_meaningful_priority(state, *source_id, *ability_index)
-            )
-        })
+        && mana_actions_include_meaningful_sacrifice(state, &activatable_object_mana_actions(state))
+}
+
+/// Slice-taking core of [`has_activatable_sacrifice_for_mana`]: given a
+/// precomputed activatable mana-action sweep, true iff any action is a
+/// meaningful (sacrifice-for-mana) mana activation. Extracted so
+/// `auto_pass_recommended` can compute the sweep ONCE and share it between the
+/// G1 beneficial-mana-tap hold (rung 5) and this rung-9 sac check, avoiding the
+/// PR #5229 double-evaluation of the mana-action sweep.
+fn mana_actions_include_meaningful_sacrifice(
+    state: &GameState,
+    object_mana_actions: &[GameAction],
+) -> bool {
+    object_mana_actions.iter().any(|action| {
+        matches!(
+            action,
+            GameAction::ActivateAbility {
+                source_id,
+                ability_index,
+            } if activate_ability_is_meaningful_priority(state, *source_id, *ability_index)
+        )
+    })
 }
 
 /// True when `actions` contains a priority action that materially changes the
@@ -809,10 +822,16 @@ fn auto_passes_initial_priority_by_default(state: &GameState) -> bool {
 /// accepts via manual mana-ability payment even though the simulation oracle
 /// (`SimulationFilter`) rejects the Auto-mode `CastSpell` candidate (issue #562,
 /// #583). Frontends surface these via `spell_costs` + manual cast dispatch.
-fn has_feasibly_castable_spell(state: &GameState, player: PlayerId) -> bool {
+fn has_feasibly_castable_spell(
+    state: &GameState,
+    player: PlayerId,
+    probe: Option<&crate::game::casting::PriorityCastProbe>,
+) -> bool {
     crate::game::casting::spell_objects_available_to_cast(state, player)
         .iter()
-        .any(|&object_id| crate::game::casting::can_cast_object_now(state, player, object_id))
+        .any(|&object_id| {
+            crate::game::casting::can_cast_object_now_with_probe(state, player, object_id, probe)
+        })
 }
 
 /// CR 605.3a + CR 603.6 + CR 117.1d: A sacrifice-for-mana activation blocks
@@ -887,6 +906,98 @@ fn trigger_fires_on_leaving_battlefield(trigger: &TriggerDefinition) -> bool {
     }
 }
 
+/// G1 — stage 2 of the beneficial mana-tap trigger hold (CR 605.1b window).
+///
+/// The caller has already confirmed the cheap stage-1 gate (own-turn,
+/// empty-stack main phase) and that `beneficial_sources` — the player's
+/// permanents carrying a *beneficial* non-mana `TapsForMana` / `ManaAdded`
+/// trigger — is non-empty. This stage sweeps the (already-computed, §C.3-shared)
+/// activatable mana-action list and returns `true` iff tapping one of the
+/// player's own currently-activatable mana sources would actually FIRE such a
+/// trigger (CR 106.12a). Post-filter this is hold-on-presence again: a single
+/// firing beneficial trigger justifies holding priority.
+///
+/// Self-quiescing: once the source is tapped it drops out of the mana-action
+/// sweep, so the hold releases on the next call (no infinite hold).
+fn beneficial_mana_tap_trigger_hold(
+    state: &GameState,
+    player: PlayerId,
+    object_mana_actions: &[GameAction],
+    beneficial_sources: &[ObjectId],
+) -> bool {
+    object_mana_actions.iter().any(|action| {
+        // CR 106.12a: only a mana ability whose activation cost includes {T}
+        // emits the `TappedForMana` event these triggers key off. The
+        // `TapLandForMana` shortcut is always a single {T} option (its tap
+        // component is trivially satisfied); an `ActivateAbility` may be a
+        // non-tap mana ability, so consult the ability's cost.
+        let mana_source = match action {
+            GameAction::TapLandForMana { object_id } => *object_id,
+            GameAction::ActivateAbility {
+                source_id,
+                ability_index,
+            } => {
+                let has_tap = state
+                    .objects
+                    .get(source_id)
+                    .and_then(|obj| obj.abilities.get(*ability_index))
+                    .is_some_and(|ability| mana_sources::has_tap_component(&ability.cost));
+                if !has_tap {
+                    return false;
+                }
+                *source_id
+            }
+            _ => return false,
+        };
+
+        beneficial_sources.iter().any(|&trigger_source| {
+            let Some(obj) = state.objects.get(&trigger_source) else {
+                return false;
+            };
+            obj.trigger_definitions.iter_all().any(|trigger| {
+                if !mana_sources::is_non_mana_tap_trigger(trigger)
+                    || !mana_sources::trigger_chain_benefits_controller(trigger)
+                {
+                    return false;
+                }
+                match trigger.mode {
+                    // CR 106.12a: the card-identity + tapping-player authority is
+                    // `taps_for_mana_card_matches` + `valid_player_matches`, the
+                    // same predicates the trigger resolver uses. `taps_for_mana_card_matches`
+                    // ignores `taps_for_mana_produced`, so a produced-mana filter is
+                    // treated as matching (over-approx, err-to-hold).
+                    crate::types::triggers::TriggerMode::TapsForMana => {
+                        crate::game::trigger_matchers::taps_for_mana_card_matches(
+                            trigger,
+                            state,
+                            mana_source,
+                            trigger_source,
+                        ) && crate::game::trigger_matchers::valid_player_matches(
+                            trigger,
+                            state,
+                            player,
+                            trigger_source,
+                        )
+                    }
+                    // CR 605.1b: a `ManaAdded` trigger has no card filter
+                    // (`match_mana_added` matches any mana-added event), so it fires
+                    // on any own mana activation — over-approximate to firing
+                    // (err-to-hold; zero such beneficial cards printed today).
+                    crate::types::triggers::TriggerMode::ManaAdded => {
+                        crate::game::trigger_matchers::valid_player_matches(
+                            trigger,
+                            state,
+                            player,
+                            trigger_source,
+                        )
+                    }
+                    _ => false,
+                }
+            })
+        })
+    })
+}
+
 /// Determines whether the frontend should auto-pass the current priority window.
 ///
 /// Returns `true` when auto-passing is recommended:
@@ -914,6 +1025,17 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
         WaitingFor::Priority { player } => *player,
         _ => return false,
     };
+
+    // Lazy, compute-once locals shared across rungs (§C):
+    //  - `cast_probe`: one `PriorityCastProbe` built when the first castability
+    //    rung is reached (rungs 7/8 are mutually exclusive on `active_player`,
+    //    so it is built at most once), reused so the auto-tap source cache and
+    //    layer flush are not rebuilt per candidate spell.
+    //  - `object_mana_actions`: one activatable mana-action sweep shared by the
+    //    G1 beneficial-tap hold (rung 5) and the rung-9 sac-for-mana check,
+    //    avoiding the PR #5229 double-evaluation.
+    let mut cast_probe: Option<crate::game::casting::PriorityCastProbe> = None;
+    let mut object_mana_actions: Option<Vec<GameAction>> = None;
 
     // A phase stop on the current phase (empty stack = initial priority window)
     // means the player asked to pause here — never recommend auto-pass. Moved
@@ -945,6 +1067,35 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
         return true;
     }
 
+    // Rung 5 — G1 (CR 605.1b + CR 603.3): hold priority when tapping one of the
+    // player's own currently-activatable mana sources would fire a *beneficial*
+    // non-mana tap trigger (opponent-scoped damage/life-loss or controller-scoped
+    // life gain — Zhur-Taa Druid's "deals 1 damage to each opponent"). Such a
+    // trigger USES THE STACK (it fails CR 605.1b's mana-ability test), so a real
+    // priority window exists to hold in. Scoped to own-turn, empty-stack MAIN
+    // phases (the deliberate residual instant-speed windows delegate to phase
+    // stops). Stage 1 is a clone-free AST gate (§C.2); the mana-action sweep is
+    // computed lazily only past the gate and shared with the rung-9 sac check.
+    if state.stack.is_empty()
+        && state.active_player == player
+        && matches!(state.phase, Phase::PreCombatMain | Phase::PostCombatMain)
+    {
+        let beneficial_sources =
+            mana_sources::beneficial_non_mana_tap_trigger_sources(state, player);
+        if !beneficial_sources.is_empty() {
+            let sweep =
+                object_mana_actions.get_or_insert_with(|| activatable_object_mana_actions(state));
+            if beneficial_mana_tap_trigger_hold(
+                state,
+                player,
+                sweep.as_slice(),
+                &beneficial_sources,
+            ) {
+                return false;
+            }
+        }
+    }
+
     // CR 117.1d (issue #4388): On an opponent's turn the priority player may
     // hold to cast an instant/flash spell paid for with their own mana
     // abilities (Gaea's Cradle, Itlimoc, basic lands). Hold ONLY when they
@@ -958,8 +1109,13 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
     // opponent's turn are still held below by `has_meaningful_priority_action`;
     // a dedicated `has_feasibly_activatable_ability` opponent-turn seam
     // (the ability analogue of this predicate) is deferred as future work.
-    if state.active_player != player && has_feasibly_castable_spell(state, player) {
-        return false;
+    if state.active_player != player {
+        let probe: &_ = cast_probe.get_or_insert_with(|| {
+            crate::game::casting::PriorityCastProbe::from_flushed_state(state.clone(), player)
+        });
+        if has_feasibly_castable_spell(probe.state(), player, Some(probe)) {
+            return false;
+        }
     }
 
     // Own-turn upkeep/draw fast path. This MUST stay above the own-turn
@@ -973,8 +1129,13 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
         return true;
     }
 
-    if state.active_player == player && has_feasibly_castable_spell(state, player) {
-        return false;
+    if state.active_player == player {
+        let probe: &_ = cast_probe.get_or_insert_with(|| {
+            crate::game::casting::PriorityCastProbe::from_flushed_state(state.clone(), player)
+        });
+        if has_feasibly_castable_spell(probe.state(), player, Some(probe)) {
+            return false;
+        }
     }
 
     // A genuinely meaningful non-mana priority action always holds. A
@@ -986,9 +1147,14 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
     // no downstream use is not a meaningful priority window — let auto-pass fire.
     // Short-circuit order preserves perf: the followup scan runs only when the
     // flat list is not already meaningful AND a sac-for-mana source is present.
-    let holds = flat_actions_have_meaningful_priority(state, actions)
-        || (has_activatable_sacrifice_for_mana(state)
-            && sacrifice_for_mana_enables_followup(state, player));
+    let holds = flat_actions_have_meaningful_priority(state, actions) || {
+        // Short-circuit: only sweep (or reuse the rung-5 sweep) when the flat
+        // list is not already meaningful AND a sac-for-mana source is present.
+        let sweep =
+            object_mana_actions.get_or_insert_with(|| activatable_object_mana_actions(state));
+        mana_actions_include_meaningful_sacrifice(state, sweep.as_slice())
+            && sacrifice_for_mana_enables_followup(state, player)
+    };
     if !holds {
         return true;
     }
@@ -1413,13 +1579,14 @@ mod tests {
         legal_actions_full, stuck_decision_diagnostic, validated_candidate_actions,
     };
     use crate::game::engine::apply_as_current;
+    use crate::game::mana_sources;
     use crate::game::zones::create_object;
     use crate::parser::oracle::parse_oracle_text;
     use crate::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, ChoiceType, ContinuousModification,
         ControllerRef, Effect, FilterProp, ManaContribution, ManaProduction, QuantityExpr,
         ResolvedAbility, SacrificeCost, SearchSelectionConstraint, StaticDefinition, TargetFilter,
-        TargetRef, TypedFilter,
+        TargetRef, TriggerDefinition, TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
@@ -2804,7 +2971,7 @@ mod tests {
         // Positive reach-guard: prove the {G} instant is feasibly castable so
         // the HOLD assertion below cannot pass vacuously.
         assert!(
-            super::has_feasibly_castable_spell(runner.state(), P0),
+            super::has_feasibly_castable_spell(runner.state(), P0, None),
             "precondition: the {{G}} instant is feasibly castable"
         );
         assert!(
@@ -3020,7 +3187,7 @@ mod tests {
         );
         // Nothing castable — the produced mana would feed no spell (case 1 false).
         assert!(
-            !super::has_feasibly_castable_spell(&state, PlayerId(0)),
+            !super::has_feasibly_castable_spell(&state, PlayerId(0), None),
             "precondition: empty hand, nothing feasibly castable"
         );
 
@@ -3060,7 +3227,7 @@ mod tests {
         // Positive reach-guard: the {G} instant is genuinely castable, so the HOLD
         // cannot pass vacuously.
         assert!(
-            super::has_feasibly_castable_spell(runner.state(), P0),
+            super::has_feasibly_castable_spell(runner.state(), P0, None),
             "precondition: the {{G}} instant is feasibly castable"
         );
         assert!(
@@ -3085,7 +3252,7 @@ mod tests {
             state.waiting_for = WaitingFor::Priority { player: P0 };
         }
         assert!(
-            !super::has_feasibly_castable_spell(bare_runner.state(), P0),
+            !super::has_feasibly_castable_spell(bare_runner.state(), P0, None),
             "precondition (negative): no castable spell on the bare board"
         );
         assert!(
@@ -3200,7 +3367,6 @@ mod tests {
     /// lives on a different permanent, proving the scan sweeps all permanents.
     #[test]
     fn sac_for_mana_holds_with_beneficial_death_trigger() {
-        use crate::types::ability::TriggerDefinition;
         use crate::types::triggers::TriggerMode;
 
         let mut state = GameState::new_two_player(42);
@@ -3262,7 +3428,7 @@ mod tests {
     /// invariant for disjunctive dies/leaves triggers.
     #[test]
     fn sac_for_mana_holds_with_disjunctive_leaves_battlefield_clause_trigger() {
-        use crate::types::ability::{OriginConstraint, TriggerDefinition, ZoneChangeClause};
+        use crate::types::ability::{OriginConstraint, ZoneChangeClause};
         use crate::types::triggers::TriggerMode;
 
         let mut state = GameState::new_two_player(42);
@@ -3322,7 +3488,6 @@ mod tests {
     /// `SpellCast` must NOT match `trigger_fires_on_leaving_battlefield`.
     #[test]
     fn sac_for_mana_auto_passes_with_only_non_leaving_trigger() {
-        use crate::types::ability::TriggerDefinition;
         use crate::types::triggers::TriggerMode;
 
         let mut state = GameState::new_two_player(42);
@@ -3371,12 +3536,298 @@ mod tests {
         );
     }
 
+    // ── G1: beneficial mana-tap trigger hold (CR 605.1b) ────────────────────
+
+    /// A `{T}: Add {G}` mana creature (Zhur-Taa Druid shape). `trigger`, when
+    /// given, is attached as the TapsForMana beneficial trigger. The creature is
+    /// not summoning-sick so its tap ability is genuinely activatable and appears
+    /// in `activatable_object_mana_actions`.
+    fn add_mana_tap_creature(
+        state: &mut GameState,
+        controller: PlayerId,
+        trigger: Option<TriggerDefinition>,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(810),
+            controller,
+            "Mana Dork".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.summoning_sick = false;
+        Arc::make_mut(&mut obj.abilities).push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Tap),
+        );
+        if let Some(trigger) = trigger {
+            obj.trigger_definitions.push(trigger);
+        }
+        id
+    }
+
+    /// Zhur-Taa Druid's live trigger: `Whenever you tap ~ for mana, it deals 1
+    /// damage to each opponent.` (`valid_card: SelfRef`, `valid_target:
+    /// Controller`, execute `DamageEachPlayer { Opponent }`).
+    fn zhur_taa_trigger() -> TriggerDefinition {
+        use crate::types::ability::PlayerFilter;
+        use crate::types::triggers::TriggerMode;
+        TriggerDefinition::new(TriggerMode::TapsForMana)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::DamageEachPlayer {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player_filter: PlayerFilter::Opponent,
+                },
+            ))
+            .valid_card(TargetFilter::SelfRef)
+            .valid_target(TargetFilter::Controller)
+    }
+
+    fn own_main_priority() -> GameState {
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+        state
+    }
+
+    /// False-pass POSITIVE (revert-failing): Zhur-Taa Druid on own PreCombatMain,
+    /// empty stack, nothing else to do → HOLD. If the G1 rung is reverted, rung 9
+    /// finds no meaningful action (a bare mana ability) and auto-passes, so the
+    /// `!auto_pass_recommended` assertion flips.
+    #[test]
+    fn g1_holds_for_beneficial_mana_tap_trigger_own_main() {
+        let mut state = own_main_priority();
+        add_mana_tap_creature(&mut state, PlayerId(0), Some(zhur_taa_trigger()));
+        let flat = super::flat_priority_actions(&state);
+
+        // Reach-guards (non-vacuous): stage-1 finds the beneficial source AND the
+        // tap ability is genuinely activatable (so stage-2 is reached), yet the
+        // flat list is NOT meaningful (a bare mana ability), so a HOLD here can
+        // only come from the G1 rung.
+        assert!(
+            !mana_sources::beneficial_non_mana_tap_trigger_sources(&state, PlayerId(0)).is_empty(),
+            "precondition: stage-1 AST gate finds the beneficial trigger source"
+        );
+        assert!(
+            !super::activatable_object_mana_actions(&state).is_empty(),
+            "precondition: the {{T}} mana ability is activatable (stage-2 reached)"
+        );
+        assert!(
+            !super::flat_actions_have_meaningful_priority(&state, &flat),
+            "precondition: the flat list is not meaningful (hold is not from rung 9)"
+        );
+
+        assert!(
+            !super::auto_pass_recommended(&state, &flat),
+            "beneficial mana-tap trigger on own main → HOLD (G1 rung)"
+        );
+    }
+
+    /// NEGATIVE — Manabarbs shape (`DealDamage { TriggeringPlayer }`): the effect
+    /// harms the tapper, not an opponent, so the sign classifier rejects it and
+    /// auto-pass fires. Reach-guard: the tap ability is still activatable (so the
+    /// pass is due to the sign classifier, not an unreachable stage 2).
+    #[test]
+    fn g1_auto_passes_for_manabarbs_shape() {
+        use crate::types::triggers::TriggerMode;
+        let mut state = own_main_priority();
+        let manabarbs = TriggerDefinition::new(TriggerMode::TapsForMana)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::DealDamage {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::TriggeringPlayer,
+                    damage_source: None,
+                    excess: None,
+                },
+            ))
+            .valid_card(TargetFilter::Typed(TypedFilter::land()));
+        add_mana_tap_creature(&mut state, PlayerId(0), Some(manabarbs));
+        let flat = super::flat_priority_actions(&state);
+
+        assert!(
+            !super::activatable_object_mana_actions(&state).is_empty(),
+            "reach-guard: the tap ability is activatable; only the sign rejects it"
+        );
+        assert!(
+            mana_sources::beneficial_non_mana_tap_trigger_sources(&state, PlayerId(0)).is_empty(),
+            "the harm-the-tapper effect is not classified beneficial"
+        );
+        assert!(
+            super::auto_pass_recommended(&state, &flat),
+            "Manabarbs-shaped self-harm trigger → auto-pass"
+        );
+    }
+
+    /// NEGATIVE — Forbidden Orchard token (`Effect::Token` owner Opponent): a
+    /// fully-parsed effect that is not a CR 119/120 life/damage swing, so the
+    /// sign classifier's documented default arm rejects it → auto-pass.
+    /// Reach-guard: the tap ability is activatable (only the sign rejects it).
+    #[test]
+    fn g1_auto_passes_for_forbidden_orchard_token() {
+        use crate::types::ability::PtValue;
+        use crate::types::triggers::TriggerMode;
+        let mut state = own_main_priority();
+        // Forbidden Orchard's live shape: "target opponent creates a 1/1 Spirit".
+        let orchard = TriggerDefinition::new(TriggerMode::TapsForMana)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::Token {
+                    name: "Spirit".to_string(),
+                    power: PtValue::Fixed(1),
+                    toughness: PtValue::Fixed(1),
+                    types: vec!["Creature".to_string(), "Spirit".to_string()],
+                    colors: vec![],
+                    keywords: vec![],
+                    tapped: false,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    owner: TargetFilter::Typed(TypedFilter {
+                        type_filters: vec![],
+                        controller: Some(ControllerRef::Opponent),
+                        properties: vec![],
+                    }),
+                    attach_to: None,
+                    enters_attacking: false,
+                    supertypes: vec![],
+                    static_abilities: vec![],
+                    enter_with_counters: vec![],
+                },
+            ))
+            .valid_card(TargetFilter::SelfRef);
+        add_mana_tap_creature(&mut state, PlayerId(0), Some(orchard));
+        let flat = super::flat_priority_actions(&state);
+
+        assert!(
+            !super::activatable_object_mana_actions(&state).is_empty(),
+            "reach-guard: the tap ability is activatable; only the sign rejects it"
+        );
+        assert!(
+            mana_sources::beneficial_non_mana_tap_trigger_sources(&state, PlayerId(0)).is_empty(),
+            "a token-creation rider is not a CR 119/120 benefit"
+        );
+        assert!(
+            super::auto_pass_recommended(&state, &flat),
+            "Forbidden-Orchard token rider → auto-pass"
+        );
+    }
+
+    /// NEGATIVE — opponent-controlled trigger source (also covers "trigger on the
+    /// opponent's battlefield"): the beneficial dork is P1's, so on P0's turn
+    /// `beneficial_non_mana_tap_trigger_sources(P0)` is empty and P1's source is
+    /// absent from P0's mana sweep → auto-pass. Reach-guard: the SAME dork
+    /// controlled by P0 would hold (verified by the positive test).
+    #[test]
+    fn g1_auto_passes_for_opponent_controlled_source() {
+        let mut state = own_main_priority();
+        add_mana_tap_creature(&mut state, PlayerId(1), Some(zhur_taa_trigger()));
+        let flat = super::flat_priority_actions(&state);
+
+        assert!(
+            mana_sources::beneficial_non_mana_tap_trigger_sources(&state, PlayerId(0)).is_empty(),
+            "an opponent-controlled beneficial source is not P0's"
+        );
+        assert!(
+            super::auto_pass_recommended(&state, &flat),
+            "opponent-controlled beneficial trigger source → auto-pass"
+        );
+    }
+
+    /// NEGATIVE — the beneficial dork is already tapped, so its tap ability is
+    /// absent from the mana sweep: stage 1 still finds the source, but stage 2
+    /// finds no activatable matching mana action → auto-pass. Reach-guard:
+    /// stage-1 non-empty (so the pass is a stage-2 miss, not a stage-1 miss).
+    #[test]
+    fn g1_auto_passes_when_source_already_tapped() {
+        let mut state = own_main_priority();
+        let dork = add_mana_tap_creature(&mut state, PlayerId(0), Some(zhur_taa_trigger()));
+        state.objects.get_mut(&dork).unwrap().tapped = true;
+        let flat = super::flat_priority_actions(&state);
+
+        assert!(
+            !mana_sources::beneficial_non_mana_tap_trigger_sources(&state, PlayerId(0)).is_empty(),
+            "reach-guard: stage-1 still finds the beneficial source"
+        );
+        assert!(
+            super::activatable_object_mana_actions(&state).is_empty(),
+            "the tapped source has no activatable mana action (stage-2 miss)"
+        );
+        assert!(
+            super::auto_pass_recommended(&state, &flat),
+            "tapped beneficial source → auto-pass (self-quiescing)"
+        );
+    }
+
+    /// NEGATIVE — wrong window (own Upkeep, not a main phase): the G1 window gate
+    /// requires PreCombatMain/PostCombatMain, so on own Upkeep the beneficial hold
+    /// does not apply. Reach-guard: on the SAME board at PreCombatMain the hold
+    /// fires (asserted first), proving only the phase axis flips the result.
+    #[test]
+    fn g1_auto_passes_on_own_upkeep_wrong_phase() {
+        let mut state = own_main_priority();
+        add_mana_tap_creature(&mut state, PlayerId(0), Some(zhur_taa_trigger()));
+        let flat = super::flat_priority_actions(&state);
+
+        // Reach-guard: at a main phase this exact board HOLDS.
+        assert!(
+            !super::auto_pass_recommended(&state, &flat),
+            "reach-guard: the same board holds at PreCombatMain"
+        );
+
+        // Flip only the phase to Upkeep — G1's window no longer applies.
+        state.phase = Phase::Upkeep;
+        assert!(
+            super::auto_pass_recommended(&state, &flat),
+            "own Upkeep is outside G1's mains-only window → auto-pass"
+        );
+    }
+
+    /// NEGATIVE — wrong window (opponent's turn): G1 requires `active_player ==
+    /// player`. On the opponent's turn the beneficial hold does not apply; the
+    /// opponent-turn castability rung (rung 7) governs instead, and with nothing
+    /// castable auto-pass fires. Reach-guard: the same board on P0's turn holds.
+    #[test]
+    fn g1_auto_passes_on_opponents_turn_wrong_window() {
+        let mut state = own_main_priority();
+        add_mana_tap_creature(&mut state, PlayerId(0), Some(zhur_taa_trigger()));
+        let flat = super::flat_priority_actions(&state);
+
+        assert!(
+            !super::auto_pass_recommended(&state, &flat),
+            "reach-guard: on P0's own turn the board holds"
+        );
+
+        // Flip only the turn — it is now the opponent's (P1's) turn.
+        state.active_player = PlayerId(1);
+        assert!(
+            super::auto_pass_recommended(&state, &flat),
+            "opponent's turn is outside G1's own-turn window → auto-pass"
+        );
+    }
+
     /// V6b (predicate boundary): direct unit coverage of
     /// `trigger_fires_on_leaving_battlefield`, pinning the `OriginConstraint`
     /// semantics for the disjunctive-clause arm (CR 603.6c).
     #[test]
     fn trigger_fires_on_leaving_battlefield_predicate_boundary() {
-        use crate::types::ability::{OriginConstraint, TriggerDefinition, ZoneChangeClause};
+        use crate::types::ability::{OriginConstraint, ZoneChangeClause};
         use crate::types::triggers::TriggerMode;
 
         // Direct battlefield-exit modes always fire.

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -2108,7 +2108,8 @@ fn set_priority_yield_add_binds_from_stack_after_token_ceased() {
             player: PlayerId(0),
             target: crate::types::game_state::YieldTarget::ThisObject {
                 source_id: source,
-                incarnation: 4,
+                incarnation: Some(4),
+                trigger_description: None,
             },
         }],
         "Add must bind the incarnation latched on the on-stack trigger",
@@ -2146,13 +2147,21 @@ fn set_priority_yield_add_no_op_without_matching_stack_entry() {
     );
 }
 
-/// CR 400.7 None-boundary: a `ThisObject` add on a trigger with no latched
-/// incarnation no-ops, while an `AllCopies` add on the same trigger still stores.
+/// G6 (CR 400.7): a `ThisObject` add on a trigger with no latched incarnation
+/// (a synthetic/delayed game-rule trigger) now STORES a `None`-incarnation yield
+/// through the real `SetPriorityYield` pipeline and that yield matches its own
+/// trigger — previously this add was a silent no-op. An `AllCopies` add on the
+/// same trigger also stores.
 #[test]
-fn set_priority_yield_this_object_none_incarnation_no_ops_but_all_copies_works() {
+fn set_priority_yield_this_object_none_incarnation_latches_and_matches() {
     let mut state = setup_game_at_main_phase();
     let source = ObjectId(0); // synthetic game-rule trigger source
     push_token_trigger(&mut state, source, PlayerId(0), None, Some(CardId(77)));
+    let entry = state
+        .stack
+        .back()
+        .cloned()
+        .expect("reach-guard: the synthetic trigger is on the stack");
 
     apply(
         &mut state,
@@ -2165,11 +2174,24 @@ fn set_priority_yield_this_object_none_incarnation_no_ops_but_all_copies_works()
         },
     )
     .expect("legal");
+    assert_eq!(
+        state.priority_yields,
+        vec![crate::types::game_state::PriorityYield {
+            player: PlayerId(0),
+            target: crate::types::game_state::YieldTarget::ThisObject {
+                source_id: source,
+                incarnation: None,
+                trigger_description: None,
+            },
+        }],
+        "G6: ThisObject add must latch a None-incarnation yield, not no-op"
+    );
     assert!(
-        state.priority_yields.is_empty(),
-        "ThisObject add must no-op when the trigger latched no incarnation"
+        state.is_priority_yielded(PlayerId(0), &entry),
+        "G6: the None-incarnation latch must match its own synthetic trigger"
     );
 
+    state.clear_priority_yields(PlayerId(0));
     apply(
         &mut state,
         PlayerId(0),
@@ -2256,7 +2278,8 @@ fn until_end_of_turn_yielded_opponent_top_passes_not_finishes() {
         PlayerId(0),
         crate::types::game_state::YieldTarget::ThisObject {
             source_id: source,
-            incarnation: 4,
+            incarnation: Some(4),
+            trigger_description: None,
         },
     );
     assert!(

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -15,7 +15,8 @@
 
 use crate::types::ability::ManaSpendRestriction;
 use crate::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, Effect, ManaProduction, QuantityExpr, TargetFilter,
+    AbilityCost, AbilityDefinition, AbilityKind, ControllerRef, Effect, ManaProduction,
+    PlayerFilter, QuantityExpr, TargetFilter, TriggerDefinition, TypedFilter,
 };
 use crate::types::card_type::CoreType;
 use crate::types::game_state::{GameState, ProductionOverride};
@@ -454,6 +455,116 @@ pub(crate) fn mana_ability_penalty(ability: &AbilityDefinition) -> ManaSourcePen
         return ManaSourcePenalty::HasIrreversibleContinuation;
     }
     ManaSourcePenalty::None
+}
+
+/// CR 119.3 (life) / CR 120.3 (damage → life loss): The benefit twin of
+/// [`effect_controller_harm_amount`]. Returns `true` iff a single `Effect`
+/// favors the player who caused the trigger (the tapper): opponent-scoped
+/// damage / life loss, or controller-scoped life gain. Presence-only (no amount)
+/// — a mana-tap hold is a hold-on-presence decision, not a value sum.
+///
+/// Exact AST shapes (verified against `types/ability.rs`): opponent scope is
+/// `TargetFilter::Typed(TypedFilter { controller: Some(ControllerRef::Opponent),
+/// .. })` — there is NO bare `TargetFilter::Opponent` variant (cf.
+/// `player_matches_filter`). `DamageEachPlayer { player_filter: Opponent }` is
+/// Zhur-Taa Druid's live shape. `GainLife.player` is a `TargetFilter` that
+/// serde-defaults to `Controller` (never `None` in the AST). Everything else —
+/// self / triggering-player scope, `Unimplemented`, `GenericEffect`, and every
+/// unmodeled shape — falls through the documented default arm to `false`
+/// (default-pass). Broadening beyond CR 119 / CR 120 is a deliberate follow-up.
+fn effect_benefits_trigger_controller(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::DamageEachPlayer {
+            player_filter: PlayerFilter::Opponent,
+            ..
+        } | Effect::DealDamage {
+            target: TargetFilter::Typed(TypedFilter {
+                controller: Some(ControllerRef::Opponent),
+                ..
+            }),
+            ..
+        } | Effect::LoseLife {
+            target: Some(TargetFilter::Typed(TypedFilter {
+                controller: Some(ControllerRef::Opponent),
+                ..
+            })),
+            ..
+        } | Effect::GainLife {
+            player: TargetFilter::Controller,
+            ..
+        }
+    )
+}
+
+/// CR 603.2: Walk a trigger's `execute` continuation graph (top effect plus the
+/// `sub_ability` / `else_ability` links, mirroring `chain_harms_controller_amount`)
+/// and return `true` iff any link's effect benefits the trigger's controller. A
+/// trigger with no `execute` chain benefits no one.
+pub(crate) fn trigger_chain_benefits_controller(trigger: &TriggerDefinition) -> bool {
+    fn walk(ability: &AbilityDefinition) -> bool {
+        if effect_benefits_trigger_controller(&ability.effect) {
+            return true;
+        }
+        if let Some(sub) = ability.sub_ability.as_deref() {
+            if walk(sub) {
+                return true;
+            }
+        }
+        if let Some(other) = ability.else_ability.as_deref() {
+            if walk(other) {
+                return true;
+            }
+        }
+        false
+    }
+    trigger.execute.as_deref().is_some_and(walk)
+}
+
+/// CR 605.1b (+ CR 603.3): True when `trigger` is a *non-mana* tap-triggered
+/// ability — mode `TapsForMana` or `ManaAdded` whose `execute` chain contains
+/// any effect other than mana production.
+///
+/// Such a trigger FAILS CR 605.1b's mana-ability criteria (it does not "add mana
+/// to a player's mana pool when it resolves"), so it goes on the stack and uses
+/// a priority window (CR 603.3) — unlike a pure-mana tap trigger, which is a
+/// mana ability that resolves inline without the stack (CR 605.4a). That stack
+/// use is exactly why a beneficial one is worth holding for. A whole-`Effect::Mana`
+/// chain (the aura mana-fixing case: Utopia Sprawl, Fertile Ground) is excluded —
+/// mirrors `chain_has_non_mana_effect`, but here the top-level `execute.effect`
+/// is also inspected (it carries the trigger's own effect, not mana production).
+pub(crate) fn is_non_mana_tap_trigger(trigger: &TriggerDefinition) -> bool {
+    matches!(
+        trigger.mode,
+        TriggerMode::TapsForMana | TriggerMode::ManaAdded
+    ) && trigger.execute.as_deref().is_some_and(|execute| {
+        !matches!(*execute.effect, Effect::Mana { .. }) || chain_has_non_mana_effect(execute)
+    })
+}
+
+/// CR 605.1b: Battlefield permanents controlled by `player` that carry a
+/// *beneficial* non-mana tap trigger — one that both [`is_non_mana_tap_trigger`]
+/// (uses the stack) and [`trigger_chain_benefits_controller`] (favors the
+/// tapper). This is the clone-free stage-1 AST gate for the G1 beneficial
+/// mana-tap hold: a linear battlefield walk with early-out, no state clones.
+pub(crate) fn beneficial_non_mana_tap_trigger_sources(
+    state: &GameState,
+    player: PlayerId,
+) -> Vec<ObjectId> {
+    state
+        .battlefield
+        .iter()
+        .copied()
+        .filter(|object_id| {
+            state.objects.get(object_id).is_some_and(|obj| {
+                obj.controller == player
+                    && obj.trigger_definitions.iter_all().any(|trigger| {
+                        is_non_mana_tap_trigger(trigger)
+                            && trigger_chain_benefits_controller(trigger)
+                    })
+            })
+        })
+        .collect()
 }
 
 /// Return all currently activatable tap-mana options for a land.
@@ -4027,5 +4138,220 @@ mod tests {
             matches!(&pips[1], ManaPip::OneOfColors(colors) if colors.len() == 5),
             "second pip must be OneOfColors with 5 options, got: {pips:?}"
         );
+    }
+
+    // ── G1: beneficial mana-tap trigger classifier ──────────────────────────
+
+    fn fixed(value: i32) -> QuantityExpr {
+        QuantityExpr::Fixed { value }
+    }
+
+    fn opponent_scope() -> TargetFilter {
+        TargetFilter::Typed(TypedFilter {
+            type_filters: vec![],
+            controller: Some(ControllerRef::Opponent),
+            properties: vec![],
+        })
+    }
+
+    #[test]
+    fn effect_benefits_classifier_covers_every_arm() {
+        // Zhur-Taa Druid's live shape: opponent-scoped each-player damage → benefit.
+        assert!(effect_benefits_trigger_controller(
+            &Effect::DamageEachPlayer {
+                amount: fixed(1),
+                player_filter: PlayerFilter::Opponent,
+            }
+        ));
+        // Self-scoped each-player damage (would hit the tapper) → pass.
+        assert!(!effect_benefits_trigger_controller(
+            &Effect::DamageEachPlayer {
+                amount: fixed(1),
+                player_filter: PlayerFilter::Controller,
+            }
+        ));
+        // "Deals damage to target opponent" (opponent player scope) → benefit.
+        assert!(effect_benefits_trigger_controller(&Effect::DealDamage {
+            amount: fixed(1),
+            target: opponent_scope(),
+            damage_source: None,
+            excess: None,
+        }));
+        // Manabarbs: damage to the TRIGGERING player (the tapper) → pass.
+        assert!(!effect_benefits_trigger_controller(&Effect::DealDamage {
+            amount: fixed(1),
+            target: TargetFilter::TriggeringPlayer,
+            damage_source: None,
+            excess: None,
+        }));
+        // Controller-scoped damage (the tapper harms themselves) → pass.
+        assert!(!effect_benefits_trigger_controller(&Effect::DealDamage {
+            amount: fixed(1),
+            target: TargetFilter::Controller,
+            damage_source: None,
+            excess: None,
+        }));
+        // Opponent-scoped life loss → benefit.
+        assert!(effect_benefits_trigger_controller(&Effect::LoseLife {
+            amount: fixed(1),
+            target: Some(opponent_scope()),
+        }));
+        // Untargeted life loss (defaults to the resolving player) → pass.
+        assert!(!effect_benefits_trigger_controller(&Effect::LoseLife {
+            amount: fixed(1),
+            target: None,
+        }));
+        // Controller life gain → benefit.
+        assert!(effect_benefits_trigger_controller(&Effect::GainLife {
+            amount: fixed(1),
+            player: TargetFilter::Controller,
+        }));
+        // Opponent life gain → pass (helps the opponent, not the tapper).
+        assert!(!effect_benefits_trigger_controller(&Effect::GainLife {
+            amount: fixed(1),
+            player: opponent_scope(),
+        }));
+        // Unknown / unmodeled shapes default-pass (documented catch-all).
+        assert!(!effect_benefits_trigger_controller(
+            &Effect::Unimplemented {
+                name: "runaway growth".to_string(),
+                description: None,
+            }
+        ));
+        assert!(!effect_benefits_trigger_controller(
+            &Effect::GenericEffect {
+                static_abilities: vec![],
+                duration: None,
+                target: None,
+            }
+        ));
+    }
+
+    fn taps_for_mana_trigger_with(effect: Effect) -> TriggerDefinition {
+        TriggerDefinition::new(TriggerMode::TapsForMana)
+            .execute(AbilityDefinition::new(AbilityKind::Database, effect))
+            .valid_card(TargetFilter::SelfRef)
+    }
+
+    #[test]
+    fn trigger_chain_benefits_walks_sub_ability_and_requires_execute() {
+        // No execute chain → benefits no one.
+        assert!(!trigger_chain_benefits_controller(&TriggerDefinition::new(
+            TriggerMode::TapsForMana
+        )));
+        // Top-level beneficial effect.
+        assert!(trigger_chain_benefits_controller(
+            &taps_for_mana_trigger_with(Effect::DamageEachPlayer {
+                amount: fixed(1),
+                player_filter: PlayerFilter::Opponent,
+            })
+        ));
+        // Beneficial effect nested in a sub_ability link is still found.
+        let mut nested = AbilityDefinition::new(
+            AbilityKind::Database,
+            Effect::Unimplemented {
+                name: "noop".to_string(),
+                description: None,
+            },
+        );
+        nested.sub_ability = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Database,
+            Effect::GainLife {
+                amount: fixed(2),
+                player: TargetFilter::Controller,
+            },
+        )));
+        assert!(trigger_chain_benefits_controller(
+            &TriggerDefinition::new(TriggerMode::TapsForMana).execute(nested)
+        ));
+    }
+
+    #[test]
+    fn is_non_mana_tap_trigger_excludes_pure_mana_and_wrong_mode() {
+        // Non-mana TapsForMana (Zhur-Taa) → true.
+        assert!(is_non_mana_tap_trigger(&taps_for_mana_trigger_with(
+            Effect::DamageEachPlayer {
+                amount: fixed(1),
+                player_filter: PlayerFilter::Opponent,
+            }
+        )));
+        // Pure-mana TapsForMana (Wild Growth aura) → false (it IS a mana ability).
+        let pure_mana =
+            TriggerDefinition::new(TriggerMode::TapsForMana).execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Additional,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            ));
+        assert!(!is_non_mana_tap_trigger(&pure_mana));
+        // ManaAdded with a non-mana effect → true.
+        let mana_added =
+            TriggerDefinition::new(TriggerMode::ManaAdded).execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::GainLife {
+                    amount: fixed(1),
+                    player: TargetFilter::Controller,
+                },
+            ));
+        assert!(is_non_mana_tap_trigger(&mana_added));
+        // Wrong mode (a beneficial effect on a non-tap trigger) → false.
+        let wrong_mode =
+            TriggerDefinition::new(TriggerMode::ChangesZone).execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::DamageEachPlayer {
+                    amount: fixed(1),
+                    player_filter: PlayerFilter::Opponent,
+                },
+            ));
+        assert!(!is_non_mana_tap_trigger(&wrong_mode));
+    }
+
+    #[test]
+    fn beneficial_sources_scan_scopes_to_controller() {
+        let mut state = GameState::new_two_player(42);
+        // P0's Zhur-Taa-shaped dork.
+        let dork = create_object(
+            &mut state,
+            CardId(800),
+            PlayerId(0),
+            "Beneficial Dork".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&dork)
+            .unwrap()
+            .trigger_definitions
+            .push(taps_for_mana_trigger_with(Effect::DamageEachPlayer {
+                amount: fixed(1),
+                player_filter: PlayerFilter::Opponent,
+            }));
+        // An opponent-controlled copy of the same shape must NOT appear for P0.
+        let opp_dork = create_object(
+            &mut state,
+            CardId(801),
+            PlayerId(1),
+            "Opponent Dork".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&opp_dork)
+            .unwrap()
+            .trigger_definitions
+            .push(taps_for_mana_trigger_with(Effect::DamageEachPlayer {
+                amount: fixed(1),
+                player_filter: PlayerFilter::Opponent,
+            }));
+
+        let sources = beneficial_non_mana_tap_trigger_sources(&state, PlayerId(0));
+        assert_eq!(sources, vec![dork], "only P0's controlled source is listed");
     }
 }

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -615,7 +615,7 @@ fn valid_source_controller_matches(
     }
 }
 
-pub(super) fn valid_player_matches(
+pub(crate) fn valid_player_matches(
     trigger: &TriggerDefinition,
     state: &GameState,
     player_id: PlayerId,
@@ -2830,7 +2830,7 @@ pub(super) fn match_revealed(
 /// Extracted as a standalone authority so the aura mana-refund probe
 /// (`mana_sources::aura_taps_for_mana_sources_for_land`) can ask the same
 /// question without synthesizing a `GameEvent`.
-pub(super) fn taps_for_mana_card_matches(
+pub(crate) fn taps_for_mana_card_matches(
     trigger: &TriggerDefinition,
     state: &GameState,
     mana_source: ObjectId,

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1530,12 +1530,16 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.add_priority_yield(
             PlayerId(0),
-            crate::types::game_state::YieldTarget::AllCopies { card_id: CardId(9) },
+            crate::types::game_state::YieldTarget::AllCopies {
+                card_id: CardId(9),
+                trigger_description: None,
+            },
         );
         state.add_priority_yield(
             PlayerId(1),
             crate::types::game_state::YieldTarget::AllCopies {
                 card_id: CardId(10),
+                trigger_description: None,
             },
         );
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -714,19 +714,37 @@ pub enum YieldScope {
 /// latched at the moment the yield is registered.
 ///
 /// `ThisObject` binds a concrete object incarnation: a matching stack entry must
-/// carry the same `source_id` and `source_incarnation`. A `source_incarnation`
-/// of `None` therefore never matches (unlike the epoch guard's "None = always
-/// current" convention) — synthetic game-rule triggers cannot be yielded this
-/// way. `AllCopies` binds a `CardId`: any trigger whose `source_card_id` equals
-/// it matches, regardless of which object (or whether the object still exists).
+/// carry the same `source_id` and `source_incarnation`. Here `incarnation` is an
+/// `Option<u64>`, so an `incarnation` of `None` matches a trigger whose
+/// `source_incarnation` is *also* `None` — synthetic/delayed game-rule triggers
+/// that never latched an incarnation can now be yielded (Option == Option
+/// compare). `AllCopies` binds a `CardId`: any trigger whose `source_card_id`
+/// equals it matches, regardless of which object (or whether the object still
+/// exists, CR 704.5d).
+///
+/// Both variants carry an optional `trigger_description`, the per-trigger
+/// discriminator the stack entry already exposes
+/// (`StackEntryKind::TriggeredAbility.description`). A `trigger_description` of
+/// `None` is a **wildcard** that matches ANY entry description (the coarse,
+/// source-level yield used by legacy persisted yields and pre-upgrade saves),
+/// while `Some(desc)` gives per-trigger precision so one source's distinct
+/// triggers can be yielded independently.
+///
+// serde: legacy bare-u64 incarnation loads as Some (serde maps only null→None),
+// so old persisted `{"incarnation":26}` still deserializes and matches; an
+// absent `trigger_description` defaults to None (the wildcard).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum YieldTarget {
     ThisObject {
         source_id: ObjectId,
-        incarnation: u64,
+        incarnation: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        trigger_description: Option<String>,
     },
     AllCopies {
         card_id: CardId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        trigger_description: Option<String>,
     },
 }
 
@@ -8830,19 +8848,33 @@ impl GameState {
     pub fn is_priority_yielded(&self, player: PlayerId, entry: &StackEntry) -> bool {
         match &entry.kind {
             StackEntryKind::TriggeredAbility {
-                source_id, ability, ..
+                source_id,
+                ability,
+                description,
+                ..
             } => self.priority_yields.iter().any(|y| {
                 y.player == player
                     && match &y.target {
                         YieldTarget::ThisObject {
                             source_id: yielded_id,
                             incarnation,
+                            trigger_description,
                         } => {
+                            // CR 400.7: incarnation identity — a None-yield
+                            // matches a trigger that latched no incarnation
+                            // (synthetic/delayed), Some matches the same epoch.
                             *source_id == *yielded_id
-                                && ability.source_incarnation == Some(*incarnation)
+                                && ability.source_incarnation == *incarnation
+                                && (trigger_description.is_none()
+                                    || trigger_description.as_deref() == description.as_deref())
                         }
-                        YieldTarget::AllCopies { card_id } => {
+                        YieldTarget::AllCopies {
+                            card_id,
+                            trigger_description,
+                        } => {
                             ability.source_card_id == Some(*card_id)
+                                && (trigger_description.is_none()
+                                    || trigger_description.as_deref() == description.as_deref())
                         }
                     }
             }),
@@ -8856,9 +8888,10 @@ impl GameState {
     /// concrete `YieldTarget` by scanning the stack (top-down) for that source's
     /// triggered ability and reading the identity it captured at push. Returns
     /// `None` — caller no-ops — when no matching triggered entry is on the stack,
-    /// or when the requested scope needs an identity the trigger never latched (a
-    /// `ThisObject` yield on a trigger with no `source_incarnation`, or an
-    /// `AllCopies` yield on one with no `source_card_id`).
+    /// or when the requested `AllCopies` scope needs a `source_card_id` the
+    /// trigger never latched. A `ThisObject` yield always resolves: a trigger
+    /// with no `source_incarnation` latches `incarnation: None`, which matches
+    /// only entries that likewise latched no incarnation (CR 400.7).
     pub fn resolve_yield_target_from_stack(
         &self,
         source_id: ObjectId,
@@ -8868,19 +8901,25 @@ impl GameState {
             StackEntryKind::TriggeredAbility {
                 source_id: sid,
                 ability,
+                description,
                 ..
             } if *sid == source_id => match scope {
-                YieldScope::ThisObject => {
+                // CR 400.7: latch the incarnation identity (now Option — a
+                // synthetic/delayed trigger with no `source_incarnation` still
+                // yields, storing `None`) and the per-trigger description.
+                YieldScope::ThisObject => Some(YieldTarget::ThisObject {
+                    source_id,
+                    incarnation: ability.source_incarnation,
+                    trigger_description: description.clone(),
+                }),
+                YieldScope::AllCopies => {
                     ability
-                        .source_incarnation
-                        .map(|incarnation| YieldTarget::ThisObject {
-                            source_id,
-                            incarnation,
+                        .source_card_id
+                        .map(|card_id| YieldTarget::AllCopies {
+                            card_id,
+                            trigger_description: description.clone(),
                         })
                 }
-                YieldScope::AllCopies => ability
-                    .source_card_id
-                    .map(|card_id| YieldTarget::AllCopies { card_id }),
             },
             _ => None,
         })
@@ -11185,7 +11224,8 @@ mod tests {
             PlayerId(0),
             YieldTarget::ThisObject {
                 source_id: ObjectId(5),
-                incarnation: 3,
+                incarnation: Some(3),
+                trigger_description: None,
             },
         );
         assert!(state.is_priority_yielded(PlayerId(0), &entry));
@@ -11202,7 +11242,8 @@ mod tests {
             PlayerId(0),
             YieldTarget::ThisObject {
                 source_id: ObjectId(5),
-                incarnation: 3,
+                incarnation: Some(3),
+                trigger_description: None,
             },
         );
         let same = triggered_entry(
@@ -11228,7 +11269,13 @@ mod tests {
     #[test]
     fn all_copies_yield_matches_every_same_card_id_trigger() {
         let mut state = GameState::new_two_player(1);
-        state.add_priority_yield(PlayerId(0), YieldTarget::AllCopies { card_id: CardId(9) });
+        state.add_priority_yield(
+            PlayerId(0),
+            YieldTarget::AllCopies {
+                card_id: CardId(9),
+                trigger_description: None,
+            },
+        );
         let token_a = triggered_entry(
             ObjectId(10),
             ObjectId(5),
@@ -11252,7 +11299,13 @@ mod tests {
     #[test]
     fn all_copies_yield_does_not_match_different_card_id() {
         let mut state = GameState::new_two_player(1);
-        state.add_priority_yield(PlayerId(0), YieldTarget::AllCopies { card_id: CardId(9) });
+        state.add_priority_yield(
+            PlayerId(0),
+            YieldTarget::AllCopies {
+                card_id: CardId(9),
+                trigger_description: None,
+            },
+        );
         let real_card = triggered_entry(
             ObjectId(12),
             ObjectId(7),
@@ -11268,7 +11321,13 @@ mod tests {
     #[test]
     fn spell_and_activated_tops_never_yielded() {
         let mut state = GameState::new_two_player(1);
-        state.add_priority_yield(PlayerId(0), YieldTarget::AllCopies { card_id: CardId(9) });
+        state.add_priority_yield(
+            PlayerId(0),
+            YieldTarget::AllCopies {
+                card_id: CardId(9),
+                trigger_description: None,
+            },
+        );
         let spell = StackEntry {
             id: ObjectId(20),
             source_id: ObjectId(5),
@@ -11303,11 +11362,13 @@ mod tests {
         assert!(!state.is_priority_yielded(PlayerId(0), &activated));
     }
 
-    /// CR 400.7 None-boundary: a `ThisObject` yield never matches a trigger with
-    /// no latched incarnation (synthetic game-rule triggers), but an `AllCopies`
-    /// yield still matches when the card identity is present.
+    /// CR 400.7 incarnation identity: a `Some`-incarnation `ThisObject` yield
+    /// never matches a trigger that latched no incarnation (synthetic game-rule
+    /// triggers, `source_incarnation: None`), but an `AllCopies` yield still
+    /// matches when the card identity is present. (The matching `None`-yield /
+    /// `None`-trigger case is covered by the G6 synthetic-latch test.)
     #[test]
-    fn this_object_none_incarnation_never_matches_but_all_copies_can() {
+    fn this_object_some_incarnation_never_matches_none_trigger_but_all_copies_can() {
         let mut state = GameState::new_two_player(1);
         let entry = triggered_entry(
             ObjectId(10),
@@ -11320,19 +11381,29 @@ mod tests {
             PlayerId(0),
             YieldTarget::ThisObject {
                 source_id: ObjectId(0),
-                incarnation: 0,
+                incarnation: Some(0),
+                trigger_description: None,
             },
         );
         assert!(!state.is_priority_yielded(PlayerId(0), &entry));
         state.clear_priority_yields(PlayerId(0));
-        state.add_priority_yield(PlayerId(0), YieldTarget::AllCopies { card_id: CardId(9) });
+        state.add_priority_yield(
+            PlayerId(0),
+            YieldTarget::AllCopies {
+                card_id: CardId(9),
+                trigger_description: None,
+            },
+        );
         assert!(state.is_priority_yielded(PlayerId(0), &entry));
     }
 
     #[test]
     fn add_priority_yield_is_idempotent_and_remove_and_clear_work() {
         let mut state = GameState::new_two_player(1);
-        let t = YieldTarget::AllCopies { card_id: CardId(9) };
+        let t = YieldTarget::AllCopies {
+            card_id: CardId(9),
+            trigger_description: None,
+        };
         state.add_priority_yield(PlayerId(0), t.clone());
         state.add_priority_yield(PlayerId(0), t.clone());
         assert_eq!(state.priority_yields.len(), 1, "dedup: no duplicate yield");
@@ -11344,7 +11415,8 @@ mod tests {
             PlayerId(1),
             YieldTarget::ThisObject {
                 source_id: ObjectId(5),
-                incarnation: 1,
+                incarnation: Some(1),
+                trigger_description: None,
             },
         );
         state.clear_priority_yields(PlayerId(1));
@@ -11368,12 +11440,16 @@ mod tests {
             state.resolve_yield_target_from_stack(ObjectId(5), YieldScope::ThisObject),
             Some(YieldTarget::ThisObject {
                 source_id: ObjectId(5),
-                incarnation: 7,
+                incarnation: Some(7),
+                trigger_description: None,
             })
         );
         assert_eq!(
             state.resolve_yield_target_from_stack(ObjectId(5), YieldScope::AllCopies),
-            Some(YieldTarget::AllCopies { card_id: CardId(9) })
+            Some(YieldTarget::AllCopies {
+                card_id: CardId(9),
+                trigger_description: None
+            })
         );
         // No matching source on the stack → None (caller no-ops).
         assert_eq!(
@@ -11382,10 +11458,11 @@ mod tests {
         );
     }
 
-    /// A `ThisObject` scope on a trigger that never latched an incarnation
-    /// resolves to `None`, so the caller stores nothing.
+    /// G6 (CR 400.7): a `ThisObject` scope on a trigger that never latched an
+    /// incarnation now resolves to `Some` with `incarnation: None` — the
+    /// synthetic/delayed latch that was previously a silent no-op.
     #[test]
-    fn resolve_yield_target_none_incarnation_returns_none() {
+    fn resolve_yield_target_none_incarnation_latches_none() {
         let mut state = GameState::new_two_player(1);
         state.stack.push_back(triggered_entry(
             ObjectId(10),
@@ -11396,11 +11473,18 @@ mod tests {
         ));
         assert_eq!(
             state.resolve_yield_target_from_stack(ObjectId(0), YieldScope::ThisObject),
-            None
+            Some(YieldTarget::ThisObject {
+                source_id: ObjectId(0),
+                incarnation: None,
+                trigger_description: None,
+            })
         );
         assert_eq!(
             state.resolve_yield_target_from_stack(ObjectId(0), YieldScope::AllCopies),
-            Some(YieldTarget::AllCopies { card_id: CardId(9) })
+            Some(YieldTarget::AllCopies {
+                card_id: CardId(9),
+                trigger_description: None
+            })
         );
     }
 
@@ -11415,10 +11499,17 @@ mod tests {
             PlayerId(0),
             YieldTarget::ThisObject {
                 source_id: ObjectId(5),
-                incarnation: 3,
+                incarnation: Some(3),
+                trigger_description: None,
             },
         );
-        state.add_priority_yield(PlayerId(1), YieldTarget::AllCopies { card_id: CardId(9) });
+        state.add_priority_yield(
+            PlayerId(1),
+            YieldTarget::AllCopies {
+                card_id: CardId(9),
+                trigger_description: None,
+            },
+        );
         let json = serde_json::to_string(&state).unwrap();
         let restored: GameState = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.priority_yields, state.priority_yields);
@@ -11428,5 +11519,207 @@ mod tests {
         let mut other = state.clone();
         other.priority_yields.clear();
         assert_ne!(other, state);
+    }
+
+    /// Same as `triggered_entry` but latches a per-trigger `description`
+    /// (the G5 discriminator the stack entry already carries).
+    fn triggered_entry_desc(
+        entry_id: ObjectId,
+        source_id: ObjectId,
+        controller: PlayerId,
+        incarnation: Option<u64>,
+        card_id: Option<CardId>,
+        description: Option<String>,
+    ) -> StackEntry {
+        let mut entry = triggered_entry(entry_id, source_id, controller, incarnation, card_id);
+        if let StackEntryKind::TriggeredAbility { description: d, .. } = &mut entry.kind {
+            *d = description;
+        }
+        entry
+    }
+
+    /// G5 (CR 117.3d per-ability key): one source with two distinctly-described
+    /// triggers. Yielding the resolved target of trigger A must pass A but leave
+    /// trigger B (same source, same incarnation, different description) held.
+    #[test]
+    fn this_object_yield_is_per_trigger_description_scoped() {
+        let mut state = GameState::new_two_player(1);
+        let entry_a = triggered_entry_desc(
+            ObjectId(10),
+            ObjectId(5),
+            PlayerId(1),
+            Some(3),
+            Some(CardId(9)),
+            Some("Whenever this enters, draw a card.".to_string()),
+        );
+        // Resolve the concrete yield target off trigger A on the stack.
+        state.stack.push_back(entry_a.clone());
+        let target = state
+            .resolve_yield_target_from_stack(ObjectId(5), YieldScope::ThisObject)
+            .expect("trigger A is on the stack");
+        assert_eq!(
+            target,
+            YieldTarget::ThisObject {
+                source_id: ObjectId(5),
+                incarnation: Some(3),
+                trigger_description: Some("Whenever this enters, draw a card.".to_string()),
+            },
+            "resolve must latch trigger A's description"
+        );
+        state.add_priority_yield(PlayerId(0), target);
+
+        // Trigger B: same source + incarnation, DIFFERENT description.
+        let entry_b = triggered_entry_desc(
+            ObjectId(11),
+            ObjectId(5),
+            PlayerId(1),
+            Some(3),
+            Some(CardId(9)),
+            Some("Whenever this enters, gain 2 life.".to_string()),
+        );
+        // Reach-guard: the yield really matches trigger A (input reached compare).
+        assert!(
+            state.is_priority_yielded(PlayerId(0), &entry_a),
+            "trigger A must stay yielded"
+        );
+        // Per-trigger precision: trigger B is NOT swept up by A's yield.
+        assert!(
+            !state.is_priority_yielded(PlayerId(0), &entry_b),
+            "a distinct trigger on the same source must remain held"
+        );
+    }
+
+    /// G6 (CR 400.7 synthetic latch): a trigger that latched no incarnation
+    /// (`source_incarnation: None`, e.g. a synthetic/delayed game-rule trigger)
+    /// now resolves to a `ThisObject` yield storing `incarnation: None`, and that
+    /// yield matches the same None-incarnation entry — previously a silent no-op.
+    #[test]
+    fn this_object_none_incarnation_yield_matches_synthetic_trigger() {
+        let mut state = GameState::new_two_player(1);
+        let synthetic = triggered_entry_desc(
+            ObjectId(10),
+            ObjectId(5),
+            PlayerId(0),
+            None,
+            None,
+            Some("At the beginning of your upkeep, draw a card.".to_string()),
+        );
+        state.stack.push_back(synthetic.clone());
+        let target = state
+            .resolve_yield_target_from_stack(ObjectId(5), YieldScope::ThisObject)
+            .expect("G6: a None-incarnation trigger must still resolve a target");
+        assert_eq!(
+            target,
+            YieldTarget::ThisObject {
+                source_id: ObjectId(5),
+                incarnation: None,
+                trigger_description: Some(
+                    "At the beginning of your upkeep, draw a card.".to_string()
+                ),
+            }
+        );
+        state.add_priority_yield(PlayerId(0), target);
+        assert!(
+            state.is_priority_yielded(PlayerId(0), &synthetic),
+            "G6: the None-incarnation latch must match its own trigger"
+        );
+        // Discrimination: a Some-incarnation entry (a real, latched object) must
+        // NOT match the None-incarnation synthetic yield.
+        let latched = triggered_entry_desc(
+            ObjectId(11),
+            ObjectId(5),
+            PlayerId(0),
+            Some(1),
+            None,
+            Some("At the beginning of your upkeep, draw a card.".to_string()),
+        );
+        assert!(
+            !state.is_priority_yielded(PlayerId(0), &latched),
+            "None-incarnation yield must not match a Some-incarnation entry"
+        );
+    }
+
+    /// B3 (legacy-compat wildcard): a yield deserialized from a pre-upgrade save
+    /// carries `trigger_description: None` (serde default) with a real
+    /// incarnation. `None` is a wildcard, so it still matches its source's
+    /// trigger regardless of that entry's description — old saves keep working.
+    #[test]
+    fn legacy_none_description_yield_is_source_level_wildcard() {
+        let mut state = GameState::new_two_player(1);
+        // Simulates a deserialized legacy yield (bare u64 incarnation → Some).
+        state.add_priority_yield(
+            PlayerId(0),
+            YieldTarget::ThisObject {
+                source_id: ObjectId(5),
+                incarnation: Some(7),
+                trigger_description: None,
+            },
+        );
+        let described = triggered_entry_desc(
+            ObjectId(10),
+            ObjectId(5),
+            PlayerId(0),
+            Some(7),
+            Some(CardId(9)),
+            Some("Whenever this attacks, draw a card.".to_string()),
+        );
+        assert!(
+            state.is_priority_yielded(PlayerId(0), &described),
+            "None-description wildcard must match any described entry"
+        );
+        // Reach-guard / non-vacuous: incarnation is still enforced, so a blinked
+        // (Some(8)) entry does NOT match — the wildcard is on description only.
+        let blinked = triggered_entry_desc(
+            ObjectId(11),
+            ObjectId(5),
+            PlayerId(0),
+            Some(8),
+            Some(CardId(9)),
+            Some("Whenever this attacks, draw a card.".to_string()),
+        );
+        assert!(
+            !state.is_priority_yielded(PlayerId(0), &blinked),
+            "wildcard applies to description only, not incarnation"
+        );
+    }
+
+    /// G5 for `AllCopies`: a card-scoped yield can also be description-scoped.
+    /// A matching description passes; a different trigger on the same card holds.
+    #[test]
+    fn all_copies_yield_respects_trigger_description() {
+        let mut state = GameState::new_two_player(1);
+        state.add_priority_yield(
+            PlayerId(0),
+            YieldTarget::AllCopies {
+                card_id: CardId(9),
+                trigger_description: Some("Whenever this enters, draw a card.".to_string()),
+            },
+        );
+        let matching = triggered_entry_desc(
+            ObjectId(10),
+            ObjectId(5),
+            PlayerId(1),
+            Some(1),
+            Some(CardId(9)),
+            Some("Whenever this enters, draw a card.".to_string()),
+        );
+        let other_trigger = triggered_entry_desc(
+            ObjectId(11),
+            ObjectId(6),
+            PlayerId(1),
+            Some(2),
+            Some(CardId(9)),
+            Some("Whenever this dies, gain 2 life.".to_string()),
+        );
+        // Reach-guard positive: the card id matches, so the description compare
+        // is actually consulted (not a vacuous card-id miss).
+        assert!(
+            state.is_priority_yielded(PlayerId(0), &matching),
+            "same card + same description must match"
+        );
+        assert!(
+            !state.is_priority_yielded(PlayerId(0), &other_trigger),
+            "same card but different trigger description must remain held"
+        );
     }
 }


### PR DESCRIPTION
## Auto-pass priority-window overhaul

Fixes 5 of the 6 gaps from the auto-pass audit in `auto_pass_recommended` (the single authority for priority auto-pass). Each is decomposed into reusable primitives, not card special-cases.

**G1 — beneficial mana-tap trigger hold** (`83cc21d`): holds priority when tapping your own mana source would fire a *beneficial* non-mana tap trigger (Zhur-Taa Druid pings each opponent). Self-punishers/symmetric triggers (Manabarbs, Price of Glory, Forbidden Orchard) correctly keep auto-passing. Value-gated by beneficiary sign computed structurally from the AST. CR 605.1b/603.3.

**G2 — gated upkeep/draw fast path** (`6dadfe4`): the bare fast path fast-passed *any* empty-stack upkeep/draw window — including an opponent's upkeep where you hold priority, and your own upkeep with a meaningful activated ability. Now gated on `active_player == player` + a `flat_actions_have_meaningful_noncast_priority` predicate that holds for meaningful non-cast actions while letting merely-castable instants keep auto-passing (MTGA parity). The loop-firewall primitive stays byte-identical.

**G3 — hoist own-top-of-stack** (`6dadfe4`): own object on top now outranks the castability rungs, so holding a castable instant no longer nags you to respond to your own spell/ability. Explicit CR 117.3d yields still win.

**G5 — per-trigger yield precision** (`679be20`): `YieldTarget` gains `trigger_description`, so yielding one of a source's triggers no longer silently yields its siblings. `None` = source-level wildcard (preserves legacy yields).

**G6 — synthetic-trigger yield latch** (`679be20`): `ThisObject.incarnation` becomes `Option<u64>`; synthetic/delayed triggers (previously a silent no-op) can now be yielded. CR 400.7.

### Verification
- Full independent `/review-impl` on each cycle — all clean.
- G1/G2/G3 verified with the full engine test suite green (18174 tests).
- G5/G6 reviewed clean by static analysis (serde migration, engine↔FE wildcard parity, non-vacuous negatives, CRs 117.3d/400.7/704.5d all verified); its runtime tests are validated by CI here (local box was resource-constrained).

### Serialized surface
`YieldTarget` is in `GameState` (saves/multiplayer/WASM). Migration is serde-default-driven — legacy bare-`u64` incarnations load as `Some`, absent `trigger_description` defaults `None`. No migration code. `engine_wasm.d.ts` unchanged (opaque JSON).

### Deferred
**G4** (feasible manual-float activated-ability hold) is intentionally **not** in this PR — it's the separable, deepest change (threads `ManaAffordability` through `casting.rs` mana internals) and needs its own discriminating fixture. Follow-up.
