### PR TITLE
fix(engine): cast/played permanents you don't own enter under your control (#696)

### DIFF
--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -451,6 +451,126 @@ fn spell_auto_tap_honors_exile_any_color_permission() {
     assert_eq!(state.players[0].mana_pool.mana.len(), 0);
 }
 
+#[test]
+fn cast_permanent_from_granted_permission_enters_under_caster_control() {
+    // GitHub phase-rs/phase#696 (Evelyn, the Covetous) — surfaced independently
+    // via Ragavan, Nimble Pilferer. CR 601.2a + CR 110.2/110.2a: casting a
+    // permanent you don't own via a granted CastingPermission::PlayFromExile
+    // must put it under the CASTER's control, not the card's owner.
+    let mut state = setup_game_at_main_phase();
+    // Owned by P1, sitting in exile, with a permission granting P0 the right
+    // to cast it — mirrors spell_auto_tap_honors_exile_any_color_permission's
+    // construction pattern above, but with owner != granted_to.
+    let permanent = create_object(
+        &mut state,
+        CardId(51),
+        PlayerId(1),
+        "Borrowed Creature".to_string(),
+        Zone::Exile,
+    );
+    {
+        let obj = state.objects.get_mut(&permanent).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.power = Some(1);
+        obj.toughness = Some(1);
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![],
+            generic: 0,
+        };
+        obj.casting_permissions
+            .push(CastingPermission::PlayFromExile {
+                duration: Duration::Permanent,
+                granted_to: PlayerId(0),
+                frequency: CastFrequency::Unlimited,
+                source_id: None,
+                exiled_by_ability_controller: None,
+                mana_spend_permission: None,
+                card_filter: None,
+                single_use_group: None,
+                single_use: false,
+                cast_cost_raise: None,
+                land_enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+            });
+    }
+
+    let mut runner = crate::game::scenario::GameRunner::from_state(state);
+    let outcome = runner.cast(permanent).resolve();
+
+    // Reach-guard: the permanent must actually resolve onto the battlefield
+    // before the controller assertion below means anything.
+    outcome.assert_zone(&[permanent], Zone::Battlefield);
+    outcome.assert_controls(PlayerId(0), permanent);
+    assert_eq!(
+        outcome.state().objects[&permanent].owner,
+        PlayerId(1),
+        "owner must remain P1 — only controller should change"
+    );
+}
+
+#[test]
+fn play_land_from_granted_permission_enters_under_player_control() {
+    // GitHub phase-rs/phase#696 (Evelyn, the Covetous): her "you may play a
+    // card from exile" grants CastingPermission::PlayFromExile the same as
+    // the spell case above, but "play" also covers lands (CR 305.1), which
+    // never touch the stack — a structurally separate code path
+    // (handle_play_land) from the spell-cast test above. Same CR 110.2/
+    // 110.2a defaulting bug, independently reachable.
+    let mut state = setup_game_at_main_phase();
+    let land = create_object(
+        &mut state,
+        CardId(52),
+        PlayerId(1),
+        "Borrowed Land".to_string(),
+        Zone::Exile,
+    );
+    {
+        let obj = state.objects.get_mut(&land).unwrap();
+        obj.card_types.core_types.push(CoreType::Land);
+        obj.casting_permissions
+            .push(CastingPermission::PlayFromExile {
+                duration: Duration::Permanent,
+                granted_to: PlayerId(0),
+                frequency: CastFrequency::Unlimited,
+                source_id: None,
+                exiled_by_ability_controller: None,
+                mana_spend_permission: None,
+                card_filter: None,
+                single_use_group: None,
+                single_use: false,
+                cast_cost_raise: None,
+                land_enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+            });
+    }
+    let card_id = state.objects[&land].card_id;
+
+    let mut runner = crate::game::scenario::GameRunner::from_state(state);
+    let result = runner
+        .act(GameAction::PlayLand {
+            object_id: land,
+            card_id,
+        })
+        .unwrap();
+    let _ = result;
+
+    // Reach-guard: the land must actually resolve onto the battlefield
+    // before the controller assertion below means anything.
+    assert_eq!(
+        runner.state().objects[&land].zone,
+        Zone::Battlefield,
+        "land must actually enter the battlefield"
+    );
+    assert_eq!(
+        runner.state().objects[&land].controller,
+        PlayerId(0),
+        "controller must be P0 (the player who played it), not P1 (the owner)"
+    );
+    assert_eq!(
+        runner.state().objects[&land].owner,
+        PlayerId(1),
+        "owner must remain P1 — only controller should change"
+    );
+}
+
 fn foretell_test_cost() -> ManaCost {
     ManaCost::Cost {
         shards: vec![ManaCostShard::X, ManaCostShard::X, ManaCostShard::White],

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5646,6 +5646,27 @@ fn handle_play_land(
         None,
     );
 
+    // CR 110.2 + CR 110.2a (GitHub #696): A played land's controller
+    // defaults to whoever played it, not the card's owner. `player` is the
+    // acting land-player already resolved above (turn_resource_owner, or
+    // acting_player under shared team turns) — the same identity already
+    // used throughout this function for hand/zone lookups, and the correct
+    // one even under Mindslaver-style turn control (the turn's rightful
+    // player controls what gets played on their turn, not whoever is
+    // making the decisions). This is a no-op for the overwhelmingly common
+    // owner==player case. A genuine self-ETB "enters under [X]'s control"
+    // replacement (enters_under) still wins — it runs later in the same
+    // replacement pipeline this event is routed through below, and
+    // hard-overwrites this default unconditionally (identical safety
+    // property to the stack.rs spell-cast seam this mirrors).
+    if let crate::types::proposed_event::ProposedEvent::ZoneChange {
+        controller_override,
+        ..
+    } = &mut proposed
+    {
+        *controller_override = Some(player);
+    }
+
     // CR 306.5b + CR 310.4b + CR 614.1c: Seed the intrinsic "enters with N
     // counters" replacement for planeswalkers and battles entering the
     // battlefield via a play-from-zone action.

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -733,6 +733,26 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                 Zone::Battlefield,
                 None,
             );
+            // CR 601.2a + CR 110.2/110.2a (GitHub #696): A cast permanent's
+            // controller defaults to whoever cast it, not the card's owner —
+            // "that player becomes its controller" (601.2a) when the spell is
+            // put on the stack, and per 110.2a "that object enters the
+            // battlefield under that player's control unless the effect
+            // states otherwise." `entry.controller` is the actual caster
+            // (stamped at announce_spell_on_stack from the real
+            // GameAction::CastSpell dispatch), fixed for the spell's lifetime
+            // on the stack. This is a no-op for the overwhelmingly common
+            // owner==caster case. A genuine self-ETB "enters under [X]'s
+            // control" replacement (enters_under) still wins — it runs later,
+            // in replace_event below, and hard-overwrites this default
+            // unconditionally.
+            if let crate::types::proposed_event::ProposedEvent::ZoneChange {
+                controller_override,
+                ..
+            } = &mut proposed
+            {
+                *controller_override = Some(entry.controller);
+            }
             // CR 702.190b: Sneak-cast permanent enters the battlefield tapped.
             // Seed the ZoneChange so ETB-tapped goes through the replacement
             // pipeline (CR 614.1c).

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -733,10 +733,10 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                 Zone::Battlefield,
                 None,
             );
-            // CR 601.2a + CR 110.2/110.2a (GitHub #696): A cast permanent's
+            // CR 601.2a + CR 110.2 + CR 110.2a (GitHub #696): A cast permanent's
             // controller defaults to whoever cast it, not the card's owner —
-            // "that player becomes its controller" (601.2a) when the spell is
-            // put on the stack, and per 110.2a "that object enters the
+            // "that player becomes its controller" (CR 601.2a) when the spell is
+            // put on the stack, and per CR 110.2a "that object enters the
             // battlefield under that player's control unless the effect
             // states otherwise." `entry.controller` is the actual caster
             // (stamped at announce_spell_on_stack from the real


### PR DESCRIPTION
## Summary

Closes #696 (Evelyn, the Covetous cast cards from exile isn't working with enemy cards). Also independently surfaced via Ragavan, Nimble Pilferer — same root cause, different card.

**The bug**: when a permanent enters the battlefield via a cast spell (`stack.rs`) or a played land (`engine.rs::handle_play_land`), the constructed `ProposedEvent::ZoneChange` left `controller_override` at its `None` default, so `reset_for_battlefield_entry` fell back to `self.controller = self.owner`. Per **CR 601.2a** ("...that player becomes its controller") and **CR 110.2a** ("that object enters the battlefield under that player's control unless the effect states otherwise"), the correct default is whoever cast/played it — not the card's owner.

This is invisible whenever `owner == caster/player` (the overwhelming majority of casts/plays) and only manifests when a granted permission (`CastingPermission::PlayFromExile`, which both Ragavan and Evelyn grant) lets a player cast or play a card they don't own.

**Two sibling seams, one fix pattern**: Evelyn's own ability says "**play**" (not "cast"), which is why this needed fixing in both `stack.rs` (spell casts) and `engine.rs::handle_play_land` (land plays) — her collection counter can land on a land card in an opponent's library. Both fixes feed an existing, already-correct, already CR-annotated consumer (`zones::apply_battlefield_entry_controller_override`, via `zone_pipeline.rs`'s `ctrl_override` check) that was previously only ever wired to the "enters_under" self-ETB replacement mechanism (e.g. a static that says "~ enters the battlefield under an opponent's control"). That mechanism still wins in both seams — it runs later in the pipeline (`replace_event`) and hard-overwrites the new default unconditionally, so this doesn't regress anything that already explicitly specifies control.

This class of bug also affects any future "cast/play a card you don't own" design (Bribery, Mind's Desire, Praetor's Grasp, Etali-class effects) — the fix lives in the generic resolution pipeline, not in any card's own ability definition.

## Process note

This plan went through two full adversarial `/review-engine-plan` rounds before implementation, given the blast radius (every permanent cast/land play in the game passes through these two seams):
- **Round 1** found a missing sibling-seam gap (the original plan only fixed the spell-cast path, missing that `handle_play_land` has the identical bug) and a fabricated CR citation (608.2f, which is actually about APNAP ordering, not controller stability — corrected to 601.2a).
- **Round 2** independently re-verified the revised plan's interaction with Mindslaver-style turn-control effects (confirmed the fix correctly uses the turn's rightful player, not whoever is making decisions) and confirmed `GameRunner::act()` can drive the land-play test (no dedicated `.play_land()` builder exists, but the generic action-dispatch escape hatch does).

## Test plan
- [x] Added `cast_permanent_from_granted_permission_enters_under_caster_control`: casts an opponent-owned permanent from exile via a granted `PlayFromExile` permission, asserts the resulting permanent's controller is the caster while owner is unchanged.
- [x] Added `play_land_from_granted_permission_enters_under_player_control`: plays an opponent-owned land from exile via the same permission type, same assertions, through the independent `handle_play_land` code path.
- [ ] **I was not able to get a local `cargo check`/`cargo test` run to complete in this sandbox** — four consecutive attempts across two different cargo subcommands failed. The first three were killed mid-compile at the identical point (`Checking engine v0.18.0`, immediately after all dependencies compiled successfully). The fourth failed with **unrelated** third-party dependency crates (`serde_core`, `zerocopy`, `windows-sys`, `bitmaps`) failing to compile simultaneously with generic "process didn't exit successfully" errors — none of which this change touches, pointing to sandbox resource exhaustion rather than a defect in this diff. **CI should be treated as the first real compile/test confirmation for this PR** — please pay particular attention to the two new tests actually passing, given I could not confirm that locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)