### PR TITLE
test(parser): verify Molten Echoes' chosen-type filter + LastCreated anaphors

### DIFF
--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -5358,6 +5358,81 @@ fn etb_token_copier_exile_anaphor_binds_created_token() {
         }
 }
 
+/// Molten Echoes (GitHub #4709/#4708): "Whenever a nontoken creature you
+/// control of the chosen type enters, create a token that's a copy of that
+/// creature. That token gains haste. Exile it at the beginning of the next
+/// end step." Distinct from the Flameshadow Conjuring/Inalla analogs above:
+/// the trigger filter carries an extra `IsChosenCreatureType` predicate
+/// (CR 205.3m creature-type restriction resolved against a stored ETB
+/// choice). This asserts the chosen-type filter on the trigger condition
+/// does not disturb the "that token"/"it" anaphor rewriting that binds the
+/// haste grant and delayed exile to `TargetFilter::LastCreated` (the
+/// created token), not to the entering creature that matched the filter.
+#[test]
+fn molten_echoes_chosen_type_filter_preserves_last_created_anaphors() {
+    fn collect<'a>(def: &'a AbilityDefinition, out: &mut Vec<&'a Effect>) {
+        out.push(&def.effect);
+        if let Effect::CreateDelayedTrigger { effect: inner, .. } = &*def.effect {
+            collect(inner, out);
+        }
+        if let Some(sub) = def.sub_ability.as_deref() {
+            collect(sub, out);
+        }
+        if let Some(els) = def.else_ability.as_deref() {
+            collect(els, out);
+        }
+    }
+    fn copy_source(effs: &[&Effect]) -> Option<TargetFilter> {
+        effs.iter().find_map(|e| match e {
+            Effect::CopyTokenOf { target, .. } => Some(target.clone()),
+            _ => None,
+        })
+    }
+    fn exile_target(effs: &[&Effect]) -> Option<TargetFilter> {
+        effs.iter().find_map(|e| match e {
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                target,
+                ..
+            } => Some(target.clone()),
+            _ => None,
+        })
+    }
+
+    let text = "Whenever a nontoken creature you control of the chosen type enters, create a token that's a copy of that creature. That token gains haste. Exile it at the beginning of the next end step.";
+    let def = parse_trigger_line(text, "Molten Echoes");
+
+    match &def.valid_card {
+        Some(TargetFilter::Typed(typed)) => {
+            assert!(
+                typed.properties.contains(&FilterProp::IsChosenCreatureType),
+                "expected IsChosenCreatureType prop on the trigger filter, got {:?}",
+                typed.properties
+            );
+            assert!(
+                typed.properties.contains(&FilterProp::NonToken),
+                "expected NonToken prop on the trigger filter, got {:?}",
+                typed.properties
+            );
+        }
+        other => panic!("expected Typed trigger filter, got {other:?}"),
+    }
+
+    let exec = def.execute.as_ref().expect("execute must be Some");
+    let mut effs = Vec::new();
+    collect(exec, &mut effs);
+    assert_eq!(
+        copy_source(&effs),
+        Some(TargetFilter::TriggeringSource),
+        "CopyTokenOf source must stay TriggeringSource (copy the entering creature that matched the chosen-type filter)"
+    );
+    assert_eq!(
+        exile_target(&effs),
+        Some(TargetFilter::LastCreated),
+        "delayed exile must bind the created token (LastCreated), not the entering creature"
+    );
+}
+
 /// CR 603.7a + CR 118.12a (issue #4369): Ashling, the Limitless — "Whenever
 /// you sacrifice a nontoken Elemental, create a token that's a copy of it.
 /// The token gains haste until end of turn. At the beginning of your next

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -5398,6 +5398,29 @@ fn molten_echoes_chosen_type_filter_preserves_last_created_anaphors() {
             _ => None,
         })
     }
+    fn haste_target(effs: &[&Effect]) -> Option<TargetFilter> {
+        effs.iter().find_map(|e| match e {
+            Effect::GenericEffect {
+                static_abilities,
+                target,
+                ..
+            } if static_abilities.iter().any(|static_def| {
+                static_def.affected == Some(TargetFilter::LastCreated)
+                    && static_def.modifications.iter().any(|modification| {
+                        matches!(
+                            modification,
+                            ContinuousModification::AddKeyword {
+                                keyword: Keyword::Haste,
+                            }
+                        )
+                    })
+            }) =>
+            {
+                target.clone()
+            }
+            _ => None,
+        })
+    }
 
     let text = "Whenever a nontoken creature you control of the chosen type enters, create a token that's a copy of that creature. That token gains haste. Exile it at the beginning of the next end step.";
     let def = parse_trigger_line(text, "Molten Echoes");
@@ -5425,6 +5448,11 @@ fn molten_echoes_chosen_type_filter_preserves_last_created_anaphors() {
         copy_source(&effs),
         Some(TargetFilter::TriggeringSource),
         "CopyTokenOf source must stay TriggeringSource (copy the entering creature that matched the chosen-type filter)"
+    );
+    assert_eq!(
+        haste_target(&effs),
+        Some(TargetFilter::LastCreated),
+        "haste grant must bind the created token (LastCreated), not the entering creature"
     );
     assert_eq!(
         exile_target(&effs),


### PR DESCRIPTION
## Summary

Closes the verification gap on #4709 and #4708 (Molten Echoes: wrong-card haste / exile not firing).

Molten Echoes' trigger — "Whenever a nontoken creature you control of the chosen type enters, create a token that's a copy of that creature. That token gains haste. Exile it at the beginning of the next end step." — combines the `IsChosenCreatureType` filter predicate on the trigger condition with the "that token"/"it" anaphor-rewriting already proven correct for Flameshadow Conjuring and Inalla, Archmage Ritualist (see `etb_token_copier_exile_anaphor_binds_created_token`).

That specific combination (chosen-type filter + the LastCreated haste/exile tail) was untested. I verified the exact combination live before closing out the backlog item:

- `CopyTokenOf` source stays `TriggeringSource` (copies the entering creature that matched the chosen-type filter) — correct, so the haste grant lands on the token, not the original.
- The delayed exile target rewrites to `TargetFilter::LastCreated` (the created token) — correct, so exile fires on the token, not the entering creature.

**No production code change was needed** — both reported bugs are already fixed by the existing `lower.rs` anaphor-rewriting building block (`rewrite_parent_target_to_last_created` and the "that token"/"the token" rewrite at `oracle_effect/lower.rs:3357-3364` / `3555-3591`). This PR adds the missing test coverage for that specific card's filter combination so the claim is verified, not just extrapolated from analogous cards.

## Test plan

- [x] New test `molten_echoes_chosen_type_filter_preserves_last_created_anaphors` passes (`cargo test -p engine --lib parser::oracle_trigger::tests::molten_echoes_chosen_type_filter_preserves_last_created_anaphors`)
- [x] Full `parser::oracle_trigger::tests` module re-run clean: 964 passed, 0 failed, 0 regressions
- [x] Verified on a branch cut fresh from `origin/main` (includes #5349), not just the working branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMa6DrxXyFHBdGxz3uLgvM