### PR TITLE
feat(client): mana-font iconography + dialog z-layer

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
     "framer-motion": "^12.35.1",
     "i18next": "^26.2.0",
     "idb-keyval": "^6.2.2",
+    "mana-font": "^1.18.0",
     "peerjs": "^1.5.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       idb-keyval:
         specifier: ^6.2.2
         version: 6.2.2
+      mana-font:
+        specifier: ^1.18.0
+        version: 1.18.0
       peerjs:
         specifier: ^1.5.5
         version: 1.5.5
@@ -1261,105 +1264,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1535,79 +1522,66 @@ packages:
     resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
     resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.0':
     resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.0':
     resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.0':
     resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.0':
     resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.0':
     resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.0':
     resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.0':
     resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.0':
     resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.0':
     resolution: {integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.0':
     resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.0':
     resolution: {integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==}
@@ -1702,42 +1676,36 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.33':
     resolution: {integrity: sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.33':
     resolution: {integrity: sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.33':
     resolution: {integrity: sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.33':
     resolution: {integrity: sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.33':
     resolution: {integrity: sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.33':
     resolution: {integrity: sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g==}
@@ -1813,28 +1781,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -1895,35 +1859,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.1':
     resolution: {integrity: sha512-mNA5dbbqPqDUdTIwdUYYuhO2GvIe9UnB2r0VU2njxBOS3Opbx4gKNC5yP0Iu4rYmEmqdlwry9VzGZQ3wq9dyFg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.1':
     resolution: {integrity: sha512-fZj3Gwq+6fUs305T5WQiD5iSGJw+j/4w/HGmk4sHDAcy+rp9zU5eaxB7nOyz5/I/nkNAuKPqfp6uIbiUBXkBCw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.1':
     resolution: {integrity: sha512-XFxGxOvHM7jjeD6ozCKdGfhzJ7lERYDGZl1/Kb4fsvchaJsfLJ981TlyTG8Qy/gFq+f5GitH3bfrX9JAkjPEyw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.1':
     resolution: {integrity: sha512-d5C2/Zm+68v7R9wTuTCjRQEVrWjcdMkJBZ1+rXse+QdMMlTB9+u9PDNDLw9PQflWxYLaYZ7tjxxL9Nb9II6PbA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.1':
     resolution: {integrity: sha512-YdeVWFAR1pTXzUU6NLstPq4G6OLxuDrXCXEBdmBH+5EZIDXUx0D2kJlz3+YjpazkKvAzYpgziTsyRagls0OfRQ==}
@@ -3282,28 +3241,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3370,6 +3325,9 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  mana-font@1.18.0:
+    resolution: {integrity: sha512-PKCR5z/eeOBbox0Lu5b6A0QUWVUUa3A3LWXb9sw4N5ThIWXxRbCagXPSL4k6Cnh2Fre6Y4+2Xl819OrY7m1cUA==}
 
   matcher-collection@2.0.1:
     resolution: {integrity: sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==}
@@ -7686,6 +7644,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.0
+
+  mana-font@1.18.0: {}
 
   matcher-collection@2.0.1:
     dependencies:

--- a/client/src/components/board/KeywordStrip.tsx
+++ b/client/src/components/board/KeywordStrip.tsx
@@ -2,12 +2,15 @@ import { memo, useMemo } from "react";
 
 import type { Keyword } from "../../adapter/types";
 import {
+  getKeywordDetail,
   getKeywordDisplayText,
+  getKeywordIconClass,
   getKeywordName,
   getKeywordReminderText,
   isGrantedKeyword,
   sortKeywords,
 } from "../../viewmodel/keywordProps";
+import { ManaFontIcon } from "../icons/ManaFontIcon";
 
 interface KeywordStripProps {
   keywords: Keyword[];
@@ -20,12 +23,44 @@ interface KeywordStripProps {
    * without source info.
    */
   sourceByKeyword?: Map<string, string>;
+  /**
+   * Square badge edge length as a CSS length. The column applies it as its own
+   * `font-size`, so every inner dimension is an `em` multiple and the badges
+   * scale with the host card. The parent picks it from the card's width var
+   * (`--card-w` / `--art-crop-w`).
+   */
+  badgeSize: string;
+  /** Cap on visible cells; the last becomes a "+N" overflow indicator. */
+  maxVisible: number;
 }
+
+/**
+ * Compact 2\u20133 char label for keywords with no mana-font glyph, so the fallback
+ * still reads as a square badge rather than a wide text pill. Multi-word names
+ * collapse to initials ("Start Your Engines" \u2192 "SYE"); single words keep their
+ * first two letters.
+ */
+function keywordAbbrev(name: string): string {
+  const words = name.split(/\s+/).filter(Boolean);
+  if (words.length > 1) {
+    return words
+      .map((w) => w[0])
+      .join("")
+      .slice(0, 3)
+      .toUpperCase();
+  }
+  return name.slice(0, 2).toUpperCase();
+}
+
+const BADGE_CLASS =
+  "pointer-events-auto relative flex h-[1em] w-[1em] items-center justify-center rounded-[0.16em] bg-black/80 shadow-md ring-1";
 
 export const KeywordStrip = memo(function KeywordStrip({
   keywords,
   baseKeywords,
   sourceByKeyword,
+  badgeSize,
+  maxVisible,
 }: KeywordStripProps) {
   const sorted = useMemo(() => sortKeywords(keywords), [keywords]);
 
@@ -34,7 +69,10 @@ export const KeywordStrip = memo(function KeywordStrip({
       sorted.map((kw) => {
         const name = getKeywordName(kw);
         return {
+          name,
+          detail: getKeywordDetail(kw),
           text: getKeywordDisplayText(kw),
+          iconClass: getKeywordIconClass(kw),
           granted: isGrantedKeyword(kw, baseKeywords),
           source: sourceByKeyword?.get(name),
           reminder: getKeywordReminderText(kw),
@@ -45,29 +83,65 @@ export const KeywordStrip = memo(function KeywordStrip({
 
   if (items.length === 0) return null;
 
-  const fullText = items
-    .map((i) => (i.source ? `${i.text} (from ${i.source})` : i.text))
-    .join(" \u00B7 ");
+  // MTGA-style square badges in a vertical column straddling the card's top-left
+  // edge (rendered at the overflow-visible card level so the off-card half is
+  // not clipped). Sizes are `em` multiples of `badgeSize` so the column scales
+  // with the card. The column is capped at `maxVisible` cells so a keyword-heavy
+  // creature can't run badges off the bottom \u2014 the last cell becomes a "+N"
+  // overflow indicator listing the hidden keywords on hover.
+  const overflowing = items.length > maxVisible;
+  const shown = overflowing ? items.slice(0, maxVisible - 1) : items;
+  const hidden = overflowing ? items.slice(maxVisible - 1) : [];
 
   return (
     <div
-      className="absolute inset-x-0 bottom-0 z-20 overflow-hidden truncate bg-black/60 px-1 py-[1px] text-[9px] leading-tight"
-      title={fullText}
+      className="pointer-events-none absolute left-0 top-[26%] z-30 flex -translate-x-[15%] flex-col gap-[0.18em]"
+      style={{ fontSize: badgeSize }}
     >
-      {items.map((item, i) => (
+      {shown.map((item, i) => {
+        const title = [
+          item.source ? `${item.text} \u2014 from ${item.source}` : item.text,
+          item.reminder,
+        ]
+          .filter(Boolean)
+          .join("\n");
+        const ring = item.granted ? "ring-indigo-300/80" : "ring-white/25";
+        const tint = item.granted ? "text-indigo-100" : "text-white";
+        return (
+          <span key={i} title={title} className={`${BADGE_CLASS} ${ring} ${tint}`}>
+            {item.iconClass ? (
+              <ManaFontIcon
+                iconClass={item.iconClass}
+                fallbackText={keywordAbbrev(item.name)}
+                label={item.reminder ?? item.text}
+                style={{ fontSize: "0.72em" }}
+              />
+            ) : (
+              <span className="font-bold leading-none" style={{ fontSize: "0.46em" }}>
+                {keywordAbbrev(item.name)}
+              </span>
+            )}
+            {item.detail && (
+              <span
+                className="absolute -right-[0.12em] -bottom-[0.12em] rounded-[0.1em] bg-black px-[0.08em] font-bold leading-none ring-1 ring-white/20"
+                style={{ fontSize: "0.4em" }}
+              >
+                {item.detail}
+              </span>
+            )}
+          </span>
+        );
+      })}
+      {hidden.length > 0 && (
         <span
-          key={i}
-          title={[
-            item.source ? `${item.text} \u2014 from ${item.source}` : item.text,
-            item.reminder,
-          ].filter(Boolean).join("\n")}
+          title={hidden.map((h) => h.text).join("\n")}
+          className={`${BADGE_CLASS} text-white ring-white/30`}
         >
-          {i > 0 && <span className="text-gray-500"> &middot; </span>}
-          <span className={item.granted ? "text-indigo-300" : "text-white"}>
-            {item.text}
+          <span className="font-bold leading-none" style={{ fontSize: "0.46em" }}>
+            +{hidden.length}
           </span>
         </span>
-      ))}
+      )}
     </div>
   );
 });

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -19,8 +19,10 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { buildGrantedKeywordSources, buildPTSources } from "../../viewmodel/attribution.ts";
-import { COUNTER_COLORS, computePTDisplay, formatCounterType, toRoman } from "../../viewmodel/cardProps.ts";
+import { COUNTER_COLORS, computePTDisplay, counterIconClass, formatCounterType, toRoman } from "../../viewmodel/cardProps.ts";
+import { loyaltyStartIconClasses } from "../../viewmodel/costLabel.ts";
 import { getCardDisplayColors } from "../card/cardFrame.ts";
+import { ManaFontIcon } from "../icons/ManaFontIcon.tsx";
 import { CounterTooltip } from "../ui/CounterTooltip.tsx";
 import { useBoardInteractionState } from "./BoardInteractionContext.tsx";
 import { KeywordStrip } from "./KeywordStrip.tsx";
@@ -473,13 +475,17 @@ export const PermanentCard = memo(function PermanentCard({
   // Filter out loyalty counters — shown separately as the loyalty badge
   const counters = Object.entries(obj.counters).filter((entry): entry is [string, number] => entry[1] != null && entry[0] !== "loyalty");
 
+  // mana-font shield glyph for the current loyalty total, or null when the
+  // total has no numeral glyph (falls back to the plain amber badge below).
+  const loyaltyShield = obj.loyalty != null ? loyaltyStartIconClasses(obj.loyalty) : null;
+
   // Tap rotation: 17deg in MTGA mode (or compact-height), 90deg in classic mode
-  const tapBaseOpacity = (isCompactHeight || tapRotation === "mtga") && obj.tapped && !isAttacking ? 0.85 : 1;
+  const tapBaseOpacity = (isCompactHeight || tapRotation === "mtga") && obj.tapped ? 0.85 : 1;
   // CR 702.26: Phased-out permanents render at 70% opacity (matching the
   // player-area phasing treatment in PlayerArea.tsx commit 4d6cfb506) so the
   // sky-blue tint reads as "ethereal" rather than overpowering the art.
   const tapOpacity = isPhasedOut ? Math.min(tapBaseOpacity, 0.7) : tapBaseOpacity;
-  const isRotatedFull = isAttacking || obj.tapped;
+  const isRotatedFull = obj.tapped;
 
   // Attacker slide-forward: player creatures slide up, opponent creatures slide down.
   // Reduced on compact-height where 30px would overflow the small creature row.
@@ -732,14 +738,6 @@ export const PermanentCard = memo(function PermanentCard({
         <>
           <div className="relative z-10 rounded-lg overflow-hidden">
             <CardImage cardName={imgName} faceIndex={imgFace} oracleId={imgOracleId} faceName={imgFaceName} size="small" unimplementedMechanics={obj.unimplemented_mechanics} colors={displayColors} isToken={obj.display_source === "Token"} tokenFilters={obj.display_source === "Token" ? tokenFiltersForObject(obj) : undefined} tokenImageRef={obj.token_image_ref} oracleText={obj.display_source === "Token" ? obj.token_rules_text : undefined} faceDown={obj.face_down} />
-            {/* Keyword strip overlay — inside the card image wrapper so absolute positioning works */}
-            {showKeywordStrip && obj.keywords.length > 0 && !obj.face_down && (
-              <KeywordStrip
-                keywords={obj.keywords}
-                baseKeywords={obj.base_keywords}
-                sourceByKeyword={keywordSourceMap}
-              />
-            )}
             {/* CR 702.26: phased-out tint overlay — sky-blue mix-blend-screen
                 matches the player-area treatment (PlayerArea.tsx 4d6cfb506). */}
             {isPhasedOut && (
@@ -767,12 +765,26 @@ export const PermanentCard = memo(function PermanentCard({
             </div>
           )}
 
-          {/* Loyalty shield for planeswalkers */}
-          {obj.loyalty != null && (
+          {/* Loyalty shield for planeswalkers — mana-font shield glyph when a
+              numeral exists, else the plain amber badge (also the FOUC path). */}
+          {obj.loyalty != null && (loyaltyShield ? (
+            // Font-size on the wrapper drives the glyph: `.ms-loyalty-start` is
+            // 2em, so ~13px here → a ~26px shield with a white numeral overlay.
+            <div
+              className="absolute bottom-0 left-1/2 z-20 -translate-x-1/2 font-bold leading-none text-amber-300 drop-shadow-[0_1px_1px_rgba(0,0,0,0.9)]"
+              style={{ fontSize: "13px" }}
+            >
+              <ManaFontIcon
+                iconClass={loyaltyShield}
+                fallbackText={String(obj.loyalty)}
+                label={String(obj.loyalty)}
+              />
+            </div>
+          ) : (
             <div className="absolute bottom-0 left-1/2 z-20 -translate-x-1/2 rounded-t bg-gray-900/90 px-1.5 py-0.5 text-xs font-bold text-amber-300">
               {obj.loyalty}
             </div>
-          )}
+          ))}
 
           {/* Class level badge (CR 716) — gold-leaf bookmark */}
           {obj.class_level != null && (
@@ -808,26 +820,77 @@ export const PermanentCard = memo(function PermanentCard({
             </div>
           )}
 
-          {/* Counter badges (top-right to avoid overlap with P/T box) */}
-          {counters.length > 0 && (
-            <div className="absolute right-1 top-1 z-[60] flex flex-col gap-0.5">
-              {counters.map(([type, count]) => (
+          {/* Top-right overlay stack: counter badges kept clear of the
+              bottom-right P/T box. */}
+          <div className="absolute right-0.5 top-0.5 z-[60] flex flex-col items-end gap-0.5">
+            {counters.map(([type, count]) => {
+              const iconClass = counterIconClass(type);
+              return (
                 <CounterTooltip key={type} type={type} count={count}>
                   <span
-                    className={`rounded px-1 text-[10px] font-bold text-white ${COUNTER_COLORS[type] ?? "bg-purple-600"}`}
+                    className={`flex items-center gap-0.5 rounded px-1 text-[10px] font-bold text-white ${COUNTER_COLORS[type] ?? "bg-purple-600"}`}
                   >
+                    {iconClass && (
+                      <ManaFontIcon
+                        iconClass={iconClass}
+                        fallbackText=""
+                        label={formatCounterType(type)}
+                      />
+                    )}
                     {formatCounterType(type)} x{count}
                   </span>
                 </CounterTooltip>
-              ))}
-            </div>
-          )}
+              );
+            })}
+          </div>
 
         </>
       )}
 
+      {/* Keyword badges: a vertical column of square glyph badges straddling
+          the card's top-left edge. Rendered at the SHARED motion.div level
+          (after the art-crop/full-card ternary) so it appears in BOTH display
+          modes, and — being at the overflow-visible level, outside the rounded
+          overflow-hidden art wrapper — the half-off-card portion isn't clipped.
+          Badge size scales off the active card width var. */}
+      {showKeywordStrip && obj.keywords.length > 0 && !obj.face_down && (
+        <KeywordStrip
+          keywords={obj.keywords}
+          baseKeywords={obj.base_keywords}
+          sourceByKeyword={keywordSourceMap}
+          badgeSize={
+            useArtCrop
+              ? "clamp(11px, calc(var(--art-crop-w) * 0.22), 22px)"
+              : "clamp(13px, calc(var(--card-w) * 0.2), 26px)"
+          }
+          maxVisible={useArtCrop ? 4 : 5}
+        />
+      )}
+
       {hasSummoningSickness && (
         <SummoningSicknessOverlay variant={useArtCrop ? "artCrop" : "fullCard"} />
+      )}
+
+      {/* Tapped indicator: a light wash + a centered tap glyph. The glyph
+          counter-rotates by the card's tap angle so it reads upright even when
+          the whole card is turned 90°. */}
+      {obj.tapped && !obj.face_down && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-lg bg-white/20"
+        >
+          <ManaFontIcon
+            iconClass="ms-tap"
+            fallbackText=""
+            className="text-white/90 drop-shadow-[0_1px_4px_rgba(0,0,0,0.95)]"
+            style={{
+              fontSize: useArtCrop
+                ? "clamp(16px, calc(var(--art-crop-w) * 0.42), 40px)"
+                : "clamp(20px, calc(var(--card-w) * 0.4), 56px)",
+              transform: `rotate(${-tapAngle}deg)`,
+            }}
+          />
+        </div>
       )}
 
       {glowClass && (
@@ -848,10 +911,10 @@ export const PermanentCard = memo(function PermanentCard({
 
       {isSelectableForBoardChoice && boardChoice && (
         // Selected cards get a checkmark + solid, white-ringed badge; eligible-
-        // but-unselected cards get the same label dimmed, so the current
+        // but-unselected cards get the same opaque label, so the current
         // selection is unambiguous and the badge reads as a toggle.
         <div
-          className={`pointer-events-none absolute ${isUnderAttack || isValidTarget ? "left-1 top-7" : "left-1 top-1"} z-40 rounded ${boardChoiceBadgeClass(boardChoice.intent)} px-1.5 py-0.5 text-[9px] font-black uppercase leading-none tracking-normal shadow-[0_1px_4px_rgba(0,0,0,0.75)] ${isSelectedForBoardChoice ? "ring-1 ring-white/90" : "opacity-60 ring-1 ring-black/70"}`}
+          className={`pointer-events-none absolute ${isUnderAttack || isValidTarget ? "right-1 top-7" : "right-1 top-1"} z-40 rounded ${boardChoiceBadgeClass(boardChoice.intent)} px-1.5 py-0.5 text-[9px] font-black uppercase leading-none tracking-normal shadow-[0_1px_4px_rgba(0,0,0,0.75)] ${isSelectedForBoardChoice ? "ring-1 ring-white/90" : "ring-1 ring-black/70"}`}
         >
           {isSelectedForBoardChoice ? `✓ ${t(`permanent.boardChoiceBadges.${boardChoice.intent}`)}` : t(`permanent.boardChoiceBadges.${boardChoice.intent}`)}
         </div>

--- a/client/src/components/board/TypeIconBadge.tsx
+++ b/client/src/components/board/TypeIconBadge.tsx
@@ -1,0 +1,52 @@
+import { memo, type CSSProperties } from "react";
+
+import { cardTypeIconClass } from "../../viewmodel/typeIcons.ts";
+import { ManaFontIcon } from "../icons/ManaFontIcon.tsx";
+import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
+
+interface TypeIconBadgeProps {
+  /** `obj.card_types.core_types`, already in canonical print order. */
+  coreTypes: string[];
+  className?: string;
+  /** Inline style on the container — parents set `fontSize` here to a
+   * card-relative `calc(...)` so the glyphs scale with the card. */
+  style?: CSSProperties;
+}
+
+/**
+ * Prominent mana-font glyph strip for a permanent's card types. One glyph per
+ * core type that has a shipped glyph, in the engine's canonical type-line
+ * order. Glyphs inherit `font-size` (set by the parent via `style`) and render
+ * white on a subtle dark backing so they read on any art. Hovering a glyph
+ * shows its type name in the shared `GameplayTooltip`.
+ */
+export const TypeIconBadge = memo(function TypeIconBadge({
+  coreTypes,
+  className,
+  style,
+}: TypeIconBadgeProps) {
+  const icons = coreTypes.flatMap((type) => {
+    const iconClass = cardTypeIconClass(type);
+    return iconClass ? [{ type, iconClass }] : [];
+  });
+  if (icons.length === 0) return null;
+
+  return (
+    <div
+      className={[
+        "flex flex-row items-center gap-[0.2em] rounded-[0.25em] bg-black/45 px-[0.2em] py-[0.15em] text-white ring-1 ring-white/10 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)]",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={style}
+    >
+      {icons.map(({ type, iconClass }) => (
+        <span key={type} className="group relative inline-flex leading-none">
+          <ManaFontIcon iconClass={iconClass} fallbackText="" label={type} />
+          <GameplayTooltip>{type}</GameplayTooltip>
+        </span>
+      ))}
+    </div>
+  );
+});

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -116,7 +116,7 @@ describe("ActionButton", () => {
 
     render(<ActionButton />);
 
-    expect(screen.getByRole("button", { name: /^Resolve Pass priority/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
   });
 
   it("disables resolve controls while Resolve All is draining", () => {
@@ -136,9 +136,9 @@ describe("ActionButton", () => {
 
     render(<ActionButton />);
 
-    expect(screen.getByRole("button", { name: /^Resolve Pass priority/ })).toBeDisabled();
-    expect(screen.getByRole("button", { name: /^Resolve All Keep passing priority/ })).toBeDisabled();
-    expect(screen.getByRole("button", { name: /^Resolve All Keep passing priority/ })).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByRole("button", { name: "Resolve" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Resolve All" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Resolve All" })).toHaveAttribute("aria-busy", "true");
   });
 
   it("passes an empty AI-seat list in local hotseat so Resolve All auto-yields instead of AI-driving human seats (#4978)", () => {

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -645,6 +645,32 @@ describe("PermanentCard attachments", () => {
     expect(container.querySelector('[data-summoning-sickness-underwater="true"]')).toBeTruthy();
   });
 
+  it("does not render a selected attacker as tapped until the engine marks it tapped", () => {
+    useUiStore.setState({
+      combatMode: "attackers",
+      selectedAttackers: [1],
+    });
+
+    const { container } = renderPermanent();
+
+    expect(container.querySelector(".ms-tap")).toBeNull();
+
+    act(() => {
+      const gameState = useGameStore.getState().gameState!;
+      useGameStore.setState({
+        gameState: {
+          ...gameState,
+          objects: {
+            ...gameState.objects,
+            1: { ...gameState.objects[1], tapped: true },
+          },
+        },
+      });
+    });
+
+    expect(container.querySelector(".ms-tap")).not.toBeNull();
+  });
+
   it("opens the ability picker when a land has mana actions plus a non-mana activated ability", () => {
     const kessig = makeObject({
       id: 39,

--- a/client/src/components/card/ArtCropCard.tsx
+++ b/client/src/components/card/ArtCropCard.tsx
@@ -8,10 +8,10 @@ import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { cardImageLookup, tokenFiltersForObject } from "../../services/cardImageLookup.ts";
 import { CARD_BACK_URL } from "../../services/scryfall.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
-import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { COUNTER_COLORS, computePTDisplay, toRoman } from "../../viewmodel/cardProps.ts";
-import { KeywordStrip } from "../board/KeywordStrip.tsx";
+import { loyaltyStartIconClasses } from "../../viewmodel/costLabel.ts";
+import { ManaFontIcon } from "../icons/ManaFontIcon.tsx";
 import { CounterTooltip } from "../ui/CounterTooltip.tsx";
 import { frameNeedsLightText, getCardDisplayColors, getFrameGradient } from "./cardFrame.ts";
 
@@ -30,7 +30,6 @@ export const ArtCropCard = memo(function ArtCropCard({ objectId }: ArtCropCardPr
   const obj = useGameStore((s) => s.gameState?.objects[objectId]);
   const isMobile = useIsMobile();
   const inspectObject = useUiStore((s) => s.inspectObject);
-  const showKeywordStrip = usePreferencesStore((s) => s.showKeywordStrip) ?? true;
   const isCompactHeight = useIsCompactHeight();
   const controllerIdentity = useGameStore(
     (s) => obj && s.gameState?.players?.find((p) => p.id === obj.controller)?.commander_color_identity,
@@ -70,6 +69,9 @@ export const ArtCropCard = memo(function ArtCropCard({ objectId }: ArtCropCardPr
   // Filter out loyalty counters — shown separately as the loyalty badge
   const counters = Object.entries(obj.counters).filter((entry): entry is [string, number] => entry[1] != null && entry[0] !== "loyalty");
   const devotionValue = obj.devotion ?? null;
+  // mana-font shield glyph for the current loyalty total (null when out of the
+  // glyph range → the plain silver-ring badge below remains the fallback).
+  const loyaltyShield = obj.loyalty != null ? loyaltyStartIconClasses(obj.loyalty) : null;
 
   // --- Dynamic Text Sizing Logic ---
   let ptNumClass = "text-[14px]";
@@ -182,25 +184,24 @@ export const ArtCropCard = memo(function ArtCropCard({ objectId }: ArtCropCardPr
 
               <div className="absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-black/50 to-transparent pointer-events-none" />
 
-              {/* Keyword strip */}
-              {showKeywordStrip && obj.keywords.length > 0 && !obj.face_down && (
-                <KeywordStrip keywords={obj.keywords} baseKeywords={obj.base_keywords} />
-              )}
+              {/* Keyword badges are rendered by the parent PermanentCard at its
+                  overflow-visible level (so they can straddle the card edge),
+                  covering both art-crop and full-card modes. */}
 
-              {counters.length > 0 && (
-                <div className="absolute top-1 right-1 z-[60] flex flex-col gap-0.5">
-                  {counters.map(([type, count]) => (
-                    <CounterTooltip key={type} type={type} count={count}>
-                      <span
-                        className={`rounded-full flex items-center justify-center font-bold text-white shadow-md border border-black/50 ${COUNTER_COLORS[type] ?? "bg-purple-600"}`}
-                        style={counterStyle}
-                      >
-                        {count}
-                      </span>
-                    </CounterTooltip>
-                  ))}
-                </div>
-              )}
+              {/* Top-right overlay stack: counter badges kept clear of the
+                  bottom P/T and loyalty badges. */}
+              <div className="absolute top-0.5 right-0.5 z-[60] flex flex-col items-end gap-0.5">
+                {counters.map(([type, count]) => (
+                  <CounterTooltip key={type} type={type} count={count}>
+                    <span
+                      className={`rounded-full flex items-center justify-center font-bold text-white shadow-md border border-black/50 ${COUNTER_COLORS[type] ?? "bg-purple-600"}`}
+                      style={counterStyle}
+                    >
+                      {count}
+                    </span>
+                  </CounterTooltip>
+                ))}
+              </div>
 
               {hasDfc && (
                 <button
@@ -273,8 +274,21 @@ export const ArtCropCard = memo(function ArtCropCard({ objectId }: ArtCropCardPr
         </div>
       )}
 
-      {/* Floating loyalty — shifts left when P/T is also visible (animated planeswalker-creature) */}
-      {obj.loyalty != null && (
+      {/* Floating loyalty — shifts left when P/T is also visible (animated
+          planeswalker-creature). mana-font shield glyph when a numeral exists,
+          else the plain silver-ring badge (also the FOUC fallback path). */}
+      {obj.loyalty != null && (loyaltyShield ? (
+        <div
+          className={`absolute -bottom-[5px] z-20 font-bold leading-none text-amber-300 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)] ${ptDisplay ? "-left-[5px]" : "-right-[5px]"}`}
+          style={{ fontSize: "clamp(7px, calc(var(--art-crop-h) * 0.11), 12px)" }}
+        >
+          <ManaFontIcon
+            iconClass={loyaltyShield}
+            fallbackText={String(obj.loyalty)}
+            label={String(obj.loyalty)}
+          />
+        </div>
+      ) : (
         <div className={`absolute -bottom-[3px] z-20 ${ptDisplay ? "-left-[3px]" : "-right-[3px]"}`}>
           <div className="rounded-full bg-gradient-to-b from-[#e2e4e6] to-[#888c91] p-[2px] shadow-[inset_0_1px_1px_rgba(255,255,255,0.9),inset_0_-1px_1px_rgba(0,0,0,0.5),0_2px_4px_rgba(0,0,0,0.8)] border border-black/80">
             <div className="bg-gray-800 border-[1px] border-amber-600/50 rounded-full px-2.5 py-[1px] min-w-[2.75rem] flex justify-center items-center shadow-[inset_0_2px_4px_rgba(0,0,0,0.8),inset_0_1px_2px_rgba(0,0,0,0.9),0_1px_0_rgba(255,255,255,0.2)]">
@@ -284,7 +298,7 @@ export const ArtCropCard = memo(function ArtCropCard({ objectId }: ArtCropCardPr
             </div>
           </div>
         </div>
-      )}
+      ))}
     </div>
   );
 });

--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from "react-i18next";
 
 import type { ChosenAttribute, GameObject, Keyword, ManaCost, Zone } from "../../adapter/types.ts";
 import { collectObjectActions } from "../../viewmodel/cardActionChoice.ts";
-import { abilityLabel } from "../../viewmodel/costLabel.ts";
+import { abilityLabel, loyaltyBadge, stripLoyaltyCostPrefix } from "../../viewmodel/costLabel.ts";
+import { ManaFontIcon } from "../icons/ManaFontIcon.tsx";
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import type { SourcePrinting } from "../../hooks/useCardImage.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
@@ -628,15 +629,27 @@ function CardImagePreview({
   // {1}{G}{G}). See cardImageLookup / back_face wiring.
   const effectiveCost = useGameStore((s) => obj ? s.spellCosts[String(obj.id)] : undefined);
   const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
-  const activateLabels = useMemo(() => {
+  const activateLabels = useMemo<ActivateLabel[]>(() => {
     if (!obj || obj.zone !== "Battlefield") return [];
-    return collectObjectActions(legalActionsByObject, obj.id)
-      .flatMap((action) => {
-        if (action.type !== "ActivateAbility") return [];
-        const ability = obj.abilities[action.data.ability_index];
-        return ability ? [abilityLabel(ability)] : [];
-      })
-      .filter((label, index, labels) => label && labels.indexOf(label) === index);
+    const seen = new Set<string>();
+    const result: ActivateLabel[] = [];
+    for (const action of collectObjectActions(legalActionsByObject, obj.id)) {
+      if (action.type !== "ActivateAbility") continue;
+      const ability = obj.abilities[action.data.ability_index];
+      if (!ability) continue;
+      const rawLabel = abilityLabel(ability);
+      if (!rawLabel || seen.has(rawLabel)) continue;
+      seen.add(rawLabel);
+      // CR 606.1: a Loyalty ability cost renders as a mana-font badge; strip
+      // the "[+2]"-style prefix so the cost isn't shown twice.
+      const loyalty = loyaltyBadge(ability.cost);
+      result.push({
+        rawLabel,
+        label: loyalty ? stripLoyaltyCostPrefix(rawLabel) : rawLabel,
+        loyalty,
+      });
+    }
+    return result;
   }, [legalActionsByObject, obj]);
   const castManaZones: Zone[] = ["Hand", "Command", "Exile", "Graveyard", "Library"];
   const showCastManaCost =
@@ -864,6 +877,14 @@ function ParsedAbilitiesPanel({ name, cardTypes, keywords, localizedTypeLine, pa
   );
 }
 
+/** A battlefield-activatable ability's cost summary for the preview panel.
+ * `loyalty` is set only for planeswalker Loyalty costs (rendered as a badge). */
+type ActivateLabel = {
+  rawLabel: string;
+  label: string;
+  loyalty: { iconClasses: string; text: string } | null;
+};
+
 function CardInfoPanel({
   obj,
   altAvailable,
@@ -871,7 +892,7 @@ function CardInfoPanel({
 }: {
   obj: GameObject;
   altAvailable: boolean;
-  activateLabels: string[];
+  activateLabels: ActivateLabel[];
 }) {
   const { t } = useTranslation("game");
   const ptDisplay = computePTDisplay(obj);
@@ -963,14 +984,28 @@ function CardInfoPanel({
 
       {activateLabels.length > 0 && (
         <div className="mt-1 text-cyan-300/90">
-          {activateLabels.map((label) => (
-            <RichLabel
-              key={label}
-              text={t("preview.activateCost", { cost: label })}
-              size="xs"
-              className="block"
-            />
-          ))}
+          {activateLabels.map((entry) =>
+            entry.loyalty ? (
+              <div key={entry.rawLabel} className="flex items-center gap-1">
+                <ManaFontIcon
+                  iconClass={entry.loyalty.iconClasses}
+                  fallbackText={entry.loyalty.text}
+                  label={entry.loyalty.text}
+                />
+                <RichLabel
+                  text={t("preview.activateCost", { cost: entry.label })}
+                  size="xs"
+                />
+              </div>
+            ) : (
+              <RichLabel
+                key={entry.rawLabel}
+                text={t("preview.activateCost", { cost: entry.label })}
+                size="xs"
+                className="block"
+              />
+            ),
+          )}
         </div>
       )}
 

--- a/client/src/components/hud/HudBadges.tsx
+++ b/client/src/components/hud/HudBadges.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 import { useTranslation } from "react-i18next";
 
 import { RingBenefitsPopover } from "./RingBenefitsPopover.tsx";
+import { ManaFontIcon } from "../icons/ManaFontIcon.tsx";
 import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
 import type {
   DungeonId,
@@ -168,7 +169,10 @@ export function CounterBadge({ kind, value, ringBearerName }: CounterBadgeProps)
             aria-hidden
             className="absolute -bottom-1 left-1/2 h-3 w-5 -translate-x-1/2 rounded-[45%] bg-lime-950/28 blur-[1px]"
           />
-          <span className="relative">{value}</span>
+          <span className="relative inline-flex items-center gap-px">
+            <span aria-hidden>☠</span>
+            {value}
+          </span>
         </span>
       </BadgeTip>
     );
@@ -186,7 +190,10 @@ export function CounterBadge({ kind, value, ringBearerName }: CounterBadgeProps)
             aria-hidden
             className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.95)_0_9%,transparent_11%),radial-gradient(circle_at_68%_30%,rgba(207,250,254,0.9)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(8,145,178,0.7)_0_11%,transparent_13%),linear-gradient(135deg,#ecfeff_0%,#67e8f9_36%,#0891b2_72%,#083344_100%)]"
           />
-          <span className="relative">⚡{value}</span>
+          <span className="relative inline-flex items-center gap-px">
+            <ManaFontIcon iconClass="ms-energy" fallbackText="⚡" />
+            {value}
+          </span>
         </span>
       </BadgeTip>
     );
@@ -238,7 +245,10 @@ export function CounterBadge({ kind, value, ringBearerName }: CounterBadgeProps)
             aria-hidden
             className="absolute -bottom-1 left-1/2 h-3 w-5 -translate-x-1/2 rounded-[45%] bg-amber-950/28 blur-[1px]"
           />
-          <span className="relative">☢{value}</span>
+          <span className="relative inline-flex items-center gap-px">
+            <ManaFontIcon iconClass="ms-counter-rad" fallbackText="☢" />
+            {value}
+          </span>
         </span>
       </BadgeTip>
     );

--- a/client/src/components/hud/__tests__/TurnStatusLine.test.tsx
+++ b/client/src/components/hud/__tests__/TurnStatusLine.test.tsx
@@ -57,7 +57,13 @@ describe("TurnStatusLine", () => {
     setup({ seat: 0, waitingFor: { type: "Priority", data: { player: 0 } }, state: { active_player: 0 } });
     render(<TurnStatusLine />);
     const region = screen.getByRole("status");
-    expect(region).toHaveTextContent("Your priority — main phase");
+    expect(region).toHaveTextContent("Your priority");
+    // The reason sentence lives in the GameplayTooltip, which now portals to
+    // document.body (escaping the card/overlay stacking context), so assert it
+    // on the tooltip element rather than as inline text of the status region.
+    expect(screen.getByRole("tooltip", { hidden: true })).toHaveTextContent(
+      "Your priority — main phase",
+    );
     expect(region).toHaveAttribute("aria-live", "polite");
   });
 
@@ -68,7 +74,10 @@ describe("TurnStatusLine", () => {
       state: { active_player: 0, stack: ONE_STACK_ENTRY },
     });
     render(<TurnStatusLine />);
-    expect(screen.getByRole("status")).toHaveTextContent("Waiting for Sorin — responding to the stack");
+    expect(screen.getByRole("status")).toHaveTextContent("Waiting for Sorin");
+    expect(screen.getByRole("tooltip", { hidden: true })).toHaveTextContent(
+      "Waiting for Sorin — responding to the stack",
+    );
   });
 
   it("never frames the decision as the spectator's own", () => {

--- a/client/src/components/icons/ManaFontIcon.tsx
+++ b/client/src/components/icons/ManaFontIcon.tsx
@@ -1,0 +1,117 @@
+import { useSyncExternalStore, type CSSProperties } from "react";
+
+/**
+ * mana-font (Andrew Gioia) icon renderer. Wraps an `<i class="ms …">` glyph
+ * from the "Mana" webfont declared in `mana-font/css/mana.css` (imported once in
+ * `main.tsx`). Callers pass the mana-font class(es) — e.g. `"ms-ability-flying"`
+ * or `"ms-loyalty-up ms-loyalty-2"` — plus a `fallbackText` that renders as
+ * plain text until the webfont is ready (and forever, in a non-browser env).
+ */
+
+/** Maps the icon size to a Tailwind text-size class (mana-font glyphs scale
+ * with `font-size`). Omit `size` to inherit the parent's font size — the right
+ * choice inside already-sized rows like the keyword strip. */
+const SIZE_CLASS: Record<NonNullable<ManaFontIconProps["size"]>, string> = {
+  xs: "text-xs",
+  sm: "text-sm",
+  md: "text-base",
+  lg: "text-lg",
+};
+
+// ── Shared font-readiness gate (the ONLY place FOUC is handled) ──────────────
+// A single module-level load of the "Mana" family, shared across every icon
+// instance via a useSyncExternalStore-compatible store. Until the font resolves
+// we render `fallbackText`, so no glyph flashes as a tofu box on first paint.
+let manaFontReady = false;
+let loadStarted = false;
+const readyListeners = new Set<() => void>();
+
+function markReady(): void {
+  manaFontReady = true;
+  for (const listener of readyListeners) listener();
+}
+
+function startManaFontLoad(): void {
+  if (loadStarted) return;
+  loadStarted = true;
+  // Non-browser env (SSR/tests without a DOM) or a browser lacking the Font
+  // Loading API: treat as ready so consumers fall straight through to the glyph
+  // path rather than being pinned on fallback text forever.
+  if (typeof document === "undefined" || !("fonts" in document)) {
+    manaFontReady = true;
+    return;
+  }
+  document.fonts.load("1em Mana").then(markReady, markReady);
+}
+
+function subscribe(listener: () => void): () => void {
+  readyListeners.add(listener);
+  startManaFontLoad();
+  return () => {
+    readyListeners.delete(listener);
+  };
+}
+
+/**
+ * `true` once the "Mana" webfont has loaded (or immediately in a non-browser
+ * env). Kicks off the shared one-time load on first subscription.
+ */
+export function useManaFontReady(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => manaFontReady,
+    () => false,
+  );
+}
+
+interface ManaFontIconProps {
+  /** mana-font class(es), space-separated (e.g. `"ms-loyalty-up ms-loyalty-2"`). */
+  iconClass: string;
+  /** Icon size; omit to inherit the parent's font size. */
+  size?: "xs" | "sm" | "md" | "lg";
+  /** When set, the glyph is exposed as an image with this accessible name;
+   * otherwise it is decorative (`aria-hidden`). */
+  label?: string;
+  /** Plain-text shown until the webfont is ready (and in non-browser envs). */
+  fallbackText: string;
+  className?: string;
+  /** Inline style, e.g. a card-relative `fontSize` clamp or a counter-rotation
+   * that can't be expressed as a static Tailwind class. Applied to both the
+   * glyph and its pre-load fallback so sizing stays stable across the swap. */
+  style?: CSSProperties;
+}
+
+export function ManaFontIcon({
+  iconClass,
+  size,
+  label,
+  fallbackText,
+  className,
+  style,
+}: ManaFontIconProps) {
+  const ready = useManaFontReady();
+  const sizeClass = size ? SIZE_CLASS[size] : "";
+  const a11y = label
+    ? ({ role: "img", "aria-label": label } as const)
+    : ({ "aria-hidden": true } as const);
+
+  if (!ready) {
+    return (
+      <span
+        className={[sizeClass, className].filter(Boolean).join(" ")}
+        style={style}
+        {...a11y}
+      >
+        {fallbackText}
+      </span>
+    );
+  }
+
+  return (
+    <i
+      className={["ms", iconClass, sizeClass, className].filter(Boolean).join(" ")}
+      style={style}
+      {...a11y}
+    />
+  );
+}

--- a/client/src/components/modal/ChoiceModal.tsx
+++ b/client/src/components/modal/ChoiceModal.tsx
@@ -9,6 +9,8 @@ export interface ChoiceOption {
   id: string;
   label: string;
   description?: string;
+  /** Optional glyph rendered before the label (e.g. a loyalty badge). */
+  icon?: ReactNode;
 }
 
 interface ChoiceModalProps {
@@ -63,6 +65,7 @@ export function ChoiceModal({
               className="min-h-11 rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 text-left transition hover:bg-white/8 hover:ring-1 hover:ring-cyan-400/40"
             >
               <span className="font-semibold text-white">
+                {opt.icon && <span className="mr-1.5 align-middle">{opt.icon}</span>}
                 <RichLabel text={opt.label} size="sm" />
               </span>
               {opt.description && (

--- a/client/src/components/modal/DialogHost.tsx
+++ b/client/src/components/modal/DialogHost.tsx
@@ -8,6 +8,7 @@ import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { getBoardChoiceView } from "../../viewmodel/gameStateView.ts";
+import { GAME_Z_LAYER } from "../../constants/ui.ts";
 import { DialogPeekCtx, type DialogPeekContext } from "./dialogPeekContext.ts";
 
 // `WaitingFor` variants that do NOT render a centered dialog/overlay.
@@ -132,13 +133,13 @@ export function DialogHost({ children }: { children: ReactNode }) {
   // not the board, so suppress click-through to restore pointer events.
   const clickThrough = isClickThroughDialog(waitingFor, objects) && !hasUiDialog;
   // BASE INVARIANT: every visible prompt is anchored in this viewport-level
-  // `fixed inset-0 z-40` stacking context, so no prompt can ever be trapped
-  // beneath the board. The board grid is its own `relative z-10` stacking
-  // context; framer-motion leaves a `transform`/`will-change: transform` on
+  // DialogHost stacking context, so no prompt can ever be trapped beneath the
+  // board. The board grid is its own lower stacking context; framer-motion
+  // leaves a `transform`/`will-change: transform` on
   // this node, which would demote an un-anchored (className="") host to a
   // `z-auto` context that paints BELOW the board — burying the dialog behind
-  // the HUD and hand. Anchoring at an explicit `z-40` keeps the context at
-  // level 40 (above the board) regardless of any transform framer applies.
+  // the HUD and hand. Anchoring at GAME_Z_LAYER.dialogHost keeps the context
+  // above the board regardless of any transform framer applies.
   // Click-through is achieved with `pointer-events: none` (below), NOT by
   // un-anchoring, so board taps still reach the battlefield.
   const anchored = dialogVisible;
@@ -179,7 +180,7 @@ export function DialogHost({ children }: { children: ReactNode }) {
 
   return (
     <DialogPeekCtx.Provider value={ctxValue}>
-      {/* When a dialog is visible the host fills the viewport as a `z-40`
+      {/* When a dialog is visible the host fills the viewport at the DialogHost
           stacking context so descendants render above the board; when none is
           up it collapses to an in-flow 0-size box that intercepts nothing.
           `pointer-events: none` lets taps/hovers pass through to the
@@ -188,7 +189,7 @@ export function DialogHost({ children }: { children: ReactNode }) {
           with `pointer-events-auto`. Otherwise the dialog handles events
           normally. */}
       <motion.div
-        className={anchored ? "fixed inset-0 z-40" : ""}
+        className={anchored ? `fixed inset-0 ${GAME_Z_LAYER.dialogHost}` : ""}
         style={
           anchored
             ? { pointerEvents: clickThrough || peeked ? "none" : undefined }
@@ -252,7 +253,7 @@ export function PeekRestoreTab({
         scale: { delay: 0.1, duration: 0.2 },
         boxShadow: { duration: 2.4, repeat: Infinity, ease: "easeInOut" },
       }}
-      className={`fixed z-[60] flex items-center justify-center border border-cyan-400/40 bg-[#0b1020]/96 text-cyan-200 backdrop-blur-md transition-colors hover:bg-cyan-500/20 hover:text-white ${positionClass}`}
+      className={`fixed ${GAME_Z_LAYER.floatingOverlay} flex items-center justify-center border border-cyan-400/40 bg-[#0b1020]/96 text-cyan-200 backdrop-blur-md transition-colors hover:bg-cyan-500/20 hover:text-white ${positionClass}`}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/client/src/components/targeting/TargetingOverlay.tsx
+++ b/client/src/components/targeting/TargetingOverlay.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../viewmodel/gameStateView.ts";
 import { renderDescription } from "../../utils/description.ts";
 import type { GameEvent, GameObject } from "../../adapter/types.ts";
+import { GAME_Z_LAYER } from "../../constants/ui.ts";
 import { RichLabel } from "../mana/RichLabel.tsx";
 
 export function TargetingOverlay() {
@@ -175,7 +176,7 @@ export function TargetingOverlay() {
   return (
     <AnimatePresence>
       <motion.div
-        className="pointer-events-none fixed inset-0 z-40"
+        className={`pointer-events-none fixed inset-0 ${GAME_Z_LAYER.dialogHost}`}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}

--- a/client/src/components/targeting/__tests__/TargetingOverlay.test.tsx
+++ b/client/src/components/targeting/__tests__/TargetingOverlay.test.tsx
@@ -246,6 +246,47 @@ describe("TargetingOverlay", () => {
     });
   });
 
+  it("cancels crew selection back to priority", () => {
+    const dispatch = vi.fn().mockResolvedValue([]);
+    const gameState = createGameState({
+      objects: buildObjectMap(
+        buildGameObjectWithCoreTypes(["Artifact"], {
+          id: 20,
+          name: "Vehicle",
+        }),
+        buildGameObjectWithCoreTypes(["Creature"], {
+          id: 21,
+          name: "Pilot One",
+          power: 2,
+        }),
+      ),
+      waiting_for: {
+        type: "CrewVehicle",
+        data: {
+          player: 0,
+          vehicle_id: 20,
+          crew_power: 2,
+          eligible_creatures: [21],
+          contributions: [2],
+        },
+      },
+    });
+
+    act(() => {
+      useGameStore.setState({
+        gameState,
+        waitingFor: gameState.waiting_for,
+        dispatch,
+      });
+    });
+
+    render(<TargetingOverlay />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(dispatch).toHaveBeenCalledWith({ type: "CancelCast" });
+  });
+
   it("informs the player when the target slot is a spell on the stack", () => {
     const dispatch = vi.fn().mockResolvedValue([]);
     const stackSpellTarget = buildGameObjectWithCoreTypes(["Instant"], {

--- a/client/src/components/ui/GameplayTooltip.tsx
+++ b/client/src/components/ui/GameplayTooltip.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
 
 interface GameplayTooltipProps {
   id?: string;
@@ -6,82 +13,98 @@ interface GameplayTooltipProps {
   className?: string;
 }
 
+/**
+ * Hover/focus tooltip rendered in a portal on `document.body` so it escapes the
+ * transformed / overflow-clipped stacking contexts of its trigger — most
+ * importantly a battlefield card's rotating `motion.div`, which otherwise traps
+ * the tooltip beneath the `z-[100]` hover card preview no matter how high its
+ * own z-index. Visibility mirrors the closest `.group` ancestor's hover/focus
+ * (the same trigger the previous CSS `group-hover` implementation used, so call
+ * sites need no changes), and the fixed position is measured from that trigger
+ * and clamped into the viewport with an 8px margin. Non-positional `className`
+ * overrides (width, padding, text) still apply; positional ones are superseded
+ * by the automatic viewport-aware placement.
+ */
 export function GameplayTooltip({
   id,
   children,
   className,
 }: GameplayTooltipProps) {
-  const ref = useRef<HTMLSpanElement>(null);
-  const [shift, setShift] = useState({ x: 0, y: 0 });
-  // Tracks the shift currently applied so each measurement can recover the
-  // tooltip's NATURAL position (rect − shift) and avoid a measure→shift→measure
-  // feedback loop.
-  const shiftRef = useRef({ x: 0, y: 0 });
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const tipRef = useRef<HTMLSpanElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+  const [visible, setVisible] = useState(false);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
 
-  // The tooltip is shown purely via CSS `group-hover`; mirror that trigger in
-  // JS so we can measure it only while visible and nudge it back inside the
-  // viewport. Same 8px-margin clamp idiom as `BoardContextMenu`. Listening on
-  // the closest `.group` ancestor — the element the CSS `group-hover` responds
-  // to — keeps this self-contained with no call-site changes.
   useEffect(() => {
-    const el = ref.current;
-    const trigger = el?.closest(".group");
-    if (!el || !trigger) return;
-
-    const clamp = () => {
-      const r = el.getBoundingClientRect();
-      if (r.width === 0 && r.height === 0) return; // not actually visible yet
-      const m = 8;
-      const { x: sx, y: sy } = shiftRef.current;
-      // Natural (un-shifted) edges.
-      const left = r.left - sx;
-      const right = r.right - sx;
-      const top = r.top - sy;
-      const bottom = r.bottom - sy;
-      let x = 0;
-      let y = 0;
-      if (left < m) x = m - left;
-      else if (right > window.innerWidth - m) x = window.innerWidth - m - right;
-      if (top < m) y = m - top;
-      else if (bottom > window.innerHeight - m) y = window.innerHeight - m - bottom;
-      shiftRef.current = { x, y };
-      setShift({ x, y });
-    };
-    const reset = () => {
-      shiftRef.current = { x: 0, y: 0 };
-      setShift({ x: 0, y: 0 });
-    };
-
-    trigger.addEventListener("pointerenter", clamp);
-    trigger.addEventListener("focusin", clamp);
-    trigger.addEventListener("pointerleave", reset);
-    trigger.addEventListener("focusout", reset);
+    const trigger = anchorRef.current?.closest(".group") ?? null;
+    triggerRef.current = trigger;
+    if (!trigger) return;
+    const show = () => setVisible(true);
+    const hide = () => setVisible(false);
+    trigger.addEventListener("pointerenter", show);
+    trigger.addEventListener("focusin", show);
+    trigger.addEventListener("pointerleave", hide);
+    trigger.addEventListener("focusout", hide);
     return () => {
-      trigger.removeEventListener("pointerenter", clamp);
-      trigger.removeEventListener("focusin", clamp);
-      trigger.removeEventListener("pointerleave", reset);
-      trigger.removeEventListener("focusout", reset);
+      trigger.removeEventListener("pointerenter", show);
+      trigger.removeEventListener("focusin", show);
+      trigger.removeEventListener("pointerleave", hide);
+      trigger.removeEventListener("focusout", hide);
     };
   }, []);
 
+  // Once visible, place the tooltip above the trigger with right edges aligned,
+  // flipping below when there's no room above and clamping horizontally so it
+  // never leaves the viewport (8px margin). setPos returns the previous object
+  // when the numbers are unchanged so a changing `children` identity can't spin
+  // a measure→setState→measure loop.
+  useLayoutEffect(() => {
+    if (!visible) return;
+    const trigger = triggerRef.current;
+    const tip = tipRef.current;
+    if (!trigger || !tip) return;
+    const r = trigger.getBoundingClientRect();
+    const m = 8;
+    const w = tip.offsetWidth;
+    const h = tip.offsetHeight;
+    let left = r.right - w;
+    if (left + w > window.innerWidth - m) left = window.innerWidth - m - w;
+    if (left < m) left = m;
+    let top = r.top - m - h;
+    if (top < m) top = r.bottom + m;
+    setPos((prev) =>
+      prev && prev.left === left && prev.top === top ? prev : { left, top },
+    );
+  }, [visible, children]);
+
+  const shown = visible && pos !== null;
+
   return (
-    <span
-      ref={ref}
-      id={id}
-      role="tooltip"
-      className={[
-        "pointer-events-none absolute right-0 bottom-full z-[130] mb-2 hidden w-64 rounded-[8px] border border-white/10 bg-slate-950 px-3 py-2 text-left text-[11px] leading-snug font-medium text-slate-100 shadow-xl shadow-black/40 group-hover:block group-focus-visible:block",
-        className,
-      ]
-        .filter(Boolean)
-        .join(" ")}
-      style={
-        shift.x || shift.y
-          ? { transform: `translate(${shift.x}px, ${shift.y}px)` }
-          : undefined
-      }
-    >
-      {children}
-    </span>
+    <>
+      <span ref={anchorRef} className="hidden" aria-hidden />
+      {createPortal(
+        <span
+          ref={tipRef}
+          id={id}
+          role="tooltip"
+          style={{
+            position: "fixed",
+            left: pos?.left ?? 0,
+            top: pos?.top ?? 0,
+            visibility: shown ? "visible" : "hidden",
+          }}
+          className={[
+            "pointer-events-none z-[130] w-64 rounded-[8px] border border-white/10 bg-slate-950 px-3 py-2 text-left text-[11px] leading-snug font-medium text-slate-100 shadow-xl shadow-black/40",
+            className,
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        >
+          {children}
+        </span>,
+        document.body,
+      )}
+    </>
   );
 }

--- a/client/src/constants/__tests__/ui.test.ts
+++ b/client/src/constants/__tests__/ui.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { GAME_Z, GAME_Z_LAYER } from "../ui.ts";
+
+describe("GAME_Z", () => {
+  it("keeps board-choice controls below prompt overlays but above HUD rails", () => {
+    expect(GAME_Z.boardChoiceGrid).toBeGreaterThan(GAME_Z.hudRail);
+    expect(GAME_Z.boardChoiceGrid).toBeLessThan(GAME_Z.dialogHost);
+  });
+
+  it("keeps Tailwind layer classes aligned with numeric layer values", () => {
+    expect(GAME_Z_LAYER.board).toBe(`z-${GAME_Z.board}`);
+    expect(GAME_Z_LAYER.hudRail).toBe(`z-${GAME_Z.hudRail}`);
+    expect(GAME_Z_LAYER.boardChoiceGrid).toBe(`z-[${GAME_Z.boardChoiceGrid}]`);
+    expect(GAME_Z_LAYER.dialogHost).toBe(`z-${GAME_Z.dialogHost}`);
+    expect(GAME_Z_LAYER.modal).toBe(`z-${GAME_Z.modal}`);
+    expect(GAME_Z_LAYER.floatingOverlay).toBe(`z-[${GAME_Z.floatingOverlay}]`);
+    expect(GAME_Z_LAYER.nestedDialog).toBe(`z-[${GAME_Z.nestedDialog}]`);
+    expect(GAME_Z_LAYER.debugPanel).toBe(`z-[${GAME_Z.debugPanel}]`);
+  });
+});

--- a/client/src/constants/ui.ts
+++ b/client/src/constants/ui.ts
@@ -3,3 +3,33 @@ export const COMBAT_TILT_DEGREES = 15;
 
 /** Default animation duration in ms for UI transitions. */
 export const DEFAULT_ANIMATION_DURATION_MS = 200;
+
+/**
+ * Game-surface stacking layers. Use these for board, prompt, modal, and debug
+ * surfaces instead of raw z-* classes.
+ *
+ * Keep board-choice chrome above ordinary rails, but below DialogHost: the host
+ * owns prompt controls such as targeting/crew/sacrifice Confirm buttons while
+ * using pointer-events:none so battlefield clicks still pass through.
+ */
+export const GAME_Z = {
+  board: 10,
+  hudRail: 30,
+  boardChoiceGrid: 35,
+  dialogHost: 40,
+  modal: 50,
+  floatingOverlay: 60,
+  nestedDialog: 70,
+  debugPanel: 9999,
+} as const;
+
+export const GAME_Z_LAYER = {
+  board: "z-10",
+  hudRail: "z-30",
+  boardChoiceGrid: "z-[35]",
+  dialogHost: "z-40",
+  modal: "z-50",
+  floatingOverlay: "z-[60]",
+  nestedDialog: "z-[70]",
+  debugPanel: "z-[9999]",
+} as const;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,6 +3,12 @@ import { createRoot } from "react-dom/client";
 // CDN). Newsreader = serif display; JetBrains Mono = codes / tabular numbers.
 import "@fontsource-variable/newsreader";
 import "@fontsource-variable/jetbrains-mono";
+// Mana/loyalty/counter iconography (Andrew Gioia's mana-font). The vendored
+// mana.css ships legacy eot/woff/ttf/svg faces for "Mana" plus an unused
+// "MPlantin" serif; the `trimManaFont` Vite plugin rewrites this import at build
+// time to a single woff2-only "Mana" @font-face (see vite.config.ts) so only one
+// 187 KB font is bundled here and in the Tauri app.
+import "mana-font/css/mana.css";
 import "./index.css";
 import "./i18n"; // initialize i18next before any component renders
 import { App } from "./App";

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -139,7 +139,13 @@ import { SpectatorChrome } from "../components/spectator/SpectatorChrome.tsx";
 import { useSpectatorMode } from "../hooks/useSpectatorMode.ts";
 import { GameProvider } from "../providers/GameProvider.tsx";
 import { useCanActForWaitingState, usePerspectivePlayerId, usePlayerId } from "../hooks/usePlayerId.ts";
-import { abilityChoiceLabel, formatAbilityCost } from "../viewmodel/costLabel.ts";
+import {
+  abilityChoiceLabel,
+  formatAbilityCost,
+  loyaltyBadge,
+  stripLoyaltyCostPrefix,
+} from "../viewmodel/costLabel.ts";
+import { ManaFontIcon } from "../components/icons/ManaFontIcon.tsx";
 import {
   getCastableZoneViewerTarget,
   getBoardChoiceView,
@@ -152,6 +158,7 @@ import {
   type ZoneViewerTarget,
 } from "../viewmodel/gameStateView.ts";
 import { gameButtonClass } from "../components/ui/buttonStyles.ts";
+import { GAME_Z_LAYER } from "../constants/ui.ts";
 
 type ZoneRailStyle = CSSProperties & {
   "--card-w": string;
@@ -1272,9 +1279,12 @@ function GamePageContent({
 
       <DebugModeBanner />
 
-      {/* Full-screen board layout — CSS Grid with 3 rows: opp hand, battlefield, player hand */}
+      {/* Full-screen board layout — CSS Grid with 3 rows: opp hand, battlefield, player hand.
+          Board choices lift the grid above normal HUD rails, but must stay below
+          DialogHost/TargetingOverlay so confirm controls are not hidden behind
+          the player hand. Keep this ordering in GAME_Z_LAYER. */}
       <div
-        className={`relative ${boardChoiceLayerActive && !isReconnecting ? "z-[45]" : "z-10"} grid min-w-0 h-full${isReconnecting ? " pointer-events-none" : ""}`}
+        className={`relative ${boardChoiceLayerActive && !isReconnecting ? GAME_Z_LAYER.boardChoiceGrid : GAME_Z_LAYER.board} grid min-w-0 h-full${isReconnecting ? " pointer-events-none" : ""}`}
         style={{
           paddingTop: "var(--game-top-overlay-offset, 0px)",
           gridTemplateRows,
@@ -2821,6 +2831,29 @@ function AbilityChoiceModal() {
           objects,
           webSlingingCosts,
         );
+        // CR 606.1: prefix a loyalty badge for planeswalker ability costs,
+        // reading the structured Loyalty cost (never parsing the label string).
+        const ability =
+          action.type === "ActivateAbility"
+            ? obj.abilities[action.data.ability_index]
+            : undefined;
+        const badge = loyaltyBadge(ability?.cost);
+        if (badge) {
+          return {
+            id: String(i),
+            label: stripLoyaltyCostPrefix(label),
+            description,
+            // No `size`: mana-font scales the loyalty glyph off the parent's
+            // font-size (font-size:1.5em), so it inherits the option row size.
+            icon: (
+              <ManaFontIcon
+                iconClass={badge.iconClasses}
+                fallbackText={badge.text}
+                label={badge.text}
+              />
+            ),
+          };
+        }
         return { id: String(i), label, description };
       })}
       onChoose={(id) => {

--- a/client/src/viewmodel/__tests__/gameStateView.test.ts
+++ b/client/src/viewmodel/__tests__/gameStateView.test.ts
@@ -299,6 +299,7 @@ describe("getBoardChoiceView", () => {
       type: "CrewVehicle",
       data: { vehicle_id: 30, creature_ids: [10, 11] },
     });
+    expect(choice.cancelAction).toEqual({ type: "CancelCast" });
   });
 
   // Regression: a Pilot token (Shorikai) has printed power 1 but crews "as though

--- a/client/src/viewmodel/__tests__/manaFontIconClasses.test.ts
+++ b/client/src/viewmodel/__tests__/manaFontIconClasses.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+import { describe, expect, it } from "vitest";
+
+import { COUNTER_ICON_CLASS } from "../cardProps.ts";
+import { loyaltyIconClasses, loyaltyStartIconClasses } from "../costLabel.ts";
+import { KEYWORD_ICON_CLASS } from "../keywordProps.ts";
+import { CARD_TYPE_ICON_CLASS } from "../typeIcons.ts";
+
+// Guardrail: every mana-font class emitted by our mapping tables MUST exist as
+// a selector in the shipped mana.css. This fails CI on an upstream rename or a
+// typo in a table, catching silently-broken icons before they reach the board.
+const require = createRequire(import.meta.url);
+const MANA_CSS = readFileSync(require.resolve("mana-font/css/mana.css"), "utf-8");
+
+/** True if `.<cls>` appears as a selector in mana.css (class-name boundary). */
+function hasSelector(cls: string): boolean {
+  // Escape regex metacharacters, then require a non-[word/hyphen] char after so
+  // "ms-loyalty-2" doesn't match inside "ms-loyalty-20".
+  const escaped = cls.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\.${escaped}(?![\\w-])`).test(MANA_CSS);
+}
+
+/** All space-separated class tokens across a set of icon-class strings. */
+function tokensOf(classStrings: Iterable<string>): Set<string> {
+  const tokens = new Set<string>();
+  for (const cs of classStrings) {
+    for (const token of cs.split(/\s+/).filter(Boolean)) tokens.add(token);
+  }
+  return tokens;
+}
+
+// mana-font ships loyalty numerals for these magnitudes only.
+const LOYALTY_MAGNITUDES = [...Array.from({ length: 21 }, (_, i) => i), 25];
+
+describe("mana-font icon class tables", () => {
+  it("sanity-checks the CSS fixture loaded", () => {
+    expect(hasSelector("ms")).toBe(true);
+    expect(hasSelector("ms-ability-flying")).toBe(true);
+    expect(hasSelector("ms-nonexistent-glyph-xyz")).toBe(false);
+  });
+
+  it("keyword icon classes all exist in mana.css", () => {
+    for (const cls of tokensOf(Object.values(KEYWORD_ICON_CLASS))) {
+      expect(hasSelector(cls), cls).toBe(true);
+    }
+  });
+
+  it("card-type icon classes all exist in mana.css", () => {
+    for (const cls of tokensOf(Object.values(CARD_TYPE_ICON_CLASS))) {
+      expect(hasSelector(cls), cls).toBe(true);
+    }
+  });
+
+  it("counter icon classes all exist in mana.css", () => {
+    for (const cls of tokensOf(Object.values(COUNTER_ICON_CLASS))) {
+      expect(hasSelector(cls), cls).toBe(true);
+    }
+  });
+
+  it("loyalty cost icon classes exist across the full valid range", () => {
+    const emitted = new Set<string>();
+    // Zero.
+    emitted.add(loyaltyIconClasses(0)!);
+    // Positive and negative magnitudes with a shipped numeral.
+    for (const n of LOYALTY_MAGNITUDES) {
+      if (n === 0) continue;
+      emitted.add(loyaltyIconClasses(n)!);
+      emitted.add(loyaltyIconClasses(-n)!);
+    }
+    for (const cls of emitted) expect(cls, "expected non-null loyalty classes").not.toBeNull();
+    for (const cls of tokensOf(emitted)) {
+      expect(hasSelector(cls), cls).toBe(true);
+    }
+    // Magnitudes with no glyph return null (caller falls back to text).
+    expect(loyaltyIconClasses(21)).toBeNull();
+    expect(loyaltyIconClasses(-24)).toBeNull();
+  });
+
+  it("loyalty shield (start) icon classes exist across the full valid range", () => {
+    const emitted = new Set<string>();
+    for (const n of LOYALTY_MAGNITUDES) emitted.add(loyaltyStartIconClasses(n)!);
+    for (const cls of emitted) expect(cls, "expected non-null shield classes").not.toBeNull();
+    for (const cls of tokensOf(emitted)) {
+      expect(hasSelector(cls), cls).toBe(true);
+    }
+    expect(loyaltyStartIconClasses(21)).toBeNull();
+  });
+});

--- a/client/src/viewmodel/cardProps.ts
+++ b/client/src/viewmodel/cardProps.ts
@@ -92,6 +92,52 @@ export function formatCounterType(type: string): string {
   return type;
 }
 
+/**
+ * Counter serde key (from `CounterType::as_str`, e.g. "P1P1", "stun", "charge")
+ * → mana-font `ms-counter-*` glyph class. Every value is verified present in
+ * `mana-font/css/mana.css` by the guardrail test; counter types with no shipped
+ * glyph are absent and render text-only.
+ */
+export const COUNTER_ICON_CLASS: Record<string, string> = {
+  P1P1: "ms-counter-plus",
+  M1M1: "ms-counter-minus",
+  loyalty: "ms-counter-loyalty",
+  lore: "ms-counter-lore",
+  stun: "ms-counter-stun",
+  shield: "ms-counter-shield",
+  time: "ms-counter-time",
+  charge: "ms-counter-charge",
+  gold: "ms-counter-gold",
+  ki: "ms-counter-ki",
+  rad: "ms-counter-rad",
+  verse: "ms-counter-verse",
+  void: "ms-counter-void",
+  flame: "ms-counter-flame",
+  flood: "ms-counter-flood",
+  fungus: "ms-counter-fungus",
+  muster: "ms-counter-muster",
+  doom: "ms-counter-doom",
+  echo: "ms-counter-echo",
+  finality: "ms-counter-finality",
+  brick: "ms-counter-brick",
+  mining: "ms-counter-mining",
+  paw: "ms-counter-paw",
+  pin: "ms-counter-pin",
+  scream: "ms-counter-scream",
+  skull: "ms-counter-skull",
+  slime: "ms-counter-slime",
+  vortex: "ms-counter-vortex",
+  goad: "ms-counter-goad",
+  damage: "ms-counter-damage",
+  deathtouch: "ms-counter-deathtouch",
+  devotion: "ms-counter-devotion",
+};
+
+/** Resolve a counter type's mana-font glyph class, or null when none ships. */
+export function counterIconClass(type: string): string | null {
+  return COUNTER_ICON_CLASS[type] ?? null;
+}
+
 type CounterTooltipTranslator = (
   key: string,
   options?: { count?: number; label?: string; description?: string },

--- a/client/src/viewmodel/costLabel.ts
+++ b/client/src/viewmodel/costLabel.ts
@@ -177,12 +177,53 @@ function quantityIsPlural(q: QuantityExpr | number | undefined): boolean {
   return q.type === "Fixed" ? q.value > 1 : true;
 }
 
+// mana-font ships loyalty numerals only for these magnitudes (0–20 and 25);
+// any other value has no glyph and must fall back to plain text.
+const LOYALTY_NUMERALS: ReadonlySet<number> = new Set([
+  ...Array.from({ length: 21 }, (_, i) => i),
+  25,
+]);
+
+// Single source of truth for a loyalty amount's sign → mana-font direction
+// segment + magnitude, shared by the text label (formatCost) and the icon
+// helpers so the two can never drift on how they classify +/−/0.
+function loyaltyDirection(amount: number): {
+  dir: "up" | "down" | "zero";
+  magnitude: number;
+} {
+  if (amount > 0) return { dir: "up", magnitude: amount };
+  if (amount < 0) return { dir: "down", magnitude: -amount };
+  return { dir: "zero", magnitude: 0 };
+}
+
+/**
+ * mana-font classes for a planeswalker ability's loyalty COST (e.g. `+2`, `−7`,
+ * `0`) — an up/down/zero arrow plus the numeral. Returns null when the
+ * magnitude has no shipped numeral glyph (caller falls back to text).
+ */
+export function loyaltyIconClasses(amount: number): string | null {
+  const { dir, magnitude } = loyaltyDirection(amount);
+  if (!LOYALTY_NUMERALS.has(magnitude)) return null;
+  return `ms-loyalty-${dir} ms-loyalty-${magnitude}`;
+}
+
+/**
+ * mana-font classes for a planeswalker's current loyalty TOTAL rendered in the
+ * shield glyph (`ms-loyalty-start` + numeral). Returns null when the total has
+ * no shipped numeral glyph (caller keeps the plain amber badge).
+ */
+export function loyaltyStartIconClasses(amount: number): string | null {
+  if (!LOYALTY_NUMERALS.has(amount)) return null;
+  return `ms-loyalty-start ms-loyalty-${amount}`;
+}
+
 export function formatCost(cost: SerializedCost): string {
   switch (cost.type) {
     case "Loyalty": {
       // CR 606.1: Loyalty cost is always a literal `i32` on the Rust side.
       const amt = (typeof cost.amount === "number" ? cost.amount : 0);
-      return amt > 0 ? `+${amt}` : `${amt}`;
+      const { dir, magnitude } = loyaltyDirection(amt);
+      return dir === "up" ? `+${magnitude}` : dir === "down" ? `-${magnitude}` : "0";
     }
     case "Tap": return "{T}";
     case "Untap": return "{Q}";
@@ -217,6 +258,33 @@ export function formatCost(cost: SerializedCost): string {
     default:
       return "Activate";
   }
+}
+
+/**
+ * Loyalty badge descriptor for a planeswalker ability cost, or null when the
+ * cost isn't a Loyalty cost with a shipped numeral glyph. Reads the structured
+ * `{ type: "Loyalty", amount }` cost — never parses "+N" strings. `text` is the
+ * plain fallback shown before the mana-font is ready ("+2" / "-7" / "0").
+ */
+export function loyaltyBadge(
+  cost: SerializedAbilityCost | undefined,
+): { iconClasses: string; text: string } | null {
+  const c = cost as SerializedCost | undefined;
+  if (!c || c.type !== "Loyalty") return null;
+  const amount = typeof c.amount === "number" ? c.amount : 0;
+  const iconClasses = loyaltyIconClasses(amount);
+  if (!iconClasses) return null;
+  return { iconClasses, text: formatCost(c) };
+}
+
+/**
+ * Strip a leading bracket/bare loyalty-cost prefix ("[+2]:", "[−1]", "+2:",
+ * "0") from a label so it isn't shown twice alongside a loyalty badge. Only
+ * applied to options that already resolved to a loyalty badge, so it can't
+ * over-strip a non-loyalty label.
+ */
+export function stripLoyaltyCostPrefix(label: string): string {
+  return label.replace(/^\[?\s*[+\-−–]?\d+\s*\]?:?\s*/, "");
 }
 
 export function abilityLabel(ability: SerializedAbility | null | undefined): string {

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -467,6 +467,7 @@ export function getBoardChoiceView(
         },
         response: { type: "CrewVehicle", vehicleId: waitingFor.data.vehicle_id },
         sourceId: waitingFor.data.vehicle_id,
+        cancelAction: { type: "CancelCast" },
       };
     case "SaddleMount":
       return {

--- a/client/src/viewmodel/keywordProps.ts
+++ b/client/src/viewmodel/keywordProps.ts
@@ -100,6 +100,120 @@ export function getKeywordReminderText(kw: Keyword): string | null {
   return KEYWORD_REMINDER_TEXT[getKeywordName(kw)] ?? null;
 }
 
+/**
+ * Keyword display name (as returned by `getKeywordName`) → mana-font
+ * `ms-ability-*` glyph class. Every value here is verified to exist as a
+ * selector in `mana-font/css/mana.css` by the guardrail test; keywords with no
+ * shipped glyph are simply absent and fall back to their text chip. Keys are
+ * the human display names so both bare-string keywords ("Flying") and
+ * parameterized ones ({ Ward: … } → "Ward") resolve through one lookup.
+ */
+export const KEYWORD_ICON_CLASS: Record<string, string> = {
+  // Evergreen / combat
+  "Flying": "ms-ability-flying",
+  "Reach": "ms-ability-reach",
+  "First Strike": "ms-ability-first-strike",
+  "Double Strike": "ms-ability-double-strike",
+  "Deathtouch": "ms-ability-deathtouch",
+  "Trample": "ms-ability-trample",
+  "Lifelink": "ms-ability-lifelink",
+  "Vigilance": "ms-ability-vigilance",
+  "Haste": "ms-ability-haste",
+  "Menace": "ms-ability-menace",
+  "Defender": "ms-ability-defender",
+  "Hexproof": "ms-ability-hexproof",
+  "Shroud": "ms-ability-shroud",
+  "Indestructible": "ms-ability-indestructible",
+  "Ward": "ms-ability-ward",
+  "Protection": "ms-ability-protection",
+  "Flash": "ms-ability-flash",
+  "Prowess": "ms-ability-prowess",
+  "Skulk": "ms-ability-skulk",
+  "Fear": "ms-ability-fear",
+  "Infect": "ms-ability-infect",
+  "Intimidate": "ms-ability-intimidate",
+  "Changeling": "ms-ability-changeling",
+  "Totem Armor": "ms-ability-totem-armor",
+  "Enchant": "ms-ability-enchant",
+  // Set / supplemental mechanics
+  "Adapt": "ms-ability-adapt",
+  "Afflict": "ms-ability-afflict",
+  "Afterlife": "ms-ability-afterlife",
+  "Amass": "ms-ability-amass",
+  "Annihilator": "ms-ability-annihilator",
+  "Ascend": "ms-ability-ascend",
+  "Backup": "ms-ability-backup",
+  "Bargain": "ms-ability-bargain",
+  "Battle Cry": "ms-ability-battle-cry",
+  "Blitz": "ms-ability-blitz",
+  "Boast": "ms-ability-boast",
+  "Casualty": "ms-ability-casualty",
+  "Channel": "ms-ability-channel",
+  "Cleave": "ms-ability-cleave",
+  "Cloak": "ms-ability-cloak",
+  "Companion": "ms-ability-companion",
+  "Convoke": "ms-ability-convoke",
+  "Craft": "ms-ability-craft",
+  "Crew": "ms-ability-crew",
+  "Cycling": "ms-ability-cycling",
+  "Delve": "ms-ability-delve",
+  "Discover": "ms-ability-discover",
+  "Disguise": "ms-ability-disguise",
+  "Disturb": "ms-ability-disturb",
+  "Embalm": "ms-ability-embalm",
+  "Enlist": "ms-ability-enlist",
+  "Enrage": "ms-ability-enrage",
+  "Escape": "ms-ability-escape",
+  "Eternalize": "ms-ability-eternalize",
+  "Evolve": "ms-ability-evolve",
+  "Exalted": "ms-ability-exalted",
+  "Exploit": "ms-ability-exploit",
+  "Fabricate": "ms-ability-fabricate",
+  "Fading": "ms-ability-fading",
+  "Forage": "ms-ability-forage",
+  "Foretell": "ms-ability-foretell",
+  "Goad": "ms-ability-goad",
+  "Haunt": "ms-ability-haunt",
+  "Hideaway": "ms-ability-hideaway",
+  "Impending": "ms-ability-impending",
+  "Improvise": "ms-ability-improvise",
+  "Ingest": "ms-ability-ingest",
+  "Jumpstart": "ms-ability-jumpstart",
+  "Kicker": "ms-ability-kicker",
+  "Learn": "ms-ability-learn",
+  "Mentor": "ms-ability-mentor",
+  "Morph": "ms-ability-morph",
+  "Mutate": "ms-ability-mutate",
+  "Ninjutsu": "ms-ability-ninjutsu",
+  "Offspring": "ms-ability-offspring",
+  "Outlast": "ms-ability-outlast",
+  "Plot": "ms-ability-plot",
+  "Prototype": "ms-ability-prototype",
+  "Read Ahead": "ms-ability-read-ahead",
+  "Reconfigure": "ms-ability-reconfigure",
+  "Regenerate": "ms-ability-regenerate",
+  "Riot": "ms-ability-riot",
+  "Saddle": "ms-ability-saddle",
+  "Soulshift": "ms-ability-soulshift",
+  "Spectacle": "ms-ability-spectacle",
+  "Spree": "ms-ability-spree",
+  "Survival": "ms-ability-survival",
+  "Suspect": "ms-ability-suspect",
+  "Toxic": "ms-ability-toxic",
+  "Training": "ms-ability-training",
+  "Undying": "ms-ability-undying",
+  "Unearth": "ms-ability-unearth",
+};
+
+/**
+ * Resolve a keyword to its mana-font `ms-ability-*` glyph class, or null when
+ * no glyph is shipped for it. Keyed off `getKeywordName` so parameterized
+ * keywords (Ward {2}, Protection from red) resolve by their base name.
+ */
+export function getKeywordIconClass(kw: Keyword): string | null {
+  return KEYWORD_ICON_CLASS[getKeywordName(kw)] ?? null;
+}
+
 /** Combat-relevant keywords displayed first, in this order. */
 const KEYWORD_DISPLAY_ORDER: string[] = [
   "Flying", "First Strike", "Double Strike", "Deathtouch", "Trample",

--- a/client/src/viewmodel/typeIcons.ts
+++ b/client/src/viewmodel/typeIcons.ts
@@ -1,0 +1,28 @@
+import type { CoreType } from "../adapter/types.ts";
+
+/**
+ * Card core type → mana-font `ms-*` type glyph class. Every value is verified
+ * present in `mana-font/css/mana.css` by the guardrail test. The `Record` is
+ * keyed by the full `CoreType` union so a new engine core type is a compile
+ * error here until it's mapped.
+ */
+export const CARD_TYPE_ICON_CLASS: Record<CoreType, string> = {
+  Artifact: "ms-artifact",
+  Creature: "ms-creature",
+  Enchantment: "ms-enchantment",
+  Instant: "ms-instant",
+  Land: "ms-land",
+  Planeswalker: "ms-planeswalker",
+  Sorcery: "ms-sorcery",
+  Battle: "ms-battle",
+  Dungeon: "ms-dungeon",
+  // No `ms-kindred` glyph exists; Tribal and Kindred are the old and new names
+  // for the same card type, so both resolve to the tribal glyph.
+  Tribal: "ms-tribal",
+  Kindred: "ms-tribal",
+};
+
+/** Resolve a core type to its mana-font glyph class, or null when none ships. */
+export function cardTypeIconClass(coreType: string): string | null {
+  return CARD_TYPE_ICON_CLASS[coreType as CoreType] ?? null;
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -30,6 +30,32 @@ function wasmEnvShim(): Plugin {
   };
 }
 
+// mana-font ships a legacy @font-face (eot/woff/ttf/svg) for BOTH the "Mana"
+// glyph family AND an unused "MPlantin" text family. Imported verbatim, Vite
+// emits every referenced url() — ~3.4 MB of fonts (a 1.8 MB SVG among them,
+// plus the whole unused MPlantin family) into the web dist AND the Tauri
+// bundle, when the only asset any `.ms-*` class needs is the 187 KB woff2 the
+// vendored CSS never references. Rewrite that one stylesheet at build time to a
+// single woff2-only @font-face for "Mana" and drop the rest, so exactly one
+// font file is emitted. Keeps the npm package as the source of truth for the
+// glyph classes (no vendored copy, updates on version bump). enforce:"pre" so
+// this runs before Vite's CSS plugin resolves url()s into emitted assets.
+function trimManaFont(): Plugin {
+  return {
+    name: "trim-mana-font",
+    enforce: "pre",
+    transform(code, id) {
+      if (!id.replace(/\\/g, "/").endsWith("mana-font/css/mana.css")) return;
+      const classes = code.replace(/@font-face\s*\{[^}]*\}/g, "");
+      const woff2Face =
+        '@font-face{font-family:"Mana";' +
+        'src:url("../fonts/mana.woff2") format("woff2");' +
+        "font-weight:normal;font-style:normal;}\n";
+      return { code: woff2Face + classes, map: null };
+    },
+  };
+}
+
 function gitHash(): string {
   try {
     return execSync("git rev-parse --short HEAD").toString().trim();
@@ -136,6 +162,7 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     wasmEnvShim(),
+    trimManaFont(),
     react(),
     tailwindcss(),
     wasm(),
@@ -146,6 +173,14 @@ export default defineConfig(({ mode }) => ({
       includeAssets: ["**/*.mp3", "**/*.m4a"],
       workbox: {
         maximumFileSizeToCacheInBytes: 15 * 1024 * 1024,
+        // Workbox's default globPatterns (`**/*.{js,wasm,css,html}`) omit fonts,
+        // so the hashed self-hosted webfonts (@fontsource-variable/* and
+        // mana-font, all emitted as .woff2) are bundled but never precached —
+        // they'd 404 offline. Extend the default generically to cover every
+        // font family's woff2 (no per-font special case). The .wasm engine/draft
+        // bundles are still handled by their dedicated runtimeCaching rules
+        // below via globIgnores.
+        globPatterns: ["**/*.{js,wasm,css,html,woff2}"],
         // changelog{,-meta}.json are committed to public/ but stripped from the
         // Pages bundle on deploy (manifest-driven rm in deploy.yml/release.yml)
         // and served from R2. The precache manifest is generated BEFORE that


### PR DESCRIPTION
Add Andrew Gioia's mana-font for in-game iconography, bundled woff2-only
via a trimManaFont Vite plugin (~3.4MB of legacy faces -> 187KB), and route
tooltips/dialogs through a shared stacking model.

- Keyword ability icons as square badges straddling the card's top-left edge,
  scaling with card size, capped with a "+N" overflow indicator
- Loyalty +N/-N/0 badges in planeswalker ability choices, read from the
  structured Loyalty cost (never parsed from the label string)
- Counter glyphs on battlefield pills; energy/rad glyphs + poison skull on HUD
- Tapped-card overlay with a centered, counter-rotated tap glyph
- GameplayTooltip portals to document.body so it escapes the card's transformed
  stacking context (was buried under the z-[100] hover preview)
- DialogHost / floating overlays anchored via shared GAME_Z_LAYER constants
