### PR TITLE
MULTIPLAYER: resume server-hosted rooms after reload

### DIFF
--- a/client/src/hooks/useHostingSession.ts
+++ b/client/src/hooks/useHostingSession.ts
@@ -11,7 +11,12 @@ import { useMultiplayerStore } from "../stores/multiplayerStore";
 export function useHostingSession(): void {
   const pendingGameRoute = useMultiplayerStore((s) => s.pendingGameRoute);
   const clearPendingGameRoute = useMultiplayerStore((s) => s.clearPendingGameRoute);
+  const resumeServerHosting = useMultiplayerStore((s) => s.resumeServerHosting);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    resumeServerHosting();
+  }, [resumeServerHosting]);
 
   useEffect(() => {
     if (pendingGameRoute) {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,3 +1,4 @@
+import "./polyfills/cryptoRandomUUID";
 import { createRoot } from "react-dom/client";
 // Self-hosted variable webfonts (served from node_modules by Vite — no Google
 // CDN). Newsreader = serif display; JetBrains Mono = codes / tabular numbers.

--- a/client/src/pages/MultiplayerPage.tsx
+++ b/client/src/pages/MultiplayerPage.tsx
@@ -50,7 +50,6 @@ type PendingAction =
       password?: string;
       format?: GameFormat;
       isP2P?: boolean;
-      reservationToken?: string | null;
       /**
        * Full lobby row, populated when the join originated from a lobby list
        * click (not from a typed code). Lets the deck-select view render
@@ -291,24 +290,14 @@ export function MultiplayerPage() {
    * is referenced as an identifier (stable across renders via React).
    */
   const joinP2PRoom = useCallback(
-    async (
-      code: string,
-      initialPassword?: string,
-      reservationToken?: string | null,
-    ): Promise<boolean> => {
+    async (code: string, initialPassword?: string): Promise<boolean> => {
       let password = initialPassword;
       while (true) {
-        const result = await resolveGuestFromStore(code, password, { reservationToken });
+        const result = await resolveGuestFromStore(code, password);
         if (result.ok) {
           const gameId = crypto.randomUUID();
           useGameStore.setState({ gameId });
           const roomCode = stripPeerIdPrefix(result.peerInfo.host_peer_id);
-          if (result.peerInfo.reservation_token) {
-            window.sessionStorage.setItem(
-              `phase-p2p-reservation:${roomCode}`,
-              result.peerInfo.reservation_token,
-            );
-          }
           navigate(`/game/${gameId}?mode=p2p-join&code=${roomCode}`);
           return true;
         }
@@ -482,7 +471,7 @@ export function MultiplayerPage() {
         const { code, password, context } = action;
 
         if (context?.is_p2p === true || action.isP2P === true) {
-          return joinP2PRoom(code, password, action.reservationToken);
+          return joinP2PRoom(code, password);
         }
 
         const p2pCode = parseRoomCode(code);
@@ -498,12 +487,7 @@ export function MultiplayerPage() {
         saveActiveGame({ id: gameId, mode: "online", difficulty: "" });
         useGameStore.setState({ gameId });
         const params = new URLSearchParams({ mode: "join", code });
-        if (action.reservationToken) {
-          window.sessionStorage.setItem(
-            `phase-join-reservation:${code}`,
-            action.reservationToken,
-          );
-        }
+        window.sessionStorage.removeItem(`phase-join-reservation:${code}`);
         if (password) {
           params.set("password", password);
         }
@@ -614,25 +598,18 @@ export function MultiplayerPage() {
       let resolvedFormat = format;
       let resolvedPassword = password;
       let resolvedIsP2P = context?.is_p2p === true;
-      let reservationToken: string | null = null;
-      const reserveOptions = {
-        reserve: true,
-        displayName: useMultiplayerStore.getState().displayName || "Player",
-      };
-      const result = await lookupJoinTargetFromStore(code, resolvedPassword, reserveOptions);
+      const result = await lookupJoinTargetFromStore(code, resolvedPassword);
       if (result.ok) {
         resolvedFormat = result.info.format_config?.format ?? resolvedFormat;
         resolvedIsP2P = result.info.is_p2p;
-        reservationToken = result.info.reservation_token ?? null;
       } else if (result.reason === "password_required") {
         const entered = window.prompt(t("page.passwordPrompt"));
         if (!entered) return;
         resolvedPassword = entered;
-        const retry = await lookupJoinTargetFromStore(code, resolvedPassword, reserveOptions);
+        const retry = await lookupJoinTargetFromStore(code, resolvedPassword);
         if (retry.ok) {
           resolvedFormat = retry.info.format_config?.format ?? resolvedFormat;
           resolvedIsP2P = retry.info.is_p2p;
-          reservationToken = retry.info.reservation_token ?? null;
         } else {
           showToast(retry.message);
           return;
@@ -647,7 +624,6 @@ export function MultiplayerPage() {
         password: resolvedPassword,
         format: resolvedFormat,
         isP2P: resolvedIsP2P,
-        reservationToken,
         context,
       };
       setPendingAction(action);
@@ -658,13 +634,6 @@ export function MultiplayerPage() {
 
   const handleBack = () => {
     if (view === "deck-select") {
-      if (pendingAction?.type === "join" && pendingAction.reservationToken) {
-        void lookupJoinTargetFromStore(
-          pendingAction.code,
-          pendingAction.password,
-          { releaseReservationToken: pendingAction.reservationToken },
-        );
-      }
       // With a pending action the user clearly came from a host/join
       // attempt; without one they came from the "Change Deck" affordance,
       // and `deckSelectReturn` remembers which view rendered that button.

--- a/client/src/polyfills/__tests__/cryptoRandomUUID.test.ts
+++ b/client/src/polyfills/__tests__/cryptoRandomUUID.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createRandomUUID,
+  installCryptoRandomUUID,
+} from "../cryptoRandomUUID";
+
+const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+
+function setCrypto(value: Partial<Crypto> | undefined): void {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value,
+  });
+}
+
+afterEach(() => {
+  if (originalCryptoDescriptor) {
+    Object.defineProperty(globalThis, "crypto", originalCryptoDescriptor);
+  }
+});
+
+describe("crypto.randomUUID polyfill", () => {
+  it("creates RFC 4122 version 4 UUIDs from Web Crypto bytes", () => {
+    const uuid = createRandomUUID((array) => {
+      array.set([
+        0x00, 0x11, 0x22, 0x33,
+        0x44, 0x55,
+        0x66, 0x77,
+        0x88, 0x99,
+        0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+      ]);
+      return array;
+    });
+
+    expect(uuid).toBe("00112233-4455-4677-8899-aabbccddeeff");
+  });
+
+  it("installs randomUUID when getRandomValues exists but randomUUID does not", () => {
+    setCrypto({
+      getRandomValues: ((array: Uint8Array) => {
+        array.fill(0xab);
+        return array;
+      }) as unknown as Crypto["getRandomValues"],
+    });
+
+    installCryptoRandomUUID();
+
+    expect(globalThis.crypto.randomUUID()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("keeps the browser implementation when randomUUID already exists", () => {
+    const randomUUID = () => "native-random-uuid";
+    setCrypto({
+      getRandomValues: ((array: Uint8Array) => array) as unknown as Crypto["getRandomValues"],
+      randomUUID: randomUUID as Crypto["randomUUID"],
+    });
+
+    installCryptoRandomUUID();
+
+    expect(globalThis.crypto.randomUUID).toBe(randomUUID);
+  });
+});

--- a/client/src/polyfills/cryptoRandomUUID.ts
+++ b/client/src/polyfills/cryptoRandomUUID.ts
@@ -1,0 +1,28 @@
+type RandomUuid = `${string}-${string}-${string}-${string}-${string}`;
+type FillRandomValues = (bytes: Uint8Array) => Uint8Array;
+
+export function createRandomUUID(
+  getRandomValues: FillRandomValues = (bytes) => globalThis.crypto.getRandomValues(bytes),
+): RandomUuid {
+  const bytes = new Uint8Array(16);
+  getRandomValues(bytes);
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, "0"));
+  return `${hex[0]}${hex[1]}${hex[2]}${hex[3]}-${hex[4]}${hex[5]}-${hex[6]}${hex[7]}-${hex[8]}${hex[9]}-${hex[10]}${hex[11]}${hex[12]}${hex[13]}${hex[14]}${hex[15]}`;
+}
+
+export function installCryptoRandomUUID(): void {
+  if (!globalThis.crypto || typeof globalThis.crypto.randomUUID === "function") {
+    return;
+  }
+
+  Object.defineProperty(globalThis.crypto, "randomUUID", {
+    value: () => createRandomUUID(),
+    configurable: true,
+  });
+}
+
+installCryptoRandomUUID();

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -847,8 +847,6 @@ export function GameProvider({
             //    their original seat.
             const sessionKey = `phase-${code}`;
             const existing = await loadP2PSession(sessionKey);
-            const reservationToken =
-              window.sessionStorage.getItem(`phase-p2p-reservation:${code}`) ?? undefined;
             signal.throwIfAborted();
             const adapter = new P2PGuestAdapter(
               deckList,
@@ -857,7 +855,7 @@ export function GameProvider({
               conn,
               existing?.playerToken,
               useMultiplayerStore.getState().displayName || undefined,
-              reservationToken,
+              undefined,
               sessionKey,
             );
             p2pAdapter = adapter;
@@ -954,9 +952,9 @@ export function GameProvider({
       const sessionKey = `phase-join-password:${joinCode ?? ""}`;
       let password: string | undefined =
         (joinCode && window.sessionStorage.getItem(sessionKey)) || undefined;
-      const reservationSessionKey = `phase-join-reservation:${joinCode ?? ""}`;
-      const reservationToken: string | undefined =
-        (joinCode && window.sessionStorage.getItem(reservationSessionKey)) || undefined;
+      if (joinCode) {
+        window.sessionStorage.removeItem(`phase-join-reservation:${joinCode}`);
+      }
       if (!password && urlParams.has("password")) {
         password = urlParams.get("password") ?? undefined;
         if (password && joinCode) {
@@ -983,7 +981,7 @@ export function GameProvider({
           deck,
           wsMode === "join" ? joinCode : undefined,
           wsMode === "join" ? password : undefined,
-          wsMode === "join" ? reservationToken : undefined,
+          undefined,
           useMultiplayerStore.getState().displayName || "Player",
         );
 

--- a/client/src/services/__tests__/brokerClient.test.ts
+++ b/client/src/services/__tests__/brokerClient.test.ts
@@ -187,6 +187,38 @@ describe("lookupJoinTargetOver", () => {
     );
     await promise;
   });
+
+  it("defaults deck-selection lookups to non-reserving metadata reads", async () => {
+    const ws = new MockWebSocket();
+    const promise = lookupJoinTargetOver(makePhaseSocket(ws), "ABC123");
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: "LookupJoinTarget",
+        data: {
+          game_code: "ABC123",
+          password: null,
+          reserve: false,
+          display_name: null,
+          release_reservation_token: null,
+        },
+      }),
+    );
+
+    ws.deliver(
+      JSON.stringify({
+        type: "JoinTargetInfo",
+        data: {
+          game_code: "ABC123",
+          is_p2p: false,
+          player_count: 2,
+          filled_seats: 1,
+          match_config: { match_type: "Bo1" },
+        },
+      }),
+    );
+    await promise;
+  });
 });
 
 describe("subscribeLobbyOver", () => {

--- a/client/src/services/__tests__/multiplayerSession.test.ts
+++ b/client/src/services/__tests__/multiplayerSession.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearWsSession,
+  loadWsSession,
+  saveWsSession,
+  WS_SESSION_STORAGE_KEY,
+} from "../multiplayerSession";
+
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "localStorage",
+);
+
+function setLocalStorage(storage: Partial<Storage>): void {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+}
+
+function setMemoryLocalStorage(): void {
+  const items = new Map<string, string>();
+  setLocalStorage({
+    getItem: (key) => items.get(key) ?? null,
+    setItem: (key, value) => {
+      items.set(key, value);
+    },
+    removeItem: (key) => {
+      items.delete(key);
+    },
+    clear: () => {
+      items.clear();
+    },
+  });
+}
+
+beforeEach(() => {
+  setMemoryLocalStorage();
+});
+
+afterEach(() => {
+  if (originalLocalStorageDescriptor) {
+    Object.defineProperty(globalThis, "localStorage", originalLocalStorageDescriptor);
+  }
+});
+
+describe("multiplayer WebSocket session persistence", () => {
+  it("loads a valid reconnect session", () => {
+    const session = {
+      gameCode: "ABCDE",
+      playerToken: "token",
+      serverUrl: "wss://play.example/ws",
+      timestamp: Date.now(),
+    };
+
+    saveWsSession(session);
+
+    expect(loadWsSession()).toEqual(session);
+  });
+
+  it("removes expired reconnect sessions", () => {
+    localStorage.setItem(
+      WS_SESSION_STORAGE_KEY,
+      JSON.stringify({
+        gameCode: "ABCDE",
+        playerToken: "token",
+        serverUrl: "wss://play.example/ws",
+        timestamp: 0,
+      }),
+    );
+
+    expect(loadWsSession()).toBeNull();
+    expect(localStorage.getItem(WS_SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it("does not crash app startup when localStorage reads are blocked", () => {
+    setLocalStorage({
+      getItem: () => {
+        throw new Error("storage blocked");
+      },
+      removeItem: () => undefined,
+    });
+
+    expect(loadWsSession()).toBeNull();
+  });
+
+  it("does not crash hosting when localStorage writes are blocked", () => {
+    setLocalStorage({
+      setItem: () => {
+        throw new Error("quota exceeded");
+      },
+    });
+
+    expect(() => {
+      saveWsSession({
+        gameCode: "ABCDE",
+        playerToken: "token",
+        serverUrl: "wss://play.example/ws",
+        timestamp: Date.now(),
+      });
+    }).not.toThrow();
+  });
+
+  it("does not crash cleanup when localStorage removal is blocked", () => {
+    setLocalStorage({
+      removeItem: () => {
+        throw new Error("storage blocked");
+      },
+    });
+
+    expect(() => clearWsSession()).not.toThrow();
+  });
+});

--- a/client/src/services/multiplayerSession.ts
+++ b/client/src/services/multiplayerSession.ts
@@ -1,11 +1,21 @@
+import type { FormatConfig, MatchType } from "../adapter/types";
+
 export const WS_SESSION_STORAGE_KEY = "phase-ws-session";
 export const WS_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
+
+export interface WsHostSessionData {
+  formatConfig: FormatConfig;
+  timerSeconds: number | null;
+  matchType: MatchType;
+}
 
 export interface WsSessionData {
   gameCode: string;
   playerToken: string;
   serverUrl: string;
   timestamp: number;
+  hostSession?: WsHostSessionData;
+  hostIsPublic?: boolean;
 }
 
 export function isWsSessionValid(session: WsSessionData): boolean {

--- a/client/src/services/multiplayerSession.ts
+++ b/client/src/services/multiplayerSession.ts
@@ -23,10 +23,10 @@ export function isWsSessionValid(session: WsSessionData): boolean {
 }
 
 export function loadWsSession(): WsSessionData | null {
-  const raw = localStorage.getItem(WS_SESSION_STORAGE_KEY);
-  if (!raw) return null;
-
   try {
+    const raw = localStorage.getItem(WS_SESSION_STORAGE_KEY);
+    if (!raw) return null;
+
     const session = JSON.parse(raw) as WsSessionData;
     if (!isWsSessionValid(session)) {
       clearWsSession();
@@ -40,9 +40,17 @@ export function loadWsSession(): WsSessionData | null {
 }
 
 export function saveWsSession(session: WsSessionData): void {
-  localStorage.setItem(WS_SESSION_STORAGE_KEY, JSON.stringify(session));
+  try {
+    localStorage.setItem(WS_SESSION_STORAGE_KEY, JSON.stringify(session));
+  } catch {
+    // A blocked/quota-limited store disables reconnect persistence, not hosting.
+  }
 }
 
 export function clearWsSession(): void {
-  localStorage.removeItem(WS_SESSION_STORAGE_KEY);
+  try {
+    localStorage.removeItem(WS_SESSION_STORAGE_KEY);
+  } catch {
+    // Nothing else can be done if the browser refuses storage access.
+  }
 }

--- a/client/src/stores/__tests__/multiplayerStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.test.ts
@@ -1,6 +1,30 @@
 import { waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const localStorageItems = vi.hoisted(() => {
+  const items = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => items.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        items.set(key, value);
+      },
+      removeItem: (key: string) => {
+        items.delete(key);
+      },
+      clear: () => {
+        items.clear();
+      },
+      key: (index: number) => [...items.keys()][index] ?? null,
+      get length() {
+        return items.size;
+      },
+    },
+  });
+  return items;
+});
+
 import type { PlayerSlot } from "../../multiplayer/seatTypes";
 import { formatMetadata } from "../../data/formatRegistry";
 import {
@@ -9,6 +33,11 @@ import {
   type HostingSettings,
   useMultiplayerStore,
 } from "../multiplayerStore";
+import {
+  clearWsSession,
+  loadWsSession,
+  saveWsSession,
+} from "../../services/multiplayerSession";
 
 const p2pMocks = vi.hoisted(() => ({
   hostDestroy: vi.fn(),
@@ -22,6 +51,14 @@ const p2pMocks = vi.hoisted(() => ({
 
 const socketMocks = vi.hoisted(() => ({
   send: vi.fn(),
+  close: vi.fn(),
+  currentWs: null as {
+    send: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    onmessage: ((event: MessageEvent) => void) | null;
+    onerror: (() => void) | null;
+    onclose: (() => void) | null;
+  } | null,
 }));
 
 vi.mock("../../network/connection", () => ({
@@ -57,14 +94,18 @@ vi.mock("../../services/openPhaseSocket", () => ({
     }
   },
   openPhaseSocket: vi.fn(async () => ({
-    serverInfo: { mode: "Full", protocolVersion: 1 },
-    ws: {
+    serverInfo: { mode: "Full", protocolVersion: 13 },
+    ws: (() => {
+      const ws = {
       send: socketMocks.send,
       close: vi.fn(),
       onmessage: null,
       onerror: null,
       onclose: null,
-    },
+      };
+      socketMocks.currentWs = ws;
+      return ws;
+    })(),
   })),
   withReconnect: vi.fn(),
 }));
@@ -88,10 +129,19 @@ function hostingSettings(
   };
 }
 
+function emitServerMessage(type: string, data?: unknown): void {
+  socketMocks.currentWs?.onmessage?.({
+    data: JSON.stringify({ type, data }),
+  } as MessageEvent);
+}
+
 describe("multiplayerStore", () => {
   beforeEach(() => {
     useMultiplayerStore.getState().cancelHosting();
     vi.clearAllMocks();
+    socketMocks.currentWs = null;
+    localStorageItems.clear();
+    clearWsSession();
     useMultiplayerStore.setState({
       displayName: "",
       connectionStatus: "disconnected",
@@ -198,6 +248,122 @@ describe("multiplayerStore", () => {
       data: { ai_seats: unknown[] };
     };
     expect(frame.data.ai_seats).toEqual(aiSeats);
+  });
+
+  it("saves server-host metadata with the reconnect token while waiting for players", async () => {
+    useMultiplayerStore.getState().startHosting(
+      hostingSettings(),
+      {
+        main_deck: ["Forest"],
+        sideboard: [],
+        commander: ["Goreclaw, Terror of Qal Sisma"],
+      },
+    );
+
+    await waitFor(() => expect(socketMocks.send).toHaveBeenCalled());
+    emitServerMessage("GameCreated", {
+      game_code: "ABCDE",
+      player_token: "host-token",
+    });
+
+    expect(loadWsSession()).toMatchObject({
+      gameCode: "ABCDE",
+      playerToken: "host-token",
+      serverUrl: "ws://localhost:8787",
+      hostIsPublic: true,
+      hostSession: {
+        formatConfig: FORMAT_DEFAULTS.Commander,
+        timerSeconds: null,
+        matchType: "Bo1",
+      },
+    });
+  });
+
+  it("resumes a saved server-host room and receives joined-seat updates", async () => {
+    saveWsSession({
+      gameCode: "ABCDE",
+      playerToken: "host-token",
+      serverUrl: "ws://localhost:8787",
+      timestamp: Date.now(),
+      hostIsPublic: true,
+      hostSession: {
+        formatConfig: FORMAT_DEFAULTS.Commander,
+        timerSeconds: null,
+        matchType: "Bo1",
+      },
+    });
+
+    expect(useMultiplayerStore.getState().resumeServerHosting()).toBe(true);
+
+    await waitFor(() => expect(socketMocks.send).toHaveBeenCalled());
+    expect(JSON.parse(socketMocks.send.mock.calls[0][0] as string)).toEqual({
+      type: "Reconnect",
+      data: {
+        game_code: "ABCDE",
+        player_token: "host-token",
+      },
+    });
+
+    const slots: PlayerSlot[] = [
+      { playerId: 0, name: "Host", kind: { type: "HostHuman" } },
+      { playerId: 1, name: "Guest", kind: { type: "JoinedHuman" } },
+    ];
+    emitServerMessage("GameCreated", {
+      game_code: "ABCDE",
+      player_token: "host-token",
+    });
+    emitServerMessage("PlayerSlotsUpdate", { slots });
+
+    await waitFor(() => {
+      expect(useMultiplayerStore.getState()).toMatchObject({
+        hostingStatus: "waiting",
+        hostGameCode: "ABCDE",
+        hostIsPublic: true,
+        hostSession: {
+          formatConfig: FORMAT_DEFAULTS.Commander,
+          timerSeconds: null,
+          matchType: "Bo1",
+        },
+        playerSlots: slots,
+      });
+    });
+  });
+
+  it("does not resume ordinary in-game websocket sessions as pregame hosts", async () => {
+    saveWsSession({
+      gameCode: "ABCDE",
+      playerToken: "host-token",
+      serverUrl: "ws://localhost:8787",
+      timestamp: Date.now(),
+    });
+
+    expect(useMultiplayerStore.getState().resumeServerHosting()).toBe(false);
+    expect(socketMocks.send).not.toHaveBeenCalled();
+  });
+
+  it("removes pregame host metadata once the server starts the game", async () => {
+    useMultiplayerStore.getState().startHosting(
+      hostingSettings(),
+      {
+        main_deck: ["Forest"],
+        sideboard: [],
+        commander: ["Goreclaw, Terror of Qal Sisma"],
+      },
+    );
+    await waitFor(() => expect(socketMocks.send).toHaveBeenCalled());
+    emitServerMessage("GameCreated", {
+      game_code: "ABCDE",
+      player_token: "host-token",
+    });
+
+    emitServerMessage("GameStarted", {});
+
+    expect(loadWsSession()).toMatchObject({
+      gameCode: "ABCDE",
+      playerToken: "host-token",
+      serverUrl: "ws://localhost:8787",
+    });
+    expect(loadWsSession()?.hostSession).toBeUndefined();
   });
 
   it("applies setup-time AI seats when starting a P2P host session", async () => {

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -320,6 +320,7 @@ interface MultiplayerActions {
   setLatency: (ms: number | null) => void;
   // Hosting session actions
   startHosting: (settings: HostingSettings, deck: HostingDeck) => void;
+  resumeServerHosting: () => boolean;
   cancelHosting: () => void;
   clearPendingGameRoute: () => void;
   setServerInfo: (info: ServerInfo | null) => void;
@@ -526,6 +527,194 @@ export function migratePersistedMultiplayerState(
   return migrated;
 }
 
+type MultiplayerSet = (
+  partial:
+    | Partial<MultiplayerState>
+    | ((state: MultiplayerState) => Partial<MultiplayerState>),
+) => void;
+type MultiplayerGet = () => MultiplayerState & MultiplayerActions;
+
+function resetServerHostSession(set: MultiplayerSet): void {
+  clearWsSession();
+  set({
+    hostGameCode: null,
+    hostIsPublic: false,
+    hostingStatus: "idle",
+    hostSession: null,
+    playerSlots: [],
+  });
+}
+
+function savePregameHostSession(
+  get: MultiplayerGet,
+  data: { game_code: string; player_token: string },
+): void {
+  const existing = loadWsSession();
+  const hostSession = get().hostSession ?? existing?.hostSession;
+  saveWsSession({
+    gameCode: data.game_code,
+    playerToken: data.player_token,
+    serverUrl: get().serverAddress,
+    timestamp: Date.now(),
+    ...(hostSession ? { hostSession } : {}),
+    ...(hostSession ? { hostIsPublic: get().hostIsPublic } : {}),
+  });
+}
+
+function clearPregameHostMetadataFromWsSession(): void {
+  const session = loadWsSession();
+  if (!session) return;
+  saveWsSession({
+    gameCode: session.gameCode,
+    playerToken: session.playerToken,
+    serverUrl: session.serverUrl,
+    timestamp: Date.now(),
+  });
+}
+
+function handleServerHostMessage(
+  set: MultiplayerSet,
+  get: MultiplayerGet,
+  ws: WebSocket,
+  msg: { type: string; data?: unknown },
+): void {
+  if (msg.type === "GameCreated") {
+    const data = msg.data as { game_code: string; player_token: string };
+    savePregameHostSession(get, data);
+    // Reset reconnect counter on successful (re)connection.
+    hostReconnectAttempt = 0;
+    set({ hostGameCode: data.game_code, hostingStatus: "waiting" });
+  } else if (msg.type === "GameStarted") {
+    gameStartedFired = true;
+    clearPregameHostMetadataFromWsSession();
+    ws.close();
+    hostWs = null;
+    const gameId = crypto.randomUUID();
+    saveActiveGame({ id: gameId, mode: "online", difficulty: "" });
+    useGameStore.setState({ gameId });
+    const names = new Map<number, string>();
+    for (const slot of get().playerSlots) {
+      if (slot.name) names.set(slot.playerId, slot.name);
+    }
+    set({
+      hostGameCode: null,
+      hostingStatus: "idle",
+      hostSession: null,
+      playerNames: names,
+      playerSlots: [],
+      pendingGameRoute: `/game/${gameId}?mode=host`,
+    });
+  } else if (msg.type === "PlayerSlotsUpdate") {
+    const data = msg.data as { slots: PlayerSlot[] };
+    const prior = get().playerSlots;
+    const newJoiners = data.slots.filter((slot) => {
+      if (slot.kind.type !== "JoinedHuman") return false;
+      const before = prior.find((p) => p.playerId === slot.playerId);
+      return !before || before.kind.type !== "JoinedHuman";
+    });
+    set({ playerSlots: data.slots });
+    for (const joiner of newJoiners) {
+      get().showToast(`${joiner.name} joined the game.`);
+    }
+  } else if (msg.type === "Error") {
+    const data = msg.data as { message: string };
+    console.error("Host error:", data.message);
+    get().showToast(data.message || "Failed to create game.");
+    if (get().hostingStatus !== "waiting") {
+      get().cancelHosting();
+    }
+  }
+}
+
+async function openServerHostSocket(
+  set: MultiplayerSet,
+  get: MultiplayerGet,
+  setupFrame: () => unknown,
+  onReopen: () => void,
+): Promise<void> {
+  if (!isValidWebSocketUrl(get().serverAddress)) {
+    resetServerHostSession(set);
+    get().showToast("Invalid server address. Update it in Settings.");
+    return;
+  }
+
+  let socket;
+  try {
+    socket = await openPhaseSocket(get().serverAddress);
+  } catch (err) {
+    if (
+      err instanceof HandshakeError &&
+      err.kind === "protocol_mismatch"
+    ) {
+      get().showToast(err.message);
+      get().cancelHosting();
+      return;
+    }
+    if (!gameStartedFired) {
+      hostWs = null;
+      onReopen();
+    }
+    return;
+  }
+
+  set({ serverInfo: socket.serverInfo });
+  hostWs = socket.ws;
+
+  socket.ws.onmessage = (event) => {
+    const msg = JSON.parse(event.data as string) as {
+      type: string;
+      data?: unknown;
+    };
+    handleServerHostMessage(set, get, socket.ws, msg);
+  };
+  socket.ws.onerror = () => {
+    if (!gameStartedFired) {
+      hostWs = null;
+      onReopen();
+    }
+  };
+  socket.ws.onclose = () => {
+    if (!gameStartedFired && hostWs === socket.ws) {
+      hostWs = null;
+      onReopen();
+    }
+  };
+
+  socket.ws.send(JSON.stringify(setupFrame()));
+}
+
+function attemptServerHostReconnect(
+  set: MultiplayerSet,
+  get: MultiplayerGet,
+): void {
+  if (gameStartedFired) return;
+  const session = loadWsSession();
+  if (!session || hostReconnectAttempt >= HOST_MAX_RECONNECT_ATTEMPTS) {
+    resetServerHostSession(set);
+    get().showToast("Connection to server lost.");
+    return;
+  }
+
+  hostReconnectAttempt++;
+  const delay = Math.pow(2, hostReconnectAttempt - 1) * 1000;
+  hostReconnectTimer = setTimeout(() => {
+    hostReconnectTimer = null;
+    if (gameStartedFired) return;
+    void openServerHostSocket(
+      set,
+      get,
+      () => ({
+        type: "Reconnect",
+        data: {
+          game_code: session.gameCode,
+          player_token: session.playerToken,
+        },
+      }),
+      () => attemptServerHostReconnect(set, get),
+    );
+  }, delay);
+}
+
 export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>()(
   persist(
     (set, get) => ({
@@ -670,176 +859,9 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
           pendingGameRoute: null,
         });
 
-        // Shared post-handshake message handler. ServerHello is handled
-        // upstream by `openPhaseSocket`, so by the time we get here the
-        // server's identity is already known and compatible.
-        const handleHostMessage = (ws: WebSocket, msg: { type: string; data?: unknown }) => {
-          if (msg.type === "GameCreated") {
-            const data = msg.data as { game_code: string; player_token: string };
-            saveWsSession({
-              gameCode: data.game_code,
-              playerToken: data.player_token,
-              serverUrl: get().serverAddress,
-              timestamp: Date.now(),
-            });
-            // Reset reconnect counter on successful (re)connection
-            hostReconnectAttempt = 0;
-            set({ hostGameCode: data.game_code, hostingStatus: "waiting" });
-          } else if (msg.type === "GameStarted") {
-            gameStartedFired = true;
-            ws.close();
-            hostWs = null;
-            const gameId = crypto.randomUUID();
-            saveActiveGame({ id: gameId, mode: "online", difficulty: "" });
-            useGameStore.setState({ gameId });
-            const names = new Map<number, string>();
-            for (const slot of get().playerSlots) {
-              if (slot.name) names.set(slot.playerId, slot.name);
-            }
-            // Reset hosting state FIRST so tile hides, then set route
-            set({
-              hostGameCode: null,
-              hostingStatus: "idle",
-              hostSession: null,
-              playerNames: names,
-              playerSlots: [],
-              pendingGameRoute: `/game/${gameId}?mode=host`,
-            });
-          } else if (msg.type === "PlayerSlotsUpdate") {
-            const data = msg.data as { slots: PlayerSlot[] };
-            // Toast newly-arrived human guests so the host gets per-joiner
-            // feedback in 3+ player lobbies. Without this, only the first
-            // joiner is signaled (via the `gameCreated` → `GameStarted`
-            // boundary in ws-adapter); subsequent guests appear silently in
-            // the slot list. Diff against the prior `playerSlots` snapshot:
-            // any slot whose seat transitioned from non-human-occupied to
-            // `JoinedHuman` is a fresh guest.
-            const prior = get().playerSlots;
-            const newJoiners = data.slots.filter((slot) => {
-              if (slot.kind.type !== "JoinedHuman") return false;
-              const before = prior.find((p) => p.playerId === slot.playerId);
-              return !before || before.kind.type !== "JoinedHuman";
-            });
-            set({ playerSlots: data.slots });
-            for (const joiner of newJoiners) {
-              get().showToast(`${joiner.name} joined the game.`);
-            }
-          } else if (msg.type === "Error") {
-            const data = msg.data as { message: string };
-            console.error("Host error:", data.message);
-            get().showToast(data.message || "Failed to create game.");
-            // Keep the pregame lobby open for recoverable errors (failed
-            // Start, seat edits, bracket checks). Only tear down when we
-            // never reached a lobby or the connection itself failed.
-            if (get().hostingStatus !== "waiting") {
-              get().cancelHosting();
-            }
-          }
-        };
-
-        // Open a phase socket (handshake + version gate) then attach our
-        // post-handshake message/close handlers and send `setupFrame`. All
-        // callers (initial connect + reconnect) funnel through here so the
-        // handshake policy lives in one place.
-        const openHostSocket = async (
-          setupFrame: () => unknown,
-          onReopen: () => void,
-        ): Promise<void> => {
-          if (!isValidWebSocketUrl(get().serverAddress)) {
-            clearWsSession();
-            set({
-              hostGameCode: null,
-              hostIsPublic: false,
-              hostingStatus: "idle",
-              hostSession: null,
-              playerSlots: [],
-            });
-            get().showToast("Invalid server address. Update it in Settings.");
-            return;
-          }
-
-          let socket;
-          try {
-            socket = await openPhaseSocket(get().serverAddress);
-          } catch (err) {
-            if (
-              err instanceof HandshakeError &&
-              err.kind === "protocol_mismatch"
-            ) {
-              get().showToast(err.message);
-              get().cancelHosting();
-              return;
-            }
-            if (!gameStartedFired) {
-              hostWs = null;
-              onReopen();
-            }
-            return;
-          }
-
-          set({ serverInfo: socket.serverInfo });
-          hostWs = socket.ws;
-
-          socket.ws.onmessage = (event) => {
-            const msg = JSON.parse(event.data as string) as {
-              type: string;
-              data?: unknown;
-            };
-            handleHostMessage(socket.ws, msg);
-          };
-          socket.ws.onerror = () => {
-            if (!gameStartedFired) {
-              hostWs = null;
-              onReopen();
-            }
-          };
-          socket.ws.onclose = () => {
-            if (!gameStartedFired && hostWs === socket.ws) {
-              hostWs = null;
-              onReopen();
-            }
-          };
-
-          socket.ws.send(JSON.stringify(setupFrame()));
-        };
-
-        // Attempt to reconnect the hosting WS using stored session token
-        const attemptHostReconnect = () => {
-          if (gameStartedFired) return;
-          const session = loadWsSession();
-          if (!session || hostReconnectAttempt >= HOST_MAX_RECONNECT_ATTEMPTS) {
-            // No session to reconnect or exhausted attempts — give up
-            clearWsSession();
-            set({
-              hostGameCode: null,
-              hostIsPublic: false,
-              hostingStatus: "idle",
-              hostSession: null,
-              playerSlots: [],
-            });
-            get().showToast("Connection to server lost.");
-            return;
-          }
-
-          hostReconnectAttempt++;
-          const delay = Math.pow(2, hostReconnectAttempt - 1) * 1000;
-          hostReconnectTimer = setTimeout(() => {
-            hostReconnectTimer = null;
-            if (gameStartedFired) return;
-            void openHostSocket(
-              () => ({
-                type: "Reconnect",
-                data: {
-                  game_code: session.gameCode,
-                  player_token: session.playerToken,
-                },
-              }),
-              attemptHostReconnect,
-            );
-          }, delay);
-        };
-
-        void openHostSocket(
+        void openServerHostSocket(
+          set,
+          get,
           () => ({
             type: "CreateGameWithSettings",
             data: {
@@ -860,8 +882,45 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
               ranked: settings.ranked,
             },
           }),
-          attemptHostReconnect,
+          () => attemptServerHostReconnect(set, get),
         );
+      },
+
+      resumeServerHosting: () => {
+        if (hostWs || get().hostingStatus !== "idle") {
+          return get().hostingStatus !== "idle";
+        }
+
+        const session = loadWsSession();
+        if (!session?.hostSession || session.serverUrl !== get().serverAddress) {
+          return false;
+        }
+
+        gameStartedFired = false;
+        hostReconnectAttempt = 0;
+        set({
+          hostIsPublic: session.hostIsPublic ?? false,
+          hostingStatus: "connecting",
+          hostGameCode: null,
+          hostSession: session.hostSession,
+          pendingGameRoute: null,
+          playerSlots: [],
+        });
+
+        void openServerHostSocket(
+          set,
+          get,
+          () => ({
+            type: "Reconnect",
+            data: {
+              game_code: session.gameCode,
+              player_token: session.playerToken,
+            },
+          }),
+          () => attemptServerHostReconnect(set, get),
+        );
+
+        return true;
       },
 
       cancelHosting: () => {

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -26,7 +26,6 @@ import {
   type LookupJoinTargetResult,
   type RegisterHostRequest,
   type ResolveResult,
-  type ResolveGuestOptions,
 } from "../services/brokerClient";
 import {
   HandshakeError,
@@ -353,11 +352,7 @@ interface MultiplayerActions {
    * alive. Does NOT navigate — the caller inspects the result and handles
    * password retry, build mismatch, etc. before navigation.
    */
-  resolveGuest: (
-    code: string,
-    password?: string,
-    opts?: Pick<ResolveGuestOptions, "reservationToken">,
-  ) => Promise<ResolveResult>;
+  resolveGuest: (code: string, password?: string) => Promise<ResolveResult>;
   /**
    * Read-only typed-code lookup. Returns format/routing metadata without
    * consuming a seat.
@@ -1302,7 +1297,7 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
         subscriptionReconnect = null;
       },
 
-      resolveGuest: async (code, password, opts) => {
+      resolveGuest: async (code, password) => {
         const socket = await get().ensureSubscriptionSocket();
         if (!socket) {
           return {
@@ -1319,7 +1314,6 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
         try {
           return await resolveGuestOver(socket, code, password, {
             signal: ac.signal,
-            reservationToken: opts?.reservationToken,
             // The broker rejects a blank display_name on the resolve frame
             // (required-label rule) and the worker shell drops it without a
             // reply — the guest then times out at deck-select. Always carry


### PR DESCRIPTION
## Summary

Restores server-hosted pregame rooms after a browser reload by persisting host-session metadata with the WebSocket reconnect token. Also moves LAN HTTP `crypto.randomUUID()` support into client source and fixes the join flow so connection-scoped seat reservation tokens are not carried from a lobby lookup socket into a later game join socket.

## Behavioral note

The reservation issue is easiest to hit on Full-mode servers. The official multiplayer deployment currently behaves as a LobbyOnly broker, so the pre-fix P2P join path resolved the guest over the same long-lived lobby socket that created the reservation. Full-mode self-hosted servers run the actual game on the server, so deck selection previously reserved a seat on the lobby socket, then the game route opened a new WebSocket and tried to use that token there. The server correctly rejected that as a foreign reservation.

Seat reservations are intentionally bound to the WebSocket connection that received them. This PR keeps the deck-selection lookup read-only and clears stale reservation handoff storage before opening the game WebSocket.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):

> Frontend/client-only multiplayer persistence, browser runtime, and join-flow fixes. This does not change `crates/engine/` parser, effects, resolver, targeting, or rules behavior.

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

None.

## Verification

- `./node_modules/.bin/vitest run src/services/__tests__/multiplayerSession.test.ts src/polyfills/__tests__/cryptoRandomUUID.test.ts src/stores/__tests__/multiplayerStore.test.ts` — passed, 25 tests.
- `./node_modules/.bin/vitest run src/services/__tests__/brokerClient.test.ts src/stores/__tests__/multiplayerStore.test.ts src/services/__tests__/multiplayerSession.test.ts src/polyfills/__tests__/cryptoRandomUUID.test.ts` — passed, 34 tests.
- `node ../scripts/check-protocol-version.mjs && ./node_modules/.bin/tsc -b --noEmit` — passed.
- `./node_modules/.bin/eslint src/pages/MultiplayerPage.tsx src/providers/GameProvider.tsx src/stores/multiplayerStore.ts src/services/__tests__/brokerClient.test.ts` — passed.
- `cargo test -p lobby-broker foreign_` — passed, 2 tests.
- Live `ServerHello` comparison confirmed the official multiplayer deployment is LobbyOnly while the affected self-hosted deployment was Full mode.
- Self-hosted Full-mode deploy from `a56056306301f60a2f53cbb078d513ac7ec41378` verified the expected build commit, protocol version, and Full mode in `ServerHello`.
- Served bundle check in the self-hosted deployment confirmed join lookup calls the store without reservation options, and the online join path clears stale `phase-join-reservation:*` storage before navigation.
- Post-deploy server log check found no `You may only release or use a seat reservation issued to this connection` errors after the fix.
- Manual self-hosted Full-mode verification: a host room survived browser reload and a guest could join afterward.
