### PR TITLE
feat(parser): compound player+object hexproof/shroud static (CR 702.11 / CR 702.18 / CR 611.3a)

### DIFF
--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -1429,10 +1429,14 @@ pub fn player_cannot_be_targeted_by(
         return true;
     }
     // CR 702.11c: hexproof on a player — can't be the target of spells or
-    // abilities opponents control.
+    // abilities opponents control. CR 102.2 / CR 102.3: "opponent" is team-aware
+    // (2HG teammates are not opponents), so reuse `players::is_opponent` rather
+    // than a bare `ctrl != player_id` inequality that would treat teammates as
+    // opponents.
     let source_controller = state.objects.get(&source_id).map(|o| o.controller);
     if player_has_hexproof(state, player_id)
-        && source_controller.is_some_and(|ctrl| ctrl != player_id)
+        && source_controller
+            .is_some_and(|ctrl| crate::game::players::is_opponent(state, player_id, ctrl))
     {
         return true;
     }
@@ -3027,6 +3031,60 @@ mod tests {
         assert!(
             !player_cannot_be_targeted_by(&state, PlayerId(0), own_source),
             "hexproof player may still be targeted by their own spells"
+        );
+    }
+
+    /// CR 702.11c + CR 102.2 / CR 102.3: In 2HG, a teammate is not an opponent,
+    /// so player hexproof must not block a teammate source while still blocking
+    /// the opposing team.
+    #[test]
+    fn player_cannot_be_targeted_by_hexproof_allows_2hg_teammate() {
+        use crate::types::format::FormatConfig;
+
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+        // 2HG seats: P0+P1 one team, P2+P3 the other. Grant hexproof to P0.
+        let grantor = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "You Have Hexproof".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&grantor).unwrap().static_definitions =
+            vec![
+                StaticDefinition::new(StaticMode::Hexproof).affected(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+            ]
+            .into();
+        crate::game::layers::flush_layers(&mut state);
+
+        let teammate_source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Teammate Source".to_string(),
+            Zone::Battlefield,
+        );
+        let opposing_source = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(2),
+            "Opposing Team Source".to_string(),
+            Zone::Battlefield,
+        );
+
+        assert!(
+            player_has_hexproof(&state, PlayerId(0)),
+            "P0 must still report player hexproof in 2HG"
+        );
+        assert!(
+            !player_cannot_be_targeted_by(&state, PlayerId(0), teammate_source),
+            "2HG teammate must still be able to target the hexproof player"
+        );
+        assert!(
+            player_cannot_be_targeted_by(&state, PlayerId(0), opposing_source),
+            "opposing-team source must still be blocked by player hexproof"
         );
     }
 

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -2995,7 +2995,7 @@ mod tests {
                 )),
             ]
             .into();
-        crate::game::layers::apply_continuous_effects(&mut state);
+        crate::game::layers::flush_layers(&mut state);
 
         let opponent_source = create_object(
             &mut state,
@@ -3048,7 +3048,7 @@ mod tests {
                 )),
             ]
             .into();
-        crate::game::layers::apply_continuous_effects(&mut state);
+        crate::game::layers::flush_layers(&mut state);
 
         let opponent_source = create_object(
             &mut state,

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -574,7 +574,10 @@ fn handle_flashback(
     }]
 }
 
-/// Handler for Shroud -- permanent cannot be the target of spells or abilities.
+/// CR 702.18a: Shroud — surfaces a RuleModification marker for registry/
+/// coverage consumers. Permanent-scope shroud is enforced via
+/// `Keyword::Shroud` on the object; player-scope shroud (`StaticMode::Shroud`
+/// on a player-affected static) is enforced by [`player_cannot_be_targeted_by`].
 fn handle_shroud(
     _state: &GameState,
     _mode: &StaticMode,
@@ -586,10 +589,11 @@ fn handle_shroud(
 }
 
 /// CR 702.11: Hexproof — surfaces a RuleModification marker so downstream
-/// coverage/registry consumers see the grant. Runtime targeting for
-/// permanent-scope hexproof flows through `Keyword::Hexproof` on the object
-/// (granted via `ContinuousModification::AddKeyword` paths); the player-scope
-/// marker mirrors `handle_shroud`.
+/// coverage/registry consumers see the grant. Permanent-scope hexproof flows
+/// through `Keyword::Hexproof` on the object (`AddKeyword` paths). Player-scope
+/// hexproof (`StaticMode::Hexproof` on a player-affected static — Crystal
+/// Barricade / Sigarda's player half) is enforced by
+/// [`player_cannot_be_targeted_by`] (CR 702.11c).
 fn handle_hexproof(
     _state: &GameState,
     _mode: &StaticMode,
@@ -1368,11 +1372,79 @@ pub fn player_has_protection_from_everything(state: &GameState, player_id: Playe
     false
 }
 
+/// CR 702.11c: Whether `player_id` currently has hexproof as a player.
+///
+/// True when a functioning `StaticMode::Hexproof` static's `affected` filter
+/// matches the player (Battlefield/command-zone grantors — Sigarda's player
+/// half, "You have hexproof.") or when a transient continuous effect grants
+/// `AddStaticMode { Hexproof }` to that player specifically. Does **not**
+/// inspect permanent-scope `Keyword::Hexproof` (that is the object target path
+/// in `targeting::can_target`).
+pub fn player_has_hexproof(state: &GameState, player_id: PlayerId) -> bool {
+    check_static_ability(
+        state,
+        StaticMode::Hexproof,
+        &StaticCheckContext {
+            player_id: Some(player_id),
+            ..Default::default()
+        },
+    ) || transient_grants_static_mode_to_player(state, player_id, &StaticMode::Hexproof)
+}
+
+/// CR 702.18a: Whether `player_id` currently has shroud as a player.
+///
+/// Symmetric to [`player_has_hexproof`] for `StaticMode::Shroud` / transient
+/// `AddStaticMode { Shroud }` grants. Permanent-scope shroud stays on the
+/// object keyword path.
+pub fn player_has_shroud(state: &GameState, player_id: PlayerId) -> bool {
+    check_static_ability(
+        state,
+        StaticMode::Shroud,
+        &StaticCheckContext {
+            player_id: Some(player_id),
+            ..Default::default()
+        },
+    ) || transient_grants_static_mode_to_player(state, player_id, &StaticMode::Shroud)
+}
+
+/// CR 702.11c + CR 702.18a + CR 702.16b: Single authority for whether a player
+/// may be chosen as a target of the spell/ability identified by `source_id`.
+///
+/// Invoked by every player-candidate enumeration in `targeting` (typed player
+/// filters, `Any`/`add_players`, and specific-player pins). Composes:
+/// - Shroud — blocks **every** source (CR 702.18a), including the player's own;
+/// - Hexproof — blocks only **opponents'** sources (CR 702.11c);
+/// - Protection — quality match against the source (CR 702.16b / CR 702.16j).
+///
+/// Detection Tower–class `IgnoreHexproof` does **not** bypass player hexproof:
+/// CR 702.11e speaks to choosing a *creature* as though it lacked hexproof.
+pub fn player_cannot_be_targeted_by(
+    state: &GameState,
+    player_id: PlayerId,
+    source_id: ObjectId,
+) -> bool {
+    // CR 702.18a: shroud on a player — can't be the target of spells or abilities
+    // from any player.
+    if player_has_shroud(state, player_id) {
+        return true;
+    }
+    // CR 702.11c: hexproof on a player — can't be the target of spells or
+    // abilities opponents control.
+    let source_controller = state.objects.get(&source_id).map(|o| o.controller);
+    if player_has_hexproof(state, player_id)
+        && source_controller.is_some_and(|ctrl| ctrl != player_id)
+    {
+        return true;
+    }
+    // CR 702.16b + CR 702.16j: protection from the source.
+    player_protection_from(state, player_id, Some(source_id))
+}
+
 /// CR 702.16: Single authority for player-scoped protection enforcement.
 ///
 /// Returns `true` if `player_id` has protection from `source` (identified by
-/// `source` ObjectId). Consulted by targeting (CR 702.16b) and damage
-/// prevention (CR 702.16e + CR 615.1).
+/// `source` ObjectId). Consulted by targeting (via [`player_cannot_be_targeted_by`],
+/// CR 702.16b) and damage prevention (CR 702.16e + CR 615.1).
 ///
 /// Short-circuits on `player_has_protection_from_everything` (the transient-
 /// effect `Everything` authority, CR 702.16j), then scans battlefield/command-
@@ -2901,6 +2973,107 @@ mod tests {
         assert!(
             !player_protection_from(&state, PlayerId(1), Some(own_source)),
             "the opponent gains no protection — affected is the controller only"
+        );
+    }
+
+    /// CR 702.11c: A functioning player-scope `StaticMode::Hexproof` makes its
+    /// controller illegal as an opponent's target, but not as their own.
+    #[test]
+    fn player_cannot_be_targeted_by_respects_player_hexproof() {
+        let mut state = setup();
+        let grantor = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "You Have Hexproof".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&grantor).unwrap().static_definitions =
+            vec![
+                StaticDefinition::new(StaticMode::Hexproof).affected(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+            ]
+            .into();
+        crate::game::layers::apply_continuous_effects(&mut state);
+
+        let opponent_source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Opponent Source".to_string(),
+            Zone::Battlefield,
+        );
+        let own_source = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Own Source".to_string(),
+            Zone::Battlefield,
+        );
+
+        assert!(
+            player_has_hexproof(&state, PlayerId(0)),
+            "controller must report player hexproof"
+        );
+        assert!(
+            !player_has_hexproof(&state, PlayerId(1)),
+            "opponent is not hexproof"
+        );
+        assert!(
+            player_cannot_be_targeted_by(&state, PlayerId(0), opponent_source),
+            "opponent may not target the hexproof player"
+        );
+        assert!(
+            !player_cannot_be_targeted_by(&state, PlayerId(0), own_source),
+            "hexproof player may still be targeted by their own spells"
+        );
+    }
+
+    /// CR 702.18a: Player shroud blocks targeting from every controller.
+    #[test]
+    fn player_cannot_be_targeted_by_respects_player_shroud() {
+        let mut state = setup();
+        let grantor = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "You Have Shroud".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&grantor).unwrap().static_definitions =
+            vec![
+                StaticDefinition::new(StaticMode::Shroud).affected(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+            ]
+            .into();
+        crate::game::layers::apply_continuous_effects(&mut state);
+
+        let opponent_source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Opponent Source".to_string(),
+            Zone::Battlefield,
+        );
+        let own_source = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Own Source".to_string(),
+            Zone::Battlefield,
+        );
+
+        assert!(player_has_shroud(&state, PlayerId(0)));
+        assert!(player_cannot_be_targeted_by(
+            &state,
+            PlayerId(0),
+            opponent_source
+        ));
+        assert!(
+            player_cannot_be_targeted_by(&state, PlayerId(0), own_source),
+            "shroud blocks the player's own targeting too"
         );
     }
 

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -4408,6 +4408,63 @@ mod tests {
         assert!(targets.contains(&TargetRef::Player(PlayerId(3))));
     }
 
+    /// CR 702.11c + CR 102.2 / CR 102.3: Player hexproof must not exclude a
+    /// 2HG teammate source from targeting the protected player, while still
+    /// blocking an opposing-team source.
+    #[test]
+    fn find_legal_targets_player_hexproof_allows_2hg_teammate_blocks_opposing() {
+        use crate::types::ability::{ControllerRef, StaticDefinition, TypedFilter};
+        use crate::types::format::FormatConfig;
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+        // Seats: P0+P1 one team, P2+P3 the other. Hexproof on P0.
+        let grantor = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "You Have Hexproof".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&grantor).unwrap().static_definitions =
+            vec![
+                StaticDefinition::new(StaticMode::Hexproof).affected(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+            ]
+            .into();
+        crate::game::layers::flush_layers(&mut state);
+
+        let teammate_source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Teammate Source".to_string(),
+            Zone::Battlefield,
+        );
+        let opposing_source = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(2),
+            "Opposing Team Source".to_string(),
+            Zone::Battlefield,
+        );
+
+        let teammate_targets =
+            find_legal_targets(&state, &TargetFilter::Any, PlayerId(1), teammate_source);
+        assert!(
+            teammate_targets.contains(&TargetRef::Player(PlayerId(0))),
+            "2HG teammate must still be able to target the hexproof player, got {teammate_targets:?}"
+        );
+
+        let opposing_targets =
+            find_legal_targets(&state, &TargetFilter::Any, PlayerId(2), opposing_source);
+        assert!(
+            !opposing_targets.contains(&TargetRef::Player(PlayerId(0))),
+            "opposing-team source must not target the hexproof player, got {opposing_targets:?}"
+        );
+    }
+
     fn make_resolved_with_targets(
         targets: Vec<TargetRef>,
         source: ObjectId,

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -201,12 +201,10 @@ fn find_legal_targets_with_context(
                 if player.is_eliminated {
                     continue;
                 }
-                // CR 702.16b + CR 702.16j: A player with protection from the
-                // spell/ability's source can't be targeted by it.
-                if super::static_abilities::player_protection_from(
-                    state,
-                    player.id,
-                    Some(source_id),
+                // CR 702.11c + CR 702.18a + CR 702.16b: Player-scope hexproof,
+                // shroud, and protection exclude illegal player targets.
+                if super::static_abilities::player_cannot_be_targeted_by(
+                    state, player.id, source_id,
                 ) {
                     continue;
                 }
@@ -1867,9 +1865,9 @@ fn add_players(state: &GameState, targets: &mut Vec<TargetRef>, source_id: Objec
         if player.is_eliminated {
             continue;
         }
-        // CR 702.16b: A player with protection from the spell/ability's source
-        // can't be targeted by it.
-        if super::static_abilities::player_protection_from(state, player.id, Some(source_id)) {
+        // CR 702.11c + CR 702.18a + CR 702.16b: Player-scope hexproof, shroud,
+        // and protection exclude illegal player targets.
+        if super::static_abilities::player_cannot_be_targeted_by(state, player.id, source_id) {
             continue;
         }
         targets.push(TargetRef::Player(player.id));
@@ -1888,7 +1886,7 @@ fn add_specific_player(
     if player.is_phased_out() || player.is_eliminated {
         return;
     }
-    if super::static_abilities::player_protection_from(state, player.id, Some(source_id)) {
+    if super::static_abilities::player_cannot_be_targeted_by(state, player.id, source_id) {
         return;
     }
     targets.push(TargetRef::Player(player.id));
@@ -4144,6 +4142,162 @@ mod tests {
             crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(0)),
             &state
         ));
+    }
+
+    /// CR 702.11c: A player with hexproof (Crystal Barricade / Sigarda player
+    /// half) cannot be targeted by an opponent, but remains a legal target of
+    /// their own spells/abilities.
+    #[test]
+    fn find_legal_targets_excludes_player_hexproof_from_opponents() {
+        use crate::types::ability::{ControllerRef, StaticDefinition, TypedFilter};
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new_two_player(42);
+        // Sigarda-class grantor on P0 carries player-scope Hexproof.
+        let grantor = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "You Have Hexproof Source".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&grantor).unwrap().static_definitions =
+            vec![
+                StaticDefinition::new(StaticMode::Hexproof).affected(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+            ]
+            .into();
+        crate::game::layers::apply_continuous_effects(&mut state);
+
+        let opponent_source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Opponent Bolt".to_string(),
+            Zone::Battlefield,
+        );
+        let own_source = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Own Targeting Spell".to_string(),
+            Zone::Battlefield,
+        );
+
+        let opponent_targets =
+            find_legal_targets(&state, &TargetFilter::Any, PlayerId(1), opponent_source);
+        assert!(
+            !opponent_targets.contains(&TargetRef::Player(PlayerId(0))),
+            "opponent must NOT be able to target a hexproof player, got {opponent_targets:?}"
+        );
+        assert!(
+            opponent_targets.contains(&TargetRef::Player(PlayerId(1))),
+            "opponent remains able to target themselves (no hexproof on P1)"
+        );
+
+        let own_targets = find_legal_targets(&state, &TargetFilter::Any, PlayerId(0), own_source);
+        assert!(
+            own_targets.contains(&TargetRef::Player(PlayerId(0))),
+            "controller may still target themselves despite having hexproof, got {own_targets:?}"
+        );
+    }
+
+    /// CR 702.11c: Typed "target opponent" enumeration must also exclude a
+    /// hexproof opponent (same branch as typed-player protection).
+    #[test]
+    fn find_legal_targets_typed_opponent_excludes_hexproof_player() {
+        use crate::types::ability::{ControllerRef, StaticDefinition, TypedFilter};
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new_two_player(42);
+        let grantor = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Hexproof Player Grantor".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&grantor).unwrap().static_definitions =
+            vec![
+                StaticDefinition::new(StaticMode::Hexproof).affected(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+            ]
+            .into();
+        crate::game::layers::apply_continuous_effects(&mut state);
+
+        let source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Target Opponent Spell".to_string(),
+            Zone::Battlefield,
+        );
+        let filter =
+            TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent));
+        let targets = find_legal_targets(&state, &filter, PlayerId(0), source);
+        assert!(
+            !targets.contains(&TargetRef::Player(PlayerId(1))),
+            "hexproof opponent must be excluded from typed Opponent targets, got {targets:?}"
+        );
+        assert!(
+            targets.is_empty(),
+            "no other opponent exists: expected empty, got {targets:?}"
+        );
+    }
+
+    /// CR 702.18a: Player shroud blocks targeting by **every** player, including
+    /// the shrouded player's own spells — stricter than hexproof.
+    #[test]
+    fn find_legal_targets_excludes_player_shroud_from_all_sources() {
+        use crate::types::ability::{ControllerRef, StaticDefinition, TypedFilter};
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new_two_player(42);
+        let grantor = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "You Have Shroud Source".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&grantor).unwrap().static_definitions =
+            vec![
+                StaticDefinition::new(StaticMode::Shroud).affected(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+            ]
+            .into();
+        crate::game::layers::apply_continuous_effects(&mut state);
+
+        let opponent_source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Opponent Bolt".to_string(),
+            Zone::Battlefield,
+        );
+        let own_source = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Own Targeting Spell".to_string(),
+            Zone::Battlefield,
+        );
+
+        let opponent_targets =
+            find_legal_targets(&state, &TargetFilter::Any, PlayerId(1), opponent_source);
+        assert!(
+            !opponent_targets.contains(&TargetRef::Player(PlayerId(0))),
+            "opponent must not target a shrouded player, got {opponent_targets:?}"
+        );
+
+        let own_targets = find_legal_targets(&state, &TargetFilter::Any, PlayerId(0), own_source);
+        assert!(
+            !own_targets.contains(&TargetRef::Player(PlayerId(0))),
+            "player shroud also blocks the player's own targeting, got {own_targets:?}"
+        );
     }
 
     /// CR 702.16b + CR 702.16j: A player with protection from everything

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -4168,7 +4168,7 @@ mod tests {
                 )),
             ]
             .into();
-        crate::game::layers::apply_continuous_effects(&mut state);
+        crate::game::layers::flush_layers(&mut state);
 
         let opponent_source = create_object(
             &mut state,
@@ -4225,7 +4225,7 @@ mod tests {
                 )),
             ]
             .into();
-        crate::game::layers::apply_continuous_effects(&mut state);
+        crate::game::layers::flush_layers(&mut state);
 
         let source = create_object(
             &mut state,
@@ -4269,7 +4269,7 @@ mod tests {
                 )),
             ]
             .into();
-        crate::game::layers::apply_continuous_effects(&mut state);
+        crate::game::layers::flush_layers(&mut state);
 
         let opponent_source = create_object(
             &mut state,

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -352,58 +352,119 @@ pub(crate) fn parse_compound_subject_rule_static(
     )
 }
 
-/// CR 702.16 + CR 609.6: Compound-subject keyword-grant statics of the form
-/// `"You and creatures you control have <keyword>"` — a single keyword grant
-/// bound to a player plus an object subset. A single `StaticDefinition` cannot
-/// carry both a player scope and an object scope, so decompose into two:
-///   - an object-half `Continuous` def whose `affected` is the object subset;
-///   - a player-half `PlayerProtection` def whose `affected` is the controller.
+/// CR 702.11 + CR 702.16 + CR 702.18 + CR 611.3a: Compound-subject keyword-grant
+/// statics of the form `"You and <object subject> have <keyword>"` — a single
+/// keyword grant bound to a player plus an object subset.
 ///
-/// Restricted to `Protection(_)` grants — the only player-applicable keyword
-/// with a runtime-implemented `PlayerProtection` mode. Returns `None` for any
-/// other granted keyword (a player cannot meaningfully "have flying").
+/// A single `StaticDefinition` cannot carry both a player scope and an object
+/// scope, so decompose into two:
+///   - an object-half `Continuous` def whose `affected` is the object subset;
+///   - a player-half def whose mode is the player-applicable keyword mode
+///     (`PlayerProtection` / `Hexproof` / `Shroud`) and whose `affected` is the
+///     controller.
+///
+/// Object subjects reuse [`parse_rule_static_subject_filter`] so subtype scopes
+/// ("Humans you control"), self refs ("this creature"), and "other <subtype>
+/// you control" all resolve — not a hard-coded alt of three controller phrases.
+///
+/// Only player-applicable keywords claim this pattern (a player cannot
+/// meaningfully "have flying"). Leading `"During your turn, "` gates both
+/// halves with `DuringYourTurn` (Gruul Spellbreaker). Trailing `" as long as
+/// <cond>"` is applied by `parse_continuous_gets_has` on the object half and
+/// then copied onto the player half; inverted `"As long as <cond>, …"` forms
+/// are rewritten to that trailing shape by the multi-dispatch path before
+/// reaching here.
 pub(crate) fn parse_compound_subject_keyword_static(
     text: &str,
     lower: &str,
 ) -> Option<Vec<StaticDefinition>> {
     type VE<'a> = OracleError<'a>;
 
-    // Subject: "you and <object subject phrase> ".
-    let (after_you, _) = tag::<_, _, VE<'_>>("you and ").parse(lower).ok()?;
-    let (predicate_lower, _) = alt((
-        tag::<_, _, VE<'_>>("creatures you control "),
-        tag("other creatures you control "),
-        tag("permanents you control "),
-    ))
-    .parse(after_you)
-    .ok()?;
+    // Optional leading turn window (Gruul Spellbreaker class).
+    let (body_lower, turn_condition) =
+        if let Ok((rest, _)) = tag::<_, _, VE<'_>>("during your turn, ").parse(lower) {
+            (rest, Some(StaticCondition::DuringYourTurn))
+        } else {
+            (lower, None)
+        };
 
-    // Map the matched lowercase spans back onto the original-case text so the
-    // object-subject filter and predicate retain their original casing.
-    let object_subject = text[text.len() - after_you.len()..text.len() - predicate_lower.len()]
+    // Subject: "you and <object subject phrase>".
+    let (after_you, _) = tag::<_, _, VE<'_>>("you and ").parse(body_lower).ok()?;
+
+    // Locate the continuous predicate verb ("have"/"has"/"gain"/"gains"/…) so
+    // the object subject can be any phrase `parse_rule_static_subject_filter`
+    // understands — not a hard-coded controller-phrase alt list.
+    let subject_end = find_continuous_predicate_start(after_you)?;
+    let object_subject_lower = after_you[..subject_end].trim();
+    let predicate_lower = after_you[subject_end..].trim();
+    if object_subject_lower.is_empty() || predicate_lower.is_empty() {
+        return None;
+    }
+
+    // Map the matched lowercase spans back onto the original-case text. When a
+    // leading turn window was peeled, recover its original-case body slice first.
+    // Do NOT trim body_original — its byte length must stay aligned with
+    // `body_lower` / `after_you` for the offset arithmetic below.
+    let body_original = if turn_condition.is_some() {
+        let prefix_len = lower.len() - body_lower.len();
+        text.get(prefix_len..)?
+    } else {
+        text
+    };
+    debug_assert_eq!(body_original.len(), body_lower.len());
+    let after_you_len = after_you.len();
+    let body_after_you_start = body_original.len().checked_sub(after_you_len)?;
+    let object_subject = body_original
+        .get(body_after_you_start..body_after_you_start + subject_end)?
         .trim()
         .trim_end_matches(' ');
-    let predicate = text[text.len() - predicate_lower.len()..].trim();
+    let predicate = body_original
+        .get(body_after_you_start + subject_end..)?
+        .trim();
 
     let affected = parse_rule_static_subject_filter(object_subject)?;
+    // Player half is reserved for the controller; refuse a second player scope
+    // ("you and each player have …") so we never emit two player defs.
+    if rule_static_affected_is_player_scope(&affected) {
+        return None;
+    }
 
-    // Object-half: delegate the predicate to the shared keyword-grant builder.
-    let object_def = parse_continuous_gets_has(predicate, affected, text)?;
+    // Object-half: delegate the predicate to the shared keyword-grant builder
+    // (also peels trailing " as long as <cond>" onto `object_def.condition`).
+    let mut object_def = parse_continuous_gets_has(predicate, affected, text)?;
 
-    // Extract the granted protection target — only `Protection(_)` grants get a
-    // player-half. Any other keyword (or no keyword) → not this pattern.
-    let protection_target = object_def.modifications.iter().find_map(|m| match m {
+    // Derive the player-half mode from the granted keyword. Only player-
+    // applicable keyword modes claim this pattern.
+    let player_mode = object_def.modifications.iter().find_map(|m| match m {
         ContinuousModification::AddKeyword {
             keyword: crate::types::keywords::Keyword::Protection(pt),
-        } => Some(pt.clone()),
+        } => Some(StaticMode::PlayerProtection(pt.clone())),
+        ContinuousModification::AddKeyword {
+            keyword: crate::types::keywords::Keyword::Hexproof,
+        } => Some(StaticMode::Hexproof),
+        ContinuousModification::AddKeyword {
+            keyword: crate::types::keywords::Keyword::Shroud,
+        } => Some(StaticMode::Shroud),
         _ => None,
     })?;
 
-    let player_def = StaticDefinition::new(StaticMode::PlayerProtection(protection_target))
+    // Propagate leading turn-window / trailing as-long-as gates onto both halves
+    // so the compound grant stays time-locked as one continuous effect (CR 611.3a).
+    object_def.condition = match (turn_condition, object_def.condition.take()) {
+        (Some(turn), Some(trailing)) => Some(StaticCondition::And {
+            conditions: vec![turn, trailing],
+        }),
+        (Some(turn), None) => Some(turn),
+        (None, Some(trailing)) => Some(trailing),
+        (None, None) => None,
+    };
+
+    let mut player_def = StaticDefinition::new(player_mode)
         .affected(TargetFilter::Typed(
             TypedFilter::default().controller(ControllerRef::You),
         ))
         .description(text.to_string());
+    player_def.condition = object_def.condition.clone();
 
     Some(vec![object_def, player_def])
 }

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -378,51 +378,30 @@ pub(crate) fn parse_compound_subject_keyword_static(
     text: &str,
     lower: &str,
 ) -> Option<Vec<StaticDefinition>> {
-    type VE<'a> = OracleError<'a>;
+    let input = TextPair::new(text, lower);
 
     // Optional leading turn window (Gruul Spellbreaker class).
-    let (body_lower, turn_condition) =
-        if let Ok((rest, _)) = tag::<_, _, VE<'_>>("during your turn, ").parse(lower) {
-            (rest, Some(StaticCondition::DuringYourTurn))
-        } else {
-            (lower, None)
-        };
+    let (body, turn_condition) = if let Some(rest) = nom_tag_tp(&input, "during your turn, ") {
+        (rest, Some(StaticCondition::DuringYourTurn))
+    } else {
+        (input, None)
+    };
 
     // Subject: "you and <object subject phrase>".
-    let (after_you, _) = tag::<_, _, VE<'_>>("you and ").parse(body_lower).ok()?;
+    let after_you = nom_tag_tp(&body, "you and ")?;
 
     // Locate the continuous predicate verb ("have"/"has"/"gain"/"gains"/…) so
     // the object subject can be any phrase `parse_rule_static_subject_filter`
     // understands — not a hard-coded controller-phrase alt list.
-    let subject_end = find_continuous_predicate_start(after_you)?;
-    let object_subject_lower = after_you[..subject_end].trim();
-    let predicate_lower = after_you[subject_end..].trim();
-    if object_subject_lower.is_empty() || predicate_lower.is_empty() {
+    let subject_end = find_continuous_predicate_start(after_you.lower)?;
+    let (object_subject, predicate) = after_you.split_at(subject_end);
+    let object_subject = object_subject.trim_start().trim_end();
+    let predicate = predicate.trim_start().trim_end();
+    if object_subject.is_empty() || predicate.is_empty() {
         return None;
     }
 
-    // Map the matched lowercase spans back onto the original-case text. When a
-    // leading turn window was peeled, recover its original-case body slice first.
-    // Do NOT trim body_original — its byte length must stay aligned with
-    // `body_lower` / `after_you` for the offset arithmetic below.
-    let body_original = if turn_condition.is_some() {
-        let prefix_len = lower.len() - body_lower.len();
-        text.get(prefix_len..)?
-    } else {
-        text
-    };
-    debug_assert_eq!(body_original.len(), body_lower.len());
-    let after_you_len = after_you.len();
-    let body_after_you_start = body_original.len().checked_sub(after_you_len)?;
-    let object_subject = body_original
-        .get(body_after_you_start..body_after_you_start + subject_end)?
-        .trim()
-        .trim_end_matches(' ');
-    let predicate = body_original
-        .get(body_after_you_start + subject_end..)?
-        .trim();
-
-    let affected = parse_rule_static_subject_filter(object_subject)?;
+    let affected = parse_rule_static_subject_filter(object_subject.original)?;
     // Player half is reserved for the controller; refuse a second player scope
     // ("you and each player have …") so we never emit two player defs.
     if rule_static_affected_is_player_scope(&affected) {
@@ -431,7 +410,7 @@ pub(crate) fn parse_compound_subject_keyword_static(
 
     // Object-half: delegate the predicate to the shared keyword-grant builder
     // (also peels trailing " as long as <cond>" onto `object_def.condition`).
-    let mut object_def = parse_continuous_gets_has(predicate, affected, text)?;
+    let mut object_def = parse_continuous_gets_has(predicate.original, affected, text)?;
 
     // Derive the player-half mode from the granted keyword. Only player-
     // applicable keyword modes claim this pattern.

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1222,6 +1222,29 @@ fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
         if !defs.is_empty() {
             return defs;
         }
+        // CR 702.11 + CR 702.18 + CR 611.3a: Inverted player+object compound
+        // keyword grants ("As long as <cond>, you and <objects> have hexproof")
+        // must decompose into TWO defs (object Continuous + player Hexproof/
+        // Shroud/PlayerProtection). The single-return inverted rewrite can only
+        // keep one def, so rewrite to the canonical trailing-gate form and
+        // re-enter through the multi compound-keyword splitter here.
+        let canon_lower = split.canonical.to_lowercase();
+        if let Some(mut defs) =
+            parse_compound_subject_keyword_static(&split.canonical, &canon_lower)
+        {
+            let condition = parse_static_condition(&split.condition_text).unwrap_or(
+                StaticCondition::Unrecognized {
+                    text: split.condition_text.clone(),
+                },
+            );
+            for def in &mut defs {
+                if def.condition.is_none() {
+                    def.condition = Some(condition.clone());
+                }
+                def.description = Some(stripped.to_string());
+            }
+            return defs;
+        }
     }
 
     // CR 601.2 + CR 602.5: City of Solitude class — "can cast spells and
@@ -1241,6 +1264,11 @@ fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
         return defs;
     }
 
+    // CR 702.11 + CR 702.16 + CR 702.18 + CR 611.3a: "You and <objects> have
+    // <player-applicable keyword>" (Sigarda / Serra's Emissary / Gruul Spellbreaker).
+    // Must claim before the single-return fallback, which otherwise emits one
+    // bogus Continuous Or{empty-typed You, objects} that grants the keyword to
+    // every permanent you control.
     if let Some(defs) = parse_compound_subject_keyword_static(&stripped, &lower) {
         return defs;
     }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -185,6 +185,207 @@ fn compound_subject_keyword_static_splits_serras_emissary() {
     );
 }
 
+/// CR 702.11c + CR 702.11b + CR 611.3a: Sigarda, Heron's Grace —
+/// "You and Humans you control have hexproof." must decompose into two defs,
+/// NOT a single Continuous Or{empty-typed You, …} that grants hexproof to every
+/// permanent you control (the live Discord bug / #5322).
+#[test]
+fn compound_subject_keyword_static_splits_sigarda_hexproof() {
+    use crate::types::keywords::Keyword;
+
+    let defs = parse_static_line_multi("You and Humans you control have hexproof.");
+    assert_eq!(
+        defs.len(),
+        2,
+        "expected object Continuous + player Hexproof, got {defs:?}"
+    );
+
+    let object_def = &defs[0];
+    assert_eq!(object_def.mode, StaticMode::Continuous);
+    match &object_def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert_eq!(
+                tf.get_subtype(),
+                Some("Human"),
+                "object-half must affect Humans, got {:?}",
+                tf.type_filters
+            );
+            assert!(
+                !tf.type_filters.is_empty() || tf.get_subtype().is_some(),
+                "object-half must not be the empty-typed You filter that layers treat as all permanents"
+            );
+        }
+        other => panic!("object-half affected must be Typed(Humans you control), got {other:?}"),
+    }
+    assert_eq!(
+        object_def.modifications,
+        vec![ContinuousModification::AddKeyword {
+            keyword: Keyword::Hexproof
+        }],
+    );
+
+    let player_def = &defs[1];
+    assert_eq!(player_def.mode, StaticMode::Hexproof);
+    assert_eq!(
+        player_def.affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You)
+        )),
+    );
+    // The player half must NOT also grant Keyword::Hexproof via Continuous mods
+    // (that would again empty-typed-filter into all permanents).
+    assert!(
+        player_def.modifications.is_empty(),
+        "player Hexproof mode carries no AddKeyword mods, got {:?}",
+        player_def.modifications
+    );
+}
+
+/// CR 702.11 + CR 611.3a: "You and permanents you control have hexproof."
+/// (I Am Untouchable / scheme static class).
+#[test]
+fn compound_subject_keyword_static_splits_permanents_hexproof() {
+    use crate::types::keywords::Keyword;
+
+    let defs = parse_static_line_multi("You and permanents you control have hexproof.");
+    assert_eq!(defs.len(), 2, "expected two defs, got {defs:?}");
+    assert_eq!(defs[0].mode, StaticMode::Continuous);
+    match &defs[0].affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Permanent),
+                "object-half must affect permanents you control, got {tf:?}"
+            );
+            // Empty-typed + You is the PLAYER filter — refuse that for the object half.
+            assert!(
+                !(tf.type_filters.is_empty() && tf.properties.is_empty()),
+                "object-half must not be empty-typed You (player scope misfiled as object): {tf:?}"
+            );
+        }
+        other => panic!("expected Typed permanents filter, got {other:?}"),
+    }
+    assert!(defs[0]
+        .modifications
+        .contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Hexproof
+        }));
+    assert_eq!(defs[1].mode, StaticMode::Hexproof);
+}
+
+/// CR 702.11 + CR 611.3a: Gruul Spellbreaker —
+/// "During your turn, you and this creature have hexproof."
+#[test]
+fn compound_subject_keyword_static_splits_gruul_spellbreaker_turn_gate() {
+    use crate::types::keywords::Keyword;
+
+    let defs = parse_static_line_multi("During your turn, you and this creature have hexproof.");
+    assert_eq!(defs.len(), 2, "expected two defs, got {defs:?}");
+
+    let object_def = &defs[0];
+    assert_eq!(object_def.mode, StaticMode::Continuous);
+    assert_eq!(object_def.affected, Some(TargetFilter::SelfRef));
+    assert!(object_def
+        .modifications
+        .contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Hexproof
+        }));
+    assert_eq!(
+        object_def.condition,
+        Some(StaticCondition::DuringYourTurn),
+        "leading turn window must gate the object half"
+    );
+
+    let player_def = &defs[1];
+    assert_eq!(player_def.mode, StaticMode::Hexproof);
+    assert_eq!(
+        player_def.condition,
+        Some(StaticCondition::DuringYourTurn),
+        "leading turn window must gate the player half"
+    );
+}
+
+/// CR 702.11 + CR 611.3a: Captain America, Super-Soldier —
+/// "As long as Captain America has a shield counter on him, you and other Heroes
+/// you control have hexproof." Inverted gate must still emit the two-def split.
+#[test]
+fn compound_subject_keyword_static_splits_inverted_as_long_as_heroes_hexproof() {
+    use crate::types::keywords::Keyword;
+
+    let defs = parse_static_line_multi(
+        "As long as Captain America has a shield counter on him, you and other Heroes you control have hexproof.",
+    );
+    assert_eq!(
+        defs.len(),
+        2,
+        "inverted compound hexproof must still split into two defs, got {defs:?}"
+    );
+
+    let object_def = &defs[0];
+    assert_eq!(object_def.mode, StaticMode::Continuous);
+    match &object_def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert_eq!(tf.get_subtype(), Some("Hero"));
+            assert!(
+                tf.properties.contains(&FilterProp::Another),
+                "other Heroes must carry FilterProp::Another, got {:?}",
+                tf.properties
+            );
+        }
+        other => panic!("expected Typed(other Heroes you control), got {other:?}"),
+    }
+    assert!(object_def
+        .modifications
+        .contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Hexproof
+        }));
+    assert!(
+        object_def.condition.is_some(),
+        "inverted as-long-as gate must land on the object half, got {:?}",
+        object_def.condition
+    );
+
+    let player_def = &defs[1];
+    assert_eq!(player_def.mode, StaticMode::Hexproof);
+    assert_eq!(
+        player_def.condition, object_def.condition,
+        "player half must share the object half's continuous gate"
+    );
+}
+
+/// CR 702.18a + CR 611.3a: Compound shroud sibling of the hexproof class.
+#[test]
+fn compound_subject_keyword_static_splits_you_and_creatures_shroud() {
+    use crate::types::keywords::Keyword;
+
+    let defs = parse_static_line_multi("You and creatures you control have shroud.");
+    assert_eq!(defs.len(), 2, "expected two defs, got {defs:?}");
+    assert_eq!(defs[0].mode, StaticMode::Continuous);
+    assert!(defs[0]
+        .modifications
+        .contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Shroud
+        }));
+    assert_eq!(defs[1].mode, StaticMode::Shroud);
+}
+
+/// Negative: a non-player-applicable keyword compound must NOT claim the
+/// compound-subject keyword splitter (a player cannot meaningfully "have flying").
+#[test]
+fn compound_subject_keyword_static_declines_flying_compound() {
+    let defs = parse_static_line_multi("You and creatures you control have flying.");
+    assert!(
+        defs.iter()
+            .all(|d| !matches!(d.mode, StaticMode::Hexproof | StaticMode::Shroud))
+            && !defs
+                .iter()
+                .any(|d| matches!(d.mode, StaticMode::PlayerProtection(_))),
+        "flying compound must not emit a player-scope keyword mode, got {defs:?}"
+    );
+}
+
 // CR 611.3a + CR 604.3 + CR 613.4a: Angry Mob — a two-clause turn-window CDA. "During
 // your turn, ~'s power and toughness are each equal to 2 plus the number of
 // Swamps your opponents control. During turns other than yours, ~'s power and


### PR DESCRIPTION
## Summary

- Generalizes `parse_compound_subject_keyword_static` from Protection-only / hard-coded controller subjects into the full **player + object compound keyword-grant** class (Hexproof / Shroud / Protection).
- Object subjects now reuse `parse_rule_static_subject_filter` (Humans, `this creature`, other Heroes, permanents, …).
- Emits two defs: object `Continuous{AddKeyword}` + player `StaticMode::{Hexproof,Shroud,PlayerProtection}` — fixes the Sigarda empty-typed `Or` misparse (#5322 class).
- Leading `During your turn,` and inverted `As long as <cond>,` gates both halves (Gruul Spellbreaker / Captain America).

Same structural pattern as #5219: dedicated compound handler before the incomplete single-subject sibling, reuse existing predicate builders, no new runtime modes.

Closes #5366

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo check -p engine --lib`
- [x] `./scripts/check-parser-combinators.sh` (Gate A exit 0)
- [ ] CI: `parser::oracle_static` compound_subject_keyword_static_* tests (Sigarda / permanents / Gruul / Cap / shroud / flying decline / Serra's Emissary regression)
- [ ] Confirm parse-diff sticky once CI posts for Life-and-Limb sibling class gains
