### PR TITLE
fix(parser): keep amass after 'lose life and …' compound (#5341)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2405,6 +2405,13 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     // trailing space; keep it in the bare-and splitter instead of letting the
     // Draw parser swallow it as an ignored tail.
     .or(value((), tag("proliferate")))
+    // CR 701.47a + CR 608.2c: "you lose 1 life and amass Zombies 1"
+    // (Dreadhorde Invasion — issue #5341) is two independent instructions.
+    // Without this arm the LoseLife half greedily swallows the whole chunk and
+    // the Amass conjunct is dropped, so the upkeep trigger only loses life.
+    // Trailing space mirrors other transitive keyword actions (`create `,
+    // `sacrifice `): amass always takes a subtype + count.
+    .or(value((), tag("amass ")))
     // CR 701.20a (issue #516): "reveal " as an imperative clause starter so
     // chains like "choose land or nonland and reveal cards from the top of
     // your library ..." split at the bare " and " and each half reaches its
@@ -7401,6 +7408,15 @@ mod tests {
         // Lotho: "you lose 1 life and create a Treasure token"
         let chunks = clause_texts("you lose 1 life and create a Treasure token");
         assert_eq!(chunks, vec!["you lose 1 life", "create a Treasure token"]);
+    }
+
+    #[test]
+    fn bare_and_splits_lose_life_and_amass() {
+        // CR 701.47a + CR 608.2c (issue #5341): Dreadhorde Invasion —
+        // "you lose 1 life and amass Zombies 1". Without splitting the Amass
+        // conjunct, LoseLife swallows the remainder and the Army never arrives.
+        let chunks = clause_texts("you lose 1 life and amass Zombies 1");
+        assert_eq!(chunks, vec!["you lose 1 life", "amass Zombies 1"]);
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -8252,6 +8252,35 @@ fn effect_chain_lose_life_and_endure_keeps_both_clauses() {
     );
 }
 
+// CR 701.47a + CR 608.2c (issue #5341): "you lose 1 life and amass Zombies 1"
+// — Amass must survive as a SequentialSibling; previously the LoseLife half
+// greedily absorbed the whole clause and the upkeep trigger never amassed.
+#[test]
+fn effect_chain_lose_life_and_amass_keeps_both_clauses() {
+    let def = parse_effect_chain("you lose 1 life and amass Zombies 1", AbilityKind::Spell);
+    assert!(
+        matches!(*def.effect, Effect::LoseLife { .. }),
+        "expected LoseLife head, got {:?}",
+        def.effect
+    );
+    let sub = def
+        .sub_ability
+        .expect("amass conjunct must survive as a sub_ability");
+    match *sub.effect {
+        Effect::Amass {
+            ref subtype,
+            ref count,
+        } => {
+            assert_eq!(subtype, "Zombie");
+            assert!(
+                matches!(count, QuantityExpr::Fixed { value: 1 }),
+                "expected Amass count 1, got {count:?}"
+            );
+        }
+        other => panic!("expected chained Amass{{Zombie, 1}}, got {other:?}"),
+    }
+}
+
 // CR 701.63: Endure — every printed card prefixes a self-referential
 // subject ("it endures N", "this creature endures N", "~ endures N" after
 // card-name normalization). The subject layer must strip the subject so the

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -7489,6 +7489,41 @@ fn trigger_you_cast_another_spell_keeps_another_filter() {
     );
 }
 
+/// CR 701.47a + CR 603.1 (issue #5341): Dreadhorde Invasion upkeep trigger —
+/// "you lose 1 life and amass Zombies 1" must keep Amass as a sub_ability.
+/// Coverage previously claimed support while only emitting LoseLife.
+#[test]
+fn dreadhorde_invasion_upkeep_lose_life_and_amass() {
+    let def = parse_trigger_line(
+        "At the beginning of your upkeep, you lose 1 life and amass Zombies 1.",
+        "Dreadhorde Invasion",
+    );
+    assert_eq!(def.mode, TriggerMode::Phase);
+    assert_eq!(def.phase, Some(Phase::Upkeep));
+    let execute = def.execute.expect("execute");
+    assert!(
+        matches!(*execute.effect, Effect::LoseLife { .. }),
+        "expected LoseLife head, got {:?}",
+        execute.effect
+    );
+    let sub = execute
+        .sub_ability
+        .expect("amass conjunct must survive as a sub_ability");
+    match *sub.effect {
+        Effect::Amass {
+            ref subtype,
+            ref count,
+        } => {
+            assert_eq!(subtype, "Zombie");
+            assert!(
+                matches!(count, QuantityExpr::Fixed { value: 1 }),
+                "expected Amass count 1, got {count:?}"
+            );
+        }
+        other => panic!("expected Amass{{Zombie, 1}}, got {other:?}"),
+    }
+}
+
 /// CR 603.4 + CR 122.1: "at the beginning of your end step, if there are
 /// thirty or more counters among artifacts and creatures you control, ..."
 /// — intervening-if with counter-count condition that sums across every

--- a/crates/engine/tests/dreadhorde_invasion_amass.rs
+++ b/crates/engine/tests/dreadhorde_invasion_amass.rs
@@ -8,17 +8,17 @@
 //!
 //! CR ANCHORS (verified against docs/MagicCompRules.txt):
 //!   * CR 701.47a — Amass [subtype] N creates an Army token / puts counters /
-//!                 adds the subtype.
-//!   * CR 603.1  — Triggered ability places on the stack and resolves its
-//!                 effect.
+//!     adds the subtype.
+//!   * CR 603.1 — Triggered ability places on the stack and resolves its
+//!     effect.
 //!   * CR 608.2c — Instructions are followed in written order (LoseLife then
-//!                 Amass).
+//!     Amass).
 //!
 //! CARD TEXT (verified from client/public/card-data.json):
-//!   "At the beginning of your upkeep, you lose 1 life and amass Zombies 1.
-//!    (Put a +1/+1 counter on an Army you control. It's also a Zombie. If you
-//!    don't control an Army, create a 0/0 black Zombie Army creature token
-//!    first.)"
+//! "At the beginning of your upkeep, you lose 1 life and amass Zombies 1.
+//! (Put a +1/+1 counter on an Army you control. It's also a Zombie. If you
+//! don't control an Army, create a 0/0 black Zombie Army creature token
+//! first.)"
 
 use engine::game::scenario::{GameScenario, P0};
 use engine::types::card_type::CoreType;

--- a/crates/engine/tests/dreadhorde_invasion_amass.rs
+++ b/crates/engine/tests/dreadhorde_invasion_amass.rs
@@ -1,0 +1,82 @@
+//! Runtime coverage for GitHub issue #5341: Dreadhorde Invasion's upkeep
+//! trigger must both lose 1 life AND amass Zombies 1.
+//!
+//! Coverage previously claimed support for the compound clause while the
+//! bare-" and " splitter omitted `amass`, so LoseLife swallowed the remainder
+//! and the Army never arrived. Parser + resolver pins here cover the class
+//! ("lose N life and amass [subtype] N"), not only this card.
+//!
+//! CR ANCHORS (verified against docs/MagicCompRules.txt):
+//!   * CR 701.47a — Amass [subtype] N creates an Army token / puts counters /
+//!                 adds the subtype.
+//!   * CR 603.1  — Triggered ability places on the stack and resolves its
+//!                 effect.
+//!   * CR 608.2c — Instructions are followed in written order (LoseLife then
+//!                 Amass).
+//!
+//! CARD TEXT (verified from client/public/card-data.json):
+//!   "At the beginning of your upkeep, you lose 1 life and amass Zombies 1.
+//!    (Put a +1/+1 counter on an Army you control. It's also a Zombie. If you
+//!    don't control an Army, create a 0/0 black Zombie Army creature token
+//!    first.)"
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::phase::Phase;
+
+const DREADHORDE_INVASION_ORACLE: &str = "At the beginning of your upkeep, you lose 1 life and amass Zombies 1. (Put a +1/+1 counter on an Army you control. It's also a Zombie. If you don't control an Army, create a 0/0 black Zombie Army creature token first.)\nWhenever a Zombie token you control with power 6 or greater attacks, it gains lifelink until end of turn.";
+
+#[test]
+fn dreadhorde_invasion_upkeep_amasses_zombie_army() {
+    let mut scenario = GameScenario::new();
+    // Start at Untap so advancing into Upkeep fires the synthesized phase
+    // trigger (CR 503.1a + CR 603.2).
+    scenario.at_phase(Phase::Untap);
+    scenario.with_life(P0, 20);
+    scenario
+        .add_creature(P0, "Dreadhorde Invasion", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(DREADHORDE_INVASION_ORACLE);
+
+    let mut runner = scenario.build();
+    runner.advance_to_upkeep();
+    // Resolve the upkeep trigger (LoseLife → Amass).
+    runner.resolve_top();
+
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        19,
+        "controller must lose 1 life from the upkeep trigger"
+    );
+
+    let armies: Vec<_> = runner
+        .state()
+        .battlefield
+        .iter()
+        .filter_map(|id| runner.state().objects.get(id))
+        .filter(|obj| {
+            obj.controller == P0
+                && obj.card_types.core_types.contains(&CoreType::Creature)
+                && obj.card_types.subtypes.iter().any(|s| s == "Army")
+        })
+        .collect();
+    assert_eq!(
+        armies.len(),
+        1,
+        "amass with no existing Army must create a Zombie Army token"
+    );
+    let army = armies[0];
+    assert!(army.is_token, "amassed Army must be a token");
+    assert!(
+        army.card_types.subtypes.iter().any(|s| s == "Zombie"),
+        "amassed Army must be a Zombie subtype"
+    );
+    assert_eq!(
+        army.counters.get(&CounterType::Plus1Plus1).copied(),
+        Some(1),
+        "amass Zombies 1 must put one +1/+1 counter on the Army"
+    );
+    assert_eq!(army.power, Some(1));
+    assert_eq!(army.toughness, Some(1));
+}


### PR DESCRIPTION
## Summary

Dreadhorde Invasion's upkeep trigger claimed coverage support but only resolved `LoseLife` — `amass Zombies 1` was dropped by the parser, so the Army never arrived. This fix teaches the bare-`" and "` clause splitter to treat `amass ` as an imperative clause starter so LoseLife + Amass compound instructions both survive.

Fixes [#5341](https://github.com/phase-rs/phase/issues/5341).

## Root cause

Coverage for

> At the beginning of your upkeep, you lose 1 life and amass Zombies 1.

marked the upkeep clause `supported: true`, but `parse_details` / card-data only emitted `LoseLife`. The bare-`" and "` splitter in `oracle_effect/sequence.rs` did not recognize `amass ` as a clause start, so the whole chunk stayed one clause and the LoseLife half greedily swallowed the Amass remainder.

Standalone amass (Herald of the Dreadhorde, Dreadhorde Twins) already worked — only the compound `"lose … life and amass …"` shape was broken.

## Changes

### Parser — bare-and clause starter

- Added `tag("amass ")` to `starts_bare_and_clause_lower` (CR 701.47a + CR 608.2c).
- Trailing space mirrors other transitive keyword actions (`create `, `sacrifice `): amass always takes a subtype + count.
- Covers the class of `"lose N life and amass [subtype] N"` compounds, not only this card.

### Tests

- Splitter: `bare_and_splits_lose_life_and_amass`
- Effect chain: `effect_chain_lose_life_and_amass_keeps_both_clauses`
- Trigger parse: `dreadhorde_invasion_upkeep_lose_life_and_amass`
- Runtime (GameScenario + real upkeep advance): `dreadhorde_invasion_upkeep_amasses_zombie_army` — controller loses 1 life and gets a Zombie Army token with one +1/+1 counter

## Out of scope

- Regenerating `card-data.json` / coverage so shipped card data reflects the Amass sub_ability (needs the usual card-data pipeline after merge).
- The second ability (Zombie token power ≥6 attacks → lifelink) was already parsed correctly and is unchanged.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p engine --lib bare_and_splits_lose_life_and_amass`
- [x] `cargo test -p engine --lib effect_chain_lose_life_and_amass`
- [x] `cargo test -p engine --lib dreadhorde_invasion_upkeep_lose_life_and_amass`
- [x] `cargo test -p engine --test dreadhorde_invasion_amass`
- [ ] After merge: regenerate card-data and confirm coverage children include Amass under the upkeep Phase trigger

## Risk notes

- The splitter change is additive: `amass ` was never treated as a noun-phrase continuation, so recognizing it as a clause start only unlocks previously dropped conjuncts.
- Existing solo-amass and LoseLife-only cards are unaffected.
