### PR TITLE
fix(client): restore opponent hand + avatar hover previews in split-board layout

### DIFF
--- a/client/src/components/board/OpponentSeatHeader.tsx
+++ b/client/src/components/board/OpponentSeatHeader.tsx
@@ -21,6 +21,7 @@ import {
   StatusBadge,
   UnboundedBadge,
 } from "../hud/HudBadges.tsx";
+import { AvatarHoverPreview } from "../hud/AvatarHoverPreview.tsx";
 import { KickConfirmDialog } from "../hud/KickConfirmDialog.tsx";
 import { NextUpBadge } from "../hud/NextUpBadge.tsx";
 
@@ -127,20 +128,36 @@ export function OpponentSeatHeader({ playerId, compact = false, onKickPlayer }: 
         />
       ) : null}
       <div className={`pointer-events-none absolute left-1/2 top-1/2 z-10 flex min-w-0 ${identityWidth} -translate-x-1/2 -translate-y-1/2 items-center justify-center ${compact ? "gap-1" : "gap-1.5"}`}>
-        <div
-          className={`flex shrink-0 items-center justify-center overflow-hidden rounded-md border bg-slate-950 font-bold text-white transition ${avatarSize} ${
-            isValidPlayerTarget ? "ring-2 ring-cyan-300/70" : ""
-          } ${isValidPlayerTarget ? "pointer-events-none" : ""}`}
-          style={{ borderColor: `${seatColor}cc`, backgroundColor: `${seatColor}44` }}
-          title={isValidPlayerTarget ? t("opponentHud.clickToTarget", { name: label }) : label}
-        >
-          {avatarUrl ? (
+        {avatarUrl ? (
+          // Portrait-preview on hover, matching the 1v1 OpponentHud avatar. The
+          // enclosing identity block is pointer-events-none, so the tile must
+          // re-enable pointer events to receive hover — except while this seat is
+          // a legal target, where the header's full-area target button must win.
+          <AvatarHoverPreview
+            avatarUrl={avatarUrl}
+            label={label}
+            seatColor={seatColor}
+            title={isValidPlayerTarget ? t("opponentHud.clickToTarget", { name: label }) : label}
+            className={`relative flex shrink-0 items-center justify-center overflow-hidden rounded-md border bg-slate-950 font-bold text-white transition ${avatarSize} ${
+              isValidPlayerTarget ? "pointer-events-none ring-2 ring-cyan-300/70" : "pointer-events-auto"
+            }`}
+            style={{ borderColor: `${seatColor}cc`, backgroundColor: `${seatColor}44` }}
+          >
             <img src={avatarUrl} alt={label} className="h-full w-full object-cover" />
-          ) : (
-            label.charAt(0).toUpperCase()
-          )}
-          {isUnderAttack && <span className="absolute inset-0 rounded-md ring-2 ring-red-400/70" />}
-        </div>
+            {isUnderAttack && <span className="absolute inset-0 rounded-md ring-2 ring-red-400/70" />}
+          </AvatarHoverPreview>
+        ) : (
+          <div
+            className={`relative flex shrink-0 items-center justify-center overflow-hidden rounded-md border bg-slate-950 font-bold text-white transition ${avatarSize} ${
+              isValidPlayerTarget ? "ring-2 ring-cyan-300/70" : ""
+            }`}
+            style={{ borderColor: `${seatColor}cc`, backgroundColor: `${seatColor}44` }}
+            title={label}
+          >
+            {label.charAt(0).toUpperCase()}
+            {isUnderAttack && <span className="absolute inset-0 rounded-md ring-2 ring-red-400/70" />}
+          </div>
+        )}
 
         <div className={`flex min-w-0 shrink items-center justify-center ${compact ? "gap-1" : "gap-1.5"}`}>
           <span

--- a/client/src/components/board/OpponentSeatPane.tsx
+++ b/client/src/components/board/OpponentSeatPane.tsx
@@ -91,7 +91,15 @@ export function OpponentSeatPane({
           header, clear of the global menu cluster that overlays the first
           pane's header corner) and the track ends at the fan's left edge, so
           a long label truncates instead of colliding with the hand. */}
-      <div className="pointer-events-none absolute inset-x-0 top-[calc(0.25rem+var(--game-seat-header-height,2.25rem))] z-20 grid h-[var(--game-seat-hand-peek,2rem)] grid-cols-[1fr_auto_1fr] overflow-hidden">
+      {/* z-40 (matching the header's wrapper, but later in DOM order) lifts the
+          peeking hand fan above the z-30 zone-pile rail and the header so its
+          cards are the topmost hit-test target where they're visible — without
+          it, `elementFromPoint` returns the header/piles and both the card
+          `onMouseEnter` and usePreviewDismiss's poll see no `[data-card-hover]`,
+          so the preview never opens. The container stays pointer-events-none and
+          only the card <img>s re-enable pointer events, so gaps between cards
+          still fall through to the header (click-to-target, life, kick). */}
+      <div className="pointer-events-none absolute inset-x-0 top-[calc(0.25rem+var(--game-seat-header-height,2.25rem))] z-40 grid h-[var(--game-seat-hand-peek,2rem)] grid-cols-[1fr_auto_1fr] overflow-hidden">
         <div className="flex min-w-0 items-center justify-start pl-1.5">
           {waitingReasonText && (
             <span
@@ -104,7 +112,7 @@ export function OpponentSeatPane({
             </span>
           )}
         </div>
-        <div className="pointer-events-auto -translate-y-[52%]">
+        <div className="pointer-events-none -translate-y-[52%]">
           <OpponentHand playerId={playerId} showCards={showCards} layout="split" />
         </div>
       </div>

--- a/client/src/components/hand/OpponentHand.tsx
+++ b/client/src/components/hand/OpponentHand.tsx
@@ -112,7 +112,12 @@ function OpponentCardThumbnail({ cardId, cardName }: { cardId: ObjectId; cardNam
       <img
         src={src}
         alt={cardName}
-        className="rounded-lg border border-gray-600 shadow-md object-cover"
+        // `pointer-events-auto` so the card is the hit-test target even when an
+        // ancestor opts out of pointer events (the split-seat fan wrapper does,
+        // so gaps between cards fall through to the seat header beneath). In the
+        // default layout the ancestor chain is already interactive, so this is a
+        // no-op there.
+        className="pointer-events-auto rounded-lg border border-gray-600 shadow-md object-cover"
         style={cardStyle}
         draggable={false}
         {...hoverHandlers}


### PR DESCRIPTION
In the split-board seat the opponent hand fan (z-20) was occluded by the
seat header (z-40) and zone-pile rail (z-30), so elementFromPoint at every
card returned an occluder — the card's onMouseEnter never fired and
usePreviewDismiss's poll force-cleared any preview. The avatar had a second
gap: the split header never wired AvatarHoverPreview (only the 1v1 OpponentHud
did) and its tile sat inside a pointer-events-none block.

- OpponentSeatPane: lift the hand-fan row to z-40 (matches the header ceiling,
  wins by DOM order over header + piles) and make the fan wrapper
  pointer-events-none so only the cards capture the pointer.
- OpponentHand: card face img gets pointer-events-auto so each card is the
  hit-test target while gaps fall through to the header (no-op in 1v1 layout).
- OpponentSeatHeader: wrap the avatar in AvatarHoverPreview (portrait preview,
  as in 1v1) and make the tile pointer-events-auto except while it's a legal
  target, where click-to-target must win.
