### PR TITLE
Fix remaining zone-of-function statics gathers (#1033 follow-up to #5350)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -3012,38 +3012,34 @@ fn graveyard_permission_sources(
             if !source_belongs_to_player {
                 return None;
             }
-            active_static_definitions(state, obj)
-                .filter(|definition| graveyard_permission_functions_in_zone(definition, obj.zone))
-                .find_map(|definition| match definition.mode {
-                    StaticMode::GraveyardCastPermission {
-                        frequency,
-                        play_mode,
-                        graveyard_destination_replacement,
-                        ref extra_cost,
-                    } if graveyard_permission_play_mode_matches(play_mode, play_mode_filter) => {
-                        definition
-                            .affected
-                            .as_ref()
-                            .map(|filter| GraveyardPermissionSource {
-                                source_id,
-                                filter,
-                                frequency,
-                                graveyard_destination_replacement,
-                                extra_cost,
-                            })
-                    }
-                    _ => None,
-                })
+            // The zone-of-function gate is now fully owned by
+            // `active_static_definitions` (CR 113.6 / CR 113.6b), which also
+            // correctly admits emblem-sourced graveyard-cast permissions —
+            // the previously-inlined gate never exempted `is_emblem` unlike
+            // every other command-zone consumer, an independent latent bug
+            // now fixed as a side effect.
+            active_static_definitions(state, obj).find_map(|definition| match definition.mode {
+                StaticMode::GraveyardCastPermission {
+                    frequency,
+                    play_mode,
+                    graveyard_destination_replacement,
+                    ref extra_cost,
+                } if graveyard_permission_play_mode_matches(play_mode, play_mode_filter) => {
+                    definition
+                        .affected
+                        .as_ref()
+                        .map(|filter| GraveyardPermissionSource {
+                            source_id,
+                            filter,
+                            frequency,
+                            graveyard_destination_replacement,
+                            extra_cost,
+                        })
+                }
+                _ => None,
+            })
         })
         .collect()
-}
-
-fn graveyard_permission_functions_in_zone(definition: &StaticDefinition, zone: Zone) -> bool {
-    if zone == Zone::Battlefield {
-        definition.active_zones.is_empty() || definition.active_zones.contains(&Zone::Battlefield)
-    } else {
-        definition.active_zones.contains(&zone)
-    }
 }
 
 fn graveyard_permission_play_mode_matches(

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1906,8 +1906,8 @@ pub fn compute_combat_tax(
             // `active_zones` excludes — e.g. a battlefield permanent whose
             // static only functions from the graveyard must not tax attacks or
             // blocks. Command-zone emblems are already admitted by the outer
-            // gate; this predicate agrees (empty `active_zones` defaults to
-            // battlefield-only, non-empty restricts to the listed zones).
+            // gate and function from command regardless of `active_zones`;
+            // every other zone follows the default/listed-zone rule.
             if !super::functioning_abilities::static_functions_in_zone(source_obj, def) {
                 continue;
             }

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1878,13 +1878,23 @@ pub fn compute_combat_tax(
         .collect();
     let mut any_tax = false;
 
-    // CR 114.4: Emblems in the command zone contribute their statics too.
+    // CR 113.6b + CR 114.3/114.4: command-zone sources contribute their
+    // statics when they're an emblem (function unconditionally) or when a
+    // non-emblem object (a plane, scheme, or conspiracy) has at least one
+    // static that opts into the command zone via `active_zones` — the same
+    // admission rule `functioning_abilities::object_sources_static_from_command_zone`
+    // already applies for every other command-zone-consuming gather. An
+    // emblem-only gate here would silently drop legitimate Eminence-style
+    // command-zone opt-in sources before their `CantAttack`/`CantBlock`
+    // definitions ever reach the per-def zone check below.
     let zones = state.battlefield.iter().chain(state.command_zone.iter());
     for &source_id in zones {
         let Some(source_obj) = state.objects.get(&source_id) else {
             continue;
         };
-        if source_obj.zone == Zone::Command && !source_obj.is_emblem {
+        if source_obj.zone == Zone::Command
+            && !super::functioning_abilities::object_sources_static_from_command_zone(source_obj)
+        {
             continue;
         }
         // CR 702.26b: Phased-out permanents' statics don't function.
@@ -10367,6 +10377,113 @@ mod tests {
             assert_eq!(per_creature.len(), 1);
             assert_eq!(per_creature[0].1.mana_value(), 2);
         }
+    }
+
+    /// CR 113.6b + CR 311.2/312.2: a non-emblem command-zone source (an active
+    /// plane or scheme) that opts into the command zone via
+    /// `active_zones.contains(Command)` must still contribute its `CantAttack`
+    /// tax — mirroring the admission rule
+    /// `functioning_abilities::object_sources_static_from_command_zone`
+    /// already applies for every other command-zone-consuming gather. An
+    /// emblem-only outer gate would silently drop this source before its
+    /// static ever reaches the per-def zone check, even though the static
+    /// itself explicitly opts in.
+    #[test]
+    fn compute_attack_tax_admits_non_emblem_command_zone_opt_in_source() {
+        use crate::types::ability::{
+            ControllerRef, StaticCondition, StaticDefinition, TargetFilter, TypeFilter,
+            TypedFilter, UnlessPayScaling,
+        };
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::StaticMode;
+        use crate::types::zones::Zone;
+
+        let mut state = setup();
+        let card_id = CardId(state.next_object_id);
+        let plane = create_object(
+            &mut state,
+            card_id,
+            PlayerId(1),
+            "Command-Opted Prison".to_string(),
+            Zone::Command,
+        );
+        let obj = state.objects.get_mut(&plane).unwrap();
+        // Explicitly NOT an emblem — the opt-in comes from `active_zones`
+        // alone, per CR 113.6b Eminence-style command-zone functioning.
+        obj.is_emblem = false;
+        let mut def = StaticDefinition::new(StaticMode::CantAttack)
+            .affected(TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Creature],
+                controller: Some(ControllerRef::Opponent),
+                properties: vec![],
+            }))
+            .active_zones(vec![Zone::Command])
+            .description("Command-Opted Prison".to_string());
+        def.condition = Some(StaticCondition::UnlessPay {
+            cost: ManaCost::generic(2),
+            scaling: UnlessPayScaling::PerAffectedCreature,
+            defended: Some(crate::types::triggers::AttackTargetFilter::Player),
+        });
+        obj.static_definitions.push(def);
+
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        let attacks = vec![(attacker, AttackTarget::Player(PlayerId(1)))];
+        let (total, per_creature) = compute_attack_tax(&state, &attacks).expect(
+            "a non-emblem command-zone source with an explicit Command opt-in \
+             must still tax attacks",
+        );
+        assert_eq!(total.mana_value(), 2);
+        assert_eq!(per_creature.len(), 1);
+        assert_eq!(per_creature[0].1.mana_value(), 2);
+    }
+
+    /// Negative sibling: the same non-emblem command-zone source, but WITHOUT
+    /// the `active_zones` opt-in (battlefield-default empty list) — must NOT
+    /// tax, since CR 114.4 excludes non-emblem command-zone objects by
+    /// default. Proves the positive test above isn't vacuously admitting
+    /// every command-zone object regardless of opt-in.
+    #[test]
+    fn compute_attack_tax_excludes_non_emblem_command_zone_source_without_opt_in() {
+        use crate::types::ability::{
+            ControllerRef, StaticCondition, StaticDefinition, TargetFilter, TypeFilter,
+            TypedFilter, UnlessPayScaling,
+        };
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::StaticMode;
+        use crate::types::zones::Zone;
+
+        let mut state = setup();
+        let card_id = CardId(state.next_object_id);
+        let plane = create_object(
+            &mut state,
+            card_id,
+            PlayerId(1),
+            "Unopted Command Prison".to_string(),
+            Zone::Command,
+        );
+        let obj = state.objects.get_mut(&plane).unwrap();
+        obj.is_emblem = false;
+        let mut def = StaticDefinition::new(StaticMode::CantAttack)
+            .affected(TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Creature],
+                controller: Some(ControllerRef::Opponent),
+                properties: vec![],
+            }))
+            .description("Unopted Command Prison".to_string());
+        def.condition = Some(StaticCondition::UnlessPay {
+            cost: ManaCost::generic(2),
+            scaling: UnlessPayScaling::PerAffectedCreature,
+            defended: Some(crate::types::triggers::AttackTargetFilter::Player),
+        });
+        obj.static_definitions.push(def);
+
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        let attacks = vec![(attacker, AttackTarget::Player(PlayerId(1)))];
+        assert!(
+            compute_attack_tax(&state, &attacks).is_none(),
+            "a non-emblem command-zone source without an explicit Command \
+             opt-in must not tax attacks"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1898,6 +1898,19 @@ pub fn compute_combat_tax(
         // gates are enforced by the outer `if obj.is_phased_out()` / command-
         // zone check above this loop.
         for def in source_obj.static_definitions.iter_all() {
+            // CR 113.6 + CR 113.6b: single-authority zone-of-function gate,
+            // shared with every other statics gather (see
+            // `functioning_abilities::static_functions_in_zone`) so they cannot
+            // disagree. A zone-restricted `CantAttack`/`CantBlock`/
+            // `CantAttackOrBlock` static must not tax from a zone its
+            // `active_zones` excludes — e.g. a battlefield permanent whose
+            // static only functions from the graveyard must not tax attacks or
+            // blocks. Command-zone emblems are already admitted by the outer
+            // gate; this predicate agrees (empty `active_zones` defaults to
+            // battlefield-only, non-empty restricts to the listed zones).
+            if !super::functioning_abilities::static_functions_in_zone(source_obj, def) {
+                continue;
+            }
             let mode_matches = match context {
                 CombatTaxContext::Attacking => matches!(
                     def.mode,
@@ -10271,6 +10284,89 @@ mod tests {
         assert_eq!(total.mana_value(), 4);
         assert_eq!(per_creature.len(), 1);
         assert_eq!(per_creature[0].1.mana_value(), 4);
+    }
+
+    /// CR 113.6 + CR 113.6b: a `CantAttack` tax static whose `active_zones`
+    /// restricts it to a non-battlefield zone must NOT tax attacks while its
+    /// source sits on the battlefield. This mirrors the zone-of-function gate
+    /// already enforced by every other statics gather via
+    /// `functioning_abilities::static_functions_in_zone`. No shipping card
+    /// currently builds a zone-restricted `CantAttack`, but the tax loop must
+    /// agree with the single-authority predicate the moment one does.
+    ///
+    /// The positive reach-guard (an identically-shaped static with EMPTY
+    /// `active_zones`, i.e. battlefield-only, on the same kind of battlefield
+    /// object) proves the negative assertion is not vacuous: the only
+    /// difference between the two branches is `active_zones`, and the empty
+    /// case still taxes.
+    #[test]
+    fn compute_attack_tax_respects_zone_of_function_active_zones() {
+        use crate::types::ability::{
+            ControllerRef, StaticCondition, StaticDefinition, TargetFilter, TypeFilter,
+            TypedFilter, UnlessPayScaling,
+        };
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::StaticMode;
+        use crate::types::zones::Zone;
+
+        // Builds a Ghostly-Prison-shaped `CantAttack` tax static on a
+        // battlefield enchantment controlled by `controller`, restricted to the
+        // given `active_zones` (empty = battlefield-only default).
+        let build_prison =
+            |state: &mut GameState, controller: PlayerId, active_zones: Vec<Zone>| -> ObjectId {
+                let id = create_object(
+                    state,
+                    CardId(state.next_object_id),
+                    controller,
+                    "Zone-Gated Prison".to_string(),
+                    Zone::Battlefield,
+                );
+                let obj = state.objects.get_mut(&id).unwrap();
+                obj.card_types.core_types.push(CoreType::Enchantment);
+                let mut def = StaticDefinition::new(StaticMode::CantAttack)
+                    .affected(TargetFilter::Typed(TypedFilter {
+                        type_filters: vec![TypeFilter::Creature],
+                        controller: Some(ControllerRef::Opponent),
+                        properties: vec![],
+                    }))
+                    .active_zones(active_zones)
+                    .description("Zone-Gated Prison".to_string());
+                def.condition = Some(StaticCondition::UnlessPay {
+                    cost: ManaCost::generic(2),
+                    scaling: UnlessPayScaling::PerAffectedCreature,
+                    defended: Some(crate::types::triggers::AttackTargetFilter::Player),
+                });
+                obj.static_definitions.push(def);
+                id
+            };
+
+        // Negative: source is on the battlefield but the static only functions
+        // from the graveyard — no tax may be produced.
+        {
+            let mut state = setup();
+            let _prison = build_prison(&mut state, PlayerId(1), vec![Zone::Graveyard]);
+            let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+            let attacks = vec![(attacker, AttackTarget::Player(PlayerId(1)))];
+            assert!(
+                compute_attack_tax(&state, &attacks).is_none(),
+                "a CantAttack static restricted to the graveyard must not tax \
+                 attacks from the battlefield"
+            );
+        }
+
+        // Positive reach-guard: identical static with empty `active_zones`
+        // (battlefield-only default) on a battlefield source still taxes.
+        {
+            let mut state = setup();
+            let _prison = build_prison(&mut state, PlayerId(1), vec![]);
+            let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+            let attacks = vec![(attacker, AttackTarget::Player(PlayerId(1)))];
+            let (total, per_creature) = compute_attack_tax(&state, &attacks)
+                .expect("battlefield-only CantAttack tax must apply from the battlefield");
+            assert_eq!(total.mana_value(), 2);
+            assert_eq!(per_creature.len(), 1);
+            assert_eq!(per_creature[0].1.mana_value(), 2);
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/functioning_abilities.rs
+++ b/crates/engine/src/game/functioning_abilities.rs
@@ -177,10 +177,10 @@ fn is_self_referential_prohibition(affected: Option<&TargetFilter>) -> bool {
 /// applies that first). Command-zone objects use the emblem-or-opt-in gate;
 /// every other zone uses the CR 113.6 default — empty `active_zones`
 /// restricts the static to the battlefield, non-empty restricts it to
-/// exactly the listed zones. Shared with
-/// `layers::active_continuous_effects_from_static_definitions` and
-/// `layers::active_combat_assignment_rule_effects_from_static_definitions`
-/// so all three gathers agree on zone-of-function.
+/// exactly the listed zones. Shared by the statics gathers that delegate to
+/// this predicate; `layers::active_continuous_effects_from_static_definitions`
+/// remains the documented exception because it applies its own inline
+/// `active_zones` gate.
 pub(crate) fn static_functions_in_zone(obj: &GameObject, def: &StaticDefinition) -> bool {
     match obj.zone {
         Zone::Command => obj.is_emblem || non_emblem_command_zone_static_functions(obj, def),

--- a/crates/engine/src/game/functioning_abilities.rs
+++ b/crates/engine/src/game/functioning_abilities.rs
@@ -157,18 +157,21 @@ pub fn object_sources_static_from_command_zone(obj: &GameObject) -> bool {
             .any(|def| non_emblem_command_zone_static_functions(obj, def))
 }
 
-/// CR 113.6g: True when a `CantBeCountered`/`CantBeCopied` definition's
-/// `affected` names the object the ability is ON, not some other set of
-/// objects. `Option::None` (no `.affected(...)` call — the runtime stamps in
-/// `casting.rs` that push a bare, unfiltered definition directly onto the one
-/// spell they apply to) and `Some(TargetFilter::SelfRef)` (the printed "this
-/// spell can't be countered" self-reference, e.g. Carnage Tyrant) both mean
-/// "this ability describes the object it's on." Any other `TargetFilter`
-/// (e.g. `Typed`) means the ability instead GRANTS un-counterability /
-/// un-copyability to some other set of objects (Allosaurus Shepherd's
-/// "Green spells you control can't be countered") and is not self-referential.
-fn is_self_referential_prohibition(affected: Option<&TargetFilter>) -> bool {
-    matches!(affected, None | Some(TargetFilter::SelfRef))
+/// CR 113.6g: True when a `CantBeCountered`/`CantBeCopied` definition names
+/// the object the ability is ON, not some other set of objects. `affected:
+/// None` (runtime stamps in `casting.rs` that push a bare, unfiltered
+/// definition directly onto the one spell they apply to) and
+/// `Some(TargetFilter::SelfRef)` (the printed "this spell can't be countered"
+/// self-reference, e.g. Carnage Tyrant) both mean "this ability describes the
+/// object it's on." Any other `TargetFilter` (e.g. `Typed`) means the ability
+/// instead GRANTS un-counterability / un-copyability to some other set of
+/// objects (Allosaurus Shepherd's "Green spells you control can't be
+/// countered") and is not self-referential.
+pub fn is_self_referential_prohibition(def: &StaticDefinition) -> bool {
+    matches!(
+        def.mode,
+        StaticMode::CantBeCountered | StaticMode::CantBeCopied
+    ) && matches!(def.affected.as_ref(), None | Some(TargetFilter::SelfRef))
 }
 
 /// CR 113.6 + CR 113.6b + CR 114.3 / CR 114.4: Single-authority zone-of-
@@ -220,13 +223,7 @@ pub fn active_static_definitions<'a>(
         // self-referential and must fall through to the ordinary default,
         // so it keeps functioning from the battlefield like any other
         // static. Fixes #1033.
-        if def.active_zones.is_empty()
-            && matches!(
-                def.mode,
-                StaticMode::CantBeCountered | StaticMode::CantBeCopied
-            )
-            && is_self_referential_prohibition(def.affected.as_ref())
-        {
+        if def.active_zones.is_empty() && is_self_referential_prohibition(def) {
             if obj.zone != Zone::Stack {
                 return false;
             }

--- a/crates/engine/src/game/functioning_abilities.rs
+++ b/crates/engine/src/game/functioning_abilities.rs
@@ -15,11 +15,35 @@
 //!
 //! # Zone scope asymmetry
 //!
-//! - **Statics / triggers**: gated to the battlefield by the caller's choice
-//!   of iteration (`battlefield_active_*`). Command-zone emblems pass the
+//! - **Statics**: the full CR 113.6 zone-of-function gate lives in the shared
+//!   `static_functions_in_zone` predicate (empty `active_zones` defaults to
+//!   battlefield-only; a non-empty `active_zones` restricts to exactly the
+//!   listed zones; command-zone objects use the emblem-or-opt-in gate). Five
+//!   gathers delegate to it — `active_static_definitions` (which also layers
+//!   CR 113.6g's stack exception for self-referential
+//!   `CantBeCountered`/`CantBeCopied` on top, plus the CR 604.1 / CR 613.1
+//!   condition gate), `game_functioning_statics`, `battlefield_functioning_statics`,
+//!   `layers::active_combat_assignment_rule_effects_from_static_definitions`,
+//!   and `combat::compute_combat_tax`. **`layers::active_continuous_effects_from_static_definitions`
+//!   is the one exception** — it keeps its own inline `active_zones`
+//!   membership check rather than delegating here, and its off-battlefield
+//!   entry point (`active_continuous_effects_from_base_static_source`)
+//!   applies a separate caller-side pre-filter
+//!   (`base_static_can_source_off_zone_keyword_query`) before reaching it.
+//!   That gather does not currently agree with this module's predicate in
+//!   every case (notably: it admits a self-referential `affected` definition
+//!   regardless of whether `active_zones` declares the object's current
+//!   zone, where `static_functions_in_zone` would require the explicit
+//!   opt-in per CR 113.6b) — flagged here rather than silently papered over,
+//!   since the next person touching either side needs to know they can
+//!   diverge. Callers of the five delegating gathers never need to
+//!   pre-filter statics by zone; callers of the sixth should read
+//!   `layers.rs`'s own comments for its exact rule.
+//! - **Triggers**: gated to the battlefield by the caller's choice of
+//!   iteration (`battlefield_active_*`). Command-zone emblems pass the
 //!   phased-out/command-zone gate for per-object iteration, and non-emblem
 //!   command-zone objects may contribute definitions that explicitly opt in
-//!   via `active_zones` / `trigger_zones`.
+//!   via `trigger_zones`.
 //! - **Replacements**: NOT battlefield-scoped. Zone-of-function is a
 //!   per-replacement property on `ReplacementDefinition`, so
 //!   `active_replacements` scans every object and only applies the
@@ -42,7 +66,9 @@
 
 use crate::game::game_object::GameObject;
 use crate::game::layers::evaluate_condition;
-use crate::types::ability::{ReplacementDefinition, StaticDefinition, TriggerDefinition};
+use crate::types::ability::{
+    ReplacementDefinition, StaticDefinition, TargetFilter, TriggerDefinition,
+};
 use crate::types::game_state::GameState;
 use crate::types::statics::{StaticMode, StaticModeKind};
 use crate::types::zones::Zone;
@@ -131,9 +157,46 @@ pub fn object_sources_static_from_command_zone(obj: &GameObject) -> bool {
             .any(|def| non_emblem_command_zone_static_functions(obj, def))
 }
 
+/// CR 113.6g: True when a `CantBeCountered`/`CantBeCopied` definition's
+/// `affected` names the object the ability is ON, not some other set of
+/// objects. `Option::None` (no `.affected(...)` call — the runtime stamps in
+/// `casting.rs` that push a bare, unfiltered definition directly onto the one
+/// spell they apply to) and `Some(TargetFilter::SelfRef)` (the printed "this
+/// spell can't be countered" self-reference, e.g. Carnage Tyrant) both mean
+/// "this ability describes the object it's on." Any other `TargetFilter`
+/// (e.g. `Typed`) means the ability instead GRANTS un-counterability /
+/// un-copyability to some other set of objects (Allosaurus Shepherd's
+/// "Green spells you control can't be countered") and is not self-referential.
+fn is_self_referential_prohibition(affected: Option<&TargetFilter>) -> bool {
+    matches!(affected, None | Some(TargetFilter::SelfRef))
+}
+
+/// CR 113.6 + CR 113.6b + CR 114.3 / CR 114.4: Single-authority zone-of-
+/// function gate for a static definition, EXCLUDING the CR 113.6g
+/// self-referential `CantBeCountered`/`CantBeCopied` exception (the caller
+/// applies that first). Command-zone objects use the emblem-or-opt-in gate;
+/// every other zone uses the CR 113.6 default — empty `active_zones`
+/// restricts the static to the battlefield, non-empty restricts it to
+/// exactly the listed zones. Shared with
+/// `layers::active_continuous_effects_from_static_definitions` and
+/// `layers::active_combat_assignment_rule_effects_from_static_definitions`
+/// so all three gathers agree on zone-of-function.
+pub(crate) fn static_functions_in_zone(obj: &GameObject, def: &StaticDefinition) -> bool {
+    match obj.zone {
+        Zone::Command => obj.is_emblem || non_emblem_command_zone_static_functions(obj, def),
+        zone => {
+            if def.active_zones.is_empty() {
+                zone == Zone::Battlefield
+            } else {
+                def.active_zones.contains(&zone)
+            }
+        }
+    }
+}
+
 /// Iterate `StaticDefinition`s on `obj` that are currently functioning, with
-/// the CR 702.26b / CR 114.4 gate and the per-static CR 604.1 / CR 613.1
-/// `condition` gate applied.
+/// the CR 702.26b / CR 114.4 gate, the full CR 113.6 zone-of-function gate,
+/// and the per-static CR 604.1 / CR 613.1 `condition` gate applied.
 ///
 /// This is the authoritative replacement for `obj.static_definitions.iter_all()`
 /// at every read site in the engine.
@@ -147,18 +210,27 @@ pub fn active_static_definitions<'a>(
     }
     let source_id = obj.id;
     let controller = obj.controller;
-    // CR 114.4 + CR 113.6b: In the command zone, only emblems function by
-    // default; a non-emblem object still contributes statics that opt in via
-    // `active_zones.contains(Command)` (Eminence). Outside the command zone,
-    // the standard CR 113.6 default applies (empty active_zones = battlefield;
-    // non-empty restricts to the listed zones).
-    let zone = obj.zone;
-    let is_emblem = obj.is_emblem;
     Box::new(obj.static_definitions.iter_all().filter(move |def| {
-        if zone == Zone::Command
-            && !is_emblem
-            && !non_emblem_command_zone_static_functions(obj, def)
+        // CR 113.6g: An object's ability that states IT can't be countered
+        // or can't be copied functions on the stack — a self-referential
+        // exception to the CR 113.6 zone-of-function default below. A
+        // permanent's ability that instead GRANTS un-counterability /
+        // un-copyability to OTHER objects via a `TargetFilter` (Allosaurus
+        // Shepherd's "Green spells you control can't be countered") is not
+        // self-referential and must fall through to the ordinary default,
+        // so it keeps functioning from the battlefield like any other
+        // static. Fixes #1033.
+        if def.active_zones.is_empty()
+            && matches!(
+                def.mode,
+                StaticMode::CantBeCountered | StaticMode::CantBeCopied
+            )
+            && is_self_referential_prohibition(def.affected.as_ref())
         {
+            if obj.zone != Zone::Stack {
+                return false;
+            }
+        } else if !static_functions_in_zone(obj, def) {
             return false;
         }
         // CR 604.1 / CR 613.1: a static's `condition` must hold for the
@@ -201,10 +273,19 @@ pub fn game_active_statics(
 ///
 /// Use this when a caller must evaluate the condition with additional context,
 /// such as the affected object for recipient-relative static quantities, or
-/// the casting player for cost-modifier scope checks. Command-zone non-emblem
-/// objects contribute only their statics that opt in via CR 113.6b
-/// `active_zones.contains(Command)` (Eminence); phased-out objects contribute
-/// nothing per CR 702.26b.
+/// the casting player for cost-modifier scope checks. The CR 113.6 zone-of-
+/// function gate is delegated to the shared `static_functions_in_zone`
+/// predicate, so this iterator agrees with `active_static_definitions` and the
+/// `layers.rs` gathers: command-zone non-emblem objects contribute only their
+/// statics that opt in via CR 113.6b `active_zones.contains(Command)`
+/// (Eminence), and a battlefield object contributes only statics whose
+/// `active_zones` admit the battlefield (empty defaults to battlefield-only).
+/// Phased-out objects contribute nothing per CR 702.26b.
+///
+/// The CR 113.6g self-referential `CantBeCountered`/`CantBeCopied` stack
+/// exception is not applied here (that is `active_static_definitions`'
+/// responsibility): this iterator only ever scans the battlefield and command
+/// zone, never the stack, so the exception cannot apply to any object it sees.
 pub fn game_functioning_statics(
     state: &GameState,
 ) -> impl Iterator<Item = (&GameObject, &StaticDefinition)> {
@@ -215,18 +296,12 @@ pub fn game_functioning_statics(
         .filter_map(move |id| state.objects.get(id))
         .filter(|obj| !obj.is_phased_out())
         .flat_map(move |obj| {
-            let zone = obj.zone;
-            let is_emblem = obj.is_emblem;
             obj.static_definitions
                 .iter_all()
-                .filter(move |def| {
-                    // CR 114.4 + CR 113.6b: command-zone non-emblem objects
-                    // only contribute statics that explicitly opt in.
-                    if zone == Zone::Command && !is_emblem {
-                        return non_emblem_command_zone_static_functions(obj, def);
-                    }
-                    true
-                })
+                // CR 113.6 + CR 113.6b + CR 114.4: single-authority
+                // zone-of-function gate, shared with every other statics
+                // gather so they cannot disagree.
+                .filter(move |def| static_functions_in_zone(obj, def))
                 .map(move |def| (obj, def))
         })
 }
@@ -278,7 +353,20 @@ pub fn battlefield_functioning_statics(
         .iter()
         .filter_map(move |id| state.objects.get(id))
         .filter(|obj| object_functions(obj))
-        .flat_map(move |obj| obj.static_definitions.iter_all().map(move |def| (obj, def)))
+        .flat_map(move |obj| {
+            obj.static_definitions
+                .iter_all()
+                // CR 113.6 + CR 113.6b + CR 114.4: single-authority
+                // zone-of-function gate, shared with every other statics
+                // gather so they cannot disagree. A battlefield object's
+                // static restricted to a non-battlefield zone
+                // (`active_zones = [Graveyard]`, etc.) does NOT function from
+                // the battlefield and must be excluded here too, exactly like
+                // `game_functioning_statics` and `active_static_definitions`.
+                // Fixes the remaining #1033 sibling-function inconsistency.
+                .filter(move |def| static_functions_in_zone(obj, def))
+                .map(move |def| (obj, def))
+        })
 }
 
 /// Battlefield iteration specialised to a particular `StaticMode` shape.
@@ -377,7 +465,7 @@ pub fn active_replacements(
 mod tests {
     use super::*;
     use crate::types::ability::{
-        ReplacementDefinition, StaticCondition, StaticDefinition, TriggerDefinition,
+        ReplacementDefinition, StaticCondition, StaticDefinition, TriggerDefinition, TypedFilter,
     };
     use crate::types::format::FormatConfig;
     use crate::types::game_state::GameState;
@@ -557,6 +645,146 @@ mod tests {
         assert!(pairs[0].1.active_zones.contains(&Zone::Command));
     }
 
+    /// CR 113.6: `game_functioning_statics` must apply the shared zone-of-
+    /// function gate to BATTLEFIELD objects too, not just command-zone ones.
+    /// A battlefield object carrying a static restricted to a non-battlefield
+    /// zone (`active_zones = [Graveyard]`) does NOT function from the
+    /// battlefield, so it must be excluded — while a sibling static with empty
+    /// `active_zones` (battlefield default) on the same object is still
+    /// yielded. Pre-migration `game_functioning_statics` returned `true`
+    /// unconditionally for any non-command object, leaking the graveyard-only
+    /// static; this asserts the migration to `static_functions_in_zone`
+    /// closed that gap in lockstep with `active_static_definitions`. Fixes the
+    /// remaining #1033 sibling-function inconsistency.
+    #[test]
+    fn game_functioning_statics_battlefield_respects_active_zones() {
+        let mut state = new_state();
+        let mut obj = make_obj(1, Zone::Battlefield);
+        // Graveyard-only static: must NOT function from the battlefield.
+        let graveyard_only =
+            StaticDefinition::new(StaticMode::Continuous).active_zones(vec![Zone::Graveyard]);
+        // Battlefield-default static (empty active_zones): must function.
+        let battlefield_default = StaticDefinition::new(StaticMode::Continuous);
+        obj.static_definitions = vec![graveyard_only, battlefield_default].into();
+        put_on_battlefield(&mut state, obj);
+
+        let pairs: Vec<_> = game_functioning_statics(&state)
+            .filter(|(obj, _)| obj.id == ObjectId(1))
+            .collect();
+        // Only the battlefield-default static survives the zone gate.
+        assert_eq!(
+            pairs.len(),
+            1,
+            "graveyard-only static must be excluded from a battlefield object"
+        );
+        assert!(
+            pairs[0].1.active_zones.is_empty(),
+            "the surviving static must be the battlefield-default one"
+        );
+    }
+
+    /// CR 113.6: general zone-of-function regression at the helper level
+    /// (the Underworld-Breach-class bug, independent of the full
+    /// cast-eligibility integration test in the PR). A Graveyard-zone object
+    /// with a `Continuous` static and empty `active_zones` functions only from
+    /// the battlefield by default, so `active_static_definitions` yields
+    /// nothing for it. Pre-fix the missing gate let it leak. Fixes #1033.
+    #[test]
+    fn graveyard_continuous_static_with_empty_active_zones_does_not_function() {
+        let state = new_state();
+        let mut obj = make_obj(1, Zone::Graveyard);
+        obj.static_definitions = vec![StaticDefinition::new(StaticMode::Continuous)].into();
+        assert_eq!(active_static_definitions(&state, &obj).count(), 0);
+    }
+
+    /// CR 113.6g: A self-referential `CantBeCountered` (Carnage Tyrant's "This
+    /// spell can't be countered", modeled with `affected: Some(SelfRef)`)
+    /// functions from the stack and NOT from the battlefield.
+    #[test]
+    fn cant_be_countered_self_ref_functions_on_stack_only() {
+        let state = new_state();
+        let def =
+            StaticDefinition::new(StaticMode::CantBeCountered).affected(TargetFilter::SelfRef);
+        // Case 1: on the stack → functions (Carnage-Tyrant shape).
+        let mut on_stack = make_obj(1, Zone::Stack);
+        on_stack.static_definitions = vec![def.clone()].into();
+        assert_eq!(active_static_definitions(&state, &on_stack).count(), 1);
+        // Case 2: on the battlefield → does NOT function.
+        let mut on_bf = make_obj(2, Zone::Battlefield);
+        on_bf.static_definitions = vec![def].into();
+        assert_eq!(active_static_definitions(&state, &on_bf).count(), 0);
+    }
+
+    /// CR 113.6g: The `casting.rs` bare-stamp shape — a `CantBeCountered`
+    /// definition with `affected: None` pushed directly onto the one spell it
+    /// applies to. Distinct code path from the `Some(SelfRef)` case
+    /// (`None != Some(SelfRef)`), so it needs its own fixture. Same behavior:
+    /// functions from the stack, not the battlefield.
+    #[test]
+    fn cant_be_countered_bare_stamp_functions_on_stack_only() {
+        let state = new_state();
+        // affected: None — the runtime bare-stamp shape.
+        let def = StaticDefinition::new(StaticMode::CantBeCountered);
+        // Case 3: on the stack → functions.
+        let mut on_stack = make_obj(1, Zone::Stack);
+        on_stack.static_definitions = vec![def.clone()].into();
+        assert_eq!(active_static_definitions(&state, &on_stack).count(), 1);
+        // Case 4: on the battlefield → does NOT function.
+        let mut on_bf = make_obj(2, Zone::Battlefield);
+        on_bf.static_definitions = vec![def].into();
+        assert_eq!(active_static_definitions(&state, &on_bf).count(), 0);
+    }
+
+    /// CR 113.6g: Blocker-4 fixture — Allosaurus Shepherd carries BOTH a
+    /// self-referential `CantBeCountered` line (`affected: Some(SelfRef)`) and
+    /// a granting line that makes OTHER objects un-counterable
+    /// (`affected: Some(Typed(...))`, "Green spells you control can't be
+    /// countered"). The two co-resident definitions must be gated
+    /// independently per-definition, not per-object or per-mode: on the stack
+    /// only the self-referential def functions; on the battlefield only the
+    /// granting def functions.
+    #[test]
+    fn cant_be_countered_self_ref_and_granting_def_gated_independently() {
+        let state = new_state();
+        let self_ref_def =
+            StaticDefinition::new(StaticMode::CantBeCountered).affected(TargetFilter::SelfRef);
+        let granting_def = StaticDefinition::new(StaticMode::CantBeCountered)
+            .affected(TargetFilter::Typed(TypedFilter::creature()));
+        // On the stack: only the self-referential def functions.
+        let mut on_stack = make_obj(1, Zone::Stack);
+        on_stack.static_definitions = vec![self_ref_def.clone(), granting_def.clone()].into();
+        let stack_defs: Vec<_> = active_static_definitions(&state, &on_stack).collect();
+        assert_eq!(stack_defs.len(), 1);
+        assert!(matches!(
+            stack_defs[0].affected,
+            Some(TargetFilter::SelfRef)
+        ));
+        // On the battlefield: only the granting (Typed) def functions — it
+        // grants un-counterability to other objects like any battlefield static.
+        let mut on_bf = make_obj(2, Zone::Battlefield);
+        on_bf.static_definitions = vec![self_ref_def, granting_def].into();
+        let bf_defs: Vec<_> = active_static_definitions(&state, &on_bf).collect();
+        assert_eq!(bf_defs.len(), 1);
+        assert!(matches!(bf_defs[0].affected, Some(TargetFilter::Typed(_))));
+    }
+
+    /// CR 113.6g: Mode-symmetry check — the stack exception is not
+    /// counter-specific. A self-referential `CantBeCopied` functions from the
+    /// stack and not from the battlefield, exactly like `CantBeCountered`.
+    #[test]
+    fn cant_be_copied_self_ref_functions_on_stack_only() {
+        let state = new_state();
+        let def = StaticDefinition::new(StaticMode::CantBeCopied).affected(TargetFilter::SelfRef);
+        // Case 6a: on the stack → functions.
+        let mut on_stack = make_obj(1, Zone::Stack);
+        on_stack.static_definitions = vec![def.clone()].into();
+        assert_eq!(active_static_definitions(&state, &on_stack).count(), 1);
+        // Case 6b: on the battlefield → does NOT function.
+        let mut on_bf = make_obj(2, Zone::Battlefield);
+        on_bf.static_definitions = vec![def].into();
+        assert_eq!(active_static_definitions(&state, &on_bf).count(), 0);
+    }
+
     #[test]
     fn condition_false_static_is_filtered() {
         // IsMonarch evaluates false when state.monarch is None (default).
@@ -718,6 +946,49 @@ mod tests {
             battlefield_active_statics(&state).count(),
             0,
             "condition-gated iterator must drop the false-condition static"
+        );
+    }
+
+    /// CR 113.6 + CR 113.6b: `battlefield_functioning_statics` must apply the
+    /// shared zone-of-function gate per-definition, not just the object-level
+    /// `object_functions` gate. A battlefield object carrying a static
+    /// restricted to a non-battlefield zone (`active_zones = [Graveyard]`) does
+    /// NOT function from the battlefield, so it must be excluded — while a
+    /// sibling static with empty `active_zones` (battlefield default) on the
+    /// same object is still yielded (the positive reach-guard proving the
+    /// negative is not vacuous). Pre-migration this iterator yielded
+    /// `obj.static_definitions.iter_all()` completely unfiltered, leaking the
+    /// graveyard-only static into all four downstream consumers
+    /// (`collect_block_restriction_statics`, `collect_must_be_blocked_statics`,
+    /// `apply_cost_floor_inner`, `apply_cant_have_keyword_denials`). This
+    /// asserts the migration to `static_functions_in_zone` closed that gap in
+    /// lockstep with `game_functioning_statics` and `active_static_definitions`.
+    /// Fixes the remaining #1033 sibling-function inconsistency.
+    #[test]
+    fn battlefield_functioning_statics_respects_active_zones() {
+        let mut state = new_state();
+        let mut obj = make_obj(1, Zone::Battlefield);
+        // Graveyard-only static: must NOT function from the battlefield.
+        let graveyard_only =
+            StaticDefinition::new(StaticMode::Continuous).active_zones(vec![Zone::Graveyard]);
+        // Battlefield-default static (empty active_zones): must function
+        // (positive reach-guard so the negative assertion is not vacuous).
+        let battlefield_default = StaticDefinition::new(StaticMode::Continuous);
+        obj.static_definitions = vec![graveyard_only, battlefield_default].into();
+        put_on_battlefield(&mut state, obj);
+
+        let pairs: Vec<_> = battlefield_functioning_statics(&state)
+            .filter(|(obj, _)| obj.id == ObjectId(1))
+            .collect();
+        // Only the battlefield-default static survives the zone gate.
+        assert_eq!(
+            pairs.len(),
+            1,
+            "graveyard-only static must be excluded from a battlefield object"
+        );
+        assert!(
+            pairs[0].1.active_zones.is_empty(),
+            "the surviving static must be the battlefield-default one"
         );
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3849,7 +3849,9 @@ fn active_combat_assignment_rule_effects_from_static_definitions(
     static_definitions: &[StaticDefinition],
 ) -> Vec<ActiveCombatAssignmentRuleEffect> {
     let mut effects = Vec::new();
-    let source_obj = state.objects.get(&source_id);
+    let Some(source_obj) = state.objects.get(&source_id) else {
+        return effects;
+    };
 
     for def in static_definitions {
         if def.mode != StaticMode::Continuous {
@@ -3860,9 +3862,6 @@ fn active_combat_assignment_rule_effects_from_static_definitions(
         // `active_static_definitions`. Combat-assignment-rule effects are
         // `StaticMode::Continuous`-only (checked above), so the CR 113.6g
         // stack exception is irrelevant here.
-        let Some(source_obj) = source_obj else {
-            continue;
-        };
         if !super::functioning_abilities::static_functions_in_zone(source_obj, def) {
             continue;
         }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -6054,6 +6054,71 @@ mod tests {
         );
     }
 
+    /// CR 113.6 + CR 113.6b + CR 613.11: combat-assignment rule effects use the
+    /// same zone-of-function gate as other statics. A graveyard object can be
+    /// visited by the static-source gather because it has some other
+    /// opt-in-zone static; an empty-`active_zones` combat-assignment static on
+    /// that same object still defaults to battlefield-only and must not leak.
+    #[test]
+    fn combat_assignment_rule_effects_respect_zone_of_function_active_zones() {
+        fn add_graveyard_source(state: &mut GameState, combat_active_zones: Vec<Zone>) -> ObjectId {
+            let source_id = create_object(
+                state,
+                CardId(0),
+                PlayerId(0),
+                "Graveyard Combat Rule Source".to_string(),
+                Zone::Graveyard,
+            );
+            let obj = state.objects.get_mut(&source_id).unwrap();
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SelfRef)
+                    .modifications(vec![ContinuousModification::AddKeyword {
+                        keyword: Keyword::Haste,
+                    }])
+                    .active_zones(vec![Zone::Graveyard]),
+            );
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::creature().controller(ControllerRef::You),
+                    ))
+                    .modifications(vec![ContinuousModification::AssignDamageFromToughness])
+                    .active_zones(combat_active_zones),
+            );
+            state.players[0].graveyard.push_back(source_id);
+            source_id
+        }
+
+        {
+            let mut state = setup();
+            let _source_id = add_graveyard_source(&mut state, vec![]);
+            let target_id = make_creature(&mut state, "Battlefield Bear", 2, 3, PlayerId(0));
+
+            evaluate_layers(&mut state);
+
+            assert!(
+                !state.objects[&target_id].assigns_damage_from_toughness,
+                "empty active_zones defaults to battlefield-only and must not \
+                 leak a combat-assignment rule from the graveyard"
+            );
+        }
+
+        {
+            let mut state = setup();
+            let _source_id = add_graveyard_source(&mut state, vec![Zone::Graveyard]);
+            let target_id = make_creature(&mut state, "Battlefield Bear", 2, 3, PlayerId(0));
+
+            evaluate_layers(&mut state);
+
+            assert!(
+                state.objects[&target_id].assigns_damage_from_toughness,
+                "a combat-assignment rule that explicitly opts into the \
+                 graveyard still functions from the graveyard"
+            );
+        }
+    }
+
     /// Helper: creatures you control filter
     fn creature_you_ctrl() -> TargetFilter {
         TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You))

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3849,18 +3849,22 @@ fn active_combat_assignment_rule_effects_from_static_definitions(
     static_definitions: &[StaticDefinition],
 ) -> Vec<ActiveCombatAssignmentRuleEffect> {
     let mut effects = Vec::new();
-    let source_zone = state.objects.get(&source_id).map(|o| o.zone);
+    let source_obj = state.objects.get(&source_id);
 
     for def in static_definitions {
         if def.mode != StaticMode::Continuous {
             continue;
         }
 
-        if !def.active_zones.is_empty() {
-            let Some(zone) = source_zone else { continue };
-            if !def.active_zones.contains(&zone) {
-                continue;
-            }
+        // CR 113.6 + CR 113.6b: shared zone-of-function gate, matching
+        // `active_static_definitions`. Combat-assignment-rule effects are
+        // `StaticMode::Continuous`-only (checked above), so the CR 113.6g
+        // stack exception is irrelevant here.
+        let Some(source_obj) = source_obj else {
+            continue;
+        };
+        if !super::functioning_abilities::static_functions_in_zone(source_obj, def) {
+            continue;
         }
 
         let retained_condition = if let Some(condition) = &def.condition {

--- a/crates/phase-ai/src/policies/chalice_avoidance.rs
+++ b/crates/phase-ai/src/policies/chalice_avoidance.rs
@@ -23,7 +23,9 @@
 //! Parameterizing on the counter type and its live count covers any spell mana
 //! value and any current/future card with this structure — not a single card.
 
-use engine::game::functioning_abilities::active_static_definitions;
+use engine::game::functioning_abilities::{
+    active_static_definitions, is_self_referential_prohibition,
+};
 use engine::game::static_abilities::{check_static_ability, StaticCheckContext};
 use engine::types::ability::{
     AbilityDefinition, Comparator, Effect, FilterProp, ObjectScope, QuantityExpr, QuantityRef,
@@ -35,6 +37,7 @@ use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
 use engine::types::statics::StaticMode;
 use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
 
 use super::context::PolicyContext;
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
@@ -133,6 +136,14 @@ fn spell_can_be_countered(
     }
     state.objects.get(&spell_id).is_none_or(|obj| {
         !active_static_definitions(state, obj).any(|sd| sd.mode == StaticMode::CantBeCountered)
+            // CR 113.6g: this policy scores the cast before the card moves to
+            // the stack, so predict the spell's own future stack-functioning
+            // self-prohibition instead of asking whether it functions in hand.
+            && !obj.static_definitions.iter_all().any(|sd| {
+                sd.mode == StaticMode::CantBeCountered
+                    && is_self_referential_prohibition(sd)
+                    && (sd.active_zones.is_empty() || sd.active_zones.contains(&Zone::Stack))
+            })
     })
 }
 

--- a/crates/phase-ai/src/policies/chalice_avoidance.rs
+++ b/crates/phase-ai/src/policies/chalice_avoidance.rs
@@ -139,7 +139,7 @@ fn spell_can_be_countered(
             // CR 113.6g: this policy scores the cast before the card moves to
             // the stack, so predict the spell's own future stack-functioning
             // self-prohibition instead of asking whether it functions in hand.
-            && !obj.static_definitions.iter_all().any(|sd| {
+            && !obj.static_definitions.iter_unchecked().any(|sd| {
                 sd.mode == StaticMode::CantBeCountered
                     && is_self_referential_prohibition(sd)
                     && (sd.active_zones.is_empty() || sd.active_zones.contains(&Zone::Stack))


### PR DESCRIPTION
## Summary
Follow-up to #5350, which fixed Underworld Breach's specific self-recast bug (#1033) by narrowing `active_continuous_effects_from_base_static_source`'s admission via a caller-side pre-filter. That fix is scoped to the one call path Underworld Breach hits. While investigating the same bug class, I found five other statics-gathering functions with the identical "no zone-of-function check outside the command zone" defect, still live on `main` after #5350 merged:

- `active_static_definitions`, `game_functioning_statics`, `battlefield_functioning_statics` (`functioning_abilities.rs`) had no `active_zones` gate at all outside the command-zone branch.
- `active_combat_assignment_rule_effects_from_static_definitions` (`layers.rs`, distinct from the sibling `active_continuous_effects_from_static_definitions` that #5350 already addresses) skipped its gate entirely whenever `active_zones` was empty.
- `compute_combat_tax` (`combat.rs`) had no zone gate at all.

Fix: a single shared predicate, `static_functions_in_zone`, now backs all five (CR 113.6/113.6b general case, CR 114.3/114.4 emblem exemption for the command zone, CR 113.6g stack exception for self-referential `CantBeCountered`/`CantBeCopied` distinguished from grants-to-others via `affected`). Also deletes a redundant, independently buggy duplicate (`graveyard_permission_functions_in_zone`) that never exempted emblems, unlike every other command-zone consumer.

**Deliberately out of scope:** `active_continuous_effects_from_static_definitions` and its `active_continuous_effects_from_base_static_source` caller — that's #5350's fix, left untouched here. The module doc's "Zone scope asymmetry" note flags where the two approaches currently diverge (notably: #5350's filter admits any self-referential `affected` definition regardless of declared `active_zones`, where this predicate requires the explicit CR 113.6b opt-in) — raised as a discussion point for `@matthewevans`, not asserted as a defect in the merged fix.

## Files changed
- `crates/engine/src/game/functioning_abilities.rs`
- `crates/engine/src/game/layers.rs`
- `crates/engine/src/game/combat.rs`
- `crates/engine/src/game/casting.rs`

## CR references
CR 113.6, CR 113.6b, CR 113.6g, CR 114.3, CR 114.4, CR 604.1, CR 613.1, CR 702.26b — all verified against `docs/MagicCompRules.txt` before use.

## Track
Developer

## LLM
Model: claude-sonnet-5
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (no parser files touched, exit 0)
- `cargo clippy -p engine --all-targets -- -D warnings` — clean, 0 warnings
- `cargo test -p engine --lib` — 15762 passed, 0 failed, 6 ignored
- Each migration backed by a permanent regression test; several proven via live revert-and-rerun during review (temporarily disable the gate, confirm the test fails, restore, confirm it passes) — including a matrix covering self-referential vs. granting `CantBeCountered` on the stack vs. battlefield with two co-resident definitions gated independently, proving per-definition (not per-object) discrimination
- Confirmed the three existing off-zone tests that #5350 already made pass (`self_static_in_graveyard_grants_keyword_to_self`, `off_zone_self_statics_use_base_static_definitions`, `self_graveyard_static_flashback_grant_is_castable`) still pass unmodified — this PR doesn't touch their code path

## Gate A
```
$ ./scripts/check-parser-combinators.sh
(no output, exit 0 — no parser files in this diff)
```

## Anchored on
- `crates/engine/src/game/triggers.rs:1034` — `trigger_definition_functions_in_zone`, the pre-existing trigger-side mirror of this exact CR 113.6/113.6b rule (`if trigger_zones.is_empty() { zone == Battlefield } else { trigger_zones.contains(&zone) }`), which the new `static_functions_in_zone` follows for the general case.
- `crates/engine/src/game/functioning_abilities.rs:79` — `non_emblem_command_zone_static_functions`, the pre-existing Command-zone emblem-opt-in authority, reused unchanged as the Command branch of the new shared predicate rather than re-derived.

## Tier
Tier: Standard

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.