### PR TITLE
fix(parser): recognize "skip their next <step>" for each-player step skips

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -9204,10 +9204,17 @@ fn try_parse_still_a_type(tp: TextPair) -> Option<ParsedEffectClause> {
 /// CR 614.10a: Parse "[subject] skip[s] [their|your] next [step] step[s]" —
 /// one-shot step skips. Handles controller and target-player forms.
 fn try_parse_skip_next_step(tp: TextPair, ctx: &ParseContext) -> Option<ParsedEffectClause> {
+    // CR 614.10a: "[you ]skip your next <step>" — controller-subject one-shot
+    // step skip. The "skip their next <step>" form is the per-player body a
+    // for-each-player distributor leaves after stripping its "each opponent" /
+    // "each player" head (Brine Elemental: "each opponent skips their next untap
+    // step"); it resolves relative to the iterating player, so it lowers to the
+    // same `Controller`-targeted skip.
     if let Some((step, rest)) = nom_on_lower(tp.original, tp.lower, |input| {
         let (input, _) = alt((
             tag::<_, _, OracleError<'_>>("you skip your next "),
             tag("skip your next "),
+            tag("skip their next "),
         ))
         .parse(input)?;
         let (input, step) = parse_skip_step_name(input)?;

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -33360,6 +33360,36 @@ fn skip_next_untap_step_parses_as_step_skip() {
     );
 }
 
+/// CR 614.10a: "Each opponent skips their next untap step" (Brine Elemental) — a
+/// for-each-player distributor strips the "each opponent" head (setting
+/// `player_scope: Opponent`) and leaves "skip their next untap step", the
+/// third-person per-player body. It lowers to the same `Controller`-targeted
+/// `SkipNextStep` as "skip your next untap step" (each iterating opponent skips
+/// their own next untap step).
+#[test]
+fn each_opponent_skips_next_untap_step_parses_as_step_skip() {
+    let def = parse_effect_chain(
+        "Each opponent skips their next untap step.",
+        AbilityKind::Activated,
+    );
+    assert_eq!(
+        def.player_scope,
+        Some(crate::types::ability::PlayerFilter::Opponent)
+    );
+    let Effect::SkipNextStep {
+        target,
+        step,
+        scope,
+        ..
+    } = &*def.effect
+    else {
+        panic!("expected SkipNextStep, got {:?}", def.effect);
+    };
+    assert_eq!(target, &TargetFilter::Controller);
+    assert_eq!(step, &StepSkipTarget::Step(Phase::Untap));
+    assert_eq!(scope, &SkipScope::NextOccurrence);
+}
+
 /// CR 614.10 + CR 614.10a + CR 502.3: "Skip the untap step of that turn" (the
 /// second sentence of Savor the Moment / Time Bends to My Will, following an
 /// extra-turn effect) is the current-turn-anaphor sibling of "skip your next


### PR DESCRIPTION
## What

"Each opponent skips their next untap step" (**Brine Elemental**) dropped to `Unimplemented`. The for-each-player distributor correctly strips the `each opponent` head (setting `player_scope: Opponent`) and hands the per-player body `skip their next untap step` to the effect parser — but `try_parse_skip_next_step` only recognized the first-person `[you ]skip your next <step>` form, not the third-person `skip their next <step>` a distributor produces.

Adds `"skip their next "` alongside the existing `"skip your next "` tag. The body still lowers to the same `SkipNextStep { target: Controller }`, which resolves relative to each iterating player, so every step the skip parser already handles (untap / draw / upkeep) now works under an `each opponent` / `each player` head.

## No engine change

`Effect::SkipNextStep` and the player-scope distributor are unchanged; this is purely a parser-recognition gap. (The `target player` / `that player` subjects already parsed via the declared-target and anaphor paths.)

## Tests

Asserts the each-opponent chain lowers to `player_scope: Opponent` + `SkipNextStep { Controller, Untap, NextOccurrence }`; existing `skip your next` / `target opponent skips` tests unchanged.

Verified locally: `cargo fmt`, full engine lib suite (15,771 passed / 0 failed), `clippy -p engine --all-targets -D warnings` clean; rebased onto latest `main`.

## CR references
CR 614.10a (skip a step) · CR 102.2 / CR 115.1 (player references).