### PR TITLE
feat(parser): N-way Oxford-comma compound-subject keyword static — Shalai, Voice of Plenty (CR 611.3a)

### DIFF
--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -501,8 +501,13 @@ fn parse_oxford_object_conjuncts(text: &str) -> Option<TargetFilter> {
         conjuncts.push(item.trim());
         remaining = rest;
     }
-    let last = remaining.trim();
-    conjuncts.push(last.strip_prefix("and ").unwrap_or(last).trim());
+    // Pattern 1 (PATTERNS.md): strip the Oxford "and " connector from the final
+    // conjunct via `opt(tag(...))` rather than `strip_prefix` — the connector is
+    // genuinely optional (absent when only 2 total object conjuncts follow "you").
+    let (last, _) = opt(tag::<_, _, OracleError<'_>>("and "))
+        .parse(remaining.trim())
+        .ok()?;
+    conjuncts.push(last.trim());
     if conjuncts.len() < 2 {
         return None;
     }

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -353,12 +353,16 @@ pub(crate) fn parse_compound_subject_rule_static(
 }
 
 /// CR 702.11 + CR 702.16 + CR 702.18 + CR 611.3a: Compound-subject keyword-grant
-/// statics of the form `"You and <object subject> have <keyword>"` — a single
-/// keyword grant bound to a player plus an object subset.
+/// statics of the form `"You and <object subject> have <keyword>"` (the bare
+/// 2-item form) or `"You, <object subject>, …, and <object subject> have
+/// <keyword>"` (the Oxford-comma N-item form; Shalai, Voice of Plenty: "You,
+/// planeswalkers you control, and other creatures you control have hexproof.")
+/// — a single keyword grant bound to a player plus one or more object subsets.
 ///
 /// A single `StaticDefinition` cannot carry both a player scope and an object
 /// scope, so decompose into two:
-///   - an object-half `Continuous` def whose `affected` is the object subset;
+///   - an object-half `Continuous` def whose `affected` is the object subset
+///     (an `Or` of every conjunct's filter when 2+ object subjects are listed);
 ///   - a player-half def whose mode is the player-applicable keyword mode
 ///     (`PlayerProtection` / `Hexproof` / `Shroud`) and whose `affected` is the
 ///     controller.
@@ -366,6 +370,9 @@ pub(crate) fn parse_compound_subject_rule_static(
 /// Object subjects reuse [`parse_rule_static_subject_filter`] so subtype scopes
 /// ("Humans you control"), self refs ("this creature"), and "other <subtype>
 /// you control" all resolve — not a hard-coded alt of three controller phrases.
+/// The N-item form delegates conjunct splitting to
+/// [`parse_oxford_object_conjuncts`], which resolves each conjunct through that
+/// same subject resolver rather than a bespoke list grammar.
 ///
 /// Only player-applicable keywords claim this pattern (a player cannot
 /// meaningfully "have flying"). Leading `"During your turn, "` gates both
@@ -387,8 +394,18 @@ pub(crate) fn parse_compound_subject_keyword_static(
         (input, None)
     };
 
-    // Subject: "you and <object subject phrase>".
-    let after_you = nom_tag_tp(&body, "you and ")?;
+    // Subject: the bare 2-item form "you and <object subject phrase>", or the
+    // Oxford-comma N-item form "you, <object subject phrase>, …". The comma-led
+    // form is a disjoint grammar path from the bare "and" form — gating on the
+    // leading comma leaves the 2-item path's existing fallthrough to
+    // `parse_rule_static_subject_filter` (which itself resolves an object
+    // subject with an internal bare "and", e.g. "artifacts and creatures you
+    // control", via `parse_type_phrase`'s own trailing-suffix distribution)
+    // completely unchanged.
+    let (after_you, multi_object) = match nom_tag_tp(&body, "you, ") {
+        Some(rest) => (rest, true),
+        None => (nom_tag_tp(&body, "you and ")?, false),
+    };
 
     // Locate the continuous predicate verb ("have"/"has"/"gain"/"gains"/…) so
     // the object subject can be any phrase `parse_rule_static_subject_filter`
@@ -401,12 +418,17 @@ pub(crate) fn parse_compound_subject_keyword_static(
         return None;
     }
 
-    let affected = parse_rule_static_subject_filter(object_subject.original)?;
-    // Player half is reserved for the controller; refuse a second player scope
-    // ("you and each player have …") so we never emit two player defs.
-    if rule_static_affected_is_player_scope(&affected) {
-        return None;
-    }
+    let affected = if multi_object {
+        parse_oxford_object_conjuncts(object_subject.original)?
+    } else {
+        let filter = parse_rule_static_subject_filter(object_subject.original)?;
+        // Player half is reserved for the controller; refuse a second player
+        // scope ("you and each player have …") so we never emit two player defs.
+        if rule_static_affected_is_player_scope(&filter) {
+            return None;
+        }
+        filter
+    };
 
     // Object-half: delegate the predicate to the shared keyword-grant builder
     // (also peels trailing " as long as <cond>" onto `object_def.condition`).
@@ -446,6 +468,54 @@ pub(crate) fn parse_compound_subject_keyword_static(
     player_def.condition = object_def.condition.clone();
 
     Some(vec![object_def, player_def])
+}
+
+/// CR 611.3a: Resolve an Oxford-comma object-subject list (`"<A>, <B>, and
+/// <C>"`) into an `Or` of per-conjunct filters for
+/// [`parse_compound_subject_keyword_static`]'s N-item form. Shalai, Voice of
+/// Plenty is the anchor card: "You, planeswalkers you control, and other
+/// creatures you control have hexproof." — after the caller peels the leading
+/// `"You, "`, the object list handed here is "planeswalkers you control, and
+/// other creatures you control".
+///
+/// Each conjunct is a COMPLETE, independently-resolvable subject phrase — unlike
+/// the Silkguard-class object list in `parse_type_phrase` (`oracle_target.rs`),
+/// where a single trailing suffix distributes backward across bare type nouns
+/// with no clause of their own ("Auras, Equipment, and modified creatures you
+/// control"). So every conjunct here is resolved one at a time through the same
+/// [`parse_rule_static_subject_filter`] the 2-item form uses, rather than a
+/// bespoke list grammar. Splitting is nom-based (`split_once_on`), peeling
+/// `", "`-separated conjuncts and stripping the final conjunct's `"and "`
+/// connector — never a bare `" and "` split, so the 2-item form's own
+/// internal-"and" handling (via `parse_type_phrase`'s trailing-suffix
+/// distribution) is never shadowed.
+///
+/// Declines (returns `None`, the strict-fail signal) if any conjunct fails to
+/// resolve or is itself a player scope — the same "no second player scope"
+/// guard the 2-item form applies, now checked per conjunct. A partial resolve
+/// would silently drop a disjunct rather than surfacing the failure.
+fn parse_oxford_object_conjuncts(text: &str) -> Option<TargetFilter> {
+    let mut conjuncts: Vec<&str> = Vec::new();
+    let mut remaining = text;
+    while let Ok((_, (item, rest))) = nom_primitives::split_once_on(remaining, ", ") {
+        conjuncts.push(item.trim());
+        remaining = rest;
+    }
+    let last = remaining.trim();
+    conjuncts.push(last.strip_prefix("and ").unwrap_or(last).trim());
+    if conjuncts.len() < 2 {
+        return None;
+    }
+
+    let mut filters = Vec::with_capacity(conjuncts.len());
+    for conjunct in conjuncts {
+        let filter = parse_rule_static_subject_filter(conjunct)?;
+        if rule_static_affected_is_player_scope(&filter) {
+            return None;
+        }
+        filters.push(filter);
+    }
+    Some(TargetFilter::Or { filters })
 }
 
 /// CR 702.16 + CR 702.16k + CR 702.16i: Player-SUBJECT protection of the form

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1265,10 +1265,12 @@ fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
     }
 
     // CR 702.11 + CR 702.16 + CR 702.18 + CR 611.3a: "You and <objects> have
-    // <player-applicable keyword>" (Sigarda / Serra's Emissary / Gruul Spellbreaker).
-    // Must claim before the single-return fallback, which otherwise emits one
-    // bogus Continuous Or{empty-typed You, objects} that grants the keyword to
-    // every permanent you control.
+    // <player-applicable keyword>" (Sigarda / Serra's Emissary / Gruul
+    // Spellbreaker), or the Oxford-comma N-item form "You, <objects>, …, and
+    // <objects> have <keyword>" (Shalai, Voice of Plenty). Must claim before
+    // the single-return fallback, which otherwise emits one bogus Continuous
+    // Or{empty-typed You, objects} that grants the keyword to every permanent
+    // you control.
     if let Some(defs) = parse_compound_subject_keyword_static(&stripped, &lower) {
         return defs;
     }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -386,6 +386,103 @@ fn compound_subject_keyword_static_declines_flying_compound() {
     );
 }
 
+/// CR 702.11a + CR 702.11b + CR 611.3a: Shalai, Voice of Plenty — "You,
+/// planeswalkers you control, and other creatures you control have hexproof."
+/// The Oxford-comma N-item form of the compound-subject keyword splitter: the
+/// object half is an `Or` of two independently-resolved conjuncts (planeswalkers
+/// you control; other creatures you control — Shalai herself excluded by
+/// "other"), and the player half grants the controller `StaticMode::Hexproof`.
+#[test]
+fn compound_subject_keyword_static_splits_shalai_three_way() {
+    use crate::types::keywords::Keyword;
+
+    let defs = parse_static_line_multi(
+        "You, planeswalkers you control, and other creatures you control have hexproof.",
+    );
+    assert_eq!(
+        defs.len(),
+        2,
+        "expected object Continuous + player Hexproof, got {defs:?}"
+    );
+
+    let object_def = &defs[0];
+    assert_eq!(object_def.mode, StaticMode::Continuous);
+    match &object_def.affected {
+        Some(TargetFilter::Or { filters }) => {
+            assert_eq!(filters.len(), 2, "expected a 2-way Or, got {filters:#?}");
+            assert!(
+                filters.contains(&TargetFilter::Typed(
+                    TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::You)
+                )),
+                "must include planeswalkers you control: {filters:#?}"
+            );
+            assert!(
+                filters.contains(&TargetFilter::Typed(
+                    TypedFilter::creature()
+                        .controller(ControllerRef::You)
+                        .properties(vec![FilterProp::Another])
+                )),
+                "must include other creatures you control: {filters:#?}"
+            );
+        }
+        other => panic!("object-half affected must be a 2-way Or, got {other:?}"),
+    }
+    assert_eq!(
+        object_def.modifications,
+        vec![ContinuousModification::AddKeyword {
+            keyword: Keyword::Hexproof
+        }],
+    );
+
+    let player_def = &defs[1];
+    assert_eq!(player_def.mode, StaticMode::Hexproof);
+    assert_eq!(
+        player_def.affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You)
+        )),
+    );
+    assert!(
+        player_def.modifications.is_empty(),
+        "player Hexproof mode carries no AddKeyword mods, got {:?}",
+        player_def.modifications
+    );
+}
+
+/// Negative/boundary: an Oxford-list conjunct that can't be resolved must fail
+/// the WHOLE line closed (strict-fail), never silently drop the bad disjunct
+/// and emit a narrower-than-printed hexproof grant.
+#[test]
+fn compound_subject_keyword_static_declines_oxford_list_unresolvable_conjunct() {
+    let defs = parse_static_line_multi(
+        "You, blorptastic wobbling nonsense, and other creatures you control have hexproof.",
+    );
+    assert!(
+        !defs
+            .iter()
+            .any(|d| matches!(d.mode, StaticMode::Hexproof | StaticMode::Shroud)),
+        "an unresolvable conjunct must not yield a partial hexproof grant, got {defs:?}"
+    );
+}
+
+/// General arity check: the Oxford-comma splitter is not hard-coded to exactly
+/// two object conjuncts (Shalai's arity) — a synthetic four-item list must
+/// split into a 3-way object Or the same way a three-item list splits into 2-way.
+#[test]
+fn compound_subject_keyword_static_splits_four_item_oxford_list() {
+    let defs = parse_static_line_multi(
+        "You, artifacts you control, enchantments you control, and lands you control have shroud.",
+    );
+    assert_eq!(defs.len(), 2, "expected two defs, got {defs:?}");
+    match &defs[0].affected {
+        Some(TargetFilter::Or { filters }) => {
+            assert_eq!(filters.len(), 3, "expected a 3-way Or, got {filters:#?}");
+        }
+        other => panic!("object-half affected must be a 3-way Or, got {other:?}"),
+    }
+    assert_eq!(defs[1].mode, StaticMode::Shroud);
+}
+
 // CR 611.3a + CR 604.3 + CR 613.4a: Angry Mob — a two-clause turn-window CDA. "During
 // your turn, ~'s power and toughness are each equal to 2 plus the number of
 // Swamps your opponents control. During turns other than yours, ~'s power and


### PR DESCRIPTION
## Summary

Fixes #5383.

`parse_compound_subject_keyword_static` (`crates/engine/src/parser/oracle_static/evasion.rs`) decomposes the compound player+object keyword-grant pattern `"You and <object subject> have <keyword>"` (Sigarda, Heron's Grace; Serra's Emissary; Gruul Spellbreaker) into an object-half `Continuous`/`AddKeyword` def and a player-half `Hexproof`/`Shroud`/`PlayerProtection` def, since a single `StaticDefinition` can't carry both a player scope and an object scope.

Its subject match was hard-coded to the literal seam `"you and "` — exactly one object conjunct. **Shalai, Voice of Plenty**'s real Oracle text uses a 3-item Oxford-comma list instead:

```
Flying
You, planeswalkers you control, and other creatures you control have hexproof.
{4}{G}{G}: Put a +1/+1 counter on each creature you control.
```

(verified via Scryfall, `oracle_id: a0c47ab6-dfb4-46ee-a3f7-9e1521b4bb4b`)

Because the line starts with `"You, "` rather than `"You and "`, the tag match failed immediately and the line fell through to the generic fallback, which couldn't resolve it either — `client/public/card-data.json` recorded it as `Unimplemented("static_structure", "Static pattern matched but line failed static parser: …")`. Shalai's entire signature ability was silently dropped.

## Why this is a class, not a card

The object-only N-way Oxford-comma case already works (`parse_type_phrase` + `distribute_controller_to_or`, proven by the Silkguard test and *Kismet*), but only when a single trailing suffix distributes backward across bare type-noun legs with no clause of their own. Shalai's shape is different: `"you"` is the first list item, and each subsequent conjunct (`"planeswalkers you control"`, `"other creatures you control"`) is a **complete, independently-resolvable subject phrase** — exactly what `parse_rule_static_subject_filter` already resolves one at a time inside the existing 2-item function. Nothing peeled the leading `"you"` token off an arbitrary-length Oxford list and Or-combined the resolved remainder.

This is a straight generalization of the function's "object subject" axis from exactly-one-conjunct to N-conjuncts, following this repo's "parameterize, don't proliferate" convention rather than hand-rolling a Shalai-specific branch.

## Changes

- `evasion.rs`: `parse_compound_subject_keyword_static` now accepts `"you, "` (Oxford-comma N-item form) as an alternate lead to the existing `"you and "` (bare 2-item form). The comma gate keeps the two grammars disjoint — the 2-item path's existing fallthrough to `parse_rule_static_subject_filter` (which itself resolves an object subject with an internal bare `"and"`, e.g. `"artifacts and creatures you control"`, via `parse_type_phrase`'s own trailing-suffix distribution) is completely unchanged.
- New `parse_oxford_object_conjuncts` helper: nom-based (`split_once_on`), peels `", "`-separated conjuncts plus the final `", and "`/`"and "` connector, resolves each conjunct through the existing `parse_rule_static_subject_filter`, and Or-combines them. Applies the same "no second player scope" guard the 2-item form already applies, now per conjunct.
- Both existing call sites of `parse_compound_subject_keyword_static` (the direct dispatch and the inverted `"As long as <cond>, …"` rewrite path) pick up the generalization automatically since it's one function, not a new sibling dispatcher.
- `shared.rs`: updated the dispatch-site comment to document the new N-item form.
- `tests.rs`: flips no existing test (none previously exercised this exact shape); adds:
  - `compound_subject_keyword_static_splits_shalai_three_way` — the real card, asserting the 2-way object `Or` (planeswalkers you control; other creatures you control) and the player-half `Hexproof` mode.
  - `compound_subject_keyword_static_declines_oxford_list_unresolvable_conjunct` — boundary guard: an unresolvable conjunct must strict-fail the whole line, not silently drop the bad disjunct.
  - `compound_subject_keyword_static_splits_four_item_oxford_list` — arity generality check (synthetic 4-item list → 3-way object `Or`), proving the splitter isn't hard-coded to Shalai's 3-item arity.

## CR references

- `CR 611.3a` — a continuous effect generated by a static ability applies to whatever its text indicates.
- `CR 702.11a`/`CR 702.11b` — hexproof.
- `CR 702.16` — protection.
- `CR 702.18` — shroud.

## Verification

- `cargo fmt -p engine -- --check` — clean, no diff.
- **Local `cargo check`/`cargo test` could not be run to completion in the environment this PR was authored in** — the sandbox has no working MSVC linker (`link.exe` on `PATH` resolves to Git for Windows' coreutils `link`, not the MSVC linker) and no Docker/WSL fallback, so native build-script compilation fails for unrelated foundational crates (`serde`, `proc-macro2`, etc.) before reaching this crate's code. I verified the change through careful manual review (type/signature cross-checks against every function called, hand-traced the split logic against the real Shalai text and three synthetic inputs) and via `cargo fmt`'s parse-clean check, but **please treat CI as the first real compile/test signal for this PR** and let me know if anything surfaces.

## Scope Expansion

None.
