### PR TITLE
fix(parser): support "attacking the last chosen player" statics (Triarch Stalker)

### DIFF
--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -10200,6 +10200,66 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn attacking_defender_matches_source_chosen_player() {
+        // CR 508.1b + CR 613.1: Triarch Stalker / Beckoning Will-o'-Wisp scope
+        // attackers by the source's persisted chosen player. `attacking_defender_
+        // matches` resolves `Some(SourceChosenPlayer)` through the generic
+        // `controller_ref_player` arm, which reads the choice durably persisted on
+        // the source object (`ChosenAttribute::Player`). An attacker attacking the
+        // chosen player matches; one attacking any other player does not.
+        use crate::game::zones::create_object;
+        use crate::types::ability::ChosenAttribute;
+
+        let mut state = GameState::new_two_player(7);
+        let card_id = CardId(state.next_object_id);
+        let src = create_object(
+            &mut state,
+            card_id,
+            PlayerId(0),
+            "Triarch Stalker".to_string(),
+            crate::types::zones::Zone::Battlefield,
+        );
+        // The combat trigger persisted P1 as the chosen player.
+        state
+            .objects
+            .get_mut(&src)
+            .unwrap()
+            .chosen_attributes
+            .push(ChosenAttribute::Player(PlayerId(1)));
+
+        let source_ctx = SourceContext {
+            id: src,
+            controller: Some(PlayerId(0)),
+            attached_to: None,
+            source_is_aura: false,
+            source_is_equipment: false,
+            chosen_creature_type: None,
+            chosen_attributes: &[],
+            ability: None,
+            recipient_id: None,
+        };
+
+        assert!(
+            attacking_defender_matches(
+                &state,
+                &source_ctx,
+                PlayerId(1),
+                Some(&ControllerRef::SourceChosenPlayer),
+            ),
+            "an attacker attacking the persisted chosen player must match"
+        );
+        assert!(
+            !attacking_defender_matches(
+                &state,
+                &source_ctx,
+                PlayerId(0),
+                Some(&ControllerRef::SourceChosenPlayer),
+            ),
+            "an attacker attacking a non-chosen player must not match"
+        );
+    }
+
     // ===========================================================================
     // CR 702.73a — Changeling subtype expansion cascade.
     //

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1300,7 +1300,11 @@ fn reconcile_host_bound_phase_outs_in_ability(def: &mut AbilityDefinition) {
 /// the resolution-scoped `ChosenPlayer { index }`). This pass flips `persist` to
 /// `true` on those choices ONLY when the card also carries a durable
 /// `SourceChosenPlayer` reference — mirroring the "persist when referred back to"
-/// intent documented on `Effect::Choose`.
+/// intent documented on `Effect::Choose`. The reference can live in a static
+/// (`Creatures attacking the last chosen player ...`), an activated ability, or a
+/// triggered ability — a phase trigger scoped to "the chosen player's" step
+/// (`oracle_trigger.rs`) or an effect keyed to the chosen player — so all three
+/// surfaces are scanned as readers.
 fn reconcile_persisted_player_choice_for_source_chosen_ref(result: &mut ParsedAbilities) {
     let references_source_chosen_player = result
         .statics
@@ -1309,7 +1313,11 @@ fn reconcile_persisted_player_choice_for_source_chosen_ref(result: &mut ParsedAb
         || result
             .abilities
             .iter()
-            .any(ability_references_source_chosen_player);
+            .any(ability_references_source_chosen_player)
+        || result
+            .triggers
+            .iter()
+            .any(trigger_references_source_chosen_player);
     if !references_source_chosen_player {
         return;
     }
@@ -1331,6 +1339,20 @@ fn static_references_source_chosen_player(def: &StaticDefinition) -> bool {
         .is_some_and(filter_references_source_chosen_player)
 }
 
+/// Whether a triggered ability reads the source's persisted chosen player —
+/// either via its own `valid_target` (a phase trigger scoped to "the chosen
+/// player's" step) or anywhere in its executed effect chain.
+fn trigger_references_source_chosen_player(trigger: &TriggerDefinition) -> bool {
+    trigger
+        .valid_target
+        .as_ref()
+        .is_some_and(filter_references_source_chosen_player)
+        || trigger
+            .execute
+            .as_deref()
+            .is_some_and(ability_references_source_chosen_player)
+}
+
 /// Whether an ability's effect targets the source's persisted chosen player, so
 /// a "choose a player" earlier in the same card must persist it. Recurses the
 /// sub-ability chain.
@@ -1342,11 +1364,14 @@ fn ability_references_source_chosen_player(def: &AbilityDefinition) -> bool {
             .is_some_and(ability_references_source_chosen_player)
 }
 
+/// Whether any target filter carried by `effect` reads the source's persisted
+/// chosen player. Uses the generic `Effect::target_filter` accessor so every
+/// player-targeting effect variant is covered (damage, life loss/gain, draw,
+/// discard, mill, ...), not a single hand-enumerated case.
 fn effect_targets_source_chosen_player(effect: &Effect) -> bool {
-    match effect {
-        Effect::DealDamage { target, .. } => filter_references_source_chosen_player(target),
-        _ => false,
-    }
+    effect
+        .target_filter()
+        .is_some_and(filter_references_source_chosen_player)
 }
 
 /// Tree-walks a `TargetFilter` for a durable `SourceChosenPlayer` reference —

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1285,6 +1285,115 @@ fn reconcile_host_bound_phase_outs_in_ability(def: &mut AbilityDefinition) {
     }
 }
 
+/// CR 613.1 + CR 608.2c: A `choose a player` / `choose an opponent` instruction
+/// whose chosen player is later read by a CONTINUOUS ability must persist that
+/// choice durably on the source as a `ChosenAttribute::Player`; otherwise the
+/// resolution-scoped choice vanishes when the trigger finishes resolving and the
+/// static reads nothing. Triarch Stalker / Beckoning Will-o'-Wisp pair a combat
+/// trigger (`At the beginning of combat on your turn, choose an opponent`) with a
+/// separate static (`Creatures attacking the last chosen player ...`) that reads
+/// the choice via `ControllerRef::SourceChosenPlayer`.
+///
+/// The general path (`lower_choose_ast`) leaves player/opponent choices
+/// `persist: false` because most such choices are consumed within the same
+/// resolution (Ruhan's `choose an opponent. ~ attacks that player`, which reads
+/// the resolution-scoped `ChosenPlayer { index }`). This pass flips `persist` to
+/// `true` on those choices ONLY when the card also carries a durable
+/// `SourceChosenPlayer` reference — mirroring the "persist when referred back to"
+/// intent documented on `Effect::Choose`.
+fn reconcile_persisted_player_choice_for_source_chosen_ref(result: &mut ParsedAbilities) {
+    let references_source_chosen_player = result
+        .statics
+        .iter()
+        .any(static_references_source_chosen_player)
+        || result
+            .abilities
+            .iter()
+            .any(ability_references_source_chosen_player);
+    if !references_source_chosen_player {
+        return;
+    }
+    for ability in &mut result.abilities {
+        persist_player_choice_in_ability(ability);
+    }
+    for trigger in &mut result.triggers {
+        if let Some(execute) = trigger.execute.as_mut() {
+            persist_player_choice_in_ability(execute);
+        }
+    }
+}
+
+/// Whether a static definition's `affected` filter reads the source's persisted
+/// chosen player (`ControllerRef::SourceChosenPlayer`).
+fn static_references_source_chosen_player(def: &StaticDefinition) -> bool {
+    def.affected
+        .as_ref()
+        .is_some_and(filter_references_source_chosen_player)
+}
+
+/// Whether an ability's effect targets the source's persisted chosen player, so
+/// a "choose a player" earlier in the same card must persist it. Recurses the
+/// sub-ability chain.
+fn ability_references_source_chosen_player(def: &AbilityDefinition) -> bool {
+    effect_targets_source_chosen_player(&def.effect)
+        || def
+            .sub_ability
+            .as_deref()
+            .is_some_and(ability_references_source_chosen_player)
+}
+
+fn effect_targets_source_chosen_player(effect: &Effect) -> bool {
+    match effect {
+        Effect::DealDamage { target, .. } => filter_references_source_chosen_player(target),
+        _ => false,
+    }
+}
+
+/// Tree-walks a `TargetFilter` for a durable `SourceChosenPlayer` reference —
+/// the bare player-target filter, a `TypedFilter` whose controller or attacking
+/// defender is the chosen player, or any of those nested under And/Or/Not.
+fn filter_references_source_chosen_player(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::SourceChosenPlayer => true,
+        TargetFilter::Typed(TypedFilter {
+            controller,
+            properties,
+            ..
+        }) => {
+            *controller == Some(ControllerRef::SourceChosenPlayer)
+                || properties.iter().any(|prop| {
+                    matches!(
+                        prop,
+                        FilterProp::Attacking {
+                            defender: Some(ControllerRef::SourceChosenPlayer),
+                        }
+                    )
+                })
+        }
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(filter_references_source_chosen_player)
+        }
+        TargetFilter::Not { filter } => filter_references_source_chosen_player(filter),
+        _ => false,
+    }
+}
+
+/// Flips a `choose a player` / `choose an opponent` effect (and any in its
+/// sub-ability chain) to `persist: true` so its choice is stored durably.
+fn persist_player_choice_in_ability(def: &mut AbilityDefinition) {
+    if let Effect::Choose {
+        choice_type: ChoiceType::Player | ChoiceType::Opponent { .. },
+        persist,
+        ..
+    } = def.effect.as_mut()
+    {
+        *persist = true;
+    }
+    if let Some(sub) = def.sub_ability.as_mut() {
+        persist_player_choice_in_ability(sub);
+    }
+}
+
 fn chain_contains_host_bound_tap_rider(def: &AbilityDefinition) -> bool {
     if is_host_bound_phase_in_tap_rider_node(def) {
         return true;
@@ -4649,6 +4758,7 @@ pub(crate) fn parse_oracle_ir(
     reconcile_choose_then_chosen_dependent_etb_counters(&mut result);
     reconcile_self_chosen_type_statics(&mut result, types);
     reconcile_host_bound_phase_outs(&mut result);
+    reconcile_persisted_player_choice_for_source_chosen_ref(&mut result);
 
     // Architectural rule: the parser must never silently discard Oracle
     // text. Run the swallow audit against the parsed result so any unrep-

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -511,20 +511,26 @@ fn filter_prop_has_power_comparison(prop: &FilterProp) -> bool {
     }
 }
 
-/// CR 508.1b + CR 303.4b: Parse the `"[all ]creatures attacking <scope> "` prefix
-/// of an attacker-scoped continuous static, returning the remaining predicate
-/// text (original case) and the defending-player [`ControllerRef`]. The defender
-/// scope is the sole varying axis, so it is a single `alt` rather than one
-/// dispatch arm per scope: controller (`you`), any opponent (`your opponents`,
-/// whose `and/or planeswalkers they control` long form collapses to the same
-/// `Opponent` scope), or the enchanted player (`enchanted player`). The trailing
-/// space in each phrase enforces a word boundary — `"you "` never swallows the
-/// `"your"` of `"your opponents"`.
+/// CR 508.1b + CR 303.4b + CR 613.1: Parse the `"[all ]creatures attacking
+/// <scope> "` prefix of an attacker-scoped continuous static, returning the
+/// remaining predicate text (original case) and the defending-player
+/// [`ControllerRef`]. The defender scope is the sole varying axis, so it is a
+/// single `alt` rather than one dispatch arm per scope: controller (`you`), any
+/// opponent (`your opponents`, whose `and/or planeswalkers they control` long
+/// form collapses to the same `Opponent` scope), the enchanted player
+/// (`enchanted player`), or the source's persisted chosen player (`the last
+/// chosen player` / `the chosen player`; Triarch Stalker, Beckoning
+/// Will-o'-Wisp — a combat trigger `choose an opponent` persists a
+/// `ChosenAttribute::Player` that this static reads via
+/// `ControllerRef::SourceChosenPlayer`). The trailing space in each phrase
+/// enforces a word boundary — `"you "` never swallows the `"your"` of
+/// `"your opponents"`.
 fn parse_attacking_defender_scope<'a>(tp: &TextPair<'a>) -> Option<(&'a str, ControllerRef)> {
     let rest = nom_tag_tp(tp, "all creatures attacking ")
         .or_else(|| nom_tag_tp(tp, "creatures attacking "))?;
     // Longest-first so the "your opponents and/or …" long form wins before the
-    // bare "your opponents ".
+    // bare "your opponents ", and "the last chosen player " before the shorter
+    // "the chosen player ".
     for (phrase, defender) in [
         ("you ", ControllerRef::You),
         (
@@ -533,6 +539,8 @@ fn parse_attacking_defender_scope<'a>(tp: &TextPair<'a>) -> Option<(&'a str, Con
         ),
         ("your opponents ", ControllerRef::Opponent),
         ("enchanted player ", ControllerRef::EnchantedPlayer),
+        ("the last chosen player ", ControllerRef::SourceChosenPlayer),
+        ("the chosen player ", ControllerRef::SourceChosenPlayer),
     ] {
         if let Some(after) = nom_tag_tp(&rest, phrase) {
             return Some((after.original, defender));

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -9675,6 +9675,55 @@ fn choose_opponent_without_source_chosen_reference_does_not_persist() {
 }
 
 #[test]
+fn choose_persists_when_only_a_trigger_reads_the_chosen_player() {
+    // CR 613.1 + CR 503.1a: the durable `SourceChosenPlayer` reference can live in
+    // a TRIGGER (a phase trigger scoped to "the chosen player's upkeep", plus its
+    // effect targeting that player) rather than a static or activated ability. The
+    // reconcile pass must scan triggers as READERS, not only as writers, so the
+    // preceding "choose an opponent" is flipped to persist. LOAD-BEARING
+    // REGRESSION: without the `result.triggers` reader scan the choose stays
+    // `persist: false` and the chosen player is lost after the choice resolves.
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::ChoiceType;
+
+    let parsed = parse_oracle_text(
+        "When this artifact enters the battlefield, choose an opponent.\nAt the beginning of the chosen player's upkeep, this artifact deals 1 damage to that player.",
+        "Chosen-Player Rack",
+        &[],
+        &["Artifact".to_string()],
+        &[],
+    );
+    // Sanity: the reference lives only in the phase trigger's `valid_target`.
+    assert!(
+        parsed
+            .triggers
+            .iter()
+            .any(|t| t.valid_target == Some(TargetFilter::SourceChosenPlayer)),
+        "expected a phase trigger scoped to SourceChosenPlayer, got {:?}",
+        parsed.triggers
+    );
+    // The ETB choose must be flipped to persist by the trigger-reader scan.
+    let choose = parsed
+        .triggers
+        .iter()
+        .filter_map(|t| t.execute.as_deref())
+        .find(|a| matches!(&*a.effect, Effect::Choose { .. }))
+        .expect("expected a triggered choose ability");
+    assert!(
+        matches!(
+            &*choose.effect,
+            Effect::Choose {
+                choice_type: ChoiceType::Opponent { .. },
+                persist: true,
+                ..
+            }
+        ),
+        "a choose read only by a trigger must still persist, got {:?}",
+        choose.effect
+    );
+}
+
+#[test]
 fn boarded_window_full_text_has_no_swallowed_clause_regression() {
     use crate::parser::oracle::parse_oracle_text;
     use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -9540,6 +9540,141 @@ fn static_creatures_attacking_you_get_pump() {
 }
 
 #[test]
+fn static_creatures_attacking_last_chosen_player_scope() {
+    // CR 508.1b + CR 613.1: Triarch Stalker / Beckoning Will-o'-Wisp scope the
+    // attacking axis by the source's persisted chosen player. Both "the last
+    // chosen player" and the shorter "the chosen player" phrasing map to
+    // `ControllerRef::SourceChosenPlayer`, reusing the same `FilterProp::Attacking`
+    // + `parse_continuous_gets_has` path as the you/opponents/enchanted scopes.
+    let menace =
+        parse_static_line("Creatures attacking the last chosen player have menace.").unwrap();
+    assert_eq!(menace.mode, StaticMode::Continuous);
+    assert_eq!(
+        menace.affected,
+        Some(TargetFilter::Typed(TypedFilter::creature().properties(
+            vec![FilterProp::Attacking {
+                defender: Some(ControllerRef::SourceChosenPlayer)
+            }]
+        ),))
+    );
+    assert!(menace
+        .modifications
+        .contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Menace,
+        }));
+
+    let pump = parse_static_line("Creatures attacking the last chosen player get +1/+0.").unwrap();
+    assert_eq!(
+        pump.affected,
+        Some(TargetFilter::Typed(TypedFilter::creature().properties(
+            vec![FilterProp::Attacking {
+                defender: Some(ControllerRef::SourceChosenPlayer)
+            }]
+        ),))
+    );
+    assert!(pump
+        .modifications
+        .contains(&ContinuousModification::AddPower { value: 1 }));
+
+    // Shorter "the chosen player" phrasing resolves to the same scope.
+    let short = parse_static_line("Creatures attacking the chosen player have menace.").unwrap();
+    assert_eq!(
+        short.affected,
+        Some(TargetFilter::Typed(TypedFilter::creature().properties(
+            vec![FilterProp::Attacking {
+                defender: Some(ControllerRef::SourceChosenPlayer)
+            }]
+        ),))
+    );
+}
+
+#[test]
+fn triarch_stalker_choose_opponent_persists_for_last_chosen_player_static() {
+    // CR 613.1 + CR 608.2c: the combat trigger "choose an opponent" must persist
+    // its choice durably (as `ChosenAttribute::Player`) BECAUSE a separate
+    // continuous static reads it via `ControllerRef::SourceChosenPlayer`. The
+    // `reconcile_persisted_player_choice_for_source_chosen_ref` pass flips the
+    // choice's `persist` to true when such a reference is present.
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::ChoiceType;
+
+    let parsed = parse_oracle_text(
+        "Targeting Relay — At the beginning of combat on your turn, choose an opponent.\nCreatures attacking the last chosen player have menace.",
+        "Triarch Stalker",
+        &[],
+        &["Artifact".to_string(), "Creature".to_string()],
+        &["Necron".to_string()],
+    );
+
+    // The static reads the source's persisted chosen player.
+    assert!(
+        parsed.statics.iter().any(|s| matches!(
+            &s.affected,
+            Some(TargetFilter::Typed(tf)) if tf.properties.contains(&FilterProp::Attacking {
+                defender: Some(ControllerRef::SourceChosenPlayer),
+            })
+        )),
+        "static must scope attackers by SourceChosenPlayer, got {:?}",
+        parsed.statics
+    );
+
+    // The combat trigger's opponent choice must persist so the static can read it.
+    let choose = parsed
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_deref())
+        .expect("expected a triggered choose ability");
+    assert!(
+        matches!(
+            &*choose.effect,
+            Effect::Choose {
+                choice_type: ChoiceType::Opponent { .. },
+                persist: true,
+                ..
+            }
+        ),
+        "choose an opponent must persist when a SourceChosenPlayer static reads it, got {:?}",
+        choose.effect
+    );
+}
+
+#[test]
+fn choose_opponent_without_source_chosen_reference_does_not_persist() {
+    // Targeted-pass regression: a "choose an opponent" trigger whose choice is
+    // consumed WITHIN the same resolution (Ruhan — the forced attack reads the
+    // resolution-scoped `ChosenPlayer { index }`) carries no durable
+    // `SourceChosenPlayer` reference, so the reconcile pass must leave it
+    // `persist: false`.
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::ChoiceType;
+
+    let parsed = parse_oracle_text(
+        "At the beginning of combat on your turn, choose an opponent at random. ~ attacks that player this combat if able.",
+        "Ruhan of the Fomori",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let choose = parsed
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_deref())
+        .expect("expected a triggered choose ability");
+    assert!(
+        matches!(
+            &*choose.effect,
+            Effect::Choose {
+                choice_type: ChoiceType::Opponent { .. },
+                persist: false,
+                ..
+            }
+        ),
+        "a same-resolution opponent choice must NOT be flipped to persist, got {:?}",
+        choose.effect
+    );
+}
+
+#[test]
 fn boarded_window_full_text_has_no_swallowed_clause_regression() {
     use crate::parser::oracle::parse_oracle_text;
     use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;


### PR DESCRIPTION
Closes #5391.

## What

Makes **Triarch Stalker** and **Beckoning Will-o'-Wisp** work. Both pair a combat trigger *"At the beginning of combat on your turn, choose an opponent"* with a continuous static *"Creatures attacking the last chosen player have menace / get +1/+0"*. Neither functioned: the static line failed to parse, and the opponent choice was not persisted for a continuous ability to read.

## How (routes to existing runtime, no engine changes)

**1. Static scope** — `parse_attacking_defender_scope` gains `"the last chosen player"` / `"the chosen player"` → `ControllerRef::SourceChosenPlayer`, alongside the existing you / your-opponents / enchanted-player scopes (same `alt`, one new axis value). The static parses to `FilterProp::Attacking { defender: Some(SourceChosenPlayer) }` + the modification, resolved by the existing `attacking_defender_matches` → `controller_ref_player` → `source_chosen_player` path.

**2. Durable persist** — new `reconcile_persisted_player_choice_for_source_chosen_ref` post-pass flips a `choose a player` / `choose an opponent` effect to `persist: true` **only when** the card carries a durable `SourceChosenPlayer` reference, so the choice is stored as `ChosenAttribute::Player`. This mirrors the "persist when referred back to" intent documented on `Effect::Choose`, and the runtime already re-runs layers for persisted `Player`/`Opponent` choices.

Targeted: a *same-resolution* opponent choice (Ruhan — reads the resolution-scoped `ChosenPlayer { index }`) has no durable reference and is left `persist: false`.

## Tests

- Static scope parsing (both phrasings) → `Attacking { defender: SourceChosenPlayer }` + menace / +1/+0.
- Full-card persist flip (Triarch Stalker) → trigger `Choose { Opponent, persist: true }`.
- Negative regression (Ruhan) → `persist: false` (pass stays targeted).
- Runtime `attacking_defender_matches` resolves against a persisted chosen player (matches the chosen player, rejects others).

## CR

CR 508.1b (attacking-player scope) + CR 613.1 / CR 608.2c (persisted "chosen player" read by a continuous ability).

## Verification

`cargo fmt --all` ✓ · engine lib suite **15,812 pass / 0 fail** ✓ · `clippy -p engine --all-targets -D warnings` clean ✓
