### PR TITLE
Fix Veyran, Voice of Duality

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -5180,6 +5180,41 @@ fn trigger_cause_matches(
             // additional time when a dungeon room is entered.
             matches!(event, Some(GameEvent::RoomEntered { .. }))
         }
+        TriggerCause::ControllerCastOrCopiedSpell { core_types } => {
+            // CR 601.2 + CR 707.10: Veyran-class doublers fire only for
+            // triggers caused by the doubler's controller casting or copying
+            // a spell. Both event kinds qualify ("you casting or copying");
+            // a copy is not cast (CR 707.10), so `SpellCopied` is a distinct
+            // event and must be matched explicitly.
+            let (controller, object_id) = match event {
+                Some(GameEvent::SpellCast {
+                    controller,
+                    object_id,
+                    ..
+                })
+                | Some(GameEvent::SpellCopied {
+                    controller,
+                    object_id,
+                    ..
+                }) => (*controller, *object_id),
+                _ => return false,
+            };
+            if controller != doubler_controller {
+                return false;
+            }
+            if core_types.is_empty() {
+                return true;
+            }
+            // CR 603.2d: The spell's type is named in the qualifier ("an
+            // instant or sorcery spell") — the stack object's core types must
+            // intersect the predicate's list.
+            state.objects.get(&object_id).is_some_and(|obj| {
+                obj.card_types
+                    .core_types
+                    .iter()
+                    .any(|ct| core_types.contains(ct))
+            })
+        }
     }
 }
 

--- a/crates/engine/src/game/triggers_dedup_regression_tests.rs
+++ b/crates/engine/src/game/triggers_dedup_regression_tests.rs
@@ -1156,6 +1156,152 @@ fn panharmonicon_does_not_double_attack_triggers() {
     );
 }
 
+/// CR 603.2d + CR 601.2 + CR 707.10: Veyran, Voice of Duality
+/// (`ControllerCastOrCopiedSpell { [Instant, Sorcery] }`) doubles a
+/// magecraft-style trigger when its controller casts an instant.
+#[test]
+fn veyran_doubles_trigger_caused_by_controller_casting_instant() {
+    use crate::types::statics::TriggerCause;
+
+    let (mut state, observer) = setup_with_observer(TriggerMode::SpellCastOrCopy);
+    let _veyran = install_doubler(
+        &mut state,
+        TriggerCause::ControllerCastOrCopiedSpell {
+            core_types: vec![CoreType::Instant, CoreType::Sorcery],
+        },
+    );
+
+    // An instant spell on the stack, cast by the doubler's controller.
+    let spell = create_object(
+        &mut state,
+        CardId(200),
+        PlayerId(0),
+        "Opt".to_string(),
+        Zone::Stack,
+    );
+    state
+        .objects
+        .get_mut(&spell)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Instant);
+
+    let event = GameEvent::SpellCast {
+        card_id: CardId(200),
+        controller: PlayerId(0),
+        object_id: spell,
+    };
+
+    process_triggers(&mut state, &[event]);
+    // CR 603.3b (#531): drain the per-controller ordering prompt.
+    super::drain_order_triggers_with_identity(&mut state);
+    let observer_triggers = state
+        .stack
+        .iter()
+        .filter(|e| e.source_id == observer)
+        .count();
+    assert_eq!(
+        observer_triggers, 2,
+        "Veyran must double a trigger caused by its controller casting an instant"
+    );
+}
+
+/// CR 603.2d: Veyran does NOT double attack triggers — the cause predicate is
+/// `ControllerCastOrCopiedSpell`, not `CreatureAttacking`. Regression for
+/// issue #5291 (Veyran was copying an attack trigger).
+#[test]
+fn veyran_does_not_double_attack_triggers() {
+    use crate::types::statics::TriggerCause;
+
+    let (mut state, observer) = setup_with_observer(TriggerMode::Attacks);
+    state
+        .objects
+        .get_mut(&observer)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
+    let _veyran = install_doubler(
+        &mut state,
+        TriggerCause::ControllerCastOrCopiedSpell {
+            core_types: vec![CoreType::Instant, CoreType::Sorcery],
+        },
+    );
+
+    let event = GameEvent::AttackersDeclared {
+        attacker_ids: vec![observer],
+        defending_player: PlayerId(1),
+        attacks: vec![(
+            observer,
+            crate::game::combat::AttackTarget::Player(PlayerId(1)),
+        )],
+    };
+
+    process_triggers(&mut state, &[event]);
+    // CR 603.3b (#531): drain the per-controller ordering prompt.
+    super::drain_order_triggers_with_identity(&mut state);
+    let observer_triggers = state
+        .stack
+        .iter()
+        .filter(|e| e.source_id == observer)
+        .count();
+    assert_eq!(
+        observer_triggers, 1,
+        "Veyran must NOT double attack triggers — cause is ControllerCastOrCopiedSpell (#5291)"
+    );
+}
+
+/// CR 603.2d + CR 601.2: Veyran does NOT double a trigger caused by an
+/// OPPONENT casting a spell — "you casting or copying" scopes the cause to
+/// the doubler's controller.
+#[test]
+fn veyran_does_not_double_opponent_cast_trigger() {
+    use crate::types::statics::TriggerCause;
+
+    let (mut state, observer) = setup_with_observer(TriggerMode::SpellCastOrCopy);
+    let _veyran = install_doubler(
+        &mut state,
+        TriggerCause::ControllerCastOrCopiedSpell {
+            core_types: vec![CoreType::Instant, CoreType::Sorcery],
+        },
+    );
+
+    // An instant spell on the stack, cast by the OPPONENT.
+    let spell = create_object(
+        &mut state,
+        CardId(201),
+        PlayerId(1),
+        "Opt".to_string(),
+        Zone::Stack,
+    );
+    state
+        .objects
+        .get_mut(&spell)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Instant);
+
+    let event = GameEvent::SpellCast {
+        card_id: CardId(201),
+        controller: PlayerId(1),
+        object_id: spell,
+    };
+
+    process_triggers(&mut state, &[event]);
+    super::drain_order_triggers_with_identity(&mut state);
+    let observer_triggers = state
+        .stack
+        .iter()
+        .filter(|e| e.source_id == observer)
+        .count();
+    assert_eq!(
+        observer_triggers, 1,
+        "Veyran must NOT double a trigger caused by an opponent's cast"
+    );
+}
+
 /// Helper: install a source-restricted `DoubleTriggers` static
 /// (Splinter-class) — cause `Any`, narrowed by an `affected` source filter —
 /// controlled by PlayerId(0).

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -3160,7 +3160,37 @@ pub(crate) fn parse_static_line_inner(
     if nom_primitives::scan_contains(tp.lower, "triggers an additional time")
         || nom_primitives::scan_contains(tp.lower, "trigger an additional time")
     {
-        let cause = if nom_primitives::scan_contains(tp.lower, "being dealt damage causes")
+        let cause = if let Some((_, spell_qualifier, _)) =
+            nom_primitives::scan_preceded(tp.lower, |i| {
+                // CR 601.2 + CR 707.10: "you casting or copying <types> spell
+                // causes" — Veyran, Voice of Duality class. The qualifier
+                // between the verb pair and " spell causes" names the spell
+                // types ("an instant or sorcery").
+                preceded(
+                    tag::<_, _, OracleError<'_>>("you casting or copying "),
+                    take_until(" spell causes"),
+                )
+                .parse(i)
+            }) {
+            let mut core_types: Vec<CoreType> = Vec::new();
+            if nom_primitives::scan_contains(spell_qualifier, "instant") {
+                core_types.push(CoreType::Instant);
+            }
+            if nom_primitives::scan_contains(spell_qualifier, "sorcery") {
+                core_types.push(CoreType::Sorcery);
+            }
+            if nom_primitives::scan_contains(spell_qualifier, "artifact") {
+                core_types.push(CoreType::Artifact);
+            }
+            if nom_primitives::scan_contains(spell_qualifier, "creature") {
+                core_types.push(CoreType::Creature);
+            }
+            if nom_primitives::scan_contains(spell_qualifier, "enchantment") {
+                core_types.push(CoreType::Enchantment);
+            }
+            // An unqualified "a spell" leaves core_types empty = any spell.
+            TriggerCause::ControllerCastOrCopiedSpell { core_types }
+        } else if nom_primitives::scan_contains(tp.lower, "being dealt damage causes")
             || nom_primitives::scan_contains(tp.lower, "dealt damage causes")
         {
             TriggerCause::ControlledCreatureDealtDamage

--- a/crates/engine/src/parser/oracle_static/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_static/snapshot_tests.rs
@@ -626,6 +626,31 @@ fn parses_wayta_damage_caused_doubler() {
     );
 }
 
+/// CR 603.2d + CR 601.2 + CR 707.10: Cast-or-copy-caused trigger doubler
+/// (Veyran, Voice of Duality). "If you casting or copying an instant or
+/// sorcery spell causes ..." must produce a `ControllerCastOrCopiedSpell`
+/// cause narrowed to instants and sorceries — never the unrestricted `Any`
+/// fallback, which wrongly doubled attack/ETB triggers (issue #5291).
+#[test]
+fn parses_veyran_cast_or_copy_caused_doubler() {
+    let def = parse_static_line(
+        "If you casting or copying an instant or sorcery spell causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
+    )
+    .expect("expected DoubleTriggers static for Veyran");
+    assert_eq!(
+        def.mode,
+        StaticMode::DoubleTriggers {
+            cause: TriggerCause::ControllerCastOrCopiedSpell {
+                core_types: vec![CoreType::Instant, CoreType::Sorcery]
+            }
+        }
+    );
+    assert!(
+        def.affected.is_none(),
+        "bare 'a permanent you control' must not add a redundant affected filter"
+    );
+}
+
 /// CR 603.2d: Source-restricted trigger doubler (Splinter, Radical Rat).
 /// "If a triggered ability of a Ninja creature you control triggers, that
 /// ability triggers an additional time." The cause is unrestricted (`Any`),

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -590,6 +590,17 @@ pub enum TriggerCause {
     /// `GameEvent::DamageDealt` whose target is a creature controlled by the
     /// doubler's controller.
     ControlledCreatureDealtDamage,
+    /// CR 601.2 + CR 707.10: Trigger was caused by the doubler's controller
+    /// casting or copying a spell (Veyran, Voice of Duality-class: "If you
+    /// casting or copying an instant or sorcery spell causes ..."). Matches
+    /// `GameEvent::SpellCast` and `GameEvent::SpellCopied` events whose
+    /// controller is the doubler's controller. The `core_types` list narrows
+    /// the spell's type — for Veyran this is `[Instant, Sorcery]`; an empty
+    /// list means any spell.
+    ControllerCastOrCopiedSpell {
+        #[serde(default)]
+        core_types: Vec<super::card_type::CoreType>,
+    },
     /// CR 309.4c: Trigger was caused by entering a dungeon room
     /// (Hama Pashar-class). Matches `GameEvent::RoomEntered` events.
     RoomEntered,
@@ -607,6 +618,10 @@ impl fmt::Display for TriggerCause {
             TriggerCause::CreatureDying => write!(f, "CreatureDying"),
             TriggerCause::ControlledCreatureDealtDamage => {
                 write!(f, "ControlledCreatureDealtDamage")
+            }
+            TriggerCause::ControllerCastOrCopiedSpell { core_types } => {
+                let names: Vec<String> = core_types.iter().map(|ct| format!("{ct:?}")).collect();
+                write!(f, "ControllerCastOrCopiedSpell([{}])", names.join(","))
             }
             TriggerCause::RoomEntered => write!(f, "RoomEntered"),
         }


### PR DESCRIPTION
## Summary
Fixes the trigger-cause misclassification for **Veyran, Voice of Duality**. The "If ... causes a triggered ability ... to trigger, that ability triggers an additional time" parser had no arm for the "you casting or copying an instant or sorcery spell" qualifier and fell back to `TriggerCause::Any`, so Veyran doubled *every* trigger its controller owned — attack triggers, ETB triggers — instead of only triggers caused by casting or copying an instant or sorcery spell.

Closes #5291

## Files changed
- `crates/engine/src/types/statics.rs`
- `crates/engine/src/parser/oracle_static/dispatch.rs`
- `crates/engine/src/game/triggers.rs`
- `crates/engine/src/parser/oracle_static/snapshot_tests.rs`
- `crates/engine/src/game/triggers_dedup_regression_tests.rs`

## CR references
- CR 603.2d — trigger doubling cause classification
- CR 601.2 — casting a spell
- CR 707.10 — a copy of a spell is not cast; `SpellCopied` matched explicitly alongside `SpellCast`

## Gate A
```
$ ./scripts/check-parser-combinators.sh
(exit 0 — no violations reported; the script emits output only on violations)
```

## Anchored on
- `crates/engine/src/parser/oracle_static/dispatch.rs:3193-3202` — existing cause-classification chain (`ControlledCreatureDealtDamage` / `CreatureAttacking` / `EntersBattlefield`) that the new `ControllerCastOrCopiedSpell` arm extends, using the same `nom_primitives` scanning family
- `crates/engine/src/parser/oracle_static/dispatch.rs:2042` — existing `nom_primitives::scan_preceded` + combinator usage that the new spell-qualifier extraction mirrors
- `crates/engine/src/game/triggers.rs:5146-5178` — existing `trigger_cause_matches` arms (`CreatureAttacking`, `ControlledCreatureDealtDamage`, `RoomEntered`) that the new event-matching arm mirrors

Tier: Frontier

## Track
Developer

## LLM
Model: claude-fable-5-thinking
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `cargo clippy-strict` — clean (workspace, 0 warnings)
- `./scripts/check-parser-combinators.sh` — clean (exit 0)
- `cargo test -p engine --lib` — 15796 pass / 0 fail (pre-rebase full run; 4 new Veyran tests re-run green post-rebase)
- Parser snapshot: Veyran's static line parses to `DoubleTriggers { cause: ControllerCastOrCopiedSpell { [Instant, Sorcery] } }`
- Runtime regressions: doubles controller's instant-cast trigger; does NOT double attack triggers (the #5291 repro); does NOT double opponent-cast triggers

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

Made with [Cursor](https://cursor.com)