### PR TITLE
fix(engine): defer Kodama ETB triggers until search tutor spell finishes (#5336)

### DIFF
--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -1203,6 +1203,7 @@ mod tests {
             outcome,
             ResolutionChoiceOutcome::WaitingFor(_)
                 | ResolutionChoiceOutcome::WaitingForWithInlineTriggers(_)
+                | ResolutionChoiceOutcome::WaitingForWithParkedObservers(_)
                 | ResolutionChoiceOutcome::ActionResult(_)
         ));
         assert_eq!(state.players[0].life, 23);
@@ -1360,6 +1361,7 @@ mod tests {
         match outcome {
             ResolutionChoiceOutcome::WaitingFor(_) => {}
             ResolutionChoiceOutcome::WaitingForWithInlineTriggers(_) => {}
+            ResolutionChoiceOutcome::WaitingForWithParkedObservers(_) => {}
             ResolutionChoiceOutcome::ActionResult(_) => {}
         }
 
@@ -1470,6 +1472,7 @@ mod tests {
             outcome,
             ResolutionChoiceOutcome::WaitingFor(_)
                 | ResolutionChoiceOutcome::WaitingForWithInlineTriggers(_)
+                | ResolutionChoiceOutcome::WaitingForWithParkedObservers(_)
                 | ResolutionChoiceOutcome::ActionResult(_)
         ));
         assert_eq!(state.players[0].hand.len(), 2);

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -649,6 +649,7 @@ fn pass_priority_once_with_pipeline(
         events,
         &state.waiting_for.clone(),
         skip_triggers,
+        false,
     )?;
     sync_waiting_for(state, &wf);
 
@@ -1114,6 +1115,7 @@ fn apply_action(
 
     let mut events = Vec::new();
     let mut triggers_processed_inline = false;
+    let mut skip_deferred_trigger_drain = false;
 
     // CancelAutoPass works from any WaitingFor state (player may cancel during
     // interactive choices). Routed by `actor` — previously used
@@ -4014,6 +4016,7 @@ fn apply_action(
                 &mut events,
                 &WaitingFor::Priority { player: p },
                 true,
+                false,
             )?
         }
         // CR 702.94a: Miracle reveal — decline path. Reuses the generic
@@ -4033,6 +4036,7 @@ fn apply_action(
                 &mut events,
                 &WaitingFor::Priority { player: p },
                 true,
+                false,
             )?
         }
         // CR 702.94a + CR 608.2g: Miracle cast offer — the miracle triggered
@@ -4086,6 +4090,7 @@ fn apply_action(
                 &mut events,
                 &WaitingFor::Priority { player: p },
                 true,
+                false,
             )?
         }
         // CR 702.35a: Madness cast offer — the madness triggered ability has
@@ -4149,6 +4154,7 @@ fn apply_action(
                         &mut events,
                         &WaitingFor::Priority { player: p },
                         true,
+                        false,
                     )?
                 }
                 // The graveyard move paused on a CR 616.1 ordering choice; the
@@ -4177,6 +4183,13 @@ fn apply_action(
                     waiting_for,
                 ) => {
                     triggers_processed_inline = true;
+                    waiting_for
+                }
+                engine_resolution_choices::ResolutionChoiceOutcome::WaitingForWithParkedObservers(
+                    waiting_for,
+                ) => {
+                    triggers_processed_inline = true;
+                    skip_deferred_trigger_drain = true;
                     waiting_for
                 }
                 engine_resolution_choices::ResolutionChoiceOutcome::ActionResult(result) => {
@@ -4970,6 +4983,7 @@ fn apply_action(
             &mut events,
             &waiting_for,
             triggers_processed_inline,
+            skip_deferred_trigger_drain,
         )?;
         state.waiting_for = wf.clone();
         return Ok(ActionResult {

--- a/crates/engine/src/game/engine_exile_return_tests.rs
+++ b/crates/engine/src/game/engine_exile_return_tests.rs
@@ -391,6 +391,7 @@ fn exile_return_end_to_end_through_pipeline() {
         &mut events,
         &default_wf,
         true,
+        false,
     )
     .unwrap();
 
@@ -480,6 +481,7 @@ fn until_source_leaves_return_brings_back_all_merge_components() {
         &mut events,
         &default_wf,
         true,
+        false,
     )
     .unwrap();
 
@@ -607,6 +609,7 @@ fn exile_return_after_destroy_resolution_via_apply() {
         &mut state,
         &mut events,
         &default_wf,
+        false,
         false,
     )
     .unwrap();
@@ -760,8 +763,14 @@ fn white_auracite_real_oracle_text_returns_exiled_card() {
     let default_wf = WaitingFor::Priority {
         player: PlayerId(0),
     };
-    crate::game::engine_priority::run_post_action_pipeline(state, &mut events, &default_wf, false)
-        .unwrap();
+    crate::game::engine_priority::run_post_action_pipeline(
+        state,
+        &mut events,
+        &default_wf,
+        false,
+        false,
+    )
+    .unwrap();
 
     // Confirm WA is in graveyard and the exiled enchantment has returned.
     assert!(
@@ -902,6 +911,7 @@ fn haytham_kenway_per_opponent_exile_returns_when_source_leaves() {
             player: PlayerId(0),
         },
         true,
+        false,
     )
     .unwrap();
 
@@ -1004,8 +1014,14 @@ fn journey_to_nowhere_two_trigger_oracle_returns_exiled_creature() {
     let default_wf = WaitingFor::Priority {
         player: PlayerId(0),
     };
-    crate::game::engine_priority::run_post_action_pipeline(state, &mut events, &default_wf, false)
-        .unwrap();
+    crate::game::engine_priority::run_post_action_pipeline(
+        state,
+        &mut events,
+        &default_wf,
+        false,
+        false,
+    )
+    .unwrap();
 
     assert!(state.players[0].graveyard.contains(&journey_id));
     assert!(state.battlefield.contains(&creature_id));

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -1195,6 +1195,7 @@ pub(super) fn handle_unless_payment(
                         event_start,
                         &default_wf,
                         false,
+                        false,
                     )?;
                     state.waiting_for = wf;
                     return Ok(action_result(events, state.waiting_for.clone()));
@@ -1251,6 +1252,7 @@ pub(super) fn handle_unless_payment(
             events,
             event_start,
             &default_wf,
+            false,
             false,
         )?;
         state.waiting_for = wf;

--- a/crates/engine/src/game/engine_priority.rs
+++ b/crates/engine/src/game/engine_priority.rs
@@ -12,8 +12,16 @@ pub(super) fn run_post_action_pipeline(
     events: &mut Vec<GameEvent>,
     default_wf: &WaitingFor,
     skip_trigger_scan: bool,
+    skip_deferred_trigger_drain: bool,
 ) -> Result<WaitingFor, EngineError> {
-    run_post_action_pipeline_from(state, events, 0, default_wf, skip_trigger_scan)
+    run_post_action_pipeline_from(
+        state,
+        events,
+        0,
+        default_wf,
+        skip_trigger_scan,
+        skip_deferred_trigger_drain,
+    )
 }
 
 /// Run the normal post-action settlement while scanning only events produced at
@@ -25,6 +33,7 @@ pub(crate) fn run_post_action_pipeline_from(
     event_start: usize,
     default_wf: &WaitingFor,
     skip_trigger_scan: bool,
+    skip_deferred_trigger_drain: bool,
 ) -> Result<WaitingFor, EngineError> {
     // Capture stack depth before any trigger/SBA processing so we can detect
     // whether new triggered abilities were added during this pipeline pass.
@@ -141,6 +150,7 @@ pub(crate) fn run_post_action_pipeline_from(
     // handled by the check below.
     if matches!(state.waiting_for, WaitingFor::Priority { .. })
         && !state.deferred_triggers.is_empty()
+        && !skip_deferred_trigger_drain
     {
         if let Some(wf) = triggers::drain_deferred_trigger_queue(state, events) {
             state.waiting_for = wf;

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -77,7 +77,7 @@ fn batch_or_drain_observer_triggers(
     }
 }
 
-/// CR 603.2 + CR 603.3b + CR 707.10: after a search tutor's put/shuffle
+/// CR 603.2 + CR 603.3b + CR 701.23: after a search tutor's put/shuffle
 /// continuation drains, park ETB/dies/discards observers for the next priority
 /// checkpoint instead of dispatching them while the test harness (or UI) may
 /// still be inside the same `SelectCards` action (issue #5336).

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -23,6 +23,10 @@ use super::{casting, casting_costs, mana_abilities};
 pub(super) enum ResolutionChoiceOutcome {
     WaitingFor(WaitingFor),
     WaitingForWithInlineTriggers(WaitingFor),
+    /// CR 603.3b: observer triggers from a completed search put/shuffle were
+    /// collected into `deferred_triggers` but must not drain until the caller
+    /// receives priority again (issue #5336: Kodama + Nature's Lore).
+    WaitingForWithParkedObservers(WaitingFor),
     ActionResult(ActionResult),
 }
 
@@ -71,6 +75,33 @@ fn batch_or_drain_observer_triggers(
         super::triggers::collect_triggers_into_deferred(state, &trigger_events);
         None
     }
+}
+
+/// CR 603.2 + CR 603.3b + CR 707.10: after a search tutor's put/shuffle
+/// continuation drains, park ETB/dies/discards observers for the next priority
+/// checkpoint instead of dispatching them while the test harness (or UI) may
+/// still be inside the same `SelectCards` action (issue #5336).
+fn park_search_observer_triggers(
+    state: &mut GameState,
+    events: &[GameEvent],
+    events_before_drain: usize,
+) -> ResolutionChoiceOutcome {
+    let trigger_events: Vec<GameEvent> = events[events_before_drain..]
+        .iter()
+        .filter(|ev| !matches!(ev, GameEvent::PhaseChanged { .. }))
+        .cloned()
+        .collect();
+    if !trigger_events.is_empty() {
+        super::triggers::collect_triggers_into_deferred(state, &trigger_events);
+    }
+    // The parent spell already left the stack; clear the stashed resolving entry
+    // so the next priority pass can drain `deferred_triggers`.
+    if state.pending_continuation.is_none()
+        && matches!(state.waiting_for, WaitingFor::Priority { .. })
+    {
+        state.resolving_stack_entry = None;
+    }
+    ResolutionChoiceOutcome::WaitingForWithParkedObservers(state.waiting_for.clone())
 }
 
 pub(super) fn handles(waiting_for: &WaitingFor) -> bool {
@@ -2210,15 +2241,19 @@ pub(super) fn handle_resolution_choice(
                 }
                 // CR 609.3 fast-path: found <= primary_count, so ALL chosen go to
                 // the primary destination and the rest is empty. No second prompt.
+                let events_before_drain = events.len();
                 apply_search_partition(state, &chosen, &[], &split, source_id, player, events)?;
                 set_priority(state, player);
                 effects::drain_pending_continuation(state, events);
-                return Ok(ResolutionChoiceOutcome::WaitingFor(
-                    state.waiting_for.clone(),
+                return Ok(park_search_observer_triggers(
+                    state,
+                    events,
+                    events_before_drain,
                 ));
             }
 
             set_priority(state, player);
+            let events_before_drain = events.len();
             // CR 400.7 + CR 608.2c: Count found-set cards exiled from a hand so
             // the shared "That player ... draws a card for each card exiled from
             // their hand this way" rider (The End, Deadly Cover-Up, Test of
@@ -2270,7 +2305,7 @@ pub(super) fn handle_resolution_choice(
                 state.pending_continuation = Some(cont);
             }
             effects::drain_pending_continuation(state, events);
-            ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
+            park_search_observer_triggers(state, events, events_before_drain)
         }
         (
             WaitingFor::SearchPartitionChoice {
@@ -2314,6 +2349,7 @@ pub(super) fn handle_resolution_choice(
                 primary_enter_tapped,
                 rest_destination,
             };
+            let events_before_partition = events.len();
             apply_search_partition(
                 state,
                 &primary_chosen,
@@ -2325,7 +2361,7 @@ pub(super) fn handle_resolution_choice(
             )?;
             set_priority(state, player);
             effects::drain_pending_continuation(state, events);
-            ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
+            park_search_observer_triggers(state, events, events_before_partition)
         }
         (
             WaitingFor::OutsideGameChoice {

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1835,6 +1835,7 @@ fn resolve_proven_self_counter_batch(
             event_start,
             &default_wf,
             false,
+            false,
         )
         .ok()?;
         if !matches!(wf, WaitingFor::Priority { .. })

--- a/crates/engine/tests/integration/issue_5336_kodama_mana_value_filter.rs
+++ b/crates/engine/tests/integration/issue_5336_kodama_mana_value_filter.rs
@@ -1,0 +1,380 @@
+//! Issue #5336 — Kodama of the East Tree deck interaction (Nature's Lore ramp chain).
+//!
+//! https://github.com/phase-rs/phase/issues/5336
+//!
+//! Kodama's optional put-from-hand sub-ability must honor the entering permanent's
+//! mana value (`with equal or lesser mana value`) and must not re-trigger on
+//! permanents it placed itself (CR 603.4 anti-recursion guard).
+//!
+//! The existing `kodama_anti_recursion_intervening_if` tests omit the MV qualifier;
+//! this file exercises the full Oracle line in runtime scenarios matching the
+//! reported deck (Kodama + Nature's Lore ramp).
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const KODAMA_ORACLE: &str = "Reach\nWhenever another permanent you control enters, if it wasn't \
+     put onto the battlefield with this ability, you may put a permanent card with equal or lesser \
+     mana value from your hand onto the battlefield.";
+
+const NATURES_LORE_ORACLE: &str =
+    "Search your library for a Forest card, put that card onto the battlefield, then shuffle.";
+
+fn floating_generic(n: usize) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn cast_from_hand(runner: &mut engine::game::scenario::GameRunner, id: ObjectId) {
+    let card_id = runner.state().objects[&id].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: id,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast from hand");
+}
+
+fn advance_to_optional_choice(runner: &mut engine::game::scenario::GameRunner) -> bool {
+    for _ in 0..60 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => return true,
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    return false;
+                }
+                if runner.state().stack.is_empty()
+                    && runner.state().deferred_triggers.is_empty()
+                    && runner.state().pending_trigger.is_none()
+                    && matches!(runner.state().waiting_for, WaitingFor::Priority { .. })
+                {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn resolve_optional_and_stack(runner: &mut engine::game::scenario::GameRunner, accept: bool) {
+    runner
+        .act(GameAction::DecideOptionalEffect { accept })
+        .expect("optional Kodama decision");
+    runner.advance_until_stack_empty();
+}
+
+/// Seed a basic Forest with the correct land type + subtype on the library top.
+fn seed_forest_on_library_top(runner: &mut engine::game::scenario::GameRunner) -> ObjectId {
+    use engine::types::card_type::CoreType;
+    let card_id = engine::types::identifiers::CardId(runner.state().next_object_id);
+    let id = engine::game::zones::create_object(
+        runner.state_mut(),
+        card_id,
+        P0,
+        "Forest".to_string(),
+        Zone::Library,
+    );
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Land);
+    obj.base_card_types = obj.card_types.clone();
+    obj.card_types.subtypes.push("Forest".to_string());
+    runner.state_mut().players[P0.0 as usize]
+        .library
+        .insert(0, id);
+    id
+}
+
+/// CR 603.6a: a Forest entering from the library must trigger Kodama when
+/// `process_triggers` runs on the emitted `ZoneChanged` event.
+#[test]
+fn kodama_triggers_on_forest_etb_from_library() {
+    use engine::game::triggers::process_triggers;
+    use engine::game::zones::move_to_zone;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature_from_oracle(P0, "Kodama of the East Tree", 6, 4, KODAMA_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let forest = seed_forest_on_library_top(&mut runner);
+
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), forest, Zone::Battlefield, &mut events);
+    process_triggers(runner.state_mut(), &events);
+
+    assert!(
+        advance_to_optional_choice(&mut runner),
+        "Kodama must trigger on Forest ETB; waiting={:?}, stack={}, deferred={}",
+        runner.state().waiting_for,
+        runner.state().stack.len(),
+        runner.state().deferred_triggers.len(),
+    );
+}
+
+/// CR 603.4: ability-placement provenance from *another* ability must not
+/// suppress Kodama — only placements by Kodama itself are excluded.
+#[test]
+fn kodama_triggers_when_entering_permanent_has_foreign_ability_provenance() {
+    use engine::game::triggers::process_triggers;
+    use engine::game::zones::move_to_zone;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature_from_oracle(P0, "Kodama of the East Tree", 6, 4, KODAMA_ORACLE)
+        .id();
+    let foreign_placer = scenario.add_creature(P0, "Nature's Lore", 0, 0).id();
+
+    let mut runner = scenario.build();
+    let forest = seed_forest_on_library_top(&mut runner);
+
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), forest, Zone::Battlefield, &mut events);
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&forest)
+        .unwrap()
+        .entered_via_ability_source = Some(foreign_placer);
+    process_triggers(runner.state_mut(), &events);
+
+    assert!(
+        advance_to_optional_choice(&mut runner),
+        "Kodama must trigger even when the entering permanent was placed by another ability"
+    );
+}
+
+/// CR 603.2: ETB observers must still fire while a sorcery's `resolving_stack_entry`
+/// is stashed mid-resolution (Nature's Lore search-put path).
+#[test]
+fn kodama_triggers_on_forest_etb_with_resolving_stack_entry_stashed() {
+    use engine::game::triggers::process_triggers;
+    use engine::game::zones::move_to_zone;
+    use engine::types::game_state::{CastingVariant, StackEntry, StackEntryKind};
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let kodama = scenario
+        .add_creature_from_oracle(P0, "Kodama of the East Tree", 6, 4, KODAMA_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let forest = seed_forest_on_library_top(&mut runner);
+
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), forest, Zone::Battlefield, &mut events);
+    runner.state_mut().resolving_stack_entry = Some(StackEntry {
+        id: ObjectId(9999),
+        source_id: ObjectId(9998),
+        controller: P0,
+        kind: StackEntryKind::Spell {
+            card_id: engine::types::identifiers::CardId(9998),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&forest)
+        .unwrap()
+        .entered_via_ability_source = Some(ObjectId(9998));
+
+    process_triggers(runner.state_mut(), &events);
+
+    assert!(
+        advance_to_optional_choice(&mut runner),
+        "Kodama must trigger with stashed resolving_stack_entry; kodama={kodama:?}, waiting={:?}, stack={}",
+        runner.state().waiting_for,
+        runner.state().stack.len(),
+    );
+}
+
+/// CR 202.3 + CR 603.4: when a 2-MV creature enters normally, Kodama's optional
+/// put-from-hand must not cheat in a higher-MV permanent.
+#[test]
+fn kodama_hand_choice_respects_entering_permanent_mana_value() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature_from_oracle(P0, "Kodama of the East Tree", 6, 4, KODAMA_ORACLE)
+        .id();
+
+    let trigger_creature = scenario
+        .add_creature_to_hand(P0, "Two Drop", 2, 2)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let eligible = scenario
+        .add_creature_to_hand(P0, "Also Two", 2, 2)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let too_big = scenario
+        .add_creature_to_hand(P0, "Five Drop", 5, 5)
+        .with_mana_cost(ManaCost::generic(5))
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].mana_pool.mana = floating_generic(2);
+    cast_from_hand(&mut runner, trigger_creature);
+
+    assert!(
+        advance_to_optional_choice(&mut runner),
+        "Kodama must offer its optional put-from-hand ability"
+    );
+    resolve_optional_and_stack(&mut runner, true);
+
+    assert_eq!(
+        runner.state().objects[&eligible].zone,
+        Zone::Battlefield,
+        "the eligible 2-MV permanent must be put onto the battlefield"
+    );
+    assert_eq!(
+        runner.state().objects[&too_big].zone,
+        Zone::Hand,
+        "the 5-MV permanent must stay in hand when a 2-MV creature triggered Kodama"
+    );
+}
+
+/// CR 202.3 + CR 603.6a: Nature's Lore putting a Forest (MV 0) triggers Kodama,
+/// and only 0-MV permanents may be put from hand.
+#[test]
+fn kodama_natures_lore_forest_limits_hand_to_zero_mana_value() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_basic_land(P0, ManaColor::Green);
+    scenario.add_basic_land(P0, ManaColor::Green);
+
+    scenario
+        .add_creature_from_oracle(P0, "Kodama of the East Tree", 6, 4, KODAMA_ORACLE)
+        .id();
+
+    let zero_drop = scenario
+        .add_creature_to_hand(P0, "Free Creature", 1, 1)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+    let three_drop = scenario
+        .add_creature_to_hand(P0, "Three Drop", 3, 3)
+        .with_mana_cost(ManaCost::generic(3))
+        .id();
+
+    let natures_lore = scenario
+        .add_spell_to_hand_from_oracle(P0, "Nature's Lore", false, NATURES_LORE_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let forest = seed_forest_on_library_top(&mut runner);
+    runner.cast(natures_lore).search_first_legal().resolve();
+
+    assert_eq!(
+        runner.state().objects[&forest].zone,
+        Zone::Battlefield,
+        "Nature's Lore must put the searched Forest onto the battlefield"
+    );
+
+    let kodama_id = runner
+        .state()
+        .battlefield
+        .iter()
+        .find(|id| runner.state().objects[id].name == "Kodama of the East Tree")
+        .copied()
+        .expect("Kodama on battlefield");
+    assert_eq!(
+        runner.state().objects[&kodama_id].trigger_definitions.len(),
+        1,
+        "Kodama must have exactly one parsed ETB trigger"
+    );
+    let cond = runner.state().objects[&kodama_id].trigger_definitions[0]
+        .condition
+        .as_ref()
+        .expect("Kodama trigger must carry intervening-if");
+    assert!(
+        matches!(
+            cond,
+            engine::types::ability::TriggerCondition::Not { condition }
+                if matches!(
+                    condition.as_ref(),
+                    engine::types::ability::TriggerCondition::PlacedByAbilitySource
+                )
+        ),
+        "expected Not(PlacedByAbilitySource), got {cond:?}"
+    );
+    assert!(
+        runner.state().objects[&forest]
+            .entered_via_ability_source
+            .is_some(),
+        "Forest from Nature's Lore must record ability-placement provenance"
+    );
+
+    assert!(
+        advance_to_optional_choice(&mut runner),
+        "Forest ETB from Nature's Lore must trigger Kodama's optional ability; \
+         waiting_for={:?}, deferred={}, stack={}, pending_cont={:?}",
+        runner.state().waiting_for,
+        runner.state().deferred_triggers.len(),
+        runner.state().stack.len(),
+        runner.state().pending_continuation.is_some(),
+    );
+    resolve_optional_and_stack(&mut runner, true);
+
+    assert_eq!(
+        runner.state().objects[&zero_drop].zone,
+        Zone::Battlefield,
+        "0-MV hand permanent must be eligible when a Forest (MV 0) triggered Kodama"
+    );
+    assert_eq!(
+        runner.state().objects[&three_drop].zone,
+        Zone::Hand,
+        "3-MV hand permanent must stay in hand when a Forest (MV 0) triggered Kodama"
+    );
+}
+
+/// CR 609.3: declining Kodama's optional ability with no eligible hand cards must
+/// resolve cleanly (no stall on an empty EffectZoneChoice).
+#[test]
+fn kodama_decline_with_no_eligible_hand_cards_resolves_cleanly() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature_from_oracle(P0, "Kodama of the East Tree", 6, 4, KODAMA_ORACLE)
+        .id();
+
+    let trigger_creature = scenario
+        .add_creature_to_hand(P0, "Two Drop", 2, 2)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    scenario
+        .add_creature_to_hand(P0, "Five Drop", 5, 5)
+        .with_mana_cost(ManaCost::generic(5))
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].mana_pool.mana = floating_generic(2);
+    cast_from_hand(&mut runner, trigger_creature);
+
+    assert!(advance_to_optional_choice(&mut runner));
+    resolve_optional_and_stack(&mut runner, false);
+
+    assert!(
+        runner.state().stack.is_empty(),
+        "stack must settle after declining Kodama with no eligible picks"
+    );
+    assert_eq!(
+        runner.state().objects[&trigger_creature].zone,
+        Zone::Battlefield,
+        "the triggering creature must remain on the battlefield"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -424,6 +424,7 @@ mod issue_4921_skullscorch_unless_deal_damage;
 mod issue_4962_volo_guide_to_monsters;
 mod issue_5145_violent_eruption_choose_target_distribution;
 mod issue_5159_attacks_alone_investigate;
+mod issue_5336_kodama_mana_value_filter;
 mod issue_5339_armory_automaton;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;


### PR DESCRIPTION
## Summary

Nature's Lore putting a Forest onto the battlefield was not surfacing Kodama of the East Tree's optional put-from-hand ability. The search-put `ZoneChanged` event was either dispatched mid-resolution (trigger auto-resolved/declined inside the cast driver) or never drained at the right boundary. This fix parks ETB observers in `deferred_triggers` when `SearchChoice` / `SearchPartitionChoice` completes and drains them on the next priority pass.

Fixes [#5336](https://github.com/phase-rs/phase/issues/5336).

## Root cause

CR 603.3b requires triggered abilities from a spell's resolution steps to wait until that spell finishes resolving before going on the stack. Nature's Lore pauses at `SearchChoice`; when the player picks a Forest, the continuation emits `ZoneChanged`.

Two failure modes:

1. **`process_triggers` in the SearchChoice handler** put Kodama on the stack while the cast resolution driver was still running. With default `OptionalPolicy::Decline`, the driver auto-declined the optional trigger before the test could assert on `OptionalEffectChoice`.

2. **Immediate `batch_or_drain_observer_triggers` drain** had the same timing problem — deferred triggers were drained in the same `SelectCards` action's post-action pipeline.

The scry-choice regression (`scry_choice_not_clobbered_by_triggers.rs`) already established the pattern: collect observers during resolution choices, defer drain until priority truly settles.

## Changes

### Engine — search choice completion

- Added `park_search_observer_triggers`: collects observer events into `deferred_triggers`, clears `resolving_stack_entry` when the put/shuffle continuation is complete, returns `WaitingForWithParkedObservers`.
- Wired `SearchChoice` (plain and Cultivate fast-path) and `SearchPartitionChoice` through the parked path instead of `process_triggers` / immediate drain.
- Added `WaitingForWithParkedObservers` outcome variant; `apply_action` skips both trigger re-scan and deferred drain for that action.
- Extended `run_post_action_pipeline` with `skip_deferred_trigger_drain` so parked observers drain on the **next** priority pass (e.g. test harness `advance_to_optional_choice`).

### Tests

- `issue_5336_kodama_mana_value_filter.rs`: six regression tests covering MV filtering, anti-recursion, foreign provenance, stashed `resolving_stack_entry`, decline-with-no-eligible-cards, and the full Nature's Lore cast pipeline.

## Out of scope

- Other resolution-choice handlers already using `batch_or_drain_observer_triggers` when a true settle boundary exists (DiscardChoice, etc.) — unchanged.
- Overseer of Vault 76 / Tocasia's Welcome / Reliquary Tower mentioned in the Discord thread — separate cards, not part of this engine timing fix.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p engine --test integration issue_5336` (6/6)
- [x] `cargo test -p engine scry_with_two_watchers` (no regression on deferred scry watchers)
- [ ] Tilt `test-engine` green after merge

## Risk notes

- Search-tutor ETB triggers (Kodama, Soul Warden, etc.) now appear one priority step later — rules-correct per CR 603.3b, but any UI that assumed synchronous ETB prompts inside the search modal will see them after the search action completes.
- `resolving_stack_entry` is cleared when search continuation finishes; spells that need the stashed entry across a *later* optional choice on the same resolution (Chain copy) are unaffected — those pause before search completes.
