### PR TITLE
feat(engine): Kaya, Geist Hunter -2 token doubling (floating until-EOT replacement)

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -2687,6 +2687,28 @@ fn create_token_applier(
     events: &mut Vec<GameEvent>,
 ) -> ApplyResult {
     use crate::types::ability::QuantityModification;
+    // Extract the seven fields the applier reads, given a def and the controller
+    // that installed it. Shared by the object-hosted branch and the floating
+    // (`ObjectId(0)` sentinel) branch so both produce an identical tuple.
+    let extract = |def: &ReplacementDefinition, controller: PlayerId| {
+        (
+            def.quantity_modification.clone(),
+            def.additional_token_spec.clone(),
+            def.ensure_token_specs.clone(),
+            def.token_owner_redirect.clone(),
+            // CR 614.1a + CR 111.1: Full token-substitution payload
+            // (Divine Visitation) — carried as an Effect::Token in the
+            // existing `execute` field (Approach A, no new field).
+            def.execute
+                .as_deref()
+                .map(|ability| (*ability.effect).clone())
+                .filter(|effect| matches!(effect, Effect::Token { .. })),
+            def.execute
+                .as_deref()
+                .is_some_and(is_choose_token_substitution),
+            controller,
+        )
+    };
     let (
         modification,
         additional_spec,
@@ -2695,34 +2717,31 @@ fn create_token_applier(
         substitute_effect,
         choose_token_substitution,
         source_controller,
-    ) = state
-        .objects
-        .get(&rid.source)
-        .and_then(|obj| {
-            obj.replacement_definitions
-                .get(rid.index)
-                .map(|def| (def, obj.controller))
-        })
-        .map(|(def, controller)| {
-            (
-                def.quantity_modification.clone(),
-                def.additional_token_spec.clone(),
-                def.ensure_token_specs.clone(),
-                def.token_owner_redirect.clone(),
-                // CR 614.1a + CR 111.1: Full token-substitution payload
-                // (Divine Visitation) — carried as an Effect::Token in the
-                // existing `execute` field (Approach A, no new field).
-                def.execute
-                    .as_deref()
-                    .map(|ability| (*ability.effect).clone())
-                    .filter(|effect| matches!(effect, Effect::Token { .. })),
-                def.execute
-                    .as_deref()
-                    .is_some_and(is_choose_token_substitution),
-                controller,
-            )
-        })
-        .unwrap_or((None, None, None, None, None, false, PlayerId(0)));
+    ) = if rid.source == ObjectId(0) {
+        // CR 614.1a + CR 111.2: Floating token-creation replacements (Kaya,
+        // Geist Hunter −2) live under the `ObjectId(0)` sentinel in
+        // `pending_damage_replacements`; their installing controller is latched
+        // in `source_controller` (mirrors `damage_modification_for_rid`). Fall
+        // back to the active player when unstamped.
+        state
+            .pending_damage_replacements
+            .get(rid.index)
+            .map(|def| {
+                let controller = def.source_controller.unwrap_or(state.active_player);
+                extract(def, controller)
+            })
+            .unwrap_or((None, None, None, None, None, false, PlayerId(0)))
+    } else {
+        state
+            .objects
+            .get(&rid.source)
+            .and_then(|obj| {
+                obj.replacement_definitions
+                    .get(rid.index)
+                    .map(|def| extract(def, obj.controller))
+            })
+            .unwrap_or((None, None, None, None, None, false, PlayerId(0)))
+    };
 
     if let ProposedEvent::CreateToken {
         owner,
@@ -4459,6 +4478,34 @@ fn apply_state_level_gates(
             event,
         ) {
             return false;
+        }
+    }
+    // CR 111.2 + CR 614.1a: "under your control" — a floating token-creation
+    // replacement (Kaya, Geist Hunter −2) only doubles tokens whose owner is the
+    // installing controller (`source_controller`). Mirrors the object-path gate
+    // in `object_replacement_candidate_applies`, but keyed on the latched
+    // installer instead of a live object controller. Fail-closed on every scope
+    // that has no meaningful installer-relative reading here.
+    if let Some(ref scope) = repl_def.token_owner_scope {
+        if let ProposedEvent::CreateToken { owner, .. } = event {
+            let matches = match scope {
+                crate::types::ability::ControllerRef::You => *owner == source_controller,
+                crate::types::ability::ControllerRef::Opponent => *owner != source_controller,
+                crate::types::ability::ControllerRef::ScopedPlayer
+                | crate::types::ability::ControllerRef::TargetPlayer
+                | crate::types::ability::ControllerRef::TargetOpponent
+                | crate::types::ability::ControllerRef::ParentTargetController
+                | crate::types::ability::ControllerRef::ParentTargetOwner
+                | crate::types::ability::ControllerRef::DefendingPlayer
+                | crate::types::ability::ControllerRef::SourceChosenPlayer
+                | crate::types::ability::ControllerRef::ChosenPlayer { .. }
+                | crate::types::ability::ControllerRef::TriggeringPlayer
+                | crate::types::ability::ControllerRef::EnchantedPlayer
+                | crate::types::ability::ControllerRef::ActivePlayer => false,
+            };
+            if !matches {
+                return false;
+            }
         }
     }
     true

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -1716,6 +1716,44 @@ fn try_parse_leave_battlefield_exile_replacement(lower: &str) -> Option<Effect> 
     })
 }
 
+/// CR 614.1a + CR 111.2 + CR 514.2: Install an until-end-of-turn floating
+/// token-creation replacement (Kaya, Geist Hunter −2: "Until end of turn, if one
+/// or more tokens would be created under your control, twice that many of those
+/// tokens are created instead."). Unlike Doubling Season (an object-hosted static
+/// replacement), this is a one-shot loyalty effect that *creates* a turn-bound
+/// replacement effect — it must survive Kaya leaving the battlefield and lapse at
+/// cleanup, so it is installed as a controller-anchored floating replacement
+/// (`AddTargetReplacement { target: None }` → `pending_damage_replacements`) with
+/// an explicit EOT expiry rather than hosted on Kaya's object.
+///
+/// The token-doubling shape (`token_owner_scope`, `quantity_modification`,
+/// `event: CreateToken`) is built by the shared `parse_token_replacement`
+/// building block, so any future ×N / halving / plus-spec until-EOT installer
+/// reuses this path.
+fn parse_token_creation_replacement_effect(lower: &str) -> Option<Effect> {
+    // Strip the optional leading "until end of turn[, ]" duration prefix via nom;
+    // the EOT lifetime is carried explicitly on the def below, so the remainder
+    // (the token-creation replacement clause) is what we hand to the shared
+    // builder.
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>("until end of turn"))
+        .parse(lower)
+        .ok()?;
+    let (rest, _) = opt(alt((tag::<_, _, OracleError<'_>>(", "), tag(" "))))
+        .parse(rest)
+        .ok()?;
+
+    let mut def = crate::parser::oracle_replacement::parse_token_replacement(rest, rest)?;
+    // CR 514.2: The installed replacement lasts "until end of turn"; stamp the
+    // expiry directly so the lifetime is self-contained (not dependent on the
+    // ability frame's duration threading) — mirrors `try_parse_die_exile_rider`.
+    def.expiry = Some(RestrictionExpiry::EndOfTurn);
+
+    Some(Effect::AddTargetReplacement {
+        replacement: Box::new(def),
+        target: TargetFilter::None,
+    })
+}
+
 pub(crate) fn parse_optional_period_and_end(input: &str) -> Option<()> {
     let (rest, _) = nom::combinator::opt(tag::<_, _, OracleError<'_>>("."))
         .parse(input)
@@ -6995,6 +7033,14 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return parsed_clause(effect);
     }
     if let Some(effect) = try_parse_leave_battlefield_exile_replacement(&lower) {
+        return parsed_clause(effect);
+    }
+    // CR 614.1a + CR 111.2 + CR 514.2: "Until end of turn, if one or more tokens
+    // would be created under your control, twice that many … are created instead"
+    // (Kaya, Geist Hunter −2) installs a floating until-EOT token-creation
+    // replacement. Routed here beside the other replacement-installing effect
+    // helpers, before the generic clause dispatch / Unimplemented fallback.
+    if let Some(effect) = parse_token_creation_replacement_effect(&lower) {
         return parsed_clause(effect);
     }
     // CR 614.1a + CR 901.9c: "if a player would planeswalk as a result of rolling

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -7025,7 +7025,10 @@ fn parse_optional_token_substitution_choice(
 /// Deepest Foundation's "three times that many"), plus "those tokens plus [spec]"
 /// (Chatterfang — "that many 1/1 green Squirrel creature tokens"; Donatello —
 /// "a Mutagen token").
-fn parse_token_replacement(lower: &str, original_text: &str) -> Option<ReplacementDefinition> {
+pub(crate) fn parse_token_replacement(
+    lower: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
     use crate::types::ability::QuantityModification;
 
     let modification_mode = parse_token_replacement_shape(lower)?;

--- a/crates/engine/tests/integration/kaya_geist_hunter.rs
+++ b/crates/engine/tests/integration/kaya_geist_hunter.rs
@@ -1,0 +1,259 @@
+//! Kaya, Geist Hunter [−2] — until-end-of-turn token-creation doubling.
+//!
+//! Oracle (verbatim, Scryfall):
+//!   +1: Creatures you control gain deathtouch until end of turn. Put a +1/+1
+//!       counter on up to one target creature token you control.
+//!   −2: Until end of turn, if one or more tokens would be created under your
+//!       control, twice that many of those tokens are created instead.
+//!   −6: Exile all cards from all graveyards, then create a 1/1 white Spirit
+//!       creature token with flying for each card exiled this way.
+//!
+//! The [−2] installs a floating (controller-anchored, non-object-hosted)
+//! until-EOT `CreateToken` replacement in `pending_damage_replacements`
+//! (CR 614.1a "instead", CR 111.2 "under your control", CR 514.2 EOT expiry).
+//! These tests drive the real production path — `handle_activate_loyalty`
+//! → stack resolution installs the replacement, then a real token-creating
+//! effect resolves through the replacement pipeline.
+
+use std::sync::Arc;
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::planeswalker;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{
+    AbilityCost, AbilityKind, ControllerRef, Effect, QuantityModification, TargetFilter,
+};
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::events::GameEvent;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::replacements::ReplacementEvent;
+
+const KAYA_ORACLE: &str = "+1: Creatures you control gain deathtouch until end of turn. Put a +1/+1 counter on up to one target creature token you control.\n\
+−2: Until end of turn, if one or more tokens would be created under your control, twice that many of those tokens are created instead.\n\
+−6: Exile all cards from all graveyards, then create a 1/1 white Spirit creature token with flying for each card exiled this way.";
+
+const MINUS_TWO_EFFECT: &str =
+    "Until end of turn, if one or more tokens would be created under your control, twice that many of those tokens are created instead.";
+
+const SOLDIER_TOKEN: &str = "Create a 1/1 white Soldier creature token.";
+
+fn parsed_kaya() -> engine::parser::oracle::ParsedAbilities {
+    parse_oracle_text(
+        KAYA_ORACLE,
+        "Kaya, Geist Hunter",
+        &[],
+        &["Legendary".to_string()],
+        &["Kaya".to_string()],
+    )
+}
+
+/// Find the index of Kaya's [−2] loyalty ability.
+fn minus_two_index(parsed: &engine::parser::oracle::ParsedAbilities) -> usize {
+    parsed
+        .abilities
+        .iter()
+        .position(|a| matches!(a.cost, Some(AbilityCost::Loyalty { amount: -2 })))
+        .expect("Kaya must parse a [−2] loyalty ability")
+}
+
+/// Wire Kaya as a planeswalker with 3 starting loyalty and her parsed abilities.
+fn wire_kaya(
+    state: &mut engine::types::game_state::GameState,
+    kaya: ObjectId,
+    parsed: &engine::parser::oracle::ParsedAbilities,
+) {
+    let obj = state.objects.get_mut(&kaya).expect("kaya");
+    obj.card_types.core_types = vec![CoreType::Planeswalker];
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = None;
+    obj.toughness = None;
+    obj.loyalty = Some(3);
+    obj.counters.insert(CounterType::Loyalty, 3);
+    obj.abilities = Arc::new(parsed.abilities.clone());
+    obj.base_abilities = Arc::new(parsed.abilities.clone());
+}
+
+/// Resolve a real "Create a 1/1 white Soldier creature token." effect under
+/// `controller`, driving through the `CreateToken` replacement pipeline.
+fn create_one_token(runner: &mut GameRunner, source: ObjectId, controller: PlayerId) {
+    let def = parse_effect_chain(SOLDIER_TOKEN, AbilityKind::Spell);
+    let resolved = build_resolved_from_def(&def, source, controller);
+    let mut events = Vec::<GameEvent>::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("token creation resolves");
+}
+
+/// Count token objects controlled by `player`.
+fn token_count_for(runner: &GameRunner, player: PlayerId) -> usize {
+    runner
+        .state()
+        .objects
+        .values()
+        .filter(|o| o.is_token && o.controller == player)
+        .count()
+}
+
+/// Activate Kaya's [−2] for `player`, resolve the install, and assert the
+/// reach guard (loyalty 3 → 1) proving the ability actually resolved.
+fn activate_minus_two(runner: &mut GameRunner, kaya: ObjectId, player: PlayerId, index: usize) {
+    let mut events = Vec::<GameEvent>::new();
+    let waiting =
+        planeswalker::handle_activate_loyalty(runner.state_mut(), player, kaya, index, &mut events)
+            .expect("activate [−2]");
+    assert!(
+        matches!(waiting, WaitingFor::Priority { .. }),
+        "loyalty activation should reach priority with ability on stack, got {waiting:?}"
+    );
+    // CR 606.4: loyalty cost paid at activation — reach guard proving install.
+    assert_eq!(
+        runner.state().objects.get(&kaya).unwrap().loyalty,
+        Some(1),
+        "[−2] must drop Kaya's loyalty 3 → 1 (proves the ability was activated)"
+    );
+    runner.advance_until_stack_empty();
+}
+
+#[test]
+fn kaya_minus2_doubles_tokens_under_your_control() {
+    let parsed = parsed_kaya();
+    let index = minus_two_index(&parsed);
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let kaya = scenario.add_creature(P0, "Kaya, Geist Hunter", 0, 0).id();
+    let mut runner = scenario.build();
+    wire_kaya(runner.state_mut(), kaya, &parsed);
+
+    activate_minus_two(&mut runner, kaya, P0, index);
+
+    let before = token_count_for(&runner, P0);
+    create_one_token(&mut runner, kaya, P0);
+    let after = token_count_for(&runner, P0);
+
+    // CR 614.1a + CR 111.2: one proposed token under P0's control is doubled.
+    // Reverting the applier sentinel, the pending-scan gate, or the parser
+    // helper drops this delta to 1.
+    assert_eq!(
+        after - before,
+        2,
+        "Kaya [−2] must double a single token created under her controller"
+    );
+}
+
+#[test]
+fn kaya_minus2_does_not_double_opponents_tokens() {
+    let parsed = parsed_kaya();
+    let index = minus_two_index(&parsed);
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let kaya = scenario.add_creature(P0, "Kaya, Geist Hunter", 0, 0).id();
+    // A P1-controlled source object so the opponent's token is created under P1.
+    let opp_source = scenario.add_creature(P1, "Opp Source", 1, 1).id();
+    let mut runner = scenario.build();
+    wire_kaya(runner.state_mut(), kaya, &parsed);
+
+    activate_minus_two(&mut runner, kaya, P0, index);
+
+    // Positive reach-guard (non-vacuous negative): the replacement really is
+    // installed and doubling — a token under P0's control IS doubled. Without
+    // this, a silently-failed install would make the P1 assertion below pass
+    // vacuously.
+    let p0_before = token_count_for(&runner, P0);
+    create_one_token(&mut runner, kaya, P0);
+    assert_eq!(
+        token_count_for(&runner, P0) - p0_before,
+        2,
+        "reach guard: Kaya [−2] doubling must be installed and active for P0"
+    );
+
+    // CR 111.2 + CR 614.1a: "under YOUR control" — the token_owner_scope(You)
+    // gate rejects P1's token (owner != source_controller). Not doubled.
+    let p1_before = token_count_for(&runner, P1);
+    create_one_token(&mut runner, opp_source, P1);
+    assert_eq!(
+        token_count_for(&runner, P1) - p1_before,
+        1,
+        "Kaya [−2] must NOT double a token created under the opponent's control"
+    );
+}
+
+#[test]
+fn kaya_minus2_doubling_lapses_at_end_of_turn() {
+    let parsed = parsed_kaya();
+    let index = minus_two_index(&parsed);
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let kaya = scenario.add_creature(P0, "Kaya, Geist Hunter", 0, 0).id();
+    let mut runner = scenario.build();
+    wire_kaya(runner.state_mut(), kaya, &parsed);
+
+    activate_minus_two(&mut runner, kaya, P0, index);
+
+    // Reach guard: doubling is active THIS turn (proves the install happened,
+    // so a green post-cleanup result can't come from a silently-failed install).
+    let before_same_turn = token_count_for(&runner, P0);
+    create_one_token(&mut runner, kaya, P0);
+    assert_eq!(
+        token_count_for(&runner, P0) - before_same_turn,
+        2,
+        "doubling must be active during the same turn"
+    );
+
+    // CR 514.2: advance through this turn's cleanup into the next turn — the
+    // EOT-expiry pending replacement is pruned by `execute_cleanup`.
+    runner.advance_to_upkeep();
+
+    let before_next_turn = token_count_for(&runner, P0);
+    create_one_token(&mut runner, kaya, P0);
+    assert_eq!(
+        token_count_for(&runner, P0) - before_next_turn,
+        1,
+        "doubling must lapse at cleanup — next turn a single token is not doubled"
+    );
+}
+
+#[test]
+fn kaya_minus2_parses_to_floating_token_replacement() {
+    // Parser SHAPE test: the verbatim [−2] effect text parses to an
+    // AddTargetReplacement{target: None} floating token-creation replacement.
+    let def = parse_effect_chain(MINUS_TWO_EFFECT, AbilityKind::Spell);
+
+    let Effect::AddTargetReplacement {
+        replacement,
+        target,
+    } = &*def.effect
+    else {
+        panic!("expected AddTargetReplacement, got {:?}", def.effect);
+    };
+    assert_eq!(
+        *target,
+        TargetFilter::None,
+        "floating (non-object-hosted) install uses target: None"
+    );
+    assert_eq!(replacement.event, ReplacementEvent::CreateToken);
+    assert_eq!(
+        replacement.quantity_modification,
+        Some(QuantityModification::Times { factor: 2 }),
+        "twice that many → Times {{ factor: 2 }}"
+    );
+    assert_eq!(
+        replacement.token_owner_scope,
+        Some(ControllerRef::You),
+        "under your control → token_owner_scope(You)"
+    );
+
+    // Reach guard: the clause is no longer swallowed to Unimplemented.
+    assert!(
+        !matches!(&*def.effect, Effect::Unimplemented { .. }),
+        "Kaya [−2] must not fall through to Effect::Unimplemented"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -472,6 +472,7 @@ mod issue_haze_frog_other_creature_prevention;
 mod jace_wielder_empty_library_win;
 mod json_smoke_test;
 mod kaito_integration;
+mod kaya_geist_hunter;
 mod kaya_spirits_justice_per_opponent_exile;
 mod kaysa_green_anthem;
 mod knighthood_first_strike_grant;


### PR DESCRIPTION
Kaya's -2 ('Until end of turn, if one or more tokens would be created under your
control, twice that many of those tokens are created instead') parsed to
Unimplemented. Object-hosted token doubling (Doubling Season) already worked; the
missing piece was the FLOATING, non-object-hosted instance a one-shot loyalty
ability needs.

Parser (oracle_effect): parse_token_creation_replacement_effect strips 'until end
of turn', delegates to parse_token_replacement (now pub(crate)), and emits
AddTargetReplacement { target: None } with expiry EndOfTurn — a turn-bound global
replacement in pending_damage_replacements (the general floating registry), so it
survives layer rebuilds and Kaya leaving the battlefield.
Engine (replacement): create_token_applier gains an ObjectId(0) sentinel branch
reading the floating def (mirroring damage_modification_for_rid), and
apply_state_level_gates gains a CreateToken token_owner_scope gate on the derived
source_controller (pending path only; object path untouched). No new variant,
field, or registry.

CR 111.1 / 111.2 / 614.1a / 514.2 / 616.1.
