### PR TITLE
feat(parser): Vraska, Betrayal's Sting -2 become-Treasure and -9 poison-to-difference

### DIFF
--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -68,7 +68,7 @@
 
 use std::str::FromStr;
 
-use crate::parser::oracle_nom::error::OracleError;
+use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::char;
@@ -77,6 +77,7 @@ use nom::sequence::preceded;
 use nom::Parser;
 
 use super::super::oracle_keyword::parse_keyword_from_oracle;
+use super::super::oracle_nom::bridge::{nom_on_lower, split_once_on_lower};
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_static::{parse_quoted_ability_modifications, split_keyword_list};
 use super::super::oracle_util::canonicalize_subtype_name;
@@ -785,6 +786,109 @@ pub(super) fn parse_its_a_type_loses_others(
     result.append(&mut modifications);
     result.extend(ability_mods);
     Some((rest, result))
+}
+
+/// CR 205.1a + CR 613.1d + CR 613.1f + CR 613.8a: "<article> <type words> [with
+/// \"<ability>\"] and loses all other card types and abilities" — the
+/// full-replacement animation used by "<subject> becomes …" effects that both
+/// replace the card-type set AND wipe every ability.
+///
+/// Vraska, Betrayal's Sting [-2] is the canonical member: "Target creature
+/// becomes a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana
+/// of any color\" and loses all other card types and abilities." (`build_become_clause`
+/// strips the "becomes " verb, so this receives "a Treasure artifact with …".)
+///
+/// Distinct from [`parse_its_a_type_loses_others`] (the copy-except form): that
+/// path uses the "it's a" contraction and loses only *card types*; this path is
+/// reached from the become-animation dispatch and also loses *abilities*, so it
+/// emits a `RemoveAllAbilities` before the granted ability.
+///
+/// The produced modification set is ordered per CR 613.7a (a single effect's
+/// modifications apply in written order):
+///   1. `SetCardTypes[named core types]` — Layer 4 (CR 613.1d + CR 205.1a):
+///      replaces the core card-type set, satisfying "loses all other card
+///      types", and drops the correlated subtypes of removed types.
+///   2. `RemoveAllSubtypes{Creature}` + `RemoveAllSubtypes{Artifact}` — clear a
+///      pre-existing Artifact Creature's creature and artifact subtypes so only
+///      the newly added subtype survives. MUST precede the `AddSubtype` (removals
+///      after the add would wipe it).
+///   3. `AddSubtype` per named subtype (e.g. Treasure).
+///   4. `RemoveAllAbilities` — Layer 6 (CR 613.1f): "loses all abilities".
+///   5. Granted ability modifications from the quoted `with "…"` clause, ordered
+///      AFTER the removal (CR 613.8a: the grant depends on the removal, so the
+///      removal is applied first and the grant survives).
+///
+/// Returns `None` unless the "and loses all other card types and abilities"
+/// signal is present, terminates the sentence, and at least one core type is
+/// named.
+/// Consume a leading "a "/"an " article. Named (not an inline closure) so the
+/// `nom_on_lower` bridge's higher-ranked lifetime bound is satisfied.
+fn parse_leading_article(input: &str) -> OracleResult<'_, ()> {
+    value((), alt((tag("a "), tag("an ")))).parse(input)
+}
+
+pub(super) fn parse_becomes_type_loses_all(
+    become_text: &str,
+) -> Option<Vec<ContinuousModification>> {
+    // Oracle text after normalization is ASCII, so the lowercase view is
+    // byte-length aligned with the original — safe for the bridge split helpers,
+    // and the original case is preserved for the quoted-ability parse.
+    let lower = become_text.to_lowercase();
+
+    // Leading article "a "/"an ".
+    let (_, after_article) = nom_on_lower(become_text, &lower, parse_leading_article)?;
+    let after_article_lower = &lower[become_text.len() - after_article.len()..];
+
+    // CR 205.1a + CR 613.1f: the replacement signal. The head before it is the
+    // "<type words> [with \"<ability>\"]" phrase.
+    let signal = " and loses all other card types and abilities";
+    let (head, tail) = split_once_on_lower(after_article, after_article_lower, signal)?;
+    // The signal must terminate the sentence (only a trailing period may follow).
+    if !tail.trim().trim_end_matches('.').is_empty() {
+        return None;
+    }
+
+    // CR 707.9a: peel an optional `with "<ability>"` clause off the head before
+    // the type list so its text is never mistaken for type words. Only the
+    // quoted form is granted; a non-quoted `with` clause yields no ability mods.
+    let head_lower = head.to_lowercase();
+    let (type_text, ability_mods) = match split_once_on_lower(head, &head_lower, " with ") {
+        Some((types, after_with)) => (types, parse_quoted_ability_modifications(after_with)),
+        None => (head, Vec::new()),
+    };
+
+    // CR 205.1b: classify each type word. Core types form the replacement set;
+    // everything else is an added subtype.
+    let mut core_types = Vec::new();
+    let mut subtype_mods = Vec::new();
+    for word in type_text.split_whitespace() {
+        let canonical = canonicalize_subtype_name(word);
+        if let Ok(core_type) = CoreType::from_str(&canonical) {
+            core_types.push(core_type);
+        } else {
+            subtype_mods.push(ContinuousModification::AddSubtype { subtype: canonical });
+        }
+    }
+    // "loses all other card types" is a card-type statement — with no named core
+    // type there is nothing to replace the set with.
+    if core_types.is_empty() {
+        return None;
+    }
+
+    // CR 613.7a: modifications from one effect apply in written order; removals
+    // MUST precede AddSubtype so the added subtype survives.
+    let mut result = vec![ContinuousModification::SetCardTypes { core_types }];
+    result.push(ContinuousModification::RemoveAllSubtypes {
+        set: SubtypeSet::Creature,
+    });
+    result.push(ContinuousModification::RemoveAllSubtypes {
+        set: SubtypeSet::Artifact,
+    });
+    result.append(&mut subtype_mods);
+    // CR 613.1f + CR 613.8a: "loses all abilities" ordered before the grant.
+    result.push(ContinuousModification::RemoveAllAbilities);
+    result.extend(ability_mods);
+    Some(result)
 }
 
 /// "it has {keyword[, keyword, ...]}" — each keyword becomes `AddKeyword`.

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -9990,15 +9990,15 @@ pub(super) fn try_parse_player_counter(lower: &str) -> Option<ImperativeFamilyAs
         return None;
     }
 
-    // CR 122.1b: Map to typed PlayerCounterKind — reject anything that's an object counter.
-    // Energy counters are NOT included — they use the dedicated GainEnergy effect.
-    let kind = match counter_kind {
-        "poison" => PlayerCounterKind::Poison,
-        "experience" => PlayerCounterKind::Experience,
-        "rad" => PlayerCounterKind::Rad,
-        "ticket" => PlayerCounterKind::Ticket,
-        _ => return None,
-    };
+    // CR 122.1: Map to typed PlayerCounterKind — reject anything that's an object
+    // counter. Energy counters are NOT included (they use the dedicated
+    // GainEnergy effect). Single authority: `nom_primitives::parse_player_counter_kind`,
+    // shared with the oracle_nom threshold rider. `all_consuming` enforces that
+    // the whole kind word is a recognized player counter (so "poisonx" is
+    // rejected rather than matching the "poison" prefix).
+    let (_, kind) = all_consuming(nom_primitives::parse_player_counter_kind)
+        .parse(counter_kind)
+        .ok()?;
 
     let _ = plural; // plural is just grammatical, doesn't affect semantics
     Some(ImperativeFamilyAst::GivePlayerCounter {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23677,6 +23677,67 @@ pub(crate) fn parse_effect_chain_ir(
             }
         }
 
+        // CR 122.1 + CR 122.1f + CR 107.1b: Threshold player-counter top-up
+        // rider (Vraska, Betrayal's Sting [-9]: "If target player has fewer
+        // than nine poison counters, they get a number of poison counters equal
+        // to the difference."). Dispatched BEFORE `split_leading_conditional`
+        // so the whole sentence is captured as one `GivePlayerCounter` with a
+        // `max(0, N − current)` count. Splitting off the leading "If …" as a
+        // pass/fail condition would sever the "equal to the difference"
+        // arithmetic from the count, so `condition: None` is intentional: the
+        // effect always resolves and the `ClampMin { minimum: 0 }` makes the
+        // already-at-or-above-`N` case a zero no-op (CR 107.1b; the resolver
+        // no-ops at amount 0). The count reads the chosen TARGET player's
+        // counters via `QuantityRef::TargetControllerCounter`, bound at
+        // resolution by `parent_target_controller`.
+        {
+            let chunk_lower = normalized_text.to_ascii_lowercase();
+            if let Some((kind, threshold, target)) =
+                crate::parser::oracle_nom::player_counter_difference::try_parse(&chunk_lower)
+            {
+                let count = QuantityExpr::ClampMin {
+                    inner: Box::new(QuantityExpr::Offset {
+                        inner: Box::new(QuantityExpr::Multiply {
+                            factor: -1,
+                            inner: Box::new(QuantityExpr::Ref {
+                                qty: QuantityRef::TargetControllerCounter { kind },
+                            }),
+                        }),
+                        offset: threshold,
+                    }),
+                    minimum: 0,
+                };
+                clauses.push(ClauseIr {
+                    parsed: parsed_clause(Effect::GivePlayerCounter {
+                        counter_kind: kind,
+                        count,
+                        target,
+                    }),
+                    boundary: chunk.boundary_after,
+                    condition: None,
+                    is_optional: false,
+                    opponent_may_scope: None,
+                    repeat_for: None,
+                    player_scope: None,
+                    starting_with: starting_with.clone(),
+                    delayed_condition: None,
+                    prefix_delayed_condition: None,
+                    intrinsic_continuation: None,
+                    followup_continuation: None,
+                    absorbed_by_followup: false,
+                    multi_target: None,
+                    where_x_expression: None,
+                    is_otherwise: false,
+                    unless_pay: None,
+                    special: None,
+                    source_text: normalized_text.to_string(),
+                    target_selection_mode: TargetSelectionMode::Chosen,
+                    target_chooser: None,
+                });
+                continue;
+            }
+        }
+
         // CR 118.9: Alternative-cost rider — "[If you cast a spell
         // this way,] pay <ability-cost> rather than paying its mana cost."
         // This is a *modifier* on the previous chain entry's `CastFromZone`

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -3780,6 +3780,36 @@ fn build_become_clause(
         return Some(clause);
     }
 
+    // CR 205.1a + CR 613.1d + CR 613.1f + CR 613.8a: "becomes a <type> [with
+    // \"<ability>\"] and loses all other card types and abilities" — full
+    // card-type replacement plus ability wipe plus optional ability grant
+    // (Vraska, Betrayal's Sting [-2]). Must intercept before parse_animation_spec,
+    // which bails on the " loses all other card types " tail and would drop both
+    // the type replacement and the granted ability.
+    if let Some(modifications) =
+        super::become_copy_except::parse_becomes_type_loses_all(become_text)
+    {
+        let affected = static_affected_for_application(&application);
+        let effect = Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition::continuous()
+                .affected(affected)
+                .modifications(modifications)
+                .description(become_text.to_string())],
+            duration: duration.clone(),
+            target: application.target.clone(),
+        };
+        return Some(ParsedEffectClause {
+            effect,
+            duration,
+            sub_ability: None,
+            distribute: None,
+            multi_target: None,
+            condition: None,
+            optional: false,
+            unless_pay: None,
+        });
+    }
+
     let (become_text, name_override) = strip_become_name_override(become_text);
     let animation = parse_animation_spec(&become_text, ctx)?;
     // CR 205.1a vs CR 205.1b: a "becomes a [type]" effect REPLACES the creature's

--- a/crates/engine/src/parser/oracle_nom/mod.rs
+++ b/crates/engine/src/parser/oracle_nom/mod.rs
@@ -14,6 +14,7 @@ pub mod duration;
 pub mod enchant;
 pub mod error;
 pub mod filter;
+pub mod player_counter_difference;
 pub mod primitives;
 pub mod quantity;
 pub mod return_as_aura;

--- a/crates/engine/src/parser/oracle_nom/player_counter_difference.rs
+++ b/crates/engine/src/parser/oracle_nom/player_counter_difference.rs
@@ -1,0 +1,138 @@
+//! CR 122.1 + CR 122.1f + CR 107.1b: threshold player-counter top-up rider.
+//!
+//! Detects the whole-sentence "top a player up to a threshold" form:
+//!
+//! ```text
+//! [then, ]if target player has fewer than <N> <kind> counters,
+//!   they get a number of <kind> counters equal to the difference[.]
+//! ```
+//!
+//! Vraska, Betrayal's Sting [-9] is the canonical member: "If target player has
+//! fewer than nine poison counters, they get a number of poison counters equal
+//! to the difference." (CR 122.1 — a counter is a marker placed on a player;
+//! CR 122.1f — ten poison counters lose the game, so nine is the pre-loss
+//! threshold this tops toward).
+//!
+//! This is a rider, dispatched by `parse_effect_chain_ir` BEFORE
+//! `split_leading_conditional` severs the sentence at its comma. The whole
+//! sentence must be captured together because the count is
+//! `max(0, N − current_<kind>)`: splitting off the "If …" clause as a pass/fail
+//! condition would drop the "equal to the difference" arithmetic. Instead the
+//! effect always resolves and the `ClampMin { minimum: 0 }` the caller builds
+//! from the returned threshold makes the already-at-or-above-`N` case a zero
+//! no-op (CR 107.1b — a negative calculation result is treated as zero).
+//!
+//! Returns `Some((kind, threshold_N, target))` only when the target is a
+//! player, both counter kinds match, and the full sentence is consumed.
+
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::character::complete::char;
+use nom::combinator::opt;
+use nom::Parser;
+
+use super::error::OracleError;
+use super::primitives::{parse_number, parse_player_counter_kind};
+use crate::parser::oracle_target::parse_target;
+use crate::types::ability::TargetFilter;
+use crate::types::player::PlayerCounterKind;
+
+/// Parse the threshold poison/player-counter top-up sentence.
+///
+/// `lower` is the pre-lowercased chunk text. The whole sentence is consumed on
+/// success; any trailing content (a following independent clause) makes this
+/// decline so the generic dispatch path handles it.
+pub fn try_parse(lower: &str) -> Option<(PlayerCounterKind, i32, TargetFilter)> {
+    // CR 608.2c: optional leading conditional connector.
+    let (rest, _) = alt((tag::<_, _, OracleError<'_>>("if "), tag("then, if ")))
+        .parse(lower)
+        .ok()?;
+
+    // "target player" → TargetFilter::Player (reject any non-player target).
+    // `parse_target` lower-cases internally, so a lowercase remainder feeds the
+    // downstream lowercase tags cleanly.
+    let (target, rest) = parse_target(rest);
+    if !matches!(target, TargetFilter::Player) {
+        return None;
+    }
+
+    // "has fewer than <N> " — the threshold count.
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" has fewer than ")
+        .parse(rest)
+        .ok()?;
+    let (rest, threshold) = parse_number(rest).ok()?;
+    let (rest, _) = char::<_, OracleError<'_>>(' ').parse(rest).ok()?;
+
+    // First counter kind (e.g. "poison"). The following " counters" tag enforces
+    // the word boundary after the matched kind.
+    let (rest, kind1) = parse_player_counter_kind(rest).ok()?;
+
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" counters, they get a number of ")
+        .parse(rest)
+        .ok()?;
+
+    // Second counter kind MUST equal the first ("a number of <kind> counters").
+    let (rest, kind2) = parse_player_counter_kind(rest).ok()?;
+    if kind1 != kind2 {
+        return None;
+    }
+
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" counters equal to the difference")
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = opt(char::<_, OracleError<'_>>('.')).parse(rest).ok()?;
+
+    // Full-sentence consumption: anything left means this is not the pure
+    // threshold form — decline so normal dispatch handles the remainder.
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    Some((kind1, threshold as i32, target))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_vraska_minus9_sentence() {
+        let text = "if target player has fewer than nine poison counters, they get a number of poison counters equal to the difference.";
+        let (kind, threshold, target) = try_parse(text).expect("must parse");
+        assert_eq!(kind, PlayerCounterKind::Poison);
+        assert_eq!(threshold, 9);
+        assert_eq!(target, TargetFilter::Player);
+    }
+
+    #[test]
+    fn parses_without_trailing_period() {
+        let text = "if target player has fewer than nine poison counters, they get a number of poison counters equal to the difference";
+        assert!(try_parse(text).is_some());
+    }
+
+    #[test]
+    fn rejects_mismatched_kinds() {
+        let text = "if target player has fewer than nine poison counters, they get a number of rad counters equal to the difference.";
+        assert!(try_parse(text).is_none());
+    }
+
+    #[test]
+    fn rejects_non_player_target() {
+        let text = "if target creature has fewer than nine poison counters, they get a number of poison counters equal to the difference.";
+        assert!(try_parse(text).is_none());
+    }
+
+    #[test]
+    fn rejects_unrelated_conditional() {
+        // A generic "if X, draw a card" sentence must fall through to normal dispatch.
+        let text = "if you control a swamp, draw a card.";
+        assert!(try_parse(text).is_none());
+    }
+
+    #[test]
+    fn rejects_object_counter_kind() {
+        // "+1/+1" is an object counter, not a player counter — reject.
+        let text = "if target player has fewer than nine +1/+1 counters, they get a number of +1/+1 counters equal to the difference.";
+        assert!(try_parse(text).is_none());
+    }
+}

--- a/crates/engine/src/parser/oracle_nom/primitives.rs
+++ b/crates/engine/src/parser/oracle_nom/primitives.rs
@@ -15,6 +15,7 @@ use crate::types::ability::PtValue;
 use crate::types::counter::{CounterType, KEYWORD_COUNTERS};
 use crate::types::keywords::KeywordKind;
 use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use crate::types::player::PlayerCounterKind;
 
 /// Parse a number from Oracle text: digit string OR English words (one through twenty).
 ///
@@ -336,6 +337,30 @@ pub fn parse_color(input: &str) -> OracleResult<'_, ManaColor> {
         value(ManaColor::Black, tag("black")),
         value(ManaColor::Red, tag("red")),
         value(ManaColor::Green, tag("green")),
+    ))
+    .parse(input)
+}
+
+/// CR 122.1: Combinator mapping a player-counter kind word to its typed
+/// [`PlayerCounterKind`].
+///
+/// Poison, experience, rad, and ticket are the counters a *player* accumulates
+/// (CR 122.1 — a counter is a marker placed on an object or player). Energy is
+/// deliberately EXCLUDED: energy is spent/gained through the dedicated
+/// `Effect::GainEnergy` path, not `GivePlayerCounter`. Any object-counter word
+/// (`+1/+1`, `charge`, …) fails the `alt`, so callers reject it as a player
+/// counter.
+///
+/// Single authority shared by the imperative "get N <kind> counters" parser
+/// (`oracle_effect::imperative::try_parse_player_counter`) and the oracle_nom
+/// threshold rider (`oracle_nom::player_counter_difference`). Operates on
+/// already-lowercased text.
+pub fn parse_player_counter_kind(input: &str) -> OracleResult<'_, PlayerCounterKind> {
+    alt((
+        value(PlayerCounterKind::Poison, tag("poison")),
+        value(PlayerCounterKind::Experience, tag("experience")),
+        value(PlayerCounterKind::Rad, tag("rad")),
+        value(PlayerCounterKind::Ticket, tag("ticket")),
     ))
     .parse(input)
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -630,6 +630,7 @@ mod vigor_regression;
 mod virulent_emissary_trigger;
 mod vivien_invocation_reflexive_power;
 mod volatile_fault_that_player_search;
+mod vraska_betrayals_sting;
 mod wedding_ring_etb_token_copy;
 mod well_of_lost_dreams_may_pay_x;
 mod wernog_riders_chaplain_investigate_count;

--- a/crates/engine/tests/integration/vraska_betrayals_sting.rs
+++ b/crates/engine/tests/integration/vraska_betrayals_sting.rs
@@ -1,0 +1,365 @@
+//! Vraska, Betrayal's Sting — the two previously-`Unimplemented` loyalty
+//! abilities.
+//!
+//! Oracle (verbatim, Scryfall):
+//!   0: You draw a card and lose 1 life. Proliferate.
+//!   −2: Target creature becomes a Treasure artifact with "{T}, Sacrifice this
+//!       artifact: Add one mana of any color" and loses all other card types and
+//!       abilities.
+//!   −9: If target player has fewer than nine poison counters, they get a number
+//!       of poison counters equal to the difference.
+//!
+//! The [−9] rider (CR 122.1 + CR 122.1f + CR 107.1b) tops the chosen target
+//! player up to nine poison via `GivePlayerCounter` with a `max(0, 9 − current)`
+//! count. The [−2] animation (CR 205.1a + CR 613.1d + CR 613.1f + CR 613.8a)
+//! replaces the target creature's card-type set with Artifact, makes it a
+//! Treasure, wipes all abilities, and grants the sacrifice-for-mana ability.
+//!
+//! These tests drive the REAL production path — `handle_activate_loyalty` via the
+//! `GameRunner` fluent activation — then read the post-resolution / post-layer
+//! state. Not AST-shape tests.
+
+use std::sync::Arc;
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::{parse_oracle_text, ParsedAbilities};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{
+    AbilityCost, AbilityKind, Effect, QuantityExpr, QuantityRef, TargetFilter,
+};
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::{PlayerCounterKind, PlayerId};
+
+const VRASKA_ORACLE: &str = "0: You draw a card and lose 1 life. Proliferate.\n\
+\u{2212}2: Target creature becomes a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color\" and loses all other card types and abilities.\n\
+\u{2212}9: If target player has fewer than nine poison counters, they get a number of poison counters equal to the difference.";
+
+/// Verbatim [−9] effect body (loyalty prefix stripped) for the parser-shape reach guards.
+const MINUS_NINE_EFFECT: &str =
+    "If target player has fewer than nine poison counters, they get a number of poison counters equal to the difference.";
+
+fn parsed_vraska() -> ParsedAbilities {
+    parse_oracle_text(
+        VRASKA_ORACLE,
+        "Vraska, Betrayal's Sting",
+        &[],
+        &["Legendary".to_string()],
+        &["Vraska".to_string()],
+    )
+}
+
+/// Locate a loyalty ability by its exact loyalty cost.
+fn loyalty_index(parsed: &ParsedAbilities, amount: i32) -> usize {
+    parsed
+        .abilities
+        .iter()
+        .position(|a| matches!(a.cost, Some(AbilityCost::Loyalty { amount: amt }) if amt == amount))
+        .unwrap_or_else(|| panic!("Vraska must parse a [{amount}] loyalty ability"))
+}
+
+fn wire_vraska(
+    state: &mut engine::types::game_state::GameState,
+    vraska: ObjectId,
+    loyalty: u32,
+    parsed: &ParsedAbilities,
+) {
+    let obj = state.objects.get_mut(&vraska).expect("vraska");
+    obj.card_types.core_types = vec![CoreType::Planeswalker];
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = None;
+    obj.toughness = None;
+    obj.base_power = None;
+    obj.base_toughness = None;
+    obj.loyalty = Some(loyalty);
+    obj.counters.insert(CounterType::Loyalty, loyalty);
+    obj.abilities = Arc::new(parsed.abilities.clone());
+    obj.base_abilities = Arc::new(parsed.abilities.clone());
+}
+
+fn poison_of(runner: &engine::game::scenario::GameRunner, player: PlayerId) -> u32 {
+    runner.state().players[player.0 as usize].poison_counters
+}
+
+// ---------------------------------------------------------------------------
+// [−9] threshold poison top-up — runtime via handle_activate_loyalty.
+// ---------------------------------------------------------------------------
+
+/// CR 122.1 + CR 107.1b: a target with 4 poison gains max(0, 9−4)=5 → 9.
+#[test]
+fn vraska_minus9_tops_target_to_nine_poison() {
+    let parsed = parsed_vraska();
+    let index = loyalty_index(&parsed, -9);
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let vraska = scenario
+        .add_creature(P0, "Vraska, Betrayal's Sting", 0, 0)
+        .id();
+    let mut runner = scenario.build();
+    wire_vraska(runner.state_mut(), vraska, 9, &parsed);
+    runner.state_mut().players[P1.0 as usize].poison_counters = 4;
+
+    runner.activate(vraska, index).target_player(P1).resolve();
+
+    // Reverting the rider (Unimplemented) or hardcoding N drops this to 4 or a
+    // wrong value.
+    assert_eq!(
+        poison_of(&runner, P1),
+        9,
+        "4 + max(0, 9 − 4) = 5 must top the target to nine poison"
+    );
+}
+
+/// CR 107.1b: a target already at the nine-poison threshold → ClampMin{0} makes
+/// the count zero, and the resolver no-ops at amount 0. Nine (not ten) is used so
+/// the fixture stays below the CR 704.5c ten-poison loss SBA while still
+/// exercising the exact `9 − 9 = 0` clamp boundary.
+#[test]
+fn vraska_minus9_no_op_when_target_already_poisoned() {
+    let parsed = parsed_vraska();
+    let index = loyalty_index(&parsed, -9);
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let vraska = scenario
+        .add_creature(P0, "Vraska, Betrayal's Sting", 0, 0)
+        .id();
+    let mut runner = scenario.build();
+    wire_vraska(runner.state_mut(), vraska, 9, &parsed);
+    runner.state_mut().players[P1.0 as usize].poison_counters = 9;
+
+    runner.activate(vraska, index).target_player(P1).resolve();
+
+    // Reach guard (non-vacuous): the ability actually resolved — all 9 loyalty
+    // counters were paid (CR 606.4). The loyalty counter is the CR 306.5b
+    // authoritative store; it is removed once it hits 0. A failed activation would
+    // leave nine loyalty counters intact.
+    let loyalty_counters = runner
+        .state()
+        .objects
+        .get(&vraska)
+        .unwrap()
+        .counters
+        .get(&CounterType::Loyalty)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        loyalty_counters, 0,
+        "[−9] must pay all 9 loyalty (proves the ability resolved, so the no-op is genuine)"
+    );
+    // CR 107.1b: 9 − 9 = 0 → no counters added.
+    assert_eq!(
+        poison_of(&runner, P1),
+        9,
+        "a target already at the nine-poison threshold must be unchanged"
+    );
+}
+
+/// CR 115.1 + CR 608.2c: the count reads the chosen TARGET player's poison via
+/// `parent_target_controller`, NOT the caster's. Hostile multi-authority fixture:
+/// caster at 9 poison, target at 2.
+#[test]
+fn vraska_minus9_reads_target_not_caster() {
+    let parsed = parsed_vraska();
+    let index = loyalty_index(&parsed, -9);
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let vraska = scenario
+        .add_creature(P0, "Vraska, Betrayal's Sting", 0, 0)
+        .id();
+    let mut runner = scenario.build();
+    wire_vraska(runner.state_mut(), vraska, 9, &parsed);
+    // Distinct authorities: caster (P0) 9 poison, target (P1) 2 poison.
+    runner.state_mut().players[P0.0 as usize].poison_counters = 9;
+    runner.state_mut().players[P1.0 as usize].poison_counters = 2;
+
+    runner.activate(vraska, index).target_player(P1).resolve();
+
+    // Target read (2): 2 + max(0, 9 − 2) = 9. If the count read the caster (9),
+    // the delta would be 0 and P1 would stay at 2.
+    assert_eq!(
+        poison_of(&runner, P1),
+        9,
+        "count must read the target's 2 poison → +7 → 9"
+    );
+    // The caster's own poison is untouched by the effect.
+    assert_eq!(
+        poison_of(&runner, P0),
+        9,
+        "caster poison must be unchanged (count binds to the target, not the caster)"
+    );
+}
+
+/// Parser reach guard: the whole [−9] sentence is captured by the rider BEFORE
+/// `split_leading_conditional` as one `GivePlayerCounter` with the
+/// `max(0, 9 − current)` count tree and `TargetFilter::Player`.
+#[test]
+fn vraska_minus9_rider_fires_before_conditional_split() {
+    let def = parse_effect_chain(MINUS_NINE_EFFECT, AbilityKind::Spell);
+
+    let Effect::GivePlayerCounter {
+        counter_kind,
+        count,
+        target,
+    } = &*def.effect
+    else {
+        panic!("expected GivePlayerCounter, got {:?}", def.effect);
+    };
+    assert_eq!(*counter_kind, PlayerCounterKind::Poison);
+    assert_eq!(*target, TargetFilter::Player);
+
+    // count = ClampMin{ Offset{ Multiply{ -1, Ref{TargetControllerCounter{Poison}} }, 9 }, 0 }
+    let QuantityExpr::ClampMin { inner, minimum } = count else {
+        panic!("expected ClampMin count, got {count:?}");
+    };
+    assert_eq!(*minimum, 0);
+    let QuantityExpr::Offset { inner, offset } = &**inner else {
+        panic!("expected Offset inside ClampMin, got {inner:?}");
+    };
+    assert_eq!(*offset, 9);
+    let QuantityExpr::Multiply { factor, inner } = &**inner else {
+        panic!("expected Multiply inside Offset, got {inner:?}");
+    };
+    assert_eq!(*factor, -1);
+    assert!(
+        matches!(
+            &**inner,
+            QuantityExpr::Ref {
+                qty: QuantityRef::TargetControllerCounter {
+                    kind: PlayerCounterKind::Poison
+                }
+            }
+        ),
+        "leaf must be TargetControllerCounter{{Poison}}, got {inner:?}"
+    );
+
+    // Reach guard: the clause is no longer swallowed to Unimplemented.
+    assert!(
+        !matches!(&*def.effect, Effect::Unimplemented { .. }),
+        "Vraska [−9] must not fall through to Effect::Unimplemented"
+    );
+}
+
+/// Negative: a generic leading conditional must NOT be captured by the rider —
+/// it routes through the normal conditional path.
+#[test]
+fn generic_leading_conditional_not_captured_by_rider() {
+    let def = parse_effect_chain("If you control a Swamp, draw a card.", AbilityKind::Spell);
+    assert!(
+        !matches!(&*def.effect, Effect::GivePlayerCounter { .. }),
+        "a generic 'if X, draw a card' must not be captured by the poison-difference rider"
+    );
+}
+
+/// Consolidation guard: after routing the kind mapping through the shared
+/// `parse_player_counter_kind` authority, "get two rad counters" still yields a
+/// `GivePlayerCounter{Rad, 2}`.
+#[test]
+fn player_counter_kind_refactor_preserves_rad() {
+    let def = parse_effect_chain("You get two rad counters.", AbilityKind::Spell);
+    let Effect::GivePlayerCounter {
+        counter_kind,
+        count,
+        ..
+    } = &*def.effect
+    else {
+        panic!("expected GivePlayerCounter, got {:?}", def.effect);
+    };
+    assert_eq!(*counter_kind, PlayerCounterKind::Rad);
+    assert!(matches!(count, QuantityExpr::Fixed { value: 2 }));
+}
+
+/// Consolidation guard (negative): an object counter (`+1/+1`) is not a player
+/// counter and must be rejected by the shared authority.
+#[test]
+fn object_counter_is_not_a_player_counter() {
+    let def = parse_effect_chain("You get a +1/+1 counter.", AbilityKind::Spell);
+    assert!(
+        !matches!(&*def.effect, Effect::GivePlayerCounter { .. }),
+        "a +1/+1 (object) counter must not parse as a player counter"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// [−2] become-Treasure — runtime via handle_activate_loyalty + layers.
+// ---------------------------------------------------------------------------
+
+/// CR 205.1a + CR 613.1d + CR 613.1f + CR 613.8a: the target creature becomes an
+/// Artifact Treasure, loses its creature type and printed abilities, and gains
+/// the granted sacrifice-for-mana ability.
+#[test]
+fn vraska_minus2_target_becomes_treasure() {
+    let parsed = parsed_vraska();
+    let index = loyalty_index(&parsed, -2);
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let vraska = scenario
+        .add_creature(P0, "Vraska, Betrayal's Sting", 0, 0)
+        .id();
+    // Target: a Goblin with an activated ability, so we can observe both the
+    // type replacement and the ability wipe + regrant.
+    let goblin = {
+        let mut b = scenario.add_creature_from_oracle(P1, "Test Goblin", 2, 2, "{T}: Draw a card.");
+        b.with_subtypes(vec!["Goblin"]);
+        b.id()
+    };
+    let mut runner = scenario.build();
+    wire_vraska(runner.state_mut(), vraska, 6, &parsed);
+    runner.state_mut().all_creature_types = vec!["Goblin".to_string()];
+
+    runner
+        .activate(vraska, index)
+        .target_object(goblin)
+        .resolve();
+
+    // Read the EFFECTIVE post-layer characteristics.
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    let obj = &runner.state().objects[&goblin];
+
+    // CR 205.1a + CR 613.1d: card-type set replaced with Artifact.
+    assert!(
+        obj.card_types.core_types.contains(&CoreType::Artifact),
+        "target must become an Artifact, got {:?}",
+        obj.card_types.core_types
+    );
+    assert!(
+        !obj.card_types.core_types.contains(&CoreType::Creature),
+        "target must lose the Creature card type, got {:?}",
+        obj.card_types.core_types
+    );
+
+    // Revert-failing for the modification ORDER fix: if AddSubtype(Treasure) were
+    // wiped by RemoveAllSubtypes(Artifact) applied afterward, Treasure would be
+    // absent.
+    assert!(
+        obj.card_types.subtypes.iter().any(|s| s == "Treasure"),
+        "target must be a Treasure (AddSubtype must survive the subtype removals), got {:?}",
+        obj.card_types.subtypes
+    );
+    assert!(
+        !obj.card_types.subtypes.iter().any(|s| s == "Goblin"),
+        "target must lose its creature subtype, got {:?}",
+        obj.card_types.subtypes
+    );
+
+    // CR 613.1f + CR 613.8a: all abilities lost, then the sac-for-mana ability
+    // granted (survives because RemoveAllAbilities is ordered before the grant).
+    assert_eq!(
+        obj.abilities.len(),
+        1,
+        "printed ability must be removed and only the granted ability remain, got {:?}",
+        obj.abilities
+    );
+    assert!(
+        matches!(*obj.abilities[0].effect, Effect::Mana { .. }),
+        "the granted Treasure ability must produce mana, got {:?}",
+        obj.abilities[0].effect
+    );
+}


### PR DESCRIPTION
Both loyalty abilities parsed to Unimplemented.

[-9] 'If target player has fewer than nine poison counters, they get a number of
poison counters equal to the difference': split_leading_conditional severed the
threshold from the body, and the body's 'a number of ... equal to the difference'
had no literal count for try_parse_player_counter. A new whole-sentence oracle_nom
rider (player_counter_difference) dispatched in parse_effect_chain_ir BEFORE the
conditional split captures the threshold N and emits GivePlayerCounter with a
ClampMin{0, Offset{9, Multiply{-1, Ref(TargetControllerCounter{Poison})}}} count =
max(0, 9 - current), bound to the same chosen target player. condition:None — the
clamp encodes the 'if fewer than' gate (>=9 -> 0 -> no-op). parse_player_counter_kind
is consolidated into oracle_nom/primitives.rs as the single kind authority.

[-2] 'Target creature becomes a Treasure artifact with {T},Sac:Add any color and
loses all other card types and abilities': ordered ContinuousModification set
(SetCardTypes[Artifact], RemoveAllSubtypes{Creature}+{Artifact} BEFORE AddSubtype
so Treasure survives per CR 613.7a written-order, RemoveAllAbilities before the
granted ability per CR 613.8a).

No new engine variants. CR 107.1b/122.1/122.1f/205.1a/613.1d/613.1f/613.7a/613.8a.
