### PR TITLE
feat(parser): Sothera, the Supervoid dies-edict exile + end-step linked reanimation

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3439,6 +3439,50 @@ fn parse_choose_discard_rest_of_hand(text: &str, lower: &str) -> Option<Targeted
     })
 }
 
+/// CR 701.13a + CR 109.5 + CR 608.2c: "choose a[n] <type> they control and
+/// [verb]s it" — the per-actor edict where the chooser both selects and acts on
+/// one of their own permanents (Sothera, the Supervoid: "each opponent chooses a
+/// creature they control and exiles it"). The "each opponent" subject and its
+/// leading verb are already stripped / de-inflected to "choose" by the
+/// player-scope layer, so this operates on the post-"choose " body; the inner
+/// verb keeps its third-person "-s" inflection ("exiles it").
+///
+/// Reparses to the controller-scoped edict ("exile a creature you control",
+/// controller `You`). `You` is CORRECT at parse time: the each-actor driver
+/// rebinds `ability.controller` to each iterated player at runtime
+/// (`set_controller_recursive`), and `FilterContext::from_ability` resolves the
+/// reparsed filter's `ControllerRef::You` to the ITERATING actor — so each actor
+/// exiles from their OWN permanents (CR 109.5). The verb axis is a single
+/// `alt()`, covering the edict class (exile / sacrifice / destroy) without
+/// proliferating recognizers.
+fn try_parse_choose_and_verb_it_edict(rest_lower: &str) -> Option<ChooseImperativeAst> {
+    let (_, (_, type_text, _, verb, _, _, _)) = (
+        alt((tag::<_, _, OracleError<'_>>("a "), tag("an "))),
+        take_until::<_, _, OracleError<'_>>(" they control and "),
+        tag::<_, _, OracleError<'_>>(" they control and "),
+        alt((
+            value("exile", tag::<_, _, OracleError<'_>>("exiles")),
+            value("sacrifice", tag("sacrifices")),
+            value("destroy", tag("destroys")),
+        )),
+        tag::<_, _, OracleError<'_>>(" it"),
+        opt(tag::<_, _, OracleError<'_>>(".")),
+        eof,
+    )
+        .parse(rest_lower)
+        .ok()?;
+    // Validate the captured phrase is a real object type with no leftover text —
+    // keeps the recognizer precise so it never hijacks unrelated "choose a …"
+    // bodies whose type phrase is junk or carries a trailing predicate.
+    let (filter, filter_rem) = parse_type_phrase(type_text);
+    if !filter_rem.trim().is_empty() || matches!(filter, TargetFilter::Any) {
+        return None;
+    }
+    Some(ChooseImperativeAst::Reparse {
+        text: format!("{verb} a {type_text} you control"),
+    })
+}
+
 pub(super) fn parse_choose_ast(
     text: &str,
     lower: &str,
@@ -3513,6 +3557,16 @@ pub(super) fn parse_choose_ast(
         // parser, mirroring `try_parse_proliferate_target`'s
         // "for each kind of counter on " + `parse_target` structure.
         if let Some(ast) = try_parse_choose_counter_on_target(rest) {
+            return Some(ast);
+        }
+
+        // CR 701.13a + CR 109.5 + CR 608.2c: "choose a <type> they control and
+        // [verb]s it" — the per-actor edict (Sothera, the Supervoid). Must
+        // precede `is_choose_as_targeting`, which would otherwise Reparse the
+        // whole conjoined body (parse_effect fails → `Effect::Unimplemented`)
+        // and drop the exile. Operates on `rest_lower` (the "choose " strip has
+        // de-inflected the leading actor verb; the inner "exiles" keeps its -s).
+        if let Some(ast) = try_parse_choose_and_verb_it_edict(rest_lower) {
             return Some(ast);
         }
 
@@ -15778,6 +15832,34 @@ mod tests {
             }
             other => panic!("Expected FromTrackedSet, got {other:?}"),
         }
+    }
+
+    // CR 701.13a + CR 109.5: Sothera, the Supervoid's per-actor edict. The
+    // post-strip body ("choose a creature they control and exiles it") must
+    // reparse to the controller-scoped edict "exile a creature you control".
+    #[test]
+    fn parse_choose_creature_they_control_and_exiles_it() {
+        let text = "choose a creature they control and exiles it";
+        let lower = text.to_lowercase();
+        let result = parse_choose_ast(text, &lower, &mut ParseContext::default());
+        match result {
+            Some(ChooseImperativeAst::Reparse { text }) => {
+                assert_eq!(text, "exile a creature you control");
+            }
+            other => panic!("Expected Reparse(\"exile a creature you control\"), got {other:?}"),
+        }
+    }
+
+    // Anti-Unimplemented reach-guard: the reparsed edict text must itself parse
+    // to a real exile effect (not Unimplemented), proving the Reparse produces a
+    // resolvable body rather than silently degrading.
+    #[test]
+    fn choose_and_exiles_it_reparse_body_is_not_unimplemented() {
+        let effect = super::super::parse_effect("exile a creature you control");
+        assert!(
+            !matches!(effect, Effect::Unimplemented { .. }),
+            "reparsed edict body must resolve to a real exile effect, got {effect:?}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -3300,6 +3300,8 @@ pub(crate) fn parse_control_conditions(input: &str) -> OracleResult<'_, StaticCo
         parse_no_opponent_controls_a,
         // "your opponents control no [type]" → Not(IsPresent { Opponent })
         parse_your_opponents_control_no,
+        // "a player controls no [type]" → QuantityComparison(EQ, ControlledByEachPlayer{Min}, 0)
+        parse_a_player_controls_no,
         // CR 702: "a creature you control has <keyword>" — subject-first
         // presence check (Odric, Lunarch Marshal). Grouped into the control
         // family so the parent dispatcher's `alt` arity stays within bounds.
@@ -3954,6 +3956,43 @@ fn parse_no_opponent_controls_a(input: &str) -> OracleResult<'_, StaticCondition
                 filter: Some(filter),
             }),
         },
+    ))
+}
+
+/// CR 603.4 + CR 608.2c: Parse "a player controls no [type]" → an existential
+/// zero-control check over every player. Sothera, the Supervoid's end-step
+/// intervening-if ("if a player controls no creatures, ...").
+///
+/// Emits a `QuantityComparison` whose LHS is
+/// `ControlledByEachPlayer { aggregate: Min }` compared `EQ 0`: the minimum
+/// per-player controlled count is zero exactly when SOME player controls none
+/// of the matching permanents. This is deliberately NOT a `Not(IsPresent)` form
+/// — that would assert "no matching permanent exists on the battlefield at all",
+/// the wrong rule (the you / opponents `control no` arms above use it because
+/// their scope is a single fixed controller). The filter is intentionally
+/// controller-less: the resolver (`game::quantity`, `ControlledByEachPlayer`
+/// arm) gates each candidate on `obj.controller == p.id`, enforcing the "they
+/// control" semantics per iterated player (CR 109.5).
+fn parse_a_player_controls_no(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = tag("a player controls no ").parse(input)?;
+    let (filter, remainder) = parse_type_phrase(rest);
+    if matches!(filter, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    let consumed = input.len() - remainder.len();
+    Ok((
+        &input[consumed..],
+        make_quantity_comparison(
+            QuantityRef::ControlledByEachPlayer {
+                filter,
+                aggregate: AggregateFunction::Min,
+            },
+            Comparator::EQ,
+            0,
+        ),
     ))
 }
 
@@ -10366,6 +10405,57 @@ mod tests {
         let (rest, c) = parse_inner_condition("you control no creatures").unwrap();
         assert_eq!(rest, "");
         assert!(matches!(c, StaticCondition::Not { .. }));
+    }
+
+    // CR 603.4 + CR 109.5: Sothera, the Supervoid's end-step intervening-if. The
+    // existential "a player controls no creatures" must emit a QuantityComparison
+    // over ControlledByEachPlayer{Min} EQ 0 with a CONTROLLER-LESS filter — NOT
+    // the Not(IsPresent) form the you / opponents `control no` arms use (those
+    // assert no such permanent exists at all; this asserts some player has none).
+    #[test]
+    fn test_a_player_controls_no_creatures() {
+        let (rest, c) = parse_inner_condition("a player controls no creatures").unwrap();
+        assert_eq!(rest, "");
+        match c {
+            StaticCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::ControlledByEachPlayer {
+                                filter,
+                                aggregate: AggregateFunction::Min,
+                            },
+                    },
+                comparator: Comparator::EQ,
+                rhs: QuantityExpr::Fixed { value: 0 },
+            } => {
+                // The filter must be controller-less: the resolver enforces
+                // "they control" via obj.controller == p.id (quantity.rs). A
+                // controller clause here would double-scope and zero the min.
+                match filter {
+                    TargetFilter::Typed(tf) => assert!(
+                        tf.controller.is_none(),
+                        "ControlledByEachPlayer filter must be controller-less, got {:?}",
+                        tf.controller
+                    ),
+                    other => panic!("expected Typed(creature) filter, got {other:?}"),
+                }
+            }
+            other => panic!(
+                "expected QuantityComparison(ControlledByEachPlayer{{Min}} EQ 0), got {other:?}"
+            ),
+        }
+    }
+
+    // Negative guard: the single-controller "you control no X" form must remain
+    // Not(IsPresent) — the new existential arm must not hijack it.
+    #[test]
+    fn test_you_control_no_is_not_quantity_comparison() {
+        let (_, c) = parse_inner_condition("you control no creatures").unwrap();
+        assert!(
+            matches!(c, StaticCondition::Not { .. }),
+            "you-scoped 'control no' must stay Not(IsPresent), got {c:?}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2922,8 +2922,16 @@ pub fn parse_type_phrase_with_ctx<'a>(
     {
         exiled_by_source = true;
         pos += exiled_offset + (remaining_exiled.len() - rest.len());
-    } else if let Ok((rest, _)) =
-        tag::<_, _, OracleError<'_>>("exiled with ~").parse(remaining_exiled)
+    } else if let Ok((rest, _)) = alt((
+        tag::<_, _, OracleError<'_>>("exiled with ~"),
+        // CR 607.2 + CR 406.6: "exiled with it" — the anaphoric "it" names the
+        // source object, identical linked-exile semantics to "exiled with ~"
+        // (Sothera, the Supervoid: "a creature card exiled with it"). The
+        // "exiled with this <type>" arm above already claimed the demonstrative
+        // form, so "it" is the disjoint pronoun variant.
+        tag("exiled with it"),
+    ))
+    .parse(remaining_exiled)
     {
         exiled_by_source = true;
         pos += exiled_offset + (remaining_exiled.len() - rest.len());
@@ -10523,6 +10531,40 @@ mod tests {
                 ],
             }
         );
+        assert_eq!(rest.trim(), "");
+    }
+
+    #[test]
+    fn creature_card_exiled_with_it_produces_and_filter() {
+        // CR 607.2 + CR 406.6: Sothera, the Supervoid's descriptor form (no
+        // "target" keyword, anaphoric "it") — "put a creature card exiled with
+        // it onto the battlefield". Must compose the typed filter with the
+        // exile-link constraint identically to the "exiled with ~" form; without
+        // the "exiled with it" arm the suffix is dropped and the target degrades
+        // to a bare battlefield "creature card".
+        let (f, rest) = parse_target("a creature card exiled with it");
+        assert_eq!(
+            f,
+            TargetFilter::And {
+                filters: vec![
+                    TargetFilter::Typed(TypedFilter::creature()),
+                    TargetFilter::ExiledBySource,
+                ],
+            },
+            "expected And{{Typed(creature), ExiledBySource}}, got {f:?} — the \
+             ExiledBySource leg (the revert-failing assertion) restricts \
+             reanimation to the source's OWN linked-exile pool"
+        );
+        assert_eq!(rest.trim(), "");
+    }
+
+    #[test]
+    fn bare_card_exiled_with_it_unaffected_by_typed_arm() {
+        // Sibling guard: the untyped "card exiled with it" form (handled by the
+        // top-of-function plural/each-card block) still yields bare
+        // ExiledBySource — the new typed arm must not perturb it.
+        let (f, rest) = parse_target("card exiled with it");
+        assert_eq!(f, TargetFilter::ExiledBySource);
         assert_eq!(rest.trim(), "");
     }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -572,6 +572,7 @@ mod sin_spiras_punishment_repeat;
 mod skullwinder_chosen_opponent;
 mod slaughter_the_strong_total_power_4380;
 mod sliver_static_grants;
+mod sothera_supervoid_edict_reanimate;
 mod specialize_runtime;
 mod spellstutter_sprite_counter_with_x;
 mod spikeshell_harrier_speed_superlative;

--- a/crates/engine/tests/integration/sothera_supervoid_edict_reanimate.rs
+++ b/crates/engine/tests/integration/sothera_supervoid_edict_reanimate.rs
@@ -1,0 +1,308 @@
+//! Sothera, the Supervoid — the two previously-`Unimplemented` triggered
+//! abilities (parser round-5 fix).
+//!
+//! Oracle (verbatim, Scryfall):
+//!   - "Whenever a creature you control dies, each opponent chooses a creature
+//!     they control and exiles it."
+//!   - "At the beginning of your end step, if a player controls no creatures,
+//!     sacrifice Sothera, then put a creature card exiled with it onto the
+//!     battlefield under your control with two additional +1/+1 counters on it."
+//!
+//! CR anchors:
+//!   - CR 700.4 (dies) + CR 109.5 (each opponent, "they/you" = the iterating
+//!     actor): the per-opponent edict. `set_controller_recursive` rebinds the
+//!     ability controller per iterated opponent, so the reparsed edict "exile a
+//!     creature you control" makes each opponent exile from their OWN board.
+//!   - CR 607.2 + CR 406.6: Sothera's exile of each opponent's creature links to
+//!     Sothera via the `ExiledBySource` interlock (Ability 2's ExiledBySource
+//!     consumer marks Sothera a tracked exile source).
+//!   - CR 122.1: reanimation with two additional +1/+1 counters.
+//!   - CR 701.21a (sacrifice), CR 603.4 (intervening-if).
+//!
+//! These tests drive the REAL resolution path — `resolve_ability_chain` on the
+//! PARSED trigger bodies wired onto the source object (mirrors
+//! `plaguecrafter_etb_class.rs`), not hand-built ASTs.
+
+use std::sync::Arc;
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::{parse_oracle_text, ParsedAbilities};
+use engine::types::ability::{AbilityDefinition, Effect};
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::events::GameEvent;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P2: PlayerId = PlayerId(2);
+
+const SOTHERA_ORACLE: &str = "Whenever a creature you control dies, each opponent chooses a creature they control and exiles it.\n\
+At the beginning of your end step, if a player controls no creatures, sacrifice Sothera, then put a creature card exiled with it onto the battlefield under your control with two additional +1/+1 counters on it.";
+
+fn parsed_sothera() -> ParsedAbilities {
+    parse_oracle_text(
+        SOTHERA_ORACLE,
+        "Sothera, the Supervoid",
+        &[],
+        &["Legendary".to_string(), "Enchantment".to_string()],
+        &[],
+    )
+}
+
+/// The DIES trigger's execute body (each-opponent exile edict). Disambiguated
+/// from the end-step reanimation by the ABSENCE of an `ExiledBySource` consumer:
+/// the edict exiles creatures the opponents control (no linked-exile reference),
+/// whereas the reanimation targets `ExiledBySource`.
+fn dies_edict_body(parsed: &ParsedAbilities) -> AbilityDefinition {
+    parsed
+        .triggers
+        .iter()
+        .filter_map(|t| t.execute.as_deref())
+        .find(|exec| !mentions_exiled_by_source(exec))
+        .cloned()
+        .expect("Sothera must parse a dies-trigger exile edict body")
+}
+
+/// The end-step trigger's execute body (sacrifice + reanimate). The reanimation
+/// lives in the `sub_ability` after the `Sacrifice` clause, so we serialize the
+/// whole `AbilityDefinition` (not just `.effect`) to see the linked-exile
+/// consumer.
+fn end_step_body(parsed: &ParsedAbilities) -> AbilityDefinition {
+    parsed
+        .triggers
+        .iter()
+        .filter_map(|t| t.execute.as_deref())
+        .find(|exec| mentions_exiled_by_source(exec))
+        .cloned()
+        .expect("Sothera must parse an end-step reanimation body")
+}
+
+/// True when the serialized ability definition (effect + sub_ability tree)
+/// contains an `ExiledBySource` linked-exile reference.
+fn mentions_exiled_by_source(def: &AbilityDefinition) -> bool {
+    serde_json::to_string(def)
+        .map(|s| s.contains("ExiledBySource"))
+        .unwrap_or(false)
+}
+
+/// Number of creature-card names a player controls on the battlefield.
+fn battlefield_creatures(state: &GameState, player: PlayerId) -> Vec<String> {
+    let mut names: Vec<String> = state
+        .objects
+        .values()
+        .filter(|o| {
+            o.zone == Zone::Battlefield
+                && o.controller == player
+                && o.card_types.core_types.contains(&CoreType::Creature)
+        })
+        .map(|o| o.name.clone())
+        .collect();
+    names.sort();
+    names
+}
+
+/// Names of creature cards currently in the Exile zone owned by `player`.
+fn exiled_owned_by(state: &GameState, player: PlayerId) -> Vec<String> {
+    let mut names: Vec<String> = state
+        .objects
+        .values()
+        .filter(|o| o.zone == Zone::Exile && o.owner == player)
+        .map(|o| o.name.clone())
+        .collect();
+    names.sort();
+    names
+}
+
+/// Wire Sothera as a Legendary Enchantment carrying its two parsed triggers so
+/// the `ExiledBySource` interlock (`source_contains_linked_exile_consumer`) sees
+/// Ability 2's consumer and marks Sothera a tracked exile source.
+fn wire_sothera(state: &mut GameState, sothera: ObjectId, parsed: &ParsedAbilities) {
+    let obj = state.objects.get_mut(&sothera).expect("sothera");
+    obj.card_types.core_types = vec![CoreType::Enchantment];
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = None;
+    obj.toughness = None;
+    obj.base_power = None;
+    obj.base_toughness = None;
+    for trig in &parsed.triggers {
+        obj.trigger_definitions.push(trig.clone());
+    }
+    obj.base_trigger_definitions = Arc::new(parsed.triggers.clone());
+}
+
+// ---------------------------------------------------------------------------
+// Ability 1 — the per-opponent exile edict (S2 controller-scoping fix).
+// ---------------------------------------------------------------------------
+
+/// CR 109.5: each opponent exiles a creature THEY control — not the caster's,
+/// not the other opponent's. Hostile 3-player fixture: P0 (caster) keeps a
+/// creature; P1 and P2 each have exactly one creature that must be exiled.
+///
+/// Revert-failing assertion: if the edict's controller scope regressed to the
+/// caster (the pre-fix bug), both opponents would target P0's board — P0's Bear
+/// would be exiled and the opponents' creatures would survive. The paired
+/// "opponents lose their creatures / P0 keeps Bear" assertions flip on revert.
+#[test]
+fn sothera_each_opponent_exiles_own_creature() {
+    let parsed = parsed_sothera();
+
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let sothera = scenario
+        .add_creature(P0, "Sothera, the Supervoid", 0, 0)
+        .id();
+    scenario.add_creature(P0, "Aegis Bear", 2, 2);
+    scenario.add_creature(P1, "Dire Wolf", 2, 2);
+    scenario.add_creature(P2, "Crag Ogre", 2, 2);
+    let mut runner = scenario.build();
+    wire_sothera(runner.state_mut(), sothera, &parsed);
+
+    let body = dies_edict_body(&parsed);
+    // Anti-Unimplemented reach guard: the edict resolves to a real exile chain.
+    assert!(
+        !matches!(body.effect.as_ref(), Effect::Unimplemented { .. }),
+        "Ability 1 edict must not be Effect::Unimplemented, got {:?}",
+        body.effect
+    );
+
+    let ability = build_resolved_from_def(&body, sothera, P0);
+    let mut events = Vec::<GameEvent>::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0).expect("edict resolves");
+
+    let state = runner.state();
+    // Each opponent exiled their OWN creature.
+    assert_eq!(
+        battlefield_creatures(state, P1),
+        Vec::<String>::new(),
+        "P1 must exile its own Dire Wolf"
+    );
+    assert_eq!(
+        battlefield_creatures(state, P2),
+        Vec::<String>::new(),
+        "P2 must exile its own Crag Ogre"
+    );
+    // The caster's creature is untouched (proves the edict is opponent-scoped,
+    // NOT caster-scoped — the S2 revert-failing assertion).
+    assert_eq!(
+        battlefield_creatures(state, P0),
+        vec!["Aegis Bear".to_string()],
+        "P0's Aegis Bear must NOT be exiled — each opponent exiles from their \
+         own board, not the caster's"
+    );
+    // The exiled cards are the opponents' own.
+    assert_eq!(exiled_owned_by(state, P1), vec!["Dire Wolf".to_string()]);
+    assert_eq!(exiled_owned_by(state, P2), vec!["Crag Ogre".to_string()]);
+
+    // CR 607.2 + CR 406.6: both exiled creatures are linked to Sothera (the
+    // ExiledBySource interlock), so Ability 2 can reanimate them.
+    let linked = state
+        .exile_links
+        .iter()
+        .filter(|l| l.source_id == sothera)
+        .count();
+    assert_eq!(
+        linked, 2,
+        "both opponent creatures must be linked to Sothera via exile_links"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ability 2 — reanimate a Sothera-linked exiled creature with two counters.
+// ---------------------------------------------------------------------------
+
+/// CR 607.2 + CR 406.6 + CR 122.1: the end-step reanimation targets only cards
+/// "exiled with it" (Sothera's linked pool) and enters with two +1/+1 counters.
+///
+/// Provenance guard: an UNRELATED creature card sitting in exile (never linked
+/// to Sothera) must NOT be reanimated — the S3 `And{Typed(Creature),
+/// ExiledBySource}` filter restricts the pool to Sothera's own exiles. If S3
+/// regressed to a bare `Typed(Creature)`, the reanimation could pull the
+/// unrelated card or a battlefield creature.
+#[test]
+fn sothera_reanimates_only_linked_creature_with_two_counters() {
+    let parsed = parsed_sothera();
+
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let sothera = scenario
+        .add_creature(P0, "Sothera, the Supervoid", 0, 0)
+        .id();
+    scenario.add_creature(P0, "Aegis Bear", 2, 2);
+    // Single opponent creature so the reanimation's "a creature card" pick has
+    // exactly one eligible candidate (forced, non-interactive). P2 controls no
+    // creature, so its edict clause is a CR 101.3 no-op.
+    scenario.add_creature(P1, "Dire Wolf", 2, 2);
+    let unrelated = scenario.add_creature(P1, "Unlinked Specter", 3, 3).id();
+    let mut runner = scenario.build();
+    wire_sothera(runner.state_mut(), sothera, &parsed);
+    // Move the unrelated creature into exile with NO link to Sothera.
+    runner.state_mut().objects.get_mut(&unrelated).unwrap().zone = Zone::Exile;
+
+    // Drive Ability 1 so the opponent's creature is exiled + linked.
+    let edict = build_resolved_from_def(&dies_edict_body(&parsed), sothera, P0);
+    let mut events = Vec::<GameEvent>::new();
+    resolve_ability_chain(runner.state_mut(), &edict, &mut events, 0).expect("edict resolves");
+
+    // Reach guard (non-vacuous): the exile actually happened and linked. Exactly
+    // one Sothera-linked card (Dire Wolf) — the unrelated Specter is NOT linked.
+    let linked_before = runner
+        .state()
+        .exile_links
+        .iter()
+        .filter(|l| l.source_id == sothera)
+        .count();
+    assert_eq!(
+        linked_before, 1,
+        "reach guard: the opponent's exile must be linked before reanimation"
+    );
+
+    // Drive Ability 2 (sacrifice Sothera, then reanimate a linked creature).
+    let reanimate = build_resolved_from_def(&end_step_body(&parsed), sothera, P0);
+    let mut events2 = Vec::<GameEvent>::new();
+    resolve_ability_chain(runner.state_mut(), &reanimate, &mut events2, 0)
+        .expect("reanimation resolves");
+
+    let state = runner.state();
+    // Exactly one Sothera-linked creature returned to the battlefield under P0's
+    // control, carrying two +1/+1 counters.
+    let reanimated: Vec<_> = state
+        .objects
+        .values()
+        .filter(|o| {
+            o.zone == Zone::Battlefield
+                && o.controller == P0
+                && o.card_types.core_types.contains(&CoreType::Creature)
+                && o.name == "Dire Wolf"
+        })
+        .collect();
+    assert_eq!(
+        reanimated.len(),
+        1,
+        "the Sothera-linked creature (Dire Wolf) must be reanimated, got {:?}",
+        reanimated.iter().map(|o| &o.name).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        reanimated[0]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied(),
+        Some(2),
+        "the reanimated creature must enter with two additional +1/+1 counters"
+    );
+
+    // Provenance guard: the unrelated exiled creature stays in exile — the
+    // ExiledBySource filter excluded it.
+    assert!(
+        state
+            .objects
+            .get(&unrelated)
+            .map(|o| o.zone == Zone::Exile)
+            .unwrap_or(true),
+        "the unrelated (non-linked) exiled creature must NOT be reanimated"
+    );
+}


### PR DESCRIPTION
Both abilities were misparsed. Three parser-only fixes, zero new engine variants:

S1 (condition.rs): 'if a player controls no <type>' intervening-if had no
existential-over-players arm (only you/opponents Not(IsPresent) forms). New
parse_a_player_controls_no emits QuantityComparison(ControlledByEachPlayer{bare
filter, Min}, EQ, 0) — the resolver enforces 'they control' via obj.controller==p.id
on the bare filter.

S2 (imperative.rs): 'each opponent chooses a creature they control and exiles it'
had only a face-down edict. New try_parse_choose_and_verb_it_edict emits
ChooseImperativeAst::Reparse('exile a creature you control') with controller:You;
the each-opponent driver rebinds ability.controller per opponent at runtime
(FilterContext::from_ability) so each opponent exiles from their own creatures.

S3 (oracle_target.rs): 'a creature card exiled with it' degraded to bare
Typed{Creature}. Added the 'exiled with it' arm to the singular typed-suffix
recognizer so it produces And[Typed(Creature), ExiledBySource]. This also arms the
runtime linked-exile interlock (should_track_exiled_by_source), so Ability 1's
exiles are tracked under Sothera and only the linked card is reanimable — verified
by a two-opponent integration test (each opponent exiles own creature; reanimation
pulls only the linked card with two +1/+1 counters, excludes an unlinked exile,
survives the sacrifice). Reanimate-with-counters reuses ReturnToBattlefield.

CR 603.4 / 603.6 / 700.4 / 406.6 / 607.2 / 109.5 / 400.7 / 122.1 / 701.13a / 701.21a / 608.2c.
