### PR TITLE
feat(parser): compound-subject chosen-type static (Rukarumel, Biologist) (#5392)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -86,11 +86,11 @@ use super::oracle_special::{
 use super::oracle_static::{
     is_speed_unlock_sentence, lower_static_ir, parse_alternative_keyword_cost,
     parse_cast_spells_alternative_cost_multi, parse_chosen_creature_type_static_prefix,
-    parse_collect_evidence_alt_cost, parse_every_creature_type_static_prefix,
-    parse_flashback_trailing_self_spell_cost_reduction, parse_spells_alternative_cost,
-    parse_static_line, parse_static_line_multi, try_parse_graveyard_keyword_grant_clause,
-    try_parse_graveyard_keyword_grant_static, try_parse_top_of_library_cast_permission,
-    GrantedCastKeywordKind,
+    parse_collect_evidence_alt_cost, parse_compound_you_control_chosen_type_static_prefix,
+    parse_every_creature_type_static_prefix, parse_flashback_trailing_self_spell_cost_reduction,
+    parse_spells_alternative_cost, parse_static_line, parse_static_line_multi,
+    try_parse_graveyard_keyword_grant_clause, try_parse_graveyard_keyword_grant_static,
+    try_parse_top_of_library_cast_permission, GrantedCastKeywordKind,
 };
 use super::oracle_trigger::{lower_trigger_ir, parse_trigger_lines_at_index};
 use super::oracle_util::{
@@ -3085,6 +3085,20 @@ pub(crate) fn parse_oracle_ir(
             &static_line,
             &static_line_lower,
             parse_every_creature_type_static_prefix,
+        ) {
+            i += 1;
+            continue;
+        }
+        // CR 611.3 + CR 607.2d: compound-subject chosen-type static with a
+        // "The same is true for ..." tail (Rukarumel, Biologist). Models the
+        // "X you control and Y you control are the chosen type ..." sentence and
+        // leaves the non-battlefield-zone tail as an `Unimplemented` residual,
+        // mirroring Arcane Adaptation / Maskwood Nexus.
+        if push_same_is_true_static_tail(
+            &mut result,
+            &static_line,
+            &static_line_lower,
+            parse_compound_you_control_chosen_type_static_prefix,
         ) {
             i += 1;
             continue;

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -685,6 +685,14 @@ pub(crate) fn parse_static_line_inner(
     if let Some(def) = parse_arcane_adaptation_chosen_type_static(&tp, &text) {
         return Some(def);
     }
+    // CR 611.3 + CR 607.2d + CR 205.1b: compound-subject sibling — "X you control
+    // and Y you control are the chosen type in addition to their other creature
+    // types" (Rukarumel, Biologist). Runs after the single-subject handler above
+    // (which declines Rukarumel's compound subject) and only claims a genuine `Or`
+    // of 2+ subjects, so single-subject lines are unaffected.
+    if let Some(def) = parse_compound_you_control_chosen_type_static(&tp, &text) {
+        return Some(def);
+    }
     // CR 305.6 + CR 607.2d: land-axis counterpart — "Lands you control are the
     // chosen type in addition to their other types" (Realmwright).
     if let Some(def) = parse_chosen_land_type_static(&tp, &text) {

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -171,7 +171,7 @@ pub(crate) use static_helpers::parse_basic_land_type_plural;
 pub(crate) use static_helpers::peel_compound_all_quantified_conjuncts;
 pub(crate) use type_change::{
     parse_additive_type_clause_modifications, parse_chosen_creature_type_static_prefix,
-    parse_every_creature_type_static_prefix,
+    parse_compound_you_control_chosen_type_static_prefix, parse_every_creature_type_static_prefix,
 };
 
 /// Parse a static/continuous ability line into a `StaticDefinition`.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -18856,6 +18856,122 @@ fn parse_arcane_adaptation_full_oracle_adds_static_and_gaps_tail() {
     );
 }
 
+// CR 611.3 + CR 607.2d + CR 205.1b + issue #5246: Rukarumel, Biologist — the
+// compound-subject chosen-type static. The modeled sentence must produce an
+// additive AddChosenSubtype{CreatureType} static whose affected set is the `Or`
+// union of the two "you control" conjuncts.
+#[test]
+fn parser_shape_rukarumel_compound_subject_chosen_type_static() {
+    let def = parse_static_line(
+        "Slivers you control and nontoken creatures you control are the chosen type in addition to their other creature types.",
+    )
+    .expect("Rukarumel's compound-subject chosen-type static must parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(
+        def.modifications,
+        vec![ContinuousModification::AddChosenSubtype {
+            kind: ChosenSubtypeKind::CreatureType,
+        }],
+        "additive chosen-creature-type only (no RemoveAllSubtypes)"
+    );
+    match &def.affected {
+        Some(TargetFilter::Or { filters }) => assert_eq!(
+            filters.len(),
+            2,
+            "affected must be the Or union of both you-control conjuncts: {filters:?}"
+        ),
+        other => panic!("expected an Or of 2 subject filters, got {other:?}"),
+    }
+}
+
+// Issue #5246: full Rukarumel oracle. The compound-subject additive static must be
+// present AND the trailing "The same is true for ..." (non-battlefield-zone)
+// sentence must surface as an Unimplemented residual — mirroring Arcane
+// Adaptation / Maskwood Nexus, not collapsing the whole line into a strict-fail.
+#[test]
+fn parse_rukarumel_full_oracle_adds_compound_static_and_gaps_tail() {
+    let oracle = "As Rukarumel enters, choose a creature type.\nSlivers you control and nontoken creatures you control are the chosen type in addition to their other creature types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 1/1 colorless Sliver creature token.";
+    let result = crate::parser::oracle::parse_oracle_text(
+        oracle,
+        "Rukarumel, Biologist",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &[],
+    );
+    let has_compound_static = result.statics.iter().any(|def| {
+        matches!(def.affected, Some(TargetFilter::Or { ref filters }) if filters.len() >= 2)
+            && def
+                .modifications
+                .contains(&ContinuousModification::AddChosenSubtype {
+                    kind: ChosenSubtypeKind::CreatureType,
+                })
+            && !def
+                .modifications
+                .iter()
+                .any(|m| matches!(m, ContinuousModification::RemoveAllSubtypes { .. }))
+    });
+    assert!(
+        has_compound_static,
+        "Rukarumel must produce the compound-subject additive static: {:?}",
+        result.statics
+    );
+    let tail_gapped = result.abilities.iter().any(|ability| {
+        matches!(
+            *ability.effect,
+            crate::types::ability::Effect::Unimplemented { description: Some(ref frag), .. }
+                // allow-noncombinator: test assertion on a gapped Unimplemented fragment, not parser dispatch
+                if frag.contains("creature spells you control")
+        )
+    });
+    assert!(
+        tail_gapped,
+        "the 'same is true for ...' tail must be gapped as Unimplemented: {:?}",
+        result.abilities
+    );
+}
+
+// Issue #5246 (no-regression): a single-subject chosen-type line must stay with
+// `parse_arcane_adaptation_chosen_type_static` — the compound handler declines it
+// (its affected set is a plain Typed filter, not an `Or`).
+#[test]
+fn single_subject_chosen_type_static_not_hijacked_by_compound_handler() {
+    let def = parse_static_line(
+        "Creatures you control are the chosen type in addition to their other types.",
+    )
+    .expect("single-subject Arcane Adaptation line must still parse");
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::AddChosenSubtype {
+                kind: ChosenSubtypeKind::CreatureType,
+            }),
+        "single-subject additive static must be produced"
+    );
+    assert!(
+        !matches!(def.affected, Some(TargetFilter::Or { .. })),
+        "single subject must not be widened into an Or: {:?}",
+        def.affected
+    );
+}
+
+// Issue #5246 (decline): a compound subject with a non-additive (CR 205.1a SET)
+// predicate — no "in addition to ..." — must NOT be claimed by the additive
+// compound handler (there is no compound SET printing to over-fit).
+#[test]
+fn compound_chosen_type_static_declines_non_additive_predicate() {
+    let def = parse_static_line("Slivers you control and Zombies you control are the chosen type.");
+    let is_additive_compound = def.as_ref().is_some_and(|d| {
+        matches!(d.affected, Some(TargetFilter::Or { .. }))
+            && d.modifications
+                == vec![ContinuousModification::AddChosenSubtype {
+                    kind: ChosenSubtypeKind::CreatureType,
+                }]
+    });
+    assert!(
+        !is_additive_compound,
+        "non-additive compound must not be claimed as an additive chosen-type static: {def:?}"
+    );
+}
+
 // CR 607.2d + CR 301.7: Lifecraft Engine grants the chosen creature subtype to
 // Vehicle permanents you control — not the Creature card type. The additive-type
 // fallback must not mis-tokenize "the chosen creature type" as AddType(Creature).

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -214,15 +214,37 @@ fn parse_chosen_creature_type_static_scope_body(
     let (input, (pronoun, scope)) = parse_chosen_creature_type_static_subject(input)?;
     let (input, _) =
         alt((tag(" the chosen type"), tag(" the chosen creature type"))).parse(input)?;
-    let (input, addition) =
-        opt((tag(" in addition to "), tag(pronoun), tag(" other types"))).parse(input)?;
-    let application = if addition.is_some() {
+    // CR 205.1b (additive) vs CR 205.1a (SET/replace): the "in addition to ..."
+    // suffix is OPTIONAL — its presence selects additive, its absence selects
+    // replacement (Conspiracy). Shared with the compound-subject sibling.
+    let (input, addition) = match parse_chosen_type_additive_suffix(input, pronoun) {
+        Ok((rest, ())) => (rest, true),
+        Err(_) => (input, false),
+    };
+    let application = if addition {
         ChosenCreatureTypeApplication::Additive
     } else {
         ChosenCreatureTypeApplication::Replacing
     };
     let (input, _) = opt(tag(".")).parse(input)?;
     Ok((input, (scope, application)))
+}
+
+/// CR 205.1b: the additive "in addition to `<pronoun>` other [creature ]types"
+/// retain-suffix, shared by the single-subject
+/// ([`parse_chosen_creature_type_static_scope_body`]) and compound-subject
+/// ([`parse_compound_you_control_chosen_type_static`]) chosen-type static
+/// handlers. The optional "creature " before "types" accepts Rukarumel's
+/// "…in addition to their other creature types" spelling; the single-subject
+/// forms omit it (Arcane Adaptation → "…their other types"), so the `opt` matches
+/// nothing there and their behavior is unchanged.
+fn parse_chosen_type_additive_suffix<'a>(input: &'a str, pronoun: &str) -> OracleResult<'a, ()> {
+    let (input, _) = tag(" in addition to ").parse(input)?;
+    let (input, _) = tag(pronoun).parse(input)?;
+    let (input, _) = tag(" other ").parse(input)?;
+    let (input, _) = opt(tag("creature ")).parse(input)?;
+    let (input, _) = tag("types").parse(input)?;
+    Ok((input, ()))
 }
 
 pub(crate) fn parse_chosen_creature_type_static_subject(
@@ -243,6 +265,93 @@ pub(crate) fn parse_chosen_creature_type_static_subject(
         ),
     ))
     .parse(input)
+}
+
+/// CR 611.3 + CR 607.2d + CR 205.1b + CR 205.3m: compound-subject sibling of
+/// [`parse_arcane_adaptation_chosen_type_static`]. "`<X>` you control and `<Y>`
+/// you control are the chosen type in addition to their other creature types"
+/// (Rukarumel, Biologist) — two independently-resolvable `you control` conjuncts
+/// joined by "and" that the single-subject dispatcher's fixed-arm subject matcher
+/// (`parse_chosen_creature_type_static_subject`) can't reach.
+///
+/// Structural mirror of [`parse_compound_all_subjects_type_change`] (#5219's
+/// compound-subject animation gate): delegate subject resolution WHOLE to the
+/// already-generic [`parse_continuous_subject_filter`] (which unions "X you
+/// control and Y you control" into an `Or` via
+/// `parse_controlled_compound_continuous_subject_filter`) and own only the
+/// predicate. Declines unless the subject is a genuine `Or` of 2+ filters, so
+/// single-subject lines fall through to the existing sibling unchanged, and
+/// declines non-additive (CR 205.1a SET) predicates. Reuses the fully-wired
+/// `AddChosenSubtype { CreatureType }` runtime — no new variant, no new runtime.
+pub(crate) fn parse_compound_you_control_chosen_type_static(
+    tp: &TextPair<'_>,
+    text: &str,
+) -> Option<StaticDefinition> {
+    let (subject_tp, predicate_tp) = tp.split_around(" are ")?;
+    let affected = parse_continuous_subject_filter(subject_tp.original)?;
+    // Require a genuine compound (Or of 2+); a single-subject filter is owned by
+    // `parse_arcane_adaptation_chosen_type_static`.
+    match &affected {
+        TargetFilter::Or { filters } if filters.len() >= 2 => {}
+        _ => return None,
+    }
+    // Additive chosen-creature-type predicate only (CR 205.1b). A compound subject
+    // is plural, so the retain pronoun is always "their".
+    nom_on_lower(
+        predicate_tp.original,
+        predicate_tp.lower,
+        parse_compound_chosen_type_additive_predicate,
+    )?;
+
+    Some(
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(vec![ContinuousModification::AddChosenSubtype {
+                kind: ChosenSubtypeKind::CreatureType,
+            }])
+            .description(text.to_string()),
+    )
+}
+
+/// nom body for [`parse_compound_you_control_chosen_type_static`]'s predicate,
+/// consumed to `eof` so it never mis-claims a longer line: "the chosen [creature ]
+/// type in addition to their other [creature ]types[.]". Additive only — a bare
+/// "the chosen type" without the retain-suffix (CR 205.1a SET) fails, so a
+/// hypothetical replacing compound is declined rather than silently reinterpreted.
+fn parse_compound_chosen_type_additive_predicate(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = alt((tag("the chosen creature type"), tag("the chosen type"))).parse(input)?;
+    let (input, ()) = parse_chosen_type_additive_suffix(input, "their")?;
+    let (input, _) = opt(tag(".")).parse(input)?;
+    eof.parse(input)?;
+    Ok((input, ()))
+}
+
+/// Prefix matcher for the `oracle.rs` "The same is true for ..." tail splitter:
+/// consumes "`<compound subject>` are the chosen [creature ]type in addition to
+/// their other [creature ]types[.]" so Rukarumel's trailing sentence is preserved
+/// as an `Unimplemented` residual (matching Arcane Adaptation / Maskwood Nexus)
+/// rather than collapsing the whole line into a strict-fail. Verifies the subject
+/// is a genuine compound `Or` before claiming, so single-subject chosen-type lines
+/// stay with [`parse_chosen_creature_type_static_prefix`].
+pub(crate) fn parse_compound_you_control_chosen_type_static_prefix(
+    input: &str,
+) -> OracleResult<'_, ()> {
+    let (after_subject, subject) =
+        take_until::<_, _, OracleError<'_>>(" are the chosen").parse(input)?;
+    match parse_continuous_subject_filter(subject) {
+        Some(TargetFilter::Or { filters }) if filters.len() >= 2 => {}
+        _ => {
+            return Err(nom::Err::Error(OracleError::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+    }
+    let (input, _) = tag(" are ").parse(after_subject)?;
+    let (input, _) = alt((tag("the chosen creature type"), tag("the chosen type"))).parse(input)?;
+    let (input, ()) = parse_chosen_type_additive_suffix(input, "their")?;
+    let (input, _) = opt(tag(".")).parse(input)?;
+    Ok((input, ()))
 }
 
 // CR 613.1d + CR 205.3m: "<creatures you control are> every creature type" —


### PR DESCRIPTION
## Summary

Fixes #5392. `Rukarumel, Biologist`'s chosen-creature-type static —
`Slivers you control and nontoken creatures you control are the chosen type in addition to their other creature types.` (Oracle text verified against `client/public/card-data.json`) — previously **strict-failed** (`static_abilities: []`); the whole line collapsed into an `Unimplemented` ability.

It's the **compound-subject** sibling of the "chosen type" static class (Arcane Adaptation, Xenograft, Lifecraft Engine) — the same structural shape as **#5219**'s compound-subject animation static: two `you control` conjuncts joined by "and", each individually resolvable, but the combination unreached because the single-subject dispatcher's subject matcher only accepts three fixed literal forms.

## Fix (mirrors #5219)

- **`parse_compound_you_control_chosen_type_static`** delegates subject resolution *whole* to the already-generic `parse_continuous_subject_filter` (which unions `X you control and Y you control` into an `Or` via `parse_controlled_compound_continuous_subject_filter`) and owns only the additive chosen-type predicate. Declines unless the subject is a genuine `Or` of 2+ filters (single-subject lines stay with the existing handler) and declines non-additive (CR 205.1a SET) predicates.
- Extract the shared **`parse_chosen_type_additive_suffix`** retain-suffix helper, extended to optionally accept `creature ` before `types` (Rukarumel's "…other **creature** types" spelling). The single-subject forms omit it, so `opt` matches nothing there and their behavior is unchanged.
- A "same is true for …" tail prefix matcher + `push_same_is_true_static_tail` call in `oracle.rs` preserve Rukarumel's trailing non-battlefield-zone sentence as an `Unimplemented` residual — matching Arcane Adaptation / Maskwood Nexus, rather than strict-failing the whole line.

## Architecture

- Nom combinators throughout; reuses `parse_continuous_subject_filter`, `each`-style helpers, and the existing tail-splitter.
- Builds for the **class** (any `X you control and Y you control` compound), not the single card.
- **No new `ContinuousModification` / `Layer` / runtime** — `AddChosenSubtype { CreatureType }` is already fully wired (Arcane Adaptation / Xenograft / Lifecraft exercise it end-to-end).
- CR-annotated: **CR 611.3 / CR 607.2d / CR 205.1b / CR 205.3m**.

## Testing

`cargo fmt` ✓ · parser-combinator gate ✓ · `cargo check -p engine` ✓ (on current `main`).

New tests (`oracle_static/tests.rs`):
- `parser_shape_rukarumel_compound_subject_chosen_type_static` — modeled sentence → `Or`-of-2 affected + `AddChosenSubtype{CreatureType}`.
- `parse_rukarumel_full_oracle_adds_compound_static_and_gaps_tail` — full card: compound static present **and** the "same is true …" tail gapped as `Unimplemented`.
- `single_subject_chosen_type_static_not_hijacked_by_compound_handler` — no-regression: single-subject Arcane Adaptation line stays a plain Typed filter (not widened to `Or`).
- `compound_chosen_type_static_declines_non_additive_predicate` — a compound SET predicate is not claimed as additive.

Regression-checked the refactored neighbors (Arcane Adaptation, Conspiracy, Lifecraft, Maskwood full-oracle) still pass.
