### PR TITLE
fix(client): count spell colors in dominant-color detection (shard variant names)

### DIFF
--- a/client/src/viewmodel/__tests__/dominantColor.test.ts
+++ b/client/src/viewmodel/__tests__/dominantColor.test.ts
@@ -98,18 +98,20 @@ describe("getDominantManaColor", () => {
   });
 
   it("counts mana cost shards of non-land permanents", () => {
+    // The engine serializes shards as Rust variant names (e.g. "White", "Red"),
+    // not MTG symbols ("W", "R") — mirror the real payload here.
     const objects: Record<string, GameObject> = {
       "1": makeGameObject({
         id: 1,
         name: "Serra Angel",
         card_types: { supertypes: [], core_types: ["Creature"], subtypes: ["Angel"] },
-        mana_cost: { type: "Cost", shards: ["W", "W"], generic: 3 },
+        mana_cost: { type: "Cost", shards: ["White", "White"], generic: 3 },
       }),
       "2": makeGameObject({
         id: 2,
         name: "Lightning Bolt",
         card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
-        mana_cost: { type: "Cost", shards: ["R"], generic: 0 },
+        mana_cost: { type: "Cost", shards: ["Red"], generic: 0 },
       }),
     };
 
@@ -118,21 +120,46 @@ describe("getDominantManaColor", () => {
     expect(result).toBe("White");
   });
 
-  it("combines land subtypes and spell mana costs", () => {
+  it("counts both halves of a hybrid shard variant", () => {
+    // "WhiteBlue" (the {W/U} hybrid variant name) must contribute to both
+    // White and Blue — SHARD_ABBREVIATION maps it to "W/U", split on "/".
     const objects: Record<string, GameObject> = {
-      "1": makeGameObject({ id: 1, card_types: { supertypes: ["Basic"], core_types: ["Land"], subtypes: ["Island"] } }),
-      "2": makeGameObject({ id: 2, card_types: { supertypes: ["Basic"], core_types: ["Land"], subtypes: ["Island"] } }),
-      "3": makeGameObject({
-        id: 3,
-        name: "Red Creature",
+      "1": makeGameObject({
+        id: 1,
+        name: "Hybrid Creature",
         card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
-        mana_cost: { type: "Cost", shards: ["R"], generic: 1 },
+        mana_cost: { type: "Cost", shards: ["WhiteBlue"], generic: 0 },
+      }),
+      "2": makeGameObject({
+        id: 2,
+        name: "Blue Creature",
+        card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
+        mana_cost: { type: "Cost", shards: ["Blue"], generic: 0 },
       }),
     };
 
-    const result = getDominantManaColor([1, 2, 3], objects, 0);
+    // White=1 (from the hybrid), Blue=2 (hybrid + mono-blue) → Blue wins.
+    const result = getDominantManaColor([1, 2], objects, 0);
 
     expect(result).toBe("Blue");
+  });
+
+  it("combines land subtypes and spell mana costs", () => {
+    const objects: Record<string, GameObject> = {
+      "1": makeGameObject({ id: 1, card_types: { supertypes: ["Basic"], core_types: ["Land"], subtypes: ["Island"] } }),
+      "2": makeGameObject({
+        id: 2,
+        name: "Red Creature",
+        card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
+        mana_cost: { type: "Cost", shards: ["Red", "Red"], generic: 1 },
+      }),
+    };
+
+    // Island=Blue 1, creature=Red 2 → Red wins (would be Blue if spell shards
+    // were silently dropped, as with the pre-fix symbol-keyed lookup).
+    const result = getDominantManaColor([1, 2], objects, 0);
+
+    expect(result).toBe("Red");
   });
 });
 

--- a/client/src/viewmodel/dominantColor.ts
+++ b/client/src/viewmodel/dominantColor.ts
@@ -1,4 +1,5 @@
 import type { GameObject, ManaColor, PlayerId } from "../adapter/types";
+import { SHARD_ABBREVIATION } from "./costLabel";
 
 const LAND_SUBTYPE_TO_COLOR: Record<string, ManaColor> = {
   Plains: "White",
@@ -8,7 +9,10 @@ const LAND_SUBTYPE_TO_COLOR: Record<string, ManaColor> = {
   Forest: "Green",
 };
 
-const SHARD_TO_COLOR: Record<string, ManaColor> = {
+// Keyed by MTG symbol halves ("W", "U", …) — the components produced by
+// splitting a shard's `SHARD_ABBREVIATION` on "/". Colorless/Snow/X/Phyrexian
+// halves have no entry and are ignored, so only true color pips are counted.
+const SYMBOL_TO_COLOR: Record<string, ManaColor> = {
   W: "White",
   U: "Blue",
   B: "Black",
@@ -35,11 +39,15 @@ function countColors(
         if (color) colorCounts.set(color, (colorCounts.get(color) ?? 0) + 1);
       }
     } else if (obj.mana_cost.type === "Cost") {
-      // Non-land permanents: count colored mana shards
+      // Non-land permanents: count colored mana shards. The engine serializes
+      // shards as Rust variant names ("White", "WhiteBlue", "PhyrexianRed"),
+      // not MTG symbols — SHARD_ABBREVIATION is the canonical bridge to symbols
+      // ("W", "W/U", "R/P"). Split hybrid/Phyrexian shards on "/" and count each
+      // colored half.
       for (const shard of obj.mana_cost.shards) {
-        // Handle hybrid shards like "W/U" — count both halves
-        for (const part of shard.split("/")) {
-          const color = SHARD_TO_COLOR[part];
+        const abbreviation = SHARD_ABBREVIATION[shard] ?? shard;
+        for (const part of abbreviation.split("/")) {
+          const color = SYMBOL_TO_COLOR[part];
           if (color) colorCounts.set(color, (colorCounts.get(color) ?? 0) + 1);
         }
       }


### PR DESCRIPTION
## Problem

The dominant-color helpers in `viewmodel/dominantColor.ts` (`getDominantManaColor`, `getDeckDominantColor`) key their shard→color lookup by MTG symbols (`W`/`U`/`B`/`R`/`G`) and split each shard on `"/"` to catch hybrids like `"W/U"`.

But the engine does not serialize `ManaCost` shards as symbols — it serializes them as **Rust variant names**: `"White"`, `"Red"`, `"WhiteBlue"`, `"PhyrexianRed"`, etc. This is the same convention `costLabel.ts` documents on `SHARD_ABBREVIATION` ("Converts Rust ManaCostShard variant names to MTG abbreviations") and that `keywordProps.ts` relies on, and it's the format used by the shared `gameObjectFactory` and every other viewmodel/game test (`shards: ["Red"]`, `["White"]`, `["WhiteBlue"]`).

Because `"White".split("/")` is `["White"]` and `SHARD_TO_COLOR["White"]` is `undefined`, **no nonland card's mana cost ever contributed a color.** Dominant-color detection collapsed to a lands-only signal, so `components/board/BattlefieldBackground.tsx` ignored spell colors entirely (a mono-red spellslinger deck with basic Islands would tint blue).

The previous `dominantColor.test.ts` masked this: its two spell-cost cases fed the fake `["W","W"]` / `["R"]` format — the lone place in the repo disagreeing with the factory and every other test.

## Fix

Bridge each shard through the canonical `SHARD_ABBREVIATION` map (variant name → symbol) before splitting on `"/"`, then look up each colored half — mirroring exactly how `keywordProps`/`costLabel` already interpret shards. This makes mono, hybrid (`WhiteBlue` → `W/U` → White + Blue), and Phyrexian (`PhyrexianRed` → `R/P` → Red) shards all count correctly, while colorless/snow/X halves are ignored.

## Tests

`viewmodel/__tests__/dominantColor.test.ts`:
- Corrected the two spell-cost cases to the real engine format (`["White","White"]`, `["Red"]`). With the pre-fix symbol-keyed lookup these now return `null`/wrong color — proven fail-before, pass-after.
- Added a hybrid case: `["WhiteBlue"]` + `["Blue"]` → Blue wins (hybrid contributes to both White and Blue).
- Added a land+spell case where the spell color must win, which would silently mis-resolve if spell shards were dropped.

Verified with vitest: all 11 tests pass after the fix; reverting only the source change fails exactly the 3 spell-color tests (discriminating).

Model: claude-opus-4-8
