### PR TITLE
fix(engine): grant dynamic Mobilize X for "where X is its power" (Infantry Shield) (#5266)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -234,6 +234,11 @@ impl KeywordTriggerInstaller {
             // one trigger is emitted per `Keyword::Soulshift(_)` on the face.
             Keyword::Soulshift(n) => vec![build_soulshift_trigger(*n)],
             Keyword::Annihilator(n) => vec![build_annihilator_trigger(*n)],
+            // CR 702.181a: Mobilize N — attacks trigger creating N tapped/attacking
+            // Warrior tokens. Enables runtime keyword grants (`AddDynamicKeyword`
+            // — Infantry Shield's "mobilize X, where X is its power") to install
+            // the trigger; the printed path uses `synthesize_mobilize` directly.
+            Keyword::Mobilize(qty) => vec![build_mobilize_trigger(qty)],
             // CR 702.39a: Provoke — attacks trigger that may untap a creature the
             // defending player controls and force it to block this attacker.
             Keyword::Provoke => vec![build_provoke_trigger()],
@@ -740,11 +745,61 @@ pub fn synthesize_ninjutsu_family(face: &mut CardFace) {
 // - `prepare_spell_cast` overrides the mana cost when cast from hand
 // - `stack.rs::resolve_top` creates a delayed exile trigger on resolution
 
+/// CR 702.181a: Build the Mobilize attack trigger — "Whenever this creature
+/// attacks, create N 1/1 red Warrior creature tokens. Those tokens enter tapped
+/// and attacking. Sacrifice them at the beginning of the next end step." Shared
+/// by the printed path ([`synthesize_mobilize`]) and the runtime keyword-grant
+/// path ([`KeywordTriggerInstaller::triggers_for`], used by `AddDynamicKeyword`
+/// when a static grants "mobilize X, where X is …" — Infantry Shield).
+fn build_mobilize_trigger(qty: &QuantityExpr) -> TriggerDefinition {
+    use crate::types::ability::PtValue;
+    use crate::types::triggers::TriggerMode;
+
+    let token_effect = Effect::Token {
+        name: "Warrior".to_string(),
+        power: PtValue::Fixed(1),
+        toughness: PtValue::Fixed(1),
+        types: vec!["Creature".to_string(), "Warrior".to_string()],
+        colors: vec![ManaColor::Red],
+        keywords: vec![],
+        tapped: true,
+        count: qty.clone(),
+        owner: TargetFilter::Controller,
+        attach_to: None,
+        enters_attacking: true,
+        supertypes: vec![],
+        static_abilities: vec![],
+        enter_with_counters: vec![],
+    };
+
+    let sacrifice_at_end_step = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::CreateDelayedTrigger {
+            condition: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+            effect: Box::new(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Sacrifice {
+                    target: TargetFilter::LastCreated,
+                    count: qty.clone(),
+                    min_count: 0,
+                },
+            )),
+            uses_tracked_set: false,
+        },
+    );
+
+    TriggerDefinition::new(TriggerMode::Attacks)
+        .execute(
+            AbilityDefinition::new(AbilityKind::Spell, token_effect)
+                .sub_ability(sacrifice_at_end_step),
+        )
+        .description("Mobilize — create Warrior tokens tapped and attacking".to_string())
+}
+
 /// Synthesize Mobilize N trigger: when this creature attacks, create N 1/1 red
 /// Warrior creature tokens tapped and attacking. Sacrifice them at the beginning
 /// of the next end step (CR 702.181a).
 pub fn synthesize_mobilize(face: &mut CardFace) {
-    use crate::types::ability::PtValue;
     use crate::types::triggers::TriggerMode;
 
     // Idempotency: skip if a Mobilize attack trigger already exists.
@@ -759,53 +814,15 @@ pub fn synthesize_mobilize(face: &mut CardFace) {
         return;
     }
 
-    for kw in &face.keywords {
-        if let Keyword::Mobilize(qty) = kw {
-            let token_effect = Effect::Token {
-                name: "Warrior".to_string(),
-                power: PtValue::Fixed(1),
-                toughness: PtValue::Fixed(1),
-                types: vec!["Creature".to_string(), "Warrior".to_string()],
-                colors: vec![ManaColor::Red],
-                keywords: vec![],
-                tapped: true,
-                count: qty.clone(),
-                owner: TargetFilter::Controller,
-                attach_to: None,
-                enters_attacking: true,
-                supertypes: vec![],
-                static_abilities: vec![],
-                enter_with_counters: vec![],
-            };
-
-            let sacrifice_at_end_step = AbilityDefinition::new(
-                AbilityKind::Spell,
-                Effect::CreateDelayedTrigger {
-                    condition: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
-                    effect: Box::new(AbilityDefinition::new(
-                        AbilityKind::Spell,
-                        Effect::Sacrifice {
-                            target: TargetFilter::LastCreated,
-                            count: qty.clone(),
-                            min_count: 0,
-                        },
-                    )),
-                    uses_tracked_set: false,
-                },
-            );
-
-            face.triggers.push(
-                TriggerDefinition::new(TriggerMode::Attacks)
-                    .execute(
-                        AbilityDefinition::new(AbilityKind::Spell, token_effect)
-                            .sub_ability(sacrifice_at_end_step),
-                    )
-                    .description(
-                        "Mobilize — create Warrior tokens tapped and attacking".to_string(),
-                    ),
-            );
-        }
-    }
+    let new_triggers: Vec<TriggerDefinition> = face
+        .keywords
+        .iter()
+        .filter_map(|kw| match kw {
+            Keyword::Mobilize(qty) => Some(build_mobilize_trigger(qty)),
+            _ => None,
+        })
+        .collect();
+    face.triggers.extend(new_triggers);
 }
 
 /// CR 702.134a: Mentor — "Whenever this creature attacks, put a +1/+1 counter on

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -8371,6 +8371,47 @@ pub(super) fn apply_where_x_effect_expression(
 /// explicit no-ops below). `apply_where_x_quantity_expression` only rewrites a
 /// `CostXPaid` / bare `Variable("X")` value, so a modification whose quantity is
 /// already a concrete reference is left unchanged.
+/// CR 613.4c + CR 702: a granted keyword's "where X is its `<P/T/mana value>`"
+/// refers to the keyword's RECIPIENT (the creature that has the keyword), not the
+/// grant's source object. The bare object-quantity parser defaults "its power" /
+/// "its toughness" / "its mana value" to `Source` scope (the correct default in a
+/// self-referential context); rebind those to `Recipient` for a granted dynamic
+/// keyword so the continuous layer resolves the value against each affected
+/// creature. Self-grants (subject `~`) are unaffected — recipient == source.
+fn rebind_dynamic_keyword_value_to_recipient(
+    value: crate::types::ability::QuantityExpr,
+) -> crate::types::ability::QuantityExpr {
+    use crate::types::ability::{ObjectScope, QuantityExpr, QuantityRef};
+    let rebound = |scope: ObjectScope| match scope {
+        ObjectScope::Source => ObjectScope::Recipient,
+        other => other,
+    };
+    match value {
+        QuantityExpr::Ref {
+            qty: QuantityRef::Power { scope },
+        } => QuantityExpr::Ref {
+            qty: QuantityRef::Power {
+                scope: rebound(scope),
+            },
+        },
+        QuantityExpr::Ref {
+            qty: QuantityRef::Toughness { scope },
+        } => QuantityExpr::Ref {
+            qty: QuantityRef::Toughness {
+                scope: rebound(scope),
+            },
+        },
+        QuantityExpr::Ref {
+            qty: QuantityRef::ObjectManaValue { scope },
+        } => QuantityExpr::Ref {
+            qty: QuantityRef::ObjectManaValue {
+                scope: rebound(scope),
+            },
+        },
+        other => other,
+    }
+}
+
 fn apply_where_x_continuous_modification(
     modification: &mut ContinuousModification,
     where_x_expression: Option<&str>,
@@ -8381,9 +8422,21 @@ fn apply_where_x_continuous_modification(
         | ContinuousModification::SetPowerDynamic { value, .. }
         | ContinuousModification::SetToughnessDynamic { value, .. }
         | ContinuousModification::AddDynamicPower { value, .. }
-        | ContinuousModification::AddDynamicToughness { value, .. }
-        | ContinuousModification::AddDynamicKeyword { value, .. } => {
+        | ContinuousModification::AddDynamicToughness { value, .. } => {
             *value = apply_where_x_quantity_expression(value.clone(), where_x_expression);
+        }
+        ContinuousModification::AddDynamicKeyword { value, .. } => {
+            *value = apply_where_x_quantity_expression(value.clone(), where_x_expression);
+            // CR 613.4c + CR 702: a GRANTED keyword's "where X is its
+            // power/toughness/mana value" refers to the keyword's RECIPIENT (the
+            // creature that has the keyword), not the grant's source object. The
+            // bare object-quantity parser defaults "its power" to `Source` scope;
+            // rebind it to `Recipient` so the continuous layer resolves the count
+            // against each affected creature (Infantry Shield: "Equipped creature
+            // has … mobilize X, where X is its power"). Self-grants are unaffected
+            // (recipient == source). This is the IR-lowering counterpart of the
+            // same rebind on the direct grant path in `oracle_static/keyword_grant.rs`.
+            *value = rebind_dynamic_keyword_value_to_recipient(value.clone());
         }
         // Resolution-time-consumed; where-X counter quantities are applied by
         // the counter/enter-with parser paths before this continuous grant pass.

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -1575,6 +1575,39 @@ pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModifi
     modifications
 }
 
+/// CR 613.4c + CR 702: In a granted-keyword "where X is its `<P/T/mana value>`"
+/// clause, "its" refers to the RECIPIENT of the grant — the creature that has the
+/// keyword — not the grant's source object. `parse_quantity_ref_complete` maps a
+/// bare "its power" / "its toughness" / "its mana value" to `Source` scope (the
+/// correct default in a self-referential context); rebind those to `Recipient` so
+/// the continuous layer resolves the value against each affected creature
+/// (Infantry Shield: "Equipped creature has … mobilize X, where X is its power" →
+/// the equipped creature's power). Self-grants (subject `~`) are unaffected — for
+/// them the recipient IS the source, so both scopes resolve identically.
+fn rebind_source_scope_to_recipient(
+    qty: crate::types::ability::QuantityRef,
+) -> crate::types::ability::QuantityRef {
+    use crate::types::ability::{ObjectScope, QuantityRef};
+    match qty {
+        QuantityRef::Power {
+            scope: ObjectScope::Source,
+        } => QuantityRef::Power {
+            scope: ObjectScope::Recipient,
+        },
+        QuantityRef::Toughness {
+            scope: ObjectScope::Source,
+        } => QuantityRef::Toughness {
+            scope: ObjectScope::Recipient,
+        },
+        QuantityRef::ObjectManaValue {
+            scope: ObjectScope::Source,
+        } => QuantityRef::ObjectManaValue {
+            scope: ObjectScope::Recipient,
+        },
+        other => other,
+    }
+}
+
 pub(crate) fn push_grant_clause_modifications(
     modifications: &mut Vec<ContinuousModification>,
     part: &str,
@@ -1627,7 +1660,9 @@ pub(crate) fn push_grant_clause_modifications(
                 {
                     modifications.push(ContinuousModification::AddDynamicKeyword {
                         kind,
-                        value: QuantityExpr::Ref { qty: qty_ref },
+                        value: QuantityExpr::Ref {
+                            qty: rebind_source_scope_to_recipient(qty_ref),
+                        },
                     });
                     return;
                 }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -16645,6 +16645,59 @@ fn dynamic_keyword_annihilator_x() {
 }
 
 #[test]
+fn dynamic_keyword_mobilize_x_infantry_shield() {
+    // Issue #5266 + CR 702.181a: Infantry Shield — "Equipped creature has menace
+    // and mobilize X, where X is its power." The mobilize count must be the
+    // dynamic equipped-creature power (AddDynamicKeyword), NOT a Fixed-1 grant.
+    let def =
+        parse_static_line("Equipped creature has menace and mobilize X, where X is its power.")
+            .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    // Menace is still granted as a plain keyword.
+    assert!(
+        def.modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: crate::types::keywords::Keyword::Menace
+            }
+        )),
+        "menace must still be granted: {:?}",
+        def.modifications
+    );
+    // Mobilize is granted as a DYNAMIC keyword whose count is the equipped
+    // creature's power — a RECIPIENT-scoped Power reference (CR 613.4c), not a
+    // Fixed-1 grant nor the Source-scoped (equipment) value that resolves to 0.
+    let mobilize_value = def.modifications.iter().find_map(|m| match m {
+        ContinuousModification::AddDynamicKeyword {
+            kind: crate::types::keywords::DynamicKeywordKind::Mobilize,
+            value,
+        } => Some(value.clone()),
+        _ => None,
+    });
+    assert_eq!(
+        mobilize_value,
+        Some(crate::types::ability::QuantityExpr::Ref {
+            qty: crate::types::ability::QuantityRef::Power {
+                scope: crate::types::ability::ObjectScope::Recipient,
+            },
+        }),
+        "mobilize must be a Recipient-scoped dynamic power grant; got {:?}",
+        def.modifications
+    );
+    // Regression guard: the buggy Fixed-count mobilize must NOT be emitted.
+    assert!(
+        !def.modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: crate::types::keywords::Keyword::Mobilize(_)
+            }
+        )),
+        "mobilize must be dynamic, not a Fixed AddKeyword: {:?}",
+        def.modifications
+    );
+}
+
+#[test]
 fn cant_be_blocked_unconditional() {
     let def = parse_static_line("This creature can't be blocked.").unwrap();
     assert_eq!(def.mode, StaticMode::CantBeBlocked);

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -312,6 +312,10 @@ pub enum KeywordKind {
 pub enum DynamicKeywordKind {
     Annihilator,
     Modular,
+    // CR 702.181a: Mobilize N — a granted mobilize whose count is a "where X is
+    // [quantity]" value (Infantry Shield: "Equipped creature has … mobilize X,
+    // where X is its power"). Resolves to `Keyword::Mobilize(Fixed { value })`.
+    Mobilize,
 }
 
 impl DynamicKeywordKind {
@@ -320,6 +324,12 @@ impl DynamicKeywordKind {
         match self {
             Self::Annihilator => Keyword::Annihilator(value),
             Self::Modular => Keyword::Modular(value),
+            // CR 702.181a: the resolved count is applied as a fixed value; the
+            // continuous layer pass re-resolves it whenever the source's power
+            // changes, so the mobilize count tracks "its power".
+            Self::Mobilize => Keyword::Mobilize(QuantityExpr::Fixed {
+                value: value as i32,
+            }),
         }
     }
 
@@ -328,6 +338,7 @@ impl DynamicKeywordKind {
         match name {
             "annihilator" => Some(Self::Annihilator),
             "modular" => Some(Self::Modular),
+            "mobilize" => Some(Self::Mobilize),
             _ => None,
         }
     }

--- a/crates/engine/tests/integration/infantry_shield_mobilize_grant.rs
+++ b/crates/engine/tests/integration/infantry_shield_mobilize_grant.rs
@@ -1,0 +1,83 @@
+//! Issue #5266: Infantry Shield — "Equipped creature has menace and mobilize X,
+//! where X is its power." The granted mobilize count must be the equipped
+//! creature's power (dynamic), and the mobilize attack trigger must be installed
+//! on the equipped creature — not a Fixed-1 mobilize with no effect.
+//!
+//! This drives the RUNTIME grant pipeline: the static's `AddDynamicKeyword`
+//! resolves "its power" against the equipped creature at layer-evaluation time
+//! (`with_value`) and installs the mobilize attack trigger via `triggers_for`.
+//!
+//! CR 702.181a (Mobilize N) + CR 301.5f (Equipment attaches to a creature).
+
+use engine::game::game_object::AttachTarget;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{Effect, QuantityExpr};
+use engine::types::card_type::CoreType;
+use engine::types::keywords::Keyword;
+use engine::types::triggers::TriggerMode;
+
+const INFANTRY_SHIELD: &str =
+    "Equipped creature has menace and mobilize X, where X is its power.\nEquip {2}";
+
+#[test]
+fn infantry_shield_grants_dynamic_mobilize_equal_to_power() {
+    let mut scenario = GameScenario::new();
+    // A 3-power creature: the equipped creature. Mobilize must resolve to 3.
+    let bear = scenario.add_creature(P0, "War Bear", 3, 3).id();
+    // Infantry Shield installs its static from Oracle. Toughness 1 so it survives
+    // build-time SBAs before we convert it into an Equipment.
+    let shield = scenario
+        .add_creature_from_oracle(P0, "Infantry Shield", 0, 1, INFANTRY_SHIELD)
+        .id();
+    let mut runner = scenario.build();
+
+    // Convert the shield into an Equipment attached to the 3-power creature so the
+    // static's `EquippedBy` affected filter (CR 301.5f) resolves to `bear`.
+    {
+        let obj = runner.state_mut().objects.get_mut(&shield).unwrap();
+        obj.card_types.core_types = vec![CoreType::Artifact];
+        obj.card_types.subtypes = vec!["Equipment".to_string()];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = None;
+        obj.toughness = None;
+        obj.base_power = None;
+        obj.base_toughness = None;
+        obj.attached_to = Some(AttachTarget::Object(bear));
+    }
+    evaluate_layers(runner.state_mut());
+
+    let host = &runner.state().objects[&bear];
+
+    // CR 702.181a: the equipped creature gains Mobilize with a count equal to its
+    // power (3), resolved by the continuous layer pass — NOT the buggy Fixed 1.
+    let mobilize_count = host.keywords.iter().find_map(|k| match k {
+        Keyword::Mobilize(qty) => Some(qty.clone()),
+        _ => None,
+    });
+    assert!(
+        matches!(mobilize_count, Some(QuantityExpr::Fixed { value: 3 })),
+        "equipped creature must have Mobilize 3 (= its power), got {mobilize_count:?}"
+    );
+
+    // Menace is still granted alongside the dynamic mobilize.
+    assert!(
+        host.keywords.contains(&Keyword::Menace),
+        "menace must be granted too, got {:?}",
+        host.keywords
+    );
+
+    // CR 702.181a: the mobilize attack trigger (create Warrior tokens) must be
+    // installed on the equipped creature, or the grant is inert ("doesn't
+    // mobilize").
+    assert!(
+        host.trigger_definitions.iter_unchecked().any(|t| {
+            matches!(t.mode, TriggerMode::Attacks)
+                && matches!(
+                    t.execute.as_deref().map(|a| &*a.effect),
+                    Some(Effect::Token { name, .. }) if name == "Warrior"
+                )
+        }),
+        "the mobilize attack trigger must be installed on the equipped creature"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -138,6 +138,7 @@ mod heroic_defiance_recipient_color_4590;
 mod hollow_one_cost_reduction;
 mod hunters_insight_combat_draw;
 mod inevitable_betrayal_no_mana_cost;
+mod infantry_shield_mobilize_grant;
 mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;


### PR DESCRIPTION
Fixes #5266.

## Summary

**Infantry Shield** — `Equipped creature has menace and mobilize X, where X is its power.` (Oracle text verified against `client/public/card-data.json`) — granted `Mobilize { Fixed: 1 }` instead of a mobilize count equal to the equipped creature's power, so it effectively **"doesn't mobilize."**

## Root cause

The granted-keyword dynamic path (`oracle_static/keyword_grant.rs`) only emits `AddDynamicKeyword` when `DynamicKeywordKind::from_name(kw)` is `Some`, and **mobilize was not a member** of `DynamicKeywordKind` (which held only `{Annihilator, Modular}`). So "mobilize X" fell through to a fixed-count `map_keyword` grant.

## Fix (mirrors the existing Annihilator/Modular dynamic-grant path)

- Add `Mobilize` to **`DynamicKeywordKind`** (+ `with_value` → `Mobilize(Fixed{n})`, + `from_name`), so "mobilize X, where X is …" becomes a dynamic keyword. *(Ran the `add-engine-variant` gate — a leaf on the existing "numeric-parameter keyword grant" registry; `cargo check` confirms no exhaustive-match breaks.)*
- Extract **`build_mobilize_trigger`** and add a `Keyword::Mobilize(qty)` arm to `KeywordTriggerInstaller::triggers_for`, so a **granted** mobilize installs its attack trigger at layer-evaluation time (`AddDynamicKeyword` → layers → `with_value` → `triggers_for`). The printed path (`synthesize_mobilize`) reuses the same builder and is unchanged.
- Rebind the where-X quantity's `Source` scope → `Recipient` for granted keywords: in "equipped creature has … where X is **its** power", "its" is the keyword's recipient (the equipped creature), not the source Equipment, so the continuous layer resolves the count against each affected creature. Self-grants (subject `~`) are unaffected — their recipient IS the source.

## Architecture

- Reuses the established `AddDynamicKeyword` grant mechanism (no new runtime); the runtime already resolves the value against the affected object and installs keyword triggers.
- No behavior change for **printed** Mobilize cards.
- CR-annotated: **CR 702.181a / CR 613.1f / CR 301.5f**.

## Testing

`cargo fmt` ✓ · parser-combinator gate ✓ · `cargo check -p engine` ✓.

- **Parser**: `dynamic_keyword_mobilize_x_infantry_shield` — the static yields dynamic `AddDynamicKeyword(Mobilize)`, not `AddKeyword Mobilize{Fixed:1}`.
- **Runtime scenario**: `infantry_shield_grants_dynamic_mobilize_equal_to_power` — equip a 3-power creature → it gains **Mobilize 3** (= its power) **and** the Warrior-token attack trigger; the buggy fixed-1 grant is gone. *(This caught a real Source-vs-Recipient resolution bug that parser tests alone missed.)*
- Regression-checked: printed-mobilize idempotency/sacrifice suite, granted-Annihilator runtime test, and dynamic-P/T tests all still pass.
