### PR TITLE
fix(parser): Etali, Primal Sickness 'get that many poison counters' binds event amount

### DIFF
--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -779,15 +779,9 @@ pub(super) fn try_parse_remove_counter(lower: &str, ctx: &mut ParseContext) -> O
     // amount is the info the rider reads from the prevented event at resolution.
     // Resolves to `EventContextAmount`, matching the `PutCounter` "that many"
     // path used by the Vigor / Phyrexian Hydra cohort.
-    let (count, rest) = if let Some(((), rest)) = nom_on_lower(after_remove, after_remove, |i| {
-        value((), alt((tag("that many "), tag("that much ")))).parse(i)
-    }) {
-        (
-            QuantityExpr::Ref {
-                qty: QuantityRef::EventContextAmount,
-            },
-            rest.trim_start(),
-        )
+    let (count, rest) = if let Ok((rest, qty)) = nom_quantity::parse_that_much_or_many(after_remove)
+    {
+        (QuantityExpr::Ref { qty }, rest.trim_start())
     } else if let Some(((), rest)) = nom_on_lower(after_remove, after_remove, |i| {
         value((), tag("all ")).parse(i)
     }) {

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -10028,12 +10028,17 @@ pub(super) fn try_parse_player_counter(lower: &str) -> Option<ImperativeFamilyAs
     };
 
     // Parse quantity + counter kind from the remaining text.
-    // Patterns: "a poison" / "an experience" / "two rad" / "10 poison"
-    let (count, counter_kind) =
-        if let Ok((kind, _)) = nom_primitives::parse_article.parse(before_counter) {
-            (1u32, kind.trim())
+    // Patterns: "that many poison" / "a poison" / "an experience" / "two rad" / "10 poison"
+    // CR 608.2h: "that many/much <kind> counters" binds the triggering event's
+    // amount (e.g. Etali, Primal Sickness — combat damage → that many poison
+    // counters); the amount is determined once, when the effect is applied.
+    let (count, counter_kind): (QuantityExpr, &str) =
+        if let Ok((rest, qty)) = nom_quantity::parse_that_much_or_many(before_counter) {
+            (QuantityExpr::Ref { qty }, rest.trim())
+        } else if let Ok((kind, _)) = nom_primitives::parse_article.parse(before_counter) {
+            (QuantityExpr::Fixed { value: 1 }, kind.trim())
         } else if let Ok((rest, n)) = nom_primitives::parse_number.parse(before_counter) {
-            (n, rest.trim())
+            (QuantityExpr::Fixed { value: n as i32 }, rest.trim())
         } else {
             return None;
         };
@@ -10057,9 +10062,7 @@ pub(super) fn try_parse_player_counter(lower: &str) -> Option<ImperativeFamilyAs
     let _ = plural; // plural is just grammatical, doesn't affect semantics
     Some(ImperativeFamilyAst::GivePlayerCounter {
         counter_kind: kind,
-        count: QuantityExpr::Fixed {
-            value: count as i32,
-        },
+        count,
     })
 }
 
@@ -14972,6 +14975,90 @@ mod tests {
         assert!(
             result.is_none(),
             "Should NOT parse unknown counter type as player counter"
+        );
+    }
+
+    /// CR 608.2h: "get that many <kind> counters" binds the triggering event's
+    /// amount (Etali, Primal Sickness: combat damage → that many poison
+    /// counters). Revert-failing: without the `parse_that_much_or_many` arm the
+    /// count matches neither `parse_article` nor `parse_number`, so
+    /// `try_parse_player_counter` returns None and the effect lowers to
+    /// `Effect::Unimplemented`.
+    #[test]
+    fn parse_player_counter_that_many_binds_event_amount() {
+        match try_parse_player_counter("get that many poison counters") {
+            Some(ImperativeFamilyAst::GivePlayerCounter {
+                counter_kind,
+                count,
+            }) => {
+                assert_eq!(counter_kind, PlayerCounterKind::Poison);
+                assert!(matches!(
+                    count,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::EventContextAmount
+                    }
+                ));
+            }
+            other => panic!("Expected GivePlayerCounter, got {other:?}"),
+        }
+    }
+
+    /// Class coverage: the "that many" amount arm generalizes across the whole
+    /// player-counter kind set (experience, not just poison).
+    #[test]
+    fn parse_player_counter_that_many_experience() {
+        match try_parse_player_counter("get that many experience counters") {
+            Some(ImperativeFamilyAst::GivePlayerCounter {
+                counter_kind,
+                count,
+            }) => {
+                assert_eq!(counter_kind, PlayerCounterKind::Experience);
+                assert!(matches!(
+                    count,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::EventContextAmount
+                    }
+                ));
+            }
+            other => panic!("Expected GivePlayerCounter, got {other:?}"),
+        }
+    }
+
+    /// Sibling reach-guard: the new that-many arm must not swallow the fixed
+    /// article/number forms — "get a poison counter" still binds Fixed 1 and
+    /// "gets two rad counters" still binds Fixed 2 (proves the fixed arms are
+    /// reached, not short-circuited).
+    #[test]
+    fn parse_player_counter_fixed_arms_unaffected() {
+        match try_parse_player_counter("get a poison counter") {
+            Some(ImperativeFamilyAst::GivePlayerCounter {
+                counter_kind,
+                count,
+            }) => {
+                assert_eq!(counter_kind, PlayerCounterKind::Poison);
+                assert!(matches!(count, QuantityExpr::Fixed { value: 1 }));
+            }
+            other => panic!("Expected GivePlayerCounter, got {other:?}"),
+        }
+        match try_parse_player_counter("gets two rad counters") {
+            Some(ImperativeFamilyAst::GivePlayerCounter {
+                counter_kind,
+                count,
+            }) => {
+                assert_eq!(counter_kind, PlayerCounterKind::Rad);
+                assert!(matches!(count, QuantityExpr::Fixed { value: 2 }));
+            }
+            other => panic!("Expected GivePlayerCounter, got {other:?}"),
+        }
+    }
+
+    /// Hostile: "+1/+1 counter" is an object counter, not a player counter —
+    /// the that-many arm must not misroute it (the `+`/`-` guard still rejects).
+    #[test]
+    fn parse_player_counter_that_many_rejects_object_counter() {
+        assert!(
+            try_parse_player_counter("gets a +1/+1 counter").is_none(),
+            "Object counter must not parse as a player counter"
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -1003,15 +1003,12 @@ pub(super) fn parse_mana_count_prefix(text: &str) -> Option<(QuantityExpr, &str)
     let trimmed = text.trim_start();
     let lower = trimmed.to_lowercase();
 
-    if let Some((_, rest)) = nom_on_lower(trimmed, &lower, |i| {
-        value((), alt((tag("that much "), tag("that many ")))).parse(i)
-    }) {
-        return Some((
-            QuantityExpr::Ref {
-                qty: QuantityRef::EventContextAmount,
-            },
-            rest.trim_start(),
-        ));
+    if let Some((qty, rest)) = nom_on_lower(
+        trimmed,
+        &lower,
+        crate::parser::oracle_nom::quantity::parse_that_much_or_many,
+    ) {
+        return Some((QuantityExpr::Ref { qty }, rest.trim_start()));
     }
 
     // Try "x " via nom (case-insensitive via lowercase)

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2781,6 +2781,22 @@ fn parse_amassed_army_property_ref(input: &str) -> OracleResult<'_, QuantityRef>
     .parse(rest)
 }
 
+/// CR 122.1 + CR 608.2 + CR 608.2h: leaf demonstrative amount "that much"/"that
+/// many" → the triggering event's amount (`QuantityRef::EventContextAmount`).
+/// Single authority for the count-prefix slot shared by the player-counter,
+/// counter-removal, and mana-production arms. Matches the bare quantifier
+/// WITHOUT a trailing space; callers `.trim_start()` the remainder. Narrower
+/// than `parse_event_context_refs` (which also matches "that damage"/"the
+/// damage dealt"/power/toughness/amass — invalid in a pure count slot). Per CR
+/// 608.2h the referenced amount is determined once, when the effect is applied.
+pub fn parse_that_much_or_many(input: &str) -> OracleResult<'_, QuantityRef> {
+    alt((
+        value(QuantityRef::EventContextAmount, tag("that much")),
+        value(QuantityRef::EventContextAmount, tag("that many")),
+    ))
+    .parse(input)
+}
+
 /// Parse event-context quantity references.
 ///
 /// CR 603.7c: "that {noun}" in a triggered ability refers to the object or
@@ -2788,8 +2804,10 @@ fn parse_amassed_army_property_ref(input: &str) -> OracleResult<'_, QuantityRef>
 /// `extract_source_from_event` → live object or LKI cache.
 fn parse_event_context_refs(input: &str) -> OracleResult<'_, QuantityRef> {
     alt((
-        value(QuantityRef::EventContextAmount, tag("that much")),
-        value(QuantityRef::EventContextAmount, tag("that many")),
+        // CR 608.2h: bare demonstrative amount — delegate to the shared
+        // single-authority combinator (also used by the player-counter,
+        // counter-removal, and mana-production count-prefix slots).
+        parse_that_much_or_many,
         value(QuantityRef::EventContextAmount, tag("that damage")),
         // CR 120.1 + CR 603.7c: "the damage dealt" bare form in a triggered
         // ability body — refers to the total from the triggering combat-damage

--- a/crates/engine/tests/integration/etali_primal_sickness_poison.rs
+++ b/crates/engine/tests/integration/etali_primal_sickness_poison.rs
@@ -1,0 +1,88 @@
+//! Regression test for Etali, Primal Sickness (back face of Etali, Primal
+//! Conqueror): "Whenever Etali deals combat damage to a player, they get that
+//! many poison counters."
+//!
+//! Before the fix, `try_parse_player_counter` had no "that many"/"that much"
+//! quantity arm, so "get that many poison counters" matched neither the article
+//! nor the number arm and the effect lowered to `Effect::Unimplemented`. The
+//! trigger fired but gave zero poison counters.
+//!
+//! The fix adds the `parse_that_much_or_many` count-prefix arm, binding the
+//! count to `QuantityRef::EventContextAmount` (CR 608.2h: the amount is the
+//! triggering combat-damage event's total, determined once when the effect
+//! applies). The "they" recipient (`resolve_they_pronoun` →
+//! `TriggeringPlayer`) and the amount resolution
+//! (`extract_amount_from_event` for `CombatDamageDealtToPlayer`) already work.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::phase::Phase;
+
+use super::rules::run_combat;
+
+/// Verbatim Oracle text of Etali, Primal Sickness
+/// (`jq '.["etali, primal sickness"].oracle_text'` in `card-data.json`).
+const ETALI_ORACLE: &str = "Trample, indestructible\n\
+Whenever Etali deals combat damage to a player, they get that many poison \
+counters. (A player with ten or more poison counters loses the game.)";
+
+/// CR 608.2h + CR 104.3d: an unblocked Etali deals combat damage to a player,
+/// and the event-bound trigger gives that player exactly that many poison
+/// counters. Revert-failing: without the "that many" quantity arm the trigger
+/// lowers to `Effect::Unimplemented` and P1 ends with 0 poison counters.
+#[test]
+fn etali_combat_damage_gives_that_many_poison_counters() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // A 7/7 Etali deals 7 combat damage to P1 → P1 gets 7 poison counters.
+    let etali = scenario
+        .add_creature_from_oracle(P0, "Etali, Primal Sickness", 7, 7, ETALI_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].poison_counters,
+        0,
+        "precondition: P1 starts with no poison counters"
+    );
+
+    // 7/7 Etali attacks P1 unblocked (CR 510.1b: 7 combat damage to P1).
+    run_combat(&mut runner, vec![etali], vec![]);
+    // CR 510.3a: the combat-damage trigger goes on the stack — drain it so the
+    // poison counters land before asserting.
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].poison_counters,
+        7,
+        "CR 608.2h: P1 takes 7 combat damage and gets that many (7) poison \
+         counters. A regression to the pre-fix parse lowers the trigger to \
+         Unimplemented and leaves P1 at 0 poison."
+    );
+}
+
+/// The count tracks the event amount, not a constant: a 3-power Etali gives 3
+/// poison counters (not 7). Pins `EventContextAmount` against a hard-coded
+/// value — a Fixed-count regression would give the same number in both tests.
+#[test]
+fn etali_poison_count_tracks_combat_damage_amount() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let etali = scenario
+        .add_creature_from_oracle(P0, "Etali, Primal Sickness", 3, 3, ETALI_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    run_combat(&mut runner, vec![etali], vec![]);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].poison_counters,
+        3,
+        "CR 608.2h: the poison count equals the combat damage dealt (3), \
+         proving the count is the event amount, not a constant"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -95,6 +95,7 @@ mod engine_invariants;
 mod enlightened_tutor_regression;
 mod equipment_etb_attach_parent_target;
 mod ertai_trickery_counter_kicked;
+mod etali_primal_sickness_poison;
 mod evelyn_regression;
 mod exchange_life_totals_cards;
 mod exhibition_tidecaller_target_player_mill;


### PR DESCRIPTION
## Etali, Primal Sickness — "get that many poison counters"

**Bug:** The back face of Etali, Primal Conqueror ("Whenever Etali deals combat damage to a player, they get that many poison counters") lowered its effect to `Effect::Unimplemented{name:"get"}`. `try_parse_player_counter` resolved the counter count only via `parse_article` (→Fixed 1) / `parse_number` (→Fixed N); there was no "that many"/"that much" arm, so "that many poison counters" matched neither and the whole effect was dropped. The player never received poison counters.

**Fix (parser-only):**
- New shared combinator `parse_that_much_or_many` (`oracle_nom/quantity.rs`) → `QuantityRef::EventContextAmount` for the leaf "that much"/"that many".
- New "that many" arm added FIRST in `try_parse_player_counter` → `GivePlayerCounter { counter_kind, count: QuantityExpr::Ref{qty: EventContextAmount} }`.
- Converged the two pre-existing inline dups (`counter.rs` counter-removal, `mana.rs` mana-production) and `parse_event_context_refs` onto the single combinator — one authority for the "that many/much" → event-amount recognition.

**Class coverage:** "get/gets that many/much <poison|experience|rad|ticket> counters" after any `EventContextAmount` event (combat damage, cards drawn, life change) — not just Etali/poison/combat.

**CR annotations (grep-verified):** 122.1 (counter def), 608.2 + 608.2h (info determined once at resolution — the "that many" = event amount rule), 104.3d + 122.1f (10 poison = loss), 510.1b/510.3a (combat damage). 603.7c deliberately NOT used (it governs delayed triggers referring to an object, not a leaf amount).

**Verification:** 8 player-counter parser tests (4 new incl. revert-failing "that many"); 2 new runtime integration tests driving the real combat path (7/7 → 7 poison, 3/3 → 3 poison — revert-failing vs pre-fix 0, and two different powers prove the count tracks the event amount, not a constant); `engine-inventory` zero new variants; clippy `-D warnings` clean. Independent `/review-impl` pass.

**⚠️ Release note:** the shipped Etali card in generated `card-data.json` still carries a stale `Unimplemented` trigger cache — a card-data regen at release refreshes it. Runtime tests use the live parser and are unaffected.
