### PR TITLE
fix(client): scry/surveil dialog scrolls to reach all cards at large counts

### DIFF
--- a/client/src/components/modal/cardChoice/libraryModals.tsx
+++ b/client/src/components/modal/cardChoice/libraryModals.tsx
@@ -7,6 +7,7 @@ import { CardImage } from "../../card/CardImage";
 import { objectImageProps } from "../../../services/cardImageLookup";
 import { useGameStore } from "../../../stores/gameStore";
 import { useGameDispatch } from "../../../hooks/useGameDispatch";
+import { useHorizontalScroll } from "../../../hooks/useHorizontalScroll.ts";
 import { useInspectHoverProps } from "../../../hooks/useInspectHoverProps";
 import { ChoiceOverlay, ConfirmButton, ScrollableCardStrip } from "../ChoiceOverlay";
 import { CHOICE_CARD_IMAGE_CLASS } from "./shared";
@@ -39,6 +40,7 @@ export function ReorderableTopChoice({
   const hoverProps = useInspectHoverProps();
   const [order, setOrder] = useState<ObjectId[]>(cards);
   const [restSet, setRestSet] = useState<Set<ObjectId>>(new Set());
+  const scrollRef = useHorizontalScroll<HTMLDivElement>({ drag: false });
 
   const toggleRest = useCallback((id: ObjectId) => {
     setRestSet((prev) => {
@@ -78,14 +80,16 @@ export function ReorderableTopChoice({
       maxWidthClassName={overlayWidthClassName}
       footer={<ConfirmButton onClick={handleConfirm} />}
     >
-      <Reorder.Group
-        as="div"
-        axis="x"
-        values={order}
-        onReorder={setOrder}
-        className="mx-auto flex min-h-0 flex-1 items-center justify-center gap-2 overflow-x-auto px-1 py-2 lg:gap-3"
-      >
-        {order.map((id) => {
+      <div ref={scrollRef} className="flex min-h-0 flex-1 overflow-x-auto">
+        <Reorder.Group
+          as="div"
+          axis="x"
+          values={order}
+          onReorder={setOrder}
+          layoutScroll
+          className="mx-auto flex w-max items-center gap-2 px-1 py-2 lg:gap-3"
+        >
+          {order.map((id) => {
           const obj = objects[id];
           if (!obj) return null;
           const isRest = restSet.has(id);
@@ -128,7 +132,8 @@ export function ReorderableTopChoice({
             </Reorder.Item>
           );
         })}
-      </Reorder.Group>
+        </Reorder.Group>
+      </div>
       <p className="mt-1 shrink-0 text-center text-xs text-slate-400">{reorderHint}</p>
     </ChoiceOverlay>
   );

--- a/client/src/hooks/useHorizontalScroll.ts
+++ b/client/src/hooks/useHorizontalScroll.ts
@@ -10,8 +10,14 @@ import { useEffect, useRef } from "react";
  * anchor, input) so we don't fight existing handlers. A click that follows a
  * drag is blocked in the capture phase so cards aren't accidentally selected
  * while panning.
+ *
+ * Pass `{ drag: false }` to keep only the wheel behavior — useful when the
+ * children own their own pointer-drag gesture (e.g. framer-motion Reorder) and
+ * a scroll-pan drag would conflict with it.
  */
-export function useHorizontalScroll<T extends HTMLElement>() {
+export function useHorizontalScroll<T extends HTMLElement>({
+  drag = true,
+}: { drag?: boolean } = {}) {
   const ref = useRef<T | null>(null);
 
   useEffect(() => {
@@ -91,23 +97,27 @@ export function useHorizontalScroll<T extends HTMLElement>() {
     };
 
     el.addEventListener("wheel", onWheel, { passive: false });
-    el.addEventListener("pointerdown", onPointerDown);
-    el.addEventListener("pointermove", onPointerMove);
-    el.addEventListener("pointerup", endDrag);
-    el.addEventListener("pointercancel", endDrag);
-    el.addEventListener("click", onClickCapture, { capture: true });
+    if (drag) {
+      el.addEventListener("pointerdown", onPointerDown);
+      el.addEventListener("pointermove", onPointerMove);
+      el.addEventListener("pointerup", endDrag);
+      el.addEventListener("pointercancel", endDrag);
+      el.addEventListener("click", onClickCapture, { capture: true });
+    }
 
     return () => {
       el.removeEventListener("wheel", onWheel);
-      el.removeEventListener("pointerdown", onPointerDown);
-      el.removeEventListener("pointermove", onPointerMove);
-      el.removeEventListener("pointerup", endDrag);
-      el.removeEventListener("pointercancel", endDrag);
-      el.removeEventListener("click", onClickCapture, { capture: true });
+      if (drag) {
+        el.removeEventListener("pointerdown", onPointerDown);
+        el.removeEventListener("pointermove", onPointerMove);
+        el.removeEventListener("pointerup", endDrag);
+        el.removeEventListener("pointercancel", endDrag);
+        el.removeEventListener("click", onClickCapture, { capture: true });
+      }
       el.style.cursor = "";
       el.style.userSelect = "";
     };
-  }, []);
+  }, [drag]);
 
   return ref;
 }


### PR DESCRIPTION
The Reorder.Group combined justify-center and overflow-x-auto on one flex
element, so at large scry/surveil counts the leading cards were centered into
negative scroll space that scrollLeft (>= 0) can never reach — only the last
~20 cards were viewable. Separate centering from scrolling: an outer
overflow-x-auto container wraps a w-max mx-auto group (auto-centers when it
fits, collapses-and-stays-reachable when it overflows). Drag-reorder is
preserved (Reorder.Group stays the flex/drag parent). useHorizontalScroll is
parameterized {drag:false} for this framer-managed path (wheel kept, drag
suppressed to avoid fighting Reorder).
