### PR TITLE
feat(engine,client): view and clear 'don't ask again' may-trigger auto-choices

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -688,6 +688,19 @@ export interface MayTriggerAutoChoiceKey {
   origin: MayTriggerOrigin;
 }
 
+export interface MayTriggerAutoChoiceRecord {
+  key: MayTriggerAutoChoiceKey;
+  choice: AutoMayChoice;
+}
+
+// CR 603.5: The mutation a `SetMayTriggerAutoChoice` action performs on the
+// acting player's stored "don't ask again" auto-choices for optional ("may")
+// triggers. `Remove` echoes a stored key verbatim; `ClearAll` drops every
+// stored auto-choice belonging to the acting player.
+export type MayTriggerAutoChoiceOp =
+  | { type: "Remove"; data: { key: MayTriggerAutoChoiceKey } }
+  | { type: "ClearAll" };
+
 // ── Casting Permission ───────────────────────────────────────────────────
 
 export type CastingPermission =
@@ -1862,6 +1875,7 @@ export type GameAction =
   | { type: "CancelAutoPass" }
   | { type: "SetPhaseStops"; data: { stops: PhaseStop[] } }
   | { type: "SetPriorityYield"; data: { op: PriorityYieldOp } }
+  | { type: "SetMayTriggerAutoChoice"; data: { op: MayTriggerAutoChoiceOp } }
   | { type: "AssignCombatDamage"; data: { assignments: [ObjectId, number][]; trample_damage: number; controller_damage: number } }
   // CR 510.1d + CR 702.22k: blocker's combat-damage division among the attackers it blocks.
   | { type: "AssignBlockerDamage"; data: { assignments: [ObjectId, number][] } }
@@ -2411,6 +2425,8 @@ export interface GameState {
   phase_stops?: Record<number, PhaseStop[]>;
   /** CR 117.3d: the viewer's standing priority-yield preferences. */
   priority_yields?: PriorityYield[];
+  /** CR 603.5: the viewer's stored "don't ask again" auto-choices for optional ("may") triggers. */
+  may_trigger_auto_choices?: MayTriggerAutoChoiceRecord[];
   lands_tapped_for_mana?: Record<number, number[]>;
   scheduled_turn_controls?: Array<{
     target_player: PlayerId;

--- a/client/src/components/board/MayTriggerAutoChoiceList.tsx
+++ b/client/src/components/board/MayTriggerAutoChoiceList.tsx
@@ -1,0 +1,113 @@
+import { useTranslation } from "react-i18next";
+
+import type { MayTriggerAutoChoiceKey } from "../../adapter/types.ts";
+import { dispatchAction } from "../../game/dispatch.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
+import { PopoverMenu } from "../menu/PopoverMenu.tsx";
+
+/**
+ * CR 603.5: the viewer's stored "don't ask again" auto-choices for optional
+ * ("may") triggered abilities. Presented as a single fixed-footprint summary
+ * chip ("Auto-deciding ×N") that opens a portaled PopoverMenu holding the
+ * scrollable, per-row remove list plus a clear-all — mirroring
+ * `PriorityYieldList` so the action rail height stays constant no matter how
+ * many auto-choices accumulate. Purely a display + dispatch surface: the engine
+ * owns the state (redacted per-viewer in `may_trigger_auto_choices`), enforces
+ * actor scoping on the write, and each remove echoes the stored key verbatim.
+ */
+export function MayTriggerAutoChoiceList() {
+  const { t } = useTranslation("game");
+  const choices = useGameStore((s) => s.gameState?.may_trigger_auto_choices);
+  const objects = useGameStore((s) => s.gameState?.objects);
+
+  if (!choices || choices.length === 0) return null;
+
+  const rowKey = (key: MayTriggerAutoChoiceKey) =>
+    key.origin.type === "Printed"
+      ? `${key.player}-${key.source_id}-p${key.origin.trigger_index}`
+      : `${key.player}-${key.source_id}-k${key.origin.keyword}`;
+
+  return (
+    <PopoverMenu
+      ariaLabel={t("mayTriggerAutoChoice.listHeader")}
+      menuWidthPx={260}
+      renderTrigger={({ ref, open, toggle }) => (
+        <button
+          ref={ref}
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          onClick={toggle}
+          className={`pointer-events-auto flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold shadow-sm ring-1 transition-colors ${
+            open
+              ? "bg-sky-400 text-black ring-sky-300"
+              : "bg-sky-500/90 text-black ring-sky-300/80 hover:bg-sky-400"
+          }`}
+        >
+          <span>{t("mayTriggerAutoChoice.menuButtonShortActive")}</span>
+          <span className="rounded-full bg-black/25 px-1.5 leading-tight">{choices.length}</span>
+        </button>
+      )}
+    >
+      {(close) => (
+        <>
+          <div className="flex items-center justify-between px-3 pb-1.5 pt-1">
+            <span className="text-sm font-bold text-white">
+              {t("mayTriggerAutoChoice.listHeader")}
+            </span>
+            <button
+              type="button"
+              className="rounded px-1.5 py-0.5 text-xs font-semibold text-sky-200 transition-colors hover:bg-white/10"
+              onClick={() => {
+                dispatchAction({
+                  type: "SetMayTriggerAutoChoice",
+                  data: { op: { type: "ClearAll" } },
+                });
+                close();
+              }}
+            >
+              {t("mayTriggerAutoChoice.clearAll")}
+            </button>
+          </div>
+          <div className="mx-2 mb-1 border-t border-white/10" />
+          <ul className="flex flex-col">
+            {choices.map((record) => {
+              const sourceName =
+                objects?.[record.key.source_id]?.name ??
+                t("mayTriggerAutoChoice.sourceFallback");
+              const decision =
+                record.choice.type === "Accept"
+                  ? t("mayTriggerAutoChoice.accept")
+                  : t("mayTriggerAutoChoice.decline");
+              return (
+                <li
+                  key={rowKey(record.key)}
+                  className="flex items-center justify-between gap-2 px-3 py-1.5"
+                >
+                  <span className="truncate text-sm text-gray-200">
+                    {t("mayTriggerAutoChoice.entryLabel", {
+                      source: sourceName,
+                      decision,
+                    })}
+                  </span>
+                  <button
+                    type="button"
+                    className="shrink-0 rounded px-1.5 py-0.5 text-xs font-semibold text-sky-200 transition-colors hover:bg-white/10"
+                    onClick={() =>
+                      dispatchAction({
+                        type: "SetMayTriggerAutoChoice",
+                        data: { op: { type: "Remove", data: { key: record.key } } },
+                      })
+                    }
+                  >
+                    {t("mayTriggerAutoChoice.remove")}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </PopoverMenu>
+  );
+}

--- a/client/src/components/board/__tests__/MayTriggerAutoChoiceList.test.tsx
+++ b/client/src/components/board/__tests__/MayTriggerAutoChoiceList.test.tsx
@@ -1,0 +1,111 @@
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { MayTriggerAutoChoiceList } from "../MayTriggerAutoChoiceList.tsx";
+import type { MayTriggerAutoChoiceRecord } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { buildGameObject, buildObjectMap } from "../../../test/factories/gameObjectFactory.ts";
+import { buildGameState } from "../../../test/factories/gameStateFactory.ts";
+
+const { dispatchActionMock } = vi.hoisted(() => ({ dispatchActionMock: vi.fn() }));
+vi.mock("../../../game/dispatch.ts", () => ({ dispatchAction: dispatchActionMock }));
+
+function record(sourceId: number, accept: boolean): MayTriggerAutoChoiceRecord {
+  return {
+    key: {
+      player: 0,
+      source_id: sourceId,
+      origin: { type: "Printed", trigger_index: 0 },
+    },
+    choice: { type: accept ? "Accept" : "Decline" },
+  };
+}
+
+function seed(records: MayTriggerAutoChoiceRecord[]) {
+  const gameState = buildGameState({
+    objects: buildObjectMap(
+      buildGameObject({ id: 50, card_id: 9, name: "Kodama of the East Tree", zone: "Battlefield" }),
+    ),
+    may_trigger_auto_choices: records,
+  });
+  act(() => {
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+  });
+}
+
+describe("MayTriggerAutoChoiceList", () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+    dispatchActionMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing when the viewer holds no auto-choices", () => {
+    seed([]);
+    const { container } = render(<MayTriggerAutoChoiceList />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("collapses stored auto-choices into a single chip that shows the count", () => {
+    seed([record(50, true), record(51, false)]);
+    render(<MayTriggerAutoChoiceList />);
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.queryByText("Clear all")).not.toBeInTheDocument();
+    expect(screen.queryByText("Remove")).not.toBeInTheDocument();
+  });
+
+  it("reveals the removable list only after the chip is opened, labeled with the stored decision", () => {
+    seed([record(50, true)]);
+    render(<MayTriggerAutoChoiceList />);
+
+    fireEvent.click(screen.getByRole("button", { name: /auto-deciding/i }));
+
+    expect(screen.getByText("Clear all")).toBeInTheDocument();
+    // Source name plus the stored decision (Accept -> "Yes").
+    expect(screen.getByText(/Kodama of the East Tree — Yes/)).toBeInTheDocument();
+    expect(screen.getByText("Remove")).toBeInTheDocument();
+  });
+
+  it("dispatches a Remove that echoes the stored key verbatim", () => {
+    seed([record(50, true)]);
+    render(<MayTriggerAutoChoiceList />);
+
+    fireEvent.click(screen.getByRole("button", { name: /auto-deciding/i }));
+    fireEvent.click(screen.getByText("Remove"));
+
+    expect(dispatchActionMock).toHaveBeenCalledWith({
+      type: "SetMayTriggerAutoChoice",
+      data: {
+        op: {
+          type: "Remove",
+          data: {
+            key: {
+              player: 0,
+              source_id: 50,
+              origin: { type: "Printed", trigger_index: 0 },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("dispatches ClearAll and closes the popover when Clear all is chosen", () => {
+    seed([record(50, true), record(51, false)]);
+    render(<MayTriggerAutoChoiceList />);
+
+    fireEvent.click(screen.getByRole("button", { name: /auto-deciding/i }));
+    fireEvent.click(screen.getByText("Clear all"));
+
+    expect(dispatchActionMock).toHaveBeenCalledWith({
+      type: "SetMayTriggerAutoChoice",
+      data: { op: { type: "ClearAll" } },
+    });
+    expect(screen.queryByText("Clear all")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1817,6 +1817,16 @@
     "reportTitle": "Stuck decision: {{kind}}",
     "reportWhatHappened": "**What happened**\n_briefly describe what you were doing_\n\n**Diagnostic**\n```\n{{diagnostic}}\n```"
   },
+  "mayTriggerAutoChoice": {
+    "listHeader": "Automatische Entscheidungen",
+    "menuButtonShortActive": "Automatisch entscheiden",
+    "clearAll": "Alle löschen",
+    "remove": "Entfernen",
+    "accept": "Ja",
+    "decline": "Nein",
+    "sourceFallback": "Effekt",
+    "entryLabel": "{{source}} – {{decision}}"
+  },
   "optionalEffect": {
     "sourceFallback": "Effekt",
     "title": "{{name}} - Optionaler Effekt",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1854,6 +1854,16 @@
     "reportTitle": "Stuck decision: {{kind}}",
     "reportWhatHappened": "**What happened**\n_briefly describe what you were doing_\n\n**Diagnostic**\n```\n{{diagnostic}}\n```"
   },
+  "mayTriggerAutoChoice": {
+    "listHeader": "Auto-choices",
+    "menuButtonShortActive": "Auto-deciding",
+    "clearAll": "Clear all",
+    "remove": "Remove",
+    "accept": "Yes",
+    "decline": "No",
+    "sourceFallback": "Effect",
+    "entryLabel": "{{source}} — {{decision}}"
+  },
   "optionalEffect": {
     "sourceFallback": "Effect",
     "title": "{{name}} - Optional Effect",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1817,6 +1817,16 @@
     "reportTitle": "Stuck decision: {{kind}}",
     "reportWhatHappened": "**What happened**\n_briefly describe what you were doing_\n\n**Diagnostic**\n```\n{{diagnostic}}\n```"
   },
+  "mayTriggerAutoChoice": {
+    "listHeader": "Decisiones automáticas",
+    "menuButtonShortActive": "Decidiendo automáticamente",
+    "clearAll": "Borrar todo",
+    "remove": "Quitar",
+    "accept": "Sí",
+    "decline": "No",
+    "sourceFallback": "Efecto",
+    "entryLabel": "{{source}} — {{decision}}"
+  },
   "optionalEffect": {
     "sourceFallback": "Efecto",
     "title": "{{name}} - Efecto opcional",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1817,6 +1817,16 @@
     "reportTitle": "Stuck decision: {{kind}}",
     "reportWhatHappened": "**What happened**\n_briefly describe what you were doing_\n\n**Diagnostic**\n```\n{{diagnostic}}\n```"
   },
+  "mayTriggerAutoChoice": {
+    "listHeader": "Choix automatiques",
+    "menuButtonShortActive": "Décision automatique",
+    "clearAll": "Tout effacer",
+    "remove": "Retirer",
+    "accept": "Oui",
+    "decline": "Non",
+    "sourceFallback": "Effet",
+    "entryLabel": "{{source}} — {{decision}}"
+  },
   "optionalEffect": {
     "sourceFallback": "Effet",
     "title": "{{name}} - Effet facultatif",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1817,6 +1817,16 @@
     "reportTitle": "Stuck decision: {{kind}}",
     "reportWhatHappened": "**What happened**\n_briefly describe what you were doing_\n\n**Diagnostic**\n```\n{{diagnostic}}\n```"
   },
+  "mayTriggerAutoChoice": {
+    "listHeader": "Scelte automatiche",
+    "menuButtonShortActive": "Decisione automatica",
+    "clearAll": "Cancella tutto",
+    "remove": "Rimuovi",
+    "accept": "Sì",
+    "decline": "No",
+    "sourceFallback": "Effetto",
+    "entryLabel": "{{source}} — {{decision}}"
+  },
   "optionalEffect": {
     "sourceFallback": "Effetto",
     "title": "{{name}} - Effetto facoltativo",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1817,6 +1817,16 @@
     "reportTitle": "Stuck decision: {{kind}}",
     "reportWhatHappened": "**What happened**\n_briefly describe what you were doing_\n\n**Diagnostic**\n```\n{{diagnostic}}\n```"
   },
+  "mayTriggerAutoChoice": {
+    "listHeader": "Wybory automatyczne",
+    "menuButtonShortActive": "Automatyczne decyzje",
+    "clearAll": "Wyczyść wszystko",
+    "remove": "Usuń",
+    "accept": "Tak",
+    "decline": "Nie",
+    "sourceFallback": "Efekt",
+    "entryLabel": "{{source}} — {{decision}}"
+  },
   "optionalEffect": {
     "sourceFallback": "Efekt",
     "title": "{{name}} - Efekt opcjonalny",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1817,6 +1817,16 @@
     "reportTitle": "Stuck decision: {{kind}}",
     "reportWhatHappened": "**What happened**\n_briefly describe what you were doing_\n\n**Diagnostic**\n```\n{{diagnostic}}\n```"
   },
+  "mayTriggerAutoChoice": {
+    "listHeader": "Escolhas automáticas",
+    "menuButtonShortActive": "Decidindo automaticamente",
+    "clearAll": "Limpar tudo",
+    "remove": "Remover",
+    "accept": "Sim",
+    "decline": "Não",
+    "sourceFallback": "Efeito",
+    "entryLabel": "{{source}} — {{decision}}"
+  },
   "optionalEffect": {
     "sourceFallback": "Efeito",
     "title": "{{name}} - Efeito Opcional",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -41,6 +41,7 @@ import { CardReportDialog } from "../components/card/CardReportDialog.tsx";
 import { ActionButton } from "../components/board/ActionButton.tsx";
 import { FullControlToggle } from "../components/controls/FullControlToggle.tsx";
 import { CombatPhaseIndicator } from "../components/controls/PhaseStopBar.tsx";
+import { MayTriggerAutoChoiceList } from "../components/board/MayTriggerAutoChoiceList.tsx";
 import { PriorityYieldList } from "../components/board/PriorityYieldList.tsx";
 import { OpponentHand } from "../components/hand/OpponentHand.tsx";
 import { MobileHandDrawer } from "../components/hand/MobileHandDrawer.tsx";
@@ -1427,6 +1428,7 @@ function GamePageContent({
             </div>
             <div className="flex items-center gap-1.5">
               <PriorityYieldList />
+              <MayTriggerAutoChoiceList />
               <FullControlToggle className="w-full" />
             </div>
           </div>
@@ -1454,6 +1456,9 @@ function GamePageContent({
                 {/* CR 117.3d: standing priority-yield summary chip, beside the
                     Full Control toggle (self-hides when no yields stand). */}
                 <PriorityYieldList />
+                {/* CR 603.5: standing "don't ask again" auto-choice summary chip,
+                    beside the priority-yield chip (self-hides when none stand). */}
+                <MayTriggerAutoChoiceList />
                 <FullControlToggle />
               </div>
               <ActionButton />

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5,12 +5,12 @@ use thiserror::Error;
 use crate::types::ability::{EffectKind, KeywordAction, TargetRef};
 #[cfg(test)]
 use crate::types::ability::{EffectScope, TapStateChange};
-use crate::types::actions::{GameAction, PriorityYieldOp};
+use crate::types::actions::{GameAction, MayTriggerAutoChoiceOp, PriorityYieldOp};
 use crate::types::events::{BendingType, ContestRound, GameEvent, ManaTapState, PlayerActionKind};
 use crate::types::game_state::{
     ActionResult, AssistState, AutoPassMode, AutoPassRequest, CastOfferKind, ConvokeMode,
-    CostResume, GameState, LandPlayRecord, PayCostKind, RetargetScope, StackEntry, StackEntryKind,
-    WaitingFor,
+    CostResume, GameState, LandPlayRecord, MayTriggerAutoChoiceKey, PayCostKind, RetargetScope,
+    StackEntry, StackEntryKind, WaitingFor,
 };
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::match_config::MatchType;
@@ -453,6 +453,7 @@ fn check_actor_authorization(
         action,
         GameAction::SetPhaseStops { .. }
             | GameAction::SetPriorityYield { .. }
+            | GameAction::SetMayTriggerAutoChoice { .. }
             | GameAction::CancelAutoPass
             | GameAction::Debug(_)
             | GameAction::GrantDebugPermission { .. }
@@ -1167,6 +1168,32 @@ fn apply_action(
             }
             PriorityYieldOp::ClearAll => {
                 state.clear_priority_yields(actor);
+            }
+        }
+        return Ok(ActionResult {
+            events: vec![],
+            waiting_for: state.waiting_for.clone(),
+            log_entries: vec![],
+        });
+    }
+
+    // CR 603.5: SetMayTriggerAutoChoice propagates the actor's stored "don't ask
+    // again" auto-choices for optional ("may") triggers. Pure preference state,
+    // routed by `actor`, and — like SetPriorityYield — handled before the
+    // loop-ring / auto-pass teardown so it is a legal any-state mutation. Actor
+    // scoping is enforced by overriding the key's player with `actor`, so a
+    // player can only mutate their own preferences regardless of the payload.
+    if let GameAction::SetMayTriggerAutoChoice { op } = &action {
+        match op {
+            MayTriggerAutoChoiceOp::Remove { key } => {
+                let actor_key = MayTriggerAutoChoiceKey {
+                    player: actor,
+                    ..*key
+                };
+                state.remove_may_trigger_auto_choice(&actor_key);
+            }
+            MayTriggerAutoChoiceOp::ClearAll => {
+                state.clear_may_trigger_auto_choices(actor);
             }
         }
         return Ok(ActionResult {

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -2248,6 +2248,133 @@ fn set_priority_yield_accepted_from_non_priority_actor() {
     );
 }
 
+// --- GameAction::SetMayTriggerAutoChoice (CR 603.5) ---
+
+/// Builds a `MayTriggerAutoChoiceKey` for `player` scoped to `source` with a
+/// printed-trigger origin (index 0), matching the shape the resolution pipeline
+/// latches for an optional ("may") triggered ability.
+fn may_trigger_key(
+    player: PlayerId,
+    source: ObjectId,
+) -> crate::types::game_state::MayTriggerAutoChoiceKey {
+    crate::types::game_state::MayTriggerAutoChoiceKey {
+        player,
+        source_id: source,
+        origin: crate::types::game_state::MayTriggerOrigin::Printed { trigger_index: 0 },
+    }
+}
+
+/// CR 603.5: `SetMayTriggerAutoChoice { Remove }` dispatched through the real
+/// `apply()` pipeline revokes the acting player's own stored auto-choice. The
+/// action is exempt from the priority-holder gate (a preference mutation), so a
+/// non-priority actor may still edit their own preferences.
+#[test]
+fn set_may_trigger_auto_choice_remove_revokes_actor_choice() {
+    use crate::types::actions::MayTriggerAutoChoiceOp;
+    use crate::types::game_state::AutoMayChoice;
+
+    let mut state = setup_game_at_main_phase();
+    let source = ObjectId(500);
+    let key = may_trigger_key(PlayerId(0), source);
+    state.set_may_trigger_auto_choice(key, AutoMayChoice::Accept);
+    assert_eq!(state.may_trigger_auto_choices.len(), 1);
+
+    apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::SetMayTriggerAutoChoice {
+            op: MayTriggerAutoChoiceOp::Remove { key },
+        },
+    )
+    .expect("SetMayTriggerAutoChoice is legal in any state");
+
+    assert!(
+        state.may_trigger_auto_choices.is_empty(),
+        "Remove revokes the actor's stored auto-choice"
+    );
+}
+
+/// CR 603.5: `SetMayTriggerAutoChoice { ClearAll }` is actor-scoped — a player
+/// may only clear THEIR OWN stored auto-choices, never another player's. Drives
+/// the real `apply()` pipeline; reverting the actor-scoping in the handler (e.g.
+/// clearing by a client-supplied player) would drop P1's record and fail the
+/// surviving-record assertion.
+#[test]
+fn set_may_trigger_auto_choice_clear_all_is_actor_scoped() {
+    use crate::types::actions::MayTriggerAutoChoiceOp;
+    use crate::types::game_state::AutoMayChoice;
+
+    let mut state = setup_game_at_main_phase();
+    let p0_key = may_trigger_key(PlayerId(0), ObjectId(500));
+    let p0_key2 = may_trigger_key(PlayerId(0), ObjectId(501));
+    let p1_key = may_trigger_key(PlayerId(1), ObjectId(600));
+    state.set_may_trigger_auto_choice(p0_key, AutoMayChoice::Accept);
+    state.set_may_trigger_auto_choice(p0_key2, AutoMayChoice::Decline);
+    state.set_may_trigger_auto_choice(p1_key, AutoMayChoice::Accept);
+    assert_eq!(state.may_trigger_auto_choices.len(), 3);
+
+    apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::SetMayTriggerAutoChoice {
+            op: MayTriggerAutoChoiceOp::ClearAll,
+        },
+    )
+    .expect("SetMayTriggerAutoChoice is legal in any state");
+
+    assert_eq!(
+        state.may_trigger_auto_choices.len(),
+        1,
+        "ClearAll drops only the acting player's auto-choices"
+    );
+    assert_eq!(
+        state.may_trigger_auto_choices[0].key.player,
+        PlayerId(1),
+        "another player's auto-choice survives an actor's ClearAll"
+    );
+}
+
+/// CR 603.5: actor scoping on `Remove` — the handler binds the removal to the
+/// acting player, ignoring the payload's key player. A malicious P1 cannot
+/// revoke P0's stored auto-choice by naming P0's key. Reverting the
+/// `player: actor` override would let P1 delete P0's record and fail the
+/// survives assertion. A reach-guard proves the auth gate is otherwise live.
+#[test]
+fn set_may_trigger_auto_choice_remove_cannot_target_another_player() {
+    use crate::types::actions::MayTriggerAutoChoiceOp;
+    use crate::types::game_state::AutoMayChoice;
+
+    let mut state = setup_game_at_main_phase();
+    let source = ObjectId(500);
+    let p0_key = may_trigger_key(PlayerId(0), source);
+    state.set_may_trigger_auto_choice(p0_key, AutoMayChoice::Accept);
+
+    // Reach-guard: a non-exempt action from P1 in P0's priority window errors,
+    // proving the auth gate is live (so the exemption below is what lets P1 act).
+    let unauthorized = apply(&mut state, PlayerId(1), GameAction::PassPriority);
+    assert!(
+        matches!(unauthorized, Err(EngineError::WrongPlayer)),
+        "a non-priority player cannot pass priority (proves the auth gate is live)"
+    );
+
+    // P1 names P0's exact key, but the handler rebinds removal to the actor (P1),
+    // so nothing P0 owns is touched.
+    apply(
+        &mut state,
+        PlayerId(1),
+        GameAction::SetMayTriggerAutoChoice {
+            op: MayTriggerAutoChoiceOp::Remove { key: p0_key },
+        },
+    )
+    .expect("SetMayTriggerAutoChoice is exempt from the priority-holder gate");
+
+    assert_eq!(
+        state.may_trigger_auto_choice(&p0_key),
+        Some(AutoMayChoice::Accept),
+        "P0's stored auto-choice survives P1's attempt to remove it"
+    );
+}
+
 /// CR 117.3d: an `UntilEndOfTurn` auto-pass session normally ends (Finish) when
 /// an opponent-controlled trigger tops the stack, so the player can respond.
 /// A matching yield keeps the session auto-passing (Pass) through that trigger;

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -4,7 +4,8 @@ use super::ability::{LibraryPosition, TargetRef};
 use super::counter::CounterType;
 use super::game_state::{
     AutoMayChoice, AutoPassRequest, CastPaymentMode, CombatDamageAssignmentMode, CounterCostChoice,
-    CounterMoveChoice, CounterRemoveChoice, ShardChoice, YieldScope, YieldTarget,
+    CounterMoveChoice, CounterRemoveChoice, MayTriggerAutoChoiceKey, ShardChoice, YieldScope,
+    YieldTarget,
 };
 use super::identifiers::{CardId, ObjectId};
 use super::keywords::Keyword;
@@ -621,6 +622,13 @@ pub enum GameAction {
     SetPriorityYield {
         op: PriorityYieldOp,
     },
+    /// CR 603.5: Update the acting player's stored "don't ask again" auto-choices
+    /// for optional ("may") triggered abilities. Legal in any WaitingFor state and
+    /// routed to the acting player (who may only mutate their own preferences),
+    /// mirroring `SetPriorityYield`. Pure preference propagation.
+    SetMayTriggerAutoChoice {
+        op: MayTriggerAutoChoiceOp,
+    },
     /// CR 510.1c/d: Assign damage from an attacker to its blockers (and optionally
     /// the defending player/PW with trample, plus PW controller with trample-over-PW).
     AssignCombatDamage {
@@ -792,6 +800,17 @@ pub enum PriorityYieldOp {
     Remove {
         target: YieldTarget,
     },
+    ClearAll,
+}
+
+/// CR 603.5: The mutation a `GameAction::SetMayTriggerAutoChoice` performs on the
+/// acting player's stored "don't ask again" auto-choices for optional ("may")
+/// triggers. `Remove` echoes a stored key verbatim; `ClearAll` drops every stored
+/// auto-choice belonging to the acting player.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum MayTriggerAutoChoiceOp {
+    Remove { key: MayTriggerAutoChoiceKey },
     ClearAll,
 }
 
@@ -1419,6 +1438,7 @@ impl GameAction {
             | GameAction::CancelAutoPass
             | GameAction::SetPhaseStops { .. }
             | GameAction::SetPriorityYield { .. }
+            | GameAction::SetMayTriggerAutoChoice { .. }
             | GameAction::AssignCombatDamage { .. }
             | GameAction::AssignBlockerDamage { .. }
             | GameAction::DistributeAmong { .. }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -8920,6 +8920,21 @@ impl GameState {
         }
     }
 
+    /// CR 603.5: Revoke a single stored "don't ask again" auto-choice for an
+    /// optional ("may") trigger. The key already scopes to one player, source,
+    /// and origin.
+    pub fn remove_may_trigger_auto_choice(&mut self, key: &MayTriggerAutoChoiceKey) {
+        self.may_trigger_auto_choices
+            .retain(|record| record.key != *key);
+    }
+
+    /// CR 603.5: Revoke all stored "don't ask again" auto-choices belonging to
+    /// `player` for optional ("may") triggers.
+    pub fn clear_may_trigger_auto_choices(&mut self, player: PlayerId) {
+        self.may_trigger_auto_choices
+            .retain(|record| record.key.player != player);
+    }
+
     /// CR 117.3d: True when `player` has a standing yield matching the top stack
     /// entry, meaning they have pre-committed to pass priority while it resolves.
     /// Only triggered abilities can be yielded — spells, activated abilities, and

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -1805,7 +1805,8 @@ pub fn convert_available_action(action: &GameAction, id: String) -> AvailableAct
         GameAction::SetAutoPass { .. }
         | GameAction::CancelAutoPass
         | GameAction::SetPhaseStops { .. }
-        | GameAction::SetPriorityYield { .. } => {
+        | GameAction::SetPriorityYield { .. }
+        | GameAction::SetMayTriggerAutoChoice { .. } => {
             AvailableActionConversion::Unsupported("local.autopass-settings-unsupported")
         }
         GameAction::AssignCombatDamage { .. } => AvailableActionConversion::Skip,

--- a/crates/server-core/src/game_action_payload_guard.rs
+++ b/crates/server-core/src/game_action_payload_guard.rs
@@ -450,6 +450,7 @@ pub fn guard_game_action_payload(action: &GameAction) -> Result<(), String> {
         | GameAction::GrantDebugPermission { .. }
         | GameAction::RevokeDebugPermission { .. }
         | GameAction::SetPriorityYield { .. }
+        | GameAction::SetMayTriggerAutoChoice { .. }
         | GameAction::Concede { .. } => {}
     }
     Ok(())

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -1122,6 +1122,32 @@ impl SessionManager {
             ));
         }
 
+        // SetMayTriggerAutoChoice: per-player "don't ask again" auto-choice
+        // preference for optional ("may") triggers, keyed to the authenticated
+        // player, not the priority holder. Bypasses the turn/legal-action
+        // prechecks (any player may adjust their own auto-choices at any time)
+        // and delegates the mutation to the engine (single authority — the write
+        // handler enforces actor scoping). Not an undo point → no takeback
+        // snapshot, mirroring SetPriorityYield. CR 603.5.
+        if matches!(action, GameAction::SetMayTriggerAutoChoice { .. }) {
+            let result = apply(&mut session.state, player, action).map_err(|e| {
+                warn!(game = %game_code, player = ?player, error = %e, reason = "engine_error", "action rejected");
+                format!("Engine error: {}", e)
+            })?;
+            let (new_legal_actions, spell_costs, by_object) =
+                engine_legal_actions_full(&session.state);
+            let auto_pass = auto_pass_recommended(&session.state, &new_legal_actions);
+            return Ok((
+                session.state.clone(),
+                result.events,
+                new_legal_actions,
+                result.log_entries,
+                auto_pass,
+                spell_costs,
+                by_object,
+            ));
+        }
+
         // ReorderHand: per-player display-preference update keyed to the
         // authenticated player, not the priority holder. Mirrors
         // CancelAutoPass / SetPhaseStops by bypassing the turn/legal-action


### PR DESCRIPTION
Adds a per-player viewer + management for the 'Don't ask me again this game'
preferences stored for optional (may) triggers (CR 603.5), mirroring the
existing SetPriorityYield / priority-yield-list feature exactly:
- game_state accessors remove_may_trigger_auto_choice / clear_may_trigger_auto_choices
- typed MayTriggerAutoChoiceOp { Remove{key}, ClearAll } + GameAction::SetMayTriggerAutoChoice
- engine.rs handler is actor-scoped (rebinds key.player to the acting player;
  a client cannot mutate another player's preferences) + auth exemption
- server-core session.rs bypass arm (per-player preference, bypasses the
  turn/legal-action gate, no takeback snapshot) + payload guard + manabrew-compat
- MayTriggerAutoChoiceList viewer (reads per-viewer-redacted state, dispatches),
  mounted in GamePage; i18n across 7 locales
- actor-scoping tests: a player cannot Remove/ClearAll another player's choices

Also verifies the reported Kodama 'Yes stored as No' concern: the save path
is correct end-to-end ('Yes' -> Accept stored verbatim, read back as Accept,
no inversion) — the viewer surfaces stored choices for user confirmation.
