### PR TITLE
Fix Sram, Senior Edificer

### DIFF
--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3391,6 +3391,25 @@ fn starts_with_type_phrase_lead(text: &str) -> bool {
 /// Guard for comma/and/or type-list continuations where core-type segments may
 /// carry their own article — e.g. "an artifact, a creature, or a land" (Braids,
 /// Cabal Minion / issue #847).
+/// Guard for a post-comma continuation of an Oxford-comma type list — the
+/// segment may carry a leading list conjunction ("or " / "and " / "and/or ")
+/// before its type word or article + type word (CR 205.3a: "an Aura,
+/// Equipment, or Vehicle spell"). Used by payload truncation logic that must
+/// distinguish a ", " continuing a type list from the ", " that begins a
+/// trailing clause (issue #5324, Sram, Senior Edificer).
+pub(crate) fn starts_with_type_list_continuation(text: &str) -> bool {
+    let text = text.trim_start();
+    let text = opt(alt((
+        tag::<_, _, OracleError<'_>>("and/or "),
+        tag("or "),
+        tag("and "),
+    )))
+    .parse(text)
+    .map(|(rest, _)| rest)
+    .unwrap_or(text);
+    starts_with_or_article_type_segment(text)
+}
+
 fn starts_with_or_article_type_segment(text: &str) -> bool {
     let text = text.trim_start();
     if let Ok((rest, _)) = alt((tag::<_, _, OracleError<'_>>("an "), tag("a "))).parse(text) {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -28,7 +28,7 @@ use super::oracle_nom::target::parse_type_phrase as parse_type_phrase_nom;
 use super::oracle_static::parse_commander_subject_filter_prefix;
 use super::oracle_target::{
     attachment_kinds_filter_prop, parse_attachment_kind_disjunction, parse_type_phrase,
-    starts_with_type_word,
+    starts_with_type_list_continuation, starts_with_type_word,
 };
 use super::oracle_util::{
     canonicalize_subtype_name, is_core_type_name, is_non_subtype_subject_name, merge_or_filters,
@@ -12356,11 +12356,27 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
             return Some((TriggerMode::SpellCast, def));
         }
 
-        // Truncate at ", " so any effect clause doesn't leak into the type parser.
-        let payload = nom_primitives::split_once_on(after, ", ")
-            .map(|(_, (before, _))| before)
-            .unwrap_or(after)
-            .trim();
+        // Truncate at ", " so any effect clause doesn't leak into the type
+        // parser — but skip commas that continue an Oxford-comma type list
+        // (CR 205.3a: "an Aura, Equipment, or Vehicle spell" is set-union
+        // sugar whose internal commas belong to the payload). Naive
+        // first-comma truncation collapsed such filters to their first leg,
+        // so the trigger fired only on the first listed type (issue #5324,
+        // Sram, Senior Edificer).
+        let payload = {
+            let mut scan = after;
+            let mut cut = after;
+            while let Ok((_, (_, rest))) = nom_primitives::split_once_on(scan, ", ") {
+                if starts_with_type_list_continuation(rest) {
+                    scan = rest;
+                } else {
+                    cut = &after[..after.len() - rest.len() - ", ".len()];
+                    break;
+                }
+            }
+            cut
+        }
+        .trim();
         let (payload, spell_not_owned_by_you) = strip_spell_not_owned_qualifier(payload);
         let (payload, turn_constraint) = peel_trailing_turn_constraint(payload);
         if let Some(constraint) = turn_constraint {

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -7302,6 +7302,44 @@ fn trigger_you_cast_a_spell_from_your_graveyard() {
     );
 }
 
+/// CR 205.3a + CR 601.2: "Whenever you cast an Aura, Equipment, or Vehicle
+/// spell" — an Oxford-comma subtype list must survive the payload truncation
+/// and produce an Or over all three subtypes. Regression for issue #5324
+/// (Sram, Senior Edificer), where naive first-comma truncation collapsed the
+/// filter to its first leg and the trigger fired only on Aura casts.
+#[test]
+fn trigger_you_cast_oxford_comma_subtype_list_spell() {
+    let def = parse_trigger_line(
+        "Whenever you cast an Aura, Equipment, or Vehicle spell, draw a card.",
+        "Sram, Senior Edificer",
+    );
+    assert_eq!(def.mode, TriggerMode::SpellCast);
+    let Some(TargetFilter::Or { filters }) = &def.valid_card else {
+        panic!("expected Or valid_card, got {:?}", def.valid_card);
+    };
+    let subtypes: Vec<&str> = filters
+        .iter()
+        .filter_map(|f| match f {
+            TargetFilter::Typed(tf) => tf.type_filters.iter().find_map(|t| match t {
+                TypeFilter::Subtype(s) => Some(s.as_str()),
+                _ => None,
+            }),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        subtypes,
+        vec!["Aura", "Equipment", "Vehicle"],
+        "expected all three subtype legs, got {filters:?}"
+    );
+    let execute = def.execute.expect("draw effect");
+    assert!(
+        matches!(execute.effect.as_ref(), Effect::Draw { .. }),
+        "expected Draw effect, got {:?}",
+        execute.effect
+    );
+}
+
 /// CR 205.2a + CR 601.2: "whenever you cast an artifact creature spell" must
 /// AND both core types into `valid_card`, so a non-creature artifact spell
 /// does NOT fire the trigger. Regression for Lux Artillery, whose spell-cast

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -7340,6 +7340,70 @@ fn trigger_you_cast_oxford_comma_subtype_list_spell() {
     );
 }
 
+/// CR 205.2a + CR 205.3a + CR 601.2: an Oxford-comma type list whose legs mix
+/// CORE types and a subtype — "an instant, sorcery, or Wizard spell" (Master of
+/// Winds, Umara Mystic, Umara Wizard, ...) — must survive the payload
+/// truncation the same way the pure-subtype list does, and each leg must be
+/// typed correctly: `instant`/`sorcery` as core-type filters, `Wizard` as a
+/// subtype. This guards the generality of the truncation fix (issue #5324):
+/// the earlier subtype-list-only approach mis-typed the core-type legs as
+/// bogus `Subtype("instant")`/`Subtype("sorcery")` filters that matched no
+/// spell, so instant/sorcery casts silently stopped triggering. The list must
+/// route through `parse_type_phrase` (which types each leg), NOT a
+/// subtype-only list parser.
+#[test]
+fn trigger_you_cast_oxford_comma_mixed_type_list_spell() {
+    let def = parse_trigger_line(
+        "Whenever you cast an instant, sorcery, or Wizard spell, draw a card.",
+        "Test Card",
+    );
+    assert_eq!(def.mode, TriggerMode::SpellCast);
+    let Some(TargetFilter::Or { filters }) = &def.valid_card else {
+        panic!(
+            "expected a 3-leg Or valid_card for a mixed core+subtype list, got {:?}",
+            def.valid_card
+        );
+    };
+    assert_eq!(
+        filters.len(),
+        3,
+        "expected 3 legs (instant, sorcery, Wizard), got {filters:?}"
+    );
+    // Flatten every leg's type_filters so we can assert on the whole set.
+    let all_type_filters: Vec<&TypeFilter> = filters
+        .iter()
+        .filter_map(|f| match f {
+            TargetFilter::Typed(tf) => Some(tf.type_filters.iter()),
+            _ => None,
+        })
+        .flatten()
+        .collect();
+    // The two core-type legs must be typed as core types, NOT subtypes.
+    assert!(
+        all_type_filters.contains(&&TypeFilter::Instant),
+        "instant leg must be TypeFilter::Instant, got {filters:?}"
+    );
+    assert!(
+        all_type_filters.contains(&&TypeFilter::Sorcery),
+        "sorcery leg must be TypeFilter::Sorcery, got {filters:?}"
+    );
+    // The subtype leg must be a subtype.
+    assert!(
+        all_type_filters
+            .iter()
+            .any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Wizard")),
+        "Wizard leg must be TypeFilter::Subtype(\"Wizard\"), got {filters:?}"
+    );
+    // Bug signature: no core type may have been mis-typed as a raw-word subtype.
+    assert!(
+        !all_type_filters.iter().any(|t| matches!(
+            t,
+            TypeFilter::Subtype(s) if s.eq_ignore_ascii_case("instant") || s.eq_ignore_ascii_case("sorcery")
+        )),
+        "core types were mis-typed as bogus subtype filters (issue #5324 regression): {filters:?}"
+    );
+}
+
 /// CR 205.2a + CR 601.2: "whenever you cast an artifact creature spell" must
 /// AND both core types into `valid_card`, so a non-creature artifact spell
 /// does NOT fire the trigger. Regression for Lux Artillery, whose spell-cast


### PR DESCRIPTION
## Summary
Fixes the Oxford-comma spell-type-list misparse for **Sram, Senior Edificer**. "Whenever you cast an Aura, Equipment, or Vehicle spell, draw a card." truncated the spell-filter payload at the *first* `", "`, collapsing the filter to `Typed[Subtype(Aura)]` — so Sram only triggered on Aura casts (never Equipment or Vehicle spells, as reported).

The SpellCast trigger arm's payload truncation now skips commas that continue an Oxford-comma type list (CR 205.3a: comma-separated type lists are set-union sugar) and cuts only at the comma that begins a non-type clause. The continuation guard is a new shared helper `starts_with_type_list_continuation` in `oracle_target.rs`, which peels an optional list conjunction (`or `/`and `/`and/or `) and delegates to the existing `starts_with_or_article_type_segment` guard that the `TYPE_SEPARATORS` recursion already uses for the same grammar — so the trigger arm and the type-phrase parser agree on what counts as a list continuation.

This is a class fix, not a card fix: any "Whenever you cast a/an/another `<A>, <B>, or <C>` spell" trigger now keeps its full type list (the downstream `parse_type_phrase` already Or-combines the list correctly once it receives the untruncated payload).

Closes #5324

## Files changed
- `crates/engine/src/parser/oracle_trigger.rs`
- `crates/engine/src/parser/oracle_target.rs`
- `crates/engine/src/parser/oracle_trigger_tests.rs`

## CR references
- CR 205.3a — comma-separated type lists are set-union
- CR 601.2 — casting a spell (trigger event)

## Gate A
```
$ ./scripts/check-parser-combinators.sh
(exit 0 — no violations reported; the script emits output only on violations)
```

## Anchored on
- `crates/engine/src/parser/oracle_trigger.rs:12331-12357` — the existing `scan_preceded` + `alt()` cast-trigger arm the truncation fix lives in; the new loop uses the same `nom_primitives::split_once_on` building block the old single-cut truncation used
- `crates/engine/src/parser/oracle_target.rs:2441-2497` — the existing `TYPE_SEPARATORS` Oxford-comma recursion whose `starts_with_or_article_type_segment` guard the new helper delegates to (same grammar, single authority)
- `crates/engine/src/parser/oracle_target.rs:3413` — `starts_with_or_article_type_segment` (Braids / issue #847), the guard wrapped by the new `starts_with_type_list_continuation`

Tier: Frontier

## Track
Developer

## LLM
Model: claude-fable-5-thinking
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `cargo clippy-strict` — clean (workspace, 0 warnings)
- `./scripts/check-parser-combinators.sh` — clean (exit 0)
- `cargo test -p engine --lib` — 15857 pass / 0 fail
- New regression test: Sram's exact line parses to `Or[Subtype(Aura), Subtype(Equipment), Subtype(Vehicle)]` with a Draw effect
- Verified unaffected shape: "Whenever you cast a creature spell, creatures you control get +1/+1 until end of turn." still parses with `valid_card = Typed[Creature]` and a `PumpAll` effect (an effect clause starting with a type word is not mistaken for a list continuation, because the condition/effect splitter has already removed the effect clause before this arm runs; probed during development)

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

Made with [Cursor](https://cursor.com)