### PR TITLE
Fix "blocks or becomes blocked by [filter]" trigger class (Cockatrice, Venom, Mammoth Harness, Karn Silver Golem, and more)

### DIFF
--- a/crates/engine/src/analysis/ability_graph.rs
+++ b/crates/engine/src/analysis/ability_graph.rs
@@ -1216,6 +1216,7 @@ fn trigger_axis(trig: &TriggerDefinition) -> Option<AxisKey> {
         | TriggerMode::Always
         | TriggerMode::EntersOrAttacks
         | TriggerMode::AttacksOrBlocks
+        | TriggerMode::BlocksOrBecomesBlocked
         | TriggerMode::StateCondition
         | TriggerMode::Airbend
         | TriggerMode::Earthbend

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -114,6 +114,7 @@ fn categorize(event: &GameEvent) -> LogCategory {
         GameEvent::AttackersDeclared { .. }
         | GameEvent::BlockersDeclared { .. }
         | GameEvent::AttackerBecameBlockedByEffect { .. }
+        | GameEvent::AttackerBecameBlockedByFilteredBlocker { .. }
         | GameEvent::CreatureExerted { .. }
         | GameEvent::CreatureEnlisted { .. }
         | GameEvent::CombatDamageDealtToPlayer { .. } => LogCategory::Combat,
@@ -603,6 +604,16 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
         // CR 509.1h: an effect made an attacker become blocked (no blockers).
         GameEvent::AttackerBecameBlockedByEffect { attacker } => {
             vec![card_seg(state, *attacker), text(" becomes blocked")]
+        }
+
+        // CR 509.3d: a disambiguated single blocker/attacker pair from a
+        // per-blocker filtered blocks-or-becomes-blocked firing.
+        GameEvent::AttackerBecameBlockedByFilteredBlocker { attacker, blocker } => {
+            vec![
+                card_seg(state, *blocker),
+                text(" blocks "),
+                card_seg(state, *attacker),
+            ]
         }
 
         GameEvent::CombatDamageDealtToPlayer {

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -419,6 +419,7 @@ pub fn mark_public_state_from_events(state: &mut GameState, events: &[GameEvent]
             | GameEvent::AttackersDeclared { .. }
             | GameEvent::BlockersDeclared { .. }
             | GameEvent::AttackerBecameBlockedByEffect { .. }
+            | GameEvent::AttackerBecameBlockedByFilteredBlocker { .. }
             | GameEvent::CombatTaxPaid { .. }
             | GameEvent::CombatTaxDeclined { .. }
             | GameEvent::BecomesTarget { .. }

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -1161,6 +1161,16 @@ fn blocked_attacker_from_event(
     event: &crate::types::events::GameEvent,
     source_id: ObjectId,
 ) -> Option<ObjectId> {
+    // CR 509.3d: a per-blocker `BecomesBlocked`/`Blocks`/`BlocksOrBecomesBlocked`
+    // firing carries an unambiguous (attacker, blocker) pair. The trigger source
+    // is the attacker (the blocked creature), so "that creature"/"the other
+    // creature" is the blocker — returned directly, with no orientation inference.
+    if let crate::types::events::GameEvent::AttackerBecameBlockedByFilteredBlocker {
+        blocker, ..
+    } = event
+    {
+        return Some(*blocker);
+    }
     // CR 509.3c: an effect-driven "becomes blocked" carries only the attacker
     // (the blocked creature); "that creature" resolves to that attacker.
     if let crate::types::events::GameEvent::AttackerBecameBlockedByEffect { attacker } = event {
@@ -1335,6 +1345,12 @@ pub(crate) fn extract_source_from_event(
         // CR 509.3c: an effect-driven "becomes blocked" trigger's source is the
         // attacker that became blocked.
         GameEvent::AttackerBecameBlockedByEffect { attacker } => Some(*attacker),
+        // CR 509.3d: a per-blocker filtered `BecomesBlocked`/`Blocks` firing
+        // resolves its `TriggeringSource`-routed "that creature"/"it" reference to
+        // the single blocker carried by the narrowed event (mirrors what the
+        // generic `BlockersDeclared` arm above returned before these firings were
+        // re-typed to the dedicated per-blocker event).
+        GameEvent::AttackerBecameBlockedByFilteredBlocker { blocker, .. } => Some(*blocker),
         _ => None,
     }
 }
@@ -4784,6 +4800,33 @@ mod tests {
         let result = resolved_targets(&ability, &TargetFilter::ParentTarget, &state);
 
         assert_eq!(result, vec![TargetRef::Object(attacker)]);
+    }
+
+    /// CR 509.3d + CR 608.2k: the disambiguated per-blocker event carries both
+    /// ids explicitly. The trigger source is the attacker, so `ParentTarget`
+    /// ("the other creature") resolves to the blocker, and the
+    /// `TriggeringSource`-routed reference (`extract_source_from_event`) also
+    /// resolves to the single carried blocker. These two arms are the runtime
+    /// fix for Quagmire Lamprey / Venom.
+    #[test]
+    fn filtered_blocker_event_resolves_parent_target_and_source_to_blocker() {
+        let (mut state, attacker, blocker) = setup_with_creatures();
+        let event = crate::types::events::GameEvent::AttackerBecameBlockedByFilteredBlocker {
+            attacker,
+            blocker,
+        };
+        state.current_trigger_event = Some(event.clone());
+        // The trigger's own source is the attacker; "the other creature"
+        // (ParentTarget) must resolve to the blocker.
+        let ability = make_resolved_with_targets(vec![], attacker);
+        assert_eq!(
+            resolved_targets(&ability, &TargetFilter::ParentTarget, &state),
+            vec![TargetRef::Object(blocker)],
+            "ParentTarget on a filtered-blocker event resolves to the blocker, not the host"
+        );
+        // TriggeringSource-routed "that creature"/"it" also resolves to the
+        // single carried blocker (preserves the pre-existing Acolyte path).
+        assert_eq!(extract_source_from_event(&event), Some(blocker));
     }
 
     /// CR 702.184a: "that creature" on a Stationed trigger is the creature that

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -204,6 +204,7 @@ pub(crate) fn keys_from_trigger_def(def: &TriggerDefinition) -> (Keys, bool) {
         | TriggerMode::YouAttackUnblocked
         | TriggerMode::Blocks
         | TriggerMode::BlockersDeclared
+        | TriggerMode::BlocksOrBecomesBlocked
         | TriggerMode::BecomesBlocked => {
             push(TriggerEventKey::Blocks);
         }
@@ -597,6 +598,7 @@ pub(crate) fn keys_from_event(event: &GameEvent, state: &GameState) -> Keys {
         // CR 509.3c: an effect-driven "becomes blocked" is a Blocks-key event so
         // "whenever ~ becomes blocked" triggers are indexed for it.
         GameEvent::AttackerBecameBlockedByEffect { .. } => push(TriggerEventKey::Blocks),
+        GameEvent::AttackerBecameBlockedByFilteredBlocker { .. } => push(TriggerEventKey::Blocks),
         GameEvent::CombatTaxPaid { .. } | GameEvent::CombatTaxDeclined { .. } => {}
         GameEvent::BecomesTarget { .. } => push(TriggerEventKey::BecomesTarget),
         GameEvent::VehicleCrewed { .. }

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -140,6 +140,7 @@ pub fn trigger_matcher(mode: TriggerMode) -> Option<TriggerMatcher> {
         TriggerMode::ManaExpend => match_mana_expend,
         TriggerMode::EntersOrAttacks => match_enters_or_attacks,
         TriggerMode::AttacksOrBlocks => match_attacks_or_blocks,
+        TriggerMode::BlocksOrBecomesBlocked => match_blocks_or_becomes_blocked,
         // CR 702.55c: ETB half only on the battlefield; haunted-dies half is synthesized
         // into exile as `HauntedCreatureDies`.
         TriggerMode::EntersOrHauntedCreatureDies => match_changes_zone,
@@ -422,6 +423,13 @@ pub fn build_trigger_registry() -> HashMap<TriggerMode, TriggerMatcher> {
 
     // Compound: attacks or blocks — fires on attack or block events
     r.insert(TriggerMode::AttacksOrBlocks, match_attacks_or_blocks);
+
+    // CR 509.1h + CR 509.3d: blocks or becomes blocked — fires on either the
+    // blocker-declaration or the becomes-blocked event.
+    r.insert(
+        TriggerMode::BlocksOrBecomesBlocked,
+        match_blocks_or_becomes_blocked,
+    );
 
     // CR 702.55c: haunt creature ETB half — haunted-dies half is synthesized in exile.
     r.insert(TriggerMode::EntersOrHauntedCreatureDies, match_changes_zone);
@@ -925,6 +933,7 @@ fn count_matching_trigger_event_subjects(
         // Mirrors BlockersDeclared: the "becomes blocked" trigger uses the
         // dedicated matcher, not this generic per-object count helper.
         | GameEvent::AttackerBecameBlockedByEffect { .. }
+        | GameEvent::AttackerBecameBlockedByFilteredBlocker { .. }
         | GameEvent::CombatTaxPaid { .. }
         | GameEvent::CombatTaxDeclined { .. }
         | GameEvent::VehicleCrewed { .. }
@@ -1805,6 +1814,18 @@ pub(super) fn match_attackers_declared(
     matches!(event, GameEvent::AttackersDeclared { .. })
 }
 
+/// CR 509.3d: A genuine CR 509 blocker/attacker filter is always an *object*
+/// filter, never `TargetFilter::Player`. `lower_trigger_ir` may surface
+/// `TargetFilter::Player` into `valid_target` purely because the effect body
+/// names a "target opponent"/"target player" (e.g. Goblin Cadets). Combat-side
+/// filter checks must treat that spurious `Player` as "no filter present".
+fn combat_filter(trigger: &TriggerDefinition) -> Option<&TargetFilter> {
+    trigger
+        .valid_target
+        .as_ref()
+        .filter(|f| !matches!(f, TargetFilter::Player))
+}
+
 pub(super) fn match_blocks(
     event: &GameEvent,
     trigger: &TriggerDefinition,
@@ -1812,6 +1833,32 @@ pub(super) fn match_blocks(
     state: &GameState,
 ) -> bool {
     !matching_block_events(event, trigger, source_id, state).is_empty()
+}
+
+/// CR 509.1h + CR 509.3d: "Whenever ~ blocks or becomes blocked [by a <filter>]"
+/// — the union of the blocker-side (`Blocks`) and attacker-side
+/// (`BecomesBlocked`) matchers for the same firing event.
+pub(super) fn match_blocks_or_becomes_blocked(
+    event: &GameEvent,
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
+) -> bool {
+    !matching_blocks_or_becomes_blocked_events(event, trigger, source_id, state).is_empty()
+}
+
+pub(super) fn matching_blocks_or_becomes_blocked_events(
+    event: &GameEvent,
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
+) -> Vec<GameEvent> {
+    matching_block_events(event, trigger, source_id, state)
+        .into_iter()
+        .chain(matching_becomes_blocked_events(
+            event, trigger, source_id, state,
+        ))
+        .collect()
 }
 
 pub(super) fn matching_block_events(
@@ -1829,7 +1876,21 @@ pub(super) fn matching_block_events(
                 } else {
                     *blocker == source_id
                 };
-                blocker_matches.then_some(GameEvent::BlockersDeclared {
+                if !blocker_matches {
+                    return None;
+                }
+                // CR 509.3b: "blocks a <filter> creature" — the attacker (the
+                // creature being blocked) must satisfy the target-side qualifier.
+                // `combat_filter` excludes a spurious `TargetFilter::Player`
+                // surfaced by the effect-text lowering, which is never a real
+                // CR 509 attacker filter.
+                let attacker_matches = match combat_filter(trigger) {
+                    Some(filter) => {
+                        target_filter_matches_object(state, *attacker, filter, source_id)
+                    }
+                    None => true,
+                };
+                attacker_matches.then_some(GameEvent::BlockersDeclared {
                     assignments: vec![(*blocker, *attacker)],
                 })
             })
@@ -3342,10 +3403,13 @@ pub(super) fn matching_becomes_blocked_events(
 ) -> Vec<GameEvent> {
     if let GameEvent::AttackerBecameBlockedByEffect { attacker } = event {
         // CR 509.3d: an effect-driven block is NOT "blocked by a creature" — the
-        // "becomes blocked by a creature" form (which carries a `valid_target`
-        // blocker filter) must NOT fire. Only the bare "becomes blocked" form
-        // (CR 509.3c) fires, and only for the matching attacker.
-        if trigger.valid_target.is_some() {
+        // "becomes blocked by a creature" form (which carries a genuine blocker
+        // filter) must NOT fire. Only the bare "becomes blocked" form (CR 509.3c)
+        // fires, and only for the matching attacker. `combat_filter` excludes a
+        // spurious `TargetFilter::Player` surfaced by effect-text lowering (e.g.
+        // Goblin Cadets' "target opponent gains control"), which is not a real
+        // CR 509 blocker filter and must not suppress this bare-form firing.
+        if combat_filter(trigger).is_some() {
             return Vec::new();
         }
         let attacker_matches = if trigger.valid_card.is_some() {
@@ -3366,7 +3430,7 @@ pub(super) fn matching_becomes_blocked_events(
         // blocker qualifier, `valid_target: None`) triggers only once each combat
         // for the attacker, regardless of how many creatures block it — so the
         // matching assignments are collapsed to a single event per attacker.
-        let per_blocker = trigger.valid_target.is_some();
+        let per_blocker = combat_filter(trigger).is_some();
         let mut emitted_attackers: Vec<ObjectId> = Vec::new();
         assignments
             .iter()
@@ -3379,7 +3443,7 @@ pub(super) fn matching_becomes_blocked_events(
                 if !attacker_matches {
                     return None;
                 }
-                let blocker_matches = match &trigger.valid_target {
+                let blocker_matches = match combat_filter(trigger) {
                     Some(filter) => {
                         target_filter_matches_object(state, *blocker, filter, source_id)
                     }
@@ -3395,8 +3459,20 @@ pub(super) fn matching_becomes_blocked_events(
                     }
                     emitted_attackers.push(*attacker);
                 }
-                Some(GameEvent::BlockersDeclared {
-                    assignments: vec![(*blocker, *attacker)],
+                // CR 509.3d: the per-blocker form carries an unambiguous
+                // (attacker, blocker) pair so "that creature"/"the other creature"
+                // resolution never has to infer orientation. The bare
+                // once-per-combat form has no single blocker to carry, so it keeps
+                // the generic `BlockersDeclared` shape.
+                Some(if per_blocker {
+                    GameEvent::AttackerBecameBlockedByFilteredBlocker {
+                        attacker: *attacker,
+                        blocker: *blocker,
+                    }
+                } else {
+                    GameEvent::BlockersDeclared {
+                        assignments: vec![(*blocker, *attacker)],
+                    }
                 })
             })
             .collect()
@@ -8901,14 +8977,20 @@ mod tests {
 
         let matched = matching_becomes_blocked_events(&event, &trigger, attacker, &state);
 
+        // CR 509.3d: the per-blocker form now emits the disambiguated
+        // `AttackerBecameBlockedByFilteredBlocker` event (carrying both ids)
+        // instead of a re-wrapped `BlockersDeclared`, so "that creature"/"the
+        // other creature" resolution never has to infer orientation.
         assert_eq!(
             matched,
             vec![
-                GameEvent::BlockersDeclared {
-                    assignments: vec![(first_blocker, attacker)]
+                GameEvent::AttackerBecameBlockedByFilteredBlocker {
+                    attacker,
+                    blocker: first_blocker,
                 },
-                GameEvent::BlockersDeclared {
-                    assignments: vec![(second_blocker, attacker)]
+                GameEvent::AttackerBecameBlockedByFilteredBlocker {
+                    attacker,
+                    blocker: second_blocker,
                 },
             ]
         );
@@ -8967,6 +9049,158 @@ mod tests {
                 assignments: vec![(first_blocker, attacker)]
             }],
             "CR 509.3c: bare 'becomes blocked' fires once per combat, not once per blocker"
+        );
+    }
+
+    /// CR 509.3d: `TargetFilter::Player` (surfaced by effect-text lowering for
+    /// "target opponent"/"target player") is never a real CR 509 blocker/attacker
+    /// filter. `combat_filter` must strip it while preserving genuine object
+    /// filters.
+    #[test]
+    fn combat_filter_excludes_player_keeps_object_filters() {
+        let mut t = make_trigger(TriggerMode::BecomesBlocked);
+        assert!(
+            combat_filter(&t).is_none(),
+            "None valid_target => no combat filter"
+        );
+        t.valid_target = Some(TargetFilter::Player);
+        assert!(
+            combat_filter(&t).is_none(),
+            "Player is never a CR 509 combat filter"
+        );
+        let typed = TargetFilter::Typed(TypedFilter::creature());
+        t.valid_target = Some(typed.clone());
+        assert_eq!(combat_filter(&t), Some(&typed));
+    }
+
+    /// CR 509.3d: a spurious `TargetFilter::Player` on a `Blocks` trigger (e.g.
+    /// Goblin Cadets' "target opponent" effect surfacing Player) must not act as
+    /// an attacker filter — the block-half must fire identically to the no-filter
+    /// case (Nascent Metamorph / Vraska's Conquistador regression).
+    #[test]
+    fn matching_block_events_treats_player_filter_as_no_filter() {
+        let mut state = setup();
+        let blocker = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Blocker".to_string(),
+            Zone::Battlefield,
+        );
+        let attacker = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        let event = GameEvent::BlockersDeclared {
+            assignments: vec![(blocker, attacker)],
+        };
+        let no_filter = make_trigger(TriggerMode::Blocks).valid_card(TargetFilter::SelfRef);
+        let mut player_filter = make_trigger(TriggerMode::Blocks).valid_card(TargetFilter::SelfRef);
+        player_filter.valid_target = Some(TargetFilter::Player);
+
+        let baseline = matching_block_events(&event, &no_filter, blocker, &state);
+        // Reach guard: the block event genuinely matches for the no-filter case.
+        assert!(
+            !baseline.is_empty(),
+            "reach guard: block event must match the bare trigger"
+        );
+        assert_eq!(
+            matching_block_events(&event, &player_filter, blocker, &state),
+            baseline,
+            "a spurious Player valid_target must not filter the attacker side"
+        );
+    }
+
+    /// CR 509.3c/509.3d: a spurious `TargetFilter::Player` on a `BecomesBlocked`
+    /// trigger must be treated as the BARE once-per-combat form (not the
+    /// per-blocker form), so it collapses multi-blocker assignments identically
+    /// to the no-filter case.
+    #[test]
+    fn matching_becomes_blocked_events_treats_player_filter_as_bare_form() {
+        let mut state = setup();
+        let attacker = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        let first_blocker = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "First Blocker".to_string(),
+            Zone::Battlefield,
+        );
+        let second_blocker = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Second Blocker".to_string(),
+            Zone::Battlefield,
+        );
+        let event = GameEvent::BlockersDeclared {
+            assignments: vec![(first_blocker, attacker), (second_blocker, attacker)],
+        };
+        let bare = make_trigger(TriggerMode::BecomesBlocked).valid_card(TargetFilter::SelfRef);
+        let mut player_filter =
+            make_trigger(TriggerMode::BecomesBlocked).valid_card(TargetFilter::SelfRef);
+        player_filter.valid_target = Some(TargetFilter::Player);
+
+        let baseline = matching_becomes_blocked_events(&event, &bare, attacker, &state);
+        // Reach guard: the bare form collapses to exactly one BlockersDeclared.
+        assert_eq!(
+            baseline,
+            vec![GameEvent::BlockersDeclared {
+                assignments: vec![(first_blocker, attacker)]
+            }],
+            "reach guard: bare becomes-blocked fires once per combat"
+        );
+        assert_eq!(
+            matching_becomes_blocked_events(&event, &player_filter, attacker, &state),
+            baseline,
+            "a spurious Player valid_target must not turn a bare trigger per-blocker"
+        );
+    }
+
+    /// CR 509.3c: the bare "becomes blocked" form must still fire when an EFFECT
+    /// makes the attacker become blocked (`AttackerBecameBlockedByEffect`). A
+    /// spurious `TargetFilter::Player` surfaced by effect-text lowering (Goblin
+    /// Cadets' "target opponent gains control of it") must NOT be mistaken for a
+    /// genuine CR 509 blocker filter and suppress the firing. Reverting the
+    /// `combat_filter(trigger).is_some()` guard to the raw
+    /// `trigger.valid_target.is_some()` check makes this assertion fail (the
+    /// Player-artifact would wrongly stop the trigger entirely).
+    #[test]
+    fn matching_becomes_blocked_events_effect_driven_block_ignores_player_filter_artifact() {
+        let mut state = setup();
+        let attacker = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        let event = GameEvent::AttackerBecameBlockedByEffect { attacker };
+        let bare = make_trigger(TriggerMode::BecomesBlocked).valid_card(TargetFilter::SelfRef);
+        let mut player_filter =
+            make_trigger(TriggerMode::BecomesBlocked).valid_card(TargetFilter::SelfRef);
+        player_filter.valid_target = Some(TargetFilter::Player);
+
+        let baseline = matching_becomes_blocked_events(&event, &bare, attacker, &state);
+        // Reach guard: the bare form genuinely fires on an effect-driven block.
+        assert_eq!(
+            baseline,
+            vec![event.clone()],
+            "reach guard: bare becomes-blocked fires on an effect-driven block"
+        );
+        assert_eq!(
+            matching_becomes_blocked_events(&event, &player_filter, attacker, &state),
+            baseline,
+            "a spurious Player valid_target must not suppress an effect-driven bare firing"
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -853,6 +853,17 @@ fn collect_matching_triggers_inner(
                 .into_iter()
                 .map(|trigger_event| vec![trigger_event])
                 .collect()
+            } else if matches!(trig_def.mode, TriggerMode::BlocksOrBecomesBlocked) {
+                // CR 509.1h + CR 509.3d: narrow each firing to its own single
+                // (attacker, blocker) event so "the other creature"/"that
+                // creature" resolves per-firing, matching the atomic
+                // `Blocks`/`BecomesBlocked` arms above.
+                super::trigger_matchers::matching_blocks_or_becomes_blocked_events(
+                    event, trig_def, obj_id, state,
+                )
+                .into_iter()
+                .map(|trigger_event| vec![trigger_event])
+                .collect()
             } else if matches!(trig_def.mode, TriggerMode::DamageDoneOnceByController) {
                 // CR 603.2c: One aggregate combat-damage event may satisfy this
                 // trigger once, while CR 608.2c makes the filtered source set
@@ -8466,14 +8477,19 @@ pub mod tests {
             .collect();
 
         assert_eq!(trigger_events.len(), 2);
+        // CR 509.3d: the per-blocker "becomes blocked by a creature" form now
+        // emits the disambiguated `AttackerBecameBlockedByFilteredBlocker` event
+        // (carrying both ids) rather than a re-wrapped per-pair `BlockersDeclared`.
         assert_eq!(
             trigger_events,
             vec![
-                &GameEvent::BlockersDeclared {
-                    assignments: vec![(first_blocker, attacker)]
+                &GameEvent::AttackerBecameBlockedByFilteredBlocker {
+                    attacker,
+                    blocker: first_blocker,
                 },
-                &GameEvent::BlockersDeclared {
-                    assignments: vec![(second_blocker, attacker)]
+                &GameEvent::AttackerBecameBlockedByFilteredBlocker {
+                    attacker,
+                    blocker: second_blocker,
                 },
             ]
         );
@@ -8505,14 +8521,16 @@ pub mod tests {
         assert_eq!(
             stack_trigger_events,
             vec![
-                &GameEvent::BlockersDeclared {
-                    assignments: vec![(first_blocker, attacker)]
+                &GameEvent::AttackerBecameBlockedByFilteredBlocker {
+                    attacker,
+                    blocker: first_blocker,
                 },
-                &GameEvent::BlockersDeclared {
-                    assignments: vec![(second_blocker, attacker)]
+                &GameEvent::AttackerBecameBlockedByFilteredBlocker {
+                    attacker,
+                    blocker: second_blocker,
                 },
             ],
-            "CR 702.25a creates one stack trigger per qualifying blocker"
+            "CR 509.3d creates one stack trigger per qualifying blocker"
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -2537,6 +2537,28 @@ pub(super) fn parse_subject_application(
         });
     }
 
+    // CR 608.2k + CR 509.1/509.3d: "the other creature" — the creature on the
+    // opposite side of a compound blocks-or-becomes-blocked pairing (Mammoth
+    // Harness, Venom). Unconditionally ParentTarget (unlike "that creature"):
+    // the antecedent flips per-firing-orientation, which
+    // `blocked_attacker_from_event` already disambiguates from the resolved
+    // event shape, regardless of ctx.subject.
+    if let Ok((rest_subject, _)) = tag::<_, _, OracleError<'_>>("the other ").parse(lower.as_str())
+    {
+        let consumed = lower.len() - rest_subject.len();
+        let original_rest = &subject[consumed..];
+        let (filter, rem) = parse_type_phrase(original_rest);
+        if rem.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
+            return Some(SubjectApplication {
+                affected: TargetFilter::ParentTarget,
+                target: Some(TargetFilter::ParentTarget),
+                multi_target: None,
+                inherits_parent: true,
+                is_optional: false,
+            });
+        }
+    }
+
     // CR 608.2c: "that creature/permanent/land" — anaphoric back-reference to a
     // previously mentioned object in the same effect sequence. Strip "that " and parse
     // the remainder as a type phrase. Covers all "that [type]" patterns generically.

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -916,6 +916,27 @@ pub fn parse_target_with_syntax<'a>(
         );
     }
 
+    // CR 608.2k + CR 509.3d: "the other creature"/"the other permanent" — the
+    // single object opposite the trigger's own source in a compound
+    // blocks-or-becomes-blocked pairing (Venom's "destroy the other creature",
+    // Mammoth Harness). This is a per-firing anaphor resolved at runtime via
+    // `blocked_attacker_from_event`, NOT the split-pile "the other" tracked-set
+    // reference in TRACKED_SET_PHRASES below — so it MUST be matched first, or
+    // the bare "the other" prefix would consume it and bind it to an
+    // (unpopulated) tracked set.
+    if let Some((filter, rest)) = nom_on_lower(text, &lower, |input| {
+        alt((
+            value(
+                TargetFilter::ParentTarget,
+                tag::<_, _, OracleError<'_>>("the other creature"),
+            ),
+            value(TargetFilter::ParentTarget, tag("the other permanent")),
+        ))
+        .parse(input)
+    }) {
+        return (filter, rest, syntax);
+    }
+
     // CR 603.7: Anaphoric tracked-set pronouns
     static TRACKED_SET_PHRASES: &[&str] = &[
         "the chosen cards",

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8657,11 +8657,30 @@ fn try_parse_event(
         return Some((mode, def));
     }
 
-    // "blocks" — fires for the blocking creature.
-    if tag::<_, _, OracleError<'_>>("blocks").parse(rest).is_ok() {
+    // "blocks or becomes blocked [by a <filter>]" — Karn (bare), Goblin Cadets
+    // (bare), Venom/Mammoth Harness (filtered). CR 509.1h + CR 509.3d: the
+    // compound form must be dispatched before the bare "blocks" arm because
+    // `tag("blocks")` would otherwise match its prefix and silently drop the
+    // "or becomes blocked [by a <filter>]" remainder.
+    if let Ok((after_compound, _)) =
+        tag::<_, _, OracleError<'_>>("blocks or becomes blocked").parse(rest)
+    {
+        let mut def = make_base();
+        def.mode = TriggerMode::BlocksOrBecomesBlocked;
+        def.valid_card = Some(subject.clone());
+        def.valid_target = parse_becomes_blocked_by_filter(after_compound);
+        return Some((TriggerMode::BlocksOrBecomesBlocked, def));
+    }
+
+    // "blocks [a <filter>]" — fires for the blocking creature. Wall of Frost
+    // (bare), High-Rise Sawjack (filtered). CR 509.3b: capture the
+    // "a <filter> creature" attacker-side qualifier so a filtered "blocks"
+    // trigger fires only against a matching attacker.
+    if let Ok((after_blocks, _)) = tag::<_, _, OracleError<'_>>("blocks").parse(rest) {
         let mut def = make_base();
         def.mode = TriggerMode::Blocks;
         def.valid_card = Some(subject.clone());
+        def.valid_target = parse_blocks_a_filter(after_blocks);
         return Some((TriggerMode::Blocks, def));
     }
 
@@ -9163,6 +9182,15 @@ fn try_parse_event(
     }
     fn parse_becomes_blocked_by_filter(input: &str) -> Option<TargetFilter> {
         let (type_phrase, _) = alt((tag::<_, _, OracleError<'_>>(" by a "), tag(" by an ")))
+            .parse(input)
+            .ok()?;
+        let (filter, rest) = parse_type_phrase(type_phrase);
+        rest.trim().is_empty().then_some(filter)
+    }
+    /// CR 509.3b: "blocks a <filter>" carries a target-side (attacker) qualifier —
+    /// mirrors `parse_becomes_blocked_by_filter`'s blocker-side qualifier exactly.
+    fn parse_blocks_a_filter(input: &str) -> Option<TargetFilter> {
+        let (type_phrase, _) = alt((tag::<_, _, OracleError<'_>>(" a "), tag(" an ")))
             .parse(input)
             .ok()?;
         let (filter, rest) = parse_type_phrase(type_phrase);

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -6603,6 +6603,198 @@ fn trigger_becomes_blocked_by_two_or_more_creatures_stays_bare() {
     );
 }
 
+/// CR 509.3b: "blocks a <filter> creature" — the plain `Blocks` mode must
+/// capture the attacker-side qualifier (High-Rise Sawjack). Without the
+/// `parse_blocks_a_filter` capture the trigger would over-fire on any block.
+#[test]
+fn trigger_blocks_a_filtered_creature_captures_attacker_filter() {
+    let def = parse_trigger_line(
+        "Whenever High-Rise Sawjack blocks a creature with flying, High-Rise Sawjack gets +2/+0 until end of turn.",
+        "High-Rise Sawjack",
+    );
+    assert_eq!(def.mode, TriggerMode::Blocks);
+    assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+    match def.valid_target {
+        Some(TargetFilter::Typed(ref tf)) => {
+            assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+            assert!(
+                tf.properties.iter().any(
+                    |p| matches!(p, FilterProp::WithKeyword { value } if *value == Keyword::Flying)
+                ),
+                "expected WithKeyword(Flying) in {:?}",
+                tf.properties
+            );
+        }
+        other => panic!("expected a flying-creature attacker filter, got {other:?}"),
+    }
+}
+
+/// CR 509.1h + CR 509.3d: bare "blocks or becomes blocked" — compound mode with
+/// no CR 509 blocker/attacker qualifier (Goblin Cadets). The effect-text
+/// lowering may surface `TargetFilter::Player` from "target opponent", which the
+/// runtime `combat_filter` guard (see trigger_matchers unit tests) treats as
+/// absent; either way there is no genuine per-blocker filter.
+#[test]
+fn trigger_blocks_or_becomes_blocked_bare_no_combat_filter() {
+    let def = parse_trigger_line(
+        "Whenever Goblin Cadets blocks or becomes blocked, target opponent gains control of it.",
+        "Goblin Cadets",
+    );
+    assert_eq!(def.mode, TriggerMode::BlocksOrBecomesBlocked);
+    assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+    // Any surfaced filter must be the spurious Player case, never a real object
+    // (CR 509) blocker/attacker filter.
+    assert!(
+        matches!(def.valid_target, None | Some(TargetFilter::Player)),
+        "bare compound trigger must not carry a real CR 509 filter, got {:?}",
+        def.valid_target
+    );
+}
+
+/// CR 509.1h + CR 509.3d: compound mode WITH a blocker/attacker qualifier
+/// (Mammoth Harness) — the "or becomes blocked by a creature" remainder must no
+/// longer be silently dropped, and "the other creature" must reach the subject
+/// parser as a `ParentTarget` grant.
+#[test]
+fn trigger_blocks_or_becomes_blocked_filtered_mammoth_harness() {
+    let def = parse_trigger_line(
+        "Whenever enchanted creature blocks or becomes blocked by a creature, the other creature gains first strike until end of turn.",
+        "Mammoth Harness",
+    );
+    assert_eq!(def.mode, TriggerMode::BlocksOrBecomesBlocked);
+    assert_eq!(def.valid_card, Some(TargetFilter::AttachedTo));
+    match def.valid_target {
+        Some(TargetFilter::Typed(ref tf)) => {
+            assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+        }
+        other => panic!("expected a creature blocker filter, got {other:?}"),
+    }
+    let execute = def
+        .execute
+        .as_deref()
+        .expect("Mammoth Harness body must lower to an execute ability");
+    // "the other creature gains first strike" — the granted keyword targets the
+    // per-firing opposite creature (ParentTarget), never the enchanted host.
+    // Reverting the subject.rs "the other <type>" arm degrades this to
+    // Effect::Unimplemented (the fallback for an unrecognized subject phrase).
+    assert!(
+        !matches!(execute.effect.as_ref(), Effect::Unimplemented { .. }),
+        "'the other creature' subject must be recognized, not dropped to Unimplemented"
+    );
+    match execute.effect.as_ref() {
+        Effect::GenericEffect { target, .. } => {
+            assert_eq!(
+                *target,
+                Some(TargetFilter::ParentTarget),
+                "the keyword grant must apply to the OTHER creature (ParentTarget), not the host"
+            );
+        }
+        other => panic!("expected a targeted GenericEffect grant, got {other:?}"),
+    }
+}
+
+/// CR 509.3d + CR 603.7: Venom — compound mode with a non-Wall exclusion filter,
+/// scheduling an end-of-combat destroy on "the other creature" (the blocker).
+#[test]
+fn trigger_blocks_or_becomes_blocked_venom_parses_delayed_destroy() {
+    let def = parse_trigger_line(
+        "Whenever enchanted creature blocks or becomes blocked by a non-Wall creature, destroy the other creature at end of combat.",
+        "Venom",
+    );
+    assert_eq!(def.mode, TriggerMode::BlocksOrBecomesBlocked);
+    assert_eq!(def.valid_card, Some(TargetFilter::AttachedTo));
+    match def.valid_target {
+        Some(TargetFilter::Typed(ref tf)) => {
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Creature),
+                "expected Creature in {:?}",
+                tf.type_filters
+            );
+            assert!(
+                tf.type_filters.iter().any(|t| matches!(
+                    t,
+                    TypeFilter::Non(inner) if matches!(inner.as_ref(), TypeFilter::Subtype(s) if s == "Wall")
+                )),
+                "expected non-Wall exclusion in {:?}",
+                tf.type_filters
+            );
+        }
+        other => panic!("expected a non-Wall creature filter, got {other:?}"),
+    }
+    let execute = def
+        .execute
+        .as_deref()
+        .expect("Venom body must lower to an execute ability");
+    match execute.effect.as_ref() {
+        Effect::CreateDelayedTrigger {
+            condition, effect, ..
+        } => {
+            assert!(
+                matches!(condition, DelayedTriggerCondition::AtNextPhase { phase } if *phase == Phase::EndCombat),
+                "expected AtNextPhase(EndCombat), got {condition:?}"
+            );
+            match effect.effect.as_ref() {
+                Effect::Destroy { target, .. } => {
+                    // "the other creature" binds to the per-firing antecedent —
+                    // lowered either as `ParentTarget` (resolved at runtime via
+                    // `blocked_attacker_from_event`) or as the tracked-set
+                    // published by the filtered trigger. Both resolve to the
+                    // blocker (proven by the runtime test
+                    // `venom_destroys_the_creature_that_blocked_it_at_end_of_combat`);
+                    // the load-bearing negative is that it is NOT the host/self.
+                    assert!(
+                        matches!(
+                            target,
+                            TargetFilter::ParentTarget
+                                | TargetFilter::TrackedSet { .. }
+                                | TargetFilter::TrackedSetFiltered { .. }
+                        ),
+                        "Venom destroys 'the other creature', never its host/self; got {target:?}"
+                    );
+                    assert!(
+                        !matches!(target, TargetFilter::SelfRef | TargetFilter::AttachedTo),
+                        "delayed destroy must not target Venom's own host; got {target:?}"
+                    );
+                }
+                other => panic!("expected delayed Destroy, got {other:?}"),
+            }
+        }
+        other => panic!("expected CreateDelayedTrigger, got {other:?}"),
+    }
+}
+
+/// Regression documentation for the Quagmire Lamprey runtime fix (5.15-sibling
+/// integration test): the parser already routes "put a -1/-1 counter on that
+/// creature" through a `ParentTarget` target on a per-blocker `BecomesBlocked`
+/// trigger. This assertion makes the runtime resolution test non-vacuous — it
+/// proves the fix is in `blocked_attacker_from_event`, not the parser.
+#[test]
+fn trigger_quagmire_lamprey_counter_targets_parent_target() {
+    let def = parse_trigger_line(
+        "Whenever Quagmire Lamprey becomes blocked by a creature, put a -1/-1 counter on that creature.",
+        "Quagmire Lamprey",
+    );
+    assert_eq!(def.mode, TriggerMode::BecomesBlocked);
+    assert!(
+        def.valid_target.is_some(),
+        "per-blocker filter must be present"
+    );
+    let execute = def
+        .execute
+        .as_deref()
+        .expect("Quagmire body must lower to an execute ability");
+    match execute.effect.as_ref() {
+        Effect::PutCounter { target, .. } => {
+            assert_eq!(
+                *target,
+                TargetFilter::ParentTarget,
+                "'that creature' on a self-ref BecomesBlocked counter effect routes via ParentTarget"
+            );
+        }
+        other => panic!("expected PutCounter, got {other:?}"),
+    }
+}
+
 #[test]
 fn trigger_becomes_blocked_pump_scales_with_creatures_blocking_it() {
     let def = parse_trigger_line(
@@ -11435,13 +11627,18 @@ fn trigger_blocks_a_creature() {
 
 #[test]
 fn trigger_blocks_or_becomes_blocked() {
-    // "blocks or becomes blocked" — parsed as Blocks (blocker side)
+    // CR 509.1h + CR 509.3d: "blocks or becomes blocked" is a compound trigger —
+    // the remainder must no longer be silently dropped into a plain `Blocks`.
     let def = parse_trigger_line(
         "Whenever Karn, Silver Golem blocks or becomes blocked, it gets -4/+4 until end of turn.",
         "Karn, Silver Golem",
     );
-    assert_eq!(def.mode, TriggerMode::Blocks);
+    assert_eq!(def.mode, TriggerMode::BlocksOrBecomesBlocked);
     assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+    assert!(
+        def.valid_target.is_none(),
+        "no blocker/attacker qualifier on Karn's trigger"
+    );
 }
 
 #[test]

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -545,6 +545,14 @@ pub enum GameEvent {
     AttackerBecameBlockedByEffect {
         attacker: ObjectId,
     },
+    /// CR 509.3d: A per-blocker `Blocks`/`BecomesBlocked`/`BlocksOrBecomesBlocked`
+    /// firing with an explicit blocker/attacker qualifier — carries both ids so
+    /// "that creature"/"the other creature" resolution never has to infer
+    /// orientation from event shape.
+    AttackerBecameBlockedByFilteredBlocker {
+        attacker: ObjectId,
+        blocker: ObjectId,
+    },
     /// CR 508.1h + CR 509.1d: The aggregate combat tax was paid; the declaration
     /// proceeds with every declared creature intact.
     CombatTaxPaid {

--- a/crates/engine/src/types/triggers.rs
+++ b/crates/engine/src/types/triggers.rs
@@ -540,6 +540,10 @@ pub enum TriggerMode {
     EntersOrAttacks,
     /// "Whenever ~ attacks or blocks" — fires on both attack (CR 508.3a) and block (CR 509.1h) events.
     AttacksOrBlocks,
+    /// CR 509.1h + CR 509.3d: "~ blocks or becomes blocked" — fires on either the
+    /// blocker-declaration event or the becomes-blocked event, with per-firing
+    /// blocker/attacker disambiguation available to the effect body.
+    BlocksOrBecomesBlocked,
     /// CR 702.55c: "~ enters or the creature it haunts dies" — parsed as one compound
     /// trigger; the ETB half fires on the battlefield and synthesis clones the effect into
     /// a `HauntedCreatureDies` trigger in exile for the haunted-dies half.
@@ -604,6 +608,7 @@ impl FromStr for TriggerMode {
             "BecomesTargetOnce" => TriggerMode::BecomesTargetOnce,
             "BlockersDeclared" => TriggerMode::BlockersDeclared,
             "Blocks" => TriggerMode::Blocks,
+            "BlocksOrBecomesBlocked" => TriggerMode::BlocksOrBecomesBlocked,
             "CaseSolved" => TriggerMode::CaseSolved,
             "Championed" => TriggerMode::Championed,
             "ChangesController" => TriggerMode::ChangesController,
@@ -893,6 +898,7 @@ mod tests {
             "BecomesTargetOnce",
             "BlockersDeclared",
             "Blocks",
+            "BlocksOrBecomesBlocked",
             "CaseSolved",
             "Championed",
             "ChangesController",

--- a/crates/engine/tests/integration/rules/combat.rs
+++ b/crates/engine/tests/integration/rules/combat.rs
@@ -190,6 +190,171 @@ fn becomes_blocked_by_creature_fires_for_each_blocker() {
     assert_eq!(state.objects[&blocker_b].damage_marked, 2);
 }
 
+/// CR 509.1h + CR 509.3d + CR 603.7: Venom's "blocks or becomes blocked by a
+/// non-Wall creature, destroy the other creature at end of combat" — the
+/// originally reported bug (a compound blocks-or-becomes-blocked trigger with a
+/// blocker filter silently dropping "or becomes blocked", and, independently,
+/// the runtime resolving "the other creature" to the wrong object).
+///
+/// Reverting the compound-mode dispatch (`oracle_trigger.rs`) → the trigger
+/// parses as plain `Blocks` and never fires when Venom's host is blocked as an
+/// attacker, so no delayed trigger is scheduled (first assert flips). Reverting
+/// the `blocked_attacker_from_event` leading arm (`targeting.rs`) → "the other
+/// creature" resolves to Venom's host instead of the blocker, so the delayed
+/// trigger targets the wrong object and the wrong creature dies (both zone
+/// asserts flip).
+///
+/// Sizing: attacker and blocker are 1/5 so both survive combat damage — the
+/// blocker's death must come from Venom's end-of-combat destroy, not combat.
+///
+/// (The real card is an Aura using "enchanted creature"; the scenario harness
+/// has no aura-attach helper, so the runtime paths — compound matcher,
+/// per-blocker filtered event emission, ParentTarget resolution, delayed-trigger
+/// scheduling — are exercised via the self-referential `SelfRef` form. The
+/// verbatim "enchanted creature" (`AttachedTo`) parse and the delayed-destroy
+/// AST shape are covered by the parser test
+/// `trigger_blocks_or_becomes_blocked_venom_parses_delayed_destroy`.)
+#[test]
+fn venom_destroys_the_creature_that_blocked_it_at_end_of_combat() {
+    use engine::types::ability::{DelayedTriggerCondition, Effect};
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let attacker = scenario
+        .add_creature(P0, "Venom", 1, 5)
+        .from_oracle_text(
+            "Whenever Venom blocks or becomes blocked by a non-Wall creature, \
+             destroy the other creature at end of combat.",
+        )
+        .id();
+    let blocker = scenario.add_creature(P1, "Bear", 1, 5).id();
+    let mut runner = scenario.build();
+
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("Venom creature should be able to attack");
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareBlockers {
+            assignments: vec![(blocker, attacker)],
+        })
+        .expect("Bear should be able to block");
+    runner.advance_until_stack_empty();
+
+    // CR 603.7: resolving the compound trigger creates a delayed "at end of
+    // combat, destroy the other creature" trigger. Its presence proves the
+    // compound mode fired from the becomes-blocked event and was NOT silently
+    // dropped: reverting the compound-mode dispatch parses Venom as plain
+    // `Blocks`, whose matcher requires the source to be the *blocker* — Venom's
+    // host is the attacker, so it never fires and no delayed trigger exists.
+    // ("The other creature" is lowered to a tracked-set target; the object it
+    // actually resolves to is proven by the graveyard assertions below.)
+    let scheduled_destroy = runner.state().delayed_triggers.iter().any(|dt| {
+        matches!(
+            dt.condition,
+            DelayedTriggerCondition::AtNextPhase {
+                phase: Phase::EndCombat
+            }
+        ) && matches!(&dt.ability.effect, Effect::Destroy { .. })
+    });
+    assert!(
+        scheduled_destroy,
+        "Venom must schedule an end-of-combat destroy (compound mode must fire, not be \
+         dropped to plain Blocks); delayed_triggers = {:?}",
+        runner.state().delayed_triggers
+    );
+
+    // Advance through combat damage into End of Combat so the delayed trigger
+    // fires. Both creatures are 1/5, so neither dies to combat damage — the
+    // blocker's death must come from Venom's end-of-combat destroy. Pass
+    // priority (resolving the delayed trigger when it lands on the stack) until
+    // the blocker leaves the battlefield or the loop bound is hit.
+    for _ in 0..40 {
+        if runner.state().objects[&blocker].zone == Zone::Graveyard {
+            break;
+        }
+        if matches!(runner.state().waiting_for, WaitingFor::OrderTriggers { .. }) {
+            runner.advance_until_stack_empty();
+        } else if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+    }
+
+    assert_eq!(
+        runner.state().objects.get(&blocker).map(|o| o.zone),
+        Some(Zone::Graveyard),
+        "the blocker must be destroyed at end of combat"
+    );
+    assert_eq!(
+        runner.state().objects.get(&attacker).map(|o| o.zone),
+        Some(Zone::Battlefield),
+        "the Venom host (attacker) must survive — Venom destroys the OTHER creature, \
+         never its own host"
+    );
+}
+
+/// CR 509.3d + CR 608.2k: Quagmire Lamprey's "becomes blocked by a creature,
+/// put a -1/-1 counter on that creature" — the pre-existing bug where the
+/// counter landed on Quagmire itself (its own host / the attacker) instead of
+/// the blocker. Fixed as an in-scope byproduct of re-typing the per-blocker
+/// event so `blocked_attacker_from_event` returns the blocker.
+///
+/// Reverting the `blocked_attacker_from_event` leading arm → the -1/-1 counter
+/// lands on Quagmire (attacker) instead of the Bear (blocker): both asserts flip.
+#[test]
+fn quagmire_lamprey_puts_minus_counter_on_blocker_not_itself() {
+    use engine::types::counter::CounterType;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let attacker = scenario
+        .add_creature(P0, "Quagmire Lamprey", 2, 2)
+        .from_oracle_text(
+            "Whenever Quagmire Lamprey becomes blocked by a creature, \
+             put a -1/-1 counter on that creature.",
+        )
+        .id();
+    let blocker = scenario.add_creature(P1, "Bear", 3, 3).id();
+    let mut runner = scenario.build();
+
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("Quagmire Lamprey should be able to attack");
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareBlockers {
+            assignments: vec![(blocker, attacker)],
+        })
+        .expect("Bear should be able to block");
+    runner.advance_until_stack_empty();
+
+    let state = runner.state();
+    assert_eq!(
+        state.objects[&blocker]
+            .counters
+            .get(&CounterType::Minus1Minus1)
+            .copied(),
+        Some(1),
+        "the -1/-1 counter must land on the blocker (Bear)"
+    );
+    assert_eq!(
+        state.objects[&attacker]
+            .counters
+            .get(&CounterType::Minus1Minus1)
+            .copied(),
+        None,
+        "Quagmire Lamprey (the attacker/host) must NOT receive its own -1/-1 counter"
+    );
+}
+
 #[test]
 fn decayed_attacker_sacrifices_at_end_of_combat() {
     let mut scenario = GameScenario::new();

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4782
-- **Total card appearances across root causes:** 4816 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4778
+- **Total card appearances across root causes:** 4812 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -12,16 +12,16 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 | # | Root cause | # cards | Fix hint (where it likely lives) |
 |---|------------|--------:|----------------------------------|
-| 1 | Relative-clause / filter restriction on target dropped | 753 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
+| 1 | Relative-clause / filter restriction on target dropped | 752 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
 | 2 | Dropped intervening-if / gating condition (condition: null) | 606 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
 | 3 | Anaphor bound to wrong referent | 404 | oracle_quantity.rs context-ref resolution + game/ability_utils.rs forward_result wiring |
 | 4 | Conjoined / chained second effect clause dropped | 387 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
 | 5 | Dropped 'for each' / dynamic count collapsed to Fixed | 333 | oracle_quantity.rs parse_for_each_clause / parse_quantity_ref — thread ForEach/ObjectCount into the effect count field |
-| 6 | Disjunctive (or-list) collapsed to first branch | 248 | oracle_nom/filter.rs + oracle_target.rs — build TargetFilter::Or across all alt() branches |
+| 6 | Disjunctive (or-list) collapsed to first branch | 247 | oracle_nom/filter.rs + oracle_target.rs — build TargetFilter::Or across all alt() branches |
 | 7 | Wrong / dropped zone parameters on zone-change effect | 211 | game/zones.rs + oracle parser zone routing — derive correct origin/destination/owner from Oracle |
 | 8 | Additional / alternative casting cost dropped | 210 | oracle_cost.rs — parse additional/alternative cost clauses into Spell.cost / AdditionalCost |
 | 9 | Wrong player/controller scope (You where Opponent/Scoped/Target/Defending needed) | 182 | oracle parser ControllerRef binding — resolve scoped/defending/iterated player refs instead of defaulting to You |
-| 10 | Trigger event/mode unrecognized → Unknown | 170 | oracle_trigger.rs — add typed TriggerMode variants for the unrecognized event classes |
+| 10 | Trigger event/mode unrecognized → Unknown | 168 | oracle_trigger.rs — add typed TriggerMode variants for the unrecognized event classes |
 | 11 | Replacement / prevention / 'instead' effect mis-modeled | 170 | add-replacement-effect: route 'would … instead' into replacements[]; preserve damage_source/target filters |
 | 12 | Modal 'choose one/N' parsed as independent abilities | 138 | oracle.rs modal dispatch — detect 'Choose one —' header, wrap modes in Effect::ChooseOneOf |
 | 13 | State/game-state condition → StaticCondition::Unrecognized | 134 | oracle_nom/condition.rs parse_inner_condition — add typed variant for the predicate class |
@@ -47,7 +47,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 ## Full card lists per root cause
 
-### 1. Relative-clause / filter restriction on target dropped  (753 cards)
+### 1. Relative-clause / filter restriction on target dropped  (752 cards)
 
 **Signature.** TargetFilter/affected emitted with empty or missing properties; a trailing restrictive clause (type, subtype, color, mana value, zone, combat/temporal/control predicate, exclusion) is silently dropped, over-broadening the filter.
 
@@ -172,7 +172,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Clever Conjurer
 - Closing Statement
 - Cloudstone Curio
-- Cockatrice
 - Coiling Stalker
 - Coils of the Medusa
 - Colfenor, the Last Yew
@@ -2584,7 +2583,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 6. Disjunctive (or-list) collapsed to first branch  (248 cards)
+### 6. Disjunctive (or-list) collapsed to first branch  (247 cards)
 
 **Signature.** An 'A or B (or C)' enumeration in a target/filter/cost/trigger/effect collapses to the first branch (or splits into a dangling Unknown); the OR/AnyOf union is never built.
 
@@ -2824,7 +2823,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Valley Floodcaller
 - Vampire Gourmand
 - Vengeful Pharaoh
-- Venom
 - Venomous Dragonfly
 - Venser's Diffusion
 - Vodalian Mindsinger
@@ -3479,7 +3477,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 10. Trigger event/mode unrecognized → Unknown  (170 cards)
+### 10. Trigger event/mode unrecognized → Unknown  (168 cards)
 
 **Signature.** TriggerMode parses as Unknown(text); the event/subject combinator (state-trigger, taps-for-mana, becomes-blocked, keyword-action, loyalty-activated, die-roll) doesn't recognize the phrasing so the trigger never fires.
 
@@ -3542,7 +3540,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Garruk Relentless
 - Ghyrson Starn, Kelermorph
 - Glorious Purpose
-- Goblin Cadets
 - Gorilla War Cry
 - Grievous Wound
 - Hidden Predators
@@ -3559,7 +3556,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Isleback Spawn
 - Kalamax, the Stormsire
 - Karmic Justice
-- Karn, Silver Golem
 - Kassandra, Eagle Bearer
 - Kishla Skimmer
 - Klaw, Master of Sound


### PR DESCRIPTION
## Summary
Fixes the "Relative-clause / filter restriction on target dropped" misparse for **Cockatrice**, the "Disjunctive (or-list) collapsed to first branch" misparse for **Venom**, and the "Trigger event/mode unrecognized → Unknown" misparse for **Goblin Cadets** and **Karn, Silver Golem** — all four are actually one root cause: `TriggerMode::Blocks`'s parser used `tag("blocks").parse(rest).is_ok()`, which matches "blocks" as a prefix and silently discards everything after it. So "blocks or becomes blocked by a non-Wall creature" collapsed to plain `Blocks` with no filter at all.

This is a real, verified card class (Scryfall full-text search `o:"blocks or becomes blocked"` / `o:"blocks a"`), not a one-card patch: **Cockatrice, Venom, Mammoth Harness, Karn Silver Golem, Goblin Cadets, High-Rise Sawjack**, plus a related pre-existing bug on **Quagmire Lamprey** (its -1/-1 counter landed on itself instead of the blocker — same root resolver, exposed by this fix's design).

Adds `TriggerMode::BlocksOrBecomesBlocked` (the CR 509 sibling of the existing `AttacksOrBlocks` compound), a new `GameEvent` variant so "that creature"/"the other creature" unambiguously resolves to the blocker rather than inferring orientation from event shape, a `combat_filter()` guard so an unrelated "target opponent" effect-text artifact (Goblin Cadets) is never mistaken for a real CR 509 blocker filter, and two new "the other creature" anaphor grammar sites. Also fixes a real, previously-undiscovered prefix-shadowing bug in `TRACKED_SET_PHRASES` that was found by the discriminating end-to-end test, not by inspection.

Backlog entries for the 4 tracked cards removed per §3.1 list hygiene (second commit); Mammoth Harness/High-Rise Sawjack/Quagmire Lamprey weren't in the backlog (found during this investigation, not the original clustering pass).

## Files changed
- crates/engine/src/parser/oracle_trigger.rs
- crates/engine/src/parser/oracle_target.rs
- crates/engine/src/parser/oracle_effect/subject.rs
- crates/engine/src/parser/oracle_trigger_tests.rs
- crates/engine/src/types/events.rs
- crates/engine/src/types/triggers.rs
- crates/engine/src/game/targeting.rs
- crates/engine/src/game/trigger_matchers.rs
- crates/engine/src/game/triggers.rs
- crates/engine/src/game/trigger_index.rs
- crates/engine/src/game/log.rs
- crates/engine/src/game/public_state.rs
- crates/engine/src/analysis/ability_graph.rs
- crates/engine/tests/integration/rules/combat.rs
- docs/parser-misparse-backlog.md

## CR references
- CR 509.1 / 509.1h — blocking status / attacking-with-blockers-becomes-blocked
- CR 509.3a-d — the "blocks"/"blocks a filter"/"becomes blocked"/"becomes blocked by a filter" trigger multiplicities
- CR 603.7 — delayed triggered abilities
- CR 608.2k — anaphora resolution ("the other creature"/"that creature")

## Track
Developer

## LLM
Model: claude-sonnet-5
Thinking: high

## Verification
- `cargo fmt --all -- --check` — clean (per-file `rustfmt` used directly; `cargo fmt --all` hits an OS command-line-length limit on this box, unrelated to formatting correctness)
- `./scripts/check-parser-combinators.sh` — clean (no output, exit 0)
- `cargo clippy --all-targets -- -D warnings` — clean, full workspace
- `cargo test -p engine --lib` — 15841 passed, 0 failed, 6 ignored
- `cargo test -p engine --test integration` — 1827 passed, 0 failed
- New parser tests assert Cockatrice/Venom/Mammoth Harness/Karn/Goblin Cadets/High-Rise Sawjack/Quagmire Lamprey's verbatim Oracle text parse to the correct mode/filter
- New `apply()`-level integration tests (not just parser-shape assertions) drive Venom and Quagmire Lamprey through the real `DeclareBlockers` pipeline: Venom destroys the creature that blocked it (not its own enchanted host), Quagmire's counter lands on the blocker (not itself)
- Plan went through 5 rounds of `/engine-planner` + `/review-engine-plan`; implementation through 2 rounds of `/review-impl` (first round found a miscited CR number and a missing regression test on one of five new guard sites, both fixed and re-verified)

## Gate A
```
$ ./scripts/check-parser-combinators.sh
(no output — clean, exit 0)
```

## Anchored on
- `crates/engine/src/parser/oracle_trigger.rs:8322` — `TriggerMode::AttacksOrBlocks`'s existing compound-trigger dispatch, the direct precedent for `BlocksOrBecomesBlocked`'s parser arm and enum placement
- `crates/engine/src/parser/oracle_trigger.rs:9164` — `parse_becomes_blocked_by_filter`, the existing filter-capture helper reused (and mirrored, for the new `parse_blocks_a_filter`) rather than reimplemented
- `crates/engine/src/types/events.rs` (`AttackerBecameBlockedByEffect`) — the existing "purpose-built synthetic combat event" pattern the new `AttackerBecameBlockedByFilteredBlocker` variant extends, including its full consumption footprint (targeting.rs, trigger_index.rs, log.rs, public_state.rs)

## Tier: Standard

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.