### PR TITLE
fix(parser): support filtered card counts in the chosen player's zone (Haunting Apparition)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1179,7 +1179,6 @@ fn parse_number_of_inner(input: &str) -> OracleResult<'_, QuantityRef> {
         // extremum-hand phrases must precede the generic target-zone and zone
         // arms they share a "cards in " prefix with.
         alt((
-            parse_number_of_cards_in_chosen_player_zone,
             // CR 402.1: "cards in the hand of the {player|opponent} with the
             // {most|fewest} cards in hand" (Adamaro P/T CDA class).
             parse_number_of_cards_in_hand_of_extremum_player,
@@ -1546,23 +1545,6 @@ fn parse_number_of_type_on_battlefield_with_keyword(input: &str) -> OracleResult
                 controller: None,
                 properties: vec![FilterProp::WithKeyword { value: keyword }],
             }),
-        },
-    ))
-}
-
-/// CR 613.1: Parse "cards in the chosen player's <zone>" after "the number of"
-/// into the general zone-count building block scoped to the source's persisted
-/// chosen player.
-fn parse_number_of_cards_in_chosen_player_zone(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (rest, _) = tag("cards in the chosen player's ").parse(input)?;
-    let (rest, zone) = parse_zone_ref_singular(rest)?;
-    Ok((
-        rest,
-        QuantityRef::ZoneCardCount {
-            zone,
-            card_types: Vec::new(),
-            scope: CountScope::SourceChosenPlayer,
-            filter: None,
         },
     ))
 }
@@ -2122,6 +2104,15 @@ fn parse_scoped_zone_ref(input: &str) -> OracleResult<'_, (ZoneRef, CountScope)>
                 parse_zone_ref_plural,
             ),
             |zone| (zone, CountScope::Opponents),
+        ),
+        // CR 613.1: "the chosen player's <zone>" — the player persisted on the
+        // source via an earlier "choose a player" (Haunting Apparition:
+        // "green creature cards in the chosen player's graveyard"). Placed on the
+        // shared scoped-zone path so card-type/color filters compose uniformly,
+        // rather than a separate unfiltered-only arm.
+        map(
+            preceded(tag("the chosen player's "), parse_zone_ref_singular),
+            |zone| (zone, CountScope::SourceChosenPlayer),
         ),
         map(preceded(tag("all "), parse_zone_ref_plural), |zone| {
             (zone, CountScope::All)

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -3333,6 +3333,57 @@ mod tests {
     }
 
     #[test]
+    fn cda_type_filtered_cards_in_chosen_players_graveyard() {
+        // CR 613.1: "creature cards in the chosen player's graveyard" — a type-
+        // filtered card count scoped to the source's persisted chosen player.
+        // Recognizing "the chosen player's <zone>" on the shared scoped-zone path
+        // lets the type filter compose, mirroring "your"/"opponents'" graveyards.
+        let expr =
+            parse_cda_quantity("the number of creature cards in the chosen player's graveyard");
+        assert_eq!(
+            expr,
+            Some(QuantityExpr::Ref {
+                qty: QuantityRef::ZoneCardCount {
+                    zone: ZoneRef::Graveyard,
+                    card_types: vec![TypeFilter::Creature],
+                    scope: CountScope::SourceChosenPlayer,
+                    filter: None,
+                },
+            }),
+            "got {expr:?}"
+        );
+    }
+
+    #[test]
+    fn cda_color_filtered_cards_in_chosen_players_graveyard() {
+        // CR 613.1: Haunting Apparition — "green creature cards in the chosen
+        // player's graveyard". A color (property) filter routes through the
+        // general typed-phrase path as an `ObjectCount`; the "the chosen player's"
+        // zone qualifier must set `ControllerRef::SourceChosenPlayer`, mirroring
+        // how "your graveyard" sets `ControllerRef::You`.
+        let expr = parse_cda_quantity(
+            "the number of green creature cards in the chosen player's graveyard",
+        );
+        let Some(QuantityExpr::Ref {
+            qty:
+                QuantityRef::ObjectCount {
+                    filter: TargetFilter::Typed(tf),
+                },
+        }) = expr
+        else {
+            panic!("expected ObjectCount with a typed filter, got {expr:?}");
+        };
+        assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+        assert_eq!(tf.controller, Some(ControllerRef::SourceChosenPlayer));
+        assert!(tf.properties.contains(&FilterProp::HasColor {
+            color: ManaColor::Green
+        }));
+        assert!(tf.properties.contains(&FilterProp::InZone {
+            zone: crate::types::zones::Zone::Graveyard
+        }));
+    }
+
+    #[test]
     fn cda_half_highest_opponent_life_rounded_up() {
         // Malignus: "half the highest life total among your opponents, rounded up".
         // The inner is a cross-player life aggregate the general nom grammar does

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -6889,6 +6889,12 @@ enum ZoneQual {
     /// "its owner's ", "that player's ", "defending player's ", "each player's ".
     /// No ownership constraint emitted; referent is resolved by context upstream.
     OtherPoss,
+    /// "the chosen player's " — the player persisted on the source via an earlier
+    /// "choose a player" (Haunting Apparition: "green creature cards in the chosen
+    /// player's graveyard"). Sets `ControllerRef::SourceChosenPlayer`, mirroring
+    /// how `You` sets `ControllerRef::You`; CR 613.1 resolves it against the
+    /// source's persisted choice.
+    ChosenPlayer,
     /// "a ", "the ", or nothing (e.g., "from exile").
     Plain,
 }
@@ -7058,6 +7064,10 @@ fn parse_zone_suffix_nom(
                 vec![FilterProp::InAnyZone { zones }],
                 Some(ControllerRef::You),
             ),
+            ZoneQual::ChosenPlayer => (
+                vec![FilterProp::InAnyZone { zones }],
+                Some(ControllerRef::SourceChosenPlayer),
+            ),
             ZoneQual::TargetPlayer => (
                 vec![
                     FilterProp::Owned {
@@ -7092,6 +7102,10 @@ fn parse_zone_suffix_nom(
                 None,
             ),
             ZoneQual::You => (vec![FilterProp::InZone { zone }], Some(ControllerRef::You)),
+            ZoneQual::ChosenPlayer => (
+                vec![FilterProp::InZone { zone }],
+                Some(ControllerRef::SourceChosenPlayer),
+            ),
             ZoneQual::TargetPlayer => (
                 vec![
                     FilterProp::Owned {
@@ -7124,6 +7138,9 @@ fn parse_zone_qual(i: &str) -> super::oracle_nom::error::OracleResult<'_, ZoneQu
             alt((tag("an opponent's "), tag("each opponent's "))),
         ),
         value(ZoneQual::You, tag("your ")),
+        // CR 613.1: must precede the `Plain` "the " arm so "the chosen player's "
+        // isn't consumed as a bare "the " article.
+        value(ZoneQual::ChosenPlayer, tag("the chosen player's ")),
         value(ZoneQual::TargetPlayer, tag("target player's ")),
         value(ZoneQual::Their, tag("their ")),
         value(


### PR DESCRIPTION
Closes #5425.

## What

Makes **Haunting Apparition** work — *"power is equal to 1 plus the number of green creature cards in the chosen player's graveyard."* A card-count quantity that's **filtered** (by card type or color) **and** scoped to *"the chosen player's"* graveyard failed to parse. The unfiltered chosen-player form (Sewer Nemesis) and the filtered your/their/opponents' forms already worked — only the filter × chosen-player combination was missing.

## How (routes to existing runtime, no engine changes)

Two count-parsing paths never learned the `"the chosen player's <zone>"` possessive they already recognize for `your`/`their`/`opponents'`:

1. **`parse_scoped_zone_ref`** (the `ZoneCardCount` scoped-zone path, type-filtered counts) gains a `"the chosen player's <zone>"` arm → `CountScope::SourceChosenPlayer`. This unifies the type-filtered and unfiltered cases, so the previously separate unfiltered-only `parse_number_of_cards_in_chosen_player_zone` special case is **removed** (single authority).
2. **`parse_zone_qual`** (the general typed-phrase zone-suffix path, color/property filters that lower to `ObjectCount`) gains a `ZoneQual::ChosenPlayer` arm → `ControllerRef::SourceChosenPlayer`, mirroring how `"your <zone>"` sets `ControllerRef::You`. Ordered before the bare `"the "` article so it isn't mis-consumed.

Both resolve against the source's persisted chosen player (`SourceChosenPlayer`, CR 613.1) via the existing filter/count runtime.

Haunting Apparition now parses to `SetDynamicPower(Offset { ObjectCount { Creature, controller: SourceChosenPlayer, [HasColor(Green), InZone(Graveyard)] }, offset: 1 })`.

## Tests

- `cda_type_filtered_cards_in_chosen_players_graveyard` → `ZoneCardCount { scope: SourceChosenPlayer, card_types: [Creature] }`.
- `cda_color_filtered_cards_in_chosen_players_graveyard` → `ObjectCount` with `controller: SourceChosenPlayer` + `HasColor(Green)` + `InZone(Graveyard)`.
- Verified no regressions across the goyf class (your / all / opponents' / their graveyards, unfiltered chosen-player).

## Verification

`cargo fmt --all` ✓ · engine lib suite **15,871 pass / 0 fail** ✓ · `clippy -p engine --all-targets -D warnings` clean ✓
