### PR TITLE
fix(parser): scope "becomes tapped during your turn" trigger to the controller's turn (Captain America) (#5325)

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -9322,6 +9322,21 @@ fn try_parse_event(
             SimpleEvent::BecomesTapped => {
                 def.mode = TriggerMode::Taps;
                 def.valid_card = Some(subject.clone());
+                // CR 603.4: "becomes tapped during your turn" carries a turn
+                // restriction (Captain America, Living Legend — "Whenever a
+                // creature you control becomes tapped during your turn, if it's
+                // the first time …"). The intervening-if extractor strips the
+                // trailing "if …" clause but leaves the "during your turn" phrase
+                // on the event tail (`remaining`); peel it into the trigger's turn
+                // constraint so the ability only fires on the controller's turn,
+                // instead of being silently dropped. `remaining` still carries the
+                // trailing ", if …/untap it" clause, so match the turn phrase as a
+                // LEADING prefix (boundary-checked), not an all-consuming peel.
+                // Builds for the class — any "<subject> becomes tapped during
+                // your/opponent's turn" trigger.
+                if let Some(constraint) = parse_leading_turn_constraint(remaining) {
+                    def.constraint = Some(constraint);
+                }
             }
             SimpleEvent::TappedForMana => {
                 def.mode = TriggerMode::TapsForMana;
@@ -14858,31 +14873,57 @@ fn parse_turn_constraint(phase_text: &str) -> Option<TriggerConstraint> {
     None
 }
 
+/// CR 603.4: match the turn specifier that follows "during " in a turn-restriction
+/// clause → the corresponding trigger constraint. Single authority shared by the
+/// trailing peel ([`peel_trailing_turn_constraint`]) and the leading matcher
+/// ([`parse_leading_turn_constraint`]).
+fn parse_during_turn_spec(input: &str) -> OracleResult<'_, TriggerConstraint> {
+    alt((
+        value(
+            TriggerConstraint::OnlyDuringOpponentsTurn,
+            alt((
+                tag("an opponent's turn"),
+                tag("each opponent's turn"),
+                tag("each opponents\u{2019} turn"),
+                tag("each opponents' turn"),
+                tag("your opponent's turn"),
+                tag("your opponents\u{2019} turn"),
+                tag("your opponents' turn"),
+                tag("each of your opponents\u{2019} turn"),
+                tag("each of your opponents' turn"),
+            )),
+        ),
+        value(
+            TriggerConstraint::OnlyDuringYourTurn,
+            alt((tag("your turn"), tag("each of your turns"))),
+        ),
+    ))
+    .parse(input)
+}
+
+/// CR 603.4: match a "during `<your/opponent's>` turn" restriction at the START of
+/// a post-event tail (Captain America, Living Legend: "becomes tapped during your
+/// turn, if it's the first time …"). Unlike [`peel_trailing_turn_constraint`] the
+/// phrase need not consume the whole tail — the intervening-if / effect clause
+/// follows it — so require a clause boundary (comma or end) after the turn spec so
+/// it doesn't misfire on a longer phrase that merely starts with "during your …".
+fn parse_leading_turn_constraint(input: &str) -> Option<TriggerConstraint> {
+    let (rest, constraint) = preceded(
+        tag::<_, _, OracleError<'_>>("during "),
+        parse_during_turn_spec,
+    )
+    .parse(input.trim_start())
+    .ok()?;
+    let rest = rest.trim_start();
+    (rest.is_empty() || rest.starts_with(',')).then_some(constraint)
+}
+
 fn peel_trailing_turn_constraint(input: &str) -> (&str, Option<TriggerConstraint>) {
     let mut remaining = input.trim();
     loop {
         if let Ok((_, constraint)) = preceded(
             tag::<_, _, OracleError<'_>>("during "),
-            all_consuming(alt((
-                value(
-                    TriggerConstraint::OnlyDuringOpponentsTurn,
-                    alt((
-                        tag("an opponent's turn"),
-                        tag("each opponent's turn"),
-                        tag("each opponents\u{2019} turn"),
-                        tag("each opponents' turn"),
-                        tag("your opponent's turn"),
-                        tag("your opponents\u{2019} turn"),
-                        tag("your opponents' turn"),
-                        tag("each of your opponents\u{2019} turn"),
-                        tag("each of your opponents' turn"),
-                    )),
-                ),
-                value(
-                    TriggerConstraint::OnlyDuringYourTurn,
-                    alt((tag("your turn"), tag("each of your turns"))),
-                ),
-            ))),
+            all_consuming(parse_during_turn_spec),
         )
         .parse(remaining)
         {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -9322,11 +9322,12 @@ fn try_parse_event(
             SimpleEvent::BecomesTapped => {
                 def.mode = TriggerMode::Taps;
                 def.valid_card = Some(subject.clone());
-                // CR 603.4: "becomes tapped during your turn" carries a turn
-                // restriction (Captain America, Living Legend — "Whenever a
-                // creature you control becomes tapped during your turn, if it's
-                // the first time …"). The intervening-if extractor strips the
-                // trailing "if …" clause but leaves the "during your turn" phrase
+                // CR 603.2e: a "becomes tapped" trigger event may carry a "during
+                // your turn" turn restriction (Captain America, Living Legend —
+                // "Whenever a creature you control becomes tapped during your turn,
+                // if it's the first time …"). The intervening-if extractor (CR
+                // 603.4) strips the trailing "if …" clause but leaves the "during
+                // your turn" phrase
                 // on the event tail (`remaining`); peel it into the trigger's turn
                 // constraint so the ability only fires on the controller's turn,
                 // instead of being silently dropped. `remaining` still carries the
@@ -14873,10 +14874,10 @@ fn parse_turn_constraint(phase_text: &str) -> Option<TriggerConstraint> {
     None
 }
 
-/// CR 603.4: match the turn specifier that follows "during " in a turn-restriction
-/// clause → the corresponding trigger constraint. Single authority shared by the
-/// trailing peel ([`peel_trailing_turn_constraint`]) and the leading matcher
-/// ([`parse_leading_turn_constraint`]).
+/// CR 603.1: match the turn specifier that follows "during " in a trigger's
+/// turn-restriction clause → the corresponding trigger constraint. Single
+/// authority shared by the trailing peel ([`peel_trailing_turn_constraint`]) and
+/// the leading matcher ([`parse_leading_turn_constraint`]).
 fn parse_during_turn_spec(input: &str) -> OracleResult<'_, TriggerConstraint> {
     alt((
         value(
@@ -14901,21 +14902,29 @@ fn parse_during_turn_spec(input: &str) -> OracleResult<'_, TriggerConstraint> {
     .parse(input)
 }
 
-/// CR 603.4: match a "during `<your/opponent's>` turn" restriction at the START of
+/// CR 603.1: match a "during `<your/opponent's>` turn" restriction at the START of
 /// a post-event tail (Captain America, Living Legend: "becomes tapped during your
 /// turn, if it's the first time …"). Unlike [`peel_trailing_turn_constraint`] the
 /// phrase need not consume the whole tail — the intervening-if / effect clause
-/// follows it — so require a clause boundary (comma or end) after the turn spec so
-/// it doesn't misfire on a longer phrase that merely starts with "during your …".
+/// follows it. The trailing `terminated(..)` boundary combinator requires the turn
+/// spec to be followed by end-of-input or a `,` (the start of the ", if …/effect"
+/// clause), so it doesn't misfire on a longer phrase that merely starts with
+/// "during your …". Boundary acceptance stays inside the nom combinator (no
+/// string dispatch).
 fn parse_leading_turn_constraint(input: &str) -> Option<TriggerConstraint> {
-    let (rest, constraint) = preceded(
-        tag::<_, _, OracleError<'_>>("during "),
-        parse_during_turn_spec,
+    terminated(
+        preceded(
+            tag::<_, _, OracleError<'_>>("during "),
+            parse_during_turn_spec,
+        ),
+        alt((
+            value((), eof),
+            value((), peek(tag::<_, _, OracleError<'_>>(","))),
+        )),
     )
     .parse(input.trim_start())
-    .ok()?;
-    let rest = rest.trim_start();
-    (rest.is_empty() || rest.starts_with(',')).then_some(constraint)
+    .map(|(_, constraint)| constraint)
+    .ok()
 }
 
 fn peel_trailing_turn_constraint(input: &str) -> (&str, Option<TriggerConstraint>) {

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -9446,6 +9446,43 @@ fn extract_if_condition_first_time_tapped_pattern() {
     assert_eq!("untap it", cleaned);
 }
 
+/// CR 603.4 + CR 701.26 + issue #5325: Captain America, Living Legend — the
+/// "during your turn" restriction embedded between the tapped-event clause and
+/// the first-time intervening-if must lower to the `OnlyDuringYourTurn` trigger
+/// constraint. It was previously dropped (left on the event tail after the
+/// intervening-if was peeled), so the ability fired on any turn.
+#[test]
+fn captain_america_becomes_tapped_during_your_turn_constraint() {
+    let def = parse_trigger_line(
+        "Whenever a creature you control becomes tapped during your turn, if it's the first time that creature has become tapped this turn, untap it.",
+        "Captain America, Living Legend",
+    );
+    assert_eq!(def.mode, TriggerMode::Taps);
+    assert_eq!(
+        def.constraint,
+        Some(crate::types::ability::TriggerConstraint::OnlyDuringYourTurn),
+        "'during your turn' must scope the tapped trigger to the controller's turn"
+    );
+    // The first-tap intervening-if must survive alongside the turn constraint.
+    assert_eq!(
+        def.condition,
+        Some(TriggerCondition::FirstTimeObjectTappedThisTurn),
+        "the first-tap intervening-if must be preserved"
+    );
+}
+
+/// Regression guard: a bare "becomes tapped" trigger (no turn phrase) must NOT
+/// gain a turn constraint.
+#[test]
+fn becomes_tapped_without_turn_phrase_has_no_constraint() {
+    let def = parse_trigger_line(
+        "Whenever Night Market Lookout becomes tapped, each opponent loses 1 life and you gain 1 life.",
+        "Night Market Lookout",
+    );
+    assert_eq!(def.mode, TriggerMode::Taps);
+    assert_eq!(def.constraint, None);
+}
+
 #[test]
 fn trigger_enchanted_land_is_tapped_for_mana() {
     let def = parse_trigger_line(

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -9446,11 +9446,12 @@ fn extract_if_condition_first_time_tapped_pattern() {
     assert_eq!("untap it", cleaned);
 }
 
-/// CR 603.4 + CR 701.26 + issue #5325: Captain America, Living Legend — the
-/// "during your turn" restriction embedded between the tapped-event clause and
-/// the first-time intervening-if must lower to the `OnlyDuringYourTurn` trigger
-/// constraint. It was previously dropped (left on the event tail after the
-/// intervening-if was peeled), so the ability fired on any turn.
+/// CR 603.2e + CR 701.26 + issue #5325: Captain America, Living Legend — the
+/// "during your turn" restriction on the "becomes tapped" trigger event (CR
+/// 603.2e), embedded ahead of the first-time intervening-if (CR 603.4), must
+/// lower to the `OnlyDuringYourTurn` trigger constraint. It was previously
+/// dropped (left on the event tail after the intervening-if was peeled), so the
+/// ability fired on any turn.
 #[test]
 fn captain_america_becomes_tapped_during_your_turn_constraint() {
     let def = parse_trigger_line(


### PR DESCRIPTION
Fixes #5325.

## Summary

**Captain America, Living Legend** — `Whenever a creature you control becomes tapped during your turn, if it's the first time that creature has become tapped this turn, untap it.` (Oracle verified against `client/public/card-data.json`) — fired on **any** turn. The "during your turn" restriction was silently dropped, so an opponent tapping your creature also triggered the untap.

## Root cause

In `try_parse_event`, the `SimpleEvent::BecomesTapped` arm consumed `"becomes tapped"` and **ignored the event tail** (`remaining`), which still carried `"during your turn"` ahead of the intervening-if / effect clause. `peel_trailing_turn_constraint` never applied (the phrase is mid-line, followed by `", if …"`), so no `TriggerConstraint` was set — the parsed trigger had `constraint: null`.

## Fix

- Add **`parse_leading_turn_constraint`** — a boundary-checked matcher for a `"during <your/opponent's> turn"` restriction at the **start** of the event tail (it need not consume the whole tail, since `", if …"` follows) — and apply it in the `BecomesTapped` arm to set `def.constraint`.
- Extract the shared **`parse_during_turn_spec`** combinator so the trailing peel and the new leading matcher use **one** turn-spec authority (no duplicated grammar; `peel_trailing_turn_constraint` is refactored to reuse it, behavior-preserving).
- Builds for the **class**: any `"<subject> becomes tapped during your/opponent's turn"` trigger. The runtime already enforces `TriggerConstraint::OnlyDuringYourTurn`, so this is a parser-only fix.

CR 603.4 (turn/intervening restriction) + CR 701.26 (tap).

## Testing

`cargo fmt` ✓ · parser-combinator gate ✓ · `cargo check -p engine` ✓.

- `captain_america_becomes_tapped_during_your_turn_constraint` — the trigger now carries `OnlyDuringYourTurn` **and** preserves the first-tap `FirstTimeObjectTappedThisTurn` intervening-if.
- `becomes_tapped_without_turn_phrase_has_no_constraint` — regression guard: a bare `"becomes tapped"` trigger gains no constraint.