### PR TITLE
fix(client): surface player curses in split-view seat header + restore badge interactivity

### DIFF
--- a/client/src/components/board/OpponentSeatHeader.tsx
+++ b/client/src/components/board/OpponentSeatHeader.tsx
@@ -22,6 +22,7 @@ import {
   UnboundedBadge,
 } from "../hud/HudBadges.tsx";
 import { AvatarHoverPreview } from "../hud/AvatarHoverPreview.tsx";
+import { EnchantmentsBadge } from "../hud/EnchantmentsBadge.tsx";
 import { KickConfirmDialog } from "../hud/KickConfirmDialog.tsx";
 import { NextUpBadge } from "../hud/NextUpBadge.tsx";
 
@@ -173,7 +174,18 @@ export function OpponentSeatHeader({ playerId, compact = false, onKickPlayer }: 
             />
           )}
           <LifeTotal playerId={playerId} size="sm" hideLabel />
-          <div className={`flex min-w-0 max-w-[9rem] shrink items-center justify-end gap-0.5 overflow-hidden ${badgeScale} [&>*]:origin-right`}>
+          {/* The enclosing identity block is pointer-events-none (so the
+              header's full-area target button owns clicks while this seat is a
+              legal target). Re-enable pointer events on the badge cluster so the
+              enchantments badge is hoverable/clickable and the counter/condition
+              tooltips fire — except while targeting, where the target button
+              must win. Mirrors the avatar's pointer-events gating above. */}
+          <div className={`flex min-w-0 max-w-[9rem] shrink items-center justify-end gap-0.5 overflow-hidden ${badgeScale} [&>*]:origin-right ${isValidPlayerTarget ? "pointer-events-none" : "pointer-events-auto"}`}>
+            {/* Player-attached Auras (Curse cycle, Faith's Fetters, Dictate of
+                Kruphix…). Reads the engine's `auras_attached_to_player`
+                projection; brings the split seat header to parity with the
+                legacy 1v1/tab HUDs, which already surface curses. */}
+            <EnchantmentsBadge playerId={playerId} />
             {designations.isMonarch ? <MonarchBadge /> : null}
             {designations.hasInitiative ? <InitiativeBadge /> : null}
             {designations.hasCityBlessing ? <CityBlessingBadge /> : null}

--- a/client/src/components/board/__tests__/OpponentSeatHeader.test.tsx
+++ b/client/src/components/board/__tests__/OpponentSeatHeader.test.tsx
@@ -86,6 +86,25 @@ describe("OpponentSeatHeader", () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
+  it("surfaces player-attached Auras (curses) for parity with the legacy HUD", () => {
+    const waitingFor = targetSelectionWaitingFor([]);
+    useGameStore.setState({
+      gameState: {
+        ...createGameState(waitingFor),
+        derived: {
+          auras_attached_to_player: { "1": [101, 102] },
+        },
+      },
+      waitingFor,
+    });
+
+    render(<OpponentSeatHeader playerId={1} />);
+
+    expect(
+      screen.getByRole("button", { name: "2 enchantments on this player" }),
+    ).toBeInTheDocument();
+  });
+
   it("renders Next Up badge with tooltip text", () => {
     const waitingFor = targetSelectionWaitingFor([]);
     useGameStore.setState({


### PR DESCRIPTION
The split-view opponent seat header rendered neither player-attached Auras
(curses) nor interactive badge affordances, unlike the legacy 1v1/tab HUDs:

- Add EnchantmentsBadge (reads the engine's auras_attached_to_player
  projection) for curse-display parity.
- Re-enable pointer events on the badge cluster, gated on isValidPlayerTarget
  so the full-area target button still wins during target selection. The
  enclosing identity block is pointer-events-none by design; without opting
  the cluster back in, the curse badge was inert and the counter/condition
  hover tooltips never fired.
