### PR TITLE
perf(engine): convert known-tokens.toml to JSON at build time for ~10x faster catalog load

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -80,6 +80,12 @@ path = "src/bin/coverage_parse_diff.rs"
 # `test = true` (default): this bin carries non-trivial diff logic with inline
 # unit tests, unlike the logic-free tool bins above that set `test = false`.
 
+[build-dependencies]
+# build.rs converts data/known-tokens.toml → JSON in OUT_DIR so the runtime
+# embed avoids the ~1s-per-process debug-mode toml_edit parse (see build.rs).
+toml = "0.8"
+serde_json = "1"
+
 [dev-dependencies]
 tempfile = "3"
 insta = { version = "1", features = ["json"] }

--- a/crates/engine/build.rs
+++ b/crates/engine/build.rs
@@ -1,0 +1,50 @@
+//! Converts `data/known-tokens.toml` (the human-reviewable catalog generated
+//! by the `tokens-gen` bin) into JSON at build time for the runtime embed in
+//! `game/token_presets.rs`.
+//!
+//! Why: parsing the ~5.9MB catalog with `toml`/`toml_edit` costs ~1s per
+//! process in debug builds, and nextest runs every test in its own process —
+//! so every token-touching test (any Oracle text naming a Treasure/Food/named
+//! token) paid the full parse. `serde_json::from_slice` of the pre-converted
+//! JSON is several times faster, and this conversion runs only when the
+//! catalog file itself changes.
+//!
+//! The conversion is purely structural (`toml::Value` → `serde_json::Value`),
+//! so it cannot drift from the typed `CatalogFile` schema: the same serde
+//! shape that used to decode the TOML decodes the JSON.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    // Explicit rerun-if-changed replaces cargo's rerun-on-any-source default,
+    // so unrelated engine edits never rerun this script.
+    println!("cargo::rerun-if-changed=data/known-tokens.toml");
+    println!("cargo::rerun-if-changed=build.rs");
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let raw = fs::read_to_string(manifest_dir.join("data/known-tokens.toml"))
+        .expect("read crates/engine/data/known-tokens.toml");
+    let value: toml::Value = toml::from_str(&raw).expect("known-tokens.toml well-formed");
+    // Bare TOML datetimes serialize through serde as a private wrapper struct
+    // that would corrupt the JSON round-trip. tokens-gen only emits quoted
+    // strings, so reject any future drift here rather than mis-decoding later.
+    assert_no_bare_datetimes(&value);
+
+    let out = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR")).join("known-tokens.json");
+    let json = serde_json::to_vec(&value).expect("known-tokens.toml converts to JSON");
+    fs::write(&out, json).expect("write known-tokens.json to OUT_DIR");
+}
+
+fn assert_no_bare_datetimes(value: &toml::Value) {
+    match value {
+        toml::Value::Datetime(dt) => panic!(
+            "known-tokens.toml contains a bare TOML datetime ({dt}); quote it as a \
+             string in tokens-gen — bare datetimes do not survive JSON conversion"
+        ),
+        toml::Value::Array(items) => items.iter().for_each(assert_no_bare_datetimes),
+        toml::Value::Table(table) => table.values().for_each(assert_no_bare_datetimes),
+        _ => {}
+    }
+}

--- a/crates/engine/src/game/token_presets.rs
+++ b/crates/engine/src/game/token_presets.rs
@@ -1,12 +1,15 @@
 //! CR 111.1 + CR 111.10 + CR 111.4: Debug-only catalog of pre-defined token
-//! presets. Loaded from `crates/engine/data/known-tokens.toml` (committed
+//! presets. Sourced from `crates/engine/data/known-tokens.toml` (committed
 //! phase-native source generated from MTGJSON set token data by the
-//! `tokens-gen` bin).
+//! `tokens-gen` bin), converted to JSON at build time by `build.rs`, and
+//! embedded via `include_bytes!` — the debug-mode toml_edit parse of the
+//! ~5.9MB catalog cost ~1s per test process under nextest's
+//! process-per-test model.
 //!
-//! The catalog is a fixed engine resource — versioned with code, embedded via
-//! `include_str!`. Runtime token-art resolution, named-token parsing, token
-//! ability materialization, and the debug-create UI all consume this single
-//! engine-typed list of bodies.
+//! The catalog is a fixed engine resource — versioned with code. Runtime
+//! token-art resolution, named-token parsing, token ability materialization,
+//! and the debug-create UI all consume this single engine-typed list of
+//! bodies.
 
 use std::sync::LazyLock;
 
@@ -165,11 +168,12 @@ struct CatalogFile {
     token: Vec<TokenPreset>,
 }
 
-/// Embedded catalog data. Path is relative to this source file:
-/// `crates/engine/src/game/token_presets.rs` → `crates/engine/data/known-tokens.toml`.
+/// Embedded catalog data: `data/known-tokens.toml` converted to JSON in
+/// `OUT_DIR` by `build.rs` (structural conversion — same serde shape).
 static PRESETS: LazyLock<Vec<TokenPreset>> = LazyLock::new(|| {
-    let raw = include_str!("../../data/known-tokens.toml");
-    let parsed: CatalogFile = toml::from_str(raw).expect("known-tokens.toml well-formed");
+    let raw = include_bytes!(concat!(env!("OUT_DIR"), "/known-tokens.json"));
+    let parsed: CatalogFile =
+        serde_json::from_slice(raw).expect("build.rs-converted known-tokens.json well-formed");
     // Duplicate-id assertion: every preset must be addressable by a unique
     // stable id (used by the FE for selection state and React keys).
     let mut seen = std::collections::HashSet::new();
@@ -551,10 +555,11 @@ mod tests {
         (state, source)
     }
 
-    /// Forces `LazyLock` evaluation in `cargo test -p engine` so a malformed
-    /// `known-tokens.toml`, an unknown `Keyword`/`CoreType`/`ManaColor`
-    /// variant, or a duplicate id panics in CI rather than at first
-    /// production access.
+    /// Forces `LazyLock` evaluation in `cargo test -p engine` so an unknown
+    /// `Keyword`/`CoreType`/`ManaColor` variant or a duplicate id panics in
+    /// CI rather than at first production access. (Malformed TOML fails
+    /// earlier, in `build.rs`; the structural conversion there cannot catch
+    /// these typed-schema violations.)
     #[test]
     fn catalog_loads_and_validates() {
         let presets = known_token_presets();

--- a/scripts/gen-card-data.sh
+++ b/scripts/gen-card-data.sh
@@ -156,9 +156,10 @@ TOOL_BINS=(--bin tokens-gen --bin oracle-gen --bin coverage-report --bin card-da
 TOOL_BIN="target/tool"
 cargo build --profile tool --features "$FEATURES" "${TOOL_BINS[@]}"
 
-# The token catalog is baked into the engine lib at compile time via
-# `include_str!("../../data/known-tokens.toml")` (token_presets.rs). Regenerate
-# it, then re-embed it only if it actually changed.
+# The token catalog is baked into the engine lib at compile time (build.rs
+# converts data/known-tokens.toml to JSON in OUT_DIR; token_presets.rs embeds
+# it via include_bytes!). Regenerate it, then re-embed it only if it actually
+# changed.
 echo "Generating token preset catalog from MTGJSON set files..."
 TOKENS_FILE="crates/engine/data/known-tokens.toml"
 # Temp beside the target so the replace below is an atomic same-filesystem
@@ -167,7 +168,7 @@ TOKENS_TMP="$(mktemp "${TOKENS_FILE}.XXXXXX")"
 "$TOOL_BIN/tokens-gen" --input "$DATA_DIR/mtgjson/sets" --output "$TOKENS_TMP"
 # tokens-gen output is deterministic, so only overwrite when content actually
 # changed — an unconditional copy bumps the file's mtime and forces a full
-# (40-65s) engine recompile via the include_str! dependency for nothing.
+# (40-65s) engine recompile via build.rs's rerun-if-changed for nothing.
 if cmp -s "$TOKENS_TMP" "$TOKENS_FILE"; then
   rm -f "$TOKENS_TMP"
 else


### PR DESCRIPTION
## Problem

`crates/engine/data/known-tokens.toml` (5.9MB, 12,654 entries) was `include_str!`-embedded and parsed with `toml_edit` inside `static PRESETS: LazyLock` — roughly **1s of CPU per process** in debug builds.

nextest runs one process per test, so *every* token-touching test (any Oracle text naming a Treasure/Food/named token) re-paid that parse from cold. Measured 3.15–4.2s wall on the worst tests.

## Fix

A new `crates/engine/build.rs` converts the catalog **structurally** (`toml::Value` → `serde_json::Value`) into `OUT_DIR/known-tokens.json`. The runtime embeds that with `include_bytes!` and decodes it with the same typed `CatalogFile` serde shape.

- **No schema mirroring, so no drift.** The build script never names a field; the same serde shape that decoded the TOML decodes the JSON.
- `rerun-if-changed` is scoped to the catalog file (+ `build.rs`), so unrelated engine edits never rerun the script.
- A bare-datetime guard rejects the one TOML construct that would not survive JSON conversion. `tokens-gen` only emits quoted strings today; this fails the build loudly if that ever drifts.

## Results

| Measurement | Before | After |
|---|---|---|
| `gluntch_three_player_chain` | 3.15s | **0.28s** |
| `gimbal_one_artifact_token` | 4.2s | **0.37s** |
| per-process catalog CPU | 1.02s | **0.12s** |
| full `test-engine` | ~720s+ | **246.5s** (18,451 passed, 0 failed) |

## Verification

- Full `test-engine` via Tilt: **18,451 passed, 0 failed**, 246.5s.
- Isolated review confirmed the full 6.2MB catalog round-trips identically (only strings / ints / arrays / tables; serde external tagging is identical in both formats).
- `cargo::` directive syntax verified against the pinned nightly toolchain.
- No other runtime consumers of the TOML.
- wasm unaffected: build scripts run on the host, and `include_bytes!` is target-independent.

**Bonus:** the embedded blob shrinks ~766KB (JSON 5.45MB vs TOML 6.21MB), which also shrinks the wasm bundle.
