### PR TITLE
feat(parser): static grant of an alt-cost keyword equal to its mana cost (Henzie "Toolbox" Torre)

### DIFF
--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -13069,6 +13069,83 @@ fn granted_blitz_offers_blitz_variant() {
     );
 }
 
+/// CR 702.152a + CR 604.1 + CR 118.9: Henzie "Toolbox" Torre — "Each creature
+/// spell you cast with mana value 4 or greater has blitz. The blitz cost is
+/// equal to its mana cost." The grant carries `Blitz(ManaCost::SelfManaCost)`, so
+/// the offered Blitz option must surface the self-referential cost (resolved to
+/// the spell's own mana cost at payment time by the shared `SelfManaCost` path,
+/// the same one the granted-flashback cost uses). This pins that a granted
+/// alternative cost equal to the card's mana cost flows intact through the
+/// casting-variant choice set rather than being dropped or fixed to a constant.
+#[test]
+fn granted_blitz_self_mana_cost_surfaces_self_referential_cost() {
+    use crate::types::ability::{FilterProp, TargetFilter, TypeFilter, TypedFilter};
+    use crate::types::keywords::Keyword;
+    use crate::types::statics::StaticMode;
+
+    let mut state = setup_game_at_main_phase();
+    add_mana(&mut state, PlayerId(0), ManaType::Colorless, 6);
+
+    // Henzie's grant, modeled as the CastWithKeyword static the parser emits:
+    // creature spells you cast with mana value >= 4 gain Blitz whose cost equals
+    // the spell's own mana cost.
+    let grantor = create_object(
+        &mut state,
+        CardId(9110),
+        PlayerId(0),
+        "Henzie".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&grantor).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_card_types.core_types.push(CoreType::Creature);
+        let def = StaticDefinition::new(StaticMode::CastWithKeyword {
+            keyword: Keyword::Blitz(ManaCost::SelfManaCost),
+        })
+        .affected(TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Creature).properties(vec![FilterProp::Cmc {
+                comparator: crate::types::ability::Comparator::GE,
+                value: crate::types::ability::QuantityExpr::Fixed { value: 4 },
+            }]),
+        ));
+        obj.static_definitions = vec![def].into();
+    }
+
+    // Recipient: a {5} creature (mana value 5 >= 4) in hand with no printed Blitz.
+    let spell_cost = ManaCost::generic(5);
+    let spell = create_object(
+        &mut state,
+        CardId(9111),
+        PlayerId(0),
+        "Big Creature".to_string(),
+        Zone::Hand,
+    );
+    {
+        let obj = state.objects.get_mut(&spell).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_card_types.core_types.push(CoreType::Creature);
+        obj.mana_cost = spell_cost.clone();
+        obj.base_mana_cost = spell_cost.clone();
+    }
+
+    let choices = casting_variant_choice_set(&state, PlayerId(0), spell);
+    let blitz = choices
+        .options
+        .iter()
+        .find(|o| o.variant == CastingVariant::Blitz)
+        .expect("granted Blitz must surface the Blitz option");
+    assert_eq!(
+        blitz.mana_cost,
+        ManaCost::SelfManaCost,
+        "granted Blitz must carry the self-referential cost (resolved to the \
+         spell's own mana cost at payment time), got {:?}",
+        blitz.mana_cost
+    );
+    // The recipient really is MV >= 4, so the grant's filter admits it.
+    assert_eq!(state.objects.get(&spell).unwrap().mana_cost, spell_cost);
+}
+
 /// CR 702.141a + CR 604.1 (seam 4: activated-ability-on-grant): Encore
 /// granted to a graveyard card by an `AddKeyword` effect must surface its
 /// graveyard activated ability. The `AddKeyword` layer seam installs only the

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -224,6 +224,39 @@ pub(crate) fn parse_spells_have_keyword_for_test(text: &str) -> Option<StaticDef
     parse_spells_have_keyword(&tp, text)
 }
 
+/// CR 702.152a + CR 118.9 + CR 601.2f: A static grant of an alternative-cost
+/// keyword whose cost is the affected spell's own mana cost — Henzie "Toolbox"
+/// Torre: "Each creature spell you cast with mana value 4 or greater has blitz.
+/// The blitz cost is equal to its mana cost." The two-sentence form (keyword +
+/// "The <kw> cost is equal to its mana cost" continuation) lowers to a single
+/// `CastWithKeyword` whose keyword carries `ManaCost::SelfManaCost`, resolved
+/// per-spell at cast time — the same self-referential cost the granted flashback
+/// path uses (Dream Devourer). Table-driven so further cast-variant alt-cost
+/// keywords that use this exact template slot in without new control flow. Only
+/// keywords the casting flow already surfaces from `effective_spell_keywords`
+/// (granted `CastingVariant::Blitz`) belong here, so the grant actually functions.
+fn parse_granted_self_cost_keyword(keyword_str: &str) -> Option<Keyword> {
+    [("blitz", Keyword::Blitz as fn(ManaCost) -> Keyword)]
+        .into_iter()
+        .find_map(|(name, ctor)| {
+            let parsed: OracleResult<'_, ()> = (|| {
+                let (i, _) = tag::<_, _, OracleError<'_>>(name).parse(keyword_str)?;
+                let (i, _) = tag(". the ").parse(i)?;
+                let (i, _) = tag(name).parse(i)?;
+                let (i, _) = tag(" cost is equal to ").parse(i)?;
+                let (i, _) = alt((tag("its"), tag("that card's"), tag("the card's"))).parse(i)?;
+                let (i, _) = tag(" mana cost").parse(i)?;
+                Ok((i, ()))
+            })();
+            let (rest, ()) = parsed.ok()?;
+            rest.trim()
+                .trim_end_matches('.')
+                .trim()
+                .is_empty()
+                .then(|| ctor(ManaCost::SelfManaCost))
+        })
+}
+
 /// Parse "[Type] spells you cast [from zone] have [keyword]" patterns.
 /// CR 702.51a: Grants a keyword (typically convoke) to spells matching a filter during casting.
 /// Also handles "Creature cards you own that aren't on the battlefield have flash."
@@ -283,7 +316,13 @@ pub(crate) fn parse_spells_have_keyword(tp: &TextPair<'_>, text: &str) -> Option
 
     // Parse the keyword — must be a valid keyword. A trailing "where X is …"
     // clause binds an earlier variable-X mana-value qualifier on the subject.
-    let (keyword, where_x) = parse_keyword_with_where_x(keyword_str)?;
+    // CR 702.152a: an alternative-cost keyword granted with "The <kw> cost is
+    // equal to its mana cost" (Henzie "Toolbox" Torre) carries the self-cost and
+    // consumes its continuation sentence here, ahead of the plain keyword parse.
+    let (keyword, where_x) = match parse_granted_self_cost_keyword(keyword_str) {
+        Some(kw) => (kw, None),
+        None => parse_keyword_with_where_x(keyword_str)?,
+    };
 
     // CR 611.2f: "The first <qualifier> spell you cast [from <zone>] <timing> has
     // [keyword]" — a once-per-turn keyword grant gated on the first qualifying

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -10439,6 +10439,65 @@ fn static_cast_as_though_flash() {
 }
 
 #[test]
+fn static_grant_blitz_self_mana_cost() {
+    // CR 702.152a + CR 604.1 + CR 118.9: Henzie "Toolbox" Torre — "Each creature
+    // spell you cast with mana value 4 or greater has blitz. The blitz cost is
+    // equal to its mana cost." lowers to a single `CastWithKeyword` granting
+    // `Blitz(SelfManaCost)` to the controller's MV>=4 creature spells; the
+    // self-referential cost resolves to each spell's own mana cost at cast time
+    // (mirrors the granted-flashback path). The two-sentence cost continuation is
+    // consumed into the same static, not dropped as a separate unimplemented line.
+    use crate::types::mana::ManaCost;
+    let def = parse_static_line(
+        "Each creature spell you cast with mana value 4 or greater has blitz. The blitz cost is equal to its mana cost.",
+    )
+    .unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::CastWithKeyword {
+            keyword: Keyword::Blitz(ManaCost::SelfManaCost),
+        }
+    );
+    let Some(TargetFilter::Typed(tf)) = &def.affected else {
+        panic!(
+            "affected must be a Typed creature filter, got {:?}",
+            def.affected
+        );
+    };
+    assert!(tf.type_filters.contains(&TypeFilter::Creature));
+    assert_eq!(tf.controller, Some(ControllerRef::You));
+    assert!(
+        tf.properties.iter().any(|p| matches!(
+            p,
+            FilterProp::Cmc {
+                comparator: Comparator::GE,
+                value: QuantityExpr::Fixed { value: 4 },
+            }
+        )),
+        "must constrain to mana value 4 or greater, got {:?}",
+        tf.properties
+    );
+}
+
+#[test]
+fn static_grant_blitz_simple_form() {
+    // The bare "Creature spells you cast have blitz. The blitz cost is equal to
+    // its mana cost." form (no mana-value qualifier) grants blitz to every
+    // creature spell the controller casts.
+    use crate::types::mana::ManaCost;
+    let def = parse_static_line(
+        "Creature spells you cast have blitz. The blitz cost is equal to its mana cost.",
+    )
+    .unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::CastWithKeyword {
+            keyword: Keyword::Blitz(ManaCost::SelfManaCost),
+        }
+    );
+}
+
+#[test]
 fn static_cast_as_though_flash_all_spells() {
     // CR 601.3b: the bare "spells" form (Leyline of Anticipation, Vedalken
     // Orrery) grants flash to every spell the controller casts.


### PR DESCRIPTION
Closes #5435.

## What

Makes **Henzie "Toolbox" Torre** (a popular commander) work — *"Each creature spell you cast with mana value 4 or greater has blitz. The blitz cost is equal to its mana cost."* previously failed to parse, so Henzie granted no blitz at all.

Single-word keyword grants (`... spells you cast have flash`) already emit `StaticMode::CastWithKeyword`, but the two-sentence **alternative-cost** form — an alt-cost keyword plus *"The `<kw>` cost is equal to its mana cost"* — was unhandled, so the whole static line was dropped.

## How (parser-only; routes to existing runtime)

`parse_spells_have_keyword` gains `parse_granted_self_cost_keyword`, which recognizes the alt-cost keyword + cost continuation and lowers it to:

```rust
CastWithKeyword { keyword: Blitz(ManaCost::SelfManaCost) }
```

scoped to the controller's MV≥4 creature spells. `SelfManaCost` resolves to each spell's own mana cost at cast time — the **same self-referential cost the granted-flashback path already uses** (Dream Devourer). The grant then functions through existing runtime with **no engine change**: `effective_spell_keywords` collects the `CastWithKeyword` grant and `casting_variant_candidates` surfaces `CastingVariant::Blitz` (already covered by `granted_blitz_offers_blitz_variant`).

The recognizer is table-driven so further cast-variant alt-cost keywords using this exact template slot in without new control flow; only keywords the casting flow already surfaces from `effective_spell_keywords` belong there.

## Out of scope (follow-up)

The **replicate** siblings (Ian Chesterton / Djinn Illuminatus / Hatchery Sliver) use the same template but need separate runtime work — granted replicate is card-build-synthesized (`synthesize_replicate`) rather than surfaced from effective keywords — so they're deliberately excluded here.

## Tests

- `static_grant_blitz_self_mana_cost` — Henzie lowers to `CastWithKeyword { Blitz(SelfManaCost) }` with the `Cmc ≥ 4` filter.
- `static_grant_blitz_simple_form` — the bare (no-qualifier) form.
- `granted_blitz_self_mana_cost_surfaces_self_referential_cost` — the granted Blitz option surfaces through the casting-variant choice set carrying the self-referential cost.

## Verification

`cargo fmt --all` ✓ · engine lib suite **15,896 pass / 0 fail** + 3 new ✓ · `clippy -p engine --all-targets -D warnings` clean ✓

## CR

CR 702.152a (Blitz) + CR 604.1 (static-granted abilities) + CR 118.9 (alternative costs).
