### PR TITLE
fix(parser): recognize "transformed" as a filter quality (Mutagen Connoisseur)

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -731,6 +731,7 @@ fn filterprop_reads_only_candidate_fp(p: &FilterProp) -> bool {
         | FilterProp::Historic
         | FilterProp::NotHistoric
         | FilterProp::FaceDown
+        | FilterProp::Transformed
         | FilterProp::HasXInManaCost
         | FilterProp::HasManaAbility
         | FilterProp::HasNoAbilities

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2338,6 +2338,7 @@ fn legacy_filter_prop(p: &FilterProp) -> bool {
         | FilterProp::AttackedOrBlockedThisTurn
         | FilterProp::CountersPutOnThisTurn { .. }
         | FilterProp::FaceDown
+        | FilterProp::Transformed
         | FilterProp::HasXInManaCost
         | FilterProp::HasXInActivationCost
         | FilterProp::WasKicked
@@ -2583,6 +2584,7 @@ fn member_bound_filter_prop(p: &FilterProp) -> bool {
         | FilterProp::AttackedOrBlockedThisTurn
         | FilterProp::CountersPutOnThisTurn { .. }
         | FilterProp::FaceDown
+        | FilterProp::Transformed
         | FilterProp::HasXInManaCost
         | FilterProp::HasXInActivationCost
         | FilterProp::WasKicked

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -970,6 +970,7 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
             FilterProp::HasSingleTarget => parts.push("single target".into()),
             FilterProp::Modal => parts.push("modal spell".into()),
             FilterProp::FaceDown => parts.push("face-down".into()),
+            FilterProp::Transformed => parts.push("transformed".into()),
             FilterProp::TargetsOnly { filter } => {
                 parts.push(format!("targets only {}", fmt_target(filter)));
             }

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -220,6 +220,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::AttackedOrBlockedThisTurn
         | FilterProp::CountersPutOnThisTurn { .. }
         | FilterProp::FaceDown
+        | FilterProp::Transformed
         | FilterProp::HasXInManaCost
         | FilterProp::WasKicked
         | FilterProp::HasXInActivationCost
@@ -444,6 +445,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::AttackedOrBlockedThisTurn
         | FilterProp::CountersPutOnThisTurn { .. }
         | FilterProp::FaceDown
+        | FilterProp::Transformed
         | FilterProp::HasXInManaCost
         | FilterProp::WasKicked
         | FilterProp::HasXInActivationCost
@@ -3138,6 +3140,7 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         // permanent — fail closed against the spell-cast snapshot.
         | FilterProp::CountersPutOnThisTurn { .. }
         | FilterProp::FaceDown
+        | FilterProp::Transformed
         | FilterProp::TargetsOnly { .. }
         | FilterProp::Targets { .. }
         // CR 201.2: Source-/target-relative name predicates require
@@ -4165,6 +4168,9 @@ fn matches_filter_prop(
         // stack entry's actual targets.
         // CR 707.2: Match face-down permanents on the battlefield.
         FilterProp::FaceDown => obj.face_down,
+        // CR 701.27g: Match transformed permanents (a transforming DFC on the
+        // battlefield with its back face up).
+        FilterProp::Transformed => obj.transformed,
         // CR 115.9c: If the object is a stack entry, ALL of its targets must match
         // the inner filter. Falls back permissive for non-stack objects so trigger
         // matchers remain the primary authority (they validate separately).
@@ -4586,6 +4592,7 @@ fn zone_change_record_matches_property(
         | FilterProp::AttachedToSource
         | FilterProp::AttachedToRecipient
         | FilterProp::FaceDown
+        | FilterProp::Transformed
         | FilterProp::Foretold
         // CR 201.2: Name-matches-any-permanent is a live-battlefield predicate
         // — a zone-change snapshot cannot represent it. Fail closed.
@@ -6810,6 +6817,26 @@ mod tests {
         let filter =
             TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Tapped]));
         assert!(matches_target_filter(&state, id, &filter, id));
+    }
+
+    // CR 701.27g: `Transformed` matches only permanents whose back face is up.
+    #[test]
+    fn transformed_property_matches_only_transformed() {
+        let mut state = setup();
+        let transformed = add_creature(&mut state, PlayerId(0), "Back Face");
+        let normal = add_creature(&mut state, PlayerId(0), "Front Face");
+        state.objects.get_mut(&transformed).unwrap().transformed = true;
+
+        let filter =
+            TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Transformed]));
+        assert!(
+            matches_target_filter(&state, transformed, &filter, transformed),
+            "a transformed permanent must match"
+        );
+        assert!(
+            !matches_target_filter(&state, normal, &filter, normal),
+            "a non-transformed permanent must not match"
+        );
     }
 
     // CR 702.171b: `IsSaddled` matches only objects with the saddled designation.

--- a/crates/engine/src/parser/oracle_nom/filter.rs
+++ b/crates/engine/src/parser/oracle_nom/filter.rs
@@ -159,6 +159,8 @@ pub fn parse_property_filter(input: &str) -> OracleResult<'_, FilterProp> {
         value(FilterProp::Token, tag("token")),
         value(FilterProp::NonToken, tag("nontoken")),
         value(FilterProp::FaceDown, tag("face down")),
+        // CR 701.27g: "transformed permanent"/"transformed creature" selector.
+        value(FilterProp::Transformed, tag("transformed")),
         value(FilterProp::Unblocked, tag("unblocked")),
         value(FilterProp::Suspected, tag("suspected")),
         value(FilterProp::Renowned, tag("renowned")),
@@ -529,6 +531,14 @@ mod tests {
         let (rest, p) = parse_property_filter("face down").unwrap();
         assert_eq!(p, FilterProp::FaceDown);
         assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn test_parse_property_filter_transformed() {
+        // CR 701.27g: "transformed permanent" selector (Mutagen Connoisseur).
+        let (rest, p) = parse_property_filter("transformed permanent").unwrap();
+        assert_eq!(p, FilterProp::Transformed);
+        assert_eq!(rest, " permanent");
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -5829,6 +5829,31 @@ mod tests {
         }
     }
 
+    /// CR 701.27g: "for each transformed permanent you control" counts
+    /// transformed permanents through the shared typed-filter grammar. Reverting
+    /// the `FilterProp::Transformed` adjective support drops the property and
+    /// collapses Mutagen Connoisseur's static to a flat modifier.
+    #[test]
+    fn for_each_transformed_permanent_you_control() {
+        let qty = parse_for_each_clause("transformed permanent you control").unwrap();
+        match qty {
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(typed),
+            } => {
+                assert_eq!(typed.controller, Some(ControllerRef::You));
+                assert!(
+                    typed
+                        .properties
+                        .iter()
+                        .any(|property| matches!(property, FilterProp::Transformed)),
+                    "expected Transformed property, got {:?}",
+                    typed.properties
+                );
+            }
+            other => panic!("Expected ObjectCount over Typed filter, got {other:?}"),
+        }
+    }
+
     /// CR 608.2c + CR 109.5: Tempt with Discovery's
     /// bonus-tutor-per-accepting-opponent step parses as a player-action count.
     /// Verb tense (searches/searched) and article (a/their) variants produce

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -26381,6 +26381,46 @@ fn static_self_dynamic_pump_for_each_other_creature_on_battlefield_with_keyword(
     );
 }
 
+/// CR 701.27g + CR 613.4c: Mutagen Connoisseur's "for each transformed
+/// permanent you control" must lower through the production static parser to a
+/// dynamic object count over `FilterProp::Transformed`, not a flat +1/+0 pump.
+#[test]
+fn static_self_gets_dynamic_power_for_each_transformed_permanent() {
+    let def = parse_static_line("~ gets +1/+0 for each transformed permanent you control.")
+        .expect("Mutagen Connoisseur dynamic P/T static must parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+
+    let dynamic_power = def
+        .modifications
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::AddDynamicPower { value } => Some(value),
+            _ => None,
+        })
+        .expect("expected AddDynamicPower, not a flat +1 modifier");
+
+    match dynamic_power {
+        QuantityExpr::Ref {
+            qty:
+                QuantityRef::ObjectCount {
+                    filter: TargetFilter::Typed(typed),
+                },
+        } => {
+            assert_eq!(typed.controller, Some(ControllerRef::You));
+            assert!(
+                typed
+                    .properties
+                    .iter()
+                    .any(|p| matches!(p, FilterProp::Transformed)),
+                "power must count transformed permanents, got {:?}",
+                typed.properties
+            );
+        }
+        other => panic!("expected ObjectCount over a Transformed filter, got {other:?}"),
+    }
+}
+
 /// CR 205.4a + CR 205.4g + CR 613.1d (Layer 4): Glittering Frost's "Enchanted
 /// land is snow." is an Aura that grants the Snow supertype (not a card type)
 /// to the enchanted land. It must lower to a `Continuous` static carrying

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -4193,6 +4193,10 @@ pub(crate) fn parse_combat_status_prefix(text: &str) -> Option<(FilterProp, usiz
                 | FilterProp::IsSaddled
                 | FilterProp::ProtectorMatches { .. }
                 | FilterProp::FaceDown
+                // CR 701.27g: "transformed" is a battlefield designation that appears
+                // as an adjective prefix in type phrases ("transformed permanent",
+                // Mutagen Connoisseur).
+                | FilterProp::Transformed
                 // CR 701.60b: "suspected" is a battlefield designation that appears
                 // as an adjective prefix in type phrases ("suspected creatures").
                 | FilterProp::Suspected

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3757,6 +3757,12 @@ pub enum FilterProp {
     /// CR 707.2: Matches face-down objects on the battlefield.
     /// Used for "face-down creature" trigger subjects.
     FaceDown,
+    /// CR 701.27g: Matches transformed permanents — a transforming double-faced
+    /// permanent on the battlefield with its back face up. Used for "transformed
+    /// permanent"/"transformed creature" selectors (Mutagen Connoisseur's "+1/+0
+    /// for each transformed permanent you control"). Mirrors `FaceDown`/`Tapped`:
+    /// a per-object battlefield state read from `GameObject::transformed`.
+    Transformed,
     /// CR 115.9c: Matches stack entries whose targets ALL satisfy the given filter.
     /// Used for "that targets only ~", "that targets only a single creature you control", etc.
     /// Permissive at the per-object filter level; validated against the stack entry's actual


### PR DESCRIPTION
Closes #5439.

## The bug

**Mutagen Connoisseur** — *"This creature gets +1/+0 for each transformed permanent you control."* — parsed to a **flat** `AddPower{1}/AddToughness{0}`. The *"for each transformed permanent you control"* scaling was silently dropped, so the card always gets +1/+0 instead of +N/+0. The parser's own swallow-audit flags a `DynamicQty` `SwallowedClause` on the line.

## Root cause

Isolation shows only the **transformed** quality is affected — `tapped`, `face-down`, `artifact`, `creature` all scale correctly:

| Phrase | Scales today |
|---|---|
| `for each tapped permanent you control` | ✅ |
| `for each artifact you control` | ✅ |
| `for each transformed permanent you control` | ❌ (flat) |

`FilterProp` has boolean battlefield-state qualities (`Tapped`, `FaceDown`, `Suspected`, `IsSaddled`, …) recognized as type-phrase adjective prefixes, but no `Transformed` variant — even though `GameObject::transformed` already exists.

## Fix

Adds `FilterProp::Transformed`, the **symmetric sibling of `FilterProp::FaceDown`** — a per-object battlefield state read from `GameObject::transformed`:
- recognized as an adjective prefix (`transformed permanent`/`transformed creature`) via `parse_property_filter` + the `parse_combat_status_prefix` whitelist;
- matched at runtime in `filter.rs` (`FilterProp::Transformed => obj.transformed`);
- threaded through the axis-classification lists / coverage display alongside `FaceDown`.

**No runtime state change** — the object flag was already tracked; this only lets the parser build the count/selector that reads it. Consistent with the existing individual-variant design for boolean state qualities (`Suspected`, `Renowned`, `IsSaddled` were all added the same way), so no parameterization refactor is implied.

## Tests

- `test_parse_property_filter_transformed` — `"transformed permanent"` → `FilterProp::Transformed`.
- `transformed_property_matches_only_transformed` — the filter matches a transformed permanent and rejects a normal one.

## Verification

`cargo fmt --all` ✓ · engine lib suite **15,904 pass / 0 fail** + 2 new ✓ · `clippy -p engine --all-targets -D warnings` clean ✓

CR 711.4.
