### PR TITLE
feat(parser): parse mixed variable+fixed P/T grant (Cranial Ram +X/+1)

### DIFF
--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -1063,8 +1063,11 @@ pub(crate) fn parse_dynamic_pt_in_text(
     let after_verb = nom_tag_lower(after_gets, after_gets, "gets ")
         .or_else(|| nom_tag_lower(after_gets, after_gets, "get "))?;
 
-    // CR 613.4c: Parse variable P/T pattern via nom combinator
-    let (_, (p_sign, p_is_x, t_sign, t_is_x)) = parse_variable_pt_pattern(after_verb).ok()?;
+    // CR 613.4c: Parse variable P/T pattern via nom combinator. Each axis is
+    // either the variable X (`None`) or a fixed magnitude (`Some(n)`).
+    let (_, (p_sign, p_mag, t_sign, t_mag)) = parse_variable_pt_pattern(after_verb).ok()?;
+    let p_is_x = p_mag.is_none();
+    let t_is_x = t_mag.is_none();
 
     if !p_is_x && !t_is_x {
         return None; // No X variable — not a dynamic P/T pattern
@@ -1093,27 +1096,38 @@ pub(crate) fn parse_dynamic_pt_in_text(
     };
 
     let mut mods = Vec::new();
-    if p_is_x {
-        let qty = if p_sign < 0 {
-            QuantityExpr::Multiply {
-                factor: -1,
-                inner: Box::new(quantity.clone()),
-            }
-        } else {
-            quantity.clone()
-        };
-        mods.push(ContinuousModification::AddDynamicPower { value: qty });
+    // CR 613.4c layer 7c: the dynamic axis grants an X-valued modification; a
+    // fixed nonzero axis grants a constant modification alongside it (the mixed
+    // "+X/+1" case). A fixed `0` axis contributes nothing.
+    match p_mag {
+        None => {
+            let qty = if p_sign < 0 {
+                QuantityExpr::Multiply {
+                    factor: -1,
+                    inner: Box::new(quantity.clone()),
+                }
+            } else {
+                quantity.clone()
+            };
+            mods.push(ContinuousModification::AddDynamicPower { value: qty });
+        }
+        Some(n) if n != 0 => mods.push(ContinuousModification::AddPower { value: p_sign * n }),
+        Some(_) => {}
     }
-    if t_is_x {
-        let qty = if t_sign < 0 {
-            QuantityExpr::Multiply {
-                factor: -1,
-                inner: Box::new(quantity),
-            }
-        } else {
-            quantity
-        };
-        mods.push(ContinuousModification::AddDynamicToughness { value: qty });
+    match t_mag {
+        None => {
+            let qty = if t_sign < 0 {
+                QuantityExpr::Multiply {
+                    factor: -1,
+                    inner: Box::new(quantity),
+                }
+            } else {
+                quantity
+            };
+            mods.push(ContinuousModification::AddDynamicToughness { value: qty });
+        }
+        Some(n) if n != 0 => mods.push(ContinuousModification::AddToughness { value: t_sign * n }),
+        Some(_) => {}
     }
 
     Some(mods)

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -7,7 +7,7 @@ use super::prelude::*;
 use super::support::*;
 use crate::types::ability::PlayerFilter;
 use nom::character::complete::{alphanumeric1, char, digit1, one_of};
-use nom::combinator::{all_consuming, map, not, opt, peek, recognize};
+use nom::combinator::{all_consuming, map_res, not, opt, peek, recognize};
 use nom::sequence::{delimited, pair};
 
 /// Lower a parsed rule-static predicate into the runtime static mode.
@@ -1063,7 +1063,7 @@ pub(crate) fn parse_variable_pt_pattern(
         // (`0` included, so "+x/+0" still yields no toughness modification).
         let (rest, mag) = alt((
             value(None, tag("x")),
-            map(digit1, |d: &str| Some(d.parse::<i32>().unwrap_or(0))),
+            map_res(digit1, |d: &str| d.parse::<i32>().map(Some)),
         ))
         .parse(rest)?;
         Ok((rest, (sign, mag)))

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -7,7 +7,7 @@ use super::prelude::*;
 use super::support::*;
 use crate::types::ability::PlayerFilter;
 use nom::character::complete::{alphanumeric1, char, digit1, one_of};
-use nom::combinator::{all_consuming, not, opt, peek, recognize};
+use nom::combinator::{all_consuming, map, not, opt, peek, recognize};
 use nom::sequence::{delimited, pair};
 
 /// Lower a parsed rule-static predicate into the runtime static mode.
@@ -1041,15 +1041,37 @@ pub(crate) fn remove_trailing_quote_connector(text: &mut String) {
 /// Returns AddDynamicPower + AddDynamicToughness modifications if found.
 /// CR 613.4c: Parse a variable P/T modifier pattern like "+x/+x", "-x/-0", "+0/-x".
 /// Returns (power_sign, power_is_x, toughness_sign, toughness_is_x) and remaining text.
+/// CR 613.4c: parse a variable P/T grant body "±P/±T" where each axis is either
+/// the variable X (dynamic — returned as `None`) or a fixed integer magnitude
+/// (returned as `Some(n)`, `n >= 0`). Accepting a fixed magnitude alongside X is
+/// what lets a MIXED grant like Cranial Ram "+X/+1" parse: previously each axis
+/// was restricted to `x`/`0`, so the fixed `+1` failed `digit`-matching and the
+/// whole pattern was rejected, dropping the equip static. The sign is returned
+/// separately per axis so the caller applies it uniformly to the dynamic
+/// quantity or the fixed magnitude.
+/// Parsed axes of a variable P/T grant: `(p_sign, p_mag, t_sign, t_mag)` where
+/// each `*_mag` is `None` for the variable X (dynamic) or `Some(n)` for a fixed
+/// integer magnitude.
+type VariablePtAxes = (i32, Option<i32>, i32, Option<i32>);
+
 pub(crate) fn parse_variable_pt_pattern(
     input: &str,
-) -> nom::IResult<&str, (i32, bool, i32, bool), OracleError<'_>> {
-    let (rest, p_sign) = alt((value(-1i32, tag("-")), value(1i32, tag("+")))).parse(input)?;
-    let (rest, p_is_x) = alt((value(true, tag("x")), value(false, tag("0")))).parse(rest)?;
+) -> nom::IResult<&str, VariablePtAxes, OracleError<'_>> {
+    fn axis(input: &str) -> nom::IResult<&str, (i32, Option<i32>), OracleError<'_>> {
+        let (rest, sign) = alt((value(-1i32, tag("-")), value(1i32, tag("+")))).parse(input)?;
+        // `None` == the variable X (dynamic); `Some(n)` == a fixed magnitude
+        // (`0` included, so "+x/+0" still yields no toughness modification).
+        let (rest, mag) = alt((
+            value(None, tag("x")),
+            map(digit1, |d: &str| Some(d.parse::<i32>().unwrap_or(0))),
+        ))
+        .parse(rest)?;
+        Ok((rest, (sign, mag)))
+    }
+    let (rest, (p_sign, p_mag)) = axis(input)?;
     let (rest, _) = tag("/").parse(rest)?;
-    let (rest, t_sign) = alt((value(-1i32, tag("-")), value(1i32, tag("+")))).parse(rest)?;
-    let (rest, t_is_x) = alt((value(true, tag("x")), value(false, tag("0")))).parse(rest)?;
-    Ok((rest, (p_sign, p_is_x, t_sign, t_is_x)))
+    let (rest, (t_sign, t_mag)) = axis(rest)?;
+    Ok((rest, (p_sign, p_mag, t_sign, t_mag)))
 }
 
 pub(crate) fn parse_fixed_pt_in_text(lower: &str) -> Option<(i32, i32)> {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -13591,6 +13591,39 @@ fn dynamic_pt_in_text_minus_x_over_0_without_where_clause_defaults_to_cost_x_pai
 }
 
 #[test]
+fn dynamic_pt_in_text_mixed_dynamic_power_fixed_toughness() {
+    // CR 613.4c layer 7c: a MIXED "+X/+1" grant (Cranial Ram, "Equipped
+    // creature gets +X/+1, where X is the number of artifacts you control")
+    // must emit BOTH an X-valued power modification and a CONSTANT +1
+    // toughness modification. Before `parse_variable_pt_pattern` accepted a
+    // fixed magnitude per axis, the `+1` failed the pattern and the entire
+    // equip static was dropped.
+    let mods = parse_dynamic_pt_in_text(
+        "equipped creature gets +x/+1",
+        Some("the number of artifacts you control"),
+    )
+    .expect("mixed +X/+1 grant must emit modifications");
+
+    assert!(
+        mods.iter()
+            .any(|m| matches!(m, ContinuousModification::AddDynamicPower { .. })),
+        "expected AddDynamicPower for the X power axis, got {mods:?}"
+    );
+    assert!(
+        mods.iter()
+            .any(|m| matches!(m, ContinuousModification::AddToughness { value: 1 })),
+        "expected fixed AddToughness {{ value: 1 }} for the +1 toughness axis, got {mods:?}"
+    );
+    // The fixed +1 toughness must be a constant, never a dynamic modification.
+    assert!(
+        !mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::AddDynamicToughness { .. })),
+        "fixed +1 toughness must not be dynamic, got {mods:?}"
+    );
+}
+
+#[test]
 fn dynamic_pt_in_text_minus_x_over_minus_x_without_where_clause_defaults_both_to_cost_x_paid() {
     // CR 107.3i: Symmetric -X/-X with no binding clause must default both
     // legs to `QuantityRef::CostXPaid` wrapped in


### PR DESCRIPTION
## Problem

`parse_variable_pt_pattern` restricted each P/T axis of a variable grant to `x` or `0`. A **mixed** grant — one dynamic axis and one fixed nonzero axis — failed the pattern outright, so the whole static was dropped.

The clearest example is **Cranial Ram**: `Equipped creature gets +X/+1, where X is the number of artifacts you control.` The `+1` toughness could not be represented, so the equip static produced no P/T modification at all.

## Fix

- `parse_variable_pt_pattern` (grammar.rs) now parses each axis as **either** the variable X (dynamic, returned as `None`) **or** a fixed integer magnitude (`Some(n)`).
- `parse_dynamic_pt_in_text` (anthem.rs) emits a constant `AddPower`/`AddToughness` for a fixed nonzero axis alongside the `AddDynamicPower`/`AddDynamicToughness` for the dynamic axis (CR 613.4c layer 7c).
- A fixed `0` axis still contributes nothing, so `+X/+0`, `-X/-X`, `+0/+X`, etc. are unchanged.

## Tests

- New `dynamic_pt_in_text_mixed_dynamic_power_fixed_toughness` asserts `+X/+1` emits both the X power modification and a constant `AddToughness { value: 1 }` (and that the fixed axis is not dynamic).
- All existing dynamic-P/T tests (`+X/+0`, `-X/-0`, `-X/-X`, `+0/+X`, cost-X defaults) remain green — the fixed-`0` path preserves their behavior.
- Full `parser::oracle_static` module: 1070 passed. `cargo fmt`, clippy (`-D warnings`), and the parser-combinator / engine-authorities gates are clean.