### PR TITLE
feat(parser): attach put Equipment to source follow-up (The Invincible Iron Man) (#4796)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1334,6 +1334,76 @@ fn parse_its_a_card_type_gate_body<'a>(
     ))
 }
 
+/// CR 608.2c + CR 301.5b + CR 701.3a: "If it's a[n] &lt;subtype&gt;, [you may] attach
+/// it to ~" follow-up on a just-put permanent (The Invincible Iron Man: "put an
+/// artifact card from your hand onto the battlefield. If it's an Equipment,
+/// attach it to ~"). The bare-"it" anaphor (CR 608.2c) binds to the moved card,
+/// and "~" (CR 201.5) is the ability's own source. Recognized as a UNIT so the
+/// generic "it's a [subtype]" condition arm can't mis-key the type gate to the
+/// ability's injected parent target (the source, not the moved card) or emit a
+/// self-attach `ParentTarget`/`ParentTarget` (an Equipment can't equip itself,
+/// CR 301.5c).
+///
+/// Emits the supported `ZoneChangedThisWay` + `Attach` forward_result idiom: the
+/// condition gates on the moved card's type (read from `last_zone_changed_ids`,
+/// independent of the target slot); the attach makes the moved card (`SelfRef`,
+/// rebound to the forwarded object at resolution) the attachment and the source
+/// (`ParentTarget`, the injected original source) the host. Only the
+/// source-as-host recipient ("~") is in scope; typed hosts remain an honest gap.
+/// Returns `(condition, attach_effect, attach_is_optional)`.
+pub(super) fn try_parse_moved_card_subtype_attach_followup(
+    text: &str,
+) -> Option<(AbilityCondition, Effect, bool)> {
+    let lower = text.to_lowercase();
+    let trimmed = lower.trim();
+    // Leading anaphoric gate: "if it's a "/"if it's an ".
+    let (after_gate, _) = alt((
+        tag::<_, _, OracleError<'_>>("if it's a "),
+        tag("if it's an "),
+    ))
+    .parse(trimmed)
+    .ok()?;
+    // Split the subtype phrase from the "attach ..." body on the first comma.
+    let (_, (subtype_phrase, body)) = nom_primitives::split_once_on(after_gate, ", ").ok()?;
+    // Require a pure subtype gate (Equipment/Aura/Fortification, ...): the type
+    // phrase must consume fully and reference at least one CR 205.3 subtype.
+    let (filter, leftover) = parse_type_phrase(subtype_phrase);
+    if !leftover.trim().is_empty() {
+        return None;
+    }
+    let TargetFilter::Typed(typed) = &filter else {
+        return None;
+    };
+    if !typed
+        .type_filters
+        .iter()
+        .any(type_filter_references_subtype)
+    {
+        return None;
+    }
+    // Body: "[you may ]attach it to ~[.]" — only the source host ("~") is in scope.
+    let (after_may, is_optional) = opt(tag::<_, _, OracleError<'_>>("you may "))
+        .parse(body)
+        .map(|(rest, matched)| (rest, matched.is_some()))
+        .unwrap_or((body, false));
+    let (after_attach, _) = tag::<_, _, OracleError<'_>>("attach it to ")
+        .parse(after_may)
+        .ok()?;
+    let (after_source, _) = tag::<_, _, OracleError<'_>>("~").parse(after_attach).ok()?;
+    let (after_dot, _) = opt(tag::<_, _, OracleError<'_>>("."))
+        .parse(after_source)
+        .ok()?;
+    if !after_dot.trim().is_empty() {
+        return None;
+    }
+    let condition = AbilityCondition::ZoneChangedThisWay { filter };
+    let attach = Effect::Attach {
+        attachment: TargetFilter::SelfRef,
+        target: TargetFilter::ParentTarget,
+    };
+    Some((condition, attach, is_optional))
+}
+
 pub(super) fn strip_card_type_conditional(text: &str) -> (Option<AbilityCondition>, String) {
     if let Some((condition, remainder)) = parse_if_revealed_card_type_conditional(text) {
         return (Some(condition), remainder);
@@ -8518,6 +8588,65 @@ mod tests {
         let (prop, use_lki) = single_prop(&cond);
         assert_eq!(*prop, FilterProp::WasDealtDamageThisTurn);
         assert!(use_lki, "past-tense look-back must use LKI per CR 400.7");
+    }
+
+    /// Issue #4796 (CR 608.2c + CR 301.5b): "if it's a[n] <subtype>, attach it
+    /// to ~" recognizer — The Invincible Iron Man's Equipment self-attach
+    /// follow-up. Emits `ZoneChangedThisWay{Equipment}` + `Attach{SelfRef,
+    /// ParentTarget}` (moved card is the attachment, source is the host), not a
+    /// self-attach and not a wrong-subject `TargetMatchesFilter`.
+    #[test]
+    fn moved_card_subtype_attach_followup_equipment_to_source() {
+        let (cond, effect, is_optional) =
+            try_parse_moved_card_subtype_attach_followup("if it's an equipment, attach it to ~.")
+                .expect("Iron Man Equipment attach follow-up must be recognized");
+        assert!(!is_optional, "the attach itself is mandatory once gated");
+        match cond {
+            AbilityCondition::ZoneChangedThisWay { filter } => match filter {
+                TargetFilter::Typed(t) => assert!(
+                    t.type_filters.iter().any(|f| matches!(
+                        f,
+                        TypeFilter::Subtype(s) if s.eq_ignore_ascii_case("Equipment")
+                    )),
+                    "expected Equipment subtype gate, got {:?}",
+                    t.type_filters
+                ),
+                other => panic!("expected Typed Equipment filter, got {other:?}"),
+            },
+            other => panic!("expected ZoneChangedThisWay condition, got {other:?}"),
+        }
+        assert!(
+            matches!(
+                effect,
+                Effect::Attach {
+                    attachment: TargetFilter::SelfRef,
+                    target: TargetFilter::ParentTarget,
+                }
+            ),
+            "moved card must be the attachment (SelfRef) and the source the host (ParentTarget), got {effect:?}"
+        );
+    }
+
+    /// The recognizer is scoped to the "attach it to ~" self-host body and to
+    /// CR 205.3 subtype gates: it declines non-attach bodies, core-type gates,
+    /// and typed (non-source) hosts so those fall through to the generic path.
+    #[test]
+    fn moved_card_subtype_attach_followup_declines_out_of_scope() {
+        // No "attach it to ~" body (reveal/scry-style follow-up).
+        assert!(try_parse_moved_card_subtype_attach_followup(
+            "if it's an equipment, you draw a card."
+        )
+        .is_none());
+        // Core type, not a CR 205.3 subtype.
+        assert!(try_parse_moved_card_subtype_attach_followup(
+            "if it's a creature, attach it to ~."
+        )
+        .is_none());
+        // Typed host (not the source "~") is an honest gap.
+        assert!(try_parse_moved_card_subtype_attach_followup(
+            "if it's an equipment, attach it to a creature you control."
+        )
+        .is_none());
     }
 
     /// CR 608.2c: Faller's Faithful "that creature wasn't dealt damage this turn"

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23800,6 +23800,45 @@ pub(crate) fn parse_effect_chain_ir(
             }
         }
 
+        // CR 608.2c + CR 301.5b + CR 701.3a: "put a permanent onto the battlefield.
+        // If it's a[n] <subtype>, attach it to ~" (The Invincible Iron Man). The
+        // moved card is the attachment and the ability's source is the host.
+        // Recognized as a UNIT — guarded on a preceding battlefield-put so it can't
+        // hijack reveal/scry-context "if it's a[n] X, ..." clauses — so the generic
+        // conditional cascade below can't mis-key the type gate to the injected
+        // parent target or emit an illegal self-attach. Sequential-clause assembly
+        // folds this into the put's `sub_ability`; `rewire_result_anchored_subchain`
+        // then re-affirms `forward_result` (moved card -> Attach source; original
+        // source -> injected target).
+        let prev_moves_to_battlefield = clauses
+            .iter()
+            .rev()
+            .find(|c| !c.absorbed_by_followup)
+            .is_some_and(|c| {
+                matches!(
+                    &c.parsed.effect,
+                    Effect::ChangeZone {
+                        destination: Zone::Battlefield,
+                        ..
+                    } | Effect::Dig {
+                        destination: Some(Zone::Battlefield),
+                        ..
+                    }
+                )
+            });
+        if prev_moves_to_battlefield {
+            if let Some((condition, attach, is_optional)) =
+                try_parse_moved_card_subtype_attach_followup(normalized_text)
+            {
+                let mut clause = meld_single_clause(attach, normalized_text);
+                clause.boundary = chunk.boundary_after;
+                clause.condition = Some(condition);
+                clause.is_optional = is_optional;
+                clauses.push(clause);
+                continue;
+            }
+        }
+
         // CR 118.9: Alternative-cost rider — "[If you cast a spell
         // this way,] pay <ability-cost> rather than paying its mana cost."
         // This is a *modifier* on the previous chain entry's `CastFromZone`

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -38413,6 +38413,66 @@ fn attach_just_moved_armored_skyhunter_dig_with_zone_changed_this_way() {
     }
 }
 
+/// The Invincible Iron Man (issue #4796): "you may put an artifact card from
+/// your hand onto the battlefield. If it's an Equipment, attach it to ~." The
+/// put is a hand->battlefield ChangeZone; the follow-up must attach the moved
+/// Equipment (`SelfRef`, rebound to the forwarded object via `forward_result`)
+/// to the source (`ParentTarget`), gated by `ZoneChangedThisWay{Equipment}` —
+/// NOT the pre-fix self-attach (`ParentTarget`/`ParentTarget`, illegal per CR
+/// 301.5c) with a wrong-subject `TargetMatchesFilter`.
+#[test]
+fn attach_just_moved_iron_man_put_from_hand_attach_equipment_to_source() {
+    use crate::types::ability::TypeFilter;
+    let def = parse_effect_chain(
+        "You may put an artifact card from your hand onto the battlefield. If it's an Equipment, attach it to ~.",
+        AbilityKind::Spell,
+    );
+    // Parent: hand->battlefield ChangeZone with forward_result.
+    match &*def.effect {
+        Effect::ChangeZone { destination, .. } => {
+            assert_eq!(*destination, Zone::Battlefield);
+        }
+        other => panic!("expected outer hand->battlefield ChangeZone, got {other:?}"),
+    }
+    assert!(
+        def.forward_result,
+        "the put parent must forward the moved card to the Attach sub_ability"
+    );
+    // Sub: Attach{attachment: SelfRef (moved card), target: ParentTarget (source)}.
+    let attach = def
+        .sub_ability
+        .as_ref()
+        .expect("expected Attach sub_ability for the Equipment follow-up");
+    match &*attach.effect {
+        Effect::Attach { attachment, target } => {
+            assert!(
+                matches!(attachment, TargetFilter::SelfRef),
+                "attachment must be the moved card (SelfRef), got {attachment:?}"
+            );
+            assert!(
+                matches!(target, TargetFilter::ParentTarget),
+                "host must be the source (ParentTarget), not a self-attach, got {target:?}"
+            );
+        }
+        other => panic!("expected Attach sub_ability, got {other:?}"),
+    }
+    // Condition gates on the MOVED card's type (ZoneChangedThisWay), not the
+    // ability's first target slot (the pre-fix TargetMatchesFilter bug).
+    match &attach.condition {
+        Some(AbilityCondition::ZoneChangedThisWay { filter }) => match filter {
+            TargetFilter::Typed(t) => assert!(
+                t.type_filters.iter().any(
+                    |f| matches!(f, TypeFilter::Subtype(s) if s.eq_ignore_ascii_case("Equipment"))
+                ),
+                "expected Equipment subtype on ZoneChangedThisWay, got {:?}",
+                t.type_filters
+            ),
+            other => panic!("expected Typed Equipment filter, got {other:?}"),
+        },
+        other => panic!("expected ZoneChangedThisWay condition on Attach, got {other:?}"),
+    }
+}
+
 /// Gilgamesh, Master-at-Arms (issue #3286): any-number Equipment dig-from-among
 /// plus CR 603.12 active-voice reflexive attach to Samurai.
 #[test]


### PR DESCRIPTION
Closes #4796.

**Bug:** The Invincible Iron Man ("At the beginning of combat on your turn, you may put an artifact card from your hand onto the battlefield. If it's an Equipment, attach it to The Invincible Iron Man.") **misparsed** the follow-up: the "if it's an Equipment, attach it to ~" clause lowered to an illegal self-attach `Attach{ParentTarget, ParentTarget}` (an Equipment can't equip itself, CR 301.5c) gated by a wrong-subject `TargetMatchesFilter` that tested the injected source (Iron Man) instead of the just-moved card. So a put Equipment was **never attached**.

**Fix:** A dedicated nom recognizer `try_parse_moved_card_subtype_attach_followup` (in `oracle_effect/conditions.rs`), dispatched in the effect-chunk loop **before** the generic conditional cascade and **guarded on a preceding battlefield put**, emits the already-supported `forward_result` idiom (the same one Armored Skyhunter / Gilgamesh use):
- parent `ChangeZone(Hand→Battlefield)` with `sub_ability` = `Attach{attachment: SelfRef (the moved card, rebound to the forwarded object), target: ParentTarget (the source host)}`
- gated by `ZoneChangedThisWay{Equipment}` (reads the moved card's type, not a target slot)

`rewire_result_anchored_subchain` re-affirms `forward_result`. **No new variant, no new runtime** — the runtime `forward_result` Attach path already resolves this shape.

Sibling cards phrased "if an Equipment **is put onto the battlefield this way**" use a different combinator and are unaffected; typed (non-source) hosts remain an honest gap.

CR 608.2c (later text modifies earlier), CR 301.5b (abilities may attach an Equipment), CR 301.5c (self-attach illegal), CR 701.3a (attach).
