### PR TITLE
feat(parser): anthem subject qualifiers "with a mana ability" / "with no abilities"

### DIFF
--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3043,9 +3043,13 @@ pub(crate) fn parse_continuous_subject_filter(subject: &str) -> Option<TargetFil
         (" with a mana ability", FilterProp::HasManaAbility),
         (" with no abilities", FilterProp::HasNoAbilities),
     ] {
-        if let Ok((_, (base_lower, after))) = nom_primitives::split_once_on(tp.lower, needle) {
-            if after.trim().is_empty() && !base_lower.trim().is_empty() {
-                let base = tp.original[..base_lower.len()].trim();
+        let parse_trailing_qualifier = all_consuming(terminated(
+            take_until::<_, _, OracleError<'_>>(needle),
+            tag::<_, _, OracleError<'_>>(needle),
+        ));
+        if let Ok((_, base_lower)) = parse_trailing_qualifier.parse(tp.lower) {
+            if !base_lower.trim().is_empty() {
+                let base = lower_subslice_to_original(&tp, base_lower)?.trim();
                 return parse_continuous_subject_filter(base).map(|f| add_property(f, prop));
             }
         }

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3043,7 +3043,7 @@ pub(crate) fn parse_continuous_subject_filter(subject: &str) -> Option<TargetFil
         (" with a mana ability", FilterProp::HasManaAbility),
         (" with no abilities", FilterProp::HasNoAbilities),
     ] {
-        let parse_trailing_qualifier = all_consuming(terminated(
+        let mut parse_trailing_qualifier = all_consuming(terminated(
             take_until::<_, _, OracleError<'_>>(needle),
             tag::<_, _, OracleError<'_>>(needle),
         ));

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3028,6 +3028,29 @@ pub(crate) fn parse_continuous_subject_filter(subject: &str) -> Option<TargetFil
         return parse_continuous_subject_filter(rest_tp.original.trim());
     }
 
+    // CR 605.1 / CR 113.1: strip a trailing "with a mana ability" / "with no
+    // abilities" object qualifier, parse the base subject recursively, and
+    // attach the runtime-evaluated `FilterProp`. Covers Raggadragga, Goregutter
+    // ("Each creature you control with a mana ability gets +2/+2"), Muraganda
+    // Petroglyphs ("Creatures with no abilities get +2/+2"), and Ruxa, Patient
+    // Professor ("Creatures you control with no abilities get +1/+1"). Both
+    // props are matched authoritatively by `game::filter`
+    // (`HasManaAbility` via the mana-ability classifier, `HasNoAbilities` via
+    // `object_has_no_abilities`), so this is a grammar-only seam. The qualifier
+    // must sit at the very end of the subject phrase (`after` empty) so a
+    // mid-phrase "with ..." clause is not misclaimed.
+    for (needle, prop) in [
+        (" with a mana ability", FilterProp::HasManaAbility),
+        (" with no abilities", FilterProp::HasNoAbilities),
+    ] {
+        if let Ok((_, (base_lower, after))) = nom_primitives::split_once_on(tp.lower, needle) {
+            if after.trim().is_empty() && !base_lower.trim().is_empty() {
+                let base = tp.original[..base_lower.len()].trim();
+                return parse_continuous_subject_filter(base).map(|f| add_property(f, prop));
+            }
+        }
+    }
+
     if let Some(filter) = parse_shared_controller_compound_subject_filter(&tp) {
         return Some(filter);
     }

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -4677,6 +4677,70 @@ fn tempest_hawk_oracle_text_produces_no_unimplemented_static() {
     );
 }
 
+/// Helper: assert a subject qualifier produces a real continuous static (no
+/// `static_structure` Unimplemented) whose affected filter carries `prop_name`.
+fn assert_anthem_carries_prop(text: &str, name: &str, types: &[&str], prop_name: &str) {
+    let r = parse(text, name, &[], types, &[]);
+    let has_static_unimpl = r.abilities.iter().any(
+        |a| matches!(&*a.effect, Effect::Unimplemented { name, .. } if name == "static_structure"),
+    );
+    assert!(
+        !has_static_unimpl,
+        "{name}: qualifier must be structured, but produced static_structure Unimplemented: {:#?}",
+        r.abilities
+    );
+    assert!(
+        !r.statics.is_empty(),
+        "{name}: expected a continuous static, got none"
+    );
+    let dump = format!("{:?}", r.statics);
+    assert!(
+        dump.contains(prop_name),
+        "{name}: affected filter must carry {prop_name}, got {dump}"
+    );
+}
+
+#[test]
+fn anthem_subject_with_mana_ability_qualifier_carries_has_mana_ability() {
+    // CR 605.1: Raggadragga, Goregutter — "Each creature you control with a
+    // mana ability gets +2/+2." The "with a mana ability" object qualifier is
+    // stripped in `parse_continuous_subject_filter` and lowered to the
+    // runtime-evaluated `FilterProp::HasManaAbility`. Before the fix the line
+    // fell through to `Effect::Unimplemented { name: "static_structure", .. }`.
+    assert_anthem_carries_prop(
+        "Each creature you control with a mana ability gets +2/+2.",
+        "Raggadragga, Goregutter",
+        &["Creature"],
+        "HasManaAbility",
+    );
+}
+
+#[test]
+fn anthem_subject_with_no_abilities_qualifier_carries_has_no_abilities() {
+    // CR 113.1: Ruxa, Patient Professor — "Creatures you control with no
+    // abilities get +1/+1." The controller-scoped plural form lowers to
+    // `FilterProp::HasNoAbilities`.
+    assert_anthem_carries_prop(
+        "Creatures you control with no abilities get +1/+1.",
+        "Ruxa, Patient Professor",
+        &["Creature"],
+        "HasNoAbilities",
+    );
+}
+
+#[test]
+fn anthem_global_with_no_abilities_qualifier_carries_has_no_abilities() {
+    // CR 113.1: Muraganda Petroglyphs — "Creatures with no abilities get
+    // +2/+2." The global (no "you control") form lowers to the same
+    // `FilterProp::HasNoAbilities` on an uncontrolled creature subject.
+    assert_anthem_carries_prop(
+        "Creatures with no abilities get +2/+2.",
+        "Muraganda Petroglyphs",
+        &["Enchantment"],
+        "HasNoAbilities",
+    );
+}
+
 #[test]
 fn lost_in_thought_ignore_effect_rider_fails_closed() {
     let r = parse(


### PR DESCRIPTION
## Problem

An anthem subject phrase carrying a **"with a mana ability"** or **"with no abilities"** object qualifier did not parse. No subject-filter arm recognized the qualifier, so the whole static line fell through to `Effect::Unimplemented { name: "static_structure", .. }` and produced **no continuous static**.

Affected real cards:
- **Raggadragga, Goregutter** — `Each creature you control with a mana ability gets +2/+2.`
- **Muraganda Petroglyphs** — `Creatures with no abilities get +2/+2.`
- **Ruxa, Patient Professor** — `Creatures you control with no abilities get +1/+1.`

## Fix

Strip the trailing qualifier in `parse_continuous_subject_filter`, parse the base subject recursively, and attach the matching `FilterProp`. Both properties are **already fully evaluated at runtime** by `game::filter` (`HasManaAbility` via the authoritative mana-ability classifier; `HasNoAbilities` via `object_has_no_abilities`) — so this is a **grammar-only** seam that reuses existing modeling.

Placing it on the shared subject-filter parser covers every subject shape at once — singular (`Each creature you control …`), global (`Creatures …`), controller-scoped plural (`Creatures you control …`), and subtype (`Elf creatures you control …`). The qualifier must sit at the very end of the subject phrase (`after` empty) so a mid-phrase `with …` clause is not misclaimed.

## Tests

Three new `oracle_tests.rs` tests (Raggadragga / Ruxa / Muraganda) assert each line produces a continuous static — **no `static_structure` Unimplemented** — whose affected filter carries the expected `FilterProp`.

Regression: `parser::oracle` module **7604 passed, 0 failed**. `cargo fmt`, clippy (`-D warnings`), and the parser-combinator / engine-authorities gates are clean. The fix lands entirely in `oracle_static/shared.rs`.