### PR TITLE
feat(parser): controller-scoped basic-land-type static subject (Ambush Commander)

### DIFF
--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15460,6 +15460,84 @@ fn lands_you_control_are_creatures_scope_and_pt() {
     }
 }
 
+/// CR 305.6 + CR 109.5 + CR 613.1d + CR 613.4b: a controller-scoped *basic-land-type*
+/// subject ("<basic land type> you control") resolves like its `All <type>` and
+/// `Lands you control` siblings. Ambush Commander — "Forests you control are 1/1
+/// green Elf creatures that are still lands." — previously strict-failed because the
+/// subject parser's basic-land-type arm did not peel the optional " you control"
+/// controller scope (only the generic "lands you control" and bare/`all ` forms
+/// were handled). The peel is a shared subject-parser parameterization, so it also
+/// covers the controller-scoped type-change form, not just this one card.
+#[test]
+fn controller_scoped_basic_land_type_subject_animates() {
+    use crate::types::card_type::CoreType;
+    use crate::types::mana::ManaColor;
+
+    let def =
+        parse_static_line("Forests you control are 1/1 green Elf creatures that are still lands.")
+            .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert!(tf.type_filters.contains(&TypeFilter::Land));
+            assert!(tf
+                .type_filters
+                .contains(&TypeFilter::Subtype("Forest".to_string())));
+            assert_eq!(
+                tf.controller,
+                Some(ControllerRef::You),
+                "\"you control\" must scope the Forest subject to the controller"
+            );
+        }
+        other => panic!("Expected Typed Forest+You land filter, got {other:?}"),
+    }
+    use ContinuousModification as CM;
+    assert_eq!(
+        def.modifications,
+        vec![
+            CM::SetPower { value: 1 },
+            CM::SetToughness { value: 1 },
+            CM::SetColor {
+                colors: vec![ManaColor::Green],
+            },
+            CM::AddType {
+                core_type: CoreType::Creature,
+            },
+            CM::AddSubtype {
+                subtype: "Elf".to_string(),
+            },
+        ],
+    );
+
+    // Same " you control" peel generalizes across the land-static class: a
+    // controller-scoped basic-land-type *type-change* resolves too, proving the fix
+    // is a shared subject-parser parameterization rather than a one-card special case.
+    let type_change = parse_static_line("Mountains you control are Islands.").unwrap();
+    match &type_change.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert!(tf
+                .type_filters
+                .contains(&TypeFilter::Subtype("Mountain".to_string())));
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+        }
+        other => panic!("Expected Typed Mountain+You land filter, got {other:?}"),
+    }
+    assert!(type_change.modifications.iter().any(|m| matches!(
+        m,
+        ContinuousModification::SetBasicLandType { land_type } if *land_type == BasicLandType::Island
+    )));
+
+    // Regression: the unscoped "All Forests" form stays controller-agnostic.
+    let all_forests =
+        parse_static_line("All Forests are 1/1 green Elf creatures that are still lands.").unwrap();
+    match &all_forests.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert!(tf.controller.is_none(), "all Forests — no controller scope")
+        }
+        other => panic!("Expected Typed Forest filter (all Forests), got {other:?}"),
+    }
+}
+
 #[test]
 fn all_lands_are_islands_in_addition_stormtide() {
     let def = parse_static_line("All lands are Islands in addition to their other types.").unwrap();

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -2434,20 +2434,43 @@ pub(crate) fn parse_land_type_change_subject(subject: &str) -> Option<TargetFilt
             // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
             TypedFilter::land().properties(vec![FilterProp::EnchantedBy]),
         )),
-        // CR 305.7: "All <basic land type> are <type>" (Conversion, Glaciers:
-        // "All Mountains are Plains"). The subject is every permanent with the
-        // named basic land subtype; the SetBasicLandType predicate is applied by
-        // the caller. Composes over all five basic land types, not one card.
-        other => {
-            let type_word = opt(tag::<_, _, OracleError<'_>>("all "))
-                .parse(other)
-                .map(|(rest, _)| rest.trim())
-                .unwrap_or(other);
-            parse_basic_land_type_plural(type_word).map(|basic| {
-                TargetFilter::Typed(TypedFilter::land().subtype(basic.as_subtype_str().to_string()))
-            })
-        }
+        // CR 305.6 + CR 305.7: "[all] <basic land type>[s] [you control]" — every
+        // permanent with the named basic land subtype (Conversion, Glaciers "All
+        // Mountains are Plains"), optionally narrowed to the static's controller
+        // (Ambush Commander "Forests you control ..."). Composes over all five basic
+        // land types and both controller scopes, not one card.
+        other => parse_basic_land_type_subject_scoped(other),
     }
+}
+
+/// CR 305.6 + CR 109.5: resolve a plural basic-land-type subject that carries an
+/// optional leading `all ` and an optional trailing ` you control` controller
+/// scope — `Forests`, `all Mountains`, `Forests you control` (Ambush Commander).
+/// The type word is resolved by [`parse_basic_land_type_plural`]; the trailing
+/// controller clause is peeled with nom (`take_until` + `tag`) so the
+/// controller-scoped form reuses the same type grammar as its unscoped sibling
+/// instead of needing its own dispatch arm (CR 109.5: `you` on a static ability's
+/// object refers to that object's controller).
+fn parse_basic_land_type_subject_scoped(subject: &str) -> Option<TargetFilter> {
+    let type_word = opt(tag::<_, _, OracleError<'_>>("all "))
+        .parse(subject)
+        .map(|(rest, _)| rest.trim())
+        .unwrap_or(subject);
+    let (type_word, controller) = match all_consuming(terminated(
+        take_until::<_, _, OracleError<'_>>(" you control"),
+        tag(" you control"),
+    ))
+    .parse(type_word)
+    {
+        Ok((_, head)) => (head, Some(ControllerRef::You)),
+        Err(_) => (type_word, None),
+    };
+    let basic = parse_basic_land_type_plural(type_word)?;
+    let mut filter = TypedFilter::land().subtype(basic.as_subtype_str().to_string());
+    if let Some(controller) = controller {
+        filter = filter.controller(controller);
+    }
+    Some(TargetFilter::Typed(filter))
 }
 
 /// CR 702.73a + CR 205.3 + CR 604.3 + CR 613.1d: Parse "[subject] {is|are}


### PR DESCRIPTION
## Summary

`<basic land type> you control` static subjects strict-failed. **Ambush Commander** — *"Forests you control are 1/1 green Elf creatures that are still lands."* — dropped the entire static, because the land-static subject parser peeled the `you control` controller scope only for the generic **`lands you control`** arm and the bare / **`all <type>`** forms. A subject that combined a *basic land type* with `you control` (`Forests you control`) fell through to the basic-land-type arm, which had no controller handling, and the whole line was lost.

## Fix — parameterize the existing seam (no new sibling handler)

`parse_land_type_change_subject`'s basic-land-type arm now delegates to one small helper, `parse_basic_land_type_subject_scoped`, that peels an **optional leading `all `** and an **optional trailing ` you control`** controller scope before resolving the type:

- The type word is still resolved by the existing `parse_basic_land_type_plural` building block.
- The trailing controller clause is peeled with **nom** (`take_until` + `tag`, `all_consuming`) — no string-method dispatch.
- When present, `ControllerRef::You` narrows the resulting filter, mirroring the existing `lands you control` arm.

Because this is the **shared** subject parser (used by both `parse_land_animation` and `parse_land_type_change`), the same peel covers the controller-scoped **type-change** form too — `"Mountains you control are Islands"` → `SetBasicLandType(Island)` scoped to `You`. It is a class of subjects (every basic land type × both controller scopes), not one card.

Unscoped forms are untouched: `All Forests …`, `Lands you control …`, `All lands …` parse exactly as before; `Creatures you control …` is correctly **not** claimed as a land subject.

## CR

- **CR 305.6** — the five basic land types (Plains/Island/Swamp/Mountain/Forest).
- **CR 109.5** — `you` on a static ability's object refers to that object's controller.
- **CR 613.1d + CR 613.4b** — the animation grants the creature type (layer 4) and base P/T (layer 7b) additively; the land keeps its land types.

## Verification

- `cargo fmt --all` ✓
- parser-combinator gate (`check-parser-combinators.sh upstream/main`) ✓ (exit 0 — nom throughout)
- `parser::oracle_static::tests` — **1022 passed, 0 failed** (no regressions)
- New discriminating test `controller_scoped_basic_land_type_subject_animates` asserts the **full** `StaticDefinition`: affected `Land + Subtype("Forest") + controller(You)` and the exact modification vector `[SetPower 1, SetToughness 1, SetColor Green, AddType Creature, AddSubtype Elf]`; plus the controller-scoped type-change generalization and an `All Forests` controller-agnostic regression.

## Scope

Parser-only. No new `ContinuousModification` / `TargetFilter` variant and no new runtime — reuses the existing land subject grammar, `AddSubtype`/`SetColor`/`SetBasicLandType` modifications, and Layer-4/7b application. CI: none added.
