### PR TITLE
perf(ci): cut card-data-gate from ~12min via write-if-changed subtypes guard, parallel oracle-gen, and cache-gated validate/coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,13 +190,57 @@ jobs:
         # Exact-match only (no restore-keys) — a stale hit would feed wrong
         # card-data into the validate/coverage gates downstream. Cargo.lock is
         # included so dep bumps that affect parsing (e.g. nom) invalidate.
+        #
+        # `crates/engine/data/**` and `build.rs` are hashed because the engine
+        # lib compiles those files IN: oracle-subtypes.json via `include_str!`,
+        # known-tokens.toml via build.rs → OUT_DIR embed. A PR touching only
+        # those changes parser behaviour, so omitting them would serve stale
+        # card-data from this cache and (via gates-cache below) skip the
+        # validate/coverage gates that would have caught it. hashFiles evaluates
+        # at step start against the clean checkout, so oracle-gen's later
+        # write-if-changed rewrite of oracle-subtypes.json cannot feed back in.
+        #
+        # ai-gate.yml carries a `cardgen-` cache whose key EXPRESSION looks
+        # identical, but the two have never shared an entry and cannot: ai-gate
+        # restores its cache before it downloads AtomicCards.json (the download
+        # sits inside its miss-gated Generate step) and that file is gitignored,
+        # so `hashFiles` silently omits it there and the digests always differ.
+        # This expression intentionally supersets ai-gate's; they are independent.
         id: cardgen-cache
         uses: actions/cache@v4
         with:
           path: |
             data/card-data.json
             data/card-names.json
-          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
+          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/data/**', 'crates/engine/build.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
+
+      - name: Cache card-data gate results
+        # Proof-of-passage cache for the two expensive steps that are pure
+        # functions of the same hashed inputs: `card-data-validate` and
+        # `coverage-report`. `actions/cache` writes its entry only when the job
+        # succeeds (`post-if: success()` on the action's post step), so an entry
+        # under this key is evidence that validate AND coverage passed for this
+        # exact input set — which is what licenses skipping them on a hit.
+        # Key expression must stay identical to `cardgen-cache`'s above.
+        #
+        # Deliberately a SEPARATE key from `cardgen-cache`, not a reuse of it.
+        # A cardgen entry proves only that generation succeeded; it is not
+        # evidence that anything validated it. ai-gate.yml generates card-data
+        # and never validates it, and while its `cardgen-` key is de-facto
+        # disjoint from this workflow's today (see the note above), that is an
+        # accident of its step order, not a guarantee. Were ai-gate ever fixed to
+        # genuinely share the key, an engine change whose output fails
+        # `card-data-validate` would red card-data-gate while ai-gate still
+        # succeeded and saved the shared entry — and gating validate on that
+        # entry would skip validation on the next push: a false green. This cache
+        # is written by card-data-gate alone, so a hit cannot lie about a gate.
+        id: gates-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            data/coverage-data.json
+            data/coverage-summary.json
+          key: cardgen-gates-v1-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/data/**', 'crates/engine/build.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
 
       - name: Generate card data
         # All engine-backed tools in this job use the SAME (profile, features)
@@ -212,11 +256,31 @@ jobs:
         # PR-time gate — the same parse the WASM does at runtime, run against
         # the freshly produced card-data. If a parser/schema change makes the
         # engine unable to read its own output, fail the build before merge.
-        # Same [tool, cli] fingerprint as card-gen above → engine cache hit.
+        # Skipped on a gates-cache hit (NOT a cardgen hit — see that step): a
+        # gates entry for this input hash is proof this exact check already
+        # passed. card-data.json is byte-identical either way, restored from
+        # cardgen or regenerated above.
+        # Same [tool, cli] fingerprint as card-gen above → engine cache hit. That
+        # hit is only real because `oracle-gen` rewrites
+        # crates/engine/data/oracle-subtypes.json solely when its bytes change:
+        # the engine lib pulls that file in via `include_str!`, so an
+        # unconditional write would bump its mtime, dirty the crate's dep-info
+        # fingerprint, and force a full engine recompile right here.
+        if: steps.gates-cache.outputs.cache-hit != 'true'
         run: cargo run --profile tool --features cli --bin card-data-validate -- data/card-data.json
 
       - name: Card support coverage report
-        # Same [tool, cli] fingerprint as card-gen above → engine cache hit.
+        # Skipped on a gates-cache hit — coverage-data.json and
+        # coverage-summary.json are restored from it, and both are deterministic
+        # in the same hashed inputs. Nothing downstream mutates either file, so
+        # the cached bytes are exactly this step's output regardless of which ref
+        # populated the entry (the main-only stamp writes a separate .stamped.json
+        # copy). The regression/parse-diff steps below still run unconditionally
+        # and consume the restored files (their R2 baselines move independently
+        # of this cache).
+        # Same [tool, cli] fingerprint as card-gen above → engine cache hit (see
+        # the oracle-subtypes note on the validate step).
+        if: steps.gates-cache.outputs.cache-hit != 'true'
         run: |
           cargo run --profile tool --features cli --bin coverage-report -- data/ --all > data/coverage-data.json
           jq '{total_cards, supported_cards, coverage_pct, coverage_by_format}' data/coverage-data.json > data/coverage-summary.json
@@ -340,13 +404,21 @@ jobs:
         # Embed the same card-data hash in both files so downstream consumers
         # can verify they're reading a consistent R2 snapshot. Gated to main
         # because the only consumer is the R2 upload below.
+        #
+        # coverage-data.json is stamped into a SEPARATE .stamped.json copy, not
+        # rewritten in place: it is a `gates-cache` path, and this step runs
+        # before that cache's post-save. Stamping in place would make the cached
+        # bytes depend on github.ref (main-push entries jq-reserialized and
+        # stamped, PR entries raw), coupling a content-addressed cache to the ref
+        # that happened to populate it. semantic-audit.json is not cached, so it
+        # is still stamped in place. The uploads below publish the stamped copy,
+        # so R2 artifacts keep exactly their current shape.
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           HASH=$(sha256sum data/card-data.json | awk '{print substr($1, 1, 16)}')
           jq --arg h "$HASH" '. + {card_data_hash: $h}' data/semantic-audit.json > data/semantic-audit.json.tmp
           mv data/semantic-audit.json.tmp data/semantic-audit.json
-          jq --arg h "$HASH" '. + {card_data_hash: $h}' data/coverage-data.json > data/coverage-data.json.tmp
-          mv data/coverage-data.json.tmp data/coverage-data.json
+          jq --arg h "$HASH" '. + {card_data_hash: $h}' data/coverage-data.json > data/coverage-data.stamped.json
 
       - name: Upload data to R2 (preview)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -356,7 +428,7 @@ jobs:
         run: |
           npx wrangler r2 object put phase-rs-data/preview/card-data.json --file data/card-data.json --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
           npx wrangler r2 object put phase-rs-data/preview/card-names.json --file data/card-names.json --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
-          npx wrangler r2 object put phase-rs-data/preview/coverage-data.json --file data/coverage-data.json --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
+          npx wrangler r2 object put phase-rs-data/preview/coverage-data.json --file data/coverage-data.stamped.json --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
           npx wrangler r2 object put phase-rs-data/preview/coverage-summary.json --file data/coverage-summary.json --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
           npx wrangler r2 object put phase-rs-data/preview/semantic-audit.json --file data/semantic-audit.json --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
           # changelog{,-meta}.json are committed to client/public/ (not generated
@@ -386,7 +458,7 @@ jobs:
           set -euo pipefail
           HASH="$(./scripts/engine-source-hash.sh HEAD)"
           npx wrangler r2 object put "phase-rs-data/parse-baselines/coverage-data-${HASH}.json" \
-            --file data/coverage-data.json --remote --content-type application/json \
+            --file data/coverage-data.stamped.json --remote --content-type application/json \
             --cache-control "public, max-age=31536000, immutable"
 
   draft-pools:

--- a/crates/engine/src/bin/oracle_gen.rs
+++ b/crates/engine/src/bin/oracle_gen.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process;
+use std::thread;
 
 use serde::{Deserialize, Serialize};
 
@@ -336,6 +337,226 @@ fn build_export_layout(
     }
 }
 
+/// Which `face_index` collision policy a pending face uses. Homonym groups
+/// (distinct cards sharing one printed name) resolve collisions differently
+/// from ordinary faces — see `homonym_face_priority` / `same_class_face_priority`.
+enum FacePriority {
+    SameClass,
+    Homonym,
+}
+
+/// Read-only inputs shared by every worker thread of the per-card parse pass.
+struct CardWorkCtx<'a> {
+    filter_names: &'a [String],
+    stats: bool,
+    token_source_metadata: &'a HashMap<TokenSourceMetadataKey, TokenSourceMetadata>,
+    rarity_map: &'a HashMap<String, BTreeSet<Rarity>>,
+    bracket_lists: &'a BracketLists,
+    #[cfg(feature = "forge")]
+    forge_index: Option<&'a engine::database::forge::ForgeIndex>,
+}
+
+/// One card's fully-parsed export payload. Produced off-thread by
+/// `build_card_work` (Oracle-text parsing dominates the pass at ~5ms/card) and
+/// merged into the order-sensitive shared indexes afterwards, in input order.
+struct CardWork<'a> {
+    mtgjson_key: &'a str,
+    /// Faces to insert into `face_index`, in the order the sequential loop emitted them.
+    entries: Vec<(String, CardExportEntry, FacePriority)>,
+    /// `(face key, source)` pairs destined for the localized sidecars.
+    localized: Vec<(String, &'a AtomicCard)>,
+    /// Number of `cards_with_unimplemented` increments this card contributes.
+    /// A homonym group increments once per unimplemented face, so this is a
+    /// count rather than a flag. Always 0 when `--stats` is off.
+    unimplemented_faces: u32,
+}
+
+/// Parse one MTGJSON atomic group into its export payload. Pure: reads only
+/// `ctx` and `faces`, touches no shared mutable state, so it is safe to run
+/// concurrently across cards. Returns `None` for cards the export skips.
+fn build_card_work<'a>(
+    ctx: &CardWorkCtx<'_>,
+    mtgjson_key: &'a str,
+    faces: &'a [AtomicCard],
+) -> Option<CardWork<'a>> {
+    // Drop officially-removed offensive cards before any other handling,
+    // so they never enter the card database (and not even an explicit
+    // --filter can resurrect them).
+    if faces
+        .first()
+        .is_some_and(|f| is_removed_offensive_card(&f.name))
+    {
+        return None;
+    }
+    // --filter: skip cards not matching any filter name
+    if !ctx.filter_names.is_empty() {
+        let card_name = faces
+            .first()
+            .map(|f| f.name.to_lowercase())
+            .unwrap_or_default();
+        if !ctx.filter_names.iter().any(|n| card_name.contains(n)) {
+            return None;
+        }
+    }
+
+    let mut work = CardWork {
+        mtgjson_key,
+        entries: Vec::new(),
+        localized: Vec::new(),
+        unimplemented_faces: 0,
+    };
+
+    let oracle_id = faces
+        .first()
+        .and_then(|f| f.identifiers.scryfall_oracle_id.clone());
+
+    let layout_kind = map_layout(&faces[0].layout);
+
+    if is_homonym_atomic_group(faces) {
+        for source in faces.iter() {
+            let oracle_id = source.identifiers.scryfall_oracle_id.clone();
+            let mut face = build_oracle_face(source, oracle_id);
+            #[cfg(feature = "forge")]
+            if let Some(fi) = ctx.forge_index {
+                engine::database::forge::apply_forge_fallback(&mut face, fi);
+            }
+            stamp_token_source_metadata(&mut face, source, ctx.token_source_metadata);
+            let key = face.name.to_lowercase();
+            let legalities = legalities_to_export_map(&normalize_legalities(&source.legalities));
+
+            if ctx.stats && card_face_has_unimplemented_parts(&face) {
+                work.unimplemented_faces += 1;
+            }
+
+            let rarities = ctx
+                .rarity_map
+                .get(&face.name.to_lowercase())
+                .cloned()
+                .unwrap_or_default();
+
+            let bracket_signals = bracket_signals_for_face(ctx.bracket_lists, &face, source);
+            work.localized.push((key.clone(), source));
+            work.entries.push((
+                key,
+                CardExportEntry {
+                    face,
+                    legalities,
+                    layout: None,
+                    printings: source.printings.clone(),
+                    rulings: source.rulings.clone(),
+                    rarities,
+                    bracket_signals,
+                },
+                FacePriority::Homonym,
+            ));
+        }
+    } else if faces.len() >= 2 {
+        let mut legalities_by_face = BTreeMap::new();
+        let layout = build_export_layout(faces, oracle_id, layout_kind);
+        for (face, source) in layout_faces(&layout).iter().zip(faces.iter()) {
+            legalities_by_face.insert(
+                face.name.to_lowercase(),
+                legalities_to_export_map(&normalize_legalities(&source.legalities)),
+            );
+        }
+
+        if ctx.stats {
+            let has_unimplemented = layout_faces(&layout)
+                .iter()
+                .any(|f| card_face_has_unimplemented_parts(f));
+            if has_unimplemented {
+                work.unimplemented_faces += 1;
+            }
+        }
+
+        for (face_idx, (face_ref, source)) in layout_faces(&layout)
+            .into_iter()
+            .zip(faces.iter())
+            .enumerate()
+        {
+            let key = face_ref.name.to_lowercase();
+            let legalities = legalities_by_face.remove(&key).unwrap_or_default();
+            let mut face = face_ref.clone();
+            #[cfg(feature = "forge")]
+            if let Some(fi) = ctx.forge_index {
+                engine::database::forge::apply_forge_fallback(&mut face, fi);
+            }
+            stamp_token_source_metadata(&mut face, source, ctx.token_source_metadata);
+            let layout_str = match layout_kind {
+                LayoutKind::Single => None,
+                _ => Some(faces[0].layout.clone()),
+            };
+            // Front face (index 0) owns the rulings; back faces get an empty vec.
+            // MTGJSON duplicates rulings across faces; this dedups at export time.
+            let rulings = if face_idx == 0 {
+                faces[0].rulings.clone()
+            } else {
+                Vec::new()
+            };
+            let rarities = ctx
+                .rarity_map
+                .get(&face.name.to_lowercase())
+                .cloned()
+                .unwrap_or_default();
+            let bracket_signals = bracket_signals_for_face(ctx.bracket_lists, &face, source);
+            // Localized sidecars cover single-faced cards only — see
+            // `collect_localized`. Multi-face `foreignData` is a combined
+            // "A // B" name with no reliable per-face split, so these faces
+            // fall back to English at the display layer.
+            work.entries.push((
+                key,
+                CardExportEntry {
+                    face,
+                    legalities,
+                    layout: layout_str,
+                    printings: faces[0].printings.clone(),
+                    rulings,
+                    rarities,
+                    bracket_signals,
+                },
+                FacePriority::SameClass,
+            ));
+        }
+    } else {
+        let mut face = build_oracle_face(&faces[0], oracle_id);
+        #[cfg(feature = "forge")]
+        if let Some(fi) = ctx.forge_index {
+            engine::database::forge::apply_forge_fallback(&mut face, fi);
+        }
+        stamp_token_source_metadata(&mut face, &faces[0], ctx.token_source_metadata);
+        let key = face.name.to_lowercase();
+        let legalities = legalities_to_export_map(&normalize_legalities(&faces[0].legalities));
+
+        if ctx.stats && card_face_has_unimplemented_parts(&face) {
+            work.unimplemented_faces += 1;
+        }
+
+        let rarities = ctx
+            .rarity_map
+            .get(&face.name.to_lowercase())
+            .cloned()
+            .unwrap_or_default();
+
+        let bracket_signals = bracket_signals_for_face(ctx.bracket_lists, &face, &faces[0]);
+        work.localized.push((key.clone(), &faces[0]));
+        work.entries.push((
+            key,
+            CardExportEntry {
+                face,
+                legalities,
+                layout: None,
+                printings: faces[0].printings.clone(),
+                rulings: faces[0].rulings.clone(),
+                rarities,
+                bracket_signals,
+            },
+            FacePriority::SameClass,
+        ));
+    }
+
+    Some(work)
+}
+
 /// Write parser-authoritative creature subtypes: CardTypes.json ∪ corroborated
 /// AtomicCards harvest (token-only + newer card-printed types).
 fn write_oracle_subtypes(
@@ -351,12 +572,32 @@ fn write_oracle_subtypes(
     // `serde_json::to_string_pretty` does not emit a trailing newline; append one
     // so the committed generated file stays POSIX-compliant (no "\ No newline at
     // end of file" diff churn on every regeneration).
+    //
+    // Write only when the bytes actually change. The engine lib pulls this file
+    // in with `include_str!` (see `parser/oracle_util.rs`), so an unconditional
+    // `fs::write` bumps its mtime, dirties the engine crate's dep-info
+    // fingerprint, and forces a full engine recompile on the next cargo
+    // invocation — a byte-identical file costing ~220s of CI rebuild. This
+    // mirrors the `cmp`/`mv` mtime-preservation dance `scripts/gen-card-data.sh`
+    // performs on `known-tokens.toml` for exactly the same reason.
     match serde_json::to_string_pretty(&list)
         .map_err(|e| e.to_string())
-        .and_then(|json| std::fs::write(&out_path, format!("{json}\n")).map_err(|e| e.to_string()))
-    {
-        Ok(()) => eprintln!(
+        .and_then(|json| {
+            let contents = format!("{json}\n");
+            if std::fs::read_to_string(&out_path).is_ok_and(|prev| prev == contents) {
+                return Ok(false);
+            }
+            std::fs::write(&out_path, contents)
+                .map(|()| true)
+                .map_err(|e| e.to_string())
+        }) {
+        Ok(true) => eprintln!(
             "Wrote {} creature subtypes to {}",
+            list.len(),
+            out_path.display()
+        ),
+        Ok(false) => eprintln!(
+            "Skipped write of {} creature subtypes to {} (unchanged)",
             list.len(),
             out_path.display()
         ),
@@ -845,178 +1086,68 @@ fn main() {
     // tiebreakers produce the same winner every time.
     let mut atomic_keys: Vec<&String> = atomic.data.keys().collect();
     atomic_keys.sort_unstable();
-    for mtgjson_key in atomic_keys {
-        let faces = &atomic.data[mtgjson_key];
-        // Drop officially-removed offensive cards before any other handling,
-        // so they never enter the card database (and not even an explicit
-        // --filter can resurrect them).
-        if faces
-            .first()
-            .is_some_and(|f| is_removed_offensive_card(&f.name))
-        {
-            continue;
-        }
-        // --filter: skip cards not matching any filter name
-        if !filter_names.is_empty() {
-            let card_name = faces
-                .first()
-                .map(|f| f.name.to_lowercase())
-                .unwrap_or_default();
-            if !filter_names.iter().any(|n| card_name.contains(n)) {
-                continue;
-            }
-        }
 
+    let ctx = CardWorkCtx {
+        filter_names: &filter_names,
+        stats,
+        token_source_metadata: &token_source_metadata,
+        rarity_map: &rarity_map,
+        bracket_lists: &bracket_lists,
+        #[cfg(feature = "forge")]
+        forge_index: forge_index.as_ref(),
+    };
+
+    // Parse pass: Oracle-text parsing dominates this loop (~5ms/card over
+    // ~35k cards) and `build_card_work` is pure, so fan it out across cores.
+    // Results are collected index-addressed — each worker owns one contiguous
+    // chunk of the sorted key list and the chunks are concatenated in order —
+    // so the merge below observes exactly the sequential iteration order. That
+    // determinism is load-bearing: `insert_face`'s collision tiebreakers are
+    // order-sensitive, and CI caches card-data.json by content hash.
+    let worker_count = thread::available_parallelism().map_or(1, |n| n.get());
+    let chunk_len = atomic_keys.len().div_ceil(worker_count).max(1);
+    let ctx = &ctx;
+    let atomic_data = &atomic.data;
+    let card_work: Vec<CardWork> = thread::scope(|scope| {
+        let handles: Vec<_> = atomic_keys
+            .chunks(chunk_len)
+            .map(|chunk| {
+                scope.spawn(move || {
+                    chunk
+                        .iter()
+                        .filter_map(|key| build_card_work(ctx, key.as_str(), &atomic_data[*key]))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .flat_map(|h| h.join().expect("card parse worker panicked"))
+            .collect()
+    });
+
+    // Merge pass: single-threaded and in sorted-key order, because every
+    // mutation here is order-sensitive (`insert_face` collision resolution,
+    // sidecar first-writer-wins) or an accumulator.
+    for card in card_work {
         total_cards += 1;
-
-        let oracle_id = faces
-            .first()
-            .and_then(|f| f.identifiers.scryfall_oracle_id.clone());
-
-        let layout_kind = map_layout(&faces[0].layout);
-
-        if is_homonym_atomic_group(faces) {
-            for source in faces.iter() {
-                let oracle_id = source.identifiers.scryfall_oracle_id.clone();
-                let mut face = build_oracle_face(source, oracle_id);
-                #[cfg(feature = "forge")]
-                if let Some(ref fi) = forge_index {
-                    engine::database::forge::apply_forge_fallback(&mut face, fi);
+        cards_with_unimplemented += card.unimplemented_faces;
+        for (key, source) in &card.localized {
+            collect_localized(&mut sidecars, key, source);
+        }
+        for (key, entry, priority) in card.entries {
+            match priority {
+                FacePriority::SameClass => {
+                    insert_face(&mut face_index, card.mtgjson_key, key, entry)
                 }
-                stamp_token_source_metadata(&mut face, source, &token_source_metadata);
-                let key = face.name.to_lowercase();
-                let legalities =
-                    legalities_to_export_map(&normalize_legalities(&source.legalities));
-
-                if stats && card_face_has_unimplemented_parts(&face) {
-                    cards_with_unimplemented += 1;
-                }
-
-                let rarities = rarity_map
-                    .get(&face.name.to_lowercase())
-                    .cloned()
-                    .unwrap_or_default();
-
-                let bracket_signals = bracket_signals_for_face(&bracket_lists, &face, source);
-                collect_localized(&mut sidecars, &key, source);
-                insert_face_with_priority(
+                FacePriority::Homonym => insert_face_with_priority(
                     &mut face_index,
-                    mtgjson_key.as_str(),
+                    card.mtgjson_key,
                     key,
-                    CardExportEntry {
-                        face,
-                        legalities,
-                        layout: None,
-                        printings: source.printings.clone(),
-                        rulings: source.rulings.clone(),
-                        rarities,
-                        bracket_signals,
-                    },
+                    entry,
                     homonym_face_priority,
-                );
+                ),
             }
-        } else if faces.len() >= 2 {
-            let mut legalities_by_face = BTreeMap::new();
-            let layout = build_export_layout(faces, oracle_id, layout_kind);
-            for (face, source) in layout_faces(&layout).iter().zip(faces.iter()) {
-                legalities_by_face.insert(
-                    face.name.to_lowercase(),
-                    legalities_to_export_map(&normalize_legalities(&source.legalities)),
-                );
-            }
-
-            if stats {
-                let has_unimplemented = layout_faces(&layout)
-                    .iter()
-                    .any(|f| card_face_has_unimplemented_parts(f));
-                if has_unimplemented {
-                    cards_with_unimplemented += 1;
-                }
-            }
-
-            for (face_idx, (face_ref, source)) in layout_faces(&layout)
-                .into_iter()
-                .zip(faces.iter())
-                .enumerate()
-            {
-                let key = face_ref.name.to_lowercase();
-                let legalities = legalities_by_face.remove(&key).unwrap_or_default();
-                let mut face = face_ref.clone();
-                #[cfg(feature = "forge")]
-                if let Some(ref fi) = forge_index {
-                    engine::database::forge::apply_forge_fallback(&mut face, fi);
-                }
-                stamp_token_source_metadata(&mut face, source, &token_source_metadata);
-                let layout_str = match layout_kind {
-                    LayoutKind::Single => None,
-                    _ => Some(faces[0].layout.clone()),
-                };
-                // Front face (index 0) owns the rulings; back faces get an empty vec.
-                // MTGJSON duplicates rulings across faces; this dedups at export time.
-                let rulings = if face_idx == 0 {
-                    faces[0].rulings.clone()
-                } else {
-                    Vec::new()
-                };
-                let rarities = rarity_map
-                    .get(&face.name.to_lowercase())
-                    .cloned()
-                    .unwrap_or_default();
-                let bracket_signals = bracket_signals_for_face(&bracket_lists, &face, source);
-                // Localized sidecars cover single-faced cards only — see
-                // `collect_localized`. Multi-face `foreignData` is a combined
-                // "A // B" name with no reliable per-face split, so these faces
-                // fall back to English at the display layer.
-                insert_face(
-                    &mut face_index,
-                    mtgjson_key.as_str(),
-                    key,
-                    CardExportEntry {
-                        face,
-                        legalities,
-                        layout: layout_str,
-                        printings: faces[0].printings.clone(),
-                        rulings,
-                        rarities,
-                        bracket_signals,
-                    },
-                );
-            }
-        } else {
-            let mut face = build_oracle_face(&faces[0], oracle_id);
-            #[cfg(feature = "forge")]
-            if let Some(ref fi) = forge_index {
-                engine::database::forge::apply_forge_fallback(&mut face, fi);
-            }
-            stamp_token_source_metadata(&mut face, &faces[0], &token_source_metadata);
-            let key = face.name.to_lowercase();
-            let legalities = legalities_to_export_map(&normalize_legalities(&faces[0].legalities));
-
-            if stats && card_face_has_unimplemented_parts(&face) {
-                cards_with_unimplemented += 1;
-            }
-
-            let rarities = rarity_map
-                .get(&face.name.to_lowercase())
-                .cloned()
-                .unwrap_or_default();
-
-            let bracket_signals = bracket_signals_for_face(&bracket_lists, &face, &faces[0]);
-            collect_localized(&mut sidecars, &key, &faces[0]);
-            insert_face(
-                &mut face_index,
-                mtgjson_key.as_str(),
-                key,
-                CardExportEntry {
-                    face,
-                    legalities,
-                    layout: None,
-                    printings: faces[0].printings.clone(),
-                    rulings: faces[0].rulings.clone(),
-                    rarities,
-                    bracket_signals,
-                },
-            );
         }
     }
 


### PR DESCRIPTION
The `card-data-gate` job was the CI critical path at ~12.2 min on every PR. Three fixes:

1. **`write_oracle_subtypes` write-if-changed** (`oracle_gen.rs`): the unconditional rewrite of `crates/engine/data/oracle-subtypes.json` bumped its mtime every run; the engine lib `include_str!`s it, so the NEXT cargo invocation (`card-data-validate`) fully recompiled the engine — a measured 221s redundant recompile in every run. Now serializes, compares, and skips byte-identical writes (mirrors `gen-card-data.sh`'s `cmp`/`mv` idiom). Proven: second consecutive run leaves mtime untouched; validate step becomes a fingerprint cache hit.

2. **Parallel per-card parse pass** (`oracle_gen.rs`): the ~34.6k-card pass ran single-threaded (187s in CI). Loop body extracted into pure `build_card_work`; `thread::scope` + contiguous chunks over the sorted key list; all order-sensitive mutation (`insert_face` tiebreakers, sidecar first-writer-wins, counters) stays single-threaded in an in-order merge. No new deps. Determinism proven: 98MB `card-data.json` + `card-names.json` byte-identical to sequential output across repeated runs; `--stats` counts identical; unchanged total CPU (~4.5x wall speedup locally).

3. **Cache-gated validate/coverage** (`ci.yml`): new `cardgen-gates-v1-` cache (`coverage-data.json` + `coverage-summary.json`) gates the Validate and Coverage steps; a hit is proof-of-passage since only a successful `card-data-gate` run saves it. Both cache keys now also hash `crates/engine/data/**` and `crates/engine/build.rs` (compiled into the engine via `include_str!`/build.rs embed — previously a false-green gap where a `known-tokens.toml`-only PR reused stale card-data). The main-only `card_data_hash` stamp now writes `coverage-data.stamped.json` so cached bytes no longer depend on `github.ref` (R2 uploads publish the stamped copy — zero consumer change).

Expected: engine PRs ~12.2 → ~6 min (253s compile + ~50s parallel gen, no redundant recompile); engine-unchanged PRs ~1.5 min (all three heavy steps skip).

Reviewed by isolated implementation review (2 rounds; `oracle_gen.rs` parallelization independently traced clean; 3 `ci.yml` findings fixed and delta-LGTM'd). Related issues filed during review: #5456 (`ai-gate.yml` cardgen cache never sees `AtomicCards.json`), #5457 (`engine-source-hash.sh` shares the same blind spot).
