### PR TITLE
fix(ci): hash crates/engine/data and build.rs in engine-source-hash.sh

### DIFF
--- a/scripts/engine-source-hash.sh
+++ b/scripts/engine-source-hash.sh
@@ -38,7 +38,7 @@ sha="$1"
 # `-r` recurses into the src tree so every file's blob hash participates; the
 # blob hashes change iff content changes. Hash the listing to a stable digest.
 # Truncated to 16 hex chars to match the card_data_hash convention (ci.yml).
-git ls-tree -r "$sha" -- \
+git ls-tree --full-tree -r "$sha" -- \
   crates/engine/src \
   crates/engine/data \
   crates/engine/build.rs \

--- a/scripts/engine-source-hash.sh
+++ b/scripts/engine-source-hash.sh
@@ -16,7 +16,10 @@
 #
 # The fingerprint covers exactly the inputs that determine parse output and
 # mirrors the cardgen-cache key (ci.yml): the engine source tree, the engine
-# crate manifest, and the lockfile (dep pins like nom affect parsing).
+# data dir (`crates/engine/data/**` — e.g. oracle-subtypes.json is `include_str!`d
+# into the parser, known-tokens.toml is embedded via build.rs → OUT_DIR), the
+# engine build script (`build.rs`), the engine crate manifest, and the lockfile
+# (dep pins like nom affect parsing).
 #
 # Implemented with `git ls-tree -r` rather than `hashFiles`/working-tree hashing
 # so it is computable for ANY commit straight from history — no checkout — which
@@ -37,6 +40,8 @@ sha="$1"
 # Truncated to 16 hex chars to match the card_data_hash convention (ci.yml).
 git ls-tree -r "$sha" -- \
   crates/engine/src \
+  crates/engine/data \
+  crates/engine/build.rs \
   crates/engine/Cargo.toml \
   Cargo.lock \
   | sha256sum \


### PR DESCRIPTION
Fixes #5457.

## Problem

`scripts/engine-source-hash.sh` is the single authority for the parse-diff baseline key (computed on both the publish and fetch sides of the coverage-parse-diff flow). It hashed only `crates/engine/src`, `crates/engine/Cargo.toml`, and `Cargo.lock` — omitting **`crates/engine/data/**`** and **`crates/engine/build.rs`**, both of which are compiled into the engine and change oracle-gen's parse output:

- `crates/engine/data/oracle-subtypes.json` is `include_str!`d into the parser (`parser/oracle_util.rs`).
- `crates/engine/data/known-tokens.toml` is embedded via `build.rs` → `OUT_DIR`.

**Consequence:** a PR touching only `known-tokens.toml` (or `build.rs`) yields an unchanged engine-source hash, so the "Parse-detail diff vs base baseline" CI step fetches `parse-baselines/coverage-data-<hash>.json` built from a *different* parser state that happens to share the hash, and under-reports the PR's parse changes. Same failure family as the `ci.yml` cache-key gap already fixed — different file.

## Fix

Add `crates/engine/data` and `crates/engine/build.rs` to the `git ls-tree` path set, and update the header comment. This mirrors `ci.yml`'s `cardgen-` cache key, which was already widened to hash `crates/engine/data/**` and `crates/engine/build.rs` (ci.yml lines 215/243).

Per the issue, changing the hash function orphans existing `coverage-data-<hash>.json` objects for one main-push cycle (PRs see "Baseline pending" until main republishes) — benign and self-healing, same as any parser-state change.

## Verification (local)

- The script still emits a 16-hex digest.
- `git ls-tree -r HEAD -- crates/engine/data crates/engine/build.rs` now contributes the three engine-compiled blobs (`build.rs`, `known-tokens.toml`, `oracle-subtypes.json`).
- The new digest **differs** from the old `src + Cargo.toml + Cargo.lock`-only formula, confirming those inputs now actually participate — so a `known-tokens.toml`/`build.rs`-only PR will now invalidate the baseline key.
- Only callers are `ci.yml` (which invoke the script and consume its output); no test hardcodes the old path set or digest.
