### PR TITLE
fix(parser): recognize "the active player has controlled continuously since the beginning of the turn" target clause (Nettling Imp, Norritt, Arcum's Whistle)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -9127,6 +9127,78 @@ mod tests {
         assert!(matches!(err, EngineError::ActionNotAllowed(_)));
     }
 
+    // Nettling Imp / Norritt / Arcum's Whistle class: "target creature the active
+    // player has controlled continuously since the beginning of the turn". Proves
+    // BOTH predicates gate legality independently — the active-player controller
+    // scope AND the continuity flag — via three fixtures, only one of which is a
+    // legal target. Positive full-set assertion (not a bare negative) so neither
+    // hostile fixture can be excluded vacuously by an upstream short-circuit.
+    #[test]
+    fn build_target_slots_active_player_controlled_continuously_since_turn_began() {
+        use crate::types::ability::{ControllerRef, FilterProp};
+        use crate::types::zones::Zone;
+
+        let mut state = GameState::new_two_player(42);
+        // Active player (CR 102.1) is PlayerId(0) at game start.
+        assert_eq!(state.active_player, PlayerId(0));
+
+        // Legal: active player's control, no summoning sickness (create_object
+        // does not set the flag — a "pre-existing" battlefield creature).
+        let continuous_active = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Continuous Active".to_string(),
+            Zone::Battlefield,
+        );
+        // Illegal via continuity: active player's control, but summoning-sick.
+        let fresh_active = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Fresh Active".to_string(),
+            Zone::Battlefield,
+        );
+        // Illegal via controller: continuous control, but by the non-active player.
+        let continuous_nonactive = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Continuous Nonactive".to_string(),
+            Zone::Battlefield,
+        );
+        for creature in [continuous_active, fresh_active, continuous_nonactive] {
+            state
+                .objects
+                .get_mut(&creature)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+        state.objects.get_mut(&fresh_active).unwrap().summoning_sick = true;
+
+        let ability = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::Typed(
+                    TypedFilter::creature()
+                        .controller(ControllerRef::ActivePlayer)
+                        .properties(vec![FilterProp::ControlledContinuouslySinceTurnBegan]),
+                ),
+            },
+            vec![],
+            ObjectId(900),
+            PlayerId(0),
+        );
+
+        let slots = build_target_slots(&state, &ability).expect("target slots should build");
+        assert_eq!(slots.len(), 1);
+        assert_eq!(
+            slots[0].legal_targets,
+            vec![TargetRef::Object(continuous_active)]
+        );
+    }
+
     #[test]
     fn build_target_slots_uses_prior_player_targets_for_relative_controller_filters() {
         use crate::types::ability::ControllerRef;

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -5451,12 +5451,19 @@ fn parse_ownership_or_controller_suffix(
     // ActivePlayer subject is recognized — no card in the corpus was found
     // using a "you've controlled/you have controlled continuously..." form
     // for this clause, so that variant is not built ahead of a card that
-    // needs it.
-    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(
-        "the active player has controlled continuously since the beginning of the turn",
+    // needs it. The clause is sequenced from three composable atoms — subject
+    // ("the active player"), verb ("has controlled"), and continuity tail
+    // ("continuously since the beginning of the turn") — rather than one
+    // verbatim tag, mirroring `parse_continuity_exemption_clause` (oracle.rs)
+    // and the "owned by" tuple idiom immediately above.
+    let active_player_continuity: nom::IResult<&str, (), OracleError<'_>> = (
+        tag("the active player"),
+        tag(" has controlled"),
+        tag(" continuously since the beginning of the turn"),
     )
-    .parse(own_ctrl)
-    {
+        .map(|_| ())
+        .parse(own_ctrl);
+    if let Ok((rest, ())) = active_player_continuity {
         *controller = Some(ControllerRef::ActivePlayer);
         properties.push(FilterProp::ControlledContinuouslySinceTurnBegan);
         return own_ctrl_offset + (own_ctrl.len() - rest.len());

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -5434,6 +5434,33 @@ fn parse_ownership_or_controller_suffix(
         }
         return own_ctrl_offset + (own_ctrl.len() - rest.len());
     }
+    // CR 102.1 + CR 302.6 + CR 508.1a: "the active player has controlled
+    // continuously since the beginning of the turn" is a target-selection
+    // relative clause (Nettling Imp / Norritt / Arcum's Whistle) — distinct
+    // from `parse_controller_suffix`'s past-tense LOOK-BACK arm ("the active
+    // player controlled", CR 608.2i, used by look-back aggregates over
+    // objects that may have since left the battlefield). This clause instead
+    // restricts a LIVE battlefield target: it must both (a) currently be
+    // controlled by the active player and (b) have been so controlled
+    // without interruption since that player's turn began — the same
+    // continuity test CR 508.1a uses to gate which creatures may attack.
+    // Both facts are pushed together: `*controller` pins the live
+    // ActivePlayer scope, and `FilterProp::ControlledContinuouslySinceTurnBegan`
+    // pins the continuity predicate (runtime-evaluated in game/filter.rs as
+    // `!obj.summoning_sick`, CR 302.6's summoning-sickness flag). Only the
+    // ActivePlayer subject is recognized — no card in the corpus was found
+    // using a "you've controlled/you have controlled continuously..." form
+    // for this clause, so that variant is not built ahead of a card that
+    // needs it.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(
+        "the active player has controlled continuously since the beginning of the turn",
+    )
+    .parse(own_ctrl)
+    {
+        *controller = Some(ControllerRef::ActivePlayer);
+        properties.push(FilterProp::ControlledContinuouslySinceTurnBegan);
+        return own_ctrl_offset + (own_ctrl.len() - rest.len());
+    }
 
     let (ctrl, ctrl_len) =
         parse_controller_suffix(text, ctx).map_or((None, 0), |(ctrl, len)| (Some(ctrl), len));
@@ -7989,6 +8016,26 @@ mod tests {
             )
         );
         assert_eq!(rest, "");
+    }
+
+    // Nettling Imp / Norritt / Arcum's Whistle class: verbatim clause from
+    // Nettling Imp's real Oracle text. Building-block test — isolates the new
+    // controller+continuity arm from the pre-existing "non-Wall" type-filter
+    // handling (already covered elsewhere).
+    #[test]
+    fn parse_target_active_player_controlled_continuously_since_turn_began() {
+        let (f, rest) = parse_target(
+            "target creature the active player has controlled continuously since the beginning of the turn",
+        );
+        assert_eq!(
+            f,
+            TargetFilter::Typed(
+                TypedFilter::creature()
+                    .controller(ControllerRef::ActivePlayer)
+                    .properties(vec![FilterProp::ControlledContinuouslySinceTurnBegan])
+            )
+        );
+        assert_eq!(rest.trim(), "");
     }
 
     #[test]

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -531,6 +531,7 @@ mod mycoloth_upkeep_trigger;
 mod mystic_forge_regression;
 mod narset_jeskai_waymaster_draw_spells_cast;
 mod necrodominance_pay_any_life_draw;
+mod nettling_imp_continuity_target;
 mod ninjutsu_cluster;
 mod nix_counter_no_mana_spent;
 mod ob_nixilis_captive_kingpin_life_loss;

--- a/crates/engine/tests/integration/nettling_imp_continuity_target.rs
+++ b/crates/engine/tests/integration/nettling_imp_continuity_target.rs
@@ -1,0 +1,141 @@
+//! Nettling Imp / Norritt / Arcum's Whistle continuity target clause — PR #5463
+//! fix round, addressing the maintainer's "test doesn't cover the actual
+//! regression" finding.
+//!
+//! The two pre-existing tests are each insufficient alone:
+//!   * `parse_target_active_player_controlled_continuously_since_turn_began`
+//!     (oracle_target.rs) only checks the isolated `parse_target` AST shape — it
+//!     never reaches target selection.
+//!   * `build_target_slots_active_player_controlled_continuously_since_turn_began`
+//!     (ability_utils.rs) hand-constructs the `FilterProp`, bypassing the parser
+//!     entirely — reverting the new parser arm leaves it green.
+//!
+//! This end-to-end test closes the gap. It parses Nettling Imp's REAL Oracle
+//! text through the top-level `parse_oracle_text` entry point and drives the
+//! resulting PARSER-PRODUCED `AbilityDefinition` through the production
+//! `build_resolved_from_def` -> `build_target_slots` path (the same path used by
+//! the live activation flow). If the decomposed continuity arm in
+//! `parse_ownership_or_controller_suffix` is reverted or broken, the parsed
+//! filter degrades to non-Wall-creature-only (no `ActivePlayer` controller, no
+//! `ControlledContinuouslySinceTurnBegan` property), so `build_target_slots`
+//! would then wrongly admit the summoning-sick and non-active-player fixtures —
+//! failing the exact `legal_targets` assertion below.
+
+use engine::game::ability_utils::{build_resolved_from_def, build_target_slots};
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{ControllerRef, FilterProp, TargetFilter, TargetRef};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::CardId;
+use engine::types::zones::Zone;
+use engine::types::PlayerId;
+
+/// Verbatim Scryfall Oracle text for Nettling Imp.
+const NETTLING_IMP_ORACLE: &str = "{T}: Choose target non-Wall creature the active player has controlled continuously since the beginning of the turn. That creature attacks this turn if able. Destroy it at the beginning of the next end step if it didn't attack this turn. Activate only during an opponent's turn, before attackers are declared.";
+
+#[test]
+fn nettling_imp_parsed_continuity_filter_restricts_target_slots_end_to_end() {
+    // --- Parse the real card through the real top-level entry point. ---
+    let parsed = parse_oracle_text(
+        NETTLING_IMP_ORACLE,
+        "Nettling Imp",
+        &[],
+        &["Creature".to_string()],
+        &["Imp".to_string()],
+    );
+    assert_eq!(
+        parsed.abilities.len(),
+        1,
+        "expected the single {{T}} activated ability"
+    );
+    let ability_def = &parsed.abilities[0];
+
+    // Positive reach-guard: prove the parse produced the FULL continuity filter
+    // (active-player controller + continuity property), not the degraded
+    // non-Wall-creature-only fallback. This is the exact seam the Finding 1
+    // decomposition parses; if that arm regresses, both facts vanish here and
+    // the slot assertion below would no longer be a meaningful discriminator.
+    let parsed_filter = ability_def
+        .effect
+        .target_filter()
+        .expect("Nettling Imp surfaces a target-selection filter");
+    let TargetFilter::Typed(typed) = parsed_filter else {
+        panic!("expected a Typed target filter, got {parsed_filter:?}");
+    };
+    assert_eq!(
+        typed.controller,
+        Some(ControllerRef::ActivePlayer),
+        "continuity clause must pin the ActivePlayer controller scope"
+    );
+    assert!(
+        typed
+            .properties
+            .contains(&FilterProp::ControlledContinuouslySinceTurnBegan),
+        "continuity clause must carry ControlledContinuouslySinceTurnBegan, got {:?}",
+        typed.properties
+    );
+
+    // --- Three fixtures; only one is a legal target. ---
+    let mut state = GameState::new_two_player(42);
+    // CR 102.1: the active player is PlayerId(0) at game start.
+    assert_eq!(state.active_player, PlayerId(0));
+
+    // Legal: active player's control, no summoning sickness (create_object does
+    // not set the flag — a "pre-existing" battlefield creature).
+    let continuous_active = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Continuous Active".to_string(),
+        Zone::Battlefield,
+    );
+    // Illegal via continuity: active player's control, but summoning-sick.
+    let fresh_active = create_object(
+        &mut state,
+        CardId(2),
+        PlayerId(0),
+        "Fresh Active".to_string(),
+        Zone::Battlefield,
+    );
+    // Illegal via controller: continuous control, but by the non-active player.
+    let continuous_nonactive = create_object(
+        &mut state,
+        CardId(3),
+        PlayerId(1),
+        "Continuous Nonactive".to_string(),
+        Zone::Battlefield,
+    );
+    for creature in [continuous_active, fresh_active, continuous_nonactive] {
+        state
+            .objects
+            .get_mut(&creature)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+    }
+    state.objects.get_mut(&fresh_active).unwrap().summoning_sick = true;
+
+    // The Nettling Imp source itself, controlled by the active player.
+    let imp = create_object(
+        &mut state,
+        CardId(4),
+        PlayerId(0),
+        "Nettling Imp".to_string(),
+        Zone::Battlefield,
+    );
+
+    // --- Drive the PARSED ability through the production target-slot builder. ---
+    let resolved = build_resolved_from_def(ability_def, imp, PlayerId(0));
+    let slots = build_target_slots(&state, &resolved).expect("target slots should build");
+    assert_eq!(slots.len(), 1, "single target selection slot");
+    // Revert-failing assertion: with the continuity arm reverted the parsed
+    // filter is non-Wall-creature-only, so this set would also contain
+    // `fresh_active` and `continuous_nonactive`.
+    assert_eq!(
+        slots[0].legal_targets,
+        vec![TargetRef::Object(continuous_active)],
+        "only the continuously-active-player-controlled creature is a legal target"
+    );
+}

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4778
-- **Total card appearances across root causes:** 4812 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4776
+- **Total card appearances across root causes:** 4810 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -12,7 +12,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 | # | Root cause | # cards | Fix hint (where it likely lives) |
 |---|------------|--------:|----------------------------------|
-| 1 | Relative-clause / filter restriction on target dropped | 752 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
+| 1 | Relative-clause / filter restriction on target dropped | 750 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
 | 2 | Dropped intervening-if / gating condition (condition: null) | 606 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
 | 3 | Anaphor bound to wrong referent | 404 | oracle_quantity.rs context-ref resolution + game/ability_utils.rs forward_result wiring |
 | 4 | Conjoined / chained second effect clause dropped | 387 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
@@ -47,7 +47,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 ## Full card lists per root cause
 
-### 1. Relative-clause / filter restriction on target dropped  (752 cards)
+### 1. Relative-clause / filter restriction on target dropped  (750 cards)
 
 **Signature.** TargetFilter/affected emitted with empty or missing properties; a trailing restrictive clause (type, subtype, color, mana value, zone, combat/temporal/control predicate, exclusion) is silently dropped, over-broadening the filter.
 
@@ -496,7 +496,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Necrotic Plague
 - Needle Drop
 - Netcaster Spider
-- Nettling Imp
 - Neural Network
 - Niambi, Esteemed Speaker
 - Nick Fury, Agent of S.H.I.E.L.D.
@@ -504,7 +503,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Nightshade Seer
 - Nimble Obstructionist
 - Noctis, Heir Apparent
-- Norritt
 - Not of This World
 - Oath of Druids
 - Oath of Ghouls


### PR DESCRIPTION
## Summary

Fixes a real 3-card class where the target-selection relative clause **"the active player has controlled continuously since the beginning of the turn"** was silently dropped by the parser, over-broadening the target filter to *any* non-Wall creature instead of one continuously controlled by the active player.

Affected cards (all share the identical clause verbatim, confirmed via a full-corpus grep of `data/mtgjson/AtomicCards.json` — exactly 3 hits, no more):
- **Nettling Imp**
- **Norritt**
- **Arcum's Whistle**

**Total War** shares the same *continuity phrase* but in a structurally different "except for" mass-exemption grammar (a `DestroyAll` exclusion clause, not a target-selection clause) — confirmed out of scope by tracing `parse_except_for_type_list_suffix`'s decline-guard (`oracle_target.rs:6279-6339`), which correctly declines Total War's filtered-subset clause rather than silently mishandling it. Left untouched.

## Root cause & fix

`parse_ownership_or_controller_suffix` (`crates/engine/src/parser/oracle_target.rs`) had no recognition arm for this clause, so it fell through and the whole relative clause was dropped. Added a new arm that:

1. Sets `controller = Some(ControllerRef::ActivePlayer)`
2. Pushes `FilterProp::ControlledContinuouslySinceTurnBegan`

Both types are **pre-existing, reused verbatim — zero new enum variants**. `FilterProp::ControlledContinuouslySinceTurnBegan` is already fully wired through runtime evaluation at [`game/filter.rs:4124`](../../blob/main/crates/engine/src/game/filter.rs) (`!obj.summoning_sick` — CR 302.6's summoning-sickness flag, cleverly reused since "controlled continuously since the beginning of the turn" is exactly that rule's definition).

No `ControllerRef::You` variant was added for a speculative "you've controlled continuously..." form — grepped all 8 occurrences of the continuity phrase across the corpus; the only real-card class using it as a *target-selection* clause is these 3 cards (all `ActivePlayer`-scoped). Building that branch ahead of a card that needs it would be exactly the kind of unexercised surface area this project's "build for the class, not the card" principle warns against in the other direction.

## Gate A — parser combinator compliance

```
$ ./scripts/check-parser-combinators.sh
(exit 0, no violations)
```

The new arm is a single `tag::<_, _, OracleError<'_>>("the active player has controlled continuously since the beginning of the turn").parse(own_ctrl)` — pure nom combinator, mirroring the five neighboring arms in the same function. No `contains()`/`starts_with()`/`find()` dispatch.

## Gate B — anchored citations (≥2)

- [`crates/engine/src/game/filter.rs:4124`](../../blob/main/crates/engine/src/game/filter.rs#L4124) — `FilterProp::ControlledContinuouslySinceTurnBegan => !obj.summoning_sick`, the pre-existing runtime evaluation this fix's parser output now reaches.
- [`crates/engine/src/parser/oracle_target.rs:5456`](../../blob/main/crates/engine/src/parser/oracle_target.rs) — the new arm itself, placed after the "owned by" passive block and before the `parse_controller_suffix` delegate fallback (the same seam as the existing "you own and control" precedent arm a few lines above it).

## CR references

- **CR 102.1** — defines the active player (the controller scope).
- **CR 302.6** — summoning-sickness rule; `!obj.summoning_sick` is exactly this rule's continuity test.
- **CR 508.1a** — near-verbatim match to the card text: "...must either have haste or have been controlled by the active player continuously since the turn began."
- **CR 608.2i** — cited to contrast: this is a *live* target-selection restriction, not the past-tense look-back pattern `parse_controller_suffix`'s existing "the active player controlled" arm handles.

## Tier

**Tier: Standard**

## Validation performed

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — exit 0
- Parser dispatch grep gate (no string-dispatch primitives in added lines) — clean
- CR-annotation diff gate — all 4 citations verified against `docs/MagicCompRules.txt`, zero `UNVERIFIED`
- `cargo clippy -p engine --all-targets -- -D warnings` — clean, zero warnings (re-verified **post-rebase** onto current `main`)
- Two discriminating tests, both passing via a full `cargo test -p engine` compile **pre-rebase**:
  - `parse_target_active_player_controlled_continuously_since_turn_began` (parser shape test — asserts the exact `TargetFilter` emitted)
  - `build_target_slots_active_player_controlled_continuously_since_turn_began` (runtime test through the real `build_target_slots` production entry point — 3 fixtures proving both the controller and continuity predicates gate legality independently: only a continuously-active-player-controlled creature is legal; a summoning-sick active-player creature and a continuously-controlled non-active-player creature are each excluded by their respective predicate)
- Independent review (`/review-impl`) — clean, no blocking findings

## Validation NOT performed (disclosed honestly)

`cargo coverage` and `cargo semantic-audit` — the corpus-wide audits that would directly confirm Nettling Imp/Norritt flip to `supported: true` in the full card database — **could not be run** due to an environment issue unrelated to this code change: `./scripts/gen-card-data.sh`'s token-set-fetch step (`fetch-token-sets.sh`) failed 100% of the time, but **only** when invoked through its specific nested-subprocess execution chain. This was diagnosed exhaustively today:

- Not resource contention — new failures kept appearing at the same rate even with the system independently confirmed fully idle.
- Not a server-side block or 404 — the exact failing URLs return HTTP 200 in <0.3s via direct manual `curl`.
- Not a bug in the shared fetch library — `mtgjson_download`/`mtgjson_curl` (`scripts/lib/mtgjson-fetch.sh`) succeeded when invoked interactively, inside a `set -euo pipefail` subshell, via a detached background task, and in a 7-code sequential loop — every isolated reproduction succeeded.
- Not session-specific networking — no proxy env vars, and the exact same session's manual curl calls succeeded.

The failure is isolated to something specific to the deep-nested subprocess chain `gen-card-data.sh` → `fetch-token-sets.sh` → `curl`, and remains unexplained. Given the additive, narrowly-scoped nature of this change (a single new `tag()` arm reusing two fully-wired pre-existing types) and the strength of the verification that *did* complete (clean clippy under `-D warnings`, passing discriminating tests through a full compile, all parser gates clean), the regression risk from skipping the corpus-wide audit is low — but I'm not claiming that verification happened.

Post-rebase, the targeted test suite itself (`cargo test -p engine --lib active_player_controlled_continuously`) also could not be re-run to completion — 5 consecutive attempts were killed mid-compile by what appears to be an unrelated background-task environment issue (not a build/test failure; no error output, always killed at the identical "Compiling engine v0.20.0" stage, with the system confirmed idle each time). The tests were confirmed passing pre-rebase via a full compile, and post-rebase `clippy` (which compiles the same code under the stricter lint pass) is clean, so I'm confident in the fix, but flagging this honestly rather than silently treating an unconfirmed post-rebase re-run as confirmed.

## Backlog hygiene

Removed `Nettling Imp` and `Norritt` from `docs/parser-misparse-backlog.md`'s category 1 list, decrementing that category's count (752→750) and the top-summary totals (4778→4776, 4812→4810) accordingly. `Arcum's Whistle` was never listed there — it has a separate, unrelated "unless controller pays X" cost-side gap, out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
