### PR TITLE
fix(frontend): surface Glasses of Urza's private hand-look to the caster

### DIFF
--- a/client/src/components/hand/OpponentHand.tsx
+++ b/client/src/components/hand/OpponentHand.tsx
@@ -10,7 +10,7 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
 import type { ObjectId, PlayerId } from "../../adapter/types.ts";
-import { getOpponentIds, resolveFocusedOpponent } from "../../viewmodel/gameStateView.ts";
+import { getOpponentIds, isPrivatelyLookedAtByViewer, resolveFocusedOpponent } from "../../viewmodel/gameStateView.ts";
 
 interface OpponentHandProps {
   playerId?: PlayerId;
@@ -60,7 +60,10 @@ export function OpponentHand({ playerId, showCards = false, layout = "default" }
         {opponent.hand.map((id, i) => {
           const obj = objects ? objects[id] : null;
           const isRevealed = (revealedCards?.includes(id) ?? false)
-            || (publicRevealedCards?.includes(id) ?? false);
+            || (publicRevealedCards?.includes(id) ?? false)
+            // CR 701.20e: Glasses of Urza / Gitaxian Probe "look at target
+            // player's hand" surfaces the card's identity only to the looker.
+            || isPrivatelyLookedAtByViewer(gameState ?? null, id, myId);
           const showFace = showCards || isRevealed;
           // Negate rotation so fan opens toward opponent (top of screen)
           const rotation = -((i - center) * rotationStep);

--- a/client/src/components/hand/__tests__/OpponentHand.test.tsx
+++ b/client/src/components/hand/__tests__/OpponentHand.test.tsx
@@ -72,4 +72,31 @@ describe("OpponentHand", () => {
     expect(screen.getByAltText("Explicit Opponent Card")).toBeInTheDocument();
     expect(screen.queryByAltText("Focused Opponent Card")).toBeNull();
   });
+
+  // CR 701.20e (phase-rs/phase#5251): Glasses of Urza / Gitaxian Probe "look at
+  // target player's hand" surfaces the looked-at cards' identities only to the
+  // looking player (`private_look_player`/`private_look_ids`), distinct from
+  // the public reveal sets already covered above. Before this fix, the
+  // opponent-hand card thumbnail only consulted `revealed_cards` /
+  // `public_revealed_cards`, so a private look never made the card visible to
+  // the looker even though the engine had already sent them its real name.
+  it("shows a card the engine privately looked at for this viewer, without showCards", () => {
+    useGameStore.setState({
+      gameState: { ...createGameState(), private_look_player: 0, private_look_ids: [22] },
+    });
+
+    render(<OpponentHand playerId={2} />);
+
+    expect(screen.getByAltText("Explicit Opponent Card")).toBeInTheDocument();
+  });
+
+  it("does not show a privately-looked-at card to a player other than the looker", () => {
+    useGameStore.setState({
+      gameState: { ...createGameState(), private_look_player: 1, private_look_ids: [22] },
+    });
+
+    render(<OpponentHand playerId={2} />);
+
+    expect(screen.queryByAltText("Explicit Opponent Card")).toBeNull();
+  });
 });

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -114,6 +114,26 @@ export function getPlayerZoneIds(
 }
 
 /**
+ * CR 701.20e: whether the engine's private "look at" set (Mishra's Bauble at an
+ * opponent's library, a scry look, Glasses of Urza / Gitaxian Probe at a hand)
+ * surfaces `objectId`'s identity to `viewerId`. Zone-agnostic — the engine's
+ * `private_look_ids`/`private_look_player` fields carry object ids regardless
+ * of which zone those objects sit in, so this same check backs both the
+ * library viewer and the opponent-hand viewer below.
+ */
+export function isPrivatelyLookedAtByViewer(
+  gameState: GameState | null,
+  objectId: ObjectId,
+  viewerId: PlayerId,
+): boolean {
+  if (!gameState) return false;
+  return (
+    gameState.private_look_player === viewerId &&
+    (gameState.private_look_ids?.includes(objectId) ?? false)
+  );
+}
+
+/**
  * Whether the engine has revealed a given library card's identity to `viewerId`.
  *
  * Mirrors the engine's library visibility (`crates/engine/src/game/visibility.rs`)
@@ -139,10 +159,7 @@ export function isLibraryCardRevealedToViewer(
   // CR 701.20e: a private "look at the top card" (Mishra's Bauble at an
   // opponent's library; your own scry look) surfaces the peeked ids only to the
   // looking player.
-  return (
-    gameState.private_look_player === viewerId &&
-    (gameState.private_look_ids?.includes(objectId) ?? false)
-  );
+  return isPrivatelyLookedAtByViewer(gameState, objectId, viewerId);
 }
 
 /**

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -124,9 +124,12 @@ export function getPlayerZoneIds(
 export function isPrivatelyLookedAtByViewer(
   gameState: GameState | null,
   objectId: ObjectId,
-  viewerId: PlayerId,
+  viewerId: PlayerId | null | undefined,
 ): boolean {
-  if (!gameState) return false;
+  // Guard against `undefined === undefined`: if the caller hasn't resolved a
+  // real viewer yet (e.g. mid-load) and `private_look_player` also happens to
+  // be unset, a bare `===` would match and leak the private look to nobody.
+  if (!gameState || viewerId == null) return false;
   return (
     gameState.private_look_player === viewerId &&
     (gameState.private_look_ids?.includes(objectId) ?? false)


### PR DESCRIPTION
## Summary

Fixes #5251 — [[Glasses of Urza]] ({T}: Look at target player's hand. — verified via [Scryfall](https://scryfall.com/card/me4/203/glasses-of-urza)) does not visibly reveal the target player's hand to the caster.

**Root cause is entirely in the frontend, not the engine.** The engine already parses and resolves this correctly:
- `parse_hand_reveal_ast` (`oracle_effect/imperative.rs`) recognizes `"look at target player's hand"` and lowers to `Effect::RevealHand { target: TargetFilter::Player, reveal: false, .. }`.
- `reveal_hand::resolve` (CR 701.20e) populates `state.private_look_ids` / `state.private_look_player` for the looking player, distinct from the public `reveal: true` path (Thoughtseize/Duress).
- `filter_state_for_viewer` (`game/visibility.rs`) leaves those object ids un-redacted for the looker — this is already covered end-to-end by `crates/engine/tests/integration/issue_3263_gitaxian_probe.rs` (Gitaxian Probe has identical Oracle wording).

So the looking player's client *does* receive the real card names. The gap: `OpponentHand.tsx`'s `isRevealed` check only consulted the public reveal sets (`revealed_cards`, `public_revealed_cards`), never `private_look_ids`/`private_look_player`, so the UI kept rendering card backs for a hand the engine had already unredacted client-side.

`isLibraryCardRevealedToViewer` (`viewmodel/gameStateView.ts`) already implements the identical CR 701.20e check for library peeks (Mishra's Bauble, scry) — its doc comment even says *"This is the same pattern `OpponentHand` uses for opponent hand cards,"* which turned out not to be true. This PR extracts the private-look half into a shared, zone-agnostic `isPrivatelyLookedAtByViewer` (the engine's `private_look_ids` carries object ids regardless of which zone they're in) and wires it into `OpponentHand`'s reveal check.

## Changes

- `client/src/viewmodel/gameStateView.ts`: extract `isPrivatelyLookedAtByViewer`, reused by `isLibraryCardRevealedToViewer`.
- `client/src/components/hand/OpponentHand.tsx`: consult it in the card-face reveal check (CR 701.20e).
- `client/src/components/hand/__tests__/OpponentHand.test.tsx`: two new tests — the looker sees the privately-looked-at card without `showCards`, and a different player does not.

## Test plan

- [x] Verified Glasses of Urza's exact Oracle text via Scryfall (not the issue's paraphrase)
- [x] `pnpm run type-check` clean
- [x] `eslint` clean on both changed source files
- [x] New tests pass; confirmed discriminating via live-revert-and-rerun (fail without the fix, pass with it restored)
- [x] Confirmed engine-side resolution already correct via existing `issue_3263_gitaxian_probe.rs` integration test (same Oracle wording, "Look at target player's hand.")
- Full frontend suite (`pnpm test`) was not clean in this environment — 69/230 files fail with `ECONNREFUSED 127.0.0.1:3000` (a local mock/dev server this fresh worktree never started), entirely unrelated files (audio, cloud sync, lobby, deck builder, etc.). Neither changed file (`OpponentHand.test.tsx`, `gameStateView.ts`) appears anywhere in that failure list; the targeted test file passes cleanly in isolation.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01XbgwGxbU9NHN9kou9isp8K