### PR TITLE
Fix ai-gate cardgen cache inputs

### DIFF
--- a/.github/actions/ai-card-data-cache/action.yml
+++ b/.github/actions/ai-card-data-cache/action.yml
@@ -1,0 +1,40 @@
+name: AI card data cache
+description: Restore MTGJSON and generated card data for AI gate jobs.
+
+outputs:
+  cardgen-cache-hit:
+    description: Whether generated card data was restored from cache.
+    value: ${{ steps.cardgen-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set cache keys
+      id: cache-keys
+      shell: bash
+      run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache MTGJSON data
+      id: mtgjson-cache
+      uses: actions/cache@v4
+      with:
+        path: data/mtgjson/AtomicCards.json
+        key: mtgjson-atomic-${{ steps.cache-keys.outputs.week }}
+
+    - name: Download MTGJSON data
+      shell: bash
+      run: |
+        if [ ! -f data/mtgjson/AtomicCards.json ]; then
+          mkdir -p data/mtgjson
+          source scripts/lib/mtgjson-fetch.sh
+          mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
+        fi
+
+    - name: Restore generated card data
+      id: cardgen-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          data/card-data.json
+          data/card-names.json
+        key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/data/**', 'crates/engine/build.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}

--- a/.github/workflows/ai-gate.yml
+++ b/.github/workflows/ai-gate.yml
@@ -6,7 +6,9 @@ on:
     paths:
       - 'crates/phase-ai/**'
       - 'data/card-data.json'
+      - 'scripts/lib/mtgjson-fetch.sh'
       - '.cargo/config.toml'
+      - '.github/actions/ai-card-data-cache/**'
       - '.github/workflows/ai-gate.yml'
   schedule:
     - cron: "0 9 * * *"
@@ -29,36 +31,12 @@ jobs:
         with:
           cache-shared-key: rust-ai-gate
 
-      - name: Set cache keys
-        id: cache-keys
-        run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache MTGJSON data
-        id: mtgjson-cache
-        uses: actions/cache@v4
-        with:
-          path: data/mtgjson/AtomicCards.json
-          key: mtgjson-atomic-${{ steps.cache-keys.outputs.week }}
-
-      - name: Download MTGJSON data
-        run: |
-          if [ ! -f data/mtgjson/AtomicCards.json ]; then
-            mkdir -p data/mtgjson
-            source scripts/lib/mtgjson-fetch.sh
-            mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
-          fi
-
-      - name: Restore generated card data
-        id: cardgen-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            data/card-data.json
-            data/card-names.json
-          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/data/**', 'crates/engine/build.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
+      - name: Restore AI card data caches
+        id: card-data-cache
+        uses: ./.github/actions/ai-card-data-cache
 
       - name: Generate card data
-        if: steps.cardgen-cache.outputs.cache-hit != 'true'
+        if: steps.card-data-cache.outputs.cardgen-cache-hit != 'true'
         run: |
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 
@@ -82,36 +60,12 @@ jobs:
         with:
           cache-shared-key: rust-ai-gate
 
-      - name: Set cache keys
-        id: cache-keys
-        run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache MTGJSON data
-        id: mtgjson-cache
-        uses: actions/cache@v4
-        with:
-          path: data/mtgjson/AtomicCards.json
-          key: mtgjson-atomic-${{ steps.cache-keys.outputs.week }}
-
-      - name: Download MTGJSON data
-        run: |
-          if [ ! -f data/mtgjson/AtomicCards.json ]; then
-            mkdir -p data/mtgjson
-            source scripts/lib/mtgjson-fetch.sh
-            mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
-          fi
-
-      - name: Restore generated card data
-        id: cardgen-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            data/card-data.json
-            data/card-names.json
-          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/data/**', 'crates/engine/build.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
+      - name: Restore AI card data caches
+        id: card-data-cache
+        uses: ./.github/actions/ai-card-data-cache
 
       - name: Generate card data
-        if: steps.cardgen-cache.outputs.cache-hit != 'true'
+        if: steps.card-data-cache.outputs.cardgen-cache-hit != 'true'
         run: |
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 
@@ -151,36 +105,12 @@ jobs:
         with:
           cache-shared-key: rust-ai-gate
 
-      - name: Set cache keys
-        id: cache-keys
-        run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache MTGJSON data
-        id: mtgjson-cache
-        uses: actions/cache@v4
-        with:
-          path: data/mtgjson/AtomicCards.json
-          key: mtgjson-atomic-${{ steps.cache-keys.outputs.week }}
-
-      - name: Download MTGJSON data
-        run: |
-          if [ ! -f data/mtgjson/AtomicCards.json ]; then
-            mkdir -p data/mtgjson
-            source scripts/lib/mtgjson-fetch.sh
-            mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
-          fi
-
-      - name: Restore generated card data
-        id: cardgen-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            data/card-data.json
-            data/card-names.json
-          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/data/**', 'crates/engine/build.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
+      - name: Restore AI card data caches
+        id: card-data-cache
+        uses: ./.github/actions/ai-card-data-cache
 
       - name: Generate card data
-        if: steps.cardgen-cache.outputs.cache-hit != 'true'
+        if: steps.card-data-cache.outputs.cardgen-cache-hit != 'true'
         run: |
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 
@@ -202,36 +132,12 @@ jobs:
         with:
           cache-shared-key: rust-ai-gate
 
-      - name: Set cache keys
-        id: cache-keys
-        run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache MTGJSON data
-        id: mtgjson-cache
-        uses: actions/cache@v4
-        with:
-          path: data/mtgjson/AtomicCards.json
-          key: mtgjson-atomic-${{ steps.cache-keys.outputs.week }}
-
-      - name: Download MTGJSON data
-        run: |
-          if [ ! -f data/mtgjson/AtomicCards.json ]; then
-            mkdir -p data/mtgjson
-            source scripts/lib/mtgjson-fetch.sh
-            mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
-          fi
-
-      - name: Restore generated card data
-        id: cardgen-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            data/card-data.json
-            data/card-names.json
-          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/data/**', 'crates/engine/build.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
+      - name: Restore AI card data caches
+        id: card-data-cache
+        uses: ./.github/actions/ai-card-data-cache
 
       - name: Generate card data
-        if: steps.cardgen-cache.outputs.cache-hit != 'true'
+        if: steps.card-data-cache.outputs.cardgen-cache-hit != 'true'
         run: |
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 

--- a/.github/workflows/ai-gate.yml
+++ b/.github/workflows/ai-gate.yml
@@ -29,6 +29,25 @@ jobs:
         with:
           cache-shared-key: rust-ai-gate
 
+      - name: Set cache keys
+        id: cache-keys
+        run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache MTGJSON data
+        id: mtgjson-cache
+        uses: actions/cache@v4
+        with:
+          path: data/mtgjson/AtomicCards.json
+          key: mtgjson-atomic-${{ steps.cache-keys.outputs.week }}
+
+      - name: Download MTGJSON data
+        run: |
+          if [ ! -f data/mtgjson/AtomicCards.json ]; then
+            mkdir -p data/mtgjson
+            source scripts/lib/mtgjson-fetch.sh
+            mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
+          fi
+
       - name: Restore generated card data
         id: cardgen-cache
         uses: actions/cache@v4
@@ -36,14 +55,11 @@ jobs:
           path: |
             data/card-data.json
             data/card-names.json
-          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
+          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/data/**', 'crates/engine/build.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
 
       - name: Generate card data
         if: steps.cardgen-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p data/mtgjson
-          source scripts/lib/mtgjson-fetch.sh
-          mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 
       - name: Run quick AI gate
@@ -66,6 +82,25 @@ jobs:
         with:
           cache-shared-key: rust-ai-gate
 
+      - name: Set cache keys
+        id: cache-keys
+        run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache MTGJSON data
+        id: mtgjson-cache
+        uses: actions/cache@v4
+        with:
+          path: data/mtgjson/AtomicCards.json
+          key: mtgjson-atomic-${{ steps.cache-keys.outputs.week }}
+
+      - name: Download MTGJSON data
+        run: |
+          if [ ! -f data/mtgjson/AtomicCards.json ]; then
+            mkdir -p data/mtgjson
+            source scripts/lib/mtgjson-fetch.sh
+            mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
+          fi
+
       - name: Restore generated card data
         id: cardgen-cache
         uses: actions/cache@v4
@@ -73,14 +108,11 @@ jobs:
           path: |
             data/card-data.json
             data/card-names.json
-          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
+          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/data/**', 'crates/engine/build.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
 
       - name: Generate card data
         if: steps.cardgen-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p data/mtgjson
-          source scripts/lib/mtgjson-fetch.sh
-          mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 
       - name: Run full AI gate
@@ -119,6 +151,25 @@ jobs:
         with:
           cache-shared-key: rust-ai-gate
 
+      - name: Set cache keys
+        id: cache-keys
+        run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache MTGJSON data
+        id: mtgjson-cache
+        uses: actions/cache@v4
+        with:
+          path: data/mtgjson/AtomicCards.json
+          key: mtgjson-atomic-${{ steps.cache-keys.outputs.week }}
+
+      - name: Download MTGJSON data
+        run: |
+          if [ ! -f data/mtgjson/AtomicCards.json ]; then
+            mkdir -p data/mtgjson
+            source scripts/lib/mtgjson-fetch.sh
+            mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
+          fi
+
       - name: Restore generated card data
         id: cardgen-cache
         uses: actions/cache@v4
@@ -126,14 +177,11 @@ jobs:
           path: |
             data/card-data.json
             data/card-names.json
-          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
+          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/data/**', 'crates/engine/build.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
 
       - name: Generate card data
         if: steps.cardgen-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p data/mtgjson
-          source scripts/lib/mtgjson-fetch.sh
-          mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 
       # debug profile (authoritative): counter VALUES are profile-independent and the
@@ -154,6 +202,25 @@ jobs:
         with:
           cache-shared-key: rust-ai-gate
 
+      - name: Set cache keys
+        id: cache-keys
+        run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache MTGJSON data
+        id: mtgjson-cache
+        uses: actions/cache@v4
+        with:
+          path: data/mtgjson/AtomicCards.json
+          key: mtgjson-atomic-${{ steps.cache-keys.outputs.week }}
+
+      - name: Download MTGJSON data
+        run: |
+          if [ ! -f data/mtgjson/AtomicCards.json ]; then
+            mkdir -p data/mtgjson
+            source scripts/lib/mtgjson-fetch.sh
+            mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
+          fi
+
       - name: Restore generated card data
         id: cardgen-cache
         uses: actions/cache@v4
@@ -161,14 +228,11 @@ jobs:
           path: |
             data/card-data.json
             data/card-names.json
-          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
+          key: cardgen-${{ hashFiles('data/mtgjson/AtomicCards.json', 'crates/engine/src/**/*.rs', 'crates/engine/data/**', 'crates/engine/build.rs', 'crates/engine/Cargo.toml', 'Cargo.lock') }}
 
       - name: Generate card data
         if: steps.cardgen-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p data/mtgjson
-          source scripts/lib/mtgjson-fetch.sh
-          mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 
       # debug profile (authoritative): counter VALUES are profile-independent and the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - 'Dockerfile'
       - '.dockerignore'
       - 'docker/**'
+      - '.github/actions/**'
       - '.github/workflows/ci.yml'
       - '.github/workflows/deploy.yml'
       - '.github/workflows/release.yml'
@@ -200,10 +201,11 @@ jobs:
         # at step start against the clean checkout, so oracle-gen's later
         # write-if-changed rewrite of oracle-subtypes.json cannot feed back in.
         #
-        # ai-gate.yml intentionally uses the same `cardgen-` key expression, so
-        # main pushes can seed generated-card-data entries that AI PR gates reuse.
-        # Both workflows download AtomicCards.json before this step so the
-        # gitignored MTGJSON input participates in `hashFiles`.
+        # The AI gate's shared card-data-cache action intentionally uses the
+        # same `cardgen-` key expression, so main pushes can seed generated
+        # entries that AI PR gates reuse. Both paths download AtomicCards.json
+        # before evaluating the key so the gitignored MTGJSON input participates
+        # in `hashFiles`.
         id: cardgen-cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,12 +200,10 @@ jobs:
         # at step start against the clean checkout, so oracle-gen's later
         # write-if-changed rewrite of oracle-subtypes.json cannot feed back in.
         #
-        # ai-gate.yml carries a `cardgen-` cache whose key EXPRESSION looks
-        # identical, but the two have never shared an entry and cannot: ai-gate
-        # restores its cache before it downloads AtomicCards.json (the download
-        # sits inside its miss-gated Generate step) and that file is gitignored,
-        # so `hashFiles` silently omits it there and the digests always differ.
-        # This expression intentionally supersets ai-gate's; they are independent.
+        # ai-gate.yml intentionally uses the same `cardgen-` key expression, so
+        # main pushes can seed generated-card-data entries that AI PR gates reuse.
+        # Both workflows download AtomicCards.json before this step so the
+        # gitignored MTGJSON input participates in `hashFiles`.
         id: cardgen-cache
         uses: actions/cache@v4
         with:
@@ -225,15 +223,12 @@ jobs:
         #
         # Deliberately a SEPARATE key from `cardgen-cache`, not a reuse of it.
         # A cardgen entry proves only that generation succeeded; it is not
-        # evidence that anything validated it. ai-gate.yml generates card-data
-        # and never validates it, and while its `cardgen-` key is de-facto
-        # disjoint from this workflow's today (see the note above), that is an
-        # accident of its step order, not a guarantee. Were ai-gate ever fixed to
-        # genuinely share the key, an engine change whose output fails
-        # `card-data-validate` would red card-data-gate while ai-gate still
-        # succeeded and saved the shared entry — and gating validate on that
-        # entry would skip validation on the next push: a false green. This cache
-        # is written by card-data-gate alone, so a hit cannot lie about a gate.
+        # evidence that anything validated it. ai-gate.yml intentionally shares
+        # `cardgen-` entries but never validates them. If this gate skipped
+        # validate/coverage on a shared cardgen hit, an engine change whose
+        # generated output fails `card-data-validate` could still seed a false
+        # green for the next push. This cache is written by card-data-gate alone,
+        # so a hit cannot lie about a gate.
         id: gates-cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
Fixes the ai-gate cardgen cache ordering for issue #5456.

Closes #5456.

## Files changed
- `.github/actions/ai-card-data-cache/action.yml`
- `.github/workflows/ai-gate.yml`
- `.github/workflows/ci.yml`

## CR references
None.

## Track
Developer

## LLM
Model: codex-5
Thinking: medium
Tier: Standard

## Anchored on
- `.github/workflows/ci.yml:153` — existing weekly `mtgjson-atomic-*` cache key setup before generated card-data cache evaluation.
- `.github/workflows/ci.yml:174` — existing file-existence-gated MTGJSON download that self-heals missing or partial cache restores.
- `.github/workflows/ci.yml:188` — existing generated card-data cache key that hashes `AtomicCards.json`, engine source, engine embedded data, build script, and lockfile.
- `.github/actions/create-auto-merge-pr/action.yml:24` — existing local composite action structure using `runs: using: composite`.

## Gate A
`./scripts/check-parser-combinators.sh` — clean, exit 0, no output.

## Verification
- `cargo fmt --all -- --check` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `/tmp/actionlint-bin/actionlint .github/workflows/ai-gate.yml .github/workflows/ci.yml` — clean
- `python3 -c 'import yaml, sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]; print("ok")' .github/workflows/ai-gate.yml .github/workflows/ci.yml .github/actions/ai-card-data-cache/action.yml` — clean
- Composite action metadata shape check — clean
- Personal `doc-guardian` — clean
- Personal `code-reviewer` — approved
- Personal `qa-tester` — READY FOR PR

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
