### PR TITLE
feat(engine): Radiance color fan-out damage (Cleansing Beam #5244)

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -795,6 +795,7 @@ fn filterprop_reads_only_candidate_fp(p: &FilterProp) -> bool {
         | FilterProp::SameNameAsParentTarget
         | FilterProp::NameMatchesAnyPermanent { .. }
         | FilterProp::DifferentNameFrom { .. }
+        | FilterProp::DistinctFrom { .. }
         | FilterProp::SharesQuality { .. }
         | FilterProp::CanEnchant { .. }
         | FilterProp::IsChosenCreatureType

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2262,6 +2262,7 @@ fn legacy_filter_prop(p: &FilterProp) -> bool {
         FilterProp::DifferentNameFrom { filter }
         | FilterProp::TargetsOnly { filter }
         | FilterProp::Targets { filter } => legacy_target_filter(filter),
+        FilterProp::DistinctFrom { reference } => legacy_target_filter(reference),
         FilterProp::SharesQuality { reference, .. } => {
             reference.as_deref().is_some_and(legacy_target_filter)
         }
@@ -2510,6 +2511,7 @@ fn member_bound_filter_prop(p: &FilterProp) -> bool {
         FilterProp::DifferentNameFrom { filter }
         | FilterProp::TargetsOnly { filter }
         | FilterProp::Targets { filter } => member_bound_target_filter(filter),
+        FilterProp::DistinctFrom { reference } => member_bound_target_filter(reference),
         FilterProp::SharesQuality { reference, .. } => {
             reference.as_deref().is_some_and(member_bound_target_filter)
         }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -892,6 +892,7 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
             FilterProp::ToughnessGTPower => parts.push("toughness > power".into()),
             FilterProp::PowerExceedsBase => parts.push("power > base power".into()),
             FilterProp::DifferentNameFrom { .. } => parts.push("different name".into()),
+            FilterProp::DistinctFrom { .. } => parts.push("other than target".into()),
             FilterProp::Other { value } => parts.push(value.clone()),
             FilterProp::InAnyZone { zones } => {
                 let zone_strs: Vec<_> = zones.iter().map(fmt_zone).collect();

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -2533,6 +2533,66 @@ mod tests {
         assert_eq!(outcome.damage_marked(src_b), 0);
     }
 
+    /// Issue #5244 — Radiance color fan-out (Cleansing Beam): "deals 2 damage to
+    /// target creature and each other creature that shares a color with it." The
+    /// chosen target and every OTHER creature sharing a color with it take 2; a
+    /// creature sharing no color takes 0. Proves the parser fan-out
+    /// (DealDamage{target} + DamageAll{SharesQuality Color, ParentTarget +
+    /// DistinctFrom ParentTarget}) resolves end-to-end and does NOT double-damage
+    /// the target (CR 120.3).
+    #[test]
+    fn radiance_cleansing_beam_color_fanout() {
+        use crate::game::scenario::{GameScenario, P0, P1};
+        use crate::types::mana::{ManaColor, ManaType, ManaUnit};
+        use crate::types::phase::Phase;
+
+        const CLEANSING_BEAM: &str = "Cleansing Beam deals 2 damage to target creature and each other creature that shares a color with it.";
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        // Big toughness so 2 marked damage is observable without dying.
+        let red_target = scenario.add_creature(P1, "Red Target", 0, 9).id();
+        let red_other = scenario.add_creature(P1, "Red Other", 0, 9).id();
+        let blue_other = scenario.add_creature(P1, "Blue Other", 0, 9).id();
+        let spell = scenario
+            .add_spell_to_hand_from_oracle(P0, "Cleansing Beam", true, CLEANSING_BEAM)
+            .id();
+        scenario.with_mana_pool(
+            P0,
+            vec![ManaUnit::new(ManaType::Colorless, ObjectId(9_999), false, vec![]); 4],
+        );
+        let mut runner = scenario.build();
+        {
+            let state = runner.state_mut();
+            state.active_player = P0;
+            state.priority_player = P0;
+            state.objects.get_mut(&red_target).unwrap().color = vec![ManaColor::Red];
+            state.objects.get_mut(&red_other).unwrap().color = vec![ManaColor::Red];
+            state.objects.get_mut(&blue_other).unwrap().color = vec![ManaColor::Blue];
+        }
+
+        let outcome = runner.cast(spell).target_objects(&[red_target]).resolve();
+
+        // Target takes 2 exactly ONCE (not doubled by the fan-out).
+        assert_eq!(
+            outcome.damage_marked(red_target),
+            2,
+            "chosen target takes 2 once (not doubled by the color fan-out)"
+        );
+        // Other red creature shares a color → takes 2.
+        assert_eq!(
+            outcome.damage_marked(red_other),
+            2,
+            "the other red creature shares a color with the target and takes 2"
+        );
+        // Blue creature shares no color → takes 0.
+        assert_eq!(
+            outcome.damage_marked(blue_other),
+            0,
+            "the blue creature shares no color with the (red) target and takes 0"
+        );
+    }
+
     /// CR 120.1 + CR 120.6: `EachSourceDealsDamage` with a `Shared` recipient — two
     /// creatures the controller controls each deal the fixed amount to one shared
     /// recipient, whose marked total accumulates across both sources (Case of the

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -4116,31 +4116,31 @@ fn matches_filter_prop(
         // reference resolution below). Used by Radiance's "each OTHER creature
         // that shares a color with it" — excludes the already-damaged target.
         FilterProp::DistinctFrom { reference } => {
-            let reference_ids: Vec<ObjectId> = if matches!(**reference, TargetFilter::ParentTarget)
-            {
-                source
-                    .ability
-                    .map(|ability| {
-                        ability
-                            .targets
-                            .iter()
-                            .filter_map(|t| match t {
-                                TargetRef::Object(id) => Some(*id),
-                                TargetRef::Player(_) => None,
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default()
+            // `matches_filter_prop` runs once per candidate object, so short-circuit
+            // via `.any()` rather than collecting the reference ids into a `Vec`.
+            //
+            // NOTE (fail-open asymmetry): the `ParentTarget` arm reads ONLY
+            // `ability.targets` — it lacks the LKI / `recipient_id` /
+            // effect-context fallback ladder that `SharesQuality`'s `ParentTarget`
+            // path carries (see `parent_target_shared_quality_values` below). When
+            // `ability` is `None` or its targets are empty this excludes nothing
+            // (fails open). That is safe for the current Radiance class — the
+            // resolving `DamageAll` sub-ability always carries the chosen target —
+            // but a future reuse in a layer-eval or recipient context would need
+            // the same fallback ladder to avoid a silent double-hit.
+            let is_referenced = if matches!(**reference, TargetFilter::ParentTarget) {
+                source.ability.is_some_and(|ability| {
+                    ability
+                        .targets
+                        .iter()
+                        .any(|t| matches!(t, TargetRef::Object(id) if *id == object_id))
+                })
             } else {
                 crate::game::targeting::resolve_event_context_targets(state, reference, source.id)
                     .into_iter()
-                    .filter_map(|t| match t {
-                        TargetRef::Object(id) => Some(id),
-                        TargetRef::Player(_) => None,
-                    })
-                    .collect()
+                    .any(|t| matches!(t, TargetRef::Object(id) if id == object_id))
             };
-            !reference_ids.contains(&object_id)
+            !is_referenced
         }
         // CR 604.3: Match objects in any of the listed zones (OR semantics).
         FilterProp::InAnyZone { zones } => zones.contains(&obj.zone),

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -124,6 +124,10 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         // so any entry/exit of a matching permanent can flip membership for a
         // pre-existing object. Unconditionally population dependent.
         FilterProp::DifferentNameFrom { .. } => true,
+        // CR 109.1: identity-exclusion against a resolved reference (e.g. the
+        // ability's chosen target) — the reference set can change, so treat as
+        // population dependent, mirroring `DifferentNameFrom`.
+        FilterProp::DistinctFrom { .. } => true,
         // CR 603.4: "shares a quality with" a reference set is population
         // dependent ONLY when a reference filter is present — the reference set
         // is battlefield-derived. The multi-target group-share form
@@ -351,6 +355,11 @@ fn entered_object_perturbs_filter_prop(
         // perturb.
         FilterProp::DifferentNameFrom { filter } => {
             matches_target_filter(state, entered_id, filter, ctx)
+        }
+        // CR 109.1: an entering object perturbs the identity-exclusion iff it
+        // matches the reference filter (it could become a new reference object).
+        FilterProp::DistinctFrom { reference } => {
+            matches_target_filter(state, entered_id, reference, ctx)
         }
         // CR 603.4: the reference set is battlefield-derived only when a
         // reference filter is present (classifier returns false for `None`). The
@@ -3147,6 +3156,10 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         | FilterProp::ToughnessGTPower
         | FilterProp::PowerExceedsBase
         | FilterProp::DifferentNameFrom { .. }
+        // CR 109.1: a spell on the stack is not the ability's chosen target
+        // permanent; identity-exclusion is a live-battlefield predicate the
+        // spell-cast snapshot cannot represent. Fail closed.
+        | FilterProp::DistinctFrom { .. }
         | FilterProp::SharesQuality { .. }
         | FilterProp::WasDealtDamageThisTurn
         | FilterProp::EnteredThisTurn
@@ -4096,6 +4109,39 @@ fn matches_filter_prop(
                 .collect();
             !controlled_names.contains(&obj.name.as_str())
         }
+        // CR 109.1 + CR 120.3: Match objects that are NOT the same object as any
+        // object the `reference` filter resolves to. `ParentTarget` resolves to
+        // the ability's chosen object target(s); other context refs resolve via
+        // the shared event-context machinery (mirrors the `SharesQuality`
+        // reference resolution below). Used by Radiance's "each OTHER creature
+        // that shares a color with it" — excludes the already-damaged target.
+        FilterProp::DistinctFrom { reference } => {
+            let reference_ids: Vec<ObjectId> = if matches!(**reference, TargetFilter::ParentTarget)
+            {
+                source
+                    .ability
+                    .map(|ability| {
+                        ability
+                            .targets
+                            .iter()
+                            .filter_map(|t| match t {
+                                TargetRef::Object(id) => Some(*id),
+                                TargetRef::Player(_) => None,
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            } else {
+                crate::game::targeting::resolve_event_context_targets(state, reference, source.id)
+                    .into_iter()
+                    .filter_map(|t| match t {
+                        TargetRef::Object(id) => Some(id),
+                        TargetRef::Player(_) => None,
+                    })
+                    .collect()
+            };
+            !reference_ids.contains(&object_id)
+        }
         // CR 604.3: Match objects in any of the listed zones (OR semantics).
         FilterProp::InAnyZone { zones } => zones.contains(&obj.zone),
         FilterProp::SharesQuality {
@@ -4646,6 +4692,9 @@ fn zone_change_record_matches_property(
         // attachments) — a zone-change snapshot cannot represent it.
         | FilterProp::Modified
         | FilterProp::DifferentNameFrom { .. }
+        // CR 109.1: identity-exclusion is a live-battlefield predicate; a
+        // zone-change snapshot cannot represent it. Fail closed.
+        | FilterProp::DistinctFrom { .. }
         | FilterProp::InAnyZone { .. }
         | FilterProp::SharesQuality { .. }
         | FilterProp::EnteredThisTurn

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -14710,6 +14710,92 @@ fn try_parse_compound_object_player_damage(lower: &str) -> Option<ParsedEffectCl
 /// compounds like "deals 3 damage to any target and you gain 3 life" fall
 /// through to the caller's compound splitter unharmed. Returns `None` (and
 /// does not mutate `ctx`) if the text is not a multi-segment damage line.
+/// CR 120.3 + CR 207.2c: Radiance color fan-out damage — "deals N damage to
+/// target `<X>` and each other `<X>` that shares a color with it" (Cleansing
+/// Beam, Wojek Embermage). The chosen target takes the damage (a `DealDamage`
+/// that also supplies the required target slot), and a `DamageAll` sub-ability
+/// fans the same damage out to every OTHER object sharing a color with the
+/// target: `SharesQuality { Color, reference: ParentTarget }` selects the
+/// color-sharers (the target itself trivially shares its own color, so it is
+/// included by that predicate and must be removed) and
+/// `DistinctFrom { reference: ParentTarget }` excludes the already-damaged
+/// target so it is not dealt damage twice. Radiance is an ability word (CR
+/// 207.2c) with no independent rules meaning.
+///
+/// The fan-out noun's type is taken from the parsed primary target (creature
+/// here; the same shape generalizes to other permanent types), so the recognizer
+/// is not hard-coded to Creature.
+fn try_parse_radiance_color_fanout_damage(
+    text: &str,
+    lower: &str,
+    ctx: &mut ParseContext,
+) -> Option<ParsedEffectClause> {
+    let (primary_effect, remainder) = try_parse_damage_with_remainder(text, lower, ctx)?;
+
+    // Primary must be a single-target DealDamage at a typed object.
+    let Effect::DealDamage {
+        amount,
+        target: TargetFilter::Typed(target_typed),
+        damage_source: None,
+        excess: None,
+    } = &primary_effect
+    else {
+        return None;
+    };
+
+    // The remainder must be exactly the color fan-out suffix.
+    let rem_lower = remainder.trim().trim_end_matches('.').trim().to_lowercase();
+    let matched = nom_on_lower(remainder.trim(), &rem_lower, |i| {
+        let (i, _) = opt(tag::<_, _, OracleError<'_>>(",")).parse(i)?;
+        let (i, _) = tag("and each other ").parse(i.trim_start())?;
+        // Consume the fan-out noun (must be a type word — creature/enchantment/…)
+        // then the fixed "that shares a color with it" tail. The noun value is not
+        // needed: the fan-out reuses the primary target's typed filter.
+        let (i, _) =
+            take_until::<_, _, OracleError<'_>>(" that shares a color with it").parse(i)?;
+        let (i, _) = tag(" that shares a color with it").parse(i)?;
+        Ok((i, ()))
+    })
+    .map(|(_, rest)| rest.trim().is_empty())
+    .unwrap_or(false);
+    if !matched {
+        return None;
+    }
+
+    // Build the fan-out filter: same object type as the target, restricted to
+    // color-sharers of the target, excluding the target itself.
+    let mut fanout = target_typed.clone();
+    fanout.properties.push(FilterProp::SharesQuality {
+        quality: SharedQuality::Color,
+        reference: Some(Box::new(TargetFilter::ParentTarget)),
+        relation: SharedQualityRelation::Shares,
+    });
+    fanout.properties.push(FilterProp::DistinctFrom {
+        reference: Box::new(TargetFilter::ParentTarget),
+    });
+
+    let fanout_effect = Effect::DamageAll {
+        amount: amount.clone(),
+        target: TargetFilter::Typed(fanout),
+        player_filter: None,
+        damage_source: None,
+    };
+
+    Some(ParsedEffectClause {
+        effect: primary_effect.clone(),
+        duration: None,
+        sub_ability: Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            fanout_effect,
+        ))),
+        distribute: None,
+        multi_target: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
+}
+
 fn try_parse_multi_target_damage_chain(
     text: &str,
     ctx: &mut ParseContext,
@@ -15108,6 +15194,16 @@ fn try_split_damage_compound(text: &str, ctx: &mut ParseContext) -> Option<Parse
     // [with X | without X] and each player" (Pyrohemia / Earthquake / Hurricane
     // class). Must run before the general split so the player half isn't dropped.
     if let Some(clause) = try_parse_compound_object_player_damage(&lower) {
+        return Some(clause);
+    }
+
+    // CR 120.3 + CR 207.2c: Radiance color fan-out — "deals N damage to target
+    // <X> and each other <X> that shares a color with it" (Cleansing Beam, Wojek
+    // Embermage). The target <X> takes the damage AND every OTHER <X> sharing a
+    // color with it. Must run before the multi-target chain (which only handles
+    // "and M damage to T2" segments) so the fan-out isn't dropped as an ignored
+    // remainder. Radiance is an ability word (CR 207.2c) with no rules meaning.
+    if let Some(clause) = try_parse_radiance_color_fanout_damage(text, &lower, ctx) {
         return Some(clause);
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -14743,6 +14743,17 @@ fn try_parse_radiance_color_fanout_damage(
         return None;
     };
 
+    // Scope: only fixed-amount Radiance damage (Cleansing Beam = 2, Wojek
+    // Embermage = 1). Brightflame deals *X* and carries a following "You gain
+    // life equal to the damage dealt this way" rider whose amount would need to
+    // bind to the fan-out's `DamageAll` total, not a preceding `DealDamage` —
+    // real engine work deferred to its own PR. Declining an X-amount fan-out
+    // keeps Brightflame honestly unsupported (its lifegain sentence is not
+    // silently dropped) rather than lowering it wrong. CR 120.3.
+    if !matches!(amount, QuantityExpr::Fixed { .. }) {
+        return None;
+    }
+
     // The remainder must be exactly the color fan-out suffix.
     let rem_lower = remainder.trim().trim_end_matches('.').trim().to_lowercase();
     let matched = nom_on_lower(remainder.trim(), &rem_lower, |i| {

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -4257,6 +4257,30 @@ fn plain_damage_no_radiance_suffix_stays_single_deal_damage() {
     );
 }
 
+/// Issue #5244 (review) — the Radiance fan-out recognizer must DECLINE
+/// Brightflame ("deals X damage to target creature and each other creature that
+/// shares a color with it. You gain life equal to the damage dealt this way.").
+/// Its X amount and "damage dealt this way" lifegain rider need the rider bound
+/// to the fan-out's DamageAll total — deferred engine work. Declining keeps the
+/// lifegain sentence intact instead of silently lowering the card wrong, so the
+/// recognizer only fires for FIXED-amount Radiance damage.
+#[test]
+fn radiance_fanout_declines_variable_x_amount() {
+    let clause = parse_effect_clause(
+        "Brightflame deals X damage to target creature and each other creature that shares a color with it.",
+        &mut ParseContext::default(),
+    );
+    // The X-amount fan-out must NOT produce a DamageAll sub-ability here.
+    assert!(
+        !matches!(
+            clause.sub_ability.as_ref().map(|s| s.effect.as_ref()),
+            Some(Effect::DamageAll { .. })
+        ),
+        "X-amount Radiance damage must not lower to the color fan-out (deferred), got {:?}",
+        clause.sub_ability
+    );
+}
+
 /// Issue #495 — Rite of Consumption. The explicit participle-possessive
 /// "the sacrificed creature's power" must resolve to the cost-paid object
 /// (CR 608.2k), NOT the source. The subject-injection rewrite for a `~`

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -4169,6 +4169,94 @@ fn target_subject_damage_compound_each_creature_and_each_opponent() {
     );
 }
 
+/// Issue #5244 — Radiance color fan-out (Cleansing Beam): "deals 2 damage to
+/// target creature and each other creature that shares a color with it." Must
+/// lower to a `DealDamage` to the chosen target (providing the target slot +
+/// the target's own damage) with a `DamageAll` sub-ability that fans the damage
+/// to color-sharers (`SharesQuality{Color, ParentTarget}`) EXCLUDING the target
+/// (`DistinctFrom{ParentTarget}`), so the target is not double-damaged.
+#[test]
+fn radiance_color_fanout_lowers_to_damage_all_sub_ability() {
+    let clause = parse_effect_clause(
+        "Cleansing Beam deals 2 damage to target creature and each other creature that shares a color with it.",
+        &mut ParseContext::default(),
+    );
+    // Primary: DealDamage to a single target creature.
+    let Effect::DealDamage {
+        amount,
+        target: TargetFilter::Typed(primary_tf),
+        ..
+    } = &clause.effect
+    else {
+        panic!("expected DealDamage primary, got {:?}", clause.effect);
+    };
+    assert_eq!(*amount, QuantityExpr::Fixed { value: 2 });
+    assert!(primary_tf
+        .type_filters
+        .iter()
+        .any(|t| matches!(t, TypeFilter::Creature)));
+
+    // Sub-ability: DamageAll over color-sharers excluding the target.
+    let sub = clause
+        .sub_ability
+        .as_ref()
+        .expect("Radiance fan-out must attach a DamageAll sub-ability");
+    let Effect::DamageAll {
+        amount: fan_amount,
+        target: TargetFilter::Typed(fan_tf),
+        player_filter: None,
+        damage_source: None,
+    } = sub.effect.as_ref()
+    else {
+        panic!(
+            "expected DamageAll fan-out sub-effect, got {:?}",
+            sub.effect
+        );
+    };
+    assert_eq!(*fan_amount, QuantityExpr::Fixed { value: 2 });
+    assert!(
+        fan_tf.properties.iter().any(|p| matches!(
+            p,
+            FilterProp::SharesQuality {
+                quality: SharedQuality::Color,
+                reference: Some(r),
+                relation: SharedQualityRelation::Shares,
+            } if matches!(**r, TargetFilter::ParentTarget)
+        )),
+        "fan-out must share a Color with ParentTarget, got {:?}",
+        fan_tf.properties
+    );
+    assert!(fan_tf.properties.iter().any(|p| matches!(
+        p,
+        FilterProp::DistinctFrom { reference } if matches!(**reference, TargetFilter::ParentTarget)
+    )), "fan-out must exclude the ParentTarget, got {:?}", fan_tf.properties);
+}
+
+/// Negative reach-guard for the Radiance recognizer: a plain single-target
+/// damage line ("deals 2 damage to target creature", no fan-out suffix) must
+/// still lower to a bare `DealDamage` with NO DamageAll sub-ability — proving
+/// the fan-out recognizer doesn't over-fire.
+#[test]
+fn plain_damage_no_radiance_suffix_stays_single_deal_damage() {
+    let clause = parse_effect_clause(
+        "Shock deals 2 damage to target creature.",
+        &mut ParseContext::default(),
+    );
+    assert!(
+        matches!(clause.effect, Effect::DealDamage { .. }),
+        "plain damage must be DealDamage, got {:?}",
+        clause.effect
+    );
+    assert!(
+        clause.sub_ability.is_none()
+            || !matches!(
+                clause.sub_ability.as_ref().map(|s| s.effect.as_ref()),
+                Some(Effect::DamageAll { .. })
+            ),
+        "plain damage must NOT gain a DamageAll fan-out sub-ability"
+    );
+}
+
 /// Issue #495 — Rite of Consumption. The explicit participle-possessive
 /// "the sacrificed creature's power" must resolve to the cost-paid object
 /// (CR 608.2k), NOT the source. The subject-injection rewrite for a `~`

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3682,6 +3682,21 @@ pub enum FilterProp {
     DifferentNameFrom {
         filter: Box<TargetFilter>,
     },
+    /// CR 109.1 + CR 120.3: Matches objects that are NOT the same object as any
+    /// object the `reference` filter resolves to — the object-identity dual of
+    /// [`FilterProp::SharesQuality`] (which carries a `reference` and tests a
+    /// shared *quality*; this tests object *identity*). Used for the "each OTHER
+    /// <X> that ..." exclusion where "other" is relative to the ability's chosen
+    /// target rather than the source: Radiance's "target creature and each other
+    /// creature that shares a color with it" (Cleansing Beam) pairs
+    /// `DistinctFrom { reference: ParentTarget }` with
+    /// `SharesQuality { Color, reference: ParentTarget }` so the fan-out damages
+    /// every color-sharer EXCEPT the already-damaged target. Distinct from
+    /// [`FilterProp::Another`] (excludes the ability *source*) and
+    /// [`FilterProp::OtherThanTriggerObject`] (excludes the *triggering* object).
+    DistinctFrom {
+        reference: Box<TargetFilter>,
+    },
     /// CR 604.3: Matches objects whose current zone is any of the listed zones (OR semantics).
     /// Used for zone-based restrictions like "cards in graveyards and libraries".
     InAnyZone {
@@ -12603,6 +12618,9 @@ fn normalized_filter_prop(prop: FilterProp) -> FilterProp {
     match prop {
         FilterProp::DifferentNameFrom { filter } => FilterProp::DifferentNameFrom {
             filter: Box::new(filter.normalized()),
+        },
+        FilterProp::DistinctFrom { reference } => FilterProp::DistinctFrom {
+            reference: Box::new(reference.normalized()),
         },
         FilterProp::SharesQuality {
             quality,


### PR DESCRIPTION
## Summary

Fixes #5244. **Cleansing Beam** — *"Radiance — Cleansing Beam deals 2 damage to target creature **and each other creature that shares a color with it**."* — lowered to a plain single-target `DealDamage`; the Radiance fan-out clause was silently dropped (`IgnoredRemainder`), so only the chosen target took damage.

The fix spans **types + runtime + parser** (the correct home for each piece):

### 1. `types/ability.rs` — new `FilterProp::DistinctFrom { reference: Box<TargetFilter> }`
The object-**identity** dual of `FilterProp::SharesQuality` (which carries a `reference` and tests a shared **quality**). Matches objects that are **not the same object** as any the `reference` resolves to.

Why a new variant: none of the existing exclusions fit — `Another` excludes the ability **source**, `OtherThanTriggerObject` excludes the **triggering** object; neither can exclude the *chosen target*. Gated through `/add-engine-variant`: chosen as a **parameterized reference-carrying** variant (mirrors `SharesQuality`/`DifferentNameFrom`), **not** a bare `OtherThanParentTarget` sibling — so it generalizes to any "other than [reference]" case and avoids a 454-call-site refactor of `Another`. CR 109.1.

### 2. `game/filter.rs` — runtime eval
`DistinctFrom { ParentTarget }` resolves the ability's chosen object target(s) (mirrors `SharesQuality`'s `ParentTarget` path at filter.rs) and matches every object except those. Plus population-dependency and spell-cast / zone-change snapshot classifier arms (fail-closed, like `DifferentNameFrom`). `ability_rw.rs` / `ai_support` / `coverage` arms updated in lockstep.

### 3. `parser/oracle_effect/mod.rs` — Radiance recognizer
`try_parse_radiance_color_fanout_damage` recognizes *"deals N damage to target `<X>` and each other `<X>` that shares a color with it"* and lowers to:
- `DealDamage { target: Typed(<X>) }` — provides the required target slot **and** the target's own damage, then
- `sub_ability: DamageAll { target: Typed(<X>).[SharesQuality{Color, ParentTarget}, DistinctFrom{ParentTarget}] }` — the color-sharers **excluding** the already-damaged target, so it is not dealt damage **twice** (CR 120.3).

Radiance is an ability word (CR 207.2c, verified — no independent rules meaning). The fan-out noun's type is taken from the parsed target, so it generalizes beyond creatures.

## Design notes (from the plan-review gate)

Two naive representations were considered and **rejected** on code evidence:
- A single `DamageAll` including the target: `DamageAll` is a mass effect that surfaces **no target slot**, so `ParentTarget` would resolve to nothing.
- `DealDamage + DamageAll{Another}`: `Another` excludes the *source*, not the target → the target would take **4** damage.

Hence the `DistinctFrom{ParentTarget}` exclusion is load-bearing.

## Class

Radiance **damage** subclass: Cleansing Beam, Wojek Embermage. **Brightflame** (X + "damage dealt this way" lifegain rider) is explicitly **deferred**.

## Tests

- **Parser**: Cleansing Beam lowers to `DealDamage` + `DamageAll{SharesQuality Color ParentTarget + DistinctFrom ParentTarget}`; **negative reach-guard** that plain *"deals 2 damage to target creature"* stays a bare `DealDamage` (recognizer doesn't over-fire).
- **Runtime** (`/card-test` recipe): red target + red creature + blue creature → target takes **2 once** (not doubled), red creature **2**, blue creature **0**.

## Verification

- `cargo check -p engine` — clean (exhaustiveness across all `FilterProp` match sites)
- `cargo clippy -p engine` — clean
- Suites pass: `game::filter` (124), `game::effects::deal_damage` (66), `parser::oracle_effect` (1370) — zero failures.

`FilterProp::DistinctFrom` is purely additive to the serialized surface (old data never references it).

CR 120.3 (fan-out damage same event) + CR 207.2c (Radiance ability word) + CR 109.1 (object identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)