### PR TITLE
fix(pr-review): anchor requested-changes expiry on the blocker, not our own sweep event

### DIFF
--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -59,6 +59,10 @@ PRIVATE_OVERRIDES = "private-overrides.json"
 SUCCESS_STATES = {"accepted", "merged"}
 BLOCK_STATES = {"blocked", "changes_requested"}
 HOLD_STATES = {"held", "held_ci"}
+# Local events that mean "this head is blocked". Single authority for both the
+# routing decision and the requested-changes expiry anchor — two copies would drift.
+LOCAL_BLOCK_EVENT_TYPES = {"review_blocked", "changes_requested", "blocked"}
+LOCAL_BLOCK_OUTCOMES = {"changes_requested", "reviewed_request_changes", "blocked"}
 TERMINAL_STATES = SUCCESS_STATES | BLOCK_STATES | {"closed"}
 PR_ATTRIBUTED_EVENTS = {
     "approval_enqueue",
@@ -529,6 +533,35 @@ def latest_events_by_pr_head(events: list[dict[str, Any]]) -> dict[tuple[int, st
             continue
         latest[(int(pr), str(head_sha))] = event
     return latest
+
+
+def is_block_event(event: dict[str, Any] | None) -> bool:
+    """True when a local event means the current head is blocked."""
+    event = event or {}
+    outcome = event.get("outcome")
+    if outcome == "ci_failed":
+        return False
+    return event.get("event_type") in LOCAL_BLOCK_EVENT_TYPES or outcome in LOCAL_BLOCK_OUTCOMES
+
+
+def first_block_events_by_pr_head(
+    events: list[dict[str, Any]],
+) -> dict[tuple[int, str], dict[str, Any]]:
+    """Earliest blocking event per (pr, head) — the requested-changes expiry anchor.
+
+    Deliberately the earliest, never the latest: every sweep re-records a `blocked`
+    event for a PR that is still blocked, and `event_id` hashes the timestamp, so
+    each pass appends a distinct row. Anchoring the expiry clock on the newest event
+    would let the loop reset its own timer, and `warning_due` could never fire.
+    """
+    first: dict[tuple[int, str], dict[str, Any]] = {}
+    for event in events:  # append-only log; file order is chronological
+        pr = event.get("pr")
+        head_sha = event.get("head_sha")
+        if pr is None or not head_sha or not is_block_event(event):
+            continue
+        first.setdefault((int(pr), str(head_sha)), event)
+    return first
 
 
 def event_sort_key(event: dict[str, Any]) -> tuple[str, str]:
@@ -1957,11 +1990,19 @@ def requested_changes_expiry_state(
     warning = latest_requested_changes_warning(packet)
     warning_timestamp = (warning or {}).get("timestamp")
     author_followup_after_warning = author_activity_after(pr, warning_timestamp)
+    # Anchor the expiry clock on the blocker itself, never on our observation of it.
+    # GitHub is authoritative, so a formal CHANGES_REQUESTED on the current head wins
+    # (a newer one correctly restarts the window). Only when no formal review exists
+    # do we fall back to the local log — and then to the FIRST block recorded for this
+    # head, because the sweep re-records `blocked` every pass and the newest event
+    # would pin blocker_age at ~0 forever, silently disabling warn/close entirely.
     blocker_timestamp = None
-    if local_block:
-        blocker_timestamp = (packet.get("local_current_event") or {}).get("timestamp")
-    if blocker_timestamp is None and current_head_changes_requested:
+    if current_head_changes_requested:
         blocker_timestamp = latest_requested_changes_review_timestamp(packet)
+    if blocker_timestamp is None and local_block:
+        blocker_timestamp = (
+            packet.get("local_first_block_event") or packet.get("local_current_event") or {}
+        ).get("timestamp")
     blocker_age = age_in_days(blocker_timestamp)
     warning_age = age_in_days(warning_timestamp)
     warning_due = (
@@ -2010,18 +2051,8 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
         parse_diff.get("updated_at"), local_event_timestamp
     )
     author_policy = packet.get("author_policy", {})
-    local_block_event = local_outcome != "ci_failed" and local_event_type in {
-        "review_blocked",
-        "changes_requested",
-        "blocked",
-    }
-    local_block_outcome = local_outcome in {
-        "changes_requested",
-        "reviewed_request_changes",
-        "blocked",
-    }
     local_hold = local_event_type == "held" or local_outcome in HOLD_STATES
-    local_block = local_block_event or local_block_outcome
+    local_block = is_block_event(local_event)
     conflicts_with_base = (
         pr.get("mergeStateStatus") == "DIRTY" or pr.get("mergeable") == "CONFLICTING"
     )
@@ -2225,6 +2256,7 @@ def make_packet(
     local_event: dict[str, Any] | None = None,
     contributor_summary: dict[str, Any] | None = None,
     gittensor: dict[str, Any] | None = None,
+    first_block_event: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     files = pr_files_from_view(pr)
     classification = classify_files(files, policy)
@@ -2299,6 +2331,7 @@ def make_packet(
             classification, (contributor_summary or {}).get("standing")
         ),
         "local_current_event": local_event,
+        "local_first_block_event": first_block_event,
     }
     packet["recommendation"] = recommend_from_packet(packet)
     return packet
@@ -2612,6 +2645,7 @@ class ReviewContext:
     private_overrides: dict[str, Any]
     acting_login: str
     local_events: dict[tuple[int, str], dict[str, Any]]
+    first_block_events: dict[tuple[int, str], dict[str, Any]]
     analytics_model: dict[str, Any]
     signal_occurrences: dict[str, list[dict[str, Any]]]
     gittensor_index: dict[str, dict[str, Any]]
@@ -2628,6 +2662,7 @@ def load_review_context(args: argparse.Namespace) -> ReviewContext:
         private_overrides=load_private_overrides(args.state_dir),
         acting_login=args.acting_login or gh_user(),
         local_events=latest_events_by_pr_head(events),
+        first_block_events=first_block_events_by_pr_head(events),
         analytics_model=build_analytics_model(
             events,
             days=None,
@@ -2644,7 +2679,9 @@ def load_review_context(args: argparse.Namespace) -> ReviewContext:
 def packet_for_pr(context: ReviewContext, pr: dict[str, Any], mode: str) -> dict[str, Any]:
     """Assemble the full packet for one normalized PR view."""
     pr_number = int(pr.get("number") or 0)
-    local_event = context.local_events.get((pr_number, pr.get("headRefOid") or ""))
+    head_key = (pr_number, pr.get("headRefOid") or "")
+    local_event = context.local_events.get(head_key)
+    first_block_event = context.first_block_events.get(head_key)
     contributor_summary = build_contributor_summary(
         (pr.get("author") or {}).get("login"),
         pr_number,
@@ -2666,6 +2703,7 @@ def packet_for_pr(context: ReviewContext, pr: dict[str, Any], mode: str) -> dict
         local_event,
         contributor_summary,
         gittensor,
+        first_block_event,
     )
 
 

--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -1986,7 +1986,14 @@ def requested_changes_expiry_state(
     current_head_changes_requested = review_decision == "CHANGES_REQUESTED" and (
         latest_commit is None or latest_commit == head
     )
-    active = local_block or current_head_changes_requested
+    # "Has this head ever been blocked?" is a property of the log's history, not of its
+    # last row. `local_block` only inspects the newest event, so once we post the stale
+    # warning that warning becomes the newest event and erases the block — `active` would
+    # drop to False and the warning could never mature into a close. Consult the first
+    # block recorded for this head instead.
+    first_block_event = packet.get("local_first_block_event")
+    head_ever_blocked = local_block or bool(first_block_event)
+    active = head_ever_blocked or current_head_changes_requested
     warning = latest_requested_changes_warning(packet)
     warning_timestamp = (warning or {}).get("timestamp")
     author_followup_after_warning = author_activity_after(pr, warning_timestamp)
@@ -1999,10 +2006,9 @@ def requested_changes_expiry_state(
     blocker_timestamp = None
     if current_head_changes_requested:
         blocker_timestamp = latest_requested_changes_review_timestamp(packet)
-    if blocker_timestamp is None and local_block:
-        blocker_timestamp = (
-            packet.get("local_first_block_event") or packet.get("local_current_event") or {}
-        ).get("timestamp")
+    if blocker_timestamp is None and head_ever_blocked:
+        anchor = first_block_event or (packet.get("local_current_event") if local_block else None)
+        blocker_timestamp = (anchor or {}).get("timestamp")
     blocker_age = age_in_days(blocker_timestamp)
     warning_age = age_in_days(warning_timestamp)
     warning_due = (

--- a/scripts/pr_review_tests.py
+++ b/scripts/pr_review_tests.py
@@ -286,6 +286,61 @@ class PrReviewTests(unittest.TestCase):
         self.assertEqual(recommendation["advisory_action"], "warn_stale_changes_for_handler")
         self.assertEqual(recommendation["reason"], "requested_changes_warning_due")
 
+    def test_posted_warning_does_not_orphan_a_local_only_block(self) -> None:
+        """The warning event must not erase the block it was posted about.
+
+        `local_block` reads only the newest event. Once the stale-changes warning is
+        recorded it becomes the newest event, so a head blocked only in the local log
+        (no formal CHANGES_REQUESTED) would flip `active` to False and its warning
+        could never mature into a close.
+        """
+        packet = {
+            "acting_login": "maintainer",
+            "pr": {
+                "number": 4805,
+                "state": "OPEN",
+                "headRefOid": "head",
+                "author_login": "contributor",
+                "reviewDecision": None,
+                "isInMergeQueue": False,
+                "comments": [],
+                "reviews": [],
+            },
+            "ci": {"state": "green"},
+            "classification": {"hard_stop_paths": [], "surface": "backend"},
+            "latest_maintainer_review_commit": None,
+            # Newest event is the warning we posted 8 days ago — NOT a block.
+            "local_current_event": {
+                "event_type": "requested_changes_warning",
+                "outcome": "requested_changes_warning",
+                "head_sha": "head",
+                "timestamp": self._days_ago(8),
+            },
+            "local_first_block_event": {
+                "event_type": "blocked",
+                "outcome": "blocked",
+                "head_sha": "head",
+                "timestamp": self._days_ago(16),
+            },
+            "policy_trace": [],
+            "policy": {
+                "requested_changes": {
+                    "warning_after_days": 7,
+                    "close_after_warning_days": 7,
+                    "warning_marker": pr_review.REQUESTED_CHANGES_EXPIRY_MARKER,
+                }
+            },
+        }
+
+        state = pr_review.requested_changes_expiry_state(packet, local_block=False, author_followup_after_local_event=False)
+
+        self.assertTrue(state["active"], "a local-only block must survive its own warning")
+        self.assertEqual(state["blocker_timestamp"], packet["local_first_block_event"]["timestamp"])
+        self.assertTrue(state["close_due"], "warning older than close_after_warning_days must close")
+
+        recommendation = pr_review.recommend_from_packet(packet)
+        self.assertEqual(recommendation["advisory_action"], "close_stale_changes_for_handler")
+
     def test_fresh_formal_review_restarts_expiry_clock(self) -> None:
         """A NEW CHANGES_REQUESTED on the same head restarts the window (GitHub wins)."""
         packet = {

--- a/scripts/pr_review_tests.py
+++ b/scripts/pr_review_tests.py
@@ -185,6 +185,188 @@ class PrReviewTests(unittest.TestCase):
         self.assertEqual(recommendation["advisory_action"], "blocked")
         self.assertEqual(recommendation["reason"], "changes_requested_current_head")
 
+    def test_expiry_clock_survives_repeated_blocked_recordings(self) -> None:
+        """A re-recorded `blocked` event must not reset the requested-changes clock.
+
+        Every sweep appends a fresh `blocked` event for a still-blocked PR, and
+        `event_id` hashes the timestamp, so each pass is a distinct row. Anchoring
+        the expiry clock on the newest local event pinned `blocker_age` at ~0 and
+        silently disabled warn/close for every PR the loop had ever blocked.
+        """
+        packet = {
+            "pr": {
+                "number": 4132,
+                "state": "OPEN",
+                "headRefOid": "head",
+                "author_login": "contributor",
+                "reviewDecision": "CHANGES_REQUESTED",
+                "isInMergeQueue": False,
+                "comments": [],
+                "reviews": [
+                    {
+                        "author": "maintainer",
+                        "state": "CHANGES_REQUESTED",
+                        "submittedAt": self._days_ago(8),
+                        "commit": "head",
+                    }
+                ],
+            },
+            "ci": {"state": "green"},
+            "classification": {"hard_stop_paths": [], "surface": "backend"},
+            "latest_maintainer_review_commit": "head",
+            # The sweep re-blocked this head one minute ago. Under the old anchor
+            # this made blocker_age ~0 and the PR stayed `blocked` forever.
+            "local_current_event": {
+                "event_type": "blocked",
+                "outcome": "blocked",
+                "head_sha": "head",
+                "timestamp": self._minutes_ago(1),
+            },
+            "local_first_block_event": {
+                "event_type": "blocked",
+                "outcome": "blocked",
+                "head_sha": "head",
+                "timestamp": self._days_ago(8),
+            },
+            "policy_trace": [],
+            "policy": {
+                "requested_changes": {
+                    "warning_after_days": 7,
+                    "close_after_warning_days": 7,
+                    "warning_marker": pr_review.REQUESTED_CHANGES_EXPIRY_MARKER,
+                }
+            },
+        }
+
+        recommendation = pr_review.recommend_from_packet(packet)
+
+        self.assertEqual(recommendation["advisory_action"], "warn_stale_changes_for_handler")
+        self.assertEqual(recommendation["reason"], "requested_changes_warning_due")
+
+    def test_expiry_clock_falls_back_to_first_local_block_without_formal_review(self) -> None:
+        """No formal CHANGES_REQUESTED: age from the FIRST local block, not the latest."""
+        packet = {
+            "pr": {
+                "number": 4589,
+                "state": "OPEN",
+                "headRefOid": "head",
+                "author_login": "contributor",
+                "reviewDecision": None,
+                "isInMergeQueue": False,
+                "comments": [],
+                "reviews": [],
+            },
+            "ci": {"state": "green"},
+            "classification": {"hard_stop_paths": [], "surface": "backend"},
+            "latest_maintainer_review_commit": None,
+            "local_current_event": {
+                "event_type": "blocked",
+                "outcome": "blocked",
+                "head_sha": "head",
+                "timestamp": self._minutes_ago(1),
+            },
+            "local_first_block_event": {
+                "event_type": "blocked",
+                "outcome": "blocked",
+                "head_sha": "head",
+                "timestamp": self._days_ago(9),
+            },
+            "policy_trace": [],
+            "policy": {
+                "requested_changes": {
+                    "warning_after_days": 7,
+                    "close_after_warning_days": 7,
+                    "warning_marker": pr_review.REQUESTED_CHANGES_EXPIRY_MARKER,
+                }
+            },
+        }
+
+        recommendation = pr_review.recommend_from_packet(packet)
+
+        self.assertEqual(recommendation["advisory_action"], "warn_stale_changes_for_handler")
+        self.assertEqual(recommendation["reason"], "requested_changes_warning_due")
+
+    def test_fresh_formal_review_restarts_expiry_clock(self) -> None:
+        """A NEW CHANGES_REQUESTED on the same head restarts the window (GitHub wins)."""
+        packet = {
+            "pr": {
+                "number": 4133,
+                "state": "OPEN",
+                "headRefOid": "head",
+                "author_login": "contributor",
+                "reviewDecision": "CHANGES_REQUESTED",
+                "isInMergeQueue": False,
+                "comments": [],
+                "reviews": [
+                    {
+                        "author": "maintainer",
+                        "state": "CHANGES_REQUESTED",
+                        "submittedAt": self._days_ago(1),
+                        "commit": "head",
+                    }
+                ],
+            },
+            "ci": {"state": "green"},
+            "classification": {"hard_stop_paths": [], "surface": "backend"},
+            "latest_maintainer_review_commit": "head",
+            "local_first_block_event": {
+                "event_type": "blocked",
+                "outcome": "blocked",
+                "head_sha": "head",
+                "timestamp": self._days_ago(30),
+            },
+            "policy_trace": [],
+            "policy": {
+                "requested_changes": {
+                    "warning_after_days": 7,
+                    "close_after_warning_days": 7,
+                    "warning_marker": pr_review.REQUESTED_CHANGES_EXPIRY_MARKER,
+                }
+            },
+        }
+
+        recommendation = pr_review.recommend_from_packet(packet)
+
+        self.assertEqual(recommendation["advisory_action"], "blocked")
+
+    def test_first_block_events_by_pr_head_keeps_earliest_and_ignores_non_blocks(self) -> None:
+        events = [
+            {"pr": 1, "head_sha": "h", "outcome": "review", "timestamp": "2026-07-01T00:00:00Z"},
+            {"pr": 1, "head_sha": "h", "outcome": "blocked", "timestamp": "2026-07-02T00:00:00Z"},
+            {"pr": 1, "head_sha": "h", "outcome": "blocked", "timestamp": "2026-07-09T00:00:00Z"},
+            {"pr": 1, "head_sha": "other", "outcome": "blocked", "timestamp": "2026-07-05T00:00:00Z"},
+        ]
+
+        first = pr_review.first_block_events_by_pr_head(events)
+
+        self.assertEqual(first[(1, "h")]["timestamp"], "2026-07-02T00:00:00Z")
+        self.assertEqual(first[(1, "other")]["timestamp"], "2026-07-05T00:00:00Z")
+
+    def test_is_block_event_covers_every_routing_block_shape(self) -> None:
+        """The expiry anchor must recognize exactly the events routing calls blocking."""
+        for event_type in pr_review.LOCAL_BLOCK_EVENT_TYPES:
+            self.assertTrue(pr_review.is_block_event({"event_type": event_type}), event_type)
+        for outcome in pr_review.LOCAL_BLOCK_OUTCOMES:
+            self.assertTrue(pr_review.is_block_event({"outcome": outcome}), outcome)
+
+        self.assertFalse(pr_review.is_block_event({"event_type": "blocked", "outcome": "ci_failed"}))
+        self.assertFalse(pr_review.is_block_event({"event_type": "review"}))
+        self.assertFalse(pr_review.is_block_event({"outcome": "approved_enqueued"}))
+        self.assertFalse(pr_review.is_block_event(None))
+
+    def test_review_blocked_event_anchors_expiry(self) -> None:
+        """`review_blocked` routes as a block, so it must also anchor the expiry clock."""
+        events = [
+            {
+                "pr": 7,
+                "head_sha": "h",
+                "event_type": "review_blocked",
+                "timestamp": "2026-07-01T00:00:00Z",
+            },
+        ]
+
+        self.assertIn((7, "h"), pr_review.first_block_events_by_pr_head(events))
+
     def test_requested_changes_warns_after_configured_age(self) -> None:
         packet = {
             "pr": {
@@ -1507,6 +1689,11 @@ class PrReviewTests(unittest.TestCase):
     @staticmethod
     def _days_ago(days: int) -> str:
         stamp = datetime.now(UTC).replace(microsecond=0) - timedelta(days=days)
+        return stamp.isoformat().replace("+00:00", "Z")
+
+    @staticmethod
+    def _minutes_ago(minutes: int) -> str:
+        stamp = datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=minutes)
         return stamp.isoformat().replace("+00:00", "Z")
 
     @staticmethod


### PR DESCRIPTION
`requested_changes_expiry_state` took `blocker_timestamp` from
`local_current_event` — the newest event for the head. Every sweep appends a
fresh `blocked` row (`event_id` hashes the timestamp, so it is never a dedup
no-op), so the loop reset its own clock on each pass. `blocker_age` was
permanently ~0 and `warning_due` could never fire for any PR the loop had ever
blocked: warn/close were dead code.

Anchor on the blocker instead of on our observation of it. Prefer GitHub's
formal CHANGES_REQUESTED on the current head (a newer review correctly restarts
the window); fall back to the earliest local block for that head, never the
latest.

Routing already treated `review_blocked` / `reviewed_request_changes` as
blocking while a second inline set did not. Extract `is_block_event()` as the
single authority so the expiry anchor and the routing decision cannot drift.

On the live event log this surfaces five PRs whose expiry was suppressed
(#4132, #4510, #4628, #4662, #4805). #4512/#4514 correctly stay silent — they
already carry a warning and are counting down to close.

Two of the new tests fail on the old anchor and pass on the new one.
