### PR TITLE
Expose read-only cast target preview over WASM

### DIFF
--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -23,6 +23,7 @@ use engine::game::{
     PlayerDeckList, ReplayPlayer,
 };
 use engine::types::format::{FormatConfig, GameFormat};
+use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::ManaCost;
 use engine::types::match_config::MatchConfig;
@@ -1177,10 +1178,36 @@ pub fn get_legal_actions_for_viewer_js(player_id: u32) -> JsValue {
 #[wasm_bindgen]
 pub fn legal_targets_for_castable_js(object_id: u32) -> JsValue {
     match with_state(|state| {
-        let slots = engine::game::casting::legal_target_slots_for_castable_spell(
-            state,
-            ObjectId(object_id as u64),
-        );
+        let slots = if let WaitingFor::Priority { player } = &state.waiting_for {
+            let probe = engine::game::casting::PriorityCastProbe::new(state, *player);
+            engine::game::casting::legal_target_slots_for_castable_spell_with_probe(
+                probe.state(),
+                *player,
+                ObjectId(object_id as u64),
+                Some(&probe),
+            )
+        } else {
+            Vec::new()
+        };
+        to_js(&slots)
+    }) {
+        Ok(val) => val,
+        Err(_) => JsValue::NULL,
+    }
+}
+
+/// Batch variant for hover/drag clients that need previews for many castable
+/// cards. The engine flushes layers once and reuses that snapshot for every id.
+#[wasm_bindgen]
+pub fn legal_targets_for_castables_js(object_ids: JsValue) -> JsValue {
+    let object_ids: Vec<u32> = serde_wasm_bindgen::from_value(object_ids).unwrap_or_default();
+    match with_state(|state| {
+        let object_ids = object_ids
+            .into_iter()
+            .map(|id| ObjectId(id as u64))
+            .collect::<Vec<_>>();
+        let slots =
+            engine::game::casting::legal_target_slots_for_castable_spells(state, object_ids);
         to_js(&slots)
     }) {
         Ok(val) => val,

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -1172,6 +1172,22 @@ pub fn get_legal_actions_for_viewer_js(player_id: u32) -> JsValue {
     }
 }
 
+/// Read-only preview of cast-time target slots for a currently castable spell.
+/// Returns `[]` for uncastable, untargeted, or target-ambiguous casts.
+#[wasm_bindgen]
+pub fn legal_targets_for_castable_js(object_id: u32) -> JsValue {
+    match with_state(|state| {
+        let slots = engine::game::casting::legal_target_slots_for_castable_spell(
+            state,
+            ObjectId(object_id as u64),
+        );
+        to_js(&slots)
+    }) {
+        Ok(val) => val,
+        Err(_) => JsValue::NULL,
+    }
+}
+
 /// Combined filtered-state + viewer-scoped legal-actions snapshot. Collapses
 /// two WASM round-trips into one for the P2P host broadcast loop. Field names
 /// match `LegalActionsResult` so the existing `legalActionsToWire` helper on

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -29,7 +29,7 @@ use crate::types::statics::{
 };
 use crate::types::zones::{ExileCostSourceZone, Zone};
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use super::ability_utils::{
     ability_target_legality_needs_chosen_x, assign_targets_in_chain, auto_select_targets,
@@ -11213,12 +11213,53 @@ pub fn legal_target_slots_for_castable_spell(
     let WaitingFor::Priority { player } = &state.waiting_for else {
         return Vec::new();
     };
-    let player = *player;
+    legal_target_slots_for_castable_spell_with_probe(state, *player, object_id, None)
+}
 
+pub fn legal_target_slots_for_castable_spell_with_probe(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+    probe: Option<&PriorityCastProbe>,
+) -> Vec<TargetSelectionSlot> {
+    if let Some(probe) = probe.filter(|probe| probe.player() == player && probe.is_for_state(state))
+    {
+        return legal_target_slots_for_castable_spell_in_flushed_state(
+            probe.state(),
+            player,
+            object_id,
+        )
+        .unwrap_or_default();
+    }
     let mut simulated = state.clone();
     super::layers::flush_layers(&mut simulated);
     legal_target_slots_for_castable_spell_in_flushed_state(&simulated, player, object_id)
         .unwrap_or_default()
+}
+
+pub fn legal_target_slots_for_castable_spells(
+    state: &GameState,
+    object_ids: impl IntoIterator<Item = ObjectId>,
+) -> HashMap<ObjectId, Vec<TargetSelectionSlot>> {
+    let WaitingFor::Priority { player } = &state.waiting_for else {
+        return HashMap::new();
+    };
+    let player = *player;
+    let probe = PriorityCastProbe::new(state, player);
+    object_ids
+        .into_iter()
+        .map(|object_id| {
+            (
+                object_id,
+                legal_target_slots_for_castable_spell_with_probe(
+                    probe.state(),
+                    player,
+                    object_id,
+                    Some(&probe),
+                ),
+            )
+        })
+        .collect()
 }
 
 fn legal_target_slots_for_castable_spell_in_flushed_state(
@@ -11268,6 +11309,19 @@ fn legal_target_slots_for_castable_spell_in_flushed_state(
             player,
         )
     };
+
+    // CR 702.47a + CR 601.2b: Splice is announced before targets and can add
+    // spell text, including additional targets, so preview waits for that choice.
+    if !splice::eligible_splice_cards(state, player, prepared.object_id).is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // CR 702.119a + CR 702.119b + CR 702.119c + CR 601.2b + CR 601.2h:
+    // Emerge chooses a sacrifice before target selection, so target legality
+    // may change before targets are chosen.
+    if prepared.casting_variant == CastingVariant::Emerge {
+        return Ok(Vec::new());
+    }
 
     let Some(obj) = state.objects.get(&prepared.object_id) else {
         return Ok(Vec::new());
@@ -11338,6 +11392,25 @@ fn legal_target_slots_for_castable_spell_in_flushed_state(
     // CR 601.2c: Once all earlier casting choices are known, enumerate the
     // targets the spell requires.
     let mut target_slots = build_target_slots(state, &resolved)?;
+    if !target_slots.is_empty() {
+        // CR 601.2b: Casualty is an optional sacrifice declared before targets.
+        if casting_costs::effective_casualty_additional_cost(state, player, prepared.object_id)
+            .is_some()
+        {
+            return Ok(Vec::new());
+        }
+        // CR 702.56a: Replicate is a repeatable optional additional cost
+        // declared before targets, just like Casualty.
+        if casting_costs::effective_replicate_additional_cost(state, player, prepared.object_id)
+            .is_some()
+        {
+            return Ok(Vec::new());
+        }
+        // CR 702.48a + CR 702.48b: Offering sacrifice is declared before targets.
+        if casting_costs::effective_offering_quality(state, player, prepared.object_id).is_some() {
+            return Ok(Vec::new());
+        }
+    }
     super::ability_utils::cap_distribution_target_slots(
         state,
         &resolved,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13,7 +13,8 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{
     ActivationResidual, CastOfferKind, CastPaymentMode, CastingVariant, CastingVariantChoiceOption,
     ConvokeMode, CostResume, GameState, NextSpellModifier, PayCostKind, PendingCast,
-    SneakPlacement, SpellCastRecord, SpellCostSource, StackEntry, StackEntryKind, WaitingFor,
+    SneakPlacement, SpellCastRecord, SpellCostSource, StackEntry, StackEntryKind,
+    TargetSelectionSlot, WaitingFor,
 };
 use crate::types::identifiers::{CardId, ObjectId, TrackedSetId};
 use crate::types::keywords::{FlashbackCost, Keyword, KeywordKind};
@@ -11200,6 +11201,136 @@ pub fn spell_has_legal_targets_with_probe(
     let mut simulated = state.clone();
     super::layers::flush_layers(&mut simulated);
     spell_has_legal_targets_in_flushed_state(&simulated, object_id, player)
+}
+
+/// CR 601.2c: Read-only preview of the target slots a currently castable spell
+/// would ask the caster to choose. Returns an empty list for uncastable spells,
+/// untargeted spells, and casts that must first choose a face, variant, mode, or X.
+pub fn legal_target_slots_for_castable_spell(
+    state: &GameState,
+    object_id: ObjectId,
+) -> Vec<TargetSelectionSlot> {
+    let WaitingFor::Priority { player } = &state.waiting_for else {
+        return Vec::new();
+    };
+    let player = *player;
+
+    let mut simulated = state.clone();
+    super::layers::flush_layers(&mut simulated);
+    legal_target_slots_for_castable_spell_in_flushed_state(&simulated, player, object_id)
+        .unwrap_or_default()
+}
+
+fn legal_target_slots_for_castable_spell_in_flushed_state(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+) -> Result<Vec<TargetSelectionSlot>, EngineError> {
+    if let Some(obj) = state.objects.get(&object_id) {
+        if (cast_face_choice_offered_from_zone(state, obj)
+            && alternative_spell_layout(obj).is_some())
+            || cast_spell_face_choice_offered_from_zone(state, obj)
+        {
+            return Ok(Vec::new());
+        }
+    }
+
+    let choices = casting_variant_choice_set(state, player, object_id);
+    if choices.options.len() > 1 {
+        return Ok(Vec::new());
+    }
+    if !can_cast_object_now(state, player, object_id) {
+        return Ok(Vec::new());
+    }
+
+    let prepared = prepare_spell_cast(state, player, object_id)?;
+    if prepared.modal.is_some() {
+        return Ok(Vec::new());
+    }
+
+    let resolved = if let Some(ref ability_def) = prepared.ability_def {
+        build_resolved_from_def(ability_def, prepared.object_id, player)
+    } else {
+        ResolvedAbility::new(
+            Effect::Unimplemented {
+                name: String::new(),
+                description: None,
+            },
+            Vec::new(),
+            prepared.object_id,
+            player,
+        )
+    };
+
+    let Some(obj) = state.objects.get(&prepared.object_id) else {
+        return Ok(Vec::new());
+    };
+
+    if obj.card_types.subtypes.iter().any(|s| s == "Aura") {
+        return Ok(obj
+            .keywords
+            .iter()
+            .find_map(|keyword| {
+                if let Keyword::Enchant(filter) = keyword {
+                    Some(TargetSelectionSlot {
+                        legal_targets: targeting::find_legal_targets(
+                            state,
+                            filter,
+                            player,
+                            prepared.object_id,
+                        ),
+                        optional: false,
+                    })
+                } else {
+                    None
+                }
+            })
+            .filter(|slot| !slot.legal_targets.is_empty())
+            .into_iter()
+            .collect());
+    }
+
+    if obj.mutate_form.is_some() {
+        let legal = targeting::find_legal_targets(
+            state,
+            &mutate_target_filter(),
+            player,
+            prepared.object_id,
+        );
+        return Ok(if legal.is_empty() {
+            Vec::new()
+        } else {
+            vec![TargetSelectionSlot {
+                legal_targets: legal,
+                optional: false,
+            }]
+        });
+    }
+
+    let distribute = prepared
+        .ability_def
+        .as_ref()
+        .and_then(|ability| ability.distribute.clone());
+    if ability_target_legality_needs_chosen_x(&resolved, distribute.as_ref()) {
+        return Ok(Vec::new());
+    }
+    let has_kicker_cost = state
+        .objects
+        .get(&prepared.object_id)
+        .and_then(|obj| obj.additional_cost.as_ref())
+        .is_some_and(|additional| matches!(additional, AdditionalCost::Kicker { .. }));
+    if has_kicker_cost && requires_additional_cost_declaration_before_targets(&resolved) {
+        return Ok(Vec::new());
+    }
+
+    let mut target_slots = build_target_slots(state, &resolved)?;
+    super::ability_utils::cap_distribution_target_slots(
+        state,
+        &resolved,
+        distribute.as_ref(),
+        &mut target_slots,
+    );
+    Ok(target_slots)
 }
 
 fn spell_has_legal_targets_in_flushed_state(

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -11227,6 +11227,9 @@ fn legal_target_slots_for_castable_spell_in_flushed_state(
     object_id: ObjectId,
 ) -> Result<Vec<TargetSelectionSlot>, EngineError> {
     if let Some(obj) = state.objects.get(&object_id) {
+        // CR 715.3 / CR 720.3 / CR 712.11b: Adventure, Omen, and modal DFC
+        // face choices happen before target selection, so no single target-slot
+        // preview exists until the face is chosen.
         if (cast_face_choice_offered_from_zone(state, obj)
             && alternative_spell_layout(obj).is_some())
             || cast_spell_face_choice_offered_from_zone(state, obj)
@@ -11235,6 +11238,8 @@ fn legal_target_slots_for_castable_spell_in_flushed_state(
         }
     }
 
+    // CR 601.2b: Alternative/additional cost choices are announced before
+    // targets, so casts with multiple viable variants are target-ambiguous.
     let choices = casting_variant_choice_set(state, player, object_id);
     if choices.options.len() > 1 {
         return Ok(Vec::new());
@@ -11244,6 +11249,8 @@ fn legal_target_slots_for_castable_spell_in_flushed_state(
     }
 
     let prepared = prepare_spell_cast(state, player, object_id)?;
+    // CR 601.2b: Modal choices are announced before targets, so a modal spell
+    // has no single target-slot preview until modes are chosen.
     if prepared.modal.is_some() {
         return Ok(Vec::new());
     }
@@ -11266,6 +11273,7 @@ fn legal_target_slots_for_castable_spell_in_flushed_state(
         return Ok(Vec::new());
     };
 
+    // CR 303.4a: An Aura spell requires a target defined by its enchant ability.
     if obj.card_types.subtypes.iter().any(|s| s == "Aura") {
         return Ok(obj
             .keywords
@@ -11290,6 +11298,8 @@ fn legal_target_slots_for_castable_spell_in_flushed_state(
             .collect());
     }
 
+    // CR 702.140a: A mutating creature spell targets a non-Human creature with
+    // the same owner as the spell.
     if obj.mutate_form.is_some() {
         let legal = targeting::find_legal_targets(
             state,
@@ -11314,6 +11324,8 @@ fn legal_target_slots_for_castable_spell_in_flushed_state(
     if ability_target_legality_needs_chosen_x(&resolved, distribute.as_ref()) {
         return Ok(Vec::new());
     }
+    // CR 601.2b: Target-dependent kicker/additional-cost declarations happen
+    // before target selection, so defer the preview until the cost is chosen.
     let has_kicker_cost = state
         .objects
         .get(&prepared.object_id)
@@ -11323,6 +11335,8 @@ fn legal_target_slots_for_castable_spell_in_flushed_state(
         return Ok(Vec::new());
     }
 
+    // CR 601.2c: Once all earlier casting choices are known, enumerate the
+    // targets the spell requires.
     let mut target_slots = build_target_slots(state, &resolved)?;
     super::ability_utils::cap_distribution_target_slots(
         state,

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -2910,6 +2910,94 @@ fn legal_target_slots_for_castable_spell_is_read_only_and_empty_when_uncastable(
 }
 
 #[test]
+fn legal_target_slots_for_castable_spells_batches_previews() {
+    let mut state = setup_game_at_main_phase();
+    let spell = create_instant_in_hand(&mut state, PlayerId(0));
+    add_mana(&mut state, PlayerId(0), ManaType::Red, 1);
+
+    let batched = legal_target_slots_for_castable_spells(&state, [spell]);
+    let slots = batched.get(&spell).expect("batch includes requested spell");
+
+    assert_eq!(slots.len(), 1);
+    assert!(
+        slots[0]
+            .legal_targets
+            .contains(&TargetRef::Player(PlayerId(1))),
+        "batched preview should match the single-card target slot"
+    );
+}
+
+#[test]
+fn legal_target_slots_for_castable_spell_empty_before_splice_choice() {
+    let mut state = setup_game_at_main_phase();
+    let spell = create_instant_in_hand(&mut state, PlayerId(0));
+    state
+        .objects
+        .get_mut(&spell)
+        .unwrap()
+        .card_types
+        .subtypes
+        .push("Arcane".to_string());
+    add_mana(&mut state, PlayerId(0), ManaType::Red, 1);
+
+    let splicer = create_object(
+        &mut state,
+        CardId(9_970),
+        PlayerId(0),
+        "Splice Preview".to_string(),
+        Zone::Hand,
+    );
+    state
+        .objects
+        .get_mut(&splicer)
+        .unwrap()
+        .keywords
+        .push(Keyword::Splice {
+            subtype: "Arcane".to_string(),
+            cost: ManaCost::NoCost,
+        });
+
+    let slots = legal_target_slots_for_castable_spell(&state, spell);
+
+    assert!(
+        slots.is_empty(),
+        "splice can add targets before CR 601.2c target selection, so preview waits for the splice choice"
+    );
+}
+
+#[test]
+fn legal_target_slots_for_castable_spell_empty_before_casualty_choice() {
+    let mut state = setup_game_at_main_phase();
+    let spell = create_instant_in_hand(&mut state, PlayerId(0));
+    state
+        .objects
+        .get_mut(&spell)
+        .unwrap()
+        .keywords
+        .push(Keyword::Casualty(1));
+    add_mana(&mut state, PlayerId(0), ManaType::Red, 1);
+
+    let creature = create_object(
+        &mut state,
+        CardId(9_971),
+        PlayerId(0),
+        "Casualty Fodder".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&creature).unwrap();
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.power = Some(1);
+    obj.toughness = Some(1);
+
+    let slots = legal_target_slots_for_castable_spell(&state, spell);
+
+    assert!(
+        slots.is_empty(),
+        "casualty sacrifice is declared before targets, so preview waits for that choice"
+    );
+}
+
+#[test]
 fn prepare_spell_cast_chains_all_non_modal_spell_abilities_in_order() {
     let mut state = setup_game_at_main_phase();
     let obj_id = create_object(

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -2880,6 +2880,36 @@ fn create_instant_in_hand(state: &mut GameState, player: PlayerId) -> ObjectId {
 }
 
 #[test]
+fn legal_target_slots_for_castable_spell_returns_cast_time_slot_shape() {
+    let mut state = setup_game_at_main_phase();
+    let spell = create_instant_in_hand(&mut state, PlayerId(0));
+    add_mana(&mut state, PlayerId(0), ManaType::Red, 1);
+
+    let slots = legal_target_slots_for_castable_spell(&state, spell);
+
+    assert_eq!(slots.len(), 1);
+    assert!(!slots[0].optional);
+    assert!(
+        slots[0]
+            .legal_targets
+            .contains(&TargetRef::Player(PlayerId(1))),
+        "Lightning Bolt-style any-target spell should expose opponent as a legal target"
+    );
+}
+
+#[test]
+fn legal_target_slots_for_castable_spell_is_read_only_and_empty_when_uncastable() {
+    let mut state = setup_game_at_main_phase();
+    let spell = create_instant_in_hand(&mut state, PlayerId(0));
+    let before = serde_json::to_value(&state).unwrap();
+
+    let slots = legal_target_slots_for_castable_spell(&state, spell);
+
+    assert!(slots.is_empty());
+    assert_eq!(serde_json::to_value(&state).unwrap(), before);
+}
+
+#[test]
 fn prepare_spell_cast_chains_all_non_modal_spell_abilities_in_order() {
     let mut state = setup_game_at_main_phase();
     let obj_id = create_object(


### PR DESCRIPTION
Model: codex-5
Thinking: high
Tier: Standard

## Summary
- add an engine-owned read-only helper that returns cast-time target slots for currently castable spells
- expose `legal_targets_for_castable_js(object_id)` through `engine-wasm`
- return `[]` for uncastable, untargeted, or target-ambiguous casts

Closes #5467

## Anchored on
- crates/engine/src/game/casting.rs:10595 — existing cast path builds Aura target slots with `find_legal_targets`
- crates/engine/src/game/casting.rs:11191 — existing read-only castability helper clones/flushes state before inspecting target legality
- crates/engine-wasm/src/lib.rs:1155 — existing WASM query delegates to engine logic and serializes with `to_js`

## Gate A
`./scripts/check-parser-combinators.sh`

Exit status: 0  
Output: no stdout

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p engine legal_target_slots_for_castable_spell`
- `cargo test -p engine-wasm`

## Notes
- Tilt was not reachable via `tilt get uiresource clippy`; used the documented direct cargo fallback.
- No parser or frontend files changed.