### PR TITLE
test(parser): snapshot CastingRestriction, SolveCondition, and StriveCost item variants

### DIFF
--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -820,6 +820,55 @@ fn bomat_courier() {
 }
 
 // ---------------------------------------------------------------------------
+// Parity-oracle coverage for otherwise-unsnapshotted document item variants
+// (Plan 01, assertion 6).
+//
+// `CastingRestriction`, `SolveCondition`, and `StriveCost` are producible
+// `OracleItemIr` variants that no lowered snapshot in this crate populated:
+// across every `*_lowered.snap` here and every `ParsedAbilities` snapshot in
+// `parser/snapshots/`, `casting_restrictions` was always empty and
+// `solve_condition`/`strive_cost` were always null. The source-order builder
+// and the assembly traversal both rewrite the item -> `ParsedAbilities` fold,
+// so without these three the fold could drop any of them silently.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn champions_victory() {
+    let (ir, lowered) = parse_two_layer(
+        "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nReturn target attacking creature to its owner's hand.",
+        "Champion's Victory",
+        &["Instant"],
+        &[],
+    );
+    insta::assert_json_snapshot!("champions_victory_ir", &ir);
+    insta::assert_json_snapshot!("champions_victory_lowered", &lowered);
+}
+
+#[test]
+fn case_of_the_crimson_pulse() {
+    let (ir, lowered) = parse_two_layer(
+        "When this Case enters, discard a card, then draw two cards.\nTo solve — You have no cards in hand. (If unsolved, solve at the beginning of your end step.)\nSolved — At the beginning of your upkeep, discard your hand, then draw two cards.",
+        "Case of the Crimson Pulse",
+        &["Enchantment"],
+        &["Case"],
+    );
+    insta::assert_json_snapshot!("case_of_the_crimson_pulse_ir", &ir);
+    insta::assert_json_snapshot!("case_of_the_crimson_pulse_lowered", &lowered);
+}
+
+#[test]
+fn aerial_formation() {
+    let (ir, lowered) = parse_two_layer(
+        "Strive — This spell costs {2}{U} more to cast for each target beyond the first.\nAny number of target creatures each get +1/+1 and gain flying until end of turn.",
+        "Aerial Formation",
+        &["Instant"],
+        &[],
+    );
+    insta::assert_json_snapshot!("aerial_formation_ir", &ir);
+    insta::assert_json_snapshot!("aerial_formation_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
 // Diagnostic snapshot tests (Phase 51, D-10)
 // ---------------------------------------------------------------------------
 

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aerial_formation_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aerial_formation_ir.snap
@@ -1,0 +1,78 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 867
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "PreLoweredSpell": {
+        "kind": "Spell",
+        "effect": {
+          "type": "GenericEffect",
+          "static_abilities": [
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "ParentTarget"
+              },
+              "modifications": [
+                {
+                  "type": "AddPower",
+                  "value": 1
+                },
+                {
+                  "type": "AddToughness",
+                  "value": 1
+                },
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Flying"
+                }
+              ],
+              "condition": null,
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "get +1/+1 and gain flying"
+            }
+          ],
+          "duration": "UntilEndOfTurn",
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": null,
+            "properties": []
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": "UntilEndOfTurn",
+        "description": "Any number of target creatures each get +1/+1 and gain flying until end of turn.",
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "multi_target": {
+          "min": 0,
+          "max": null
+        },
+        "forward_result": false
+      }
+    },
+    {
+      "StriveCost": {
+        "type": "Cost",
+        "shards": [
+          "Blue"
+        ],
+        "generic": 2
+      }
+    }
+  ],
+  "source_text": "Strive — This spell costs {2}{U} more to cast for each target beyond the first.\nAny number of target creatures each get +1/+1 and gain flying until end of turn.",
+  "card_name": "Aerial Formation"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aerial_formation_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aerial_formation_lowered.snap
@@ -1,0 +1,76 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 868
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "GenericEffect",
+        "static_abilities": [
+          {
+            "mode": "Continuous",
+            "affected": {
+              "type": "ParentTarget"
+            },
+            "modifications": [
+              {
+                "type": "AddPower",
+                "value": 1
+              },
+              {
+                "type": "AddToughness",
+                "value": 1
+              },
+              {
+                "type": "AddKeyword",
+                "keyword": "Flying"
+              }
+            ],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "get +1/+1 and gain flying"
+          }
+        ],
+        "duration": "UntilEndOfTurn",
+        "target": {
+          "type": "Typed",
+          "type_filters": [
+            "Creature"
+          ],
+          "controller": null,
+          "properties": []
+        }
+      },
+      "cost": null,
+      "sub_ability": null,
+      "duration": "UntilEndOfTurn",
+      "description": "Any number of target creatures each get +1/+1 and gain flying until end of turn.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "multi_target": {
+        "min": 0,
+        "max": null
+      },
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": [],
+  "striveCost": {
+    "type": "Cost",
+    "shards": [
+      "Blue"
+    ],
+    "generic": 2
+  }
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_crimson_pulse_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_crimson_pulse_ir.snap
@@ -1,0 +1,170 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 855
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "PreLoweredTrigger": {
+        "mode": "ChangesZone",
+        "execute": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Discard",
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "target": {
+              "type": "Controller"
+            }
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Draw",
+              "count": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "valid_card": {
+          "type": "SelfRef"
+        },
+        "origin": null,
+        "destination": "Battlefield",
+        "trigger_zones": [
+          "Battlefield"
+        ],
+        "phase": null,
+        "optional": false,
+        "damage_kind": "Any",
+        "secondary": false,
+        "valid_target": null,
+        "valid_source": null,
+        "description": "When this ~ enters, discard a card, then draw two cards.",
+        "constraint": null,
+        "condition": null,
+        "batched": false
+      }
+    },
+    {
+      "PreLoweredTrigger": {
+        "mode": "Phase",
+        "execute": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Discard",
+            "count": {
+              "type": "Ref",
+              "qty": {
+                "type": "HandSize",
+                "player": {
+                  "type": "Controller"
+                }
+              }
+            },
+            "target": {
+              "type": "Controller"
+            }
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Draw",
+              "count": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "valid_card": null,
+        "origin": null,
+        "destination": null,
+        "trigger_zones": [
+          "Battlefield"
+        ],
+        "phase": "Upkeep",
+        "optional": false,
+        "damage_kind": "Any",
+        "secondary": false,
+        "valid_target": null,
+        "valid_source": null,
+        "description": "At the beginning of your upkeep, discard your hand, then draw two cards.",
+        "constraint": {
+          "type": "OnlyDuringYourTurn"
+        },
+        "condition": null,
+        "batched": false
+      }
+    },
+    {
+      "SolveCondition": {
+        "type": "Condition",
+        "condition": {
+          "type": "QuantityComparison",
+          "lhs": {
+            "type": "Ref",
+            "qty": {
+              "type": "HandSize",
+              "player": {
+                "type": "Controller"
+              }
+            }
+          },
+          "comparator": "EQ",
+          "rhs": {
+            "type": "Fixed",
+            "value": 0
+          }
+        }
+      }
+    }
+  ],
+  "source_text": "When this Case enters, discard a card, then draw two cards.\nTo solve — You have no cards in hand. (If unsolved, solve at the beginning of your end step.)\nSolved — At the beginning of your upkeep, discard your hand, then draw two cards.",
+  "card_name": "Case of the Crimson Pulse"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_crimson_pulse_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_crimson_pulse_lowered.snap
@@ -1,0 +1,166 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 856
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "ChangesZone",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Discard",
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "target": {
+            "type": "Controller"
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Draw",
+            "count": {
+              "type": "Fixed",
+              "value": 2
+            },
+            "target": {
+              "type": "Controller"
+            }
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": "Battlefield",
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "When this ~ enters, discard a card, then draw two cards.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    },
+    {
+      "mode": "Phase",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Discard",
+          "count": {
+            "type": "Ref",
+            "qty": {
+              "type": "HandSize",
+              "player": {
+                "type": "Controller"
+              }
+            }
+          },
+          "target": {
+            "type": "Controller"
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Draw",
+            "count": {
+              "type": "Fixed",
+              "value": 2
+            },
+            "target": {
+              "type": "Controller"
+            }
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": null,
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": "Upkeep",
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "At the beginning of your upkeep, discard your hand, then draw two cards.",
+      "constraint": {
+        "type": "OnlyDuringYourTurn"
+      },
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": [],
+  "solveCondition": {
+    "type": "Condition",
+    "condition": {
+      "type": "QuantityComparison",
+      "lhs": {
+        "type": "Ref",
+        "qty": {
+          "type": "HandSize",
+          "player": {
+            "type": "Controller"
+          }
+        }
+      },
+      "comparator": "EQ",
+      "rhs": {
+        "type": "Fixed",
+        "value": 0
+      }
+    }
+  }
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__champions_victory_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__champions_victory_ir.snap
@@ -1,0 +1,56 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 843
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "PreLoweredSpell": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Bounce",
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": null,
+            "properties": [
+              {
+                "type": "Attacking"
+              }
+            ]
+          },
+          "destination": null
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": "Return target attacking creature to its owner's hand.",
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      }
+    },
+    {
+      "CastingRestriction": {
+        "type": "DeclareAttackersStep"
+      }
+    },
+    {
+      "CastingRestriction": {
+        "type": "RequiresCondition",
+        "data": {
+          "condition": {
+            "type": "BeenAttackedThisStep"
+          }
+        }
+      }
+    }
+  ],
+  "source_text": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nReturn target attacking creature to its owner's hand.",
+  "card_name": "Champion's Victory"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__champions_victory_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__champions_victory_lowered.snap
@@ -1,0 +1,54 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 844
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "Bounce",
+        "target": {
+          "type": "Typed",
+          "type_filters": [
+            "Creature"
+          ],
+          "controller": null,
+          "properties": [
+            {
+              "type": "Attacking"
+            }
+          ]
+        },
+        "destination": null
+      },
+      "cost": null,
+      "sub_ability": null,
+      "duration": null,
+      "description": "Return target attacking creature to its owner's hand.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": [],
+  "castingRestrictions": [
+    {
+      "type": "DeclareAttackersStep"
+    },
+    {
+      "type": "RequiresCondition",
+      "data": {
+        "condition": {
+          "type": "BeenAttackedThisStep"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
`CastingRestriction`, `SolveCondition`, and `StriveCost` are producible
`OracleItemIr` variants that no lowered snapshot in this crate populated.
Across every `*_lowered.snap` here and every `ParsedAbilities` snapshot in
`parser/snapshots/`, `casting_restrictions` was always empty and
`solve_condition` / `strive_cost` were always null.

That is a hole in the parity oracle exactly where upcoming work lands: the
source-order document builder rewrites the `OracleItemIr` -> `ParsedAbilities`
fold, so without these three the fold could silently drop any of them and every
existing snapshot would still pass.

`result.strive_cost` is additionally re-read as a skip guard in the main line
loop (`oracle.rs:4267`), so dropping it would change control flow, not just a
serialized field.

Fixtures use verbatim Oracle text:

- Champion's Victory        - casting restriction + bounce
- Case of the Crimson Pulse - solve condition (CR 719.1)
- Aerial Formation          - strive cost

Tests only; no production code touched.
