### PR TITLE
fix(phase-ai): clamp scaled policy deltas to the critical band (Closes #5473)

### DIFF
--- a/crates/phase-ai/src/policies/control_change_awareness.rs
+++ b/crates/phase-ai/src/policies/control_change_awareness.rs
@@ -23,9 +23,15 @@ use super::context::PolicyContext;
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
 use crate::features::DeckFeatures;
 
-/// Severe penalty for activating an ability that gives away the AI's own permanents.
-/// This should be enough to make PassPriority win over such activations.
-const CONTROL_CHANGE_PENALTY: f64 = -100.0;
+/// Severe penalty for activating an ability that gives away the AI's own
+/// permanents. Sits at the bottom of the critical band (`-CRITICAL_MAX`) — the
+/// strongest finite discouragement the score contract allows, enough for
+/// PassPriority (0) to win, without a hard `Reject` (giving away a permanent is
+/// contextually not always wrong, e.g. Donate combos / liability permanents, so
+/// this stays an overridable penalty rather than a veto). Issue #5473: this was
+/// a raw -100.0 sentinel that bypassed the band helpers and tripped the
+/// registry's critical-band assert once scaled.
+const CONTROL_CHANGE_PENALTY: f64 = -super::registry::CRITICAL_MAX;
 
 pub struct ControlChangeAwarenessPolicy;
 
@@ -166,11 +172,13 @@ fn control_change_verdict(
     }
 
     if gives_away_permanent {
-        // Apply severe penalty for giving away own permanents
-        PolicyVerdict::Score {
-            delta: CONTROL_CHANGE_PENALTY,
-            reason: PolicyReason::new("control_change_gives_away_permanent"),
-        }
+        // Apply severe penalty for giving away own permanents. Route through the
+        // critical() band helper (CR-equivalent score contract) rather than a
+        // raw Score literal so the delta stays clamped to the critical band.
+        PolicyVerdict::critical(
+            CONTROL_CHANGE_PENALTY,
+            PolicyReason::new("control_change_gives_away_permanent"),
+        )
     } else {
         PolicyVerdict::Score {
             delta: 0.0,

--- a/crates/phase-ai/src/policies/control_change_awareness.rs
+++ b/crates/phase-ai/src/policies/control_change_awareness.rs
@@ -31,6 +31,9 @@ use crate::features::DeckFeatures;
 /// this stays an overridable penalty rather than a veto). Issue #5473: this was
 /// a raw -100.0 sentinel that bypassed the band helpers and tripped the
 /// registry's critical-band assert once scaled.
+///
+/// Note: pinned at the critical ceiling, this branch is inert to `activation()`
+/// tuning — `-CRITICAL_MAX × any activation` re-bands back to `-CRITICAL_MAX`.
 const CONTROL_CHANGE_PENALTY: f64 = -super::registry::CRITICAL_MAX;
 
 pub struct ControlChangeAwarenessPolicy;

--- a/crates/phase-ai/src/policies/copy_value.rs
+++ b/crates/phase-ai/src/policies/copy_value.rs
@@ -19,11 +19,19 @@ use crate::features::DeckFeatures;
 
 use super::activation::turn_only;
 use super::context::PolicyContext;
-use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use super::registry::{
+    rescale_into_critical_band, DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy,
+};
 
 pub struct CopyValuePolicy;
 
 const COPY_SPELL_LOOP_PENALTY_SCALE: f64 = 0.004;
+
+/// Max expected magnitude of `CopyValuePolicy::score()` — the `+100` preferred-X
+/// anchor plus a copy-target evaluation/penalty tail (~±30, `score_target_choice`
+/// / `score_legend_rule_keep`). Sets where `rescale_into_critical_band` starts to
+/// saturate; below it, ordering is preserved.
+const COPY_VALUE_RAW_CEILING: f64 = 130.0;
 
 impl CopyValuePolicy {
     pub fn score(&self, ctx: &PolicyContext<'_>) -> f64 {
@@ -206,13 +214,17 @@ impl TacticalPolicy for CopyValuePolicy {
     }
 
     fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
-        // `score()` returns a raw analog scale (the +100 "preferred X" anchor and
-        // copy-target penalty sums reach ~±125) that is also consumed raw by
-        // other policies. As a *verdict* it must obey the score contract, so
-        // band-dispatch it through PolicyVerdict::score, which clamps to the
-        // critical band (issue #5473 — the raw literal bypassed the band and
-        // tripped the registry's critical-band assert once scaled).
-        PolicyVerdict::score(self.score(ctx), PolicyReason::new("copy_value_score"))
+        // `score()` is a wide analog signal (the +100 "preferred X" anchor plus
+        // copy-target penalty sums reach ~±125) also consumed raw by other
+        // policies. As a *verdict* it must obey the score contract — but routing
+        // ±125 straight through PolicyVerdict::score would SATURATE, collapsing
+        // every large candidate to the same ±CRITICAL_MAX and flattening the
+        // copy/ChooseX/legend move-ordering prior. Rescale the range into the
+        // band first so ordering survives, then band-dispatch (issue #5473).
+        PolicyVerdict::score(
+            rescale_into_critical_band(self.score(ctx), COPY_VALUE_RAW_CEILING),
+            PolicyReason::new("copy_value_score"),
+        )
     }
 }
 

--- a/crates/phase-ai/src/policies/copy_value.rs
+++ b/crates/phase-ai/src/policies/copy_value.rs
@@ -206,10 +206,13 @@ impl TacticalPolicy for CopyValuePolicy {
     }
 
     fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
-        PolicyVerdict::Score {
-            delta: self.score(ctx),
-            reason: PolicyReason::new("copy_value_score"),
-        }
+        // `score()` returns a raw analog scale (the +100 "preferred X" anchor and
+        // copy-target penalty sums reach ~±125) that is also consumed raw by
+        // other policies. As a *verdict* it must obey the score contract, so
+        // band-dispatch it through PolicyVerdict::score, which clamps to the
+        // critical band (issue #5473 — the raw literal bypassed the band and
+        // tripped the registry's critical-band assert once scaled).
+        PolicyVerdict::score(self.score(ctx), PolicyReason::new("copy_value_score"))
     }
 }
 

--- a/crates/phase-ai/src/policies/downside_awareness.rs
+++ b/crates/phase-ai/src/policies/downside_awareness.rs
@@ -74,10 +74,14 @@ impl TacticalPolicy for DownsideAwarenessPolicy {
     }
 
     fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
-        PolicyVerdict::Score {
-            delta: self.score(ctx),
-            reason: PolicyReason::new("downside_awareness_score"),
-        }
+        // `score()` accumulates and doubles per-effect gift penalties, which can
+        // run past the critical band. Band-dispatch through PolicyVerdict::score
+        // so the verdict delta stays clamped to CRITICAL_MAX (issue #5473 — the
+        // raw Score literal bypassed the band contract).
+        PolicyVerdict::score(
+            self.score(ctx),
+            PolicyReason::new("downside_awareness_score"),
+        )
     }
 }
 

--- a/crates/phase-ai/src/policies/downside_awareness.rs
+++ b/crates/phase-ai/src/policies/downside_awareness.rs
@@ -74,10 +74,11 @@ impl TacticalPolicy for DownsideAwarenessPolicy {
     }
 
     fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
-        // `score()` accumulates and doubles per-effect gift penalties, which can
-        // run past the critical band. Band-dispatch through PolicyVerdict::score
-        // so the verdict delta stays clamped to CRITICAL_MAX (issue #5473 — the
-        // raw Score literal bypassed the band contract).
+        // Range check (issue #5473): the largest gift penalty is `gift_card`
+        // (-3.0), doubled to -6.0 for pure-downside removal — so `score()` never
+        // leaves [-6.0, 0.0], comfortably inside the critical band. No rescale is
+        // needed; PolicyVerdict::score is identity here and simply upholds the
+        // band contract uniformly (no raw Score literal).
         PolicyVerdict::score(
             self.score(ctx),
             PolicyReason::new("downside_awareness_score"),

--- a/crates/phase-ai/src/policies/land_animation.rs
+++ b/crates/phase-ai/src/policies/land_animation.rs
@@ -31,6 +31,9 @@ const MANA_NEEDED_PENALTY: f64 = -2.0;
 /// discouragement the score contract allows. Issue #5473: this was a raw -100.0
 /// sentinel that bypassed the band helpers and tripped the registry's
 /// critical-band assert once scaled by `activation` (turn_only, up to 1.3x).
+///
+/// Note: pinned at the critical ceiling, this branch is inert to `activation()`
+/// tuning — `-CRITICAL_MAX × any activation` re-bands back to `-CRITICAL_MAX`.
 const TAPPED_LAND_PENALTY: f64 = -super::registry::CRITICAL_MAX;
 
 /// Bonus for animating when sufficient alternative mana sources exist.

--- a/crates/phase-ai/src/policies/land_animation.rs
+++ b/crates/phase-ai/src/policies/land_animation.rs
@@ -26,8 +26,12 @@ use crate::features::DeckFeatures;
 /// Penalty for animating a land when mana is needed for other spells.
 const MANA_NEEDED_PENALTY: f64 = -2.0;
 
-/// Penalty for animating a land that ends up tapped (no combat value).
-const TAPPED_LAND_PENALTY: f64 = -100.0;
+/// Penalty for animating a land that ends up tapped (no combat value). Sits at
+/// the bottom of the critical band (`-CRITICAL_MAX`) — the strongest finite
+/// discouragement the score contract allows. Issue #5473: this was a raw -100.0
+/// sentinel that bypassed the band helpers and tripped the registry's
+/// critical-band assert once scaled by `activation` (turn_only, up to 1.3x).
+const TAPPED_LAND_PENALTY: f64 = -super::registry::CRITICAL_MAX;
 
 /// Bonus for animating when sufficient alternative mana sources exist.
 const SUFFICIENT_MANA_BONUS: f64 = 0.3;
@@ -103,10 +107,13 @@ impl TacticalPolicy for LandAnimationPolicy {
         // turns it into a useless tapped creature. Strongly disprefer any
         // activation that leaves the source tapped.
         if animation_leaves_source_tapped(ctx, *source_id, obj, ability_def) {
-            return PolicyVerdict::Score {
-                delta: TAPPED_LAND_PENALTY,
-                reason: PolicyReason::new("land_animation_tapped"),
-            };
+            // Route the critical penalty through the band helper (CR-equivalent
+            // score contract) rather than a raw Score literal so the delta stays
+            // clamped to the critical band before `activation` scaling.
+            return PolicyVerdict::critical(
+                TAPPED_LAND_PENALTY,
+                PolicyReason::new("land_animation_tapped"),
+            );
         }
 
         // Check if this is the only source of a critical color

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -237,10 +237,11 @@ impl TacticalPolicy for RedundancyAvoidancePolicy {
                 .with_fact("effect_kind", kind_tag)
                 .with_fact("redundant_value", extra);
         }
-        PolicyVerdict::Score {
-            delta: total,
-            reason,
-        }
+        // `total` accumulates per-effect redundancy penalties over an effect
+        // chain and can exceed the critical band on wide chains. Band-dispatch
+        // through PolicyVerdict::score so the delta stays clamped to CRITICAL_MAX
+        // (issue #5473 — a raw Score literal bypassed the band contract).
+        PolicyVerdict::score(total, reason)
     }
 }
 

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -237,10 +237,14 @@ impl TacticalPolicy for RedundancyAvoidancePolicy {
                 .with_fact("effect_kind", kind_tag)
                 .with_fact("redundant_value", extra);
         }
-        // `total` accumulates per-effect redundancy penalties over an effect
-        // chain and can exceed the critical band on wide chains. Band-dispatch
-        // through PolicyVerdict::score so the delta stays clamped to CRITICAL_MAX
-        // (issue #5473 — a raw Score literal bypassed the band contract).
+        // Range check (issue #5473): per-effect penalties are small (-3.0 tap /
+        // untap / no-op, -2.0 keyword, -1.5 pump, -0.5 lifegain). Real cards
+        // carry 1-3 such redundant effects, so `total` stays within the critical
+        // band; only a pathological 5+ redundant-effect chain (no printed card)
+        // could approach 15, and there every candidate is already "strongly
+        // disprefer", so ceiling saturation is harmless — ordering that matters
+        // is preserved. PolicyVerdict::score is therefore identity in practice
+        // and upholds the band contract (no raw Score literal).
         PolicyVerdict::score(total, reason)
     }
 }

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -403,27 +403,43 @@ impl PolicyRegistry {
             let scaled = match verdict {
                 PolicyVerdict::Reject { reason } => PolicyVerdict::Reject { reason },
                 PolicyVerdict::Score { delta, reason } => {
-                    let scaled_delta = delta * activation as f64;
+                    // Scaling invariant (issue #5473). A policy's RAW verdict is
+                    // bounded to the critical band (|delta| <= CRITICAL_MAX) by
+                    // the band helpers (`score`/`nudge`/`preference`/`strong`/
+                    // `critical`). The `activation` knob then amplifies it, and
+                    // activation LEGITIMATELY exceeds 1.0 — `arch_times_turn`
+                    // reaches ~2.6 (archetype_scale 2.0 x late_game_mult 1.3) —
+                    // so the *product* is not obligated to stay within the band
+                    // on its own. The debug_assert therefore guards the invariant
+                    // the policy actually controls: the PRE-scale delta. That
+                    // turns it into a true "routed through the band helpers?"
+                    // tripwire — a policy that hand-builds an out-of-band `Score`
+                    // literal (the old LandAnimation / ControlChangeAwareness /
+                    // CopyValue -100/+100 sentinels) trips it, while a legitimate
+                    // critical delta amplified past 15 by activation does not.
                     debug_assert!(
-                        scaled_delta.abs() <= CRITICAL_MAX,
-                        "policy {:?} scaled delta {} exceeds critical band ceiling {}",
+                        delta.abs() <= CRITICAL_MAX,
+                        "policy {:?} raw delta {} exceeds critical band ceiling {} — route through PolicyVerdict band helpers",
                         policy_id,
-                        scaled_delta,
+                        delta,
                         CRITICAL_MAX
                     );
-                    if scaled_delta.abs() > CRITICAL_MAX {
+                    if delta.abs() > CRITICAL_MAX {
                         tracing::warn!(
                             target: "phase_ai::decision_trace",
                             ?policy_id,
-                            scaled_delta,
-                            activation,
-                            "policy scaled delta exceeds critical band ceiling"
+                            delta,
+                            "policy raw delta exceeds critical band ceiling — route through band helpers"
                         );
                     }
-                    PolicyVerdict::Score {
-                        delta: scaled_delta,
-                        reason,
-                    }
+                    // Single authority for the POST-scale magnitude: re-band the
+                    // amplified product through `PolicyVerdict::score`, which
+                    // dispatches and clamps to CRITICAL_MAX using the exact helper
+                    // every policy already uses (no second clamp constant to
+                    // drift). This is identity for in-band contributions and
+                    // stops any out-of-band value from leaking into the softmax
+                    // priors in release builds, where the debug_assert is absent.
+                    PolicyVerdict::score(delta * activation as f64, reason)
                 }
             };
             out.push((policy_id, scaled));
@@ -685,5 +701,80 @@ mod shared_invariant_tests {
         assert!(priors
             .iter()
             .all(|prior| (prior.prior - 0.5).abs() < f64::EPSILON));
+    }
+
+    /// Emits a critical-band verdict (`-CRITICAL_MAX`) with an activation knob
+    /// above 1.0 — mirroring `arch_times_turn`'s ~2.6 worst case (archetype_scale
+    /// 2.0 x late_game_mult 1.3). The seam must clamp the scaled product back to
+    /// the critical band rather than leak the amplified value.
+    struct HighActivationCriticalPolicy;
+
+    impl TacticalPolicy for HighActivationCriticalPolicy {
+        fn id(&self) -> PolicyId {
+            PolicyId::CopyValue
+        }
+
+        fn decision_kinds(&self) -> &'static [DecisionKind] {
+            &[DecisionKind::ActivateAbility]
+        }
+
+        fn activation(
+            &self,
+            _features: &DeckFeatures,
+            _state: &GameState,
+            _player: PlayerId,
+        ) -> Option<f32> {
+            Some(2.6)
+        }
+
+        fn verdict(&self, _ctx: &PolicyContext<'_>) -> PolicyVerdict {
+            PolicyVerdict::critical(-CRITICAL_MAX, PolicyReason::new("scaled_clamp"))
+        }
+    }
+
+    fn scaled_clamp_registry() -> PolicyRegistry {
+        let policies: Vec<Box<dyn TacticalPolicy>> = vec![Box::new(HighActivationCriticalPolicy)];
+        let mut by_kind: HashMap<DecisionKind, Vec<usize>> = HashMap::new();
+        by_kind.insert(DecisionKind::ActivateAbility, vec![0]);
+        PolicyRegistry { policies, by_kind }
+    }
+
+    /// Regression for issue #5473: a band-compliant critical verdict scaled by an
+    /// activation > 1.0 must clamp to `CRITICAL_MAX` at the seam — never leak the
+    /// amplified `-CRITICAL_MAX * 2.6 = -39` into the softmax priors (nor trip the
+    /// registry's critical-band `debug_assert`, which now guards the pre-scale
+    /// delta rather than the amplified product).
+    #[test]
+    fn scaled_delta_is_clamped_to_critical_band_when_activation_exceeds_one() {
+        let action = GameAction::ActivateAbility {
+            source_id: ObjectId(1),
+            ability_index: 0,
+        };
+        let cand = candidate(action, TacticalClass::Ability);
+        let decision = priority_decision(vec![cand.clone()]);
+        let state = GameState::new_two_player(7);
+        let config = AiConfig::default();
+        let context = crate::context::AiContext::empty(&config.weights);
+        let ctx = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &cand,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &context,
+            cast_facts: None,
+            search_depth: SearchDepth::Root,
+        };
+
+        let verdicts = scaled_clamp_registry().verdicts(&ctx);
+        assert_eq!(verdicts.len(), 1, "the single activated policy must fire");
+        let PolicyVerdict::Score { delta, .. } = &verdicts[0].1 else {
+            panic!("expected a Score verdict, got {:?}", verdicts[0].1);
+        };
+        assert!(
+            (delta + CRITICAL_MAX).abs() < 1e-9,
+            "critical delta x activation 2.6 must clamp to -CRITICAL_MAX ({}), got {delta}",
+            -CRITICAL_MAX
+        );
     }
 }

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -247,6 +247,35 @@ impl PolicyVerdict {
     }
 }
 
+/// Map a policy's wide analog signal into the critical band while **preserving
+/// order**, for policies whose natural range exceeds `CRITICAL_MAX` (e.g.
+/// `copy_value`, whose `+100` preferred-X anchor and copy-target penalty sums
+/// reach ~±125). Unlike routing a raw ±125 value straight through
+/// `PolicyVerdict::score` — which *saturates*, collapsing every magnitude past
+/// `STRONG_MAX` to a single `CRITICAL_MAX` and flattening the top of the
+/// distribution — this rescales:
+///   * magnitudes within `STRONG_MAX` pass through unchanged (below-band
+///     ordering stays exact), and
+///   * magnitudes in `(STRONG_MAX, raw_ceiling]` map linearly into
+///     `(STRONG_MAX, CRITICAL_MAX]`, so two distinct large signals stay
+///     distinguishable in the softmax prior instead of colliding at the ceiling.
+///
+/// `raw_ceiling` is the policy's own max expected magnitude; magnitudes beyond
+/// it saturate at `CRITICAL_MAX` (only the extreme tail, where ordering no
+/// longer matters). The result is always in `[-CRITICAL_MAX, CRITICAL_MAX]`, so
+/// it still routes through `PolicyVerdict::score` as identity to keep the single
+/// clamp authority. This is the `anti_self_harm` self-ceiling idea generalized
+/// to a policy whose range is too wide for a bare clamp to preserve.
+pub fn rescale_into_critical_band(raw: f64, raw_ceiling: f64) -> f64 {
+    let magnitude = raw.abs();
+    if magnitude <= STRONG_MAX {
+        return raw;
+    }
+    let ceiling = raw_ceiling.max(STRONG_MAX + f64::EPSILON);
+    let over = ((magnitude - STRONG_MAX) / (ceiling - STRONG_MAX)).clamp(0.0, 1.0);
+    raw.signum() * (STRONG_MAX + over * (CRITICAL_MAX - STRONG_MAX))
+}
+
 /// The clean `TacticalPolicy` trait — four required methods, zero defaults.
 ///
 /// Scaling discipline (CR-equivalent invariant for the AI layer):
@@ -776,5 +805,41 @@ mod shared_invariant_tests {
             "critical delta x activation 2.6 must clamp to -CRITICAL_MAX ({}), got {delta}",
             -CRITICAL_MAX
         );
+    }
+
+    /// Regression for the #5478 review (copy_value saturation): rescaling a wide
+    /// analog range must keep two distinct large signals distinguishable and
+    /// order-preserving, where a bare `score()` saturation collapses them both to
+    /// the ceiling.
+    #[test]
+    fn rescale_into_critical_band_preserves_order_where_saturation_collapses() {
+        let ceiling = 130.0;
+
+        // Below STRONG_MAX: exact identity, sign-preserving.
+        assert_eq!(rescale_into_critical_band(3.0, ceiling), 3.0);
+        assert_eq!(rescale_into_critical_band(-4.5, ceiling), -4.5);
+        assert_eq!(rescale_into_critical_band(0.0, ceiling), 0.0);
+
+        // The maintainer's case: -110 and -30 both saturate to -CRITICAL_MAX under
+        // a bare clamp; rescaling keeps them distinct and correctly ordered.
+        let a = rescale_into_critical_band(-110.0, ceiling);
+        let b = rescale_into_critical_band(-30.0, ceiling);
+        let c = rescale_into_critical_band(-8.0, ceiling);
+        assert!(a < b && b < c, "ordering must survive: {a} < {b} < {c}");
+        assert!(
+            (a - b).abs() > 1.0,
+            "distinct large signals must stay distinguishable, got {a} vs {b}"
+        );
+
+        // Everything stays within the critical band, and beyond the ceiling it
+        // saturates (only the extreme tail, where ordering no longer matters).
+        for raw in [-500.0, -130.0, -15.0, 15.0, 130.0, 500.0] {
+            let out = rescale_into_critical_band(raw, ceiling);
+            assert!(
+                out.abs() <= CRITICAL_MAX + 1e-9,
+                "{raw} -> {out} exceeds band"
+            );
+        }
+        assert!((rescale_into_critical_band(-500.0, ceiling) + CRITICAL_MAX).abs() < 1e-9);
     }
 }

--- a/crates/phase-ai/src/policies/tests/score_contract_lint.rs
+++ b/crates/phase-ai/src/policies/tests/score_contract_lint.rs
@@ -181,8 +181,17 @@ fn production_source(contents: &str) -> &str {
         if !at_line_start {
             continue;
         }
-        let after = &contents[idx + "#[cfg(test)]".len()..];
-        let next_non_blank = after.lines().find(|l| !l.trim().is_empty()).unwrap_or("");
+        // Skip to the end of the `#[cfg(test)]` line first, so a trailing comment
+        // on that line (`#[cfg(test)] // note`) can't be mistaken for the next
+        // item. The module boundary is the first non-blank line *after* it.
+        let line_end = contents[idx..]
+            .find('\n')
+            .map_or(contents.len(), |i| idx + i);
+        let after_line = &contents[line_end..];
+        let next_non_blank = after_line
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or("");
         if next_non_blank.trim_start().starts_with("mod ") {
             return &contents[..idx];
         }
@@ -223,4 +232,28 @@ mod tests {
         !production.contains("mod tests"),
         "the test module must be excluded"
     );
+}
+
+/// A trailing comment on the `#[cfg(test)]` module attribute must not fool the
+/// boundary scan (the scan starts on the *next* line). Guards the gemini review
+/// nit on #5478 — the boundary is still detected and the module still excluded.
+#[test]
+fn production_source_ignores_trailing_comment_on_cfg_test_line() {
+    let src = "\
+fn verdict() -> u8 {
+    PolicyVerdict::Score { delta: 0 }
+}
+
+#[cfg(test)] // module below
+mod tests {
+    fn t() { PolicyVerdict::Score { delta: 9 } }
+}
+";
+    let production = production_source(src);
+    assert_eq!(
+        production.matches("PolicyVerdict::Score {").count(),
+        1,
+        "the test module must still be excluded despite the trailing comment"
+    );
+    assert!(!production.contains("mod tests"));
 }

--- a/crates/phase-ai/src/policies/tests/score_contract_lint.rs
+++ b/crates/phase-ai/src/policies/tests/score_contract_lint.rs
@@ -9,28 +9,46 @@ use std::fs;
 use std::path::Path;
 
 const LEGACY_SCORE_LITERAL_COUNTS: &[(&str, usize)] = &[
+    ("aggro_pressure.rs", 10),
+    ("anthem_priority.rs", 5),
     ("board_development.rs", 1),
+    ("board_wipe_telegraph.rs", 1),
+    ("card_advantage.rs", 1),
     ("chalice_avoidance.rs", 1),
     ("combat_tax.rs", 3),
     ("combo_line.rs", 3),
     ("condition_gated_activation.rs", 1),
-    ("control_change_awareness.rs", 7),
-    ("copy_value.rs", 1),
+    ("control_change_awareness.rs", 6),
+    ("effect_timing.rs", 1),
     ("equipment_priority.rs", 1),
     ("etb_value.rs", 1),
     ("evasion_removal_priority.rs", 1),
     ("free_outlet_activation.rs", 8),
+    ("hand_disruption.rs", 1),
+    ("hold_mana_up.rs", 3),
     ("interaction_reservation.rs", 1),
-    ("land_animation.rs", 7),
+    ("land_animation.rs", 6),
     ("land_sequencing.rs", 1),
     ("landfall_timing.rs", 5),
+    ("lethality_awareness.rs", 1),
+    ("life_total_resource.rs", 1),
+    ("mana_efficiency.rs", 1),
     ("mill_targeting.rs", 4),
     ("planeswalker_loyalty.rs", 2),
     ("plus_one_counters.rs", 10),
+    ("ramp_timing.rs", 4),
     ("reactive_self_protection.rs", 0),
     ("recursion_awareness.rs", 1),
+    ("redundancy_avoidance.rs", 1),
     ("spellskite_priority.rs", 1),
+    ("spellslinger_casting.rs", 4),
     ("stack_awareness.rs", 1),
+    ("sweeper_timing.rs", 3),
+    ("synergy_casting.rs", 1),
+    ("tempo_curve.rs", 1),
+    ("tokens_wide.rs", 7),
+    ("tribal_lord_priority.rs", 7),
+    ("tutor.rs", 1),
     ("x_value.rs", 1),
 ];
 
@@ -63,7 +81,7 @@ fn new_policy_files_use_score_contract_helpers() {
         let Ok(contents) = fs::read_to_string(&path) else {
             continue;
         };
-        let production = contents.split("#[cfg(test)]").next().unwrap_or(&contents);
+        let production = production_source(&contents);
         let direct_score_count = production.matches("PolicyVerdict::Score {").count();
         let allowed_count = legacy_score_literal_count(file_name);
         if direct_score_count != allowed_count {
@@ -141,4 +159,68 @@ fn legacy_score_literal_count(file_name: &str) -> usize {
         .iter()
         .find_map(|(name, count)| (*name == file_name).then_some(*count))
         .unwrap_or(0)
+}
+
+/// Returns the production portion of a policy source file: everything before the
+/// `#[cfg(test)] mod ...` test module.
+///
+/// A naive `split("#[cfg(test)]").next()` truncates at the FIRST `#[cfg(test)]`
+/// attribute — but many policy files carry a test-only `use` import
+/// (`#[cfg(test)] use ...CastPaymentMode;`) in their top import block. Splitting
+/// there hid the entire impl below it, so real production emit sites evaded this
+/// lint (issue #5473: `redundancy_avoidance` / `downside_awareness` shipped raw
+/// out-of-band `Score` literals undetected). The module boundary is the only
+/// correct truncation point: a `#[cfg(test)]` line whose next non-blank line
+/// opens a `mod`. Attributes on individual test-only items are skipped.
+fn production_source(contents: &str) -> &str {
+    for (idx, _) in contents.match_indices("#[cfg(test)]") {
+        // Consider only a `#[cfg(test)]` that begins its line (column 0), i.e. a
+        // top-level attribute — the test module. Attributes on indented items or
+        // occurrences inside strings are not module boundaries.
+        let at_line_start = idx == 0 || contents[..idx].ends_with('\n');
+        if !at_line_start {
+            continue;
+        }
+        let after = &contents[idx + "#[cfg(test)]".len()..];
+        let next_non_blank = after.lines().find(|l| !l.trim().is_empty()).unwrap_or("");
+        if next_non_blank.trim_start().starts_with("mod ") {
+            return &contents[..idx];
+        }
+    }
+    contents
+}
+
+/// A test-only `use` (or any `#[cfg(test)]` item that is not the test module)
+/// must NOT truncate the production scan; only `#[cfg(test)] mod ...` does. This
+/// guards the blind spot that hid issue #5473's offenders.
+#[test]
+fn production_source_stops_only_at_the_test_module() {
+    let src = "\
+use foo::Bar;
+#[cfg(test)]
+use foo::TestOnly;
+
+fn verdict() -> u8 {
+    PolicyVerdict::Score { delta: 0 }
+}
+
+#[cfg(test)]
+mod tests {
+    fn t() { PolicyVerdict::Score { delta: 9 } }
+}
+";
+    let production = production_source(src);
+    assert_eq!(
+        production.matches("PolicyVerdict::Score {").count(),
+        1,
+        "the production `verdict` emit must be visible; the test-module emit must not"
+    );
+    assert!(
+        production.contains("fn verdict"),
+        "the impl below a test-only `use` must remain in the production slice"
+    );
+    assert!(
+        !production.contains("mod tests"),
+        "the test module must be excluded"
+    );
 }


### PR DESCRIPTION
## Summary
Fixes the unclamped-policy-delta crash in `phase-ai` (**Closes #5473**). Driving a Commander game with `get_ai_action` on a debug/wasm build panicked at `registry.rs` — `policy LandAnimation scaled delta -69.9 exceeds critical band ceiling 15` (and the same for `ControlChangeAwareness`), followed by `RuntimeError: unreachable`.

Two compounding defects, fixed at the seam and at the source:

1. **Seam (load-bearing).** `PolicyRegistry::verdicts()` computed `scaled_delta = delta * activation` and only `debug_assert!`d / `tracing::warn!`d on overflow — it never clamped, so in release builds an out-of-band delta leaked straight into the softmax priors, while debug/wasm hard-panicked. The assert was also mis-specified: `activation` legitimately exceeds 1.0 (`arch_times_turn` reaches ~2.6 = archetype_scale 2.0 × late_game_mult 1.3), so even a perfectly band-compliant critical delta of 15 scales to 39 and trips it. The fix re-points the `debug_assert` at the invariant the band helpers actually guarantee — the **pre-scale** `|delta| ≤ CRITICAL_MAX` — and re-bands the amplified product through `PolicyVerdict::score`, the single existing clamp authority. This is identity for in-band contributions and makes every policy safe-by-construction, present and future.

2. **Source.** Five policies hand-built `PolicyVerdict::Score { delta }` literals that bypassed the band helpers and could emit out-of-band magnitudes: `LandAnimation` / `ControlChangeAwareness` (`-100` sentinels — issue-named), `CopyValue` (a `+100`/`±125` analog anchor — **not** issue-named; found by a full-class audit), and `RedundancyAvoidance` / `DownsideAwareness` (unclamped additive totals). Each now routes through a band helper (`critical(-CRITICAL_MAX)` for the two sentinels, `score(..)` for the computed deltas). The two `-100` constants become `-CRITICAL_MAX` — the strongest *finite* discouragement the score contract allows, not a hard `Reject` (giving away a permanent / self-tapping a manland is contextually not always wrong — Donate combos, liability permanents — so it stays overridable).

3. **Recurrence (build for the class).** The `score_contract_lint` meant to catch this had a blind spot: `split("#[cfg(test)]").next()` truncated the production scan at the first `#[cfg(test)]` attribute, which for ~24 policy files is a test-only `use` import in the top import block — hiding their entire impl (exactly why `CopyValue`/`RedundancyAvoidance`/`DownsideAwareness` went undetected). Replaced with a `production_source()` helper that truncates only at the real `#[cfg(test)] mod` boundary, and grandfathered the now-visible legacy counts so no future policy can hide an out-of-band emit behind a test-only import.

## Files changed
- `crates/phase-ai/src/policies/registry.rs` — seam clamp + pre-scale assert + regression test
- `crates/phase-ai/src/policies/control_change_awareness.rs` — route `-100` sentinel through `critical(-CRITICAL_MAX)`
- `crates/phase-ai/src/policies/land_animation.rs` — route `-100` sentinel through `critical(-CRITICAL_MAX)`
- `crates/phase-ai/src/policies/copy_value.rs` — re-band the verdict wrapper through `score()`
- `crates/phase-ai/src/policies/redundancy_avoidance.rs` — re-band the additive total through `score()`
- `crates/phase-ai/src/policies/downside_awareness.rs` — re-band the verdict through `score()`
- `crates/phase-ai/src/policies/tests/score_contract_lint.rs` — fix `#[cfg(test)]` blind spot + grandfather legacy counts

## CR references
None — this is the AI tactical-scoring layer, not MTG game logic. The `PolicyVerdict` band ceiling is a *CR-equivalent* scoring invariant (documented as such in `registry.rs`), not a Comprehensive Rules rule; no CR-annotated game logic is added or changed.

## Track
Developer

## LLM
Model: claude-opus-4-8[1m]
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p phase-ai --all-targets` — 0 warnings
- `cargo test -p phase-ai --lib` — 1262 pass / 0 fail (incl. new `scaled_delta_is_clamped_to_critical_band_when_activation_exceeds_one`, `production_source_stops_only_at_the_test_module`, and the tightened `new_policy_files_use_score_contract_helpers`)
- `scripts/ai-gate.sh` — **0 FAIL, 2 WARN, 1 PASS**; all matchups within absolute mirror tolerance. The WARN drift is the expected, benign consequence of clamping deltas that previously leaked out-of-band into release priors (the AI now scores these policies at contract-correct magnitude), and no baseline refresh is required since nothing FAILs:

| matchup | exercises | baseline p0% | current p0% | flips W→L | flips L→W | sign p | status |
|---------|-----------|--------------|-------------|-----------|-----------|--------|--------|
| affinity-mirror | Artifacts, PlusOneCounters, AggroPressure | 20% | 30% | 0 | 0 | — | WARN (avg-turn drift +3.4) |
| enchantress-mirror | Enchantments | 50% | 50% | 0 | 0 | — | PASS |
| red-mirror | AggroPressure | 70% | 80% | 1 | 2 | 0.3125 | WARN (not significant) |

Behavior note: re-banding `CopyValue`'s `+100` "preferred-X" anchor to the band compresses its ranking when a copy target evaluates ≥ 15 (e.g. a 6/6). Argmax-first X-selection is unaffected (it still lands on the smallest preferred X); softmax sampling among only-large targets loses some separation. This is within ai-gate tolerance and is the correct contract-respecting behavior; flagged here for transparency.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
