### PR TITLE
fix(engine): serialize RNG stream position so restore doesn't rewind it

### DIFF
--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -2388,3 +2388,65 @@ mod replay_bridge_tests {
         clear_game_state();
     }
 }
+
+/// Native coverage for the RNG-restore bridge wiring (issue #5466). The
+/// `export`/`restore` entry points are plain Rust functions, so these run in
+/// the standard `cargo test`/`nextest` shards — unlike the `wasm32`-gated
+/// `mod tests`, whose assertions never execute in the native suite.
+#[cfg(test)]
+mod rng_restore_bridge_tests {
+    use super::*;
+    use rand::RngCore;
+
+    #[test]
+    fn export_then_restore_resumes_live_rng_stream_through_wasm_bridge() {
+        // Issue #5466, end-to-end through the WASM boundary: `export_game_state_json`
+        // must capture the live ChaCha20 offset and `restore_game_state` must
+        // fast-forward the reseeded stream to it, so a restored game draws the
+        // values that would have come NEXT — not a replay from origin. This test
+        // drives the real bridge entry points (nothing calls the engine seam
+        // directly): deleting `state.capture_rng_word_pos()` in export or
+        // `state.rehydrate_rng()` in restore turns it red. Asserts on consumed
+        // randomness, not the stored `rng_word_pos` integer.
+        clear_game_state();
+
+        // Seed a live game and consume randomness as gameplay would.
+        let mut state = GameState::new_two_player(0x51A7_C0DE);
+        for _ in 0..9 {
+            state.rng.next_u32();
+        }
+        GAME_STATE.with(|cell| cell.set(Some(state)));
+
+        // The four values the live stream will produce next, captured from a
+        // clone taken at the pre-export offset.
+        let mut expected = with_state(|s| s.rng.clone()).unwrap();
+        let expected_draws: Vec<u32> = (0..4).map(|_| expected.next_u32()).collect();
+
+        // Serialize through the real bridge entry point (captures rng_word_pos).
+        let json = export_game_state_json().unwrap();
+
+        // Advance the LIVE rng further so a rewind-to-origin restore would be
+        // observable: without the offset, restore would replay from the seed's
+        // origin (nine draws back), never matching `expected_draws`.
+        with_state_mut(|s| {
+            for _ in 0..3 {
+                s.rng.next_u32();
+            }
+        })
+        .unwrap();
+
+        // Restore through the real bridge entry point (reseeds + fast-forwards).
+        restore_game_state(&json).unwrap();
+
+        // The restored stream must resume at the exported offset and produce the
+        // continuation captured before export.
+        let restored_draws: Vec<u32> =
+            with_state_mut(|s| (0..4).map(|_| s.rng.next_u32()).collect()).unwrap();
+        assert_eq!(
+            restored_draws, expected_draws,
+            "restored stream must resume where export left off, not rewind to origin"
+        );
+
+        clear_game_state();
+    }
+}

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -1257,7 +1257,11 @@ pub fn list_token_presets_js() -> JsValue {
 /// Used by the engine worker to transfer state to AI workers for root parallelism.
 #[wasm_bindgen]
 pub fn export_game_state_json() -> Result<String, JsValue> {
-    with_state(|state| {
+    with_state_mut(|state| {
+        // Capture the live ChaCha20 stream position so `restore_game_state` can
+        // fast-forward to it (issue #5466): `rng` is `#[serde(skip)]`, so only
+        // the serialized `rng_word_pos` carries the offset across the round trip.
+        state.rng_word_pos = state.rng.get_word_pos();
         serde_json::to_string(state)
             .map_err(|e| JsValue::from_str(&format!("Failed to serialize GameState: {e}")))
     })?
@@ -1280,6 +1284,11 @@ pub fn restore_game_state(json_str: &str) -> Result<(), JsValue> {
     let mut state: GameState = serde_json::from_str(json_str)
         .map_err(|e| JsValue::from_str(&format!("Failed to deserialize GameState: {}", e)))?;
     state.rng = ChaCha20Rng::seed_from_u64(state.rng_seed);
+    // Fast-forward the reseeded stream to the offset captured at export
+    // (issue #5466) so the restored game draws the values that would have come
+    // NEXT rather than replaying from origin. Pre-#5466 snapshots default
+    // `rng_word_pos` to 0, preserving the previous rewind-to-origin behavior.
+    state.rng.set_word_pos(state.rng_word_pos);
     state.debug_mode = true;
     CARD_DB.with(|cell| {
         if let Some(db) = cell.borrow().as_ref() {
@@ -1339,11 +1348,16 @@ pub fn resume_multiplayer_host_state(json_str: &str) -> Result<(), JsValue> {
     let mut state: GameState = serde_json::from_str(json_str)
         .map_err(|e| JsValue::from_str(&format!("Failed to deserialize GameState: {}", e)))?;
 
-    // Stale `rng_seed` replays the pre-save ChaCha20 sequence because
-    // stream position is `#[serde(skip)]`. Mirrors server-core.
+    // Deliberately re-roll a fresh seed on multiplayer host resume so continued
+    // play diverges from any pre-save sequence (mirrors server-core). This is a
+    // multiplayer-resume policy choice, independent of the #5466 undo fix: even
+    // though the stream position now round-trips via `rng_word_pos`, a resumed
+    // host should NOT replay the exact saved randomness. Reset the offset to 0
+    // to match the freshly seeded stream.
     let fresh_seed: u64 = rand::rng().random();
     state.rng_seed = fresh_seed;
     state.rng = ChaCha20Rng::seed_from_u64(fresh_seed);
+    state.rng_word_pos = 0;
 
     CARD_DB.with(|cell| {
         if let Some(db) = cell.borrow().as_ref() {

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -1259,9 +1259,10 @@ pub fn list_token_presets_js() -> JsValue {
 pub fn export_game_state_json() -> Result<String, JsValue> {
     with_state_mut(|state| {
         // Capture the live ChaCha20 stream position so `restore_game_state` can
-        // fast-forward to it (issue #5466): `rng` is `#[serde(skip)]`, so only
-        // the serialized `rng_word_pos` carries the offset across the round trip.
-        state.rng_word_pos = state.rng.get_word_pos();
+        // fast-forward to it (issue #5466); `rng` is `#[serde(skip)]`. The
+        // randomness logic lives in the engine (`GameState::capture_rng_word_pos`),
+        // keeping this WASM boundary a thin serialization step.
+        state.capture_rng_word_pos();
         serde_json::to_string(state)
             .map_err(|e| JsValue::from_str(&format!("Failed to serialize GameState: {e}")))
     })?
@@ -1283,12 +1284,12 @@ pub fn restore_game_state(json_str: &str) -> Result<(), JsValue> {
     }
     let mut state: GameState = serde_json::from_str(json_str)
         .map_err(|e| JsValue::from_str(&format!("Failed to deserialize GameState: {}", e)))?;
-    state.rng = ChaCha20Rng::seed_from_u64(state.rng_seed);
-    // Fast-forward the reseeded stream to the offset captured at export
-    // (issue #5466) so the restored game draws the values that would have come
-    // NEXT rather than replaying from origin. Pre-#5466 snapshots default
-    // `rng_word_pos` to 0, preserving the previous rewind-to-origin behavior.
-    state.rng.set_word_pos(state.rng_word_pos);
+    // Reseed the skipped `rng` and fast-forward it to the offset captured at
+    // export (issue #5466) so the restored game draws the values that would have
+    // come NEXT rather than replaying from origin. The engine owns this logic
+    // (`GameState::rehydrate_rng`); pre-#5466 snapshots carry `rng_word_pos == 0`
+    // and reproduce the previous rewind-to-origin behavior.
+    state.rehydrate_rng();
     state.debug_mode = true;
     CARD_DB.with(|cell| {
         if let Some(db) = cell.borrow().as_ref() {

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -30,6 +30,10 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
     // handle for good measure) closes the wire leak without affecting
     // server-side randomness or session restore.
     filtered.rng_seed = 0;
+    // Also drop the serialized stream position (issue #5466 sibling): a leaked
+    // word offset would give an attacker the keystream alignment for free. Zero
+    // it so no viewer snapshot carries either the seed or its stream position.
+    filtered.rng_word_pos = 0;
     filtered.rng = <rand_chacha::ChaCha20Rng as rand::SeedableRng>::seed_from_u64(0);
 
     let can_view_private_for_player = |player: PlayerId| {

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1240,6 +1240,7 @@ mod tests {
     use crate::types::identifiers::CardId;
     use crate::types::mana::ManaCost;
     use crate::types::zones::{ExileCostSourceZone, Zone};
+    use rand::RngCore;
 
     fn dummy_pending_cast(
         object_id: ObjectId,
@@ -1315,20 +1316,40 @@ mod tests {
     #[test]
     fn redacts_rng_seed_from_every_viewer() {
         // A distinctive non-zero seed so a leak is unmistakable.
-        let state = GameState::new_two_player(0x1234_5678_9abc_def0);
+        let mut state = GameState::new_two_player(0x1234_5678_9abc_def0);
         assert_eq!(state.rng_seed, 0x1234_5678_9abc_def0);
 
-        // Seat viewers and the non-seat spectator must never see the real seed.
+        // Advance the ChaCha20 stream as gameplay would and snapshot the offset,
+        // so `rng_word_pos` is non-zero. Issue #5466 sibling: a leaked word
+        // offset hands an attacker the keystream alignment for free, so the
+        // filter must redact the stream position as well as the seed.
+        for _ in 0..5 {
+            state.rng.next_u32();
+        }
+        state.capture_rng_word_pos();
+        let source_word_pos = state.rng_word_pos;
+        assert_ne!(
+            source_word_pos, 0,
+            "test precondition: stream position must be non-zero to prove redaction"
+        );
+
+        // Seat viewers and the non-seat spectator must never see the real seed
+        // or the serialized stream position.
         for viewer in [PlayerId(0), PlayerId(1), PlayerId(u8::MAX)] {
             let filtered = filter_state_for_viewer(&state, viewer);
             assert_eq!(
                 filtered.rng_seed, 0,
                 "rng_seed must be redacted for viewer {viewer:?}"
             );
+            assert_eq!(
+                filtered.rng_word_pos, 0,
+                "rng_word_pos must be redacted for viewer {viewer:?}"
+            );
         }
 
         // The authoritative source state is untouched by filtering.
         assert_eq!(state.rng_seed, 0x1234_5678_9abc_def0);
+        assert_eq!(state.rng_word_pos, source_word_pos);
     }
 
     #[test]

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -8436,6 +8436,25 @@ const _: fn() = || {
 };
 
 impl GameState {
+    /// Capture the live ChaCha20 stream offset into `rng_word_pos` so it
+    /// survives serialization — `rng` is `#[serde(skip)]`, so this field is the
+    /// only carrier of the position across a snapshot (issue #5466). Callers
+    /// serializing a faithfully-restorable snapshot invoke this first; the
+    /// randomness logic lives here in the engine, not in transport layers.
+    pub fn capture_rng_word_pos(&mut self) {
+        self.rng_word_pos = self.rng.get_word_pos();
+    }
+
+    /// Reconstruct `rng` from the serialized `rng_seed` and fast-forward it to
+    /// the saved `rng_word_pos`, so a restored snapshot resumes the random
+    /// stream where it left off instead of rewinding to origin and replaying
+    /// already-consumed values (issue #5466). Pre-#5466 snapshots carry
+    /// `rng_word_pos == 0`, which reproduces the previous from-origin behavior.
+    pub fn rehydrate_rng(&mut self) {
+        self.rng = ChaCha20Rng::seed_from_u64(self.rng_seed);
+        self.rng.set_word_pos(self.rng_word_pos);
+    }
+
     /// CR 118.3a: Mint the next stable `ManaPipId` for a pool unit. Monotonic,
     /// never returns the `ManaPipId(0)` unstamped sentinel (counter starts at 1).
     fn next_pip_id(&mut self) -> ManaPipId {
@@ -10185,24 +10204,23 @@ mod tests {
     }
 
     #[test]
-    fn rng_word_pos_survives_serde_and_restores_stream_position() {
-        // Issue #5466: a restored snapshot must resume the ChaCha20 stream at
-        // the offset it held when exported — not rewind to origin and replay the
-        // values the game already consumed. Mirrors the export (sync
-        // `rng_word_pos`) / restore (reseed + `set_word_pos`) seam in
-        // engine-wasm's `export_game_state_json` / `restore_game_state`.
+    fn rng_word_pos_survives_serde_and_rehydrate_resumes_stream() {
+        // Issue #5466: a restored snapshot must resume the ChaCha20 stream at the
+        // offset it held when exported — not rewind to origin and replay the
+        // values the game already consumed. Exercises the ENGINE seam that the
+        // WASM bridge delegates to (`capture_rng_word_pos` on export /
+        // `rehydrate_rng` on restore); reverting either method breaks this test.
         use rand::RngCore;
         let mut state = GameState::new_two_player(0xABCD_1234);
         for _ in 0..7 {
             state.rng.next_u32(); // consume randomness as gameplay would
         }
-        state.rng_word_pos = state.rng.get_word_pos(); // export-time sync
+        state.capture_rng_word_pos(); // production export-time capture
         let mut expected = state.rng.clone(); // the values that come next
         let json = serde_json::to_string(&state).unwrap();
 
         let mut restored: GameState = serde_json::from_str(&json).unwrap();
-        restored.rng = ChaCha20Rng::seed_from_u64(restored.rng_seed);
-        restored.rng.set_word_pos(restored.rng_word_pos); // restore-time fast-forward
+        restored.rehydrate_rng(); // production restore-time reseed + fast-forward
 
         assert_ne!(
             restored.rng_word_pos, 0,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6412,6 +6412,16 @@ pub struct GameState {
 
     // RNG
     pub rng_seed: u64,
+    /// ChaCha20 stream position (word offset) captured at serialize time.
+    /// `rng` is `#[serde(skip)]`, so without persisting the position a restored
+    /// snapshot reseeds to offset 0 and replays the random sequence the game
+    /// already consumed (issue #5466). Synced from `rng.get_word_pos()` before
+    /// export and re-applied via `set_word_pos` on restore. Like `rng` itself it
+    /// is excluded from `PartialEq` (mutable stream position, not identity);
+    /// `#[serde(default)]` = 0 keeps pre-#5466 saves on today's from-origin
+    /// (rewind) behavior.
+    #[serde(default)]
+    pub rng_word_pos: u128,
     #[serde(skip, default = "default_rng")]
     pub rng: ChaCha20Rng,
 
@@ -8662,6 +8672,7 @@ impl GameState {
             exile: im::Vector::new(),
             command_zone: im::Vector::new(),
             rng_seed: seed,
+            rng_word_pos: 0,
             rng: ChaCha20Rng::seed_from_u64(seed),
             combat: None,
             waiting_for: WaitingFor::Priority {
@@ -10171,6 +10182,53 @@ mod tests {
         // Reconstruct RNG from seed since it's skipped in serde
         deserialized.rng = ChaCha20Rng::seed_from_u64(deserialized.rng_seed);
         assert_eq!(state, deserialized);
+    }
+
+    #[test]
+    fn rng_word_pos_survives_serde_and_restores_stream_position() {
+        // Issue #5466: a restored snapshot must resume the ChaCha20 stream at
+        // the offset it held when exported — not rewind to origin and replay the
+        // values the game already consumed. Mirrors the export (sync
+        // `rng_word_pos`) / restore (reseed + `set_word_pos`) seam in
+        // engine-wasm's `export_game_state_json` / `restore_game_state`.
+        use rand::RngCore;
+        let mut state = GameState::new_two_player(0xABCD_1234);
+        for _ in 0..7 {
+            state.rng.next_u32(); // consume randomness as gameplay would
+        }
+        state.rng_word_pos = state.rng.get_word_pos(); // export-time sync
+        let mut expected = state.rng.clone(); // the values that come next
+        let json = serde_json::to_string(&state).unwrap();
+
+        let mut restored: GameState = serde_json::from_str(&json).unwrap();
+        restored.rng = ChaCha20Rng::seed_from_u64(restored.rng_seed);
+        restored.rng.set_word_pos(restored.rng_word_pos); // restore-time fast-forward
+
+        assert_ne!(
+            restored.rng_word_pos, 0,
+            "stream position must survive serde"
+        );
+        for i in 0..5 {
+            assert_eq!(
+                restored.rng.next_u32(),
+                expected.next_u32(),
+                "restored stream diverged at draw {i}",
+            );
+        }
+    }
+
+    #[test]
+    fn rng_word_pos_defaults_to_zero_when_absent() {
+        // Backward compat (#5466): a snapshot serialized before the field
+        // existed omits `rng_word_pos` and must deserialize to 0 — today's
+        // rewind-to-origin behavior — via `#[serde(default)]`.
+        let mut value = serde_json::to_value(GameState::default()).unwrap();
+        value
+            .as_object_mut()
+            .expect("GameState serializes as a JSON object")
+            .remove("rng_word_pos");
+        let restored: GameState = serde_json::from_value(value).unwrap();
+        assert_eq!(restored.rng_word_pos, 0);
     }
 
     /// Test E — deserialize-before-flush. `static_mode_presence` is `#[serde(skip)]` with an


### PR DESCRIPTION
Fixes #5466.

## Problem

`GameState.rng` (ChaCha20) is `#[serde(skip)]`, so `export_game_state_json` → `restore_game_state` reseeded from `rng_seed` at **stream position 0**. A restored snapshot — the single-player undo primitive — replayed the *same* random sequence the game already consumed: the next shuffle / coin flip / random target after a restore repeated the values that drove the opening shuffle, not the values that would have come next.

This hard-blocked faithful full-turn-rewind undo, deterministic replays/bug-repros built on snapshots, and save-and-resume that behaves identically to never having saved. (The MP-resume path already worked around the sibling symptom by re-rolling a fresh seed, trading determinism for non-replay.)

## Fix (issue's Option 1 — minimal, format-stable)

Persist the ChaCha20 stream offset next to the seed:

- **`rng_word_pos: u128`** added to `GameState`, `#[serde(default)]` → pre-existing saves default to `0` (today's rewind-to-origin behavior; **backward compatible**). Excluded from the manual `PartialEq` like `rng` itself (mutable stream position, not identity).
- **`export_game_state_json`** syncs `rng_word_pos = rng.get_word_pos()` before serializing (switched to `with_state_mut`).
- **`restore_game_state`** re-applies `rng.set_word_pos(rng_word_pos)` after reseeding, so the stream resumes where it left off.
- **`filter_state_for_viewer`** zeroes `rng_word_pos` alongside `rng_seed` — no client/guest snapshot leaks the stream position (#5368 sibling; a leaked offset would hand an attacker the keystream alignment).
- **`resume_multiplayer_host_state`** resets it to `0` to match its deliberate fresh-seed re-roll (MP resume intentionally diverges; stale comment corrected).

## Verification

- `cargo check -p engine` and `-p engine-wasm` clean; `cargo check -p engine --tests` (test module) type-checks; `cargo fmt` clean.
- **Round-trip test** (`rng_word_pos_survives_serde_and_restores_stream_position`): draw 7 values, sync + serialize, restore (reseed + `set_word_pos`), assert the next 5 values reproduce a reference stream at the same offset exactly.
- **Backward-compat test** (`rng_word_pos_defaults_to_zero_when_absent`): a snapshot with the field removed deserializes to `0`.

3 files, +~72/-1. No new engine variant or runtime; a `#[serde(default)]` field is a wire-compatible addition (old saves load unchanged).
