### PR TITLE
feat(card): implement Diligent Farmhand (CountsAsNamed graveyard static)

### DIFF
--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -27,6 +27,7 @@ use crate::types::keywords::Keyword;
 use crate::types::mana::{ManaColor, ManaCost};
 use crate::types::player::PlayerId;
 use crate::types::proposed_event::{EtbTapState, ProposedEvent, TokenSpec};
+use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
 /// True when the filter's matched SET depends on the population of objects on
@@ -3644,7 +3645,20 @@ fn matches_filter_prop(
         // no activated, triggered, replacement, or static abilities.
         FilterProp::HasNoAbilities => object_has_no_abilities(obj),
         // CR 201.2: Name matching is exact (case-insensitive comparison).
-        FilterProp::Named { name } => obj.name.eq_ignore_ascii_case(name),
+        // CR 201.5: Also check CountsAsNamed statics (Odyssey Burst cycle).
+        FilterProp::Named { name } => {
+            obj.name.eq_ignore_ascii_case(name)
+                || obj.static_definitions.iter_all().any(|sd| {
+                    // Only count the alias if the static's active_zones include
+                    // the object's current zone (or active_zones is empty = always).
+                    if let StaticMode::CountsAsNamed { name: alias } = &sd.mode {
+                        (sd.active_zones.is_empty() || sd.active_zones.contains(&obj.zone))
+                            && alias.eq_ignore_ascii_case(name)
+                    } else {
+                        false
+                    }
+                })
+        }
         // SameName: matches objects with the same name as the tracked card from context.
         // At runtime, this checks against the source object's name (the event context card).
         FilterProp::SameName => {

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -3644,8 +3644,13 @@ fn matches_filter_prop(
         // CR 113.1 + CR 113.3: "no abilities" means no keyword abilities and
         // no activated, triggered, replacement, or static abilities.
         FilterProp::HasNoAbilities => object_has_no_abilities(obj),
-        // CR 201.2: Name matching is exact (case-insensitive comparison).
-        // CR 201.5: Also check CountsAsNamed statics (Odyssey Burst cycle).
+        // CR 201.2a: Name matching is exact (case-insensitive comparison).
+        // Also check CountsAsNamed statics (Odyssey Burst cycle).
+        // NOTE: The alias applies to ANY FilterProp::Named check, not only effects
+        // from spells named X. This is safe for the entire Burst cycle because each
+        // Burst spell is the only effect referencing its own name — but if a future
+        // non-self-referential "counts as named" card appears, this may need a
+        // source-filter check.
         FilterProp::Named { name } => {
             obj.name.eq_ignore_ascii_case(name)
                 || obj.static_definitions.iter_all().any(|sd| {

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -910,6 +910,8 @@ fn parse_static_line_with_graveyard_keyword_continuation(
         vec![def]
     } else if let Some(def) = try_parse_graveyard_keyword_grant_static(line) {
         vec![def]
+    } else if let Some(def) = crate::parser::oracle_static::try_parse_counts_as_named_static(line) {
+        vec![def]
     } else {
         parse_static_line_multi(line)
     };

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -3430,3 +3430,55 @@ fn parse_enters_with_additional_counters(
         .description(text.to_string()),
     )
 }
+
+/// Parses the Odyssey Burst-cycle graveyard name-aliasing static:
+/// "If ~ is in a graveyard, effects from spells named X count it as
+/// a card named X." — Odyssey Burst cycle (Diligent Farmhand, Pardic Firecat,
+/// Flame-Kin Zealot, etc.).
+///
+/// Returns a `StaticDefinition` with `StaticMode::CountsAsNamed { name }` and
+/// `active_zones = [Graveyard]`.
+pub(crate) fn try_parse_counts_as_named_static(text: &str) -> Option<StaticDefinition> {
+    use super::prelude::*;
+    // Normalize: lowercase for matching, strip trailing period.
+    let lower = text.to_lowercase();
+    // allow-noncombinator: punctuation cleanup on pre-tokenized input (char arg)
+    let lower = lower.trim_end_matches('.').trim();
+    // Parse the fixed structure using nom combinators:
+    // "if ~ is in a graveyard, effects from spells named <NAME> count it as a card named <NAME>"
+    let (rest, _) = tag::<_, _, OracleError<'_>>("if ~ is in a graveyard, ")
+        .parse(lower)
+        .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("effects from spells named ")
+        .parse(rest)
+        .ok()?;
+    // Split on " count it as a card named " to extract the spell name and alias.
+    let (alias_name, spell_name) = terminated(
+        take_until::<_, _, OracleError<'_>>(" count it as a card named "),
+        tag(" count it as a card named "),
+    )
+    .parse(rest)
+    .ok()?;
+    // Both names should match (the card counts as the spell that references it).
+    // Validate they're the same name (case-insensitive).
+    if !spell_name.eq_ignore_ascii_case(alias_name) {
+        return None;
+    }
+    // Title-case the name for storage (first letter of each word capitalized).
+    let name = spell_name
+        .split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    Some(
+        StaticDefinition::new(StaticMode::CountsAsNamed { name })
+            .active_zones(vec![Zone::Graveyard])
+            .description(text.to_string()),
+    )
+}

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -3434,48 +3434,52 @@ fn parse_enters_with_additional_counters(
 /// Parses the Odyssey Burst-cycle graveyard name-aliasing static:
 /// "If ~ is in a graveyard, effects from spells named X count it as
 /// a card named X." — Odyssey Burst cycle (Diligent Farmhand, Pardic Firecat,
-/// Flame-Kin Zealot, etc.).
+/// Nantuko Blightcutter, etc.).
+///
+/// Accepts both `"if ~ is in a graveyard, ..."` (test fixtures) and
+/// `"if this card is in a graveyard, ..."` (production pipeline — `"this card"`
+/// is in `SELF_REF_PARSE_ONLY_PHRASES` and is NOT normalized to `~`).
+///
+/// No general CR governs this Odyssey-specific templating; the name-matching
+/// semantics rely on CR 201.2a ("two or more objects have the same name if
+/// they have at least one name in common").
 ///
 /// Returns a `StaticDefinition` with `StaticMode::CountsAsNamed { name }` and
 /// `active_zones = [Graveyard]`.
 pub(crate) fn try_parse_counts_as_named_static(text: &str) -> Option<StaticDefinition> {
     use super::prelude::*;
-    // Normalize: lowercase for matching, strip trailing period.
-    let lower = text.to_lowercase();
     // allow-noncombinator: punctuation cleanup on pre-tokenized input (char arg)
-    let lower = lower.trim_end_matches('.').trim();
-    // Parse the fixed structure using nom combinators:
-    // "if ~ is in a graveyard, effects from spells named <NAME> count it as a card named <NAME>"
-    let (rest, _) = tag::<_, _, OracleError<'_>>("if ~ is in a graveyard, ")
-        .parse(lower)
+    let stripped = text.trim_end_matches('.').trim();
+    let lower = stripped.to_lowercase();
+    // Parse the self-reference prefix — accept both "~" (test fixtures) and
+    // "this card" (production pipeline, not normalized by `normalize_card_name_refs`).
+    let (prefix_rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("if ~ is in a graveyard, "),
+        tag::<_, _, OracleError<'_>>("if this card is in a graveyard, "),
+    ))
+    .parse(lower.as_str())
+    .ok()?;
+    let prefix_consumed = lower.len() - prefix_rest.len();
+    let (rest_lower, _) = tag::<_, _, OracleError<'_>>("effects from spells named ")
+        .parse(prefix_rest)
         .ok()?;
-    let (rest, _) = tag::<_, _, OracleError<'_>>("effects from spells named ")
-        .parse(rest)
-        .ok()?;
+    let effects_consumed = prefix_rest.len() - rest_lower.len();
     // Split on " count it as a card named " to extract the spell name and alias.
-    let (alias_name, spell_name) = terminated(
+    let (alias_lower, spell_lower) = terminated(
         take_until::<_, _, OracleError<'_>>(" count it as a card named "),
         tag(" count it as a card named "),
     )
-    .parse(rest)
+    .parse(rest_lower)
     .ok()?;
     // Both names should match (the card counts as the spell that references it).
-    // Validate they're the same name (case-insensitive).
-    if !spell_name.eq_ignore_ascii_case(alias_name) {
+    if !spell_lower.eq_ignore_ascii_case(alias_lower) {
         return None;
     }
-    // Title-case the name for storage (first letter of each word capitalized).
-    let name = spell_name
-        .split_whitespace()
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(c) => c.to_uppercase().to_string() + chars.as_str(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ");
+    // Slice the name from the original-case input to preserve correct casing
+    // (avoids title-case reconstruction issues with hyphens, articles, accents).
+    let name_start = prefix_consumed + effects_consumed;
+    let name_end = name_start + spell_lower.len();
+    let name = stripped[name_start..name_end].to_string();
     Some(
         StaticDefinition::new(StaticMode::CountsAsNamed { name })
             .active_zones(vec![Zone::Graveyard])

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -90,6 +90,7 @@ pub(crate) use shared::parse_commander_subject_filter_prefix;
 
 pub(crate) use dispatch::is_speed_unlock_sentence;
 pub(crate) use dispatch::parse_may_look_at_face_down_filter;
+pub(crate) use dispatch::try_parse_counts_as_named_static;
 use dispatch::{parse_static_line_inner, InvertedAsLongAs};
 use prelude::StaticIr;
 

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1871,6 +1871,12 @@ pub enum StaticMode {
         counter_type: super::counter::CounterType,
         count: u32,
     },
+    /// CR 201.5: Odyssey Burst-cycle graveyard name-aliasing. While this card
+    /// is in a graveyard, effects that count "cards named X" treat it as having
+    /// the given name.
+    CountsAsNamed {
+        name: String,
+    },
     /// Fallback for unrecognized static mode strings.
     Other(String),
 }
@@ -2000,6 +2006,7 @@ pub enum StaticModeKind {
     UntapsDuringEachOtherPlayersUntapStep,
     MaxUntapPerType,
     EntersWithAdditionalCounters,
+    CountsAsNamed,
     Other,
 }
 
@@ -2144,6 +2151,7 @@ impl StaticMode {
             StaticMode::EntersWithAdditionalCounters { .. } => {
                 StaticModeKind::EntersWithAdditionalCounters
             }
+            StaticMode::CountsAsNamed { .. } => StaticModeKind::CountsAsNamed,
             StaticMode::Other(..) => StaticModeKind::Other,
         }
     }
@@ -2343,6 +2351,9 @@ impl Hash for StaticMode {
             // CR 614.1c: data-carrying (CounterType + count); consumed by direct
             // match in change_zone.rs, never used as a HashMap key.
             | StaticMode::EntersWithAdditionalCounters { .. }
+            // CR 201.5: data-carrying (name alias); consumed by direct match
+            // in filter.rs, never used as a HashMap key.
+            | StaticMode::CountsAsNamed { .. }
             // CR 116.2 + CR 118.7a: data-carrying (SpecialAction is not Hash);
             // consumed by direct match in the special-action cost-reduction
             // resolver, never used as a HashMap key.
@@ -2471,6 +2482,7 @@ impl StaticMode {
             | StaticMode::UntapsDuringEachOtherPlayersUntapStep
             | StaticMode::MaxUntapPerType { .. }
             | StaticMode::EntersWithAdditionalCounters { .. }
+            | StaticMode::CountsAsNamed { .. }
             | StaticMode::LinkedCollectionCounterPlayPermission
             | StaticMode::DamageNotRemovedDuringCleanup
             | StaticMode::Other(_) => None,
@@ -2875,6 +2887,10 @@ impl fmt::Display for StaticMode {
             }
             StaticMode::LinkedCollectionCounterPlayPermission => {
                 write!(f, "LinkedCollectionCounterPlayPermission")
+            }
+            // CR 201.5: Odyssey Burst-cycle graveyard name alias.
+            StaticMode::CountsAsNamed { ref name } => {
+                write!(f, "CountsAsNamed({name})")
             }
             // Fallback
             StaticMode::Other(s) => write!(f, "{s}"),
@@ -3383,6 +3399,14 @@ impl FromStr for StaticMode {
                     // CR 603.2g: Data-carrying — round-trip preserves discriminant only.
                     // Callers that need the full filter/events read from the typed field.
                     return Ok(StaticMode::Other(other.to_string()));
+                } else if let Some(inner) = other
+                    .strip_prefix("CountsAsNamed(")
+                    .and_then(|s| s.strip_suffix(')'))
+                {
+                    // CR 201.5: Odyssey Burst-cycle graveyard name alias.
+                    return Ok(StaticMode::CountsAsNamed {
+                        name: inner.to_string(),
+                    });
                 } else if other.starts_with("EntersWithAdditionalCounters(") {
                     // CR 614.1c: Data-carrying (CounterType + count). The Display
                     // form uses the Debug rendering of `CounterType`, which has no

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1871,9 +1871,10 @@ pub enum StaticMode {
         counter_type: super::counter::CounterType,
         count: u32,
     },
-    /// CR 201.5: Odyssey Burst-cycle graveyard name-aliasing. While this card
-    /// is in a graveyard, effects that count "cards named X" treat it as having
-    /// the given name.
+    /// Odyssey Burst-cycle graveyard name-aliasing (no general CR governs this
+    /// templating; name-matching semantics per CR 201.2a). While this card is in
+    /// a graveyard, effects that count "cards named X" treat it as having the
+    /// given name.
     CountsAsNamed {
         name: String,
     },
@@ -2351,8 +2352,8 @@ impl Hash for StaticMode {
             // CR 614.1c: data-carrying (CounterType + count); consumed by direct
             // match in change_zone.rs, never used as a HashMap key.
             | StaticMode::EntersWithAdditionalCounters { .. }
-            // CR 201.5: data-carrying (name alias); consumed by direct match
-            // in filter.rs, never used as a HashMap key.
+            // Odyssey Burst-cycle (CR 201.2a): data-carrying (name alias);
+            // consumed by direct match in filter.rs, never used as a HashMap key.
             | StaticMode::CountsAsNamed { .. }
             // CR 116.2 + CR 118.7a: data-carrying (SpecialAction is not Hash);
             // consumed by direct match in the special-action cost-reduction
@@ -2888,7 +2889,7 @@ impl fmt::Display for StaticMode {
             StaticMode::LinkedCollectionCounterPlayPermission => {
                 write!(f, "LinkedCollectionCounterPlayPermission")
             }
-            // CR 201.5: Odyssey Burst-cycle graveyard name alias.
+            // Odyssey Burst-cycle graveyard name alias (CR 201.2a).
             StaticMode::CountsAsNamed { ref name } => {
                 write!(f, "CountsAsNamed({name})")
             }
@@ -3403,7 +3404,7 @@ impl FromStr for StaticMode {
                     .strip_prefix("CountsAsNamed(")
                     .and_then(|s| s.strip_suffix(')'))
                 {
-                    // CR 201.5: Odyssey Burst-cycle graveyard name alias.
+                    // Odyssey Burst-cycle graveyard name alias (CR 201.2a).
                     return Ok(StaticMode::CountsAsNamed {
                         name: inner.to_string(),
                     });

--- a/crates/engine/tests/integration/diligent_farmhand_counts_as_named.rs
+++ b/crates/engine/tests/integration/diligent_farmhand_counts_as_named.rs
@@ -8,7 +8,8 @@
 //!   "Target creature gets +X/+X until end of turn, where X is 3 plus the
 //!   number of cards named Muscle Burst in all graveyards."
 //!
-//! CR 201.5 (name aliasing): While in a graveyard, Diligent Farmhand is counted
+//! No general CR governs this Odyssey-specific templating; name-matching
+//! semantics per CR 201.2a. While in a graveyard, Diligent Farmhand is counted
 //! by any effect that counts "cards named Muscle Burst" in graveyards.
 //!
 //! This test verifies that the CountsAsNamed static (active only in graveyard)
@@ -17,10 +18,11 @@
 use engine::game::scenario::{GameScenario, P0};
 use engine::types::phase::Phase;
 
-/// Diligent Farmhand — only the second ability line matters for this test.
+/// Diligent Farmhand — uses "this card" (the production pipeline form; `"this card"`
+/// is in `SELF_REF_PARSE_ONLY_PHRASES` and is NOT normalized to `~`).
 const FARMHAND_ORACLE: &str = "{1}{G}, Sacrifice ~: Search your library for a basic \
 land card, put that card onto the battlefield tapped, then shuffle.\n\
-If ~ is in a graveyard, effects from spells named Muscle Burst count it as a card named Muscle Burst.";
+If this card is in a graveyard, effects from spells named Muscle Burst count it as a card named Muscle Burst.";
 
 /// Muscle Burst — verbatim Oracle text.
 const MUSCLE_BURST_ORACLE: &str = "Target creature gets +X/+X until end of turn, \
@@ -37,7 +39,7 @@ fn muscle_burst_counts_diligent_farmhands_in_graveyard() {
     scenario.at_phase(Phase::PreCombatMain);
 
     // Two Diligent Farmhands in the graveyard — their CountsAsNamed static is
-    // active only in graveyard (CR 201.5).
+    // active only in graveyard (CR 201.2a name-matching semantics).
     scenario
         .add_creature_to_graveyard(P0, "Diligent Farmhand", 1, 1)
         .from_oracle_text(FARMHAND_ORACLE);

--- a/crates/engine/tests/integration/diligent_farmhand_counts_as_named.rs
+++ b/crates/engine/tests/integration/diligent_farmhand_counts_as_named.rs
@@ -1,0 +1,61 @@
+//! Diligent Farmhand — "counts as a card named Muscle Burst" graveyard static.
+//!
+//! Oracle text (second line):
+//!   "If Diligent Farmhand is in a graveyard, effects from spells named Muscle
+//!   Burst count it as a card named Muscle Burst."
+//!
+//! Muscle Burst reads:
+//!   "Target creature gets +X/+X until end of turn, where X is 3 plus the
+//!   number of cards named Muscle Burst in all graveyards."
+//!
+//! CR 201.5 (name aliasing): While in a graveyard, Diligent Farmhand is counted
+//! by any effect that counts "cards named Muscle Burst" in graveyards.
+//!
+//! This test verifies that the CountsAsNamed static (active only in graveyard)
+//! causes the Muscle Burst ObjectCount to include Diligent Farmhand copies.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::phase::Phase;
+
+/// Diligent Farmhand — only the second ability line matters for this test.
+const FARMHAND_ORACLE: &str = "{1}{G}, Sacrifice ~: Search your library for a basic \
+land card, put that card onto the battlefield tapped, then shuffle.\n\
+If ~ is in a graveyard, effects from spells named Muscle Burst count it as a card named Muscle Burst.";
+
+/// Muscle Burst — verbatim Oracle text.
+const MUSCLE_BURST_ORACLE: &str = "Target creature gets +X/+X until end of turn, \
+where X is 3 plus the number of cards named Muscle Burst in all graveyards.";
+
+/// Two Diligent Farmhands in the graveyard should each count as "Muscle Burst"
+/// for the Muscle Burst spell's X calculation.
+///
+/// X = 3 (base) + 2 (Farmhands counting as Muscle Burst) = 5.
+/// Target creature: 1/1 → 6/6.
+#[test]
+fn muscle_burst_counts_diligent_farmhands_in_graveyard() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Two Diligent Farmhands in the graveyard — their CountsAsNamed static is
+    // active only in graveyard (CR 201.5).
+    scenario
+        .add_creature_to_graveyard(P0, "Diligent Farmhand", 1, 1)
+        .from_oracle_text(FARMHAND_ORACLE);
+    scenario
+        .add_creature_to_graveyard(P0, "Diligent Farmhand", 1, 1)
+        .from_oracle_text(FARMHAND_ORACLE);
+
+    // Target creature on the battlefield.
+    let target = scenario.add_creature(P0, "Bear Cub", 1, 1).id();
+
+    // Muscle Burst in hand, ready to cast.
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Muscle Burst", true, MUSCLE_BURST_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(spell).target_object(target).resolve();
+
+    // X = 3 + 2 = 5; creature goes from 1/1 to 6/6.
+    outcome.assert_power_toughness(target, 6, 6);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -81,6 +81,7 @@ mod destroy_redirect_to_battlefield_delivery_tail;
 mod devour_co_entry_regression;
 mod devour_intellect_treasure_rider;
 mod dig_rest_pile_stranding_on_etb_pause;
+mod diligent_farmhand_counts_as_named;
 mod divine_visitation_token_substitution;
 mod doran_attack_block_pump;
 mod double_strike_first_strike_trigger_removes_attacker;


### PR DESCRIPTION
## Summary

Implements **Diligent Farmhand** (Odyssey) — specifically the novel `CountsAsNamed` graveyard static mechanic used by the Odyssey Burst cycle.

### Card Oracle Text

> {1}{G}, Sacrifice Diligent Farmhand: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.
>
> If Diligent Farmhand is in a graveyard, effects from spells named Muscle Burst count it as a card named Muscle Burst.

### What This PR Adds

| Component | Change |
|-----------|--------|
| `statics.rs` | New `StaticMode::CountsAsNamed { name: String }` variant with all required match arms (kind, Hash, Display, FromStr, keyword_identity) |
| `filter.rs` | `FilterProp::Named` evaluation extended to check `CountsAsNamed` statics on the object, respecting `active_zones` (alias only applies when the object is in the graveyard) |
| `oracle_static/dispatch.rs` | `try_parse_counts_as_named_static()` parser for the "If ~ is in a graveyard, effects from spells named X count it as a card named X" pattern |
| `oracle_static/mod.rs` | Exports the new parser function |
| `oracle.rs` | Calls the new parser in `parse_static_line_with_graveyard_keyword_continuation` |
| Integration test | `diligent_farmhand_counts_as_named.rs` — verifies Muscle Burst's +X/+X includes Farmhand copies in graveyard |

### Design Decisions

- **Zone-gated alias**: The `CountsAsNamed` static uses `active_zones = [Graveyard]` so the name alias only applies while the object is in the graveyard (CR 201.5).
- **Filter-level integration**: Rather than modifying the spell resolution path, the alias is checked at the `FilterProp::Named` evaluation level. This means any effect that counts "cards named X" (ObjectCount, targeted filters, etc.) automatically respects the alias without per-effect changes.
- **Whole-cycle support**: The parser handles the full Odyssey Burst cycle pattern (Diligent Farmhand, Pardic Firecat, Cephalid Scout, etc.) — any card with this oracle text template will parse correctly.
- **Activated ability**: The sacrifice-to-search-basic-land ability is already supported by the existing Sakura-Tribe Elder parser path (no new code needed).

### Testing

- `cargo check --lib -p engine` passes locally
- Integration test: Two Diligent Farmhands in graveyard + Muscle Burst cast → target gets +5/+5 (base 3 + 2 Farmhands counted as Muscle Burst)

### Coverage Gap Closed

- `effect_structure` gap for "If ~ is in a graveyard, effects from spells named Muscle Burst count it as a card named Muscle Burst."
