### PR TITLE
fix(engine): serialize RNG stream position for faithful snapshot restore

### DIFF
--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -1279,7 +1279,11 @@ pub fn restore_game_state(json_str: &str) -> Result<(), JsValue> {
     }
     let mut state: GameState = serde_json::from_str(json_str)
         .map_err(|e| JsValue::from_str(&format!("Failed to deserialize GameState: {}", e)))?;
-    state.rng = ChaCha20Rng::seed_from_u64(state.rng_seed);
+    // Undo/restore must resume the *same* random stream: reseed from
+    // `rng_seed` and re-apply the persisted `rng_word_pos` so the next
+    // shuffle/coin-flip/random-discard continues where the snapshot left off,
+    // instead of replaying the opening shuffle's values (issue #5466).
+    state.rehydrate_rng();
     state.debug_mode = true;
     CARD_DB.with(|cell| {
         if let Some(db) = cell.borrow().as_ref() {
@@ -1305,11 +1309,14 @@ pub fn restore_game_state(json_str: &str) -> Result<(), JsValue> {
 ///
 /// Differs from `restore_game_state` in two load-bearing ways:
 ///
-/// 1. **Fresh RNG seed.** `restore_game_state` re-seeds from the saved
-///    `rng_seed`, which rewinds the ChaCha20 stream to position 0 —
-///    correct for undo (replay from origin) but wrong for resume
-///    (subsequent draws would replay the pre-save sequence). This
-///    function stamps a fresh seed so continued play diverges.
+/// 1. **Fresh RNG seed.** `restore_game_state` faithfully resumes the saved
+///    ChaCha20 stream (seed *and* `rng_word_pos`) — the right semantics for
+///    undo, which must continue exactly where the snapshot left off. Resume
+///    deliberately does not: a crash-recovered host stamps a fresh seed so the
+///    resumed game's future draws are independent of the persisted snapshot.
+///    Faithful same-stream resume is now *possible* (the stream position is
+///    serialized as of #5466); re-rolling here is a deliberate choice, not a
+///    workaround for lost stream state.
 /// 2. **Atomic multiplayer-flag flip.** Sets `MULTIPLAYER_MODE` in the
 ///    same call that loads state, so there's no window where a stray
 ///    `restore_game_state` (undo) would be accepted on the resumed
@@ -1339,8 +1346,10 @@ pub fn resume_multiplayer_host_state(json_str: &str) -> Result<(), JsValue> {
     let mut state: GameState = serde_json::from_str(json_str)
         .map_err(|e| JsValue::from_str(&format!("Failed to deserialize GameState: {}", e)))?;
 
-    // Stale `rng_seed` replays the pre-save ChaCha20 sequence because
-    // stream position is `#[serde(skip)]`. Mirrors server-core.
+    // Deliberately re-roll rather than faithfully resume: a crash-recovered
+    // host's future draws should be independent of the persisted snapshot.
+    // (`rng_word_pos` is now serialized, so `rehydrate_rng` *could* resume the
+    // exact stream — resume opts out on purpose.) Mirrors server-core.
     let fresh_seed: u64 = rand::rng().random();
     state.rng_seed = fresh_seed;
     state.rng = ChaCha20Rng::seed_from_u64(fresh_seed);
@@ -2120,9 +2129,9 @@ mod tests {
         // Flag flipped atomically with state load.
         assert!(is_multiplayer_mode());
 
-        // RNG seed was replaced with a fresh random value — stale seed would
-        // replay the pre-save ChaCha20 stream from position 0 and cause
-        // deterministic redraws.
+        // RNG seed was replaced with a fresh random value: resume deliberately
+        // diverges from the persisted snapshot rather than faithfully resuming
+        // its stream (see `resume_multiplayer_host_state`).
         let restored: GameState = serde_wasm_bindgen::from_value(get_game_state()).unwrap();
         assert_ne!(
             restored.rng_seed, 0xDEAD_BEEF_0000_0001,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -44,6 +44,39 @@ fn default_rng() -> ChaCha20Rng {
     ChaCha20Rng::seed_from_u64(0)
 }
 
+/// Serialize `rng` as just its exact ChaCha20 stream position
+/// (`get_word_pos`), emitted under the `rng_word_pos` key. The seed itself
+/// lives in the sibling `rng_seed` field; together they let
+/// [`GameState::rehydrate_rng`] reconstruct the precise stream after a load,
+/// so a restored snapshot continues the random sequence instead of rewinding
+/// to the opening shuffle (issue #5466). Reading the position off the live
+/// `rng` here means it is always captured fresh at serialize time — there is
+/// no companion field to keep in sync.
+fn serialize_rng_word_pos<S>(rng: &ChaCha20Rng, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_u128(rng.get_word_pos())
+}
+
+/// Deserialize a saved stream position into a throwaway seed-0 ChaCha20
+/// stream. The real seed is applied afterward by [`GameState::rehydrate_rng`]
+/// (which reads this position back off the stream, reseeds from `rng_seed`,
+/// and restores the position) — the sibling `rng_seed` field is not reachable
+/// from a field-level `deserialize_with`, so the position is carried here and
+/// married to the seed one step later. Pre-#5466 saves omit the `rng_word_pos`
+/// key and fall back to [`default_rng`] (position 0 = the historical
+/// rewind-to-origin behavior).
+fn deserialize_rng_word_pos<'de, D>(deserializer: D) -> Result<ChaCha20Rng, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let word_pos = u128::deserialize(deserializer)?;
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
+    rng.set_word_pos(word_pos);
+    Ok(rng)
+}
+
 fn default_game_number() -> u8 {
     1
 }
@@ -6412,7 +6445,21 @@ pub struct GameState {
 
     // RNG
     pub rng_seed: u64,
-    #[serde(skip, default = "default_rng")]
+    /// The live ChaCha20 stream. Reseeded from `rng_seed` on load, but the
+    /// seed alone does not imply the stream *position* — a game mid-play sits
+    /// somewhere past the opening shuffle. We serialize only that position
+    /// (as the `rng_word_pos` key, via `serialize_rng_word_pos`) so
+    /// [`GameState::rehydrate_rng`] can restore the exact point in the
+    /// sequence after deserialization; without it a restored snapshot would
+    /// replay the values that drove the opening shuffle (issue #5466).
+    /// Pre-#5466 saves lack the key and default to position 0 (the old
+    /// rewind-to-origin behavior).
+    #[serde(
+        rename = "rng_word_pos",
+        serialize_with = "serialize_rng_word_pos",
+        deserialize_with = "deserialize_rng_word_pos",
+        default = "default_rng"
+    )]
     pub rng: ChaCha20Rng,
 
     // Combat
@@ -8916,6 +8963,27 @@ impl GameState {
         Self::new(FormatConfig::standard(), 2, seed)
     }
 
+    /// Reconstruct the live `rng` stream after deserialization so it resumes
+    /// exactly where the snapshot left off.
+    ///
+    /// `rng` is serialized as only its stream position (the `rng_word_pos`
+    /// key); on deserialize that position lands in a throwaway seed-0 stream
+    /// (see [`deserialize_rng_word_pos`]). This reseeds from the persisted
+    /// `rng_seed` and re-applies the saved position, so the next draw
+    /// continues the sequence rather than replaying it from the opening
+    /// shuffle (issue #5466). A pre-#5466 save carries no position and lands
+    /// at 0, reproducing the historical rewind-to-origin behavior exactly.
+    ///
+    /// Call this on every path that loads a `GameState` and intends to resume
+    /// the *same* random stream — most importantly the undo/restore primitive.
+    /// Paths that deliberately want a fresh, divergent stream (multiplayer
+    /// resume, AI-search worker seeding) reseed directly and skip this.
+    pub fn rehydrate_rng(&mut self) {
+        let word_pos = self.rng.get_word_pos();
+        self.rng = ChaCha20Rng::seed_from_u64(self.rng_seed);
+        self.rng.set_word_pos(word_pos);
+    }
+
     /// CR 732.2a: adopt a match's immutable configuration, projecting the per-game
     /// runtime gate(s) it controls. The combo-detector opt-in lives on [`MatchConfig`]
     /// (chosen at match creation, whole-table, immutable during play); this is the
@@ -10168,9 +10236,67 @@ mod tests {
         let state = GameState::default();
         let serialized = serde_json::to_string(&state).unwrap();
         let mut deserialized: GameState = serde_json::from_str(&serialized).unwrap();
-        // Reconstruct RNG from seed since it's skipped in serde
-        deserialized.rng = ChaCha20Rng::seed_from_u64(deserialized.rng_seed);
+        // `rng` serializes only its stream position; rehydrate reseeds from
+        // `rng_seed` and restores that position.
+        deserialized.rehydrate_rng();
         assert_eq!(state, deserialized);
+    }
+
+    /// Issue #5466: a restored snapshot must continue the ChaCha20 stream from
+    /// where it left off, not rewind to the opening shuffle. Draw N values,
+    /// serialize, record the next M values, then restore and assert the restored
+    /// state produces those same M values — i.e. the stream position survives the
+    /// round-trip.
+    #[test]
+    fn rehydrate_rng_resumes_stream_position_after_roundtrip() {
+        use rand::RngCore;
+
+        let mut state = GameState::new_two_player(0xABCD_1234);
+        // Advance the stream past origin (as gameplay randomness would).
+        for _ in 0..7 {
+            state.rng.next_u64();
+        }
+
+        let serialized = serde_json::to_string(&state).unwrap();
+
+        // The "future" values that would come next in the live game.
+        let expected: Vec<u64> = (0..5).map(|_| state.rng.next_u64()).collect();
+
+        let mut restored: GameState = serde_json::from_str(&serialized).unwrap();
+        restored.rehydrate_rng();
+        let actual: Vec<u64> = (0..5).map(|_| restored.rng.next_u64()).collect();
+
+        assert_eq!(
+            expected, actual,
+            "restored RNG must resume the stream, not replay from position 0"
+        );
+    }
+
+    /// Backward compatibility: a pre-#5466 save has no `rng_word_pos` key, so the
+    /// field defaults and `rehydrate_rng` lands at position 0 — reproducing the
+    /// historical rewind-to-origin behavior exactly, rather than erroring.
+    #[test]
+    fn rehydrate_rng_defaults_to_origin_for_legacy_saves() {
+        use rand::RngCore;
+
+        // A legacy blob: valid GameState JSON with the `rng_word_pos` key stripped.
+        let mut state = GameState::new_two_player(99);
+        for _ in 0..3 {
+            state.rng.next_u64();
+        }
+        let mut value: serde_json::Value = serde_json::to_value(&state).unwrap();
+        value
+            .as_object_mut()
+            .expect("GameState serializes as a JSON object")
+            .remove("rng_word_pos")
+            .expect("rng_word_pos is serialized");
+
+        let mut restored: GameState = serde_json::from_value(value).unwrap();
+        restored.rehydrate_rng();
+
+        // Position 0: matches a fresh stream seeded from the same seed.
+        let mut origin = ChaCha20Rng::seed_from_u64(restored.rng_seed);
+        assert_eq!(restored.rng.next_u64(), origin.next_u64());
     }
 
     /// Test E — deserialize-before-flush. `static_mode_presence` is `#[serde(skip)]` with an

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -623,8 +623,11 @@ impl GameSession {
         state.log_player_names = ps.display_names.clone();
         rehydrate_game_from_card_db(&mut state, db);
 
-        // Re-seed RNG with fresh randomness (stale rng_seed would produce
-        // deterministic sequences identical across all restored games)
+        // Re-seed with fresh randomness on resume: a crash-recovered session's
+        // future draws should be independent of the persisted snapshot.
+        // (`rng_word_pos` is now serialized, so a faithful same-stream resume is
+        // possible — this path opts out by design, matching the WASM
+        // `resume_multiplayer_host_state`.)
         let fresh_seed: u64 = rand::rng().random();
         state.rng_seed = fresh_seed;
         state.rng = rand_chacha::ChaCha20Rng::seed_from_u64(fresh_seed);


### PR DESCRIPTION
## Summary

`GameState.rng` was `#[serde(skip)]`, so `export_game_state_json` →
`restore_game_state` reseeded ChaCha20 from `rng_seed` at stream position 0. A
restored snapshot therefore replayed the *same* random sequence the game had
already consumed since the opening shuffle — the next shuffle/coin-flip/random
discard repeated the opening-shuffle values instead of continuing the stream.
This serializes the exact stream position (`rng_word_pos`) alongside `rng_seed`
so a restore resumes the sequence exactly where the snapshot left off.

Closes #5466.

## Implementation method (required)

- [x] **Not** `/engine-implementer` — explain why below

> This is save/restore **serialization infrastructure**, not engine game logic.
> It touches no parser, effect, resolver, targeting, or rules behavior — the RNG
> still produces the identical value sequence; the change only persists *where in
> that sequence* a saved game sits so a load doesn't rewind to origin. Inside
> `crates/engine/` only `types/game_state.rs` changes (serde plumbing + a
> reconstruction helper), with no CR-governed behavior change.

## CR references

None. No rules behavior changes — this is state-serialization plumbing; the RNG's
draw sequence is unchanged, only its persisted stream position is added.

## Verification

- `cargo fmt --all` — clean.
- `cargo test -p engine --lib` — **15,956 passed, 0 failed**.
- `cargo clippy -p engine -p engine-wasm -p server-core --lib --tests -- -D warnings` — clean.
- `cargo check -p engine-wasm --target wasm32-unknown-unknown` — clean (production build).
- New round-trip tests in `crates/engine/src/types/game_state.rs`:
  - `rehydrate_rng_resumes_stream_position_after_roundtrip` — the exact test the
    issue asked for: draw N values, serialize, record the next M, restore, assert
    the next M repeat exactly.
  - `rehydrate_rng_defaults_to_origin_for_legacy_saves` — a pre-#5466 save (no
    `rng_word_pos` key) lands at position 0, reproducing today's behavior.

## Design

Option 1 from the issue (persist `get_word_pos()` — the minimal, format-stable
seam), built as a reusable building block rather than a one-off:

- `rng` now serializes **only its live stream position** (`get_word_pos()` →
  `u128`) under a new `rng_word_pos` key, via `serialize_with` /
  `deserialize_with`. Reading the position off the *live* `rng` at serialize time
  keeps it always fresh — there is no companion field to keep in sync.
- `GameState::rehydrate_rng()` is the single reconstruction authority: reseed from
  `rng_seed`, then re-apply the saved position. `restore_game_state` (the undo
  primitive) now calls it instead of hand-reseeding.
- **Backward compatible:** pre-#5466 saves omit the key → `default_rng` (position
  0) → identical to today's rewind-to-origin behavior. No `deny_unknown_fields`,
  so it is forward-compatible too.
- The deliberate fresh-seed resume paths (`resume_multiplayer_host_state`,
  server-core `from_persisted`) are left **behaviorally unchanged** — they re-roll
  on purpose so a resumed multiplayer game diverges from the snapshot. Their now
  stale comments (which cited the `#[serde(skip)]` position loss as the reason)
  are corrected to state the re-roll is a deliberate choice.

## Anchored on

- `crates/engine/src/types/game_state.rs` — `serialize_rng_word_pos` /
  `deserialize_rng_word_pos`, the `rng` field's serde attributes, and
  `GameState::rehydrate_rng()`.
- `crates/engine-wasm/src/lib.rs` — `restore_game_state` resumes the stream via
  `rehydrate_rng()`; corrected `resume_multiplayer_host_state` comments.
- `crates/server-core/src/session.rs` — comment-only consistency update in
  `from_persisted` (behavior unchanged).

## Scope Expansion

None.
