### PR TITLE
docs(parser): correct CR 609.3 -> CR 603.5 on trigger optionality

### DIFF
--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -50,7 +50,8 @@ pub(crate) enum TriggerBody {
 /// `TriggerDefinition` or compose with the body ability.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct TriggerModifiers {
-    /// CR 609.3: "You may" optional effect.
+    /// CR 603.5: Some triggered abilities' effects are optional (they contain
+    /// "may"). They go on the stack regardless; the choice is made on resolution.
     pub(crate) optional: bool,
     /// CR 118.12: "unless [player] pays {cost}" tax modifier.
     pub(crate) unless_pay: Option<UnlessPayModifier>,

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1186,12 +1186,15 @@ pub(crate) fn parse_trigger_line_with_index_ir(
             })
             .or_else(|| {
                 // CR 700.2 + CR 608.2d: Inline modal trigger body — "choose one —
-                // mode1; or mode2" on a single line (no bullet-line modes). Grenzo,
-                // Havoc Raiser is the canonical case. Route through the modal parser
-                // so each mode body is independently parsed with the trigger's
-                // established relative_player_scope (e.g. TriggeringPlayer for
-                // DamageDone triggers) so "that player" in mode bodies resolves to
-                // the damaged player (CR 603.7c).
+                // mode1; or mode2" on a single line (no bullet-line modes). No
+                // printed card currently reaches this branch: it needs an em-dash
+                // *and* "; or " inside one trigger effect body. (Grenzo, Havoc
+                // Raiser — long named here as the canonical case — uses bullet-line
+                // modes, so `raw_modes.len() == 1` and it never arrives.) Route
+                // through the modal parser so each mode body is independently
+                // parsed with the trigger's established relative_player_scope (e.g.
+                // TriggeringPlayer for DamageDone triggers) so "that player" in mode
+                // bodies resolves to the damaged player (CR 603.7c).
                 if let Some(modal_ability) = try_parse_inline_modal(
                     &effect_for_parse,
                     effect_ctx.relative_player_scope.clone(),
@@ -1286,7 +1289,9 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
             {
                 ability.optional_targeting = true;
             }
-            // CR 609.3: Propagate optional to execute ability.
+            // CR 603.5: A triggered ability whose effect is optional ("may") goes
+            // on the stack regardless; the choice is made when it resolves. Carry
+            // that optionality onto the execute ability, which is what resolves.
             if modifiers.optional {
                 ability.optional = true;
             }


### PR DESCRIPTION
CR 609.3 (docs/MagicCompRules.txt:2847) is "If an effect attempts to do
something impossible, it does only as much as possible" -- unrelated to
optionality. The rule governing "may" triggers is CR 603.5 (:2595):

  603.5. Some triggered abilities' effects are optional (they contain
  "may," as in "At the beginning of your upkeep, you may draw a card").
  These abilities go on the stack when they trigger, regardless of
  whether their controller intends to exercise the ability's option or
  not. The choice is made when the ability resolves.

Fixes both sites that annotate trigger optionality:
  - oracle_ir/trigger.rs:53   TriggerModifiers.optional
  - oracle_trigger.rs:1289    propagation onto the execute ability

Also corrects a stale comment naming Grenzo, Havoc Raiser as the
canonical inline-modal-trigger card. Grenzo uses bullet-line modes
(raw_modes.len() == 1) and cannot reach that branch; no printed card
currently does.

Comment-only. No behavior change.
