### PR TITLE
fix(engine): bind Maze of Ith's bidirectional prevent anaphor to its own target

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1838,8 +1838,10 @@ fn is_each_target_damage_sub(effect: &Effect) -> bool {
 }
 
 /// The first `TargetRef::Object` in a target list (the chain head's chosen
-/// creature for the one-sided-fight prepend).
-fn first_object_target(targets: &[TargetRef]) -> Option<ObjectId> {
+/// creature for the one-sided-fight prepend). Also reused by
+/// `prevent_damage.rs` to resolve a bare `ParentTarget` damage-source filter
+/// (issue #1094, the "dealt by" half of a bidirectional Maze-of-Ith shield).
+pub(crate) fn first_object_target(targets: &[TargetRef]) -> Option<ObjectId> {
     targets.iter().find_map(|t| match t {
         TargetRef::Object(id) => Some(*id),
         TargetRef::Player(_) => None,

--- a/crates/engine/src/game/effects/prevent_damage.rs
+++ b/crates/engine/src/game/effects/prevent_damage.rs
@@ -127,6 +127,13 @@ pub(crate) fn resolve_source_filter(
             }
             TargetFilter::Typed(resolved)
         }
+        // CR 608.2c + CR 615: a bare ParentTarget damage-source filter (the "by"
+        // half of a bidirectional Maze-of-Ith-class shield) captures the same
+        // object the parent's own instruction selected, exactly like
+        // ParentTargetSlot but without an explicit index. Issue #1094.
+        TargetFilter::ParentTarget => crate::game::effects::first_object_target(ability_targets)
+            .map(|id| TargetFilter::SpecificObject { id })
+            .unwrap_or(TargetFilter::None),
         _ => filter.clone(),
     }
 }
@@ -233,13 +240,20 @@ pub fn resolve(
     // source filter. Those targets are the damage SOURCE, not a recipient — so
     // the shield must NOT be hosted on them as a recipient object. It routes to
     // the untargeted branch (pending registry) scoped via `damage_source_filter`.
-    let source_scoped_prevent = matches!(
-        &effect_source_filter,
-        Some(TargetFilter::And { filters })
-            if filters
-                .iter()
-                .any(|f| matches!(f, TargetFilter::ParentTargetSlot { .. }))
-    );
+    //
+    // CR 615 + CR 608.2c (issue #1094): the "by"-only half of a bidirectional
+    // Maze-of-Ith-class shield carries a bare `ParentTarget` source filter (the
+    // chosen creature IS the damage source, not a recipient). Same routing: the
+    // shield is source-scoped, so it must NOT be hosted on the creature as a
+    // recipient object (which would wrongly re-impose "recipient == creature").
+    let source_scoped_prevent =
+        matches!(
+            &effect_source_filter,
+            Some(TargetFilter::And { filters })
+                if filters
+                    .iter()
+                    .any(|f| matches!(f, TargetFilter::ParentTargetSlot { .. }))
+        ) || matches!(&effect_source_filter, Some(TargetFilter::ParentTarget));
 
     // CR 615.11: A dynamic prevention amount is resolved to a concrete depletion
     // count at effect-resolution time; the Next(n) shield itself is always static.

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -563,6 +563,42 @@ impl GameScenario {
         builder
     }
 
+    /// Add a nonbasic land to the battlefield with abilities parsed from Oracle
+    /// text. Mirrors `add_creature_from_oracle`; no existing helper places a
+    /// land on the battlefield with parsed Oracle text (`add_basic_land` wires a
+    /// hard-coded mana ability; `add_land_to_hand` places in `Zone::Hand`).
+    pub fn add_land_from_oracle(
+        &mut self,
+        player: PlayerId,
+        name: &str,
+        oracle_text: &str,
+    ) -> CardBuilder<'_> {
+        let card_id = CardId(self.state.next_object_id);
+        let id = create_object(
+            &mut self.state,
+            card_id,
+            player,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        let ts = self.state.next_timestamp();
+        let obj = self.state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Land);
+        obj.base_card_types = obj.card_types.clone();
+        obj.timestamp = ts;
+        // CR 302.6 note: summoning sickness only gates creatures, but the
+        // builder models a pre-existing permanent (entered on a prior turn),
+        // matching `add_creature`'s override.
+        obj.summoning_sick = false;
+
+        let mut builder = CardBuilder {
+            state: &mut self.state,
+            id,
+        };
+        builder.from_oracle_text(oracle_text);
+        builder
+    }
+
     /// Add a creature to hand with abilities parsed from Oracle text.
     pub fn add_creature_to_hand_from_oracle(
         &mut self,

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -46,9 +46,9 @@ use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
 use super::super::oracle_target::{
-    parse_event_context_ref, parse_fight_target, parse_mass_type_union, parse_target,
-    parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase, parse_word_bounded,
-    resolve_pronoun_target, TargetSyntax,
+    parse_anaphoric_target_ref, parse_event_context_ref, parse_fight_target, parse_mass_type_union,
+    parse_target, parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase,
+    parse_word_bounded, resolve_pronoun_target, TargetSyntax,
 };
 use super::super::oracle_util::{
     contains_possessive, contains_self_or_object_pronoun, parse_count_expr, parse_mana_symbols,
@@ -4796,6 +4796,11 @@ pub(super) fn parse_utility_imperative_ast(
         return match verb {
             "prevent" => Some(UtilityImperativeAst::Prevent {
                 text: text.to_string(),
+                // CR 608.2c: capture whether an earlier chain clause selected a
+                // target for a trailing anaphor ("that creature"/"it") to bind
+                // to. This is the one construction site where `ParseContext` is
+                // live; downstream lowering has only the captured flag.
+                parent_target_available: ctx.parent_target_available,
             }),
             "regenerate" => Some(UtilityImperativeAst::Regenerate {
                 text: text.to_string(),
@@ -5322,7 +5327,10 @@ fn parse_attach_anaphor_to_token(
 
 pub(super) fn lower_utility_imperative_ast(ast: UtilityImperativeAst) -> Effect {
     match ast {
-        UtilityImperativeAst::Prevent { text } => parse_prevent_effect(&text),
+        UtilityImperativeAst::Prevent {
+            text,
+            parent_target_available,
+        } => parse_prevent_effect(&text, parent_target_available),
         UtilityImperativeAst::Regenerate { text } => {
             let lower = text.to_lowercase();
             let rest = tag::<_, _, OracleError<'_>>("regenerate ")
@@ -5351,6 +5359,36 @@ pub(super) fn lower_utility_imperative_ast(ast: UtilityImperativeAst) -> Effect 
     }
 }
 
+/// CR 615.1a: decompose the prevention amount from the LOCAL parser stream
+/// (`rest`, positioned just past "prevent ") with nom combinators. "all but "
+/// must be tried before the bare "all " arm because it shares that prefix.
+/// Shared by `parse_prevent_effect` and `try_parse_bidirectional_prevent`
+/// (issue #1094) so amount detection lives in one authority.
+pub(super) fn parse_prevention_amount(rest: &str) -> PreventionAmount {
+    if let Ok((after_all_but, _)) = tag::<_, _, OracleError<'_>>("all but ").parse(rest) {
+        let n = nom_primitives::parse_number
+            .parse(after_all_but)
+            .map(|(_, n)| n)
+            .unwrap_or(1);
+        PreventionAmount::AllBut(n)
+    } else if tag::<_, _, OracleError<'_>>("all ").parse(rest).is_ok() {
+        PreventionAmount::All
+    } else if let Ok((after_next, _)) = tag::<_, _, OracleError<'_>>("the next ").parse(rest) {
+        let n = nom_primitives::parse_number
+            .parse(after_next)
+            .map(|(_, n)| n)
+            .unwrap_or(1);
+        PreventionAmount::Next(n)
+    } else {
+        // Fallback: try to extract a number.
+        let n = nom_primitives::parse_number
+            .parse(rest)
+            .map(|(_, n)| n)
+            .unwrap_or(1);
+        PreventionAmount::Next(n)
+    }
+}
+
 /// CR 615: Parse "prevent" damage effects into `Effect::PreventDamage`.
 ///
 /// Handles patterns like:
@@ -5358,7 +5396,12 @@ pub(super) fn lower_utility_imperative_ast(ast: UtilityImperativeAst) -> Effect 
 /// - "prevent all damage that would be dealt this turn"
 /// - "prevent all combat damage that would be dealt this turn"
 /// - "prevent the next N damage that would be dealt to target creature"
-fn parse_prevent_effect(text: &str) -> Effect {
+///
+/// CR 608.2c: `parent_target_available` reflects whether an earlier clause in
+/// the same effect chain selected a target that a trailing anaphor ("that
+/// creature" / "the creature" / "it") can bind to via `ParentTarget`. When
+/// false the anaphor recognizer is a no-op and the target falls back to `Any`.
+fn parse_prevent_effect(text: &str, parent_target_available: bool) -> Effect {
     let lower = text.to_lowercase();
     let rest = tag::<_, _, OracleError<'_>>("prevent ")
         .parse(&*lower)
@@ -5383,32 +5426,7 @@ fn parse_prevent_effect(text: &str) -> Effect {
             .map(|(_, d, _)| d);
 
     // Determine amount: "all damage" vs "all but N" vs "the next N damage".
-    // CR 615.1a: decompose the prevention amount from the LOCAL parser stream
-    // (`rest`, positioned just past "prevent ") with nom combinators. "all but "
-    // must be tried before the bare "all " arm because it shares that prefix.
-    let amount =
-        if let Ok((after_all_but, _)) = tag::<_, _, OracleError<'_>>("all but ").parse(rest) {
-            let n = nom_primitives::parse_number
-                .parse(after_all_but)
-                .map(|(_, n)| n)
-                .unwrap_or(1);
-            PreventionAmount::AllBut(n)
-        } else if tag::<_, _, OracleError<'_>>("all ").parse(rest).is_ok() {
-            PreventionAmount::All
-        } else if let Ok((after_next, _)) = tag::<_, _, OracleError<'_>>("the next ").parse(rest) {
-            let n = nom_primitives::parse_number
-                .parse(after_next)
-                .map(|(_, n)| n)
-                .unwrap_or(1);
-            PreventionAmount::Next(n)
-        } else {
-            // Fallback: try to extract a number
-            let n = nom_primitives::parse_number
-                .parse(rest)
-                .map(|(_, n)| n)
-                .unwrap_or(1);
-            PreventionAmount::Next(n)
-        };
+    let amount = parse_prevention_amount(rest);
 
     // CR 609.7 + CR 615.2: prevention scoped to a chosen source (a targeted
     // spell). "Prevent all damage target instant or sorcery spell would deal
@@ -5452,6 +5470,16 @@ fn parse_prevent_effect(text: &str) -> Effect {
         || nom_primitives::scan_contains(rest, "to its controller")
     {
         TargetFilter::Controller
+    } else if let Some(anaphor_filter) = TextPair::new(text, &lower)
+        .strip_after("dealt to ")
+        .and_then(|tp| parse_anaphoric_target_ref(tp.original, parent_target_available))
+        .map(|(filter, _)| filter)
+    {
+        // CR 608.2c: "prevent [amount] damage that would be dealt to that
+        // creature/it/the creature this turn" — a single-direction anaphor
+        // bound to a target an earlier clause selected. Strict superset of the
+        // prior `Any` fallback (only reached when `parent_target_available`).
+        anaphor_filter
     } else {
         // Default: "that would be dealt" with no specific target → Any
         TargetFilter::Any
@@ -10875,8 +10903,21 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             clause
         }
         ImperativeFamilyAst::Structured(ImperativeAst::Utility(
-            UtilityImperativeAst::Prevent { ref text },
+            UtilityImperativeAst::Prevent {
+                ref text,
+                parent_target_available,
+            },
         )) => {
+            // CR 615 + CR 608.2c (issue #1094): a bidirectional "dealt to and
+            // dealt by <anaphor>" shield must split into two independent
+            // PreventDamage nodes — tried FIRST, before the distribute path
+            // (mutually exclusive markers: no card combines "distributed among"
+            // with "dealt to and dealt by").
+            if let Some(clause) =
+                super::lower::try_parse_bidirectional_prevent(text, parent_target_available)
+            {
+                return clause;
+            }
             if let Some(clause) = super::lower::try_parse_prevent_distribute(text) {
                 return clause;
             }
@@ -10884,7 +10925,10 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             // lower_utility_imperative_ast is defined in THIS file (imperative.rs),
             // called unqualified — NOT super::lower::lower_utility_imperative_ast.
             parsed_clause(lower_utility_imperative_ast(
-                UtilityImperativeAst::Prevent { text: text.clone() },
+                UtilityImperativeAst::Prevent {
+                    text: text.clone(),
+                    parent_target_available,
+                },
             ))
         }
         // CR 701.58a: "cloak a card from your hand" (Vannifar). The controller
@@ -18470,6 +18514,7 @@ mod tests {
     fn prevent_source_scoped_spell_yields_parent_target_slot_filter() {
         let effect = parse_prevent_effect(
             "Prevent all damage target instant or sorcery spell would deal this turn.",
+            false,
         );
         let Effect::PreventDamage {
             amount,
@@ -18514,6 +18559,7 @@ mod tests {
     fn prevent_recipient_scoped_creature_not_diverted_to_source() {
         let effect = parse_prevent_effect(
             "Prevent the next 3 damage that would be dealt to target creature this turn.",
+            false,
         );
         let Effect::PreventDamage {
             amount,
@@ -18542,6 +18588,7 @@ mod tests {
     fn prevent_that_other_creatures_would_deal_scopes_source_filter() {
         let effect = parse_prevent_effect(
             "Prevent all combat damage that other creatures would deal this turn.",
+            false,
         );
         let Effect::PreventDamage {
             amount,
@@ -18593,7 +18640,7 @@ mod tests {
             ),
         ];
         for (text, expected) in cases {
-            let effect = parse_prevent_effect(text);
+            let effect = parse_prevent_effect(text, false);
             let Effect::PreventDamage {
                 prevention_duration,
                 ..

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -18,7 +18,8 @@ use super::super::oracle_quantity::{
     parse_player_attribute_attr_clause, parse_quantity_ref,
 };
 use super::super::oracle_target::{
-    parse_target, parse_target_with_ctx, parse_that_clause_suffix, parse_type_phrase_with_ctx,
+    parse_anaphoric_target_ref, parse_target, parse_target_with_ctx, parse_that_clause_suffix,
+    parse_type_phrase_with_ctx,
 };
 use super::super::oracle_util::{parse_comparator_prefix, parse_count_expr, strip_after, TextPair};
 use crate::parser::oracle_ir::ast::*;
@@ -6749,6 +6750,97 @@ pub(super) fn try_parse_prevent_distribute(text: &str) -> Option<ParsedEffectCla
     })
 }
 
+/// CR 615.1a + CR 608.2c: Parse "prevent [amount] [combat] damage
+/// that would be dealt to and dealt by <anaphor> this turn" — the
+/// bidirectional shield CR 615's AND-only shield semantics cannot express as
+/// one node (`Effect::PreventDamage`'s `target` + `damage_source_filter`
+/// combine with AND semantics: recipient==X AND source==Y, never recipient==X
+/// OR source==X). Splits into two independent `PreventDamage` nodes chained via
+/// `SequentialSibling` — a recipient-scoped ("to") shield and a
+/// source-scoped-only ("by") shield with no recipient restriction. Called from
+/// the Prevent intercept arm in `lower_imperative_family_ast` BEFORE
+/// `try_parse_prevent_distribute` — mutually exclusive markers in the corpus
+/// (no card combines "distributed among" with "dealt to and dealt by").
+/// Issue #1094 (Maze of Ith).
+pub(super) fn try_parse_bidirectional_prevent(
+    text: &str,
+    parent_target_available: bool,
+) -> Option<ParsedEffectClause> {
+    let lower = text.to_lowercase();
+    // Quick-reject via the bidirectional marker before spending parse effort.
+    if !scan_contains_phrase(&lower, "dealt to and dealt by") {
+        return None;
+    }
+    // Parse "prevent " prefix and position `rest` just past it.
+    let (rest, _) = tag::<_, _, OracleError<'_>>("prevent ")
+        .parse(lower.as_str())
+        .ok()?;
+
+    // CR 615: scope — combat damage only vs all damage (mirrors
+    // `parse_prevent_effect`'s own scope detection exactly).
+    let scope = if nom_primitives::scan_contains(rest, "combat damage") {
+        PreventionScope::CombatDamage
+    } else {
+        PreventionScope::AllDamage
+    };
+
+    // CR 615.1a: shared amount detection (issue #1094 factored this out of
+    // `parse_prevent_effect` so both paths agree).
+    let amount = super::imperative::parse_prevention_amount(rest);
+
+    // CR 511.2 + CR 615: trailing duration window ("this turn" -> end of turn).
+    let prevention_duration =
+        nom_primitives::scan_preceded(rest, parse_duration).map(|(_, d, _)| d);
+
+    // CR 608.2c: isolate the anaphor phrase following the bidirectional marker
+    // and bind it to the parent's chosen target. `parse_anaphoric_target_ref`
+    // returns `None` when `parent_target_available` is false — the load-bearing
+    // gate (a standalone "dealt to and dealt by that creature" with no prior
+    // target-selecting clause must NOT split into ParentTarget shields).
+    let anaphor_tp = TextPair::new(text, &lower).strip_after("dealt to and dealt by ")?;
+    let (anaphor_filter, _) =
+        parse_anaphoric_target_ref(anaphor_tp.original, parent_target_available)?;
+
+    // CR 615: the recipient ("to") shield — scoped to the chosen creature as
+    // the damage RECIPIENT (target: ParentTarget, no source restriction).
+    let to_effect = Effect::PreventDamage {
+        amount,
+        amount_dynamic: None,
+        target: anaphor_filter.clone(),
+        scope,
+        damage_source_filter: None,
+        prevention_duration: prevention_duration.clone(),
+    };
+
+    // CR 615: the source-only ("by") shield — scoped to the chosen creature as
+    // the damage SOURCE (target: Any, damage_source_filter: ParentTarget). A
+    // SequentialSibling: an independent following instruction in the same
+    // resolution, not a per-event rider.
+    let mut by_ability = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::PreventDamage {
+            amount,
+            amount_dynamic: None,
+            target: TargetFilter::Any,
+            scope,
+            damage_source_filter: Some(anaphor_filter),
+            prevention_duration,
+        },
+    );
+    by_ability.sub_link = SubAbilityLink::SequentialSibling;
+
+    Some(ParsedEffectClause {
+        effect: to_effect,
+        duration: None,
+        sub_ability: Some(Box::new(by_ability)),
+        distribute: None,
+        multi_target: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
+}
+
 /// Thin wrapper around `try_parse_damage_with_remainder` for callers that don't
 /// need the remainder (e.g., `parse_cost_resource_ast`). The remainder is only
 /// safely discardable when `try_split_damage_compound` has already run and found
@@ -9648,6 +9740,71 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// CR 615 (issue #1094): the bidirectional interceptor must NOT claim a
+    /// "distributed among" clause — it lacks the "dealt to and dealt by"
+    /// marker, so `try_parse_bidirectional_prevent` returns `None` and the
+    /// distribute path (tried next in the family arm) still owns it. Regression
+    /// guard on the step-9 ordering.
+    #[test]
+    fn bidirectional_prevent_ignores_distribute_clause() {
+        let text =
+            "prevent the next 5 damage divided as you choose among any number of target creatures";
+        assert!(
+            super::try_parse_bidirectional_prevent(text, true).is_none(),
+            "distribute clause must not be claimed by the bidirectional interceptor"
+        );
+        // And the distribute path still parses it (ordering safety).
+        assert!(super::try_parse_prevent_distribute(text).is_some());
+    }
+
+    /// CR 615 + CR 608.2c (issue #1094): the bidirectional split with the gate
+    /// enabled produces a recipient ("to") node bound to `ParentTarget` and a
+    /// source-only ("by") SequentialSibling with `damage_source_filter ==
+    /// Some(ParentTarget)`. Driven at the interceptor level so the two-node
+    /// structure is asserted directly.
+    #[test]
+    fn bidirectional_prevent_splits_into_to_and_by_nodes() {
+        use crate::types::ability::{PreventionScope, SubAbilityLink, TargetFilter};
+        let text =
+            "prevent all combat damage that would be dealt to and dealt by that creature this turn";
+        let clause = super::try_parse_bidirectional_prevent(text, true)
+            .expect("bidirectional split with gate enabled");
+        match &clause.effect {
+            Effect::PreventDamage {
+                target,
+                damage_source_filter,
+                scope,
+                ..
+            } => {
+                assert_eq!(*target, TargetFilter::ParentTarget);
+                assert!(damage_source_filter.is_none());
+                assert_eq!(*scope, PreventionScope::CombatDamage);
+            }
+            other => panic!("expected 'to' PreventDamage, got {other:?}"),
+        }
+        let by = clause.sub_ability.as_deref().expect("'by' sub_ability");
+        assert_eq!(by.sub_link, SubAbilityLink::SequentialSibling);
+        match &*by.effect {
+            Effect::PreventDamage {
+                target,
+                damage_source_filter,
+                ..
+            } => {
+                assert_eq!(*target, TargetFilter::Any);
+                assert_eq!(
+                    damage_source_filter.as_ref(),
+                    Some(&TargetFilter::ParentTarget)
+                );
+            }
+            other => panic!("expected 'by' PreventDamage, got {other:?}"),
+        }
+        // Gate off ⇒ no split.
+        assert!(
+            super::try_parse_bidirectional_prevent(text, false).is_none(),
+            "gate false ⇒ interceptor is a no-op"
+        );
     }
 
     /// CR 400.7 + CR 700.4: A per-turn VALUE quantity's " this turn" suffix must

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1129,6 +1129,11 @@ pub(crate) enum MultiZoneExileQuantifier {
 pub(crate) enum UtilityImperativeAst {
     Prevent {
         text: String,
+        /// CR 608.2c: true when an earlier clause in the same effect chain
+        /// selected a target this clause's anaphor can bind to. Captured from
+        /// `ctx.parent_target_available` at the one construction site where
+        /// `ParseContext` is live (issue #1094).
+        parent_target_available: bool,
     },
     Regenerate {
         text: String,

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -109,6 +109,44 @@ pub(crate) fn resolve_pronoun_target(ctx: &mut ParseContext, pronoun: &str) -> T
     }
 }
 
+/// CR 608.2c: Recognize a demonstrative ("that creature"), definite-article
+/// ("the creature"), or bare-pronoun ("it") back-reference to a parent
+/// instruction's chosen target, in contexts where `resolve_pronoun_target`'s
+/// trigger-subject branch cannot apply (no live `ParseContext` at this call
+/// site — only the precomputed `parent_target_available` flag). Every
+/// verified card using this recognizer is a non-trigger activated ability or
+/// instant, so `ParentTarget` is the uniform correct answer; a future
+/// trigger-context card needing `TriggeringSource` should extend via
+/// `resolve_pronoun_target`'s ctx-threading instead of this function.
+/// Distinct from `parse_event_context_ref`'s "that creature" arm (which
+/// resolves to `TriggeringSource` for triggered-ability event context — the
+/// wrong filter for this non-trigger context).
+///
+/// Returns the bound filter and the remainder of the ORIGINAL-case `text`
+/// following the matched anaphor phrase.
+pub(crate) fn parse_anaphoric_target_ref(
+    text: &str,
+    parent_target_available: bool,
+) -> Option<(TargetFilter, &str)> {
+    if !parent_target_available {
+        return None;
+    }
+    // CR 608.2c: the anaphor grammar itself ("that <type>" / "the <type>" →
+    // `ParentTarget`, and bare word-bounded "it" → `ParentTarget` via
+    // `resolve_pronoun_target`'s default-context fallthrough) is authoritatively
+    // implemented by `parse_target` — reuse that single implementation rather
+    // than re-deriving the same rule here. `parse_target` is the ctx-free
+    // wrapper (default `ParseContext`), so no live trigger subject exists and
+    // the bare-pronoun/demonstrative back-reference uniformly resolves to
+    // `ParentTarget` — exactly the non-trigger semantics this call site needs.
+    // Accept only when the leading phrase actually resolved to the parent
+    // target; a fresh typed filter or the `Any` fallback means the text was not
+    // an anaphor, and this recognizer must decline (preserving the old
+    // combinator's None-on-no-match contract).
+    let (filter, rest) = parse_target(text);
+    matches!(filter, TargetFilter::ParentTarget).then_some((filter, rest))
+}
+
 /// Parse a word with a word boundary check: the next char after the word must be
 /// non-alphanumeric (whitespace, comma, period, etc.) or end-of-input.
 /// Prevents "it" from matching "item", "you" from matching "your", etc.

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -11345,6 +11345,269 @@ fn spell_prevention_keeps_preceding_dynamic_gain_life() {
     );
 }
 
+// ── Maze of Ith family: bidirectional combat-damage prevention (issue #1094) ──
+
+/// Recursively collect `PreventDamage` ability nodes in pre-order (self, then
+/// sub_ability, then else_ability) across the whole ability/sub-ability tree.
+fn collect_prevent_nodes(
+    abilities: &[crate::types::ability::AbilityDefinition],
+) -> Vec<crate::types::ability::AbilityDefinition> {
+    fn walk(
+        def: &crate::types::ability::AbilityDefinition,
+        out: &mut Vec<crate::types::ability::AbilityDefinition>,
+    ) {
+        if matches!(&*def.effect, Effect::PreventDamage { .. }) {
+            out.push(def.clone());
+        }
+        if let Some(sub) = def.sub_ability.as_deref() {
+            walk(sub, out);
+        }
+        if let Some(el) = def.else_ability.as_deref() {
+            walk(el, out);
+        }
+    }
+    let mut out = Vec::new();
+    for a in abilities {
+        walk(a, &mut out);
+    }
+    out
+}
+
+/// Pre-order (self, then sub_ability, then else_ability) flat list of every
+/// effect in the ability/sub-ability tree. Used to assert that non-PreventDamage
+/// sibling clauses on the same card survive the bidirectional split intact and
+/// in the correct chain position — the family assertion only inspects the two
+/// PreventDamage nodes in isolation and cannot detect a dropped/overwritten
+/// sibling rider.
+fn collect_all_effects(abilities: &[crate::types::ability::AbilityDefinition]) -> Vec<Effect> {
+    fn walk(def: &crate::types::ability::AbilityDefinition, out: &mut Vec<Effect>) {
+        out.push((*def.effect).clone());
+        if let Some(sub) = def.sub_ability.as_deref() {
+            walk(sub, out);
+        }
+        if let Some(el) = def.else_ability.as_deref() {
+            walk(el, out);
+        }
+    }
+    let mut out = Vec::new();
+    for a in abilities {
+        walk(a, &mut out);
+    }
+    out
+}
+
+/// CR 615 + CR 608.2c (issue #1094): a "... dealt to and dealt by <anaphor>
+/// this turn" clause must lower to two PreventDamage nodes:
+/// - the recipient ("to") node: `target == ParentTarget`, no source filter;
+/// - the source-only ("by") node: `target == Any`,
+///   `damage_source_filter == Some(ParentTarget)`, chained SequentialSibling.
+fn assert_bidirectional_prevent_family(oracle: &str, name: &str, types: &[&str]) {
+    use crate::types::ability::{PreventionScope, SubAbilityLink, TargetFilter};
+    let parsed = parse(oracle, name, &[], types, &[]);
+    let nodes = collect_prevent_nodes(&parsed.abilities);
+    assert_eq!(
+        nodes.len(),
+        2,
+        "{name}: expected exactly 2 PreventDamage nodes (to + by), got {:#?}",
+        nodes.iter().map(|n| &n.effect).collect::<Vec<_>>()
+    );
+    match &*nodes[0].effect {
+        Effect::PreventDamage {
+            target,
+            damage_source_filter,
+            scope,
+            ..
+        } => {
+            assert_eq!(
+                *target,
+                TargetFilter::ParentTarget,
+                "{name}: 'to' recipient must bind ParentTarget"
+            );
+            assert!(
+                damage_source_filter.is_none(),
+                "{name}: 'to' node must have no source filter, got {damage_source_filter:?}"
+            );
+            assert_eq!(
+                *scope,
+                PreventionScope::CombatDamage,
+                "{name}: prevention scope must be combat-only"
+            );
+        }
+        other => panic!("{name}: node0 not PreventDamage: {other:?}"),
+    }
+    match &*nodes[1].effect {
+        Effect::PreventDamage {
+            target,
+            damage_source_filter,
+            ..
+        } => {
+            assert_eq!(
+                *target,
+                TargetFilter::Any,
+                "{name}: 'by' recipient must be Any (source-scoped only)"
+            );
+            assert_eq!(
+                damage_source_filter.as_ref(),
+                Some(&TargetFilter::ParentTarget),
+                "{name}: 'by' source filter must bind ParentTarget"
+            );
+        }
+        other => panic!("{name}: node1 not PreventDamage: {other:?}"),
+    }
+    assert_eq!(
+        nodes[1].sub_link,
+        SubAbilityLink::SequentialSibling,
+        "{name}: 'by' node must chain as SequentialSibling"
+    );
+}
+
+#[test]
+fn maze_of_ith_bidirectional_prevent() {
+    assert_bidirectional_prevent_family(
+        "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
+        "Maze of Ith",
+        &["Land"],
+    );
+}
+
+#[test]
+fn ebony_horse_bidirectional_prevent() {
+    assert_bidirectional_prevent_family(
+        "{2}, {T}: Untap target attacking creature you control. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
+        "Ebony Horse",
+        &["Artifact"],
+    );
+}
+
+#[test]
+fn elvish_scout_bidirectional_prevent_bare_it() {
+    // Bare-pronoun anaphor ("it") instead of "that creature".
+    assert_bidirectional_prevent_family(
+        "{G}, {T}: Untap target attacking creature you control. Prevent all combat damage that would be dealt to and dealt by it this turn.",
+        "Elvish Scout",
+        &["Creature"],
+    );
+}
+
+#[test]
+fn ith_high_arcanist_bidirectional_prevent() {
+    assert_bidirectional_prevent_family(
+        "Vigilance\n{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.\nSuspend 4—{W}{U}",
+        "Ith, High Arcanist",
+        &["Legendary", "Creature"],
+    );
+}
+
+#[test]
+fn maze_of_shadows_bidirectional_prevent() {
+    // Second activated ability; anaphor after a subtype-restricted target
+    // ("attacking creature with shadow").
+    assert_bidirectional_prevent_family(
+        "{T}: Add {C}.\n{T}: Untap target attacking creature with shadow. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
+        "Maze of Shadows",
+        &["Land"],
+    );
+}
+
+#[test]
+fn foxfire_bidirectional_prevent_the_creature() {
+    // Instant; "that creature" anaphor + trailing draw rider. Full real Oracle
+    // text, both lines (verified against Scryfall).
+    const FOXFIRE: &str = "Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.\nDraw a card at the beginning of the next turn's upkeep.";
+    assert_bidirectional_prevent_family(FOXFIRE, "Foxfire", &["Instant"]);
+
+    // Coverage-gap guard (issue #1094 fix round): the bidirectional split fills the
+    // Prevent clause's `sub_ability` slot with the "by" shield (a SequentialSibling).
+    // The THIRD clause — the "Draw a card at the beginning of the next turn's
+    // upkeep" delayed trigger — must still chain onto the TAIL of the whole tree
+    // (Untap -> to-Prevent -> by-Prevent -> Draw-delayed-trigger), never
+    // overwriting/displacing the "by" shield or being dropped.
+    let parsed = parse(FOXFIRE, "Foxfire", &[], &["Instant"], &[]);
+    let effects = collect_all_effects(&parsed.abilities);
+    let prevent_positions: Vec<usize> = effects
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| matches!(e, Effect::PreventDamage { .. }))
+        .map(|(i, _)| i)
+        .collect();
+    assert_eq!(
+        prevent_positions.len(),
+        2,
+        "Foxfire: expected 2 PreventDamage nodes in the full tree, got {:#?}",
+        effects
+    );
+    let draw_pos = effects.iter().position(|e| {
+        matches!(
+            e,
+            Effect::CreateDelayedTrigger { effect, .. }
+                if matches!(&*effect.effect, Effect::Draw { .. })
+        )
+    });
+    let draw_pos = draw_pos.expect(
+        "Foxfire: the 'Draw a card at the beginning of the next turn's upkeep' delayed trigger must survive the bidirectional split, not be dropped",
+    );
+    assert!(
+        draw_pos > prevent_positions[1],
+        "Foxfire: the draw delayed trigger must chain AFTER the 'by' shield (at the tail), not overwrite it; prevent positions={prevent_positions:?}, draw position={draw_pos}"
+    );
+}
+
+#[test]
+fn delirium_bidirectional_prevent_the_creature() {
+    // Instant; definite-article anaphor ("the creature") binding a target
+    // chosen two clauses earlier ("Tap target creature that player controls").
+    // Full real Oracle text, all sentences (verified against Scryfall).
+    const DELIRIUM: &str = "Cast this spell only during an opponent's turn.\nTap target creature that player controls. That creature deals damage equal to its power to the player. Prevent all combat damage that would be dealt to and dealt by the creature this turn.";
+    assert_bidirectional_prevent_family(DELIRIUM, "Delirium", &["Instant"]);
+
+    // Coverage-gap guard (issue #1094 fix round): the two clauses that PRECEDE
+    // the Prevent sentence ("Tap target creature ..." and "That creature deals
+    // damage equal to its power to the player") must still parse and chain ahead
+    // of the now-2-node Prevent split, not be dropped or reordered by it.
+    let parsed = parse(DELIRIUM, "Delirium", &[], &["Instant"], &[]);
+    let effects = collect_all_effects(&parsed.abilities);
+    let tap_pos = effects
+        .iter()
+        .position(|e| matches!(e, Effect::SetTapState { .. }))
+        .expect("Delirium: the 'Tap target creature ...' clause must survive the split");
+    let deal_pos = effects
+        .iter()
+        .position(|e| matches!(e, Effect::DealDamage { .. }))
+        .expect("Delirium: the 'That creature deals damage ...' clause must survive the split");
+    let first_prevent = effects
+        .iter()
+        .position(|e| matches!(e, Effect::PreventDamage { .. }))
+        .expect("Delirium: the Prevent split must exist");
+    assert!(
+        tap_pos < deal_pos,
+        "Delirium: the Tap clause must precede the damage clause; tap={tap_pos}, deal={deal_pos}"
+    );
+    assert!(
+        deal_pos < first_prevent,
+        "Delirium: both preceding clauses must chain ahead of the Prevent split; tap={tap_pos}, deal={deal_pos}, first_prevent={first_prevent}"
+    );
+}
+
+/// CR 608.2c (issue #1094): the `parent_target_available` gate is load-bearing.
+/// A standalone "prevent ... dealt to that creature this turn" with NO prior
+/// target-selecting clause (so `parent_target_available == false`) must fall
+/// back to `TargetFilter::Any` on the recipient — the anaphor recognizer is a
+/// no-op without a bound antecedent.
+#[test]
+fn prevent_anaphor_without_parent_target_falls_back_to_any() {
+    use crate::parser::oracle_effect::parse_effect;
+    use crate::types::ability::TargetFilter;
+    let effect = parse_effect("prevent all damage that would be dealt to that creature this turn");
+    match effect {
+        Effect::PreventDamage { target, .. } => assert_eq!(
+            target,
+            TargetFilter::Any,
+            "no prior target ⇒ anaphor must NOT bind ParentTarget"
+        ),
+        other => panic!("expected PreventDamage, got {other:?}"),
+    }
+}
+
 // ── Coverage batch: play from exile ────────────────────────────────
 
 #[test]

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -513,6 +513,7 @@ mod maraxus_team_pump_anthem;
 mod mass_phase_out_1792_repro;
 mod master_of_ceremonies;
 mod mauhur_swarming_of_moria;
+mod maze_of_ith_untap_bidirectional_prevent;
 mod memory_plunder_free_cast_2884;
 mod militant_angel_attacked_opponents;
 mod mill_double_redirect_choice_continuation;

--- a/crates/engine/tests/integration/maze_of_ith_untap_bidirectional_prevent.rs
+++ b/crates/engine/tests/integration/maze_of_ith_untap_bidirectional_prevent.rs
@@ -1,0 +1,173 @@
+//! Runtime regression for issue #1094 (Maze of Ith): the bidirectional
+//! combat-damage prevention with anaphoric target binding.
+//!
+//! Oracle text (verified against Scryfall):
+//! > {T}: Untap target attacking creature. Prevent all combat damage that would
+//! > be dealt to and dealt by that creature this turn.
+//!
+//! This drives the real activation + combat pipeline end to end:
+//! `add_land_from_oracle` → the parser lowers the Prevent sentence into TWO
+//! `PreventDamage` nodes (a recipient-scoped "to" node bound to the chosen
+//! creature via `ParentTarget`, and a source-only "by" `SequentialSibling`
+//! whose `damage_source_filter` binds the same creature) → the ability is
+//! activated on an attacking creature → combat damage is dealt → both the "to"
+//! and "by" shields fire.
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 615 / 615.1a: prevention-effect shields.
+//!   - CR 608.2c: an anaphor ("that creature") binds to a target chosen earlier
+//!     in the same effect.
+//!   - CR 701.26a/b: Untap (the pre-existing `SetTapState` lowering — untapping
+//!     the attacker; unmodified by this fix, exercised here for completeness).
+//!
+//! https://github.com/phase-rs/phase/issues/1094
+
+use super::rules::{GameScenario, Phase, P0, P1};
+use engine::game::combat::AttackTarget;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+
+const MAZE_OF_ITH: &str = "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.";
+
+fn damage_marked(runner: &engine::game::scenario::GameRunner, obj: ObjectId) -> u32 {
+    runner.state().objects[&obj].damage_marked
+}
+
+/// CR 615 + CR 608.2c + CR 701.26a/b (issue #1094): activating Maze of Ith on a
+/// blocked attacker untaps it AND prevents combat damage in BOTH directions —
+/// the attacker deals none to its blocker ("by") and takes none from it ("to").
+/// A second, un-Mazed attacker/blocker pair in the same combat takes normal
+/// damage on both sides — the hostile fixture proving the shields are scoped to
+/// the Mazed creature's identity, not applied globally.
+#[test]
+fn maze_of_ith_untaps_and_prevents_both_directions() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+
+    // The Mazed pair: P0's attacker vs P1's blocker (2/3 each so both survive
+    // and `damage_marked` is observable without lethal SBAs firing).
+    let mazed_attacker = scenario.add_creature(P0, "Mazed Attacker", 2, 3).id();
+    let mazed_blocker = scenario.add_creature(P1, "Mazed Blocker", 2, 3).id();
+
+    // The hostile pair (un-Mazed): normal combat damage on both sides.
+    let free_attacker = scenario.add_creature(P0, "Free Attacker", 2, 3).id();
+    let free_blocker = scenario.add_creature(P1, "Free Blocker", 2, 3).id();
+
+    let mut runner = scenario.build();
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[
+            (mazed_attacker, AttackTarget::Player(P1)),
+            (free_attacker, AttackTarget::Player(P1)),
+        ])
+        .expect("declaring both attackers must be accepted");
+
+    // Reach-guard: an attacker without vigilance taps when it attacks
+    // (CR 508.1f). This proves the Untap that follows is observable.
+    assert!(
+        runner.state().objects[&mazed_attacker].tapped,
+        "attacker must be tapped after declaring the attack (reach-guard for Untap)"
+    );
+
+    // Activate Maze of Ith (its only ability, index 0) targeting the attacker.
+    runner
+        .activate(maze, 0)
+        .target_object(mazed_attacker)
+        .resolve();
+
+    // (a) CR 701.26b: the attacker is untapped after Maze resolves.
+    assert!(
+        !runner.state().objects[&mazed_attacker].tapped,
+        "Maze of Ith must untap the target attacking creature"
+    );
+
+    // Advance to the declare-blockers step and declare both blocks.
+    if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+        runner.pass_both_players();
+    }
+    runner
+        .declare_blockers(&[
+            (mazed_blocker, mazed_attacker),
+            (free_blocker, free_attacker),
+        ])
+        .expect("declaring both blocks must be accepted");
+
+    runner.combat_damage();
+
+    // (b) "to" direction: the blocker's 2 damage to the Mazed attacker is
+    // prevented — attacker takes 0.
+    assert_eq!(
+        damage_marked(&runner, mazed_attacker),
+        0,
+        "'to' shield: the Mazed attacker must take no combat damage"
+    );
+    // (c) "by" direction: the Mazed attacker's 2 damage to the blocker is
+    // prevented — blocker takes 0.
+    assert_eq!(
+        damage_marked(&runner, mazed_blocker),
+        0,
+        "'by' shield: the Mazed attacker must deal no combat damage"
+    );
+
+    // Hostile fixture: the un-Mazed pair takes normal damage on both sides,
+    // proving the shields are scoped to the Mazed creature (SpecificObject),
+    // not global.
+    assert_eq!(
+        damage_marked(&runner, free_attacker),
+        2,
+        "un-Mazed attacker must take its blocker's 2 damage"
+    );
+    assert_eq!(
+        damage_marked(&runner, free_blocker),
+        2,
+        "un-Mazed blocker must take its attacker's 2 damage"
+    );
+}
+
+/// CR 615 + CR 608.2c (issue #1094, Gap B): the defending-player-damage case.
+/// Two UNBLOCKED attackers are declared; only `attacker_a` (power 2) is Mazed.
+/// The defending player must lose EXACTLY `attacker_b.power` (3), never
+/// 2 + 3 = 5 — the "by" shield must prevent the Mazed creature's combat damage
+/// to the PLAYER, not merely damage dealt TO the creature. This is the fixture
+/// that fails without the `source_scoped_prevent` gate widening (Fix 2): without
+/// it, the "by" shield is mis-hosted onto `attacker_a` with `valid_card`
+/// auto-filled to `SelfRef`, so it only guards damage TO `attacker_a` and the
+/// player still takes damage from BOTH attackers (-5).
+#[test]
+fn maze_of_ith_prevents_mazed_attacker_damage_to_defending_player() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let attacker_a = scenario.add_creature(P0, "Mazed Attacker", 2, 2).id();
+    let attacker_b = scenario.add_creature(P0, "Free Attacker", 3, 3).id();
+
+    let mut runner = scenario.build();
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[
+            (attacker_a, AttackTarget::Player(P1)),
+            (attacker_b, AttackTarget::Player(P1)),
+        ])
+        .expect("declaring both attackers must be accepted");
+
+    runner.activate(maze, 0).target_object(attacker_a).resolve();
+    assert!(
+        !runner.state().objects[&attacker_a].tapped,
+        "Maze of Ith must untap the Mazed attacker"
+    );
+
+    let outcome = runner.combat_damage();
+
+    // Only the un-Mazed attacker_b (power 3) lands damage on P1. attacker_a's
+    // combat damage to the player is prevented by the "by" shield.
+    outcome.assert_life_delta(P1, -3);
+}


### PR DESCRIPTION
## Summary

Fixes #1094 — [[Maze of Ith]] ({T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn. — verified via [Scryfall](https://scryfall.com/card/drk/33/maze-of-ith), from The Dark, 1994) doesn't untap the creature or prevent it from dealing or taking damage.

**Root cause** (originally diagnosed by @matthewevans in the issue's coverage-classifier comment): the ability parsed as `Untap { target } + child PreventDamage { target: Any }` — the "that creature" anaphor was dropped to the default `Any` instead of binding to the same creature via `TargetFilter::ParentTarget`. Separately, the clause is **bidirectional** ("dealt to **and dealt by** that creature") and the parser had no representation at all for the "dealt by" half (damage the creature deals, not just damage dealt to it).

`Effect::PreventDamage`'s `target` + `damage_source_filter` fields combine with AND semantics (`game/replacement.rs`), so "recipient==X OR source==X" cannot be expressed as one shield. The fix splits the clause into two `PreventDamage` nodes chained via `SubAbilityLink::SequentialSibling` — a recipient-scoped "to" shield and a source-scoped-only "by" shield.

Two latent runtime gaps in `game/effects/prevent_damage.rs`, both required for the split to actually work, not scope creep:
- `resolve_source_filter` had no arm for a bare `ParentTarget` damage-source filter (only `ParentTargetSlot{index}`) — added one.
- `source_scoped_prevent`'s gate only recognized the pre-existing `And{ParentTargetSlot,...}` shape, so a bare `ParentTarget` source filter fell through to `host_on_targets`, which auto-filled `valid_card: SelfRef` and silently re-imposed the recipient constraint the source-only shield must not have — widened the gate.

## Shipped scope

7 cards sharing this exact singular-anaphor grammar ("prevent...dealt to and dealt by `<that creature|it|the creature>`"): Maze of Ith, Ebony Horse, Elvish Scout, Foxfire, Ith High Arcanist, Maze of Shadows, Delirium.

**Deliberately deferred** (separate follow-up issues, not silently dropped):
- Self-ref-activated cohort ("this creature" — Deftblade Elite, Urborg Phantom, Moonlight Geist) — would need its own `TargetFilter::SelfRef` recipient-scoping carve-out in `prevent_damage.rs::resolve()`, currently untested and out of scope here.
- Plural anaphor (Energy Arc, "those creatures").
- Multi-target + unless-pay branching (Winter's Chill) — verified via trace that `parent_target_available` is guaranteed `false` when its inner "prevent...that creature..." clause parses (its preceding sibling clause has a recognized `condition.is_some()`, which makes the backward target-referent walk bail before reaching the earlier typed target), so the new machinery is a guaranteed no-op there — no guard needed.

## Files changed

- `crates/engine/src/parser/oracle_target.rs` — `parse_anaphoric_target_ref`, a thin wrapper delegating to the existing `parse_target` building block (gated on a new `parent_target_available: bool`).
- `crates/engine/src/parser/oracle_ir/ast.rs` — `parent_target_available: bool` field on `UtilityImperativeAst::Prevent`.
- `crates/engine/src/parser/oracle_effect/imperative.rs` — threads the field through all 4 construction/consumption sites; factored `parse_prevention_amount` out for shared reuse.
- `crates/engine/src/parser/oracle_effect/lower.rs` — `try_parse_bidirectional_prevent`, the sibling-splitting interceptor.
- `crates/engine/src/game/effects/prevent_damage.rs` — the two runtime fixes above.
- `crates/engine/src/game/effects/mod.rs` — `first_object_target` promoted to `pub(crate)` for reuse.
- `crates/engine/src/game/scenario.rs` — `add_land_from_oracle`, a reusable test-harness builder (no existing helper places a land on the battlefield with parsed Oracle text).
- `crates/engine/src/parser/oracle_tests.rs` — unit tests for all 7 family cards + negative gate + sibling-clause survival (Foxfire's trailing draw trigger, Delirium's preceding tap/damage clauses).
- `crates/engine/tests/integration/maze_of_ith_untap_bidirectional_prevent.rs` (new) — discriminating runtime tests driving the real activate/combat pipeline, including a hostile un-Mazed attacker/blocker fixture and a defending-player-life-total fixture.

## CR references

CR 615, CR 615.1a, CR 615.11, CR 511.2, CR 608.2c, CR 302.6, CR 609.7, CR 701.26a/b — all verified against `docs/MagicCompRules.txt`.

## Test plan

- [x] Verified all 7 shipped cards' Oracle text via Scryfall (not paraphrases)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p engine --lib -- -D warnings` clean
- [x] `./scripts/check-parser-combinators.sh` (Gate A): 0 violations
- [x] `cargo test -p engine --lib`: 15964 passed, 0 failed
- [x] `cargo test -p engine --test integration`: 2563 passed, 0 failed (includes both new Maze of Ith tests)
- [x] Live-revert-and-rerun: independently reverted the parser split, the `resolve_source_filter` fix, and the `source_scoped_prevent` gate widening — each flips both integration tests to failing; restored and re-confirmed green
- [x] Went through 4 rounds of independent implementation review (2 planning rounds + 2 implementation rounds) before opening this PR — findings included a misapplied CR 615.5 citation (corrected to 615.1a + 608.2c) and a hand-rolled anaphor recognizer that duplicated the existing `parse_target` building block (refactored to delegate)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01XbgwGxbU9NHN9kou9isp8K