### PR TITLE
fix(engine): skip ParentTarget bounce when optional head chose zero targets (#5287)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4272,6 +4272,16 @@ fn effect_refs_parent_target(effect: &Effect) -> bool {
         .any(|filter| filter_refs_parent_target(filter))
 }
 
+/// CR 115.6: True when the resolving ability head permits zero targets and the
+/// controller chose none (no `TargetRef::Object` in `ability.targets`).
+fn optional_head_declined_all_object_targets(ability: &ResolvedAbility) -> bool {
+    ability.targeting_is_optional()
+        && !ability
+            .targets
+            .iter()
+            .any(|t| matches!(t, TargetRef::Object(_)))
+}
+
 /// Every object-target filter slot of an effect that may carry a parent-ref,
 /// INCLUDING slots `target_filter()` hides. Single source of truth for which
 /// slots a member-driven loop inspects for rebinding.
@@ -7898,6 +7908,26 @@ fn resolve_chain_body(
                 state,
             );
             resolve_ability_chain(state, &sub_with_referent, events, depth + 1)?;
+        } else if sub.targets.is_empty()
+            && ability.targets.is_empty()
+            && effect_refs_parent_target(&sub.effect)
+            && optional_head_declined_all_object_targets(ability)
+        {
+            // CR 115.6 + CR 608.2c (issue #5287): Optional multi-target / up-to-one
+            // head legally chose zero object targets — a ParentTarget consumer
+            // ("Return it", "that creature", …) has no antecedent. Skip the
+            // consumer but keep resolving trailing sequential siblings (Samwise
+            // the Stouthearted → Ring tempts you).
+            if let Some(trailing) = sub.sub_ability.as_ref() {
+                let mut trailing_resolved = trailing.as_ref().clone();
+                apply_parent_chain_context(
+                    &mut trailing_resolved,
+                    ability,
+                    effect_context_object.as_ref(),
+                    state,
+                );
+                resolve_ability_chain(state, &trailing_resolved, events, depth + 1)?;
+            }
         } else {
             // Propagate SpellContext so additional_cost_paid and other flags
             // survive through the chain (e.g., Gift delivery → spell effects

--- a/crates/engine/tests/integration/issue_5287_samwise_stouthearted.rs
+++ b/crates/engine/tests/integration/issue_5287_samwise_stouthearted.rs
@@ -1,0 +1,75 @@
+//! Issue #5287 — Samwise the Stouthearted ETB with no eligible graveyard return.
+//!
+//! Oracle: Flash
+//! When Samwise enters, choose up to one target permanent card in your graveyard
+//! that was put there from the battlefield this turn. Return it to your hand.
+//! Then the Ring tempts you.
+//!
+//! When zero graveyard cards qualify, the optional target is declined and the
+//! bounce anaphor must not fall back to Samwise himself; Ring temptation still
+//! resolves.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::move_to_zone;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+use engine::types::ObjectId;
+
+const SAMWISE_ORACLE: &str = "Flash\nWhen Samwise enters, choose up to one target permanent card in your graveyard that was put there from the battlefield this turn. Return it to your hand. Then the Ring tempts you.";
+
+fn white_mana_pool() -> Vec<ManaUnit> {
+    vec![
+        ManaUnit::new(ManaType::White, ObjectId(0), false, vec![]),
+        ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+    ]
+}
+
+#[test]
+fn samwise_etb_with_no_graveyard_return_stays_on_battlefield_and_tempts_ring() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(P0, white_mana_pool());
+    let samwise = scenario
+        .add_creature_to_hand_from_oracle(P0, "Samwise the Stouthearted", 2, 1, SAMWISE_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.cast(samwise).resolve();
+
+    assert_eq!(
+        runner.state().objects.get(&samwise).map(|o| o.zone),
+        Some(Zone::Battlefield),
+        "declining the up-to-one graveyard return must not bounce Samwise to hand"
+    );
+    assert_eq!(
+        runner.state().ring_level.get(&P0).copied(),
+        Some(1),
+        "Ring temptation must still resolve after a declined optional return"
+    );
+}
+
+#[test]
+fn samwise_etb_returns_creature_put_into_graveyard_from_battlefield_this_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(P0, white_mana_pool());
+    let victim = scenario.add_creature(P0, "Fallen Knight", 2, 2).id();
+    let samwise = scenario
+        .add_creature_to_hand_from_oracle(P0, "Samwise the Stouthearted", 2, 1, SAMWISE_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), victim, Zone::Graveyard, &mut events);
+
+    let outcome = runner.cast(samwise).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Hand);
+    outcome.assert_zone(&[samwise], Zone::Battlefield);
+    assert_eq!(
+        runner.state().ring_level.get(&P0).copied(),
+        Some(1),
+        "Ring temptation follows a successful optional return"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -431,6 +431,7 @@ mod issue_4962_volo_guide_to_monsters;
 mod issue_5145_violent_eruption_choose_target_distribution;
 mod issue_5159_attacks_alone_investigate;
 mod issue_5282_nissa_ultimate_emblem_search;
+mod issue_5287_samwise_stouthearted;
 mod issue_5328_attacks_alone_observer;
 mod issue_5335_stonehoof_mass_attack;
 mod issue_5336_kodama_mana_value_filter;


### PR DESCRIPTION
## Summary

Samwise the Stouthearted was listed as fully supported, but casting it on a turn with no permanent put into your graveyard from the battlefield incorrectly bounced Samwise to hand instead of skipping the return and still tempting the Ring. This fix teaches chain resolution to skip `ParentTarget` consumers when an optional up-to-one head legally chose zero object targets, while continuing trailing sequential siblings.

Fixes [#5287](https://github.com/phase-rs/phase/issues/5287).

## Root cause

Samwise's ETB parses as `TargetOnly` (multi_target min=0) → `Bounce { ParentTarget }` → `RingTemptsYou`. Parser and coverage were correct.

When zero graveyard cards qualify (or the controller declines the optional target):

1. `TargetOnly` resolves as a no-op with `ability.targets = []`.
2. The chained `Bounce(ParentTarget)` sub has no propagated object targets.
3. `resolved_targets` self-fallback binds `ParentTarget` to the ability source (Samwise on the battlefield).
4. Samwise is bounced to hand; Ring temptation may not run as expected.

The #5281 fix blocks independent optional slots from inheriting parent object targets, but does not cover `ParentTarget` anaphor bounce after a declined optional `TargetOnly` head.

## Changes

### Engine — chain resolution (`effects/mod.rs`)

- Added `optional_head_declined_all_object_targets` helper (CR 115.6: `targeting_is_optional()` with no `TargetRef::Object` chosen).
- In `resolve_chain_body`, when the parent head declined all object targets and the sub only references `ParentTarget`, skip the consumer effect and resolve trailing sequential siblings (Samwise → Ring tempts you).

### Tests

- `issue_5287_samwise_stouthearted.rs`: two regressions — no eligible graveyard return keeps Samwise on battlefield and tempts Ring; creature put into graveyard from battlefield this turn is returned and Ring still tempts.

## Out of scope

- Parser AST shape (`TargetOnly` → `Bounce(ParentTarget)` vs direct `ChangeZone`); runtime fix covers the whole choose-and-return anaphor class.
- Spurious `duration: UntilEndOfTurn` on `TargetOnly` in card-data (parser artifact, inert at runtime).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p engine --test integration issue_5287` (2/2)
- [x] `cargo test -p engine --test integration cruel_revival` (3/3)

## Risk notes

- Gate is narrow: requires empty parent/sub targets, `effect_refs_parent_target` on the sub, and optional head with zero object targets. Mandatory-target and effect-context-object snapshot paths (#2890) are unchanged.
- Covers the class of "choose up to one target … Return it" chains, not only Samwise.
