### PR TITLE
fix(parser): bind PutCounterAll "untap them" to countered set (#5286)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -237,6 +237,59 @@ fn patch_self_ref_head_tap_anaphor(def: &mut AbilityDefinition) {
     walk(def, false);
 }
 
+/// CR 608.2c + CR 122.1: After a mass counter placement (`PutCounterAll`), a
+/// chained "then untap them" continuation refers to the set of objects that
+/// received counters (Lulu, Loyal Hollyphant). Phase-trigger bodies carry
+/// `ctx.subject = Any`, so `resolve_it_pronoun` wrongly binds "them" to
+/// `SelfRef` (the trigger source). Rewrite to `TrackedSet(0)` so the runtime
+/// binds the published counter set via `affected_objects_from_events`. Sibling
+/// of [`patch_self_ref_head_tap_anaphor`] for the population-head / plural-
+/// anaphor polarity.
+fn patch_population_head_tap_anaphor(def: &mut AbilityDefinition) {
+    fn is_population_counter_publisher(effect: &Effect) -> bool {
+        matches!(
+            effect,
+            Effect::PutCounterAll { target, .. }
+                if !matches!(
+                    target,
+                    TargetFilter::SelfRef
+                        | TargetFilter::ParentTarget
+                        | TargetFilter::TriggeringSource
+                        | TargetFilter::CostPaidObject
+                )
+        )
+    }
+
+    fn walk(def: &mut AbilityDefinition, carried_population: bool) {
+        let active_population = if is_population_counter_publisher(&def.effect) {
+            true
+        } else {
+            match def.effect.target_filter() {
+                Some(filter) if !target_filter_is_player_scoped(filter) => false,
+                _ => carried_population,
+            }
+        };
+        if let Some(sub) = def.sub_ability.as_deref_mut() {
+            if active_population {
+                if let Effect::SetTapState {
+                    target,
+                    scope: EffectScope::Single,
+                    ..
+                } = sub.effect.as_mut()
+                {
+                    if matches!(target, TargetFilter::SelfRef | TargetFilter::ParentTarget) {
+                        *target = TargetFilter::TrackedSet {
+                            id: crate::types::identifiers::TrackedSetId(0),
+                        };
+                    }
+                }
+            }
+            walk(sub, active_population);
+        }
+    }
+    walk(def, false);
+}
+
 /// CR 608.2c: After a "choose a card …" interactive selection, the chained
 /// "… {remove|put} that many counters {from|on} it" continuation's "it" refers to
 /// the chosen card. The standalone continuation clause lowers its "it" anaphor to
@@ -576,6 +629,26 @@ mod self_ref_tap_anaphor_tests {
     /// Builds a `PutCounter{head_target}` head with a chained
     /// `SetTapState{ParentTarget, scope}` untap sub — the shape every chained
     /// tap/untap anaphor lowers to.
+    fn put_counter_all_then_untap_chain(head_target: TargetFilter) -> AbilityDefinition {
+        let mut def = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PutCounterAll {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: head_target,
+            },
+        );
+        def.sub_ability = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::SetTapState {
+                target: TargetFilter::SelfRef,
+                scope: EffectScope::Single,
+                state: TapStateChange::Untap,
+            },
+        )));
+        def
+    }
+
     fn put_counter_then_untap_chain(
         head_target: TargetFilter,
         sub_scope: EffectScope,
@@ -643,6 +716,32 @@ mod self_ref_tap_anaphor_tests {
                 }
             ),
             "Typed-head anaphor must stay ParentTarget (CR 608.2b), got {:?}",
+            sub.effect
+        );
+    }
+
+    // CR 608.2c + CR 122.1: a chained "untap them" after `PutCounterAll` binds
+    // to the countered set, not the trigger source (Lulu, Loyal Hollyphant).
+    #[test]
+    fn put_counter_all_head_plural_untap_rewrites_to_tracked_set() {
+        let mut def = put_counter_all_then_untap_chain(TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::Tapped]),
+        ));
+        patch_population_head_tap_anaphor(&mut def);
+        let sub = def.sub_ability.expect("sub-ability");
+        assert!(
+            matches!(
+                &*sub.effect,
+                Effect::SetTapState {
+                    target: TargetFilter::TrackedSet {
+                        id: crate::types::identifiers::TrackedSetId(0)
+                    },
+                    ..
+                }
+            ),
+            "PutCounterAll-head plural untap must bind TrackedSet(0), got {:?}",
             sub.effect
         );
     }
@@ -2224,6 +2323,9 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
     // ParentTarget to SelfRef so it binds the source, while a real/optional
     // target head (Tyvar Kell) keeps ParentTarget and no-ops when declined.
     patch_self_ref_head_tap_anaphor(&mut result);
+    // CR 608.2c + CR 122.1: bind a mass `PutCounterAll` head's chained "untap
+    // them" to the countered set (Lulu, Loyal Hollyphant).
+    patch_population_head_tap_anaphor(&mut result);
     // CR 608.2c: bind a "choose a card …, then {put|remove} counters {on|from} it"
     // continuation's "it" anaphor to the chosen card (Amy Pond). The standalone
     // counter clause lowers "it" to SelfRef; under an `Effect::ChooseFromZone`

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -2077,6 +2077,60 @@ fn nalia_de_arnise_counters_then_deathtouch_lowers_correctly() {
     }
 }
 
+/// CR 608.2c + CR 122.1: Lulu, Loyal Hollyphant — mass counter then "untap them"
+/// must bind the untap to the countered set via `TrackedSet(0)`, not `SelfRef`.
+#[test]
+fn lulu_loyal_hollyphant_counters_then_untap_them_lowers_correctly() {
+    let def = parse_effect_chain(
+        "put a +1/+1 counter on each tapped creature you control, then untap them",
+        AbilityKind::Spell,
+    );
+
+    match &*def.effect {
+        Effect::PutCounterAll {
+            counter_type,
+            target,
+            ..
+        } => {
+            assert_eq!(*counter_type, CounterType::Plus1Plus1);
+            match target {
+                TargetFilter::Typed(tf) => {
+                    assert!(tf.type_filters.contains(&TypeFilter::Creature));
+                    assert_eq!(tf.controller, Some(ControllerRef::You));
+                    assert!(
+                        tf.properties
+                            .iter()
+                            .any(|p| matches!(p, FilterProp::Tapped)),
+                        "must target tapped creatures only"
+                    );
+                }
+                other => panic!("expected Typed tapped creatures you control, got {other:?}"),
+            }
+        }
+        other => panic!("expected primary PutCounterAll, got {other:?}"),
+    }
+
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("'then untap them' must attach as sub_ability");
+    assert!(
+        matches!(
+            &*sub.effect,
+            Effect::SetTapState {
+                target: TargetFilter::TrackedSet {
+                    id: TrackedSetId(0)
+                },
+                scope: EffectScope::Single,
+                state: TapStateChange::Untap,
+                ..
+            }
+        ),
+        "untap them must bind TrackedSet(0), got {:?}",
+        sub.effect
+    );
+}
+
 /// Scoping regression for issue #445: a TARGETED primary counter clause must
 /// NOT be promoted to `PutCounterAll` just because a TRAILING conjunct is a
 /// mass placement. Mass detection must run against the primary clause only.

--- a/crates/engine/tests/integration/issue_5286_lulu_loyal_hollyphant.rs
+++ b/crates/engine/tests/integration/issue_5286_lulu_loyal_hollyphant.rs
@@ -1,0 +1,127 @@
+//! Regression for issue #5286: Lulu, Loyal Hollyphant end-step trigger must put
+//! +1/+1 counters on each tapped creature you control and untap those same
+//! creatures when a permanent you controlled left the battlefield this turn.
+//!
+//! https://github.com/phase-rs/phase/issues/5286
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::zones::move_to_zone;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const LULU_ORACLE: &str = "Flying\n\
+At the beginning of your end step, if a permanent you controlled left the battlefield this turn, \
+put a +1/+1 counter on each tapped creature you control, then untap them.\n\
+Choose a Background (You can have a Background as a second commander.)";
+
+fn drive_end_step_stack(runner: &mut engine::game::scenario::GameRunner) {
+    for _ in 0..64 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::DeclareAttackers { .. } => {
+                runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .expect("declare attackers");
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .ok();
+            }
+            WaitingFor::Priority { .. } if runner.state().phase == Phase::End => {
+                if runner.state().stack.is_empty() {
+                    return;
+                }
+                runner.act(GameAction::PassPriority).ok();
+            }
+            _ if runner.state().phase == Phase::End && runner.state().stack.is_empty() => return,
+            _ => runner.pass_both_players(),
+        }
+    }
+}
+
+#[test]
+fn issue_5286_lulu_counters_and_untaps_tapped_creatures_after_revolt() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let lulu = scenario
+        .add_creature_from_oracle(P0, "Lulu, Loyal Hollyphant", 3, 2, LULU_ORACLE)
+        .id();
+    let leaver = scenario.add_creature(P0, "Leaver", 1, 1).id();
+    let tapped_a = scenario.add_creature(P0, "Tapped A", 2, 2).id();
+    let tapped_b = scenario.add_creature(P0, "Tapped B", 2, 2).id();
+    let _untapped = scenario.add_creature(P0, "Untapped", 2, 2).id();
+
+    let mut runner = scenario.build();
+
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), leaver, Zone::Graveyard, &mut events);
+
+    for id in [tapped_a, tapped_b] {
+        runner.state_mut().objects.get_mut(&id).unwrap().tapped = true;
+    }
+
+    runner.advance_to_end_step();
+    drive_end_step_stack(&mut runner);
+
+    for id in [tapped_a, tapped_b] {
+        let obj = runner.state().objects.get(&id).unwrap();
+        assert_eq!(
+            obj.counters.get(&CounterType::Plus1Plus1).copied(),
+            Some(1),
+            "tapped creature {id:?} should receive a +1/+1 counter"
+        );
+        assert!(
+            !obj.tapped,
+            "tapped creature {id:?} should be untapped by Lulu's trigger"
+        );
+    }
+
+    let untapped_obj = runner.state().objects.get(&_untapped).unwrap();
+    assert!(
+        !untapped_obj.counters.contains_key(&CounterType::Plus1Plus1),
+        "untapped creatures must not receive counters"
+    );
+    assert!(
+        !untapped_obj.tapped,
+        "already-untapped creature should stay untapped"
+    );
+    assert!(
+        !runner.state().objects[&lulu].tapped,
+        "Lulu herself must not be the sole beneficiary of the untap sub"
+    );
+}
+
+#[test]
+fn issue_5286_lulu_does_nothing_without_revolt() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature_from_oracle(P0, "Lulu, Loyal Hollyphant", 3, 2, LULU_ORACLE)
+        .id();
+    let tapped = scenario.add_creature(P0, "Tapped Soldier", 2, 2).id();
+    let _opponent_creature = scenario.add_creature(P1, "Opp Creature", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().objects.get_mut(&tapped).unwrap().tapped = true;
+
+    runner.advance_to_end_step();
+    drive_end_step_stack(&mut runner);
+
+    let obj = runner.state().objects.get(&tapped).unwrap();
+    assert!(
+        !obj.counters.contains_key(&CounterType::Plus1Plus1),
+        "without a revolt event, Lulu must not place counters"
+    );
+    assert!(
+        obj.tapped,
+        "without a revolt event, tapped creatures stay tapped"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -432,6 +432,7 @@ mod issue_4962_volo_guide_to_monsters;
 mod issue_5145_violent_eruption_choose_target_distribution;
 mod issue_5159_attacks_alone_investigate;
 mod issue_5282_nissa_ultimate_emblem_search;
+mod issue_5286_lulu_loyal_hollyphant;
 mod issue_5328_attacks_alone_observer;
 mod issue_5335_stonehoof_mass_attack;
 mod issue_5336_kodama_mana_value_filter;


### PR DESCRIPTION
## Summary

Lulu, Loyal Hollyphant was listed as fully supported, but at the beginning of your end step (with revolt satisfied) it put +1/+1 counters on tapped creatures you control and then failed to untap them — only Lulu herself would untap. This fix rewrites the chained plural untap anaphor after a mass counter head to `TrackedSet(0)` so runtime resolution binds the creatures that received counters.

Fixes [#5286](https://github.com/phase-rs/phase/issues/5286).

## Root cause

Lulu's end-step trigger parses correctly through `PutCounterAll` (each tapped creature you control), but the `"then untap them"` sub lowered to `SetTapState { target: SelfRef, scope: Single }`.

Phase-trigger bodies carry `ctx.subject = Any`, so `resolve_it_pronoun` binds bare `"them"` to the trigger source (Lulu) instead of the countered population. `ParentTarget` would also no-op at runtime because `PutCounterAll` does not populate `ability.targets`.

## Changes

### Parser — lowering (`oracle_effect/lower.rs`)

- Added `patch_population_head_tap_anaphor` (sibling of `patch_self_ref_head_tap_anaphor`): when a broadcast `PutCounterAll` head chains a single-scope tap/untap anaphor (`SelfRef` or `ParentTarget`), rewrite to `TrackedSet(0)` so `tap_untap.rs` consumes the set published by `CounterAdded` events (CR 608.2c + CR 122.1).

### Tests

- Parser: `lulu_loyal_hollyphant_counters_then_untap_them_lowers_correctly`, `put_counter_all_head_plural_untap_rewrites_to_tracked_set`
- Integration: `issue_5286_lulu_loyal_hollyphant.rs` — revolt + tapped creatures get counters and untap; no revolt → no effect

## Out of scope

- Card-data regeneration (`cargo card-data`); runtime `from_oracle_text` path is fixed and integration tests use live Oracle text.
- Generalizing to other mass-effect heads (e.g. `PumpAll` + untap them); patch is scoped to `PutCounterAll` publishers.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p engine --lib lulu_loyal_hollyphant_counters_then_untap_them`
- [x] `cargo test -p engine --lib put_counter_all_head_plural_untap_rewrites_to_tracked_set`
- [x] `cargo test -p engine --test integration issue_5286` (2/2)

## Risk notes

- Gate is narrow: only `PutCounterAll` with a broadcast population filter, immediate chained `SetTapState` with `scope: Single` and `SelfRef`/`ParentTarget`. `patch_self_ref_head_tap_anaphor` and targeted-counter chains are unchanged.
- Covers the class of "put a counter on each …, then untap them" (Lulu and future cards with the same shape).
