### PR TITLE
fix(parser, engine): recognize qualified "source of your choice" damage prevention (Circle/Rune of Protection, 13 cards)

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -1376,7 +1376,7 @@ fn scope_of(target: &TargetFilter, chain_root: Option<WriteScope>) -> WriteScope
         | TargetFilter::PostReplacementDamageTargetOwner
         | TargetFilter::DefendingPlayer
         | TargetFilter::HasChosenName
-        | TargetFilter::ChosenDamageSource
+        | TargetFilter::ChosenDamageSource { .. }
         | TargetFilter::Named { .. }
         | TargetFilter::Owner
         | TargetFilter::AllPlayers => WriteScope::External,
@@ -2213,7 +2213,7 @@ fn legacy_target_filter(f: &TargetFilter) -> bool {
         | TargetFilter::PostReplacementSourceController
         | TargetFilter::PostReplacementDamageTarget
         | TargetFilter::PostReplacementDamageTargetOwner
-        | TargetFilter::ChosenDamageSource
+        | TargetFilter::ChosenDamageSource { .. }
         | TargetFilter::None
         | TargetFilter::Any
         | TargetFilter::Player
@@ -2407,7 +2407,7 @@ fn member_bound_target_filter(f: &TargetFilter) -> bool {
         | TargetFilter::ChosenCard
         | TargetFilter::HasChosenName
         | TargetFilter::SourceChosenPlayer
-        | TargetFilter::ChosenDamageSource
+        | TargetFilter::ChosenDamageSource { .. }
         | TargetFilter::AttachedTo
         | TargetFilter::Neighbor { .. }
         | TargetFilter::OriginalController
@@ -6079,7 +6079,7 @@ fn rw_target_filter(x: &TargetFilter) -> RwProfile {
         | TargetFilter::PostReplacementSourceController
         | TargetFilter::PostReplacementDamageTarget
         | TargetFilter::PostReplacementDamageTargetOwner
-        | TargetFilter::ChosenDamageSource => reads_event_live(),
+        | TargetFilter::ChosenDamageSource { .. } => reads_event_live(),
         TargetFilter::Not { filter } | TargetFilter::TrackedSetFiltered { filter, .. } => {
             rw_target_filter(filter)
         }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -2511,11 +2511,17 @@ fn scan_target_filter(x: &TargetFilter) -> Axes {
         },
         TargetFilter::DefendingPlayer => Axes::NONE,
         TargetFilter::HasChosenName => Axes::NONE,
-        TargetFilter::ChosenDamageSource => Axes {
-            event: true,
-            sibling: false,
-            projected: false,
-        },
+        TargetFilter::ChosenDamageSource { filter } => {
+            let mut acc = Axes {
+                event: true,
+                sibling: false,
+                projected: false,
+            };
+            if let Some(f) = filter {
+                acc = acc.or(scan_target_filter(f));
+            }
+            acc
+        }
         TargetFilter::Named { name: _ } => Axes::NONE,
         TargetFilter::Owner => Axes::NONE,
         TargetFilter::AllPlayers => Axes::NONE,

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -12386,7 +12386,7 @@ mod tests {
 
         let ability = ResolvedAbility::new(
             Effect::CreateDamageReplacement {
-                source_filter: Some(TargetFilter::ChosenDamageSource),
+                source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
                 combat_scope: None,
                 target_filter: None,
                 modification: None,

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -93,7 +93,7 @@ pub(crate) fn target_filter_has_pitch_bound_x(filter: &TargetFilter) -> bool {
         | TargetFilter::PostReplacementDamageTargetOwner
         | TargetFilter::DefendingPlayer
         | TargetFilter::HasChosenName
-        | TargetFilter::ChosenDamageSource
+        | TargetFilter::ChosenDamageSource { .. }
         | TargetFilter::Named { .. }
         | TargetFilter::Owner
         // CR 201.5a: a granter self-ref carries no pitch-bound X.
@@ -171,7 +171,7 @@ pub(crate) fn relax_pitch_bound_x_filter(filter: &TargetFilter) -> TargetFilter 
         | TargetFilter::PostReplacementDamageTargetOwner
         | TargetFilter::DefendingPlayer
         | TargetFilter::HasChosenName
-        | TargetFilter::ChosenDamageSource
+        | TargetFilter::ChosenDamageSource { .. }
         | TargetFilter::Named { .. }
         | TargetFilter::Owner
         // CR 201.5a: no pitch-bound X constraint to relax.

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -624,7 +624,10 @@ fn fmt_target(filter: &TargetFilter) -> String {
         }
         TargetFilter::ExiledBySource => "cards exiled by source".into(),
         TargetFilter::HasChosenName => "card with the chosen name".into(),
-        TargetFilter::ChosenDamageSource => "chosen damage source".into(),
+        TargetFilter::ChosenDamageSource { filter: Some(f) } => {
+            format!("chosen damage source matching {}", fmt_target(f))
+        }
+        TargetFilter::ChosenDamageSource { filter: None } => "chosen damage source".into(),
         TargetFilter::Named { name } => format!("card named {name}"),
         TargetFilter::Not { filter } => format!("not {}", fmt_target(filter)),
         TargetFilter::Or { filters } => filters

--- a/crates/engine/src/game/effects/create_damage_replacement.rs
+++ b/crates/engine/src/game/effects/create_damage_replacement.rs
@@ -77,13 +77,16 @@ pub fn resolve(
     // and re-enter this resolver as a continuation; on the second pass the choice
     // is recorded and we proceed.
     let resolved_source_filter = match &source_filter {
-        Some(TargetFilter::ChosenDamageSource) => {
+        Some(TargetFilter::ChosenDamageSource { filter: qualifier }) => {
             match state.last_chosen_damage_source.as_ref() {
                 Some(_choice) => {
                     // CR 609.7b: Resolve the chosen damage source filter to check if
-                    // the source matches the filter.
+                    // the source matches the filter (including any color/type
+                    // qualifier carried on the variant, rechecked live per 609.7b).
                     let resolved = resolve_source_filter(
-                        &TargetFilter::ChosenDamageSource,
+                        &TargetFilter::ChosenDamageSource {
+                            filter: qualifier.clone(),
+                        },
                         state,
                         ability.source_id,
                         &ability.targets,
@@ -95,17 +98,16 @@ pub fn resolve(
                     }
                 }
                 None => {
-                    // CR 609.7a: prompt the source choice; stash self so the
-                    // shield is built on the second pass with the choice known.
-                    // "a source of your choice" admits ANY damage source — the
-                    // `ChosenDamageSource` filter is the post-choice *referent*,
-                    // not a candidate constraint, so enumerate candidates with
-                    // `TargetFilter::Any`.
-                    let options = choose_damage_source::damage_source_options(
-                        state,
-                        ability,
-                        &TargetFilter::Any,
-                    );
+                    // CR 609.7 + CR 609.7a: prompt the source choice; stash self so
+                    // the shield is built on the second pass with the choice known.
+                    // The bare "a source of your choice" form admits ANY damage
+                    // source; the qualified form ("a blue source of your choice")
+                    // restricts the LEGAL candidates to the qualifier. A single
+                    // `prompt_filter` binding drives BOTH candidate enumeration and
+                    // the `WaitingFor` prompt so they cannot diverge.
+                    let prompt_filter = qualifier.as_deref().cloned().unwrap_or(TargetFilter::Any);
+                    let options =
+                        choose_damage_source::damage_source_options(state, ability, &prompt_filter);
                     // If no legal source exists, the replacement does nothing
                     // (CR 609.7a) — fall through with no source filter rather
                     // than wedging on an empty prompt.
@@ -114,7 +116,7 @@ pub fn resolve(
                             Some(PendingContinuation::new(Box::new(ability.clone())));
                         state.waiting_for = WaitingFor::DamageSourceChoice {
                             player: ability.controller,
-                            source_filter: TargetFilter::Any,
+                            source_filter: prompt_filter,
                             options,
                         };
                         events.push(GameEvent::EffectResolved {
@@ -777,7 +779,7 @@ mod tests {
         ResolvedAbility::new(
             Effect::CreateDamageReplacement {
                 // "a source of your choice" → ChosenDamageSource.
-                source_filter: Some(TargetFilter::ChosenDamageSource),
+                source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
                 combat_scope: None,
                 target_filter: None,
                 modification: None,
@@ -835,7 +837,7 @@ mod tests {
         // resolver) while the choice is live, then clears it.
         state.last_chosen_damage_source = Some(ChosenDamageSource {
             source_id: chosen_source,
-            source_filter: TargetFilter::ChosenDamageSource,
+            source_filter: TargetFilter::ChosenDamageSource { filter: None },
         });
         let cont = state
             .pending_continuation
@@ -896,7 +898,7 @@ mod tests {
 
         let ability = ResolvedAbility::new(
             Effect::CreateDamageReplacement {
-                source_filter: Some(TargetFilter::ChosenDamageSource),
+                source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
                 combat_scope: None,
                 target_filter: None,
                 modification: Some(DamageModification::Double),
@@ -935,7 +937,7 @@ mod tests {
         // Drive directly to the captured state (choice already made).
         state.last_chosen_damage_source = Some(ChosenDamageSource {
             source_id: chosen_source,
-            source_filter: TargetFilter::ChosenDamageSource,
+            source_filter: TargetFilter::ChosenDamageSource { filter: None },
         });
         let ability = chosen_source_redirect_ability(host, PlayerId(0));
         let mut events = Vec::new();
@@ -1107,11 +1109,11 @@ mod tests {
         // Source already chosen (covered separately by the source-choice tests).
         state.last_chosen_damage_source = Some(ChosenDamageSource {
             source_id: chosen_source,
-            source_filter: TargetFilter::ChosenDamageSource,
+            source_filter: TargetFilter::ChosenDamageSource { filter: None },
         });
         let ability = ResolvedAbility::new(
             Effect::CreateDamageReplacement {
-                source_filter: Some(TargetFilter::ChosenDamageSource),
+                source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
                 combat_scope: None,
                 target_filter: None,
                 modification: None,

--- a/crates/engine/src/game/effects/prevent_damage.rs
+++ b/crates/engine/src/game/effects/prevent_damage.rs
@@ -1,3 +1,4 @@
+use crate::game::effects::choose_damage_source;
 use crate::game::quantity::resolve_quantity;
 use crate::types::ability::{
     CombatDamageScope, DamageTargetFilter, DamageTargetPlayerScope, Effect, EffectError,
@@ -5,7 +6,7 @@ use crate::types::ability::{
     ResolvedAbility, SubAbilityLink, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, PendingContinuation, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::replacements::ReplacementEvent;
@@ -51,7 +52,7 @@ pub(crate) fn resolve_source_filter(
             })
             .map(|id| TargetFilter::SpecificObject { id })
             .unwrap_or(TargetFilter::None),
-        TargetFilter::ChosenDamageSource => state
+        TargetFilter::ChosenDamageSource { .. } => state
             .last_chosen_damage_source
             .as_ref()
             .map(|choice| {
@@ -59,7 +60,7 @@ pub(crate) fn resolve_source_filter(
                     id: choice.source_id,
                 };
                 match &choice.source_filter {
-                    TargetFilter::ChosenDamageSource | TargetFilter::Any => identity,
+                    TargetFilter::ChosenDamageSource { .. } | TargetFilter::Any => identity,
                     other => {
                         let recheck =
                             resolve_source_filter(other, state, source_id, ability_targets);
@@ -284,6 +285,48 @@ pub fn resolve(
     ) {
         shield = shield.expiry(expiry);
     }
+
+    // CR 609.7 + CR 609.7a: "prevent that damage" from "a <color/type> source of
+    // your choice" (Circle/Rune of Protection cycles) — the source is a player
+    // choice. Unlike `create_damage_replacement::resolve`, this resolver had no
+    // self-prompt path, so the choice was never offered. Prompt it now and
+    // re-enter as a continuation; the recorded choice (with its qualifier stored
+    // on `last_chosen_damage_source.source_filter`) is then resolved into a
+    // durable `SpecificObject` + qualifier `And` shield by `resolve_source_filter`
+    // below. A single `prompt_filter` drives both candidate enumeration and the
+    // `WaitingFor` prompt so they cannot diverge.
+    let effect_source_filter = match &effect_source_filter {
+        Some(TargetFilter::ChosenDamageSource { filter: qualifier }) => {
+            if state.last_chosen_damage_source.is_none() {
+                let prompt_filter = qualifier.as_deref().cloned().unwrap_or(TargetFilter::Any);
+                let options =
+                    choose_damage_source::damage_source_options(state, ability, &prompt_filter);
+                if !options.is_empty() {
+                    state.pending_continuation =
+                        Some(PendingContinuation::new(Box::new(ability.clone())));
+                    state.waiting_for = WaitingFor::DamageSourceChoice {
+                        player: ability.controller,
+                        source_filter: prompt_filter,
+                        options,
+                    };
+                    events.push(GameEvent::EffectResolved {
+                        kind: EffectKind::PreventDamage,
+                        source_id: ability.source_id,
+                    });
+                    return Ok(());
+                }
+                // CR 609.7a: no legal candidate — falls through with the record
+                // still absent; the post-choice logic below then resolves
+                // `resolve_source_filter`'s ChosenDamageSource arm against an empty
+                // `last_chosen_damage_source`, producing a `TargetFilter::None`
+                // shield that matches nothing (this activation does nothing).
+                effect_source_filter.clone()
+            } else {
+                effect_source_filter.clone()
+            }
+        }
+        other => other.clone(),
+    };
 
     // CR 615 + CR 614.1a: Resolve damage source filter from effect definition.
     // Filters using IsChosenColor need the chosen color resolved from the source object
@@ -616,7 +659,7 @@ mod tests {
                 amount_dynamic: None,
                 target: TargetFilter::Any,
                 scope: PreventionScope::AllDamage,
-                damage_source_filter: Some(TargetFilter::ChosenDamageSource),
+                damage_source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
                 prevention_duration: None,
             },
             vec![],
@@ -633,6 +676,327 @@ mod tests {
                 filters: vec![TargetFilter::SpecificObject { id: chosen }, source_filter],
             })
         );
+    }
+
+    // ---- Circle/Rune of Protection: "a <color/type> source of your choice" ----
+
+    /// A `Typed` color qualifier matching objects whose color includes `color`.
+    fn color_qualifier(color: ManaColor) -> TargetFilter {
+        TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::HasColor { color }]))
+    }
+
+    /// A Circle/Rune of Protection prevention ability: "prevent that damage" from
+    /// "a <qualifier> source of your choice". `qualifier: None` is the bare form.
+    fn source_choice_prevent_ability(
+        source: ObjectId,
+        qualifier: Option<TargetFilter>,
+    ) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::PreventDamage {
+                amount: PreventionAmount::All,
+                amount_dynamic: None,
+                target: TargetFilter::Any,
+                scope: PreventionScope::AllDamage,
+                damage_source_filter: Some(TargetFilter::ChosenDamageSource {
+                    filter: qualifier.map(Box::new),
+                }),
+                prevention_duration: None,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        )
+    }
+
+    /// Deal `amount` noncombat damage from `source` to player 0.
+    fn deal_source_damage_to_p0(state: &mut GameState, source: ObjectId, amount: i32) {
+        let ability = ResolvedAbility::new(
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: amount },
+                target: TargetFilter::Player,
+                damage_source: None,
+                excess: None,
+            },
+            vec![TargetRef::Player(PlayerId(0))],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        deal_damage::resolve(state, &ability, &mut events).expect("damage resolves");
+    }
+
+    fn add_colored_source(
+        state: &mut GameState,
+        card: u64,
+        owner: PlayerId,
+        name: &str,
+        color: ManaColor,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(card),
+            owner,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&id).unwrap().color = vec![color];
+        id
+    }
+
+    /// CR 609.7 + CR 609.7b: the PROMPT for "a red source of your choice" must
+    /// offer ONLY red sources as legal choices. Reverting the resolver's new
+    /// self-prompt block leaves `waiting_for` unchanged (no prompt), so the match
+    /// arm panics — this is the primary discriminating assertion.
+    #[test]
+    fn circle_of_protection_red_prompt_options_are_color_filtered() {
+        let mut state = GameState::new_two_player(42);
+        let cop = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Circle of Protection: Red".to_string(),
+            Zone::Battlefield,
+        );
+        let red = add_colored_source(&mut state, 2, PlayerId(1), "Red Source", ManaColor::Red);
+        let blue = add_colored_source(&mut state, 3, PlayerId(1), "Blue Source", ManaColor::Blue);
+
+        let ability = source_choice_prevent_ability(cop, Some(color_qualifier(ManaColor::Red)));
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::DamageSourceChoice { options, .. } => {
+                assert!(options.contains(&red), "red source must be a legal choice");
+                assert!(
+                    !options.contains(&blue),
+                    "blue source must NOT be offered for Circle of Protection: Red"
+                );
+            }
+            other => panic!("expected DamageSourceChoice prompt, got {other:?}"),
+        }
+    }
+
+    /// Sibling/negative: the BARE "a source of your choice" form (qualifier None)
+    /// must offer BOTH the red and blue sources — proving the qualified and bare
+    /// paths are genuinely distinguished, not both hard-filtered/unfiltered.
+    #[test]
+    fn bare_source_of_your_choice_prompt_offers_all_colors() {
+        let mut state = GameState::new_two_player(42);
+        let host = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Jade Monolith".to_string(),
+            Zone::Battlefield,
+        );
+        let red = add_colored_source(&mut state, 2, PlayerId(1), "Red Source", ManaColor::Red);
+        let blue = add_colored_source(&mut state, 3, PlayerId(1), "Blue Source", ManaColor::Blue);
+
+        let ability = source_choice_prevent_ability(host, None);
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::DamageSourceChoice { options, .. } => {
+                assert!(
+                    options.contains(&red),
+                    "bare form must offer the red source"
+                );
+                assert!(
+                    options.contains(&blue),
+                    "bare form must offer the blue source"
+                );
+            }
+            other => panic!("expected DamageSourceChoice prompt, got {other:?}"),
+        }
+    }
+
+    /// CR 609.7b + multi-authority: with TWO red sources present, the shield built
+    /// after choosing one via the real `GameAction::ChooseDamageSource` pipeline
+    /// prevents ONLY the chosen source's damage — the other red source's damage is
+    /// dealt normally even though it also matches the color qualifier.
+    #[test]
+    fn circle_of_protection_red_prevents_only_chosen_red_source() {
+        let mut state = GameState::new_two_player(42);
+        let cop = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Circle of Protection: Red".to_string(),
+            Zone::Battlefield,
+        );
+        let red1 = add_colored_source(&mut state, 2, PlayerId(1), "Red One", ManaColor::Red);
+        let red2 = add_colored_source(&mut state, 3, PlayerId(1), "Red Two", ManaColor::Red);
+
+        let ability = source_choice_prevent_ability(cop, Some(color_qualifier(ManaColor::Red)));
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // Drive the real choice through the engine resolution pipeline (this
+        // exercises `engine_resolution_choices` + the pending-continuation
+        // re-entry that builds the durable shield).
+        crate::game::engine::apply_as_current(
+            &mut state,
+            crate::types::actions::GameAction::ChooseDamageSource { source: red1 },
+        )
+        .expect("submit damage source choice");
+
+        // Chosen red source: damage prevented.
+        deal_source_damage_to_p0(&mut state, red1, 3);
+        assert_eq!(
+            state.players[0].life, 20,
+            "chosen red source's damage must be prevented"
+        );
+        // Other red source: damage NOT prevented (identity mismatch, CR 609.7b).
+        deal_source_damage_to_p0(&mut state, red2, 3);
+        assert_eq!(
+            state.players[0].life, 17,
+            "a different red source's damage must NOT be prevented"
+        );
+    }
+
+    /// CR 609.7b: the shield rechecks the chosen source's live color at damage
+    /// time. If the chosen source loses its red color before dealing damage, the
+    /// shield does not apply (and, having never matched, is not consumed).
+    #[test]
+    fn recolored_chosen_source_defeats_color_qualified_shield() {
+        let mut state = GameState::new_two_player(42);
+        let cop = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Circle of Protection: Red".to_string(),
+            Zone::Battlefield,
+        );
+        let red = add_colored_source(&mut state, 2, PlayerId(1), "Red Source", ManaColor::Red);
+
+        let ability = source_choice_prevent_ability(cop, Some(color_qualifier(ManaColor::Red)));
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        crate::game::engine::apply_as_current(
+            &mut state,
+            crate::types::actions::GameAction::ChooseDamageSource { source: red },
+        )
+        .expect("submit damage source choice");
+        // CR 615.3: the source (Circle of Protection) is a battlefield permanent,
+        // so the untargeted shield hosts on the source object, not the pending
+        // registry. Reach-guard: prove the shield was actually installed.
+        assert_eq!(
+            state
+                .objects
+                .get(&cop)
+                .unwrap()
+                .replacement_definitions
+                .len(),
+            1,
+            "shield must exist before the recheck"
+        );
+
+        // CR 609.7b: chosen source becomes colorless before it deals damage.
+        state.objects.get_mut(&red).unwrap().color = vec![];
+        deal_source_damage_to_p0(&mut state, red, 3);
+        assert_eq!(
+            state.players[0].life, 17,
+            "damage from a now-colorless source must NOT be prevented"
+        );
+        // CR 609.7b: a shield that never matched must not be consumed.
+        assert!(
+            !state.objects.get(&cop).unwrap().replacement_definitions[0].is_consumed,
+            "a shield that never matched must not be consumed (CR 609.7b)"
+        );
+    }
+
+    /// CR 609.7a: no legal source (no red objects anywhere) — no prompt fires and
+    /// the ability resolves as a no-op shield that matches nothing; the game does
+    /// not hang or error.
+    #[test]
+    fn circle_of_protection_red_no_legal_source_is_noop() {
+        let mut state = GameState::new_two_player(42);
+        let cop = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Circle of Protection: Red".to_string(),
+            Zone::Battlefield,
+        );
+        let blue = add_colored_source(&mut state, 2, PlayerId(1), "Blue Source", ManaColor::Blue);
+
+        let ability = source_choice_prevent_ability(cop, Some(color_qualifier(ManaColor::Red)));
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::DamageSourceChoice { .. }),
+            "no legal red source means no prompt should fire"
+        );
+        // The blue source's damage is not prevented (the no-op shield matches
+        // nothing).
+        deal_source_damage_to_p0(&mut state, blue, 3);
+        assert_eq!(
+            state.players[0].life, 17,
+            "no-op shield must not prevent any damage"
+        );
+    }
+
+    /// Rune of Protection: Lands exercises the TYPE-qualifier branch: the prompt
+    /// must offer only Land sources, not a creature source.
+    #[test]
+    fn rune_of_protection_lands_prompt_options_are_type_filtered() {
+        let mut state = GameState::new_two_player(42);
+        let rune = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Rune of Protection: Lands".to_string(),
+            Zone::Battlefield,
+        );
+        let land = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Damaging Land".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&land)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Land);
+        let creature = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "A Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&creature)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let land_qualifier = TargetFilter::Typed(TypedFilter::land());
+        let ability = source_choice_prevent_ability(rune, Some(land_qualifier));
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::DamageSourceChoice { options, .. } => {
+                assert!(
+                    options.contains(&land),
+                    "land source must be a legal choice"
+                );
+                assert!(
+                    !options.contains(&creature),
+                    "creature source must NOT be offered for Rune of Protection: Lands"
+                );
+            }
+            other => panic!("expected DamageSourceChoice prompt, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -100,7 +100,7 @@ pub(crate) fn affected_filter_uses_object_population(filter: &TargetFilter) -> b
         | TargetFilter::PostReplacementDamageTargetOwner
         | TargetFilter::DefendingPlayer
         | TargetFilter::HasChosenName
-        | TargetFilter::ChosenDamageSource
+        | TargetFilter::ChosenDamageSource { .. }
         | TargetFilter::Named { .. }
         | TargetFilter::Owner
         // CR 201.5a: append-only; GrantingObject is concretized to SpecificObject
@@ -317,7 +317,7 @@ pub(crate) fn entered_object_perturbs_affected_filter(
         | TargetFilter::PostReplacementDamageTargetOwner
         | TargetFilter::DefendingPlayer
         | TargetFilter::HasChosenName
-        | TargetFilter::ChosenDamageSource
+        | TargetFilter::ChosenDamageSource { .. }
         | TargetFilter::Named { .. }
         | TargetFilter::Owner
         // CR 201.5a: append-only; GrantingObject is concretized to SpecificObject
@@ -1935,7 +1935,7 @@ fn filter_inner_for_object(
         }
         // CR 609.7a: "the chosen source" — match the ObjectId selected by
         // the prior damage-source choice while its continuation resolves.
-        TargetFilter::ChosenDamageSource => {
+        TargetFilter::ChosenDamageSource { .. } => {
             let recheck_ctx = FilterContext {
                 source_id,
                 source_controller,
@@ -1952,7 +1952,7 @@ fn filter_inner_for_object(
                     choice.source_id == object_id
                         && (matches!(
                             &choice.source_filter,
-                            TargetFilter::Any | TargetFilter::ChosenDamageSource
+                            TargetFilter::Any | TargetFilter::ChosenDamageSource { .. }
                         ) || matches_target_filter(
                             state,
                             object_id,
@@ -2168,7 +2168,7 @@ fn zone_change_filter_inner(
             });
             chosen_name.is_some_and(|name| record.name.eq_ignore_ascii_case(name))
         }
-        TargetFilter::ChosenDamageSource => false,
+        TargetFilter::ChosenDamageSource { .. } => false,
         TargetFilter::Named { name } => record.name == *name,
 
         // CR 603.10a + CR 603.6e + CR 702.6: `AttachedTo` against a zone-change
@@ -2516,7 +2516,7 @@ pub fn spell_record_matches_filter(
         | TargetFilter::PostReplacementDamageTargetOwner
         | TargetFilter::DefendingPlayer
         | TargetFilter::HasChosenName
-        | TargetFilter::ChosenDamageSource
+        | TargetFilter::ChosenDamageSource { .. }
         // CR 201.5a: append-only (concretized before runtime).
         | TargetFilter::GrantingObject
         | TargetFilter::Owner => false,
@@ -2826,7 +2826,7 @@ fn spell_object_matches_filter_inner(
         | TargetFilter::PostReplacementDamageTargetOwner
         | TargetFilter::DefendingPlayer
         | TargetFilter::HasChosenName
-        | TargetFilter::ChosenDamageSource
+        | TargetFilter::ChosenDamageSource { .. }
         | TargetFilter::Named { .. }
         // CR 201.5a: append-only (concretized before runtime).
         | TargetFilter::GrantingObject

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -813,7 +813,7 @@ pub(super) fn target_filter_matches_object(
         | TargetFilter::TrackedSetFiltered { .. }
         | TargetFilter::ExiledBySource
         | TargetFilter::HasChosenName
-        | TargetFilter::ChosenDamageSource
+        | TargetFilter::ChosenDamageSource { .. }
         | TargetFilter::Named { .. } => super::filter::matches_target_filter(
             state,
             object_id,

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -16654,14 +16654,14 @@ mod tests {
         assert!(matches!(
             &*win.effect,
             Effect::CreateDamageReplacement {
-                source_filter: Some(TargetFilter::ChosenDamageSource),
+                source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
                 ..
             }
         ));
         assert!(matches!(
             &*lose.effect,
             Effect::PreventDamage {
-                damage_source_filter: Some(TargetFilter::ChosenDamageSource),
+                damage_source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
                 ..
             }
         ));

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3496,12 +3496,12 @@ fn rewrite_oneshot_selfref_to_chosen_in_effect(effect: &mut Effect) {
             damage_source_filter,
             ..
         } if matches!(damage_source_filter, Some(TargetFilter::SelfRef)) => {
-            *damage_source_filter = Some(TargetFilter::ChosenDamageSource);
+            *damage_source_filter = Some(TargetFilter::ChosenDamageSource { filter: None });
         }
         Effect::CreateDamageReplacement { source_filter, .. }
             if matches!(source_filter, Some(TargetFilter::SelfRef)) =>
         {
-            *source_filter = Some(TargetFilter::ChosenDamageSource);
+            *source_filter = Some(TargetFilter::ChosenDamageSource { filter: None });
         }
         Effect::FlipCoin {
             win_effect,

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -5753,10 +5753,43 @@ fn parse_oneshot_source_filter(body: &str) -> Option<TargetFilter> {
     .parse(subject)
     {
         if rest.trim().is_empty() {
-            return Some(TargetFilter::ChosenDamageSource);
+            return Some(TargetFilter::ChosenDamageSource { filter: None });
         }
     }
+    // CR 609.7 + CR 609.7b: qualified form — "a red source of your choice",
+    // "a land source of your choice" (Circle/Rune of Protection cycles).
+    if let Some(filter) = parse_qualified_chosen_damage_source(subject) {
+        return Some(filter);
+    }
     parse_damage_source_filter(body)
+}
+
+/// CR 609.7 + CR 609.7b: "a <color/type> source of your choice" (Circle of
+/// Protection cycle, Rune of Protection cycle) — the qualifier restricts which
+/// source may be chosen and is retained on the variant so the resolver can (a)
+/// offer only matching candidates when prompting the choice and (b) recheck
+/// source qualities at damage time. Parses the qualifier with `parse_type_phrase`
+/// directly (the shared color/type/supertype phrase combinator used throughout
+/// this file), which resolves a bare core type word like "land" to the correct
+/// `TypeFilter::Land` — so any future color/type/supertype word `parse_type_phrase`
+/// recognizes is covered for free, not just the 13 Circle/Rune of Protection cards.
+fn parse_qualified_chosen_damage_source(subject: &str) -> Option<TargetFilter> {
+    let (rest, _) = nom_primitives::parse_article.parse(subject).ok()?;
+    let (filter, rest) = parse_type_phrase(rest.trim_start());
+    if matches!(filter, TargetFilter::Any) {
+        // Bare "source" — not a qualifier; the caller's bare-anaphor branch
+        // handles "a source of your choice" directly.
+        return None;
+    }
+    let (rest, _) = tag::<_, _, OracleError<'_>>("source of your choice")
+        .parse(rest.trim_start())
+        .ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+    Some(TargetFilter::ChosenDamageSource {
+        filter: Some(Box::new(filter)),
+    })
 }
 
 /// CR 614.9: Parse the redirection recipient from the result clause by scanning
@@ -17543,7 +17576,7 @@ mod snapshot_tests {
             Effect::CreateDamageReplacement {
                 modification: Some(DamageModification::Double),
                 redirect_to: None,
-                source_filter: Some(TargetFilter::ChosenDamageSource),
+                source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
                 combat_scope: None,
                 ..
             } => {}
@@ -17616,7 +17649,7 @@ mod snapshot_tests {
                 modification: None,
                 redirect_to: Some(DamageRedirectTarget::SourceObject),
                 redirect_amount: None,
-                source_filter: Some(TargetFilter::ChosenDamageSource),
+                source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
                 ..
             } => {}
             other => panic!("expected redirect-to-source, got {other:?}"),
@@ -17635,7 +17668,7 @@ mod snapshot_tests {
                 modification: None,
                 redirect_to: Some(DamageRedirectTarget::Controller),
                 redirect_amount: None,
-                source_filter: Some(TargetFilter::ChosenDamageSource),
+                source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
                 // CR 614.9: "would deal damage to target creature" — the
                 // protected creature is a chosen original-recipient target, not
                 // a broad scope (Defect 3). `target_filter` must stay None.
@@ -17686,6 +17719,78 @@ mod snapshot_tests {
                     Some(TargetFilter::SelfRef),
                     "isolated one-shot keeps SelfRef until chain threading"
                 );
+            }
+            other => panic!("expected PreventDamage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oneshot_prevention_qualified_color_source_of_your_choice() {
+        // Circle of Protection: Red (verbatim Scryfall Oracle text) — "{1}: The
+        // next time a red source of your choice would deal damage to you this
+        // turn, prevent that damage." The qualifier must be RETAINED on the
+        // variant (CR 609.7/609.7b) so the resolver prompts only red sources and
+        // rechecks color at damage time — NOT dropped to an unconstrained shield.
+        let effect = parse_oneshot_damage_replacement(
+            "the next time a red source of your choice would deal damage to you this turn, prevent that damage",
+        )
+        .expect("Circle of Protection: Red must parse");
+        match effect {
+            Effect::PreventDamage {
+                damage_source_filter,
+                ..
+            } => {
+                let Some(TargetFilter::ChosenDamageSource {
+                    filter: Some(inner),
+                }) = damage_source_filter
+                else {
+                    panic!("expected qualified ChosenDamageSource, got {damage_source_filter:?}");
+                };
+                match *inner {
+                    TargetFilter::Typed(tf) => assert!(
+                        tf.properties.iter().any(|p| matches!(
+                            p,
+                            FilterProp::HasColor {
+                                color: ManaColor::Red
+                            }
+                        )),
+                        "inner qualifier must constrain to red sources, got {tf:?}"
+                    ),
+                    other => panic!("expected Typed color qualifier, got {other:?}"),
+                }
+            }
+            other => panic!("expected PreventDamage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oneshot_prevention_qualified_land_source_of_your_choice() {
+        // Rune of Protection: Lands (verbatim Scryfall Oracle text) — "{W}: The
+        // next time a land source of your choice would deal damage to you this
+        // turn, prevent that damage." Exercises the TYPE-qualifier branch
+        // (distinct from the color-qualified Circles/Runes).
+        let effect = parse_oneshot_damage_replacement(
+            "the next time a land source of your choice would deal damage to you this turn, prevent that damage",
+        )
+        .expect("Rune of Protection: Lands must parse");
+        match effect {
+            Effect::PreventDamage {
+                damage_source_filter,
+                ..
+            } => {
+                let Some(TargetFilter::ChosenDamageSource {
+                    filter: Some(inner),
+                }) = damage_source_filter
+                else {
+                    panic!("expected qualified ChosenDamageSource, got {damage_source_filter:?}");
+                };
+                match *inner {
+                    TargetFilter::Typed(tf) => assert!(
+                        tf.type_filters.contains(&TypeFilter::Land),
+                        "inner qualifier must constrain to Land sources, got {tf:?}"
+                    ),
+                    other => panic!("expected Typed Land qualifier, got {other:?}"),
+                }
             }
             other => panic!("expected PreventDamage, got {other:?}"),
         }

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -1962,7 +1962,7 @@ fn usable_disjunctive_permission_filter(filter: &TargetFilter) -> bool {
         | TargetFilter::PostReplacementDamageTargetOwner
         | TargetFilter::DefendingPlayer
         | TargetFilter::HasChosenName
-        | TargetFilter::ChosenDamageSource
+        | TargetFilter::ChosenDamageSource { .. }
         | TargetFilter::Named { .. }
         | TargetFilter::Owner
         | TargetFilter::AllPlayers => false,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4539,7 +4539,15 @@ pub enum TargetFilter {
     /// CR 609.7a: Matches the object stored as the source's chosen damage source.
     /// Resolution-time prevention effects should resolve this to `SpecificObject`
     /// when the shield is created so global shields do not depend on a live source.
-    ChosenDamageSource,
+    /// CR 609.7 + CR 609.7b: `filter` optionally constrains which sources are LEGAL
+    /// to choose — e.g. "a blue source of your choice" (Circle/Rune of Protection)
+    /// restricts the choice to blue sources and is rechecked against the chosen
+    /// object's live properties when damage would be dealt; `None` is the bare "a
+    /// source of your choice" / "that source" form (any source is a legal choice).
+    ChosenDamageSource {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter: Option<Box<TargetFilter>>,
+    },
     /// Matches objects with a specific hardcoded name.
     /// Used for "card named [literal]" patterns.
     Named {

--- a/crates/engine/tests/integration/issue_circle_of_protection_source_choice.rs
+++ b/crates/engine/tests/integration/issue_circle_of_protection_source_choice.rs
@@ -1,0 +1,105 @@
+//! Circle of Protection / Rune of Protection cycles — "a <color/type> source of
+//! your choice ... prevent that damage" must parse into a `PreventDamage` effect
+//! whose `damage_source_filter` is a QUALIFIED `ChosenDamageSource` (retaining
+//! the color/type qualifier), not a bare/unconstrained shield. Verifies the real
+//! production parser path against verbatim Scryfall Oracle text.
+
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{AbilityKind, Effect, FilterProp, TargetFilter, TypeFilter};
+use engine::types::keywords::Keyword;
+use engine::types::mana::ManaColor;
+
+// Verbatim Scryfall Oracle text (fetched 2026-07).
+const COP_RED: &str =
+    "{1}: The next time a red source of your choice would deal damage to you this turn, prevent that damage.";
+const RUNE_LANDS: &str = "{W}: The next time a land source of your choice would deal damage to you this turn, prevent that damage.\nCycling {2} ({2}, Discard this card: Draw a card.)";
+
+/// Extract the single `PreventDamage` effect from a parsed card.
+fn prevent_damage_source_filter(parsed: &engine::parser::oracle::ParsedAbilities) -> TargetFilter {
+    parsed
+        .abilities
+        .iter()
+        .find_map(|a| match a.effect.as_ref() {
+            Effect::PreventDamage {
+                damage_source_filter: Some(f),
+                ..
+            } => Some(f.clone()),
+            _ => None,
+        })
+        .expect("card must have a PreventDamage ability with a source filter")
+}
+
+#[test]
+fn circle_of_protection_red_parses_qualified_chosen_source() {
+    let parsed = parse_oracle_text(
+        COP_RED,
+        "Circle of Protection: Red",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+
+    // The prevention lives on an activated ability.
+    assert!(
+        parsed
+            .abilities
+            .iter()
+            .any(|a| matches!(a.kind, AbilityKind::Activated)),
+        "Circle of Protection: Red's prevention must be an activated ability"
+    );
+
+    match prevent_damage_source_filter(&parsed) {
+        TargetFilter::ChosenDamageSource {
+            filter: Some(inner),
+        } => match *inner {
+            TargetFilter::Typed(tf) => assert!(
+                tf.properties.iter().any(|p| matches!(
+                    p,
+                    FilterProp::HasColor {
+                        color: ManaColor::Red
+                    }
+                )),
+                "qualifier must constrain to red sources, got {tf:?}"
+            ),
+            other => panic!("expected Typed red qualifier, got {other:?}"),
+        },
+        other => panic!("expected qualified ChosenDamageSource, got {other:?}"),
+    }
+}
+
+#[test]
+fn rune_of_protection_lands_parses_type_qualifier_and_keeps_cycling_separate() {
+    let parsed = parse_oracle_text(
+        RUNE_LANDS,
+        "Rune of Protection: Lands",
+        &["Cycling".to_string()],
+        &["Enchantment".to_string()],
+        &[],
+    );
+
+    match prevent_damage_source_filter(&parsed) {
+        TargetFilter::ChosenDamageSource {
+            filter: Some(inner),
+        } => match *inner {
+            TargetFilter::Typed(tf) => assert!(
+                tf.type_filters.contains(&TypeFilter::Land),
+                "qualifier must constrain to Land sources, got {tf:?}"
+            ),
+            other => panic!("expected Typed Land qualifier, got {other:?}"),
+        },
+        other => panic!("expected qualified ChosenDamageSource, got {other:?}"),
+    }
+
+    // Cycling is a keyword-only line: the parser decomposes it into
+    // `extracted_keywords` (as `Keyword::Cycling`), NOT a second entry in
+    // `abilities`. Assert it is present there, independent of the prevention
+    // clause — the prevention line is not swallowed and Cycling is not lost.
+    assert!(
+        parsed
+            .extracted_keywords
+            .iter()
+            .any(|kw| matches!(kw, Keyword::Cycling(_))),
+        "Rune of Protection: Lands must extract Cycling as a keyword alongside its prevention ability, got keywords: {:?}",
+        parsed.extracted_keywords,
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -478,6 +478,7 @@ mod issue_927_tireless_provisioner;
 mod issue_934_ring_goes_south;
 mod issue_941_champions_full_party;
 mod issue_bound_by_moonsilver_sacrifice_attach;
+mod issue_circle_of_protection_source_choice;
 mod issue_desperate_gambit_choose_damage_source;
 mod issue_haze_frog_other_creature_prevention;
 mod jace_wielder_empty_library_win;

--- a/crates/mtgish-import/src/convert/condition.rs
+++ b/crates/mtgish-import/src/convert/condition.rs
@@ -1099,7 +1099,7 @@ fn target_filter_variant_name(f: &TargetFilter) -> &'static str {
         TargetFilter::PostReplacementDamageTargetOwner => "PostReplacementDamageTargetOwner",
         TargetFilter::DefendingPlayer => "DefendingPlayer",
         TargetFilter::HasChosenName => "HasChosenName",
-        TargetFilter::ChosenDamageSource => "ChosenDamageSource",
+        TargetFilter::ChosenDamageSource { .. } => "ChosenDamageSource",
         TargetFilter::Named { .. } => "Named",
         TargetFilter::Owner => "Owner",
         TargetFilter::SourceChosenPlayer => "SourceChosenPlayer",

--- a/crates/mtgish-import/src/convert/replacement.rs
+++ b/crates/mtgish-import/src/convert/replacement.rs
@@ -387,7 +387,9 @@ fn recipient_to_damage_target_filter(r: &SingleDamageRecipient) -> Option<Damage
 
 fn single_damage_source_to_filter(source: &SingleDamageSource) -> TargetFilter {
     match source {
-        SingleDamageSource::TheChosenDamageSource => TargetFilter::ChosenDamageSource,
+        SingleDamageSource::TheChosenDamageSource => {
+            TargetFilter::ChosenDamageSource { filter: None }
+        }
     }
 }
 
@@ -3442,7 +3444,10 @@ mod tests {
         else {
             panic!("expected PreventDamage, got {effect:?}");
         };
-        assert_eq!(damage_source_filter, Some(TargetFilter::ChosenDamageSource));
+        assert_eq!(
+            damage_source_filter,
+            Some(TargetFilter::ChosenDamageSource { filter: None })
+        );
     }
 
     #[test]

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4776
-- **Total card appearances across root causes:** 4810 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4763
+- **Total card appearances across root causes:** 4797 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -22,7 +22,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 8 | Additional / alternative casting cost dropped | 210 | oracle_cost.rs — parse additional/alternative cost clauses into Spell.cost / AdditionalCost |
 | 9 | Wrong player/controller scope (You where Opponent/Scoped/Target/Defending needed) | 182 | oracle parser ControllerRef binding — resolve scoped/defending/iterated player refs instead of defaulting to You |
 | 10 | Trigger event/mode unrecognized → Unknown | 168 | oracle_trigger.rs — add typed TriggerMode variants for the unrecognized event classes |
-| 11 | Replacement / prevention / 'instead' effect mis-modeled | 170 | add-replacement-effect: route 'would … instead' into replacements[]; preserve damage_source/target filters |
+| 11 | Replacement / prevention / 'instead' effect mis-modeled | 157 | add-replacement-effect: route 'would … instead' into replacements[]; preserve damage_source/target filters |
 | 12 | Modal 'choose one/N' parsed as independent abilities | 138 | oracle.rs modal dispatch — detect 'Choose one —' header, wrap modes in Effect::ChooseOneOf |
 | 13 | State/game-state condition → StaticCondition::Unrecognized | 134 | oracle_nom/condition.rs parse_inner_condition — add typed variant for the predicate class |
 | 14 | Granted/quoted ability or continuous modification dropped | 95 | oracle_static.rs continuous-modification extraction — emit all conjuncts incl. GrantAbility/GrantKeyword |
@@ -3654,7 +3654,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 11. Replacement / prevention / 'instead' effect mis-modeled  (170 cards)
+### 11. Replacement / prevention / 'instead' effect mis-modeled  (157 cards)
 
 **Signature.** A continuous replacement / damage-prevention / redirection clause (CR 614/615) is emitted as a one-shot Spell or unconditional sequential sibling, dropping the 'instead'/replacement semantics or the source/recipient filter.
 
@@ -3689,13 +3689,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Channel Harm
 - Charm Peddler
 - Circle of Protection: Art
-- Circle of Protection: Artifacts
-- Circle of Protection: Black
-- Circle of Protection: Blue
-- Circle of Protection: Green
-- Circle of Protection: Red
 - Circle of Protection: Shadow
-- Circle of Protection: White
 - Coalition Victory
 - Consign to Dream
 - Containment Priest
@@ -3793,13 +3787,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Reed Richards, Smartest Man
 - Reflect Damage
 - Reflective Gate
-- Rune of Protection: Artifacts
-- Rune of Protection: Black
-- Rune of Protection: Blue
-- Rune of Protection: Green
-- Rune of Protection: Lands
-- Rune of Protection: Red
-- Rune of Protection: White
 - Samite Blessing
 - Sanctum Guardian
 - Sandman's Quicksand


### PR DESCRIPTION
## Summary

Fixes a real 13-card class where **"the next time a `<color/type>` source of your choice would deal damage to you this turn, prevent that damage"** (Circle of Protection cycle + Rune of Protection cycle) was mishandled by the parser and resolver.

**Affected cards** (confirmed via Scryfall for all 13, verbatim grammar identical modulo cost and the color/type qualifier):
- Circle of Protection: Artifacts, Black, Blue, Green, Red, White
- Rune of Protection: Artifacts, Black, Blue, Green, Lands, Red, White

**Circle of Protection: Shadow** is explicitly excluded — it uses an unrelated `ChooseAPermanent` + Shadow-matching mechanic, not `ChooseADamageSource`.

CR 609.7 (`docs/MagicCompRules.txt`) literally quotes Circle of Protection: Red's Oracle text as its own worked example — this is a foundational rules mechanic, not a narrow card-specific fix.

## Root cause

Two independent, compounding gaps:

1. **Parser** — `parse_oneshot_source_filter` (`oracle_replacement.rs`) only recognized a *bare*, unqualified `"a source of your choice"` / `"that source"`. A qualified form like `"a blue source of your choice"` fell through the whole chain and returned `None` entirely. Net effect: these 13 cards currently create a **fully unconstrained** "prevent the next damage this turn from *any* source" shield, with **no interactive choice ever prompted** — strictly worse than doing nothing, since it silently over-delivers value with zero player agency.
2. **Resolver** — `prevent_damage.rs::resolve` (the resolver these cards actually route through, not `create_damage_replacement.rs`) had **zero** "prompt if not yet chosen" logic. Its sibling `create_damage_replacement.rs::resolve` already had this exact self-prompt pattern for the bare form (hardcoded to `TargetFilter::Any`) — `prevent_damage.rs` never got the equivalent.

## Fix

- Parameterized `TargetFilter::ChosenDamageSource` from a bare unit variant into `ChosenDamageSource { filter: Option<Box<TargetFilter>> }`, following the **direct existing precedent** of `PlayerFilter::OpponentDealtDamage { source: Option<Box<TargetFilter>> }` (`types/ability.rs:5751-5757`) and its scanner-recursion pattern (`ability_scan.rs:3039-3049`) — not a new pattern.
- Added `parse_qualified_chosen_damage_source` (`oracle_replacement.rs`), reusing `parse_type_phrase` for the qualifier — the same building block `parse_damage_source_subject_filter` already composes elsewhere in this file for non-anaphoric forms.
- Threaded the qualifier through **both** resolvers' self-prompt blocks via a single `prompt_filter` binding, consumed by *both* the candidate-enumeration call *and* `WaitingFor::DamageSourceChoice.source_filter` — so the **interactive prompt itself** is qualifier-filtered (e.g. Circle of Protection: Red only ever offers red sources as choices), not just the CR 609.7b post-choice recheck. A dedicated test (`circle_of_protection_red_prompt_options_are_color_filtered`) asserts `WaitingFor::DamageSourceChoice.options` directly, specifically to catch a regression where only the recheck stays qualifier-aware but the prompt itself silently reverts to `Any`.
- Added the missing self-prompt block to `prevent_damage.rs`, mirroring `create_damage_replacement.rs`'s existing one.
- Updated ~24 production match sites (`ability_rw.rs`, `ability_scan.rs`, `cost_payability.rs`, `coverage.rs`, `filter.rs`, `trigger_matchers.rs`, `oracle_effect/lower.rs`, `oracle_static/restriction.rs`) to compile against the new struct-variant shape. `ability_scan.rs`'s scanner arm is the one site needing real compositional logic (recursing into the nested filter for `Axes` computation), not just a mechanical `{ .. }` — it mirrors the `OpponentDealtDamage` precedent exactly.
- **Cross-crate compile-compat**: `crates/mtgish-import` (a separate workspace member) pattern-matched the old unit-variant shape in 3 places (`convert/replacement.rs`, `convert/condition.rs`), which would have broken `cargo check --workspace`. Updated mechanically (`{ filter: None }` / `{ .. }`) — no new converter functionality, purely keeping it compiling against a type it already references.

No `ControllerRef`/`bool` shortcuts anywhere; `Option<Box<TargetFilter>>` is the established idiom for this exact "optional nested filter on a fixed-shape variant" pattern.

## Gate A — parser combinator compliance

```
$ ./scripts/check-parser-combinators.sh
(exit 0, no violations)
```

## Gate B — anchored citations (≥2)

- [`crates/engine/src/types/ability.rs:5751-5757`](../../blob/main/crates/engine/src/types/ability.rs) — `PlayerFilter::OpponentDealtDamage { source: Option<Box<TargetFilter>> }`, the direct precedent for `ChosenDamageSource`'s new field shape.
- [`crates/engine/src/game/ability_scan.rs:3039-3049`](../../blob/main/crates/engine/src/game/ability_scan.rs) — that precedent's scanner-recursion pattern, mirrored exactly for `ChosenDamageSource`'s own `scan_target_filter` arm.
- [`crates/engine/src/game/effects/create_damage_replacement.rs`](../../blob/main/crates/engine/src/game/effects/create_damage_replacement.rs) (existing self-prompt block, lines ~79-131 pre-diff) — the pattern mirrored into `prevent_damage.rs`'s new block.

## CR references

- **CR 609.7** — this rule's own worked example is Circle of Protection: Red's Oracle text verbatim.
- **CR 609.7a** — the source is chosen when the effect is created.
- **CR 609.7b** — the shield rechecks the chosen source's properties when it would deal damage (the live recheck, distinct from the snapshotted identity).
- **CR 514.2** — "this turn" duration cleanup.
- **CR 614.5** — one-shot replacement consumption.
- **CR 615.3** — relevant to shield hosting: a battlefield-permanent source (Circle/Rune of Protection) hosts its shield on the source object's own `replacement_definitions`, not a global pending-registry — this distinction surfaced and was correctly resolved during a test-authoring fix mid-implementation (see Validation below).

## Tier

**Tier: Frontier**

Justification: this is a 13-card foundational-mechanic fix that parameterizes a shared `TargetFilter` enum variant across ~24 production match sites in the engine plus 3 sites in a separate workspace crate, adds a new resolver code path (`prevent_damage.rs` previously had no self-prompt logic at all), and went through 3 rounds of plan review and 3 rounds of implementation review before landing — substantially beyond a single-arm parser fix.

**Model:** claude-sonnet-5
**Thinking:** high

## Validation performed

- `cargo fmt --all` — clean (pre- and post-rebase)
- `./scripts/check-parser-combinators.sh` — exit 0
- Parser dispatch grep gate — clean (no string-dispatch primitives in added lines)
- CR-annotation diff gate — all 6 citations verified against `docs/MagicCompRules.txt`, zero `UNVERIFIED`
- `cargo clippy -p engine -p mtgish-import --all-targets -- -D warnings` — clean, zero warnings (confirmed **pre-rebase**)
- `cargo check --workspace --all-targets` — clean, confirms every workspace crate (engine, mtgish-import, engine-wasm, phase-ai, phase-server, draft-core, draft-wasm, lobby-broker, seat-reducer, manabrew-compat, feed-scraper, engine-inventory-gen) compiles against the new `ChosenDamageSource` shape
- `cargo test -p engine --lib` — **15962 passed, 0 failed, 6 ignored** (confirmed **pre-rebase**)
- `cargo test -p engine --test integration` — **2563 passed, 0 failed, 2 ignored** (confirmed **pre-rebase**) — includes a dedicated new test file covering both the color-qualifier branch (Circle of Protection: Red) and the type-qualifier branch (Rune of Protection: Lands, which also confirms its independent `Cycling` line decomposes correctly and doesn't interact with the prevention clause)
- Full discriminating-test coverage: the interactive-prompt path itself (not just the post-choice recheck), a multi-authority hostile fixture (two same-qualifier sources, only the chosen one affected), a CR 609.7b recheck-failure fixture (chosen source's color changes before damage — shield doesn't fire, isn't consumed), a no-legal-candidate fixture (empty prompt, no hang), and the bare-form regression guard (Desperate Gambit / Beacon of Destiny / Jade Monolith's existing unqualified form still works, proven by a paired test showing it offers *all* candidates rather than a qualified subset)
- Independent `/review-impl` — **3 rounds**. Round 1 found 2 issues (a test asserting the wrong shield-storage location due to a genuine CR 615.3 nuance — permanent-sourced shields host on the object, not a global registry — and a broken integration-test assertion expecting `Cycling` to appear as a second `ability` rather than in `extracted_keywords`), both fixed. Round 2 (a deliberate holistic fresh-eyes pass) found the `mtgish-import` cross-crate compile break described above, fixed and independently re-verified via direct `cargo check --workspace`. Round 3 confirmed clean end-to-end.

## Validation NOT performed (disclosed honestly)

Post-rebase, this branch could not get a **post-rebase** re-confirmation of `cargo clippy` or `cargo test -p engine --lib` — 5 consecutive attempts of each were killed mid-compile at the identical "Compiling engine v0.20.0" stage, with the system independently confirmed idle (no resource contention) each time via direct process inspection. This matches an unrelated, intermittent background-task environment issue observed repeatedly elsewhere in this session (resolved by simple retries in most other cases; this branch happened to hit the retry ceiling on both commands). The rebase itself introduced **zero code conflicts** — only `docs/parser-misparse-backlog.md`'s top-summary totals needed manual arithmetic reconciliation against a sibling PR merged in the interim (Nettling Imp, #5463) — so the regression risk from the rebase is low, but I'm not claiming a post-rebase clippy/test re-run happened when it didn't.

## Backlog hygiene

Removed all 13 cards from `docs/parser-misparse-backlog.md`'s category 11 list, decrementing that category's count (170→157) and the top-summary totals accordingly (rebased onto the post-#5463 baseline: 4776→4763 distinct, 4810→4797 total appearances). `Circle of Protection: Shadow` and the pre-existing unrelated `Circle of Protection: Art` stray entry are correctly retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
