### PR TITLE
fix(parser): scope "attacks enchanted player" trigger to the attached player (Curse of Predation #4744)

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8713,6 +8713,11 @@ fn try_parse_event(
                 value(AttackTargetFilter::Player, tag(" one of your opponents")),
                 value(AttackTargetFilter::Player, tag(" a player")),
                 value(AttackTargetFilter::Player, tag(" you")),
+                // CR 303.4a + CR 508.1a: "attacks enchanted player" — a Curse Aura
+                // trigger scoped to the player this permanent is attached to. The
+                // type axis is Player; the player-identity scope is set below via
+                // `valid_target = AttachedTo` (Curse of Predation, Curse of Bloodletting).
+                value(AttackTargetFilter::Player, tag(" enchanted player")),
                 value(AttackTargetFilter::Battle, tag(" a battle")),
             ))
             .parse(input)
@@ -8758,6 +8763,17 @@ fn try_parse_event(
             def.valid_target = Some(TargetFilter::Typed(
                 TypedFilter::default().controller(ControllerRef::Opponent),
             ));
+        } else if tag::<_, _, OracleError<'_>>(" enchanted player")
+            .parse(after)
+            .is_ok()
+        {
+            // CR 303.4a + CR 109.4: "attacks enchanted player" scopes the trigger
+            // to the player this Curse Aura is attached to. `AttachedTo` resolves
+            // to `source.attached_to.as_player()` in `player_matches_filter`, so
+            // the trigger fires only when the enchanted player is the defender
+            // (Curse of Predation, Curse of Bloodletting). Without this the trigger
+            // has no defender scope and fires on every attack, anywhere.
+            def.valid_target = Some(TargetFilter::AttachedTo);
         } else if matches!(
             def.attack_target_filter,
             Some(AttackTargetFilter::PlayerOrPlaneswalker) | Some(AttackTargetFilter::Player)

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8713,10 +8713,12 @@ fn try_parse_event(
                 value(AttackTargetFilter::Player, tag(" one of your opponents")),
                 value(AttackTargetFilter::Player, tag(" a player")),
                 value(AttackTargetFilter::Player, tag(" you")),
-                // CR 303.4a + CR 508.1a: "attacks enchanted player" — a Curse Aura
-                // trigger scoped to the player this permanent is attached to. The
-                // type axis is Player; the player-identity scope is set below via
-                // `valid_target = AttachedTo` (Curse of Predation, Curse of Bloodletting).
+                // CR 303.4e: "attacks enchanted player" — a Curse Aura trigger
+                // scoped to the player this permanent is attached to (whose
+                // controller is separate from the Aura's controller). The type axis
+                // is Player; the player-identity scope is set below via
+                // `valid_target = AttachedTo` (Curse of Predation, Curse of Chaos,
+                // Curse of Inertia).
                 value(AttackTargetFilter::Player, tag(" enchanted player")),
                 value(AttackTargetFilter::Battle, tag(" a battle")),
             ))
@@ -8767,12 +8769,14 @@ fn try_parse_event(
             .parse(after)
             .is_ok()
         {
-            // CR 303.4a + CR 109.4: "attacks enchanted player" scopes the trigger
-            // to the player this Curse Aura is attached to. `AttachedTo` resolves
-            // to `source.attached_to.as_player()` in `player_matches_filter`, so
-            // the trigger fires only when the enchanted player is the defender
-            // (Curse of Predation, Curse of Bloodletting). Without this the trigger
-            // has no defender scope and fires on every attack, anywhere.
+            // CR 303.4e: "attacks enchanted player" scopes the trigger to the
+            // player this Curse Aura is attached to (whose controller is distinct
+            // from the Aura's controller). `AttachedTo` resolves to
+            // `source.attached_to.as_player()` in `player_matches_filter`
+            // (`game/trigger_matchers.rs`), so the trigger fires only when the
+            // enchanted player is the defender (Curse of Predation, Curse of Chaos,
+            // Curse of Inertia). Without this the trigger has no defender scope and
+            // fires on every attack, anywhere.
             def.valid_target = Some(TargetFilter::AttachedTo);
         } else if matches!(
             def.attack_target_filter,

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -2800,6 +2800,26 @@ fn trigger_attacks_you_or_planeswalker_you_control() {
     assert_eq!(def.valid_target, Some(TargetFilter::Controller));
 }
 
+/// Issue #4744 — Curse of Predation: "Whenever a creature attacks enchanted
+/// player, put a +1/+1 counter on it." The "enchanted player" defender scope
+/// must bind to the Aura's attached player (`valid_target = AttachedTo`), not be
+/// dropped — otherwise the trigger fires whenever any creature attacks anyone
+/// (CR 303.4a + CR 508.1a).
+#[test]
+fn trigger_attacks_enchanted_player_scopes_to_attached_player() {
+    let def = parse_trigger_line(
+        "Whenever a creature attacks enchanted player, put a +1/+1 counter on it.",
+        "Curse of Predation",
+    );
+    assert_eq!(def.mode, TriggerMode::Attacks);
+    assert_eq!(def.attack_target_filter, Some(AttackTargetFilter::Player));
+    assert_eq!(
+        def.valid_target,
+        Some(TargetFilter::AttachedTo),
+        "'attacks enchanted player' must scope the defender to the attached player"
+    );
+}
+
 #[test]
 fn opponent_attacks_that_player_library_binds_to_triggering_player() {
     let def = parse_trigger_line(

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -2804,7 +2804,8 @@ fn trigger_attacks_you_or_planeswalker_you_control() {
 /// player, put a +1/+1 counter on it." The "enchanted player" defender scope
 /// must bind to the Aura's attached player (`valid_target = AttachedTo`), not be
 /// dropped — otherwise the trigger fires whenever any creature attacks anyone
-/// (CR 303.4a + CR 508.1a).
+/// (CR 303.4e). Runtime firing is covered by the discriminating integration
+/// test `curse_of_predation_scopes_counter_to_enchanted_player`.
 #[test]
 fn trigger_attacks_enchanted_player_scopes_to_attached_player() {
     let def = parse_trigger_line(

--- a/crates/engine/tests/integration/curse_of_predation_attacks_enchanted_player_4744.rs
+++ b/crates/engine/tests/integration/curse_of_predation_attacks_enchanted_player_4744.rs
@@ -1,0 +1,128 @@
+//! Issue #4744 — Curse of Predation: "Whenever a creature attacks enchanted
+//! player, put a +1/+1 counter on it."
+//!
+//! The "enchanted player" defender scope must bind to the Aura's attached
+//! player (parsed as `valid_target = AttachedTo`). Before the fix the trigger
+//! had no defender scope and fired on every attack anywhere; the risk the fix
+//! introduces is the opposite failure — if enchant-player attachment doesn't
+//! populate `attached_to` as a player, the trigger would never fire. This test
+//! discriminates both directions:
+//!   1. A creature attacks the ENCHANTED player  → the attacker gets a counter.
+//!   2. A creature attacks a DIFFERENT player     → no counter is placed.
+//!
+//! CR references:
+//!   - CR 303.4e: An Aura's controller is separate from the enchanted player;
+//!     the trigger's defender scope is the attached player, resolved at runtime
+//!     via `TargetFilter::AttachedTo` (`game/trigger_matchers.rs`).
+//!   - CR 508.1a: The active player chooses which creatures will attack.
+
+use engine::game::effects::attach::attach_to_player;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::trigger_index::reindex_object_triggers;
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+use super::rules::AttackTarget;
+
+const CURSE_OF_PREDATION_ORACLE: &str = "Enchant player\n\
+     Whenever a creature attacks enchanted player, put a +1/+1 counter on it.";
+
+/// +1/+1 counters on `id`.
+fn plus_one_counters(runner: &GameRunner, id: ObjectId) -> u32 {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .and_then(|o| o.counters.get(&CounterType::Plus1Plus1).copied())
+        .unwrap_or(0)
+}
+
+/// Curse of Predation enchants P1; a creature P0 controls attacks P1 (the
+/// enchanted player). The attacking creature must gain a +1/+1 counter.
+#[test]
+fn curse_of_predation_counter_placed_when_enchanted_player_attacked() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let curse_id = {
+        let mut builder = scenario.add_creature(P0, "Curse of Predation", 0, 0);
+        builder.as_enchantment();
+        builder.with_subtypes(vec!["Aura", "Curse"]);
+        builder.from_oracle_text(CURSE_OF_PREDATION_ORACLE);
+        builder.id()
+    };
+    // P0 attacks the enchanted player (P1) with this creature.
+    let attacker = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    for _ in 0..10 {
+        scenario.add_card_to_library_top(P0, "Plains");
+        scenario.add_card_to_library_top(P1, "Plains");
+    }
+
+    let mut runner = scenario.build();
+    attach_to_player(runner.state_mut(), curse_id, P1);
+    evaluate_layers(runner.state_mut());
+    reindex_object_triggers(runner.state_mut(), curse_id);
+
+    assert_eq!(
+        plus_one_counters(&runner, attacker),
+        0,
+        "no counter before combat"
+    );
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P1))])
+        .expect("DeclareAttackers should succeed");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        plus_one_counters(&runner, attacker),
+        1,
+        "attacking the enchanted player must place a +1/+1 counter on the attacker"
+    );
+}
+
+/// Discriminator: Curse of Predation enchants P1, but a creature attacks P0 (a
+/// DIFFERENT player). The trigger must NOT fire — no counter is placed. Without
+/// the defender scope this test fails (the trigger would fire on any attack);
+/// if the fix over-corrected and `AttachedTo` never resolved, the positive test
+/// above would fail instead. Together they pin both failure modes.
+#[test]
+fn curse_of_predation_no_counter_when_non_enchanted_player_attacked() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let curse_id = {
+        let mut builder = scenario.add_creature(P0, "Curse of Predation", 0, 0);
+        builder.as_enchantment();
+        builder.with_subtypes(vec!["Aura", "Curse"]);
+        builder.from_oracle_text(CURSE_OF_PREDATION_ORACLE);
+        builder.id()
+    };
+    // P1 attacks P0 — P0 is NOT the enchanted player (P1 is).
+    let attacker = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    for _ in 0..10 {
+        scenario.add_card_to_library_top(P0, "Plains");
+        scenario.add_card_to_library_top(P1, "Plains");
+    }
+
+    let mut runner = scenario.build();
+    attach_to_player(runner.state_mut(), curse_id, P1);
+    evaluate_layers(runner.state_mut());
+    reindex_object_triggers(runner.state_mut(), curse_id);
+
+    runner.state_mut().active_player = P1;
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P0))])
+        .expect("DeclareAttackers should succeed");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        plus_one_counters(&runner, attacker),
+        0,
+        "attacking a non-enchanted player must NOT place a counter (defender scope)"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -67,6 +67,7 @@ mod curse_co_departed_enchanted_player_trigger;
 mod curse_misc_triggers;
 mod curse_of_conformity_base_pt_and_lose_types;
 mod curse_of_deaths_hold_continuous_effect;
+mod curse_of_predation_attacks_enchanted_player_4744;
 mod curse_of_the_nightly_hunt_must_attack;
 mod curse_of_the_restless_dead_land_enters_trigger;
 mod curse_spell_cast_triggers;


### PR DESCRIPTION
## Summary

Fixes #4744. **Curse of Predation** — *"Whenever a creature attacks **enchanted player**, put a +1/+1 counter on it."* — parsed to a bare `Attacks` trigger with **no defender scope**, so it fired whenever any creature attacked *anyone*. The curse handed out +1/+1 counters for every attack on the board, not just attacks against the enchanted player.

## Root cause

The attack-trigger parser's `parse_attack_target` combinator recognized `" you"`, `" a player"`, `" a planeswalker"`, `" a battle"` — but had **no arm for `" enchanted player"`**, so the qualifier was silently dropped and the trigger had no defender scope.

## Fix (parser-only — the runtime already supports it)

- Add the `" enchanted player"` arm (type axis = `AttackTargetFilter::Player`).
- Set `valid_target = TargetFilter::AttachedTo` for it — `player_matches_filter` already resolves `AttachedTo` to the Aura's attached player (`source.attached_to.as_player()`).

**No engine/type change.** The runtime path is already proven: the existing `attacks_trigger_matches_player_host_for_attached_to_target` test shows an `AttachedTo`-scoped `Attacks` trigger fires **only** when the enchanted player is the defender and **not** when another player is attacked. The parser now feeds that tested path.

## Class

The Curse cycle's attack triggers (Curse of Predation, Curse of Bloodletting, …) — any "whenever … attacks enchanted player".

## Tests

- **Parser** (`trigger_attacks_enchanted_player_scopes_to_attached_player`): Curse of Predation parses to `Attacks` + `attack_target_filter = Player` + `valid_target = AttachedTo` (mirrors the existing "attacks you" → `Controller` test).
- **Runtime** coverage is provided by the pre-existing `attacks_trigger_matches_player_host_for_attached_to_target` (enchanted player attacked → matches; other player attacked → does not).

## Verification

- `cargo check -p engine` / `cargo clippy -p engine` — clean
- Suites pass: `parser::oracle_trigger` (985), `game::trigger_matchers` (254) — zero failures.

CR 303.4a (Aura attached to a player) + CR 508.1a (attack declaration) + CR 109.4 (defended player identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)