### PR TITLE
feat(engine-wasm): preview_action — non-mutating dry-run of public deltas

### DIFF
--- a/client/src/wasm/engine_wasm.d.ts
+++ b/client/src/wasm/engine_wasm.d.ts
@@ -268,6 +268,22 @@ export function load_replay_for_playback(json_str: string): number;
 export function ping(): string;
 
 /**
+ * Issue #5468: non-mutating dry-run of `action` for `actor`. Runs the action on
+ * a throwaway clone (the live `GAME_STATE` is never touched) and returns the
+ * PUBLIC deltas — life-total changes, public-zone object transitions, created
+ * tokens, and objects that ceased to exist — a viewer could observe, for
+ * hover-preview UX ("this kills that", "you take 4").
+ *
+ * Hidden-zone movements never leak: the diff is taken over
+ * `filter_state_for_viewer` snapshots (so any identity the viewer can't see is
+ * already redacted), AND a transition is surfaced only when at least one
+ * endpoint is a public zone (see `engine::game::preview`), so a fully-hidden
+ * hand↔library draw is elided even for the acting player's opponents. Returns
+ * an error string when `action` is malformed or illegal in the current state.
+ */
+export function preview_action_js(actor: number, action: any): any;
+
+/**
  * Project an authoritative seat view from Rust so frontend transports do not
  * need to understand format topology details.
  */
@@ -430,6 +446,7 @@ export interface InitOutput {
     readonly load_card_database: (a: number, b: number) => [number, number, number];
     readonly load_replay_for_playback: (a: number, b: number) => [number, number, number];
     readonly ping: () => [number, number];
+    readonly preview_action_js: (a: number, b: any) => any;
     readonly project_seat_view: (a: number, b: number) => [number, number, number];
     readonly replay_seek_js: (a: number) => [number, number, number];
     readonly resolve_all: (a: number, b: number, c: number, d: number) => [number, number, number];

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -10,9 +10,10 @@ use engine::ai_support::{auto_pass_recommended, legal_actions_for_viewer, legal_
 use engine::database::legality::{any_ai_difficulty_is_cedh, validate_cedh_bracket};
 use engine::database::{CardDatabase, CardSearchQuery};
 use engine::game::engine::{
-    apply, resolve_all_fast_forward, ResolveAllCallbackDecision,
+    apply, apply_for_simulation, resolve_all_fast_forward, ResolveAllCallbackDecision,
     ResolveAllFastForwardResult as BatchResolveResult,
 };
+use engine::game::preview::compute_preview_diff;
 use engine::game::{
     can_pair_commanders, deck_copy_limit_for, estimate_bracket, evaluate_deck_compatibility,
     filter_state_for_viewer, finalize_public_state, is_brawl_commander_eligible,
@@ -1210,6 +1211,46 @@ pub fn get_viewer_snapshot_js(player_id: u32) -> JsValue {
     }) {
         Ok(val) => val,
         Err(_) => JsValue::NULL,
+    }
+}
+
+/// Issue #5468: non-mutating dry-run of `action` for `actor`. Runs the action on
+/// a throwaway clone (the live `GAME_STATE` is never touched) and returns the
+/// PUBLIC deltas — life-total changes and public-zone object transitions — a
+/// viewer could observe, for hover-preview UX ("this kills that", "you take 4").
+///
+/// Hidden-zone movements never leak: the diff is taken over
+/// `filter_state_for_viewer` snapshots AND restricted to public zones (see
+/// `engine::game::preview`), so draws, random discards from hand, and library
+/// shuffles are elided even for the acting player's opponents. Returns an error
+/// string when `action` is malformed or illegal in the current state.
+#[wasm_bindgen]
+pub fn preview_action_js(actor: u8, action: JsValue) -> JsValue {
+    let action: GameAction = match serde_wasm_bindgen::from_value(action) {
+        Ok(a) => a,
+        Err(e) => {
+            return JsValue::from_str(&format!("Engine error: failed to deserialize action: {e}"));
+        }
+    };
+    let actor = PlayerId(actor);
+    match with_state(|state| {
+        // Simulate on a throwaway clone. `apply_for_simulation` is the same rules
+        // resolution the AI look-ahead uses; it mutates only `sim`, never the
+        // live `GAME_STATE` this closure borrows immutably.
+        let mut sim = state.clone();
+        engine::game::layers::flush_layers(&mut sim);
+        let before = filter_state_for_viewer(&sim, actor);
+        match apply_for_simulation(&mut sim, actor, action) {
+            Ok(_) => {
+                let after = filter_state_for_viewer(&sim, actor);
+                Ok(compute_preview_diff(&before, &after))
+            }
+            Err(e) => Err(format!("Engine error: {e}")),
+        }
+    }) {
+        Ok(Ok(diff)) => to_js(&diff),
+        Ok(Err(msg)) => JsValue::from_str(&msg),
+        Err(e) => e,
     }
 }
 

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -1216,14 +1216,16 @@ pub fn get_viewer_snapshot_js(player_id: u32) -> JsValue {
 
 /// Issue #5468: non-mutating dry-run of `action` for `actor`. Runs the action on
 /// a throwaway clone (the live `GAME_STATE` is never touched) and returns the
-/// PUBLIC deltas — life-total changes and public-zone object transitions — a
-/// viewer could observe, for hover-preview UX ("this kills that", "you take 4").
+/// PUBLIC deltas — life-total changes, public-zone object transitions, created
+/// tokens, and objects that ceased to exist — a viewer could observe, for
+/// hover-preview UX ("this kills that", "you take 4").
 ///
 /// Hidden-zone movements never leak: the diff is taken over
-/// `filter_state_for_viewer` snapshots AND restricted to public zones (see
-/// `engine::game::preview`), so draws, random discards from hand, and library
-/// shuffles are elided even for the acting player's opponents. Returns an error
-/// string when `action` is malformed or illegal in the current state.
+/// `filter_state_for_viewer` snapshots (so any identity the viewer can't see is
+/// already redacted), AND a transition is surfaced only when at least one
+/// endpoint is a public zone (see `engine::game::preview`), so a fully-hidden
+/// hand↔library draw is elided even for the acting player's opponents. Returns
+/// an error string when `action` is malformed or illegal in the current state.
 #[wasm_bindgen]
 pub fn preview_action_js(actor: u8, action: JsValue) -> JsValue {
     let action: GameAction = match serde_wasm_bindgen::from_value(action) {

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -124,6 +124,7 @@ pub mod planechase;
 mod planechase_tests;
 pub mod planeswalker;
 pub mod players;
+pub mod preview;
 pub mod printed_cards;
 pub mod priority;
 pub mod public_state;

--- a/crates/engine/src/game/preview.rs
+++ b/crates/engine/src/game/preview.rs
@@ -77,22 +77,20 @@ pub fn compute_preview_diff(before: &GameState, after: &GameState) -> PreviewDif
     let mut zone_changes = Vec::new();
     let mut created = Vec::new();
     for (id, a) in &after.objects {
+        // Only surface transitions where BOTH ends are public — a hand→battlefield
+        // cast or library→hand draw is elided so the preview can't reveal a hidden
+        // card's identity or a random draw/discard outcome.
         match before.objects.get(id) {
-            Some(b) => {
-                // Only surface transitions where BOTH ends are public — a
-                // hand→battlefield cast or library→hand draw is elided so the
-                // preview can't reveal a hidden card's identity or a random
-                // draw/discard outcome.
-                if b.zone != a.zone && zone_is_public(b.zone) && zone_is_public(a.zone) {
-                    zone_changes.push(ZoneChange {
-                        object_id: *id,
-                        name: a.name.clone(),
-                        controller: a.controller,
-                        from: b.zone,
-                        to: a.zone,
-                    });
-                }
+            Some(b) if b.zone != a.zone && zone_is_public(b.zone) && zone_is_public(a.zone) => {
+                zone_changes.push(ZoneChange {
+                    object_id: *id,
+                    name: a.name.clone(),
+                    controller: a.controller,
+                    from: b.zone,
+                    to: a.zone,
+                });
             }
+            Some(_) => {}
             None if zone_is_public(a.zone) => created.push(*id),
             None => {}
         }

--- a/crates/engine/src/game/preview.rs
+++ b/crates/engine/src/game/preview.rs
@@ -8,10 +8,10 @@
 //!
 //! Hidden-information safety is guaranteed two ways: callers pass
 //! `filter_state_for_viewer` outputs (hands/libraries/face-down identities
-//! already redacted), AND this only reports transitions BETWEEN public zones
-//! plus life totals — so no hidden-zone movement (draws, random discards from
-//! hand, library shuffles) is ever surfaced, even for the acting player's
-//! opponents. CR 400.2 draws the public/hidden zone line.
+//! already redacted, including in `ZoneChange.name`), AND a transition is
+//! surfaced only when at least one endpoint is a public zone — so a
+//! fully-hidden hand↔library move (a draw) is never surfaced. CR 400.2 draws
+//! the public/hidden zone line.
 
 use serde::{Deserialize, Serialize};
 
@@ -38,6 +38,18 @@ pub struct LifeDelta {
     pub delta: i32,
 }
 
+/// An object that ceased to exist during the action (`from` = the public zone it
+/// left). CR 111.7 / CR 704.5d: a token that leaves the battlefield/stack is
+/// removed by state-based actions, so it is simply gone from the after-snapshot —
+/// the headline "this kills that" case when the victim is a token.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CeasedObject {
+    pub object_id: ObjectId,
+    pub name: String,
+    pub controller: PlayerId,
+    pub from: Zone,
+}
+
 /// The public, viewer-safe result of previewing an action.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct PreviewDiff {
@@ -45,6 +57,10 @@ pub struct PreviewDiff {
     pub zone_changes: Vec<ZoneChange>,
     /// Objects newly present in a public zone (e.g. a created token).
     pub created: Vec<ObjectId>,
+    /// Objects that were in a public zone before and ceased to exist (e.g. a
+    /// token that died), so they appear in neither `after.objects` nor
+    /// `zone_changes`.
+    pub ceased: Vec<CeasedObject>,
 }
 
 /// CR 400.2: a zone whose contents every player can see. Hand and Library are
@@ -56,10 +72,15 @@ fn zone_is_public(zone: Zone) -> bool {
 /// Diff two snapshots (before/after an action) into the PUBLIC deltas a viewer
 /// could legitimately observe.
 ///
-/// Callers MUST pass `filter_state_for_viewer` outputs; on top of that this only
-/// emits public-zone-to-public-zone transitions and life-total changes, so
-/// hidden-zone movements never leak. Output ordering is deterministic (sorted by
-/// id) for stable client rendering.
+/// Callers MUST pass `filter_state_for_viewer` outputs, so any identity the
+/// viewer may not see (opponents' hands, libraries, face-down cards) is already
+/// redacted in the snapshots and in `ZoneChange.name`. On top of that, a
+/// transition is only surfaced when at least ONE endpoint is a public zone: a
+/// departure from a public zone is public information even if the destination is
+/// hidden (a bounce), and an arrival into a public zone is public even if the
+/// origin was hidden (a cast from hand, a mill). Only fully-hidden
+/// hand↔library moves (draws, hand shuffles) are elided, since neither endpoint
+/// is observable. Output ordering is deterministic (sorted by id).
 pub fn compute_preview_diff(before: &GameState, after: &GameState) -> PreviewDiff {
     let mut life_deltas = Vec::new();
     for a in &after.players {
@@ -77,11 +98,10 @@ pub fn compute_preview_diff(before: &GameState, after: &GameState) -> PreviewDif
     let mut zone_changes = Vec::new();
     let mut created = Vec::new();
     for (id, a) in &after.objects {
-        // Only surface transitions where BOTH ends are public — a hand→battlefield
-        // cast or library→hand draw is elided so the preview can't reveal a hidden
-        // card's identity or a random draw/discard outcome.
         match before.objects.get(id) {
-            Some(b) if b.zone != a.zone && zone_is_public(b.zone) && zone_is_public(a.zone) => {
+            // Observable iff at least one endpoint is public (fully-hidden
+            // hand↔library moves are elided).
+            Some(b) if b.zone != a.zone && (zone_is_public(b.zone) || zone_is_public(a.zone)) => {
                 zone_changes.push(ZoneChange {
                     object_id: *id,
                     name: a.name.clone(),
@@ -95,13 +115,32 @@ pub fn compute_preview_diff(before: &GameState, after: &GameState) -> PreviewDif
             None => {}
         }
     }
+
+    // Objects present before and gone after ceased to exist (CR 111.7 /
+    // CR 704.5d — a token leaving battlefield/stack via SBAs). Only report those
+    // that were in a public zone, so a token dying on the battlefield ("this
+    // kills that") surfaces while a hidden-zone disappearance stays hidden.
+    let mut ceased = Vec::new();
+    for (id, b) in &before.objects {
+        if !after.objects.contains_key(id) && zone_is_public(b.zone) {
+            ceased.push(CeasedObject {
+                object_id: *id,
+                name: b.name.clone(),
+                controller: b.controller,
+                from: b.zone,
+            });
+        }
+    }
+
     zone_changes.sort_by_key(|z| z.object_id.0);
     created.sort_by_key(|id| id.0);
+    ceased.sort_by_key(|c| c.object_id.0);
 
     PreviewDiff {
         life_deltas,
         zone_changes,
         created,
+        ceased,
     }
 }
 
@@ -171,40 +210,78 @@ mod tests {
     }
 
     #[test]
-    fn elides_hidden_zone_movements() {
-        // Hand↔Library↔Battlefield transitions that touch a hidden zone must NOT
-        // be reported — no draw/discard/cast leaks a hidden identity.
+    fn reports_public_endpoint_transitions_but_elides_pure_hidden_moves() {
+        // Widened predicate (#5491 review): a transition with at least one PUBLIC
+        // endpoint is observable and reported; only fully-hidden hand↔library
+        // moves (draws) are elided. A creation into a hidden zone is not reported.
         let mut before = GameState::new_two_player(1);
         let mut after = before.clone();
 
-        // Draw: library → hand (both partly hidden) — elided.
-        before
-            .objects
-            .insert(ObjectId(30), obj(30, 0, "Secret", Zone::Library));
-        after
-            .objects
-            .insert(ObjectId(30), obj(30, 0, "Secret", Zone::Hand));
-        // Cast: hand → stack (hand is hidden) — elided.
+        // Cast: hand → stack (arrival into a public zone) — REPORTED.
         before
             .objects
             .insert(ObjectId(31), obj(31, 0, "Bolt", Zone::Hand));
         after
             .objects
             .insert(ObjectId(31), obj(31, 0, "Bolt", Zone::Stack));
-        // A newly-created object that lands in the LIBRARY must not count as created.
+        // Bounce: battlefield → hand (departure from a public zone) — REPORTED.
+        before
+            .objects
+            .insert(ObjectId(32), obj(32, 0, "Bear", Zone::Battlefield));
         after
             .objects
-            .insert(ObjectId(32), obj(32, 0, "Milled", Zone::Library));
+            .insert(ObjectId(32), obj(32, 0, "Bear", Zone::Hand));
+        // Draw: library → hand (both hidden) — ELIDED.
+        before
+            .objects
+            .insert(ObjectId(33), obj(33, 0, "Secret", Zone::Library));
+        after
+            .objects
+            .insert(ObjectId(33), obj(33, 0, "Secret", Zone::Hand));
+        // Milled into the library (hidden arrival) — not `created`.
+        after
+            .objects
+            .insert(ObjectId(34), obj(34, 0, "Milled", Zone::Library));
 
         let diff = compute_preview_diff(&before, &after);
-        assert!(
-            diff.zone_changes.is_empty(),
-            "hidden-zone transitions must be elided: {:?}",
+        let changed: Vec<u64> = diff.zone_changes.iter().map(|z| z.object_id.0).collect();
+        assert_eq!(
+            changed,
+            vec![31, 32],
+            "cast + bounce reported, draw elided: {:?}",
             diff.zone_changes
         );
         assert!(
             diff.created.is_empty(),
-            "objects created in a hidden zone must not be reported"
+            "hidden-zone creation is not reported"
+        );
+    }
+
+    #[test]
+    fn reports_ceased_token_but_not_hidden_disappearance() {
+        // #5491 review blocker: a token that dies (removed from `after.objects` by
+        // state-based actions, CR 111.7 / 704.5d) must still surface — the headline
+        // "this kills that" case. A disappearance from a hidden zone must not.
+        let mut before = GameState::new_two_player(1);
+        let after = before.clone();
+        // These exist only in `before` → they ceased to exist during the action.
+        before
+            .objects
+            .insert(ObjectId(40), obj(40, 0, "Zombie Token", Zone::Battlefield));
+        before
+            .objects
+            .insert(ObjectId(41), obj(41, 0, "Milled Token", Zone::Library));
+
+        let diff = compute_preview_diff(&before, &after);
+        assert_eq!(
+            diff.ceased,
+            vec![CeasedObject {
+                object_id: ObjectId(40),
+                name: "Zombie Token".to_string(),
+                controller: PlayerId(0),
+                from: Zone::Battlefield,
+            }],
+            "public-zone token death surfaces; hidden-zone disappearance stays hidden",
         );
     }
 }

--- a/crates/engine/src/game/preview.rs
+++ b/crates/engine/src/game/preview.rs
@@ -1,0 +1,212 @@
+//! Non-mutating action preview (issue #5468).
+//!
+//! Diffs the PUBLIC deltas an action would produce — life-total changes and
+//! public-zone object transitions — so an embedder can drive hover-preview UX
+//! ("this kills that", "you take 4") without committing the action. The caller
+//! runs the action on a throwaway clone (never rendered) and passes the
+//! before/after snapshots here.
+//!
+//! Hidden-information safety is guaranteed two ways: callers pass
+//! `filter_state_for_viewer` outputs (hands/libraries/face-down identities
+//! already redacted), AND this only reports transitions BETWEEN public zones
+//! plus life totals — so no hidden-zone movement (draws, random discards from
+//! hand, library shuffles) is ever surfaced, even for the acting player's
+//! opponents. CR 400.2 draws the public/hidden zone line.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::game_state::GameState;
+use crate::types::identifiers::ObjectId;
+use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
+
+/// A single object's public zone transition (e.g. `Battlefield → Graveyard` is a
+/// death; `Stack → Graveyard` is a resolved/countered spell).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZoneChange {
+    pub object_id: ObjectId,
+    pub name: String,
+    pub controller: PlayerId,
+    pub from: Zone,
+    pub to: Zone,
+}
+
+/// A player's life-total change (`delta` is signed: negative = life lost).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LifeDelta {
+    pub player: PlayerId,
+    pub delta: i32,
+}
+
+/// The public, viewer-safe result of previewing an action.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct PreviewDiff {
+    pub life_deltas: Vec<LifeDelta>,
+    pub zone_changes: Vec<ZoneChange>,
+    /// Objects newly present in a public zone (e.g. a created token).
+    pub created: Vec<ObjectId>,
+}
+
+/// CR 400.2: a zone whose contents every player can see. Hand and Library are
+/// hidden; every other zone is public.
+fn zone_is_public(zone: Zone) -> bool {
+    !matches!(zone, Zone::Hand | Zone::Library)
+}
+
+/// Diff two snapshots (before/after an action) into the PUBLIC deltas a viewer
+/// could legitimately observe.
+///
+/// Callers MUST pass `filter_state_for_viewer` outputs; on top of that this only
+/// emits public-zone-to-public-zone transitions and life-total changes, so
+/// hidden-zone movements never leak. Output ordering is deterministic (sorted by
+/// id) for stable client rendering.
+pub fn compute_preview_diff(before: &GameState, after: &GameState) -> PreviewDiff {
+    let mut life_deltas = Vec::new();
+    for a in &after.players {
+        if let Some(b) = before.players.iter().find(|p| p.id == a.id) {
+            if a.life != b.life {
+                life_deltas.push(LifeDelta {
+                    player: a.id,
+                    delta: a.life - b.life,
+                });
+            }
+        }
+    }
+    life_deltas.sort_by_key(|l| l.player.0);
+
+    let mut zone_changes = Vec::new();
+    let mut created = Vec::new();
+    for (id, a) in &after.objects {
+        match before.objects.get(id) {
+            Some(b) => {
+                // Only surface transitions where BOTH ends are public — a
+                // hand→battlefield cast or library→hand draw is elided so the
+                // preview can't reveal a hidden card's identity or a random
+                // draw/discard outcome.
+                if b.zone != a.zone && zone_is_public(b.zone) && zone_is_public(a.zone) {
+                    zone_changes.push(ZoneChange {
+                        object_id: *id,
+                        name: a.name.clone(),
+                        controller: a.controller,
+                        from: b.zone,
+                        to: a.zone,
+                    });
+                }
+            }
+            None if zone_is_public(a.zone) => created.push(*id),
+            None => {}
+        }
+    }
+    zone_changes.sort_by_key(|z| z.object_id.0);
+    created.sort_by_key(|id| id.0);
+
+    PreviewDiff {
+        life_deltas,
+        zone_changes,
+        created,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::game_object::GameObject;
+    use crate::types::identifiers::CardId;
+
+    fn obj(id: u64, owner: u8, name: &str, zone: Zone) -> GameObject {
+        GameObject::new(
+            ObjectId(id),
+            CardId(id),
+            PlayerId(owner),
+            name.to_string(),
+            zone,
+        )
+    }
+
+    #[test]
+    fn reports_life_delta_and_public_zone_change() {
+        let mut before = GameState::new_two_player(1);
+        let mut after = before.clone();
+
+        // A creature on the battlefield in `before` dies (→ graveyard) in `after`,
+        // and player 1 loses 4 life.
+        before
+            .objects
+            .insert(ObjectId(10), obj(10, 0, "Bear", Zone::Battlefield));
+        after
+            .objects
+            .insert(ObjectId(10), obj(10, 0, "Bear", Zone::Graveyard));
+        after.players[1].life = before.players[1].life - 4;
+
+        let diff = compute_preview_diff(&before, &after);
+        assert_eq!(
+            diff.zone_changes,
+            vec![ZoneChange {
+                object_id: ObjectId(10),
+                name: "Bear".to_string(),
+                controller: PlayerId(0),
+                from: Zone::Battlefield,
+                to: Zone::Graveyard,
+            }]
+        );
+        assert_eq!(
+            diff.life_deltas,
+            vec![LifeDelta {
+                player: PlayerId(1),
+                delta: -4,
+            }]
+        );
+        assert!(diff.created.is_empty());
+    }
+
+    #[test]
+    fn reports_created_token_in_public_zone() {
+        let before = GameState::new_two_player(1);
+        let mut after = before.clone();
+        after
+            .objects
+            .insert(ObjectId(20), obj(20, 0, "Soldier", Zone::Battlefield));
+
+        let diff = compute_preview_diff(&before, &after);
+        assert_eq!(diff.created, vec![ObjectId(20)]);
+        assert!(diff.zone_changes.is_empty());
+    }
+
+    #[test]
+    fn elides_hidden_zone_movements() {
+        // Hand↔Library↔Battlefield transitions that touch a hidden zone must NOT
+        // be reported — no draw/discard/cast leaks a hidden identity.
+        let mut before = GameState::new_two_player(1);
+        let mut after = before.clone();
+
+        // Draw: library → hand (both partly hidden) — elided.
+        before
+            .objects
+            .insert(ObjectId(30), obj(30, 0, "Secret", Zone::Library));
+        after
+            .objects
+            .insert(ObjectId(30), obj(30, 0, "Secret", Zone::Hand));
+        // Cast: hand → stack (hand is hidden) — elided.
+        before
+            .objects
+            .insert(ObjectId(31), obj(31, 0, "Bolt", Zone::Hand));
+        after
+            .objects
+            .insert(ObjectId(31), obj(31, 0, "Bolt", Zone::Stack));
+        // A newly-created object that lands in the LIBRARY must not count as created.
+        after
+            .objects
+            .insert(ObjectId(32), obj(32, 0, "Milled", Zone::Library));
+
+        let diff = compute_preview_diff(&before, &after);
+        assert!(
+            diff.zone_changes.is_empty(),
+            "hidden-zone transitions must be elided: {:?}",
+            diff.zone_changes
+        );
+        assert!(
+            diff.created.is_empty(),
+            "objects created in a hidden zone must not be reported"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #5468.

## What

A read-only `preview_action_js(actor, action)` that reports what submitting an action **would** do — **life-total changes** and **public-zone object transitions** (e.g. `Battlefield → Graveyard` = a death, `Stack → Graveyard` = a resolved/countered spell) — **without committing it**. This replaces the current speculative-submit + `export`/`restore_game_state` rollback (heavy per hover, and it carried the restore side effects) with a cheap dry-run, powering hover-preview UX like "this kills that" / "you take 4".

## Implementation

- New engine module **`game::preview`** owns the diff (`PreviewDiff` / `compute_preview_diff`), so the logic is **unit-tested natively** in the engine crate rather than only across the (CI-uncompiled) WASM boundary.
- **`preview_action_js`** runs the action on a **throwaway clone** via `apply_for_simulation` — the same rules resolution the AI look-ahead already uses — so the live `GAME_STATE` is never touched, then diffs the before/after snapshots.

## Hidden-information safety (two independent guards)

This is the delicate part; it's safe by construction:

1. The diff is taken over **`filter_state_for_viewer`** snapshots (hands, libraries, face-down identities, and RNG are already redacted for the actor), **and**
2. only transitions **between public zones** plus life totals are emitted (CR 400.2 public/hidden line) — so draws, random discards from hand, and library shuffles are **never** surfaced, even for the acting player's opponents.

So the preview can only ever report deltas the actor could already observe by committing the action.

## Tests (native, `engine` crate)

- `reports_life_delta_and_public_zone_change` — a creature dies + a player loses 4 life.
- `reports_created_token_in_public_zone` — a token appears.
- `elides_hidden_zone_movements` — Hand/Library transitions (draw, cast-from-hand, mill) produce **no** output.

Verified: `cargo check -p engine --tests`, `-p engine-wasm`, and `-p engine-wasm --target wasm32-unknown-unknown` all clean; `cargo fmt` clean.

## Scope

v1 covers the primary use cases (removal/combat previews). A richer payload (per-slot resolved targets, projected log lines with hidden-zone bucketing) can follow; happy to adjust the shape/seam to your preference.
