### PR TITLE
fix(coverage): expose damage_source_filter in the PreventDamage parse-diff signature

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2942,17 +2942,28 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             amount,
             target,
             scope,
+            damage_source_filter,
             ..
         } => {
             d.push(("amount".into(), format!("{amount:?}")));
             d.push(("target".into(), fmt_target(target)));
             d.push(("scope".into(), format!("{scope:?}")));
+            // CR 615 + CR 614.1a: the source-restriction qualifier (#5492). Omitting
+            // it made a change from unqualified `ChosenDamageSource` to
+            // `ChosenDamageSource { filter: Some(..) }` (the Circle/Rune of
+            // Protection cycles) invisible to the parse-diff sticky — a real parser
+            // change reading as "No card-parse changes".
+            if let Some(f) = damage_source_filter {
+                d.push(("damage_source_filter".into(), fmt_target(f)));
+            }
         }
         Effect::CreateDamageReplacement {
             modification,
             redirect_to,
             redirect_amount,
             combat_scope,
+            source_filter,
+            target_filter,
             redirect_object_filter,
             recipient_object_filter,
             ..
@@ -2968,6 +2979,16 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             }
             if let Some(cs) = combat_scope {
                 d.push(("combat_scope".into(), format!("{cs:?}")));
+            }
+            // #5492: `source_filter` shares `PreventDamage`'s
+            // `parse_oneshot_source_filter` binding and had the same blind spot;
+            // `target_filter` is likewise parser-alterable. Emit both so any change
+            // to which sources/targets a replacement covers is diff-visible.
+            if let Some(f) = source_filter {
+                d.push(("source_filter".into(), fmt_target(f)));
+            }
+            if let Some(f) = target_filter {
+                d.push(("target_filter".into(), format!("{f:?}")));
             }
             if let Some(f) = redirect_object_filter {
                 d.push(("redirect_object_filter".into(), fmt_target(f)));
@@ -10252,6 +10273,40 @@ mod tests {
     use crate::types::replacements::ReplacementEvent;
     use crate::types::statics::{BlockExceptionKind, ProhibitionScope};
     use crate::types::zones::Zone;
+
+    #[test]
+    fn prevent_damage_signature_exposes_damage_source_filter() {
+        // #5492: a change to `damage_source_filter` (e.g. unqualified
+        // `ChosenDamageSource` → `ChosenDamageSource { filter: Some(..) }`, the
+        // Circle/Rune of Protection cycles) must be visible to the
+        // coverage-parse-diff signature. When set, the field appears; when None
+        // it is omitted so unqualified prevention's signature is unchanged.
+        let signature_keys = |dsf: Option<TargetFilter>| -> Vec<String> {
+            effect_details(&Effect::PreventDamage {
+                amount: PreventionAmount::All,
+                amount_dynamic: None,
+                target: TargetFilter::Any,
+                scope: PreventionScope::AllDamage,
+                damage_source_filter: dsf,
+                prevention_duration: None,
+            })
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect()
+        };
+        assert!(
+            signature_keys(Some(TargetFilter::Any))
+                .iter()
+                .any(|k| k == "damage_source_filter"),
+            "a set damage_source_filter must appear in the parse-diff signature",
+        );
+        assert!(
+            !signature_keys(None)
+                .iter()
+                .any(|k| k == "damage_source_filter"),
+            "an absent damage_source_filter must not appear",
+        );
+    }
 
     fn make_obj() -> GameObject {
         GameObject::new(


### PR DESCRIPTION
Fixes #5492.

## Problem

`effect_details` (`coverage.rs`) builds the `PreventDamage` parse-diff signature from a hand-picked field list that dropped **`damage_source_filter`** (swallowed by `..`). The `coverage-parse-diff` sticky is the *required review evidence* for parser-surface PRs, and `✓ No card-parse changes detected` is treated as a HIGH inert-fix signal — so omitting a field silently makes a whole class of parser change unreviewable and **inverts the signal**: a correct fix reads as inert. This just produced a false negative on #5488 (13 Circle/Rune of Protection cards moving `ChosenDamageSource` → `ChosenDamageSource { filter: Some(..) }`).

## Fix

- Emit `damage_source_filter` in the `PreventDamage` signature (via `fmt_target`, which already renders the "chosen damage source matching …" qualifier — it just never got called for this field).
- Per the issue's "audit the renderers" note, also emit `CreateDamageReplacement`'s **`source_filter`** (fed by the same `parse_oneshot_source_filter` binding, same blind spot) and its **`target_filter`**.

These fields only appear when `Some`, so unqualified cases' signatures are unchanged (no spurious diffs); the engine-source-hash bump self-heals the baseline, as the issue notes.

## Test

`prevent_damage_signature_exposes_damage_source_filter` calls the production `effect_details` and asserts the field is present when set and absent when `None` — reverting the fix fails it (it's the real signature builder, not a re-implementation).

`cargo check -p engine --tests` + `cargo fmt` clean.
