### PR TITLE
fix(engine): scope AttackersDeclared trigger to attacker + defender (Cunning Rhetoric #4736)

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1808,11 +1808,20 @@ pub(super) fn match_attacks_or_blocks(
 
 pub(super) fn match_attackers_declared(
     event: &GameEvent,
-    _trigger: &TriggerDefinition,
-    _source_id: ObjectId,
-    _state: &GameState,
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
 ) -> bool {
-    matches!(event, GameEvent::AttackersDeclared { .. })
+    // CR 508.3d + CR 508.5a: "Whenever an opponent attacks you …"
+    // (`AttackersDeclared` mode — Cunning Rhetoric, Lulu Stern Guardian) must
+    // honor the attacking-player scope (`valid_source`) AND the defending-player
+    // scope (`valid_target`): the trigger fires only when a scoped opponent
+    // declares an attack against the trigger's controller. Delegate to the shared
+    // `matching_attack_events`, which applies both scopes and the once-per-attack
+    // -declaration dedup — the same authority `match_attacks` uses. Previously
+    // this returned `true` for any `AttackersDeclared` event, so an opponent
+    // attacking a *different* player (3+ player games) wrongly triggered it (#4736).
+    !matching_attack_events(event, trigger, source_id, state).is_empty()
 }
 
 /// CR 509.3d: A genuine CR 509 blocker/attacker filter is always an *object*

--- a/crates/engine/tests/integration/cunning_rhetoric_attacks_you_scope_4736.rs
+++ b/crates/engine/tests/integration/cunning_rhetoric_attacks_you_scope_4736.rs
@@ -1,0 +1,101 @@
+//! Issue #4736 — Cunning Rhetoric: "Whenever an opponent attacks you and/or one
+//! or more planeswalkers you control, exile the top card of that player's
+//! library. ..."
+//!
+//! The trigger is scoped to attacks against **you** (the controller). It parses
+//! to `TriggerMode::AttackersDeclared` with `valid_source = Opponent` and
+//! `valid_target = Controller`, but the runtime matcher ignored those scopes and
+//! fired on every attack declaration by anyone against anyone. In a 3+ player
+//! game an opponent attacking a *different* player wrongly triggered it.
+//!
+//! This test discriminates in a 4-player game:
+//!   1. Opponent P1 attacks the controller P0     → trigger fires.
+//!   2. Opponent P1 attacks a third player P2      → trigger does NOT fire.
+//!
+//! CR references:
+//!   - CR 508.3d: "Whenever [a player] attacks [a player]" fires once per attack
+//!     declaration against the scoped defending player, not once per attacker.
+//!   - CR 508.5a: the defending player is the one the attack is declared against.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+use super::rules::AttackTarget;
+
+const P2: PlayerId = PlayerId(2);
+
+const CUNNING_RHETORIC_ORACLE: &str = "Whenever an opponent attacks you and/or one or more planeswalkers you control, \
+     exile the top card of that player's library. You may play that card for as long as it remains exiled, \
+     and you may spend mana as though it were mana of any color to cast it.";
+
+/// Count triggered abilities on the stack sourced from `source`.
+fn stack_triggers_from(runner: &GameRunner, source: ObjectId) -> usize {
+    runner
+        .state()
+        .stack
+        .iter()
+        .filter(|e| e.source_id == source)
+        .count()
+}
+
+/// Set up a 4-player game: P0 controls Cunning Rhetoric; P1 (an opponent) has a
+/// creature to attack with. Returns (runner, rhetoric_id, p1_attacker_id).
+fn setup() -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new_n_player(4, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let rhetoric = {
+        let mut builder = scenario.add_creature(P0, "Cunning Rhetoric", 0, 0);
+        builder.as_enchantment();
+        builder.from_oracle_text(CUNNING_RHETORIC_ORACLE);
+        builder.id()
+    };
+    let attacker = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+
+    // Library padding so exile-top has cards and nobody decks.
+    for p in [P0, P1, P2] {
+        for _ in 0..10 {
+            scenario.add_card_to_library_top(p, "Plains");
+        }
+    }
+
+    let runner = scenario.build();
+    (runner, rhetoric, attacker)
+}
+
+/// Opponent P1 attacks the controller P0 → Cunning Rhetoric fires.
+#[test]
+fn cunning_rhetoric_fires_when_opponent_attacks_you() {
+    let (mut runner, rhetoric, attacker) = setup();
+    runner.state_mut().active_player = P1;
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P0))])
+        .expect("P1 declares an attacker against the controller P0");
+
+    assert!(
+        stack_triggers_from(&runner, rhetoric) >= 1,
+        "Cunning Rhetoric must fire when an opponent attacks its controller"
+    );
+}
+
+/// Opponent P1 attacks a THIRD player P2 (not the controller) → Cunning Rhetoric
+/// must NOT fire. This is the discriminating case: before the fix the trigger
+/// fired on any attack declaration regardless of the defending player.
+#[test]
+fn cunning_rhetoric_does_not_fire_when_opponent_attacks_third_player() {
+    let (mut runner, rhetoric, attacker) = setup();
+    runner.state_mut().active_player = P1;
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P2))])
+        .expect("P1 declares an attacker against a third player P2");
+
+    assert_eq!(
+        stack_triggers_from(&runner, rhetoric),
+        0,
+        "Cunning Rhetoric must NOT fire when an opponent attacks a player other than its controller"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -61,6 +61,7 @@ mod craft_tithing_blade_transform;
 mod crossway_troublemakers_attacking_keywords;
 mod cultivate_split_destination;
 mod cumber_stone_opponent_debuff;
+mod cunning_rhetoric_attacks_you_scope_4736;
 mod curse_attack_triggers;
 mod curse_c17_when_enchanted_player_attacked_cycle;
 mod curse_co_departed_enchanted_player_trigger;


### PR DESCRIPTION
## Summary

Fixes #4736. **Cunning Rhetoric** — *"Whenever an opponent attacks you and/or one or more planeswalkers you control, exile the top card of that player's library. ..."* — fired on **every attack declaration**, regardless of who attacked or who was attacked.

## Root cause (runtime, not parser)

Cunning Rhetoric parses **correctly** to `TriggerMode::AttackersDeclared` with `valid_source = Opponent` (attacker) and `valid_target = Controller` (defender = you). But the runtime matcher was:

```rust
fn match_attackers_declared(event, _trigger, _source_id, _state) -> bool {
    matches!(event, GameEvent::AttackersDeclared { .. })  // ignores the trigger entirely
}
```

It dropped both scopes, so any attack declaration by anyone against anyone fired it. In a 3+ player game, an opponent attacking a **different** player wrongly triggered it.

## Fix

Delegate `match_attackers_declared` to the shared **`matching_attack_events`** — the same authority the sibling `Attacks` mode already uses. It applies:
- the attacking-player scope (`valid_source` = opponent),
- the defending-player scope (`valid_target` / `attack_target` = the controller), and
- the once-per-attack-declaration dedup (CR 508.3d + CR 508.5a).

No new logic — the scoping already existed; this mode just wasn't routed through it.

## Tests

Discriminating integration test in a **4-player** game (`cunning_rhetoric_attacks_you_scope_4736.rs`):
- Opponent attacks the **controller** → Cunning Rhetoric **fires**.
- Opponent attacks a **third player** → it does **NOT fire**.

The negative case **fails before this change** (the trigger fired on any attack). This is the discriminating step.

## Verification — no regressions

- **Full integration suite: 2572 pass**, 0 fail — every other `AttackersDeclared` card still works (Lulu, Stern Guardian; the C17 "when you're attacked" curse cycle).
- `game::trigger_matchers` (254) and `parser::oracle_trigger` (984) unit suites pass.
- `cargo clippy -p engine` clean.

CR 508.3d (once per attack declaration against the scoped defender) + CR 508.5a (the defending player is the one the attack is declared against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)