### PR TITLE
fix(parser): parse "conjure a card of your choice from [X] spellbook" as draft-from-spellbook

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7866,6 +7866,13 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return parsed_clause(effect);
     }
 
+    // Digital-only Alchemy: "conjure a card of your choice from [X]'s spellbook
+    // [+ destination]" — the "conjure ... of your choice" wording of the same
+    // draft-from-spellbook operation.
+    if let Some(effect) = try_parse_conjure_from_spellbook(tp) {
+        return parsed_clause(effect);
+    }
+
     // Digital-only: "conjure a duplicate of <reference> into/onto zone" — copies a
     // referenced card. Tried before the named form (disjoint: this requires
     // "a duplicate of", the other "named ").
@@ -8734,6 +8741,51 @@ fn try_parse_spellbook_draft(tp: TextPair) -> Option<Effect> {
     // Unmodeled tail ("twice, then …", a trailing chained clause, …) — leave it
     // to `Unimplemented` rather than dropping the rider.
     None
+}
+
+/// Digital-only Alchemy keyword action: parse "conjure a card of your choice from
+/// [X]'s spellbook [+ destination]". This is the "conjure ... of your choice" wording of
+/// the same operation as `draft a card from [X]'s spellbook`: reveal the source card's
+/// spellbook, the controller chooses one card, and it is created in the destination zone.
+/// Both map to `Effect::DraftFromSpellbook` — the resolver reads the spellbook list from the
+/// source object, so the printed source name in the text is irrelevant. The clause tail must
+/// be fully consumed (mirroring `try_parse_spellbook_draft`) so an unmodeled rider falls
+/// through to `Unimplemented` rather than parsing to a subtly wrong effect.
+///
+/// Coupling note: this mapping is correct while `Effect::DraftFromSpellbook` offers the
+/// controller the *entire* spellbook to choose from, which is exactly what "a card of your
+/// choice" means. (In Arena, `draft a card from ... spellbook` presents three random cards,
+/// whereas "conjure a card of your choice" reveals the whole book.) If `DraftFromSpellbook`
+/// is ever narrowed to model the real three-card draft, these conjure-of-your-choice cards
+/// must retain the whole-book choice rather than following it.
+fn try_parse_conjure_from_spellbook(tp: TextPair) -> Option<Effect> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("conjure a card of your choice from ")
+        .parse(tp.lower)
+        .ok()?;
+    // Consume the (irrelevant) source-card name up to "spellbook".
+    let (after_book, _src) = take_until::<_, _, OracleError<'_>>("spellbook")
+        .parse(rest)
+        .ok()?;
+    let (after_book, _) = tag::<_, _, OracleError<'_>>("spellbook")
+        .parse(after_book)
+        .ok()?;
+
+    // Destination via the shared conjure-zone parser; " tapped" only after the battlefield.
+    let (destination, zone_rest) = parse_conjure_zone(after_book)?;
+    let (tail, tapped) = if destination == Zone::Battlefield {
+        match tag::<_, _, OracleError<'_>>(" tapped").parse(zone_rest) {
+            Ok((tail, _)) => (tail, true),
+            Err(_) => (zone_rest, false),
+        }
+    } else {
+        (zone_rest, false)
+    };
+    // Fully consume the tail (nothing or a trailing period) so an unmodeled rider falls
+    // through to `Unimplemented` rather than being silently dropped.
+    (tail.is_empty() || tail == ".").then_some(Effect::DraftFromSpellbook {
+        destination,
+        tapped,
+    })
 }
 
 /// Digital-only keyword action: Parse "conjure [quantity] card(s) named {Name} into/onto {zone}"

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -32456,6 +32456,63 @@ fn conjure_quantity_graveyard() {
 }
 
 #[test]
+fn conjure_of_your_choice_from_spellbook_onto_battlefield() {
+    // "conjure a card of your choice from [X] spellbook onto the battlefield" is the
+    // "conjure ... of your choice" wording of draft-from-spellbook (digital-only Alchemy);
+    // it maps to the same Effect::DraftFromSpellbook as "draft a card from ~'s spellbook".
+    let e = parse_effect(
+        "conjure a card of your choice from the Planets Spellbook onto the battlefield",
+    );
+    match e {
+        Effect::DraftFromSpellbook {
+            destination,
+            tapped,
+        } => {
+            assert_eq!(destination, Zone::Battlefield);
+            assert!(!tapped);
+        }
+        other => panic!("expected DraftFromSpellbook, got: {other:?}"),
+    }
+}
+
+#[test]
+fn conjure_of_your_choice_from_spellbook_apostrophe_source() {
+    // The printed source name ("Follow the Tracks's spellbook") is irrelevant -- the
+    // resolver reads the spellbook list from the source object, not the text.
+    let e = parse_effect(
+        "conjure a card of your choice from Follow the Tracks's spellbook onto the battlefield",
+    );
+    assert!(matches!(
+        e,
+        Effect::DraftFromSpellbook {
+            destination: Zone::Battlefield,
+            tapped: false
+        }
+    ));
+}
+
+#[test]
+fn conjure_of_your_choice_from_spellbook_into_library() {
+    let e =
+        parse_effect("conjure a card of your choice from the Paradigm Spellbook into your library");
+    assert!(matches!(
+        e,
+        Effect::DraftFromSpellbook {
+            destination: Zone::Library,
+            tapped: false
+        }
+    ));
+}
+
+#[test]
+fn conjure_of_your_choice_from_spellbook_bare_form_is_not_parsed() {
+    // Every printed card states a destination; a bare form (no zone) is left to fall
+    // through rather than defaulting to a zone the text did not name.
+    let e = parse_effect("conjure a card of your choice from the Planets Spellbook");
+    assert!(!matches!(e, Effect::DraftFromSpellbook { .. }));
+}
+
+#[test]
 fn conjure_battlefield_tapped() {
     let e = parse_effect("conjure a card named Forest onto the battlefield tapped");
     match e {


### PR DESCRIPTION
## Summary

The parser recognized `draft a card from [X]'s spellbook` (→ `Effect::DraftFromSpellbook`) but not the semantically identical `conjure a card of your choice from [X]'s spellbook`. Both are the same digital-only Alchemy operation — reveal the source card's spellbook, the controller chooses one card, and create it in the destination zone — so the conjure wording fell through to `Unimplemented` even though the effect and its resolver already exist.

`try_parse_conjure_from_spellbook` maps the conjure-of-your-choice wording onto the same `Effect::DraftFromSpellbook`:

- reuses the shared `parse_conjure_zone` for the destination (`onto the battlefield [tapped]`, `into your hand`/`graveyard`/`library`);
- mirrors `try_parse_spellbook_draft`'s fully-consumed-tail discipline, so an unmodeled rider falls through to `Unimplemented` rather than parsing to a subtly wrong effect;
- needs no resolution change — the resolver already reads the spellbook list from the source object, so the printed source name in the text is irrelevant.

Parser-only; reuses the existing, tested effect + resolver.

## Coverage

Closes the `Effect:conjure` single-gap for **9 cards** — supported cards **31,470 → 31,479** — e.g. Vv'viza, Orbital Overseer; Drover of the Swine; Follow the Tracks; Paradigm Shifter; Saint Elenda; Porcine Portent; Volatile Orbit.

## Verification

- `cargo fmt --all`; `cargo clippy -p engine --all-targets -- -D warnings` clean
- full `cargo test -p engine` suite passes (15,994 tests, 0 failures); 4 new parser tests: onto-the-battlefield, apostrophe source name (`Follow the Tracks's spellbook`), into-your-library, and bare-form (no destination) rejection
- `cargo coverage` after regenerating card data: the 9 cards flip to `supported` (`gap_count` 0)

Model: Claude Opus 4.8
