### PR TITLE
fix(coverage): expose ChangeZone ETB entry qualifiers in the parse-diff signature (Closes #5495)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2585,7 +2585,8 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
                 d.push(("target".into(), fmt_target(target)));
             }
             if *owner_library {
-                d.push(("owner_library".into(), "true".into())); // CR 400.7
+                // CR 400.3: a card going to a library other than its owner's goes to its owner's instead.
+                d.push(("owner_library".into(), "true".into()));
             }
             if *enter_transformed {
                 d.push(("enter_transformed".into(), "true".into())); // CR 712.2
@@ -2594,7 +2595,8 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
                 d.push(("enters_under".into(), format!("{u:?}"))); // CR 110.2a
             }
             if !enter_tapped.is_unspecified() {
-                d.push(("enter_tapped".into(), format!("{enter_tapped:?}"))); // CR 614.1
+                // CR 110.5b: permanents enter untapped unless a spell or ability says otherwise.
+                d.push(("enter_tapped".into(), format!("{enter_tapped:?}")));
             }
             if *enters_attacking {
                 d.push(("enters_attacking".into(), "true".into())); // CR 508.4
@@ -2658,7 +2660,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
                 d.push(("library_position".into(), format!("{pos:?}"))); // CR 401.4
             }
             if *random_order {
-                d.push(("random_order".into(), "true".into())); // CR 401.4
+                d.push(("random_order".into(), "true".into()));
             }
         }
         Effect::Dig {

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2554,17 +2554,28 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             d.push(("player_a".into(), fmt_target(player_a)));
             d.push(("player_b".into(), fmt_target(player_b)));
         }
+        // #5495 (follow-up to #5492/#5493): every ETB entry qualifier below is
+        // parser-alterable but was swallowed by `..`, so a parser change flipping
+        // one — e.g. `enters_attacking` false→true for "put it onto the battlefield
+        // attacking" (CR 508.4, Senu #5494) — produced no row in the
+        // coverage-parse-diff sticky, reading as "No card-parse changes". The two
+        // variants' qualifier sets diverge, so they are matched separately; each
+        // field is emitted only when set so unqualified signatures stay
+        // byte-identical (the "push only when set" pattern #5493 established).
         Effect::ChangeZone {
             origin,
             destination,
             target,
-            ..
-        }
-        | Effect::ChangeZoneAll {
-            origin,
-            destination,
-            target,
-            ..
+            owner_library,
+            enter_transformed,
+            enters_under,
+            enter_tapped,
+            enters_attacking,
+            up_to,
+            enter_with_counters,
+            conditional_enter_with_counters,
+            face_down_profile,
+            enters_modified_if,
         } => {
             if let Some(o) = origin {
                 d.push(("from".into(), fmt_zone(o)));
@@ -2572,6 +2583,82 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             d.push(("to".into(), fmt_zone(destination)));
             if !matches!(target, TargetFilter::None) {
                 d.push(("target".into(), fmt_target(target)));
+            }
+            if *owner_library {
+                d.push(("owner_library".into(), "true".into())); // CR 400.7
+            }
+            if *enter_transformed {
+                d.push(("enter_transformed".into(), "true".into())); // CR 712.2
+            }
+            if let Some(u) = enters_under {
+                d.push(("enters_under".into(), format!("{u:?}"))); // CR 110.2a
+            }
+            if !enter_tapped.is_unspecified() {
+                d.push(("enter_tapped".into(), format!("{enter_tapped:?}"))); // CR 614.1
+            }
+            if *enters_attacking {
+                d.push(("enters_attacking".into(), "true".into())); // CR 508.4
+            }
+            if *up_to {
+                d.push(("up_to".into(), "true".into())); // CR 608.2d
+            }
+            if !enter_with_counters.is_empty() {
+                d.push((
+                    "enter_with_counters".into(),
+                    format!("{enter_with_counters:?}"),
+                )); // CR 122.1
+            }
+            if !conditional_enter_with_counters.is_empty() {
+                d.push((
+                    "conditional_enter_with_counters".into(),
+                    format!("{conditional_enter_with_counters:?}"),
+                )); // CR 122.1
+            }
+            if let Some(p) = face_down_profile {
+                d.push(("face_down_profile".into(), format!("{p:?}"))); // CR 708.2a
+            }
+            if let Some(f) = enters_modified_if {
+                d.push(("enters_modified_if".into(), fmt_target(f))); // CR 614.12
+            }
+        }
+        Effect::ChangeZoneAll {
+            origin,
+            destination,
+            target,
+            enters_under,
+            enter_tapped,
+            enter_with_counters,
+            face_down_profile,
+            library_position,
+            random_order,
+        } => {
+            if let Some(o) = origin {
+                d.push(("from".into(), fmt_zone(o)));
+            }
+            d.push(("to".into(), fmt_zone(destination)));
+            if !matches!(target, TargetFilter::None) {
+                d.push(("target".into(), fmt_target(target)));
+            }
+            if let Some(u) = enters_under {
+                d.push(("enters_under".into(), format!("{u:?}"))); // CR 110.2a
+            }
+            if !enter_tapped.is_unspecified() {
+                d.push(("enter_tapped".into(), format!("{enter_tapped:?}"))); // CR 110.5b
+            }
+            if !enter_with_counters.is_empty() {
+                d.push((
+                    "enter_with_counters".into(),
+                    format!("{enter_with_counters:?}"),
+                )); // CR 122.1
+            }
+            if let Some(p) = face_down_profile {
+                d.push(("face_down_profile".into(), format!("{p:?}"))); // CR 708.2a
+            }
+            if let Some(pos) = library_position {
+                d.push(("library_position".into(), format!("{pos:?}"))); // CR 401.4
+            }
+            if *random_order {
+                d.push(("random_order".into(), "true".into())); // CR 401.4
             }
         }
         Effect::Dig {
@@ -10308,6 +10395,47 @@ mod tests {
                 .iter()
                 .any(|k| k == "damage_source_filter"),
             "an absent damage_source_filter must not appear",
+        );
+    }
+
+    #[test]
+    fn change_zone_signature_exposes_enters_attacking() {
+        use crate::types::zones::EtbTapState;
+
+        // #5495: a parser change flipping `enters_attacking` false→true (e.g.
+        // "put it onto the battlefield attacking", CR 508.4, Senu #5494) must be
+        // visible to the coverage-parse-diff signature. When set the field
+        // appears; when false it is omitted so an unqualified ChangeZone's
+        // signature is unchanged. (Mirrors #5493 for PreventDamage.)
+        let signature_keys = |enters_attacking: bool| -> Vec<String> {
+            effect_details(&Effect::ChangeZone {
+                origin: Some(Zone::Graveyard),
+                destination: Zone::Battlefield,
+                target: TargetFilter::Any,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: EtbTapState::default(),
+                enters_attacking,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            })
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect()
+        };
+        assert!(
+            signature_keys(true).iter().any(|k| k == "enters_attacking"),
+            "a set enters_attacking must appear in the parse-diff signature",
+        );
+        assert!(
+            !signature_keys(false)
+                .iter()
+                .any(|k| k == "enters_attacking"),
+            "an unset enters_attacking must not appear (unqualified signature unchanged)",
         );
     }
 


### PR DESCRIPTION
Closes #5495.

## Summary

`effect_details` built the `ChangeZone` / `ChangeZoneAll` parse-diff signature from `origin`, `destination` and `target` only — every ETB **entry qualifier** was swallowed by the shared arm's `..`. A parser change flipping one produced **no row** in the `coverage-parse-diff` sticky, so that class of parser change read as "No card-parse changes". Surfaced on Senu, Keen-Eyed Protector (#5494), whose "put it onto the battlefield attacking" (CR 508.4) sets `enters_attacking` with no diff-visible evidence.

This splits the two variants (their qualifier sets diverge) and emits each qualifier **only when set**, so unqualified signatures stay byte-identical — the "push only when set" pattern established by #5493 for `PreventDamage`.

Fields now surfaced:
- **ChangeZone:** `owner_library` (CR 400.7), `enter_transformed` (CR 712.2), `enters_under` (CR 110.2a), `enter_tapped` (CR 614.1), `enters_attacking` (CR 508.4), `up_to` (CR 608.2d), `enter_with_counters` (CR 122.1), `conditional_enter_with_counters` (CR 122.1), `face_down_profile` (CR 708.2a), `enters_modified_if` (CR 614.12).
- **ChangeZoneAll:** `enters_under` (CR 110.2a), `enter_tapped` (CR 110.5b), `enter_with_counters` (CR 122.1), `face_down_profile` (CR 708.2a), `library_position` (CR 401.4), `random_order` (CR 401.4).

## Anchored on
- `crates/engine/src/game/coverage.rs` — `Effect::PreventDamage` arm in `effect_details` (added by the merged #5493, `253fff2ae`): same "emit a parser-alterable field only when set, `format!("{f:?}")` for complex types" shape.
- `crates/engine/src/game/coverage.rs` — `prevent_damage_signature_exposes_damage_source_filter` test (#5493): the new `change_zone_signature_exposes_enters_attacking` mirrors it exactly (build the effect, collect signature keys, assert present-when-set / absent-when-default).

## Gate A
`./scripts/check-parser-combinators.sh` → **exit 0** (no violations). This change adds no parser-dispatch code — it extends a review-signature renderer with typed field reads.

## CR
Every emitted qualifier reuses the CR citation already documented on its field definition in `types/ability.rs` (e.g. `enters_attacking` → CR 508.4 "enters tapped and attacking"; `library_position` → CR 401.4). No new rule interpretation is introduced.

## Verification
- `cargo test -p engine --lib coverage::tests` → **98/98 pass**, including the new `change_zone_signature_exposes_enters_attacking` (reverting the `enters_attacking` emission fails it).
- `cargo fmt -p engine` clean.
- The full destructure (no `..`) compiles, so if a future field is added to either variant the signature renderer fails to compile until it is considered — a deliberate guard against this family recurring one field at a time.

## Scope / risk
Single file, review-signature tooling only (`effect_details` feeds the `coverage-parse-diff` sticky). **No game-logic, parser, or serialization change** — it does not alter how any card parses or resolves, only what the diff sticky reports. Zero runtime/gameplay impact.

Model: claude-opus-4-8
Tier: Frontier
Thinking: High
