### PR TITLE
fix: Hall of the Bandit Lord creature-spell haste mana rider (#5283)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13190,8 +13190,11 @@ fn apply_mana_spell_grants(
         }) {
             continue;
         }
-        if !keyword_grants.iter().any(|(k, _)| k == keyword) {
-            keyword_grants.push((keyword.clone(), duration.clone()));
+        if !keyword_grants
+            .iter()
+            .any(|(k, d)| k == keyword && d == duration.as_ref())
+        {
+            keyword_grants.push((keyword.clone(), duration.as_ref().clone()));
         }
     }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13173,11 +13173,12 @@ fn apply_mana_spell_grants(
         return;
     };
     let spell_meta = build_spell_meta(state, caster, spell_id);
-    let mut keyword_grants = Vec::new();
+    let mut keyword_grants: Vec<(crate::types::keywords::Keyword, Duration)> = Vec::new();
     for grant in spent_units.iter().flat_map(|unit| unit.grants.iter()) {
         let ManaSpellGrant::AddKeywordUntilEndOfTurn {
             keyword,
             restriction,
+            duration,
         } = grant
         else {
             continue;
@@ -13189,16 +13190,16 @@ fn apply_mana_spell_grants(
         }) {
             continue;
         }
-        if !keyword_grants.contains(keyword) {
-            keyword_grants.push(keyword.clone());
+        if !keyword_grants.iter().any(|(k, _)| k == keyword) {
+            keyword_grants.push((keyword.clone(), duration.clone()));
         }
     }
 
-    for keyword in keyword_grants {
+    for (keyword, duration) in keyword_grants {
         state.add_transient_continuous_effect(
             spell_id,
             caster,
-            Duration::UntilEndOfTurn,
+            duration,
             TargetFilter::SpecificObject { id: spell_id },
             vec![ContinuousModification::AddKeyword { keyword }],
             None,

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -2425,7 +2425,7 @@ fn conditional_mana_keyword_grant_applies_to_matching_spell() {
         grants: vec![ManaSpellGrant::AddKeywordUntilEndOfTurn {
             keyword: Keyword::Haste,
             restriction: Some(ManaRestriction::OnlyForCreatureType("Dragon".to_string())),
-            duration: crate::types::ability::Duration::UntilEndOfTurn,
+            duration: Box::new(crate::types::ability::Duration::UntilEndOfTurn),
         }],
         expiry: None,
     };
@@ -2444,6 +2444,78 @@ fn conditional_mana_keyword_grant_applies_to_matching_spell() {
         vec![ContinuousModification::AddKeyword {
             keyword: Keyword::Haste
         }]
+    );
+}
+
+/// CR 106.6 + CR 702.10: Temporary and permanent keyword grants from different
+/// mana sources must both apply — dedup by `(keyword, duration)`, not keyword alone.
+#[test]
+fn mana_keyword_grants_apply_both_temporary_and_permanent_durations() {
+    let mut state = setup_game_at_main_phase();
+    let dragon_id = create_object(
+        &mut state,
+        CardId(103),
+        PlayerId(0),
+        "Dragon Whelp".to_string(),
+        Zone::Stack,
+    );
+    let dragon = state.objects.get_mut(&dragon_id).unwrap();
+    dragon.card_types.core_types.push(CoreType::Creature);
+    dragon.card_types.subtypes.push("Dragon".to_string());
+
+    let creature_restriction = ManaRestriction::OnlyForSpellType("Creature".to_string());
+    let eot_unit = ManaUnit {
+        color: ManaType::Red,
+        source_id: ObjectId(1),
+        pip_id: crate::types::mana::ManaPipId(0),
+        supertype: None,
+        source_could_produce_two_or_more_colors: false,
+        restrictions: vec![],
+        grants: vec![ManaSpellGrant::AddKeywordUntilEndOfTurn {
+            keyword: Keyword::Haste,
+            restriction: Some(creature_restriction.clone()),
+            duration: Box::new(crate::types::ability::Duration::UntilEndOfTurn),
+        }],
+        expiry: None,
+    };
+    let permanent_unit = ManaUnit {
+        color: ManaType::Colorless,
+        source_id: ObjectId(2),
+        pip_id: crate::types::mana::ManaPipId(0),
+        supertype: None,
+        source_could_produce_two_or_more_colors: false,
+        restrictions: vec![],
+        grants: vec![ManaSpellGrant::AddKeywordUntilEndOfTurn {
+            keyword: Keyword::Haste,
+            restriction: Some(creature_restriction),
+            duration: Box::new(crate::types::ability::Duration::Permanent),
+        }],
+        expiry: None,
+    };
+
+    apply_mana_spell_grants(&mut state, dragon_id, &[eot_unit, permanent_unit]);
+
+    assert_eq!(
+        state.transient_continuous_effects.len(),
+        2,
+        "both UntilEndOfTurn and Permanent haste grants must apply"
+    );
+    let durations: Vec<_> = state
+        .transient_continuous_effects
+        .iter()
+        .map(|effect| effect.duration.clone())
+        .collect();
+    assert!(
+        durations
+            .iter()
+            .any(|d| matches!(d, crate::types::ability::Duration::UntilEndOfTurn)),
+        "expected UntilEndOfTurn haste layer"
+    );
+    assert!(
+        durations
+            .iter()
+            .any(|d| matches!(d, crate::types::ability::Duration::Permanent)),
+        "expected Permanent haste layer"
     );
 }
 

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -2425,6 +2425,7 @@ fn conditional_mana_keyword_grant_applies_to_matching_spell() {
         grants: vec![ManaSpellGrant::AddKeywordUntilEndOfTurn {
             keyword: Keyword::Haste,
             restriction: Some(ManaRestriction::OnlyForCreatureType("Dragon".to_string())),
+            duration: crate::types::ability::Duration::UntilEndOfTurn,
         }],
         expiry: None,
     };

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -2418,7 +2418,7 @@ fn parse_conditional_keyword_grant(lower: &str) -> Option<ManaSpellGrant> {
     Some(ManaSpellGrant::AddKeywordUntilEndOfTurn {
         keyword,
         restriction,
-        duration,
+        duration: Box::new(duration),
     })
 }
 
@@ -3670,7 +3670,7 @@ mod tests {
             vec![ManaSpellGrant::AddKeywordUntilEndOfTurn {
                 keyword: crate::types::keywords::Keyword::Haste,
                 restriction: Some(ManaRestriction::OnlyForCreatureType("Dragon".to_string())),
-                duration: Duration::UntilEndOfTurn,
+                duration: Box::new(Duration::UntilEndOfTurn),
             }]
         );
     }
@@ -3687,7 +3687,7 @@ mod tests {
             vec![ManaSpellGrant::AddKeywordUntilEndOfTurn {
                 keyword: crate::types::keywords::Keyword::Haste,
                 restriction: Some(ManaRestriction::OnlyForSpellType("Creature".to_string())),
-                duration: Duration::Permanent,
+                duration: Box::new(Duration::Permanent),
             }]
         );
     }

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -10,7 +10,7 @@ use nom::Parser;
 use crate::parser::oracle_nom::error::OracleResult;
 use crate::parser::oracle_nom::primitives as nom_primitives;
 use crate::types::ability::{
-    AbilityKind, AbilityTag, Comparator, Effect, LinkedExileScope, ManaContribution,
+    AbilityKind, AbilityTag, Comparator, Duration, Effect, LinkedExileScope, ManaContribution,
     ManaProduction, ManaSpendRestriction, ObjectScope, QuantityExpr, QuantityRef,
 };
 use crate::types::keywords::KeywordKind;
@@ -2364,36 +2364,61 @@ pub(super) fn parse_mana_spell_grant(lower: &str) -> Option<Vec<ManaSpellGrant>>
     None
 }
 
-/// CR 106.6 + CR 702: Parse mana-rider keyword grants:
-/// "If that mana is spent on a Dragon creature spell, it gains haste until end of turn."
+/// CR 106.6 + CR 702.10: Parse mana-rider keyword grants:
+/// - "If that mana is spent on a Dragon creature spell, it gains haste until end of turn."
+/// - "If that mana is spent on a creature spell, it gains haste." (Hall of the Bandit Lord)
 fn parse_conditional_keyword_grant(lower: &str) -> Option<ManaSpellGrant> {
+    let trimmed = lower.trim().trim_end_matches('.');
     let (rest, _) = tag::<_, _, OracleError<'_>>("if that mana is spent on ")
-        .parse(lower)
+        .parse(trimmed)
         .ok()?;
     let (rest, _) = opt(alt((tag::<_, _, OracleError<'_>>("a "), tag("an "))))
         .parse(rest)
         .ok()?;
-    let (rest, subtype) = terminated(
-        take_until::<_, _, OracleError<'_>>(" creature spell, it gains "),
-        tag(" creature spell, it gains "),
-    )
-    .parse(rest)
-    .ok()?;
-    let (rest, keyword_text) = terminated(
+
+    // Filter axis: bare "creature spell" vs "[subtype] creature spell".
+    let (rest, restriction) = if let Ok((remainder, _)) =
+        tag::<_, _, OracleError<'_>>("creature spell, it gains ").parse(rest)
+    {
+        (
+            remainder,
+            Some(ManaRestriction::OnlyForSpellType("Creature".to_string())),
+        )
+    } else {
+        let (remainder, subtype) = terminated(
+            take_until::<_, _, OracleError<'_>>(" creature spell, it gains "),
+            tag(" creature spell, it gains "),
+        )
+        .parse(rest)
+        .ok()?;
+        (
+            remainder,
+            Some(ManaRestriction::OnlyForCreatureType(super::capitalize(
+                subtype.trim(),
+            ))),
+        )
+    };
+
+    let (keyword, duration) = if let Ok((remainder, keyword_text)) = terminated(
         take_until::<_, _, OracleError<'_>>(" until end of turn"),
         tag(" until end of turn"),
     )
     .parse(rest)
-    .ok()?;
-    if !rest.trim().is_empty() {
-        return None;
-    }
-    let keyword = parse_keyword_from_oracle(keyword_text.trim())?;
+    {
+        if !remainder.trim().is_empty() {
+            return None;
+        }
+        let keyword = parse_keyword_from_oracle(keyword_text.trim())?;
+        (keyword, Duration::UntilEndOfTurn)
+    } else {
+        let keyword = parse_keyword_from_oracle(rest.trim())?;
+        (keyword, Duration::Permanent)
+    };
+
     Some(ManaSpellGrant::AddKeywordUntilEndOfTurn {
         keyword,
-        restriction: Some(ManaRestriction::OnlyForCreatureType(super::capitalize(
-            subtype.trim(),
-        ))),
+        restriction,
+        duration,
     })
 }
 
@@ -3645,6 +3670,24 @@ mod tests {
             vec![ManaSpellGrant::AddKeywordUntilEndOfTurn {
                 keyword: crate::types::keywords::Keyword::Haste,
                 restriction: Some(ManaRestriction::OnlyForCreatureType("Dragon".to_string())),
+                duration: Duration::UntilEndOfTurn,
+            }]
+        );
+    }
+
+    /// CR 106.6 + CR 702.10a: Hall of the Bandit Lord — any creature spell,
+    /// permanent haste (no "until end of turn" rider).
+    #[test]
+    fn parses_hall_of_bandit_lord_creature_spell_haste_grant() {
+        let grants =
+            parse_mana_spell_grant("if that mana is spent on a creature spell, it gains haste.")
+                .expect("Hall of the Bandit Lord mana rider must parse");
+        assert_eq!(
+            grants,
+            vec![ManaSpellGrant::AddKeywordUntilEndOfTurn {
+                keyword: crate::types::keywords::Keyword::Haste,
+                restriction: Some(ManaRestriction::OnlyForSpellType("Creature".to_string())),
+                duration: Duration::Permanent,
             }]
         );
     }

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -828,16 +828,23 @@ impl ManaRestriction {
 
 /// CR 106.6: Additional effect that the mana confers upon the spell it is spent on.
 /// E.g., "that spell can't be countered" (Cavern of Souls, Delighted Halfling).
+fn default_mana_keyword_grant_duration() -> crate::types::ability::Duration {
+    crate::types::ability::Duration::UntilEndOfTurn
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ManaSpellGrant {
     /// The spell cast with this mana can't be countered.
     CantBeCountered,
-    /// CR 106.6 + CR 702: If the spell this mana is spent on satisfies
-    /// `restriction`, grant it `keyword` until end of turn.
+    /// CR 106.6 + CR 702.10: If the spell this mana is spent on satisfies
+    /// `restriction`, grant it `keyword` for `duration` (subtype lands use
+    /// `UntilEndOfTurn`; Hall of the Bandit Lord uses `Permanent`).
     AddKeywordUntilEndOfTurn {
         keyword: Keyword,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         restriction: Option<ManaRestriction>,
+        #[serde(default = "default_mana_keyword_grant_duration")]
+        duration: crate::types::ability::Duration,
     },
     /// CR 106.6 + CR 603.3: "When you spend this mana to cast a [filter] spell,
     /// [effect]" — a reflexive trigger riding the produced mana (Lapis Orb of

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -828,8 +828,8 @@ impl ManaRestriction {
 
 /// CR 106.6: Additional effect that the mana confers upon the spell it is spent on.
 /// E.g., "that spell can't be countered" (Cavern of Souls, Delighted Halfling).
-fn default_mana_keyword_grant_duration() -> crate::types::ability::Duration {
-    crate::types::ability::Duration::UntilEndOfTurn
+fn default_mana_keyword_grant_duration() -> Box<crate::types::ability::Duration> {
+    Box::new(crate::types::ability::Duration::UntilEndOfTurn)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -844,7 +844,7 @@ pub enum ManaSpellGrant {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         restriction: Option<ManaRestriction>,
         #[serde(default = "default_mana_keyword_grant_duration")]
-        duration: crate::types::ability::Duration,
+        duration: Box<crate::types::ability::Duration>,
     },
     /// CR 106.6 + CR 603.3: "When you spend this mana to cast a [filter] spell,
     /// [effect]" — a reflexive trigger riding the produced mana (Lapis Orb of

--- a/crates/engine/tests/integration/issue_5283_hall_of_bandit_lord.rs
+++ b/crates/engine/tests/integration/issue_5283_hall_of_bandit_lord.rs
@@ -1,0 +1,81 @@
+//! Regression for issue #5283: Hall of the Bandit Lord mana must grant haste to
+//! creature spells cast with its colorless mana.
+//!
+//! https://github.com/phase-rs/phase/issues/5283
+
+use engine::game::keywords::has_keyword;
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::Effect;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaCost, ManaRestriction, ManaSpellGrant};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const HALL_ORACLE: &str = "Hall of the Bandit Lord enters tapped.\n\
+{T}, Pay 3 life: Add {C}. If that mana is spent on a creature spell, it gains haste.";
+
+#[test]
+fn hall_of_bandit_lord_mana_ability_parses_creature_haste_grant() {
+    let parsed = parse_oracle_text(
+        HALL_ORACLE,
+        "Hall of the Bandit Lord",
+        &[],
+        &["Land".to_string()],
+        &[],
+    );
+    let ability = parsed
+        .abilities
+        .iter()
+        .find(|def| matches!(*def.effect, Effect::Mana { .. }))
+        .expect("Hall of the Bandit Lord must parse an activated mana ability");
+    let Effect::Mana { grants, .. } = &*ability.effect else {
+        panic!("expected Mana effect");
+    };
+    assert_eq!(
+        grants,
+        &[ManaSpellGrant::AddKeywordUntilEndOfTurn {
+            keyword: Keyword::Haste,
+            restriction: Some(ManaRestriction::OnlyForSpellType("Creature".to_string())),
+            duration: engine::types::ability::Duration::Permanent,
+        }]
+    );
+    assert!(
+        ability.sub_ability.is_none(),
+        "mana rider must fold into grants, not a Spell sub-ability"
+    );
+}
+
+#[test]
+fn hall_of_bandit_lord_mana_grants_haste_to_creature_cast_with_it() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let hall = scenario
+        .add_land_from_oracle(P0, "Hall of the Bandit Lord", HALL_ORACLE)
+        .id();
+    let bear = scenario
+        .add_creature_to_hand(P0, "Grizzly Bears", 2, 2)
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Untap Hall so we can activate it this turn.
+    runner.state_mut().objects.get_mut(&hall).unwrap().tapped = false;
+
+    let activate_outcome = runner.activate(hall, 0).resolve();
+    assert_eq!(
+        activate_outcome.mana_pool_color(P0, engine::types::mana::ManaType::Colorless),
+        1,
+        "Hall of the Bandit Lord must produce one colorless mana"
+    );
+
+    let cast_outcome = runner.cast(bear).resolve();
+    cast_outcome.assert_zone(&[bear], Zone::Battlefield);
+
+    assert!(
+        has_keyword(runner.state().objects.get(&bear).unwrap(), &Keyword::Haste),
+        "creature cast with Hall mana must have haste on the battlefield"
+    );
+}

--- a/crates/engine/tests/integration/issue_5283_hall_of_bandit_lord.rs
+++ b/crates/engine/tests/integration/issue_5283_hall_of_bandit_lord.rs
@@ -37,7 +37,7 @@ fn hall_of_bandit_lord_mana_ability_parses_creature_haste_grant() {
         &[ManaSpellGrant::AddKeywordUntilEndOfTurn {
             keyword: Keyword::Haste,
             restriction: Some(ManaRestriction::OnlyForSpellType("Creature".to_string())),
-            duration: engine::types::ability::Duration::Permanent,
+            duration: Box::new(engine::types::ability::Duration::Permanent),
         }]
     );
     assert!(

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -434,6 +434,7 @@ mod issue_4962_volo_guide_to_monsters;
 mod issue_5145_violent_eruption_choose_target_distribution;
 mod issue_5159_attacks_alone_investigate;
 mod issue_5282_nissa_ultimate_emblem_search;
+mod issue_5283_hall_of_bandit_lord;
 mod issue_5285_senu_keen_eyed_protector;
 mod issue_5286_lulu_loyal_hollyphant;
 mod issue_5287_samwise_stouthearted;


### PR DESCRIPTION


## Summary

Hall of the Bandit Lord's activated mana ability was parsed with an incorrect `Spell` sub-ability (`SelfRef` haste static) instead of a `ManaSpellGrant` on the produced mana. Creature spells cast with its colorless mana therefore did not gain haste.

Fixes [#5283](https://github.com/phase-rs/phase/issues/5283).

## Root cause

The mana-rider parser only recognized subtype-specific grants with an explicit `"until end of turn"` suffix:

`"If that mana is spent on a Dragon creature spell, it gains haste until end of turn."`

Hall of the Bandit Lord prints the broader, permanent form:

`"If that mana is spent on a creature spell, it gains haste."`

`parse_conditional_keyword_grant` declined this clause, so the sequence parser fell through to a generic `If` absorption that lowered haste onto `SelfRef` (the land) rather than folding a spend rider into `Effect::Mana.grants`.

## Changes

### Parser (`oracle_effect/mana.rs`)

- Extend `parse_conditional_keyword_grant` to accept:
  - bare `"a creature spell"` → `OnlyForSpellType("Creature")`
  - optional `"until end of turn"` suffix → `Duration::UntilEndOfTurn` vs `Duration::Permanent`
- Continuation path already folds matching clauses into `ManaGrant` on the parent `Effect::Mana`.

### Types (`types/mana.rs`)

- Parameterize `ManaSpellGrant::AddKeywordUntilEndOfTurn` with `duration: Duration` (serde-default `UntilEndOfTurn` for existing Dragon-land cards).

### Runtime (`game/casting.rs`)

- `apply_mana_spell_grants` respects per-grant `duration` instead of hardcoding `UntilEndOfTurn`.

### Tests

- Parser: `parses_hall_of_bandit_lord_creature_spell_haste_grant`
- Integration: `issue_5283_hall_of_bandit_lord.rs` (parse shape + end-to-end cast with Hall mana → haste on battlefield)

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p engine --lib bandit_lord`
- [x] `cargo test -p engine --lib conditional_mana_keyword_grant`
- [x] `cargo test -p engine --test integration issue_5283` (2/2)

## Risk notes

- Subtype + until-EOT dragon-land pattern unchanged (default duration preserves prior behavior).
- Permanent haste only applies to the new bare-creature-spell phrasing (Hall of the Bandit Lord class).
- Regenerating `card-data.json` will move Hall's rider from `sub_ability` into `grants` and clear the `SwallowedClause` warning.
