### PR TITLE
refactor(parser): source-addressed OracleItemIr and OracleDocBuilder (unit 3a)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -60,7 +60,10 @@ use super::oracle_effect::{
 };
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::diagnostic::OracleDiagnostic;
-use super::oracle_ir::doc::{OracleDocIr, OracleItemIr};
+use super::oracle_ir::doc::{
+    OracleDocBuilder, OracleDocIr, OracleNodeIr, OracleSourceSpan, PrintedAbilityIndex,
+    PrintedTriggerIndex,
+};
 pub use super::oracle_keyword::keyword_display_name;
 use super::oracle_keyword::{
     extract_keyword_line, is_keyword_cost_line, parse_keyword_from_oracle,
@@ -2398,10 +2401,14 @@ fn parse_flash_cleanup_sacrifice_casting_option(
 }
 
 /// Lower an `OracleDocIr` into the final `ParsedAbilities` via exhaustive match
-/// on each `OracleItemIr` variant.
+/// on each item's `OracleNodeIr` payload.
 ///
 /// Core IR variants are lowered through their dedicated lowering functions.
 /// PreLowered variants are identity-lowered (pushed directly to the result).
+///
+/// `ParsedAbilities` stays category-grouped because it is the runtime-facing
+/// type; only *within*-category order and explicit cross-item relations are
+/// semantic after lowering.
 pub(crate) fn lower_oracle_ir(ir: &OracleDocIr) -> ParsedAbilities {
     let mut result = ParsedAbilities {
         abilities: Vec::new(),
@@ -2418,52 +2425,52 @@ pub(crate) fn lower_oracle_ir(ir: &OracleDocIr) -> ParsedAbilities {
         parse_warnings: Vec::new(),
     };
     for item in &ir.items {
-        match item {
-            OracleItemIr::Spell(effect_ir) => {
+        match &item.node {
+            OracleNodeIr::Spell(effect_ir) => {
                 result.abilities.push(lower_effect_chain_ir(effect_ir));
             }
-            OracleItemIr::Trigger(trigger_ir) => {
+            OracleNodeIr::Trigger(trigger_ir) => {
                 result.triggers.push(lower_trigger_ir(trigger_ir));
             }
-            OracleItemIr::Static(static_ir) => {
+            OracleNodeIr::Static(static_ir) => {
                 result.statics.push(lower_static_ir(static_ir));
             }
-            OracleItemIr::Replacement(replacement_ir) => {
+            OracleNodeIr::Replacement(replacement_ir) => {
                 result
                     .replacements
                     .push(lower_replacement_ir(replacement_ir));
             }
-            OracleItemIr::Keyword(kw) => {
+            OracleNodeIr::Keyword(kw) => {
                 result.extracted_keywords.push(kw.clone());
             }
-            OracleItemIr::Modal(modal) => {
+            OracleNodeIr::Modal(modal) => {
                 result.modal = Some(modal.clone());
             }
-            OracleItemIr::AdditionalCost(cost) => {
+            OracleNodeIr::AdditionalCost(cost) => {
                 result.additional_cost = Some(cost.clone());
             }
-            OracleItemIr::CastingRestriction(restriction) => {
+            OracleNodeIr::CastingRestriction(restriction) => {
                 result.casting_restrictions.push(restriction.clone());
             }
-            OracleItemIr::CastingOption(option) => {
+            OracleNodeIr::CastingOption(option) => {
                 result.casting_options.push(option.clone());
             }
-            OracleItemIr::SolveCondition(condition) => {
+            OracleNodeIr::SolveCondition(condition) => {
                 result.solve_condition = Some(condition.clone());
             }
-            OracleItemIr::StriveCost(cost) => {
+            OracleNodeIr::StriveCost(cost) => {
                 result.strive_cost = Some(cost.clone());
             }
-            OracleItemIr::PreLoweredTrigger(def) => {
+            OracleNodeIr::PreLoweredTrigger(def) => {
                 result.triggers.push(def.clone());
             }
-            OracleItemIr::PreLoweredStatic(def) => {
+            OracleNodeIr::PreLoweredStatic(def) => {
                 result.statics.push(def.clone());
             }
-            OracleItemIr::PreLoweredReplacement(def) => {
+            OracleNodeIr::PreLoweredReplacement(def) => {
                 result.replacements.push(def.clone());
             }
-            OracleItemIr::PreLoweredSpell(def) => {
+            OracleNodeIr::PreLoweredSpell(def) => {
                 result.abilities.push(def.clone());
             }
         }
@@ -2852,7 +2859,9 @@ pub(crate) fn parse_oracle_ir(
         let mut triggers = parse_trigger_lines_at_index(
             ability_text,
             card_name,
-            Some(result.triggers.len()),
+            Some(PrintedTriggerIndex::from_category_vector_len(
+                result.triggers.len(),
+            )),
             &mut ctx,
         );
         for trigger in &mut triggers {
@@ -2871,8 +2880,11 @@ pub(crate) fn parse_oracle_ir(
         // CR 707.9a: Pass the running trigger count so any "has this ability"
         // retain modification inside a Spacecraft threshold trigger body
         // resolves to the correct printed-trigger slot.
-        let (sc_statics, sc_triggers, sc_abilities, consumed) =
-            parse_spacecraft_threshold_lines(&lines, card_name, result.triggers.len());
+        let (sc_statics, sc_triggers, sc_abilities, consumed) = parse_spacecraft_threshold_lines(
+            &lines,
+            card_name,
+            PrintedTriggerIndex::from_category_vector_len(result.triggers.len()),
+        );
         result.statics.extend(sc_statics);
         result.triggers.extend(sc_triggers);
         for mut def in sc_abilities {
@@ -3481,7 +3493,9 @@ pub(crate) fn parse_oracle_ir(
                 effect_text,
                 &line,
                 card_name,
-                Some(result.abilities.len()),
+                Some(PrintedAbilityIndex::from_category_vector_len(
+                    result.abilities.len(),
+                )),
                 &mut ctx,
             );
             // CR 702.186b: ∞ ("As long as harnessed, it has [ability]") gates an
@@ -3566,7 +3580,9 @@ pub(crate) fn parse_oracle_ir(
             let mut triggers = parse_trigger_lines_at_index(
                 &line,
                 card_name,
-                Some(result.triggers.len()),
+                Some(PrintedTriggerIndex::from_category_vector_len(
+                    result.triggers.len(),
+                )),
                 &mut ctx,
             );
             i += 1;
@@ -3603,7 +3619,9 @@ pub(crate) fn parse_oracle_ir(
                         activated_effect_text,
                         &line,
                         card_name,
-                        Some(result.abilities.len()),
+                        Some(PrintedAbilityIndex::from_category_vector_len(
+                            result.abilities.len(),
+                        )),
                         &mut ctx,
                     );
                     result.abilities.push(def);
@@ -3616,7 +3634,9 @@ pub(crate) fn parse_oracle_ir(
                 let mut triggers = parse_trigger_lines_at_index(
                     &effect_text,
                     card_name,
-                    Some(result.triggers.len()),
+                    Some(PrintedTriggerIndex::from_category_vector_len(
+                        result.triggers.len(),
+                    )),
                     &mut ctx,
                 );
                 // B7: Attach ability-word condition as fallback when extract_if_condition
@@ -4707,7 +4727,9 @@ pub(crate) fn parse_oracle_ir(
                 let mut triggers = parse_trigger_lines_at_index(
                     &effect_text,
                     card_name,
-                    Some(result.triggers.len()),
+                    Some(PrintedTriggerIndex::from_category_vector_len(
+                        result.triggers.len(),
+                    )),
                     &mut ctx,
                 );
                 i += 1;
@@ -4900,7 +4922,7 @@ fn parse_activated_ability_definition(
     effect_text: &str,
     description: &str,
     card_name: &str,
-    current_ability_index: Option<usize>,
+    current_ability_index: Option<PrintedAbilityIndex>,
     ctx: &mut ParseContext,
 ) -> (AbilityDefinition, String) {
     let (effect_text, constraints) = strip_activated_constraints(effect_text);
@@ -4921,7 +4943,8 @@ fn parse_activated_ability_definition(
     // CR 707.9a: thread the activated-ability index so "except it has this
     // ability" inside the effect body resolves to RetainPrintedAbilityFromSource.
     let prev_ability_index = ctx.current_ability_index;
-    ctx.current_ability_index = current_ability_index;
+    // `ParseContext` stores a raw `usize`; unwrap the printed-slot newtype here.
+    ctx.current_ability_index = current_ability_index.map(PrintedAbilityIndex::get);
 
     // Retry with `~` normalization if the first pass left an Unimplemented node
     // or emitted a target-fallback warning.
@@ -4956,55 +4979,78 @@ fn parse_activated_ability_definition(
 
 /// Convert a `ParsedAbilities` into an `OracleDocIr` using `PreLowered*` variants.
 ///
-/// Preserves source ordering: abilities, triggers, statics, replacements are pushed
-/// in their parsed order. Scalar fields (modal, additional_cost, solve_condition,
-/// strive_cost) are pushed as their corresponding `OracleItemIr` variants.
+/// UNIT-3B DEBT — this is the document façade, and it is still category-ordered.
+/// It runs *after* lowering and therefore has no access to the line cursor, so it
+/// cannot recover an exact source position for any item. Every item is emitted
+/// with `OracleSourceSpan::whole_document` (a true containing span, not a minimal
+/// one) and a distinct `ordinal_within_span` that reproduces today's category
+/// emission order exactly. Lowered output is therefore byte-identical.
+///
+/// Unit 3b moves emission into `parse_oracle_ir`'s dispatch loop, where the exact
+/// line/byte range is in hand; this function is deleted there (removal gate 5).
+///
+/// Routing through `OracleDocBuilder` now — rather than pushing a bare `Vec` — is
+/// what makes item identity, the CR 707.9a printed-slot counters, and the span
+/// invariants have a single authority before that move.
 fn parsed_abilities_to_doc_ir(
     result: ParsedAbilities,
     oracle_text: &str,
     card_name: &str,
     ctx: &mut ParseContext,
 ) -> OracleDocIr {
-    let mut items: Vec<OracleItemIr> = Vec::new();
+    let mut builder = OracleDocBuilder::new();
+    let mut ordinal: u32 = 0;
+
+    // One helper, so the ordinal can never be advanced without emitting, and an
+    // emission can never reuse an ordinal. Both are builder-rejected anyway; this
+    // makes the pairing structural.
+    let mut emit = |builder: &mut OracleDocBuilder, node: OracleNodeIr| {
+        let span = OracleSourceSpan::whole_document(oracle_text, ordinal);
+        ordinal += 1;
+        // `None`: a whole-document span cannot honestly name a fragment — the only
+        // text it covers is the entire card. Unit 3b supplies `Some(line)` with an
+        // `Exact` span. `emit` rejects any other combination.
+        let slot = builder.begin_item(span, None);
+        builder
+            .emit(slot, node)
+            .expect("whole-document spans carry distinct ordinals, so emit cannot reject");
+    };
+
     for def in result.abilities {
-        items.push(OracleItemIr::PreLoweredSpell(def));
+        emit(&mut builder, OracleNodeIr::PreLoweredSpell(def));
     }
     for def in result.triggers {
-        items.push(OracleItemIr::PreLoweredTrigger(def));
+        emit(&mut builder, OracleNodeIr::PreLoweredTrigger(def));
     }
     for def in result.statics {
-        items.push(OracleItemIr::PreLoweredStatic(def));
+        emit(&mut builder, OracleNodeIr::PreLoweredStatic(def));
     }
     for def in result.replacements {
-        items.push(OracleItemIr::PreLoweredReplacement(def));
+        emit(&mut builder, OracleNodeIr::PreLoweredReplacement(def));
     }
     for kw in result.extracted_keywords {
-        items.push(OracleItemIr::Keyword(kw));
+        emit(&mut builder, OracleNodeIr::Keyword(kw));
     }
     if let Some(modal) = result.modal {
-        items.push(OracleItemIr::Modal(modal));
+        emit(&mut builder, OracleNodeIr::Modal(modal));
     }
     if let Some(cost) = result.additional_cost {
-        items.push(OracleItemIr::AdditionalCost(cost));
+        emit(&mut builder, OracleNodeIr::AdditionalCost(cost));
     }
     for restriction in result.casting_restrictions {
-        items.push(OracleItemIr::CastingRestriction(restriction));
+        emit(&mut builder, OracleNodeIr::CastingRestriction(restriction));
     }
     for option in result.casting_options {
-        items.push(OracleItemIr::CastingOption(option));
+        emit(&mut builder, OracleNodeIr::CastingOption(option));
     }
     if let Some(condition) = result.solve_condition {
-        items.push(OracleItemIr::SolveCondition(condition));
+        emit(&mut builder, OracleNodeIr::SolveCondition(condition));
     }
     if let Some(cost) = result.strive_cost {
-        items.push(OracleItemIr::StriveCost(cost));
+        emit(&mut builder, OracleNodeIr::StriveCost(cost));
     }
-    OracleDocIr {
-        items,
-        source_text: oracle_text.to_string(),
-        card_name: card_name.to_string(),
-        diagnostics: std::mem::take(&mut ctx.diagnostics),
-    }
+
+    builder.finish(oracle_text, card_name, std::mem::take(&mut ctx.diagnostics))
 }
 
 /// Parse Oracle text into structured ability definitions.

--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -1,3 +1,4 @@
+use super::oracle_ir::doc::PrintedTriggerIndex;
 use crate::parser::oracle_nom::error::OracleError;
 use nom::bytes::complete::tag;
 use nom::Parser;
@@ -153,7 +154,9 @@ pub(crate) fn parse_class_oracle_text(
                 let mut triggers = parse_trigger_lines_at_index(
                     line,
                     card_name,
-                    Some(result.triggers.len()),
+                    Some(PrintedTriggerIndex::from_category_vector_len(
+                        result.triggers.len(),
+                    )),
                     &mut ParseContext::default(),
                 );
                 // CR 716.2a: Gate continuous triggers at levels > 1.
@@ -220,7 +223,9 @@ pub(crate) fn parse_class_oracle_text(
                     let mut triggers = parse_trigger_lines_at_index(
                         &effect_text,
                         card_name,
-                        Some(result.triggers.len()),
+                        Some(PrintedTriggerIndex::from_category_vector_len(
+                            result.triggers.len(),
+                        )),
                         &mut ParseContext::default(),
                     );
                     if section.level > 1 {

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -1,10 +1,29 @@
 //! Document-level Oracle IR types.
 //!
-//! `OracleDocIr` represents the complete parsed output of a card's Oracle text.
-//! `OracleItemIr` categorizes each parsed item. Core variants carry proper IR
-//! types (EffectChainIr, TriggerIr, StaticIr, ReplacementIr). PreLowered
-//! variants carry already-assembled engine types from pre-processors and
-//! dispatch paths that construct definitions directly.
+//! `OracleDocIr` represents the complete parsed output of a card's Oracle text
+//! as a list of `OracleItemIr`. Each item carries a stable `OracleItemId`, an
+//! `OracleUnitSource` (byte + line span), and a typed `OracleNodeIr` payload.
+//!
+//! Items are produced through `OracleDocBuilder`, which is the single authority
+//! for item identity, ordering, and span invariants. Nothing constructs an
+//! `OracleItemIr` directly.
+//!
+//! **Unit-3a status.** The builder orders items by `(first_line, ordinal)` and is
+//! ready to receive exact spans, but its only current producer is
+//! `parsed_abilities_to_doc_ir`, which runs after lowering and can supply only a
+//! whole-document containing span (see `OracleSourceSpan::whole_document`). So
+//! today's item order still reproduces the category order of `ParsedAbilities`.
+//! Unit 3b moves emission into the dispatch loop, at which point items become
+//! genuinely source-ordered with exact spans and this note is deleted.
+
+// NOTE ON `dead_code`: suppression in this module is **per item**, never
+// module-wide. A module-wide `#![allow(dead_code)]` also silences code not yet
+// written, and it is precisely what hid two silent defects here during review
+// (an `emit` counter that skipped every `PreLowered*` payload, and a
+// `validate_child_span` that failed open). Each suppression below names the unit
+// that gives the item a production caller, and dies when that unit lands.
+
+use std::collections::BTreeMap;
 
 use super::diagnostic::OracleDiagnostic;
 use super::effect_chain::EffectChainIr;
@@ -18,40 +37,243 @@ use crate::types::ability::{
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaCost;
 
-/// Document-level IR: the complete parsed representation of a card's Oracle text.
+// ---------------------------------------------------------------------------
+// Source identity
+// ---------------------------------------------------------------------------
+
+/// Stable document-local identity for one parsed item.
 ///
-/// Produced by `parse_oracle_ir`, consumed by `lower_oracle_ir`.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-pub(crate) struct OracleDocIr {
-    /// Parsed items in source order.
-    pub(crate) items: Vec<OracleItemIr>,
-    /// Original Oracle text (provenance).
-    pub(crate) source_text: String,
-    /// Card name for self-reference context.
-    pub(crate) card_name: String,
-    /// Typed diagnostics accumulated during parsing (D-07).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub(crate) diagnostics: Vec<OracleDiagnostic>,
+/// Reserved by `OracleDocBuilder::begin_item` *before* branch parsing, so a
+/// nested parser can name its owning item without the item existing yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
+pub(crate) struct OracleItemId(pub(crate) u32);
+
+/// Document-global identity for one independently auditable unit: an item, a
+/// clause, a modal mode, a trigger/static/replacement execute body, a granted
+/// ability body, or an explicit unsupported fallback.
+///
+/// `ordinal` is scoped to `item`; `ordinal == 0` is the item's own header unit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
+pub(crate) struct OracleUnitId {
+    pub(crate) item: OracleItemId,
+    pub(crate) ordinal: u32,
 }
 
-/// Individual parsed item from Oracle text.
+/// How precisely a span locates its unit.
 ///
-/// Core variants carry IR types (EffectChainIr, TriggerIr, StaticIr, ReplacementIr).
-/// PreLowered variants carry already-assembled engine types from pre-processors
-/// and dispatch paths that construct definitions directly.
+/// A span is always *true* — it always contains its unit — but it is not always
+/// *minimal*. A consumer that renders a position (Plan 02's per-unit
+/// diagnostics) must be able to tell the difference, because `first_line == 0`
+/// on a whole-document span is not the claim "this unit is on line 0"; it is the
+/// claim "we do not yet know which line". Rendering the former as the latter is
+/// a precise-looking wrong answer, which is worse than an admittedly coarse one.
+///
+/// Typed rather than a `bool` per CLAUDE.md: a future `LineOnly` precision (line
+/// known, byte range not) is an enum value, not a second flag.
+// No `Ord`: `Exact < WholeDocument` would be a meaningless magnitude claim on a
+// qualifier this enum's own docs call orthogonal to containment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
+pub(crate) enum SpanPrecision {
+    /// The span is the unit's exact byte/line extent. Safe to render.
+    Exact,
+    /// The span is the whole Oracle document: a true containing range whose
+    /// bounds carry no per-unit information. A renderer must NOT print
+    /// `first_line`/`start_byte` as this unit's position.
+    ///
+    /// UNIT-3B DEBT — emitted only by `OracleSourceSpan::whole_document`.
+    WholeDocument,
+}
+
+/// Position of a unit within the original Oracle text, plus how precisely that
+/// position is known (`precision`).
+///
+/// Byte ranges are required (not just line ranges) so two clauses on one
+/// physical line remain distinguishable. `ordinal_within_span` disambiguates
+/// units that share a byte span — one Oracle line may legitimately yield two
+/// items (e.g. `Kicker {2}{G}` emits a `Keyword` and an `AdditionalCost`).
+// No `PartialOrd`/`Ord`: derived lexicographic order would compare `precision`
+// ahead of `ordinal_within_span`, which is nonsense, and there is no consumer —
+// the item map is keyed by an explicit `(usize, u32)` tuple, not by this type.
+// If a future unit needs ordering, hand-implement it over
+// `(start_byte, end_byte, ordinal_within_span)` and never over `precision`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
+pub(crate) struct OracleSourceSpan {
+    pub(crate) first_line: usize,
+    pub(crate) last_line: usize,
+    pub(crate) start_byte: usize,
+    pub(crate) end_byte: usize,
+    /// Whether the bounds above locate this unit exactly. See `SpanPrecision`.
+    pub(crate) precision: SpanPrecision,
+    pub(crate) ordinal_within_span: u32,
+}
+
+impl OracleSourceSpan {
+    /// The whole Oracle document, distinguished only by `ordinal_within_span`.
+    ///
+    /// UNIT-3B DEBT, and deliberately coarse rather than fabricated. Items are
+    /// currently emitted by `parsed_abilities_to_doc_ir`, which runs *after*
+    /// lowering and never sees the line cursor, so no exact position is
+    /// recoverable there. Recovering one by searching `source_text` for a
+    /// lowered definition's `description` would be precisely the lowered-shape
+    /// scan this plan exists to delete.
+    ///
+    /// This span is *true* — the document does contain the item — merely not
+    /// minimal. Unit 3b moves emission into the dispatch loop, where the exact
+    /// line/byte range is in hand, and this constructor disappears.
+    ///
+    /// Invariants still hold: `is_contained_by` is satisfied by construction,
+    /// and `conflicts_with` cannot fire because ordinals are distinct.
+    ///
+    /// Carries `SpanPrecision::WholeDocument` so a consumer cannot mistake
+    /// `first_line == 0` for "this unit is on line 0".
+    pub(crate) fn whole_document(source_text: &str, ordinal_within_span: u32) -> Self {
+        Self {
+            first_line: 0,
+            last_line: source_text.lines().count().saturating_sub(1),
+            start_byte: 0,
+            end_byte: source_text.len(),
+            precision: SpanPrecision::WholeDocument,
+            ordinal_within_span,
+        }
+    }
+
+    /// An exactly-located span. The constructor unit 3b uses once emission moves
+    /// into the dispatch loop and the real line/byte range is in hand.
+    #[allow(dead_code)] // production caller lands in unit 3b.
+    pub(crate) fn exact(
+        first_line: usize,
+        last_line: usize,
+        start_byte: usize,
+        end_byte: usize,
+        ordinal_within_span: u32,
+    ) -> Self {
+        Self {
+            first_line,
+            last_line,
+            start_byte,
+            end_byte,
+            precision: SpanPrecision::Exact,
+            ordinal_within_span,
+        }
+    }
+
+    /// True when this span's bounds locate the unit exactly. A position renderer
+    /// must consult this before printing a line number or byte offset.
+    ///
+    /// Live in production today: `check_fragment_precision` <- `emit`.
+    pub(crate) fn is_exact(&self) -> bool {
+        matches!(self.precision, SpanPrecision::Exact)
+    }
+
+    /// True when `self` and `other` cover overlapping bytes *and* claim the same
+    /// `ordinal_within_span`. Co-located siblings with distinct ordinals are
+    /// legal; that is what `ordinal_within_span` exists for.
+    pub(crate) fn conflicts_with(&self, other: &Self) -> bool {
+        self.ordinal_within_span == other.ordinal_within_span
+            && self.start_byte < other.end_byte
+            && other.start_byte < self.end_byte
+    }
+
+    /// True when `self` lies entirely within `other`'s byte range.
+    #[allow(dead_code)] // production caller lands in unit 3b.
+    pub(crate) fn is_contained_by(&self, other: &Self) -> bool {
+        self.start_byte >= other.start_byte && self.end_byte <= other.end_byte
+    }
+}
+
+/// A unit's identity, its source position, and — when that position is exact —
+/// the verbatim fragment it covers.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-#[allow(dead_code)] // Core IR variants used in tests + wired in future phases.
-#[allow(clippy::large_enum_variant)] // Intentional: variants carry engine types directly.
-pub(crate) enum OracleItemIr {
-    /// Spell or activated ability effect chain (carries EffectChainIr since Phase 49).
+pub(crate) struct OracleUnitSource {
+    id: OracleUnitId,
+    span: OracleSourceSpan,
+    /// The verbatim Oracle text this unit covers — **only** when `span.precision`
+    /// is `Exact`.
+    ///
+    /// `None` under `WholeDocument`, because the only "fragment" such a span could
+    /// honestly report is the entire card. Handing a diagnostic renderer the whole
+    /// card as "the offending clause" is a precise-looking wrong answer, exactly
+    /// what `SpanPrecision` exists to prevent — guarding the span while leaving the
+    /// fragment lying would move the lie, not remove it.
+    ///
+    /// `emit` rejects any unit whose fragment presence disagrees with its precision.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fragment: Option<String>,
+}
+
+impl OracleUnitSource {
+    #[allow(dead_code)] // consumed by Plan 02's per-unit diagnostics.
+    pub(crate) fn id(&self) -> OracleUnitId {
+        self.id
+    }
+
+    #[allow(dead_code)] // consumed by Plan 02's per-unit diagnostics.
+    pub(crate) fn span(&self) -> &OracleSourceSpan {
+        &self.span
+    }
+
+    /// `Some` iff the span is `Exact`. See the field docs.
+    #[allow(dead_code)] // consumed by Plan 02's per-unit diagnostics.
+    pub(crate) fn fragment(&self) -> Option<&str> {
+        self.fragment.as_deref()
+    }
+
+    /// Fields are private so a nested parser holding a `UnitAllocator` cannot
+    /// forge a source with an arbitrary span. The only constructors are
+    /// `OracleDocBuilder::begin_item` and `UnitAllocator::allocate_with_span`,
+    /// both of which validate.
+    fn new(id: OracleUnitId, span: OracleSourceSpan, fragment: Option<&str>) -> Self {
+        Self {
+            id,
+            span,
+            fragment: fragment.map(str::to_owned),
+        }
+    }
+
+    /// A unit whose fragment presence contradicts its span precision is a parser
+    /// contract violation, not an Oracle-text problem. Fail closed.
+    fn check_fragment_precision(&self) -> Result<(), DocBuilderError> {
+        if self.fragment.is_some() == self.span.is_exact() {
+            Ok(())
+        } else {
+            Err(DocBuilderError::FragmentPrecisionMismatch {
+                unit: self.id,
+                precision: self.span.precision,
+            })
+        }
+    }
+}
+
+/// One source-addressed parsed item.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct OracleItemIr {
+    pub(crate) id: OracleItemId,
+    pub(crate) source: OracleUnitSource,
+    pub(crate) node: OracleNodeIr,
+}
+
+/// The typed payload of a document item. Identity and provenance live on
+/// `OracleItemIr`; this enum carries only the parsed category.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[allow(clippy::large_enum_variant)] // Intentional: variants carry parser IR directly.
+pub(crate) enum OracleNodeIr {
+    /// Spell or activated ability effect chain.
+    ///
+    /// Unit 3b replaces this payload with `AbilityIr { source, body, shell }` so
+    /// the activation metadata the router currently applies around the chain
+    /// becomes typed IR rather than a pre-lowered `AbilityDefinition`.
+    #[allow(dead_code)] // constructed by ordinary dispatch in unit 3b.
     Spell(EffectChainIr),
-    /// Triggered ability (carries TriggerIr since Phase 49).
+    /// Triggered ability.
+    #[allow(dead_code)] // constructed by ordinary dispatch in unit 3b.
     Trigger(TriggerIr),
-    /// Static ability (carries StaticIr since Phase 49).
+    /// Static ability.
+    #[allow(dead_code)] // constructed by ordinary dispatch in unit 3b.
     Static(StaticIr),
-    /// Replacement effect (carries ReplacementIr since Phase 49).
+    /// Replacement effect.
+    #[allow(dead_code)] // constructed by ordinary dispatch in unit 3b.
     Replacement(ReplacementIr),
-    /// Keyword ability from keyword-only line.
+    /// Keyword ability from a keyword line.
     Keyword(Keyword),
     /// Modal spell block (Choose one/two/etc.).
     Modal(ModalChoice),
@@ -65,56 +287,977 @@ pub(crate) enum OracleItemIr {
     SolveCondition(SolveCondition),
     /// Strive per-target surcharge.
     StriveCost(ManaCost),
-    /// Pre-lowered trigger from pre-processors (saga, leveler, spacecraft, exert, etc.)
-    /// that construct `TriggerDefinition` directly without going through branch IR parsers.
+
+    // -----------------------------------------------------------------------
+    // UNIT-4 DEBT — pre-lowered escape hatches.
+    //
+    // These four variants carry already-assembled engine definitions rather
+    // than IR. They exist for exactly one reason: the five preprocessors
+    // (`parse_saga_chapters`, `parse_attraction_visit_triggers`,
+    // `parse_level_blocks`, `parse_spacecraft_threshold_lines`,
+    // `parse_class_oracle_text`) return lowered engine types and have nowhere
+    // else to go. Converting them is unit 4, whose file set is disjoint from
+    // unit 3's.
+    //
+    // Until unit 4 lands, ordinary dispatch ALSO routes through these (unit 3b
+    // converts ordinary dispatch to `Spell`/`Trigger`/`Static`/`Replacement`).
+    //
+    // Removal gate 4 ("grep finds no `PreLowered*`") is satisfied only after
+    // unit 4. Do not add a new producer of these variants.
+    // -----------------------------------------------------------------------
+    /// Pre-lowered trigger from a preprocessor. UNIT-4 DEBT.
     PreLoweredTrigger(TriggerDefinition),
-    /// Pre-lowered static from pre-processors (leveler, defiler, etc.)
-    /// that construct `StaticDefinition` directly.
+    /// Pre-lowered static from a preprocessor. UNIT-4 DEBT.
     PreLoweredStatic(StaticDefinition),
-    /// Pre-lowered replacement from pre-processors (saga ETB replacement, etc.)
-    /// that construct `ReplacementDefinition` directly.
+    /// Pre-lowered replacement from a preprocessor. UNIT-4 DEBT.
     PreLoweredReplacement(ReplacementDefinition),
-    /// Pre-lowered spell/activated ability from dispatch paths that construct
-    /// `AbilityDefinition` directly with post-processing (equip, loyalty,
-    /// activated abilities with manual cost/restriction, etc.).
+    /// Pre-lowered spell/activated ability from a preprocessor or dispatch path
+    /// that constructs an `AbilityDefinition` directly. UNIT-4 DEBT.
     PreLoweredSpell(AbilityDefinition),
+}
+
+// ---------------------------------------------------------------------------
+// CR 707.9a printed-slot indices
+// ---------------------------------------------------------------------------
+
+/// The printed slot the next emitted ability will occupy.
+///
+/// CR 707.9a: "Some copy effects cause the copy to gain an ability as part of the
+/// copying process. This ability becomes part of the copiable values for the
+/// copy, along with any other abilities that were copied." An "…except it has
+/// this ability" clause must resolve to the correct *printed* slot, so the index
+/// threaded into the parser has to be the emission count, not a vector length.
+///
+/// A newtype rather than `usize` so a category-vector length cannot be passed by
+/// accident. The only unrestricted producer is `OracleDocBuilder::ability_index`;
+/// the one escape hatch is loudly named and deleted in unit 3b.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct PrintedAbilityIndex(usize);
+
+/// The printed slot the next emitted trigger will occupy. See
+/// `PrintedAbilityIndex`; same rule, same reasoning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct PrintedTriggerIndex(usize);
+
+macro_rules! printed_index_impl {
+    ($t:ty) => {
+        impl $t {
+            /// The raw slot, for the parser internals that still store `usize`.
+            pub(crate) fn get(self) -> usize {
+                self.0
+            }
+
+            /// The slot `n` positions after this one. Compound splitting emits
+            /// several definitions from one line and needs each one's own slot.
+            #[allow(dead_code)] // ability side gains a caller in unit 3b.
+            pub(crate) fn offset(self, n: usize) -> Self {
+                Self(self.0 + n)
+            }
+
+            /// **UNIT-3B DEBT — the sole legal way to build a printed index from
+            /// a category-vector length.**
+            ///
+            /// In unit 3a the builder is constructed inside
+            /// `parsed_abilities_to_doc_ir`, i.e. *after* the dispatch loop has
+            /// run, so the loop's index reads have no builder in scope and must
+            /// still derive the slot from `Vec::len()`. That is correct today and
+            /// only today: emission is category-ordered, so `len()` *is* the
+            /// printed slot. Unit 3b emits in source order and the equality dies.
+            ///
+            /// Rather than trust a comment, the newtype forces every such read to
+            /// name this function, so `rg from_category_vector_len` enumerates every
+            /// site that derives an **absolute** printed slot from a category vector.
+            /// Unit 3b deletes this constructor; afterwards
+            /// `Some(result.triggers.len())` does not compile and
+            /// `OracleDocBuilder` is the only producer.
+            ///
+            /// **That grep is complete for absolute derivations and for nothing else.**
+            /// `offset(n)` displaces an already-correct base and is NOT part of this
+            /// cutover, but its argument can carry debt of its own:
+            ///
+            /// * `oracle_trigger.rs` (`base.offset(i)`, two sites) — `i` indexes the
+            ///   compound halves of ONE trigger line. Structural; correct under any
+            ///   emission order; not debt.
+            /// * `oracle_spacecraft.rs` (`base.offset(output.triggers.len())`) — a
+            ///   `len()` read of the preprocessor's OWN local vector, so it is
+            ///   relative and survives document reordering, but unit 4 replaces it
+            ///   with an emission counter when that preprocessor emits through the
+            ///   builder.
+            ///
+            /// So: `rg from_category_vector_len` for the 3b cutover; `rg '\.offset\('`
+            /// to review the relative sites, one of which is unit-4 debt. Claiming a
+            /// single grep is exhaustive would be a false safety promise, which is the
+            /// defect class this whole type exists to remove.
+            ///
+            /// A `debug_assert_eq!(counter, vec.len())` was considered and rejected:
+            /// it holds only while emission is category-ordered, so it would fire on
+            /// *correct* code the moment 3b reorders, and it is compiled out of the
+            /// release profile that generates `card-data.json`.
+            pub(crate) fn from_category_vector_len(len: usize) -> Self {
+                Self(len)
+            }
+        }
+    };
+}
+
+printed_index_impl!(PrintedAbilityIndex);
+printed_index_impl!(PrintedTriggerIndex);
+
+/// Test-only constructors. Kept behind `cfg(test)` so production code cannot
+/// mint a printed index out of a bare integer: the only production producers are
+/// `OracleDocBuilder::{ability_index, trigger_index}` and the loudly-named
+/// `from_category_vector_len` escape hatch that unit 3b deletes.
+#[cfg(test)]
+impl PrintedTriggerIndex {
+    pub(crate) fn from_slot_for_test(slot: usize) -> Self {
+        Self(slot)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Document
+// ---------------------------------------------------------------------------
+
+/// Document-level IR: the complete parsed representation of a card's Oracle text.
+///
+/// Produced by `parse_oracle_ir`, consumed by `lower_oracle_ir`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct OracleDocIr {
+    /// Parsed items in Oracle source order.
+    pub(crate) items: Vec<OracleItemIr>,
+    /// Original Oracle text (provenance).
+    pub(crate) source_text: String,
+    /// Card name for self-reference context.
+    pub(crate) card_name: String,
+    /// Typed diagnostics accumulated during parsing (D-07).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) diagnostics: Vec<OracleDiagnostic>,
+}
+
+impl OracleDocIr {
+    /// Look up an item by its stable id. Cross-item lowering binds through this,
+    /// never by scanning category vectors for a matching shape.
+    #[allow(dead_code)] // production caller lands in unit 3b.
+    pub(crate) fn item(&self, id: OracleItemId) -> Option<&OracleItemIr> {
+        self.items.iter().find(|item| item.id == id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+/// Reason an item or unit was rejected by the builder. These are contract
+/// violations in the parser, not Oracle-text problems.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // production caller lands in unit 3b.
+pub(crate) enum DocBuilderError {
+    DuplicateItemPosition {
+        span: OracleSourceSpan,
+    },
+    OverlappingSiblingSpans {
+        first: OracleSourceSpan,
+        second: OracleSourceSpan,
+    },
+    ChildSpanOutsideItem {
+        item: OracleItemId,
+        child: OracleSourceSpan,
+    },
+    /// A unit carries a fragment without an `Exact` span, or vice versa.
+    FragmentPrecisionMismatch {
+        unit: OracleUnitId,
+        precision: SpanPrecision,
+    },
+}
+
+/// Item-scoped allocator for child `OracleUnitId`s.
+///
+/// Handed to nested clause/mode/body parsers through `ParseContext`. A nested
+/// parser may allocate child units but can never invent an `OracleItemId`.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // production caller lands in unit 3b.
+pub(crate) struct UnitAllocator {
+    item: OracleItemId,
+    /// The owning item's span. Held here, not on `ItemSlot`, because the
+    /// allocator is what nested parsers actually receive (through `ParseContext`)
+    /// — see `allocate_with_span`.
+    parent_span: OracleSourceSpan,
+    next_ordinal: u32,
+    issued: Vec<u32>,
+}
+
+#[allow(dead_code)] // production caller lands in unit 3b.
+impl UnitAllocator {
+    fn new(item: OracleItemId, parent_span: OracleSourceSpan) -> Self {
+        // Ordinal 0 is reserved for the item's own header unit.
+        Self {
+            item,
+            parent_span,
+            next_ordinal: 1,
+            issued: vec![0],
+        }
+    }
+
+    /// Allocate a child unit **with** its source, validating containment.
+    ///
+    /// This is the only way to obtain an `OracleUnitSource` for a nested clause,
+    /// mode, or execute body, and it is why `OracleUnitSource`'s fields are
+    /// private. A validator that merely *offered* to check a child span would be
+    /// advisory: nested parsers hold this allocator, detached from the `ItemSlot`,
+    /// so a `validate_child_span` living on the slot is not reachable from the
+    /// code that needs it. Putting the parent span here makes the check
+    /// unavoidable rather than available.
+    ///
+    /// Fails closed on an out-of-range child and on a fragment/precision mismatch.
+    pub(crate) fn allocate_with_span(
+        &mut self,
+        span: OracleSourceSpan,
+        fragment: Option<&str>,
+    ) -> Result<OracleUnitSource, DocBuilderError> {
+        if !span.is_contained_by(&self.parent_span) {
+            return Err(DocBuilderError::ChildSpanOutsideItem {
+                item: self.item,
+                child: span,
+            });
+        }
+        let source = OracleUnitSource::new(self.allocate(), span, fragment);
+        source.check_fragment_precision()?;
+        Ok(source)
+    }
+
+    pub(crate) fn item(&self) -> OracleItemId {
+        self.item
+    }
+
+    /// Allocate the next child unit id. **Private on purpose**: an id handed to a
+    /// nested parser without a validated span is exactly the forge path
+    /// `allocate_with_span` exists to close. Making `OracleUnitSource`'s fields
+    /// private is the load-bearing half; leaving a span-less allocator beside the
+    /// new constructor would be theatre.
+    fn allocate(&mut self) -> OracleUnitId {
+        let ordinal = self.next_ordinal;
+        self.next_ordinal += 1;
+        self.issued.push(ordinal);
+        OracleUnitId {
+            item: self.item,
+            ordinal,
+        }
+    }
+}
+
+/// Source-positioned document collector.
+///
+/// Keyed by `(first_line, ordinal_within_span)` so emission order is irrelevant
+/// and the final `Vec` is always in Oracle source order. This is what makes the
+/// document IR source-ordered rather than category-ordered.
+#[derive(Debug, Default)]
+pub(crate) struct OracleDocBuilder {
+    items: BTreeMap<(usize, u32), OracleItemIr>,
+    next_item_id: u32,
+    /// CR 707.9a printed-**trigger** index: the slot the next emitted trigger
+    /// occupies.
+    ///
+    /// CR 707.9a: "Some copy effects cause the copy to gain an ability as part of
+    /// the copying process. This ability becomes part of the copiable values for
+    /// the copy, along with any other abilities that were copied."
+    ///
+    /// **The rule is not "never derive an index from a vector length."** It is
+    /// *never derive an ABSOLUTE printed slot from a DOCUMENT category vector*,
+    /// whose order unit 3b changes. Deriving from an **emission-ordered id stack**
+    /// is exactly right — that is why `ability_index()` is `spells_emitted.len()`
+    /// and has no counter of its own.
+    ///
+    /// **UNIT-4 PRECONDITION.** This is a bare counter rather than
+    /// `triggers_emitted.len()` only because no `triggers.pop()` exists anywhere in
+    /// the parser (control-verified against the `result.abilities.pop()` that does).
+    /// Triggers are insert-only, so the counter cannot disagree with `items`.
+    ///
+    /// Unit 4 makes preprocessors emit through this builder. The first
+    /// `take_last_trigger` — or any API handing out a `&mut OracleNodeIr` able to
+    /// change an emitted item's variant — lets this counter disagree with `items`
+    /// and reintroduces the CR 707.9a two-triggers-one-slot collision. Convert it
+    /// to a symmetric `triggers_emitted: Vec<OracleItemId>` **before** either lands.
+    ///
+    /// Do **not** "derive" it by filtering `items` for trigger variants. That
+    /// couples the printed-slot index to variant mutation (flip a `Trigger` to a
+    /// `Keyword` and the derived index silently decrements) and adds a third
+    /// representation of a fact `spells_emitted` already models correctly with a
+    /// stack.
+    trigger_index: usize,
+    /// Ids of emitted spells, in **emission** order — and the sole authority for
+    /// the CR 707.9a ability index, which is simply `spells_emitted.len()`.
+    ///
+    /// There is deliberately no separate `ability_index: usize`. A counter beside
+    /// this vector could disagree with it (push without increment, pop without
+    /// decrement, or a rejected `emit` mutating one but not the other); deriving
+    /// the index from the vector's length makes disagreement unrepresentable
+    /// rather than merely tested for. `take_last_spell` pops here, not from the
+    /// source-ordered item map, because slots are assigned at *emission* time.
+    spells_emitted: Vec<OracleItemId>,
+}
+
+/// A reserved item slot: the id exists, the payload does not yet.
+#[derive(Debug)]
+pub(crate) struct ItemSlot {
+    id: OracleItemId,
+    source: OracleUnitSource,
+    allocator: UnitAllocator,
+}
+
+#[allow(dead_code)] // production caller lands in unit 3b.
+impl ItemSlot {
+    pub(crate) fn id(&self) -> OracleItemId {
+        self.id
+    }
+
+    pub(crate) fn source(&self) -> &OracleUnitSource {
+        &self.source
+    }
+
+    pub(crate) fn allocator(&mut self) -> &mut UnitAllocator {
+        &mut self.allocator
+    }
+}
+
+impl OracleDocBuilder {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// The printed slot the next emitted ability will occupy (CR 707.9a). Read
+    /// before emission. This — not `Vec::len()` — is the authority in unit 3b.
+    ///
+    /// **UNIT-3B PRECONDITION, do not lose this.** An ability's *real* printed slot
+    /// is its source rank among spells: `lower_oracle_ir` fills `result.abilities`
+    /// by iterating `ir.items`, which is key-ordered by source position. This
+    /// counter instead reports the *emission* rank. The two agree only while `emit`
+    /// is called in nondecreasing `first_line` order — which unit 3a satisfies by
+    /// accident (every span is `WholeDocument`, so the key degenerates to the
+    /// emission ordinal) and which unit 3b's dispatch-loop emission must either
+    /// guarantee or replace.
+    ///
+    /// So unit 3b must do one of: (a) assert `emit` is called in nondecreasing
+    /// `first_line` order, or (b) derive both counters at `finish()` from the
+    /// source-ordered item vector rather than at `emit()`. Option (b) is the honest
+    /// one; (a) merely re-states today's accident as a rule.
+    #[allow(dead_code)] // becomes the sole index authority in unit 3b.
+    pub(crate) fn ability_index(&self) -> PrintedAbilityIndex {
+        PrintedAbilityIndex(self.spells_emitted.len())
+    }
+
+    /// The next trigger's printed index (CR 707.9a). Read before emission.
+    #[allow(dead_code)] // becomes the sole index authority in unit 3b.
+    pub(crate) fn trigger_index(&self) -> PrintedTriggerIndex {
+        PrintedTriggerIndex(self.trigger_index)
+    }
+
+    /// Reserve an `OracleItemId` and its header unit **before** branch parsing,
+    /// returning an item-scoped allocator for nested units.
+    pub(crate) fn begin_item(
+        &mut self,
+        span: OracleSourceSpan,
+        fragment: Option<&str>,
+    ) -> ItemSlot {
+        let id = OracleItemId(self.next_item_id);
+        self.next_item_id += 1;
+        let source = OracleUnitSource::new(
+            OracleUnitId {
+                item: id,
+                ordinal: 0,
+            },
+            span.clone(),
+            fragment,
+        );
+        ItemSlot {
+            id,
+            source,
+            allocator: UnitAllocator::new(id, span),
+        }
+    }
+
+    /// Commit a reserved slot with its parsed payload.
+    ///
+    /// Rejects a duplicate `(first_line, ordinal_within_span)` position, any
+    /// sibling whose byte span conflicts (overlapping bytes at the same ordinal),
+    /// and any item whose fragment presence contradicts its span precision.
+    pub(crate) fn emit(
+        &mut self,
+        slot: ItemSlot,
+        node: OracleNodeIr,
+    ) -> Result<OracleItemId, DocBuilderError> {
+        slot.source.check_fragment_precision()?;
+        let span = slot.source.span.clone();
+        let key = (span.first_line, span.ordinal_within_span);
+        if self.items.contains_key(&key) {
+            return Err(DocBuilderError::DuplicateItemPosition { span });
+        }
+        for existing in self.items.values() {
+            if existing.source.span.conflicts_with(&span) {
+                return Err(DocBuilderError::OverlappingSiblingSpans {
+                    first: existing.source.span.clone(),
+                    second: span,
+                });
+            }
+        }
+        // CR 707.9a printed-slot counters. EXHAUSTIVE ON PURPOSE — no `_` arm.
+        // A pre-lowered spell/trigger occupies a printed slot exactly like a core
+        // one, so it must advance the counter. A wildcard here would silently
+        // mis-index every card that reaches a preprocessor. When a variant is
+        // added, the compiler must ask whether it consumes a printed slot.
+        match node {
+            // Pushing IS the increment: `ability_index()` reads `spells_emitted.len()`.
+            // Reached only after the duplicate/conflict/fragment early-returns above,
+            // so a rejected `emit` mutates neither counter.
+            OracleNodeIr::Spell(_) | OracleNodeIr::PreLoweredSpell(_) => {
+                self.spells_emitted.push(slot.id);
+            }
+            OracleNodeIr::Trigger(_) | OracleNodeIr::PreLoweredTrigger(_) => {
+                self.trigger_index += 1
+            }
+            OracleNodeIr::Static(_)
+            | OracleNodeIr::PreLoweredStatic(_)
+            | OracleNodeIr::Replacement(_)
+            | OracleNodeIr::PreLoweredReplacement(_)
+            | OracleNodeIr::Keyword(_)
+            | OracleNodeIr::Modal(_)
+            | OracleNodeIr::AdditionalCost(_)
+            | OracleNodeIr::CastingRestriction(_)
+            | OracleNodeIr::CastingOption(_)
+            | OracleNodeIr::SolveCondition(_)
+            | OracleNodeIr::StriveCost(_) => {}
+        }
+        let id = slot.id;
+        self.items.insert(
+            key,
+            OracleItemIr {
+                id,
+                source: slot.source,
+                node,
+            },
+        );
+        Ok(id)
+    }
+
+    /// Remove the most recently **emitted** spell item, returning it. The typed
+    /// replacement for `result.abilities.pop()` (`oracle.rs`), used by cross-line
+    /// "instead" composition, which folds the previous ability into the new one.
+    ///
+    /// **Emission order, not source order — this is the whole correctness argument.**
+    /// `emit` assigns a printed slot from `ability_index` at *emission* time, while
+    /// `items` is a `BTreeMap` keyed by *source* position and this builder
+    /// explicitly supports out-of-order emission (see
+    /// `builder_returns_items_in_source_order_regardless_of_emission_order`). Popping
+    /// the greatest source key would therefore free the wrong slot: emit spell A at
+    /// line 5 (slot 0), then spell B at line 1 (slot 1); the max key is A, so taking
+    /// it decrements `ability_index` to 1 while B still holds slot 1 — and the next
+    /// emitted spell is issued slot 1 as well. Two abilities, one CR 707.9a printed
+    /// slot, and a copy's "except it has this ability" binds the wrong one, silently.
+    /// Popping `spells_emitted` mirrors `Vec::pop()` on the emission-ordered
+    /// `result.abilities` exactly, which is what this method replaces.
+    ///
+    /// **Takes no id, on purpose.** An id-taking `take_item` would accept *any* item
+    /// while implementing `pop()` semantics, expressing that same slot collision.
+    /// Restricting the taker to the last emitted spell makes the call
+    /// unrepresentable rather than merely discouraged.
+    ///
+    /// It cannot remove a trigger, so the trigger counter can never drift. There is
+    /// no counter to underflow: the ability index *is* `spells_emitted.len()`, so
+    /// popping the vector and freeing the printed slot are the same operation. An
+    /// empty builder yields `None` from the first `?`.
+    ///
+    /// Exactly mirrors production, verified: `result.abilities.pop()` is the only
+    /// category `pop()` in the parser — no `triggers.pop()`, `statics.pop()`, or
+    /// `replacements.pop()` exists.
+    // Production caller lands in unit 3b: the `result.abilities.pop()` in
+    // `oracle.rs`. Named by symbol, not by line — a line number in a comment is an
+    // unchecked claim, and the one that stood here had already rotted inside this
+    // very diff, moved by lines the diff itself added above it.
+    #[allow(dead_code)]
+    pub(crate) fn take_last_spell(&mut self) -> Option<OracleItemIr> {
+        let id = self.spells_emitted.pop()?;
+        let key = *self
+            .items
+            .iter()
+            .find(|(_, i)| i.id == id)
+            .map(|(k, _)| k)
+            .expect("spells_emitted holds only ids that `emit` inserted");
+        // Popping IS the decrement: the freed printed slot is the popped spell's.
+        // `spells_emitted` can never name an id absent from `items` — `emit` inserts
+        // both together, and this is the only removal path.
+        self.items.remove(&key)
+    }
+
+    /// Finish, producing items already in Oracle source order.
+    pub(crate) fn finish(
+        self,
+        source_text: &str,
+        card_name: &str,
+        diagnostics: Vec<OracleDiagnostic>,
+    ) -> OracleDocIr {
+        OracleDocIr {
+            items: self.items.into_values().collect(),
+            source_text: source_text.to_string(),
+            card_name: card_name.to_string(),
+            diagnostics,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn oracle_doc_ir_empty_construction() {
-        let doc = OracleDocIr {
-            items: vec![],
-            source_text: "Flying".to_string(),
-            card_name: "Serra Angel".to_string(),
-            diagnostics: vec![],
-        };
-        assert!(doc.items.is_empty());
-        assert_eq!(doc.source_text, "Flying");
-        assert_eq!(doc.card_name, "Serra Angel");
-        assert!(doc.diagnostics.is_empty());
+    fn span(first_line: usize, start: usize, end: usize, ordinal: u32) -> OracleSourceSpan {
+        OracleSourceSpan::exact(first_line, first_line, start, end, ordinal)
     }
 
     #[test]
-    fn oracle_item_ir_keyword_variant() {
-        let item = OracleItemIr::Keyword(Keyword::Flying);
-        assert!(matches!(item, OracleItemIr::Keyword(Keyword::Flying)));
+    fn builder_returns_items_in_source_order_regardless_of_emission_order() {
+        let mut b = OracleDocBuilder::new();
+        // Emit line 2 before line 0 — the builder must still order by source.
+        let s2 = b.begin_item(span(2, 20, 30, 0), Some("Creatures you control get +1/+1."));
+        b.emit(s2, OracleNodeIr::Keyword(Keyword::Flying)).unwrap();
+        let s0 = b.begin_item(span(0, 0, 10, 0), Some("Flying"));
+        b.emit(s0, OracleNodeIr::Keyword(Keyword::Vigilance))
+            .unwrap();
+
+        let doc = b.finish(
+            "Flying\n\nCreatures you control get +1/+1.",
+            "Probe",
+            vec![],
+        );
+        let lines: Vec<usize> = doc
+            .items
+            .iter()
+            .map(|i| i.source.span().first_line)
+            .collect();
+        assert_eq!(
+            lines,
+            vec![0, 2],
+            "items must be ordered by source position"
+        );
+    }
+
+    /// One physical line may yield two items (`Kicker {2}{G}` → `Keyword` +
+    /// `AdditionalCost`). They share a byte span and are separated by
+    /// `ordinal_within_span`, so the overlap rule must not reject them.
+    #[test]
+    fn kicker_two_items_from_one_line_do_not_trip_overlap_rejection() {
+        let mut b = OracleDocBuilder::new();
+        let kw = b.begin_item(span(0, 0, 14, 0), Some("Kicker {2}{G}"));
+        b.emit(kw, OracleNodeIr::Keyword(Keyword::Flying)).unwrap();
+
+        let cost = b.begin_item(span(0, 0, 14, 1), Some("Kicker {2}{G}"));
+        let emitted = b.emit(cost, OracleNodeIr::Keyword(Keyword::Vigilance));
+        assert!(
+            emitted.is_ok(),
+            "co-located items with distinct ordinals must be accepted: {emitted:?}"
+        );
+        assert_eq!(b.finish("Kicker {2}{G}", "Probe", vec![]).items.len(), 2);
     }
 
     #[test]
-    fn oracle_doc_ir_mixed_items() {
-        let doc = OracleDocIr {
-            items: vec![
-                OracleItemIr::Keyword(Keyword::Flying),
-                OracleItemIr::Keyword(Keyword::Vigilance),
-            ],
-            source_text: "Flying\nVigilance".to_string(),
-            card_name: "Test Angel".to_string(),
-            diagnostics: vec![],
-        };
+    fn overlapping_sibling_spans_at_same_ordinal_are_rejected() {
+        let mut b = OracleDocBuilder::new();
+        let a = b.begin_item(span(0, 0, 10, 0), Some("abc"));
+        b.emit(a, OracleNodeIr::Keyword(Keyword::Flying)).unwrap();
+        let c = b.begin_item(span(1, 5, 15, 0), Some("def"));
+        let err = b.emit(c, OracleNodeIr::Keyword(Keyword::Vigilance));
+        assert!(
+            matches!(err, Err(DocBuilderError::OverlappingSiblingSpans { .. })),
+            "overlapping bytes at the same ordinal must be rejected, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn duplicate_item_position_is_rejected() {
+        let mut b = OracleDocBuilder::new();
+        let a = b.begin_item(span(0, 0, 5, 0), Some("abc"));
+        b.emit(a, OracleNodeIr::Keyword(Keyword::Flying)).unwrap();
+        let c = b.begin_item(span(0, 0, 5, 0), Some("abc"));
+        assert!(matches!(
+            b.emit(c, OracleNodeIr::Keyword(Keyword::Vigilance)),
+            Err(DocBuilderError::DuplicateItemPosition { .. })
+        ));
+    }
+
+    /// DISCRIMINATING. Nested parsers hold the `UnitAllocator`, handed out by
+    /// `ItemSlot::allocator()` and threaded through `ParseContext` — NOT the
+    /// `ItemSlot` itself. So the containment check has to live where the allocator
+    /// is, or the intended caller cannot reach it.
+    ///
+    /// Two earlier shapes both failed:
+    ///   * builder-side `validate_child_span(id, ..)` — the item is not in the map
+    ///     between `begin_item` and `emit`, which is exactly when nested parsers
+    ///     run, so it returned `Ok(())` for every child. Fail-open.
+    ///   * slot-side `validate_child_span(..)` — unreachable from a detached
+    ///     allocator, and `OracleUnitSource`'s fields were `pub(crate)`, so a nested
+    ///     parser could forge one anyway. Advisory, not enforced.
+    ///
+    /// `allocate_with_span` is the only way to mint a child `OracleUnitSource`, and
+    /// it validates. This test allocates BEFORE `emit`.
+    #[test]
+    fn allocator_rejects_child_span_outside_item_before_emit() {
+        let mut b = OracleDocBuilder::new();
+        let mut slot = b.begin_item(span(0, 0, 10, 0), Some("abcdefghij"));
+        let alloc = slot.allocator();
+
+        let ok = alloc.allocate_with_span(span(0, 2, 8, 1), Some("cdefgh"));
+        assert!(
+            ok.is_ok(),
+            "a contained child must be accepted pre-emit: {ok:?}"
+        );
+
+        let bad = alloc.allocate_with_span(span(0, 2, 30, 2), Some("x"));
+        assert!(
+            matches!(bad, Err(DocBuilderError::ChildSpanOutsideItem { .. })),
+            "an out-of-range child must be REJECTED pre-emit, got {bad:?}"
+        );
+
+        // Fragment/precision coupling is enforced on children too. This span IS
+        // contained (0..10 of a 10-byte document), so only the precision mismatch
+        // can reject it — the assertion cannot pass for the wrong reason.
+        let mism = alloc.allocate_with_span(
+            OracleSourceSpan::whole_document("abcdefghij", 3),
+            Some("abc"),
+        );
+        assert!(
+            matches!(mism, Err(DocBuilderError::FragmentPrecisionMismatch { .. })),
+            "a WholeDocument child carrying a fragment must be rejected, got {mism:?}"
+        );
+
+        // ...and the converse: an Exact span with no fragment is equally rejected.
+        let missing = alloc.allocate_with_span(span(0, 2, 6, 4), None);
+        assert!(
+            matches!(
+                missing,
+                Err(DocBuilderError::FragmentPrecisionMismatch { .. })
+            ),
+            "an Exact child without a fragment must be rejected, got {missing:?}"
+        );
+
+        b.emit(slot, OracleNodeIr::Keyword(Keyword::Flying))
+            .unwrap();
+    }
+
+    /// DISCRIMINATING, and the reason `take_last_spell` pops `spells_emitted`
+    /// rather than the source-ordered map.
+    ///
+    /// `emit` assigns the printed slot at EMISSION time; `items` is keyed by SOURCE
+    /// position and out-of-order emission is a supported contract. Taking the
+    /// greatest source key would free the wrong slot: A@line5 holds slot 0, B@line1
+    /// holds slot 1; popping A leaves B on slot 1 while `ability_index` says the
+    /// next spell also gets slot 1. Two abilities, one CR 707.9a printed slot.
+    #[test]
+    fn take_last_spell_pops_emission_order_not_source_order() {
+        let mut b = OracleDocBuilder::new();
+
+        // Emit LATER source line first — the builder's advertised contract.
+        let a = b.begin_item(span(5, 50, 60, 0), Some("{T}: Add {G}."));
+        let a_id = a.id();
+        b.emit(a, spell_node()).unwrap(); // printed slot 0
+        let bb = b.begin_item(span(1, 10, 20, 0), Some("{T}: Add {R}."));
+        let b_id = bb.id();
+        b.emit(bb, spell_node()).unwrap(); // printed slot 1
+        assert_eq!(b.ability_index().get(), 2);
+
+        let taken = b.take_last_spell().expect("a spell is present");
+        assert_eq!(
+            taken.id, b_id,
+            "must pop the LAST EMITTED spell (slot 1), not the greatest source key (line 5)"
+        );
+        assert_eq!(
+            b.ability_index().get(),
+            1,
+            "the freed slot must be the one the popped spell held"
+        );
+
+        // The survivor is the earlier-emitted spell, still holding slot 0.
+        let doc = b.finish("x", "Probe", vec![]);
+        assert_eq!(doc.items.len(), 1);
+        assert_eq!(doc.items[0].id, a_id);
+    }
+
+    /// FIX G: nothing asserted this after `last_spell_id`'s removal. Three of us
+    /// reasoned it was trivially `None`; none of us had run it.
+    #[test]
+    fn take_last_spell_on_an_empty_builder_is_none() {
+        let mut b = OracleDocBuilder::new();
+        assert!(b.take_last_spell().is_none(), "no spell has been emitted");
+        assert_eq!(
+            b.ability_index().get(),
+            0,
+            "and no printed slot was consumed"
+        );
+    }
+
+    /// DISCRIMINATING. A take followed by a re-emit is where an off-by-one hides:
+    /// `spells_emitted` must be a true stack, and `ability_index` must track it.
+    ///
+    /// It cannot drift, because there is no separate counter — `ability_index()` IS
+    /// `spells_emitted.len()`. This test pins that: cross-line "instead" composition
+    /// takes the previous ability and emits the composed one in its place, so the
+    /// take → emit → take cycle is the production path, not a synthetic one.
+    #[test]
+    fn take_then_reemit_then_take_returns_the_reemitted_spell() {
+        let mut b = OracleDocBuilder::new();
+
+        let a = b.begin_item(span(0, 0, 10, 0), Some("{T}: Add {G}."));
+        let a_id = a.id();
+        b.emit(a, spell_node()).unwrap();
+        let c = b.begin_item(span(1, 11, 21, 0), Some("{T}: Add {R}."));
+        let c_id = c.id();
+        b.emit(c, spell_node()).unwrap();
+        assert_eq!(b.ability_index().get(), 2);
+
+        // Take the last emitted spell (C), as the "instead" composition does.
+        assert_eq!(b.take_last_spell().unwrap().id, c_id);
+        assert_eq!(b.ability_index().get(), 1, "C's slot is freed");
+
+        // Re-emit a composed ability in its place.
+        let composed = b.begin_item(span(1, 11, 21, 0), Some("{T}: Add {R}."));
+        let composed_id = composed.id();
+        b.emit(composed, spell_node()).unwrap();
+        assert_eq!(
+            b.ability_index().get(),
+            2,
+            "the composed ability retakes slot 1"
+        );
+        assert_ne!(composed_id, c_id, "a fresh item id, not a resurrected one");
+
+        // The next take must return the RE-EMITTED spell, not A and not stale C.
+        let second = b.take_last_spell().expect("a spell is present");
+        assert_eq!(
+            second.id, composed_id,
+            "the stack must return the most recently emitted spell after a re-emit"
+        );
+        assert_eq!(b.ability_index().get(), 1);
+
+        // A survives, still on slot 0, and is the last one left.
+        assert_eq!(b.take_last_spell().unwrap().id, a_id);
+        assert_eq!(b.ability_index().get(), 0);
+        assert!(b.take_last_spell().is_none(), "drained");
+    }
+
+    /// The allocator's only public way out is `allocate_with_span`, which
+    /// validates. `allocate()` is private: an id handed to a nested parser without
+    /// a checked span is the forge path this design closes. Ordinal 0 is the item's
+    /// own header unit, so children start at 1 and never collide.
+    #[test]
+    fn allocator_issues_distinct_child_ordinals_starting_after_the_header() {
+        let mut b = OracleDocBuilder::new();
+        let mut slot = b.begin_item(span(0, 0, 10, 0), Some("abcdefghij"));
+        let header = slot.source().id();
+        assert_eq!(header.ordinal, 0, "the item's own unit is ordinal 0");
+
+        let alloc = slot.allocator();
+        let u1 = alloc
+            .allocate_with_span(span(0, 0, 4, 1), Some("abcd"))
+            .expect("contained child");
+        let u2 = alloc
+            .allocate_with_span(span(0, 4, 8, 2), Some("efgh"))
+            .expect("contained child");
+
+        assert_ne!(
+            u1.id().ordinal,
+            u2.id().ordinal,
+            "ordinals must be distinct"
+        );
+        assert_ne!(
+            u1.id().ordinal,
+            0,
+            "children never reuse the header ordinal"
+        );
+        assert_eq!(u1.id().item, u2.id().item, "both belong to the same item");
+    }
+
+    fn spell_node() -> OracleNodeIr {
+        OracleNodeIr::PreLoweredSpell(AbilityDefinition::new(
+            crate::types::ability::AbilityKind::Spell,
+            crate::types::ability::Effect::NoOp,
+        ))
+    }
+
+    fn trigger_node() -> OracleNodeIr {
+        OracleNodeIr::PreLoweredTrigger(TriggerDefinition::new(
+            crate::types::triggers::TriggerMode::ChangesZone,
+        ))
+    }
+
+    /// CR 707.9a: the printed index must be an explicit emission counter, not a
+    /// vector length. A source-ordered builder interleaves categories, so a
+    /// trigger emitted between two abilities must not shift the ability index.
+    ///
+    /// This asserts the *positive* direction too: a spell/trigger item MUST
+    /// advance its counter. An earlier draft only checked that a keyword item
+    /// advanced neither, which passes vacuously even if `emit` never counts.
+    #[test]
+    fn printed_indices_are_explicit_counters_not_vector_lengths() {
+        let mut b = OracleDocBuilder::new();
+        assert_eq!(b.ability_index().get(), 0);
+        assert_eq!(b.trigger_index().get(), 0);
+
+        // Keyword advances neither.
+        let kw = b.begin_item(span(0, 0, 5, 0), Some("Flying"));
+        b.emit(kw, OracleNodeIr::Keyword(Keyword::Flying)).unwrap();
+        assert_eq!(
+            b.ability_index().get(),
+            0,
+            "keyword must not consume an ability slot"
+        );
+        assert_eq!(
+            b.trigger_index().get(),
+            0,
+            "keyword must not consume a trigger slot"
+        );
+
+        // Spell advances only the ability index.
+        let a0 = b.begin_item(span(1, 10, 20, 0), Some("{T}: Add {G}."));
+        b.emit(a0, spell_node()).unwrap();
+        assert_eq!(b.ability_index().get(), 1);
+        assert_eq!(b.trigger_index().get(), 0);
+
+        // A trigger emitted BETWEEN two abilities must not shift the ability index.
+        let t0 = b.begin_item(span(2, 21, 40, 0), Some("When this enters, draw a card."));
+        b.emit(t0, trigger_node()).unwrap();
+        assert_eq!(
+            b.ability_index().get(),
+            1,
+            "trigger must not consume an ability slot"
+        );
+        assert_eq!(b.trigger_index().get(), 1);
+
+        let a1 = b.begin_item(span(3, 41, 55, 0), Some("{T}: Add {R}."));
+        b.emit(a1, spell_node()).unwrap();
+        assert_eq!(
+            b.ability_index().get(),
+            2,
+            "second ability must occupy slot 1, i.e. next index 2, despite the interleaved trigger"
+        );
+        assert_eq!(b.trigger_index().get(), 1);
+
+        // `take_last_spell` frees the printed slot again (cross-line "instead"
+        // composition, oracle.rs `result.abilities.pop()`).
+        b.take_last_spell()
+            .expect("a spell was emitted, so one must be takeable");
+        assert_eq!(
+            b.ability_index().get(),
+            1,
+            "removing a spell must free its printed slot"
+        );
+        assert_eq!(b.trigger_index().get(), 1);
+    }
+
+    /// Discriminating guard for the `emit` counter match: pre-lowered payloads
+    /// occupy printed slots exactly like core ones. A `_ => {}` wildcard would
+    /// silently skip them and mis-index every preprocessor-routed card.
+    #[test]
+    fn prelowered_payloads_consume_printed_slots() {
+        let mut b = OracleDocBuilder::new();
+        let s = b.begin_item(span(0, 0, 5, 0), Some("a"));
+        b.emit(s, spell_node()).unwrap();
+        let t = b.begin_item(span(1, 6, 10, 0), Some("b"));
+        b.emit(t, trigger_node()).unwrap();
+        assert_eq!((b.ability_index().get(), b.trigger_index().get()), (1, 1));
+    }
+
+    /// DISCRIMINATING. `take_last_spell` must remove the LAST spell, never an
+    /// earlier one, and must leave the trigger counter alone.
+    ///
+    /// The replaced `take_item(id)` accepted any id while implementing `pop()`
+    /// counter semantics: taking `a0` here would decrement `ability_index` to 1
+    /// while `a1` still occupies printed slot 1, so the next emitted spell would
+    /// be issued slot 1 as well — two abilities, one CR 707.9a slot. `take_item`
+    /// let a caller express that; `take_last_spell` cannot.
+    #[test]
+    fn take_last_spell_removes_the_last_spell_and_leaves_triggers_alone() {
+        let mut b = OracleDocBuilder::new();
+        let a0 = b.begin_item(span(0, 0, 10, 0), Some("{T}: Add {G}."));
+        let a0_id = a0.id();
+        b.emit(a0, spell_node()).unwrap();
+
+        let t0 = b.begin_item(span(1, 11, 30, 0), Some("When this enters, draw a card."));
+        b.emit(t0, trigger_node()).unwrap();
+
+        let a1 = b.begin_item(span(2, 31, 45, 0), Some("{T}: Add {R}."));
+        let a1_id = a1.id();
+        b.emit(a1, spell_node()).unwrap();
+        assert_eq!((b.ability_index().get(), b.trigger_index().get()), (2, 1));
+
+        let taken = b.take_last_spell().expect("a spell is present");
+        assert_eq!(taken.id, a1_id, "must take the LAST spell, not the first");
+        assert_eq!(
+            b.ability_index().get(),
+            1,
+            "the freed slot is the last one; a0 keeps slot 0"
+        );
+        assert_eq!(
+            b.trigger_index().get(),
+            1,
+            "taking a spell must never move the trigger counter"
+        );
+
+        // a0 survives, and the interleaved trigger is untouched.
+        let doc = b.finish("x", "Probe", vec![]);
         assert_eq!(doc.items.len(), 2);
+        assert_eq!(doc.items[0].id, a0_id);
+
+        // Exhausted: no spell left to take.
+        let mut b2 = OracleDocBuilder::new();
+        let t = b2.begin_item(span(0, 0, 5, 0), Some("t"));
+        b2.emit(t, trigger_node()).unwrap();
+        assert!(
+            b2.take_last_spell().is_none(),
+            "a trigger is not a spell and must not be taken"
+        );
+        assert_eq!(b2.trigger_index().get(), 1);
+
+        // A keyword is not a spell either. (Also guards the pre-lowered matcher:
+        // `spell_node()` is a `PreLoweredSpell`, so a `Spell(_)`-only match in
+        // `take_last_spell` would make every assertion above fail.)
+        let mut b3 = OracleDocBuilder::new();
+        let kw = b3.begin_item(span(0, 0, 6, 0), Some("Flying"));
+        b3.emit(kw, OracleNodeIr::Keyword(Keyword::Flying)).unwrap();
+        assert!(b3.take_last_spell().is_none(), "a keyword is not a spell");
+        assert_eq!(b3.ability_index().get(), 0);
+    }
+
+    /// A whole-document span must be self-describing: `first_line == 0` is "we
+    /// don't know the line", not "line 0". `SpanPrecision` carries that.
+    #[test]
+    fn span_precision_distinguishes_coarse_from_exact() {
+        let coarse = OracleSourceSpan::whole_document("Flying\n{T}: Add {G}.", 0);
+        assert_eq!(coarse.precision, SpanPrecision::WholeDocument);
+        assert!(
+            !coarse.is_exact(),
+            "a renderer must be able to refuse to print line 0 for this span"
+        );
+
+        let exact = OracleSourceSpan::exact(1, 1, 7, 20, 0);
+        assert_eq!(exact.precision, SpanPrecision::Exact);
+        assert!(exact.is_exact());
+
+        // Both are true containing spans; precision is orthogonal to containment.
+        assert!(exact.is_contained_by(&coarse));
+    }
+
+    /// The 3a document span is coarse but true: it contains the item, and
+    /// distinct ordinals keep co-located siblings from tripping the overlap rule.
+    #[test]
+    fn whole_document_span_contains_items_and_never_conflicts() {
+        let text = "Flying\n{T}: Add {G}.";
+        let first = OracleSourceSpan::whole_document(text, 0);
+        let second = OracleSourceSpan::whole_document(text, 1);
+        assert!(first.is_contained_by(&second) && second.is_contained_by(&first));
+        assert!(
+            !first.conflicts_with(&second),
+            "distinct ordinals must not conflict even with identical byte ranges"
+        );
+        assert!(
+            first.conflicts_with(&first.clone()),
+            "same ordinal + overlapping bytes must still conflict (rule is live)"
+        );
+        assert_eq!(first.last_line, 1);
+        assert_eq!(first.end_byte, text.len());
     }
 }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aerial_formation_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aerial_formation_ir.snap
@@ -1,75 +1,108 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 867
 expression: "&ir"
 ---
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "GenericEffect",
-          "static_abilities": [
-            {
-              "mode": "Continuous",
-              "affected": {
-                "type": "ParentTarget"
-              },
-              "modifications": [
-                {
-                  "type": "AddPower",
-                  "value": 1
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 162,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "GenericEffect",
+            "static_abilities": [
+              {
+                "mode": "Continuous",
+                "affected": {
+                  "type": "ParentTarget"
                 },
-                {
-                  "type": "AddToughness",
-                  "value": 1
-                },
-                {
-                  "type": "AddKeyword",
-                  "keyword": "Flying"
-                }
-              ],
-              "condition": null,
-              "affected_zone": null,
-              "effect_zone": null,
-              "active_zones": [],
-              "characteristic_defining": false,
-              "description": "get +1/+1 and gain flying"
-            }
-          ],
-          "duration": "UntilEndOfTurn",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
+                "modifications": [
+                  {
+                    "type": "AddPower",
+                    "value": 1
+                  },
+                  {
+                    "type": "AddToughness",
+                    "value": 1
+                  },
+                  {
+                    "type": "AddKeyword",
+                    "keyword": "Flying"
+                  }
+                ],
+                "condition": null,
+                "affected_zone": null,
+                "effect_zone": null,
+                "active_zones": [],
+                "characteristic_defining": false,
+                "description": "get +1/+1 and gain flying"
+              }
             ],
-            "controller": null,
-            "properties": []
-          }
-        },
-        "cost": null,
-        "sub_ability": null,
-        "duration": "UntilEndOfTurn",
-        "description": "Any number of target creatures each get +1/+1 and gain flying until end of turn.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "multi_target": {
-          "min": 0,
-          "max": null
-        },
-        "forward_result": false
+            "duration": "UntilEndOfTurn",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            }
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": "Any number of target creatures each get +1/+1 and gain flying until end of turn.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "multi_target": {
+            "min": 0,
+            "max": null
+          },
+          "forward_result": false
+        }
       }
     },
     {
-      "StriveCost": {
-        "type": "Cost",
-        "shards": [
-          "Blue"
-        ],
-        "generic": 2
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 162,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "StriveCost": {
+          "type": "Cost",
+          "shards": [
+            "Blue"
+          ],
+          "generic": 2
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_ir.snap
@@ -5,200 +5,268 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "ChangeZone",
-          "origin": null,
-          "destination": "Exile",
-          "target": {
-            "type": "SelfRef"
-          },
-          "owner_library": false,
-          "enter_transformed": false,
-          "enter_tapped": false,
-          "enters_attacking": false
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Mana",
-          "cost": {
-            "type": "Cost",
-            "shards": [
-              "Blue"
-            ],
-            "generic": 0
-          }
-        },
-        "sub_ability": {
-          "kind": "Spell",
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 264,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
           "effect": {
-            "type": "CreateDelayedTrigger",
-            "condition": {
-              "type": "AtNextPhase",
-              "phase": "End"
+            "type": "ChangeZone",
+            "origin": null,
+            "destination": "Exile",
+            "target": {
+              "type": "SelfRef"
             },
-            "effect": {
-              "kind": "Activated",
-              "effect": {
-                "type": "ChangeZone",
-                "origin": "Exile",
-                "destination": "Battlefield",
-                "target": {
-                  "type": "ParentTarget"
-                },
-                "owner_library": false,
-                "enter_transformed": false,
-                "enter_tapped": false,
-                "enters_attacking": false
-              },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false,
-              "sub_link": "SequentialSibling"
-            },
-            "uses_tracked_set": true
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
           },
-          "cost": null,
-          "sub_ability": null,
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Blue"
+              ],
+              "generic": 0
+            }
+          },
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "CreateDelayedTrigger",
+              "condition": {
+                "type": "AtNextPhase",
+                "phase": "End"
+              },
+              "effect": {
+                "kind": "Activated",
+                "effect": {
+                  "type": "ChangeZone",
+                  "origin": "Exile",
+                  "destination": "Battlefield",
+                  "target": {
+                    "type": "ParentTarget"
+                  },
+                  "owner_library": false,
+                  "enter_transformed": false,
+                  "enter_tapped": false,
+                  "enters_attacking": false
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false,
+                "sub_link": "SequentialSibling"
+              },
+              "uses_tracked_set": true
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
           "duration": null,
-          "description": null,
+          "description": "{U}: Exile ~. Return it to the battlefield under its owner's control at the beginning of the next end step.",
           "target_prompt": null,
           "condition": null,
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        },
-        "duration": null,
-        "description": "{U}: Exile ~. Return it to the battlefield under its owner's control at the beginning of the next end step.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "GenericEffect",
-          "static_abilities": [
-            {
-              "mode": "CantBeBlocked",
-              "affected": {
-                "type": "SelfRef"
-              },
-              "modifications": [
-                {
-                  "type": "AddStaticMode",
-                  "mode": "CantBeBlocked"
-                }
-              ],
-              "condition": null,
-              "affected_zone": null,
-              "effect_zone": null,
-              "active_zones": [],
-              "characteristic_defining": false,
-              "description": "can't be blocked"
-            }
-          ],
-          "duration": "UntilEndOfTurn",
-          "target": null
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Mana",
-          "cost": {
-            "type": "Cost",
-            "shards": [
-              "Blue"
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 264,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "GenericEffect",
+            "static_abilities": [
+              {
+                "mode": "CantBeBlocked",
+                "affected": {
+                  "type": "SelfRef"
+                },
+                "modifications": [
+                  {
+                    "type": "AddStaticMode",
+                    "mode": "CantBeBlocked"
+                  }
+                ],
+                "condition": null,
+                "affected_zone": null,
+                "effect_zone": null,
+                "active_zones": [],
+                "characteristic_defining": false,
+                "description": "can't be blocked"
+              }
             ],
-            "generic": 0
-          }
-        },
-        "sub_ability": null,
-        "duration": "UntilEndOfTurn",
-        "description": "{U}: ~ can't be blocked this turn.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+            "duration": "UntilEndOfTurn",
+            "target": null
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Blue"
+              ],
+              "generic": 0
+            }
+          },
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": "{U}: ~ can't be blocked this turn.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Pump",
-          "power": {
-            "type": "Fixed",
-            "value": 1
-          },
-          "toughness": {
-            "type": "Fixed",
-            "value": -1
-          },
-          "target": {
-            "type": "SelfRef"
-          }
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Mana",
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 264,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Pump",
+            "power": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "toughness": {
+              "type": "Fixed",
+              "value": -1
+            },
+            "target": {
+              "type": "SelfRef"
+            }
+          },
           "cost": {
-            "type": "Cost",
-            "shards": [],
-            "generic": 1
-          }
-        },
-        "sub_ability": null,
-        "duration": "UntilEndOfTurn",
-        "description": "{1}: ~ gets +1/-1 until end of turn.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 1
+            }
+          },
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": "{1}: ~ gets +1/-1 until end of turn.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Pump",
-          "power": {
-            "type": "Fixed",
-            "value": -1
-          },
-          "toughness": {
-            "type": "Fixed",
-            "value": 1
-          },
-          "target": {
-            "type": "SelfRef"
-          }
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Mana",
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 264,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 3
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Pump",
+            "power": {
+              "type": "Fixed",
+              "value": -1
+            },
+            "toughness": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "target": {
+              "type": "SelfRef"
+            }
+          },
           "cost": {
-            "type": "Cost",
-            "shards": [],
-            "generic": 1
-          }
-        },
-        "sub_ability": null,
-        "duration": "UntilEndOfTurn",
-        "description": "{1}: ~ gets -1/+1 until end of turn.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 1
+            }
+          },
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": "{1}: ~ gets -1/+1 until end of turn.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__baneslayer_angel_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__baneslayer_angel_ir.snap
@@ -5,22 +5,39 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Flying, first strike, lifelink, protection from Demons and from Dragons"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Flying, first strike, lifelink, protection from Demons and from Dragons",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 71,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Flying, first strike, lifelink, protection from Demons and from Dragons"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Flying, first strike, lifelink, protection from Demons and from Dragons",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__batterskull_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__batterskull_ir.snap
@@ -5,116 +5,184 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Bounce",
-          "target": {
-            "type": "SelfRef"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 236,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Bounce",
+            "target": {
+              "type": "SelfRef"
+            },
+            "destination": null
           },
-          "destination": null
-        },
-        "cost": {
-          "type": "Mana",
           "cost": {
-            "type": "Cost",
-            "shards": [],
-            "generic": 3
-          }
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "{3}: Return ~ to its owner's hand.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 3
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{3}: Return ~ to its owner's hand.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Attach",
-          "target": {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 236,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Attach",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": []
+            }
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 5
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "Equip {5}",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
+          "ability_tag": {
+            "type": "Equip"
+          },
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 236,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
             "type": "Typed",
             "type_filters": [
               "Creature"
             ],
-            "controller": "You",
-            "properties": []
-          }
-        },
-        "cost": {
-          "type": "Mana",
-          "cost": {
-            "type": "Cost",
-            "shards": [],
-            "generic": 5
-          }
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "Equip {5}",
-        "target_prompt": null,
-        "activation_restrictions": [
-          {
-            "type": "AsSorcery"
-          }
-        ],
-        "ability_tag": {
-          "type": "Equip"
-        },
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredStatic": {
-        "mode": "Continuous",
-        "affected": {
-          "type": "Typed",
-          "type_filters": [
-            "Creature"
-          ],
-          "controller": null,
-          "properties": [
+            "controller": null,
+            "properties": [
+              {
+                "type": "EquippedBy"
+              }
+            ]
+          },
+          "modifications": [
             {
-              "type": "EquippedBy"
+              "type": "AddPower",
+              "value": 4
+            },
+            {
+              "type": "AddToughness",
+              "value": 4
+            },
+            {
+              "type": "AddKeyword",
+              "keyword": "Vigilance"
+            },
+            {
+              "type": "AddKeyword",
+              "keyword": "Lifelink"
             }
-          ]
-        },
-        "modifications": [
-          {
-            "type": "AddPower",
-            "value": 4
-          },
-          {
-            "type": "AddToughness",
-            "value": 4
-          },
-          {
-            "type": "AddKeyword",
-            "keyword": "Vigilance"
-          },
-          {
-            "type": "AddKeyword",
-            "keyword": "Lifelink"
-          }
-        ],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "Equipped creature gets +4/+4 and has vigilance and lifelink."
+          ],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "Equipped creature gets +4/+4 and has vigilance and lifelink."
+        }
       }
     },
     {
-      "Keyword": "LivingWeapon"
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 236,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 3
+        }
+      },
+      "node": {
+        "Keyword": "LivingWeapon"
+      }
     }
   ],
   "source_text": "Living weapon (When this Equipment enters, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)\nEquipped creature gets +4/+4 and has vigilance and lifelink.\n{3}: Return this Equipment to its owner's hand.\nEquip {5}",

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
@@ -5,56 +5,90 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Flying"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Flying",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 38,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Flying"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Flying",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Mana",
-          "produced": {
-            "type": "AnyOneColor",
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "color_options": [
-              "White",
-              "Blue",
-              "Black",
-              "Red",
-              "Green"
-            ]
-          }
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Tap"
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "{T}: Add one mana of any color.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false,
-        "is_mana_ability": true
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 38,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Mana",
+            "produced": {
+              "type": "AnyOneColor",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "color_options": [
+                "White",
+                "Blue",
+                "Black",
+                "Red",
+                "Green"
+              ]
+            }
+          },
+          "cost": {
+            "type": "Tap"
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{T}: Add one mana of any color.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false,
+          "is_mana_ability": true
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
@@ -1,131 +1,181 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 806
 expression: "&ir"
 ---
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Haste"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Haste",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "ChangeZoneAll",
-          "origin": "Exile",
-          "destination": "Hand",
-          "target": {
-            "type": "ExiledBySource"
-          }
-        },
-        "cost": {
-          "type": "Composite",
-          "costs": [
-            {
-              "type": "Mana",
-              "cost": {
-                "type": "Cost",
-                "shards": [
-                  "Red"
-                ],
-                "generic": 0
-              }
-            },
-            {
-              "type": "Discard",
-              "count": {
-                "type": "Ref",
-                "qty": {
-                  "type": "HandSize",
-                  "player": {
-                    "type": "Controller"
-                  }
-                }
-              },
-              "filter": null,
-              "random": false,
-              "self_ref": false
-            },
-            {
-              "type": "Sacrifice",
-              "target": {
-                "type": "SelfRef"
-              },
-              "count": 1
-            }
-          ]
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "{R}, Discard your hand, Sacrifice ~: Put all cards exiled with ~ into their owners' hands.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredTrigger": {
-        "mode": "Attacks",
-        "execute": {
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 222,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
           "kind": "Spell",
           "effect": {
-            "type": "ExileTop",
-            "player": {
-              "type": "Controller"
-            },
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "face_down": true
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Haste"
           },
           "cost": null,
           "sub_ability": null,
           "duration": null,
-          "description": null,
+          "description": "Haste",
           "target_prompt": null,
           "condition": null,
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "valid_card": {
-          "type": "SelfRef"
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 222,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "ChangeZoneAll",
+            "origin": "Exile",
+            "destination": "Hand",
+            "target": {
+              "type": "ExiledBySource"
+            }
+          },
+          "cost": {
+            "type": "Composite",
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "Red"
+                  ],
+                  "generic": 0
+                }
+              },
+              {
+                "type": "Discard",
+                "count": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "HandSize",
+                    "player": {
+                      "type": "Controller"
+                    }
+                  }
+                },
+                "filter": null,
+                "random": false,
+                "self_ref": false
+              },
+              {
+                "type": "Sacrifice",
+                "target": {
+                  "type": "SelfRef"
+                },
+                "count": 1
+              }
+            ]
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{R}, Discard your hand, Sacrifice ~: Put all cards exiled with ~ into their owners' hands.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
         },
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "Whenever ~ attacks, exile the top card of your library face down.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 222,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Attacks",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "ExileTop",
+              "player": {
+                "type": "Controller"
+              },
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "face_down": true
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever ~ attacks, exile the top card of your library face down.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bone_splinters_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bone_splinters_ir.snap
@@ -5,45 +5,79 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Destroy",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": []
-          },
-          "cant_regenerate": false
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Destroy target creature.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 88,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Destroy",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            "cant_regenerate": false
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Destroy target creature.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "AdditionalCost": {
-        "type": "Required",
-        "data": {
-          "type": "Sacrifice",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": []
-          },
-          "count": 1
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 88,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "AdditionalCost": {
+          "type": "Required",
+          "data": {
+            "type": "Sacrifice",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            "count": 1
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bonecrusher_giant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bonecrusher_giant_ir.snap
@@ -5,50 +5,67 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "BecomesTarget",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "DealDamage",
-            "amount": {
-              "type": "Fixed",
-              "value": 2
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 110,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "BecomesTarget",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "DealDamage",
+              "amount": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "target": {
+                "type": "TriggeringSpellController"
+              }
             },
-            "target": {
-              "type": "TriggeringSpellController"
-            }
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
           "optional": false,
-          "forward_result": false
-        },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": {
-          "type": "StackSpell"
-        },
-        "description": "Whenever ~ becomes the target of a spell, ~ deals 2 damage to that spell's controller.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": {
+            "type": "StackSpell"
+          },
+          "description": "Whenever ~ becomes the target of a spell, ~ deals 2 damage to that spell's controller.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
@@ -5,163 +5,204 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Mana",
-          "produced": {
-            "type": "Fixed",
-            "colors": [
-              "Green"
-            ]
-          }
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Tap"
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "{T}: Add {G}.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false,
-        "is_mana_ability": true
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 330,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Mana",
+            "produced": {
+              "type": "Fixed",
+              "colors": [
+                "Green"
+              ]
+            }
+          },
+          "cost": {
+            "type": "Tap"
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{T}: Add {G}.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false,
+          "is_mana_ability": true
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Destroy",
-          "target": {
-            "type": "Or",
-            "filters": [
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 330,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Destroy",
+            "target": {
+              "type": "Or",
+              "filters": [
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Artifact"
+                  ],
+                  "controller": "Opponent",
+                  "properties": []
+                },
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Enchantment"
+                  ],
+                  "controller": "Opponent",
+                  "properties": []
+                },
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Land"
+                  ],
+                  "controller": "Opponent",
+                  "properties": [
+                    {
+                      "type": "NotSupertype",
+                      "value": "Basic"
+                    }
+                  ]
+                }
+              ]
+            },
+            "cant_regenerate": false
+          },
+          "cost": {
+            "type": "Composite",
+            "costs": [
               {
-                "type": "Typed",
-                "type_filters": [
-                  "Artifact"
-                ],
-                "controller": "Opponent",
-                "properties": []
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "Green"
+                  ],
+                  "generic": 1
+                }
               },
               {
-                "type": "Typed",
-                "type_filters": [
-                  "Enchantment"
-                ],
-                "controller": "Opponent",
-                "properties": []
-              },
-              {
-                "type": "Typed",
-                "type_filters": [
-                  "Land"
-                ],
-                "controller": "Opponent",
-                "properties": [
-                  {
-                    "type": "NotSupertype",
-                    "value": "Basic"
-                  }
-                ]
+                "type": "Discard",
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                },
+                "filter": null,
+                "random": false,
+                "self_ref": true
               }
             ]
           },
-          "cant_regenerate": false
-        },
-        "cost": {
-          "type": "Composite",
-          "costs": [
-            {
-              "type": "Mana",
-              "cost": {
-                "type": "Cost",
-                "shards": [
-                  "Green"
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "SearchLibrary",
+              "filter": {
+                "type": "Typed",
+                "type_filters": [
+                  "Land",
+                  {
+                    "AnyOf": [
+                      {
+                        "Subtype": "Plains"
+                      },
+                      {
+                        "Subtype": "Island"
+                      },
+                      {
+                        "Subtype": "Swamp"
+                      },
+                      {
+                        "Subtype": "Mountain"
+                      },
+                      {
+                        "Subtype": "Forest"
+                      }
+                    ]
+                  }
                 ],
-                "generic": 1
-              }
-            },
-            {
-              "type": "Discard",
+                "controller": null,
+                "properties": []
+              },
               "count": {
                 "type": "Fixed",
                 "value": 1
               },
-              "filter": null,
-              "random": false,
-              "self_ref": true
-            }
-          ]
-        },
-        "sub_ability": {
-          "kind": "Spell",
-          "effect": {
-            "type": "SearchLibrary",
-            "filter": {
-              "type": "Typed",
-              "type_filters": [
-                "Land",
-                {
-                  "AnyOf": [
-                    {
-                      "Subtype": "Plains"
-                    },
-                    {
-                      "Subtype": "Island"
-                    },
-                    {
-                      "Subtype": "Swamp"
-                    },
-                    {
-                      "Subtype": "Mountain"
-                    },
-                    {
-                      "Subtype": "Forest"
-                    }
-                  ]
-                }
-              ],
-              "controller": null,
-              "properties": []
-            },
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "reveal": false,
-            "target_player": {
-              "type": "ParentTargetController"
-            }
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "ChangeZone",
-              "origin": "Library",
-              "destination": "Battlefield",
-              "target": {
-                "type": "Any"
-              },
-              "owner_library": false,
-              "enter_transformed": false,
-              "enter_tapped": false,
-              "enters_attacking": false
+              "reveal": false,
+              "target_player": {
+                "type": "ParentTargetController"
+              }
             },
             "cost": null,
             "sub_ability": {
               "kind": "Spell",
               "effect": {
-                "type": "Shuffle",
+                "type": "ChangeZone",
+                "origin": "Library",
+                "destination": "Battlefield",
                 "target": {
-                  "type": "ParentTargetController"
-                }
+                  "type": "Any"
+                },
+                "owner_library": false,
+                "enter_transformed": false,
+                "enter_tapped": false,
+                "enters_attacking": false
               },
               "cost": null,
-              "sub_ability": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "Shuffle",
+                  "target": {
+                    "type": "ParentTargetController"
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
               "duration": null,
               "description": null,
               "target_prompt": null,
@@ -175,49 +216,42 @@ expression: "&ir"
             "target_prompt": null,
             "condition": null,
             "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            "optional": true,
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
           },
           "duration": null,
-          "description": null,
+          "description": "Channel — {1}{G}, Discard this card: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control.",
           "target_prompt": null,
+          "activation_zone": "Hand",
           "condition": null,
           "optional_targeting": false,
-          "optional": true,
-          "forward_result": false,
-          "sub_link": "SequentialSibling"
-        },
-        "duration": null,
-        "description": "Channel — {1}{G}, Discard this card: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control.",
-        "target_prompt": null,
-        "activation_zone": "Hand",
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "cost_reduction": {
-          "amount_per": 1,
-          "count": {
-            "type": "Ref",
-            "qty": {
-              "type": "ObjectCount",
-              "filter": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": "You",
-                "properties": [
-                  {
-                    "type": "HasSupertype",
-                    "value": "Legendary"
-                  }
-                ]
+          "optional": false,
+          "cost_reduction": {
+            "amount_per": 1,
+            "count": {
+              "type": "Ref",
+              "qty": {
+                "type": "ObjectCount",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "HasSupertype",
+                      "value": "Legendary"
+                    }
+                  ]
+                }
               }
             }
-          }
-        },
-        "forward_result": false,
-        "consumes_source": true
+          },
+          "forward_result": false,
+          "consumes_source": true
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__brazen_borrower_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__brazen_borrower_ir.snap
@@ -5,72 +5,123 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Flash"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Flash",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 64,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Flash"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Flash",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Flying"
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Flying",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 64,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Flying"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Flying",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredStatic": {
-        "mode": {
-          "BlockRestriction": {
-            "filter": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": [
-                {
-                  "type": "WithKeyword",
-                  "value": "Flying"
-                }
-              ]
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 64,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": {
+            "BlockRestriction": {
+              "filter": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": null,
+                "properties": [
+                  {
+                    "type": "WithKeyword",
+                    "value": "Flying"
+                  }
+                ]
+              }
             }
-          }
-        },
-        "affected": {
-          "type": "SelfRef"
-        },
-        "modifications": [],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "~ can block only creatures with flying."
+          },
+          "affected": {
+            "type": "SelfRef"
+          },
+          "modifications": [],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "~ can block only creatures with flying."
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_crimson_pulse_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_crimson_pulse_ir.snap
@@ -1,40 +1,63 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 855
 expression: "&ir"
 ---
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "ChangesZone",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Discard",
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "target": {
-              "type": "Controller"
-            }
-          },
-          "cost": null,
-          "sub_ability": {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 239,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
             "kind": "Spell",
             "effect": {
-              "type": "Draw",
+              "type": "Discard",
               "count": {
                 "type": "Fixed",
-                "value": 2
+                "value": 1
               },
               "target": {
                 "type": "Controller"
               }
             },
             "cost": null,
-            "sub_ability": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "Draw",
+                "count": {
+                  "type": "Fixed",
+                  "value": 2
+                },
+                "target": {
+                  "type": "Controller"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
             "duration": null,
             "description": null,
             "target_prompt": null,
@@ -43,42 +66,137 @@ expression: "&ir"
             "optional": false,
             "forward_result": false
           },
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
           "optional": false,
-          "forward_result": false
-        },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "origin": null,
-        "destination": "Battlefield",
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "When this ~ enters, discard a card, then draw two cards.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When this ~ enters, discard a card, then draw two cards.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     },
     {
-      "PreLoweredTrigger": {
-        "mode": "Phase",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Discard",
-            "count": {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 239,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Phase",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Discard",
+              "count": {
+                "type": "Ref",
+                "qty": {
+                  "type": "HandSize",
+                  "player": {
+                    "type": "Controller"
+                  }
+                }
+              },
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "Draw",
+                "count": {
+                  "type": "Fixed",
+                  "value": 2
+                },
+                "target": {
+                  "type": "Controller"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": "Upkeep",
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "At the beginning of your upkeep, discard your hand, then draw two cards.",
+          "constraint": {
+            "type": "OnlyDuringYourTurn"
+          },
+          "condition": null,
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 239,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "SolveCondition": {
+          "type": "Condition",
+          "condition": {
+            "type": "QuantityComparison",
+            "lhs": {
               "type": "Ref",
               "qty": {
                 "type": "HandSize",
@@ -87,79 +205,11 @@ expression: "&ir"
                 }
               }
             },
-            "target": {
-              "type": "Controller"
+            "comparator": "EQ",
+            "rhs": {
+              "type": "Fixed",
+              "value": 0
             }
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Draw",
-              "count": {
-                "type": "Fixed",
-                "value": 2
-              },
-              "target": {
-                "type": "Controller"
-              }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
-        },
-        "valid_card": null,
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": "Upkeep",
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "At the beginning of your upkeep, discard your hand, then draw two cards.",
-        "constraint": {
-          "type": "OnlyDuringYourTurn"
-        },
-        "condition": null,
-        "batched": false
-      }
-    },
-    {
-      "SolveCondition": {
-        "type": "Condition",
-        "condition": {
-          "type": "QuantityComparison",
-          "lhs": {
-            "type": "Ref",
-            "qty": {
-              "type": "HandSize",
-              "player": {
-                "type": "Controller"
-              }
-            }
-          },
-          "comparator": "EQ",
-          "rhs": {
-            "type": "Fixed",
-            "value": 0
           }
         }
       }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_ir.snap
@@ -5,103 +5,137 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "SpellCast",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Counter",
-            "target": {
-              "type": "TriggeringSource"
-            }
-          },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "valid_card": {
-          "type": "Typed",
-          "type_filters": [
-            "Card"
-          ],
-          "controller": null,
-          "properties": [
-            {
-              "type": "Cmc",
-              "comparator": "EQ",
-              "value": {
-                "type": "Ref",
-                "qty": {
-                  "type": "CountersOn",
-                  "scope": {
-                    "type": "Source"
-                  },
-                  "counter_type": "charge"
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 175,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "SpellCast",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Counter",
+              "target": {
+                "type": "TriggeringSource"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "Typed",
+            "type_filters": [
+              "Card"
+            ],
+            "controller": null,
+            "properties": [
+              {
+                "type": "Cmc",
+                "comparator": "EQ",
+                "value": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "CountersOn",
+                    "scope": {
+                      "type": "Source"
+                    },
+                    "counter_type": "charge"
+                  }
                 }
               }
-            }
-          ]
-        },
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "Whenever a player casts a spell with mana value equal to the number of charge counters on ~, counter that spell.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+            ]
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever a player casts a spell with mana value equal to the number of charge counters on ~, counter that spell.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     },
     {
-      "PreLoweredReplacement": {
-        "event": "Moved",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "PutCounter",
-            "counter_type": "charge",
-            "count": {
-              "type": "Ref",
-              "qty": {
-                "type": "CostXPaid"
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 175,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredReplacement": {
+          "event": "Moved",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "charge",
+              "count": {
+                "type": "Ref",
+                "qty": {
+                  "type": "CostXPaid"
+                }
+              },
+              "target": {
+                "type": "SelfRef"
               }
             },
-            "target": {
-              "type": "SelfRef"
-            }
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
+          "mode": {
+            "type": "Mandatory"
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "description": "~ enters with X charge counters on it.",
           "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
-        },
-        "mode": {
-          "type": "Mandatory"
-        },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "description": "~ enters with X charge counters on it.",
-        "condition": null,
-        "destination_zone": "Battlefield"
+          "destination_zone": "Battlefield"
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__champions_victory_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__champions_victory_ir.snap
@@ -1,51 +1,101 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 843
 expression: "&ir"
 ---
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Bounce",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": [
-              {
-                "type": "Attacking"
-              }
-            ]
-          },
-          "destination": null
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Return target attacking creature to its owner's hand.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 152,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Bounce",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "Attacking"
+                }
+              ]
+            },
+            "destination": null
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Return target attacking creature to its owner's hand.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "CastingRestriction": {
-        "type": "DeclareAttackersStep"
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 152,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "CastingRestriction": {
+          "type": "DeclareAttackersStep"
+        }
       }
     },
     {
-      "CastingRestriction": {
-        "type": "RequiresCondition",
-        "data": {
-          "condition": {
-            "type": "BeenAttackedThisStep"
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 152,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "CastingRestriction": {
+          "type": "RequiresCondition",
+          "data": {
+            "condition": {
+              "type": "BeenAttackedThisStep"
+            }
           }
         }
       }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__changeling_outcast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__changeling_outcast_ir.snap
@@ -5,52 +5,103 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Changeling"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Changeling",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 94,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Changeling"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Changeling",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredStatic": {
-        "mode": "CantBlock",
-        "affected": {
-          "type": "SelfRef"
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "modifications": [],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "~ can't block and can't be blocked."
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 94,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "CantBlock",
+          "affected": {
+            "type": "SelfRef"
+          },
+          "modifications": [],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "~ can't block and can't be blocked."
+        }
       }
     },
     {
-      "PreLoweredStatic": {
-        "mode": "CantBeBlocked",
-        "affected": {
-          "type": "SelfRef"
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
         },
-        "modifications": [],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "~ can't block and can't be blocked."
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 94,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "CantBeBlocked",
+          "affected": {
+            "type": "SelfRef"
+          },
+          "modifications": [],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "~ can't block and can't be blocked."
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
@@ -1,81 +1,114 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 364
 expression: "&ir"
 ---
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "ChangesZone",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "GainLife",
-            "amount": {
-              "type": "Ref",
-              "qty": {
-                "type": "Power",
-                "scope": {
-                  "type": "Anaphoric"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 196,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GainLife",
+              "amount": {
+                "type": "Ref",
+                "qty": {
+                  "type": "Power",
+                  "scope": {
+                    "type": "Anaphoric"
+                  }
                 }
               }
-            }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": "Battlefield",
+          "destination": "Graveyard",
+          "trigger_zones": [
+            "Graveyard"
+          ],
+          "phase": null,
           "optional": false,
-          "forward_result": false
-        },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "origin": "Battlefield",
-        "destination": "Graveyard",
-        "trigger_zones": [
-          "Graveyard"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "When ~ dies, you gain life equal to its power.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When ~ dies, you gain life equal to its power.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     },
     {
-      "PreLoweredReplacement": {
-        "event": "AddCounter",
-        "execute": null,
-        "mode": {
-          "type": "Mandatory"
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "valid_card": {
-          "type": "Typed",
-          "type_filters": [
-            "Creature"
-          ],
-          "controller": "You",
-          "properties": []
-        },
-        "description": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead.",
-        "condition": null,
-        "quantity_modification": {
-          "type": "Plus",
-          "value": 1
-        },
-        "counter_match": {
-          "type": "OfType",
-          "data": "P1P1"
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 196,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredReplacement": {
+          "event": "AddCounter",
+          "execute": null,
+          "mode": {
+            "type": "Mandatory"
+          },
+          "valid_card": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": "You",
+            "properties": []
+          },
+          "description": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead.",
+          "condition": null,
+          "quantity_modification": {
+            "type": "Plus",
+            "value": 1
+          },
+          "counter_match": {
+            "type": "OfType",
+            "data": "P1P1"
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dark_confidant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dark_confidant_ir.snap
@@ -5,60 +5,84 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "Phase",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "RevealTop",
-            "player": {
-              "type": "Controller"
-            },
-            "count": 1
-          },
-          "cost": null,
-          "sub_ability": {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 141,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Phase",
+          "execute": {
             "kind": "Spell",
             "effect": {
-              "type": "ChangeZone",
-              "origin": null,
-              "destination": "Hand",
-              "target": {
-                "type": "ParentTarget"
+              "type": "RevealTop",
+              "player": {
+                "type": "Controller"
               },
-              "owner_library": false,
-              "enter_transformed": false,
-              "enter_tapped": false,
-              "enters_attacking": false
+              "count": 1
             },
             "cost": null,
             "sub_ability": {
               "kind": "Spell",
               "effect": {
-                "type": "LoseLife",
-                "amount": {
-                  "type": "Ref",
-                  "qty": {
-                    "type": "ObjectManaValue",
-                    "scope": {
-                      "type": "Anaphoric"
-                    }
-                  }
-                },
+                "type": "ChangeZone",
+                "origin": null,
+                "destination": "Hand",
                 "target": {
-                  "type": "Controller"
-                }
+                  "type": "ParentTarget"
+                },
+                "owner_library": false,
+                "enter_transformed": false,
+                "enter_tapped": false,
+                "enters_attacking": false
               },
               "cost": null,
-              "sub_ability": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "LoseLife",
+                  "amount": {
+                    "type": "Ref",
+                    "qty": {
+                      "type": "ObjectManaValue",
+                      "scope": {
+                        "type": "Anaphoric"
+                      }
+                    }
+                  },
+                  "target": {
+                    "type": "Controller"
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false,
+                "sub_link": "SequentialSibling"
+              },
               "duration": null,
               "description": null,
               "target_prompt": null,
               "condition": null,
               "optional_targeting": false,
               "optional": false,
-              "forward_result": false,
-              "sub_link": "SequentialSibling"
+              "forward_result": false
             },
             "duration": null,
             "description": null,
@@ -68,32 +92,25 @@ expression: "&ir"
             "optional": false,
             "forward_result": false
           },
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": "Upkeep",
           "optional": false,
-          "forward_result": false
-        },
-        "valid_card": null,
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": "Upkeep",
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value.",
-        "constraint": {
-          "type": "OnlyDuringYourTurn"
-        },
-        "condition": null,
-        "batched": false
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value.",
+          "constraint": {
+            "type": "OnlyDuringYourTurn"
+          },
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__deadly_rollick_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__deadly_rollick_ir.snap
@@ -5,43 +5,77 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "ChangeZone",
-          "origin": null,
-          "destination": "Exile",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": []
-          },
-          "owner_library": false,
-          "enter_transformed": false,
-          "enter_tapped": false,
-          "enters_attacking": false
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Exile target creature.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 104,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "ChangeZone",
+            "origin": null,
+            "destination": "Exile",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Exile target creature.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "CastingOption": {
-        "kind": "CastWithoutManaCost",
-        "condition": {
-          "type": "YouControlSubtypeCountAtLeast",
-          "subtype": "commander",
-          "count": 1
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 104,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "CastingOption": {
+          "kind": "CastWithoutManaCost",
+          "condition": {
+            "type": "YouControlSubtypeCountAtLeast",
+            "subtype": "commander",
+            "count": 1
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dismember_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dismember_ir.snap
@@ -5,36 +5,53 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Pump",
-          "power": {
-            "type": "Fixed",
-            "value": -5
-          },
-          "toughness": {
-            "type": "Fixed",
-            "value": -5
-          },
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": []
-          }
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": "UntilEndOfTurn",
-        "description": "Target creature gets -5/-5 until end of turn.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 92,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Pump",
+            "power": {
+              "type": "Fixed",
+              "value": -5
+            },
+            "toughness": {
+              "type": "Fixed",
+              "value": -5
+            },
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            }
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": "Target creature gets -5/-5 until end of turn.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__edgewall_innkeeper_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__edgewall_innkeeper_ir.snap
@@ -5,55 +5,72 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "SpellCast",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Draw",
-            "count": {
-              "type": "Fixed",
-              "value": 1
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 125,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "SpellCast",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Draw",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "Controller"
+              }
             },
-            "target": {
-              "type": "Controller"
-            }
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
-        },
-        "valid_card": {
-          "type": "Typed",
-          "type_filters": [
-            "Creature"
+          "valid_card": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": null,
+            "properties": []
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
           ],
-          "controller": null,
-          "properties": []
-        },
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": {
-          "type": "Controller"
-        },
-        "valid_source": null,
-        "description": "Whenever you cast a creature spell that has an Adventure, draw a card.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": {
+            "type": "Controller"
+          },
+          "valid_source": null,
+          "description": "Whenever you cast a creature spell that has an Adventure, draw a card.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__eidolon_of_the_great_revel_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__eidolon_of_the_great_revel_ir.snap
@@ -5,62 +5,79 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "SpellCast",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "DealDamage",
-            "amount": {
-              "type": "Fixed",
-              "value": 2
-            },
-            "target": {
-              "type": "TriggeringPlayer"
-            }
-          },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "valid_card": {
-          "type": "Typed",
-          "type_filters": [
-            "Card"
-          ],
-          "controller": null,
-          "properties": [
-            {
-              "type": "Cmc",
-              "comparator": "LE",
-              "value": {
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 103,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "SpellCast",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "DealDamage",
+              "amount": {
                 "type": "Fixed",
-                "value": 3
+                "value": 2
+              },
+              "target": {
+                "type": "TriggeringPlayer"
               }
-            }
-          ]
-        },
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "Whenever a player casts a spell with mana value 3 or less, ~ deals 2 damage to that player.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "Typed",
+            "type_filters": [
+              "Card"
+            ],
+            "controller": null,
+            "properties": [
+              {
+                "type": "Cmc",
+                "comparator": "LE",
+                "value": {
+                  "type": "Fixed",
+                  "value": 3
+                }
+              }
+            ]
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever a player casts a spell with mana value 3 or less, ~ deals 2 damage to that player.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
@@ -1,56 +1,89 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 416
 expression: "&ir"
 ---
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Evolve"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Evolve",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 341,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Evolve"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Evolve",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Regenerate",
-          "target": {
-            "type": "ParentTarget"
-          }
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "RemoveCounter",
-          "count": 2,
-          "counter_type": {
-            "type": "OfType",
-            "data": "P1P1"
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 341,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Regenerate",
+            "target": {
+              "type": "ParentTarget"
+            }
           },
-          "target": null,
-          "selection": "SingleObject"
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "Remove two +1/+1 counters from ~: Regenerate it.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+          "cost": {
+            "type": "RemoveCounter",
+            "count": 2,
+            "counter_type": {
+              "type": "OfType",
+              "data": "P1P1"
+            },
+            "target": null,
+            "selection": "SingleObject"
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "Remove two +1/+1 counters from ~: Regenerate it.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__figure_of_destiny_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__figure_of_destiny_ir.snap
@@ -1,259 +1,309 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 706
 expression: "&ir"
 ---
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "GenericEffect",
-          "static_abilities": [
-            {
-              "mode": "Continuous",
-              "affected": {
-                "type": "SelfRef"
-              },
-              "modifications": [
-                {
-                  "type": "SetPower",
-                  "value": 2
-                },
-                {
-                  "type": "SetToughness",
-                  "value": 2
-                },
-                {
-                  "type": "AddType",
-                  "core_type": "Creature"
-                },
-                {
-                  "type": "RemoveAllSubtypes",
-                  "set": "Creature"
-                },
-                {
-                  "type": "AddSubtype",
-                  "subtype": "Kithkin"
-                },
-                {
-                  "type": "AddSubtype",
-                  "subtype": "Spirit"
-                }
-              ],
-              "condition": null,
-              "affected_zone": null,
-              "effect_zone": null,
-              "active_zones": [],
-              "characteristic_defining": false,
-              "description": "become a Kithkin Spirit with base power and toughness 2/2"
-            }
-          ],
-          "duration": "Permanent",
-          "target": null
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Mana",
-          "cost": {
-            "type": "Cost",
-            "shards": [
-              "RedWhite"
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 365,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "GenericEffect",
+            "static_abilities": [
+              {
+                "mode": "Continuous",
+                "affected": {
+                  "type": "SelfRef"
+                },
+                "modifications": [
+                  {
+                    "type": "SetPower",
+                    "value": 2
+                  },
+                  {
+                    "type": "SetToughness",
+                    "value": 2
+                  },
+                  {
+                    "type": "AddType",
+                    "core_type": "Creature"
+                  },
+                  {
+                    "type": "RemoveAllSubtypes",
+                    "set": "Creature"
+                  },
+                  {
+                    "type": "AddSubtype",
+                    "subtype": "Kithkin"
+                  },
+                  {
+                    "type": "AddSubtype",
+                    "subtype": "Spirit"
+                  }
+                ],
+                "condition": null,
+                "affected_zone": null,
+                "effect_zone": null,
+                "active_zones": [],
+                "characteristic_defining": false,
+                "description": "become a Kithkin Spirit with base power and toughness 2/2"
+              }
             ],
-            "generic": 0
-          }
-        },
-        "sub_ability": null,
-        "duration": "Permanent",
-        "description": "{R/W}: ~ becomes a Kithkin Spirit with base power and toughness 2/2.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+            "duration": "Permanent",
+            "target": null
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "RedWhite"
+              ],
+              "generic": 0
+            }
+          },
+          "sub_ability": null,
+          "duration": "Permanent",
+          "description": "{R/W}: ~ becomes a Kithkin Spirit with base power and toughness 2/2.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "GenericEffect",
-          "static_abilities": [
-            {
-              "mode": "Continuous",
-              "affected": {
-                "type": "SelfRef"
-              },
-              "modifications": [
-                {
-                  "type": "SetPower",
-                  "value": 4
-                },
-                {
-                  "type": "SetToughness",
-                  "value": 4
-                },
-                {
-                  "type": "AddType",
-                  "core_type": "Creature"
-                },
-                {
-                  "type": "RemoveAllSubtypes",
-                  "set": "Creature"
-                },
-                {
-                  "type": "AddSubtype",
-                  "subtype": "Kithkin"
-                },
-                {
-                  "type": "AddSubtype",
-                  "subtype": "Spirit"
-                },
-                {
-                  "type": "AddSubtype",
-                  "subtype": "Warrior"
-                }
-              ],
-              "condition": null,
-              "affected_zone": null,
-              "effect_zone": null,
-              "active_zones": [],
-              "characteristic_defining": false,
-              "description": "become a Kithkin Spirit Warrior with base power and toughness 4/4"
-            }
-          ],
-          "duration": "Permanent",
-          "target": null
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Mana",
-          "cost": {
-            "type": "Cost",
-            "shards": [
-              "RedWhite",
-              "RedWhite",
-              "RedWhite"
-            ],
-            "generic": 0
-          }
-        },
-        "sub_ability": null,
-        "duration": "Permanent",
-        "description": "{R/W}{R/W}{R/W}: If ~ is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4.",
-        "target_prompt": null,
-        "condition": {
-          "type": "SourceMatchesFilter",
-          "filter": {
-            "type": "Typed",
-            "type_filters": [
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 365,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "GenericEffect",
+            "static_abilities": [
               {
-                "Subtype": "Spirit"
+                "mode": "Continuous",
+                "affected": {
+                  "type": "SelfRef"
+                },
+                "modifications": [
+                  {
+                    "type": "SetPower",
+                    "value": 4
+                  },
+                  {
+                    "type": "SetToughness",
+                    "value": 4
+                  },
+                  {
+                    "type": "AddType",
+                    "core_type": "Creature"
+                  },
+                  {
+                    "type": "RemoveAllSubtypes",
+                    "set": "Creature"
+                  },
+                  {
+                    "type": "AddSubtype",
+                    "subtype": "Kithkin"
+                  },
+                  {
+                    "type": "AddSubtype",
+                    "subtype": "Spirit"
+                  },
+                  {
+                    "type": "AddSubtype",
+                    "subtype": "Warrior"
+                  }
+                ],
+                "condition": null,
+                "affected_zone": null,
+                "effect_zone": null,
+                "active_zones": [],
+                "characteristic_defining": false,
+                "description": "become a Kithkin Spirit Warrior with base power and toughness 4/4"
               }
             ],
-            "controller": null,
-            "properties": []
-          }
-        },
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+            "duration": "Permanent",
+            "target": null
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "RedWhite",
+                "RedWhite",
+                "RedWhite"
+              ],
+              "generic": 0
+            }
+          },
+          "sub_ability": null,
+          "duration": "Permanent",
+          "description": "{R/W}{R/W}{R/W}: If ~ is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4.",
+          "target_prompt": null,
+          "condition": {
+            "type": "SourceMatchesFilter",
+            "filter": {
+              "type": "Typed",
+              "type_filters": [
+                {
+                  "Subtype": "Spirit"
+                }
+              ],
+              "controller": null,
+              "properties": []
+            }
+          },
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "GenericEffect",
-          "static_abilities": [
-            {
-              "mode": "Continuous",
-              "affected": {
-                "type": "SelfRef"
-              },
-              "modifications": [
-                {
-                  "type": "AddKeyword",
-                  "keyword": "Flying"
-                },
-                {
-                  "type": "AddKeyword",
-                  "keyword": "FirstStrike"
-                },
-                {
-                  "type": "RemoveAllSubtypes",
-                  "set": "Creature"
-                },
-                {
-                  "type": "AddSubtype",
-                  "subtype": "Kithkin"
-                },
-                {
-                  "type": "AddSubtype",
-                  "subtype": "Spirit"
-                },
-                {
-                  "type": "AddSubtype",
-                  "subtype": "Warrior"
-                },
-                {
-                  "type": "AddSubtype",
-                  "subtype": "Avatar"
-                },
-                {
-                  "type": "SetPower",
-                  "value": 8
-                },
-                {
-                  "type": "SetToughness",
-                  "value": 8
-                }
-              ],
-              "condition": null,
-              "affected_zone": null,
-              "effect_zone": null,
-              "active_zones": [],
-              "characteristic_defining": false,
-              "description": "become a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike"
-            }
-          ],
-          "duration": "Permanent",
-          "target": null
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Mana",
-          "cost": {
-            "type": "Cost",
-            "shards": [
-              "RedWhite",
-              "RedWhite",
-              "RedWhite",
-              "RedWhite",
-              "RedWhite",
-              "RedWhite"
-            ],
-            "generic": 0
-          }
-        },
-        "sub_ability": null,
-        "duration": "Permanent",
-        "description": "{R/W}{R/W}{R/W}{R/W}{R/W}{R/W}: If ~ is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike.",
-        "target_prompt": null,
-        "condition": {
-          "type": "SourceMatchesFilter",
-          "filter": {
-            "type": "Typed",
-            "type_filters": [
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 365,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "GenericEffect",
+            "static_abilities": [
               {
-                "Subtype": "Warrior"
+                "mode": "Continuous",
+                "affected": {
+                  "type": "SelfRef"
+                },
+                "modifications": [
+                  {
+                    "type": "AddKeyword",
+                    "keyword": "Flying"
+                  },
+                  {
+                    "type": "AddKeyword",
+                    "keyword": "FirstStrike"
+                  },
+                  {
+                    "type": "RemoveAllSubtypes",
+                    "set": "Creature"
+                  },
+                  {
+                    "type": "AddSubtype",
+                    "subtype": "Kithkin"
+                  },
+                  {
+                    "type": "AddSubtype",
+                    "subtype": "Spirit"
+                  },
+                  {
+                    "type": "AddSubtype",
+                    "subtype": "Warrior"
+                  },
+                  {
+                    "type": "AddSubtype",
+                    "subtype": "Avatar"
+                  },
+                  {
+                    "type": "SetPower",
+                    "value": 8
+                  },
+                  {
+                    "type": "SetToughness",
+                    "value": 8
+                  }
+                ],
+                "condition": null,
+                "affected_zone": null,
+                "effect_zone": null,
+                "active_zones": [],
+                "characteristic_defining": false,
+                "description": "become a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike"
               }
             ],
-            "controller": null,
-            "properties": []
-          }
-        },
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+            "duration": "Permanent",
+            "target": null
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "RedWhite",
+                "RedWhite",
+                "RedWhite",
+                "RedWhite",
+                "RedWhite",
+                "RedWhite"
+              ],
+              "generic": 0
+            }
+          },
+          "sub_ability": null,
+          "duration": "Permanent",
+          "description": "{R/W}{R/W}{R/W}{R/W}{R/W}{R/W}: If ~ is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike.",
+          "target_prompt": null,
+          "condition": {
+            "type": "SourceMatchesFilter",
+            "filter": {
+              "type": "Typed",
+              "type_filters": [
+                {
+                  "Subtype": "Warrior"
+                }
+              ],
+              "controller": null,
+              "properties": []
+            }
+          },
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__goblin_guide_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__goblin_guide_ir.snap
@@ -5,93 +5,127 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Haste"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Haste",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredTrigger": {
-        "mode": "Attacks",
-        "execute": {
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 151,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
           "kind": "Spell",
           "effect": {
-            "type": "RevealTop",
-            "player": {
-              "type": "DefendingPlayer"
-            },
-            "count": 1
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Haste"
           },
           "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "ChangeZone",
-              "origin": null,
-              "destination": "Hand",
-              "target": {
-                "type": "ParentTarget"
-              },
-              "owner_library": false,
-              "enter_transformed": false,
-              "enter_tapped": false,
-              "enters_attacking": false
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": {
-              "type": "RevealedHasCardType",
-              "card_types": [
-                "Land"
-              ]
-            },
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
-          },
+          "sub_ability": null,
           "duration": null,
-          "description": null,
+          "description": "Haste",
           "target_prompt": null,
           "condition": null,
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "Whenever ~ attacks, defending player reveals the top card of their library. If it's a land card, that player puts it into their hand.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 151,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Attacks",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "RevealTop",
+              "player": {
+                "type": "DefendingPlayer"
+              },
+              "count": 1
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "ChangeZone",
+                "origin": null,
+                "destination": "Hand",
+                "target": {
+                  "type": "ParentTarget"
+                },
+                "owner_library": false,
+                "enter_transformed": false,
+                "enter_tapped": false,
+                "enters_attacking": false
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": {
+                "type": "RevealedHasCardType",
+                "card_types": [
+                  "Land"
+                ]
+              },
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false,
+              "sub_link": "SequentialSibling"
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever ~ attacks, defending player reveals the top card of their library. If it's a land card, that player puts it into their hand.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jace_the_mind_sculptor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jace_the_mind_sculptor_ir.snap
@@ -5,217 +5,144 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Dig",
-          "player": {
-            "type": "Player"
-          },
-          "count": {
-            "type": "Fixed",
-            "value": 1
-          },
-          "destination": null,
-          "keep_count": 0,
-          "up_to": false,
-          "filter": {
-            "type": "Any"
-          },
-          "rest_destination": null,
-          "reveal": false,
-          "enter_tapped": false
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Loyalty",
-          "amount": 2
-        },
-        "sub_ability": {
-          "kind": "Spell",
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 374,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
           "effect": {
-            "type": "PutAtLibraryPosition",
-            "target": {
-              "type": "ParentTarget"
+            "type": "Dig",
+            "player": {
+              "type": "Player"
             },
             "count": {
               "type": "Fixed",
               "value": 1
             },
-            "position": {
-              "type": "Bottom"
-            }
-          },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": true,
-          "forward_result": false,
-          "sub_link": "SequentialSibling"
-        },
-        "duration": null,
-        "description": "[+2]: Look at the top card of target player's library. You may put that card on the bottom of that player's library.",
-        "target_prompt": null,
-        "activation_restrictions": [
-          {
-            "type": "AsSorcery"
-          }
-        ],
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Draw",
-          "count": {
-            "type": "Fixed",
-            "value": 3
-          },
-          "target": {
-            "type": "Controller"
-          }
-        },
-        "cost": {
-          "type": "Loyalty",
-          "amount": 0
-        },
-        "sub_ability": {
-          "kind": "Spell",
-          "effect": {
-            "type": "PutAtLibraryPosition",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Card"
-              ],
-              "controller": "You",
-              "properties": [
-                {
-                  "type": "InZone",
-                  "zone": "Hand"
-                }
-              ]
+            "destination": null,
+            "keep_count": 0,
+            "up_to": false,
+            "filter": {
+              "type": "Any"
             },
-            "count": {
-              "type": "Fixed",
-              "value": 2
-            },
-            "position": {
-              "type": "Top"
-            }
+            "rest_destination": null,
+            "reveal": false,
+            "enter_tapped": false
           },
-          "cost": null,
-          "sub_ability": null,
+          "cost": {
+            "type": "Loyalty",
+            "amount": 2
+          },
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutAtLibraryPosition",
+              "target": {
+                "type": "ParentTarget"
+              },
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "position": {
+                "type": "Bottom"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": true,
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
+          },
           "duration": null,
-          "description": null,
+          "description": "[+2]: Look at the top card of target player's library. You may put that card on the bottom of that player's library.",
           "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
           "condition": null,
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        },
-        "duration": null,
-        "description": "[0]: Draw three cards, then put two cards from your hand on top of your library in any order.",
-        "target_prompt": null,
-        "activation_restrictions": [
-          {
-            "type": "AsSorcery"
-          }
-        ],
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Bounce",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": []
-          },
-          "destination": null
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Loyalty",
-          "amount": -1
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "[−1]: Return target creature to its owner's hand.",
-        "target_prompt": null,
-        "activation_restrictions": [
-          {
-            "type": "AsSorcery"
-          }
-        ],
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "ChangeZoneAll",
-          "origin": "Library",
-          "destination": "Exile",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Card"
-            ],
-            "controller": null,
-            "properties": [
-              {
-                "type": "Owned",
-                "controller": "TargetPlayer"
-              },
-              {
-                "type": "InZone",
-                "zone": "Library"
-              }
-            ]
-          }
-        },
-        "cost": {
-          "type": "Loyalty",
-          "amount": -12
-        },
-        "sub_ability": {
-          "kind": "Spell",
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 374,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
           "effect": {
-            "type": "ChangeZoneAll",
-            "origin": "Hand",
-            "destination": "Library",
+            "type": "Draw",
+            "count": {
+              "type": "Fixed",
+              "value": 3
+            },
             "target": {
-              "type": "ParentTargetController"
+              "type": "Controller"
             }
           },
-          "cost": null,
+          "cost": {
+            "type": "Loyalty",
+            "amount": 0
+          },
           "sub_ability": {
             "kind": "Spell",
             "effect": {
-              "type": "Shuffle",
+              "type": "PutAtLibraryPosition",
               "target": {
-                "type": "ParentTargetController"
+                "type": "Typed",
+                "type_filters": [
+                  "Card"
+                ],
+                "controller": "You",
+                "properties": [
+                  {
+                    "type": "InZone",
+                    "zone": "Hand"
+                  }
+                ]
+              },
+              "count": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "position": {
+                "type": "Top"
               }
             },
             "cost": null,
@@ -229,25 +156,166 @@ expression: "&ir"
             "forward_result": false
           },
           "duration": null,
-          "description": null,
+          "description": "[0]: Draw three cards, then put two cards from your hand on top of your library in any order.",
           "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
           "condition": null,
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
         },
-        "duration": null,
-        "description": "[−12]: Exile all cards from target player's library, then that player shuffles their hand into their library.",
-        "target_prompt": null,
-        "activation_restrictions": [
-          {
-            "type": "AsSorcery"
-          }
-        ],
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 374,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Bounce",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            "destination": null
+          },
+          "cost": {
+            "type": "Loyalty",
+            "amount": -1
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "[−1]: Return target creature to its owner's hand.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 374,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 3
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "ChangeZoneAll",
+            "origin": "Library",
+            "destination": "Exile",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Card"
+              ],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "Owned",
+                  "controller": "TargetPlayer"
+                },
+                {
+                  "type": "InZone",
+                  "zone": "Library"
+                }
+              ]
+            }
+          },
+          "cost": {
+            "type": "Loyalty",
+            "amount": -12
+          },
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "ChangeZoneAll",
+              "origin": "Hand",
+              "destination": "Library",
+              "target": {
+                "type": "ParentTargetController"
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "Shuffle",
+                "target": {
+                  "type": "ParentTargetController"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": "[−12]: Exile all cards from target player's library, then that player shuffles their hand into their library.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jade_mage_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jade_mage_ir.snap
@@ -5,55 +5,72 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Token",
-          "name": "Saproling",
-          "power": {
-            "type": "Fixed",
-            "value": 1
-          },
-          "toughness": {
-            "type": "Fixed",
-            "value": 1
-          },
-          "types": [
-            "Creature",
-            "Saproling"
-          ],
-          "colors": [
-            "Green"
-          ],
-          "keywords": [],
-          "tapped": false,
-          "count": {
-            "type": "Fixed",
-            "value": 1
-          },
-          "owner": {
-            "type": "Controller"
-          },
-          "enters_attacking": false
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Mana",
-          "cost": {
-            "type": "Cost",
-            "shards": [
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 52,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Token",
+            "name": "Saproling",
+            "power": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "toughness": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "types": [
+              "Creature",
+              "Saproling"
+            ],
+            "colors": [
               "Green"
             ],
-            "generic": 2
-          }
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "{2}{G}: Create a 1/1 green Saproling creature token.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+            "keywords": [],
+            "tapped": false,
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "owner": {
+              "type": "Controller"
+            },
+            "enters_attacking": false
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Green"
+              ],
+              "generic": 2
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{2}{G}: Create a 1/1 green Saproling creature token.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_ir.snap
@@ -5,83 +5,127 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "ChangesZone",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Sacrifice",
-            "target": {
-              "type": "SelfRef"
-            },
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            }
-          },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "origin": null,
-        "destination": "Battlefield",
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "When ~ enters, sacrifice it unless it escaped.",
-        "constraint": null,
-        "condition": {
-          "type": "Not",
-          "condition": {
-            "type": "CastVariantPaid",
-            "variant": "Escape"
-          }
-        },
-        "batched": false
-      }
-    },
-    {
-      "PreLoweredTrigger": {
-        "mode": "EntersOrAttacks",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Discard",
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "target": {
-              "type": "Controller"
-            }
-          },
-          "cost": null,
-          "sub_ability": {
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 324,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
             "kind": "Spell",
             "effect": {
-              "type": "LoseLife",
-              "amount": {
+              "type": "Sacrifice",
+              "target": {
+                "type": "SelfRef"
+              },
+              "count": {
                 "type": "Fixed",
-                "value": 3
+                "value": 1
               }
             },
             "cost": null,
             "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When ~ enters, sacrifice it unless it escaped.",
+          "constraint": null,
+          "condition": {
+            "type": "Not",
+            "condition": {
+              "type": "CastVariantPaid",
+              "variant": "Escape"
+            }
+          },
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 324,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "EntersOrAttacks",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Discard",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "LoseLife",
+                "amount": {
+                  "type": "Fixed",
+                  "value": 3
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false,
+              "player_scope": {
+                "type": "Opponent"
+              }
+            },
             "duration": null,
             "description": null,
             "target_prompt": null,
@@ -93,79 +137,86 @@ expression: "&ir"
               "type": "Opponent"
             }
           },
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
           "optional": false,
-          "forward_result": false,
-          "player_scope": {
-            "type": "Opponent"
-          }
-        },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "origin": null,
-        "destination": "Battlefield",
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "Whenever ~ enters or attacks, each opponent discards a card, then each opponent who didn't discard a nonland card this way loses 3 life.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever ~ enters or attacks, each opponent discards a card, then each opponent who didn't discard a nonland card this way loses 3 life.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     },
     {
-      "Keyword": {
-        "Escape": {
-          "type": "NonMana",
-          "data": {
-            "type": "Composite",
-            "costs": [
-              {
-                "type": "Mana",
-                "cost": {
-                  "type": "Cost",
-                  "shards": [
-                    "Black",
-                    "Black",
-                    "Red",
-                    "Red"
-                  ],
-                  "generic": 0
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 324,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "Keyword": {
+          "Escape": {
+            "type": "NonMana",
+            "data": {
+              "type": "Composite",
+              "costs": [
+                {
+                  "type": "Mana",
+                  "cost": {
+                    "type": "Cost",
+                    "shards": [
+                      "Black",
+                      "Black",
+                      "Red",
+                      "Red"
+                    ],
+                    "generic": 0
+                  }
+                },
+                {
+                  "type": "Exile",
+                  "count": 5,
+                  "zone": "Graveyard",
+                  "filter": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Card"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      },
+                      {
+                        "type": "InZone",
+                        "zone": "Graveyard"
+                      }
+                    ]
+                  }
                 }
-              },
-              {
-                "type": "Exile",
-                "count": 5,
-                "zone": "Graveyard",
-                "filter": {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Card"
-                  ],
-                  "controller": "You",
-                  "properties": [
-                    {
-                      "type": "Another"
-                    },
-                    {
-                      "type": "InZone",
-                      "zone": "Graveyard"
-                    }
-                  ]
-                }
-              }
-            ]
+              ]
+            }
           }
         }
       }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leonin_arbiter_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leonin_arbiter_ir.snap
@@ -5,22 +5,39 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "static_structure",
-          "description": "Static pattern matched but line failed static parser: Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn."
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 111,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "static_structure",
+            "description": "Static pattern matched but line failed static parser: Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn."
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leyline_of_anticipation_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leyline_of_anticipation_ir.snap
@@ -5,55 +5,89 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "BeginGame",
-        "effect": {
-          "type": "ChangeZone",
-          "origin": "Hand",
-          "destination": "Battlefield",
-          "target": {
-            "type": "SelfRef"
-          },
-          "owner_library": false,
-          "enter_transformed": false,
-          "enter_tapped": false,
-          "enters_attacking": false
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "If this card is in your opening hand, you may begin the game with it on the battlefield.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": true,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 134,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "BeginGame",
+          "effect": {
+            "type": "ChangeZone",
+            "origin": "Hand",
+            "destination": "Battlefield",
+            "target": {
+              "type": "SelfRef"
+            },
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "If this card is in your opening hand, you may begin the game with it on the battlefield.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": true,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredStatic": {
-        "mode": {
-          "CastWithKeyword": {
-            "keyword": "Flash"
-          }
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "affected": {
-          "type": "Typed",
-          "type_filters": [
-            "Card"
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 134,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": {
+            "CastWithKeyword": {
+              "keyword": "Flash"
+            }
+          },
+          "affected": {
+            "type": "Typed",
+            "type_filters": [
+              "Card"
+            ],
+            "controller": "You",
+            "properties": []
+          },
+          "modifications": [],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [
+            "Battlefield"
           ],
-          "controller": "You",
-          "properties": []
-        },
-        "modifications": [],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [
-          "Battlefield"
-        ],
-        "characteristic_defining": false,
-        "description": "You may cast spells as though they had flash."
+          "characteristic_defining": false,
+          "description": "You may cast spells as though they had flash."
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_of_the_veil_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_of_the_veil_ir.snap
@@ -5,139 +5,190 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Discard",
-          "count": {
-            "type": "Fixed",
-            "value": 1
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 217,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Discard",
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "target": {
+              "type": "Controller"
+            }
           },
-          "target": {
-            "type": "Controller"
+          "cost": {
+            "type": "Loyalty",
+            "amount": 1
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "[+1]: Each player discards a card.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false,
+          "player_scope": {
+            "type": "All"
           }
-        },
-        "cost": {
-          "type": "Loyalty",
-          "amount": 1
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "[+1]: Each player discards a card.",
-        "target_prompt": null,
-        "activation_restrictions": [
-          {
-            "type": "AsSorcery"
-          }
-        ],
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false,
-        "player_scope": {
-          "type": "All"
         }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Sacrifice",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": "TargetPlayer",
-            "properties": []
-          },
-          "count": {
-            "type": "Fixed",
-            "value": 1
-          }
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Loyalty",
-          "amount": -2
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "[−2]: Target player sacrifices a creature.",
-        "target_prompt": null,
-        "activation_restrictions": [
-          {
-            "type": "AsSorcery"
-          }
-        ],
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "separate",
-          "description": "Separate all permanents target player controls into two piles"
-        },
-        "cost": {
-          "type": "Loyalty",
-          "amount": -6
-        },
-        "sub_ability": {
-          "kind": "Spell",
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 217,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
           "effect": {
             "type": "Sacrifice",
             "target": {
               "type": "Typed",
               "type_filters": [
-                "Permanent"
+                "Creature"
               ],
-              "controller": "ParentTargetController",
+              "controller": "TargetPlayer",
               "properties": []
             },
             "count": {
-              "type": "Ref",
-              "qty": {
-                "type": "ObjectCount",
-                "filter": {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Permanent"
-                  ],
-                  "controller": null,
-                  "properties": []
-                }
-              }
+              "type": "Fixed",
+              "value": 1
             }
           },
-          "cost": null,
+          "cost": {
+            "type": "Loyalty",
+            "amount": -2
+          },
           "sub_ability": null,
           "duration": null,
-          "description": null,
+          "description": "[−2]: Target player sacrifices a creature.",
           "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
           "condition": null,
           "optional_targeting": false,
           "optional": false,
-          "forward_result": false,
-          "sub_link": "SequentialSibling"
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
         },
-        "duration": null,
-        "description": "[−6]: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.",
-        "target_prompt": null,
-        "activation_restrictions": [
-          {
-            "type": "AsSorcery"
-          }
-        ],
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 217,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "separate",
+            "description": "Separate all permanents target player controls into two piles"
+          },
+          "cost": {
+            "type": "Loyalty",
+            "amount": -6
+          },
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Sacrifice",
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Permanent"
+                ],
+                "controller": "ParentTargetController",
+                "properties": []
+              },
+              "count": {
+                "type": "Ref",
+                "qty": {
+                  "type": "ObjectCount",
+                  "filter": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Permanent"
+                    ],
+                    "controller": null,
+                    "properties": []
+                  }
+                }
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
+          },
+          "duration": null,
+          "description": "[−6]: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_ir.snap
@@ -5,29 +5,46 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Mana",
-          "produced": {
-            "type": "Fixed",
-            "colors": [
-              "Green"
-            ]
-          }
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Tap"
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "{T}: Add {G}.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false,
-        "is_mana_ability": true
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 13,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Mana",
+            "produced": {
+              "type": "Fixed",
+              "colors": [
+                "Green"
+              ]
+            }
+          },
+          "cost": {
+            "type": "Tap"
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{T}: Add {G}.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false,
+          "is_mana_ability": true
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lovestruck_beast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lovestruck_beast_ir.snap
@@ -5,56 +5,73 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredStatic": {
-        "mode": "CantAttack",
-        "affected": {
-          "type": "SelfRef"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "modifications": [],
-        "condition": {
-          "type": "Not",
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 61,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "CantAttack",
+          "affected": {
+            "type": "SelfRef"
+          },
+          "modifications": [],
           "condition": {
-            "type": "IsPresent",
-            "filter": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": "You",
-              "properties": [
-                {
-                  "type": "PtComparison",
-                  "stat": "Power",
-                  "scope": "Current",
-                  "comparator": "EQ",
-                  "value": {
-                    "type": "Fixed",
-                    "value": 1
+            "type": "Not",
+            "condition": {
+              "type": "IsPresent",
+              "filter": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": [
+                  {
+                    "type": "PtComparison",
+                    "stat": "Power",
+                    "scope": "Current",
+                    "comparator": "EQ",
+                    "value": {
+                      "type": "Fixed",
+                      "value": 1
+                    }
+                  },
+                  {
+                    "type": "PtComparison",
+                    "stat": "Toughness",
+                    "scope": "Current",
+                    "comparator": "EQ",
+                    "value": {
+                      "type": "Fixed",
+                      "value": 1
+                    }
+                  },
+                  {
+                    "type": "InZone",
+                    "zone": "Battlefield"
                   }
-                },
-                {
-                  "type": "PtComparison",
-                  "stat": "Toughness",
-                  "scope": "Current",
-                  "comparator": "EQ",
-                  "value": {
-                    "type": "Fixed",
-                    "value": 1
-                  }
-                },
-                {
-                  "type": "InZone",
-                  "zone": "Battlefield"
-                }
-              ]
+                ]
+              }
             }
-          }
-        },
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "~ can't attack unless you control a 1/1 creature."
+          },
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "~ can't attack unless you control a 1/1 creature."
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__luminarch_aspirant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__luminarch_aspirant_ir.snap
@@ -5,54 +5,71 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "Phase",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "PutCounter",
-            "counter_type": "P1P1",
-            "count": {
-              "type": "Fixed",
-              "value": 1
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 92,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Phase",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "P1P1",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              }
             },
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": "You",
-              "properties": []
-            }
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": "BeginCombat",
           "optional": false,
-          "forward_result": false
-        },
-        "valid_card": null,
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": "BeginCombat",
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.",
-        "constraint": {
-          "type": "OnlyDuringYourTurn"
-        },
-        "condition": null,
-        "batched": false
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.",
+          "constraint": {
+            "type": "OnlyDuringYourTurn"
+          },
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__manamorphose_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__manamorphose_ir.snap
@@ -5,57 +5,74 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Mana",
-          "produced": {
-            "type": "AnyCombination",
-            "count": {
-              "type": "Fixed",
-              "value": 2
-            },
-            "color_options": [
-              "White",
-              "Blue",
-              "Black",
-              "Red",
-              "Green"
-            ]
-          }
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": {
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 55,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
           "kind": "Spell",
           "effect": {
-            "type": "Draw",
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "target": {
-              "type": "Controller"
+            "type": "Mana",
+            "produced": {
+              "type": "AnyCombination",
+              "count": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "color_options": [
+                "White",
+                "Blue",
+                "Black",
+                "Red",
+                "Green"
+              ]
             }
           },
           "cost": null,
-          "sub_ability": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Draw",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
+          },
           "duration": null,
-          "description": null,
+          "description": "Add two mana in any combination of colors.\nDraw a card.",
           "target_prompt": null,
           "condition": null,
           "optional_targeting": false,
           "optional": false,
           "forward_result": false,
-          "sub_link": "SequentialSibling"
-        },
-        "duration": null,
-        "description": "Add two mana in any combination of colors.\nDraw a card.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false,
-        "is_mana_ability": true
+          "is_mana_ability": true
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mishra_eminent_one_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mishra_eminent_one_ir.snap
@@ -5,168 +5,185 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "Phase",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "CopyTokenOf",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Artifact",
-                {
-                  "Non": "Creature"
-                }
-              ],
-              "controller": "You",
-              "properties": []
-            },
-            "owner": {
-              "type": "Controller"
-            },
-            "enters_attacking": false,
-            "tapped": false,
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "additional_modifications": [
-              {
-                "type": "SetPower",
-                "value": 4
-              },
-              {
-                "type": "SetToughness",
-                "value": 4
-              },
-              {
-                "type": "AddSubtype",
-                "subtype": "Construct"
-              },
-              {
-                "type": "AddType",
-                "core_type": "Artifact"
-              },
-              {
-                "type": "AddType",
-                "core_type": "Creature"
-              },
-              {
-                "type": "SetName",
-                "name": "Mishra's Warform"
-              }
-            ]
-          },
-          "cost": null,
-          "sub_ability": {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 310,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Phase",
+          "execute": {
             "kind": "Spell",
             "effect": {
-              "type": "GenericEffect",
-              "static_abilities": [
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "LastCreated"
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Haste"
-                    }
-                  ],
-                  "condition": null,
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain haste"
-                }
-              ],
-              "duration": "UntilEndOfTurn",
+              "type": "CopyTokenOf",
               "target": {
-                "type": "LastCreated"
-              }
+                "type": "Typed",
+                "type_filters": [
+                  "Artifact",
+                  {
+                    "Non": "Creature"
+                  }
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "owner": {
+                "type": "Controller"
+              },
+              "enters_attacking": false,
+              "tapped": false,
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "additional_modifications": [
+                {
+                  "type": "SetPower",
+                  "value": 4
+                },
+                {
+                  "type": "SetToughness",
+                  "value": 4
+                },
+                {
+                  "type": "AddSubtype",
+                  "subtype": "Construct"
+                },
+                {
+                  "type": "AddType",
+                  "core_type": "Artifact"
+                },
+                {
+                  "type": "AddType",
+                  "core_type": "Creature"
+                },
+                {
+                  "type": "SetName",
+                  "name": "Mishra's Warform"
+                }
+              ]
             },
             "cost": null,
             "sub_ability": {
               "kind": "Spell",
               "effect": {
-                "type": "CreateDelayedTrigger",
-                "condition": {
-                  "type": "AtNextPhase",
-                  "phase": "End"
-                },
-                "effect": {
-                  "kind": "Spell",
-                  "effect": {
-                    "type": "Sacrifice",
-                    "target": {
+                "type": "GenericEffect",
+                "static_abilities": [
+                  {
+                    "mode": "Continuous",
+                    "affected": {
                       "type": "LastCreated"
                     },
-                    "count": {
-                      "type": "Fixed",
-                      "value": 1
-                    }
-                  },
-                  "cost": null,
-                  "sub_ability": null,
-                  "duration": null,
-                  "description": null,
-                  "target_prompt": null,
-                  "condition": null,
-                  "optional_targeting": false,
-                  "optional": false,
-                  "forward_result": false,
-                  "sub_link": "SequentialSibling"
-                },
-                "uses_tracked_set": false
+                    "modifications": [
+                      {
+                        "type": "AddKeyword",
+                        "keyword": "Haste"
+                      }
+                    ],
+                    "condition": null,
+                    "affected_zone": null,
+                    "effect_zone": null,
+                    "active_zones": [],
+                    "characteristic_defining": false,
+                    "description": "gain haste"
+                  }
+                ],
+                "duration": "UntilEndOfTurn",
+                "target": {
+                  "type": "LastCreated"
+                }
               },
               "cost": null,
-              "sub_ability": null,
-              "duration": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "CreateDelayedTrigger",
+                  "condition": {
+                    "type": "AtNextPhase",
+                    "phase": "End"
+                  },
+                  "effect": {
+                    "kind": "Spell",
+                    "effect": {
+                      "type": "Sacrifice",
+                      "target": {
+                        "type": "LastCreated"
+                      },
+                      "count": {
+                        "type": "Fixed",
+                        "value": 1
+                      }
+                    },
+                    "cost": null,
+                    "sub_ability": null,
+                    "duration": null,
+                    "description": null,
+                    "target_prompt": null,
+                    "condition": null,
+                    "optional_targeting": false,
+                    "optional": false,
+                    "forward_result": false,
+                    "sub_link": "SequentialSibling"
+                  },
+                  "uses_tracked_set": false
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "duration": "UntilEndOfTurn",
               "description": null,
               "target_prompt": null,
               "condition": null,
               "optional_targeting": false,
               "optional": false,
-              "forward_result": false
+              "forward_result": false,
+              "sub_link": "SequentialSibling"
             },
-            "duration": "UntilEndOfTurn",
+            "duration": null,
             "description": null,
             "target_prompt": null,
             "condition": null,
             "optional_targeting": false,
             "optional": false,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
+            "forward_result": false
           },
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": "BeginCombat",
           "optional": false,
-          "forward_result": false
-        },
-        "valid_card": null,
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": "BeginCombat",
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "At the beginning of combat on your turn, create a token that's a copy of target noncreature artifact you control, except its name is ~'s Warform and it's a 4/4 Construct artifact creature in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
-        "constraint": {
-          "type": "OnlyDuringYourTurn"
-        },
-        "condition": null,
-        "batched": false
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "At the beginning of combat on your turn, create a token that's a copy of target noncreature artifact you control, except its name is ~'s Warform and it's a 4/4 Construct artifact creature in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
+          "constraint": {
+            "type": "OnlyDuringYourTurn"
+          },
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__monastery_swiftspear_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__monastery_swiftspear_ir.snap
@@ -5,41 +5,75 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Haste"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Haste",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 98,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Haste"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Haste",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Prowess"
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Prowess",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 98,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Prowess"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Prowess",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mother_of_runes_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mother_of_runes_ir.snap
@@ -5,69 +5,86 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Choose",
-          "choice_type": "Color",
-          "persist": true
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Tap"
-        },
-        "sub_ability": {
-          "kind": "Spell",
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 98,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
           "effect": {
-            "type": "GenericEffect",
-            "static_abilities": [
-              {
-                "mode": "Continuous",
-                "affected": {
-                  "type": "ParentTarget"
-                },
-                "modifications": [
-                  {
-                    "type": "AddKeyword",
-                    "keyword": {
-                      "Protection": "ChosenColor"
-                    }
-                  }
-                ],
-                "condition": null,
-                "affected_zone": null,
-                "effect_zone": null,
-                "active_zones": [],
-                "characteristic_defining": false,
-                "description": "gain protection from the color of your choice"
-              }
-            ],
-            "duration": "UntilEndOfTurn",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": "You",
-              "properties": []
-            }
+            "type": "Choose",
+            "choice_type": "Color",
+            "persist": true
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
+          "cost": {
+            "type": "Tap"
+          },
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GenericEffect",
+              "static_abilities": [
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "ParentTarget"
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": {
+                        "Protection": "ChosenColor"
+                      }
+                    }
+                  ],
+                  "condition": null,
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain protection from the color of your choice"
+                }
+              ],
+              "duration": "UntilEndOfTurn",
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": "UntilEndOfTurn",
+          "description": "{T}: Target creature you control gains protection from the color of your choice until end of turn.",
           "target_prompt": null,
           "condition": null,
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        },
-        "duration": "UntilEndOfTurn",
-        "description": "{T}: Target creature you control gains protection from the color of your choice until end of turn.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__murderous_rider_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__murderous_rider_ir.snap
@@ -5,70 +5,104 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Lifelink"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Lifelink",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredTrigger": {
-        "mode": "ChangesZone",
-        "execute": {
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 78,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
           "kind": "Spell",
           "effect": {
-            "type": "PutAtLibraryPosition",
-            "target": {
-              "type": "ParentTarget"
-            },
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "position": {
-              "type": "Bottom"
-            }
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Lifelink"
           },
           "cost": null,
           "sub_ability": null,
           "duration": null,
-          "description": null,
+          "description": "Lifelink",
           "target_prompt": null,
           "condition": null,
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "origin": "Battlefield",
-        "destination": "Graveyard",
-        "trigger_zones": [
-          "Graveyard"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "When ~ dies, put it on the bottom of its owner's library.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 78,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutAtLibraryPosition",
+              "target": {
+                "type": "ParentTarget"
+              },
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "position": {
+                "type": "Bottom"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": "Battlefield",
+          "destination": "Graveyard",
+          "trigger_zones": [
+            "Graveyard"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When ~ dies, put it on the bottom of its owner's library.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
@@ -5,72 +5,72 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Vigilance, deathtouch, haste"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Vigilance, deathtouch, haste",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "AddRestriction",
-          "restriction": {
-            "type": "DamagePreventionDisabled",
-            "source": 0,
-            "expiry": {
-              "type": "EndOfTurn"
-            },
-            "scope": {
-              "type": "SourcesControlledBy",
-              "data": 0
-            }
-          }
-        },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": null,
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredTrigger": {
-        "mode": "DamageDone",
-        "execute": {
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 305,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
           "kind": "Spell",
           "effect": {
-            "type": "DealDamage",
-            "amount": {
-              "type": "Ref",
-              "qty": {
-                "type": "EventContextAmount"
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Vigilance, deathtouch, haste"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Vigilance, deathtouch, haste",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 305,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "AddRestriction",
+            "restriction": {
+              "type": "DamagePreventionDisabled",
+              "source": 0,
+              "expiry": {
+                "type": "EndOfTurn"
+              },
+              "scope": {
+                "type": "SourcesControlledBy",
+                "data": 0
               }
-            },
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Planeswalker"
-              ],
-              "controller": "TargetPlayer",
-              "properties": []
             }
           },
           "cost": null,
@@ -82,67 +82,135 @@ expression: "&ir"
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        },
-        "valid_card": null,
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "CombatOnly",
-        "secondary": false,
-        "valid_target": {
-          "type": "Typed",
-          "type_filters": [],
-          "controller": "Opponent",
-          "properties": []
-        },
-        "valid_source": {
-          "type": "SelfRef"
-        },
-        "description": "Whenever ~ deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+        }
       }
     },
     {
-      "PreLoweredStatic": {
-        "mode": {
-          "CantBeBlockedBy": {
-            "filter": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": [
-                {
-                  "type": "PtComparison",
-                  "stat": "Power",
-                  "scope": "Current",
-                  "comparator": "LE",
-                  "value": {
-                    "type": "Fixed",
-                    "value": 2
-                  }
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 305,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "DamageDone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "DealDamage",
+              "amount": {
+                "type": "Ref",
+                "qty": {
+                  "type": "EventContextAmount"
                 }
-              ]
+              },
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Planeswalker"
+                ],
+                "controller": "TargetPlayer",
+                "properties": []
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "CombatOnly",
+          "secondary": false,
+          "valid_target": {
+            "type": "Typed",
+            "type_filters": [],
+            "controller": "Opponent",
+            "properties": []
+          },
+          "valid_source": {
+            "type": "SelfRef"
+          },
+          "description": "Whenever ~ deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 3,
+          "start_byte": 0,
+          "end_byte": 305,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 3
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": {
+            "CantBeBlockedBy": {
+              "filter": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": null,
+                "properties": [
+                  {
+                    "type": "PtComparison",
+                    "stat": "Power",
+                    "scope": "Current",
+                    "comparator": "LE",
+                    "value": {
+                      "type": "Fixed",
+                      "value": 2
+                    }
+                  }
+                ]
+              }
             }
-          }
-        },
-        "affected": {
-          "type": "SelfRef"
-        },
-        "modifications": [],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "~ can't be blocked by creatures with power 2 or less."
+          },
+          "affected": {
+            "type": "SelfRef"
+          },
+          "modifications": [],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "~ can't be blocked by creatures with power 2 or less."
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
@@ -5,112 +5,163 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Haste"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Haste",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredTrigger": {
-        "mode": "ChangesZone",
-        "execute": {
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 245,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
           "kind": "Spell",
           "effect": {
-            "type": "GenericEffect",
-            "static_abilities": [
-              {
-                "mode": "Continuous",
-                "affected": {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Creature"
-                  ],
-                  "controller": "You",
-                  "properties": [
-                    {
-                      "type": "Another"
-                    }
-                  ]
-                },
-                "modifications": [
-                  {
-                    "type": "AddPower",
-                    "value": 1
-                  },
-                  {
-                    "type": "AddToughness",
-                    "value": 0
-                  },
-                  {
-                    "type": "AddKeyword",
-                    "keyword": "Haste"
-                  }
-                ],
-                "condition": null,
-                "affected_zone": null,
-                "effect_zone": null,
-                "active_zones": [],
-                "characteristic_defining": false,
-                "description": "get +1/+0 and gain haste"
-              }
-            ],
-            "duration": "UntilEndOfTurn",
-            "target": null
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Haste"
           },
           "cost": null,
           "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": null,
+          "duration": null,
+          "description": "Haste",
           "target_prompt": null,
           "condition": null,
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "origin": null,
-        "destination": "Battlefield",
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "When ~ enters, if its surge cost was paid, other creatures you control get +1/+0 and gain haste until end of turn.",
-        "constraint": null,
-        "condition": {
-          "type": "CastVariantPaid",
-          "variant": "Surge"
-        },
-        "batched": false
+        }
       }
     },
     {
-      "Keyword": {
-        "Surge": {
-          "type": "Cost",
-          "shards": [
-            "Red"
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 245,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GenericEffect",
+              "static_abilities": [
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      }
+                    ]
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddPower",
+                      "value": 1
+                    },
+                    {
+                      "type": "AddToughness",
+                      "value": 0
+                    },
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Haste"
+                    }
+                  ],
+                  "condition": null,
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "get +1/+0 and gain haste"
+                }
+              ],
+              "duration": "UntilEndOfTurn",
+              "target": null
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
           ],
-          "generic": 1
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When ~ enters, if its surge cost was paid, other creatures you control get +1/+0 and gain haste until end of turn.",
+          "constraint": null,
+          "condition": {
+            "type": "CastVariantPaid",
+            "variant": "Surge"
+          },
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 245,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "Keyword": {
+          "Surge": {
+            "type": "Cost",
+            "shards": [
+              "Red"
+            ],
+            "generic": 1
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__savage_summoning_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__savage_summoning_ir.snap
@@ -5,55 +5,89 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredStatic": {
-        "mode": "CantBeCountered",
-        "affected": {
-          "type": "SelfRef"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "modifications": [],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "This spell can't be countered."
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 201,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "CantBeCountered",
+          "affected": {
+            "type": "SelfRef"
+          },
+          "modifications": [],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "This spell can't be countered."
+        }
       }
     },
     {
-      "PreLoweredReplacement": {
-        "event": "Moved",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "PutCounter",
-            "counter_type": "P1P1",
-            "count": {
-              "type": "Fixed",
-              "value": 1
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 201,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredReplacement": {
+          "event": "Moved",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "P1P1",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "SelfRef"
+              }
             },
-            "target": {
-              "type": "SelfRef"
-            }
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
+          "mode": {
+            "type": "Mandatory"
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "description": "The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters with an additional +1/+1 counter on it.",
           "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
-        },
-        "mode": {
-          "type": "Mandatory"
-        },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "description": "The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters with an additional +1/+1 counter on it.",
-        "condition": null,
-        "destination_zone": "Battlefield"
+          "destination_zone": "Battlefield"
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__serra_angel_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__serra_angel_ir.snap
@@ -5,41 +5,75 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Flying"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Flying",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 64,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Flying"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Flying",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Vigilance"
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Vigilance",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 64,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Vigilance"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Vigilance",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__short_sword_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__short_sword_ir.snap
@@ -5,76 +5,110 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "Attach",
-          "target": {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 110,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Attach",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": []
+            }
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 1
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "Equip {1}",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
+          "ability_tag": {
+            "type": "Equip"
+          },
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 110,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
             "type": "Typed",
             "type_filters": [
               "Creature"
             ],
-            "controller": "You",
-            "properties": []
-          }
-        },
-        "cost": {
-          "type": "Mana",
-          "cost": {
-            "type": "Cost",
-            "shards": [],
-            "generic": 1
-          }
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "Equip {1}",
-        "target_prompt": null,
-        "activation_restrictions": [
-          {
-            "type": "AsSorcery"
-          }
-        ],
-        "ability_tag": {
-          "type": "Equip"
-        },
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredStatic": {
-        "mode": "Continuous",
-        "affected": {
-          "type": "Typed",
-          "type_filters": [
-            "Creature"
-          ],
-          "controller": null,
-          "properties": [
-            {
-              "type": "EquippedBy"
-            }
-          ]
-        },
-        "modifications": [
-          {
-            "type": "AddPower",
-            "value": 1
+            "controller": null,
+            "properties": [
+              {
+                "type": "EquippedBy"
+              }
+            ]
           },
-          {
-            "type": "AddToughness",
-            "value": 1
-          }
-        ],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "Equipped creature gets +1/+1."
+          "modifications": [
+            {
+              "type": "AddPower",
+              "value": 1
+            },
+            {
+              "type": "AddToughness",
+              "value": 1
+            }
+          ],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "Equipped creature gets +1/+1."
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__slippery_bogle_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__slippery_bogle_ir.snap
@@ -5,22 +5,39 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Hexproof"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Hexproof",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 91,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Hexproof"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Hexproof",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__smugglers_copter_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__smugglers_copter_ir.snap
@@ -1,49 +1,68 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 260
 expression: "&ir"
 ---
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Flying"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Flying",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 233,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Flying"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Flying",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredTrigger": {
-        "mode": "AttacksOrBlocks",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Draw",
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "target": {
-              "type": "Controller"
-            }
-          },
-          "cost": null,
-          "sub_ability": {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 233,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "AttacksOrBlocks",
+          "execute": {
             "kind": "Spell",
             "effect": {
-              "type": "Discard",
+              "type": "Draw",
               "count": {
                 "type": "Fixed",
                 "value": 1
@@ -53,52 +72,83 @@ expression: "&ir"
               }
             },
             "cost": null,
-            "sub_ability": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "Discard",
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                },
+                "target": {
+                  "type": "Controller"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": {
+                "type": "EffectOutcome",
+                "signal": "OptionalEffectPerformed"
+              },
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false,
+              "sub_link": "SequentialSibling"
+            },
             "duration": null,
             "description": null,
             "target_prompt": null,
-            "condition": {
-              "type": "EffectOutcome",
-              "signal": "OptionalEffectPerformed"
-            },
+            "condition": null,
             "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
+            "optional": true,
+            "forward_result": false
           },
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
           "optional": true,
-          "forward_result": false
-        },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": true,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "Whenever ~ attacks or blocks, you may draw a card. If you do, discard a card.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever ~ attacks or blocks, you may draw a card. If you do, discard a card.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     },
     {
-      "Keyword": {
-        "Crew": {
-          "power": 1,
-          "once_per_turn": null
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 233,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "Keyword": {
+          "Crew": {
+            "power": 1,
+            "once_per_turn": null
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__snapcaster_mage_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__snapcaster_mage_ir.snap
@@ -5,119 +5,153 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Flash"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Flash",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredTrigger": {
-        "mode": "ChangesZone",
-        "execute": {
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 246,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
           "kind": "Spell",
           "effect": {
-            "type": "GenericEffect",
-            "static_abilities": [
-              {
-                "mode": "Continuous",
-                "affected": {
-                  "type": "ParentTarget"
-                },
-                "modifications": [
-                  {
-                    "type": "AddKeyword",
-                    "keyword": {
-                      "Flashback": {
-                        "type": "Mana",
-                        "data": {
-                          "type": "SelfManaCost"
-                        }
-                      }
-                    }
-                  }
-                ],
-                "condition": null,
-                "affected_zone": null,
-                "effect_zone": null,
-                "active_zones": [],
-                "characteristic_defining": false,
-                "description": "gain flashback"
-              }
-            ],
-            "duration": "UntilEndOfTurn",
-            "target": {
-              "type": "Or",
-              "filters": [
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Instant"
-                  ],
-                  "controller": "You",
-                  "properties": [
-                    {
-                      "type": "InZone",
-                      "zone": "Graveyard"
-                    }
-                  ]
-                },
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Sorcery"
-                  ],
-                  "controller": "You",
-                  "properties": [
-                    {
-                      "type": "InZone",
-                      "zone": "Graveyard"
-                    }
-                  ]
-                }
-              ]
-            }
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Flash"
           },
           "cost": null,
           "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": null,
+          "duration": null,
+          "description": "Flash",
           "target_prompt": null,
           "condition": null,
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "origin": null,
-        "destination": "Battlefield",
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "When ~ enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 246,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GenericEffect",
+              "static_abilities": [
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "ParentTarget"
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": {
+                        "Flashback": {
+                          "type": "Mana",
+                          "data": {
+                            "type": "SelfManaCost"
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "condition": null,
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain flashback"
+                }
+              ],
+              "duration": "UntilEndOfTurn",
+              "target": {
+                "type": "Or",
+                "filters": [
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Instant"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "InZone",
+                        "zone": "Graveyard"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Sorcery"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "InZone",
+                        "zone": "Graveyard"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When ~ enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__stoneforge_mystic_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__stoneforge_mystic_ir.snap
@@ -5,111 +5,152 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "ChangeZone",
-          "origin": "Hand",
-          "destination": "Battlefield",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              {
-                "Subtype": "Equipment"
-              }
-            ],
-            "controller": "You",
-            "properties": [
-              {
-                "type": "InZone",
-                "zone": "Hand"
-              }
-            ]
-          },
-          "owner_library": false,
-          "enter_transformed": false,
-          "enter_tapped": false,
-          "enters_attacking": false
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Composite",
-          "costs": [
-            {
-              "type": "Mana",
-              "cost": {
-                "type": "Cost",
-                "shards": [
-                  "White"
-                ],
-                "generic": 1
-              }
-            },
-            {
-              "type": "Tap"
-            }
-          ]
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": true,
-        "target_choice_timing": "Resolution",
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredTrigger": {
-        "mode": "ChangesZone",
-        "execute": {
-          "kind": "Spell",
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 205,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
           "effect": {
-            "type": "SearchLibrary",
-            "filter": {
+            "type": "ChangeZone",
+            "origin": "Hand",
+            "destination": "Battlefield",
+            "target": {
               "type": "Typed",
               "type_filters": [
-                "Artifact",
                 {
                   "Subtype": "Equipment"
                 }
               ],
-              "controller": null,
-              "properties": []
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "InZone",
+                  "zone": "Hand"
+                }
+              ]
             },
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "reveal": true
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
           },
-          "cost": null,
-          "sub_ability": {
+          "cost": {
+            "type": "Composite",
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "White"
+                  ],
+                  "generic": 1
+                }
+              },
+              {
+                "type": "Tap"
+              }
+            ]
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": true,
+          "target_choice_timing": "Resolution",
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 205,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
             "kind": "Spell",
             "effect": {
-              "type": "ChangeZone",
-              "origin": "Library",
-              "destination": "Hand",
-              "target": {
-                "type": "Any"
+              "type": "SearchLibrary",
+              "filter": {
+                "type": "Typed",
+                "type_filters": [
+                  "Artifact",
+                  {
+                    "Subtype": "Equipment"
+                  }
+                ],
+                "controller": null,
+                "properties": []
               },
-              "owner_library": false,
-              "enter_transformed": false,
-              "enter_tapped": false,
-              "enters_attacking": false
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "reveal": true
             },
             "cost": null,
             "sub_ability": {
               "kind": "Spell",
               "effect": {
-                "type": "Shuffle",
+                "type": "ChangeZone",
+                "origin": "Library",
+                "destination": "Hand",
                 "target": {
-                  "type": "Controller"
-                }
+                  "type": "Any"
+                },
+                "owner_library": false,
+                "enter_transformed": false,
+                "enter_tapped": false,
+                "enters_attacking": false
               },
               "cost": null,
-              "sub_ability": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "Shuffle",
+                  "target": {
+                    "type": "Controller"
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
               "duration": null,
               "description": null,
               "target_prompt": null,
@@ -123,35 +164,28 @@ expression: "&ir"
             "target_prompt": null,
             "condition": null,
             "optional_targeting": false,
-            "optional": false,
+            "optional": true,
             "forward_result": false
           },
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
           "optional": true,
-          "forward_result": false
-        },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "origin": null,
-        "destination": "Battlefield",
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": true,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "When ~ enters, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When ~ enters, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__student_of_warfare_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__student_of_warfare_ir.snap
@@ -5,84 +5,135 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredStatic": {
-        "mode": "Continuous",
-        "affected": {
-          "type": "SelfRef"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "modifications": [
-          {
-            "type": "SetPower",
-            "value": 3
+        "span": {
+          "first_line": 0,
+          "last_line": 6,
+          "start_byte": 0,
+          "end_byte": 130,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
+            "type": "SelfRef"
           },
-          {
-            "type": "SetToughness",
-            "value": 3
-          },
-          {
-            "type": "AddKeyword",
-            "keyword": "FirstStrike"
-          }
-        ],
-        "condition": {
-          "type": "HasCounters",
-          "counters": {
-            "type": "OfType",
-            "data": "level"
-          },
-          "minimum": 2,
-          "maximum": 6
-        },
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "LEVEL 2-6 / 3/3 / First strike"
-      }
-    },
-    {
-      "PreLoweredStatic": {
-        "mode": "Continuous",
-        "affected": {
-          "type": "SelfRef"
-        },
-        "modifications": [
-          {
-            "type": "SetPower",
-            "value": 4
-          },
-          {
-            "type": "SetToughness",
-            "value": 4
-          },
-          {
-            "type": "AddKeyword",
-            "keyword": "DoubleStrike"
-          }
-        ],
-        "condition": {
-          "type": "HasCounters",
-          "counters": {
-            "type": "OfType",
-            "data": "level"
-          },
-          "minimum": 7
-        },
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "LEVEL 7+ / 4/4 / Double strike"
-      }
-    },
-    {
-      "Keyword": {
-        "LevelUp": {
-          "type": "Cost",
-          "shards": [
-            "White"
+          "modifications": [
+            {
+              "type": "SetPower",
+              "value": 3
+            },
+            {
+              "type": "SetToughness",
+              "value": 3
+            },
+            {
+              "type": "AddKeyword",
+              "keyword": "FirstStrike"
+            }
           ],
-          "generic": 0
+          "condition": {
+            "type": "HasCounters",
+            "counters": {
+              "type": "OfType",
+              "data": "level"
+            },
+            "minimum": 2,
+            "maximum": 6
+          },
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "LEVEL 2-6 / 3/3 / First strike"
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 6,
+          "start_byte": 0,
+          "end_byte": 130,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
+            "type": "SelfRef"
+          },
+          "modifications": [
+            {
+              "type": "SetPower",
+              "value": 4
+            },
+            {
+              "type": "SetToughness",
+              "value": 4
+            },
+            {
+              "type": "AddKeyword",
+              "keyword": "DoubleStrike"
+            }
+          ],
+          "condition": {
+            "type": "HasCounters",
+            "counters": {
+              "type": "OfType",
+              "data": "level"
+            },
+            "minimum": 7
+          },
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "LEVEL 7+ / 4/4 / Double strike"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 6,
+          "start_byte": 0,
+          "end_byte": 130,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "Keyword": {
+          "LevelUp": {
+            "type": "Cost",
+            "shards": [
+              "White"
+            ],
+            "generic": 0
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_ir.snap
@@ -5,61 +5,78 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "ChangeZone",
-          "origin": null,
-          "destination": "Exile",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": []
-          },
-          "owner_library": false,
-          "enter_transformed": false,
-          "enter_tapped": false,
-          "enters_attacking": false
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": {
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 68,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
           "kind": "Spell",
           "effect": {
-            "type": "GainLife",
-            "amount": {
-              "type": "Ref",
-              "qty": {
-                "type": "Power",
-                "scope": {
-                  "type": "Target"
-                }
-              }
+            "type": "ChangeZone",
+            "origin": null,
+            "destination": "Exile",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
             },
-            "player": {
-              "type": "ParentTargetController"
-            }
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
           },
           "cost": null,
-          "sub_ability": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GainLife",
+              "amount": {
+                "type": "Ref",
+                "qty": {
+                  "type": "Power",
+                  "scope": {
+                    "type": "Target"
+                  }
+                }
+              },
+              "player": {
+                "type": "ParentTargetController"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
+          },
           "duration": null,
-          "description": null,
+          "description": "Exile target creature. Its controller gains life equal to its power.",
           "target_prompt": null,
           "condition": null,
           "optional_targeting": false,
           "optional": false,
-          "forward_result": false,
-          "sub_link": "SequentialSibling"
-        },
-        "duration": null,
-        "description": "Exile target creature. Its controller gains life equal to its power.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_safekeeper_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_safekeeper_ir.snap
@@ -5,60 +5,77 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "GenericEffect",
-          "static_abilities": [
-            {
-              "mode": "Continuous",
-              "affected": {
-                "type": "ParentTarget"
-              },
-              "modifications": [
-                {
-                  "type": "AddKeyword",
-                  "keyword": "Shroud"
-                }
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 77,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "GenericEffect",
+            "static_abilities": [
+              {
+                "mode": "Continuous",
+                "affected": {
+                  "type": "ParentTarget"
+                },
+                "modifications": [
+                  {
+                    "type": "AddKeyword",
+                    "keyword": "Shroud"
+                  }
+                ],
+                "condition": null,
+                "affected_zone": null,
+                "effect_zone": null,
+                "active_zones": [],
+                "characteristic_defining": false,
+                "description": "gain shroud"
+              }
+            ],
+            "duration": "UntilEndOfTurn",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
               ],
-              "condition": null,
-              "affected_zone": null,
-              "effect_zone": null,
-              "active_zones": [],
-              "characteristic_defining": false,
-              "description": "gain shroud"
+              "controller": "You",
+              "properties": []
             }
-          ],
-          "duration": "UntilEndOfTurn",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": "You",
-            "properties": []
-          }
-        },
-        "cost": {
-          "type": "Sacrifice",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Land"
-            ],
-            "controller": null,
-            "properties": []
           },
-          "count": 1
-        },
-        "sub_ability": null,
-        "duration": "UntilEndOfTurn",
-        "description": "Sacrifice a land: Target creature you control gains shroud until end of turn.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+          "cost": {
+            "type": "Sacrifice",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Land"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            "count": 1
+          },
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": "Sacrifice a land: Target creature you control gains shroud until end of turn.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tarmogoyf_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tarmogoyf_ir.snap
@@ -5,31 +5,31 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredStatic": {
-        "mode": "Continuous",
-        "affected": {
-          "type": "SelfRef"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "modifications": [
-          {
-            "type": "SetDynamicPower",
-            "value": {
-              "type": "Ref",
-              "qty": {
-                "type": "DistinctCardTypes",
-                "source": {
-                  "type": "Zone",
-                  "zone": "Graveyard",
-                  "scope": "All"
-                }
-              }
-            }
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 134,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
+            "type": "SelfRef"
           },
-          {
-            "type": "SetDynamicToughness",
-            "value": {
-              "type": "Offset",
-              "inner": {
+          "modifications": [
+            {
+              "type": "SetDynamicPower",
+              "value": {
                 "type": "Ref",
                 "qty": {
                   "type": "DistinctCardTypes",
@@ -39,17 +39,34 @@ expression: "&ir"
                     "scope": "All"
                   }
                 }
-              },
-              "offset": 1
+              }
+            },
+            {
+              "type": "SetDynamicToughness",
+              "value": {
+                "type": "Offset",
+                "inner": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "DistinctCardTypes",
+                    "source": {
+                      "type": "Zone",
+                      "zone": "Graveyard",
+                      "scope": "All"
+                    }
+                  }
+                },
+                "offset": 1
+              }
             }
-          }
-        ],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": true,
-        "description": "~'s power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1."
+          ],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": true,
+          "description": "~'s power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1."
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
@@ -5,61 +5,95 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "First strike"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "First strike",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 54,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "First strike"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "First strike",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredStatic": {
-        "mode": {
-          "ModifyCost": {
-            "mode": "Raise",
-            "amount": {
-              "type": "Cost",
-              "shards": [],
-              "generic": 1
-            },
-            "spell_filter": {
-              "type": "Typed",
-              "type_filters": [
-                {
-                  "Non": "Creature"
-                }
-              ],
-              "controller": null,
-              "properties": []
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 54,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": {
+            "ModifyCost": {
+              "mode": "Raise",
+              "amount": {
+                "type": "Cost",
+                "shards": [],
+                "generic": 1
+              },
+              "spell_filter": {
+                "type": "Typed",
+                "type_filters": [
+                  {
+                    "Non": "Creature"
+                  }
+                ],
+                "controller": null,
+                "properties": []
+              }
             }
-          }
-        },
-        "affected": {
-          "type": "Typed",
-          "type_filters": [
-            "Card"
-          ],
-          "controller": null,
-          "properties": []
-        },
-        "modifications": [],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "Noncreature spells cost {1} more to cast."
+          },
+          "affected": {
+            "type": "Typed",
+            "type_filters": [
+              "Card"
+            ],
+            "controller": null,
+            "properties": []
+          },
+          "modifications": [],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "Noncreature spells cost {1} more to cast."
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thunderous_velocipede_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thunderous_velocipede_ir.snap
@@ -5,148 +5,199 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredStatic": {
-        "mode": {
-          "EntersWithAdditionalCounters": {
-            "counter_type": "P1P1",
-            "count": 1
-          }
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "affected": {
-          "type": "And",
-          "filters": [
-            {
-              "type": "Typed",
-              "type_filters": [],
-              "controller": null,
-              "properties": [
-                {
-                  "type": "Cmc",
-                  "comparator": "LE",
-                  "value": {
-                    "type": "Fixed",
-                    "value": 4
-                  }
-                }
-              ]
-            },
-            {
-              "type": "Or",
-              "filters": [
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Artifact",
-                    {
-                      "Subtype": "Vehicle"
-                    }
-                  ],
-                  "controller": "You",
-                  "properties": [
-                    {
-                      "type": "Another"
-                    }
-                  ]
-                },
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Creature"
-                  ],
-                  "controller": "You",
-                  "properties": [
-                    {
-                      "type": "Another"
-                    }
-                  ]
-                }
-              ]
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 201,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": {
+            "EntersWithAdditionalCounters": {
+              "counter_type": "P1P1",
+              "count": 1
             }
-          ]
-        },
-        "modifications": [],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+          },
+          "affected": {
+            "type": "And",
+            "filters": [
+              {
+                "type": "Typed",
+                "type_filters": [],
+                "controller": null,
+                "properties": [
+                  {
+                    "type": "Cmc",
+                    "comparator": "LE",
+                    "value": {
+                      "type": "Fixed",
+                      "value": 4
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "Or",
+                "filters": [
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Artifact",
+                      {
+                        "Subtype": "Vehicle"
+                      }
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "modifications": [],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+        }
       }
     },
     {
-      "PreLoweredStatic": {
-        "mode": {
-          "EntersWithAdditionalCounters": {
-            "counter_type": "P1P1",
-            "count": 3
-          }
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "affected": {
-          "type": "And",
-          "filters": [
-            {
-              "type": "Typed",
-              "type_filters": [],
-              "controller": null,
-              "properties": [
-                {
-                  "type": "Cmc",
-                  "comparator": "GT",
-                  "value": {
-                    "type": "Fixed",
-                    "value": 4
-                  }
-                }
-              ]
-            },
-            {
-              "type": "Or",
-              "filters": [
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Artifact",
-                    {
-                      "Subtype": "Vehicle"
-                    }
-                  ],
-                  "controller": "You",
-                  "properties": [
-                    {
-                      "type": "Another"
-                    }
-                  ]
-                },
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Creature"
-                  ],
-                  "controller": "You",
-                  "properties": [
-                    {
-                      "type": "Another"
-                    }
-                  ]
-                }
-              ]
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 201,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": {
+            "EntersWithAdditionalCounters": {
+              "counter_type": "P1P1",
+              "count": 3
             }
-          ]
-        },
-        "modifications": [],
-        "condition": null,
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+          },
+          "affected": {
+            "type": "And",
+            "filters": [
+              {
+                "type": "Typed",
+                "type_filters": [],
+                "controller": null,
+                "properties": [
+                  {
+                    "type": "Cmc",
+                    "comparator": "GT",
+                    "value": {
+                      "type": "Fixed",
+                      "value": 4
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "Or",
+                "filters": [
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Artifact",
+                      {
+                        "Subtype": "Vehicle"
+                      }
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "modifications": [],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+        }
       }
     },
     {
-      "Keyword": {
-        "Crew": {
-          "power": 3,
-          "once_per_turn": null
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 201,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "Keyword": {
+          "Crew": {
+            "power": 3,
+            "once_per_turn": null
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tireless_tracker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tireless_tracker_ir.snap
@@ -5,99 +5,133 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "ChangesZone",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Investigate"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 217,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Investigate"
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
-        },
-        "valid_card": {
-          "type": "Typed",
-          "type_filters": [
-            "Land"
+          "valid_card": {
+            "type": "Typed",
+            "type_filters": [
+              "Land"
+            ],
+            "controller": "You",
+            "properties": []
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
           ],
-          "controller": "You",
-          "properties": []
-        },
-        "origin": null,
-        "destination": "Battlefield",
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "Whenever a land you control enters, investigate.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever a land you control enters, investigate.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     },
     {
-      "PreLoweredTrigger": {
-        "mode": "Sacrificed",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "PutCounter",
-            "counter_type": "P1P1",
-            "count": {
-              "type": "Fixed",
-              "value": 1
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 217,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Sacrificed",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "P1P1",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "SelfRef"
+              }
             },
-            "target": {
-              "type": "SelfRef"
-            }
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
-        },
-        "valid_card": {
-          "type": "Typed",
-          "type_filters": [
-            {
-              "Subtype": "Clue"
-            }
+          "valid_card": {
+            "type": "Typed",
+            "type_filters": [
+              {
+                "Subtype": "Clue"
+              }
+            ],
+            "controller": "You",
+            "properties": []
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
           ],
-          "controller": "You",
-          "properties": []
-        },
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": null,
-        "valid_source": null,
-        "description": "Whenever you sacrifice a Clue, put a +1/+1 counter on ~.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever you sacrifice a Clue, put a +1/+1 counter on ~.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__village_rites_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__village_rites_ir.snap
@@ -5,43 +5,77 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Draw",
-          "count": {
-            "type": "Fixed",
-            "value": 2
-          },
-          "target": {
-            "type": "Controller"
-          }
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Draw two cards.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 79,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Draw",
+            "count": {
+              "type": "Fixed",
+              "value": 2
+            },
+            "target": {
+              "type": "Controller"
+            }
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Draw two cards.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "AdditionalCost": {
-        "type": "Required",
-        "data": {
-          "type": "Sacrifice",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": []
-          },
-          "count": 1
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 79,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "AdditionalCost": {
+          "type": "Required",
+          "data": {
+            "type": "Sacrifice",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            "count": 1
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__vines_of_vastwood_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__vines_of_vastwood_ir.snap
@@ -1,111 +1,161 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 320
 expression: "&ir"
 ---
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "GenericEffect",
-          "static_abilities": [
-            {
-              "mode": "Continuous",
-              "affected": {
-                "type": "ParentTarget"
-              },
-              "modifications": [
-                {
-                  "type": "AddKeyword",
-                  "keyword": "Hexproof"
-                }
-              ],
-              "condition": null,
-              "affected_zone": null,
-              "effect_zone": null,
-              "active_zones": [],
-              "characteristic_defining": false,
-              "description": "can't be the target of spells or abilities your opponents control"
-            }
-          ],
-          "duration": "UntilEndOfTurn",
-          "target": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": []
-          }
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": {
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 229,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
           "kind": "Spell",
           "effect": {
-            "type": "Pump",
-            "power": {
-              "type": "Fixed",
-              "value": 4
-            },
-            "toughness": {
-              "type": "Fixed",
-              "value": 4
-            },
+            "type": "GenericEffect",
+            "static_abilities": [
+              {
+                "mode": "Continuous",
+                "affected": {
+                  "type": "ParentTarget"
+                },
+                "modifications": [
+                  {
+                    "type": "AddKeyword",
+                    "keyword": "Hexproof"
+                  }
+                ],
+                "condition": null,
+                "affected_zone": null,
+                "effect_zone": null,
+                "active_zones": [],
+                "characteristic_defining": false,
+                "description": "can't be the target of spells or abilities your opponents control"
+              }
+            ],
+            "duration": "UntilEndOfTurn",
             "target": {
-              "type": "ParentTarget"
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
             }
           },
           "cost": null,
-          "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": null,
-          "target_prompt": null,
-          "condition": {
-            "type": "AdditionalCostPaid"
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Pump",
+              "power": {
+                "type": "Fixed",
+                "value": 4
+              },
+              "toughness": {
+                "type": "Fixed",
+                "value": 4
+              },
+              "target": {
+                "type": "ParentTarget"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": {
+              "type": "AdditionalCostPaid"
+            },
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
           },
+          "duration": "UntilEndOfTurn",
+          "description": "Target creature can't be the target of spells or abilities your opponents control this turn. If this spell was kicked, that creature gets +4/+4 until end of turn.",
+          "target_prompt": null,
+          "condition": null,
           "optional_targeting": false,
           "optional": false,
-          "forward_result": false,
-          "sub_link": "SequentialSibling"
-        },
-        "duration": "UntilEndOfTurn",
-        "description": "Target creature can't be the target of spells or abilities your opponents control this turn. If this spell was kicked, that creature gets +4/+4 until end of turn.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "Keyword": {
-        "Kicker": {
-          "type": "Cost",
-          "shards": [
-            "Green"
-          ],
-          "generic": 0
+          "forward_result": false
         }
       }
     },
     {
-      "AdditionalCost": {
-        "type": "Kicker",
-        "data": {
-          "costs": [
-            {
-              "type": "Mana",
-              "cost": {
-                "type": "Cost",
-                "shards": [
-                  "Green"
-                ],
-                "generic": 0
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 229,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "Keyword": {
+          "Kicker": {
+            "type": "Cost",
+            "shards": [
+              "Green"
+            ],
+            "generic": 0
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 229,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "AdditionalCost": {
+          "type": "Kicker",
+          "data": {
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "Green"
+                  ],
+                  "generic": 0
+                }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__walking_ballista_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__walking_ballista_ir.snap
@@ -5,107 +5,158 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "PutCounter",
-          "counter_type": "P1P1",
-          "count": {
-            "type": "Fixed",
-            "value": 1
-          },
-          "target": {
-            "type": "SelfRef"
-          }
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": {
-          "type": "Mana",
-          "cost": {
-            "type": "Cost",
-            "shards": [],
-            "generic": 4
-          }
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "{4}: Put a +1/+1 counter on ~.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredSpell": {
-        "kind": "Activated",
-        "effect": {
-          "type": "DealDamage",
-          "amount": {
-            "type": "Fixed",
-            "value": 1
-          },
-          "target": {
-            "type": "Any"
-          }
-        },
-        "cost": {
-          "type": "RemoveCounter",
-          "count": 1,
-          "counter_type": {
-            "type": "OfType",
-            "data": "P1P1"
-          },
-          "target": null,
-          "selection": "SingleObject"
-        },
-        "sub_ability": null,
-        "duration": null,
-        "description": "Remove a +1/+1 counter from ~: It deals 1 damage to any target.",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
-      }
-    },
-    {
-      "PreLoweredReplacement": {
-        "event": "Moved",
-        "execute": {
-          "kind": "Spell",
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 168,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
           "effect": {
             "type": "PutCounter",
             "counter_type": "P1P1",
             "count": {
-              "type": "Ref",
-              "qty": {
-                "type": "CostXPaid"
-              }
+              "type": "Fixed",
+              "value": 1
             },
             "target": {
               "type": "SelfRef"
             }
           },
-          "cost": null,
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 4
+            }
+          },
           "sub_ability": null,
           "duration": null,
-          "description": null,
+          "description": "{4}: Put a +1/+1 counter on ~.",
           "target_prompt": null,
           "condition": null,
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "mode": {
-          "type": "Mandatory"
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 168,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "DealDamage",
+            "amount": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "target": {
+              "type": "Any"
+            }
+          },
+          "cost": {
+            "type": "RemoveCounter",
+            "count": 1,
+            "counter_type": {
+              "type": "OfType",
+              "data": "P1P1"
+            },
+            "target": null,
+            "selection": "SingleObject"
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "Remove a +1/+1 counter from ~: It deals 1 damage to any target.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
         },
-        "valid_card": {
-          "type": "SelfRef"
-        },
-        "description": "~ enters with X +1/+1 counters on it.",
-        "condition": null,
-        "destination_zone": "Battlefield"
+        "span": {
+          "first_line": 0,
+          "last_line": 2,
+          "start_byte": 0,
+          "end_byte": 168,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 2
+        }
+      },
+      "node": {
+        "PreLoweredReplacement": {
+          "event": "Moved",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "P1P1",
+              "count": {
+                "type": "Ref",
+                "qty": {
+                  "type": "CostXPaid"
+                }
+              },
+              "target": {
+                "type": "SelfRef"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "mode": {
+            "type": "Mandatory"
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "description": "~ enters with X +1/+1 counters on it.",
+          "condition": null,
+          "destination_zone": "Battlefield"
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wolfir_silverheart_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wolfir_silverheart_ir.snap
@@ -5,48 +5,82 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredSpell": {
-        "kind": "Spell",
-        "effect": {
-          "type": "Unimplemented",
-          "name": "unknown",
-          "description": "Soulbond"
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
         },
-        "cost": null,
-        "sub_ability": null,
-        "duration": null,
-        "description": "Soulbond",
-        "target_prompt": null,
-        "condition": null,
-        "optional_targeting": false,
-        "optional": false,
-        "forward_result": false
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 242,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Soulbond"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Soulbond",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     },
     {
-      "PreLoweredStatic": {
-        "mode": "Continuous",
-        "affected": {
-          "type": "SourceOrPaired"
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
         },
-        "modifications": [
-          {
-            "type": "AddPower",
-            "value": 4
+        "span": {
+          "first_line": 0,
+          "last_line": 1,
+          "start_byte": 0,
+          "end_byte": 242,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 1
+        }
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
+            "type": "SourceOrPaired"
           },
-          {
-            "type": "AddToughness",
-            "value": 4
-          }
-        ],
-        "condition": {
-          "type": "SourceIsPaired"
-        },
-        "affected_zone": null,
-        "effect_zone": null,
-        "active_zones": [],
-        "characteristic_defining": false,
-        "description": "As long as ~ is paired with another creature, each of those creatures gets +4/+4."
+          "modifications": [
+            {
+              "type": "AddPower",
+              "value": 4
+            },
+            {
+              "type": "AddToughness",
+              "value": 4
+            }
+          ],
+          "condition": {
+            "type": "SourceIsPaired"
+          },
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "As long as ~ is paired with another creature, each of those creatures gets +4/+4."
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__young_pyromancer_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__young_pyromancer_ir.snap
@@ -5,87 +5,104 @@ expression: "&ir"
 {
   "items": [
     {
-      "PreLoweredTrigger": {
-        "mode": "SpellCast",
-        "execute": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Token",
-            "name": "Elemental",
-            "power": {
-              "type": "Fixed",
-              "value": 1
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 89,
+          "precision": "WholeDocument",
+          "ordinal_within_span": 0
+        }
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "SpellCast",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Token",
+              "name": "Elemental",
+              "power": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "toughness": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "types": [
+                "Creature",
+                "Elemental"
+              ],
+              "colors": [
+                "Red"
+              ],
+              "keywords": [],
+              "tapped": false,
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "owner": {
+                "type": "Controller"
+              },
+              "enters_attacking": false
             },
-            "toughness": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "types": [
-              "Creature",
-              "Elemental"
-            ],
-            "colors": [
-              "Red"
-            ],
-            "keywords": [],
-            "tapped": false,
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "owner": {
-              "type": "Controller"
-            },
-            "enters_attacking": false
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
+          "valid_card": {
+            "type": "Or",
+            "filters": [
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Instant"
+                ],
+                "controller": null,
+                "properties": []
+              },
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Sorcery"
+                ],
+                "controller": null,
+                "properties": []
+              }
+            ]
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
           "optional": false,
-          "forward_result": false
-        },
-        "valid_card": {
-          "type": "Or",
-          "filters": [
-            {
-              "type": "Typed",
-              "type_filters": [
-                "Instant"
-              ],
-              "controller": null,
-              "properties": []
-            },
-            {
-              "type": "Typed",
-              "type_filters": [
-                "Sorcery"
-              ],
-              "controller": null,
-              "properties": []
-            }
-          ]
-        },
-        "origin": null,
-        "destination": null,
-        "trigger_zones": [
-          "Battlefield"
-        ],
-        "phase": null,
-        "optional": false,
-        "damage_kind": "Any",
-        "secondary": false,
-        "valid_target": {
-          "type": "Controller"
-        },
-        "valid_source": null,
-        "description": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
-        "constraint": null,
-        "condition": null,
-        "batched": false
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": {
+            "type": "Controller"
+          },
+          "valid_source": null,
+          "description": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_spacecraft.rs
+++ b/crates/engine/src/parser/oracle_spacecraft.rs
@@ -29,6 +29,7 @@ use super::oracle::{find_activated_colon, has_unimplemented, strip_activated_con
 use super::oracle_cost::parse_oracle_cost;
 use super::oracle_effect::parse_effect_chain;
 use super::oracle_ir::context::ParseContext;
+use super::oracle_ir::doc::PrintedTriggerIndex;
 use super::oracle_keyword::parse_keyword_from_oracle;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_special::normalize_self_refs_for_static;
@@ -71,7 +72,7 @@ pub fn max_spacecraft_threshold(lines: &[&str]) -> Option<u32> {
 pub(crate) fn parse_spacecraft_threshold_lines(
     lines: &[&str],
     card_name: &str,
-    base_trigger_index: usize,
+    base_trigger_index: PrintedTriggerIndex,
 ) -> (
     Vec<StaticDefinition>,
     Vec<TriggerDefinition>,
@@ -147,7 +148,7 @@ struct ThresholdParser<'a> {
     threshold: u32,
     static_cond: StaticCondition,
     trigger_cond: TriggerCondition,
-    base_trigger_index: usize,
+    base_trigger_index: PrintedTriggerIndex,
 }
 
 struct ThresholdOutput<'a> {
@@ -180,7 +181,9 @@ impl ThresholdParser<'_> {
             let mut parsed = parse_trigger_lines_at_index(
                 body,
                 self.card_name,
-                Some(self.base_trigger_index + output.triggers.len()),
+                // Printed slot of the next trigger this preprocessor emits.
+                // Unit 4 replaces `output.triggers.len()` with an emission counter.
+                Some(self.base_trigger_index.offset(output.triggers.len())),
                 &mut ParseContext::default(),
             );
             for trig in &mut parsed {
@@ -324,8 +327,11 @@ mod tests {
     #[test]
     fn keyword_threshold_line_parses_to_addkeyword_static() {
         let lines = ["12+ | Flying"];
-        let (statics, triggers, abilities, consumed) =
-            parse_spacecraft_threshold_lines(&lines, "Test", 0);
+        let (statics, triggers, abilities, consumed) = parse_spacecraft_threshold_lines(
+            &lines,
+            "Test",
+            PrintedTriggerIndex::from_slot_for_test(0),
+        );
         assert_eq!(consumed, vec![0]);
         assert!(triggers.is_empty());
         assert!(abilities.is_empty());
@@ -345,7 +351,11 @@ mod tests {
     #[test]
     fn multi_keyword_threshold_line_parses_all() {
         let lines = ["8+ | Flying, trample"];
-        let (statics, _, _, consumed) = parse_spacecraft_threshold_lines(&lines, "Test", 0);
+        let (statics, _, _, consumed) = parse_spacecraft_threshold_lines(
+            &lines,
+            "Test",
+            PrintedTriggerIndex::from_slot_for_test(0),
+        );
         assert_eq!(consumed, vec![0]);
         assert_eq!(statics.len(), 1);
         assert_eq!(statics[0].modifications.len(), 2);
@@ -357,8 +367,11 @@ mod tests {
             "8+ | Flying",
             "Other artifacts you control have hexproof and indestructible.",
         ];
-        let (statics, triggers, abilities, consumed) =
-            parse_spacecraft_threshold_lines(&lines, "Inspirit, Flagship Vessel", 0);
+        let (statics, triggers, abilities, consumed) = parse_spacecraft_threshold_lines(
+            &lines,
+            "Inspirit, Flagship Vessel",
+            PrintedTriggerIndex::from_slot_for_test(0),
+        );
         assert_eq!(consumed, vec![0, 1]);
         assert!(triggers.is_empty());
         assert!(abilities.is_empty());
@@ -381,8 +394,11 @@ mod tests {
             "8+ | Flying",
             "Other artifacts you control have hexproof and indestructible.",
         ];
-        let (statics, triggers, _, consumed) =
-            parse_spacecraft_threshold_lines(&lines, "Inspirit, Flagship Vessel", 0);
+        let (statics, triggers, _, consumed) = parse_spacecraft_threshold_lines(
+            &lines,
+            "Inspirit, Flagship Vessel",
+            PrintedTriggerIndex::from_slot_for_test(0),
+        );
         assert_eq!(consumed, vec![0, 1, 2]);
         assert_eq!(triggers.len(), 1);
         assert!(matches!(
@@ -398,8 +414,11 @@ mod tests {
     #[test]
     fn trigger_threshold_line_parses_with_condition() {
         let lines = ["3+ | Whenever you cast an artifact spell, draw a card."];
-        let (_, triggers, _, consumed) =
-            parse_spacecraft_threshold_lines(&lines, "Uthros Research Craft", 0);
+        let (_, triggers, _, consumed) = parse_spacecraft_threshold_lines(
+            &lines,
+            "Uthros Research Craft",
+            PrintedTriggerIndex::from_slot_for_test(0),
+        );
         assert_eq!(consumed, vec![0]);
         assert_eq!(triggers.len(), 1);
         assert!(matches!(
@@ -413,8 +432,11 @@ mod tests {
         let lines = [
             "3+ | Whenever you cast an artifact spell, draw a card. Put a charge counter on this Spacecraft.",
         ];
-        let (_, triggers, _, consumed) =
-            parse_spacecraft_threshold_lines(&lines, "Uthros Research Craft", 0);
+        let (_, triggers, _, consumed) = parse_spacecraft_threshold_lines(
+            &lines,
+            "Uthros Research Craft",
+            PrintedTriggerIndex::from_slot_for_test(0),
+        );
         assert_eq!(consumed, vec![0]);
         assert_eq!(triggers.len(), 1);
         let counter = triggers[0]
@@ -437,7 +459,11 @@ mod tests {
     #[test]
     fn activated_threshold_line_gets_counter_threshold_restriction() {
         let lines = ["1+ | {T}: Draw a card."];
-        let (_, _, abilities, consumed) = parse_spacecraft_threshold_lines(&lines, "Test", 0);
+        let (_, _, abilities, consumed) = parse_spacecraft_threshold_lines(
+            &lines,
+            "Test",
+            PrintedTriggerIndex::from_slot_for_test(0),
+        );
         assert_eq!(consumed, vec![0]);
         assert_eq!(abilities.len(), 1);
         let restr = &abilities[0].activation_restrictions;

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -13,6 +13,7 @@ use super::oracle_effect::{
     try_parse_grant_graveyard_keyword_to_target, try_parse_reanimator_aura_etb_effect,
 };
 use super::oracle_ir::context::ParseContext;
+use super::oracle_ir::doc::PrintedTriggerIndex;
 use super::oracle_ir::trigger::{FirstTimeLimit, TriggerBody, TriggerIr, TriggerModifiers};
 use super::oracle_modal::try_parse_inline_modal;
 use super::oracle_nom::condition::parse_inner_condition;
@@ -597,7 +598,7 @@ fn resolve_difference_anaphor_in_effect(effect: &mut Effect, bound: Option<&Quan
 pub(crate) fn parse_trigger_lines_at_index(
     text: &str,
     card_name: &str,
-    base_trigger_index: Option<usize>,
+    base_trigger_index: Option<PrintedTriggerIndex>,
     ctx: &mut ParseContext,
 ) -> Vec<TriggerDefinition> {
     parse_trigger_lines_at_index_ir(text, card_name, base_trigger_index, ctx)
@@ -611,7 +612,7 @@ pub(crate) fn parse_trigger_lines_at_index(
 pub(crate) fn parse_trigger_lines_at_index_ir(
     text: &str,
     card_name: &str,
-    base_trigger_index: Option<usize>,
+    base_trigger_index: Option<PrintedTriggerIndex>,
     ctx: &mut ParseContext,
 ) -> Vec<TriggerIr> {
     let stripped = strip_reminder_text(text);
@@ -636,7 +637,7 @@ pub(crate) fn parse_trigger_lines_at_index_ir(
             results.push(parse_trigger_line_with_index_ir(
                 &trigger_text,
                 card_name,
-                base_trigger_index.map(|b| b + i),
+                base_trigger_index.map(|b| b.offset(i)),
                 ctx,
             ));
         }
@@ -673,7 +674,7 @@ pub(crate) fn parse_trigger_lines_at_index_ir(
             results.push(parse_trigger_line_with_index_ir(
                 &trigger_text,
                 card_name,
-                base_trigger_index.map(|b| b + i),
+                base_trigger_index.map(|b| b.offset(i)),
                 ctx,
             ));
         }
@@ -995,7 +996,7 @@ pub fn parse_trigger_line(text: &str, card_name: &str) -> TriggerDefinition {
 pub(crate) fn parse_trigger_line_with_index_ir(
     text: &str,
     card_name: &str,
-    current_trigger_index: Option<usize>,
+    current_trigger_index: Option<PrintedTriggerIndex>,
     ctx: &mut ParseContext,
 ) -> TriggerIr {
     let text = strip_reminder_text(text);
@@ -1082,7 +1083,9 @@ pub(crate) fn parse_trigger_line_with_index_ir(
     let mut effect_ctx = ParseContext {
         subject: Some(trigger_subject.clone()),
         card_name: Some(card_name.to_string()),
-        current_trigger_index,
+        // `ParseContext` still stores a raw `usize`; unwrap the printed-slot
+        // newtype at this boundary. Unit 3b may lift the newtype into `ctx`.
+        current_trigger_index: current_trigger_index.map(PrintedTriggerIndex::get),
         // CR 303.4 + CR 702.103: Propagate the enclosing card's typed host
         // self-reference (set by `parse_oracle_ir` for Aura/bestow cards) into
         // the per-trigger effect context. The trigger body's effect parser
@@ -1824,7 +1827,7 @@ fn introduces_chosen_object_target(effect: &Effect) -> bool {
 pub(crate) fn parse_trigger_line_with_index(
     text: &str,
     card_name: &str,
-    current_trigger_index: Option<usize>,
+    current_trigger_index: Option<PrintedTriggerIndex>,
     ctx: &mut ParseContext,
 ) -> TriggerDefinition {
     let ir = parse_trigger_line_with_index_ir(text, card_name, current_trigger_index, ctx);

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -3,6 +3,7 @@ use crate::game::scenario::{GameScenario, P0, P1};
 use crate::parser::oracle::parse_oracle_text;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
+use crate::parser::oracle_ir::doc::PrintedTriggerIndex;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
     AttackSubject, BounceSelection, CardSelectionMode, CastingPermission, ChosenAttribute,
@@ -21288,7 +21289,7 @@ fn trigger_become_copy_with_set_name_and_retain_this_ability() {
     let def = parse_trigger_line_with_index(
             "At the beginning of combat on your turn, ~ becomes a copy of up to one other target creature you control, except her name is ~ and she has this ability. Then put a +1/+1 counter on her.",
             "Irma, Part-Time Mutant",
-            Some(0),
+            Some(PrintedTriggerIndex::from_slot_for_test(0)),
             &mut ParseContext::default(),
         );
     // Phase + constraint: BoC on your turn.
@@ -21375,7 +21376,7 @@ fn trigger_become_copy_he_has_this_ability() {
     let def = parse_trigger_line_with_index(
             "At the beginning of your upkeep, ~ becomes a copy of target creature you control, except his name is ~ and he has this ability.",
             "Test Mutant",
-            Some(0),
+            Some(PrintedTriggerIndex::from_slot_for_test(0)),
             &mut ParseContext::default(),
         );
     let execute = def.execute.as_deref().unwrap();
@@ -21411,7 +21412,7 @@ fn trigger_become_copy_it_has_this_ability_neuter() {
     let def = parse_trigger_line_with_index(
             "At the beginning of your upkeep, ~ becomes a copy of another target creature, except it has this ability.",
             "Test Cloner",
-            Some(0),
+            Some(PrintedTriggerIndex::from_slot_for_test(0)),
             &mut ParseContext::default(),
         );
     let execute = def.execute.as_deref().unwrap();
@@ -21456,7 +21457,7 @@ fn trigger_gogo_distributes_pump_haste_must_attack_to_both() {
     let def = parse_trigger_line_with_index(
             "At the beginning of combat on your turn, you may have ~ become a copy of another target creature you control until end of turn, except its name is ~. If you do, ~ and that creature each get +2/+0 and gain haste until end of turn and attack this turn if able.",
             "Gogo, Mysterious Mime",
-            Some(0),
+            Some(PrintedTriggerIndex::from_slot_for_test(0)),
             &mut ParseContext::default(),
         );
     assert_eq!(def.mode, TriggerMode::Phase);


### PR DESCRIPTION
Introduce a source-addressed document IR as the safe midpoint of the Oracle
parser provenance refactor. Zero lowered-output change: `data/card-data.json`
is byte-identical under a same-base A/B regen, and no snapshot outside
`oracle_ir/snapshots` moves.

- `OracleItemIr { id, source, node }` + `OracleNodeIr`, retaining the four
  `PreLowered*` variants as unit-4 debt.
- `OracleDocBuilder` emits items through a single guarded path. `emit` fails
  closed on fragment/precision mismatch, duplicate item position, and
  overlapping sibling spans, in that order, before mutating any state.
- `PrintedAbilityIndex` / `PrintedTriggerIndex` newtypes for CR 707.9a printed
  slots. Private field, no `From<usize>`, no `Default`; the sole escape hatch
  `from_category_vector_len` is the exact, compiler-enforced cutover list for
  unit 3b. Adding it surfaced two absolute index derivations in
  `oracle_class.rs` that no grep or runtime assertion had found, because the
  Class path early-returns before the main dispatch loop.
- `ability_index()` is `spells_emitted.len()` rather than a parallel counter:
  two values that must agree can drift, one value cannot. `take_last_spell()`
  pops that emission-ordered stack, mirroring the parser's only category
  `pop()`, so an earlier spell's printed slot cannot be freed.
- `SpanPrecision { Exact, WholeDocument }` so a consumer can refuse to print a
  line number rather than print a coarse one. `fragment` is `Option<String>`,
  `None` unless the span is exact.
- Child spans are validated by `UnitAllocator::allocate_with_span`, the only
  way to mint an `OracleUnitSource`, which nested parsers actually receive.

Three review rounds found five latent CR 707.9a mis-indexing hazards, none of
them reachable by any current card and none detectable by the test suite, the
snapshots, or the 35k-card corpus.
