### PR TITLE
feat(parser): parse "gets an additional +N/+M" P/T grants

### DIFF
--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1580,6 +1580,13 @@ pub(crate) fn parse_pt_mod_with_remainder(input: &str) -> OracleResult<'_, (i32,
 /// nom combinator doesn't handle (it requires explicit +/- signs).
 pub(crate) fn parse_pt_mod(text: &str) -> Option<(i32, i32)> {
     let text = text.trim();
+    // CR 613.4c: consume an optional "an additional " qualifier ("gets an
+    // additional +N/+M" — Taste for Mayhem, Divine Sacrament, Patriarch's Desire,
+    // Strange Augmentation). It marks a second Layer 7c grant stacked on the base
+    // modification but carries no P/T semantics of its own, so the underlying
+    // +N/+M is parsed identically (the enclosing gate is attached separately).
+    let lower = text.to_lowercase();
+    let text = nom_tag_lower(text, &lower, "an additional ").unwrap_or(text);
     // Try the nom combinator first — handles +N/+M, -N/-M, +N/-M patterns.
     if let Ok((_, (p, t))) = nom_primitives::parse_pt_modifier.parse(text) {
         return Some((p, t));

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1584,9 +1584,16 @@ pub(crate) fn parse_pt_mod(text: &str) -> Option<(i32, i32)> {
     // additional +N/+M" — Taste for Mayhem, Divine Sacrament, Patriarch's Desire,
     // Strange Augmentation). It marks a second Layer 7c grant stacked on the base
     // modification but carries no P/T semantics of its own, so the underlying
-    // +N/+M is parsed identically (the enclosing gate is attached separately).
-    let lower = text.to_lowercase();
-    let text = nom_tag_lower(text, &lower, "an additional ").unwrap_or(text);
+    // +N/+M is parsed identically (the enclosing gate is attached separately). The
+    // cheap "an" guard keeps the common no-qualifier call off the lowercase
+    // allocation path.
+    let text = match text.get(..2) {
+        Some(head) if head.eq_ignore_ascii_case("an") => {
+            let lower = text.to_lowercase();
+            nom_tag_lower(text, &lower, "an additional ").unwrap_or(text)
+        }
+        _ => text,
+    };
     // Try the nom combinator first — handles +N/+M, -N/-M, +N/-M patterns.
     if let Ok((_, (p, t))) = nom_primitives::parse_pt_modifier.parse(text) {
         return Some((p, t));

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -27302,3 +27302,55 @@ fn subgoyf_cda_power_is_bare_count_toughness_is_count_plus_one() {
         def.modifications
     );
 }
+
+/// CR 613.4c: "gets/get an additional +N/+M" is a second Layer 7c additive P/T
+/// grant. The "an additional " qualifier is consumed by `parse_pt_mod`; the
+/// underlying +N/+M and the enclosing "as long as <cond>" gate parse as usual.
+#[test]
+fn an_additional_pt_grant_parses_with_gate() {
+    let cases: &[(&str, &str, &str)] = &[
+        (
+            "Hellbent — Enchanted creature gets an additional +2/+0 as long as you have no cards in hand.",
+            "Taste for Mayhem",
+            "AddPower { value: 2 }",
+        ),
+        (
+            "Threshold — White creatures get an additional +1/+1 as long as there are seven or more cards in your graveyard.",
+            "Divine Sacrament",
+            "AddPower { value: 1 }",
+        ),
+        (
+            "Delirium — Enchanted creature gets an additional +2/+2 as long as there are four or more card types among cards in your graveyard.",
+            "Strange Augmentation",
+            "AddToughness { value: 2 }",
+        ),
+    ];
+    for (line, name, needle) in cases {
+        let statics = super::shared::parse_static_line_multi(line);
+        assert!(
+            !statics.is_empty(),
+            "{name}: expected a static, got none for {line:?}"
+        );
+        let dump = format!("{statics:?}");
+        assert!(dump.contains(needle), "{name}: expected {needle} in {dump}");
+        assert!(
+            dump.contains("condition: Some"),
+            "{name}: expected an attached 'as long as' condition, got {dump}"
+        );
+        assert!(
+            !dump.contains("Unrecognized"),
+            "{name}: condition must be a recognized StaticCondition, got {dump}"
+        );
+    }
+}
+
+/// The bare (ungated) "an additional +N/+M" grant also parses — the qualifier is
+/// consumed regardless of an enclosing condition.
+#[test]
+fn an_additional_pt_grant_bare_parses() {
+    let statics =
+        super::shared::parse_static_line_multi("Enchanted creature gets an additional +2/+0.");
+    assert_eq!(statics.len(), 1, "expected exactly one static: {statics:?}");
+    let dump = format!("{statics:?}");
+    assert!(dump.contains("AddPower { value: 2 }"), "got {dump}");
+}

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -27306,51 +27306,132 @@ fn subgoyf_cda_power_is_bare_count_toughness_is_count_plus_one() {
 /// CR 613.4c: "gets/get an additional +N/+M" is a second Layer 7c additive P/T
 /// grant. The "an additional " qualifier is consumed by `parse_pt_mod`; the
 /// underlying +N/+M and the enclosing "as long as <cond>" gate parse as usual.
+/// Each case asserts the typed P/T modifications AND the specific
+/// `StaticCondition` variant so a wrong-but-present condition can't pass.
 #[test]
 fn an_additional_pt_grant_parses_with_gate() {
-    let cases: &[(&str, &str, &str)] = &[
-        (
-            "Hellbent — Enchanted creature gets an additional +2/+0 as long as you have no cards in hand.",
-            "Taste for Mayhem",
-            "AddPower { value: 2 }",
+    // Taste for Mayhem (Hellbent, +2/+0) — gated on an empty hand.
+    let s = super::shared::parse_static_line_multi(
+        "Hellbent — Enchanted creature gets an additional +2/+0 as long as you have no cards in hand.",
+    );
+    assert_eq!(s.len(), 1, "Taste for Mayhem: {s:?}");
+    assert!(s[0]
+        .modifications
+        .contains(&ContinuousModification::AddPower { value: 2 }));
+    assert!(s[0]
+        .modifications
+        .contains(&ContinuousModification::AddToughness { value: 0 }));
+    assert!(
+        matches!(
+            s[0].condition,
+            Some(StaticCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize { .. }
+                },
+                comparator: Comparator::EQ,
+                rhs: QuantityExpr::Fixed { value: 0 },
+            })
         ),
-        (
-            "Threshold — White creatures get an additional +1/+1 as long as there are seven or more cards in your graveyard.",
-            "Divine Sacrament",
-            "AddPower { value: 1 }",
+        "Taste for Mayhem (empty-hand gate): {:?}",
+        s[0].condition
+    );
+
+    // Divine Sacrament (Threshold, +1/+1) — 7+ cards in your graveyard.
+    let s = super::shared::parse_static_line_multi(
+        "Threshold — White creatures get an additional +1/+1 as long as there are seven or more cards in your graveyard.",
+    );
+    assert_eq!(s.len(), 1, "Divine Sacrament: {s:?}");
+    assert!(s[0]
+        .modifications
+        .contains(&ContinuousModification::AddPower { value: 1 }));
+    assert!(s[0]
+        .modifications
+        .contains(&ContinuousModification::AddToughness { value: 1 }));
+    assert!(
+        matches!(
+            s[0].condition,
+            Some(StaticCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::GraveyardSize { .. }
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 7 },
+            })
         ),
-        (
-            "Delirium — Enchanted creature gets an additional +2/+2 as long as there are four or more card types among cards in your graveyard.",
-            "Strange Augmentation",
-            "AddToughness { value: 2 }",
+        "Divine Sacrament (Threshold gate): {:?}",
+        s[0].condition
+    );
+
+    // Patriarch's Desire (Threshold, +2/-2) — the ONLY mixed-sign case, which
+    // exercises `parse_pt_modifier`'s +N/-M path after the prefix is stripped.
+    let s = super::shared::parse_static_line_multi(
+        "Threshold — Enchanted creature gets an additional +2/-2 as long as there are seven or more cards in your graveyard.",
+    );
+    assert_eq!(s.len(), 1, "Patriarch's Desire: {s:?}");
+    assert!(s[0]
+        .modifications
+        .contains(&ContinuousModification::AddPower { value: 2 }));
+    assert!(s[0]
+        .modifications
+        .contains(&ContinuousModification::AddToughness { value: -2 }));
+    assert!(
+        matches!(
+            s[0].condition,
+            Some(StaticCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::GraveyardSize { .. }
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 7 },
+            })
         ),
-    ];
-    for (line, name, needle) in cases {
-        let statics = super::shared::parse_static_line_multi(line);
-        assert!(
-            !statics.is_empty(),
-            "{name}: expected a static, got none for {line:?}"
-        );
-        let dump = format!("{statics:?}");
-        assert!(dump.contains(needle), "{name}: expected {needle} in {dump}");
-        assert!(
-            dump.contains("condition: Some"),
-            "{name}: expected an attached 'as long as' condition, got {dump}"
-        );
-        assert!(
-            !dump.contains("Unrecognized"),
-            "{name}: condition must be a recognized StaticCondition, got {dump}"
-        );
-    }
+        "Patriarch's Desire (Threshold gate): {:?}",
+        s[0].condition
+    );
+
+    // Strange Augmentation (Delirium, +2/+2) — 4+ card types in your graveyard.
+    let s = super::shared::parse_static_line_multi(
+        "Delirium — Enchanted creature gets an additional +2/+2 as long as there are four or more card types among cards in your graveyard.",
+    );
+    assert_eq!(s.len(), 1, "Strange Augmentation: {s:?}");
+    assert!(s[0]
+        .modifications
+        .contains(&ContinuousModification::AddPower { value: 2 }));
+    assert!(s[0]
+        .modifications
+        .contains(&ContinuousModification::AddToughness { value: 2 }));
+    assert!(
+        matches!(
+            s[0].condition,
+            Some(StaticCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::DistinctCardTypes { .. }
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 4 },
+            })
+        ),
+        "Strange Augmentation (Delirium gate): {:?}",
+        s[0].condition
+    );
 }
 
 /// The bare (ungated) "an additional +N/+M" grant also parses — the qualifier is
-/// consumed regardless of an enclosing condition.
+/// consumed regardless of an enclosing condition, and no gate is attached.
 #[test]
 fn an_additional_pt_grant_bare_parses() {
     let statics =
         super::shared::parse_static_line_multi("Enchanted creature gets an additional +2/+0.");
     assert_eq!(statics.len(), 1, "expected exactly one static: {statics:?}");
-    let dump = format!("{statics:?}");
-    assert!(dump.contains("AddPower { value: 2 }"), "got {dump}");
+    assert!(statics[0]
+        .modifications
+        .contains(&ContinuousModification::AddPower { value: 2 }));
+    assert!(statics[0]
+        .modifications
+        .contains(&ContinuousModification::AddToughness { value: 0 }));
+    assert!(
+        statics[0].condition.is_none(),
+        "bare grant carries no gate: {:?}",
+        statics[0].condition
+    );
 }


### PR DESCRIPTION
## Problem

An `"an additional +N/+M"` additive P/T grant dropped **entirely**: `parse_pt_mod` (and the anthem grant path that delegates to it) did not recognize the `"an additional "` qualifier, so the whole static line failed and produced no continuous grant.

This is the last blocker for a class of real, gated grants — the `as long as <condition>` gating **already works** (via `parse_conditional_static`); only the `"an additional"` wording was missing:

- **Taste for Mayhem** (Hellbent): `Enchanted creature gets an additional +2/+0 as long as you have no cards in hand.`
- **Divine Sacrament** (Threshold): `White creatures get an additional +1/+1 as long as there are seven or more cards in your graveyard.`
- **Patriarch's Desire** (Threshold): `Enchanted creature gets an additional +2/-2 as long as …`
- **Strange Augmentation** (Delirium): `Enchanted creature gets an additional +2/+2 as long as …`

## Fix

Consume the optional `"an additional "` qualifier in `parse_pt_mod` (CR 613.4c). It marks a second Layer 7c modification stacked on the base grant but carries no P/T semantics of its own, so the underlying `+N/+M` parses identically, and the enclosing gate is attached separately by the existing condition path. One clean-file, 7-line change.

## Tests

- `an_additional_pt_grant_parses_with_gate`: the three ability-word-gated cards (Hellbent/Threshold/Delirium) each produce the grant **with a recognized `StaticCondition`** attached (not `Unrecognized`).
- `an_additional_pt_grant_bare_parses`: the ungated form parses too.
- Regression: `parser::oracle` **7634 passed, 0 failed**; `cargo fmt`, clippy (`-D warnings`), parser-combinator + engine-authorities gates all clean.