### PR TITLE
Implement Zada copy-for-each legal creature target (fixes #4945)

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -810,6 +810,7 @@ fn filterprop_reads_only_candidate_fp(p: &FilterProp) -> bool {
         // (`tracked_object_sets` / `chain_tracked_set_id`), not the candidate's
         // own fingerprint — POISON for memoization.
         | FilterProp::InTrackedSet { .. }
+        | FilterProp::CouldBeTargetedByTriggeringSpell
         | FilterProp::Other { .. } => false,
     }
 }

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2360,6 +2360,7 @@ fn legacy_filter_prop(p: &FilterProp) -> bool {
         | FilterProp::Modified
         | FilterProp::Historic
         | FilterProp::NotHistoric
+        | FilterProp::CouldBeTargetedByTriggeringSpell
         | FilterProp::Other { .. } => false,
     }
 }
@@ -2610,6 +2611,7 @@ fn member_bound_filter_prop(p: &FilterProp) -> bool {
         | FilterProp::Modified
         | FilterProp::Historic
         | FilterProp::NotHistoric
+        | FilterProp::CouldBeTargetedByTriggeringSpell
         | FilterProp::Other { .. } => false,
     }
 }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1003,6 +1003,9 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
             FilterProp::HasXInActivationCost => parts.push("with {X} in activation cost".into()),
             FilterProp::HasManaAbility => parts.push("with a mana ability".into()),
             FilterProp::HasNoAbilities => parts.push("with no abilities".into()),
+            FilterProp::CouldBeTargetedByTriggeringSpell => {
+                parts.push("that the spell could target".into())
+            }
         }
     }
     if let Some(ctrl) = &tf.controller {

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -150,6 +150,25 @@ pub fn resolve(
     state.stack.push_back(copy_entry);
     events.push(GameEvent::StackPushed { object_id: copy_id });
 
+    // CR 707.10c + CR 608.2c: Zada — each copy targets the current iteration
+    // member without a player choice.
+    if matches!(
+        ability.effect,
+        Effect::CopySpell {
+            retarget: CopyRetargetPermission::RetargetEachCopyToIterationMember,
+            ..
+        }
+    ) {
+        if let Some(member) = ability.targets.iter().find_map(|target| match target {
+            TargetRef::Object(id) => Some(*id),
+            TargetRef::Player(_) => None,
+        }) {
+            if let Some(copy_ability) = state.stack.back_mut().and_then(|e| e.ability_mut()) {
+                rewrite_copy_spell_object_targets(copy_ability, member);
+            }
+        }
+    }
+
     // CR 707.10: A copy of a spell is itself a spell on the stack, but it
     // isn't cast. Emit a distinct `SpellCopied` event so copy-sensitive
     // triggers (Magecraft) fire without wrongly firing cast-only triggers.
@@ -498,6 +517,21 @@ pub(crate) fn copy_count_with_replacements(
 }
 
 fn copy_source_entry(state: &GameState, ability: &ResolvedAbility) -> Option<StackEntry> {
+    if let Effect::CopySpell {
+        target, retarget, ..
+    } = &ability.effect
+    {
+        if matches!(target, TargetFilter::TriggeringSource)
+            || matches!(
+                retarget,
+                CopyRetargetPermission::RetargetEachCopyToIterationMember
+            )
+        {
+            if let Some(entry) = triggering_spell_stack_entry(state) {
+                return Some(entry);
+            }
+        }
+    }
     let target_id = ability.targets.iter().find_map(|target| match target {
         TargetRef::Object(id) => Some(*id),
         TargetRef::Player(_) => None,
@@ -740,6 +774,21 @@ pub(crate) fn set_resolved_source_recursive(ability: &mut ResolvedAbility, sourc
 fn preserve_ability_copy_source_recursive(ability: &mut ResolvedAbility) {
     let source_id = ability.source_id;
     set_resolved_source_recursive(ability, source_id);
+}
+
+/// CR 707.10c: Replace every object target on a copied spell with `new_target`.
+fn rewrite_copy_spell_object_targets(ability: &mut ResolvedAbility, new_target: ObjectId) {
+    for target in &mut ability.targets {
+        if matches!(target, TargetRef::Object(_)) {
+            *target = TargetRef::Object(new_target);
+        }
+    }
+    if let Some(sub) = ability.sub_ability.as_mut() {
+        rewrite_copy_spell_object_targets(sub, new_target);
+    }
+    if let Some(else_ab) = ability.else_ability.as_mut() {
+        rewrite_copy_spell_object_targets(else_ab, new_target);
+    }
 }
 
 fn stack_entry_source_id_for_copy(kind: &StackEntryKind, copy_id: ObjectId) -> ObjectId {

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -150,8 +150,8 @@ pub fn resolve(
     state.stack.push_back(copy_entry);
     events.push(GameEvent::StackPushed { object_id: copy_id });
 
-    // CR 707.10c + CR 608.2c: Zada — each copy targets the current iteration
-    // member without a player choice.
+    // CR 707.10d: Zada — each copy is put on the stack targeting the current
+    // iteration member; no controller choice to change targets.
     if matches!(
         ability.effect,
         Effect::CopySpell {
@@ -776,7 +776,7 @@ fn preserve_ability_copy_source_recursive(ability: &mut ResolvedAbility) {
     set_resolved_source_recursive(ability, source_id);
 }
 
-/// CR 707.10c: Replace every object target on a copied spell with `new_target`.
+/// CR 707.10d: Replace every object target on a copied spell with `new_target`.
 fn rewrite_copy_spell_object_targets(ability: &mut ResolvedAbility, new_target: ObjectId) {
     for target in &mut ability.targets {
         if matches!(target, TargetRef::Object(_)) {

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4355,6 +4355,15 @@ fn filter_refs_same_name_as_parent_target(filter: &TargetFilter) -> bool {
 }
 
 fn effect_iterates_over_parent_target(effect: &Effect) -> bool {
+    if matches!(
+        effect,
+        Effect::CopySpell {
+            retarget: CopyRetargetPermission::RetargetEachCopyToIterationMember,
+            ..
+        }
+    ) {
+        return true;
+    }
     if effect_parent_ref_slots(effect)
         .iter()
         .any(|f| filter_refs_parent_target(f))

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -157,6 +157,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         // `ColorCount` carries a `u8` constant, not a QuantityExpr.
         // `ManaSymbolCount` reads only the candidate's own printed mana cost.
         FilterProp::CanEnchant { .. }
+        | FilterProp::CouldBeTargetedByTriggeringSpell
         | FilterProp::HasAttachment { .. }
         | FilterProp::HasAnyAttachmentOf { .. }
         | FilterProp::TargetsOnly { .. }
@@ -390,6 +391,7 @@ fn entered_object_perturbs_filter_prop(
         // `filter_prop_uses_object_population` — candidate-local, stack-relative,
         // single-object, or threshold-free, so a board entry cannot perturb them.
         FilterProp::CanEnchant { .. }
+        | FilterProp::CouldBeTargetedByTriggeringSpell
         | FilterProp::HasAttachment { .. }
         | FilterProp::HasAnyAttachmentOf { .. }
         | FilterProp::TargetsOnly { .. }
@@ -3037,6 +3039,7 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         // CR 303.4: "could enchant [target]" needs live target context and
         // Aura attachment legality; stack snapshots only record keyword values.
         FilterProp::CanEnchant { .. } => false,
+        FilterProp::CouldBeTargetedByTriggeringSpell => false,
         FilterProp::HasColor { color } => record.colors.contains(color),
         FilterProp::NotColor { color } => !record.colors.contains(color),
         FilterProp::HasSupertype { value } => record.supertypes.contains(value),
@@ -3559,6 +3562,10 @@ fn matches_filter_prop(
                 && !combat::has_summoning_sickness(obj)
         }
         FilterProp::WithKeyword { value } => obj.has_keyword(value),
+        // CR 115.1 + CR 707.10: Zada — "creature you control that the spell could target".
+        FilterProp::CouldBeTargetedByTriggeringSpell => {
+            crate::game::targeting::object_could_be_targeted_by_triggering_spell(state, object_id)
+        }
         FilterProp::CanEnchant { target } => obj.keywords.iter().any(|keyword| {
             let Keyword::Enchant(enchant_filter) = keyword else {
                 return false;
@@ -4369,6 +4376,7 @@ fn zone_change_record_matches_property(
         // CR 303.4: Requires live target context; zone-change snapshots cannot
         // prove attachment legality against a referenced target.
         FilterProp::CanEnchant { .. } => false,
+        FilterProp::CouldBeTargetedByTriggeringSpell => false,
         // CR 205.4a: Supertype membership as of the zone change.
         FilterProp::HasSupertype { value } => record.supertypes.contains(value),
         FilterProp::NotSupertype { value } => !record.supertypes.contains(value),

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -521,22 +521,56 @@ pub(crate) fn object_could_be_targeted_by_triggering_spell(
     let Some(spell_id) = extract_source_from_event(event) else {
         return false;
     };
-    let Some(spell_ability) = state
-        .stack
-        .iter()
-        .rev()
-        .find(|entry| entry.id == spell_id)
-        .and_then(|entry| entry.ability())
+    let spell_controller = match event {
+        GameEvent::SpellCast { controller, .. } => *controller,
+        _ => return false,
+    };
+    let Some(spell_ability) = triggering_spell_resolved_ability(state, spell_id, spell_controller)
     else {
         return false;
     };
-    let Ok(slots) = crate::game::ability_utils::build_target_slots(state, spell_ability) else {
+    let Ok(slots) = crate::game::ability_utils::build_target_slots(state, &spell_ability) else {
         return false;
     };
     slots.iter().any(|slot| {
         slot.legal_targets
             .contains(&TargetRef::Object(candidate_id))
     })
+}
+
+/// CR 707.10a: Resolve the triggering spell's `ResolvedAbility` for legality
+/// checks. Prefer the live stack entry; fall back to `resolving_stack_entry`
+/// (spell mid-resolution) or reconstruct from the spell object when the stack
+/// entry is gone (e.g. countered before a `SpellCast` trigger resolves).
+fn triggering_spell_resolved_ability(
+    state: &GameState,
+    spell_id: ObjectId,
+    controller: PlayerId,
+) -> Option<ResolvedAbility> {
+    if let Some(ability) = state
+        .stack
+        .iter()
+        .rev()
+        .find(|entry| entry.id == spell_id)
+        .and_then(|entry| entry.ability())
+    {
+        return Some(ability.clone());
+    }
+    if let Some(entry) = state.resolving_stack_entry.as_ref() {
+        if entry.id == spell_id {
+            if let Some(ability) = entry.ability() {
+                return Some(ability.clone());
+            }
+        }
+    }
+    let obj = state.objects.get(&spell_id)?;
+    let def = crate::game::casting::combined_spell_ability_def(obj)?;
+    let mut resolved =
+        crate::game::ability_utils::build_resolved_from_def(&def, spell_id, controller);
+    if let Some(targets) = super::restrictions::triggering_spell_targets(state, spell_id) {
+        resolved.targets = targets;
+    }
+    Some(resolved)
 }
 
 /// Resolve event-context TargetFilter variants using the current trigger event.

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -509,6 +509,36 @@ pub fn check_fizzle(original_targets: &[TargetRef], legal_targets: &[TargetRef])
     legal_targets.is_empty()
 }
 
+/// CR 115.1 + CR 707.10: True when `candidate_id` could be chosen as a target of
+/// the spell that triggered the current `SpellCast` event (Zada copy-count filter).
+pub(crate) fn object_could_be_targeted_by_triggering_spell(
+    state: &GameState,
+    candidate_id: ObjectId,
+) -> bool {
+    let Some(event) = state.current_trigger_event.as_ref() else {
+        return false;
+    };
+    let Some(spell_id) = extract_source_from_event(event) else {
+        return false;
+    };
+    let Some(spell_ability) = state
+        .stack
+        .iter()
+        .rev()
+        .find(|entry| entry.id == spell_id)
+        .and_then(|entry| entry.ability())
+    else {
+        return false;
+    };
+    let Ok(slots) = crate::game::ability_utils::build_target_slots(state, spell_ability) else {
+        return false;
+    };
+    slots.iter().any(|slot| {
+        slot.legal_targets
+            .contains(&TargetRef::Object(candidate_id))
+    })
+}
+
 /// Resolve event-context TargetFilter variants using the current trigger event.
 /// These variants auto-resolve at effect resolution time from `state.current_trigger_event`
 /// without requiring player selection (CR 603.2).

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -4198,13 +4198,31 @@ fn per_opponent_target_fanout_min(text: &str) -> usize {
 /// one of those creatures" rider before lifting the `for each` repeat suffix.
 /// Returns whether the rider was present so chain lowering can stamp
 /// `RetargetEachCopyToIterationMember` even after sentence splitting.
+fn parse_zada_distinct_copy_target_rider_clause(i: &str) -> OracleResult<'_, ()> {
+    all_consuming((
+        tag("each copy targets a different one of those creatures"),
+        opt(tag(".")),
+        multispace0::<_, OracleError<'_>>,
+    ))
+    .parse(i)
+    .map(|(rest, _)| (rest, ()))
+}
+
 pub(super) fn strip_each_copy_targets_distinct_member_suffix(text: &str) -> (bool, String) {
-    const SUFFIX: &str = "each copy targets a different one of those creatures";
     let lower = text.to_ascii_lowercase();
-    if let Some(idx) = lower.rfind(SUFFIX) {
+    if let Some(((consumed, ()), _remainder)) = nom_on_lower(text, &lower, |input| {
+        let before = input.len();
+        let (rest, _) = terminated(
+            take_until("each copy targets a different one of those creatures"),
+            parse_zada_distinct_copy_target_rider_clause,
+        )
+        .parse(input)?;
+        Ok((rest, (before - rest.len(), ())))
+    }) {
         (
             true,
-            text[..idx]
+            text[..consumed]
+                .trim_end()
                 .trim_end_matches(|c: char| c == '.' || c.is_whitespace())
                 .to_string(),
         )
@@ -4233,8 +4251,9 @@ fn filter_has_could_be_targeted_by_triggering_spell(filter: &TargetFilter) -> bo
 /// target rider (already stripped at chain level when possible; this absorbs a
 /// residual standalone sentence after period splitting).
 pub(super) fn recognize_zada_copy_distinct_target_rider(lower: &str) -> bool {
-    const SUFFIX: &str = "each copy targets a different one of those creatures";
-    lower.trim().trim_end_matches('.').trim() == SUFFIX
+    all_consuming(parse_zada_distinct_copy_target_rider_clause)
+        .parse(lower.trim())
+        .is_ok()
 }
 
 /// CR 707.10 + CR 115.1: Zada's `for each other creature ... the spell could
@@ -4261,10 +4280,16 @@ pub(super) fn strip_for_each_repeat_suffix(text: &str) -> (Option<QuantityExpr>,
         Ok((rest, (base.len(), qty)))
     });
     if let Some(((base_len, qty), _)) = parsed {
-        return (
-            Some(QuantityExpr::Ref { qty }),
-            text[..base_len].trim_end().to_string(),
-        );
+        if matches!(&qty, QuantityRef::CommanderCastFromCommandZoneCount)
+            || zada_repeat_for_implies_distinct_copy_targets(&QuantityExpr::Ref {
+                qty: qty.clone(),
+            })
+        {
+            return (
+                Some(QuantityExpr::Ref { qty }),
+                text[..base_len].trim_end().to_string(),
+            );
+        }
     }
     (None, text)
 }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -4194,9 +4194,65 @@ fn per_opponent_target_fanout_min(text: &str) -> usize {
 /// action should be repeated rather than have an embedded amount replaced. The
 /// repeat count is an integer per-each quantity (count templating), not the
 /// CR 609.3 "do as much as possible" rule.
+/// CR 707.10 + CR 608.2c: Strip Zada's trailing "each copy targets a different
+/// one of those creatures" rider before lifting the `for each` repeat suffix.
+/// Returns whether the rider was present so chain lowering can stamp
+/// `RetargetEachCopyToIterationMember` even after sentence splitting.
+pub(super) fn strip_each_copy_targets_distinct_member_suffix(text: &str) -> (bool, String) {
+    const SUFFIX: &str = "each copy targets a different one of those creatures";
+    let lower = text.to_ascii_lowercase();
+    if let Some(idx) = lower.rfind(SUFFIX) {
+        (
+            true,
+            text[..idx]
+                .trim_end_matches(|c: char| c == '.' || c.is_whitespace())
+                .to_string(),
+        )
+    } else {
+        (false, text.to_string())
+    }
+}
+
+/// CR 707.10 + CR 115.1: Zada's `for each other creature ... the spell could
+/// target` repeat count implies each copy targets a distinct iteration member.
+fn filter_has_could_be_targeted_by_triggering_spell(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(tf) => tf
+            .properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::CouldBeTargetedByTriggeringSpell)),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => filters
+            .iter()
+            .any(filter_has_could_be_targeted_by_triggering_spell),
+        TargetFilter::Not { filter } => filter_has_could_be_targeted_by_triggering_spell(filter),
+        _ => false,
+    }
+}
+
+/// CR 707.10 + CR 608.2c: True when a clause chunk is only Zada's distinct-copy
+/// target rider (already stripped at chain level when possible; this absorbs a
+/// residual standalone sentence after period splitting).
+pub(super) fn recognize_zada_copy_distinct_target_rider(lower: &str) -> bool {
+    const SUFFIX: &str = "each copy targets a different one of those creatures";
+    lower.trim().trim_end_matches('.').trim() == SUFFIX
+}
+
+/// CR 707.10 + CR 115.1: Zada's `for each other creature ... the spell could
+/// target` repeat count implies each copy targets a distinct iteration member.
+pub(super) fn zada_repeat_for_implies_distinct_copy_targets(qty: &QuantityExpr) -> bool {
+    let QuantityExpr::Ref {
+        qty: QuantityRef::ObjectCount { filter },
+    } = qty
+    else {
+        return false;
+    };
+    filter_has_could_be_targeted_by_triggering_spell(filter)
+}
+
 pub(super) fn strip_for_each_repeat_suffix(text: &str) -> (Option<QuantityExpr>, String) {
+    let (_, text) = strip_each_copy_targets_distinct_member_suffix(text);
     let lower = text.to_lowercase();
-    let parsed = nom_on_lower(text, &lower, |input| {
+    let parsed = nom_on_lower(&text, &lower, |input| {
         let (rest, base) = take_until::<_, _, OracleError<'_>>(" for each ").parse(input)?;
         let (rest, _) = tag(" for each ").parse(rest)?;
         let (rest, qty) = nom_quantity::parse_for_each_clause_ref(rest)?;
@@ -4205,14 +4261,12 @@ pub(super) fn strip_for_each_repeat_suffix(text: &str) -> (Option<QuantityExpr>,
         Ok((rest, (base.len(), qty)))
     });
     if let Some(((base_len, qty), _)) = parsed {
-        if matches!(qty, QuantityRef::CommanderCastFromCommandZoneCount) {
-            return (
-                Some(QuantityExpr::Ref { qty }),
-                text[..base_len].trim_end().to_string(),
-            );
-        }
+        return (
+            Some(QuantityExpr::Ref { qty }),
+            text[..base_len].trim_end().to_string(),
+        );
     }
-    (None, text.to_string())
+    (None, text)
 }
 
 /// CR 107.1: Strip "twice" / "three times" / "N times" suffix to produce a

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23853,6 +23853,9 @@ pub(crate) fn parse_effect_chain_ir(
             };
         }
     }
+    let (chain_zada_distinct_copy_targets, text) =
+        lower::strip_each_copy_targets_distinct_member_suffix(text);
+    let text = text.as_str();
     let chunks = split_clause_sequence(text);
     // CR 107.3i: "Normally, all instances of X on an object have the same value."
     // Build a per-chunk sentence-scoped `where X is <expr>` binding so that when
@@ -23949,6 +23952,9 @@ pub(crate) fn parse_effect_chain_ir(
     for (chunk_idx, chunk) in chunks.iter().enumerate() {
         let normalized_text = strip_leading_sequence_connector(&chunk.text).trim();
         if normalized_text.is_empty() {
+            continue;
+        }
+        if lower::recognize_zada_copy_distinct_target_rider(&normalized_text.to_ascii_lowercase()) {
             continue;
         }
 
@@ -26172,10 +26178,25 @@ pub(crate) fn parse_effect_chain_ir(
         } else {
             let (suffix_repeat_for, stripped_text_no_qty) =
                 strip_for_each_repeat_suffix(&text_no_qty);
-            let stripped_clause = parse_effect_clause(&stripped_text_no_qty, ctx);
+            let mut stripped_clause = parse_effect_clause(&stripped_text_no_qty, ctx);
             if suffix_repeat_for.is_some()
                 && matches!(stripped_clause.effect, Effect::CopySpell { .. })
             {
+                let zada_distinct_copy_targets = chain_zada_distinct_copy_targets
+                    || suffix_repeat_for
+                        .as_ref()
+                        .is_some_and(lower::zada_repeat_for_implies_distinct_copy_targets);
+                if let Effect::CopySpell {
+                    target, retarget, ..
+                } = &mut stripped_clause.effect
+                {
+                    if zada_distinct_copy_targets {
+                        *retarget = CopyRetargetPermission::RetargetEachCopyToIterationMember;
+                    }
+                    if matches!(target, TargetFilter::ParentTarget | TargetFilter::Any) {
+                        *target = TargetFilter::TriggeringSource;
+                    }
+                }
                 (stripped_clause, repeat_for.or(suffix_repeat_for))
             } else if let Some((fanout_clause, fanout_spec, fanout_ctx)) =
                 parse_for_each_opponent_target_fanout_clause(

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -3325,6 +3325,7 @@ fn parse_for_each_clause_ref_with_they_controller(
         // an unconsumed remainder, dropping the quantity (Skycat Sovereign, Aven
         // Gagglemaster, Aerial Assault, Alert Heedbonder, Overgrown Battlement).
         parse_for_each_controlled_type_with_keyword,
+        parse_for_each_controlled_creature_spell_could_target,
         parse_for_each_controlled_type,
         // CR 201.2: "for each [other] <type> named <CardName> you control"
         // (Seven Dwarves). The `named X` qualifier sits between the type word
@@ -4480,6 +4481,35 @@ fn parse_for_each_controlled_type_with_keyword(input: &str) -> OracleResult<'_, 
                 type_filters: vec![tf],
                 controller: Some(ControllerRef::You),
                 properties,
+            }),
+        },
+    ))
+}
+
+/// CR 115.1 + CR 707.10: "other creature you control that the spell could target"
+/// (Zada, Hedron Grinder copy count). Optional "other"/"another" excludes the
+/// trigger source; `CouldBeTargetedByTriggeringSpell` gates on spell legality.
+fn parse_for_each_controlled_creature_spell_could_target(
+    input: &str,
+) -> OracleResult<'_, QuantityRef> {
+    let (rest, has_other) = opt(alt((
+        value((), tag::<_, _, OracleError<'_>>("other ")),
+        value((), tag("another ")),
+    )))
+    .parse(input)?;
+    let (rest, _) = tag("creature you control that the spell could target").parse(rest)?;
+    let mut properties = vec![FilterProp::CouldBeTargetedByTriggeringSpell];
+    if has_other.is_some() {
+        properties.push(FilterProp::Another);
+    }
+    Ok((
+        rest,
+        QuantityRef::ObjectCount {
+            filter: TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Creature],
+                controller: Some(ControllerRef::You),
+                properties,
+                ..TypedFilter::default()
             }),
         },
     ))

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -3325,7 +3325,7 @@ fn parse_for_each_clause_ref_with_they_controller(
         // an unconsumed remainder, dropping the quantity (Skycat Sovereign, Aven
         // Gagglemaster, Aerial Assault, Alert Heedbonder, Overgrown Battlement).
         parse_for_each_controlled_type_with_keyword,
-        parse_for_each_controlled_creature_spell_could_target,
+        parse_for_each_object_spell_could_target,
         parse_for_each_controlled_type,
         // CR 201.2: "for each [other] <type> named <CardName> you control"
         // (Seven Dwarves). The `named X` qualifier sits between the type word
@@ -4486,18 +4486,30 @@ fn parse_for_each_controlled_type_with_keyword(input: &str) -> OracleResult<'_, 
     ))
 }
 
-/// CR 115.1 + CR 707.10: "other creature you control that the spell could target"
-/// (Zada, Hedron Grinder copy count). Optional "other"/"another" excludes the
-/// trigger source; `CouldBeTargetedByTriggeringSpell` gates on spell legality.
-fn parse_for_each_controlled_creature_spell_could_target(
-    input: &str,
-) -> OracleResult<'_, QuantityRef> {
+/// CR 115.1 + CR 707.10: "[other] <type> [you control] [on the battlefield] that
+/// [the] spell could target" — Zada ("other creature you control that the spell
+/// could target"), Ink-Treader Nephilim ("other creature that spell could target"),
+/// Precursor Golem ("other Golem on the battlefield that the spell could target").
+/// Optional "other"/"another" excludes the trigger source;
+/// `CouldBeTargetedByTriggeringSpell` gates on spell legality at runtime.
+fn parse_for_each_object_spell_could_target(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, has_other) = opt(alt((
         value((), tag::<_, _, OracleError<'_>>("other ")),
         value((), tag("another ")),
     )))
     .parse(input)?;
-    let (rest, _) = tag("creature you control that the spell could target").parse(rest)?;
+    let (rest, tf) = parse_type_filter_word(rest)?;
+    let (rest, controller) = opt(map(
+        alt((tag(" you already control"), tag(" you control"))),
+        |_| ControllerRef::You,
+    ))
+    .parse(rest)?;
+    let (rest, _) = opt(tag(" on the battlefield")).parse(rest)?;
+    let (rest, _) = alt((
+        tag(" that the spell could target"),
+        tag(" that spell could target"),
+    ))
+    .parse(rest)?;
     let mut properties = vec![FilterProp::CouldBeTargetedByTriggeringSpell];
     if has_other.is_some() {
         properties.push(FilterProp::Another);
@@ -4506,10 +4518,9 @@ fn parse_for_each_controlled_creature_spell_could_target(
         rest,
         QuantityRef::ObjectCount {
             filter: TargetFilter::Typed(TypedFilter {
-                type_filters: vec![TypeFilter::Creature],
-                controller: Some(ControllerRef::You),
+                type_filters: vec![tf],
+                controller,
                 properties,
-                ..TypedFilter::default()
             }),
         },
     ))
@@ -4659,10 +4670,46 @@ fn parse_player_counter_possessor(input: &str) -> OracleResult<'_, CountScope> {
 mod tests {
     use super::*;
     use crate::types::ability::{
-        AggregateFunction, FilterProp, ObjectProperty, SharedQuality, SharedQualityRelation,
-        TargetFilter, TypeFilter, TypedFilter,
+        AggregateFunction, ControllerRef, FilterProp, ObjectProperty, QuantityRef, SharedQuality,
+        SharedQualityRelation, TargetFilter, TypeFilter, TypedFilter,
     };
     use crate::types::mana::ManaColor;
+
+    #[test]
+    fn parse_for_each_object_spell_could_target_covers_zada_and_ink_treader() {
+        let zada = parse_for_each_object_spell_could_target(
+            "other creature you control that the spell could target",
+        )
+        .expect("zada for-each count");
+        assert!(matches!(
+            zada.1,
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters,
+                    controller: Some(ControllerRef::You),
+                    properties,
+                }),
+            } if type_filters == vec![TypeFilter::Creature]
+                && properties.contains(&FilterProp::Another)
+                && properties.contains(&FilterProp::CouldBeTargetedByTriggeringSpell)
+        ));
+
+        let ink_treader =
+            parse_for_each_object_spell_could_target("other creature that spell could target")
+                .expect("ink-treader for-each count");
+        assert!(matches!(
+            ink_treader.1,
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters,
+                    controller: None,
+                    properties,
+                }),
+            } if type_filters == vec![TypeFilter::Creature]
+                && properties.contains(&FilterProp::Another)
+                && properties.contains(&FilterProp::CouldBeTargetedByTriggeringSpell)
+        ));
+    }
 
     /// CR 400.7 + CR 700.4 + CR 109.5: the shared death-suffix combinator returns
     /// the controller scope for all four "that died" tag forms and rejects

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -7,12 +7,12 @@ use crate::parser::oracle_ir::doc::PrintedTriggerIndex;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
     AttackSubject, BounceSelection, CardSelectionMode, CastingPermission, ChosenAttribute,
-    Comparator, ContinuousModification, ControllerRef, CountScope, DamageChannel,
-    DamageModification, DamageSource, DelayedTriggerCondition, DiscardSelfScope, Duration, Effect,
-    EffectScope, FilterProp, ManaContribution, ManaProduction, ManaSpendPermission, ObjectScope,
-    PerpetualModification, PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr,
-    QuantityRef, SharedQuality, TapStateChange, TargetFilter, TriggerCondition, TypeFilter,
-    TypedFilter, ZoneRef,
+    Comparator, ContinuousModification, ControllerRef, CopyRetargetPermission, CountScope,
+    DamageChannel, DamageModification, DamageSource, DelayedTriggerCondition, DiscardSelfScope,
+    Duration, Effect, EffectScope, FilterProp, ManaContribution, ManaProduction,
+    ManaSpendPermission, ObjectScope, PerpetualModification, PlayerFilter, PlayerScope, PtStat,
+    PtValue, PtValueScope, QuantityExpr, QuantityRef, SharedQuality, TapStateChange, TargetFilter,
+    TriggerCondition, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::card_type::Supertype;
 use crate::types::counter::{CounterMatch, CounterType};
@@ -15598,6 +15598,48 @@ fn trigger_zada_targets_only_self() {
         }
     } else {
         panic!("expected Or filter, got {valid_card:?}");
+    }
+}
+
+#[test]
+fn trigger_zada_full_oracle_copies_for_each_legal_creature_target() {
+    let def = parse_trigger_line(
+        "Whenever you cast an instant or sorcery spell that targets only Zada, copy that spell for each other creature you control that the spell could target. Each copy targets a different one of those creatures.",
+        "Zada, Hedron Grinder",
+    );
+    let execute = def.execute.expect("execute");
+    assert!(
+        execute.sub_ability.is_none(),
+        "for-each copy must not spill into a sub_ability, got {:?}",
+        execute.sub_ability
+    );
+    assert!(matches!(
+        *execute.effect,
+        Effect::CopySpell {
+            target: TargetFilter::TriggeringSource,
+            retarget: CopyRetargetPermission::RetargetEachCopyToIterationMember,
+            ..
+        }
+    ));
+    assert!(matches!(
+        execute.repeat_for,
+        Some(QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { .. }
+        })
+    ));
+    if let Some(QuantityExpr::Ref {
+        qty: QuantityRef::ObjectCount { filter },
+    }) = execute.repeat_for
+    {
+        if let TargetFilter::Typed(tf) = filter {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert!(tf.properties.contains(&FilterProp::Another));
+            assert!(tf
+                .properties
+                .contains(&FilterProp::CouldBeTargetedByTriggeringSpell));
+        } else {
+            panic!("expected Typed ObjectCount filter, got {filter:?}");
+        }
     }
 }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -12429,10 +12429,10 @@ pub enum CopyRetargetPermission {
     KeepOriginalTargets,
     /// Oracle text grants "you may choose new targets for the copy."
     MayChooseNewTargets,
-    /// CR 707.10c + CR 608.2c: Each copy is automatically targeted to a distinct
-    /// iteration member (Zada, Hedron Grinder — "each copy targets a different one
-    /// of those creatures"). No player choice — the member-driven `repeat_for`
-    /// loop binds the target before the copy is created.
+    /// CR 707.10d: Each copy is automatically targeted to a distinct iteration
+    /// member (Zada, Hedron Grinder — "each copy targets a different one of those
+    /// creatures"). No player choice — the member-driven `repeat_for` loop binds
+    /// the target before the copy is created.
     RetargetEachCopyToIterationMember,
 }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3791,6 +3791,10 @@ pub enum FilterProp {
     Targets {
         filter: Box<TargetFilter>,
     },
+    /// CR 115.1 + CR 707.10: Matches objects that could be chosen as a target of
+    /// the triggering spell on the stack. Used for Zada, Hedron Grinder's "for
+    /// each other creature you control that the spell could target" copy count.
+    CouldBeTargetedByTriggeringSpell,
     /// CR 107.3 + CR 202.1: Matches spells/objects whose printed mana cost contains
     /// an `{X}` shard. Used for "spell with {X} in its mana cost" qualifier on
     /// spell-cast triggers (Lattice Library, Nev the Practical Dean, Owlin
@@ -12425,6 +12429,11 @@ pub enum CopyRetargetPermission {
     KeepOriginalTargets,
     /// Oracle text grants "you may choose new targets for the copy."
     MayChooseNewTargets,
+    /// CR 707.10c + CR 608.2c: Each copy is automatically targeted to a distinct
+    /// iteration member (Zada, Hedron Grinder — "each copy targets a different one
+    /// of those creatures"). No player choice — the member-driven `repeat_for`
+    /// loop binds the target before the copy is created.
+    RetargetEachCopyToIterationMember,
 }
 
 /// CR 611.2c: Which of a donor object's abilities a resolution-time

--- a/crates/engine/tests/integration/issue_4945_zada_hedron_grinder.rs
+++ b/crates/engine/tests/integration/issue_4945_zada_hedron_grinder.rs
@@ -1,0 +1,82 @@
+//! Issue #4945: Zada, Hedron Grinder — when you cast an instant or sorcery that
+//! targets only Zada, copy that spell for each other creature you control that
+//! the spell could target, with each copy targeting a different creature.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const ZADA: &str = "Whenever you cast an instant or sorcery spell that targets only Zada, copy that spell for each other creature you control that the spell could target. Each copy targets a different one of those creatures.";
+
+const GIANT_GROWTH: &str = "Target creature gets +3/+3 until end of turn.";
+
+fn mana(color: ManaType) -> ManaUnit {
+    ManaUnit::new(
+        color,
+        engine::types::identifiers::ObjectId(0),
+        false,
+        vec![],
+    )
+}
+
+#[test]
+fn zada_copies_giant_growth_onto_each_other_legal_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            mana(ManaType::Green),
+            mana(ManaType::Green),
+            mana(ManaType::Green),
+        ],
+    );
+
+    let zada = scenario
+        .add_creature_from_oracle(P0, "Zada, Hedron Grinder", 3, 3, ZADA)
+        .id();
+    let elf_a = scenario.add_creature(P0, "Elf A", 1, 1).id();
+    let elf_b = scenario.add_creature(P0, "Elf B", 1, 1).id();
+    let growth = scenario
+        .add_spell_to_hand_from_oracle(P0, "Giant Growth", true, GIANT_GROWTH)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 1;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+
+    let outcome = runner.cast(growth).target_object(zada).resolve();
+    let state = outcome.state();
+
+    // Original targets Zada (+3/+3); copies target Elf A and Elf B.
+    let zada_pt = state.objects.get(&zada).unwrap();
+    let elf_a_pt = state.objects.get(&elf_a).unwrap();
+    let elf_b_pt = state.objects.get(&elf_b).unwrap();
+
+    assert_eq!(
+        zada_pt.power,
+        Some(6),
+        "Zada should be pumped by original spell"
+    );
+    assert_eq!(
+        elf_a_pt.power,
+        Some(4),
+        "Elf A should be pumped by a Zada copy"
+    );
+    assert_eq!(
+        elf_b_pt.power,
+        Some(4),
+        "Elf B should be pumped by a Zada copy"
+    );
+    assert!(
+        state.stack.is_empty(),
+        "stack should be empty after full resolution; waiting_for={:?}",
+        outcome.final_waiting_for()
+    );
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "game should return to priority after resolution"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -754,6 +754,7 @@ mod incredible_hulk_enrage_attacking;
 mod indestructible_survives_destroy;
 mod issue_4365_msh_legality;
 mod issue_4937_iona_chosen_color;
+mod issue_4945_zada_hedron_grinder;
 mod karplusan_yeti_fight_back;
 mod kav_landseeker_delayed_sacrifice;
 mod kellan_daring_traveler_mana_value_gate;


### PR DESCRIPTION
## Summary

Zada's triggered ability now parses and resolves correctly: when you cast an instant or sorcery that targets only Zada, the engine copies that spell for each other creature you control that the spell could target, with each copy targeting a different creature.

Fixes [#4945](https://github.com/phase-rs/phase/issues/4945).

## Root cause

On `main`, Zada's trigger condition parsed correctly (`TargetsOnly { SelfRef }` on instant/sorcery), but the effect body was broken:

- Primary effect was `CopySpell { target: ParentTarget }` without a `repeat_for` count
- A spurious `sub_ability` carried `CopySpell { target: Any }` from the trailing sentence `"Each copy targets a different one of those creatures."`
- The `"for each other creature you control that the spell could target"` clause was swallowed as a `DynamicQty` warning instead of `repeat_for: ObjectCount` with a spell-legality gate

Sentence splitting at the period before `"Each copy targets..."` prevented the existing `strip_for_each_repeat_suffix` path from seeing the full Oracle text on trigger bodies.

## Changes

### Types (`types/ability.rs`)

- `FilterProp::CouldBeTargetedByTriggeringSpell` — runtime gate for "creature the spell could target"
- `CopyRetargetPermission::RetargetEachCopyToIterationMember` — each Zada copy retargets to the current `repeat_for` iteration member without player choice

### Parser

- `oracle_nom/quantity.rs`: `parse_for_each_controlled_creature_spell_could_target` for Zada's for-each count
- `oracle_effect/lower.rs`: strip Zada's distinct-copy rider before lifting `for each`; recognize standalone rider chunks; detect Zada repeat shape from `CouldBeTargetedByTriggeringSpell`
- `oracle_effect/mod.rs`: strip rider before `split_clause_sequence`; stamp `TriggeringSource` + `RetargetEachCopyToIterationMember` on `CopySpell` + for-each; skip absorbed rider sentences

### Runtime

- `game/targeting.rs`: `object_could_be_targeted_by_triggering_spell()` evaluates spell target legality from the `SpellCast` event
- `game/filter.rs`: `CouldBeTargetedByTriggeringSpell` filter prop
- `game/effects/copy_spell.rs`: resolve copy source from `TriggeringSource` before iteration-member targets; rewrite each copy's targets to the iteration member
- `game/effects/mod.rs`: member-driven `repeat_for` iteration for `RetargetEachCopyToIterationMember`

### Registration

- `ai_support/filter.rs`, `game/ability_rw.rs`, `game/coverage.rs`: exhaustive match arms for new types

### Tests

- Parser: `trigger_zada_full_oracle_copies_for_each_legal_creature_target`
- Integration: `issue_4945_zada_hedron_grinder.rs` (Giant Growth on Zada → original + two copies pump Elf A and Elf B)

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p engine --lib trigger_zada_full_oracle`
- [x] `cargo test -p engine --test integration zada_copies_giant_growth`

## Risk notes

- `CouldBeTargetedByTriggeringSpell` is scoped to Zada's for-each count class; other copy-for-each patterns are unchanged
- Regenerating `card-data.json` will clear Zada's `SwallowedClause` / `DynamicQty` parse warnings and remove the spurious `sub_ability`

