### PR TITLE
fix(parser): infer the command zone as a move origin

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -28393,6 +28393,13 @@ fn infer_origin_zone(lower: &str) -> Option<Zone> {
         || contains_possessive(lower, "from", "library")
     {
         Some(Zone::Library)
+    } else if scan_contains_phrase(lower, "from the command zone") {
+        // CR 408.1 + CR 903.6: The command zone holds a player's commander(s)
+        // until moved. "put a commander you own from the command zone onto the
+        // battlefield" (Hellkite Courser, #5256) reanimates from the command
+        // zone; without this the origin was inferred as None and the commander
+        // was never found.
+        Some(Zone::Command)
     } else if scan_contains_phrase(lower, "graveyard") && !scan_contains_phrase(lower, "from") {
         // CR 404.1: Possessive graveyard references without "from" — e.g.,
         // "exile each opponent's graveyard", "exile target player's graveyard"

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -1228,6 +1228,23 @@ fn infer_origin_zone_handles_top_of_your_library() {
 }
 
 #[test]
+fn infer_origin_zone_handles_command_zone() {
+    // CR 408.1 + CR 903.6: "put your commander into your hand from the command
+    // zone" (Command Beacon, Road of Return, Netherborn Altar) and "put a
+    // commander you own from the command zone onto the battlefield" (Hellkite
+    // Courser, #5256). Before this the origin was inferred as None, so the
+    // resolver searched the wrong zone for the commander.
+    assert_eq!(
+        infer_origin_zone("put your commander into your hand from the command zone"),
+        Some(Zone::Command)
+    );
+    assert_eq!(
+        infer_origin_zone("put a commander you own from the command zone onto the battlefield"),
+        Some(Zone::Command)
+    );
+}
+
+#[test]
 fn inferred_top_of_your_library_origin_adds_owner_constraint() {
     let filter = add_inferred_origin_constraints_to_target(
         TargetFilter::Typed(TypedFilter::card()),


### PR DESCRIPTION
CR 408.1 + CR 903.6

## Bug

`infer_origin_zone` maps `from your graveyard`/`from exile`/`from your hand`/`from your library` to their zones, but had **no arm for `from the command zone`**, so it returned `None`. A `None` origin makes the `ChangeZone` resolver search the wrong zone for the card, so "move a commander from the command zone" effects never found it.

Fully broken cards (all share the `put your commander into your hand from the command zone` phrasing):

- **Command Beacon** — `{T}, Sacrifice this land: Put your commander into your hand from the command zone.`
- **Netherborn Altar**
- **Road of Return** (second mode)

Partially addressed:

- **Hellkite Courser** ([#5256](https://github.com/phase-rs/phase/issues/5256)) — `put a commander you own from the command zone onto the battlefield` now infers the correct origin. The indefinite `a commander you own` subject filter in the reanimation put-path is a **separate** gap and is not claimed here.

## Fix

Add the `from the command zone` arm to `infer_origin_zone` → `Zone::Command`. `parse_zone_word` already recognizes the multi-word `command zone` token, so definite forms (`put`/`return target commander … from the command zone …`) now parse to a complete `ChangeZone { origin: Command, target: { IsCommander, Owned } }`.

## Verification

- New unit test `infer_origin_zone_handles_command_zone`.
- Full parser suite green: **7821 passed / 0 failed**.
- Parser-combinator gate clean (exit 0).
- Parser gap analysis unchanged (**3977** unsupported) — no regression.