### PR TITLE
fix(coverage): expose Mana effect grants in the parse-diff signature (Closes #5507)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2768,8 +2768,35 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         Effect::ChooseDamageSource { source_filter } => {
             d.push(("source".into(), fmt_target(source_filter)));
         }
-        Effect::Mana { produced, .. } => {
+        Effect::Mana {
+            produced,
+            restrictions,
+            grants,
+            expiry,
+            target,
+        } => {
+            // #5507 (third instance after #5492/#5495): the mana effect rendered
+            // only `produced`, swallowing `restrictions`/`grants`/`expiry`/`target`
+            // with `..`. So a parser change that attaches a `ManaSpellGrant` to the
+            // produced mana (e.g. Hall of the Bandit Lord's creature-spell haste
+            // rider, #5502) never showed a compensating addition in the sticky —
+            // removals-with-no-addition, the signature of a regression, when it was
+            // really a half-rendered effect. Fully destructure (no `..`) so a new
+            // Mana field is a compile error, not another silent omission, and emit
+            // each field only when set so unqualified signatures stay byte-identical.
             d.push(("mana".into(), fmt_mana_production(produced)));
+            if !restrictions.is_empty() {
+                d.push(("restrictions".into(), format!("{restrictions:?}")));
+            }
+            if !grants.is_empty() {
+                d.push(("grants".into(), format!("{grants:?}")));
+            }
+            if let Some(e) = expiry {
+                d.push(("expiry".into(), format!("{e:?}")));
+            }
+            if let Some(t) = target {
+                d.push(("target".into(), fmt_target(t)));
+            }
         }
         Effect::RevealHand {
             target,
@@ -10431,6 +10458,48 @@ mod tests {
                 .iter()
                 .any(|k| k == "damage_source_filter"),
             "an absent damage_source_filter must not appear",
+        );
+    }
+
+    #[test]
+    fn mana_signature_exposes_grants() {
+        use crate::types::ability::ManaContribution;
+        use crate::types::mana::ManaSpellGrant;
+
+        // #5507: a `ManaSpellGrant` attached to produced mana (e.g. Hall of the
+        // Bandit Lord's creature-spell haste rider, #5502) is parser-alterable but
+        // was swallowed by `..`. It must appear in the mana signature when set and
+        // be absent when the grants list is empty, so unqualified mana signatures
+        // stay byte-identical. (Mirrors #5493/#5501.)
+        let signature_keys = |grants: Vec<ManaSpellGrant>| -> Vec<String> {
+            effect_details(&Effect::Mana {
+                produced: ManaProduction::AnyOneColor {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    color_options: vec![ManaColor::White, ManaColor::Blue],
+                    contribution: ManaContribution::Base,
+                },
+                restrictions: vec![],
+                grants,
+                expiry: None,
+                target: None,
+            })
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect()
+        };
+        assert!(
+            signature_keys(vec![ManaSpellGrant::AddKeywordUntilEndOfTurn {
+                keyword: Keyword::Haste,
+                restriction: None,
+                duration: Box::new(Duration::UntilEndOfTurn),
+            }])
+            .iter()
+            .any(|k| k == "grants"),
+            "a set ManaSpellGrant must appear in the mana parse-diff signature",
+        );
+        assert!(
+            !signature_keys(vec![]).iter().any(|k| k == "grants"),
+            "an empty grants list must not appear (unqualified mana signature unchanged)",
         );
     }
 


### PR DESCRIPTION
Closes #5507.

## Summary

The mana effect's parse-diff signature in `effect_details` rendered only `produced`, swallowing `restrictions` / `grants` / `expiry` / `target` with `..`. So a parser change that attaches a `ManaSpellGrant` to produced mana — e.g. Hall of the Bandit Lord's creature-spell haste rider (#5502) — showed only **removals** in the coverage-parse-diff sticky with no compensating addition: the signature of a regression, when it was actually a half-rendered effect.

This is the third instance of the family (#5492 `PreventDamage` → #5493; #5495 `ChangeZone` → #5501). Following #5501's approach, `Effect::Mana` is now **fully destructured** (no `..`), so a newly added field becomes a compile error rather than another silent omission, and each field is emitted **only when set** so unqualified mana signatures stay byte-identical.

Fields now surfaced: `restrictions`, **`grants`** (the named blind spot — `ManaSpellGrant`), `expiry`, `target`.

## Anchored on
- `crates/engine/src/game/coverage.rs` — the `Effect::ChangeZone`/`ChangeZoneAll` arms (merged #5501): same fully-destructure-and-emit-only-when-set shape, `format!("{:?}")` for complex payloads.
- `crates/engine/src/game/coverage.rs` — `prevent_damage_signature_exposes_damage_source_filter` / `change_zone_signature_exposes_enters_attacking` tests (#5493/#5501): the new `mana_signature_exposes_grants` mirrors them exactly (build the effect, collect signature keys, assert present-when-set / absent-when-empty).

## CR
None. Per CLAUDE.md, `effect_details` is a signature renderer (review plumbing), not rule-implementing code, so no CR annotations are added — consistent with the maintainer note on #5500 that these annotations are not required here (and it avoids a wrong-citation risk).

## Gate A
`./scripts/check-parser-combinators.sh` → **exit 0** (no violations). No parser-dispatch code — this extends a signature renderer with typed field reads.

## Verification
- `cargo test -p engine --lib coverage::tests` → green, including the new `mana_signature_exposes_grants` (grants appears when a `ManaSpellGrant` is set, absent when empty; reverting the emission fails it).
- `cargo fmt -p engine` clean.
- Full destructure (no `..`) compiles, so any future `Effect::Mana` field is a compile error until it's considered here.

## Scope / risk
Single file, review-signature tooling only (`effect_details` feeds the coverage-parse-diff sticky). **No game-logic, parser, or serialization change** — it does not alter how any card parses or resolves, only what the diff sticky reports. Zero runtime impact.

Model: claude-opus-4-8
Tier: Frontier
Thinking: High
