### PR TITLE
refactor(parser): typed AbilityIr shell + source-addressed builder key (unit 3b, byte-safe subset)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -147,7 +147,9 @@ use self::subject::{
 };
 use crate::parser::oracle_ir::ast::*;
 pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup};
-use crate::parser::oracle_ir::effect_chain::{ClauseIr, EffectChainIr, SpecialClause};
+use crate::parser::oracle_ir::effect_chain::{
+    AbilityIr, AbilityShellIr, ClauseIr, EffectChainIr, SpecialClause,
+};
 use crate::types::mana::ManaExpiry;
 
 /// CR 608.2k: True when `text` is a standalone object pronoun referring to
@@ -23114,38 +23116,113 @@ fn rewrite_filter_prop_another_to_tracked_set(prop: &mut FilterProp) {
     }
 }
 
-pub fn parse_effect_chain(text: &str, kind: AbilityKind) -> AbilityDefinition {
-    if let Some(def) =
-        try_parse_conditional_protection_grant_ability(text, kind, &mut ParseContext::default())
-    {
-        return def;
+/// Which whole-body bypass set a chain-lowering entry point runs.
+///
+/// The two entry points do **not** run the same set, and the difference is
+/// carried here as typed data rather than duplicated as two hand-maintained
+/// `if let` stacks:
+///
+/// | mode | bypasses | bypass #1's `ParseContext` |
+/// |---|---|---|
+/// | `Standalone` | 8 | a fresh `default()`, discarded |
+/// | `WithContext` | the same 8 as a strict prefix, plus `try_parse_exile_pile_shuffle_cloak` | the caller's real `ctx` |
+///
+/// Callers split cleanly: die-result branch bodies (`oracle_special.rs`) take
+/// `Standalone`; spell/activated dispatch takes `WithContext`.
+///
+/// **The asymmetry is suspected-accidental and is preserved byte-for-byte on
+/// purpose.** Nothing about a die-roll branch body should exclude the cloak
+/// recognizer, but unifying to 9 makes die branches newly take it and unifying
+/// to 8 makes spells lose it — either is silent lowered drift across the
+/// die-result cards. Fixing it is a separate, reviewed change with its own
+/// discriminating card; a parity migration never absorbs a bug fix.
+///
+/// Exhaustive match, no `_` arm and no `Default`: a third entry point must state
+/// which set it runs and fail to compile until it does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChainLoweringMode {
+    Standalone,
+    WithContext,
+}
+
+/// Run the whole-body recognizers that build a definition directly, in order.
+///
+/// Returns `None` when the text falls through to the ordinary clause pipeline.
+fn try_parse_chain_bypass(
+    text: &str,
+    kind: AbilityKind,
+    mode: ChainLoweringMode,
+    ctx: &mut ParseContext,
+) -> Option<AbilityDefinition> {
+    // The eight shared bypasses, in their established order. Only the first
+    // consults `ctx`.
+    if let Some(def) = try_parse_conditional_protection_grant_ability(text, kind, ctx) {
+        return Some(def);
     }
     if let Some(def) = try_parse_exile_top_each_library_with_collection_counter(text, kind) {
-        return def;
+        return Some(def);
     }
     if let Some(def) = try_parse_grant_graveyard_keyword_to_target(text, kind) {
-        return def;
+        return Some(def);
     }
     if let Some(def) = try_parse_balance_equalization(text, kind) {
-        return def;
+        return Some(def);
     }
     if let Some(def) = try_parse_each_player_copy_chosen(text, kind) {
-        return def;
+        return Some(def);
     }
     if let Some(def) = try_parse_catch_up_draw(text, kind) {
-        return def;
+        return Some(def);
     }
     if let Some(def) = try_parse_return_target_and_same_name_from_your_graveyard(text, kind) {
-        return def;
+        return Some(def);
     }
     if let Some(def) = try_parse_for_each_attacker_copy_blocker(text, kind) {
+        return Some(def);
+    }
+    match mode {
+        ChainLoweringMode::Standalone => None,
+        ChainLoweringMode::WithContext => try_parse_exile_pile_shuffle_cloak(text, kind),
+    }
+}
+
+/// Lowering: assemble an `AbilityDefinition` from an `AbilityIr`.
+///
+/// The single authority for what an effect-chain entry point does *after*
+/// parsing: lower the chain, finalize it, anchor it, then apply the shell. Every
+/// caller that lowers a whole ability body goes through here, so no call site
+/// can forget a step.
+///
+/// `finalize_effect_chain` and the owner-library anchor belong here and not in
+/// `lower_effect_chain_ir`: pushing them down would newly apply them at the
+/// production callers that lower a *chain* without being a whole ability body.
+pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
+    let mut def = lower_effect_chain_ir(&ir.body);
+    finalize_effect_chain(&mut def);
+    apply_owner_library_reveal_anchor_from_text(&mut def, &ir.source_text);
+    // CR 608.2e: a root the chain cannot describe (it has no previous boundary).
+    if let Some(sub_link) = ir.shell.sub_link {
+        def.sub_link = sub_link;
+    }
+    def
+}
+
+pub fn parse_effect_chain(text: &str, kind: AbilityKind) -> AbilityDefinition {
+    // A fresh context per call, exactly as before: the bypasses may mutate `ctx`
+    // before declining, and those mutations must not reach `parse_effect_chain_ir`.
+    if let Some(def) = try_parse_chain_bypass(
+        text,
+        kind,
+        ChainLoweringMode::Standalone,
+        &mut ParseContext::default(),
+    ) {
         return def;
     }
-    let ir = parse_effect_chain_ir(text, kind, &mut ParseContext::default());
-    let mut def = lower_effect_chain_ir(&ir);
-    finalize_effect_chain(&mut def);
-    apply_owner_library_reveal_anchor_from_text(&mut def, text);
-    def
+    lower_ability_ir(&AbilityIr {
+        source_text: text.to_string(),
+        body: parse_effect_chain_ir(text, kind, &mut ParseContext::default()),
+        shell: AbilityShellIr::default(),
+    })
 }
 
 /// Parse a compound effect chain with subject context for pronoun resolution.
@@ -23156,38 +23233,14 @@ pub(crate) fn parse_effect_chain_with_context(
     kind: AbilityKind,
     ctx: &mut ParseContext,
 ) -> AbilityDefinition {
-    if let Some(def) = try_parse_conditional_protection_grant_ability(text, kind, ctx) {
+    if let Some(def) = try_parse_chain_bypass(text, kind, ChainLoweringMode::WithContext, ctx) {
         return def;
     }
-    if let Some(def) = try_parse_exile_top_each_library_with_collection_counter(text, kind) {
-        return def;
-    }
-    if let Some(def) = try_parse_grant_graveyard_keyword_to_target(text, kind) {
-        return def;
-    }
-    if let Some(def) = try_parse_balance_equalization(text, kind) {
-        return def;
-    }
-    if let Some(def) = try_parse_each_player_copy_chosen(text, kind) {
-        return def;
-    }
-    if let Some(def) = try_parse_catch_up_draw(text, kind) {
-        return def;
-    }
-    if let Some(def) = try_parse_return_target_and_same_name_from_your_graveyard(text, kind) {
-        return def;
-    }
-    if let Some(def) = try_parse_for_each_attacker_copy_blocker(text, kind) {
-        return def;
-    }
-    if let Some(def) = try_parse_exile_pile_shuffle_cloak(text, kind) {
-        return def;
-    }
-    let ir = parse_effect_chain_ir(text, kind, ctx);
-    let mut def = lower_effect_chain_ir(&ir);
-    finalize_effect_chain(&mut def);
-    apply_owner_library_reveal_anchor_from_text(&mut def, text);
-    def
+    lower_ability_ir(&AbilityIr {
+        source_text: text.to_string(),
+        body: parse_effect_chain_ir(text, kind, ctx),
+        shell: AbilityShellIr::default(),
+    })
 }
 
 /// CR 701.24a + CR 701.58a/e + CR 608.2c: Expose the Culprit mode 2 — "Exile any

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -547,12 +547,26 @@ impl UnitAllocator {
 
 /// Source-positioned document collector.
 ///
-/// Keyed by `(first_line, ordinal_within_span)` so emission order is irrelevant
-/// and the final `Vec` is always in Oracle source order. This is what makes the
+/// Emission order is irrelevant: items are keyed by their source position (see
+/// the `items` field for the exact key and why each component is load-bearing)
+/// so the final `Vec` is always in Oracle source order. This is what makes the
 /// document IR source-ordered rather than category-ordered.
 #[derive(Debug, Default)]
 pub(crate) struct OracleDocBuilder {
-    items: BTreeMap<(usize, u32), OracleItemIr>,
+    /// Keyed by `(first_line, start_byte, ordinal_within_span)`.
+    ///
+    /// `start_byte` is load-bearing even though it is `0` for every item today.
+    /// `OracleSourceSpan`'s contract says byte ranges exist "so two clauses on one
+    /// physical line remain distinguishable" — but `conflicts_with` only rejects
+    /// siblings whose bytes OVERLAP. Two exact, non-overlapping clauses on one
+    /// line with the same `ordinal_within_span` therefore pass the conflict check
+    /// and then collide on the map key, and a `(first_line, ordinal)` key would
+    /// also order same-line siblings by ordinal rather than by position — so an
+    /// emitter assigning ordinals out of byte order would have `finish()` return
+    /// them reversed, and `lower_oracle_ir` would lower them reversed. Silently.
+    ///
+    /// Inert until unit 3b emits exact spans; fixed here, before it can fire.
+    items: BTreeMap<(usize, usize, u32), OracleItemIr>,
     next_item_id: u32,
     /// CR 707.9a printed-**trigger** index: the slot the next emitted trigger
     /// occupies.
@@ -687,7 +701,7 @@ impl OracleDocBuilder {
     ) -> Result<OracleItemId, DocBuilderError> {
         slot.source.check_fragment_precision()?;
         let span = slot.source.span.clone();
-        let key = (span.first_line, span.ordinal_within_span);
+        let key = (span.first_line, span.start_byte, span.ordinal_within_span);
         if self.items.contains_key(&key) {
             return Err(DocBuilderError::DuplicateItemPosition { span });
         }
@@ -866,6 +880,50 @@ mod tests {
         assert!(
             matches!(err, Err(DocBuilderError::OverlappingSiblingSpans { .. })),
             "overlapping bytes at the same ordinal must be rejected, got {err:?}"
+        );
+    }
+
+    /// DISCRIMINATING. Two exact, NON-OVERLAPPING clauses on one physical line,
+    /// both at `ordinal_within_span: 0`.
+    ///
+    /// `conflicts_with` accepts them — it only rejects siblings whose bytes
+    /// overlap. Against the old `(first_line, ordinal_within_span)` key they then
+    /// collided on `DuplicateItemPosition`, and the second clause was lost. With
+    /// `start_byte` in the key they coexist and, crucially, `finish()` returns
+    /// them in BYTE order rather than in emission or ordinal order.
+    ///
+    /// This is the shape unit 3b produces the moment it emits exact spans:
+    /// `"Destroy target creature. It can't be regenerated."` is two clauses on
+    /// one line.
+    #[test]
+    fn two_exact_clauses_on_one_line_coexist_and_order_by_byte() {
+        let mut b = OracleDocBuilder::new();
+
+        // Emit the LATER clause first, to prove ordering comes from the key and
+        // not from emission order.
+        let second = b.begin_item(span(0, 24, 48, 0), Some("It can't be regenerated."));
+        let second_id = second.id();
+        b.emit(second, OracleNodeIr::Keyword(Keyword::Vigilance))
+            .unwrap();
+
+        let first = b.begin_item(span(0, 0, 24, 0), Some("Destroy target creature."));
+        let first_id = first.id();
+        let emitted = b.emit(first, OracleNodeIr::Keyword(Keyword::Flying));
+        assert!(
+            emitted.is_ok(),
+            "non-overlapping same-ordinal clauses on one line must coexist: {emitted:?}"
+        );
+
+        let doc = b.finish(
+            "Destroy target creature. It can't be regenerated.",
+            "Probe",
+            vec![],
+        );
+        let ids: Vec<OracleItemId> = doc.items.iter().map(|i| i.id).collect();
+        assert_eq!(
+            ids,
+            vec![first_id, second_id],
+            "items must be ordered by start_byte, not by emission order or ordinal"
         );
     }
 

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -12,7 +12,7 @@ use super::ast::{ClauseBoundary, ContinuationAst, ParsedEffectClause};
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ControllerRef,
     DelayedTriggerCondition, MultiTargetSpec, OpponentMayScope, PlayerFilter, QuantityExpr,
-    RoundingMode, TargetFilter, TargetSelectionMode, UnlessPayModifier,
+    RoundingMode, SubAbilityLink, TargetFilter, TargetSelectionMode, UnlessPayModifier,
 };
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaExpiry;
@@ -40,6 +40,61 @@ pub(crate) struct EffectChainIr {
     /// this process" directive is recognized. Lowering applies it to the root
     /// `AbilityDefinition` so the resolver re-follows the whole chain.
     pub(crate) repeat_until: Option<crate::types::ability::RepeatContinuation>,
+}
+
+/// Root-level `AbilityDefinition` metadata that no `ClauseIr` can express.
+///
+/// The shell is the typed replacement for the `AbilityDefinition` escape hatch:
+/// a whole-body recognizer that must stamp a root field returns an `AbilityIr`
+/// carrying that field here, rather than a hand-built definition.
+///
+/// **Scope is measured, not guessed.** Auditing the `return` expressions of the
+/// nine effect-side bypasses (not a field-name grep — a field set on a *nested*
+/// sub-ability reads identically to one set on the returned root) shows they set
+/// exactly `kind`, `effect`, `sub_ability`, `duration`, `player_scope`, and
+/// `sub_link`. The first five are already `ParsedEffectClause`/`ClauseIr` fields.
+/// `sub_link` is the sole residue, so it is the sole shell field.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub(crate) struct AbilityShellIr {
+    /// CR 608.2e: how the lowered root attaches to its parent — a resolution step
+    /// of the parent's instruction, or an independent following instruction that
+    /// resolves even when an optional parent is declined.
+    ///
+    /// `None` = keep whatever `lower_effect_chain_ir` stamped. `Some(_)` overrides
+    /// it, which is required because the root clause has no *previous* boundary:
+    /// `lower.rs` derives `sub_link` from `prev_boundary`, and `None` maps
+    /// unconditionally to `ContinuationStep`. A recognizer whose root is three
+    /// independent steps (`try_parse_balance_equalization`) therefore cannot say so
+    /// through the chain, only through the shell.
+    ///
+    /// `Option<SubAbilityLink>` rather than a bare `SubAbilityLink`: the latter's
+    /// `Default` is `ContinuationStep`, so a defaulted shell would silently
+    /// *overwrite* the lowered stamp instead of deferring to it.
+    pub(crate) sub_link: Option<SubAbilityLink>,
+}
+
+/// An effect chain plus the root-level metadata applied around it.
+///
+/// Lowered by `lower_ability_ir`, which is the single authority for
+/// "lower the chain, then finalize it, then anchor it, then apply the shell".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct AbilityIr {
+    /// The verbatim text this ability was parsed from.
+    ///
+    /// **Not an `OracleUnitSource`, on purpose.** `OracleUnitSource`'s fields are
+    /// private and its only constructor is `UnitAllocator::allocate_with_span`,
+    /// which requires a containing item span. That allocator is not yet threaded
+    /// through `ParseContext`, and the entry points that build an `AbilityIr`
+    /// (`parse_effect_chain`, `parse_effect_chain_with_context`, and die-result
+    /// branch bodies) receive a bare fragment with no line/byte offsets into the
+    /// card. Minting a span here would mean fabricating precision — the exact
+    /// failure `SpanPrecision` exists to prevent. This becomes an
+    /// `OracleUnitSource` in the unit that threads the allocator, not before.
+    ///
+    /// Read by `apply_owner_library_reveal_anchor_from_text`, which is text-driven.
+    pub(crate) source_text: String,
+    pub(crate) body: EffectChainIr,
+    pub(crate) shell: AbilityShellIr,
 }
 
 /// CR 608.2c + CR 601.2c: Subject of a "does the same / does so" effect-replication


### PR DESCRIPTION
## Parser IR remediation — unit 3b (byte-safe subset)

Two byte-identical parser migrations from Plan 01 unit 3b. No behavior changes; all three lowered-parity oracles held (60 `*_lowered.snap`, 21 `parser/snapshots/…pipeline_snapshot_tests…`, and a `data/card-data.json` regen).

### `7c2b0dfabf` — unit 3b-1: source-address the builder key
`OracleDocBuilder.items` re-keyed `(first_line, ordinal_within_span)` → `(first_line, start_byte, ordinal_within_span)`. `conflicts_with` rejects only *overlapping* sibling bytes, so two exact non-overlapping clauses on one physical line with the same ordinal passed the conflict check and then collided on the map key (second clause lost); the old key also ordered same-line siblings by ordinal rather than byte position. Inert today (every item spans the whole document, `start_byte == 0`) — fixed before unit-3b emission can fire it. Discriminating test `two_exact_clauses_on_one_line_coexist_and_order_by_byte` was watched go red against the reconstructed old key (sole failure among 18,620 tests).

### `20e5cf0eb7` — units 3b-2/3b-3: typed `AbilityIr` shell
- `AbilityShellIr { sub_link: Option<SubAbilityLink> }` — the typed home for the one root `AbilityDefinition` field no `ClauseIr`/`ParsedEffectClause` can express (verified by auditing the *return expressions* of all 9 effect-side bypasses: they set only clause-expressible fields plus balance's root `sub_link`). `Option<_>` so a defaulted shell defers to the lowered stamp instead of overwriting it.
- `AbilityIr { source_text, body: EffectChainIr, shell }` — no `AbilityDefinition` escape-hatch field. `source_text` (not `OracleUnitSource`) because the unit allocator is not threaded through `ParseContext` yet; minting a span here would fabricate precision.
- `ChainLoweringMode { Standalone, WithContext }` (exhaustive, no `_`, no `Default`) types the 8-vs-9 bypass-set asymmetry between the two shims (ISSUES #9), dispatched by one `try_parse_chain_bypass`, **preserved byte-for-byte** — a parity migration never absorbs a bug fix.
- `lower_ability_ir` is the single post-parse authority (lower → finalize → anchor → shell). **`finalize_effect_chain` + `apply_owner_library_reveal_anchor_from_text` were relocated out of both shims into `lower_ability_ir`** (`oracle_effect/mod.rs`) — the deletion site for unit 7's removal gate moved accordingly.

### Deferred (out of this byte-safe migration)
**3b-3′ / 3b-4 / 3b-5 as originally specified are deferred to a dedicated recognizer→IR bring-up plan.** They require converting whole-body **def-building** recognizers (the 9 bypasses; the 8 `TriggerBody::PreLowered` producers — vote/pile/modal/reanimator) into IR. Those recognizers have no `EffectChainIr` sibling and deliberately skip the standard lowering transforms, so the conversion is **behavioral, not byte-safe** — blocked at source: `oracle_trigger.rs:1155` ("chain parsing would fragment it into Unimplemented chunks"). Per the parity migration's #1 rule ("a moved byte is a stop"), it is handed off rather than absorbed. The byte-safe boundary landed here: clause-expressible bodies got `AbilityShellIr`; whole-body recognizers stay as-is.
