### PR TITLE
feat(parser): support "whenever you discover, discover again for the same value"

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2034,6 +2034,7 @@ fn legacy_quantity_ref(x: &QuantityRef) -> bool {
         | QuantityRef::LifeTotal { .. }
         | QuantityRef::LifeAboveStarting
         | QuantityRef::StartingLifeTotal
+        | QuantityRef::TriggeringDiscoverValue
         | QuantityRef::GraveyardSize { .. }
         | QuantityRef::ObjectCount { .. }
         | QuantityRef::ObjectCountDistinct { .. }
@@ -5526,6 +5527,10 @@ fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
             reads_player_of(StateKind::PlayerLife)
         }
         QuantityRef::StartingLifeTotal => RwProfile::empty(),
+        // CR 701.57a: reads the transient last-discover scalar, written only by
+        // discover resolution (never by a sibling trigger) — no ordering-relevant
+        // read/write, mirroring StartingLifeTotal.
+        QuantityRef::TriggeringDiscoverValue => RwProfile::empty(),
         QuantityRef::GraveyardSize { .. } => reads_zone_membership(),
         QuantityRef::ObjectCount { filter }
         | QuantityRef::ObjectCountDistinct { filter, .. }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1581,6 +1581,9 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             projected: true,
         },
         QuantityRef::StartingLifeTotal => Axes::NONE,
+        // CR 701.57a: reads a transient game-state scalar (the last discover's
+        // mana-value limit); no growing resource, sibling, or projected axis.
+        QuantityRef::TriggeringDiscoverValue => Axes::NONE,
         QuantityRef::ObjectCount { filter } => {
             let mut acc = Axes {
                 event: false,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1261,6 +1261,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
         }
         QuantityRef::LifeAboveStarting => "life above starting".into(),
         QuantityRef::StartingLifeTotal => "starting life total".into(),
+        QuantityRef::TriggeringDiscoverValue => "the triggering discover's value".into(),
         QuantityRef::Speed { player } => {
             format!("speed ({})", fmt_player_scope(player))
         }
@@ -7082,6 +7083,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::GraveyardSize { .. } => ("GraveyardSize", Handled),
         QuantityRef::LifeAboveStarting => ("LifeAboveStarting", Handled),
         QuantityRef::StartingLifeTotal => ("StartingLifeTotal", Unhandled),
+        QuantityRef::TriggeringDiscoverValue => ("TriggeringDiscoverValue", Handled),
         QuantityRef::Speed { .. } => ("Speed", Handled),
         QuantityRef::ObjectCount { .. } => ("ObjectCount", Handled),
         QuantityRef::ObjectCountDistinct { .. } => ("ObjectCountDistinct", Handled),

--- a/crates/engine/src/game/effects/discover.rs
+++ b/crates/engine/src/game/effects/discover.rs
@@ -34,6 +34,11 @@ pub fn resolve(
         _ => return Err(EffectError::InvalidParam("Expected Discover".to_string())),
     };
 
+    // CR 701.57a: record this discover's mana-value limit so a "whenever you
+    // discover" trigger's effect can reference "the same value" (Curator of
+    // Sun's Creation). Set before the trigger fires on the EffectResolved event.
+    state.last_discover_value = Some(limit as i32);
+
     let player = state
         .players
         .iter()

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2129,6 +2129,7 @@ fn quantity_ref_reads_zone(qty: &QuantityRef, zone: Zone) -> bool {
         | QuantityRef::LifeTotal { .. }
         | QuantityRef::LifeAboveStarting
         | QuantityRef::StartingLifeTotal
+        | QuantityRef::TriggeringDiscoverValue
         | QuantityRef::UnspentMana { .. }
         | QuantityRef::CountersOnObjects { .. }
         | QuantityRef::ControlledByEachPlayer { .. }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -350,6 +350,7 @@ fn quantity_ref_uses_unspent_mana(qty: &QuantityRef) -> bool {
         | QuantityRef::GraveyardSize { .. }
         | QuantityRef::LifeAboveStarting
         | QuantityRef::StartingLifeTotal
+        | QuantityRef::TriggeringDiscoverValue
         | QuantityRef::ObjectCount { .. }
         | QuantityRef::ObjectCountDistinct { .. }
         | QuantityRef::ObjectCountBySharedQuality { .. }
@@ -627,6 +628,7 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::GraveyardSize { .. }
         | QuantityRef::LifeAboveStarting
         | QuantityRef::StartingLifeTotal
+        | QuantityRef::TriggeringDiscoverValue
         | QuantityRef::PlayerCount { .. }
         | QuantityRef::CountersOn { .. }
         | QuantityRef::PlayerCounter { .. }
@@ -821,6 +823,7 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::GraveyardSize { .. }
         | QuantityRef::LifeAboveStarting
         | QuantityRef::StartingLifeTotal
+        | QuantityRef::TriggeringDiscoverValue
         | QuantityRef::PlayerCount { .. }
         | QuantityRef::CountersOn { .. }
         | QuantityRef::PlayerCounter { .. }
@@ -1663,6 +1666,10 @@ fn resolve_ref(
         }),
         // CR 103.4: The format's starting life total.
         QuantityRef::StartingLifeTotal => state.format_config.starting_life,
+        // CR 701.57a: the mana-value limit of the discover that fired the current
+        // "whenever you discover" trigger (Curator of Sun's Creation, "the same
+        // value"). 0 outside a discover-trigger context.
+        QuantityRef::TriggeringDiscoverValue => state.last_discover_value.unwrap_or(0),
         // CR 118.4 + CR 119.3: Life lost this turn, scoped via PlayerScope (Π-3).
         QuantityRef::LifeLostThisTurn { player } => {
             resolve_per_player_scalar(state, player, controller, ctx, targets, ability, |p| {
@@ -12330,6 +12337,22 @@ mod tests {
             },
         };
         assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), ObjectId(0)), 3);
+    }
+
+    #[test]
+    fn triggering_discover_value_reads_last_discover_scalar() {
+        // CR 701.57a: "discover again for the same value" (Curator of Sun's
+        // Creation) reads `GameState::last_discover_value`, set when the prior
+        // discover resolved.
+        let mut state = GameState::new_two_player(42);
+        let qty = QuantityExpr::Ref {
+            qty: QuantityRef::TriggeringDiscoverValue,
+        };
+        // Unset → 0 (fail-safe outside a discover-trigger context).
+        assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), ObjectId(0)), 0);
+        // Set by a resolved `discover 5` → 5.
+        state.last_discover_value = Some(5);
+        assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), ObjectId(0)), 5);
     }
 
     #[test]

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -7619,6 +7619,7 @@ fn quantity_ref_refs_cost_paid_object(qty: &QuantityRef) -> bool {
         | QuantityRef::GraveyardSize { .. }
         | QuantityRef::LifeAboveStarting
         | QuantityRef::StartingLifeTotal
+        | QuantityRef::TriggeringDiscoverValue
         | QuantityRef::PlayerCount { .. }
         | QuantityRef::PlayerCounter { .. }
         | QuantityRef::TargetControllerCounter { .. }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7765,6 +7765,28 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         });
     }
 
+    // CR 701.57a: "discover again for the same value" (Curator of Sun's
+    // Creation) — a re-discover whose N is the mana-value limit of the discover
+    // that fired the current "whenever you discover" trigger, read back via
+    // `QuantityRef::TriggeringDiscoverValue`. Composed from tags (the "again"
+    // marks the re-discover; "for the same value" is the fixed anaphor).
+    if let Ok((rest, _)) = (
+        tag::<_, _, OracleError<'_>>("discover "),
+        tag("again "),
+        tag("for the same value"),
+    )
+        .parse(tp.lower)
+    {
+        if rest.trim().trim_end_matches('.').trim().is_empty() {
+            return parsed_clause(Effect::Discover {
+                mana_value_limit: QuantityExpr::Ref {
+                    qty: QuantityRef::TriggeringDiscoverValue,
+                },
+                player: TargetFilter::Controller,
+            });
+        }
+    }
+
     // CR 701.57a: "[player] discover[s] N" / "[player] discover[s] X" — effect
     // variant. An optional leading player subject ("you", "that player", "target
     // opponent", …) redirects who performs the discover (Zoyowa's Justice: "Then

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -13126,6 +13126,19 @@ fn try_parse_player_action_trigger(lower: &str) -> Option<(TriggerMode, TriggerD
         let Ok((rest, ())) = value((), tag::<_, _, OracleError<'_>>(prefix)).parse(lower) else {
             continue;
         };
+        // CR 701.57a: "whenever/when <player> discover[s]" — the discover keyword
+        // action is NOT a `PlayerActionKind`; it has a dedicated `TriggerMode::
+        // Discover` matched against the `EffectResolved{Discover}` event by
+        // `match_discover` (Curator of Sun's Creation). Intercept the BARE
+        // discover form here, before the `parse_player_action_list` path (which
+        // does not recognize "discover"). A compound "discover, investigate, …"
+        // subject (Val, Marooned Surveyor) is left to the action-list path.
+        if is_bare_discover_subject(rest) {
+            let mut def = make_base();
+            def.valid_target = valid_target.clone();
+            def.mode = TriggerMode::Discover;
+            return Some((TriggerMode::Discover, def));
+        }
         let actions = parse_player_action_list(rest)?;
         let mut def = make_base();
         def.valid_target = valid_target.clone();
@@ -13168,6 +13181,22 @@ fn try_parse_player_action_trigger(lower: &str) -> Option<(TriggerMode, TriggerD
     }
 
     None
+}
+
+/// CR 701.57a: True when `text` is a BARE "discover"/"discovers" trigger subject
+/// (end-of-condition or trailing `.`/`;`) — NOT a compound action list such as
+/// "discover, investigate, scry, surveil, or seek …" (Val, Marooned Surveyor),
+/// which must reach `parse_player_action_list`. The discover keyword action has a
+/// dedicated `TriggerMode::Discover` (matched on `EffectResolved{Discover}`), so
+/// this routes "whenever you discover" straight to it.
+fn is_bare_discover_subject(text: &str) -> bool {
+    let Ok((rest, _)) =
+        alt((tag::<_, _, OracleError<'_>>("discovers"), tag("discover"))).parse(text)
+    else {
+        return false;
+    };
+    let rest = rest.trim_start();
+    rest.is_empty() || rest.starts_with(['.', ';'])
 }
 
 fn parse_player_action_list(text: &str) -> Option<Vec<PlayerActionKind>> {

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -10434,6 +10434,41 @@ fn trigger_you_investigate_bare() {
 }
 
 #[test]
+fn trigger_curator_discover_again_for_the_same_value() {
+    // Curator of Sun's Creation (#5270): "Whenever you discover, discover again
+    // for the same value. This ability triggers only once each turn." The bare
+    // discover subject maps to the dedicated TriggerMode::Discover (matched on
+    // EffectResolved{Discover}); "the same value" re-discovers with N equal to
+    // the triggering discover's mana-value limit (TriggeringDiscoverValue).
+    let def = parse_trigger_line(
+        "Whenever you discover, discover again for the same value. This ability triggers only once each turn.",
+        "Curator of Sun's Creation",
+    );
+    assert_eq!(def.mode, TriggerMode::Discover);
+    assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+    assert_eq!(
+        def.constraint,
+        Some(crate::types::ability::TriggerConstraint::OncePerTurn),
+    );
+    let execute = def
+        .execute
+        .as_ref()
+        .expect("trigger should have execute step");
+    match execute.effect.as_ref() {
+        Effect::Discover {
+            mana_value_limit, ..
+        } => assert_eq!(
+            mana_value_limit,
+            &crate::types::ability::QuantityExpr::Ref {
+                qty: crate::types::ability::QuantityRef::TriggeringDiscoverValue,
+            },
+            "\"discover again for the same value\" must reuse the triggering discover's value",
+        ),
+        other => panic!("expected Effect::Discover, got {other:?}"),
+    }
+}
+
+#[test]
 fn trigger_you_collect_evidence() {
     // Surveillance Monitor (MKM): "Whenever you collect evidence, create a 1/1 colorless
     // Thopter artifact creature token with flying."

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4885,6 +4885,12 @@ pub enum QuantityRef {
     LifeAboveStarting,
     /// CR 103.4: The format's starting life total (20 for Standard, 40 for Commander, etc.).
     StartingLifeTotal,
+    /// CR 701.57a: The mana-value limit `N` of the discover that fired the
+    /// current "whenever you discover" trigger — read from
+    /// `GameState::last_discover_value`. Curator of Sun's Creation: "discover
+    /// again for the same value". Resolves to 0 outside a discover-trigger
+    /// context (fail-safe; no card references it elsewhere).
+    TriggeringDiscoverValue,
     /// Count of objects on the battlefield matching a filter.
     /// Used for "for each creature you control" and similar patterns.
     ObjectCount { filter: TargetFilter },

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -8061,6 +8061,14 @@ pub struct GameState {
     /// Event-context filters that can legally compare against a group read this.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub current_trigger_events: Vec<GameEvent>,
+    /// CR 701.57a: The mana-value limit `N` of the most recently resolved
+    /// discover. Set when a `discover N` resolves so that a "whenever you
+    /// discover" trigger's effect can reference "the same value" (Curator of
+    /// Sun's Creation: "discover again for the same value" →
+    /// `QuantityRef::TriggeringDiscoverValue`). Transient — not part of durable
+    /// game state, but serialized so a mid-resolution pause round-trips.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_discover_value: Option<i32>,
     /// Full event batches for triggered abilities currently on the stack,
     /// keyed by stack entry id. Single-event triggers omit an entry here.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -8910,6 +8918,7 @@ impl GameState {
             current_trigger_match_count: None,
             resolving_stack_entry: None,
             current_trigger_events: Vec::new(),
+            last_discover_value: None,
             stack_trigger_event_batches: HashMap::new(),
             lki_cache: HashMap::new(),
             linked_exile_lki: HashMap::new(),


### PR DESCRIPTION
Fixes #5270 (Curator of Sun's Creation). CR 701.57a.

"Whenever you discover, discover again for the same value. This ability triggers only once each turn." parsed to an **Unknown** trigger with an **Unimplemented** effect — the ability did nothing. The discover *trigger* (`TriggerMode::Discover` + `match_discover`) and *effect* (`Effect::Discover`) both already exist; this wires the two missing parser paths plus the "same value" quantity.

## 1. Trigger — "whenever you discover"

`whenever/when <player> discover[s]` (bare) → `TriggerMode::Discover` (matched on the `EffectResolved{Discover}` event). The discover keyword action is **not** a `PlayerActionKind`, so a dedicated `is_bare_discover_subject` gate routes it before the `parse_player_action_list` path. A compound `discover, investigate, scry, …` subject (Val, Marooned Surveyor) is deliberately left to the action-list path.

## 2. Effect — "discover again for the same value"

→ `Effect::Discover { mana_value_limit: QuantityRef::TriggeringDiscoverValue, player: Controller }` (composed from tags, not a verbatim match).

## 3. `QuantityRef::TriggeringDiscoverValue` (new)

The mana-value limit `N` of the discover that fired the current "whenever you discover" trigger. Threaded via a transient `GameState::last_discover_value`, set in the discover resolver before the `EffectResolved` event fires; resolves to `0` outside a discover context. Classified per the engine-variant checklist:
- **ability-scan**: `Axes::NONE` (reads a bounded game-state scalar; no growing/sibling/projected axis).
- **read/write profiler**: `empty()` (written only by discover resolution, never a sibling trigger).
- **cast-time board-state classifier**: falls to the `_ => false` trigger-event-context arm (correctly non-evaluable before activation).
- coverage + resolver arms added.

The `OncePerTurn` constraint already parsed, so `Curator` no longer loops on itself.

## Verification

- New tests: `trigger_curator_discover_again_for_the_same_value` (parser), `triggering_discover_value_reads_last_discover_scalar` (resolver).
- **Full engine lib suite: 16026 passed / 0 failed** (touches shared `game/quantity`, `ability_scan`, `ability_rw`, `layers`, `triggers`, `coverage`).
- Combinator gate clean (exit 0); clippy clean; parser gap analysis unchanged.