### PR TITLE
Fix Gandalf the White trigger doubling (issue #5332)

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -22,7 +22,9 @@ use crate::types::keywords::WardCost;
 use crate::types::keywords::{Keyword, KeywordKind};
 use crate::types::phase::Phase;
 use crate::types::player::{Player, PlayerCounterKind, PlayerId};
-use crate::types::statics::{StaticMode, SuppressedTriggerEvent, TriggerCause};
+use crate::types::statics::{
+    StaticMode, SuppressedTriggerEvent, TriggerCause, ZoneChangeQualifier,
+};
 use crate::types::triggers::{AttackTargetFilter, TriggerMode};
 use crate::types::zones::Zone;
 
@@ -5182,6 +5184,21 @@ fn apply_trigger_doubling(state: &GameState, pending: &mut Vec<PendingTriggerCon
 ///   so no further type check is required.
 /// - `TriggerCause::ControlledCreatureDealtDamage` matches `DamageDealt`
 ///   events whose target is a creature controlled by `doubler_controller`.
+/// CR 603.6a + CR 603.6c: Disjunctive qualifier check against a zone-change
+/// snapshot. Empty qualifiers match any permanent.
+fn zone_change_qualifiers_match(
+    record: &crate::types::game_state::ZoneChangeRecord,
+    qualifiers: &[ZoneChangeQualifier],
+) -> bool {
+    if qualifiers.is_empty() {
+        return true;
+    }
+    qualifiers.iter().any(|qualifier| match qualifier {
+        ZoneChangeQualifier::CoreType(core_type) => record.core_types.contains(core_type),
+        ZoneChangeQualifier::Supertype(supertype) => record.supertypes.contains(supertype),
+    })
+}
+
 fn trigger_cause_matches(
     state: &GameState,
     cause: &TriggerCause,
@@ -5287,6 +5304,27 @@ fn trigger_cause_matches(
                     .iter()
                     .any(|ct| core_types.contains(ct))
             })
+        }
+        TriggerCause::BattlefieldTransition {
+            enter,
+            leave,
+            qualifiers,
+        } => {
+            // CR 603.6a + CR 603.6c: Match zone changes to/from the battlefield
+            // whose causing permanent satisfies the disjunctive qualifier list.
+            let Some(GameEvent::ZoneChanged {
+                from, to, record, ..
+            }) = event
+            else {
+                return false;
+            };
+            let is_enter = *to == Zone::Battlefield;
+            let is_leave = from.as_ref() == Some(&Zone::Battlefield);
+            let direction_ok = (*enter && is_enter) || (*leave && is_leave);
+            if !direction_ok {
+                return false;
+            }
+            zone_change_qualifiers_match(record, qualifiers)
         }
     }
 }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -5169,21 +5169,6 @@ fn apply_trigger_doubling(state: &GameState, pending: &mut Vec<PendingTriggerCon
     pending.extend(extra);
 }
 
-/// CR 603.2d: Predicate check — does a `TriggerCause` match the event that
-/// spawned a pending trigger? Called once per (doubler, pending-trigger) pair.
-///
-/// - `TriggerCause::Any` matches any event (even absent events — some state
-///   triggers carry `trigger_event = None`, and unrestricted doublers should
-///   still cover them).
-/// - `TriggerCause::EntersBattlefield { core_types }` matches `ZoneChanged`
-///   events moving to the battlefield whose object's core types intersect
-///   the predicate's `core_types`. An empty `core_types` list means "any
-///   permanent" (reserved for hypothetical cards that don't narrow by type).
-/// - `TriggerCause::CreatureAttacking` matches `AttackersDeclared` events.
-///   CR 508.1a: every object declared as an attacker must be a creature,
-///   so no further type check is required.
-/// - `TriggerCause::ControlledCreatureDealtDamage` matches `DamageDealt`
-///   events whose target is a creature controlled by `doubler_controller`.
 /// CR 603.6a + CR 603.6c: Disjunctive qualifier check against a zone-change
 /// snapshot. Empty qualifiers match any permanent.
 fn zone_change_qualifiers_match(
@@ -5199,6 +5184,21 @@ fn zone_change_qualifiers_match(
     })
 }
 
+/// CR 603.2d: Predicate check — does a `TriggerCause` match the event that
+/// spawned a pending trigger? Called once per (doubler, pending-trigger) pair.
+///
+/// - `TriggerCause::Any` matches any event (even absent events — some state
+///   triggers carry `trigger_event = None`, and unrestricted doublers should
+///   still cover them).
+/// - `TriggerCause::EntersBattlefield { core_types }` matches `ZoneChanged`
+///   events moving to the battlefield whose object's core types intersect
+///   the predicate's `core_types`. An empty `core_types` list means "any
+///   permanent" (reserved for hypothetical cards that don't narrow by type).
+/// - `TriggerCause::CreatureAttacking` matches `AttackersDeclared` events.
+///   CR 508.1a: every object declared as an attacker must be a creature,
+///   so no further type check is required.
+/// - `TriggerCause::ControlledCreatureDealtDamage` matches `DamageDealt`
+///   events whose target is a creature controlled by `doubler_controller`.
 fn trigger_cause_matches(
     state: &GameState,
     cause: &TriggerCause,

--- a/crates/engine/src/game/triggers_dedup_regression_tests.rs
+++ b/crates/engine/src/game/triggers_dedup_regression_tests.rs
@@ -5,7 +5,7 @@ use crate::types::ability::{
     TargetFilter, TargetRef, TriggerDefinition, TypedFilter,
 };
 use crate::types::actions::GameAction;
-use crate::types::card_type::CoreType;
+use crate::types::card_type::{CoreType, Supertype};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
     AutoMayChoice, GameState, MayTriggerAutoChoiceKey, MayTriggerOrigin, WaitingFor,
@@ -1014,6 +1014,174 @@ fn install_doubler(state: &mut GameState, cause: TriggerCause) -> ObjectId {
             StaticMode::DoubleTriggers { cause },
         ));
     id
+}
+
+/// CR 603.2d + CR 603.6a + CR 603.6c: Gandalf the White-class doubler.
+fn install_gandalf_doubler(state: &mut GameState) -> ObjectId {
+    use crate::types::statics::{TriggerCause, ZoneChangeQualifier};
+    install_doubler(
+        state,
+        TriggerCause::BattlefieldTransition {
+            enter: true,
+            leave: true,
+            qualifiers: vec![
+                ZoneChangeQualifier::Supertype(Supertype::Legendary),
+                ZoneChangeQualifier::CoreType(CoreType::Artifact),
+            ],
+        },
+    )
+}
+
+/// CR 603.2d: Gandalf doubles ETB triggers caused by a legendary permanent.
+#[test]
+fn gandalf_doubles_legendary_etb_triggers() {
+    let (mut state, observer) = setup_with_observer(TriggerMode::ChangesZone);
+    state
+        .objects
+        .get_mut(&observer)
+        .unwrap()
+        .trigger_definitions[0]
+        .destination = Some(Zone::Battlefield);
+    let _gandalf = install_gandalf_doubler(&mut state);
+
+    let norin = create_object(
+        &mut state,
+        CardId(5332),
+        PlayerId(0),
+        "Norin the Wary".to_string(),
+        Zone::Battlefield,
+    );
+    state.objects.get_mut(&norin).unwrap().card_types = crate::types::card_type::CardType {
+        core_types: vec![CoreType::Creature],
+        supertypes: vec![Supertype::Legendary],
+        subtypes: vec![],
+    };
+
+    let event = GameEvent::ZoneChanged {
+        object_id: norin,
+        from: Some(Zone::Exile),
+        to: Zone::Battlefield,
+        record: Box::new(ZoneChangeRecord {
+            name: "Norin the Wary".to_string(),
+            core_types: vec![CoreType::Creature],
+            supertypes: vec![Supertype::Legendary],
+            ..ZoneChangeRecord::test_minimal(norin, Some(Zone::Exile), Zone::Battlefield)
+        }),
+    };
+
+    process_triggers(&mut state, &[event]);
+    super::drain_order_triggers_with_identity(&mut state);
+    let observer_triggers = state
+        .stack
+        .iter()
+        .filter(|e| e.source_id == observer)
+        .count();
+    assert_eq!(
+        observer_triggers, 2,
+        "Gandalf must double ETB triggers caused by a legendary permanent re-entering"
+    );
+}
+
+/// CR 603.2d: Gandalf doubles ETB triggers caused by an artifact.
+#[test]
+fn gandalf_doubles_artifact_etb_triggers() {
+    let (mut state, observer) = setup_with_observer(TriggerMode::ChangesZone);
+    state
+        .objects
+        .get_mut(&observer)
+        .unwrap()
+        .trigger_definitions[0]
+        .destination = Some(Zone::Battlefield);
+    let _gandalf = install_gandalf_doubler(&mut state);
+
+    let genesis = create_object(
+        &mut state,
+        CardId(5333),
+        PlayerId(0),
+        "Genesis Chamber".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&genesis)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Artifact);
+
+    let event = GameEvent::ZoneChanged {
+        object_id: genesis,
+        from: Some(Zone::Hand),
+        to: Zone::Battlefield,
+        record: Box::new(ZoneChangeRecord {
+            name: "Genesis Chamber".to_string(),
+            core_types: vec![CoreType::Artifact],
+            ..ZoneChangeRecord::test_minimal(genesis, Some(Zone::Hand), Zone::Battlefield)
+        }),
+    };
+
+    process_triggers(&mut state, &[event]);
+    super::drain_order_triggers_with_identity(&mut state);
+    let observer_triggers = state
+        .stack
+        .iter()
+        .filter(|e| e.source_id == observer)
+        .count();
+    assert_eq!(
+        observer_triggers, 2,
+        "Gandalf must double ETB triggers caused by an artifact entering"
+    );
+}
+
+/// CR 603.2d: Gandalf does not double ETB triggers from ordinary non-artifact creatures.
+#[test]
+fn gandalf_does_not_double_ordinary_creature_etb_triggers() {
+    let (mut state, observer) = setup_with_observer(TriggerMode::ChangesZone);
+    state
+        .objects
+        .get_mut(&observer)
+        .unwrap()
+        .trigger_definitions[0]
+        .destination = Some(Zone::Battlefield);
+    let _gandalf = install_gandalf_doubler(&mut state);
+
+    let greeter = create_object(
+        &mut state,
+        CardId(5334),
+        PlayerId(0),
+        "Gala Greeters".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&greeter)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
+
+    let event = GameEvent::ZoneChanged {
+        object_id: greeter,
+        from: Some(Zone::Hand),
+        to: Zone::Battlefield,
+        record: Box::new(ZoneChangeRecord {
+            name: "Gala Greeters".to_string(),
+            core_types: vec![CoreType::Creature],
+            ..ZoneChangeRecord::test_minimal(greeter, Some(Zone::Hand), Zone::Battlefield)
+        }),
+    };
+
+    process_triggers(&mut state, &[event]);
+    super::drain_order_triggers_with_identity(&mut state);
+    let observer_triggers = state
+        .stack
+        .iter()
+        .filter(|e| e.source_id == observer)
+        .count();
+    assert_eq!(
+        observer_triggers, 1,
+        "Gandalf must not double ETB triggers caused by a non-legendary non-artifact creature"
+    );
 }
 
 /// CR 603.2d: Isshin (CreatureAttacking cause) doubles attack triggers

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -3300,6 +3300,8 @@ pub(crate) fn parse_static_line_inner(
             TriggerCause::CreatureAttacking
         } else if nom_primitives::scan_contains(tp.lower, "dying causes") {
             TriggerCause::CreatureDying
+        } else if let Some(cause) = parse_battlefield_transition_cause(tp.lower) {
+            cause
         } else if nom_primitives::scan_contains(tp.lower, "entering")
             || nom_primitives::scan_contains(tp.lower, "enters the battlefield")
         {
@@ -3342,6 +3344,55 @@ pub(crate) fn parse_static_line_inner(
     }
 
     None
+}
+
+/// CR 603.6a + CR 603.6c: Extract disjunctive qualifiers on the permanent whose
+/// zone change caused a trigger doubler (Gandalf the White-class).
+fn parse_zone_change_qualifiers(lower: &str) -> Vec<ZoneChangeQualifier> {
+    let mut qualifiers = Vec::new();
+    if nom_primitives::scan_contains(lower, "legendary") {
+        qualifiers.push(ZoneChangeQualifier::Supertype(Supertype::Legendary));
+    }
+    if nom_primitives::scan_contains(lower, "artifact") {
+        qualifiers.push(ZoneChangeQualifier::CoreType(CoreType::Artifact));
+    }
+    if nom_primitives::scan_contains(lower, "creature") {
+        qualifiers.push(ZoneChangeQualifier::CoreType(CoreType::Creature));
+    }
+    if nom_primitives::scan_contains(lower, "enchantment") {
+        qualifiers.push(ZoneChangeQualifier::CoreType(CoreType::Enchantment));
+    }
+    if nom_primitives::scan_contains(lower, "land") {
+        qualifiers.push(ZoneChangeQualifier::CoreType(CoreType::Land));
+    }
+    if nom_primitives::scan_contains(lower, "planeswalker") {
+        qualifiers.push(ZoneChangeQualifier::CoreType(CoreType::Planeswalker));
+    }
+    qualifiers
+}
+
+/// CR 603.6a + CR 603.6c: Parse Gandalf-class battlefield transition causes.
+/// Returns `None` for Panharmonicon-style enter-only lines without a legendary
+/// supertype so the legacy `EntersBattlefield` path stays stable.
+fn parse_battlefield_transition_cause(lower: &str) -> Option<TriggerCause> {
+    let enter = nom_primitives::scan_contains(lower, "entering")
+        || nom_primitives::scan_contains(lower, "enters the battlefield");
+    let leave = nom_primitives::scan_contains(lower, "leaving")
+        || nom_primitives::scan_contains(lower, "leaves the battlefield");
+    if !enter && !leave {
+        return None;
+    }
+
+    let has_legendary = nom_primitives::scan_contains(lower, "legendary");
+    if enter && !leave && !has_legendary {
+        return None;
+    }
+
+    Some(TriggerCause::BattlefieldTransition {
+        enter,
+        leave,
+        qualifiers: parse_zone_change_qualifiers(lower),
+    })
 }
 
 /// CR 309.4c: "Room abilities of dungeons you own trigger(s) an additional time."

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -63,6 +63,7 @@ mod prelude {
         CombatAloneAction, CombatAloneRequirement, CostModifyMode, CostPaymentProhibition,
         CrewAction, CrewContributionKind, ExileCardPool, ExileCastCost, ExileCastTiming,
         HandSizeModification, ProhibitionScope, StaticMode, SuppressedTriggerEvent, TriggerCause,
+        ZoneChangeQualifier,
     };
     pub(super) use crate::types::zones::Zone;
 }

--- a/crates/engine/src/parser/oracle_static/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_static/snapshot_tests.rs
@@ -797,6 +797,35 @@ fn panharmonicon_doubler_has_no_source_filter() {
     );
 }
 
+/// CR 603.2d + CR 603.6a + CR 603.6c: Gandalf the White — legendary OR
+/// artifact entering/leaving doubles controlled triggers (issue #5332).
+#[test]
+fn gandalf_the_white_doubler_static() {
+    let def = parse_static_line(
+        "If a legendary permanent or an artifact entering or leaving the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
+    )
+    .expect("expected DoubleTriggers static for Gandalf the White");
+    assert_eq!(
+        def.mode,
+        StaticMode::DoubleTriggers {
+            cause: TriggerCause::BattlefieldTransition {
+                enter: true,
+                leave: true,
+                qualifiers: vec![
+                    ZoneChangeQualifier::Supertype(Supertype::Legendary),
+                    ZoneChangeQualifier::CoreType(CoreType::Artifact),
+                ],
+            }
+        },
+        "Gandalf must parse as legendary-or-artifact battlefield transition doubling"
+    );
+    assert!(
+        def.affected.is_none(),
+        "bare 'permanent you control' source must leave affected None, got {:?}",
+        def.affected
+    );
+}
+
 #[test]
 fn hama_pashar_room_ability_doubler_static() {
     let def = parse_static_line("Room abilities of dungeons you own trigger an additional time.")

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -562,6 +562,16 @@ pub struct CastExtraCost {
 /// This is a typed enum rather than a boolean because the design space is
 /// open-ended: new cards routinely introduce novel cause predicates, and
 /// `bool` fields cannot grow to accommodate them.
+///
+/// CR 603.6a + CR 603.6c: Disjunctive qualifier on the permanent whose
+/// battlefield transition caused a trigger (Gandalf the White-class). The
+/// causing object matches if it satisfies ANY listed qualifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ZoneChangeQualifier {
+    CoreType(super::card_type::CoreType),
+    Supertype(super::card_type::Supertype),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TriggerCause {
     /// Unrestricted doubler — matches any trigger cause.
@@ -604,6 +614,24 @@ pub enum TriggerCause {
     /// CR 309.4c: Trigger was caused by entering a dungeon room
     /// (Hama Pashar-class). Matches `GameEvent::RoomEntered` events.
     RoomEntered,
+    /// CR 603.6a + CR 603.6c: Trigger was caused by a permanent entering
+    /// and/or leaving the battlefield (Gandalf the White-class). `enter` /
+    /// `leave` select which directions qualify; when both are true, either
+    /// direction matches. `qualifiers` narrows the causing permanent against
+    /// its zone-change snapshot (CR 603.10a LKI) — empty means any permanent;
+    /// Gandalf uses `[Supertype(Legendary), CoreType(Artifact)]` (disjunctive).
+    BattlefieldTransition {
+        #[serde(default = "default_true")]
+        enter: bool,
+        #[serde(default)]
+        leave: bool,
+        #[serde(default)]
+        qualifiers: Vec<ZoneChangeQualifier>,
+    },
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl fmt::Display for TriggerCause {
@@ -624,6 +652,24 @@ impl fmt::Display for TriggerCause {
                 write!(f, "ControllerCastOrCopiedSpell([{}])", names.join(","))
             }
             TriggerCause::RoomEntered => write!(f, "RoomEntered"),
+            TriggerCause::BattlefieldTransition {
+                enter,
+                leave,
+                qualifiers,
+            } => {
+                let qual_names: Vec<String> = qualifiers
+                    .iter()
+                    .map(|q| match q {
+                        ZoneChangeQualifier::CoreType(ct) => format!("{ct:?}"),
+                        ZoneChangeQualifier::Supertype(st) => format!("{st:?}"),
+                    })
+                    .collect();
+                write!(
+                    f,
+                    "BattlefieldTransition(enter={enter},leave={leave},[{}])",
+                    qual_names.join(",")
+                )
+            }
         }
     }
 }

--- a/crates/engine/tests/integration/issue_5332_gandalf_trigger_doubling.rs
+++ b/crates/engine/tests/integration/issue_5332_gandalf_trigger_doubling.rs
@@ -1,0 +1,153 @@
+//! Regression for issue #5332: Gandalf the White only parsed artifact ETB as
+//! its trigger-doubling cause, dropping the legendary supertype and
+//! leaves-the-battlefield half of its Oracle text.
+//!
+//! https://github.com/phase-rs/phase/issues/5332
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::oracle_static::parse_static_line;
+use engine::types::ability::{StaticDefinition, TargetFilter, TriggerDefinition};
+use engine::types::card_type::{CoreType, Supertype};
+use engine::types::events::GameEvent;
+use engine::types::game_state::{GameState, ZoneChangeRecord};
+use engine::types::identifiers::CardId;
+use engine::types::phase::Phase;
+use engine::types::statics::{StaticMode, TriggerCause, ZoneChangeQualifier};
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+const GANDALF_DOUBLER: &str = "If a legendary permanent or an artifact entering or leaving the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.";
+
+fn main_phase_two_player() -> GameState {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.build().state().clone()
+}
+
+fn install_etb_observer(state: &mut GameState) -> engine::types::identifiers::ObjectId {
+    let observer = create_object(
+        state,
+        CardId(53320),
+        P0,
+        "ETB Observer".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&observer).unwrap();
+    obj.card_types.core_types.push(CoreType::Enchantment);
+    obj.trigger_definitions.push(
+        TriggerDefinition::new(TriggerMode::ChangesZone)
+            .valid_card(TargetFilter::Any)
+            .destination(Zone::Battlefield),
+    );
+    observer
+}
+
+fn install_gandalf_doubler(state: &mut GameState) -> engine::types::identifiers::ObjectId {
+    let StaticDefinition { mode, .. } =
+        parse_static_line(GANDALF_DOUBLER).expect("Gandalf doubler static must parse");
+    assert_eq!(
+        mode,
+        StaticMode::DoubleTriggers {
+            cause: TriggerCause::BattlefieldTransition {
+                enter: true,
+                leave: true,
+                qualifiers: vec![
+                    ZoneChangeQualifier::Supertype(Supertype::Legendary),
+                    ZoneChangeQualifier::CoreType(CoreType::Artifact),
+                ],
+            }
+        },
+        "Gandalf must parse legendary-or-artifact enter/leave doubling (#5332)"
+    );
+    let gandalf = create_object(
+        state,
+        CardId(53321),
+        P0,
+        "Gandalf the White".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&gandalf).unwrap();
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.static_definitions
+        .push(parse_static_line(GANDALF_DOUBLER).unwrap());
+    gandalf
+}
+
+#[test]
+fn gandalf_parsed_static_doubles_legendary_reentry_triggers() {
+    let mut state = main_phase_two_player();
+    let observer = install_etb_observer(&mut state);
+    let _gandalf = install_gandalf_doubler(&mut state);
+
+    let norin = create_object(
+        &mut state,
+        CardId(53322),
+        P0,
+        "Norin the Wary".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&norin)
+        .unwrap()
+        .card_types
+        .supertypes
+        .push(Supertype::Legendary);
+    state
+        .objects
+        .get_mut(&norin)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
+
+    let event = GameEvent::ZoneChanged {
+        object_id: norin,
+        from: Some(Zone::Exile),
+        to: Zone::Battlefield,
+        record: Box::new(ZoneChangeRecord {
+            object_id: norin,
+            name: "Norin the Wary".to_string(),
+            core_types: vec![CoreType::Creature],
+            supertypes: vec![Supertype::Legendary],
+            subtypes: Vec::new(),
+            keywords: Vec::new(),
+            power: None,
+            toughness: None,
+            base_power: None,
+            base_toughness: None,
+            colors: Vec::new(),
+            mana_value: 0,
+            controller: P0,
+            owner: P0,
+            from_zone: Some(Zone::Exile),
+            cast_from_zone: None,
+            played_from_zone: None,
+            to_zone: Zone::Battlefield,
+            attachments: Vec::new(),
+            linked_exile_snapshot: Vec::new(),
+            is_token: false,
+            combat_status: Default::default(),
+            trigger_definitions: Vec::new(),
+            co_departed: Vec::new(),
+            attached_to: None,
+            entered_incarnation: None,
+            turn_zone_change_index: 0,
+            is_suspected: false,
+        }),
+    };
+
+    engine::game::triggers::process_triggers(&mut state, &[event]);
+    engine::game::triggers::drain_order_triggers_with_identity(&mut state);
+
+    let doubled = state
+        .stack
+        .iter()
+        .filter(|e| e.source_id == observer)
+        .count();
+    assert_eq!(
+        doubled, 2,
+        "legendary permanent re-entering must double controlled ETB triggers under Gandalf"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -440,6 +440,7 @@ mod issue_5285_senu_keen_eyed_protector;
 mod issue_5286_lulu_loyal_hollyphant;
 mod issue_5287_samwise_stouthearted;
 mod issue_5328_attacks_alone_observer;
+mod issue_5332_gandalf_trigger_doubling;
 mod issue_5335_stonehoof_mass_attack;
 mod issue_5336_kodama_mana_value_filter;
 mod issue_5339_armory_automaton;


### PR DESCRIPTION
## Summary

Gandalf the White's static ability was only parsed as `DoubleTriggers { cause: EntersBattlefield { core_types: [Artifact] } }`, dropping two clauses from the Oracle text:

1. **"legendary permanent"** — the supertype qualifier was never recognized.
2. **"or leaving the battlefield"** — only ETB was modeled; LTB/exile-and-return causes (e.g. Norin the Wary) did not double triggers.

This adds a composable `TriggerCause::BattlefieldTransition` variant with disjunctive `ZoneChangeQualifier` predicates (supertype or core type) and enter/leave direction flags, wires runtime matching in `apply_trigger_doubling`, and extends the static parser dispatch path.

Fixes [#5332](https://github.com/phase-rs/phase/issues/5332).

## Changes

### Type system (`crates/engine/src/types/statics.rs`)

- New `ZoneChangeQualifier` enum: `CoreType` | `Supertype` (disjunctive matching).
- New `TriggerCause::BattlefieldTransition { enter, leave, qualifiers }` for Gandalf-class doublers.
- Panharmonicon-style enter-only lines without a legendary supertype remain on legacy `EntersBattlefield`.

### Runtime (`crates/engine/src/game/triggers.rs`)

- `zone_change_qualifiers_match` helper evaluates causing permanent against zone-change LKI snapshot (CR 603.10a).
- `trigger_cause_matches` arm for `BattlefieldTransition` handles enter and/or leave directions.

### Parser (`crates/engine/src/parser/oracle_static/dispatch.rs`)

- `parse_zone_change_qualifiers` extracts legendary/artifact/creature/etc. qualifiers.
- `parse_battlefield_transition_cause` routes Gandalf-class lines to `BattlefieldTransition`; Panharmonicon stays on `EntersBattlefield`.

### Tests

- Parser snapshot: `gandalf_the_white_doubler_static`
- Runtime regression: legendary ETB, artifact ETB, ordinary creature ETB (no double)
- Integration: `issue_5332_gandalf_trigger_doubling` (parsed static + Norin-style legendary re-entry)

## Suggested branch name

```
fix/5332-gandalf-trigger-doubling
```

## Suggested commit message

```
Fix Gandalf the White trigger doubling for legendary and LTB causes (#5332)

Gandalf's doubler was parsed as artifact-only ETB, so legendary re-entries
like Norin the Wary never doubled controlled triggers. Add BattlefieldTransition
with supertype/core-type qualifiers and enter/leave directions; keep Panharmonicon
on the legacy EntersBattlefield path.
```

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p engine --lib gandalf`
- [x] `cargo test -p engine --test integration gandalf`
- [ ] `tilt logs clippy` / `tilt logs test-engine` (when Tilt is up)
- [ ] Regenerated `card-data.json` picks up Gandalf's corrected static after card-data pipeline run

## Risk

Low — additive enum variant; existing `EntersBattlefield` / Panharmonicon behavior unchanged. Card-data will update Gandalf's serialized static on next pipeline run.
