### PR TITLE
Fix Veteran Bodyguard / Weathered Bodyguards — dropped tap-gate + unblocked/combat source restriction on damage redirection

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -8058,21 +8058,62 @@ fn parse_cant_become_untapped_replacement(
     )
 }
 
-/// CR 614.1a: Parse damage redirection replacement effects.
+/// CR 614.9 + CR 509.1h: Extract the optional "by <source>" scope-restriction
+/// clause from a damage-redirection body — "...would be dealt to you by
+/// unblocked creatures is dealt to ~ instead." (Veteran Bodyguard, Weathered
+/// Bodyguards). Delegates entirely to `parse_damage_source_subject_filter`
+/// (the same subject-typing helper every other damage-source clause in this
+/// module already uses), which itself falls back to `parse_type_phrase` — the
+/// SAME combinator that already resolves "unblocked creatures" / "unblocked
+/// attacking creatures" to `FilterProp::Unblocked` via
+/// `parse_combat_status_prefix` (`oracle_target.rs`), proven by the existing
+/// `parse_type_phrase_unblocked_attacking_creatures_you_control` test. This
+/// function adds NO new unblocked-detection — only the "by ... is dealt to"
+/// boundary extraction that the redirection grammar does not yet have.
+/// Returns `None` when no "by " clause is present, so the unrestricted-source
+/// class (Pariah / Palisade Giant) is unaffected.
+fn parse_damage_redirection_source_clause(working_lower: &str) -> Option<TargetFilter> {
+    let (_, (_, after_by)) = nom_primitives::split_once_on(working_lower, " by ").ok()?;
+    let (_, (subject, _)) = nom_primitives::split_once_on(after_by, " is dealt to").ok()?;
+    parse_damage_source_subject_filter(subject.trim())
+}
+
+/// CR 614.1a + CR 604.2: Parse damage redirection replacement effects.
 /// Handles "all damage that would be dealt to [target] is dealt to ~ instead" (Pariah, Palisade Giant)
 /// and "if a source would deal damage to you, prevent that damage. ~ deals that much damage to
 /// any target" (Pariah's Shield).
+///
+/// CR 604.2: an optional leading "as long as <tap-state>, " gate (a printed
+/// static ability's own continuous-effect activation condition) is stripped and
+/// lifted to a typed `ReplacementCondition` before the body is parsed, so the
+/// redirect only applies while the condition holds (Veteran Bodyguard's
+/// "as long as this creature is untapped" — the redirect must NOT fire while the
+/// permanent is tapped).
+///
+/// CR 614.9 + CR 509.1h: an optional "by <source>" clause ("...by unblocked
+/// creatures...") scopes the redirect to a damage-source filter, and a
+/// "combat damage" qualifier scopes it to combat damage only — so the redirect
+/// applies only to combat damage from unblocked creatures rather than to all
+/// damage from every source (Veteran Bodyguard is source-restricted only;
+/// Weathered Bodyguards is both source- and combat-restricted).
 fn parse_damage_redirection_replacement(
     norm_lower: &str,
     original_text: &str,
 ) -> Option<ReplacementDefinition> {
+    // CR 604.2: lift a leading "as long as <tap-state>, " gate to a typed
+    // condition before parsing the body. `working_lower` is the bare body used
+    // for every subsequent check (Pattern 1 and Pattern 3). Pariah / Pariah's
+    // Shield never carry this prefix, so this is a no-op for them.
+    let (working_lower, prefix_condition) = strip_as_long_as_condition_prefix(norm_lower);
+
     // Pattern 1: "all damage that would be dealt to [X] is dealt to ~ instead" (Pariah)
     // Pattern 2: "damage that would be dealt to [X] is dealt to ~ instead" (Palisade Giant)
     // CR 615.1a: Redirect = prevent original + deal to new target
-    if nom_primitives::scan_contains(norm_lower, "would be dealt to")
-        && nom_primitives::scan_contains(norm_lower, "is dealt to")
+    if nom_primitives::scan_contains(working_lower, "would be dealt to")
+        && nom_primitives::scan_contains(working_lower, "is dealt to")
     {
-        let target_filter = if nom_primitives::scan_contains(norm_lower, "would be dealt to you") {
+        let target_filter = if nom_primitives::scan_contains(working_lower, "would be dealt to you")
+        {
             Some(damage_target_controller())
         } else {
             // "would be dealt to ~" or other targets — no specific filter
@@ -8080,12 +8121,17 @@ fn parse_damage_redirection_replacement(
         };
 
         // Determine redirect destination
-        let redirect = if nom_primitives::scan_contains(norm_lower, "is dealt to ~ instead") {
+        let redirect = if nom_primitives::scan_contains(working_lower, "is dealt to ~ instead") {
             // Redirect to self (the permanent with this ability)
             Some(TargetFilter::SelfRef)
         } else {
             None
         };
+
+        // CR 614.9 + CR 509.1h: optional "by <source>" scope-restriction.
+        let source_filter = parse_damage_redirection_source_clause(working_lower);
+        // CR 615: optional "combat damage" qualifier scopes to combat damage only.
+        let combat_scope = scan_combat_scope(working_lower);
 
         let mut def = ReplacementDefinition::new(ReplacementEvent::DamageDone)
             .prevention_shield(PreventionAmount::All)
@@ -8096,14 +8142,24 @@ fn parse_damage_redirection_replacement(
         if let Some(rt) = redirect {
             def = def.redirect_target(rt);
         }
+        // CR 604.2: attach the leading "as long as <tap-state>" gate.
+        if let Some(cond) = prefix_condition {
+            def = def.condition(cond);
+        }
+        if let Some(sf) = source_filter {
+            def = def.damage_source_filter(sf);
+        }
+        if let Some(cs) = combat_scope {
+            def = def.combat_scope(cs);
+        }
         return Some(def);
     }
 
     // Pattern 3: "if a source would deal damage to you, prevent that damage"
     // followed by "~ deals that much damage to any target" (Pariah's Shield)
     // CR 615.1a: Prevention + redirect combination
-    if nom_primitives::scan_contains(norm_lower, "would deal damage to you")
-        && nom_primitives::scan_contains(norm_lower, "prevent that damage")
+    if nom_primitives::scan_contains(working_lower, "would deal damage to you")
+        && nom_primitives::scan_contains(working_lower, "prevent that damage")
     {
         return Some(
             ReplacementDefinition::new(ReplacementEvent::DamageDone)
@@ -8238,10 +8294,17 @@ fn parse_damage_to_player_instead_followup(
     )
 }
 
-/// CR 614.1a: Strip a leading "as long as <condition>, " gate from a damage
-/// prevention replacement's normalized lowercase text and lift it to a typed
+/// CR 604.2: Strip a leading "as long as <condition>, " gate — a printed static
+/// ability's own continuous-effect activation condition — from a damage
+/// replacement's normalized lowercase text and lift it to a typed
 /// `ReplacementCondition`. Returns the trimmed slice plus the gate (or the
 /// untouched input and `None` when no parseable gate is present).
+///
+/// Shared by both `parse_damage_prevention_replacement` and
+/// `parse_damage_redirection_replacement` — both need to lift a leading
+/// `"as long as <tap-state>, "` gate into a typed `ReplacementCondition` before
+/// parsing the replacement body (prevention: Multiclass Baldric; redirection:
+/// Veteran Bodyguard, Weathered Bodyguards).
 ///
 /// Shares `replacement_condition_from_static` with `parse_source_state_external_entry`
 /// so any condition shape the static-condition lifter supports — quantity
@@ -8251,12 +8314,10 @@ fn parse_damage_to_player_instead_followup(
 /// When the prefix is present but the body fails to parse or doesn't lift to a
 /// supported `ReplacementCondition`, the function returns the untouched input
 /// and `None`. The caller continues with the original text rather than failing
-/// — preserving prior coverage for prevention lines whose gate the typed
-/// surface can't yet carry (still applies the description-based shield, same
-/// as before this gate-extraction was added).
-fn strip_as_long_as_prefix_for_prevention(
-    norm_lower: &str,
-) -> (&str, Option<ReplacementCondition>) {
+/// — preserving prior coverage for lines whose gate the typed surface can't yet
+/// carry (still applies the description-based shield, same as before this
+/// gate-extraction was added).
+fn strip_as_long_as_condition_prefix(norm_lower: &str) -> (&str, Option<ReplacementCondition>) {
     let parsed = (|| -> Option<(&str, ReplacementCondition)> {
         let (rest, _) = tag::<_, _, OracleError<'_>>("as long as ")
             .parse(norm_lower)
@@ -8305,7 +8366,7 @@ fn parse_damage_prevention_replacement(
     // and lift it to a typed `ReplacementCondition` so the rest of the parser
     // operates on the bare prevention clause. Shares `replacement_condition_from_static`
     // with `parse_source_state_external_entry` and other "as long as" callers.
-    let (working_lower, prefix_condition) = strip_as_long_as_prefix_for_prevention(norm_lower);
+    let (working_lower, prefix_condition) = strip_as_long_as_condition_prefix(norm_lower);
 
     // Must contain "prevent" and "damage" to be a prevention pattern
     if !nom_primitives::scan_contains(working_lower, "prevent")
@@ -11163,7 +11224,7 @@ mod tests {
     #[test]
     fn strip_as_long_as_prefix_returns_input_unchanged_when_absent() {
         // No "as long as" prefix: function leaves the slice untouched and reports no gate.
-        let (rest, cond) = strip_as_long_as_prefix_for_prevention(
+        let (rest, cond) = strip_as_long_as_condition_prefix(
             "prevent all damage that would be dealt to equipped creature.",
         );
         assert_eq!(
@@ -11179,7 +11240,7 @@ mod tests {
         // Function leaves the slice untouched so the rest of the parser can still
         // produce a description-only replacement (no regression vs. pre-fix behavior).
         let input = "as long as ~ has flying, prevent all damage that would be dealt to it.";
-        let (rest, cond) = strip_as_long_as_prefix_for_prevention(input);
+        let (rest, cond) = strip_as_long_as_condition_prefix(input);
         assert_eq!(rest, input);
         assert!(cond.is_none());
     }
@@ -15645,6 +15706,88 @@ mod tests {
             }
         ));
         assert_eq!(def.redirect_target, Some(TargetFilter::SelfRef));
+    }
+
+    #[test]
+    fn veteran_bodyguard_redirect_source_restricted_no_combat_scope() {
+        // CR 604.2 (static "as long as" gate) + CR 614.9 (redirection) + CR 509.1h
+        // (unblocked). Veteran Bodyguard has NO "combat" qualifier — it redirects
+        // ALL damage from unblocked creatures, combat or not.
+        let def = parse_replacement_line(
+            "As long as this creature is untapped, all damage that would be dealt to you by unblocked creatures is dealt to this creature instead.",
+            "Veteran Bodyguard",
+        )
+        .expect("Veteran Bodyguard's redirect must parse");
+
+        assert_eq!(
+            def.combat_scope, None,
+            "Veteran Bodyguard has no \"combat\" qualifier and must not be combat-scoped"
+        );
+        assert_eq!(
+            def.condition,
+            Some(ReplacementCondition::SourceTappedState { tapped: false }),
+            "the leading \"as long as this creature is untapped\" gate must lift to SourceTappedState{{ tapped: false }}"
+        );
+        match &def.damage_source_filter {
+            Some(TargetFilter::Typed(tf)) => assert!(
+                tf.properties.contains(&FilterProp::Unblocked),
+                "expected Unblocked property, got {:?}",
+                tf.properties
+            ),
+            other => panic!("expected a Typed damage_source_filter with Unblocked, got {other:?}"),
+        }
+        assert_eq!(def.damage_target_filter, Some(damage_target_controller()));
+        assert_eq!(def.redirect_target, Some(TargetFilter::SelfRef));
+    }
+
+    #[test]
+    fn weathered_bodyguards_redirect_is_combat_only_and_source_restricted() {
+        // CR 604.2 + CR 614.9 + CR 509.1h. Weathered Bodyguards HAS the "combat"
+        // qualifier — only combat damage from unblocked creatures redirects.
+        let def = parse_replacement_line(
+            "As long as this creature is untapped, all combat damage that would be dealt to you by unblocked creatures is dealt to this creature instead.",
+            "Weathered Bodyguards",
+        )
+        .expect("Weathered Bodyguards' redirect must parse");
+
+        assert_eq!(
+            def.combat_scope,
+            Some(CombatDamageScope::CombatOnly),
+            "Weathered Bodyguards' \"combat damage\" qualifier must scope the redirect to combat damage only"
+        );
+        assert_eq!(
+            def.condition,
+            Some(ReplacementCondition::SourceTappedState { tapped: false })
+        );
+        match &def.damage_source_filter {
+            Some(TargetFilter::Typed(tf)) => {
+                assert!(tf.properties.contains(&FilterProp::Unblocked))
+            }
+            other => panic!("expected a Typed damage_source_filter with Unblocked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn palisade_giant_current_oracle_no_unblocked_source_restriction() {
+        // Palisade Giant's REAL current Oracle text (Scryfall-verified) has NO
+        // tap-condition and NO combat/unblocked qualifier. The recipient-list half
+        // ("and other permanents you control") has its own separate, pre-existing
+        // bug in this same conditional — deferred as a separate follow-up, NOT
+        // fixed by this PR. This test only guards the redirection-scope
+        // regression this PR touches.
+        let def = parse_replacement_line(
+            "All damage that would be dealt to you and other permanents you control is dealt to this creature instead.",
+            "Palisade Giant",
+        )
+        .expect("Palisade Giant's redirect must still parse after the Bodyguard fix");
+
+        // Positive: the redirect itself still applies (reach guard).
+        assert_eq!(def.redirect_target, Some(TargetFilter::SelfRef));
+
+        // Negative: no unblocked/combat restriction was spuriously attached.
+        assert_eq!(def.combat_scope, None);
+        assert_eq!(def.damage_source_filter, None);
+        assert_eq!(def.condition, None);
     }
 
     #[test]

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -875,6 +875,7 @@ mod umbra_stalker_graveyard_chroma_4066;
 mod unless_pay_routes_through_authority;
 mod valakut_fireboar_switch_pt_on_attack;
 mod vannifar_cloak_from_hand;
+mod veteran_bodyguard_tap_redirect;
 mod weeping_angel_combat_prevention;
 mod winding_way_reveal_partition_2931;
 mod witchs_oven_food_tokens;

--- a/crates/engine/tests/integration/veteran_bodyguard_tap_redirect.rs
+++ b/crates/engine/tests/integration/veteran_bodyguard_tap_redirect.rs
@@ -1,0 +1,260 @@
+//! GameRunner integration regression for Veteran Bodyguard's tap-gated damage
+//! redirection (CR 604.2 + CR 614.9 + CR 509.1h).
+//!
+//! Oracle text under test (verbatim, Scryfall-verified):
+//!   "As long as this creature is untapped, all damage that would be dealt to
+//!    you by unblocked creatures is dealt to this creature instead."
+//!
+//! Two cases:
+//!  1. Untapped — the redirect fires: an unblocked attacker's damage lands on
+//!     Veteran Bodyguard instead of the defending player.
+//!  2. Tapped — the redirect does NOT fire: the same unblocked attacker's
+//!     damage lands on the defending player normally.
+//!
+//! The Bodyguard is controlled by the defending player (P1); P0 (the active
+//! player) attacks P1 with a 3/3, so "you" in the Oracle text — the Bodyguard's
+//! controller, P1 — is the damaged player whose damage redirects to itself.
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+
+use super::rules::run_combat;
+
+/// Verbatim Veteran Bodyguard redirection text (Scryfall-verified).
+const VETERAN_BODYGUARD_TEXT: &str = "As long as this creature is untapped, all damage that \
+    would be dealt to you by unblocked creatures is dealt to this creature instead.";
+
+/// Drive the game from the current state (at or before DeclareAttackers) through
+/// the end-of-combat step. `attacker_player` declares `attacker` against
+/// `defend_player` unblocked; every other prompt is auto-passed / no-op. This is
+/// a simplified `weeping_angel_combat_prevention::run_combat` with no blocker,
+/// since both cases exercise the "unblocked" axis.
+fn run_combat_unblocked(
+    runner: &mut engine::game::scenario::GameRunner,
+    attacker_player: engine::types::player::PlayerId,
+    attacker: engine::types::identifiers::ObjectId,
+    defend_player: engine::types::player::PlayerId,
+) {
+    let mut attacked = false;
+
+    for _ in 0..400 {
+        match runner.state().phase {
+            Phase::EndCombat | Phase::PostCombatMain => break,
+            _ => {}
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                if runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            WaitingFor::DeclareAttackers { player, .. } if !attacked => {
+                attacked = true;
+                let attacks = if player == attacker_player {
+                    vec![(attacker, AttackTarget::Player(defend_player))]
+                } else {
+                    vec![]
+                };
+                if runner.declare_attackers(&attacks).is_err() {
+                    break;
+                }
+            }
+            WaitingFor::DeclareAttackers { .. } => {
+                if runner.declare_attackers(&[]).is_err() {
+                    break;
+                }
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                if runner.declare_blockers(&[]).is_err() {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+}
+
+/// CR 604.2 + CR 614.9 + CR 509.1h: while Veteran Bodyguard is untapped, all
+/// damage an unblocked creature would deal to its controller is dealt to the
+/// Bodyguard instead — so the defending player (the Bodyguard's controller)
+/// takes no life loss from the unblocked attacker.
+///
+/// This asserts the in-scope behavior of this fix: while UNTAPPED, the shield
+/// FIRES and the controller is protected. It is the positive reach-guard that
+/// makes the tapped negative below non-vacuous (it proves the shield actually
+/// reaches the prevention arm for this fixture).
+///
+/// NOTE (out of scope — confirmed pre-existing runtime gap): per the card, the
+/// redirected damage should be *dealt to the Bodyguard* (marking damage on it,
+/// potentially lethal per CR 614.9). This test does NOT assert `damage_marked`
+/// on the Bodyguard because the runtime never actually redirects for this card
+/// class: `parse_replacement_line` emits `shield_kind = ShieldKind::Prevention
+/// { amount: PreventionAmount::All }` with `redirect_target: SelfRef` as a
+/// separate field, but `game::replacement::damage_done_applier`'s CR 614.9
+/// redirection logic ("Branch 1b", the `ShieldKind::Redirection { .. }` guard)
+/// only fires for `ShieldKind::Redirection`; the `ShieldKind::Prevention` arm
+/// ("Branch 2") returns `ApplyResult::Prevented` and never reads
+/// `redirect_target`. So `redirect_target: SelfRef` is dead data for the whole
+/// "damage is dealt to X instead" class (Pariah, Palisade Giant, and this
+/// cycle) — they currently only prevent, never redirect. That is a shared
+/// runtime-resolver gap with a wide blast radius, filed as a separate
+/// follow-up, NOT fixed by this parser-scoped PR. This test therefore asserts
+/// only the in-scope prevention half (controller protected while untapped).
+#[test]
+fn veteran_bodyguard_untapped_protects_controller_from_unblocked_damage() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P1 (the defending player) controls Veteran Bodyguard, a 2/5 with the
+    // tap-gated redirection static ability. Untapped by builder default.
+    scenario
+        .add_creature_from_oracle(P1, "Veteran Bodyguard", 2, 5, VETERAN_BODYGUARD_TEXT)
+        .id();
+
+    // P0 (the active player) controls a 3/3 vanilla attacker.
+    let attacker = scenario.add_creature(P0, "Charging Bear", 3, 3).id();
+
+    let mut runner = scenario.build();
+    let p1_life_before = runner.life(P1);
+
+    runner.advance_to_combat();
+    run_combat_unblocked(&mut runner, P0, attacker, P1);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.life(P1),
+        p1_life_before,
+        "P1 must take NO life loss — while the Veteran Bodyguard is untapped, the \
+         unblocked attacker's damage to P1 is redirected away (CR 604.2 + CR 614.9)"
+    );
+}
+
+/// CR 604.2: while Veteran Bodyguard is TAPPED, its "as long as this creature is
+/// untapped" gate is false, so the redirect does NOT fire. The unblocked
+/// attacker's damage lands on the defending player normally.
+///
+/// Discriminating: this test fails if the leading "as long as ... untapped" gate
+/// is dropped (the redirect would fire unconditionally, P1 would take 0 damage
+/// and the Bodyguard 3). It is the revert-guard for the condition half of the fix.
+#[test]
+fn veteran_bodyguard_tapped_does_not_redirect_unblocked_damage() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let bodyguard = scenario
+        .add_creature_from_oracle(P1, "Veteran Bodyguard", 2, 5, VETERAN_BODYGUARD_TEXT)
+        .id();
+    let attacker = scenario.add_creature(P0, "Charging Bear", 3, 3).id();
+
+    let mut runner = scenario.build();
+    let p1_life_before = runner.life(P1);
+
+    runner.advance_to_combat();
+
+    // Tap the Bodyguard so its untapped-gate is false. No untap step occurs
+    // between here and combat damage (same turn, past the untap step), so the
+    // tapped state persists. Direct state mutation mirrors the precondition
+    // setup pattern in weeping_angel_combat_prevention.rs.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&bodyguard)
+        .unwrap()
+        .tapped = true;
+
+    run_combat_unblocked(&mut runner, P0, attacker, P1);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.life(P1),
+        p1_life_before - 3,
+        "P1 must take the full 3 combat damage — the redirect is gated on the \
+         Bodyguard being untapped and must NOT fire while it is tapped (CR 604.2)"
+    );
+    assert_eq!(
+        runner.state().objects[&bodyguard].damage_marked,
+        0,
+        "no damage may be redirected to the tapped Veteran Bodyguard"
+    );
+}
+
+/// CR 509.1h + CR 510.1c + CR 702.19b + CR 604.2: the redirect covers only damage
+/// dealt "by unblocked creatures" — the source filter (`FilterProp::Unblocked`).
+/// A BLOCKED attacker with trample is a *blocked* creature (CR 509.1h), so even
+/// though its trample excess is dealt to the defending player (CR 510.1c +
+/// CR 702.19b), that damage is NOT dealt "by an unblocked creature" and must NOT
+/// be caught by the shield. The Bodyguard is kept UNTAPPED here so the tap-gate is
+/// satisfied and the ONLY variable under test is the unblocked-source restriction.
+///
+/// Discriminating: this test FAILS if the "unblocked creatures" source filter is
+/// dropped or inverted. Without the filter the shield would match ALL damage to
+/// P1 and (per the same prevention-only runtime path exercised by the untapped
+/// test above) prevent the trample excess, so P1 would lose 0 and the -3
+/// assertion would fail. With the correct `FilterProp::Unblocked` restriction the
+/// blocked trampler's damage is untouched and P1 takes the full 3.
+///
+/// The 5/5 trampler blocked by a 2/2 assigns lethal 2 to the blocker and 3
+/// trample excess to P1 (CR 702.19b) — the shared trample-assignment harness
+/// (`super::rules::run_combat`, as used by `power_fist_combat_damage_regression`)
+/// drives the `AssignCombatDamage` prompt.
+#[test]
+fn veteran_bodyguard_untapped_does_not_redirect_blocked_trample_damage() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P1 (defending player, "you") controls an UNTAPPED Veteran Bodyguard so the
+    // tap-gate is satisfied — the source-filter is the only variable under test.
+    let bodyguard = scenario
+        .add_creature_from_oracle(P1, "Veteran Bodyguard", 2, 5, VETERAN_BODYGUARD_TEXT)
+        .id();
+
+    // P1 also controls a 2/2 blocker so P0's attacker becomes a *blocked* creature
+    // (CR 509.1h) rather than unblocked.
+    let blocker = scenario.add_creature(P1, "Blocking Bear", 2, 2).id();
+
+    // P0 (active player) attacks with a 5/5; grant it trample so its excess damage
+    // spills over to P1 even though it is blocked.
+    let attacker = scenario.add_creature(P0, "Trampling Rhino", 5, 5).id();
+
+    let mut runner = scenario.build();
+    {
+        // CR 702.19: grant trample directly (mirrors the keyword-push precondition
+        // in `power_fist_combat_damage_regression::trample_splits_damage_when_blocked_single_blocker`).
+        let obj = runner.state_mut().objects.get_mut(&attacker).unwrap();
+        obj.base_keywords.push(Keyword::Trample);
+        obj.keywords.push(Keyword::Trample);
+    }
+    let p1_life_before = runner.life(P1);
+
+    // 5/5 trampler blocked by the 2/2: 2 lethal to the blocker, 3 trample excess
+    // to P1 (CR 702.19b + CR 510.1c). `run_combat` declares P0's attack on P1 and
+    // resolves the trample `AssignCombatDamage` prompt automatically.
+    run_combat(&mut runner, vec![attacker], vec![(blocker, attacker)]);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.life(P1),
+        p1_life_before - 3,
+        "P1 must take the full 3 trample damage — the blocked attacker is NOT an \
+         'unblocked creature' (CR 509.1h), so the redirect's source filter excludes \
+         it and the damage is dealt to P1 normally (CR 510.1c + CR 702.19b)"
+    );
+    assert_eq!(
+        runner.state().objects[&bodyguard].damage_marked,
+        0,
+        "the untapped Bodyguard must take NO damage from the blocked trampler — its \
+         shield only covers unblocked creatures"
+    );
+}

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4763
-- **Total card appearances across root causes:** 4797 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4761
+- **Total card appearances across root causes:** 4795 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -12,7 +12,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 | # | Root cause | # cards | Fix hint (where it likely lives) |
 |---|------------|--------:|----------------------------------|
-| 1 | Relative-clause / filter restriction on target dropped | 750 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
+| 1 | Relative-clause / filter restriction on target dropped | 748 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
 | 2 | Dropped intervening-if / gating condition (condition: null) | 606 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
 | 3 | Anaphor bound to wrong referent | 404 | oracle_quantity.rs context-ref resolution + game/ability_utils.rs forward_result wiring |
 | 4 | Conjoined / chained second effect clause dropped | 387 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
@@ -47,7 +47,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 ## Full card lists per root cause
 
-### 1. Relative-clause / filter restriction on target dropped  (750 cards)
+### 1. Relative-clause / filter restriction on target dropped  (748 cards)
 
 **Signature.** TargetFilter/affected emitted with empty or missing properties; a trailing restrictive clause (type, subtype, color, mana value, zone, combat/temporal/control predicate, exclusion) is silently dropped, over-broadening the filter.
 
@@ -765,7 +765,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Warpath
 - Wash Away
 - Waste Not
-- Weathered Bodyguards
 - Weathered Runestone
 - Weaver of Harmony
 - West Coast Expansion
@@ -1380,7 +1379,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Verity Circle
 - Vessel of the All-Consuming
 - Vesuvan Drifter
-- Veteran Bodyguard
 - Visage of Bolas
 - Vision, Synthezoid Avenger
 - Visions of Beyond


### PR DESCRIPTION
## Summary
Fixes the "Replacement / prevention / 'instead' effect mis-modeled" misparse for **Veteran Bodyguard** and **Weathered Bodyguards**.

Both cards use the shape "As long as this creature is untapped, all [combat] damage that would be dealt to you [by unblocked creatures] is dealt to this creature instead." The parser was dropping three things: the leading "as long as untapped" condition gate (CR 604.2), the "by unblocked creatures" source-filter restriction (CR 509.1h), and the "combat damage" vs. plain "damage" scope distinction. Net effect before this fix: both cards redirected **all** damage to their controller, unconditionally, regardless of tapped state or source — strictly wrong per their printed text.

`parse_damage_redirection_replacement` (`crates/engine/src/parser/oracle_replacement.rs`) now parses all three, reusing pre-existing types verbatim — no new enum variants or struct fields anywhere, including `types/ability.rs`:
- `ReplacementCondition::SourceTappedState { tapped: bool }` for the tap-gate
- `FilterProp::Unblocked` for the "unblocked creatures" source restriction (via the pre-existing `parse_damage_source_subject_filter` → `parse_type_phrase` → `parse_combat_status_prefix` chain)
- `CombatDamageScope::CombatOnly` for Weathered Bodyguards' "combat damage" scope (via the pre-existing `scan_combat_scope`)

Palisade Giant is deliberately excluded from the source-filter class — its real Oracle text has no "unblocked" restriction — and has its own dedicated regression-guard test proving the exclusion.

Also renamed `strip_as_long_as_prefix_for_prevention` → `strip_as_long_as_condition_prefix`, since it is now shared between the prevention and redirection parsers (it was previously only used by the former).

### Discovered pre-existing bug (out of scope)

While tracing the runtime path, I found that `game/replacement.rs`'s `damage_done_applier` only reads the shield's `redirect_target` field inside its `ShieldKind::Redirection` branch (~line 1190-1193, CR 614.9). This entire card class — Pariah, Palisade Giant, Veteran Bodyguard, Weathered Bodyguards — parses to `ShieldKind::Prevention` with `redirect_target: SelfRef` as a *separate* field. The `ShieldKind::Prevention` branch (~line 1336-1349) never reads `redirect_target` and just returns `ApplyResult::Prevented` (~1382-1383). Net effect: this whole "damage is dealt to X instead" class only ever **prevents** damage to the controller — the "instead" creature never actually takes the redirected damage, can never die from it, and never triggers "dealt damage" abilities off it.

This is real, but it's in shared runtime resolver code affecting multiple already-shipped cards and needs its own dedicated plan+review cycle — it is **not** fixed by this PR, which is scoped to the parser only (tap-gate + source-filter + combat-scope, all upstream of `ShieldKind` dispatch and confirmed live/consumed at the replacement-candidate-eligibility gate regardless of this gap). The new tests document this in code comments and intentionally assert the life-total delta rather than `damage_marked` on the Bodyguard as their discriminator, so they don't silently mask the gap.

## Files changed
- `crates/engine/src/parser/oracle_replacement.rs`
- `crates/engine/tests/integration/main.rs`
- `crates/engine/tests/integration/veteran_bodyguard_tap_redirect.rs` (new)
- `docs/parser-misparse-backlog.md`

## Gate A
```
$ ./scripts/check-parser-combinators.sh
(exit 0, no output — no violations)
```

## Anchored on
- `crates/engine/src/parser/oracle_replacement.rs:8360` — existing `parse_damage_prevention_replacement`, the direct precedent this PR mirrors for adding a leading "as long as" tap-gate to a damage replacement parser.
- `crates/engine/src/parser/oracle_replacement.rs:5937` — existing `parse_damage_source_subject_filter`, reused as-is (not reimplemented) to resolve the "unblocked creatures" source clause via its existing fallthrough to `parse_type_phrase`'s combat-status recognition.
- `crates/engine/src/parser/oracle_replacement.rs:6268` — existing `scan_combat_scope`, reused as-is to resolve the "combat damage" vs. plain "damage" scope distinction for Weathered Bodyguards.

## CR references
- CR 604.2 — static ability's own "as long as" continuous-effect activation gate
- CR 614.9 — damage redirection effects
- CR 509.1h — blocked/unblocked creature definition
- CR 614.1a — "would deal damage... instead" replacement shape
- CR 615.1a — prevent + redirect combination
- CR 510.1c — blocked creature assigns damage to blockers (new trample discriminator test)
- CR 702.19b — trample excess damage assignment (new trample discriminator test)

## Track
Developer

## LLM
Model: claude-sonnet-5
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine --all-targets -- -D warnings` — clean, zero warnings (confirmed post-rebase)
- `./scripts/check-parser-combinators.sh` — clean, exit 0
- `cargo test -p engine --lib` — 16041 passed, 0 failed, 6 ignored (confirmed post-rebase)
- `cargo test -p engine --test integration -- veteran_bodyguard` — 3 passed, 0 failed (confirmed post-rebase): tap-gate positive/negative pair plus a new discriminating test proving a blocked+trampling attacker's excess damage to the defending player is correctly *not* caught by the shield (the "unblocked creatures" source filter axis)
- Independent `/review-impl` — 2 rounds. Round 1 found zero blocking findings but flagged one non-blocking test-coverage gap (the source-filter and combat-scope axes were only proven at the parser-AST level, not through a full combat scenario). Addressed by adding the trample discriminator test. Round 2 (fresh reviewer, fresh context) confirmed clean, independently re-verified all CR citations and traced the new test's production path end-to-end.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
