### PR TITLE
fix(release): stop Windows server build from timing out and cancelling releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -686,7 +686,12 @@ jobs:
     name: Build Server (${{ matrix.os }})
     needs: [resolve-release-ref, tauri-preflight, build-wasm, build-server-binary]
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 35
+    # The Windows leg ran ~33-34 min warm against a 35-min ceiling, so any cache
+    # miss tripped the timeout and cancelled the release (a timed-out job reports
+    # as `cancelled`, which fails the publish job's `build-server == success`
+    # gate). The server-release profile change cuts this well below 35; the
+    # headroom here guards against a cold cache or a slow runner.
+    timeout-minutes: 55
     env:
       RELEASE_TAG: ${{ needs.resolve-release-ref.outputs.release_tag }}
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,10 +49,17 @@ codegen-units = 1
 strip = true
 panic = 'abort'
 
-# Native server: speed over size, unwind so tokio catches per-task panics
+# Native server: speed over size, unwind so tokio catches per-task panics.
+# Overrides release's fat LTO + single codegen unit (those exist for WASM
+# binary size, not native servers): they pushed the Windows release build to
+# ~34 min against the 35-min CI timeout, cancelling the daily release. Thin LTO
+# keeps cross-crate inlining at a fraction of the compile cost, and 16 codegen
+# units parallelize the build.
 [profile.server-release]
 inherits = "release"
 opt-level = 2
+lto = "thin"
+codegen-units = 16
 panic = 'unwind'
 
 # CLI tools (oracle-gen, coverage-report): fast compile, decent runtime


### PR DESCRIPTION
The build-server Windows leg ran ~33-34 min warm against a 35-min CI
timeout; any cache miss tripped it, and a timed-out job reports as
'cancelled', which fails the release job's build-server==success gate and
silently skips the GitHub Release + production deploy. This happened on
most daily releases, requiring manual re-runs.

Root cause: server-release inherited release's fat LTO + codegen-units=1
(those exist for WASM binary size, not native servers). Switch to thin
LTO + 16 codegen units to cut compile time well under the ceiling, and
raise the timeout to 55 min for headroom against a cold cache.
