### PR TITLE
feat(parser): source-anchored combat-relationship subject static (Alms Beast)

### DIFF
--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -44,11 +44,11 @@ mod prelude {
     };
     pub(super) use crate::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, ActivationRestriction,
-        AttachmentKind, BasicLandType, CardPlayMode, ChosenSubtypeKind, Comparator,
-        ContinuousModification, ControllerRef, CostCategory, CountScope, FilterProp, ObjectScope,
-        ParsedCondition, PlayerFilter, PtStat, PtValueScope, QuantityExpr, QuantityRef,
-        SharedQuality, SharedQualityRelation, StaticCondition, StaticDefinition, TargetFilter,
-        TypeFilter, TypedFilter,
+        AttachmentKind, BasicLandType, CardPlayMode, ChosenSubtypeKind, CombatRelation,
+        CombatRelationSubject, Comparator, ContinuousModification, ControllerRef, CostCategory,
+        CountScope, FilterProp, ObjectScope, ParsedCondition, PlayerFilter, PtStat, PtValueScope,
+        QuantityExpr, QuantityRef, SharedQuality, SharedQualityRelation, StaticCondition,
+        StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
     };
     pub(super) use crate::types::card_type::{
         noncreature_subtype_set, CoreType, SubtypeSet, Supertype,

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3055,6 +3055,38 @@ pub(crate) fn parse_continuous_subject_filter(subject: &str) -> Option<TargetFil
         }
     }
 
+    // CR 509.1g / CR 509.1h: strip a trailing "blocking or blocked by ~" /
+    // "blocking or blocked by this creature" combat-relationship qualifier and
+    // attach a source-anchored `FilterProp::CombatRelation` (Alms Beast,
+    // "Creatures blocking or blocked by ~ have lifelink"). The self-reference is
+    // normalized to "~"; "this creature" is accepted for the literal phrasing.
+    // Mirrors the already-parsed target-relative form in `oracle_target`;
+    // `game::filter` evaluates `CombatRelationSubject::Source` authoritatively,
+    // so this is a grammar-only seam.
+    for needle in [
+        " blocking or blocked by ~",
+        " blocking or blocked by this creature",
+    ] {
+        let mut parse_trailing_qualifier = all_consuming(terminated(
+            take_until::<_, _, OracleError<'_>>(needle),
+            tag::<_, _, OracleError<'_>>(needle),
+        ));
+        if let Ok((_, base_lower)) = parse_trailing_qualifier.parse(tp.lower) {
+            if !base_lower.trim().is_empty() {
+                let base = lower_subslice_to_original(&tp, base_lower)?.trim();
+                return parse_continuous_subject_filter(base).map(|f| {
+                    add_property(
+                        f,
+                        FilterProp::CombatRelation {
+                            relation: CombatRelation::BlockingOrBlockedBy,
+                            subject: CombatRelationSubject::Source,
+                        },
+                    )
+                });
+            }
+        }
+    }
+
     if let Some(filter) = parse_shared_controller_compound_subject_filter(&tp) {
         return Some(filter);
     }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -27435,3 +27435,46 @@ fn an_additional_pt_grant_bare_parses() {
         statics[0].condition
     );
 }
+
+/// CR 509.1g / CR 509.1h: Alms Beast — "Creatures blocking or blocked by ~ have
+/// lifelink." The self-relative combat-relationship subject lowers to a
+/// source-anchored `FilterProp::CombatRelation`, and the keyword grant rides on
+/// that filter. Both the normalized self-reference ("~") and the literal "this
+/// creature" phrasing resolve identically.
+#[test]
+fn combat_relation_subject_static_binds_source_anchored_filter() {
+    for line in [
+        "Creatures blocking or blocked by this creature have lifelink.",
+        "Creatures blocking or blocked by ~ have lifelink.",
+    ] {
+        let s = super::shared::parse_static_line_multi(line);
+        assert_eq!(s.len(), 1, "{line:?}: expected one static, got {s:?}");
+        assert!(
+            s[0].modifications
+                .contains(&ContinuousModification::AddKeyword {
+                    keyword: Keyword::Lifelink
+                }),
+            "{line:?}: expected a lifelink grant, got {:?}",
+            s[0].modifications
+        );
+        let props = match &s[0].affected {
+            Some(TargetFilter::Typed(tf)) => {
+                assert_eq!(
+                    tf.type_filters,
+                    vec![TypeFilter::Creature],
+                    "{line:?}: expected a creature subject, got {:?}",
+                    tf.type_filters
+                );
+                &tf.properties
+            }
+            other => panic!("{line:?}: expected a Typed affected filter, got {other:?}"),
+        };
+        assert!(
+            props.contains(&FilterProp::CombatRelation {
+                relation: CombatRelation::BlockingOrBlockedBy,
+                subject: CombatRelationSubject::Source,
+            }),
+            "{line:?}: expected a source-anchored BlockingOrBlockedBy prop, got {props:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

A self-relative combat-relationship subject failed to parse — **Alms Beast**: `Creatures blocking or blocked by ~ have lifelink.` No subject-filter arm recognized the `blocking or blocked by <self>` qualifier, so the whole static line dropped (`static_structure` Unimplemented).

The **target-relative** form (`… blocking or blocked by target creature`) is already parsed in `oracle_target`; only the **self/source-relative static** form was missing.

## Fix

Strip the trailing `blocking or blocked by ~` / `blocking or blocked by this creature` qualifier in `parse_continuous_subject_filter`, parse the base subject recursively, and attach a source-anchored `FilterProp::CombatRelation { relation: BlockingOrBlockedBy, subject: Source }`.

That `FilterProp` (and `CombatRelationSubject::Source`) is **already fully evaluated at runtime** by `game::filter` — so this is a **grammar-only** seam. The self-reference is normalized to `~`; `this creature` is accepted for the literal phrasing. Mirrors the existing merged qualifier-strip pattern in the same function.

## Tests

`combat_relation_subject_static_binds_source_anchored_filter` asserts (typed AST, both `~` and `this creature` forms) that the line produces a single static whose affected filter is a creature subject carrying `FilterProp::CombatRelation { BlockingOrBlockedBy, Source }`, with an `AddKeyword { Lifelink }` grant.

Local: `parser::oracle_static` passes; `cargo fmt`, clippy (`-D warnings`), parser-combinator + engine-authorities gates all clean.