### PR TITLE
fix(release): always build macOS Tauri, shipping an ad-hoc .dmg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -811,40 +811,12 @@ jobs:
         with:
           ref: ${{ env.RELEASE_SHA }}
 
-      - name: Check macOS signing secrets
-        id: macos-signing
-        if: matrix.os == 'macos'
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          set -euo pipefail
-          missing=0
-          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
-            if [ -z "${!name:-}" ]; then
-              echo "::warning::Missing macOS signing secret: ${name}"
-              missing=1
-            fi
-          done
-          if [ "$missing" -ne 0 ]; then
-            echo "::warning::Skipping macOS Tauri build — Apple signing secrets not configured. The .dmg requires notarization to avoid Gatekeeper errors."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-        shell: bash
-
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        if: steps.macos-signing.outputs.skip != 'true'
         with:
           target: wasm32-unknown-unknown
           cache-shared-key: rust-tauri-${{ matrix.os }}
 
       - uses: taiki-e/install-action@v2
-        if: steps.macos-signing.outputs.skip != 'true'
         with:
           tool: wasm-bindgen-cli@0.2.121
 
@@ -855,7 +827,7 @@ jobs:
           echo "$PWD/binaryen-version_123/bin" >> $GITHUB_PATH
 
       - name: Install binaryen (macOS)
-        if: matrix.os == 'macos' && steps.macos-signing.outputs.skip != 'true'
+        if: matrix.os == 'macos'
         run: brew install binaryen
 
       - name: Install binaryen (Windows)
@@ -867,12 +839,10 @@ jobs:
         shell: pwsh
 
       - uses: pnpm/action-setup@v4
-        if: steps.macos-signing.outputs.skip != 'true'
         with:
           version: 9
 
       - uses: actions/setup-node@v4
-        if: steps.macos-signing.outputs.skip != 'true'
         with:
           node-version: 22
           cache: pnpm
@@ -886,21 +856,18 @@ jobs:
           rustup target add x86_64-unknown-linux-musl
 
       - name: Download card data
-        if: steps.macos-signing.outputs.skip != 'true'
         uses: actions/download-artifact@v4
         with:
           name: card-data
           path: client/public
 
       - name: Download frontend data files
-        if: steps.macos-signing.outputs.skip != 'true'
         uses: actions/download-artifact@v4
         with:
           name: frontend-data-files
           path: client/public
 
       - name: Verify Tauri bundled data files
-        if: steps.macos-signing.outputs.skip != 'true'
         run: |
           test -s client/public/card-data.json
           node - <<'NODE'
@@ -915,7 +882,6 @@ jobs:
         shell: bash
 
       - name: Build phase-server sidecar
-        if: steps.macos-signing.outputs.skip != 'true'
         run: |
           if [ "${{ matrix.os }}" = "linux" ]; then
             cargo build --profile server-release --bin phase-server --target x86_64-unknown-linux-musl
@@ -926,7 +892,7 @@ jobs:
         shell: bash
 
       - name: Place sidecar binary (Unix)
-        if: matrix.os != 'windows' && steps.macos-signing.outputs.skip != 'true'
+        if: matrix.os != 'windows'
         run: |
           if [ "${{ matrix.os }}" = "linux" ]; then
             cp target/x86_64-unknown-linux-musl/server-release/phase-server client/src-tauri/binaries/phase-server-${{ matrix.sidecar_triple }}
@@ -940,16 +906,13 @@ jobs:
         shell: pwsh
 
       - name: Build WASM for Tauri
-        if: steps.macos-signing.outputs.skip != 'true'
         run: ./scripts/build-wasm.sh release
         shell: bash
 
       - name: Install frontend dependencies
-        if: steps.macos-signing.outputs.skip != 'true'
         run: cd client && pnpm install --frozen-lockfile
 
       - name: Build Tauri
-        if: steps.macos-signing.outputs.skip != 'true'
         uses: tauri-apps/tauri-action@v0
         env:
           # tauri-action runs beforeBuildCommand (pnpm build) as a child process,
@@ -977,7 +940,6 @@ jobs:
           projectPath: client
 
       - name: Stage Tauri artifacts
-        if: steps.macos-signing.outputs.skip != 'true'
         run: |
           mkdir -p staging
           find client/src-tauri/target/release/bundle \
@@ -990,7 +952,6 @@ jobs:
         shell: bash
 
       - name: Upload Tauri artifact
-        if: steps.macos-signing.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}


### PR DESCRIPTION
The 'Check macOS signing secrets' gate set skip=true whenever any of the
five APPLE_* secrets was missing, and every downstream step was gated on
it — so with no Apple secrets configured the macOS leg did checkout + the
check (~17s), skipped the build, and exited 'success'. No phase-tauri-macos
artifact was ever produced, and the release published silently without a
.dmg.

tauri-action already adapts to whichever signing secrets are present
(sign only if APPLE_CERTIFICATE/APPLE_SIGNING_IDENTITY set, notarize only
if APPLE_ID/APPLE_PASSWORD/APPLE_TEAM_ID set), so the gate was redundant
and harmful. Remove it and let the macOS leg always build: an ad-hoc,
un-notarized .dmg today (users clear Gatekeeper via the xattr -cr line
already documented in the release notes), and an automatically
signed+notarized .dmg if the Apple secrets are ever added.
