### PR TITLE
fix(client): move mobile card-preview Report button to bottom-left

### DIFF
--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -549,7 +549,7 @@ function MobilePreviewOverlay({
             </button>
           )}
           {report && (
-            <div className="absolute right-3 top-3 rounded-full border border-white/20 bg-black/70 px-3 py-1.5 shadow-lg backdrop-blur">
+            <div className="absolute bottom-3 left-3 rounded-full border border-white/20 bg-black/70 px-3 py-1.5 shadow-lg backdrop-blur">
               <ReportCardButton key={report.oracleId || report.name} {...report} />
             </div>
           )}


### PR DESCRIPTION
On the mobile full-screen card overlay, the 'Report a problem' pill was
pinned top-right (right-3 top-3), directly over the card face's printed
mana cost. Move it to bottom-left (bottom-3 left-3) so it no longer
obscures the mana value; bottom-center stays clear of the flip button.
