### PR TITLE
feat(engine): support "conjure a random card from [X] spellbook" (random draft)

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -4094,10 +4094,7 @@ fn rw_effect(
             (p, None)
         }
         Effect::Learn => (ext_write(StateKind::HandLibrary), None),
-        Effect::DraftFromSpellbook {
-            destination: _,
-            tapped: _,
-        } => (ext_write(StateKind::HandLibrary), None),
+        Effect::DraftFromSpellbook { .. } => (ext_write(StateKind::HandLibrary), None),
         Effect::Clash => (ext_write(StateKind::HandLibrary), None),
         Effect::ChooseDrawnThisTurnPayOrTopdeck {
             count,

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1531,10 +1531,7 @@ fn scan_effect(x: &Effect) -> Axes {
             acc = acc.or(scan_quantity_expr(amount));
             acc
         }
-        Effect::DraftFromSpellbook {
-            destination: _,
-            tapped: _,
-        } => Axes::NONE,
+        Effect::DraftFromSpellbook { .. } => Axes::NONE,
         Effect::ChooseCounterAdjustment {
             adjustment: _,
             count,

--- a/crates/engine/src/game/effects/spellbook.rs
+++ b/crates/engine/src/game/effects/spellbook.rs
@@ -15,6 +15,8 @@
 //! source object (`GameObject::spellbook`, copied from
 //! `CardFace::metadata.spellbook`); the resolver reads it from the source.
 
+use rand::Rng;
+
 use crate::types::ability::{
     ConjureCard, ConjureSource, Effect, EffectError, EffectKind, QuantityExpr, ResolvedAbility,
 };
@@ -33,6 +35,7 @@ pub fn resolve(
     let Effect::DraftFromSpellbook {
         destination,
         tapped,
+        random,
     } = &ability.effect
     else {
         return Err(EffectError::MissingParam("DraftFromSpellbook".to_string()));
@@ -53,6 +56,25 @@ pub fn resolve(
             source_id: ability.source_id,
         });
         return Ok(());
+    }
+
+    // "conjure a random card from ~'s spellbook": the engine picks one uniformly at random
+    // and conjures it immediately, instead of pausing for the controller to choose. Random
+    // vs. choice is the only difference from draft-from-spellbook, so both share this
+    // resolver and the same card-creation path (`complete_draft`).
+    if *random {
+        let index = state.rng.random_range(0..spellbook.len());
+        let card = spellbook[index].clone();
+        return complete_draft(
+            state,
+            ability.controller,
+            ability.source_id,
+            &spellbook,
+            &card,
+            *destination,
+            *tapped,
+            events,
+        );
     }
 
     // Digital-only Alchemy spellbook choice: pause for the controller to choose

--- a/crates/engine/src/game/effects/spellbook_tests.rs
+++ b/crates/engine/src/game/effects/spellbook_tests.rs
@@ -19,6 +19,7 @@ fn draft_ability(
         Effect::DraftFromSpellbook {
             destination,
             tapped: false,
+            random: false,
         },
         Vec::new(),
         source,
@@ -181,6 +182,7 @@ fn parser_maps_draft_clauses_to_the_right_destination() {
         Effect::DraftFromSpellbook {
             destination: Zone::Hand,
             tapped: false,
+            random: false,
         }
     ));
     assert!(matches!(
@@ -190,6 +192,7 @@ fn parser_maps_draft_clauses_to_the_right_destination() {
         Effect::DraftFromSpellbook {
             destination: Zone::Battlefield,
             tapped: false,
+            random: false,
         }
     ));
     assert!(matches!(
@@ -197,6 +200,7 @@ fn parser_maps_draft_clauses_to_the_right_destination() {
         Effect::DraftFromSpellbook {
             destination: Zone::Exile,
             tapped: false,
+            random: false,
         }
     ));
 }
@@ -211,6 +215,7 @@ fn parser_honours_the_tapped_rider() {
         Effect::DraftFromSpellbook {
             destination: Zone::Battlefield,
             tapped: true,
+            random: false,
         }
     ));
 }
@@ -258,6 +263,7 @@ fn spellbook_pick_drives_the_draft_and_conjures_the_chosen_card() {
                 Effect::DraftFromSpellbook {
                     destination: Zone::Hand,
                     tapped: false,
+                    random: false,
                 },
             )
             .cost(AbilityCost::Tap),
@@ -298,6 +304,65 @@ fn spellbook_pick_drives_the_draft_and_conjures_the_chosen_card() {
     );
 }
 
+/// Runtime guard for the RANDOM spellbook draft ("conjure a random card from
+/// ~'s spellbook"): unlike the interactive draft it must NOT pause for a pick —
+/// the engine picks from the source's spellbook and conjures immediately. A
+/// single-card spellbook makes the pick deterministic regardless of the RNG.
+/// Reverting the `random` resolver arm re-introduces the `SpellbookDraft` pause,
+/// so resolution would halt there instead of returning to `Priority`, flipping
+/// both assertions.
+#[test]
+fn random_spellbook_draft_conjures_without_pausing() {
+    use crate::game::scenario::GameScenario;
+    use crate::types::ability::{AbilityCost, AbilityDefinition, AbilityKind};
+    use crate::types::phase::Phase;
+
+    let p0 = PlayerId(0);
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(p0, "Alchemist", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::DraftFromSpellbook {
+                    destination: Zone::Hand,
+                    tapped: false,
+                    random: true,
+                },
+            )
+            .cost(AbilityCost::Tap),
+        )
+        .id();
+    let mut runner = scenario.build();
+
+    // Single-card spellbook -> the random pick is deterministic.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&source)
+        .unwrap()
+        .spellbook = vec!["Lion Sash".to_string()];
+
+    // No `.spellbook_pick(..)`: a random draft must resolve without pausing.
+    let outcome = runner.activate(source, 0).resolve();
+
+    let drafted = outcome.state().players[0]
+        .hand
+        .iter()
+        .filter_map(|id| outcome.state().objects.get(id))
+        .any(|o| o.name == "Lion Sash");
+    assert!(
+        drafted,
+        "a random spellbook draft must conjure a card from the list into hand"
+    );
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "a random draft must not pause on SpellbookDraft; got {:?}",
+        outcome.final_waiting_for()
+    );
+}
+
 /// Multi-authority provenance: with two permanents carrying DIFFERENT
 /// spellbooks, activating one must offer ONLY that source's list — proving the
 /// offered options come from the drafting source, not any other permanent.
@@ -316,6 +381,7 @@ fn spellbook_draft_offers_only_the_activated_sources_list() {
             Effect::DraftFromSpellbook {
                 destination: Zone::Hand,
                 tapped: false,
+                random: false,
             },
         )
         .cost(AbilityCost::Tap)

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -8736,6 +8736,7 @@ fn try_parse_spellbook_draft(tp: TextPair) -> Option<Effect> {
         return Some(Effect::DraftFromSpellbook {
             destination: Zone::Hand,
             tapped: false,
+            random: false,
         });
     }
 
@@ -8750,6 +8751,7 @@ fn try_parse_spellbook_draft(tp: TextPair) -> Option<Effect> {
         return tail_done(tail).then_some(Effect::DraftFromSpellbook {
             destination: Zone::Battlefield,
             tapped,
+            random: false,
         });
     }
 
@@ -8759,6 +8761,7 @@ fn try_parse_spellbook_draft(tp: TextPair) -> Option<Effect> {
         return tail_done(tail).then_some(Effect::DraftFromSpellbook {
             destination: Zone::Exile,
             tapped: false,
+            random: false,
         });
     }
 
@@ -8783,9 +8786,19 @@ fn try_parse_spellbook_draft(tp: TextPair) -> Option<Effect> {
 /// is ever narrowed to model the real three-card draft, these conjure-of-your-choice cards
 /// must retain the whole-book choice rather than following it.
 fn try_parse_conjure_from_spellbook(tp: TextPair) -> Option<Effect> {
-    let (rest, _) = tag::<_, _, OracleError<'_>>("conjure a card of your choice from ")
-        .parse(tp.lower)
-        .ok()?;
+    // Two wordings of the same draft-from-spellbook operation: "of your choice" lets the
+    // controller choose (random = false); "a random card" has the engine pick (random = true).
+    let (rest, random) = if let Ok((rest, _)) =
+        tag::<_, _, OracleError<'_>>("conjure a card of your choice from ").parse(tp.lower)
+    {
+        (rest, false)
+    } else if let Ok((rest, _)) =
+        tag::<_, _, OracleError<'_>>("conjure a random card from ").parse(tp.lower)
+    {
+        (rest, true)
+    } else {
+        return None;
+    };
     // Consume the (irrelevant) source-card name up to "spellbook".
     let (after_book, _src) = take_until::<_, _, OracleError<'_>>("spellbook")
         .parse(rest)
@@ -8809,6 +8822,7 @@ fn try_parse_conjure_from_spellbook(tp: TextPair) -> Option<Effect> {
     (tail.is_empty() || tail == ".").then_some(Effect::DraftFromSpellbook {
         destination,
         tapped,
+        random,
     })
 }
 

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -32467,9 +32467,11 @@ fn conjure_of_your_choice_from_spellbook_onto_battlefield() {
         Effect::DraftFromSpellbook {
             destination,
             tapped,
+            random,
         } => {
             assert_eq!(destination, Zone::Battlefield);
             assert!(!tapped);
+            assert!(!random);
         }
         other => panic!("expected DraftFromSpellbook, got: {other:?}"),
     }
@@ -32486,7 +32488,8 @@ fn conjure_of_your_choice_from_spellbook_apostrophe_source() {
         e,
         Effect::DraftFromSpellbook {
             destination: Zone::Battlefield,
-            tapped: false
+            tapped: false,
+            random: false
         }
     ));
 }
@@ -32499,7 +32502,36 @@ fn conjure_of_your_choice_from_spellbook_into_library() {
         e,
         Effect::DraftFromSpellbook {
             destination: Zone::Library,
-            tapped: false
+            tapped: false,
+            random: false
+        }
+    ));
+}
+
+#[test]
+fn conjure_a_random_card_from_spellbook_onto_battlefield() {
+    // "conjure a random card from [X] spellbook" is the engine-picks wording of
+    // draft-from-spellbook: same Effect::DraftFromSpellbook, with random = true.
+    let e = parse_effect("conjure a random card from the Slivers Spellbook onto the battlefield");
+    assert!(matches!(
+        e,
+        Effect::DraftFromSpellbook {
+            destination: Zone::Battlefield,
+            tapped: false,
+            random: true
+        }
+    ));
+}
+
+#[test]
+fn conjure_a_random_card_from_spellbook_into_hand() {
+    let e = parse_effect("conjure a random card from ~'s spellbook into your hand");
+    assert!(matches!(
+        e,
+        Effect::DraftFromSpellbook {
+            destination: Zone::Hand,
+            tapped: false,
+            random: true
         }
     ));
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -12160,6 +12160,8 @@ pub enum Effect {
         destination: Zone,
         #[serde(default)]
         tapped: bool,
+        #[serde(default)]
+        random: bool,
     },
     /// CR 701.55 + CR 608.2d: Inline "[player] chooses/faces [effect A] or
     /// [effect B]" — the configured chooser scope chooses at resolution which


### PR DESCRIPTION
## Summary

The parser recognized "conjure a card of your choice from [X]'s spellbook" (and "draft a card from [X]'s spellbook") → `Effect::DraftFromSpellbook`, but not the engine-picks-at-random wording "conjure a random card from [X]'s spellbook". Both are the same digital-only Alchemy operation; the only difference is who picks — the controller (choice) or the engine (random).

This extends `Effect::DraftFromSpellbook` with a `#[serde(default)] random: bool`:

- **Resolver**: when `random`, pick one card uniformly at random (`state.rng.random_range`, the deterministic `ChaCha20Rng`) and conjure it immediately via the existing `complete_draft`, instead of pausing on `WaitingFor::SpellbookDraft` for a choice. Random-vs-choice is the only difference, so both share the resolver and the same card-creation path.
- **Parser**: the conjure-from-spellbook parser is generalized to accept both wordings — "of your choice" → `random: false`, "a random card" → `random: true` — reusing `parse_conjure_zone` and the fully-consumed-tail discipline.

## Coverage

Closes the `Effect:conjure` single-gap for **10 cards** (supported 31,485 → 31,495), e.g. Tome of the Infinite. Cards whose destination `parse_conjure_zone` does not yet model ("into exile", "into the top five cards of your library at random") correctly fall through to `Unimplemented` rather than parsing to a subtly wrong effect — a separate destination gap.

## Verification

- `cargo fmt --all`; `cargo clippy -p engine --all-targets -- -D warnings` clean
- full `cargo test -p engine` passes (16,043 tests, 0 failures)
- New tests: two parser tests (random onto-the-battlefield, random into-your-hand) and a resolver test (`random_spellbook_draft_conjures_without_pausing`) proving a random draft conjures a card into hand and returns to `Priority` without pausing for a pick
- `cargo coverage` after regenerating card data: the 10 cards flip to `supported`

Model: Claude Opus 4.8
