### PR TITLE
fix(engine): resolve remembered-Accept "may" triggers with no target slot

### DIFF
--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -2325,7 +2325,16 @@ fn ability_has_no_legal_resolution_targets(
     let context_snapshot =
         super::triggers::push_trigger_event_context(state, trigger_event, &trigger_events, None);
     let empty = build_target_slots(state, ability).is_ok_and(|slots| {
-        (ability.effect.target_filter().is_some() && slots.is_empty())
+        // CR 115.1: only effects that DECLARE a target surface a chooseable slot.
+        // `extract_target_filter_from_effect` is the single authority the slot
+        // builder itself uses — it returns `None` not only for context-refs
+        // ("you may draw a card") but for every resolution-time selection
+        // (Sacrifice, at-resolution Bounce, put-from-hand ChangeZone/CastFromZone,
+        // etc.), all of which are ALWAYS resolvable. Testing raw `target_filter()`
+        // here would fork from that authority and silently drop an auto-accepted
+        // "you may put a creature from your hand …" trigger (Kaalia et al.).
+        (super::triggers::extract_target_filter_from_effect(&ability.effect).is_some()
+            && slots.is_empty())
             || (!slots.is_empty() && slots.iter().all(|slot| slot.legal_targets.is_empty()))
     });
     super::triggers::restore_trigger_event_context(state, context_snapshot);
@@ -2955,7 +2964,9 @@ mod tests {
         ResolvedAbility, TargetFilter, TargetRef, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::CoreType;
-    use crate::types::game_state::{MayTriggerOrigin, WaitingFor};
+    use crate::types::game_state::{
+        AutoMayChoice, MayTriggerAutoChoiceKey, MayTriggerOrigin, WaitingFor,
+    };
     use crate::types::identifiers::CardId;
     use crate::types::keywords::Keyword;
     use crate::types::mana::ManaCost;
@@ -2964,6 +2975,50 @@ mod tests {
 
     fn setup() -> GameState {
         GameState::new_two_player(42)
+    }
+
+    /// CR 115.1 + CR 603.3d — regression twin for the "don't ask again → Yes
+    /// silently answers No" bug, covering the stack.rs consumer
+    /// (`optional_ability_is_inert_under_auto_choice` →
+    /// `ability_has_no_legal_resolution_targets`, reached by the on-stack
+    /// inert-noop fast-forward). An auto-ACCEPTED optional ability that surfaces
+    /// no stack-time target slot must NOT be classified inert. The `Sacrifice`
+    /// arm (a non-context-ref filter that `extract_target_filter_from_effect`
+    /// still declines) is the discriminator a context-ref-only guard would drop.
+    #[test]
+    fn auto_accepted_no_target_slot_ability_is_not_inert() {
+        let source_id = ObjectId(100);
+        let origin = MayTriggerOrigin::Printed { trigger_index: 0 };
+        for effect in [
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            Effect::Sacrifice {
+                target: TargetFilter::Typed(TypedFilter::creature()),
+                count: QuantityExpr::Fixed { value: 1 },
+                min_count: 0,
+            },
+        ] {
+            let mut state = setup();
+            let mut ability = ResolvedAbility::new(effect, vec![], source_id, PlayerId(0));
+            ability.optional = true;
+            ability.may_trigger_origin = Some(origin);
+            state.set_may_trigger_auto_choice(
+                MayTriggerAutoChoiceKey {
+                    player: PlayerId(0),
+                    source_id,
+                    origin,
+                },
+                AutoMayChoice::Accept,
+            );
+
+            assert!(
+                !optional_ability_is_inert_under_auto_choice(&mut state, &ability, None),
+                "an auto-accepted ability with no stack-time target slot is always \
+                 resolvable and must not be suppressed as an inert no-op"
+            );
+        }
     }
 
     fn back_face_data(

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3163,7 +3163,17 @@ fn pending_trigger_has_no_legal_resolution_targets(
     );
     let empty = match super::ability_utils::build_target_slots(state, &pending.ability) {
         Ok(slots) => {
-            (pending.ability.effect.target_filter().is_some() && slots.is_empty())
+            // CR 115.1: only effects that DECLARE a target surface a chooseable
+            // slot. `extract_target_filter_from_effect` is the single authority
+            // the slot builder itself uses — it returns `None` not only for
+            // context-refs ("you may draw a card") but for every resolution-time
+            // selection (Sacrifice, at-resolution Bounce, put-from-hand
+            // ChangeZone/CastFromZone, etc.), all of which are ALWAYS resolvable.
+            // Testing raw `target_filter()` here would fork from that authority
+            // and silently drop an auto-accepted "you may put a creature from
+            // your hand …" trigger (Kaalia et al.).
+            (extract_target_filter_from_effect(&pending.ability.effect).is_some()
+                && slots.is_empty())
                 || (!slots.is_empty() && slots.iter().all(|slot| slot.legal_targets.is_empty()))
         }
         Err(_) => true,

--- a/crates/engine/src/game/triggers_dedup_regression_tests.rs
+++ b/crates/engine/src/game/triggers_dedup_regression_tests.rs
@@ -2756,6 +2756,75 @@ fn make_optional_phase_trigger_with_no_legal_target(
     id
 }
 
+/// Helper: install an optional upkeep trigger whose accepted resolution runs
+/// `effect`. Used with effects that surface no stack-time target slot (CR 115.1):
+/// context-refs whose "target" is the controller / "you" (`Effect::Draw`,
+/// `Effect::Token`), and resolution-time selections (`Effect::Sacrifice`). All
+/// are ALWAYS resolvable, so an auto-accepted instance must NOT be suppressed as
+/// inert.
+fn make_optional_phase_trigger_effect(
+    state: &mut GameState,
+    owner: PlayerId,
+    name: &str,
+    effect: Effect,
+) -> ObjectId {
+    let id = make_creature(state, owner, name, 1, 1);
+    let trig_def = TriggerDefinition::new(TriggerMode::Phase)
+        .phase(Phase::Upkeep)
+        .optional()
+        .execute(AbilityDefinition::new(AbilityKind::Database, effect).optional())
+        .description(format!("{name}: at the beginning of upkeep, you may."));
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.trigger_definitions.push(trig_def.clone());
+    std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(trig_def);
+    id
+}
+
+/// A context-ref "you may draw a card" effect (target is the controller).
+fn optional_draw_effect() -> Effect {
+    Effect::Draw {
+        count: QuantityExpr::Fixed { value: 1 },
+        target: TargetFilter::Controller,
+    }
+}
+
+/// A context-ref "you may create a 1/1 token" effect (owner is the controller) —
+/// the Brood Sliver class. Goes through a DIFFERENT `target_filter()` match arm
+/// than `Effect::Draw`, so it independently exercises the context-ref guard.
+fn optional_create_token_effect() -> Effect {
+    Effect::Token {
+        name: "Sliver".into(),
+        power: crate::types::ability::PtValue::Fixed(1),
+        toughness: crate::types::ability::PtValue::Fixed(1),
+        types: vec!["Creature".into()],
+        colors: vec![],
+        keywords: vec![],
+        tapped: false,
+        count: QuantityExpr::Fixed { value: 1 },
+        owner: TargetFilter::Controller,
+        attach_to: None,
+        enters_attacking: false,
+        supertypes: vec![],
+        static_abilities: vec![],
+        enter_with_counters: vec![],
+    }
+}
+
+/// A "you may sacrifice a creature" effect. CR 701.21a: Sacrifice chooses its
+/// permanents at RESOLUTION (via `EffectZoneChoice`), so
+/// `extract_target_filter_from_effect` returns `None` (no stack-time slot) even
+/// though raw `target_filter()` yields a NON-context-ref filter. This is the
+/// discriminator between the single-authority fix and a narrow context-ref-only
+/// guard: only delegating to the slot builder keeps this trigger off the inert
+/// list.
+fn optional_sacrifice_effect() -> Effect {
+    Effect::Sacrifice {
+        target: TargetFilter::Typed(TypedFilter::creature()),
+        count: QuantityExpr::Fixed { value: 1 },
+        min_count: 0,
+    }
+}
+
 /// Read the source IDs of the current stack entries in stack-bottom-to-top
 /// order. Each `StackEntry::source_id` lets the test discriminate which
 /// trigger ended up where.
@@ -2910,6 +2979,76 @@ fn auto_accepted_optional_triggers_without_legal_targets_are_suppressed() {
         state.stack.is_empty(),
         "suppressed inert triggers must not reach the stack"
     );
+}
+
+/// CR 603.3d + CR 115.1 — regression for the "don't ask again → Yes silently
+/// answers No" report. An auto-ACCEPTED optional trigger that surfaces no
+/// stack-time target slot is ALWAYS resolvable, so it MUST reach the stack — it
+/// is not an inert no-op.
+///
+/// The perf refactor (#3917) gated inert-suppression on raw
+/// `target_filter().is_some() && slots.is_empty()`. But `target_filter()` is not
+/// the authority for "surfaces a chooseable slot": `extract_target_filter_from_effect`
+/// is, and it returns `None` for both context-refs (CR 121.1 "you may draw a
+/// card", the controller is never a declared target) AND resolution-time
+/// selections (CR 701.21a "you may sacrifice a creature", chosen during
+/// resolution). All report a `Some(non-context-ref)` from raw `target_filter()`
+/// yet build zero slots, so the gate mistook a remembered Accept for "no legal
+/// targets" and dropped the trigger — indistinguishable from a decline.
+///
+/// Three arms cover the class through THREE distinct `target_filter()`/authority
+/// paths: "you may draw a card" (`Effect::Draw`), Brood Sliver's "you may create
+/// a Sliver token" (`Effect::Token`), and "you may sacrifice a creature"
+/// (`Effect::Sacrifice`). The Sacrifice arm is the discriminator that a
+/// context-ref-only guard would still drop — it forces the fix to delegate to
+/// the slot-builder authority rather than re-derive a subset.
+///
+/// This drives `process_triggers` — the trigger-collection/stack path where the
+/// drop happens — so it cannot be satisfied by the resolution-path coverage in
+/// `effects/mod.rs` (`saved_accept_for_may_trigger_resolves_without_prompt`).
+#[test]
+fn auto_accepted_optional_context_ref_effect_reaches_stack() {
+    for (label, effect) in [
+        ("you may draw a card", optional_draw_effect()),
+        ("you may create a token", optional_create_token_effect()),
+        ("you may sacrifice a creature", optional_sacrifice_effect()),
+    ] {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.phase = Phase::Upkeep;
+        let src = make_optional_phase_trigger_effect(&mut state, PlayerId(0), "Remembered", effect);
+
+        // Player remembered "yes, do it every time" for this trigger.
+        state.set_may_trigger_auto_choice(
+            MayTriggerAutoChoiceKey {
+                player: PlayerId(0),
+                source_id: src,
+                origin: MayTriggerOrigin::Printed { trigger_index: 0 },
+            },
+            AutoMayChoice::Accept,
+        );
+
+        process_triggers(
+            &mut state,
+            &[GameEvent::PhaseChanged {
+                phase: Phase::Upkeep,
+            }],
+        );
+
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }),
+            "[{label}] a single auto-accepted trigger needs no ordering prompt; got {:?}",
+            state.waiting_for
+        );
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "[{label}] an auto-accepted context-ref trigger is always resolvable \
+             (its controller target is never chosen) and must reach the stack — \
+             not be dropped as an inert no-op"
+        );
+    }
 }
 
 /// CR 603.3b: Two genuinely INDISTINGUISHABLE no-input triggers (same


### PR DESCRIPTION
An auto-accepted optional ("you may") trigger whose effect surfaces no
stack-time target slot — "you may draw a card", "you may create a token"
(Brood Sliver), "you may sacrifice a creature", "you may put a creature
from your hand ..." (Kaalia) — was misclassified as an inert no-op and
silently dropped, so "don't ask again -> Yes" behaved like "No".

The inert-noop filter (#3917) gated suppression on raw
Effect::target_filter(), which reports Some(_) for context-refs and
resolution-time selections that never surface a chooseable slot. Delegate
both twinned predicates (stack.rs + triggers.rs) to
extract_target_filter_from_effect -- the single authority the slot builder
itself uses -- so only a genuinely-choosable-but-empty target set counts
as inert. CR 115.1.
