### PR TITLE
Fix Blood Artist each-player sacrifice triggers

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -22,7 +22,8 @@ use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{
     AutoMayChoice, CastOfferKind, ClauseMinimumSnapshot, DayNight, GameState, LKISnapshot,
     MayTriggerAutoChoiceKey, PendingContinuation, PendingCopyTokenBatch,
-    PendingRepeatedOptionalPayment, WaitingFor, ZoneChangeRecord,
+    PendingPlayerScopeSacrificeChoice, PendingRepeatedOptionalPayment, WaitingFor,
+    ZoneChangeRecord,
 };
 use crate::types::identifiers::{ObjectId, TrackedSetId};
 use crate::types::mana::ManaCost;
@@ -5491,6 +5492,278 @@ fn mark_exile_choice_tracks_by_source(state: &mut GameState, source: ObjectId) {
     }
 }
 
+struct PlayerScopeSacrificePrompt {
+    player: PlayerId,
+    cards: Vec<ObjectId>,
+    count: usize,
+    min_count: usize,
+    up_to: bool,
+}
+
+enum PlayerScopeSacrificeStep {
+    Noop,
+    Auto {
+        player: PlayerId,
+        cards: Vec<ObjectId>,
+    },
+    Prompt(PlayerScopeSacrificePrompt),
+}
+
+pub(crate) enum PendingPlayerScopeSacrificeOutcome {
+    WaitingForNextChoice,
+    Completed {
+        events_before_sacrifice: usize,
+        events_after_sacrifice: usize,
+    },
+}
+
+fn scoped_player_sacrifice_ability(
+    template: &ResolvedAbility,
+    original_controller: PlayerId,
+    player: PlayerId,
+) -> ResolvedAbility {
+    let mut scoped = template.clone();
+    scoped.set_original_controller_recursive(original_controller);
+    scoped.set_controller_recursive(player);
+    scoped.set_scoped_player_recursive(player);
+    scoped
+}
+
+fn player_scope_sacrifice_step(
+    state: &mut GameState,
+    template: &ResolvedAbility,
+    original_controller: PlayerId,
+    player: PlayerId,
+) -> PlayerScopeSacrificeStep {
+    let scoped = scoped_player_sacrifice_ability(template, original_controller, player);
+    let Effect::Sacrifice {
+        target,
+        count,
+        min_count,
+    } = &scoped.effect
+    else {
+        return PlayerScopeSacrificeStep::Noop;
+    };
+    let (count_expr, up_to) = count.peel_up_to();
+    let count = crate::game::quantity::resolve_quantity_with_targets(state, count_expr, &scoped)
+        .max(0) as usize;
+    if count == 0 {
+        return PlayerScopeSacrificeStep::Noop;
+    }
+
+    let ctx = crate::game::filter::FilterContext::from_ability(&scoped);
+    let eligible: Vec<ObjectId> = state
+        .battlefield
+        .iter()
+        .copied()
+        .filter(|id| {
+            state.objects.get(id).is_some_and(|obj| {
+                obj.controller == player
+                    && !obj.is_emblem
+                    && crate::game::filter::matches_target_filter(state, *id, target, &ctx)
+                    && !crate::game::static_abilities::triggered_cause_sacrifice_or_exile_muzzled(
+                        state, &scoped, *id, player,
+                    )
+            })
+        })
+        .collect();
+
+    if eligible.is_empty() {
+        if !up_to {
+            state.cost_payment_failed_flag = true;
+        }
+        return PlayerScopeSacrificeStep::Noop;
+    }
+
+    if !up_to && eligible.len() <= count {
+        return PlayerScopeSacrificeStep::Auto {
+            player,
+            cards: eligible,
+        };
+    }
+
+    let choice_count = count.min(eligible.len());
+    PlayerScopeSacrificeStep::Prompt(PlayerScopeSacrificePrompt {
+        player,
+        cards: eligible,
+        count: choice_count,
+        min_count: (*min_count).min(choice_count),
+        up_to,
+    })
+}
+
+fn set_player_scope_sacrifice_waiting_for(
+    state: &mut GameState,
+    prompt: PlayerScopeSacrificePrompt,
+    source_id: ObjectId,
+) {
+    state.waiting_for = WaitingFor::EffectZoneChoice {
+        player: prompt.player,
+        cards: prompt.cards,
+        count: prompt.count,
+        min_count: prompt.min_count,
+        up_to: prompt.up_to,
+        source_id,
+        effect_kind: EffectKind::Sacrifice,
+        zone: Zone::Battlefield,
+        destination: None,
+        enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+        enter_transformed: false,
+        enters_under_player: None,
+        enters_attacking: false,
+        owner_library: false,
+        track_exiled_by_source: false,
+        face_down_profile: None,
+        enter_with_counters: vec![],
+        conditional_enter_with_counters: vec![],
+        count_param: 0,
+        library_position: None,
+        is_cost_payment: false,
+        enters_modified_if: None,
+    };
+}
+
+fn perform_player_scope_sacrifices(
+    state: &mut GameState,
+    source_id: ObjectId,
+    selections: Vec<(PlayerId, Vec<ObjectId>)>,
+    events: &mut Vec<GameEvent>,
+) -> Result<(usize, usize), EffectError> {
+    let events_before_sacrifice = events.len();
+    let mut all_chosen = Vec::new();
+    let mut sacrificed = 0;
+
+    // CR 101.4 + CR 701.21a: after every player has made the required APNAP
+    // choice, the chosen permanents are moved to their owners' graveyards as
+    // one simultaneous sacrifice instruction.
+    for (player, cards) in selections {
+        for card in cards {
+            all_chosen.push(card);
+            match crate::game::sacrifice::sacrifice_permanent(state, card, player, events)
+                .map_err(|error| EffectError::InvalidParam(error.to_string()))?
+            {
+                crate::game::sacrifice::SacrificeOutcome::Complete => sacrificed += 1,
+                crate::game::sacrifice::SacrificeOutcome::NeedsReplacementChoice(choice_player) => {
+                    state.waiting_for = crate::game::replacement::replacement_choice_waiting_for(
+                        choice_player,
+                        state,
+                    );
+                    return Ok((events_before_sacrifice, events.len()));
+                }
+            }
+        }
+    }
+
+    crate::game::zones::mark_simultaneous_departures(
+        &mut events[events_before_sacrifice..],
+        &crate::game::zones::departed_subset(state, &all_chosen),
+    );
+    state.last_effect_count = Some(sacrificed);
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::Sacrifice,
+        source_id,
+    });
+    let events_after_sacrifice = events.len();
+
+    let mut ids: Vec<ObjectId> = events[events_before_sacrifice..events_after_sacrifice]
+        .iter()
+        .filter_map(|event| match event {
+            GameEvent::ZoneChanged { object_id, .. }
+            | GameEvent::PermanentSacrificed { object_id, .. } => Some(*object_id),
+            _ => None,
+        })
+        .collect();
+    ids.sort_unstable_by_key(|id| id.0);
+    ids.dedup();
+    state.last_zone_changed_ids = ids;
+
+    Ok((events_before_sacrifice, events_after_sacrifice))
+}
+
+fn should_collect_player_scope_sacrifice_choices(ability: &ResolvedAbility) -> bool {
+    matches!(ability.effect, Effect::Sacrifice { .. }) && ability.sub_ability.is_none()
+}
+
+fn start_player_scope_sacrifice_choices(
+    state: &mut GameState,
+    template: &ResolvedAbility,
+    original_controller: PlayerId,
+    matching_players: &[PlayerId],
+    after_scope: Option<Box<ResolvedAbility>>,
+    events: &mut Vec<GameEvent>,
+    depth: u32,
+) -> Result<(), EffectError> {
+    let mut selections = Vec::new();
+    for (i, player) in matching_players.iter().copied().enumerate() {
+        match player_scope_sacrifice_step(state, template, original_controller, player) {
+            PlayerScopeSacrificeStep::Noop => {}
+            PlayerScopeSacrificeStep::Auto { player, cards } => selections.push((player, cards)),
+            PlayerScopeSacrificeStep::Prompt(prompt) => {
+                if let Some(after_scope) = after_scope {
+                    append_to_pending_continuation(state, Some(after_scope));
+                }
+                state.pending_player_scope_sacrifice_choice =
+                    Some(PendingPlayerScopeSacrificeChoice {
+                        ability: Box::new(template.clone()),
+                        remaining_players: matching_players[i + 1..].to_vec(),
+                        selections,
+                    });
+                set_player_scope_sacrifice_waiting_for(state, prompt, template.source_id);
+                return Ok(());
+            }
+        }
+    }
+
+    let _ = perform_player_scope_sacrifices(state, template.source_id, selections, events)?;
+    if let Some(after_scope) = after_scope {
+        resolve_ability_chain(state, &after_scope, events, depth + 1)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn advance_pending_player_scope_sacrifice_choice(
+    state: &mut GameState,
+    player: PlayerId,
+    chosen: &[ObjectId],
+    events: &mut Vec<GameEvent>,
+) -> Result<PendingPlayerScopeSacrificeOutcome, EffectError> {
+    let Some(mut pending) = state.pending_player_scope_sacrifice_choice.take() else {
+        return Ok(PendingPlayerScopeSacrificeOutcome::WaitingForNextChoice);
+    };
+    let original_controller = pending.ability.controller;
+    if !chosen.is_empty() {
+        pending.selections.push((player, chosen.to_vec()));
+    }
+
+    while let Some(next_player) = pending.remaining_players.first().copied() {
+        pending.remaining_players.remove(0);
+        match player_scope_sacrifice_step(state, &pending.ability, original_controller, next_player)
+        {
+            PlayerScopeSacrificeStep::Noop => {}
+            PlayerScopeSacrificeStep::Auto { player, cards } => {
+                pending.selections.push((player, cards));
+            }
+            PlayerScopeSacrificeStep::Prompt(prompt) => {
+                let source_id = pending.ability.source_id;
+                state.pending_player_scope_sacrifice_choice = Some(pending);
+                set_player_scope_sacrifice_waiting_for(state, prompt, source_id);
+                return Ok(PendingPlayerScopeSacrificeOutcome::WaitingForNextChoice);
+            }
+        }
+    }
+
+    let (events_before_sacrifice, events_after_sacrifice) = perform_player_scope_sacrifices(
+        state,
+        pending.ability.source_id,
+        pending.selections,
+        events,
+    )?;
+    Ok(PendingPlayerScopeSacrificeOutcome::Completed {
+        events_before_sacrifice,
+        events_after_sacrifice,
+    })
+}
+
 /// Resolve an ability and follow its sub_ability chain using typed nested structs.
 /// No SVar lookup, no parse_ability(). The depth is bounded by the data structure.
 pub fn resolve_ability_chain(
@@ -6089,6 +6362,19 @@ fn resolve_chain_body(
         let after_scope_needs_linked_exile = after_scope.as_ref().is_some_and(|tail| {
             crate::game::exile_links::ability_contains_linked_exile_consumer(tail)
         });
+
+        if should_collect_player_scope_sacrifice_choices(&scoped_template) {
+            start_player_scope_sacrifice_choices(
+                state,
+                &scoped_template,
+                controller,
+                &matching_players,
+                after_scope,
+                events,
+                depth,
+            )?;
+            return Ok(());
+        }
 
         let initial_waiting_for = state.waiting_for.clone();
         let mut paused = false;

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5511,6 +5511,15 @@ enum PlayerScopeSacrificeStep {
 
 pub(crate) enum PendingPlayerScopeSacrificeOutcome {
     WaitingForNextChoice,
+    PausedForReplacement,
+    Completed {
+        events_before_sacrifice: usize,
+        events_after_sacrifice: usize,
+    },
+}
+
+enum PlayerScopeSacrificePerformOutcome {
+    PausedForReplacement,
     Completed {
         events_before_sacrifice: usize,
         events_after_sacrifice: usize,
@@ -5535,6 +5544,7 @@ fn player_scope_sacrifice_step(
     original_controller: PlayerId,
     player: PlayerId,
 ) -> PlayerScopeSacrificeStep {
+    // CR 701.21a: a player can sacrifice only a permanent they control.
     let scoped = scoped_player_sacrifice_ability(template, original_controller, player);
     let Effect::Sacrifice {
         target,
@@ -5569,9 +5579,6 @@ fn player_scope_sacrifice_step(
         .collect();
 
     if eligible.is_empty() {
-        if !up_to {
-            state.cost_payment_failed_flag = true;
-        }
         return PlayerScopeSacrificeStep::Noop;
     }
 
@@ -5625,30 +5632,44 @@ fn set_player_scope_sacrifice_waiting_for(
 
 fn perform_player_scope_sacrifices(
     state: &mut GameState,
-    source_id: ObjectId,
-    selections: Vec<(PlayerId, Vec<ObjectId>)>,
+    ability: &ResolvedAbility,
+    mut selections: Vec<(PlayerId, Vec<ObjectId>)>,
     events: &mut Vec<GameEvent>,
-) -> Result<(usize, usize), EffectError> {
+) -> Result<PlayerScopeSacrificePerformOutcome, EffectError> {
     let events_before_sacrifice = events.len();
     let mut all_chosen = Vec::new();
     let mut sacrificed = 0;
 
-    // CR 101.4 + CR 701.21a: after every player has made the required APNAP
-    // choice, the chosen permanents are moved to their owners' graveyards as
-    // one simultaneous sacrifice instruction.
-    for (player, cards) in selections {
-        for card in cards {
+    // CR 101.4: after every player has made the required APNAP choice, the
+    // chosen permanents are moved as one simultaneous instruction.
+    // CR 701.21a: to sacrifice a permanent, its controller moves it from the
+    // battlefield to its owner's graveyard.
+    while !selections.is_empty() {
+        let (player, mut cards) = selections.remove(0);
+        while !cards.is_empty() {
+            let card = cards.remove(0);
             all_chosen.push(card);
             match crate::game::sacrifice::sacrifice_permanent(state, card, player, events)
                 .map_err(|error| EffectError::InvalidParam(error.to_string()))?
             {
                 crate::game::sacrifice::SacrificeOutcome::Complete => sacrificed += 1,
                 crate::game::sacrifice::SacrificeOutcome::NeedsReplacementChoice(choice_player) => {
+                    if !cards.is_empty() {
+                        selections.insert(0, (player, cards));
+                    }
+                    if !selections.is_empty() {
+                        state.pending_player_scope_sacrifice_choice =
+                            Some(PendingPlayerScopeSacrificeChoice {
+                                ability: Box::new(ability.clone()),
+                                remaining_players: vec![],
+                                selections,
+                            });
+                    }
                     state.waiting_for = crate::game::replacement::replacement_choice_waiting_for(
                         choice_player,
                         state,
                     );
-                    return Ok((events_before_sacrifice, events.len()));
+                    return Ok(PlayerScopeSacrificePerformOutcome::PausedForReplacement);
                 }
             }
         }
@@ -5661,7 +5682,7 @@ fn perform_player_scope_sacrifices(
     state.last_effect_count = Some(sacrificed);
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::Sacrifice,
-        source_id,
+        source_id: ability.source_id,
     });
     let events_after_sacrifice = events.len();
 
@@ -5677,7 +5698,10 @@ fn perform_player_scope_sacrifices(
     ids.dedup();
     state.last_zone_changed_ids = ids;
 
-    Ok((events_before_sacrifice, events_after_sacrifice))
+    Ok(PlayerScopeSacrificePerformOutcome::Completed {
+        events_before_sacrifice,
+        events_after_sacrifice,
+    })
 }
 
 fn should_collect_player_scope_sacrifice_choices(ability: &ResolvedAbility) -> bool {
@@ -5693,6 +5717,8 @@ fn start_player_scope_sacrifice_choices(
     events: &mut Vec<GameEvent>,
     depth: u32,
 ) -> Result<(), EffectError> {
+    // CR 101.4: If multiple players make choices for one instruction, choices
+    // are announced in APNAP order before the simultaneous action happens.
     let mut selections = Vec::new();
     for (i, player) in matching_players.iter().copied().enumerate() {
         match player_scope_sacrifice_step(state, template, original_controller, player) {
@@ -5714,9 +5740,13 @@ fn start_player_scope_sacrifice_choices(
         }
     }
 
-    let _ = perform_player_scope_sacrifices(state, template.source_id, selections, events)?;
-    if let Some(after_scope) = after_scope {
-        resolve_ability_chain(state, &after_scope, events, depth + 1)?;
+    match perform_player_scope_sacrifices(state, template, selections, events)? {
+        PlayerScopeSacrificePerformOutcome::PausedForReplacement => {}
+        PlayerScopeSacrificePerformOutcome::Completed { .. } => {
+            if let Some(after_scope) = after_scope {
+                resolve_ability_chain(state, &after_scope, events, depth + 1)?;
+            }
+        }
     }
     Ok(())
 }
@@ -5727,6 +5757,8 @@ pub(crate) fn advance_pending_player_scope_sacrifice_choice(
     chosen: &[ObjectId],
     events: &mut Vec<GameEvent>,
 ) -> Result<PendingPlayerScopeSacrificeOutcome, EffectError> {
+    // CR 101.4: Resume the APNAP choice walk until every player has chosen or a
+    // nested replacement choice pauses the simultaneous action.
     let Some(mut pending) = state.pending_player_scope_sacrifice_choice.take() else {
         return Ok(PendingPlayerScopeSacrificeOutcome::WaitingForNextChoice);
     };
@@ -5752,16 +5784,41 @@ pub(crate) fn advance_pending_player_scope_sacrifice_choice(
         }
     }
 
-    let (events_before_sacrifice, events_after_sacrifice) = perform_player_scope_sacrifices(
-        state,
-        pending.ability.source_id,
-        pending.selections,
-        events,
-    )?;
-    Ok(PendingPlayerScopeSacrificeOutcome::Completed {
-        events_before_sacrifice,
-        events_after_sacrifice,
-    })
+    match perform_player_scope_sacrifices(state, &pending.ability, pending.selections, events)? {
+        PlayerScopeSacrificePerformOutcome::PausedForReplacement => {
+            Ok(PendingPlayerScopeSacrificeOutcome::PausedForReplacement)
+        }
+        PlayerScopeSacrificePerformOutcome::Completed {
+            events_before_sacrifice,
+            events_after_sacrifice,
+        } => Ok(PendingPlayerScopeSacrificeOutcome::Completed {
+            events_before_sacrifice,
+            events_after_sacrifice,
+        }),
+    }
+}
+
+pub(crate) fn drain_pending_player_scope_sacrifice_after_replacement(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<PendingPlayerScopeSacrificeOutcome, EffectError> {
+    // CR 101.4: After a CR 616.1 replacement choice resumes one selected
+    // sacrifice, continue the remaining already-announced simultaneous action.
+    let Some(pending) = state.pending_player_scope_sacrifice_choice.take() else {
+        return Ok(PendingPlayerScopeSacrificeOutcome::WaitingForNextChoice);
+    };
+    match perform_player_scope_sacrifices(state, &pending.ability, pending.selections, events)? {
+        PlayerScopeSacrificePerformOutcome::PausedForReplacement => {
+            Ok(PendingPlayerScopeSacrificeOutcome::PausedForReplacement)
+        }
+        PlayerScopeSacrificePerformOutcome::Completed {
+            events_before_sacrifice,
+            events_after_sacrifice,
+        } => Ok(PendingPlayerScopeSacrificeOutcome::Completed {
+            events_before_sacrifice,
+            events_after_sacrifice,
+        }),
+    }
 }
 
 /// Resolve an ability and follow its sub_ability chain using typed nested structs.

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -822,6 +822,28 @@ pub(super) fn handle_replacement_choice(
                 }
             }
 
+            if matches!(waiting_for, WaitingFor::Priority { .. })
+                && state.pending_player_scope_sacrifice_choice.is_some()
+            {
+                // CR 101.4: a simultaneous each-player sacrifice paused by a
+                // CR 616.1 replacement choice resumes the already-announced
+                // remaining sacrifices before any parked continuation can run.
+                match effects::drain_pending_player_scope_sacrifice_after_replacement(state, events)
+                    .map_err(|error| EngineError::InvalidAction(error.to_string()))?
+                {
+                    effects::PendingPlayerScopeSacrificeOutcome::WaitingForNextChoice => {}
+                    effects::PendingPlayerScopeSacrificeOutcome::PausedForReplacement => {
+                        waiting_for = state.waiting_for.clone();
+                    }
+                    effects::PendingPlayerScopeSacrificeOutcome::Completed { .. } => {
+                        effects::drain_pending_continuation(state, events);
+                        if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+                            waiting_for = state.waiting_for.clone();
+                        }
+                    }
+                }
+            }
+
             // CR 101.4 + CR 616.1: An `EachPlayerCopyChosen` per-player step
             // paused on a replacement choice for its inner token copy or its
             // +1/+1 counter placement. Both primitives drained above (copy at the

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -3193,12 +3193,20 @@ pub(super) fn handle_resolution_choice(
             if matches!(effect_kind, EffectKind::Sacrifice)
                 && state.pending_player_scope_sacrifice_choice.is_some()
             {
+                // CR 101.4: If multiple players make choices for one
+                // instruction, collect those choices before the simultaneous
+                // sacrifice action happens.
                 let outcome = effects::advance_pending_player_scope_sacrifice_choice(
                     state, player, &chosen, events,
                 )
                 .map_err(|error| EngineError::InvalidAction(error.to_string()))?;
                 match outcome {
                     effects::PendingPlayerScopeSacrificeOutcome::WaitingForNextChoice => {
+                        return Ok(ResolutionChoiceOutcome::WaitingFor(
+                            state.waiting_for.clone(),
+                        ));
+                    }
+                    effects::PendingPlayerScopeSacrificeOutcome::PausedForReplacement => {
                         return Ok(ResolutionChoiceOutcome::WaitingFor(
                             state.waiting_for.clone(),
                         ));

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -3190,6 +3190,40 @@ pub(super) fn handle_resolution_choice(
                 let _ = state.devour_eligible_snapshot.take();
             }
 
+            if matches!(effect_kind, EffectKind::Sacrifice)
+                && state.pending_player_scope_sacrifice_choice.is_some()
+            {
+                let outcome = effects::advance_pending_player_scope_sacrifice_choice(
+                    state, player, &chosen, events,
+                )
+                .map_err(|error| EngineError::InvalidAction(error.to_string()))?;
+                match outcome {
+                    effects::PendingPlayerScopeSacrificeOutcome::WaitingForNextChoice => {
+                        return Ok(ResolutionChoiceOutcome::WaitingFor(
+                            state.waiting_for.clone(),
+                        ));
+                    }
+                    effects::PendingPlayerScopeSacrificeOutcome::Completed {
+                        events_before_sacrifice,
+                        events_after_sacrifice,
+                    } => {
+                        set_priority(state, player);
+                        resume_with_error_propagation(state, events)?;
+                        if let Some(outcome) = batch_or_drain_observer_triggers(
+                            state,
+                            events,
+                            events_before_sacrifice,
+                            events_after_sacrifice,
+                        ) {
+                            return Ok(outcome);
+                        }
+                        return Ok(ResolutionChoiceOutcome::WaitingFor(
+                            state.waiting_for.clone(),
+                        ));
+                    }
+                }
+            }
+
             if chosen.is_empty() && matches!(effect_kind, EffectKind::CastFromZone) {
                 // CR 609.1 / CR 601.2a: Declining an optional
                 // Electrodominance-style hand cast consumes the stashed

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1370,9 +1370,12 @@ pub struct PendingPerPlayerZoneChoice {
     pub accumulated: bool,
 }
 
-/// CR 101.4 + CR 701.21a: Per-player sacrifice choices for one simultaneous
-/// instruction such as "each player sacrifices a creature." Players choose in
-/// APNAP order, then all chosen permanents are sacrificed together.
+/// CR 101.4: If players make choices for one instruction, they choose in
+/// APNAP order before the simultaneous action happens.
+/// CR 701.21a: To sacrifice a permanent, its controller moves it from the
+/// battlefield to its owner's graveyard.
+/// Per-player sacrifice choices for one simultaneous instruction such as
+/// "each player sacrifices a creature."
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PendingPlayerScopeSacrificeChoice {
     /// The scoped sacrifice ability template. The current chooser is rebound
@@ -7683,10 +7686,12 @@ pub struct GameState {
     /// tracked set before "put those cards onto the battlefield" resolves.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_per_player_zone_choice: Option<PendingPerPlayerZoneChoice>,
-    /// CR 101.4 + CR 701.21a: Per-player sacrifice choices paused by the
-    /// current player's `EffectZoneChoice`. Drained by the choice handler before
-    /// normal `pending_continuation` so all choices are known before any
-    /// permanent is moved.
+    /// CR 101.4: If players make choices for one instruction, they choose in
+    /// APNAP order before the simultaneous action happens.
+    /// CR 701.21a: To sacrifice a permanent, its controller moves it from the
+    /// battlefield to its owner's graveyard.
+    /// Per-player sacrifice choices paused by the current player's
+    /// `EffectZoneChoice`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_player_scope_sacrifice_choice: Option<PendingPlayerScopeSacrificeChoice>,
     /// CR 608.2c + CR 105.1 / CR 205.2a: Per-category-member

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1370,6 +1370,21 @@ pub struct PendingPerPlayerZoneChoice {
     pub accumulated: bool,
 }
 
+/// CR 101.4 + CR 701.21a: Per-player sacrifice choices for one simultaneous
+/// instruction such as "each player sacrifices a creature." Players choose in
+/// APNAP order, then all chosen permanents are sacrificed together.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PendingPlayerScopeSacrificeChoice {
+    /// The scoped sacrifice ability template. The current chooser is rebound
+    /// onto a clone before each prompt is built.
+    pub ability: Box<ResolvedAbility>,
+    /// Players not yet prompted, in APNAP order.
+    pub remaining_players: Vec<PlayerId>,
+    /// Already collected choices, paired with the player who will sacrifice
+    /// those permanents once all choices are known.
+    pub selections: Vec<(PlayerId, Vec<ObjectId>)>,
+}
+
 /// CR 608.2c + CR 105.1 / CR 205.2a: Per-category-member
 /// `Effect::ForEachCategoryExile` iteration paused by the current member's
 /// interactive choice. Mirrors [`PendingPerPlayerZoneChoice`], but the
@@ -7668,6 +7683,12 @@ pub struct GameState {
     /// tracked set before "put those cards onto the battlefield" resolves.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_per_player_zone_choice: Option<PendingPerPlayerZoneChoice>,
+    /// CR 101.4 + CR 701.21a: Per-player sacrifice choices paused by the
+    /// current player's `EffectZoneChoice`. Drained by the choice handler before
+    /// normal `pending_continuation` so all choices are known before any
+    /// permanent is moved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_player_scope_sacrifice_choice: Option<PendingPlayerScopeSacrificeChoice>,
     /// CR 608.2c + CR 105.1 / CR 205.2a: Per-category-member
     /// `Effect::ForEachCategoryExile` iteration paused by the current member's
     /// interactive choice ("for each color/card type, you may exile a card of
@@ -8934,6 +8955,7 @@ impl GameState {
             pending_choose_one_of: None,
             pending_vote_ballot_iteration: None,
             pending_per_player_zone_choice: None,
+            pending_player_scope_sacrifice_choice: None,
             pending_per_category_zone_choice: None,
             pending_counter_moves: None,
             pending_counter_removals: None,
@@ -9632,6 +9654,8 @@ impl PartialEq for GameState {
             && self.pending_choose_one_of == other.pending_choose_one_of
             && self.pending_vote_ballot_iteration == other.pending_vote_ballot_iteration
             && self.pending_per_player_zone_choice == other.pending_per_player_zone_choice
+            && self.pending_player_scope_sacrifice_choice
+                == other.pending_player_scope_sacrifice_choice
             && self.pending_counter_moves == other.pending_counter_moves
             && self.pending_counter_removals == other.pending_counter_removals
             && self.pending_batch_deliveries == other.pending_batch_deliveries

--- a/crates/engine/tests/integration/issue_4752_blood_artist_each_player_sacrifice.rs
+++ b/crates/engine/tests/integration/issue_4752_blood_artist_each_player_sacrifice.rs
@@ -1,0 +1,147 @@
+//! Regression for issue #4752: each-player sacrifice choices are announced
+//! first, then the selected permanents are sacrificed simultaneously.
+//!
+//! CR 101.4: If players make choices and then take actions, APNAP choices are
+//! announced first and then the actions happen simultaneously.
+//! CR 603.10a: Leaves-the-battlefield triggers use the game state before the
+//! event to determine whether they trigger.
+//! CR 701.21a: To sacrifice a permanent, its controller moves it from the
+//! battlefield to its owner's graveyard.
+
+use engine::game::effects::resolve_ability_chain;
+use engine::game::engine::apply_as_current;
+use engine::game::triggers::drain_order_triggers_with_identity;
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, PlayerFilter, QuantityExpr, ResolvedAbility,
+    TargetFilter, TriggerDefinition, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+fn make_creature(state: &mut GameState, card: u64, controller: PlayerId, name: &str) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(card),
+        controller,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.base_power = Some(1);
+    obj.base_toughness = Some(1);
+    obj.power = Some(1);
+    obj.toughness = Some(1);
+    id
+}
+
+fn install_blood_artist_like_trigger(state: &mut GameState, source: ObjectId) {
+    let trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
+        .origin(Zone::Battlefield)
+        .destination(Zone::Graveyard)
+        .valid_card(TargetFilter::Typed(TypedFilter::creature()))
+        .execute(AbilityDefinition::new(
+            AbilityKind::Database,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+        ));
+
+    let obj = state.objects.get_mut(&source).unwrap();
+    obj.trigger_definitions.push(trigger.clone());
+    std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(trigger);
+}
+
+#[test]
+fn blood_artist_observes_each_creature_in_simultaneous_each_player_sacrifice() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+    state.priority_player = PlayerId(0);
+    state.players[0].life = 20;
+
+    let blood_artist = make_creature(&mut state, 10, PlayerId(0), "Blood Artist");
+    let decoy = make_creature(&mut state, 11, PlayerId(0), "Decoy");
+    let opp_a = make_creature(&mut state, 20, PlayerId(1), "Opponent Creature A");
+    let opp_b = make_creature(&mut state, 21, PlayerId(1), "Opponent Creature B");
+    install_blood_artist_like_trigger(&mut state, blood_artist);
+
+    let mut ability = ResolvedAbility::new(
+        Effect::Sacrifice {
+            target: TargetFilter::Typed(TypedFilter::creature()),
+            count: QuantityExpr::Fixed { value: 1 },
+            min_count: 0,
+        },
+        vec![],
+        ObjectId(100),
+        PlayerId(0),
+    );
+    ability.player_scope = Some(PlayerFilter::All);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    match &state.waiting_for {
+        WaitingFor::EffectZoneChoice { player, cards, .. } => {
+            assert_eq!(*player, PlayerId(0));
+            assert!(cards.contains(&blood_artist));
+            assert!(cards.contains(&decoy));
+        }
+        other => panic!("expected P0 sacrifice choice, got {other:?}"),
+    }
+
+    apply_as_current(
+        &mut state,
+        GameAction::SelectCards {
+            cards: vec![blood_artist],
+        },
+    )
+    .expect("P0 chooses Blood Artist");
+
+    assert_eq!(
+        state.objects[&blood_artist].zone,
+        Zone::Battlefield,
+        "the first player's choice must be announced before the simultaneous \
+         sacrifice action happens"
+    );
+
+    match &state.waiting_for {
+        WaitingFor::EffectZoneChoice { player, cards, .. } => {
+            assert_eq!(*player, PlayerId(1));
+            assert!(cards.contains(&opp_a));
+            assert!(cards.contains(&opp_b));
+        }
+        other => panic!("expected P1 sacrifice choice, got {other:?}"),
+    }
+
+    apply_as_current(&mut state, GameAction::SelectCards { cards: vec![opp_a] })
+        .expect("P1 chooses a creature");
+
+    for _ in 0..20 {
+        match &state.waiting_for {
+            WaitingFor::OrderTriggers { .. } => {
+                drain_order_triggers_with_identity(&mut state);
+            }
+            WaitingFor::Priority { .. } if state.stack.is_empty() => break,
+            WaitingFor::Priority { .. } => {
+                apply_as_current(&mut state, GameAction::PassPriority)
+                    .expect("resolve Blood Artist trigger");
+            }
+            other => panic!("unexpected waiting_for while resolving triggers: {other:?}"),
+        }
+    }
+
+    assert_eq!(state.objects[&blood_artist].zone, Zone::Graveyard);
+    assert_eq!(state.objects[&opp_a].zone, Zone::Graveyard);
+    assert_eq!(
+        state.players[0].life, 22,
+        "Blood Artist must observe both creatures dying in the simultaneous \
+         each-player sacrifice"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -421,6 +421,7 @@ mod issue_4560_winter_soldier;
 mod issue_4564_captain_america_team_leader;
 mod issue_4566_jocasta;
 mod issue_4663_chosen_x_ptcomparison_targets;
+mod issue_4752_blood_artist_each_player_sacrifice;
 mod issue_4786_wrenn_realmbreaker;
 mod issue_4792_isochron_scepter;
 mod issue_4824_light_paws_aura_attach;


### PR DESCRIPTION
## Summary
Fixes player-scoped sacrifice resolution so each affected player announces their choice first, then all selected permanents are sacrificed simultaneously.

Closes #4752.

## Files changed
- crates/engine/src/game/effects/mod.rs
- crates/engine/src/game/engine_resolution_choices.rs
- crates/engine/src/types/game_state.rs
- crates/engine/tests/integration/issue_4752_blood_artist_each_player_sacrifice.rs
- crates/engine/tests/integration/main.rs

## CR references
- CR 101.4
- CR 603.10a
- CR 701.21a

## Track
Developer

## LLM
Model: codex-5
Thinking: high
Tier: Standard

## Verification
- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo test -p engine blood_artist_observes_each_creature_in_simultaneous_each_player_sacrifice -- --nocapture` — clean
- `cargo test -p engine` — clean
- `git diff --check origin/main..HEAD` — clean
- Card-data/coverage/semantic-audit gates not applicable: no parser or card-data export changes.

## Gate A
Full output from `./scripts/check-parser-combinators.sh`:
```text
```

## Anchored on
- crates/engine/src/types/game_state.rs:1356 — existing pending per-player zone-choice state stored on `GameState`.
- crates/engine/src/game/engine_resolution_choices.rs:2624 — existing choice handler detects pending per-player choice state before normal continuation.
- crates/engine/src/game/engine_resolution_choices.rs:3830 — existing simultaneous departure path marks co-departures and drains observer triggers.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
