### PR TITLE
Fix commander ninjutsu activation from the command zone

### DIFF
--- a/client/src/components/zone/CommanderCardZone.tsx
+++ b/client/src/components/zone/CommanderCardZone.tsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 import type { PanInfo } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
-import type { GameAction, GameObject, PlayerId } from "../../adapter/types.ts";
+import type { GameObject, PlayerId } from "../../adapter/types.ts";
 import { dispatchAction } from "../../game/dispatch.ts";
 import { useCardHover } from "../../hooks/useCardHover.ts";
 import { useCardImage } from "../../hooks/useCardImage.ts";
@@ -11,6 +11,10 @@ import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { useDragToCast } from "../../hooks/useDragToCast.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
+import {
+  collectObjectActions,
+  resolveSingleActionDispatch,
+} from "../../viewmodel/cardActionChoice.ts";
 import { CASTABLE_AFFORDANCE_ACTIVE } from "../../viewmodel/castableAffordance.ts";
 import { commandersInZone } from "../../viewmodel/commanderColumn.ts";
 import { ManaCostPips } from "../mana/ManaCostPips.tsx";
@@ -57,28 +61,49 @@ function CommanderCard({
 }) {
   const { t } = useTranslation("game");
   const isCompactHeight = useIsCompactHeight();
-  const legalActions = useGameStore((s) => s.legalActions);
+  const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
   const effectiveCost = useGameStore(
     (s) => s.spellCosts[String(commander.id)],
   );
   const inspectObject = useUiStore((s) => s.inspectObject);
+  const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
   const { src } = useCardImage(commander.name, { size: "normal" });
   const { handlers: hoverHandlers, firedRef } = useCardHover(commander.id);
   const tax = commander.commander_tax ?? 0;
 
-  const castAction = useMemo(() => {
-    for (const action of legalActions) {
-      if (action.type === "CastSpell") {
-        const data = (
-          action as Extract<GameAction, { type: "CastSpell" }>
-        ).data;
-        if (Number(data.object_id) === commander.id) return action;
-      }
-    }
-    return null;
-  }, [legalActions, commander.id]);
+  // Engine authority (GameAction::source_object): both CastSpell (cast from the
+  // command zone) and ActivateNinjutsu (commander ninjutsu, CR 702.49d) anchor
+  // to this commander's id, so the map lookup surfaces every action the engine
+  // legally offers for it — no client-side legality inference.
+  const commanderActions = useMemo(
+    () => collectObjectActions(legalActionsByObject, commander.id),
+    [legalActionsByObject, commander.id],
+  );
+  const castAction = useMemo(
+    () => commanderActions.find((a) => a.type === "CastSpell") ?? null,
+    [commanderActions],
+  );
+  const ninjutsuActions = useMemo(
+    () => commanderActions.filter((a) => a.type === "ActivateNinjutsu"),
+    [commanderActions],
+  );
 
   const canCast = castAction !== null;
+  const canNinjutsu = ninjutsuActions.length > 0;
+
+  // CR 702.49d: commander ninjutsu returns an unblocked attacker and puts this
+  // commander onto the battlefield tapped and attacking. The engine emits one
+  // ActivateNinjutsu per returnable attacker; route through the shared dispatch
+  // authority so a lone option fires immediately and multiple options surface
+  // the choice modal — mirroring hand-zone ninjutsu (PlayerHand.playCard).
+  const activateNinjutsu = () => {
+    const auto = resolveSingleActionDispatch(ninjutsuActions, commander);
+    if (auto) {
+      dispatchAction(auto);
+    } else {
+      setPendingAbilityChoice({ objectId: commander.id, actions: ninjutsuActions });
+    }
+  };
   const displayCost = effectiveCost ?? commander.mana_cost;
   // canCast is engine-authoritative: the action is in legalActions only when
   // priority + mana + timing all permit the cast. Reuse it as the drag gate
@@ -109,6 +134,12 @@ function CommanderCard({
           useUiStore.getState().openDebugContextMenu({ objectId: commander.id, x: e.clientX, y: e.clientY });
           return;
         }
+        // Commander ninjutsu is a click affordance (unlike drag-to-cast): a
+        // legal ActivateNinjutsu takes precedence over inspecting the card.
+        if (canNinjutsu) {
+          activateNinjutsu();
+          return;
+        }
         inspectObject(commander.id);
       }}
       onDoubleClick={canCast ? () => dispatchAction(castAction) : undefined}
@@ -116,15 +147,19 @@ function CommanderCard({
       dragSnapToOrigin
       onDragEnd={onDragEnd}
       whileDrag={{ cursor: "grabbing", scale: 1.04 }}
-      className={`group relative ${canCast ? "cursor-grab" : "cursor-default"}`}
+      className={`group relative ${
+        canCast ? "cursor-grab" : canNinjutsu ? "cursor-pointer" : "cursor-default"
+      }`}
       title={
         canCast
           ? tax > 0
             ? t("zone.castCommanderTax", { name: commander.name, tax })
             : t("zone.castCommander", { name: commander.name })
-          : tax > 0
-            ? t("zone.commanderTitleTax", { name: commander.name, tax })
-            : t("zone.commanderTitle", { name: commander.name })
+          : canNinjutsu
+            ? t("zone.ninjutsuCommander", { name: commander.name })
+            : tax > 0
+              ? t("zone.commanderTitleTax", { name: commander.name, tax })
+              : t("zone.commanderTitle", { name: commander.name })
       }
       style={{ width: "var(--card-w)", height: "var(--card-h)" }}
     >
@@ -143,10 +178,11 @@ function CommanderCard({
           </div>
         )}
 
-        {/* Translucent overlay — amber tint, lighter when castable */}
+        {/* Translucent overlay — amber tint, lighter when actionable (castable
+            or commander-ninjutsu available) */}
         <div
           className={`absolute inset-0 transition-colors ${
-            canCast
+            canCast || canNinjutsu
               ? "bg-amber-600/20 group-hover:bg-amber-600/5"
               : "bg-gray-900/50"
           }`}
@@ -161,8 +197,8 @@ function CommanderCard({
         </div>
       )}
 
-      {/* Castable glow ring */}
-      {canCast && (
+      {/* Actionable glow ring — castable or commander-ninjutsu available */}
+      {(canCast || canNinjutsu) && (
         <div className={`absolute inset-0 rounded-lg ${CASTABLE_AFFORDANCE_ACTIVE}`} />
       )}
 

--- a/client/src/components/zone/__tests__/CommanderCardZone.test.tsx
+++ b/client/src/components/zone/__tests__/CommanderCardZone.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameAction, GameObject } from "../../../adapter/types.ts";
+import { dispatchAction } from "../../../game/dispatch.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
+import {
+  buildCommanderGameObject,
+  buildObjectMap,
+} from "../../../test/factories/gameObjectFactory.ts";
+import {
+  buildGameState,
+  buildPlayers,
+  buildPriorityWaitingFor,
+} from "../../../test/factories/gameStateFactory.ts";
+import { CommanderCardZone } from "../CommanderCardZone.tsx";
+
+vi.mock("../../../game/dispatch.ts", () => ({
+  dispatchAction: vi.fn(),
+}));
+
+// Keep the test hermetic: the card-image hook otherwise fires a dev-server
+// asset fetch (localhost:3000) that has nothing to do with the affordance.
+vi.mock("../../../hooks/useCardImage.ts", () => ({
+  useCardImage: () => ({ src: null }),
+}));
+
+const COMMANDER_ID = 101;
+
+function makeState(commander: GameObject) {
+  return buildGameState({
+    active_player: 0,
+    priority_player: 0,
+    players: buildPlayers([0, 1]),
+    objects: buildObjectMap(commander),
+    command_zone: [commander.id],
+    battlefield: [],
+    exile: [],
+    stack: [],
+    waiting_for: buildPriorityWaitingFor(),
+  });
+}
+
+function ninjutsuAction(creatureToReturn: number): GameAction {
+  return {
+    type: "ActivateNinjutsu",
+    data: { ninjutsu_object_id: COMMANDER_ID, creature_to_return: creatureToReturn },
+  };
+}
+
+function castAction(): GameAction {
+  return {
+    type: "CastSpell",
+    data: { object_id: COMMANDER_ID, card_id: 201, targets: [] },
+  };
+}
+
+/** Seed both stores for a command-zone commander with the given legal actions. */
+function seedStores(actions: GameAction[]) {
+  const commander = buildCommanderGameObject({ id: COMMANDER_ID });
+  const gameState = makeState(commander);
+  useGameStore.setState({
+    gameState,
+    waitingFor: gameState.waiting_for,
+    legalActions: actions,
+    legalActionsByObject: { [String(COMMANDER_ID)]: actions },
+    spellCosts: {},
+  });
+  useUiStore.setState({
+    inspectedObjectId: null,
+    pendingAbilityChoice: null,
+    debugInteractionMode: false,
+  });
+}
+
+describe("CommanderCardZone commander ninjutsu (issue #5239)", () => {
+  beforeEach(() => {
+    vi.mocked(dispatchAction).mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("dispatches the lone ActivateNinjutsu action when the commander is clicked", () => {
+    const action = ninjutsuAction(9);
+    seedStores([action]);
+
+    render(<CommanderCardZone playerId={0} />);
+    fireEvent.click(screen.getByRole("button"));
+
+    // A single legal ninjutsu (one unblocked attacker) auto-fires — mirrors
+    // hand-zone ninjutsu via resolveSingleActionDispatch.
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).toHaveBeenCalledWith(action);
+    // Auto-dispatch does not open the choice modal, and does not inspect.
+    expect(useUiStore.getState().pendingAbilityChoice).toBeNull();
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+  });
+
+  it("opens the ability-choice modal when multiple attackers can be returned", () => {
+    const actions = [ninjutsuAction(9), ninjutsuAction(12)];
+    seedStores(actions);
+
+    render(<CommanderCardZone playerId={0} />);
+    fireEvent.click(screen.getByRole("button"));
+
+    // More than one returnable attacker is a genuine choice — surface the modal
+    // rather than auto-firing an arbitrary one.
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(useUiStore.getState().pendingAbilityChoice).toEqual({
+      objectId: COMMANDER_ID,
+      actions,
+    });
+  });
+
+  it("inspects (does not cast) on a single click when only a cast action is legal", () => {
+    seedStores([castAction()]);
+
+    render(<CommanderCardZone playerId={0} />);
+    fireEvent.click(screen.getByRole("button"));
+
+    // Casting a commander is a double-click / drag affordance; a single click
+    // must still inspect, not cast — the ninjutsu branch must not hijack it.
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(useUiStore.getState().inspectedObjectId).toBe(COMMANDER_ID);
+  });
+});

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -463,6 +463,7 @@
     "commanderTitleTax": "Kommandeur: {{name}} (Steuer: +{{tax}})",
     "castCommander": "{{name}} wirken — Doppelklick oder ziehen zum Spielen",
     "castCommanderTax": "{{name}} wirken (Steuer: +{{tax}}) — Doppelklick oder ziehen zum Spielen",
+    "ninjutsuCommander": "Kommandeur-Ninjutsu: {{name}} — klicken, um einen ungeblockten Angreifer auf die Hand zurückzunehmen und diesen Kommandeur getappt und angreifend ins Spiel zu bringen",
     "tax": "Steuer: +{{tax}}",
     "companion": "Gefährte",
     "companionTitle": "Gefährte: {{name}}",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -495,6 +495,7 @@
     "commanderTitleTax": "Commander: {{name}} (Tax: +{{tax}})",
     "castCommander": "Cast {{name}} — double-click or drag to play",
     "castCommanderTax": "Cast {{name}} (Tax: +{{tax}}) — double-click or drag to play",
+    "ninjutsuCommander": "Commander ninjutsu: {{name}} — click to return an unblocked attacker to hand and put this commander onto the battlefield tapped and attacking",
     "tax": "Tax: +{{tax}}",
     "companion": "Companion",
     "companionTitle": "Companion: {{name}}",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -463,6 +463,7 @@
     "commanderTitleTax": "Comandante: {{name}} (Impuesto: +{{tax}})",
     "castCommander": "Lanza {{name}} — haz doble clic o arrastra para jugar",
     "castCommanderTax": "Lanza {{name}} (Impuesto: +{{tax}}) — haz doble clic o arrastra para jugar",
+    "ninjutsuCommander": "Ninjutsu de comandante: {{name}} — haz clic para devolver un atacante no bloqueado a la mano y poner a este comandante en el campo de batalla girado y atacando",
     "tax": "Impuesto: +{{tax}}",
     "companion": "Compañero",
     "companionTitle": "Compañero: {{name}}",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -463,6 +463,7 @@
     "commanderTitleTax": "Commandant : {{name}} (Taxe : +{{tax}})",
     "castCommander": "Lancer {{name}} — double-cliquez ou glissez pour jouer",
     "castCommanderTax": "Lancer {{name}} (Taxe : +{{tax}}) — double-cliquez ou glissez pour jouer",
+    "ninjutsuCommander": "Ninjutsu de commandant : {{name}} — cliquez pour renvoyer un attaquant non bloqué en main et mettre ce commandant sur le champ de bataille engagé et attaquant",
     "tax": "Taxe : +{{tax}}",
     "companion": "Compagnon",
     "companionTitle": "Compagnon : {{name}}",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -463,6 +463,7 @@
     "commanderTitleTax": "Comandante: {{name}} (Tassa: +{{tax}})",
     "castCommander": "Lancia {{name}} — doppio clic o trascina per giocare",
     "castCommanderTax": "Lancia {{name}} (Tassa: +{{tax}}) — doppio clic o trascina per giocare",
+    "ninjutsuCommander": "Ninjutsu del comandante: {{name}} — clicca per far tornare in mano un attaccante non bloccato e mettere questo comandante sul campo di battaglia TAPpato e attaccante",
     "tax": "Tassa: +{{tax}}",
     "companion": "Compagno",
     "companionTitle": "Compagno: {{name}}",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -463,6 +463,7 @@
     "commanderTitleTax": "Dowódca: {{name}} (Podatek: +{{tax}})",
     "castCommander": "Rzuć {{name}} — kliknij dwukrotnie lub przeciągnij, aby zagrać",
     "castCommanderTax": "Rzuć {{name}} (Podatek: +{{tax}}) — kliknij dwukrotnie lub przeciągnij, aby zagrać",
+    "ninjutsuCommander": "Ninjutsu dowódcy: {{name}} — kliknij, aby zwrócić niezablokowanego atakującego do ręki i umieścić tego dowódcę na polu bitwy przekręconego i atakującego",
     "tax": "Podatek: +{{tax}}",
     "companion": "Towarzysz",
     "companionTitle": "Towarzysz: {{name}}",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -463,6 +463,7 @@
     "commanderTitleTax": "Comandante: {{name}} (Taxa: +{{tax}})",
     "castCommander": "Conjure {{name}} — clique duas vezes ou arraste para jogar",
     "castCommanderTax": "Conjure {{name}} (Taxa: +{{tax}}) — clique duas vezes ou arraste para jogar",
+    "ninjutsuCommander": "Ninjutsu de comandante: {{name}} — clique para devolver um atacante não bloqueado à mão e colocar este comandante no campo de batalha virado e atacando",
     "tax": "Taxa: +{{tax}}",
     "companion": "Companheiro",
     "companionTitle": "Companheiro: {{name}}",


### PR DESCRIPTION
## Summary
Fixes commander ninjutsu activation for a commander in the command zone.
`CommanderCardZone` only offered a `CastSpell` affordance, so a commander
with commander ninjutsu (CR 702.49d) — e.g. Yuriko, the Tiger's Shadow —
had no click/drag affordance to activate it, even though the engine
legally offers `ActivateNinjutsu` from the command zone. The card now
unifies its action lookup onto the engine-authoritative
`legalActionsByObject` map and adds a single-click ninjutsu affordance
routed through the shared `resolveSingleActionDispatch` /
`setPendingAbilityChoice` authority (lone attacker auto-fires; multiple
returnable attackers surface the choice modal), mirroring hand-zone
ninjutsu (`PlayerHand.playCard`). Engine side was already correct.

Closes #5239

## Files changed
- client/src/components/zone/CommanderCardZone.tsx
- client/src/components/zone/__tests__/CommanderCardZone.test.tsx
- client/src/i18n/locales/{en,fr,es,it,de,pt,pl}/game.json

## CR references
- CR 702.49d — commander ninjutsu (functions from hand or command zone)

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
Frontend-only change (no Rust/cargo surface). Tilt was down, so frontend
checks were run directly (documented fallback):
- `tsc -b --noEmit` (type-check) — clean
- `eslint` (component + test) — clean
- i18n parity + encoding suite — 67 pass / 0 fail
- `CommanderCardZone.test.tsx` (new) — 3 pass / 0 fail
  (lone-attacker auto-dispatch, multi-attacker modal, cast-only single-click still inspects)

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
