### PR TITLE
feat(parser): apply same-name mass debuff on "target X and all other X with the same name"

### DIFF
--- a/crates/engine/src/game/effects/pump.rs
+++ b/crates/engine/src/game/effects/pump.rs
@@ -95,6 +95,14 @@ pub fn resolve_all(
         _ => return Ok(()),
     };
 
+    // CR 608.2c: Concretize contextual filters against this ability's inherited
+    // target before the mass scan — e.g. `Not{ParentTarget}` from a "target X and
+    // all other X with the same name get -N/-M" chain (Bile Blight) becomes
+    // `Not{SpecificObject{target}}`, excluding the already-pumped target so it is
+    // not shrunk twice. No-op for filters without contextual refs, mirroring the
+    // single `resolve` (above) and `destroy`/`bounce`.
+    let target_filter = crate::game::effects::resolved_object_filter(ability, &target_filter);
+
     let dur = ability.duration.clone().unwrap_or(Duration::UntilEndOfTurn);
 
     // CR 608.2h + CR 613.4c: same recipient-relative parity as `resolve` — an
@@ -497,6 +505,54 @@ mod tests {
         // Opponent unchanged
         assert_eq!(state.objects[&opp].power, Some(3));
         assert_eq!(state.objects[&opp].toughness, Some(3));
+    }
+
+    /// Issue #4727 (CR 611.2a): "Target creature and all other creatures with the
+    /// same name as that creature get -N/-M" (Bile Blight). The mass
+    /// `PumpAll{ And[ SameNameAsParentTarget, Not{ParentTarget} ] }` sub-ability
+    /// must shrink OTHER same-name creatures but EXCLUDE the announced target
+    /// (which the paired single `Pump` already covers) so it is not shrunk twice.
+    /// Guards the `resolved_object_filter` line in `resolve_all`: without it,
+    /// `Not{ParentTarget}` never concretizes and the target is wrongly caught.
+    #[test]
+    fn pump_all_same_name_excludes_parent_target() {
+        let mut state = GameState::new_two_player(42);
+        let target = make_creature(&mut state, "Grizzly Bears", 5, 5, PlayerId(0));
+        let same_name = make_creature(&mut state, "Grizzly Bears", 5, 5, PlayerId(0));
+        let other = make_creature(&mut state, "Runeclaw Bear", 5, 5, PlayerId(0));
+
+        let ability = ResolvedAbility::new(
+            Effect::PumpAll {
+                power: PtValue::Fixed(-3),
+                toughness: PtValue::Fixed(-3),
+                target: TargetFilter::And {
+                    filters: vec![
+                        TypedFilter::creature()
+                            .properties(vec![FilterProp::SameNameAsParentTarget])
+                            .into(),
+                        TargetFilter::Not {
+                            filter: Box::new(TargetFilter::ParentTarget),
+                        },
+                    ],
+                },
+            },
+            vec![TargetRef::Object(target)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve_all(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        // Announced target is EXCLUDED from the mass debuff (Not{ParentTarget}).
+        assert_eq!(state.objects[&target].power, Some(5));
+        assert_eq!(state.objects[&target].toughness, Some(5));
+        // Another creature sharing the name IS shrunk -3/-3.
+        assert_eq!(state.objects[&same_name].power, Some(2));
+        assert_eq!(state.objects[&same_name].toughness, Some(2));
+        // Differently-named creature is unaffected.
+        assert_eq!(state.objects[&other].power, Some(5));
+        assert_eq!(state.objects[&other].toughness, Some(5));
     }
 
     /// Regression: Prowess-style abilities use `SelfRef` with an empty `targets` list.

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -130,6 +130,14 @@ pub(super) fn try_parse_subject_predicate_ast(
         ));
     }
 
+    // CR 611.2 + CR 201.2a: "target <T> and all other <T>s with the same name as
+    // that <T> get -N/-M" (Bile Blight, Echoing Decay/Courage). Must run before
+    // the generic continuous clause, which resolves only the first conjunct and
+    // drops the same-name mass debuff (issue #4727).
+    if let Some(clause) = try_parse_target_and_same_name_pump_clause(text, ctx) {
+        return Some(clause);
+    }
+
     if let Some(clause) = try_parse_subject_additive_type_clause(text, ctx) {
         return Some(clause);
     }
@@ -1286,6 +1294,120 @@ fn try_parse_source_and_other_restriction_clause(
             sub_ability: Some(Box::new(secondary_def)),
         }),
     })
+}
+
+/// CR 611.2 + CR 201.2a + CR 115.1: "target &lt;T&gt; and all other &lt;T&gt;s with the same
+/// name as that &lt;T&gt; get -N/-M [until end of turn]" (Bile Blight, Echoing Decay,
+/// Echoing Courage's +2/+2). A compound subject sharing one pump predicate: the
+/// announced creature is a single `Pump` and the same-name others are a mass
+/// `PumpAll`. CR 611.2a — each object receives the continuous P/T change exactly
+/// once, so the `PumpAll` must EXCLUDE the announced target (which the primary
+/// `Pump` already covers); the `Not{ParentTarget}` conjunct is concretized
+/// against the inherited target at resolution (`pump::resolve_all`), mirroring
+/// Maelstrom Pulse's `Destroy`+`DestroyAll`. Runs before the generic continuous
+/// clause, which resolves only the first conjunct and silently drops the mass
+/// debuff (issue #4727).
+fn try_parse_target_and_same_name_pump_clause(
+    text: &str,
+    ctx: &mut ParseContext,
+) -> Option<ClauseAst> {
+    let lower = text.to_lowercase();
+
+    // Locate the pump predicate boundary (" gets " / " get ") with nom take_until
+    // (nom-combinator dispatch, not string methods).
+    let ((), predicate_with_space) = nom_on_lower(text, &lower, |input| {
+        alt((
+            value((), take_until::<_, _, OracleError<'_>>(" gets ")),
+            value((), take_until::<_, _, OracleError<'_>>(" get ")),
+        ))
+        .parse(input)
+    })?;
+    let subject = text[..text.len() - predicate_with_space.len()].trim();
+    let predicate = predicate_with_space.trim_start();
+
+    // Class gate: the predicate must be a P/T pump ("get -3/-3 until end of turn").
+    // Non-pump predicates fall through to the generic subject grammar.
+    let (power, toughness, duration) =
+        super::lower::parse_pump_clause_with_context(predicate, ctx)?;
+
+    // The subject must be a two-part conjunction "&lt;target&gt; and &lt;same-name mass&gt;".
+    let subject_lower = subject.to_lowercase();
+    let subject_pair = TextPair::new(subject, &subject_lower);
+    let (primary_tp, secondary_tp) = subject_pair.split_around(" and ")?;
+
+    // Primary conjunct must announce a target ("target creature") — this is what
+    // carries the CR 115.1 target slot the mass sub-ability inherits.
+    let primary = parse_subject_application(primary_tp.original.trim(), ctx)?;
+    primary.target.as_ref()?;
+
+    // Secondary conjunct must be the same-name mass ("all other creatures with
+    // the same name as that creature") — a class filter, not a target slot. The
+    // `SameNameAsParentTarget` gate is the load-bearing discriminator: a plain
+    // "target creature and each creature you control get +1/+1" secondary lacks
+    // it and returns `None`, leaving the generic path untouched.
+    let (secondary_filter, rest) = parse_target(secondary_tp.original.trim());
+    if !rest.trim().is_empty() || !filter_carries_same_name_as_parent_target(&secondary_filter) {
+        return None;
+    }
+
+    // Primary: single-target Pump on the announced creature.
+    let primary_effect = build_pump_effect(&primary, power.clone(), toughness.clone());
+
+    // Mass: PumpAll over the same-name others, EXCLUDING the announced target.
+    let mass_target = TargetFilter::And {
+        filters: vec![
+            secondary_filter,
+            TargetFilter::Not {
+                filter: Box::new(TargetFilter::ParentTarget),
+            },
+        ],
+    };
+    let mass_clause = ParsedEffectClause {
+        effect: Effect::PumpAll {
+            power,
+            toughness,
+            target: mass_target,
+        },
+        duration: duration.clone().or(Some(Duration::UntilEndOfTurn)),
+        sub_ability: None,
+        distribute: None,
+        multi_target: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    };
+    let mass_def = super::ability_definition_from_clause(AbilityKind::Spell, mass_clause);
+
+    Some(ClauseAst::SubjectPredicate {
+        subject: Box::new(SubjectPhraseAst {
+            affected: primary.affected,
+            target: primary.target,
+            multi_target: None,
+            inherits_parent: primary.inherits_parent,
+            is_optional: primary.is_optional,
+        }),
+        predicate: Box::new(PredicateAst::Continuous {
+            effect: primary_effect,
+            duration: duration.or(Some(Duration::UntilEndOfTurn)),
+            sub_ability: Some(Box::new(mass_def)),
+        }),
+    })
+}
+
+/// Walks a `TargetFilter` for `FilterProp::SameNameAsParentTarget` (parser-side
+/// mirror of the runtime `filter_refs_same_name_as_parent_target`).
+fn filter_carries_same_name_as_parent_target(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed
+            .properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::SameNameAsParentTarget)),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => filters
+            .iter()
+            .any(filter_carries_same_name_as_parent_target),
+        TargetFilter::Not { filter } => filter_carries_same_name_as_parent_target(filter),
+        _ => false,
+    }
 }
 
 fn try_parse_subject_restriction_clause(

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -1064,6 +1064,139 @@ fn parse(
     parse_oracle_text(text, name, &keyword_names, &types, &subtypes)
 }
 
+/// Issue #4727 (CR 611.2 + CR 201.2a): "Target creature and all other creatures
+/// with the same name as that creature get -3/-3 until end of turn" (Bile Blight)
+/// must emit BOTH a single-target `Pump` on the announced creature AND a mass
+/// `PumpAll` over the same-name others that EXCLUDES the target (so it isn't
+/// shrunk twice). Pre-fix the mass debuff was silently dropped.
+#[test]
+fn bile_blight_target_and_same_name_creatures_emit_pump_plus_pumpall() {
+    let def = parse_effect_chain(
+        "Target creature and all other creatures with the same name as that creature get -3/-3 until end of turn.",
+        AbilityKind::Spell,
+    );
+
+    // Primary: single-target Pump -3/-3 on the announced creature.
+    match &*def.effect {
+        Effect::Pump {
+            power,
+            toughness,
+            target,
+        } => {
+            assert_eq!(*power, PtValue::Fixed(-3));
+            assert_eq!(*toughness, PtValue::Fixed(-3));
+            assert!(
+                matches!(target, TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Creature)),
+                "primary target must be a creature filter, got {target:?}"
+            );
+        }
+        other => panic!("expected primary Pump, got {other:?}"),
+    }
+    assert_eq!(def.duration, Some(Duration::UntilEndOfTurn));
+
+    // REVERT-GUARD: pre-fix `sub_ability` is None (mass debuff dropped) — fails on old AST.
+    let sub = def
+        .sub_ability
+        .as_deref()
+        .expect("mass PumpAll sub_ability must exist");
+    match &*sub.effect {
+        Effect::PumpAll {
+            power,
+            toughness,
+            target,
+        } => {
+            assert_eq!(*power, PtValue::Fixed(-3));
+            assert_eq!(*toughness, PtValue::Fixed(-3));
+            let TargetFilter::And { filters } = target else {
+                panic!("expected And-filter on PumpAll, got {target:?}");
+            };
+            // Carries SameNameAsParentTarget…
+            assert!(
+                filters.iter().any(|f| matches!(f,
+                    TargetFilter::Typed(tf) if tf.properties.contains(&FilterProp::SameNameAsParentTarget))),
+                "mass filter must carry SameNameAsParentTarget, got {filters:?}"
+            );
+            // …AND excludes the parent target (this is what prevents -6/-6).
+            assert!(
+                filters.iter().any(|f| matches!(f,
+                    TargetFilter::Not { filter } if matches!(**filter, TargetFilter::ParentTarget))),
+                "mass filter must exclude the parent target, got {filters:?}"
+            );
+        }
+        other => panic!("expected PumpAll sub_ability, got {other:?}"),
+    }
+    assert_eq!(sub.duration, Some(Duration::UntilEndOfTurn));
+}
+
+/// Class coverage: the +N/+N sibling (Echoing Courage) takes the same recognizer,
+/// proving it is sign-agnostic and not a Bile-Blight one-off.
+#[test]
+fn echoing_courage_plus_variant_same_name_pump_covers_class() {
+    let def = parse_effect_chain(
+        "Target creature and all other creatures with the same name as that creature get +2/+2 until end of turn.",
+        AbilityKind::Spell,
+    );
+    let Effect::Pump {
+        power, toughness, ..
+    } = &*def.effect
+    else {
+        panic!("expected primary Pump, got {:?}", def.effect);
+    };
+    assert_eq!(*power, PtValue::Fixed(2));
+    assert_eq!(*toughness, PtValue::Fixed(2));
+    let sub = def
+        .sub_ability
+        .as_deref()
+        .expect("mass PumpAll sub_ability must exist");
+    assert!(
+        matches!(&*sub.effect, Effect::PumpAll { .. }),
+        "expected PumpAll sub_ability, got {:?}",
+        sub.effect
+    );
+}
+
+/// Negative (reach-guard for the paired positive above): a plain single-target
+/// shrink has no "and … same name" continuation, so it must stay a single
+/// `Pump` with no mass sub_ability — proving the recognizer fails closed.
+#[test]
+fn plain_single_target_pump_stays_single_no_pumpall() {
+    let def = parse_effect_chain(
+        "Target creature gets -3/-3 until end of turn.",
+        AbilityKind::Spell,
+    );
+    assert!(
+        matches!(&*def.effect, Effect::Pump { .. }),
+        "expected a single Pump, got {:?}",
+        def.effect
+    );
+    assert!(
+        def.sub_ability.is_none(),
+        "a plain single-target pump must not gain a same-name mass sub_ability"
+    );
+}
+
+/// Negative: a compound subject WITHOUT the same-name gate ("… and each creature
+/// you control …") must NOT be intercepted — the recognizer must not synthesize a
+/// SameNameAsParentTarget mass effect for it.
+#[test]
+fn target_and_non_same_name_compound_not_intercepted() {
+    let def = parse_effect_chain(
+        "Target creature and each creature you control get +1/+1 until end of turn.",
+        AbilityKind::Spell,
+    );
+    let carries_same_name = |e: &Effect| {
+        matches!(e, Effect::PumpAll { target, .. }
+            if format!("{target:?}").contains("SameNameAsParentTarget"))
+    };
+    assert!(
+        !carries_same_name(&def.effect),
+        "must not synthesize a same-name mass effect for a non-same-name compound"
+    );
+    if let Some(sub) = def.sub_ability.as_deref() {
+        assert!(!carries_same_name(&sub.effect));
+    }
+}
+
 /// As Foretold (WHO/AKH): the once-per-turn "pay {0} rather than pay the mana
 /// cost" free-cast line is correctly UNSUPPORTED. As Foretold places no zone
 /// restriction on which spell the cost applies to, but the engine's


### PR DESCRIPTION
Closes #4727.

**Bug:** Bile Blight ("Target creature and all other creatures with the same name as that creature get -3/-3 until end of turn") — and its class (Echoing Decay, Echoing Courage's +2/+2) — **misparsed** to a single-target `Pump` on the announced creature, silently **dropping the same-name mass debuff**. Only the targeted creature was shrunk.

**Fix:** A dedicated recognizer `try_parse_target_and_same_name_pump_clause` (in `oracle_effect/subject.rs`), dispatched before the generic continuous-clause path, splits the compound subject, gates on the pump predicate + a `SameNameAsParentTarget` secondary, and emits:
- `Effect::Pump{ target: Typed(Creature), -N/-M }` (the announced target), plus
- a `sub_ability` `Effect::PumpAll{ And[ <same-name others>, Not{ParentTarget} ], -N/-M }` — **excluding the announced target** so it isn't shrunk twice (CR 611.2a).

This mirrors Maelstrom Pulse's existing `Destroy`+`DestroyAll`. It also aligns `PumpAll::resolve_all` with `resolve`/`destroy`/`bounce` by concretizing contextual filters (`resolved_object_filter`), so `Not{ParentTarget}` → `Not{SpecificObject{target}}` at resolution — a **no-op** for every existing `PumpAll` card.

Covers a **class** (Bile Blight, Echoing Decay, Echoing Courage), composes existing primitives, **no new variant**. Tests: 4 parser AST (positive + revert-guard, +N/+N class sibling, two fail-closed negatives) + a runtime `resolve_all` test proving the target is excluded (no -6/-6), the same-name creature is shrunk, and a differently-named creature is untouched.

CR 611.2/611.2a (continuous P/T effect), CR 201.2a (same name), CR 115.1 (targeting).
