### PR TITLE
Test/5329 mana echoes shares type regression

### DIFF
--- a/crates/engine/src/game/effects/mana.rs
+++ b/crates/engine/src/game/effects/mana.rs
@@ -2348,7 +2348,7 @@ mod tests {
         };
         use crate::types::events::GameEvent;
         use crate::types::game_state::ZoneChangeRecord;
-        use crate::types::identifiers::{CardId, ObjectId};
+        use crate::types::identifiers::CardId;
         use crate::types::player::PlayerId;
 
         let mut state = GameState::new_two_player(42);

--- a/crates/engine/src/game/effects/mana.rs
+++ b/crates/engine/src/game/effects/mana.rs
@@ -2338,4 +2338,107 @@ mod tests {
         .unwrap();
         assert_eq!(state.players[0].mana_pool.total(), 0);
     }
+
+    #[test]
+    fn colorless_production_counts_creatures_sharing_type_with_triggering_source() {
+        use crate::game::zones::create_object;
+        use crate::types::ability::{
+            ControllerRef, FilterProp, QuantityExpr, QuantityRef, SharedQuality,
+            SharedQualityRelation, TypedFilter,
+        };
+        use crate::types::events::GameEvent;
+        use crate::types::game_state::ZoneChangeRecord;
+        use crate::types::identifiers::{CardId, ObjectId};
+        use crate::types::player::PlayerId;
+
+        let mut state = GameState::new_two_player(42);
+        state.all_creature_types = vec!["Goblin".to_string()];
+        let mana_echoes = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Mana Echoes".to_string(),
+            Zone::Battlefield,
+        );
+        let goblin_a = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Goblin A".to_string(),
+            Zone::Battlefield,
+        );
+        let goblin_b = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Goblin B".to_string(),
+            Zone::Battlefield,
+        );
+        let entering = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Goblin C".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [goblin_a, goblin_b, entering] {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Goblin".to_string());
+        }
+
+        state.current_trigger_event = Some(GameEvent::ZoneChanged {
+            object_id: entering,
+            from: Some(Zone::Hand),
+            to: Zone::Battlefield,
+            record: Box::new(ZoneChangeRecord::test_minimal(
+                entering,
+                Some(Zone::Hand),
+                Zone::Battlefield,
+            )),
+        });
+
+        let filter = TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::SharesQuality {
+                    quality: SharedQuality::CreatureType,
+                    reference: Some(Box::new(TargetFilter::TriggeringSource)),
+                    relation: SharedQualityRelation::Shares,
+                }]),
+        );
+        let ability = ResolvedAbility::new(
+            Effect::Mana {
+                produced: ManaProduction::Colorless {
+                    count: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: filter.clone(),
+                        },
+                    },
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+            vec![],
+            mana_echoes,
+            PlayerId(0),
+        );
+
+        let produced = super::resolve_mana_types_for_ability(
+            &ManaProduction::Colorless {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { filter },
+                },
+            },
+            &state,
+            &ability,
+        );
+        assert_eq!(
+            produced.len(),
+            3,
+            "Mana Echoes must produce one colorless per matching creature"
+        );
+    }
 }

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -7597,6 +7597,290 @@ mod tests {
     }
 
     #[test]
+    fn game_scenario_mana_echoes_shares_type_count_with_triggering_source() {
+        use crate::game::quantity::object_count_matching_ids;
+        use crate::game::scenario::{GameScenario, P0};
+        use crate::types::ability::{ManaProduction, QuantityExpr, QuantityRef};
+        use crate::types::events::GameEvent;
+        use crate::types::game_state::ZoneChangeRecord;
+        use crate::types::zones::Zone;
+
+        const ORACLE: &str = "Whenever a creature enters, you may add an amount of {C} equal to the number of creatures you control that share a creature type with it.";
+
+        let mut scenario = GameScenario::new();
+        let mana_echoes = scenario
+            .add_creature_from_oracle(P0, "Mana Echoes", 0, 0, ORACLE)
+            .id();
+        scenario
+            .add_creature(P0, "Goblin A", 1, 1)
+            .with_subtypes(vec!["Goblin"]);
+        scenario
+            .add_creature(P0, "Goblin B", 1, 1)
+            .with_subtypes(vec!["Goblin"]);
+        let mut runner = scenario.build();
+        runner.state_mut().all_creature_types = vec!["Goblin".to_string()];
+
+        let entering = {
+            let state = runner.state_mut();
+            let card_id = crate::types::identifiers::CardId(state.next_object_id);
+            let id = crate::game::zones::create_object(
+                state,
+                card_id,
+                P0,
+                "Goblin C".to_string(),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Creature);
+            obj.card_types.subtypes.push("Goblin".to_string());
+            id
+        };
+
+        let trigger = &runner.state().objects[&mana_echoes].trigger_definitions[0];
+        let execute = trigger.execute.as_ref().expect("execute");
+        let ability = crate::game::triggers::build_triggered_ability(
+            runner.state(),
+            trigger,
+            mana_echoes,
+            P0,
+        );
+
+        let filter = match execute.effect.as_ref() {
+            crate::types::ability::Effect::Mana {
+                produced: ManaProduction::Colorless { count },
+                ..
+            } => {
+                let QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { filter },
+                } = count
+                else {
+                    panic!("expected ObjectCount quantity");
+                };
+                filter
+            }
+            other => panic!("expected colorless mana, got {other:?}"),
+        };
+
+        let mut state = runner.state().clone();
+        state.current_trigger_event = Some(GameEvent::ZoneChanged {
+            object_id: entering,
+            from: Some(Zone::Hand),
+            to: Zone::Battlefield,
+            record: Box::new(ZoneChangeRecord::test_minimal(
+                entering,
+                Some(Zone::Hand),
+                Zone::Battlefield,
+            )),
+        });
+        let ctx = super::FilterContext::from_ability_with_controller(&ability, P0);
+        assert_eq!(
+            object_count_matching_ids(&state, filter, &ctx, mana_echoes).len(),
+            3,
+            "GameScenario-built Mana Echoes must count three sharing Goblins"
+        );
+    }
+
+    #[test]
+    fn mana_echoes_optional_stack_pause_preserves_shares_type_count() {
+        use crate::game::quantity::{object_count_matching_ids, resolve_quantity_with_targets};
+        use crate::game::scenario::{GameScenario, P0};
+        use crate::game::triggers::{drain_order_triggers_with_identity, process_triggers};
+        use crate::game::zones::move_to_zone;
+        use crate::types::ability::{ManaProduction, QuantityExpr, QuantityRef};
+        use crate::types::actions::GameAction;
+        use crate::types::card_type::CoreType;
+        use crate::types::game_state::WaitingFor;
+        use crate::types::identifiers::CardId;
+        use crate::types::zones::Zone;
+
+        const ORACLE: &str = "Whenever a creature enters, you may add an amount of {C} equal to the number of creatures you control that share a creature type with it.";
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(crate::types::phase::Phase::PreCombatMain);
+        let mana_echoes = scenario
+            .add_creature_from_oracle(P0, "Mana Echoes", 0, 0, ORACLE)
+            .id();
+        scenario
+            .add_creature(P0, "Goblin A", 1, 1)
+            .with_subtypes(vec!["Goblin"]);
+        scenario
+            .add_creature(P0, "Goblin B", 1, 1)
+            .with_subtypes(vec!["Goblin"]);
+        let mut runner = scenario.build();
+        runner.state_mut().all_creature_types = vec!["Goblin".to_string()];
+        runner.advance_until_stack_empty();
+
+        let entering = {
+            let state = runner.state_mut();
+            let card_id = CardId(state.next_object_id);
+            let id = crate::game::zones::create_object(
+                state,
+                card_id,
+                P0,
+                "Goblin C".to_string(),
+                Zone::Hand,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Goblin".to_string());
+            id
+        };
+
+        let mut events = Vec::new();
+        move_to_zone(runner.state_mut(), entering, Zone::Battlefield, &mut events);
+        process_triggers(runner.state_mut(), &events);
+        drain_order_triggers_with_identity(runner.state_mut());
+
+        for _ in 0..48 {
+            if matches!(
+                runner.state().waiting_for,
+                WaitingFor::OptionalEffectChoice { .. }
+            ) {
+                break;
+            }
+            if runner.state().stack.is_empty() {
+                break;
+            }
+            runner
+                .act(GameAction::PassPriority)
+                .expect("pass priority to optional mana");
+        }
+
+        let pending = runner
+            .state()
+            .pending_optional_effect
+            .as_ref()
+            .expect("optional mana must stash pending ability");
+        let pending_event = runner
+            .state()
+            .pending_optional_trigger_event
+            .clone()
+            .expect("optional mana must stash trigger event");
+
+        let filter = match &pending.effect {
+            crate::types::ability::Effect::Mana {
+                produced: ManaProduction::Colorless { count },
+                ..
+            } => {
+                let QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { filter },
+                } = count
+                else {
+                    panic!("expected ObjectCount");
+                };
+                filter.clone()
+            }
+            other => panic!("expected Mana effect, got {other:?}"),
+        };
+
+        let mut probe = runner.state().clone();
+        probe.current_trigger_event = Some(pending_event);
+        let ctx = super::FilterContext::from_ability_with_controller(pending, P0);
+        assert_eq!(
+            object_count_matching_ids(&probe, &filter, &ctx, mana_echoes).len(),
+            3,
+            "paused optional ability must count three sharing Goblins"
+        );
+        assert_eq!(
+            resolve_quantity_with_targets(
+                &probe,
+                &QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount {
+                        filter: filter.clone()
+                    },
+                },
+                pending,
+            ),
+            3
+        );
+
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: true })
+            .expect("accept optional mana");
+        assert_eq!(
+            runner.state().players[P0.0 as usize]
+                .mana_pool
+                .count_color(crate::types::mana::ManaType::Colorless),
+            3,
+            "accepting optional Mana Echoes must add three colorless"
+        );
+    }
+
+    #[test]
+    fn object_count_shares_creature_type_with_triggering_source_for_mana_echoes() {
+        use crate::game::quantity::object_count_matching_ids;
+        use crate::types::ability::{
+            ControllerRef, Effect, ManaProduction, QuantityExpr, QuantityRef, ResolvedAbility,
+            SharedQualityRelation, TypedFilter,
+        };
+        use crate::types::events::GameEvent;
+
+        let mut state = setup();
+        state.all_creature_types = vec!["Goblin".to_string()];
+        let mana_echoes = add_creature(&mut state, PlayerId(0), "Mana Echoes");
+        let goblin_a = add_creature(&mut state, PlayerId(0), "Goblin A");
+        let goblin_b = add_creature(&mut state, PlayerId(0), "Goblin B");
+        let entering = add_creature(&mut state, PlayerId(0), "Goblin C");
+        for id in [goblin_a, goblin_b, entering] {
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .subtypes
+                .push("Goblin".to_string());
+        }
+
+        state.current_trigger_event = Some(GameEvent::ZoneChanged {
+            object_id: entering,
+            from: Some(Zone::Hand),
+            to: Zone::Battlefield,
+            record: Box::new(ZoneChangeRecord::test_minimal(
+                entering,
+                Some(Zone::Hand),
+                Zone::Battlefield,
+            )),
+        });
+
+        let filter = TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::SharesQuality {
+                    quality: SharedQuality::CreatureType,
+                    reference: Some(Box::new(TargetFilter::TriggeringSource)),
+                    relation: SharedQualityRelation::Shares,
+                }]),
+        );
+        let ability = ResolvedAbility::new(
+            Effect::Mana {
+                produced: ManaProduction::Colorless {
+                    count: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: filter.clone(),
+                        },
+                    },
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+            vec![],
+            mana_echoes,
+            PlayerId(0),
+        );
+        let ctx = FilterContext::from_ability(&ability);
+
+        assert_eq!(
+            object_count_matching_ids(&state, &filter, &ctx, mana_echoes).len(),
+            3,
+            "all three Goblins share a creature type with the entering creature"
+        );
+    }
+
+    #[test]
     fn shares_quality_reference_can_use_discarded_trigger_object() {
         let mut state = setup();
         let source = add_creature(&mut state, PlayerId(0), "Diviner");

--- a/crates/engine/tests/integration/issue_5329_mana_echoes.rs
+++ b/crates/engine/tests/integration/issue_5329_mana_echoes.rs
@@ -1,0 +1,189 @@
+//! Regression for issue #5329: Mana Echoes must add colorless mana equal to the
+//! number of creatures you control sharing a creature type with the entering
+//! creature — not zero due to a broken SharesQuality reference binding.
+//!
+//! https://github.com/phase-rs/phase/issues/5329
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::triggers::{drain_order_triggers_with_identity, process_triggers};
+use engine::game::zones::{create_object, move_to_zone};
+use engine::types::ability::{FilterProp, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::CardId;
+use engine::types::mana::ManaType;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const MANA_ECHOES_ORACLE: &str =
+    "Whenever a creature enters, you may add an amount of {C} equal to the number of creatures you control that share a creature type with it.";
+
+fn colorless_in_pool(runner: &engine::game::scenario::GameRunner) -> usize {
+    runner.state().players[P0.0 as usize]
+        .mana_pool
+        .count_color(ManaType::Colorless)
+}
+
+fn enter_creature_from_hand(
+    runner: &mut engine::game::scenario::GameRunner,
+    name: &str,
+    subtypes: &[&str],
+) -> engine::types::identifiers::ObjectId {
+    let state = runner.state_mut();
+    let card_id = CardId(state.next_object_id);
+    let id = create_object(state, card_id, P0, name.to_string(), Zone::Hand);
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.power = Some(1);
+    obj.toughness = Some(1);
+    obj.base_power = Some(1);
+    obj.base_toughness = Some(1);
+    for st in subtypes {
+        obj.card_types.subtypes.push((*st).to_string());
+    }
+    obj.base_card_types = obj.card_types.clone();
+    id
+}
+
+fn resolve_mana_echoes_trigger(
+    runner: &mut engine::game::scenario::GameRunner,
+    mana_echoes: engine::types::identifiers::ObjectId,
+    creature: engine::types::identifiers::ObjectId,
+) {
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), creature, Zone::Battlefield, &mut events);
+    process_triggers(runner.state_mut(), &events);
+    drain_order_triggers_with_identity(runner.state_mut());
+
+    let triggers_on_stack = runner
+        .state()
+        .stack
+        .iter()
+        .filter(|e| e.source_id == mana_echoes)
+        .count();
+    assert_eq!(
+        triggers_on_stack,
+        1,
+        "Mana Echoes must trigger once on creature ETB; stack={:?}, waiting_for={:?}",
+        runner.state().stack,
+        runner.state().waiting_for
+    );
+
+    let mut saw_optional = false;
+    for _ in 0..48 {
+        if matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ) {
+            saw_optional = true;
+            break;
+        }
+        if runner.state().stack.is_empty() {
+            break;
+        }
+        runner
+            .act(GameAction::PassPriority)
+            .expect("pass priority to Mana Echoes trigger");
+    }
+    assert!(
+        saw_optional,
+        "Mana Echoes optional mana trigger must prompt before resolving; waiting_for={:?}",
+        runner.state().waiting_for
+    );
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept optional mana");
+}
+
+#[test]
+fn mana_echoes_parse_binds_shares_type_to_triggering_source() {
+    let mut scenario = GameScenario::new();
+    let mana_echoes = scenario
+        .add_creature(P0, "Mana Echoes", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(MANA_ECHOES_ORACLE)
+        .id();
+    let runner = scenario.build();
+    let trigger = &runner.state().objects[&mana_echoes].trigger_definitions[0];
+    let execute = trigger.execute.as_ref().expect("execute");
+    let engine::types::ability::Effect::Mana {
+        produced: engine::types::ability::ManaProduction::Colorless { count },
+        ..
+    } = execute.effect.as_ref()
+    else {
+        panic!("expected colorless mana effect, got {:?}", execute.effect);
+    };
+    let engine::types::ability::QuantityExpr::Ref {
+        qty: engine::types::ability::QuantityRef::ObjectCount { filter },
+    } = count
+    else {
+        panic!("expected ObjectCount, got {count:?}");
+    };
+    let TargetFilter::Typed(tf) = filter else {
+        panic!("expected typed filter, got {filter:?}");
+    };
+    let shares = tf.properties.iter().find_map(|p| match p {
+        FilterProp::SharesQuality { reference, .. } => reference.as_deref(),
+        _ => None,
+    });
+    assert_eq!(
+        shares,
+        Some(&TargetFilter::TriggeringSource),
+        "shares-type reference must bind to the entering creature"
+    );
+}
+
+#[test]
+fn mana_echoes_adds_colorless_for_creatures_sharing_type_with_entering_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mana_echoes = scenario
+        .add_creature_from_oracle(P0, "Mana Echoes", 0, 0, MANA_ECHOES_ORACLE)
+        .id();
+    scenario
+        .add_creature(P0, "Goblin A", 1, 1)
+        .with_subtypes(vec!["Goblin"]);
+    scenario
+        .add_creature(P0, "Goblin B", 1, 1)
+        .with_subtypes(vec!["Goblin"]);
+
+    let mut runner = scenario.build();
+    runner.state_mut().all_creature_types = vec!["Goblin".to_string()];
+    runner.advance_until_stack_empty();
+
+    let entering = enter_creature_from_hand(&mut runner, "Goblin C", &["Goblin"]);
+    resolve_mana_echoes_trigger(&mut runner, mana_echoes, entering);
+
+    assert_eq!(
+        colorless_in_pool(&runner),
+        3,
+        "three Goblins share a creature type with the entering Goblin — expect 3 colorless"
+    );
+}
+
+#[test]
+fn mana_echoes_adds_zero_when_entering_creature_has_no_creature_subtypes() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mana_echoes = scenario
+        .add_creature_from_oracle(P0, "Mana Echoes", 0, 0, MANA_ECHOES_ORACLE)
+        .id();
+    scenario
+        .add_creature(P0, "Goblin", 1, 1)
+        .with_subtypes(vec!["Goblin"]);
+
+    let mut runner = scenario.build();
+    runner.state_mut().all_creature_types = vec!["Goblin".to_string(), "Bear".to_string()];
+    runner.advance_until_stack_empty();
+
+    // A creature with no creature subtypes shares no type with anything on board.
+    let entering = enter_creature_from_hand(&mut runner, "Subtypeless", &[]);
+    resolve_mana_echoes_trigger(&mut runner, mana_echoes, entering);
+
+    assert_eq!(
+        colorless_in_pool(&runner),
+        0,
+        "a subtypeless entering creature shares no creature type with the Goblin"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -441,6 +441,7 @@ mod issue_5285_senu_keen_eyed_protector;
 mod issue_5286_lulu_loyal_hollyphant;
 mod issue_5287_samwise_stouthearted;
 mod issue_5328_attacks_alone_observer;
+mod issue_5329_mana_echoes;
 mod issue_5330_scavengers_talent_graveyard_return;
 mod issue_5332_gandalf_trigger_doubling;
 mod issue_5334_furious_rise_may_play;


### PR DESCRIPTION
## Summary
Mana Echoes ("Whenever a creature enters, you may add an amount of {C} equal to the number of creatures you control that share a creature type with it.") was reported as producing zero mana. Investigation on current `main` shows the full stack path already works when:
1. **Parser** binds `SharesQuality` to `TargetFilter::TriggeringSource` (not `ParentTarget`).
2. **Optional resume** stashes `pending_optional_trigger_event` and restores it on `DecideOptionalEffect { accept: true }`.
3. **`all_creature_types`** is populated (deck load / test seed) so `CreatureType` sharing resolves.
No engine logic changes were required. This PR adds regression coverage so a future regression in parser binding, optional trigger-event plumbing, or shares-type counting is caught immediately.
## Root cause of the original report (triage)
| Layer | Finding |
|-------|---------|
| Parser AST | `SharesQuality { reference: TriggeringSource }` on `ObjectCount` filter |
| Stack + optional | Trigger event round-trips through optional pause; mana lands on accept |
| Quantity / filter | `object_count_matching_ids` returns correct count with `current_trigger_event` set |
| Integration harness foot-gun | Test helper cloned `base_card_types` **before** subtypes were pushed, which broke subtype-based matching in some paths |
## Changes
### Integration tests (`crates/engine/tests/integration/issue_5329_mana_echoes.rs`)
- Parse assertion: shares-type reference is `TriggeringSource`.
- Runtime positive: three Goblins on board + Goblin ETB → 3 colorless after accepting optional trigger.
- Runtime zero case: subtypeless entering creature + Goblin on board → 0 colorless (no shared creature type).
- Helper fixes: priority loop passes until `OptionalEffectChoice` (no `pass_both_players` fallback); `enter_creature_from_hand` syncs `base_card_types` after subtypes.

### Unit tests
- `filter.rs`: `game_scenario_mana_echoes_shares_type_count_with_triggering_source`, `mana_echoes_optional_stack_pause_preserves_shares_type_count`
- Existing: `object_count_shares_creature_type_with_triggering_source_for_mana_echoes`, `colorless_production_counts_creatures_sharing_type_with_triggering_source`
### Registration
- `mod issue_5329_mana_echoes;` in `crates/engine/tests/integration/main.rs`
## Verification
```bash
cargo fmt --all
cargo test -p engine mana_echoes
cargo test -p engine game_scenario_mana_echoes mana_echoes_optional_stack object_count_shares_creature colorless_production_counts
```

## Test plan
- [x] `cargo test -p engine mana_echoes` — 3 integration + lib unit tests green
- [x] Manual: Mana Echoes on battlefield, accept optional on creature ETB, mana pool increases by matching creature count
- [x] Manual: decline optional — no mana added

Closes #5329 