### PR TITLE
feat(parser): parse "into exile" as a conjure destination

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -9027,6 +9027,9 @@ fn parse_conjure_zone(lower: &str) -> Option<(Zone, &str)> {
         value(Zone::Hand, tag(" into their hand")),
         value(Zone::Graveyard, tag(" into their graveyard")),
         value(Zone::Library, tag(" into their library")),
+        // Digital-only Alchemy conjures can also land in exile (e.g. a random card
+        // conjured from a spellbook into exile with a play-permission rider).
+        value(Zone::Exile, tag(" into exile")),
     ))
     .parse(lower)
     .ok()

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -32545,6 +32545,29 @@ fn conjure_of_your_choice_from_spellbook_bare_form_is_not_parsed() {
 }
 
 #[test]
+fn conjure_named_into_exile() {
+    let e = parse_effect("conjure a card named Black Lotus into exile");
+    match e {
+        Effect::Conjure { destination, .. } => assert_eq!(destination, Zone::Exile),
+        other => panic!("expected Conjure, got: {other:?}"),
+    }
+}
+
+#[test]
+fn conjure_random_from_spellbook_into_exile() {
+    // The exile destination composes with the random draft-from-spellbook wording.
+    let e = parse_effect("conjure a random card from ~'s spellbook into exile");
+    assert!(matches!(
+        e,
+        Effect::DraftFromSpellbook {
+            destination: Zone::Exile,
+            tapped: false,
+            random: true
+        }
+    ));
+}
+
+#[test]
 fn conjure_battlefield_tapped() {
     let e = parse_effect("conjure a card named Forest onto the battlefield tapped");
     match e {


### PR DESCRIPTION
## Summary

`parse_conjure_zone` — the shared destination parser for the conjure family — modeled `onto the battlefield` and `into your/their hand/graveyard/library`, but not `into exile`. So conjures that land a card in exile (named, of-your-choice, and random draft-from-spellbook) fell through to `Unimplemented`.

This adds `Zone::Exile` (`" into exile"`) to the destination alternatives, which unblocks every conjure wording that targets exile at once.

## Coverage

Closes the `Effect:conjure` single-gap for **7 cards** (supported 31,495 → 31,502).

## Verification

- `cargo fmt --all`; `cargo clippy -p engine --all-targets -- -D warnings` clean
- full `cargo test -p engine` passes; two new parser tests: `conjure a card named X into exile`, and the random draft-from-spellbook wording composing with the exile destination
- `cargo coverage` after regenerating card data: +7 cards flip to `supported`

Model: Claude Opus 4.8
