### PR TITLE
Fix Lighthouse Chronologist level trigger condition

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -2865,7 +2865,16 @@ pub(crate) fn parse_oracle_ir(
             &mut ctx,
         );
         for trigger in &mut triggers {
-            trigger.condition = Some(trigger_condition.clone());
+            trigger.condition = Some(match trigger.condition.take() {
+                // CR 711.2a + CR 711.2b + CR 603.4: a level-gated trigger's
+                // level-counter range is an additional gate; it must compose
+                // with any printed intervening-if condition instead of
+                // replacing it.
+                Some(existing) => TriggerCondition::And {
+                    conditions: vec![existing, trigger_condition.clone()],
+                },
+                None => trigger_condition.clone(),
+            });
         }
         result.triggers.extend(triggers);
     }

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -16817,6 +16817,69 @@ fn trigger_while_attacking_composes_with_existing_condition() {
     }
 }
 
+/// CR 711.2a + CR 711.2b + CR 603.4 (issue #4728, Lighthouse Chronologist):
+/// level-block reparsing must AND-compose the level-counter gate with the
+/// printed intervening-if condition. Before the fix, the level-block pass
+/// overwrote `if it's not your turn`, so the extra-turn trigger fired at the
+/// controller's own end step once LEVEL 7+ was active.
+#[test]
+fn level_trigger_preserves_printed_intervening_if_condition() {
+    use crate::types::phase::Phase;
+
+    const LIGHTHOUSE_CHRONOLOGIST: &str =
+        "Level up {U} ({U}: Put a level counter on this. Level up only as a sorcery.)\n\
+LEVEL 4-6\n\
+2/4\n\
+LEVEL 7+\n\
+3/5\n\
+At the beginning of each end step, if it's not your turn, take an extra turn after this one.";
+
+    let parsed = parse_oracle_text(
+        LIGHTHOUSE_CHRONOLOGIST,
+        "Lighthouse Chronologist",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Wizard".to_string()],
+    );
+
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|trigger| trigger.mode == TriggerMode::Phase && trigger.phase == Some(Phase::End))
+        .unwrap_or_else(|| panic!("expected end-step phase trigger, got {:?}", parsed.triggers));
+
+    let Some(TriggerCondition::And { conditions }) = &trigger.condition else {
+        panic!(
+            "expected level gate AND not-your-turn gate, got {:?}",
+            trigger.condition
+        );
+    };
+    assert!(
+        conditions.iter().any(|condition| matches!(
+            condition,
+            TriggerCondition::HasCounters {
+                counters: CounterMatch::OfType(CounterType::Generic(name)),
+                minimum: 7,
+                maximum: None,
+            } if name == "level"
+        )),
+        "LEVEL 7+ counter gate missing from {conditions:?}"
+    );
+    assert!(
+        conditions.iter().any(|condition| matches!(
+            condition,
+            TriggerCondition::Not { condition }
+                if matches!(
+                    condition.as_ref(),
+                    TriggerCondition::DuringPlayersTurn {
+                        player: PlayerFilter::Controller
+                    }
+                )
+        )),
+        "`if it's not your turn` gate missing from {conditions:?}"
+    );
+}
+
 /// CR 603.4 + CR 122.1 (issue #2376, Pyromancer's Ascension): the
 /// `"while this enchantment has two or more quest counters on it"` gate on
 /// a cast trigger must surface as a `HasCounters` condition, not fire on


### PR DESCRIPTION
## Summary
Fixes the level-trigger condition composition for **Lighthouse Chronologist**.

Closes #4728.

The LEVEL 7+ trigger now keeps both required gates: the creature must have at least seven level counters, and the printed intervening-if condition (`if it's not your turn`) must also be true. Previously the level-block reparse replaced the printed condition with the level-counter gate, allowing the extra-turn trigger to fire on the controller's own end step.

## Files changed
- `crates/engine/src/parser/oracle.rs`
- `crates/engine/src/parser/oracle_trigger_tests.rs`

## CR references
- `CR 711.2a`
- `CR 711.2b`
- `CR 603.4`

## Track
Developer

## LLM
Model: codex-5
Thinking: high
Tier: Standard

## Gate A
`./scripts/check-parser-combinators.sh` exited 0 with no output.

## Anchored on
- `crates/engine/src/parser/oracle_trigger.rs:6964` - existing trigger-condition composition helper wraps an existing condition and a new gate in `TriggerCondition::And`.
- `crates/engine/src/parser/oracle_trigger_tests.rs:16796` - existing regression test for composing a trigger gate with a printed intervening-if condition.

## Verification
- `cargo fmt --all -- --check` - clean
- `./scripts/check-parser-combinators.sh` - clean
- `git diff --check origin/main...HEAD` - clean
- `cargo test -p engine level_trigger_preserves_printed_intervening_if_condition` - 1 passed / 0 failed
- `cargo clippy -p engine --all-targets -- -D warnings` - clean

Tilt was not running, so direct cargo fallback was used.

## Scope Expansion
None.

## Validation Failures
Independent fresh-context subagent review was not run because subagent delegation was not explicitly requested; local `doc-guardian` and `code-reviewer` checklist passes found no findings.

## CI Failures
None.
