### PR TITLE
Add Doctor Doom land-discard trigger regression tests (#5327)

### DIFF
--- a/crates/engine/tests/integration/issue_5327_doctor_doom_land_discard.rs
+++ b/crates/engine/tests/integration/issue_5327_doctor_doom_land_discard.rs
@@ -1,0 +1,179 @@
+//! Regression for issue #5327: Doctor Doom's discard trigger must fire only when
+//! you discard one or more land cards, not on every discard.
+//!
+//! https://github.com/phase-rs/phase/issues/5327
+
+use engine::game::effects::resolve_ability_chain;
+use engine::game::engine::apply_as_current;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{
+    AbilityKind, CardSelectionMode, Effect, QuantityExpr, ResolvedAbility, TargetFilter, TypeFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::triggers::TriggerMode;
+
+const DOCTOR_DOOM_ORACLE: &str = "Whenever you discard one or more land cards, each opponent loses 2 life.\n\
+At the beginning of combat on your turn, target Villain you control gains menace until end of turn. It connives.";
+
+fn doctor_doom_discard_trigger(
+    triggers: &[engine::types::ability::TriggerDefinition],
+) -> &engine::types::ability::TriggerDefinition {
+    triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::DiscardedAll)
+        .expect("Doctor Doom land-discard trigger")
+}
+
+fn discard_one_card_chain(
+    source_id: ObjectId,
+    controller: engine::types::player::PlayerId,
+) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::Discard {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+            selection: CardSelectionMode::Chosen,
+            unless_filter: None,
+            filter: None,
+        },
+        vec![],
+        source_id,
+        controller,
+    )
+    .kind(AbilityKind::Spell)
+}
+
+fn drain_stack(runner: &mut engine::game::scenario::GameRunner) {
+    let mut guard = 0;
+    while !runner.state().stack.is_empty() {
+        guard += 1;
+        assert!(guard < 64, "stack did not drain");
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("resolve trigger");
+            }
+            other => panic!("unexpected wait while draining stack: {other:?}"),
+        }
+    }
+}
+
+fn opponent_life_delta_after_discard(discard_land: bool) -> i32 {
+    let mut scenario = GameScenario::new();
+    scenario
+        .add_creature(P0, "Doctor Doom, King of Latveria", 4, 4)
+        .from_oracle_text(DOCTOR_DOOM_ORACLE);
+    scenario.add_card_to_hand(P0, "Decoy");
+    let discard_target = if discard_land {
+        scenario.add_land_to_hand(P0, "Forest").id()
+    } else {
+        scenario.add_creature_to_hand(P0, "Bear", 2, 2).id()
+    };
+    let mut runner = scenario.build();
+    let p1_before = runner.state().players[P1.0 as usize].life;
+
+    let trigger = doctor_doom_discard_trigger(
+        runner
+            .state()
+            .objects
+            .values()
+            .find(|o| o.name.contains("Doctor Doom"))
+            .expect("doom")
+            .trigger_definitions
+            .as_slice(),
+    );
+    assert!(
+        trigger.valid_card.is_some(),
+        "runtime trigger must carry land valid_card filter (issue #5327 regression)"
+    );
+
+    let mut events = Vec::new();
+    resolve_ability_chain(
+        runner.state_mut(),
+        &discard_one_card_chain(ObjectId(999), P0),
+        &mut events,
+        0,
+    )
+    .expect("begin discard");
+
+    match &runner.state().waiting_for {
+        WaitingFor::DiscardChoice { .. } => {}
+        other => panic!("expected DiscardChoice, got {other:?}"),
+    }
+
+    apply_as_current(
+        runner.state_mut(),
+        GameAction::SelectCards {
+            cards: vec![discard_target],
+        },
+    )
+    .expect("discard selected card");
+
+    assert!(
+        runner.state().players[P0.0 as usize]
+            .graveyard
+            .contains(&discard_target),
+        "selected card must be in graveyard after discard"
+    );
+
+    drain_stack(&mut runner);
+    runner.state().players[P1.0 as usize].life - p1_before
+}
+
+#[test]
+fn doctor_doom_discard_trigger_parses_land_card_filter() {
+    let parsed = parse_oracle_text(
+        DOCTOR_DOOM_ORACLE,
+        "Doctor Doom, King of Latveria",
+        &[],
+        &["Creature".to_string()],
+        &[
+            "Human".to_string(),
+            "Noble".to_string(),
+            "Villain".to_string(),
+        ],
+    );
+    let trigger = doctor_doom_discard_trigger(&parsed.triggers);
+    assert_eq!(trigger.valid_target, Some(TargetFilter::Controller));
+    assert!(trigger.batched);
+    let engine::types::ability::TargetFilter::Typed(tf) =
+        trigger.valid_card.as_ref().expect("land card filter")
+    else {
+        panic!("expected typed valid_card, got {:?}", trigger.valid_card);
+    };
+    assert!(
+        tf.type_filters.contains(&TypeFilter::Land),
+        "expected Land filter, got {:?}",
+        tf.type_filters
+    );
+    assert_eq!(tf.controller, None);
+    assert!(
+        matches!(
+            trigger.execute.as_ref().map(|e| e.effect.as_ref()),
+            Some(Effect::LoseLife { .. })
+        ),
+        "trigger must lose life for each opponent"
+    );
+}
+
+#[test]
+fn doctor_doom_loses_opponent_life_when_you_discard_land() {
+    assert_eq!(
+        opponent_life_delta_after_discard(true),
+        -2,
+        "discarding a land must make each opponent lose 2 life"
+    );
+}
+
+#[test]
+fn doctor_doom_does_not_trigger_when_you_discard_nonland() {
+    assert_eq!(
+        opponent_life_delta_after_discard(false),
+        0,
+        "discarding a nonland must not trigger Doctor Doom's life loss"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -440,6 +440,7 @@ mod issue_5283_hall_of_bandit_lord;
 mod issue_5285_senu_keen_eyed_protector;
 mod issue_5286_lulu_loyal_hollyphant;
 mod issue_5287_samwise_stouthearted;
+mod issue_5327_doctor_doom_land_discard;
 mod issue_5328_attacks_alone_observer;
 mod issue_5329_mana_echoes;
 mod issue_5330_scavengers_talent_graveyard_return;


### PR DESCRIPTION
## Summary

Doctor Doom, King of Latveria ("Whenever you discard one or more land cards, each opponent loses 2 life.") was reported as triggering on **any** discard, including connive self-discards of nonland Villains. Investigation on current `main` shows the full path already works:

1. **Parser** sets `TriggerMode::DiscardedAll` with `batched: true`, `valid_target: Controller`, and `valid_card: Typed(Land)` — not a plain `Card` filter.
2. **Matcher** (`match_discarded` → `valid_card_matches`) rejects nonland discards and accepts controller land discards independently of `valid_target`.
3. **Batched dispatch** (`matching_batched_trigger_events`) only enqueues the trigger when at least one batch event passes the land filter.

No engine logic changes were required. This PR adds end-to-end regression coverage so a future regression in parser binding, card-data synthesis, or batched discard matching is caught immediately.

## Root cause of the original report (triage)

| Layer | Finding |
|-------|---------|
| Parser AST | `valid_card` carries `TypeFilter::Land`; `is_plain_card_filter` correctly omits setting filter only for plain "cards" |
| Runtime object | `from_oracle_text` preserves `valid_card` on `trigger_definitions` |
| Matcher | `discarded_all_valid_target_and_valid_card_are_independent` unit test already green |
| Integration | Land discard → P1 loses 2; nonland discard → no life loss |

The issue is labeled `status:fixed-unreleased` on GitHub — behavior is fixed in tree but not yet in a public build when the report was filed.

## Changes

### Integration tests (`crates/engine/tests/integration/issue_5327_doctor_doom_land_discard.rs`)

- Parse assertion: `DiscardedAll` + `Land` `valid_card` + `LoseLife` execute.
- Runtime positive: discard a land → opponent loses 2 life.
- Runtime negative: discard a nonland creature → no life loss (covers connive-style nonland self-discard class).
- Runtime guard: `valid_card` is present on the battlefield object's trigger definition after `from_oracle_text`.

### Registration

- `mod issue_5327_doctor_doom_land_discard;` in `crates/engine/tests/integration/main.rs`

## Verification

```bash
cargo fmt --all
cargo test -p engine doctor_doom
cargo test -p engine trigger_you_discard_one_or_more_land_cards discarded_all_valid_target
```

## Test plan

- [x] `cargo test -p engine doctor_doom` — 3 integration tests green
- [x] Manual: Doctor Doom on battlefield, discard land → opponents lose 2
- [x] Manual: Doctor Doom connives, discards nonland Villain → no life loss
