### PR TITLE
refactor(parser): source-order Oracle emission for CR 707.9a printed-ability slots

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -61,8 +61,8 @@ use super::oracle_effect::{
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::diagnostic::OracleDiagnostic;
 use super::oracle_ir::doc::{
-    OracleDocBuilder, OracleDocIr, OracleNodeIr, OracleSourceSpan, PrintedAbilityIndex,
-    PrintedTriggerIndex,
+    OracleDocBuilder, OracleDocIr, OracleItemIr, OracleNodeIr, OracleSourceSpan, OracleUnitSource,
+    PrintedAbilityIndex, PrintedTriggerIndex,
 };
 pub use super::oracle_keyword::keyword_display_name;
 use super::oracle_keyword::{
@@ -2701,6 +2701,194 @@ fn parse_strive_cost_line(line: &str) -> Option<ManaCost> {
         .parse(i)
     })?;
     Some(cost)
+}
+
+/// Single-authority source-order emission surface for the unit-4 cutover.
+///
+/// Owns the `OracleDocBuilder` and the parse-local line→byte geometry so EVERY
+/// emission in `parse_oracle_ir` — the per-line dispatch loop, the preprocessors,
+/// and the post-loop singletons — routes through ONE place that (a) computes the
+/// item's exact source span, (b) draws its `ordinal_within_span` from the
+/// builder's single `next_ordinal_for_line` authority, and (c) calls
+/// `begin_item` + `emit`. Every typed method is trivial and uniform — it does
+/// EXACTLY `begin_item(exact_span, Some(fragment)) + emit(node)` and nothing else
+/// (no reordering, no per-method divergence): the method bodies are the fidelity
+/// surface, so the source-order guarantee is a property of this one type rather
+/// than of 90 hand-written call sites.
+///
+/// This replaces the former category-ordered `parsed_abilities_to_doc_ir` on
+/// every non-Class path. `whole_document` spans survive only in the Class shim.
+#[allow(dead_code)] // wired by the dispatch-loop/preprocessor cutover in this unit.
+struct DocEmitter<'a> {
+    builder: OracleDocBuilder,
+    lines: &'a [&'a str],
+    /// Byte offset of the start of each line in the normalized Oracle text:
+    /// `line_start[i] = Σ_{j<i} (lines[j].len() + 1)` (one `'\n'` per prior line).
+    /// Byte values only order items — they are parser-internal and never reach
+    /// `card-data.json` (spans are not serialized into the lowered output).
+    line_start: Vec<usize>,
+}
+
+#[allow(dead_code)] // wired by the dispatch-loop/preprocessor cutover in this unit.
+impl<'a> DocEmitter<'a> {
+    fn new(lines: &'a [&'a str]) -> Self {
+        let mut line_start = Vec::with_capacity(lines.len());
+        let mut acc = 0usize;
+        for line in lines {
+            line_start.push(acc);
+            acc += line.len() + 1; // +1 for the '\n' separator split() removed.
+        }
+        Self {
+            builder: OracleDocBuilder::new(),
+            lines,
+            line_start,
+        }
+    }
+
+    /// Exact byte range `[start, end)` of `line` in the normalized text.
+    fn byte_range(&self, line: usize) -> (usize, usize) {
+        let start = self.line_start[line];
+        (start, start + self.lines[line].len())
+    }
+
+    /// An Exact span for `line`, drawing a fresh ordinal from the single per-line
+    /// authority so no two items on one line can collide on the map key.
+    fn exact_span(&mut self, line: usize) -> OracleSourceSpan {
+        let ordinal = self.builder.next_ordinal_for_line(line);
+        let (start, end) = self.byte_range(line);
+        OracleSourceSpan::exact(line, line, start, end, ordinal)
+    }
+
+    /// The one emit primitive; every typed method funnels here. The `expect` is
+    /// sound: `emit` only rejects a duplicate `(first_line, start_byte, ordinal)`
+    /// key or an overlapping same-ordinal sibling, and the single-authority
+    /// ordinal makes every same-line item's key distinct.
+    fn emit_at(&mut self, line: usize, node: OracleNodeIr) {
+        let span = self.exact_span(line);
+        let fragment = self.lines[line];
+        let slot = self.builder.begin_item(span, Some(fragment));
+        self.builder.emit(slot, node).expect(
+            "single-authority ordinals keep same-line item keys distinct, so emit cannot reject",
+        );
+    }
+
+    /// Emit an item spanning `first_line..=last_line` (a multi-line unit, e.g. a
+    /// leveler block-summary static whose span ends at the last
+    /// modification-contributing line). Ordinal is drawn on `first_line`.
+    fn emit_span(&mut self, first_line: usize, last_line: usize, node: OracleNodeIr) {
+        let ordinal = self.builder.next_ordinal_for_line(first_line);
+        let (start, _) = self.byte_range(first_line);
+        let (_, end) = self.byte_range(last_line);
+        let span = OracleSourceSpan::exact(first_line, last_line, start, end, ordinal);
+        // Fragment must be the verbatim covered slice for an Exact span; the
+        // caller passes contiguous lines, so the byte range is honest.
+        let slot = self.builder.begin_item(span, Some(self.lines[first_line]));
+        self.builder
+            .emit(slot, node)
+            .expect("single-authority ordinals keep multi-line item keys distinct");
+    }
+
+    fn ability_at(&mut self, line: usize, def: AbilityDefinition) {
+        self.emit_at(line, OracleNodeIr::PreLoweredSpell(def));
+    }
+    fn trigger_at(&mut self, line: usize, def: TriggerDefinition) {
+        self.emit_at(line, OracleNodeIr::PreLoweredTrigger(def));
+    }
+    fn static_at(&mut self, line: usize, def: StaticDefinition) {
+        self.emit_at(line, OracleNodeIr::PreLoweredStatic(def));
+    }
+    fn replacement_at(&mut self, line: usize, def: ReplacementDefinition) {
+        self.emit_at(line, OracleNodeIr::PreLoweredReplacement(def));
+    }
+    fn keyword_at(&mut self, line: usize, kw: Keyword) {
+        self.emit_at(line, OracleNodeIr::Keyword(kw));
+    }
+    fn casting_restriction_at(&mut self, line: usize, r: CastingRestriction) {
+        self.emit_at(line, OracleNodeIr::CastingRestriction(r));
+    }
+    fn casting_option_at(&mut self, line: usize, o: SpellCastingOption) {
+        self.emit_at(line, OracleNodeIr::CastingOption(o));
+    }
+    fn additional_cost_at(&mut self, line: usize, c: AdditionalCost) {
+        self.emit_at(line, OracleNodeIr::AdditionalCost(c));
+    }
+    fn solve_condition_at(&mut self, line: usize, c: SolveCondition) {
+        self.emit_at(line, OracleNodeIr::SolveCondition(c));
+    }
+    fn strive_cost_at(&mut self, line: usize, c: ManaCost) {
+        self.emit_at(line, OracleNodeIr::StriveCost(c));
+    }
+    fn modal_at(&mut self, line: usize, m: ModalChoice) {
+        self.emit_at(line, OracleNodeIr::Modal(m));
+    }
+
+    /// A card-data (MTGJSON) keyword that has NO printed source line: a zero-width
+    /// Exact span anchored at `(0, 0, 0)`-bytes, ordinal drawn from the SAME
+    /// `next_ordinal_for_line(0)` authority so multiple card-data keywords keep
+    /// their emission order. `whole_document` is deliberately NOT used — it must
+    /// remain a reliable Class-shim-only marker. The empty fragment is honest: a
+    /// zero-width span covers no text.
+    fn card_data_keyword(&mut self, kw: Keyword) {
+        let ordinal = self.builder.next_ordinal_for_line(0);
+        let span = OracleSourceSpan::exact(0, 0, 0, 0, ordinal);
+        let slot = self.builder.begin_item(span, Some(""));
+        self.builder
+            .emit(slot, OracleNodeIr::Keyword(kw))
+            .expect("distinct ordinals keep zero-width card-data keyword keys distinct");
+    }
+
+    /// Remove and return the most recently emitted spell item — the typed
+    /// `result.abilities.pop()` for the cross-line "instead" fold. The caller
+    /// folds it into a new ability and re-emits via `reemit_spell` at the base
+    /// item's ORIGINAL span.
+    fn pop_last_spell(&mut self) -> Option<OracleItemIr> {
+        self.builder.take_last_spell()
+    }
+
+    /// Re-emit a spell at a template item's ORIGINAL span — same `first_line`,
+    /// bytes, AND `ordinal_within_span`, the key `take_last_spell` just freed.
+    ///
+    /// m2-shell correction: reuse the original ordinal, never fresh-allocate. The
+    /// key was freed by the take, so re-emit cannot collide; and a fresh (higher)
+    /// ordinal would REORDER the spell past any co-located sibling that shares its
+    /// `(first_line, start_byte)` (e.g. a `push_same_is_true_*` static + ability
+    /// from one line). Original-ordinal re-emit is position- and slot-preserving.
+    fn reemit_spell(&mut self, source: &OracleUnitSource, def: AbilityDefinition) {
+        let span = source.span().clone();
+        let fragment = source.fragment();
+        let slot = self.builder.begin_item(span, fragment);
+        self.builder
+            .emit(slot, OracleNodeIr::PreLoweredSpell(def))
+            .expect("re-emitting at the just-freed original key cannot collide");
+    }
+
+    /// The typed `result.abilities.last_mut()` for min_x_value stamping: pop the
+    /// last emitted spell, mutate it, re-emit at its original span. A no-op when
+    /// no spell has been emitted (mirrors `last_mut()` returning `None`).
+    ///
+    /// `take_last_spell` pops the emission-ordered spell stack, which equals
+    /// `abilities.last_mut()` regardless of triggers/statics emitted in between.
+    fn mutate_last_spell(&mut self, f: impl FnOnce(&mut AbilityDefinition)) {
+        let Some(item) = self.builder.take_last_spell() else {
+            return;
+        };
+        let OracleItemIr { source, node, .. } = item;
+        let OracleNodeIr::PreLoweredSpell(mut def) = node else {
+            unreachable!("take_last_spell returns only PreLoweredSpell items");
+        };
+        f(&mut def);
+        self.reemit_spell(&source, def);
+    }
+
+    /// Finish, producing items already in Oracle source order.
+    fn finish(
+        self,
+        oracle_text: &str,
+        card_name: &str,
+        diagnostics: Vec<OracleDiagnostic>,
+    ) -> OracleDocIr {
+        self.builder.finish(oracle_text, card_name, diagnostics)
+    }
 }
 
 /// Produce an `OracleDocIr` from Oracle text — the IR-production half of the

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -2859,9 +2859,7 @@ pub(crate) fn parse_oracle_ir(
         let mut triggers = parse_trigger_lines_at_index(
             ability_text,
             card_name,
-            Some(PrintedTriggerIndex::from_category_vector_len(
-                result.triggers.len(),
-            )),
+            Some(PrintedTriggerIndex::placeholder()),
             &mut ctx,
         );
         for trigger in &mut triggers {
@@ -2880,11 +2878,8 @@ pub(crate) fn parse_oracle_ir(
         // CR 707.9a: Pass the running trigger count so any "has this ability"
         // retain modification inside a Spacecraft threshold trigger body
         // resolves to the correct printed-trigger slot.
-        let (sc_statics, sc_triggers, sc_abilities, consumed) = parse_spacecraft_threshold_lines(
-            &lines,
-            card_name,
-            PrintedTriggerIndex::from_category_vector_len(result.triggers.len()),
-        );
+        let (sc_statics, sc_triggers, sc_abilities, consumed) =
+            parse_spacecraft_threshold_lines(&lines, card_name, PrintedTriggerIndex::placeholder());
         result.statics.extend(sc_statics);
         result.triggers.extend(sc_triggers);
         for mut def in sc_abilities {
@@ -3493,9 +3488,7 @@ pub(crate) fn parse_oracle_ir(
                 effect_text,
                 &line,
                 card_name,
-                Some(PrintedAbilityIndex::from_category_vector_len(
-                    result.abilities.len(),
-                )),
+                Some(PrintedAbilityIndex::placeholder()),
                 &mut ctx,
             );
             // CR 702.186b: ∞ ("As long as harnessed, it has [ability]") gates an
@@ -3580,9 +3573,7 @@ pub(crate) fn parse_oracle_ir(
             let mut triggers = parse_trigger_lines_at_index(
                 &line,
                 card_name,
-                Some(PrintedTriggerIndex::from_category_vector_len(
-                    result.triggers.len(),
-                )),
+                Some(PrintedTriggerIndex::placeholder()),
                 &mut ctx,
             );
             i += 1;
@@ -3619,9 +3610,7 @@ pub(crate) fn parse_oracle_ir(
                         activated_effect_text,
                         &line,
                         card_name,
-                        Some(PrintedAbilityIndex::from_category_vector_len(
-                            result.abilities.len(),
-                        )),
+                        Some(PrintedAbilityIndex::placeholder()),
                         &mut ctx,
                     );
                     result.abilities.push(def);
@@ -3634,9 +3623,7 @@ pub(crate) fn parse_oracle_ir(
                 let mut triggers = parse_trigger_lines_at_index(
                     &effect_text,
                     card_name,
-                    Some(PrintedTriggerIndex::from_category_vector_len(
-                        result.triggers.len(),
-                    )),
+                    Some(PrintedTriggerIndex::placeholder()),
                     &mut ctx,
                 );
                 // B7: Attach ability-word condition as fallback when extract_if_condition
@@ -4727,9 +4714,7 @@ pub(crate) fn parse_oracle_ir(
                 let mut triggers = parse_trigger_lines_at_index(
                     &effect_text,
                     card_name,
-                    Some(PrintedTriggerIndex::from_category_vector_len(
-                        result.triggers.len(),
-                    )),
+                    Some(PrintedTriggerIndex::placeholder()),
                     &mut ctx,
                 );
                 i += 1;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -621,18 +621,20 @@ fn parse_begin_game_counter_clause(
     ))
 }
 
-fn parsed_result_recently_granted_flashback(result: &ParsedAbilities) -> bool {
-    result
-        .abilities
-        .last()
+fn parsed_result_recently_granted_flashback(emitter: &DocEmitter<'_>) -> bool {
+    // u4-c2: reads the emitter's last-emitted-per-category peeks instead of
+    // `result.{abilities,triggers,statics}.last()` (the vectors moved into the
+    // source-ordered builder). Same semantics: was flashback just granted?
+    emitter
+        .last_ability()
         .is_some_and(definition_grants_flashback)
-        || result.triggers.last().is_some_and(|trigger| {
+        || emitter.last_trigger().is_some_and(|trigger| {
             trigger
                 .execute
                 .as_deref()
                 .is_some_and(definition_grants_flashback)
         })
-        || result.statics.last().is_some_and(|static_def| {
+        || emitter.last_static().is_some_and(|static_def| {
             static_def.modifications.iter().any(|modification| {
                 matches!(
                     modification,
@@ -1600,7 +1602,8 @@ fn is_self_chosen_type_description(description: &str) -> bool {
 }
 
 fn push_same_is_true_static_tail<F>(
-    result: &mut ParsedAbilities,
+    emitter: &mut DocEmitter<'_>,
+    item_line: usize,
     line: &str,
     lower: &str,
     parse_modeled_sentence: F,
@@ -1611,14 +1614,12 @@ where
     if let Some((modeled_sentence, unmodeled_tail)) =
         split_same_is_true_static_tail(line, lower, parse_modeled_sentence)
     {
-        result
-            .statics
-            .extend(parse_static_line_with_graveyard_keyword_continuation(
-                modeled_sentence,
-                None,
-                None,
-            ));
-        result.abilities.push(make_unimplemented(unmodeled_tail));
+        for __item in
+            parse_static_line_with_graveyard_keyword_continuation(modeled_sentence, None, None)
+        {
+            emitter.static_at(item_line, __item);
+        }
+        emitter.ability_at(item_line, make_unimplemented(unmodeled_tail));
         return true;
     }
 
@@ -1647,7 +1648,8 @@ where
 /// rather than an inert `AddKeyword(Unknown)` static, so it stays a loud
 /// unsupported gap in coverage instead of silently reading as supported.
 fn push_graveyard_keyword_same_is_true_tail(
-    result: &mut ParsedAbilities,
+    emitter: &mut DocEmitter<'_>,
+    item_line: usize,
     line: &str,
     lower: &str,
 ) -> bool {
@@ -1700,12 +1702,14 @@ fn push_graveyard_keyword_same_is_true_tail(
         }
         statics.push(new_def);
     }
-    result.statics.extend(statics);
+    for __item in statics {
+        emitter.static_at(item_line, __item);
+    }
     if !unqualified.is_empty() {
-        result.abilities.push(make_unimplemented(&format!(
-            "the same is true for {}",
-            unqualified.join(", ")
-        )));
+        emitter.ability_at(
+            item_line,
+            make_unimplemented(&format!("the same is true for {}", unqualified.join(", "))),
+        );
     }
     true
 }
@@ -2409,7 +2413,7 @@ fn parse_flash_cleanup_sacrifice_casting_option(
 /// `ParsedAbilities` stays category-grouped because it is the runtime-facing
 /// type; only *within*-category order and explicit cross-item relations are
 /// semantic after lowering.
-pub(crate) fn lower_oracle_ir(ir: &OracleDocIr) -> ParsedAbilities {
+pub(crate) fn lower_oracle_ir(ir: &OracleDocIr, types: &[String]) -> ParsedAbilities {
     let mut result = ParsedAbilities {
         abilities: Vec::new(),
         triggers: Vec::new(),
@@ -2476,6 +2480,56 @@ pub(crate) fn lower_oracle_ir(ir: &OracleDocIr) -> ParsedAbilities {
         }
     }
     result.parse_warnings = ir.diagnostics.clone();
+
+    // ---- u4-c2 relocated post-fold passes -------------------------------------
+    // These five consumers read the ASSEMBLED `result` vectors, which the
+    // source-order cutover moved off the old `result` accumulator and into the
+    // document builder. They therefore run HERE (post-fold), not in the dispatch
+    // loop. PLACEMENT PIN: immediately after the item fold + `parse_warnings`
+    // copy, in their original relative order (the 4 reconciles, then the swallow
+    // audit), and BEFORE `synthesize_etb_exile_ltb_return_pair` /
+    // `bind_active_player_punisher_target`. This reproduces today's global order
+    // (reconciles → swallow → fold → synthesize → bind) exactly.
+    //
+    // The `PreLowered*` nodes identity-lower (the fold reproduces the same defs),
+    // and finish()'s CR 707.9a stamping does not touch the fields these mutate, so
+    // this is behavior-preserving. Kept STANDALONE (not merged) so a future
+    // `LinkedChoice` conversion of the three cross-item reconciles is unimpeded.
+    reconcile_choose_then_chosen_dependent_etb_counters(&mut result);
+    reconcile_self_chosen_type_statics(&mut result, types);
+    reconcile_host_bound_phase_outs(&mut result);
+    reconcile_persisted_player_choice_for_source_chosen_ref(&mut result);
+
+    // Architectural rule: the parser must never silently discard Oracle text. Run
+    // the swallow audit against the parsed result so any unrepresented clause
+    // surfaces as a parse_warning. Post-relocation the audit runs after `finish()`
+    // has sealed `OracleDocIr.diagnostics`, so its warnings DIRECT-APPEND to
+    // `result.parse_warnings` (card-data parity holds — both routes end in
+    // `parse_warnings`, same order: loop diagnostics then swallow diagnostics).
+    // `OracleDocIr.diagnostics` no longer carries swallow warnings until Plan 02
+    // re-homes the audit — see ISSUES.md #17. Source text is the original
+    // (un-normalized) `ir.source_text`, matching today's swallow input.
+    let mut swallow_diags = Vec::new();
+    // Draft-time "draft matters" lines (CR 905) are intentionally consumed as
+    // no-ops; their "you may"/"if you do"/"as long as" markers would otherwise be
+    // reported as swallowed clauses. Strip them before the audit; constructed-play
+    // lines on the same card remain and are still checked.
+    let swallow_text;
+    let swallow_input: &str = if ir.source_text.lines().any(is_draft_matters_sentence) {
+        swallow_text = ir
+            .source_text
+            .lines()
+            .filter(|line| !is_draft_matters_sentence(line))
+            .collect::<Vec<_>>()
+            .join("\n");
+        &swallow_text
+    } else {
+        &ir.source_text
+    };
+    super::swallow_check::check_swallowed_clauses(swallow_input, &result, &mut swallow_diags);
+    result.parse_warnings.extend(swallow_diags);
+    // ---------------------------------------------------------------------------
+
     // CR 607.1 + CR 610.3: Two-trigger exile-return synthesis. Cards like
     // Journey to Nowhere and Oblivion Ring use a two-trigger design:
     //   Line 1 (ETB): "When ~ enters, exile target creature."
@@ -2727,6 +2781,18 @@ struct DocEmitter<'a> {
     /// Byte values only order items — they are parser-internal and never reach
     /// `card-data.json` (spans are not serialized into the lowered output).
     line_start: Vec<usize>,
+    /// Last-emitted TRIGGER / STATIC, for the ONE mid-loop reader that inspects
+    /// `result.{triggers,statics}.last()` (`parsed_result_recently_granted_flashback`).
+    /// INSERTION recency: overwritten on each emit of that category. Safe as a
+    /// clone-on-emit slot because NO `triggers.pop()`/`statics.pop()` exists in the
+    /// parser (doc.rs verifies this) — nothing can revert them. The ABILITY peek is
+    /// deliberately NOT here: it must be pop-aware, so `last_ability()` reads the
+    /// builder's `spells_emitted` stack via `peek_last_spell` instead.
+    ///
+    /// If a trigger/static pop is ever introduced, make these
+    /// `*_emitted: Vec<OracleItemId>` stacks (like `spells_emitted`) first.
+    last_trigger: Option<TriggerDefinition>,
+    last_static: Option<StaticDefinition>,
 }
 
 #[allow(dead_code)] // wired by the dispatch-loop/preprocessor cutover in this unit.
@@ -2742,6 +2808,8 @@ impl<'a> DocEmitter<'a> {
             builder: OracleDocBuilder::new(),
             lines,
             line_start,
+            last_trigger: None,
+            last_static: None,
         }
     }
 
@@ -2789,13 +2857,63 @@ impl<'a> DocEmitter<'a> {
     }
 
     fn ability_at(&mut self, line: usize, def: AbilityDefinition) {
+        // No `last_ability` clone: the ability peek is pop-aware, read from the
+        // builder's `spells_emitted` stack (see `last_ability`).
         self.emit_at(line, OracleNodeIr::PreLoweredSpell(def));
     }
     fn trigger_at(&mut self, line: usize, def: TriggerDefinition) {
+        self.last_trigger = Some(def.clone());
         self.emit_at(line, OracleNodeIr::PreLoweredTrigger(def));
     }
     fn static_at(&mut self, line: usize, def: StaticDefinition) {
+        self.last_static = Some(def.clone());
         self.emit_at(line, OracleNodeIr::PreLoweredStatic(def));
+    }
+
+    /// Last-emitted definition per category — the read-only peeks for
+    /// `parsed_result_recently_granted_flashback` (the one mid-loop reader of
+    /// `result.{abilities,triggers,statics}.last()`). All three are INSERTION
+    /// recency; `last_ability` is pop-aware (via `spells_emitted`), the other two
+    /// are clone-on-emit slots (no pop exists to revert them).
+    fn last_ability(&self) -> Option<&AbilityDefinition> {
+        self.builder.peek_last_spell()
+    }
+    fn last_trigger(&self) -> Option<&TriggerDefinition> {
+        self.last_trigger.as_ref()
+    }
+    fn last_static(&self) -> Option<&StaticDefinition> {
+        self.last_static.as_ref()
+    }
+
+    /// Move every vector item a `&mut ParsedAbilities`-taking mutator just pushed
+    /// into the builder at `item_line`, then clear them. Used for the complex
+    /// cross-file mutators (modal / enters-replacement lowering) that the (B)
+    /// tuple-return design does NOT rewrite internally: they still push into a
+    /// scratch `ParsedAbilities`, and this drains that scratch into source-ordered
+    /// emission. `result`'s SINGLETON fields (modal/additional_cost/…) are left
+    /// untouched — the caller handles those.
+    fn drain_result_vectors(&mut self, item_line: usize, result: &mut ParsedAbilities) {
+        for def in std::mem::take(&mut result.abilities) {
+            self.ability_at(item_line, def);
+        }
+        for def in std::mem::take(&mut result.triggers) {
+            self.trigger_at(item_line, def);
+        }
+        for def in std::mem::take(&mut result.statics) {
+            self.static_at(item_line, def);
+        }
+        for def in std::mem::take(&mut result.replacements) {
+            self.replacement_at(item_line, def);
+        }
+        for kw in std::mem::take(&mut result.extracted_keywords) {
+            self.keyword_at(item_line, kw);
+        }
+        for r in std::mem::take(&mut result.casting_restrictions) {
+            self.casting_restriction_at(item_line, r);
+        }
+        for o in std::mem::take(&mut result.casting_options) {
+            self.casting_option_at(item_line, o);
+        }
     }
     fn replacement_at(&mut self, line: usize, def: ReplacementDefinition) {
         self.emit_at(line, OracleNodeIr::PreLoweredReplacement(def));
@@ -2955,11 +3073,40 @@ pub(crate) fn parse_oracle_ir(
     let oracle_text_owned = normalize_card_name_refs(oracle_text, card_name);
     let lines: Vec<&str> = oracle_text_owned.split('\n').collect();
 
-    // CR 714 / CR 717: Pre-parse Saga chapters and Attraction visit lines.
+    // u4-c2 source-order emission: the document builder, wrapped in the emitter
+    // that owns the single per-line ordinal authority. Every non-Class emission —
+    // preprocessors and the dispatch loop — routes through it, in printed source
+    // order. `result` is retained ONLY as the holder for the four order-agnostic
+    // SINGLETON fields (additional_cost / solve_condition / strive_cost / modal),
+    // which need mid-loop read-back/merge/dedup; its VECTOR fields stay empty and
+    // are emitted through the builder instead. The singletons are emitted post-loop
+    // at their captured source line.
+    let mut emitter = DocEmitter::new(&lines);
+    let mut additional_cost_line: Option<usize> = None;
+    let mut solve_condition_line: Option<usize> = None;
+    let mut strive_cost_line: Option<usize> = None;
+    let mut modal_line: Option<usize> = None;
+
+    // CR 716: Class cards use the whole-document shim (unit 6 unifies the path).
+    // HOISTED above the saga/attraction/level/spacecraft pre-loop blocks so the
+    // shim can never drop a pre-emitted builder item — the emitter is provably
+    // empty at this early return.
+    if subtypes.iter().any(|s| s == "Class") {
+        let class_result =
+            parse_class_oracle_text(&lines, card_name, mtgjson_keyword_names, result);
+        return parsed_abilities_to_doc_ir(class_result, oracle_text, card_name, &mut ctx);
+    }
+
+    // CR 714 / CR 717: Pre-parse Saga chapters and Attraction visit lines, emitting
+    // each at its printed source line (multi-numeral chapters share a line and get
+    // ascending ordinals from the single authority in numeral order — CR 714.2c).
     let mut preparsed_consumed = if subtypes.iter().any(|s| s == "Saga") {
-        let (chapter_triggers, etb_replacement, consumed) = parse_saga_chapters(&lines, card_name);
-        result.triggers.extend(chapter_triggers);
-        result.replacements.push(etb_replacement);
+        let (chapter_triggers, (etb_line, etb_replacement), consumed) =
+            parse_saga_chapters(&lines, card_name);
+        for (line, trigger) in chapter_triggers {
+            emitter.trigger_at(line, trigger);
+        }
+        emitter.replacement_at(etb_line, etb_replacement);
         consumed
     } else {
         std::collections::HashSet::new()
@@ -2969,26 +3116,23 @@ pub(crate) fn parse_oracle_ir(
         .any(|s| s.eq_ignore_ascii_case("Attraction"))
     {
         let (visit_triggers, consumed) = parse_attraction_visit_triggers(&lines, card_name);
-        result.triggers.extend(visit_triggers);
+        for (line, trigger) in visit_triggers {
+            emitter.trigger_at(line, trigger);
+        }
         preparsed_consumed.extend(consumed);
     }
 
-    // CR 716: Pre-parse Class level sections into level-gated abilities.
-    if subtypes.iter().any(|s| s == "Class") {
-        let class_result =
-            parse_class_oracle_text(&lines, card_name, mtgjson_keyword_names, result);
-        return parsed_abilities_to_doc_ir(class_result, oracle_text, card_name, &mut ctx);
-    }
-
-    // CR 711: Pre-parse leveler LEVEL blocks into counter-gated static abilities.
+    // CR 711: Pre-parse leveler LEVEL blocks into counter-gated static abilities,
+    // each emitted at its own source span (block-summary statics span
+    // header..=max(mod_lines) via `emit_span`).
     let (level_statics, level_consumed, level_ability_lines) =
         parse_level_blocks(&lines, card_name);
-    if !level_statics.is_empty() {
-        result.statics.extend(level_statics);
+    for (sd, first_line, last_line) in level_statics {
+        emitter.emit_span(first_line, last_line, OracleNodeIr::PreLoweredStatic(sd));
     }
     // CR 711.2a + CR 711.2b: Re-parse ability lines found within LEVEL blocks through
     // the normal trigger/activated/static pipeline, then attach the level counter condition.
-    for (ability_text, level_condition) in &level_ability_lines {
+    for (ability_text, level_condition, level_line) in &level_ability_lines {
         let (minimum, maximum) = match level_condition {
             StaticCondition::HasCounters {
                 minimum, maximum, ..
@@ -3028,7 +3172,7 @@ pub(crate) fn parse_oracle_ir(
             def.activation_restrictions = restrictions;
             extract_cost_reduction_from_chain(&mut def);
             extract_mana_spend_trigger_from_chain(&mut def);
-            result.abilities.push(def);
+            emitter.ability_at(*level_line, def);
             continue;
         }
 
@@ -3053,7 +3197,9 @@ pub(crate) fn parse_oracle_ir(
         for trigger in &mut triggers {
             trigger.condition = Some(trigger_condition.clone());
         }
-        result.triggers.extend(triggers);
+        for trigger in triggers {
+            emitter.trigger_at(*level_line, trigger);
+        }
     }
 
     // CR 702.184a + CR 721.2: Pre-parse Spacecraft "N+ | body" threshold lines
@@ -3068,12 +3214,18 @@ pub(crate) fn parse_oracle_ir(
         // resolves to the correct printed-trigger slot.
         let (sc_statics, sc_triggers, sc_abilities, consumed) =
             parse_spacecraft_threshold_lines(&lines, card_name, PrintedTriggerIndex::placeholder());
-        result.statics.extend(sc_statics);
-        result.triggers.extend(sc_triggers);
-        for mut def in sc_abilities {
+        for (line, sd) in sc_statics {
+            emitter.static_at(line, sd);
+        }
+        for (line, trigger) in sc_triggers {
+            emitter.trigger_at(line, trigger);
+        }
+        // Post-processing runs here (pre-emit), exactly as before — the (B)
+        // tuple-return design obviates moving it inside the preprocessor.
+        for (line, mut def) in sc_abilities {
             extract_cost_reduction_from_chain(&mut def);
             extract_mana_spend_trigger_from_chain(&mut def);
-            result.abilities.push(def);
+            emitter.ability_at(line, def);
         }
         consumed
             .into_iter()
@@ -3084,10 +3236,12 @@ pub(crate) fn parse_oracle_ir(
 
     // CR 207.2c + CR 601.2f: Pre-parse Strive ability word cost before main loop.
     // Strive lines have the form: "Strive — This spell costs {X} more to cast for each
-    // target beyond the first." — extract the per-target surcharge cost.
-    for raw in &lines {
+    // target beyond the first." — extract the per-target surcharge cost. Captured as
+    // a loop-local singleton (emitted post-loop at its source line).
+    for (idx, raw) in lines.iter().enumerate() {
         if let Some(cost) = parse_strive_cost_line(raw) {
             result.strive_cost = Some(cost);
+            strive_cost_line = Some(idx);
             break;
         }
     }
@@ -3110,6 +3264,12 @@ pub(crate) fn parse_oracle_ir(
             i += 1;
             continue;
         }
+
+        // u4-c2: the source line where THIS iteration's dispatch begins. Every item
+        // emitted this iteration anchors here — not at `i`, which some multi-line
+        // consumers advance mid-iteration (a 2-line ability's printed line is its
+        // first line, the dispatch-start line, regardless of how many `i` consumes).
+        let item_line = i;
 
         let raw_line = lines[i].trim();
         if raw_line.is_empty() {
@@ -3139,9 +3299,9 @@ pub(crate) fn parse_oracle_ir(
         let line = strip_x_cant_be_zero_suffix(&line);
         if line.is_empty() {
             if min_x_value > 0 {
-                if let Some(previous) = result.abilities.last_mut() {
+                emitter.mutate_last_spell(|previous| {
                     previous.min_x_value = previous.min_x_value.max(min_x_value);
-                }
+                });
             }
             // Priority 14: entirely parenthesized reminder text
             i += 1;
@@ -3160,6 +3320,9 @@ pub(crate) fn parse_oracle_ir(
                 split_additional_cost_trailing_spell_reduction(&line, &lower);
             let cost_lower = cost_line.to_lowercase();
             result.additional_cost = parse_additional_cost_line(&cost_lower, cost_line);
+            if result.additional_cost.is_some() {
+                additional_cost_line.get_or_insert(item_line);
+            }
             if let Some(reduction_text) = trailing_reduction {
                 if let Some(mut def) = parse_static_line(reduction_text) {
                     // CR 702.166a analogue: reduction only applies when the optional
@@ -3170,7 +3333,7 @@ pub(crate) fn parse_oracle_ir(
                         },
                         None => StaticCondition::AdditionalCostPaid,
                     });
-                    result.statics.push(def);
+                    emitter.static_at(item_line, def);
                 }
             }
             i += 1;
@@ -3193,7 +3356,9 @@ pub(crate) fn parse_oracle_ir(
                 if all_keywords {
                     for part in &parts {
                         if let Some(extracted) = extract_keyword_line(part, mtgjson_keyword_names) {
-                            result.extracted_keywords.extend(extracted);
+                            for __item in extracted {
+                                emitter.keyword_at(item_line, __item);
+                            }
                         }
                     }
                     i += 1;
@@ -3206,12 +3371,19 @@ pub(crate) fn parse_oracle_ir(
         // Must run before keyword extraction so "Spree" header + follow-on `+` lines
         // are consumed as a modal block, not swallowed as a keyword-only line.
         if let Some((block, next_i)) = parse_oracle_block(&lines, i) {
+            // Modal lowering still pushes into a scratch `ParsedAbilities`; drain
+            // its vector output into source-ordered emission at the block's line,
+            // and capture the `modal` singleton's line for post-loop emission.
             lower_oracle_block(
                 block,
                 card_name,
                 ctx.host_self_reference.clone(),
                 &mut result,
             );
+            emitter.drain_result_vectors(item_line, &mut result);
+            if result.modal.is_some() {
+                modal_line.get_or_insert(item_line);
+            }
             i = next_i;
             continue;
         }
@@ -3223,7 +3395,7 @@ pub(crate) fn parse_oracle_ir(
         // ability and still needs the synthesized activation body.
         if lower_starts_with(&lower, "equip") && !lower_starts_with(&lower, "equipped") {
             if let Some(ability) = try_parse_equip(&line) {
-                result.abilities.push(ability);
+                emitter.ability_at(item_line, ability);
                 i += 1;
                 continue;
             }
@@ -3235,7 +3407,7 @@ pub(crate) fn parse_oracle_ir(
         // and would consume the line, dropping the cadence sentence.
         if lower_starts_with(&lower, "crew ") {
             if let Some(crew_kw) = parse_crew_keyword(&lower) {
-                result.extracted_keywords.push(crew_kw);
+                emitter.keyword_at(item_line, crew_kw);
                 i += 1;
                 continue;
             }
@@ -3249,8 +3421,11 @@ pub(crate) fn parse_oracle_ir(
             if let Some(extracted) = extract_keyword_line(&line, mtgjson_keyword_names) {
                 if let Some(cost) = parse_kicker_additional_cost_line(&line, &lower) {
                     merge_kicker_additional_cost(&mut result.additional_cost, cost);
+                    additional_cost_line.get_or_insert(item_line);
                 }
-                result.extracted_keywords.extend(extracted);
+                for __item in extracted {
+                    emitter.keyword_at(item_line, __item);
+                }
                 i += 1;
                 continue;
             }
@@ -3264,12 +3439,18 @@ pub(crate) fn parse_oracle_ir(
         // (Cairn Wanderer) — distribute the gated grant per keyword before the
         // chosen/every-type same-is-true arms (which gap the tail) or the generic
         // static path (which mis-tokenizes the keyword list) can claim the line.
-        if push_graveyard_keyword_same_is_true_tail(&mut result, &static_line, &static_line_lower) {
+        if push_graveyard_keyword_same_is_true_tail(
+            &mut emitter,
+            item_line,
+            &static_line,
+            &static_line_lower,
+        ) {
             i += 1;
             continue;
         }
         if push_same_is_true_static_tail(
-            &mut result,
+            &mut emitter,
+            item_line,
             &static_line,
             &static_line_lower,
             parse_chosen_creature_type_static_prefix,
@@ -3278,7 +3459,8 @@ pub(crate) fn parse_oracle_ir(
             continue;
         }
         if push_same_is_true_static_tail(
-            &mut result,
+            &mut emitter,
+            item_line,
             &static_line,
             &static_line_lower,
             parse_every_creature_type_static_prefix,
@@ -3292,7 +3474,8 @@ pub(crate) fn parse_oracle_ir(
         // leaves the non-battlefield-zone tail as an `Unimplemented` residual,
         // mirroring Arcane Adaptation / Maskwood Nexus.
         if push_same_is_true_static_tail(
-            &mut result,
+            &mut emitter,
+            item_line,
             &static_line,
             &static_line_lower,
             parse_compound_you_control_chosen_type_static_prefix,
@@ -3309,7 +3492,7 @@ pub(crate) fn parse_oracle_ir(
                     if let Some(static_def) =
                         try_parse_graveyard_keyword_static_with_continuation(&combined_static_line)
                     {
-                        result.statics.push(static_def);
+                        emitter.static_at(item_line, static_def);
                         i += 2;
                         continue;
                     }
@@ -3339,14 +3522,16 @@ pub(crate) fn parse_oracle_ir(
                     ContinuousModification::SetColor { .. }
                 );
             if is_self_color_cda {
-                result.statics.extend(defs);
+                for __item in defs {
+                    emitter.static_at(item_line, __item);
+                }
                 i += 1;
                 continue;
             }
         }
 
         if lower == "start your engines!" || lower == "start your engines" {
-            result.extracted_keywords.push(Keyword::StartYourEngines);
+            emitter.keyword_at(item_line, Keyword::StartYourEngines);
             i += 1;
             continue;
         }
@@ -3358,7 +3543,9 @@ pub(crate) fn parse_oracle_ir(
                 Some(card_name),
             );
             if !defs.is_empty() {
-                result.statics.extend(defs);
+                for __item in defs {
+                    emitter.static_at(item_line, __item);
+                }
                 i += 1;
                 continue;
             }
@@ -3395,14 +3582,14 @@ pub(crate) fn parse_oracle_ir(
                 .trim_start_matches(" \u{2014} ")
                 .trim_start_matches(" - ");
             if let Some(ability) = try_parse_equip(equip_part) {
-                result.abilities.push(ability);
+                emitter.ability_at(item_line, ability);
                 i += 1;
                 continue;
             }
         }
         // Priority 11: Planeswalker loyalty abilities: +N:, −N:, 0:, [+N]:, [−N]:, [0]:
         if let Some(ability) = try_parse_loyalty_line(&line, &mut ctx) {
-            result.abilities.push(ability);
+            emitter.ability_at(item_line, ability);
             i += 1;
             continue;
         }
@@ -3414,13 +3601,13 @@ pub(crate) fn parse_oracle_ir(
                     let trimmed = clause.trim().trim_end_matches('.');
                     if !trimmed.is_empty() {
                         let clause_dot = format!("{trimmed}.");
-                        result.statics.extend(
-                            parse_static_line_with_graveyard_keyword_continuation(
-                                &clause_dot,
-                                None,
-                                None,
-                            ),
-                        );
+                        for __item in parse_static_line_with_graveyard_keyword_continuation(
+                            &clause_dot,
+                            None,
+                            None,
+                        ) {
+                            emitter.static_at(item_line, __item);
+                        }
                     }
                 }
                 i += 1;
@@ -3435,7 +3622,9 @@ pub(crate) fn parse_oracle_ir(
                 Some(card_name),
             );
             if !defs.is_empty() {
-                result.statics.extend(defs);
+                for __item in defs {
+                    emitter.static_at(item_line, __item);
+                }
                 i += 1;
                 continue;
             }
@@ -3447,6 +3636,7 @@ pub(crate) fn parse_oracle_ir(
         }) {
             let rest_lower = rest_original.to_lowercase();
             result.solve_condition = Some(parse_solve_condition(&rest_lower));
+            solve_condition_line.get_or_insert(item_line);
             i += 1;
             continue;
         }
@@ -3476,7 +3666,7 @@ pub(crate) fn parse_oracle_ir(
                 if !constraints.restrictions.is_empty() {
                     def.activation_restrictions.extend(constraints.restrictions);
                 }
-                result.abilities.push(def);
+                emitter.ability_at(item_line, def);
                 i += 1;
                 continue;
             }
@@ -3506,7 +3696,7 @@ pub(crate) fn parse_oracle_ir(
                 // sub_ability in the chain (it may be several levels deep).
                 extract_cost_reduction_from_chain(&mut def);
                 extract_mana_spend_trigger_from_chain(&mut def);
-                result.abilities.push(def);
+                emitter.ability_at(item_line, def);
                 i += 1;
                 continue;
             }
@@ -3544,7 +3734,7 @@ pub(crate) fn parse_oracle_ir(
                 def.ability_tag = Some(AbilityTag::Boast);
                 extract_cost_reduction_from_chain(&mut def);
                 extract_mana_spend_trigger_from_chain(&mut def);
-                result.abilities.push(def);
+                emitter.ability_at(item_line, def);
                 i += 1;
                 continue;
             }
@@ -3573,7 +3763,7 @@ pub(crate) fn parse_oracle_ir(
                 def.ability_tag = Some(AbilityTag::Exhaust);
                 extract_cost_reduction_from_chain(&mut def);
                 extract_mana_spend_trigger_from_chain(&mut def);
-                result.abilities.push(def);
+                emitter.ability_at(item_line, def);
                 i += 1;
                 continue;
             }
@@ -3613,7 +3803,7 @@ pub(crate) fn parse_oracle_ir(
                     },
                     condition: Some(ParsedCondition::SourceEnteredThisTurn),
                 });
-                result.abilities.push(def);
+                emitter.ability_at(item_line, def);
                 i += 1;
                 continue;
             }
@@ -3651,7 +3841,7 @@ pub(crate) fn parse_oracle_ir(
                     .push(ActivationRestriction::OnlyOnceEachTurn);
                 extract_cost_reduction_from_chain(&mut def);
                 extract_mana_spend_trigger_from_chain(&mut def);
-                result.abilities.push(def);
+                emitter.ability_at(item_line, def);
                 i += 1;
                 continue;
             }
@@ -3701,7 +3891,7 @@ pub(crate) fn parse_oracle_ir(
             if has_roll_die_pattern(&effect_text.to_lowercase()) {
                 i = attach_die_result_branches_to_chain(&mut def, &lines, i);
             }
-            result.abilities.push(def);
+            emitter.ability_at(item_line, def);
             continue;
         }
 
@@ -3730,7 +3920,7 @@ pub(crate) fn parse_oracle_ir(
             && !scan_contains(&lower, "enters this way,")
         {
             if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                result.replacements.push(rep_def);
+                emitter.replacement_at(item_line, rep_def);
                 i += 1;
                 continue;
             }
@@ -3745,7 +3935,7 @@ pub(crate) fn parse_oracle_ir(
         if is_spell && has_trigger_prefix(&lower) {
             if let Some(def) = try_parse_temporal_delayed_trigger_ability(&line, AbilityKind::Spell)
             {
-                result.abilities.push(def);
+                emitter.ability_at(item_line, def);
                 i += 1;
                 continue;
             }
@@ -3774,7 +3964,9 @@ pub(crate) fn parse_oracle_ir(
                     }
                 }
             }
-            result.triggers.extend(triggers);
+            for __item in triggers {
+                emitter.trigger_at(item_line, __item);
+            }
             continue;
         }
 
@@ -3801,7 +3993,7 @@ pub(crate) fn parse_oracle_ir(
                         Some(PrintedAbilityIndex::placeholder()),
                         &mut ctx,
                     );
-                    result.abilities.push(def);
+                    emitter.ability_at(item_line, def);
                     i += 1;
                     continue;
                 }
@@ -3829,7 +4021,9 @@ pub(crate) fn parse_oracle_ir(
                         }
                     }
                 }
-                result.triggers.extend(triggers);
+                for __item in triggers {
+                    emitter.trigger_at(item_line, __item);
+                }
                 continue;
             }
         }
@@ -3868,7 +4062,7 @@ pub(crate) fn parse_oracle_ir(
                     .trigger_zones(vec![Zone::Battlefield])
                     .execute(effect_def)
                     .description(line.to_string());
-                result.triggers.push(trigger);
+                emitter.trigger_at(item_line, trigger);
             }
             i += 1;
             continue;
@@ -3891,7 +4085,7 @@ pub(crate) fn parse_oracle_ir(
                     .trigger_zones(vec![Zone::Battlefield])
                     .execute(effect_def)
                     .description(line.to_string());
-                result.triggers.push(trigger);
+                emitter.trigger_at(item_line, trigger);
             }
             i += 1;
             continue;
@@ -3914,7 +4108,7 @@ pub(crate) fn parse_oracle_ir(
                     .trigger_zones(vec![Zone::Battlefield])
                     .execute(effect_def)
                     .description(line.to_string());
-                result.triggers.push(trigger);
+                emitter.trigger_at(item_line, trigger);
             }
             i += 1;
             continue;
@@ -3929,7 +4123,7 @@ pub(crate) fn parse_oracle_ir(
                     lines.get(i + 1).map(|l| l.to_lowercase())
                 })
             {
-                result.statics.push(static_def);
+                emitter.static_at(item_line, static_def);
                 i += if consumes_next_line { 2 } else { 1 };
                 continue;
             }
@@ -3943,7 +4137,7 @@ pub(crate) fn parse_oracle_ir(
         // Effect::PayCost.
         if is_spells_alternative_cost_pattern(&lower) {
             if let Some(static_def) = parse_spells_alternative_cost(&line) {
-                result.statics.push(static_def);
+                emitter.static_at(item_line, static_def);
                 i += 1;
                 continue;
             }
@@ -3955,7 +4149,9 @@ pub(crate) fn parse_oracle_ir(
         if is_cast_spells_alternative_cost_pattern(&lower) {
             let defs = parse_cast_spells_alternative_cost_multi(&line);
             if !defs.is_empty() {
-                result.statics.extend(defs);
+                for __item in defs {
+                    emitter.static_at(item_line, __item);
+                }
                 i += 1;
                 continue;
             }
@@ -3968,7 +4164,7 @@ pub(crate) fn parse_oracle_ir(
         // and would miss this verb form.
         if is_collect_evidence_alt_cost_pattern(&lower) {
             if let Some(static_def) = parse_collect_evidence_alt_cost(&line) {
-                result.statics.push(static_def);
+                emitter.static_at(item_line, static_def);
                 i += 1;
                 continue;
             }
@@ -3984,7 +4180,9 @@ pub(crate) fn parse_oracle_ir(
                 Some(card_name),
             );
             if !defs.is_empty() {
-                result.statics.extend(defs);
+                for __item in defs {
+                    emitter.static_at(item_line, __item);
+                }
                 i += 1;
                 continue;
             }
@@ -3995,7 +4193,7 @@ pub(crate) fn parse_oracle_ir(
         // New Perspectives (cycling) / Heart of Kiran (crew) / Gavi class.
         if is_alternative_keyword_cost_pattern(&lower) {
             if let Some(static_def) = parse_alternative_keyword_cost(&line) {
-                result.statics.push(static_def);
+                emitter.static_at(item_line, static_def);
                 i += 1;
                 continue;
             }
@@ -4011,7 +4209,7 @@ pub(crate) fn parse_oracle_ir(
         if is_enters_tapped_cant_untap_compound(&lower) {
             let mut consumed = false;
             if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                result.replacements.push(rep_def);
+                emitter.replacement_at(item_line, rep_def);
                 consumed = true;
             }
             let defs = parse_static_line_with_graveyard_keyword_continuation(
@@ -4020,7 +4218,9 @@ pub(crate) fn parse_oracle_ir(
                 Some(card_name),
             );
             if !defs.is_empty() {
-                result.statics.extend(defs);
+                for __item in defs {
+                    emitter.static_at(item_line, __item);
+                }
                 consumed = true;
             }
             if consumed {
@@ -4030,8 +4230,8 @@ pub(crate) fn parse_oracle_ir(
         }
 
         if let Some((option, trigger)) = parse_flash_cleanup_sacrifice_casting_option(&line) {
-            result.casting_options.push(option);
-            result.triggers.push(trigger);
+            emitter.casting_option_at(item_line, option);
+            emitter.trigger_at(item_line, trigger);
             i += 1;
             continue;
         }
@@ -4048,8 +4248,12 @@ pub(crate) fn parse_oracle_ir(
         if let Some((statics, replacements)) =
             parse_static_replacement_compound(&static_line, &static_line_lower, card_name)
         {
-            result.statics.extend(statics);
-            result.replacements.extend(replacements);
+            for __item in statics {
+                emitter.static_at(item_line, __item);
+            }
+            for __item in replacements {
+                emitter.replacement_at(item_line, __item);
+            }
             i += 1;
             continue;
         }
@@ -4083,10 +4287,8 @@ pub(crate) fn parse_oracle_ir(
                     let rider_gap =
                         TriggerDefinition::new(TriggerMode::Unknown("when you do".to_string()))
                             .description(line.to_string());
-                    result
-                        .statics
-                        .push(static_def.description(line.to_string()));
-                    result.triggers.push(rider_gap);
+                    emitter.static_at(item_line, static_def.description(line.to_string()));
+                    emitter.trigger_at(item_line, rider_gap);
                     i += 1;
                     continue;
                 }
@@ -4101,7 +4303,7 @@ pub(crate) fn parse_oracle_ir(
             if line.contains('\u{2014}') {
                 let lower_clean = lower.trim_end_matches('.').trim();
                 if let Some(kw) = parse_keyword_from_oracle(lower_clean) {
-                    result.extracted_keywords.push(kw);
+                    emitter.keyword_at(item_line, kw);
                     i += 1;
                     continue;
                 }
@@ -4110,12 +4312,12 @@ pub(crate) fn parse_oracle_ir(
             {
                 let flashback_lower = flashback_part.to_lowercase();
                 if let Some(kw) = parse_keyword_from_oracle(&flashback_lower) {
-                    result.extracted_keywords.push(kw);
+                    emitter.keyword_at(item_line, kw);
                 }
                 if let Some(def) =
                     parse_flashback_trailing_self_spell_cost_reduction(reduction_part)
                 {
-                    result.statics.push(def);
+                    emitter.static_at(item_line, def);
                 }
                 i += 1;
                 continue;
@@ -4164,18 +4366,20 @@ pub(crate) fn parse_oracle_ir(
             // routes the duration-gated replacement fallback.
             if find_copy_verb_present(&lower) {
                 if let Some(rep_defs) = parse_replacement_sentence_sequence(&line, card_name) {
-                    result.replacements.extend(rep_defs);
+                    for __item in rep_defs {
+                        emitter.replacement_at(item_line, __item);
+                    }
                     i += 1;
                     continue;
                 }
                 if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                    result.replacements.push(rep_def);
+                    emitter.replacement_at(item_line, rep_def);
                     i += 1;
                     continue;
                 }
             } else if lower_starts_with(&lower, "as long as ") && is_replacement_pattern(&lower) {
                 if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                    result.replacements.push(rep_def);
+                    emitter.replacement_at(item_line, rep_def);
                     i += 1;
                     continue;
                 }
@@ -4189,7 +4393,7 @@ pub(crate) fn parse_oracle_ir(
                 // enters-with-counter replacement returns `None` and falls
                 // through to the static parser below.
                 if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                    result.replacements.push(rep_def);
+                    emitter.replacement_at(item_line, rep_def);
                     i += 1;
                     continue;
                 }
@@ -4225,7 +4429,9 @@ pub(crate) fn parse_oracle_ir(
                         for def in &mut defs {
                             def.description = Some(line.to_string());
                         }
-                        result.statics.extend(defs);
+                        for __item in defs {
+                            emitter.static_at(item_line, __item);
+                        }
                         i += 1;
                         continue;
                     }
@@ -4238,13 +4444,13 @@ pub(crate) fn parse_oracle_ir(
                         let trimmed = clause.trim().trim_end_matches('.');
                         if !trimmed.is_empty() {
                             let clause_dot = format!("{trimmed}.");
-                            result.statics.extend(
-                                parse_static_line_with_graveyard_keyword_continuation(
-                                    &clause_dot,
-                                    None,
-                                    None,
-                                ),
-                            );
+                            for __item in parse_static_line_with_graveyard_keyword_continuation(
+                                &clause_dot,
+                                None,
+                                None,
+                            ) {
+                                emitter.static_at(item_line, __item);
+                            }
                         }
                     }
                     i += 1;
@@ -4259,13 +4465,13 @@ pub(crate) fn parse_oracle_ir(
                         let trimmed = clause.trim().trim_end_matches('.');
                         if !trimmed.is_empty() {
                             let clause_dot = format!("{trimmed}.");
-                            result.statics.extend(
-                                parse_static_line_with_graveyard_keyword_continuation(
-                                    &clause_dot,
-                                    None,
-                                    None,
-                                ),
-                            );
+                            for __item in parse_static_line_with_graveyard_keyword_continuation(
+                                &clause_dot,
+                                None,
+                                None,
+                            ) {
+                                emitter.static_at(item_line, __item);
+                            }
                         }
                     }
                     i += 1;
@@ -4281,7 +4487,9 @@ pub(crate) fn parse_oracle_ir(
                     Some(card_name),
                 );
                 if !defs.is_empty() {
-                    result.statics.extend(defs);
+                    for __item in defs {
+                        emitter.static_at(item_line, __item);
+                    }
                     i += 1;
                     continue;
                 }
@@ -4324,7 +4532,7 @@ pub(crate) fn parse_oracle_ir(
                 },
             ))
             .description(line.to_string());
-            result.abilities.push(def);
+            emitter.ability_at(item_line, def);
             i += 1;
             continue;
         }
@@ -4354,7 +4562,7 @@ pub(crate) fn parse_oracle_ir(
             ctx.actor = None;
             let def = parse_effect_chain_with_context(&line, AbilityKind::Spell, &mut ctx);
             if !has_unimplemented(&def) {
-                result.abilities.push(def);
+                emitter.ability_at(item_line, def);
                 i += 1;
                 continue;
             }
@@ -4374,6 +4582,10 @@ pub(crate) fn parse_oracle_ir(
             if is_as_enters_becomes_choice_pattern(&lower)
                 && lower_as_enters_becomes_choice_modal(&line, &mut result)
             {
+                emitter.drain_result_vectors(item_line, &mut result);
+                if result.modal.is_some() {
+                    modal_line.get_or_insert(item_line);
+                }
                 i += 1;
                 continue;
             }
@@ -4387,6 +4599,7 @@ pub(crate) fn parse_oracle_ir(
             // PutCounter-SelfRef guard makes it fall through on any non-counter
             // as-enters line, so the choose/becomes/enters-with siblings are safe.
             if lower_as_enters_or_face_up_counters(&line, &mut result) {
+                emitter.drain_result_vectors(item_line, &mut result);
                 i += 1;
                 continue;
             }
@@ -4398,12 +4611,14 @@ pub(crate) fn parse_oracle_ir(
             // replacement sentences. Parse each replacement sentence instead of
             // letting the first successful parser drop sibling modifiers.
             if let Some(rep_defs) = parse_replacement_sentence_sequence(&line, card_name) {
-                result.replacements.extend(rep_defs);
+                for __item in rep_defs {
+                    emitter.replacement_at(item_line, __item);
+                }
                 i += 1;
                 continue;
             }
             if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                result.replacements.push(rep_def);
+                emitter.replacement_at(item_line, rep_def);
                 i += 1;
                 continue;
             }
@@ -4418,12 +4633,14 @@ pub(crate) fn parse_oracle_ir(
             if let Some(effect_text) = strip_ability_word(&line) {
                 if let Some(rep_defs) = parse_replacement_sentence_sequence(&effect_text, card_name)
                 {
-                    result.replacements.extend(rep_defs);
+                    for __item in rep_defs {
+                        emitter.replacement_at(item_line, __item);
+                    }
                     i += 1;
                     continue;
                 }
                 if let Some(rep_def) = parse_replacement_line(&effect_text, card_name) {
-                    result.replacements.push(rep_def);
+                    emitter.replacement_at(item_line, rep_def);
                     i += 1;
                     continue;
                 }
@@ -4431,7 +4648,7 @@ pub(crate) fn parse_oracle_ir(
         }
 
         if let Some(def) = try_parse_opening_hand_reveal_delayed_trigger(&line, &lower) {
-            result.abilities.push(def);
+            emitter.ability_at(item_line, def);
             i += 1;
             continue;
         }
@@ -4441,7 +4658,7 @@ pub(crate) fn parse_oracle_ir(
         // through the stack — see `AbilityKind::Mulligan` and the guard in
         // `effects/mod.rs`. Runtime dispatch lives in `mulligan.rs`.
         if let Some(def) = try_parse_mulligan_time_ability(&line, &lower) {
-            result.abilities.push(def);
+            emitter.ability_at(item_line, def);
             i += 1;
             continue;
         }
@@ -4453,7 +4670,7 @@ pub(crate) fn parse_oracle_ir(
         // optional "with [counters] on it" clause and the optional "If you do,
         // [effect]" dependent sub-ability.
         if let Some(def) = parse_begin_game_clause(&line, &lower) {
-            result.abilities.push(def);
+            emitter.ability_at(item_line, def);
             i += 1;
             continue;
         }
@@ -4468,13 +4685,15 @@ pub(crate) fn parse_oracle_ir(
 
         // CR 601.3: "Cast this spell only [condition]" — applies to any card type, not just instants/sorceries.
         if let Some(restrictions) = parse_casting_restriction_line(&line) {
-            result.casting_restrictions.extend(restrictions);
+            for __item in restrictions {
+                emitter.casting_restriction_at(item_line, __item);
+            }
             i += 1;
             continue;
         }
 
         if let Some(option) = parse_spell_casting_option_line(&line, card_name) {
-            result.casting_options.push(option);
+            emitter.casting_option_at(item_line, option);
             i += 1;
             continue;
         }
@@ -4491,7 +4710,7 @@ pub(crate) fn parse_oracle_ir(
                 AbilityKind::Activated
             },
         ) {
-            result.abilities.push(def);
+            emitter.ability_at(item_line, def);
             i = next_i;
             continue;
         }
@@ -4503,7 +4722,7 @@ pub(crate) fn parse_oracle_ir(
         // the is_spell branch and produce an Unimplemented effect.
         if lower_starts_with(&lower, "suspend ") {
             if let Some(kw) = parse_keyword_from_oracle(&lower) {
-                result.extracted_keywords.push(kw);
+                emitter.keyword_at(item_line, kw);
                 i += 1;
                 continue;
             }
@@ -4513,7 +4732,7 @@ pub(crate) fn parse_oracle_ir(
         // when it appears as a standalone rules line; intercept before dispatch fallback.
         if lower_starts_with(&lower, "specialize ") {
             if let Some(kw) = parse_keyword_from_oracle(&lower) {
-                result.extracted_keywords.push(kw);
+                emitter.keyword_at(item_line, kw);
                 i += 1;
                 continue;
             }
@@ -4528,7 +4747,7 @@ pub(crate) fn parse_oracle_ir(
         // priority 1b already handles this. This is a fallback for test/edge cases.
         if lower_starts_with(&lower, "harmonize ") {
             if let Some(harmonize_kw) = parse_harmonize_keyword(&line) {
-                result.extracted_keywords.push(harmonize_kw);
+                emitter.keyword_at(item_line, harmonize_kw);
                 i += 1;
                 continue;
             }
@@ -4540,7 +4759,7 @@ pub(crate) fn parse_oracle_ir(
         // imperative catch-all so the line is a keyword, not an effect.
         if lower_starts_with(&lower, "mayhem ") {
             if let Some(mayhem_kw) = parse_mayhem_keyword(&line) {
-                result.extracted_keywords.push(mayhem_kw);
+                emitter.keyword_at(item_line, mayhem_kw);
                 i += 1;
                 continue;
             }
@@ -4565,7 +4784,7 @@ pub(crate) fn parse_oracle_ir(
                 merge_kicker_additional_cost(&mut result.additional_cost, cost);
             }
             if let Some(kw) = parse_keyword_from_oracle(&lower) {
-                result.extracted_keywords.push(kw);
+                emitter.keyword_at(item_line, kw);
             }
             i += 1;
             continue;
@@ -4581,7 +4800,7 @@ pub(crate) fn parse_oracle_ir(
         if lower_starts_with(&lower, "buyback") && line.contains('\u{2014}') {
             let lower_clean = lower.trim_end_matches('.').trim();
             if let Some(kw) = parse_keyword_from_oracle(lower_clean) {
-                result.extracted_keywords.push(kw);
+                emitter.keyword_at(item_line, kw);
                 i += 1;
                 continue;
             }
@@ -4597,7 +4816,7 @@ pub(crate) fn parse_oracle_ir(
         {
             let lower_clean = lower.trim_end_matches('.').trim();
             if let Some(kw) = parse_keyword_from_oracle(lower_clean) {
-                result.extracted_keywords.push(kw);
+                emitter.keyword_at(item_line, kw);
                 i += 1;
                 continue;
             }
@@ -4616,7 +4835,7 @@ pub(crate) fn parse_oracle_ir(
             // case where the keyword-cost line is its own main-loop iteration.
             if is_keyword_cost_line(&lower) {
                 if let Some(kw) = parse_keyword_from_oracle(&lower) {
-                    result.extracted_keywords.push(kw);
+                    emitter.keyword_at(item_line, kw);
                     i += 1;
                     continue;
                 }
@@ -4761,7 +4980,19 @@ pub(crate) fn parse_oracle_ir(
             // ability becomes the fallback when the condition is not met.
             if is_instead || is_instead_replacement_line(&effect_line) {
                 if let Some(condition) = def.condition.take() {
-                    if let Some(mut base) = result.abilities.pop() {
+                    if let Some(base_item) = emitter.pop_last_spell() {
+                        // Re-emit the merged ability at the BASE item's ORIGINAL
+                        // span (recoverable from the popped item) — NOT the current
+                        // line — so the composed ability keeps the base's printed
+                        // slot and source position.
+                        let OracleItemIr {
+                            source: base_source,
+                            node: base_node,
+                            ..
+                        } = base_item;
+                        let OracleNodeIr::PreLoweredSpell(mut base) = base_node else {
+                            unreachable!("pop_last_spell returns only PreLoweredSpell items");
+                        };
                         // Save the base ability's continuation chain in else_ability
                         // so the engine can run it when the condition is NOT met.
                         def.condition = Some(AbilityCondition::ConditionInstead {
@@ -4769,14 +5000,14 @@ pub(crate) fn parse_oracle_ir(
                         });
                         def.else_ability = base.sub_ability.take();
                         base.sub_ability = Some(Box::new(def));
-                        result.abilities.push(base);
+                        emitter.reemit_spell(&base_source, base);
                         continue;
                     }
                     // No previous ability to compose with — restore condition and push standalone.
                     def.condition = Some(condition);
                 }
             }
-            result.abilities.push(def);
+            emitter.ability_at(item_line, def);
             continue;
         }
 
@@ -4788,15 +5019,16 @@ pub(crate) fn parse_oracle_ir(
 
         // "The flashback cost is equal to its mana cost" → extract Flashback keyword
         if is_flashback_equal_mana_cost(&lower) {
-            if parsed_result_recently_granted_flashback(&result) {
+            if parsed_result_recently_granted_flashback(&emitter) {
                 i += 1;
                 continue;
             }
-            result.extracted_keywords.push(Keyword::Flashback(
-                crate::types::keywords::FlashbackCost::Mana(
+            emitter.keyword_at(
+                item_line,
+                Keyword::Flashback(crate::types::keywords::FlashbackCost::Mana(
                     crate::types::mana::ManaCost::SelfManaCost,
-                ),
-            ));
+                )),
+            );
             i += 1;
             continue;
         }
@@ -4804,7 +5036,7 @@ pub(crate) fn parse_oracle_ir(
         // CR 702.49d: Commander ninjutsu is not in MTGJSON keywords — extract explicitly.
         if lower_starts_with(&lower, "commander ninjutsu ") {
             if let Some(kw) = parse_keyword_from_oracle(&lower) {
-                result.extracted_keywords.push(kw);
+                emitter.keyword_at(item_line, kw);
                 i += 1;
                 continue;
             }
@@ -4822,7 +5054,7 @@ pub(crate) fn parse_oracle_ir(
         // Format: "Cumulative upkeep—[cost]" or "Cumulative upkeep {mana}" (space-separated).
         if lower_starts_with(&lower, "cumulative upkeep") {
             if let Some(kw) = parse_cumulative_upkeep_keyword(&line) {
-                result.extracted_keywords.push(kw);
+                emitter.keyword_at(item_line, kw);
                 i += 1;
                 continue;
             }
@@ -4837,12 +5069,12 @@ pub(crate) fn parse_oracle_ir(
             {
                 let flashback_lower = flashback_part.to_lowercase();
                 if let Some(kw) = parse_keyword_from_oracle(&flashback_lower) {
-                    result.extracted_keywords.push(kw);
+                    emitter.keyword_at(item_line, kw);
                 }
                 if let Some(def) =
                     parse_flashback_trailing_self_spell_cost_reduction(reduction_part)
                 {
-                    result.statics.push(def);
+                    emitter.static_at(item_line, def);
                 }
                 i += 1;
                 continue;
@@ -4850,7 +5082,7 @@ pub(crate) fn parse_oracle_ir(
         }
         if is_keyword_cost_line(&lower) {
             if let Some(kw) = parse_keyword_from_oracle(&lower) {
-                result.extracted_keywords.push(kw);
+                emitter.keyword_at(item_line, kw);
             }
             i += 1;
             continue;
@@ -4882,9 +5114,9 @@ pub(crate) fn parse_oracle_ir(
         // handling stamps the previous ability's `min_x_value`; this guard is a
         // defensive fallback for already-normalized forms.
         if lower.trim_end_matches('.') == "x can't be 0" {
-            if let Some(previous) = result.abilities.last_mut() {
+            emitter.mutate_last_spell(|previous| {
                 previous.min_x_value = previous.min_x_value.max(1);
-            }
+            });
             i += 1;
             continue;
         }
@@ -4914,7 +5146,9 @@ pub(crate) fn parse_oracle_ir(
                         }
                     }
                 }
-                result.triggers.extend(triggers);
+                for __item in triggers {
+                    emitter.trigger_at(item_line, __item);
+                }
                 continue;
             }
             // Try as keyword — the ability-word prefix ("Void Shields —") was
@@ -4922,7 +5156,7 @@ pub(crate) fn parse_oracle_ir(
             // missed because it ran on the unprefixed original line.
             if let Some(kw) = parse_keyword_from_oracle(&effect_lower) {
                 if !matches!(kw, Keyword::Unknown(_)) {
-                    result.extracted_keywords.push(kw);
+                    emitter.keyword_at(item_line, kw);
                     i += 1;
                     continue;
                 }
@@ -4943,7 +5177,9 @@ pub(crate) fn parse_oracle_ir(
                             }
                         }
                     }
-                    result.statics.extend(defs);
+                    for __item in defs {
+                        emitter.static_at(item_line, __item);
+                    }
                     i += 1;
                     continue;
                 }
@@ -4953,7 +5189,7 @@ pub(crate) fn parse_oracle_ir(
             ctx.actor = None;
             let def = parse_effect_chain_with_context(&effect_text, AbilityKind::Spell, &mut ctx);
             if !has_unimplemented(&def) {
-                result.abilities.push(def);
+                emitter.ability_at(item_line, def);
                 i += 1;
                 continue;
             }
@@ -4969,7 +5205,9 @@ pub(crate) fn parse_oracle_ir(
             Some(card_name),
         );
         if !defs.is_empty() {
-            result.statics.extend(defs);
+            for __item in defs {
+                emitter.static_at(item_line, __item);
+            }
             i += 1;
             continue;
         }
@@ -4979,7 +5217,7 @@ pub(crate) fn parse_oracle_ir(
         // `effect` (e.g. `distribute`, `multi_target`) are preserved.
         let nom_def = dispatch_line_nom(&line, card_name, ctx.host_self_reference.clone());
         if !matches!(*nom_def.effect, Effect::Unimplemented { .. }) {
-            result.abilities.push(nom_def);
+            emitter.ability_at(item_line, nom_def);
             i += 1;
             continue;
         }
@@ -4987,45 +5225,33 @@ pub(crate) fn parse_oracle_ir(
         // Priority 15: Final fallback — the unimplemented def already carries
         // diagnostic info from dispatch_line_nom; push it as-is.
         tracing::debug!(oracle_text = line, "unimplemented ability line");
-        result.abilities.push(nom_def);
+        emitter.ability_at(item_line, nom_def);
         i += 1;
     }
 
-    reconcile_choose_then_chosen_dependent_etb_counters(&mut result);
-    reconcile_self_chosen_type_statics(&mut result, types);
-    reconcile_host_bound_phase_outs(&mut result);
-    reconcile_persisted_player_choice_for_source_chosen_ref(&mut result);
+    // NOTE (u4-c2): the 4 reconciles and the swallow audit that ran here now run
+    // post-fold in `lower_oracle_ir` (they read the assembled `result` vectors,
+    // which the source-order cutover moves into the document builder). Reconciles
+    // run once, at the placement pin, preserving today's reconciles→swallow order.
 
-    // Architectural rule: the parser must never silently discard Oracle
-    // text. Run the swallow audit against the parsed result so any unrep-
-    // resented clause surfaces as a parse_warning instead of disappearing
-    // (Phase 1: observability only — see swallow_check.rs for detector
-    // catalog and Phase 2 demotion plan).
-    let mut swallow_diags = Vec::new();
-    // Draft-time "draft matters" lines (CR 905) are intentionally consumed as
-    // no-ops by `is_draft_matters_sentence` — they never produce a parsed
-    // ability, so the swallow detectors must not scan them (their "you may",
-    // "if you do", and "as long as" markers would otherwise be reported as
-    // swallowed clauses). Strip them before the audit; constructed-play lines
-    // on the same card remain and are still checked. Cards with no draft text
-    // (the overwhelming majority) feed the unmodified Oracle text unchanged.
-    let swallow_text;
-    let swallow_input: &str = if oracle_text.lines().any(is_draft_matters_sentence) {
-        swallow_text = oracle_text
-            .lines()
-            .filter(|line| !is_draft_matters_sentence(line))
-            .collect::<Vec<_>>()
-            .join("\n");
-        &swallow_text
-    } else {
-        oracle_text
-    };
-    super::swallow_check::check_swallowed_clauses(swallow_input, &result, &mut swallow_diags);
-    for d in swallow_diags {
-        ctx.push_diagnostic(d);
+    // Emit the four order-agnostic SINGLETONS (held on `result` for mid-loop
+    // read-back/merge/dedup) as Exact items at their captured source line, then
+    // finish — producing items already in Oracle source order. `whole_document`
+    // survives only in the Class shim, which returned earlier.
+    if let Some(modal) = result.modal {
+        emitter.modal_at(modal_line.unwrap_or(0), modal);
+    }
+    if let Some(cost) = result.additional_cost {
+        emitter.additional_cost_at(additional_cost_line.unwrap_or(0), cost);
+    }
+    if let Some(condition) = result.solve_condition {
+        emitter.solve_condition_at(solve_condition_line.unwrap_or(0), condition);
+    }
+    if let Some(cost) = result.strive_cost {
+        emitter.strive_cost_at(strive_cost_line.unwrap_or(0), cost);
     }
 
-    parsed_abilities_to_doc_ir(result, oracle_text, card_name, &mut ctx)
+    emitter.finish(oracle_text, card_name, std::mem::take(&mut ctx.diagnostics))
 }
 
 fn activation_zone_from_self_cost(cost: &AbilityCost) -> Option<Zone> {
@@ -5250,7 +5476,7 @@ pub fn parse_oracle_text(
         types,
         subtypes,
     );
-    let mut parsed = lower_oracle_ir(&ir);
+    let mut parsed = lower_oracle_ir(&ir, types);
     scrub_granting_placeholder_descriptions(&mut parsed);
     parsed
 }

--- a/crates/engine/src/parser/oracle_attraction.rs
+++ b/crates/engine/src/parser/oracle_attraction.rs
@@ -40,11 +40,18 @@ pub(crate) fn parse_visit_trigger(line: &str, card_name: &str) -> Option<Trigger
     )
 }
 
-/// Returns line indices consumed by visit triggers (for oracle.rs dispatcher).
+/// Returns visit triggers paired with their source line index (for source-order
+/// emission in `parse_oracle_ir`, unit-4 c2) plus the consumed line indices.
+///
+/// CR 717: each Attraction visit line yields at most one trigger, emitted at its
+/// own printed line.
 pub(crate) fn parse_attraction_visit_triggers(
     lines: &[&str],
     card_name: &str,
-) -> (Vec<TriggerDefinition>, std::collections::HashSet<usize>) {
+) -> (
+    Vec<(usize, TriggerDefinition)>,
+    std::collections::HashSet<usize>,
+) {
     let mut triggers = Vec::new();
     let mut consumed = std::collections::HashSet::new();
     for (idx, line) in lines.iter().enumerate() {
@@ -55,7 +62,7 @@ pub(crate) fn parse_attraction_visit_triggers(
         let lower = trimmed.to_ascii_lowercase();
         if is_attraction_visit_line(&lower) {
             if let Some(trigger) = parse_visit_trigger(trimmed, card_name) {
-                triggers.push(trigger);
+                triggers.push((idx, trigger));
                 consumed.insert(idx);
             }
         }

--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -154,9 +154,7 @@ pub(crate) fn parse_class_oracle_text(
                 let mut triggers = parse_trigger_lines_at_index(
                     line,
                     card_name,
-                    Some(PrintedTriggerIndex::from_category_vector_len(
-                        result.triggers.len(),
-                    )),
+                    Some(PrintedTriggerIndex::placeholder()),
                     &mut ParseContext::default(),
                 );
                 // CR 716.2a: Gate continuous triggers at levels > 1.
@@ -223,9 +221,7 @@ pub(crate) fn parse_class_oracle_text(
                     let mut triggers = parse_trigger_lines_at_index(
                         &effect_text,
                         card_name,
-                        Some(PrintedTriggerIndex::from_category_vector_len(
-                            result.triggers.len(),
-                        )),
+                        Some(PrintedTriggerIndex::placeholder()),
                         &mut ParseContext::default(),
                     );
                     if section.level > 1 {
@@ -360,17 +356,23 @@ fn wrap_replacement_with_class_level(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::parser::oracle::parse_oracle_text;
     use crate::types::ability::{ContinuousModification, Effect};
 
     /// CR 707.9a + CR 716.2a: A Class-level trigger body using "becomes a copy
-    /// of <X>, except <pronoun> has this ability" must emit
-    /// `RetainPrintedTriggerFromSource { source_trigger_index: <N> }` where
-    /// `<N>` is the trigger's index in the card's full printed-trigger list.
-    /// This guards against the regression where Class-level triggers called
-    /// `parse_trigger_lines` (no index thread), causing the retain modification
-    /// to either silently drop or point at trigger index 0 regardless of where
-    /// the trigger actually sits in the printed list.
+    /// of <X>, except <pronoun> has this ability" must resolve
+    /// `RetainPrintedTriggerFromSource { source_trigger_index: <N> }` to `<N>` =
+    /// the trigger's index in the card's full printed-trigger list.
+    ///
+    /// Drives the FULL pipeline (`parse_oracle_text`) rather than the
+    /// `parse_class_oracle_text` preprocessor alone: under late-binding the
+    /// dispatch/preprocessor path bakes a `placeholder()` (= 0) into the retain
+    /// modification, and only `finish()` resolves it to the item's real printed
+    /// slot from the source-ordered document. A preprocessor-only call would
+    /// observe the unresolved placeholder, so this test must run the whole path.
+    /// It guards both the class trigger-index threading and the `finish()`-time
+    /// resolution: reverting the `finish()` stamp yields `source_trigger_index:
+    /// 0` and this assertion fails.
     #[test]
     fn class_level_trigger_become_copy_threads_trigger_index() {
         // Synthetic two-level Class enchantment: level 1 has a trigger
@@ -379,38 +381,20 @@ mod tests {
         // "At the beginning of your upkeep, ~ becomes a copy of … and
         // it has this ability".
         //
-        // Without the index thread, `RetainPrintedTriggerFromSource` would
-        // come out as `source_trigger_index: 0`, pointing at the wrong
-        // trigger. With the thread, it correctly points at index 1.
-        //
         // The level-2 body uses a phase trigger (At the beginning of …)
         // rather than the class-level `When ~ becomes level N` trigger,
         // because the latter takes a special path that doesn't dispatch
         // to the chain parser for the body — the AtClassLevel trigger is
         // a registration-time event, not a body-effect trigger.
-        let lines = vec![
-            "When this Class enters, draw a card.",
-            "{2}: Level 2",
-            "At the beginning of your upkeep, ~ becomes a copy of target creature you control, except its name is ~ and it has this ability.",
-        ];
-        let result = parse_class_oracle_text(
-            &lines,
+        let oracle_text = "When this Class enters, draw a card.\n\
+             {2}: Level 2\n\
+             At the beginning of your upkeep, ~ becomes a copy of target creature you control, except its name is ~ and it has this ability.";
+        let result = parse_oracle_text(
+            oracle_text,
             "Test Class",
             &[],
-            ParsedAbilities {
-                abilities: Vec::new(),
-                triggers: Vec::new(),
-                statics: Vec::new(),
-                replacements: Vec::new(),
-                extracted_keywords: Vec::new(),
-                modal: None,
-                additional_cost: None,
-                casting_restrictions: Vec::new(),
-                casting_options: Vec::new(),
-                solve_condition: None,
-                strive_cost: None,
-                parse_warnings: Vec::new(),
-            },
+            &["Enchantment".to_string()],
+            &["Class".to_string()],
         );
 
         // Find the level-2 BecomeCopy trigger.

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -31,8 +31,9 @@ use super::replacement::ReplacementIr;
 use super::static_ir::StaticIr;
 use super::trigger::TriggerIr;
 use crate::types::ability::{
-    AbilityDefinition, AdditionalCost, CastingRestriction, ModalChoice, ReplacementDefinition,
-    SolveCondition, SpellCastingOption, StaticDefinition, TriggerDefinition,
+    AbilityDefinition, AdditionalCost, CastingPermission, CastingRestriction,
+    ContinuousModification, Effect, ModalChoice, ReplacementDefinition, SolveCondition,
+    SpellCastingOption, StaticDefinition, TriggerDefinition, VoteSubject,
 };
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaCost;
@@ -354,47 +355,23 @@ macro_rules! printed_index_impl {
                 Self(self.0 + n)
             }
 
-            /// **UNIT-3B DEBT — the sole legal way to build a printed index from
-            /// a category-vector length.**
+            /// A parse-time placeholder printed slot (always `0`).
             ///
-            /// In unit 3a the builder is constructed inside
-            /// `parsed_abilities_to_doc_ir`, i.e. *after* the dispatch loop has
-            /// run, so the loop's index reads have no builder in scope and must
-            /// still derive the slot from `Vec::len()`. That is correct today and
-            /// only today: emission is category-ordered, so `len()` *is* the
-            /// printed slot. Unit 3b emits in source order and the equality dies.
+            /// CR 707.9a: an "…except it has this ability" clause must resolve to
+            /// the ability's **printed** slot, which is its final position in the
+            /// source-ordered document. That position is not known while the
+            /// dispatch loop is still running, so the loop bakes this placeholder
+            /// into `RetainPrinted{Trigger,Ability}FromSource` and `finish()`
+            /// overwrites it via `stamp_retained_printed_slot` from the item's
+            /// resolved slot.
             ///
-            /// Rather than trust a comment, the newtype forces every such read to
-            /// name this function, so `rg from_category_vector_len` enumerates every
-            /// site that derives an **absolute** printed slot from a category vector.
-            /// Unit 3b deletes this constructor; afterwards
-            /// `Some(result.triggers.len())` does not compile and
-            /// `OracleDocBuilder` is the only producer.
-            ///
-            /// **That grep is complete for absolute derivations and for nothing else.**
-            /// `offset(n)` displaces an already-correct base and is NOT part of this
-            /// cutover, but its argument can carry debt of its own:
-            ///
-            /// * `oracle_trigger.rs` (`base.offset(i)`, two sites) — `i` indexes the
-            ///   compound halves of ONE trigger line. Structural; correct under any
-            ///   emission order; not debt.
-            /// * `oracle_spacecraft.rs` (`base.offset(output.triggers.len())`) — a
-            ///   `len()` read of the preprocessor's OWN local vector, so it is
-            ///   relative and survives document reordering, but unit 4 replaces it
-            ///   with an emission counter when that preprocessor emits through the
-            ///   builder.
-            ///
-            /// So: `rg from_category_vector_len` for the 3b cutover; `rg '\.offset\('`
-            /// to review the relative sites, one of which is unit-4 debt. Claiming a
-            /// single grep is exhaustive would be a false safety promise, which is the
-            /// defect class this whole type exists to remove.
-            ///
-            /// A `debug_assert_eq!(counter, vec.len())` was considered and rejected:
-            /// it holds only while emission is category-ordered, so it would fire on
-            /// *correct* code the moment 3b reorders, and it is compiled out of the
-            /// release profile that generates `card-data.json`.
-            pub(crate) fn from_category_vector_len(len: usize) -> Self {
-                Self(len)
+            /// This replaces the former `from_category_vector_len` constructor.
+            /// Deriving the slot from a category-vector length was correct only
+            /// while emission was category-ordered; the source-ordered document
+            /// builder makes that equality false, so the late-bind at `finish()`
+            /// is the single authority and the length constructor is gone.
+            pub(crate) fn placeholder() -> Self {
+                Self(0)
             }
         }
     };
@@ -405,8 +382,8 @@ printed_index_impl!(PrintedTriggerIndex);
 
 /// Test-only constructors. Kept behind `cfg(test)` so production code cannot
 /// mint a printed index out of a bare integer: the only production producers are
-/// `OracleDocBuilder::{ability_index, trigger_index}` and the loudly-named
-/// `from_category_vector_len` escape hatch that unit 3b deletes.
+/// `OracleDocBuilder::{ability_index, trigger_index}` and the const-zero
+/// `placeholder()` that the dispatch loop bakes in and `finish()` overwrites.
 #[cfg(test)]
 impl PrintedTriggerIndex {
     pub(crate) fn from_slot_for_test(slot: usize) -> Self {
@@ -803,17 +780,519 @@ impl OracleDocBuilder {
 
     /// Finish, producing items already in Oracle source order.
     pub(crate) fn finish(
-        self,
+        mut self,
         source_text: &str,
         card_name: &str,
         diagnostics: Vec<OracleDiagnostic>,
     ) -> OracleDocIr {
+        // CR 707.9a: resolve every "…except it has this ability" printed slot now.
+        //
+        // The load-bearing invariant is PER-CATEGORY COUNTING, not source order:
+        // `parsed_abilities_to_doc_ir` still emits items in CATEGORY order today
+        // (all abilities, then all triggers, …) — see its own note — so
+        // `values_mut()` does NOT yet visit in printed source order. The walk is
+        // correct regardless because it counts each category SEPARATELY
+        // (`trigger_slot` among triggers, `ability_slot` among abilities), which
+        // reproduces exactly the position the parse-time `from_category_vector_len`
+        // computed. Each `RetainPrinted{Trigger,Ability}FromSource` is a
+        // self-reference to its enclosing item (CR 603.1 / CR 602.1), stamped with
+        // that item's per-category slot, replacing the `placeholder()` (= 0) the
+        // dispatch loop baked in. This per-category counting stays correct when a
+        // later commit makes item ordering truly source-based.
+        //
+        // Match is EXHAUSTIVE over `OracleNodeIr` (no `_`), mirroring `emit`'s
+        // printed-slot match above: a future node variant — or the currently
+        // never-constructed `Trigger`/`Spell` IR variants once a later commit emits
+        // them — must fail to compile here until its slot behavior is decided,
+        // rather than being silently skipped (which would mis-index every later
+        // trigger/ability).
+        let mut trigger_slot = 0usize;
+        let mut ability_slot = 0usize;
+        for item in self.items.values_mut() {
+            match &mut item.node {
+                OracleNodeIr::PreLoweredTrigger(trigger) => {
+                    stamp_trigger_printed_slot(trigger, trigger_slot, PrintedItemKind::Trigger);
+                    trigger_slot += 1;
+                }
+                OracleNodeIr::PreLoweredSpell(def) => {
+                    stamp_retained_printed_slot(def, ability_slot, PrintedItemKind::Ability);
+                    ability_slot += 1;
+                }
+                // No retain modification can reach these today: the `*` IR variants
+                // are never constructed in unit 3a, and the remaining categories do
+                // not carry a copy-except body. Left explicit (not `_`) so a new
+                // slot-bearing node is a compile error, per the note above.
+                OracleNodeIr::Trigger(_)
+                | OracleNodeIr::Spell(_)
+                | OracleNodeIr::Static(_)
+                | OracleNodeIr::PreLoweredStatic(_)
+                | OracleNodeIr::Replacement(_)
+                | OracleNodeIr::PreLoweredReplacement(_)
+                | OracleNodeIr::Keyword(_)
+                | OracleNodeIr::Modal(_)
+                | OracleNodeIr::AdditionalCost(_)
+                | OracleNodeIr::CastingRestriction(_)
+                | OracleNodeIr::CastingOption(_)
+                | OracleNodeIr::SolveCondition(_)
+                | OracleNodeIr::StriveCost(_) => {}
+            }
+        }
         OracleDocIr {
             items: self.items.into_values().collect(),
             source_text: source_text.to_string(),
             card_name: card_name.to_string(),
             diagnostics,
         }
+    }
+}
+
+/// Which printed category a finish()-time slot stamp targets.
+///
+/// A walk parameter local to this module — deliberately NOT a `ParseContext`
+/// field. `ParseContext`'s `current_trigger_index`/`current_ability_index` carry
+/// the parse-time placeholder; this enum only selects which
+/// `RetainPrinted*FromSource` variant `finish()` rewrites for a given item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrintedItemKind {
+    Trigger,
+    Ability,
+}
+
+/// Stamp the resolved printed slot into a pre-lowered trigger's body.
+///
+/// The retain modification lives inside the trigger's `execute` ability
+/// (CR 603.1: "this ability" refers to the triggered ability itself), so the
+/// walk descends into it.
+fn stamp_trigger_printed_slot(trigger: &mut TriggerDefinition, slot: usize, kind: PrintedItemKind) {
+    if let Some(execute) = &mut trigger.execute {
+        stamp_retained_printed_slot(execute, slot, kind);
+    }
+}
+
+/// CR 707.9a: rewrite every `RetainPrinted{Trigger,Ability}FromSource` reachable
+/// from `def` with the enclosing item's resolved printed slot.
+///
+/// Mirrors the immutable `collect_effects`/`collect_effects_in_effect`
+/// (`analysis/ability_graph.rs`) as a `&mut` walk: the head effect plus the
+/// chained `sub_ability`/`else_ability`/`mode_abilities` and the nested-`Effect`
+/// ability payloads.
+fn stamp_retained_printed_slot(def: &mut AbilityDefinition, slot: usize, kind: PrintedItemKind) {
+    stamp_effect_printed_slot(&mut def.effect, slot, kind);
+    if let Some(sub) = &mut def.sub_ability {
+        stamp_retained_printed_slot(sub, slot, kind);
+    }
+    if let Some(els) = &mut def.else_ability {
+        stamp_retained_printed_slot(els, slot, kind);
+    }
+    for m in &mut def.mode_abilities {
+        stamp_retained_printed_slot(m, slot, kind);
+    }
+}
+
+/// Stamp the printed slot into a static ability's continuous modifications.
+fn stamp_static_printed_slot(sd: &mut StaticDefinition, slot: usize, kind: PrintedItemKind) {
+    stamp_retained_mods(&mut sd.modifications, slot, kind);
+}
+
+/// Stamp the printed slot into a granted casting permission's modifications.
+///
+/// Exhaustive over `CastingPermission` (no `_`): a future permission variant that
+/// carries continuous modifications must fail to compile until its arm visits
+/// them, so a CR 707.9a stamp can never silently miss a carrier here either.
+fn stamp_permission_printed_slot(
+    permission: &mut CastingPermission,
+    slot: usize,
+    kind: PrintedItemKind,
+) {
+    match permission {
+        CastingPermission::ExileWithAltCost {
+            enters_with_modifications,
+            ..
+        } => stamp_retained_mods(enters_with_modifications, slot, kind),
+        CastingPermission::AdventureCreature | CastingPermission::ExileWithEnergyCost => {}
+        CastingPermission::PlayFromExile { .. }
+        | CastingPermission::ExileWithAltAbilityCost { .. }
+        | CastingPermission::WarpExile { .. }
+        | CastingPermission::Plotted { .. }
+        | CastingPermission::Foretold { .. } => {}
+    }
+}
+
+/// Rewrite the printed slot on the retain modifications for `kind`.
+///
+/// A trigger item only ever holds `RetainPrintedTriggerFromSource`, an ability
+/// item only `RetainPrintedAbilityFromSource` — `parse_has_this_ability` selects
+/// the variant from whichever `ParseContext` index is set — so the stamp is
+/// keyed on `kind`. The modification-variant match keeps a `_` arm on purpose:
+/// only two of `ContinuousModification`'s many variants carry a printed slot.
+fn stamp_retained_mods(mods: &mut [ContinuousModification], slot: usize, kind: PrintedItemKind) {
+    for m in mods.iter_mut() {
+        match (kind, m) {
+            (
+                PrintedItemKind::Trigger,
+                ContinuousModification::RetainPrintedTriggerFromSource {
+                    source_trigger_index,
+                },
+            ) => *source_trigger_index = slot,
+            (
+                PrintedItemKind::Ability,
+                ContinuousModification::RetainPrintedAbilityFromSource {
+                    source_ability_index,
+                },
+            ) => *source_ability_index = slot,
+            _ => {}
+        }
+    }
+}
+
+/// CR 707.9a: stamp every retain modification reachable from a single `Effect`.
+///
+/// The match is EXHAUSTIVE ON PURPOSE — no `_` arm. Every `Effect` variant that
+/// carries a `Vec<ContinuousModification>` (directly, or via a nested
+/// `StaticDefinition`/`TriggerDefinition`/`CastingPermission`), and every variant
+/// that carries a nested `AbilityDefinition`, has an explicit arm. A future
+/// variant that adds a modification carrier must fail to compile until its arm
+/// visits that carrier, so the "…except it has this ability" stamp can never
+/// silently miss a slot (the exact defect class this walk closes). Leaf variants
+/// carry no printed-slot self-reference and resolve to `=> {}`.
+fn stamp_effect_printed_slot(effect: &mut Effect, slot: usize, kind: PrintedItemKind) {
+    match effect {
+        // ---- Direct Vec<ContinuousModification> carriers ---------------------
+        // The "…except it has this ability" copy-except clause (CR 707.9a) lands
+        // in one of these on the enclosing trigger/ability.
+        Effect::CopySpell {
+            additional_modifications,
+            ..
+        }
+        | Effect::CopyTokenOf {
+            additional_modifications,
+            ..
+        }
+        | Effect::BecomeCopy {
+            additional_modifications,
+            ..
+        } => stamp_retained_mods(additional_modifications, slot, kind),
+        Effect::ReturnAsAura { grants, .. } => stamp_retained_mods(grants, slot, kind),
+        Effect::AddPendingEntersModifications { modifications, .. } => {
+            stamp_retained_mods(modifications, slot, kind)
+        }
+        Effect::EachPlayerCopyChosen {
+            copy_modifications, ..
+        } => stamp_retained_mods(copy_modifications, slot, kind),
+        Effect::GrantCastingPermission { permission, .. } => {
+            stamp_permission_printed_slot(permission, slot, kind)
+        }
+        // ---- StaticDefinition / TriggerDefinition carriers -------------------
+        Effect::Token {
+            static_abilities, ..
+        }
+        | Effect::GenericEffect {
+            static_abilities, ..
+        } => {
+            for sd in static_abilities {
+                stamp_static_printed_slot(sd, slot, kind);
+            }
+        }
+        Effect::CreateEmblem {
+            statics, triggers, ..
+        } => {
+            for sd in statics {
+                stamp_static_printed_slot(sd, slot, kind);
+            }
+            for td in triggers {
+                stamp_trigger_printed_slot(td, slot, kind);
+            }
+        }
+        // ---- Nested AbilityDefinition payloads (mirror collect_effects) ------
+        Effect::Vote {
+            per_choice_effect,
+            subject,
+            ..
+        } => {
+            for d in per_choice_effect {
+                stamp_retained_printed_slot(d, slot, kind);
+            }
+            if let VoteSubject::Objects {
+                outcome_template, ..
+            } = subject
+            {
+                stamp_retained_printed_slot(outcome_template, slot, kind);
+            }
+        }
+        Effect::SeparateIntoPiles {
+            chosen_pile_effect,
+            unchosen_pile_effect,
+            ..
+        } => {
+            stamp_retained_printed_slot(chosen_pile_effect, slot, kind);
+            if let Some(unchosen) = unchosen_pile_effect {
+                stamp_retained_printed_slot(unchosen, slot, kind);
+            }
+        }
+        Effect::RevealFromHand { on_decline, .. } => {
+            if let Some(d) = on_decline {
+                stamp_retained_printed_slot(d, slot, kind);
+            }
+        }
+        Effect::CreateDelayedTrigger { effect, .. } => {
+            stamp_retained_printed_slot(effect, slot, kind)
+        }
+        Effect::RollDie { results, .. } => {
+            for branch in results {
+                stamp_retained_printed_slot(&mut branch.effect, slot, kind);
+            }
+        }
+        Effect::FlipCoin {
+            win_effect,
+            lose_effect,
+            ..
+        }
+        | Effect::FlipCoins {
+            win_effect,
+            lose_effect,
+            ..
+        } => {
+            if let Some(d) = win_effect {
+                stamp_retained_printed_slot(d, slot, kind);
+            }
+            if let Some(d) = lose_effect {
+                stamp_retained_printed_slot(d, slot, kind);
+            }
+        }
+        Effect::FlipCoinUntilLose { win_effect } => {
+            stamp_retained_printed_slot(win_effect, slot, kind)
+        }
+        Effect::ChooseOneOf { branches, .. } => {
+            for d in branches {
+                stamp_retained_printed_slot(d, slot, kind);
+            }
+        }
+        // ---- Leaf variants: no printed-slot self-reference -------------------
+        Effect::StartYourEngines { .. } => {}
+        Effect::ChangeSpeed { .. } => {}
+        Effect::DealDamage { .. } => {}
+        Effect::ApplyPostReplacementDamage { .. } => {}
+        Effect::EachDealsDamageEqualToPower { .. } => {}
+        Effect::EachSourceDealsDamage { .. } => {}
+        Effect::Draw { .. } => {}
+        Effect::Pump { .. } => {}
+        Effect::PairWith { .. } => {}
+        Effect::Destroy { .. } => {}
+        Effect::Regenerate { .. } => {}
+        Effect::RemoveAllDamage { .. } => {}
+        Effect::Counter { .. } => {}
+        Effect::CounterAll { .. } => {}
+        Effect::GainLife { .. } => {}
+        Effect::LoseLife { .. } => {}
+        Effect::SetTapState { .. } => {}
+        Effect::RemoveCounter { .. } => {}
+        Effect::Sacrifice { .. } => {}
+        Effect::DiscardCard { .. } => {}
+        Effect::Mill { .. } => {}
+        Effect::Scry { .. } => {}
+        Effect::PumpAll { .. } => {}
+        Effect::DamageAll { .. } => {}
+        Effect::DamageEachPlayer { .. } => {}
+        Effect::DestroyAll { .. } => {}
+        Effect::ChangeZone { .. } => {}
+        Effect::ChangeZoneAll { .. } => {}
+        Effect::Dig { .. } => {}
+        Effect::GainControl { .. } => {}
+        Effect::GainControlAll { .. } => {}
+        Effect::ControlNextTurn { .. } => {}
+        Effect::Attach { .. } => {}
+        Effect::UnattachAll { .. } => {}
+        Effect::Surveil { .. } => {}
+        Effect::Fight { .. } => {}
+        Effect::Bounce { .. } => {}
+        Effect::BounceAll { .. } => {}
+        Effect::Explore => {}
+        Effect::ExploreAll { .. } => {}
+        Effect::Investigate => {}
+        Effect::Tribute { .. } => {}
+        Effect::TimeTravel => {}
+        Effect::BecomeMonarch => {}
+        Effect::NoOp => {}
+        Effect::Proliferate => {}
+        Effect::ProliferateTarget { .. } => {}
+        Effect::Populate => {}
+        Effect::Clash => {}
+        Effect::Behold { .. } => {}
+        Effect::EndTheTurn => {}
+        Effect::EndCombatPhase => {}
+        Effect::SwitchPT { .. } => {}
+        Effect::EpicCopy { .. } => {}
+        Effect::CastCopyOfCard { .. } => {}
+        Effect::CreateTokenCopyFromPool { .. } => {}
+        Effect::Myriad => {}
+        Effect::Encore => {}
+        Effect::CombineHost { .. } => {}
+        Effect::ChooseAugmentAndCombineWithHost { .. } => {}
+        Effect::Meld { .. } => {}
+        Effect::ExileHaunting { .. } => {}
+        Effect::HideawayConceal { .. } => {}
+        Effect::CopyTokenBlockingAttacker { .. } => {}
+        Effect::GainActivatedAbilitiesOfTarget { .. } => {}
+        Effect::ChooseCard { .. } => {}
+        Effect::PutCounter { .. } => {}
+        Effect::ChooseCounterKind { .. } => {}
+        Effect::PutChosenCounter { .. } => {}
+        Effect::PutCounterAll { .. } => {}
+        Effect::MultiplyCounter { .. } => {}
+        Effect::ChooseCounterAdjustment { .. } => {}
+        Effect::DoublePT { .. } => {}
+        Effect::DoublePTAll { .. } => {}
+        Effect::MoveCounters { .. } => {}
+        Effect::Animate { .. } => {}
+        Effect::RegisterBending { .. } => {}
+        Effect::Cleanup { .. } => {}
+        Effect::Mana { .. } => {}
+        Effect::Discard { .. } => {}
+        Effect::Shuffle { .. } => {}
+        Effect::Transform { .. } => {}
+        Effect::SearchLibrary { .. } => {}
+        Effect::SearchOutsideGame { .. } => {}
+        Effect::RevealHand { .. } => {}
+        Effect::Reveal { .. } => {}
+        Effect::RevealTop { .. } => {}
+        Effect::ExileTop { .. } => {}
+        Effect::TargetOnly { .. } => {}
+        Effect::Choose { .. } => {}
+        Effect::OpponentGuess { .. } => {}
+        Effect::SwapChosenLabels { .. } => {}
+        Effect::ChooseDamageSource { .. } => {}
+        Effect::Suspect { .. } => {}
+        Effect::Unsuspect { .. } => {}
+        Effect::Connive { .. } => {}
+        Effect::PhaseOut { .. } => {}
+        Effect::PhaseIn { .. } => {}
+        Effect::ForceBlock { .. } => {}
+        Effect::ForceAttack { .. } => {}
+        Effect::SolveCase => {}
+        Effect::BecomePrepared { .. } => {}
+        Effect::BecomeUnprepared { .. } => {}
+        Effect::BecomeSaddled { .. } => {}
+        Effect::SetClassLevel { .. } => {}
+        // Nested-definition boundary — deliberately NOT recursed (see the grouped
+        // note on `CreateDrawReplacement`/`CreatePlaneswalkReplacement` below).
+        // `AddTargetReplacement.replacement: Box<ReplacementDefinition>` is built
+        // structurally here (oracle_effect/mod.rs:1697 hand-constructs a fixed
+        // `ChangeZone` `ReplacementDefinition`), never from a copy-except body, so
+        // no `RetainPrinted*FromSource` can appear inside it.
+        Effect::AddTargetReplacement { .. } => {}
+        Effect::AddRestriction { .. } => {}
+        Effect::ReduceNextSpellCost { .. } => {}
+        Effect::GrantNextSpellAbility { .. } => {}
+        Effect::AddPendingETBCounters { .. } => {}
+        Effect::PayCost { .. } => {}
+        Effect::CastFromZone { .. } => {}
+        Effect::FreeCastFromZones { .. } => {}
+        Effect::ExileResolvingSpellInsteadOfGraveyard => {}
+        Effect::PreventDamage { .. } => {}
+        Effect::CreateDamageReplacement { .. } => {}
+        // Nested-definition boundary — intentionally NOT recursed. Both carry a
+        // nested substitute (`replacement_effect: Box<Effect>`) parsed by
+        // `parse_effect` (oracle_replacement.rs:5464 / :5520), which threads a bare
+        // `ParseContext::default()` (oracle_effect/mod.rs:564) — an index-less ctx.
+        // `parse_has_this_ability` reads `ctx.current_{trigger,ability}_index`, both
+        // `None` there, so it declines and no `RetainPrinted*FromSource` can be
+        // produced past this boundary; the `=> {}` is correct, not a missed carrier.
+        //
+        // The asymmetry is deliberate: top-level mod-vec carriers above are
+        // over-visited defensively (the stamp is a no-op on non-retain mods), but a
+        // nested-definition boundary resets the parse context and severs producer
+        // propagation, so recursion would be inert. If a future change ever threads
+        // a live trigger/ability index past a nested-definition boundary into a
+        // copy-except-capable substitute, recurse here.
+        Effect::CreateDrawReplacement { .. } => {}
+        Effect::CreatePlaneswalkReplacement { .. } => {}
+        Effect::LoseTheGame { .. } => {}
+        Effect::WinTheGame { .. } => {}
+        Effect::RingTemptsYou => {}
+        Effect::VentureIntoDungeon => {}
+        Effect::VentureInto { .. } => {}
+        Effect::TakeTheInitiative => {}
+        Effect::Planeswalk => {}
+        Effect::ChaosEnsues => {}
+        Effect::ReverseTurnOrder => {}
+        Effect::RedistributeLifeTotals => {}
+        Effect::OpenAttractions { .. } => {}
+        Effect::RollToVisitAttractions => {}
+        Effect::AssembleContraptions { .. } => {}
+        Effect::AssembleContraptionsFromRollDifference => {}
+        Effect::CrankContraptions { .. } => {}
+        Effect::ReassembleContraption { .. } => {}
+        Effect::AssembleContraptionOnSprocket { .. } => {}
+        Effect::ReassembleContraptionOnSprocket { .. } => {}
+        Effect::PutSticker { .. } => {}
+        Effect::ApplySticker { .. } => {}
+        Effect::ProcessRadCounters => {}
+        Effect::ChooseFromZone { .. } => {}
+        Effect::RememberCard { .. } => {}
+        Effect::ForEachCategoryExile { .. } => {}
+        Effect::ChooseObjectsIntoTrackedSet { .. } => {}
+        Effect::ChooseAndSacrificeRest { .. } => {}
+        Effect::Exploit { .. } => {}
+        Effect::GainEnergy { .. } => {}
+        Effect::GivePlayerCounter { .. } => {}
+        Effect::LoseAllPlayerCounters { .. } => {}
+        Effect::ExileFromTopUntil { .. } => {}
+        Effect::RevealUntil { .. } => {}
+        Effect::Discover { .. } => {}
+        Effect::Heist { .. } => {}
+        Effect::HeistExile => {}
+        Effect::Cascade => {}
+        Effect::Ripple { .. } => {}
+        Effect::MiracleCast { .. } => {}
+        Effect::MadnessCast { .. } => {}
+        Effect::PutAtLibraryPosition { .. } => {}
+        Effect::ChooseDrawnThisTurnPayOrTopdeck { .. } => {}
+        Effect::PutOnTopOrBottom { .. } => {}
+        Effect::GiftDelivery { .. } => {}
+        Effect::Goad { .. } => {}
+        Effect::GoadAll { .. } => {}
+        Effect::Detain { .. } => {}
+        Effect::SetRoomDoorLock { .. } => {}
+        Effect::ExchangeControl { .. } => {}
+        Effect::ChangeTargets { .. } => {}
+        Effect::Manifest { .. } => {}
+        Effect::ManifestDread => {}
+        Effect::Cloak { .. } => {}
+        Effect::TurnFaceUp { .. } => {}
+        Effect::TurnFaceDown { .. } => {}
+        Effect::ExtraTurn { .. } => {}
+        Effect::GrantExtraLoyaltyActivations { .. } => {}
+        Effect::SkipNextTurn { .. } => {}
+        Effect::SkipNextStep { .. } => {}
+        Effect::AdditionalPhase { .. } => {}
+        Effect::Double { .. } => {}
+        Effect::RuntimeHandled { .. } => {}
+        Effect::Incubate { .. } => {}
+        Effect::Amass { .. } => {}
+        Effect::Monstrosity { .. } => {}
+        Effect::Specialize => {}
+        Effect::Renown { .. } => {}
+        Effect::Bolster { .. } => {}
+        Effect::Adapt { .. } => {}
+        Effect::Learn => {}
+        Effect::Forage => {}
+        Effect::Harness => {}
+        Effect::CollectEvidence { .. } => {}
+        Effect::Endure { .. } => {}
+        Effect::BlightEffect { .. } => {}
+        Effect::Seek { .. } => {}
+        Effect::SetLifeTotal { .. } => {}
+        Effect::ExchangeLifeWithStat { .. } => {}
+        Effect::ExchangeLifeTotals { .. } => {}
+        Effect::SetDayNight { .. } => {}
+        Effect::GiveControl { .. } => {}
+        Effect::RemoveFromCombat { .. } => {}
+        Effect::BecomeBlocked { .. } => {}
+        Effect::Conjure { .. } => {}
+        Effect::ApplyPerpetual { .. } => {}
+        Effect::Intensify { .. } => {}
+        Effect::DraftFromSpellbook { .. } => {}
+        Effect::Unimplemented { .. } => {}
     }
 }
 

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -564,9 +564,10 @@ pub(crate) struct OracleDocBuilder {
     /// Allocation order across different `start_byte`s on one line may hand a
     /// later-byte item a smaller ordinal, but the map key sorts by `start_byte`
     /// BEFORE `ordinal_within_span`, so source order is preserved regardless of the
-    /// order in which ordinals are drawn. Ordinals need only be distinct, not
-    /// dense: a `take_last_spell` re-emit fresh-allocates and the skipped value is
-    /// harmless.
+    /// order in which ordinals are drawn. A `take_last_spell` re-emit does NOT draw
+    /// a new ordinal from here — it reuses the popped item's ORIGINAL span+ordinal
+    /// (the key it just freed), which is position-preserving; so this allocator only
+    /// ever hands out fresh ordinals to genuinely new emissions.
     #[allow(dead_code)] // wired by the unit-4 dispatch-loop/preprocessor cutover.
     next_ordinal_by_line: BTreeMap<usize, u32>,
     /// CR 707.9a printed-**trigger** index: the slot the next emitted trigger
@@ -644,9 +645,10 @@ impl OracleDocBuilder {
     /// Single cross-category authority (unit 4): see `next_ordinal_by_line`. Every
     /// emitter holding `&mut self` — pre-loop scans, preprocessors, the dispatch
     /// loop, post-loop emission — draws its ordinal from here so no two items on
-    /// one line can collide on the map key. The counter never decrements; a
-    /// `take_last_spell` re-emit fresh-allocates and any skipped value is harmless
-    /// because ordinals need only be distinct, not dense.
+    /// one line can collide on the map key. The counter never decrements. A
+    /// `take_last_spell` re-emit does NOT call this — it reuses the popped item's
+    /// ORIGINAL span+ordinal (the freed key), which is position-preserving — so this
+    /// allocator only ever advances for genuinely new emissions.
     #[allow(dead_code)] // wired by the unit-4 dispatch-loop/preprocessor cutover.
     pub(crate) fn next_ordinal_for_line(&mut self, first_line: usize) -> u32 {
         let slot = self.next_ordinal_by_line.entry(first_line).or_insert(0);
@@ -816,6 +818,26 @@ impl OracleDocBuilder {
         // `spells_emitted` can never name an id absent from `items` — `emit` inserts
         // both together, and this is the only removal path.
         self.items.remove(&key)
+    }
+
+    /// Peek the most-recently-EMITTED spell's definition without removing it —
+    /// INSERTION recency, via the `spells_emitted` stack. This is the pop-aware
+    /// source of truth for the old `result.abilities.last()` read: `take_last_spell`
+    /// pops this stack and the "instead"/min_x re-emit re-pushes, so a peek derived
+    /// from it is correct across any pop/re-emit interleave — unlike a clone-on-emit
+    /// mirror, which a pop would not revert. Deliberately NOT a `self.items` span
+    /// maximum: a preprocessor may emit a higher-line spell before the dispatch loop
+    /// emits a lower-line one, and the reader wants the JUST-emitted (loop) spell.
+    #[allow(dead_code)] // used by the dispatch-loop reader in unit 4.
+    pub(crate) fn peek_last_spell(&self) -> Option<&AbilityDefinition> {
+        let id = *self.spells_emitted.last()?;
+        self.items
+            .values()
+            .find(|i| i.id == id)
+            .and_then(|i| match &i.node {
+                OracleNodeIr::PreLoweredSpell(def) => Some(def),
+                _ => None,
+            })
     }
 
     /// Finish, producing items already in Oracle source order.

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -545,6 +545,30 @@ pub(crate) struct OracleDocBuilder {
     /// Inert until unit 3b emits exact spans; fixed here, before it can fire.
     items: BTreeMap<(usize, usize, u32), OracleItemIr>,
     next_item_id: u32,
+    /// Per-line `ordinal_within_span` allocator, keyed on `first_line` ONLY —
+    /// deliberately category-BLIND (unit 4).
+    ///
+    /// The item map key `(first_line, start_byte, ordinal_within_span)` carries no
+    /// category, so any two items on the SAME line with the SAME `start_byte` and
+    /// ordinal `0` collide as `DuplicateItemPosition` regardless of category. Same-
+    /// line multi-category emissions are common (casting_option+trigger,
+    /// static+replacement, `push_same_is_true_*` static+ability, multi-keyword
+    /// lines, a Saga ETB replacement on the chapter-1 line, a multi-numeral Saga
+    /// chapter line — CR 714.2c). A per-site counter cannot see cross-category or
+    /// cross-stage siblings and would make those collisions a latent parse failure,
+    /// so every emitter that holds `&mut self` draws its ordinal from this ONE map
+    /// via `next_ordinal_for_line`: pre-loop scans (strive, the Saga ETB
+    /// replacement), the preprocessors, the dispatch loop, and any post-loop
+    /// emission.
+    ///
+    /// Allocation order across different `start_byte`s on one line may hand a
+    /// later-byte item a smaller ordinal, but the map key sorts by `start_byte`
+    /// BEFORE `ordinal_within_span`, so source order is preserved regardless of the
+    /// order in which ordinals are drawn. Ordinals need only be distinct, not
+    /// dense: a `take_last_spell` re-emit fresh-allocates and the skipped value is
+    /// harmless.
+    #[allow(dead_code)] // wired by the unit-4 dispatch-loop/preprocessor cutover.
+    next_ordinal_by_line: BTreeMap<usize, u32>,
     /// CR 707.9a printed-**trigger** index: the slot the next emitted trigger
     /// occupies.
     ///
@@ -613,6 +637,22 @@ impl ItemSlot {
 impl OracleDocBuilder {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    /// Allocate the next distinct `ordinal_within_span` for `first_line`.
+    ///
+    /// Single cross-category authority (unit 4): see `next_ordinal_by_line`. Every
+    /// emitter holding `&mut self` — pre-loop scans, preprocessors, the dispatch
+    /// loop, post-loop emission — draws its ordinal from here so no two items on
+    /// one line can collide on the map key. The counter never decrements; a
+    /// `take_last_spell` re-emit fresh-allocates and any skipped value is harmless
+    /// because ordinals need only be distinct, not dense.
+    #[allow(dead_code)] // wired by the unit-4 dispatch-loop/preprocessor cutover.
+    pub(crate) fn next_ordinal_for_line(&mut self, first_line: usize) -> u32 {
+        let slot = self.next_ordinal_by_line.entry(first_line).or_insert(0);
+        let ordinal = *slot;
+        *slot += 1;
+        ordinal
     }
 
     /// The printed slot the next emitted ability will occupy (CR 707.9a). Read

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -28,7 +28,7 @@ fn parse_two_layer_with_keywords(
     let types: Vec<String> = types.iter().map(|s| s.to_string()).collect();
     let subtypes: Vec<String> = subtypes.iter().map(|s| s.to_string()).collect();
     let ir = parse_oracle_ir(oracle_text, card_name, &keywords, &types, &subtypes);
-    let lowered = lower_oracle_ir(&ir);
+    let lowered = lower_oracle_ir(&ir, &types);
     (ir, lowered)
 }
 

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aerial_formation_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aerial_formation_ir.snap
@@ -5,6 +5,33 @@ expression: "&ir"
 {
   "items": [
     {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 81,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Strive — This spell costs {2}{U} more to cast for each target beyond the first."
+      },
+      "node": {
+        "StriveCost": {
+          "type": "Cost",
+          "shards": [
+            "Blue"
+          ],
+          "generic": 2
+        }
+      }
+    },
+    {
       "id": 0,
       "source": {
         "id": {
@@ -12,13 +39,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
+          "start_byte": 82,
           "end_byte": 162,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Any number of target creatures each get +1/+1 and gain flying until end of turn."
       },
       "node": {
         "PreLoweredSpell": {
@@ -76,32 +104,6 @@ expression: "&ir"
             "max": null
           },
           "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 1,
-      "source": {
-        "id": {
-          "item": 1,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 162,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
-      },
-      "node": {
-        "StriveCost": {
-          "type": "Cost",
-          "shards": [
-            "Blue"
-          ],
-          "generic": 2
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 3,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 264,
-          "precision": "WholeDocument",
+          "end_byte": 107,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "{U}: Exile ~. Return it to the battlefield under its owner's control at the beginning of the next end step."
       },
       "node": {
         "PreLoweredSpell": {
@@ -108,13 +109,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 3,
-          "start_byte": 0,
-          "end_byte": 264,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 108,
+          "end_byte": 142,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{U}: ~ can't be blocked this turn."
       },
       "node": {
         "PreLoweredSpell": {
@@ -173,13 +175,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 3,
-          "start_byte": 0,
-          "end_byte": 264,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 143,
+          "end_byte": 179,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{1}: ~ gets +1/-1 until end of turn."
       },
       "node": {
         "PreLoweredSpell": {
@@ -225,13 +228,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 3,
           "last_line": 3,
-          "start_byte": 0,
-          "end_byte": 264,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 3
-        }
+          "start_byte": 180,
+          "end_byte": 216,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{1}: ~ gets -1/+1 until end of turn."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__baneslayer_angel_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__baneslayer_angel_ir.snap
@@ -16,9 +16,10 @@ expression: "&ir"
           "last_line": 0,
           "start_byte": 0,
           "end_byte": 71,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Flying, first strike, lifelink, protection from Demons and from Dragons"
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__batterskull_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__batterskull_ir.snap
@@ -13,40 +13,16 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 3,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 236,
-          "precision": "WholeDocument",
+          "end_byte": 104,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Living weapon (When ~ enters, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Bounce",
-            "target": {
-              "type": "SelfRef"
-            },
-            "destination": null
-          },
-          "cost": {
-            "type": "Mana",
-            "cost": {
-              "type": "Cost",
-              "shards": [],
-              "generic": 3
-            }
-          },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{3}: Return ~ to its owner's hand.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
-        }
+        "Keyword": "LivingWeapon"
       }
     },
     {
@@ -57,70 +33,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 3,
-          "start_byte": 0,
-          "end_byte": 236,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
-      },
-      "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Attach",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": "You",
-              "properties": []
-            }
-          },
-          "cost": {
-            "type": "Mana",
-            "cost": {
-              "type": "Cost",
-              "shards": [],
-              "generic": 5
-            }
-          },
-          "sub_ability": null,
-          "duration": null,
-          "description": "Equip {5}",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "AsSorcery"
-            }
-          ],
-          "ability_tag": {
-            "type": "Equip"
-          },
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 2,
-      "source": {
-        "id": {
-          "item": 2,
-          "ordinal": 0
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 105,
+          "end_byte": 165,
+          "precision": "Exact",
+          "ordinal_within_span": 0
         },
-        "span": {
-          "first_line": 0,
-          "last_line": 3,
-          "start_byte": 0,
-          "end_byte": 236,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+        "fragment": "Equipped creature gets +4/+4 and has vigilance and lifelink."
       },
       "node": {
         "PreLoweredStatic": {
@@ -165,6 +85,52 @@ expression: "&ir"
       }
     },
     {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 166,
+          "end_byte": 200,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{3}: Return ~ to its owner's hand."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Bounce",
+            "target": {
+              "type": "SelfRef"
+            },
+            "destination": null
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 3
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{3}: Return ~ to its owner's hand.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
       "id": 3,
       "source": {
         "id": {
@@ -172,16 +138,54 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 3,
           "last_line": 3,
-          "start_byte": 0,
-          "end_byte": 236,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 3
-        }
+          "start_byte": 201,
+          "end_byte": 210,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Equip {5}"
       },
       "node": {
-        "Keyword": "LivingWeapon"
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Attach",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": []
+            }
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 5
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "Equip {5}",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
+          "ability_tag": {
+            "type": "Equip"
+          },
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 38,
-          "precision": "WholeDocument",
+          "end_byte": 6,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Flying"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
+          "start_byte": 7,
           "end_byte": 38,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{T}: Add one mana of any color."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 2,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 222,
-          "precision": "WholeDocument",
+          "end_byte": 5,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Haste"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,78 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 222,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 6,
+          "end_byte": 95,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever ~ attacks, exile the top card of your library face down. (You can't look at it.)"
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Attacks",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "ExileTop",
+              "player": {
+                "type": "Controller"
+              },
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "face_down": true
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever ~ attacks, exile the top card of your library face down.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
         }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 96,
+          "end_byte": 186,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{R}, Discard your hand, Sacrifice ~: Put all cards exiled with ~ into their owners' hands."
       },
       "node": {
         "PreLoweredSpell": {
@@ -112,69 +178,6 @@ expression: "&ir"
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 2,
-      "source": {
-        "id": {
-          "item": 2,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 222,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
-      },
-      "node": {
-        "PreLoweredTrigger": {
-          "mode": "Attacks",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "ExileTop",
-              "player": {
-                "type": "Controller"
-              },
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "face_down": true
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever ~ attacks, exile the top card of your library face down.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bone_splinters_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bone_splinters_ir.snap
@@ -5,6 +5,41 @@ expression: "&ir"
 {
   "items": [
     {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 63,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "As an additional cost to cast this spell, sacrifice a creature."
+      },
+      "node": {
+        "AdditionalCost": {
+          "type": "Required",
+          "data": {
+            "type": "Sacrifice",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            "count": 1
+          }
+        }
+      }
+    },
+    {
       "id": 0,
       "source": {
         "id": {
@@ -12,13 +47,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
+          "start_byte": 64,
           "end_byte": 88,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Destroy target creature."
       },
       "node": {
         "PreLoweredSpell": {
@@ -44,40 +80,6 @@ expression: "&ir"
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 1,
-      "source": {
-        "id": {
-          "item": 1,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 88,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
-      },
-      "node": {
-        "AdditionalCost": {
-          "type": "Required",
-          "data": {
-            "type": "Sacrifice",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
-            },
-            "count": 1
-          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bonecrusher_giant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bonecrusher_giant_ir.snap
@@ -15,10 +15,11 @@ expression: "&ir"
           "first_line": 0,
           "last_line": 0,
           "start_byte": 0,
-          "end_byte": 110,
-          "precision": "WholeDocument",
+          "end_byte": 86,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Whenever ~ becomes the target of a spell, ~ deals 2 damage to that spell's controller."
       },
       "node": {
         "PreLoweredTrigger": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 330,
-          "precision": "WholeDocument",
+          "end_byte": 13,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "{T}: Add {G}."
       },
       "node": {
         "PreLoweredSpell": {
@@ -55,13 +56,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
+          "start_byte": 14,
           "end_byte": 330,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Channel — {1}{G}, Discard this card: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__brazen_borrower_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__brazen_borrower_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 2,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 64,
-          "precision": "WholeDocument",
+          "end_byte": 5,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Flash"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 64,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 6,
+          "end_byte": 12,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Flying"
       },
       "node": {
         "PreLoweredSpell": {
@@ -84,13 +86,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 2,
           "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 64,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+          "start_byte": 13,
+          "end_byte": 52,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "~ can block only creatures with flying."
       },
       "node": {
         "PreLoweredStatic": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_crimson_pulse_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_crimson_pulse_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 2,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 239,
-          "precision": "WholeDocument",
+          "end_byte": 56,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "When this ~ enters, discard a card, then draw two cards."
       },
       "node": {
         "PreLoweredTrigger": {
@@ -88,6 +89,46 @@ expression: "&ir"
       }
     },
     {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 57,
+          "end_byte": 152,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "To solve — You have no cards in hand. (If unsolved, solve at the beginning of your end step.)"
+      },
+      "node": {
+        "SolveCondition": {
+          "type": "Condition",
+          "condition": {
+            "type": "QuantityComparison",
+            "lhs": {
+              "type": "Ref",
+              "qty": {
+                "type": "HandSize",
+                "player": {
+                  "type": "Controller"
+                }
+              }
+            },
+            "comparator": "EQ",
+            "rhs": {
+              "type": "Fixed",
+              "value": 0
+            }
+          }
+        }
+      }
+    },
+    {
       "id": 1,
       "source": {
         "id": {
@@ -95,13 +136,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 2,
           "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 239,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "start_byte": 153,
+          "end_byte": 236,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Solved — At the beginning of your upkeep, discard your hand, then draw two cards."
       },
       "node": {
         "PreLoweredTrigger": {
@@ -172,45 +214,6 @@ expression: "&ir"
           },
           "condition": null,
           "batched": false
-        }
-      }
-    },
-    {
-      "id": 2,
-      "source": {
-        "id": {
-          "item": 2,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 239,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
-      },
-      "node": {
-        "SolveCondition": {
-          "type": "Condition",
-          "condition": {
-            "type": "QuantityComparison",
-            "lhs": {
-              "type": "Ref",
-              "qty": {
-                "type": "HandSize",
-                "player": {
-                  "type": "Controller"
-                }
-              }
-            },
-            "comparator": "EQ",
-            "rhs": {
-              "type": "Fixed",
-              "value": 0
-            }
-          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_ir.snap
@@ -13,12 +13,70 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 175,
-          "precision": "WholeDocument",
+          "end_byte": 38,
+          "precision": "Exact",
           "ordinal_within_span": 0
+        },
+        "fragment": "~ enters with X charge counters on it."
+      },
+      "node": {
+        "PreLoweredReplacement": {
+          "event": "Moved",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "charge",
+              "count": {
+                "type": "Ref",
+                "qty": {
+                  "type": "CostXPaid"
+                }
+              },
+              "target": {
+                "type": "SelfRef"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "mode": {
+            "type": "Mandatory"
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "description": "~ enters with X charge counters on it.",
+          "condition": null,
+          "destination_zone": "Battlefield"
         }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 39,
+          "end_byte": 151,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever a player casts a spell with mana value equal to the number of charge counters on ~, counter that spell."
       },
       "node": {
         "PreLoweredTrigger": {
@@ -79,62 +137,6 @@ expression: "&ir"
           "constraint": null,
           "condition": null,
           "batched": false
-        }
-      }
-    },
-    {
-      "id": 1,
-      "source": {
-        "id": {
-          "item": 1,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 175,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
-      },
-      "node": {
-        "PreLoweredReplacement": {
-          "event": "Moved",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutCounter",
-              "counter_type": "charge",
-              "count": {
-                "type": "Ref",
-                "qty": {
-                  "type": "CostXPaid"
-                }
-              },
-              "target": {
-                "type": "SelfRef"
-              }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "mode": {
-            "type": "Mandatory"
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "description": "~ enters with X charge counters on it.",
-          "condition": null,
-          "destination_zone": "Battlefield"
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__champions_victory_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__champions_victory_ir.snap
@@ -13,12 +13,64 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 152,
-          "precision": "WholeDocument",
+          "end_byte": 98,
+          "precision": "Exact",
           "ordinal_within_span": 0
+        },
+        "fragment": "Cast this spell only during the declare attackers step and only if you've been attacked this step."
+      },
+      "node": {
+        "CastingRestriction": {
+          "type": "DeclareAttackersStep"
         }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 98,
+          "precision": "Exact",
+          "ordinal_within_span": 1
+        },
+        "fragment": "Cast this spell only during the declare attackers step and only if you've been attacked this step."
+      },
+      "node": {
+        "CastingRestriction": {
+          "type": "RequiresCondition",
+          "data": {
+            "condition": {
+              "type": "BeenAttackedThisStep"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 99,
+          "end_byte": 152,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Return target attacking creature to its owner's hand."
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,55 +100,6 @@ expression: "&ir"
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 1,
-      "source": {
-        "id": {
-          "item": 1,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 152,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
-      },
-      "node": {
-        "CastingRestriction": {
-          "type": "DeclareAttackersStep"
-        }
-      }
-    },
-    {
-      "id": 2,
-      "source": {
-        "id": {
-          "item": 2,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 152,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
-      },
-      "node": {
-        "CastingRestriction": {
-          "type": "RequiresCondition",
-          "data": {
-            "condition": {
-              "type": "BeenAttackedThisStep"
-            }
-          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__changeling_outcast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__changeling_outcast_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 94,
-          "precision": "WholeDocument",
+          "end_byte": 46,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Changeling (This card is every creature type.)"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 94,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "start_byte": 47,
+          "end_byte": 82,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "~ can't block and can't be blocked."
       },
       "node": {
         "PreLoweredStatic": {
@@ -80,13 +82,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 94,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+          "start_byte": 47,
+          "end_byte": 82,
+          "precision": "Exact",
+          "ordinal_within_span": 1
+        },
+        "fragment": "~ can't block and can't be blocked."
       },
       "node": {
         "PreLoweredStatic": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
@@ -13,12 +13,58 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 196,
-          "precision": "WholeDocument",
+          "end_byte": 137,
+          "precision": "Exact",
           "ordinal_within_span": 0
+        },
+        "fragment": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead."
+      },
+      "node": {
+        "PreLoweredReplacement": {
+          "event": "AddCounter",
+          "execute": null,
+          "mode": {
+            "type": "Mandatory"
+          },
+          "valid_card": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": "You",
+            "properties": []
+          },
+          "description": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead.",
+          "condition": null,
+          "quantity_modification": {
+            "type": "Plus",
+            "value": 1
+          },
+          "counter_match": {
+            "type": "OfType",
+            "data": "P1P1"
+          }
         }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 138,
+          "end_byte": 184,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "When ~ dies, you gain life equal to its power."
       },
       "node": {
         "PreLoweredTrigger": {
@@ -65,50 +111,6 @@ expression: "&ir"
           "constraint": null,
           "condition": null,
           "batched": false
-        }
-      }
-    },
-    {
-      "id": 1,
-      "source": {
-        "id": {
-          "item": 1,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 196,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
-      },
-      "node": {
-        "PreLoweredReplacement": {
-          "event": "AddCounter",
-          "execute": null,
-          "mode": {
-            "type": "Mandatory"
-          },
-          "valid_card": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": "You",
-            "properties": []
-          },
-          "description": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead.",
-          "condition": null,
-          "quantity_modification": {
-            "type": "Plus",
-            "value": 1
-          },
-          "counter_match": {
-            "type": "OfType",
-            "data": "P1P1"
-          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dark_confidant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dark_confidant_ir.snap
@@ -16,9 +16,10 @@ expression: "&ir"
           "last_line": 0,
           "start_byte": 0,
           "end_byte": 141,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value."
       },
       "node": {
         "PreLoweredTrigger": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__deadly_rollick_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__deadly_rollick_ir.snap
@@ -13,12 +13,41 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 104,
-          "precision": "WholeDocument",
+          "end_byte": 81,
+          "precision": "Exact",
           "ordinal_within_span": 0
+        },
+        "fragment": "If you control a commander, you may cast this spell without paying its mana cost."
+      },
+      "node": {
+        "CastingOption": {
+          "kind": "CastWithoutManaCost",
+          "condition": {
+            "type": "YouControlSubtypeCountAtLeast",
+            "subtype": "commander",
+            "count": 1
+          }
         }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 82,
+          "end_byte": 104,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Exile target creature."
       },
       "node": {
         "PreLoweredSpell": {
@@ -49,33 +78,6 @@ expression: "&ir"
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 1,
-      "source": {
-        "id": {
-          "item": 1,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 104,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
-      },
-      "node": {
-        "CastingOption": {
-          "kind": "CastWithoutManaCost",
-          "condition": {
-            "type": "YouControlSubtypeCountAtLeast",
-            "subtype": "commander",
-            "count": 1
-          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dismember_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dismember_ir.snap
@@ -12,13 +12,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
+          "start_byte": 47,
           "end_byte": 92,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Target creature gets -5/-5 until end of turn."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__edgewall_innkeeper_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__edgewall_innkeeper_ir.snap
@@ -16,9 +16,10 @@ expression: "&ir"
           "last_line": 0,
           "start_byte": 0,
           "end_byte": 125,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Whenever you cast a creature spell that has an Adventure, draw a card. (It doesn't need to have gone on the adventure first.)"
       },
       "node": {
         "PreLoweredTrigger": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__eidolon_of_the_great_revel_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__eidolon_of_the_great_revel_ir.snap
@@ -15,10 +15,11 @@ expression: "&ir"
           "first_line": 0,
           "last_line": 0,
           "start_byte": 0,
-          "end_byte": 103,
-          "precision": "WholeDocument",
+          "end_byte": 91,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Whenever a player casts a spell with mana value 3 or less, ~ deals 2 damage to that player."
       },
       "node": {
         "PreLoweredTrigger": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 341,
-          "precision": "WholeDocument",
+          "end_byte": 130,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Evolve (Whenever a creature you control enters, if that creature has greater power or toughness than ~, put a +1/+1 counter on ~.)"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 341,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "start_byte": 131,
+          "end_byte": 293,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Remove two +1/+1 counters from ~: Regenerate it. (The next time ~ would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)"
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__figure_of_destiny_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__figure_of_destiny_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 2,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 365,
-          "precision": "WholeDocument",
+          "end_byte": 68,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "{R/W}: ~ becomes a Kithkin Spirit with base power and toughness 2/2."
       },
       "node": {
         "PreLoweredSpell": {
@@ -97,13 +98,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 365,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 69,
+          "end_byte": 174,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{R/W}{R/W}{R/W}: If ~ is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4."
       },
       "node": {
         "PreLoweredSpell": {
@@ -200,13 +202,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 2,
           "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 365,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+          "start_byte": 175,
+          "end_byte": 329,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{R/W}{R/W}{R/W}{R/W}{R/W}{R/W}: If ~ is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__goblin_guide_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__goblin_guide_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 151,
-          "precision": "WholeDocument",
+          "end_byte": 5,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Haste"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 151,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "start_byte": 6,
+          "end_byte": 139,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever ~ attacks, defending player reveals the top card of their library. If it's a land card, that player puts it into their hand."
       },
       "node": {
         "PreLoweredTrigger": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jace_the_mind_sculptor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jace_the_mind_sculptor_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 3,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 374,
-          "precision": "WholeDocument",
+          "end_byte": 116,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "[+2]: Look at the top card of target player's library. You may put that card on the bottom of that player's library."
       },
       "node": {
         "PreLoweredSpell": {
@@ -95,13 +96,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 3,
-          "start_byte": 0,
-          "end_byte": 374,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 117,
+          "end_byte": 210,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "[0]: Draw three cards, then put two cards from your hand on top of your library in any order."
       },
       "node": {
         "PreLoweredSpell": {
@@ -178,13 +180,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 3,
-          "start_byte": 0,
-          "end_byte": 374,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 211,
+          "end_byte": 262,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "[−1]: Return target creature to its owner's hand."
       },
       "node": {
         "PreLoweredSpell": {
@@ -229,13 +232,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 3,
           "last_line": 3,
-          "start_byte": 0,
+          "start_byte": 263,
           "end_byte": 374,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 3
-        }
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "[−12]: Exile all cards from target player's library, then that player shuffles their hand into their library."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jade_mage_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jade_mage_ir.snap
@@ -16,9 +16,10 @@ expression: "&ir"
           "last_line": 0,
           "start_byte": 0,
           "end_byte": 52,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "{2}{G}: Create a 1/1 green Saproling creature token."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 2,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 324,
-          "precision": "WholeDocument",
+          "end_byte": 46,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "When ~ enters, sacrifice it unless it escaped."
       },
       "node": {
         "PreLoweredTrigger": {
@@ -80,13 +81,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 324,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 47,
+          "end_byte": 183,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever ~ enters or attacks, each opponent discards a card, then each opponent who didn't discard a nonland card this way loses 3 life."
       },
       "node": {
         "PreLoweredTrigger": {
@@ -166,13 +168,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 2,
           "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 324,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+          "start_byte": 184,
+          "end_byte": 316,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Escape—{B}{B}{R}{R}, Exile five other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)"
       },
       "node": {
         "Keyword": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leonin_arbiter_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leonin_arbiter_ir.snap
@@ -16,9 +16,10 @@ expression: "&ir"
           "last_line": 0,
           "start_byte": 0,
           "end_byte": 111,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leyline_of_anticipation_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leyline_of_anticipation_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 134,
-          "precision": "WholeDocument",
+          "end_byte": 88,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "If this card is in your opening hand, you may begin the game with it on the battlefield."
       },
       "node": {
         "PreLoweredSpell": {
@@ -55,13 +56,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
+          "start_byte": 89,
           "end_byte": 134,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "You may cast spells as though they had flash."
       },
       "node": {
         "PreLoweredStatic": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_of_the_veil_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_of_the_veil_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 2,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 217,
-          "precision": "WholeDocument",
+          "end_byte": 34,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "[+1]: Each player discards a card."
       },
       "node": {
         "PreLoweredSpell": {
@@ -64,13 +65,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 217,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 35,
+          "end_byte": 79,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "[−2]: Target player sacrifices a creature."
       },
       "node": {
         "PreLoweredSpell": {
@@ -118,13 +120,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 2,
           "last_line": 2,
-          "start_byte": 0,
+          "start_byte": 80,
           "end_byte": 217,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "[−6]: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_ir.snap
@@ -16,9 +16,10 @@ expression: "&ir"
           "last_line": 0,
           "start_byte": 0,
           "end_byte": 13,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "{T}: Add {G}."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lovestruck_beast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lovestruck_beast_ir.snap
@@ -15,10 +15,11 @@ expression: "&ir"
           "first_line": 0,
           "last_line": 0,
           "start_byte": 0,
-          "end_byte": 61,
-          "precision": "WholeDocument",
+          "end_byte": 49,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "~ can't attack unless you control a 1/1 creature."
       },
       "node": {
         "PreLoweredStatic": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__luminarch_aspirant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__luminarch_aspirant_ir.snap
@@ -16,9 +16,10 @@ expression: "&ir"
           "last_line": 0,
           "start_byte": 0,
           "end_byte": 92,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control."
       },
       "node": {
         "PreLoweredTrigger": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__manamorphose_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__manamorphose_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 55,
-          "precision": "WholeDocument",
+          "end_byte": 42,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Add two mana in any combination of colors."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mishra_eminent_one_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mishra_eminent_one_ir.snap
@@ -15,10 +15,11 @@ expression: "&ir"
           "first_line": 0,
           "last_line": 0,
           "start_byte": 0,
-          "end_byte": 310,
-          "precision": "WholeDocument",
+          "end_byte": 305,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "At the beginning of combat on your turn, create a token that's a copy of target noncreature artifact you control, except its name is ~'s Warform and it's a 4/4 Construct artifact creature in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step."
       },
       "node": {
         "PreLoweredTrigger": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__monastery_swiftspear_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__monastery_swiftspear_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 98,
-          "precision": "WholeDocument",
+          "end_byte": 5,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Haste"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 98,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "start_byte": 6,
+          "end_byte": 86,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Prowess (Whenever you cast a noncreature spell, ~ gets +1/+1 until end of turn.)"
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mother_of_runes_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mother_of_runes_ir.snap
@@ -16,9 +16,10 @@ expression: "&ir"
           "last_line": 0,
           "start_byte": 0,
           "end_byte": 98,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "{T}: Target creature you control gains protection from the color of your choice until end of turn."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__murderous_rider_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__murderous_rider_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 78,
-          "precision": "WholeDocument",
+          "end_byte": 8,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Lifelink"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 78,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "start_byte": 9,
+          "end_byte": 66,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "When ~ dies, put it on the bottom of its owner's library."
       },
       "node": {
         "PreLoweredTrigger": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 3,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 305,
-          "precision": "WholeDocument",
+          "end_byte": 28,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Vigilance, deathtouch, haste"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,69 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 3,
-          "start_byte": 0,
-          "end_byte": 305,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 29,
+          "end_byte": 82,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "~ can't be blocked by creatures with power 2 or less."
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": {
+            "CantBeBlockedBy": {
+              "filter": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": null,
+                "properties": [
+                  {
+                    "type": "PtComparison",
+                    "stat": "Power",
+                    "scope": "Current",
+                    "comparator": "LE",
+                    "value": {
+                      "type": "Fixed",
+                      "value": 2
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "affected": {
+            "type": "SelfRef"
+          },
+          "modifications": [],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "~ can't be blocked by creatures with power 2 or less."
         }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 83,
+          "end_byte": 161,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Combat damage that would be dealt by creatures you control can't be prevented."
       },
       "node": {
         "PreLoweredSpell": {
@@ -86,20 +143,21 @@ expression: "&ir"
       }
     },
     {
-      "id": 2,
+      "id": 3,
       "source": {
         "id": {
-          "item": 2,
+          "item": 3,
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 3,
           "last_line": 3,
-          "start_byte": 0,
-          "end_byte": 305,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+          "start_byte": 162,
+          "end_byte": 279,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever ~ deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls."
       },
       "node": {
         "PreLoweredTrigger": {
@@ -156,60 +214,6 @@ expression: "&ir"
           "constraint": null,
           "condition": null,
           "batched": false
-        }
-      }
-    },
-    {
-      "id": 3,
-      "source": {
-        "id": {
-          "item": 3,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 3,
-          "start_byte": 0,
-          "end_byte": 305,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 3
-        }
-      },
-      "node": {
-        "PreLoweredStatic": {
-          "mode": {
-            "CantBeBlockedBy": {
-              "filter": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": null,
-                "properties": [
-                  {
-                    "type": "PtComparison",
-                    "stat": "Power",
-                    "scope": "Current",
-                    "comparator": "LE",
-                    "value": {
-                      "type": "Fixed",
-                      "value": 2
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "affected": {
-            "type": "SelfRef"
-          },
-          "modifications": [],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "~ can't be blocked by creatures with power 2 or less."
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
@@ -13,12 +13,42 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 2,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 245,
-          "precision": "WholeDocument",
+          "end_byte": 112,
+          "precision": "Exact",
           "ordinal_within_span": 0
+        },
+        "fragment": "Surge {1}{R} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)"
+      },
+      "node": {
+        "Keyword": {
+          "Surge": {
+            "type": "Cost",
+            "shards": [
+              "Red"
+            ],
+            "generic": 1
+          }
         }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 113,
+          "end_byte": 118,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Haste"
       },
       "node": {
         "PreLoweredSpell": {
@@ -41,20 +71,21 @@ expression: "&ir"
       }
     },
     {
-      "id": 1,
+      "id": 2,
       "source": {
         "id": {
-          "item": 1,
+          "item": 2,
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 2,
           "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 245,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "start_byte": 119,
+          "end_byte": 233,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "When ~ enters, if its surge cost was paid, other creatures you control get +1/+0 and gain haste until end of turn."
       },
       "node": {
         "PreLoweredTrigger": {
@@ -134,34 +165,6 @@ expression: "&ir"
             "variant": "Surge"
           },
           "batched": false
-        }
-      }
-    },
-    {
-      "id": 2,
-      "source": {
-        "id": {
-          "item": 2,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 245,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
-      },
-      "node": {
-        "Keyword": {
-          "Surge": {
-            "type": "Cost",
-            "shards": [
-              "Red"
-            ],
-            "generic": 1
-          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__savage_summoning_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__savage_summoning_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 201,
-          "precision": "WholeDocument",
+          "end_byte": 30,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "This spell can't be countered."
       },
       "node": {
         "PreLoweredStatic": {
@@ -44,13 +45,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
+          "start_byte": 31,
           "end_byte": 201,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters with an additional +1/+1 counter on it."
       },
       "node": {
         "PreLoweredReplacement": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__serra_angel_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__serra_angel_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 64,
-          "precision": "WholeDocument",
+          "end_byte": 6,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Flying"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 64,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "start_byte": 7,
+          "end_byte": 52,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Vigilance (Attacking doesn't cause ~ to tap.)"
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__short_sword_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__short_sword_ir.snap
@@ -13,12 +13,64 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 110,
-          "precision": "WholeDocument",
+          "end_byte": 29,
+          "precision": "Exact",
           "ordinal_within_span": 0
+        },
+        "fragment": "Equipped creature gets +1/+1."
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": null,
+            "properties": [
+              {
+                "type": "EquippedBy"
+              }
+            ]
+          },
+          "modifications": [
+            {
+              "type": "AddPower",
+              "value": 1
+            },
+            {
+              "type": "AddToughness",
+              "value": 1
+            }
+          ],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "Equipped creature gets +1/+1."
         }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 30,
+          "end_byte": 110,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
       },
       "node": {
         "PreLoweredSpell": {
@@ -58,56 +110,6 @@ expression: "&ir"
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 1,
-      "source": {
-        "id": {
-          "item": 1,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 110,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
-      },
-      "node": {
-        "PreLoweredStatic": {
-          "mode": "Continuous",
-          "affected": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": [
-              {
-                "type": "EquippedBy"
-              }
-            ]
-          },
-          "modifications": [
-            {
-              "type": "AddPower",
-              "value": 1
-            },
-            {
-              "type": "AddToughness",
-              "value": 1
-            }
-          ],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "Equipped creature gets +1/+1."
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__slippery_bogle_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__slippery_bogle_ir.snap
@@ -15,10 +15,11 @@ expression: "&ir"
           "first_line": 0,
           "last_line": 0,
           "start_byte": 0,
-          "end_byte": 91,
-          "precision": "WholeDocument",
+          "end_byte": 79,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Hexproof (~ can't be the target of spells or abilities your opponents control.)"
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__smugglers_copter_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__smugglers_copter_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 2,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 233,
-          "precision": "WholeDocument",
+          "end_byte": 6,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Flying"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 233,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 7,
+          "end_byte": 84,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever ~ attacks or blocks, you may draw a card. If you do, discard a card."
       },
       "node": {
         "PreLoweredTrigger": {
@@ -135,13 +137,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 2,
           "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 233,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+          "start_byte": 85,
+          "end_byte": 211,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Crew 1 (Tap any number of creatures you control with total power 1 or more: ~ becomes an artifact creature until end of turn.)"
       },
       "node": {
         "Keyword": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__snapcaster_mage_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__snapcaster_mage_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 246,
-          "precision": "WholeDocument",
+          "end_byte": 5,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Flash"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 246,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "start_byte": 6,
+          "end_byte": 234,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "When ~ enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)"
       },
       "node": {
         "PreLoweredTrigger": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__stoneforge_mystic_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__stoneforge_mystic_ir.snap
@@ -13,85 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 205,
-          "precision": "WholeDocument",
+          "end_byte": 113,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
-      },
-      "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "ChangeZone",
-            "origin": "Hand",
-            "destination": "Battlefield",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                {
-                  "Subtype": "Equipment"
-                }
-              ],
-              "controller": "You",
-              "properties": [
-                {
-                  "type": "InZone",
-                  "zone": "Hand"
-                }
-              ]
-            },
-            "owner_library": false,
-            "enter_transformed": false,
-            "enter_tapped": false,
-            "enters_attacking": false
-          },
-          "cost": {
-            "type": "Composite",
-            "costs": [
-              {
-                "type": "Mana",
-                "cost": {
-                  "type": "Cost",
-                  "shards": [
-                    "White"
-                  ],
-                  "generic": 1
-                }
-              },
-              {
-                "type": "Tap"
-              }
-            ]
-          },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": true,
-          "target_choice_timing": "Resolution",
-          "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 1,
-      "source": {
-        "id": {
-          "item": 1,
-          "ordinal": 0
         },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 205,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+        "fragment": "When ~ enters, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle."
       },
       "node": {
         "PreLoweredTrigger": {
@@ -185,6 +113,80 @@ expression: "&ir"
           "constraint": null,
           "condition": null,
           "batched": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 114,
+          "end_byte": 193,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "ChangeZone",
+            "origin": "Hand",
+            "destination": "Battlefield",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                {
+                  "Subtype": "Equipment"
+                }
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "InZone",
+                  "zone": "Hand"
+                }
+              ]
+            },
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
+          },
+          "cost": {
+            "type": "Composite",
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "White"
+                  ],
+                  "generic": 1
+                }
+              },
+              {
+                "type": "Tap"
+              }
+            ]
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": true,
+          "target_choice_timing": "Resolution",
+          "forward_result": false
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__student_of_warfare_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__student_of_warfare_ir.snap
@@ -1,9 +1,39 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 312
 expression: "&ir"
 ---
 {
   "items": [
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 76,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Level up {W} ({W}: Put a level counter on this. Level up only as a sorcery.)"
+      },
+      "node": {
+        "Keyword": {
+          "LevelUp": {
+            "type": "Cost",
+            "shards": [
+              "White"
+            ],
+            "generic": 0
+          }
+        }
+      }
+    },
     {
       "id": 0,
       "source": {
@@ -12,13 +42,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 6,
-          "start_byte": 0,
-          "end_byte": 130,
-          "precision": "WholeDocument",
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 77,
+          "end_byte": 86,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "LEVEL 2-6"
       },
       "node": {
         "PreLoweredStatic": {
@@ -65,13 +96,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 6,
-          "start_byte": 0,
-          "end_byte": 130,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "first_line": 4,
+          "last_line": 4,
+          "start_byte": 104,
+          "end_byte": 112,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "LEVEL 7+"
       },
       "node": {
         "PreLoweredStatic": {
@@ -106,34 +138,6 @@ expression: "&ir"
           "active_zones": [],
           "characteristic_defining": false,
           "description": "LEVEL 7+ / 4/4 / Double strike"
-        }
-      }
-    },
-    {
-      "id": 2,
-      "source": {
-        "id": {
-          "item": 2,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 6,
-          "start_byte": 0,
-          "end_byte": 130,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
-      },
-      "node": {
-        "Keyword": {
-          "LevelUp": {
-            "type": "Cost",
-            "shards": [
-              "White"
-            ],
-            "generic": 0
-          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_ir.snap
@@ -16,9 +16,10 @@ expression: "&ir"
           "last_line": 0,
           "start_byte": 0,
           "end_byte": 68,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Exile target creature. Its controller gains life equal to its power."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_safekeeper_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_safekeeper_ir.snap
@@ -16,9 +16,10 @@ expression: "&ir"
           "last_line": 0,
           "start_byte": 0,
           "end_byte": 77,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Sacrifice a land: Target creature you control gains shroud until end of turn."
       },
       "node": {
         "PreLoweredSpell": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tarmogoyf_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tarmogoyf_ir.snap
@@ -15,10 +15,11 @@ expression: "&ir"
           "first_line": 0,
           "last_line": 0,
           "start_byte": 0,
-          "end_byte": 134,
-          "precision": "WholeDocument",
+          "end_byte": 126,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "~'s power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1."
       },
       "node": {
         "PreLoweredStatic": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 54,
-          "precision": "WholeDocument",
+          "end_byte": 12,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "First strike"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
+          "start_byte": 13,
           "end_byte": 54,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Noncreature spells cost {1} more to cast."
       },
       "node": {
         "PreLoweredStatic": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thunderous_velocipede_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thunderous_velocipede_ir.snap
@@ -12,13 +12,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 201,
-          "precision": "WholeDocument",
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 8,
+          "end_byte": 194,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
       },
       "node": {
         "PreLoweredStatic": {
@@ -98,13 +99,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 201,
-          "precision": "WholeDocument",
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 8,
+          "end_byte": 194,
+          "precision": "Exact",
           "ordinal_within_span": 1
-        }
+        },
+        "fragment": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
       },
       "node": {
         "PreLoweredStatic": {
@@ -184,13 +186,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 2,
           "last_line": 2,
-          "start_byte": 0,
+          "start_byte": 195,
           "end_byte": 201,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Crew 3"
       },
       "node": {
         "Keyword": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tireless_tracker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tireless_tracker_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 217,
-          "precision": "WholeDocument",
+          "end_byte": 139,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Landfall — Whenever a land you control enters, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice ~: Draw a card.\")"
       },
       "node": {
         "PreLoweredTrigger": {
@@ -72,13 +73,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 217,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "start_byte": 140,
+          "end_byte": 196,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever you sacrifice a Clue, put a +1/+1 counter on ~."
       },
       "node": {
         "PreLoweredTrigger": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__village_rites_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__village_rites_ir.snap
@@ -5,6 +5,41 @@ expression: "&ir"
 {
   "items": [
     {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 63,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "As an additional cost to cast this spell, sacrifice a creature."
+      },
+      "node": {
+        "AdditionalCost": {
+          "type": "Required",
+          "data": {
+            "type": "Sacrifice",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            "count": 1
+          }
+        }
+      }
+    },
+    {
       "id": 0,
       "source": {
         "id": {
@@ -12,13 +47,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
+          "start_byte": 64,
           "end_byte": 79,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Draw two cards."
       },
       "node": {
         "PreLoweredSpell": {
@@ -42,40 +78,6 @@ expression: "&ir"
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 1,
-      "source": {
-        "id": {
-          "item": 1,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 79,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
-      },
-      "node": {
-        "AdditionalCost": {
-          "type": "Required",
-          "data": {
-            "type": "Sacrifice",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
-            },
-            "count": 1
-          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__vines_of_vastwood_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__vines_of_vastwood_ir.snap
@@ -13,12 +13,79 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 229,
-          "precision": "WholeDocument",
+          "end_byte": 66,
+          "precision": "Exact",
           "ordinal_within_span": 0
+        },
+        "fragment": "Kicker {G} (You may pay an additional {G} as you cast this spell.)"
+      },
+      "node": {
+        "Keyword": {
+          "Kicker": {
+            "type": "Cost",
+            "shards": [
+              "Green"
+            ],
+            "generic": 0
+          }
         }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 66,
+          "precision": "Exact",
+          "ordinal_within_span": 1
+        },
+        "fragment": "Kicker {G} (You may pay an additional {G} as you cast this spell.)"
+      },
+      "node": {
+        "AdditionalCost": {
+          "type": "Kicker",
+          "data": {
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "Green"
+                  ],
+                  "generic": 0
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 67,
+          "end_byte": 229,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Target creature can't be the target of spells or abilities your opponents control this turn. If this spell was kicked, that creature gets +4/+4 until end of turn."
       },
       "node": {
         "PreLoweredSpell": {
@@ -92,70 +159,6 @@ expression: "&ir"
           "optional_targeting": false,
           "optional": false,
           "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 1,
-      "source": {
-        "id": {
-          "item": 1,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 229,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
-      },
-      "node": {
-        "Keyword": {
-          "Kicker": {
-            "type": "Cost",
-            "shards": [
-              "Green"
-            ],
-            "generic": 0
-          }
-        }
-      }
-    },
-    {
-      "id": 2,
-      "source": {
-        "id": {
-          "item": 2,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 229,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
-      },
-      "node": {
-        "AdditionalCost": {
-          "type": "Kicker",
-          "data": {
-            "costs": [
-              {
-                "type": "Mana",
-                "cost": {
-                  "type": "Cost",
-                  "shards": [
-                    "Green"
-                  ],
-                  "generic": 0
-                }
-              }
-            ]
-          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__walking_ballista_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__walking_ballista_ir.snap
@@ -13,111 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 2,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 168,
-          "precision": "WholeDocument",
+          "end_byte": 37,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
-      },
-      "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "PutCounter",
-            "counter_type": "P1P1",
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "target": {
-              "type": "SelfRef"
-            }
-          },
-          "cost": {
-            "type": "Mana",
-            "cost": {
-              "type": "Cost",
-              "shards": [],
-              "generic": 4
-            }
-          },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{4}: Put a +1/+1 counter on ~.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 1,
-      "source": {
-        "id": {
-          "item": 1,
-          "ordinal": 0
         },
-        "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 168,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
-      },
-      "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "DealDamage",
-            "amount": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "target": {
-              "type": "Any"
-            }
-          },
-          "cost": {
-            "type": "RemoveCounter",
-            "count": 1,
-            "counter_type": {
-              "type": "OfType",
-              "data": "P1P1"
-            },
-            "target": null,
-            "selection": "SingleObject"
-          },
-          "sub_ability": null,
-          "duration": null,
-          "description": "Remove a +1/+1 counter from ~: It deals 1 damage to any target.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
-        }
-      }
-    },
-    {
-      "id": 2,
-      "source": {
-        "id": {
-          "item": 2,
-          "ordinal": 0
-        },
-        "span": {
-          "first_line": 0,
-          "last_line": 2,
-          "start_byte": 0,
-          "end_byte": 168,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 2
-        }
+        "fragment": "~ enters with X +1/+1 counters on it."
       },
       "node": {
         "PreLoweredReplacement": {
@@ -156,6 +58,107 @@ expression: "&ir"
           "description": "~ enters with X +1/+1 counters on it.",
           "condition": null,
           "destination_zone": "Battlefield"
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 38,
+          "end_byte": 68,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{4}: Put a +1/+1 counter on ~."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "PutCounter",
+            "counter_type": "P1P1",
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "target": {
+              "type": "SelfRef"
+            }
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 4
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{4}: Put a +1/+1 counter on ~.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 69,
+          "end_byte": 132,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Remove a +1/+1 counter from ~: It deals 1 damage to any target."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "DealDamage",
+            "amount": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "target": {
+              "type": "Any"
+            }
+          },
+          "cost": {
+            "type": "RemoveCounter",
+            "count": 1,
+            "counter_type": {
+              "type": "OfType",
+              "data": "P1P1"
+            },
+            "target": null,
+            "selection": "SingleObject"
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "Remove a +1/+1 counter from ~: It deals 1 damage to any target.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wolfir_silverheart_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wolfir_silverheart_ir.snap
@@ -13,12 +13,13 @@ expression: "&ir"
         },
         "span": {
           "first_line": 0,
-          "last_line": 1,
+          "last_line": 0,
           "start_byte": 0,
-          "end_byte": 242,
-          "precision": "WholeDocument",
+          "end_byte": 136,
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Soulbond (You may pair ~ with another unpaired creature when either enters. They remain paired for as long as you control both of them.)"
       },
       "node": {
         "PreLoweredSpell": {
@@ -48,13 +49,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 0,
+          "first_line": 1,
           "last_line": 1,
-          "start_byte": 0,
-          "end_byte": 242,
-          "precision": "WholeDocument",
-          "ordinal_within_span": 1
-        }
+          "start_byte": 137,
+          "end_byte": 218,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "As long as ~ is paired with another creature, each of those creatures gets +4/+4."
       },
       "node": {
         "PreLoweredStatic": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__young_pyromancer_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__young_pyromancer_ir.snap
@@ -16,9 +16,10 @@ expression: "&ir"
           "last_line": 0,
           "start_byte": 0,
           "end_byte": 89,
-          "precision": "WholeDocument",
+          "precision": "Exact",
           "ordinal_within_span": 0
-        }
+        },
+        "fragment": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token."
       },
       "node": {
         "PreLoweredTrigger": {

--- a/crates/engine/src/parser/oracle_level.rs
+++ b/crates/engine/src/parser/oracle_level.rs
@@ -25,6 +25,15 @@ use super::oracle_util::strip_reminder_text;
 /// Flying, trample
 /// ```
 ///
+/// Return shape of [`parse_level_blocks`]: level-gated statics with their
+/// `(first_line, last_line)` spans, consumed line indices, and body ability
+/// lines paired with the level condition that gates them.
+type LevelBlocksParse = (
+    Vec<(StaticDefinition, usize, usize)>,
+    Vec<usize>,
+    Vec<(String, StaticCondition, usize)>,
+);
+
 /// Each LEVEL block defines static abilities gated on level counter count.
 /// P/T lines use SetPower/SetToughness (Layer 7b), keyword lines use AddKeyword (Layer 6).
 /// Both are conditioned on `StaticCondition::HasCounters` with min/max.
@@ -35,15 +44,17 @@ use super::oracle_util::strip_reminder_text;
 /// - `Vec<(String, StaticCondition)>`: Ability text lines found within level blocks,
 ///   paired with the level condition they should be gated by. These need re-parsing
 ///   by the main Oracle dispatcher as triggers, activated abilities, or statics.
-pub(crate) fn parse_level_blocks(
-    lines: &[&str],
-    card_name: &str,
-) -> (
-    Vec<StaticDefinition>,
-    Vec<usize>,
-    Vec<(String, StaticCondition)>,
-) {
-    let mut statics = Vec::new();
+pub(crate) fn parse_level_blocks(lines: &[&str], card_name: &str) -> LevelBlocksParse {
+    // Each static carries its source span `(first_line, last_line)` so
+    // `parse_oracle_ir` emits it in printed order (unit-4 c2). Body statics AND the
+    // block-SUMMARY static are all emitted as SINGLE-LINE spans: body statics at
+    // their own line, the summary at the LEVEL header line. The document builder
+    // keys on `(first_line, start_byte, ordinal)` (span END not in the key), so a
+    // header-only summary span sorts identically to a header..=last-mod-line span
+    // yet cannot byte-overlap a body static printed between the header and a later
+    // P/T/keyword line (which would trip `OverlappingSiblingSpans`).
+    // `ability_lines` likewise carry their line.
+    let mut statics: Vec<(StaticDefinition, usize, usize)> = Vec::new();
     let mut consumed_indices = Vec::new();
     let mut ability_lines = Vec::new();
 
@@ -54,6 +65,7 @@ pub(crate) fn parse_level_blocks(
 
         // Detect "LEVEL N-M" or "LEVEL N+"
         if let Some(range) = parse_level_header(&lower) {
+            let header = i;
             consumed_indices.push(i);
             i += 1;
 
@@ -130,7 +142,8 @@ pub(crate) fn parse_level_blocks(
                     consumed_indices.push(i);
                     for mut sd in multi {
                         sd.condition = Some(condition.clone());
-                        statics.push(sd);
+                        // Body static: emitted at its OWN line (single-line span).
+                        statics.push((sd, i, i));
                     }
                     i += 1;
                     continue;
@@ -138,7 +151,7 @@ pub(crate) fn parse_level_blocks(
                 if let Some(mut sd) = parse_static_line(&static_text) {
                     consumed_indices.push(i);
                     sd.condition = Some(condition.clone());
-                    statics.push(sd);
+                    statics.push((sd, i, i));
                     i += 1;
                     continue;
                 }
@@ -158,7 +171,7 @@ pub(crate) fn parse_level_blocks(
                         .is_ok();
                 if is_activated || is_trigger {
                     consumed_indices.push(i);
-                    ability_lines.push((next.to_string(), condition.clone()));
+                    ability_lines.push((next.to_string(), condition.clone(), i));
                     i += 1;
                     continue;
                 }
@@ -168,13 +181,25 @@ pub(crate) fn parse_level_blocks(
             }
 
             if !modifications.is_empty() {
-                statics.push(
+                // CR 711: the block-summary static is emitted as a SINGLE-LINE
+                // header span. The document builder keys items on
+                // `(first_line, start_byte, ordinal_within_span)` — the span END is
+                // NOT in the key — so anchoring at the header alone gives the summary
+                // the same sort position (and byte-identical lowered output) as a
+                // header..=last-mod-line span would, while its byte range can no
+                // longer overlap a body static printed BETWEEN the header and a later
+                // P/T/keyword line (which would trip `OverlappingSiblingSpans` and
+                // panic `emit`). Body statics carry their own single line; the
+                // summary sorts first within the block by its header line.
+                statics.push((
                     StaticDefinition::continuous()
                         .affected(TargetFilter::SelfRef)
                         .condition(condition)
                         .modifications(modifications)
                         .description(description_parts.join(" / ")),
-                );
+                    header,
+                    header,
+                ));
             }
         } else {
             i += 1;
@@ -222,6 +247,28 @@ fn parse_pt_line(text: &str) -> Option<(i32, i32)> {
 mod tests {
     use super::*;
 
+    /// u4-c2 test shim: map the source-span-tagged preprocessor return back to the
+    /// bare-def shape the existing assertions read.
+    #[allow(clippy::type_complexity)]
+    fn level_test_blocks(
+        lines: &[&str],
+        name: &str,
+    ) -> (
+        Vec<StaticDefinition>,
+        Vec<usize>,
+        Vec<(String, StaticCondition)>,
+    ) {
+        let (statics, consumed, ability_lines) = parse_level_blocks(lines, name);
+        (
+            statics.into_iter().map(|(s, _, _)| s).collect(),
+            consumed,
+            ability_lines
+                .into_iter()
+                .map(|(text, cond, _)| (text, cond))
+                .collect(),
+        )
+    }
+
     #[test]
     fn parse_level_bounded_header() {
         assert!(matches!(
@@ -248,7 +295,7 @@ mod tests {
             "LEVEL 8+",
             "8/8",
         ];
-        let (statics, consumed, _ability_lines) = parse_level_blocks(&lines, "Test Card");
+        let (statics, consumed, _ability_lines) = level_test_blocks(&lines, "Test Card");
 
         // Should consume indices 1-5 (not index 0 which is "Level up {R}")
         assert!(!consumed.contains(&0));
@@ -284,7 +331,7 @@ mod tests {
             "6/6",
             "Whenever this creature attacks, it deals 6 damage to each creature defending player controls.",
         ];
-        let (statics, consumed, ability_lines) = parse_level_blocks(&lines, "Test Card");
+        let (statics, consumed, ability_lines) = level_test_blocks(&lines, "Test Card");
 
         // P/T modifications parsed as static
         assert_eq!(statics.len(), 1);
@@ -319,7 +366,7 @@ mod tests {
             "2/4",
             "{T}: This creature deals 3 damage to any target.",
         ];
-        let (statics, consumed, ability_lines) = parse_level_blocks(&lines, "Test Card");
+        let (statics, consumed, ability_lines) = level_test_blocks(&lines, "Test Card");
 
         // Two P/T statics
         assert_eq!(statics.len(), 2);
@@ -368,7 +415,7 @@ mod tests {
             "Flying",
             "Other Merfolk creatures you control get +1/+1.",
         ];
-        let (statics, consumed, ability_lines) = parse_level_blocks(&lines, "Coralhelm Commander");
+        let (statics, consumed, ability_lines) = level_test_blocks(&lines, "Coralhelm Commander");
 
         // Lord pump parsed directly as statics[0] (encountered first in inner loop),
         // P/T + keyword block pushed as statics[1] (after inner loop completes).

--- a/crates/engine/src/parser/oracle_saga.rs
+++ b/crates/engine/src/parser/oracle_saga.rs
@@ -117,17 +117,23 @@ fn is_chapter_body_continuation(line: &str) -> bool {
     result.is_ok()
 }
 
+/// Return shape of [`parse_saga_chapters`]: source-line-tagged chapter triggers,
+/// the `(line, ETB replacement)` pair, and the set of consumed line indices.
+type SagaChaptersParse = (
+    Vec<(usize, TriggerDefinition)>,
+    (usize, ReplacementDefinition),
+    HashSet<usize>,
+);
+
 /// CR 714: Parse all chapter lines from a Saga's Oracle text.
 /// Returns (chapter_triggers, etb_replacement, consumed_line_indices).
-pub(crate) fn parse_saga_chapters(
-    lines: &[&str],
-    _card_name: &str,
-) -> (
-    Vec<TriggerDefinition>,
-    ReplacementDefinition,
-    HashSet<usize>,
-) {
-    let mut chapters: Vec<(Vec<u32>, String)> = Vec::new();
+pub(crate) fn parse_saga_chapters(lines: &[&str], _card_name: &str) -> SagaChaptersParse {
+    // Each chapter carries its source line index so `parse_oracle_ir` can emit its
+    // trigger(s) in printed source order (unit-4 c2). A multi-numeral chapter line
+    // (CR 714.2c: "I, II — [Effect]") yields one trigger per numeral, all on the
+    // SAME line; emitting them in numeral order gives ascending ordinals on the
+    // shared `(first_line, start_byte)` key, i.e. correct printed order.
+    let mut chapters: Vec<(Vec<u32>, String, usize)> = Vec::new();
     let mut consumed = HashSet::new();
 
     for (idx, &line) in lines.iter().enumerate() {
@@ -141,7 +147,7 @@ pub(crate) fn parse_saga_chapters(
         }
 
         if let Some((nums, effect)) = parse_chapter_line(&stripped) {
-            chapters.push((nums, effect));
+            chapters.push((nums, effect, idx));
             consumed.insert(idx);
         } else if is_chapter_body_continuation(&stripped) && !chapters.is_empty() {
             // Multi-line chapter body: bullet-list continuation of previous chapter
@@ -155,7 +161,7 @@ pub(crate) fn parse_saga_chapters(
     }
 
     let mut triggers = Vec::new();
-    for (nums, effect_text) in &chapters {
+    for (nums, effect_text, line_idx) in &chapters {
         for &n in nums {
             // CR 701.38 (Council's-dilemma / Will-of-the-council vote): a saga
             // chapter may itself be a vote (Trial of a Time Lord IV: "Starting
@@ -192,7 +198,7 @@ pub(crate) fn parse_saga_chapters(
                 .execute(execute)
                 .trigger_zones(vec![Zone::Battlefield])
                 .description(format!("Chapter {n}"));
-            triggers.push(trigger);
+            triggers.push((*line_idx, trigger));
         }
     }
 
@@ -210,7 +216,13 @@ pub(crate) fn parse_saga_chapters(
         .destination_zone(Zone::Battlefield)
         .description("Saga ETB lore counter".to_string());
 
-    (triggers, etb_replacement, consumed)
+    // CR 714.3a: the ETB lore-counter replacement has no printed line of its own;
+    // anchor it at the FIRST chapter's line so it emits at/near the front of the
+    // document (preserving today's `replacements[0]` position). Falls back to line
+    // 0 for a degenerate Saga with no parsed chapters.
+    let etb_line = chapters.first().map_or(0, |(_, _, idx)| *idx);
+
+    (triggers, (etb_line, etb_replacement), consumed)
 }
 
 /// Check if a line is a saga chapter (e.g. "I —", "II —", "III —").
@@ -292,6 +304,24 @@ fn promote_generic_effect_duration(effect: &mut Effect) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// u4-c2 test shim: map the source-line-tagged preprocessor return back to the
+    /// bare-def shape the existing assertions read.
+    fn saga_test_chapters(
+        lines: &[&str],
+        name: &str,
+    ) -> (
+        Vec<TriggerDefinition>,
+        ReplacementDefinition,
+        std::collections::HashSet<usize>,
+    ) {
+        let (triggers, (_, etb), consumed) = parse_saga_chapters(lines, name);
+        (
+            triggers.into_iter().map(|(_, t)| t).collect(),
+            etb,
+            consumed,
+        )
+    }
     use crate::types::ability::{
         ContinuousModification, ControllerRef, FilterProp, PtValue, TypeFilter,
     };
@@ -381,7 +411,7 @@ mod tests {
         let lines = vec![
             "I, II, III, IV — Stampede! — Other creatures you control get +1/+0 until end of turn.",
         ];
-        let (triggers, _etb, _consumed) = parse_saga_chapters(&lines, "Summon: Choco/Mog");
+        let (triggers, _etb, _consumed) = saga_test_chapters(&lines, "Summon: Choco/Mog");
         assert_eq!(triggers.len(), 4);
 
         for trigger in triggers {
@@ -416,7 +446,7 @@ mod tests {
         use crate::types::statics::StaticMode;
 
         let lines = vec!["II, III — Until your next turn, creatures can't attack you unless their controller pays {2} for each of those creatures."];
-        let (triggers, _etb, _consumed) = parse_saga_chapters(&lines, "Summon: Yojimbo");
+        let (triggers, _etb, _consumed) = saga_test_chapters(&lines, "Summon: Yojimbo");
         assert_eq!(triggers.len(), 2);
 
         for trigger in &triggers {
@@ -476,7 +506,7 @@ mod tests {
             "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)",
             "I — This Saga gains \"{T}: Add {C}.\"",
         ];
-        let (triggers, _etb, _consumed) = parse_saga_chapters(&lines, "Urza's Saga");
+        let (triggers, _etb, _consumed) = saga_test_chapters(&lines, "Urza's Saga");
         assert_eq!(triggers.len(), 1, "expected one chapter trigger");
         let exec = triggers[0]
             .execute
@@ -501,7 +531,7 @@ mod tests {
         let lines = vec![
             "II — This Saga gains \"{2}, {T}: Create a 0/0 colorless Construct artifact creature token with 'This token gets +1/+1 for each artifact you control.'\"",
         ];
-        let (triggers, _etb, _consumed) = parse_saga_chapters(&lines, "Urza's Saga");
+        let (triggers, _etb, _consumed) = saga_test_chapters(&lines, "Urza's Saga");
         assert_eq!(triggers.len(), 1);
         let exec = triggers[0].execute.as_ref().unwrap();
         match &*exec.effect {
@@ -524,7 +554,7 @@ mod tests {
         let lines = vec![
             "II — This Saga gains \"{2}, {T}: Create a 0/0 colorless Construct artifact creature token with 'This token gets +1/+1 for each artifact you control.'\"",
         ];
-        let (triggers, _etb, _consumed) = parse_saga_chapters(&lines, "Urza's Saga");
+        let (triggers, _etb, _consumed) = saga_test_chapters(&lines, "Urza's Saga");
         assert_eq!(triggers.len(), 1);
         let exec = triggers[0].execute.as_ref().unwrap();
         let Effect::GenericEffect {
@@ -556,7 +586,7 @@ mod tests {
     fn explicit_until_end_of_turn_chapter_is_not_promoted() {
         let lines =
             vec!["IV — Dinosaurs you control gain double strike and trample until end of turn."];
-        let (triggers, _etb, _consumed) = parse_saga_chapters(&lines, "Roar of the Fifth People");
+        let (triggers, _etb, _consumed) = saga_test_chapters(&lines, "Roar of the Fifth People");
         assert_eq!(triggers.len(), 1);
         let exec = triggers[0].execute.as_ref().unwrap();
         // If the parser produced something other than a GenericEffect (e.g. a
@@ -580,7 +610,7 @@ mod tests {
         let lines = vec![
             "III — Search your library for an artifact card with mana cost {0} or {1}, put it onto the battlefield, then shuffle.",
         ];
-        let (triggers, _etb, _consumed) = parse_saga_chapters(&lines, "Urza's Saga");
+        let (triggers, _etb, _consumed) = saga_test_chapters(&lines, "Urza's Saga");
         assert_eq!(triggers.len(), 1);
         let exec = triggers[0].execute.as_ref().unwrap();
         let Effect::SearchLibrary { filter, .. } = &*exec.effect else {
@@ -633,8 +663,7 @@ mod tests {
         let lines = vec![
             "III — Exile this Saga, then return it to the battlefield transformed under your control.",
         ];
-        let (triggers, _etb, _consumed) =
-            parse_saga_chapters(&lines, "Fable of the Mirror-Breaker");
+        let (triggers, _etb, _consumed) = saga_test_chapters(&lines, "Fable of the Mirror-Breaker");
         assert_eq!(triggers.len(), 1);
         let exec = triggers[0].execute.as_ref().expect("chapter III execute");
         match &*exec.effect {
@@ -692,7 +721,7 @@ mod tests {
         let lines = vec![
             "I — Exile the top three cards of your library. Until the end of your next turn, you may play those cards.",
         ];
-        let (triggers, _etb, _consumed) = parse_saga_chapters(&lines, "The Legend of Roku");
+        let (triggers, _etb, _consumed) = saga_test_chapters(&lines, "The Legend of Roku");
         assert_eq!(triggers.len(), 1);
         let exec = triggers[0].execute.as_ref().expect("chapter I execute");
         match &*exec.effect {
@@ -735,7 +764,7 @@ mod tests {
         use crate::types::counter::CounterType;
 
         let lines = vec!["IV — Put two +1/+1 counters on each other Moogle you control."];
-        let (triggers, _etb, _consumed) = parse_saga_chapters(&lines, "Summon: Good King Mog XII");
+        let (triggers, _etb, _consumed) = saga_test_chapters(&lines, "Summon: Good King Mog XII");
         assert_eq!(triggers.len(), 1);
         let exec = triggers[0].execute.as_ref().expect("chapter IV execute");
         match &*exec.effect {

--- a/crates/engine/src/parser/oracle_spacecraft.rs
+++ b/crates/engine/src/parser/oracle_spacecraft.rs
@@ -58,6 +58,16 @@ pub fn max_spacecraft_threshold(lines: &[&str]) -> Option<u32> {
         .max()
 }
 
+/// Return shape of [`parse_spacecraft_threshold_lines`]: source-line-tagged
+/// statics, triggers, and activated abilities, plus the set of consumed line
+/// indices (so the main oracle dispatcher can skip them).
+type SpacecraftThresholdParse = (
+    Vec<(usize, StaticDefinition)>,
+    Vec<(usize, TriggerDefinition)>,
+    Vec<(usize, AbilityDefinition)>,
+    Vec<usize>,
+);
+
 /// Parse all `N+ | body` threshold lines in `lines`.
 ///
 /// Returns parsed statics / triggers / activated abilities, plus the set of
@@ -73,14 +83,9 @@ pub(crate) fn parse_spacecraft_threshold_lines(
     lines: &[&str],
     card_name: &str,
     base_trigger_index: PrintedTriggerIndex,
-) -> (
-    Vec<StaticDefinition>,
-    Vec<TriggerDefinition>,
-    Vec<AbilityDefinition>,
-    Vec<usize>,
-) {
+) -> SpacecraftThresholdParse {
     let mut statics = Vec::new();
-    let mut triggers: Vec<TriggerDefinition> = Vec::new();
+    let mut triggers: Vec<(usize, TriggerDefinition)> = Vec::new();
     let mut abilities = Vec::new();
     let mut consumed = Vec::new();
 
@@ -120,7 +125,7 @@ pub(crate) fn parse_spacecraft_threshold_lines(
             abilities: &mut abilities,
         };
 
-        if !parser.parse_body(raw.trim(), body, &mut output) {
+        if !parser.parse_body(idx, raw.trim(), body, &mut output) {
             idx += 1;
             continue;
         }
@@ -132,7 +137,9 @@ pub(crate) fn parse_spacecraft_threshold_lines(
             if continuation.is_empty() || parse_threshold_header(continuation).is_some() {
                 break;
             }
-            if !parser.parse_body(continuation, continuation, &mut output) {
+            // CR: a continuation line anchors at its OWN line (Inspirit, Flagship
+            // Vessel: two statics in one block must not share a key).
+            if !parser.parse_body(idx, continuation, continuation, &mut output) {
                 break;
             }
             consumed.push(idx);
@@ -152,23 +159,30 @@ struct ThresholdParser<'a> {
 }
 
 struct ThresholdOutput<'a> {
-    statics: &'a mut Vec<StaticDefinition>,
-    triggers: &'a mut Vec<TriggerDefinition>,
-    abilities: &'a mut Vec<AbilityDefinition>,
+    statics: &'a mut Vec<(usize, StaticDefinition)>,
+    triggers: &'a mut Vec<(usize, TriggerDefinition)>,
+    abilities: &'a mut Vec<(usize, AbilityDefinition)>,
 }
 
 impl ThresholdParser<'_> {
-    fn parse_body(&self, description: &str, body: &str, output: &mut ThresholdOutput<'_>) -> bool {
+    fn parse_body(
+        &self,
+        line_idx: usize,
+        description: &str,
+        body: &str,
+        output: &mut ThresholdOutput<'_>,
+    ) -> bool {
         // Dispatch the body: keywords first (most common), then trigger /
         // static / activated branches modeled on `parse_level_blocks`.
         if let Some(keyword_mods) = parse_keyword_only_body(body) {
-            output.statics.push(
+            output.statics.push((
+                line_idx,
                 StaticDefinition::continuous()
                     .affected(TargetFilter::SelfRef)
                     .condition(self.static_cond.clone())
                     .modifications(keyword_mods)
                     .description(description.to_string()),
-            );
+            ));
             return true;
         }
 
@@ -189,7 +203,9 @@ impl ThresholdParser<'_> {
             for trig in &mut parsed {
                 trig.condition = Some(self.trigger_cond.clone());
             }
-            output.triggers.extend(parsed);
+            for trig in parsed {
+                output.triggers.push((line_idx, trig));
+            }
             return true;
         }
 
@@ -221,7 +237,7 @@ impl ThresholdParser<'_> {
                 maximum: None,
             });
             def.activation_restrictions = restrictions;
-            output.abilities.push(def);
+            output.abilities.push((line_idx, def));
             return true;
         }
 
@@ -231,13 +247,13 @@ impl ThresholdParser<'_> {
         if !multi.is_empty() {
             for mut sd in multi {
                 sd.condition = Some(self.static_cond.clone());
-                output.statics.push(sd);
+                output.statics.push((line_idx, sd));
             }
             return true;
         }
         if let Some(mut sd) = parse_static_line(&static_text) {
             sd.condition = Some(self.static_cond.clone());
-            output.statics.push(sd);
+            output.statics.push((line_idx, sd));
             return true;
         }
 
@@ -310,6 +326,29 @@ mod tests {
     use super::*;
     use crate::types::counter::CounterType;
 
+    /// u4-c2 test shim: map the source-line-tagged preprocessor return back to the
+    /// bare-def shape the existing assertions read.
+    #[allow(clippy::type_complexity)]
+    fn spacecraft_test_lines(
+        lines: &[&str],
+        name: &str,
+        base_trigger_index: PrintedTriggerIndex,
+    ) -> (
+        Vec<StaticDefinition>,
+        Vec<TriggerDefinition>,
+        Vec<AbilityDefinition>,
+        Vec<usize>,
+    ) {
+        let (statics, triggers, abilities, consumed) =
+            parse_spacecraft_threshold_lines(lines, name, base_trigger_index);
+        (
+            statics.into_iter().map(|(_, s)| s).collect(),
+            triggers.into_iter().map(|(_, t)| t).collect(),
+            abilities.into_iter().map(|(_, a)| a).collect(),
+            consumed,
+        )
+    }
+
     #[test]
     fn threshold_header_nom_extracts_number_and_body() {
         assert_eq!(parse_threshold_header("3+ | Flying"), Some((3, "Flying")));
@@ -327,11 +366,8 @@ mod tests {
     #[test]
     fn keyword_threshold_line_parses_to_addkeyword_static() {
         let lines = ["12+ | Flying"];
-        let (statics, triggers, abilities, consumed) = parse_spacecraft_threshold_lines(
-            &lines,
-            "Test",
-            PrintedTriggerIndex::from_slot_for_test(0),
-        );
+        let (statics, triggers, abilities, consumed) =
+            spacecraft_test_lines(&lines, "Test", PrintedTriggerIndex::from_slot_for_test(0));
         assert_eq!(consumed, vec![0]);
         assert!(triggers.is_empty());
         assert!(abilities.is_empty());
@@ -351,11 +387,8 @@ mod tests {
     #[test]
     fn multi_keyword_threshold_line_parses_all() {
         let lines = ["8+ | Flying, trample"];
-        let (statics, _, _, consumed) = parse_spacecraft_threshold_lines(
-            &lines,
-            "Test",
-            PrintedTriggerIndex::from_slot_for_test(0),
-        );
+        let (statics, _, _, consumed) =
+            spacecraft_test_lines(&lines, "Test", PrintedTriggerIndex::from_slot_for_test(0));
         assert_eq!(consumed, vec![0]);
         assert_eq!(statics.len(), 1);
         assert_eq!(statics[0].modifications.len(), 2);
@@ -367,7 +400,7 @@ mod tests {
             "8+ | Flying",
             "Other artifacts you control have hexproof and indestructible.",
         ];
-        let (statics, triggers, abilities, consumed) = parse_spacecraft_threshold_lines(
+        let (statics, triggers, abilities, consumed) = spacecraft_test_lines(
             &lines,
             "Inspirit, Flagship Vessel",
             PrintedTriggerIndex::from_slot_for_test(0),
@@ -394,7 +427,7 @@ mod tests {
             "8+ | Flying",
             "Other artifacts you control have hexproof and indestructible.",
         ];
-        let (statics, triggers, _, consumed) = parse_spacecraft_threshold_lines(
+        let (statics, triggers, _, consumed) = spacecraft_test_lines(
             &lines,
             "Inspirit, Flagship Vessel",
             PrintedTriggerIndex::from_slot_for_test(0),
@@ -414,7 +447,7 @@ mod tests {
     #[test]
     fn trigger_threshold_line_parses_with_condition() {
         let lines = ["3+ | Whenever you cast an artifact spell, draw a card."];
-        let (_, triggers, _, consumed) = parse_spacecraft_threshold_lines(
+        let (_, triggers, _, consumed) = spacecraft_test_lines(
             &lines,
             "Uthros Research Craft",
             PrintedTriggerIndex::from_slot_for_test(0),
@@ -432,7 +465,7 @@ mod tests {
         let lines = [
             "3+ | Whenever you cast an artifact spell, draw a card. Put a charge counter on this Spacecraft.",
         ];
-        let (_, triggers, _, consumed) = parse_spacecraft_threshold_lines(
+        let (_, triggers, _, consumed) = spacecraft_test_lines(
             &lines,
             "Uthros Research Craft",
             PrintedTriggerIndex::from_slot_for_test(0),
@@ -459,11 +492,8 @@ mod tests {
     #[test]
     fn activated_threshold_line_gets_counter_threshold_restriction() {
         let lines = ["1+ | {T}: Draw a card."];
-        let (_, _, abilities, consumed) = parse_spacecraft_threshold_lines(
-            &lines,
-            "Test",
-            PrintedTriggerIndex::from_slot_for_test(0),
-        );
+        let (_, _, abilities, consumed) =
+            spacecraft_test_lines(&lines, "Test", PrintedTriggerIndex::from_slot_for_test(0));
         assert_eq!(consumed, vec![0]);
         assert_eq!(abilities.len(), 1);
         let restr = &abilities[0].activation_restrictions;

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -20417,3 +20417,164 @@ fn violent_urge_delirium_scopes_to_parent_target_not_all_creatures() {
         "expected a single AddKeyword(DoubleStrike) modification"
     );
 }
+
+/// CR 707.9a: the printed slot of an "…except it has this ability" clause is
+/// resolved at `finish()` from the source-ordered document, not baked at parse
+/// time. This synthetic two-trigger creature drives the full pipeline
+/// (`parse_oracle_text`): the ETB trigger prints first (slot 0) and the upkeep
+/// `BecomeCopy` trigger prints second (slot 1). The dispatch loop bakes a
+/// `placeholder()` (= 0) `source_trigger_index`; only the `finish()`-time
+/// `stamp_retained_printed_slot` walk resolves it to the item's real printed
+/// slot.
+///
+/// DISCRIMINATING: the assertion reads `source_trigger_index == 1`. Reverting the
+/// `finish()` stamp leaves the placeholder `0`, so this test would then fail —
+/// it is a regression guard on the late-bind resolution, not a shape assertion.
+/// (The two triggers are non-preprocessor, so the pre-edit `from_category_vector_len`
+/// value was also 1; this commit is byte-identical by construction, and the test
+/// pins the *new* resolution mechanism against a broken/missing `finish()` walk.)
+#[test]
+fn become_copy_except_this_ability_resolves_printed_slot_at_finish() {
+    let parsed = parse_oracle_text(
+        "When ~ enters, draw a card.\n\
+         At the beginning of your upkeep, ~ becomes a copy of target creature you control, except it has this ability.",
+        "Slot Probe",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+
+    assert_eq!(
+        parsed.triggers.len(),
+        2,
+        "expected exactly two printed triggers (ETB + upkeep BecomeCopy): {:?}",
+        parsed.triggers
+    );
+
+    // Positive reach-guard: the BecomeCopy trigger must be the SECOND printed
+    // trigger (index 1). If this fails the fixture is degenerate and the
+    // resolved-index assertion below would be vacuous.
+    let become_copy_pos = parsed
+        .triggers
+        .iter()
+        .position(|t| {
+            t.execute
+                .as_ref()
+                .is_some_and(|e| matches!(*e.effect, Effect::BecomeCopy { .. }))
+        })
+        .expect("upkeep trigger must produce a BecomeCopy effect");
+    assert_eq!(
+        become_copy_pos, 1,
+        "reach-guard: BecomeCopy trigger must occupy printed slot 1 (ETB at 0); \
+         fixture setup is wrong otherwise"
+    );
+
+    let execute = parsed.triggers[become_copy_pos]
+        .execute
+        .as_deref()
+        .expect("BecomeCopy trigger must have an execute body");
+    let Effect::BecomeCopy {
+        additional_modifications,
+        ..
+    } = execute.effect.as_ref()
+    else {
+        panic!("expected BecomeCopy, got {:?}", execute.effect);
+    };
+    let resolved = additional_modifications
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::RetainPrintedTriggerFromSource {
+                source_trigger_index,
+            } => Some(*source_trigger_index),
+            _ => None,
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a RetainPrintedTriggerFromSource modification, got {additional_modifications:?}"
+            )
+        });
+    assert_eq!(
+        resolved, 1,
+        "CR 707.9a: finish() must resolve the printed slot to this trigger's \
+         source-ordered index (1); a placeholder 0 means the finish() stamp is missing"
+    );
+}
+
+/// CR 707.9a: the `finish()` stamp must reach the retain modification through the
+/// SECOND real receiver carrier, `Effect::CopyTokenOf.additional_modifications`
+/// (token.rs), not only through `BecomeCopy`. The sole producer
+/// `parse_has_this_ability` lands `RetainPrinted*FromSource` in exactly two
+/// carriers under a real `ParseContext` (become-copy and token-copy); this drives
+/// the token-copy path end-to-end so a `CopyTokenOf` arm that skipped its inner
+/// vec — or stamped the wrong slot — is caught.
+///
+/// (`EachPlayerCopyChosen` is deliberately NOT covered: it parses its except body
+/// with a fresh `ParseContext::default()` (mod.rs), so `parse_has_this_ability`
+/// always declines there and no `RetainPrinted` mod can reach it — a test through
+/// it would assert zero stamps and be vacuous.)
+///
+/// DISCRIMINATING: the copy trigger is the SECOND printed trigger (slot 1), so the
+/// assertion `source_trigger_index == 1` flips to the placeholder `0` if the
+/// `CopyTokenOf` arm is broken or the `finish()` stamp is reverted.
+#[test]
+fn token_copy_except_this_ability_resolves_printed_slot_at_finish() {
+    let parsed = parse_oracle_text(
+        "When ~ enters, draw a card.\n\
+         Whenever another creature you control enters, create a token that's a copy of that creature, except it has this ability.",
+        "Token Slot Probe",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+
+    assert_eq!(
+        parsed.triggers.len(),
+        2,
+        "expected two printed triggers (ETB draw + copy-token): {:?}",
+        parsed.triggers
+    );
+
+    let copy_pos = parsed
+        .triggers
+        .iter()
+        .position(|t| {
+            t.execute
+                .as_ref()
+                .is_some_and(|e| matches!(*e.effect, Effect::CopyTokenOf { .. }))
+        })
+        .expect("second trigger must produce a CopyTokenOf effect");
+    assert_eq!(
+        copy_pos, 1,
+        "reach-guard: CopyTokenOf trigger must occupy printed slot 1 (ETB at 0)"
+    );
+
+    let execute = parsed.triggers[copy_pos]
+        .execute
+        .as_deref()
+        .expect("CopyTokenOf trigger must have an execute body");
+    let Effect::CopyTokenOf {
+        additional_modifications,
+        ..
+    } = execute.effect.as_ref()
+    else {
+        panic!("expected CopyTokenOf, got {:?}", execute.effect);
+    };
+    let resolved = additional_modifications
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::RetainPrintedTriggerFromSource {
+                source_trigger_index,
+            } => Some(*source_trigger_index),
+            _ => None,
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a RetainPrintedTriggerFromSource in CopyTokenOf, got {additional_modifications:?}"
+            )
+        });
+    assert_eq!(
+        resolved, 1,
+        "CR 707.9a: finish() must resolve the CopyTokenOf printed slot to the \
+         trigger's source-ordered index (1)"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -570,6 +570,7 @@ mod ponder_decline_shuffle_regression;
 mod power_fist_combat_damage_regression;
 mod power_up_keyword;
 mod primo_unbounded_fractal_counters;
+mod printed_ability_order;
 mod proliferate_zero_counter;
 mod quirion_ranger_activation;
 mod rage_reflection_double_strike_grant;

--- a/crates/engine/tests/integration/printed_ability_order.rs
+++ b/crates/engine/tests/integration/printed_ability_order.rs
@@ -1,0 +1,394 @@
+//! Printed-order regression for `ParsedAbilities::{triggers, abilities}`.
+//!
+//! CR 707.9a: "Some copy effects cause the copy to gain an ability as part of the
+//! copying process." The Unstable Shapeshifter example — "becomes a copy of that
+//! creature, except it has this ability" — requires the engine to identify *which*
+//! ability is meant. It does so by index: `result.triggers[i]` and
+//! `result.abilities[i]` are the card's *printed* ability slots.
+//!
+//! `parse_oracle_ir` builds those vectors in two concatenated stages. Four
+//! preprocessors run before the per-line dispatch loop starts (`oracle.rs:2914`)
+//! and `extend` the vectors with everything they find anywhere on the card:
+//!
+//! ```text
+//! oracle.rs:2773  parse_saga_chapters              -> triggers
+//! oracle.rs:2784  parse_attraction_visit_triggers  -> triggers
+//! oracle.rs:2799  parse_level_blocks               -> statics
+//! oracle.rs:2870  parse_level_blocks (in-block)    -> triggers
+//! oracle.rs:2888  parse_spacecraft_threshold_lines -> statics, triggers, abilities
+//! oracle.rs:2914  while i < lines.len()            -- dispatch loop starts HERE
+//! ```
+//!
+//! So each vector is `[pre-loop] ++ [dispatch-loop]`, which has nothing to do with
+//! printed order. Whenever a preprocessor claims a line printed *below* a line the
+//! dispatch loop claims, the vector comes back inverted and every printed slot
+//! after the inversion point is wrong.
+//!
+//! These are the six cards in the current corpus where that happens. Each assertion
+//! anchors on a *discriminating field*, never on a position, so the test cannot
+//! pass vacuously by matching the very ordering it is trying to pin down.
+//!
+//! # This file is necessary but NOT sufficient. Do not read a green here as "fixed."
+//!
+//! These tests assert the order of the *item vector*. They say nothing about the
+//! *printed slot index*, which is a separate value: `emit` advances it at emission
+//! time (`oracle_ir/doc.rs`, `spells_emitted.push` / `trigger_index += 1`) while the
+//! item map is keyed by source position. Emission order can never equal source order
+//! here, because the dispatch loop's skip sets are *produced by* the preprocessors and
+//! so the preprocessors must emit first.
+//!
+//! A change that gives the preprocessors exact spans — and nothing else — turns every
+//! test in this file green while `RetainPrintedTriggerFromSource { source_trigger_index }`
+//! keeps the wrong integer, baked in at parse time by `parse_has_this_ability`. The
+//! defect would survive behind a vector that looks correct.
+//!
+//! The complete fix is late binding: store the enclosing `OracleItemId` (the clause is a
+//! self-reference, not an absolute index) and resolve it once at `finish()` from the
+//! source-ordered vector. That fix needs its own **synthetic** fixture — the copy-except
+//! clause and the six cards below are disjoint in the current corpus, so no printed card
+//! exercises the interaction. See `ISSUES.md` #12.
+
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{AbilityDefinition, ActivationRestriction};
+use engine::types::triggers::TriggerMode;
+use engine::types::TriggerDefinition;
+
+/// The sole index of the element matching `pred`.
+///
+/// Panics when zero or several elements match. That panic is the point: it is an
+/// in-test control. If a parser change stops producing the ability an assertion
+/// anchors on, this test aborts instead of quietly passing on an anchor that no
+/// longer selects anything.
+fn sole_index<T>(
+    card: &str,
+    vector: &str,
+    marker: &str,
+    items: &[T],
+    pred: impl Fn(&T) -> bool,
+) -> usize {
+    let hits: Vec<usize> = items
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| pred(item))
+        .map(|(i, _)| i)
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "{card}: expected exactly one element of `{vector}` to match the anchor `{marker}`, \
+         found {}. The anchor no longer discriminates, so this test can no longer detect the \
+         printed-order bug it exists to detect. Fix the anchor before trusting a green.",
+        hits.len(),
+    );
+    hits[0]
+}
+
+/// Asserts that `anchors`, listed in printed order, occupy strictly increasing
+/// positions in the parsed vector.
+fn assert_printed_order(card: &str, vector: &str, anchors: &[(&str, usize)]) {
+    for pair in anchors.windows(2) {
+        let (earlier_marker, earlier_pos) = pair[0];
+        let (later_marker, later_pos) = pair[1];
+        assert!(
+            earlier_pos < later_pos,
+            "{card}: `{vector}` is not in printed order. `{earlier_marker}` is printed above \
+             `{later_marker}`, but lands at index {earlier_pos} while `{later_marker}` lands at \
+             index {later_pos}. CR 707.9a binds an \"except it has this ability\" clause by \
+             printed slot, so the copy would gain the wrong ability.",
+        );
+    }
+}
+
+fn strings(items: &[&str]) -> Vec<String> {
+    items.iter().map(|s| (*s).to_string()).collect()
+}
+
+fn parse_spacecraft(oracle: &str, name: &str) -> engine::parser::oracle::ParsedAbilities {
+    // Spacecraft print `Station` as an MTGJSON keyword ability; card-data is
+    // generated WITH it, so the `Station` reminder line is consumed as a keyword.
+    // Passing it here matches production — without it the bare `Station` line falls
+    // through to an `Unimplemented` ability that pollutes the `abilities` vector
+    // (irrelevant to the printed-ORDER property under test).
+    parse_oracle_text(
+        oracle,
+        name,
+        &strings(&["Station"]),
+        &strings(&["Artifact"]),
+        &strings(&["Spacecraft"]),
+    )
+}
+
+fn has_mode(mode: TriggerMode) -> impl Fn(&TriggerDefinition) -> bool {
+    move |t: &TriggerDefinition| t.mode == mode
+}
+
+fn unrestricted(a: &AbilityDefinition) -> bool {
+    a.activation_restrictions.is_empty()
+}
+
+fn counter_threshold(a: &AbilityDefinition) -> bool {
+    a.activation_restrictions
+        .iter()
+        .any(|r| matches!(r, ActivationRestriction::CounterThreshold { .. }))
+}
+
+fn level_range(min: u32, max: Option<u32>) -> impl Fn(&AbilityDefinition) -> bool {
+    move |a: &AbilityDefinition| {
+        a.activation_restrictions.iter().any(|r| {
+            matches!(
+                r,
+                ActivationRestriction::LevelCounterRange { minimum, maximum }
+                    if *minimum == min && *maximum == max
+            )
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// triggers — Spacecraft threshold blocks printed below an ETB trigger
+// ---------------------------------------------------------------------------
+
+/// Candela's `8+` block spans a *continuation* line (line 4 carries no `8+ |`
+/// prefix), so a scan keyed on text after the pipe misses it entirely.
+#[test]
+fn candela_triggers_are_in_printed_order() {
+    const ORACLE: &str = "Flash\n\
+        When Candela enters, return up to one target creature you control to its owner's hand. It perpetually gets +1/+1.\n\
+        Station\n\
+        8+ | Flying\n\
+        Whenever Candela deals combat damage to a player, you may put a creature card with mana value 3 or less from your hand onto the battlefield.";
+
+    let parsed = parse_spacecraft(ORACLE, "Candela, Aegis of Adagia");
+    let card = "Candela, Aegis of Adagia";
+
+    let etb = sole_index(
+        card,
+        "triggers",
+        "ChangesZone (line 1)",
+        &parsed.triggers,
+        has_mode(TriggerMode::ChangesZone),
+    );
+    let combat = sole_index(
+        card,
+        "triggers",
+        "DamageDone (line 4)",
+        &parsed.triggers,
+        has_mode(TriggerMode::DamageDone),
+    );
+
+    assert_printed_order(
+        card,
+        "triggers",
+        &[
+            ("ChangesZone (line 1)", etb),
+            ("DamageDone (line 4)", combat),
+        ],
+    );
+}
+
+#[test]
+fn infinite_guideline_station_triggers_are_in_printed_order() {
+    const ORACLE: &str = "When Infinite Guideline Station enters, create a tapped 2/2 colorless Robot artifact creature token for each multicolored permanent you control.\n\
+        Station (Tap another creature you control: Put charge counters equal to its power on this Spacecraft. Station only as a sorcery. It's an artifact creature at 12+.)\n\
+        12+ | Flying\n\
+        Whenever Infinite Guideline Station attacks, draw a card for each multicolored permanent you control.";
+
+    let parsed = parse_spacecraft(ORACLE, "Infinite Guideline Station");
+    let card = "Infinite Guideline Station";
+
+    let etb = sole_index(
+        card,
+        "triggers",
+        "ChangesZone (line 0)",
+        &parsed.triggers,
+        has_mode(TriggerMode::ChangesZone),
+    );
+    let attacks = sole_index(
+        card,
+        "triggers",
+        "Attacks (line 3)",
+        &parsed.triggers,
+        has_mode(TriggerMode::Attacks),
+    );
+
+    assert_printed_order(
+        card,
+        "triggers",
+        &[("ChangesZone (line 0)", etb), ("Attacks (line 3)", attacks)],
+    );
+}
+
+#[test]
+fn specimen_freighter_triggers_are_in_printed_order() {
+    const ORACLE: &str = "When this Spacecraft enters, return up to two target non-Spacecraft creatures to their owners' hands.\n\
+        Station (Tap another creature you control: Put charge counters equal to its power on this Spacecraft. Station only as a sorcery. It's an artifact creature at 9+.)\n\
+        9+ | Flying\n\
+        Whenever this Spacecraft attacks, defending player mills four cards.";
+
+    let parsed = parse_spacecraft(ORACLE, "Specimen Freighter");
+    let card = "Specimen Freighter";
+
+    let etb = sole_index(
+        card,
+        "triggers",
+        "ChangesZone (line 0)",
+        &parsed.triggers,
+        has_mode(TriggerMode::ChangesZone),
+    );
+    let attacks = sole_index(
+        card,
+        "triggers",
+        "Attacks (line 3)",
+        &parsed.triggers,
+        has_mode(TriggerMode::Attacks),
+    );
+
+    assert_printed_order(
+        card,
+        "triggers",
+        &[("ChangesZone (line 0)", etb), ("Attacks (line 3)", attacks)],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// triggers — Attraction visit line printed below an ETB trigger
+// ---------------------------------------------------------------------------
+
+/// The visit trigger is recognized by the literal `"Visit — "` prefix
+/// (`oracle_attraction.rs:19-20`), not by the prose `"When you visit"`, and it
+/// carries `description: None`. Both facts have already caused corpus scans to
+/// silently match zero Attraction cards.
+#[test]
+fn memory_test_triggers_are_in_printed_order() {
+    const ORACLE: &str = "When this Attraction enters, target opponent exiles cards from the bottom of their library until they exile five nonland cards, then turns those nonland cards face down.\n\
+        Visit — Name the exiled face-down cards, then look at them. If you named them correctly, turn them face up, then claim the prize!\n\
+        Prize — Create three 1/1 red Balloon creature tokens with flying, then sacrifice this Attraction and open an Attraction.";
+
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Memory Test",
+        &[],
+        &strings(&["Artifact"]),
+        &strings(&["Attraction"]),
+    );
+    let card = "Memory Test";
+
+    let etb = sole_index(
+        card,
+        "triggers",
+        "ChangesZone (line 0)",
+        &parsed.triggers,
+        has_mode(TriggerMode::ChangesZone),
+    );
+    let visit = sole_index(
+        card,
+        "triggers",
+        "VisitAttraction (line 1)",
+        &parsed.triggers,
+        has_mode(TriggerMode::VisitAttraction),
+    );
+
+    assert_printed_order(
+        card,
+        "triggers",
+        &[
+            ("ChangesZone (line 0)", etb),
+            ("VisitAttraction (line 1)", visit),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// abilities — threshold / level blocks printed below a plain activated ability
+// ---------------------------------------------------------------------------
+
+/// Both abilities are `{T}` → mana, so mode and cost cannot tell them apart.
+/// The only discriminating field is `activation_restrictions`.
+#[test]
+fn the_eternity_elevator_abilities_are_in_printed_order() {
+    const ORACLE: &str = "{T}: Add {C}{C}{C}.\n\
+        Station (Tap another creature you control: Put charge counters equal to its power on this Spacecraft. Station only as a sorcery.)\n\
+        20+ | {T}: Add X mana of any one color, where X is the number of charge counters on The Eternity Elevator.";
+
+    let parsed = parse_spacecraft(ORACLE, "The Eternity Elevator");
+    let card = "The Eternity Elevator";
+
+    let plain = sole_index(
+        card,
+        "abilities",
+        "unrestricted {T}: Add {C}{C}{C} (line 0)",
+        &parsed.abilities,
+        unrestricted,
+    );
+    let gated = sole_index(
+        card,
+        "abilities",
+        "CounterThreshold charge>=20 (line 2)",
+        &parsed.abilities,
+        counter_threshold,
+    );
+
+    assert_printed_order(
+        card,
+        "abilities",
+        &[
+            ("unrestricted (line 0)", plain),
+            ("CounterThreshold (line 2)", gated),
+        ],
+    );
+}
+
+/// `parse_level_blocks` runs with no subtype guard (`oracle.rs:2797`), so a Land
+/// reaches it. The unrestricted `{T}: Add {C}.` on line 1 is printed *above* both
+/// `LEVEL` blocks yet lands last.
+#[test]
+fn under_construction_skyscraper_abilities_are_in_printed_order() {
+    const ORACLE: &str =
+        "Level up {1} ({1}: Put a level counter on this. Level up only as a sorcery.)\n\
+        {T}: Add {C}.\n\
+        LEVEL 1-7\n\
+        {T}: Add {W}, {B}, {G}, or {C}.\n\
+        LEVEL 8+\n\
+        {T}: Add {W}, {B}, {G}, or {C}. Scry 1.";
+
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Under-Construction Skyscraper",
+        &[],
+        &strings(&["Land"]),
+        &[],
+    );
+    let card = "Under-Construction Skyscraper";
+
+    let plain = sole_index(
+        card,
+        "abilities",
+        "unrestricted {T}: Add {C} (line 1)",
+        &parsed.abilities,
+        unrestricted,
+    );
+    let low = sole_index(
+        card,
+        "abilities",
+        "LevelCounterRange 1..=7 (line 3)",
+        &parsed.abilities,
+        level_range(1, Some(7)),
+    );
+    let high = sole_index(
+        card,
+        "abilities",
+        "LevelCounterRange 8.. (line 5)",
+        &parsed.abilities,
+        level_range(8, None),
+    );
+
+    assert_printed_order(
+        card,
+        "abilities",
+        &[
+            ("unrestricted (line 1)", plain),
+            ("LevelCounterRange 1..=7 (line 3)", low),
+            ("LevelCounterRange 8.. (line 5)", high),
+        ],
+    );
+}


### PR DESCRIPTION
## What & why

Makes `parse_oracle_ir` emit each ability into its category vector (`triggers` / `abilities` / `statics`) in **printed source order**, so that `result.triggers[i]` is the card's printed ability slot `i`. This is the foundation CR 707.9a requires: a copy that "gains this ability" (Quicksilver Gargantuan, token-copy clauses) binds by the *printed* ability slot, and the previous `[preprocessors] ++ [dispatch-loop]` construction order didn't match printed order.

This is architecture, not user-visible behavior: the point is a correct emission foundation that surfaces ordering bugs at the source and keeps the parser composable. Card output is unchanged except for the 13 cards whose category vectors were previously mis-ordered.

## The three-commit arc

1. **Late-bind the CR 707.9a slot to `finish()`** — `RetainPrinted{Trigger,Ability}FromSource` indices resolve from each item's *final* vector position at `OracleDoc::finish()` instead of at parse time. Byte-identical (category order still reproduces the old per-category counters); decouples the slot from construction order so the reorder can't break the copy-except binding. The stamping walk is exhaustive over `Effect` / `CastingPermission` / `OracleNodeIr` (no `_` arm) so a future slot-bearing node compile-errors rather than silently missing a slot.

2. **Groundwork: per-line ordinal allocator + `DocEmitter`** — `next_ordinal_for_line` is the single category-blind ordinal authority (keys items on `(first_line, start_byte, ordinal)`); `DocEmitter` is the single-authority source-order emission surface. Both `dead_code` until the cutover wires them — no behavior change.

3. **Cutover** — moves emission from category-ordered `parsed_abilities_to_doc_ir` into the dispatch loop + preprocessors, so `lower_oracle_ir`'s order-preserving fold yields printed-source-ordered vectors and commit 1's `finish()` counters resolve the printed slot correctly. Preprocessors return source-line-tagged items; the 4 cross-item reconciles + swallow audit relocate post-fold into `lower_oracle_ir`; the Class path keeps the whole-document shim. Leveler block-summary statics anchor at a single-line header span (CR 711.2) to avoid overlapping-sibling spans.

## Verification

- **rung-1 printed-order gate**: 6/6 discriminating cards FAIL→PASS (each anchored on a discriminating field, exactly-one-match, never position).
- **Reorder scope**: exactly 13 vector-reorders across the census set, **zero** unexpected movers — content unchanged, order only (measured via clean in-branch baseline regen, same MTGJSON).
- **Snapshots**: 58 `_ir` snapshots regenerated (WholeDocument→Exact); **0 `_lowered`/card-data drift** — behavior-neutral confirmed by byte-identical regen.
- **Saga multi-numeral guard**: 94-card corpus parses (Long List of the Ents 6, City of Death 6); 0 corpus-wide emit panics.
- Full engine lib suite green.
