### PR TITLE
Fix explore-replacement double-run and interactive sequencing (#5272)

### DIFF
--- a/crates/engine/src/game/effects/explore.rs
+++ b/crates/engine/src/game/effects/explore.rs
@@ -228,11 +228,15 @@ pub fn resolve(
         })
         .unwrap_or(ability.source_id);
 
-    // CR 701.37a + CR 614.1a: Consult explore replacements (Twists and Turns,
-    // Topography Tracker, …) before the reveal/counter/land logic runs.
+    // CR 701.44a + CR 614.1a + CR 614.5: Consult explore replacements (Twists and
+    // Turns, Topography Tracker, …) before the reveal/counter/land logic runs.
+    // Seed the proposed event's applied set from the resolving ability so an
+    // explore produced by a doubling replacement's execute chain excludes the
+    // replacement that produced it (no self-invocation) while remaining open to
+    // other doublers (CR 616.1f). Empty for a first-time explore.
     let proposed = ProposedEvent::Explore {
         object_id: explorer_id,
-        applied: HashSet::new(),
+        applied: ability.replacement_applied.clone(),
     };
     match replacement::replace_event(state, proposed, events) {
         ReplacementResult::Execute(_) => {}
@@ -411,6 +415,351 @@ mod tests {
         ResolvedAbility::new(Effect::Explore, vec![], source_id, PlayerId(0))
     }
 
+    /// Build a creature carrying Topography Tracker's explore replacement:
+    /// "If a creature you control would explore, instead it explores, then it
+    /// explores again." (execute = Explore, sub_ability = Explore).
+    fn topography_replacement() -> ReplacementDefinition {
+        ReplacementDefinition::new(ReplacementEvent::Explore)
+            .execute(
+                AbilityDefinition::new(AbilityKind::Spell, Effect::Explore)
+                    .sub_ability(AbilityDefinition::new(AbilityKind::Spell, Effect::Explore)),
+            )
+            .valid_card(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You),
+            ))
+    }
+
+    /// CR 614.5 + CR 701.44a (issue #5272): Topography Tracker doubles an
+    /// explore. The two explores must resolve SEQUENTIALLY through the
+    /// interactive pipeline — the first explore reveals a nonland and pauses on
+    /// its own DigChoice; the second explore resumes only AFTER that choice.
+    /// The naive back-to-back applier revealed the same top card twice (the
+    /// first DigChoice never moved it), granting two counters up front and
+    /// clobbering the first choice. This test locks correct sequencing.
+    #[test]
+    fn topography_double_explore_sequences_two_distinct_reveals() {
+        let mut state = GameState::new_two_player(42);
+
+        // Tracker carries the double-explore replacement.
+        let tracker = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Topography Tracker".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&tracker)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        state
+            .objects
+            .get_mut(&tracker)
+            .unwrap()
+            .replacement_definitions
+            .push(topography_replacement());
+
+        // The exploring creature.
+        let explorer = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Explorer".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&explorer)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        // Three DISTINCT nonlands on top (A, B, C) so both a re-reveal of the
+        // same top card AND a spurious self-re-double are detectable, with a land
+        // beneath to anchor the library top. Card C must stay untouched: the two
+        // explores consume A and B, and the producing replacement must NOT apply
+        // to its own output (CR 614.5), so C is never revealed.
+        let bolt_a = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Lightning Bolt".to_string(),
+            Zone::Library,
+        );
+        let shock_b = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Shock".to_string(),
+            Zone::Library,
+        );
+        let spark_c = create_object(
+            &mut state,
+            CardId(6),
+            PlayerId(0),
+            "Spark".to_string(),
+            Zone::Library,
+        );
+        let land = create_object(
+            &mut state,
+            CardId(5),
+            PlayerId(0),
+            "Forest".to_string(),
+            Zone::Library,
+        );
+        state
+            .objects
+            .get_mut(&land)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Land);
+        for id in [bolt_a, shock_b, spark_c] {
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Instant);
+        }
+        state.players[0].library = vec![bolt_a, shock_b, spark_c, land].into();
+
+        let ability = make_explore_ability(explorer);
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // First explore only: exactly ONE counter so far, paused on card A's
+        // DigChoice, with the second explore stashed as a continuation.
+        assert_eq!(
+            state.objects[&explorer]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(1),
+            "only the first of the two explores should have resolved before the DigChoice"
+        );
+        match &state.waiting_for {
+            WaitingFor::DigChoice { cards, .. } => {
+                assert_eq!(
+                    cards.as_slice(),
+                    &[bolt_a],
+                    "first explore must reveal the current top card (A)"
+                );
+            }
+            other => panic!("expected DigChoice from first explore, got {other:?}"),
+        }
+        assert!(
+            state.pending_continuation.is_some(),
+            "the second explore must be stashed while the first waits on DigChoice"
+        );
+
+        // Resolve the first DigChoice: send card A to the graveyard so the
+        // second explore reveals a DIFFERENT card (B).
+        engine::apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] }).unwrap();
+
+        assert_eq!(
+            state.objects[&explorer]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(2),
+            "second explore should add another counter after the first choice resolves"
+        );
+        assert!(
+            state.players[0].graveyard.contains(&bolt_a),
+            "declined first-explore card A must be in the graveyard"
+        );
+        match &state.waiting_for {
+            WaitingFor::DigChoice { cards, .. } => {
+                assert_eq!(
+                    cards.as_slice(),
+                    &[shock_b],
+                    "second explore must reveal the NEW top card (B), not re-reveal A"
+                );
+            }
+            other => panic!("expected DigChoice from second explore, got {other:?}"),
+        }
+
+        // CR 614.5: resolving the second explore's DigChoice must TERMINATE the
+        // explore — the producing replacement cannot apply to its own output, so
+        // there is no third explore. If the second link had lost its applied-set
+        // exclusion and re-doubled, card C would be revealed here for a third
+        // counter and a fresh DigChoice.
+        engine::apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] }).unwrap();
+
+        assert_eq!(
+            state.objects[&explorer]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(2),
+            "exactly two explores must occur — the doubler must not re-apply to itself (CR 614.5)"
+        );
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::DigChoice { .. }),
+            "the doubled explore must terminate, not spawn a third DigChoice"
+        );
+        assert_eq!(
+            state.players[0].library.front().copied(),
+            Some(spark_c),
+            "card C must be untouched on top — the doubler never explores a third time"
+        );
+    }
+
+    /// CR 616.1 + CR 701.44a (issue #5272): when a multi-creature explore
+    /// ("each creature you control explores") is doubled, one creature's two
+    /// explores must stay CONSECUTIVE — the next creature must not explore
+    /// between them. Models the `Explore(C1).sub(Explore(C2))` chain that
+    /// `resolve_single_explorer` builds (Hakbal of the Surging Soul), with
+    /// Topography Tracker doubling each explore. After C1's first DigChoice
+    /// resolves, C1 must already have its SECOND counter while C2 has none.
+    #[test]
+    fn doubled_explore_keeps_one_creatures_two_explores_consecutive() {
+        let mut state = GameState::new_two_player(42);
+
+        let tracker = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Topography Tracker".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&tracker)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        state
+            .objects
+            .get_mut(&tracker)
+            .unwrap()
+            .replacement_definitions
+            .push(topography_replacement());
+
+        let c1 = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "First".to_string(),
+            Zone::Battlefield,
+        );
+        let c2 = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Second".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [c1, c2] {
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+
+        // Nonlands on top so each explore pauses on a DigChoice; a land anchors
+        // the bottom.
+        let mut lib = Vec::new();
+        for cid in 10..14 {
+            let card = create_object(
+                &mut state,
+                CardId(cid),
+                PlayerId(0),
+                format!("Nonland {cid}"),
+                Zone::Library,
+            );
+            state
+                .objects
+                .get_mut(&card)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Instant);
+            lib.push(card);
+        }
+        state.players[0].library = lib.into();
+
+        // Explore C1, then (as the printed next instruction) explore C2 — the
+        // shape `resolve_single_explorer` produces for a two-creature explore.
+        let second = ResolvedAbility::new(
+            Effect::Explore,
+            vec![TargetRef::Object(c2)],
+            c1,
+            PlayerId(0),
+        );
+        let ability = ResolvedAbility::new(
+            Effect::Explore,
+            vec![TargetRef::Object(c1)],
+            c1,
+            PlayerId(0),
+        )
+        .sub_ability(second);
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+        // C1's first explore paused on its DigChoice; C1 has one counter, C2 none.
+        assert_eq!(
+            state.objects[&c1]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(1),
+        );
+        assert_eq!(
+            state.objects[&c2].counters.get(&CounterType::Plus1Plus1),
+            None
+        );
+
+        // Resolve C1's first DigChoice. C1's SECOND explore must run next — NOT
+        // C2's — so C1 reaches two counters while C2 still has none.
+        engine::apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] }).unwrap();
+
+        assert_eq!(
+            state.objects[&c1]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(2),
+            "C1's two explores must be consecutive — C2 must not interleave between them"
+        );
+        assert_eq!(
+            state.objects[&c2].counters.get(&CounterType::Plus1Plus1),
+            None,
+            "C2 must not have explored until C1's doubled explore fully completes"
+        );
+
+        // Drain C1's second DigChoice: the appended C2 sub must now actually
+        // fire (its own doubled explore begins), proving the sub was queued
+        // AFTER C1's pair rather than dropped.
+        engine::apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] }).unwrap();
+        assert_eq!(
+            state.objects[&c1]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(2),
+            "C1 must not explore a third time after its pair completes"
+        );
+        assert_eq!(
+            state.objects[&c2]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(1),
+            "C2's explore must run once C1's doubled explore has fully resolved"
+        );
+    }
+
     #[test]
     fn explore_scry_prelude_replacement_runs_before_explore() {
         let mut state = GameState::new_two_player(42);
@@ -485,13 +834,50 @@ mod tests {
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
 
+        // CR 614.5 + CR 701.44a: "scry 1, THEN it explores" resolves in printed
+        // order through the interactive pipeline. The scry parks its choice FIRST;
+        // the explore is stashed and must not run yet (no counter, no reveal).
+        match &state.waiting_for {
+            WaitingFor::ScryChoice { player, cards } => {
+                assert_eq!(*player, PlayerId(0));
+                assert_eq!(cards.as_slice(), &[top_card]);
+            }
+            other => panic!("expected the scry prelude to pause first, got {other:?}"),
+        }
         assert!(
+            !state.objects[&explorer]
+                .counters
+                .contains_key(&CounterType::Plus1Plus1),
+            "the explore must not run until the scry choice resolves"
+        );
+        assert!(
+            state.pending_continuation.is_some(),
+            "the explore link must be stashed while the scry waits for a choice"
+        );
+
+        // Keep the card on top; the stashed explore now runs and reveals it.
+        engine::apply_as_current(
+            &mut state,
+            GameAction::SelectCards {
+                cards: vec![top_card],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
             state.objects[&explorer]
                 .counters
-                .iter()
-                .any(|(ct, _)| *ct == CounterType::Plus1Plus1),
-            "replacement scry prelude must still leave the creature exploring (+1/+1 counter)"
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(1),
+            "the scry prelude must still leave the creature exploring (+1/+1 counter)"
         );
+        match &state.waiting_for {
+            WaitingFor::DigChoice { cards, .. } => {
+                assert_eq!(cards.as_slice(), &[top_card]);
+            }
+            other => panic!("expected the explore's nonland DigChoice, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7974,6 +7974,34 @@ fn resolve_chain_body(
         {
             return Ok(());
         }
+        // CR 616.1 + CR 701.44a: An explore doubler ("…then it explores again")
+        // paused this explore, and its applier already installed the doubled
+        // second explore on `pending_continuation`. This node's own `sub_ability`
+        // — the `ExploreAll` walk to the NEXT creature (Hakbal of the Surging
+        // Soul) or a trailing rider — is a LATER instruction: a single creature's
+        // two explores stay consecutive, so no other creature may explore between
+        // them. Append the sub AFTER the installed second explore rather than
+        // prepending it ahead (the generic path below), which would interleave
+        // the next creature between the two halves. Guarded to `Effect::Explore`
+        // so it never disturbs effects (clash, PayCost) whose installed
+        // continuation IS their own sub_ability.
+        if continuation_installed_by_this_effect
+            && matches!(ability.effect, Effect::Explore)
+            && waits_for_resolution_choice(&state.waiting_for)
+        {
+            let mut sub_clone = sub.as_ref().clone();
+            if sub_clone.targets.is_empty() && !ability.targets.is_empty() {
+                sub_clone.targets = ability.targets.clone();
+            }
+            apply_parent_chain_context(
+                &mut sub_clone,
+                ability,
+                effect_context_object.as_ref(),
+                state,
+            );
+            append_to_pending_continuation(state, Some(Box::new(sub_clone)));
+            return Ok(());
+        }
         // If resolve_effect just entered a player-choice state (Scry/Dig/Surveil),
         // save the sub-ability as a continuation to execute after the player responds,
         // rather than immediately processing it (which would bypass the UI).

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1941,10 +1941,37 @@ fn scry_applier(
 
 // --- 4d. Explore (Twists and Turns / Topography Tracker) ---
 
-// CR 701.37a + CR 614.1a: A creature is about to explore. Replacement
+// CR 701.44a + CR 614.1a: A creature is about to explore. Replacement
 // effects can modify the explore action (e.g., add a scry prelude or double explore).
 fn explore_matcher(event: &ProposedEvent, _source: ObjectId, _state: &GameState) -> bool {
     matches!(event, ProposedEvent::Explore { .. })
+}
+
+/// CR 701.44a + CR 614.5: Retarget every explore/action link in a replacement's
+/// execute chain to the exploring object and carry the already-applied
+/// replacement set. The carried set makes each re-proposed explore exclude the
+/// replacement that produced it (CR 614.5 — a replacement effect cannot
+/// self-invoke) while still admitting other explore doublers (CR 616.1f). The
+/// scry prelude (Twists and Turns) keeps its own controller-scoped target; only
+/// explore/action links address the exploring object.
+fn stamp_explore_chain(
+    ability: &mut ResolvedAbility,
+    explorer: ObjectId,
+    applied: &HashSet<AppliedReplacementKey>,
+) {
+    ability.replacement_applied = applied.clone();
+    if !matches!(&ability.effect, Effect::Scry { .. }) {
+        ability.targets = vec![TargetRef::Object(explorer)];
+    }
+    if let Some(sub) = ability.sub_ability.as_deref_mut() {
+        stamp_explore_chain(sub, explorer, applied);
+    }
+    // Mirror `build_resolved_from_def`, which also populates `else_ability`, so a
+    // branching execute chain leaves no explore link with a stale target or an
+    // unseeded applied set.
+    if let Some(else_branch) = ability.else_ability.as_deref_mut() {
+        stamp_explore_chain(else_branch, explorer, applied);
+    }
 }
 
 fn explore_applier(
@@ -1968,36 +1995,23 @@ fn explore_applier(
         return ApplyResult::Modified(ProposedEvent::Explore { object_id, applied });
     };
 
-    use crate::game::ability_utils::build_resolved_from_def;
-    use crate::types::ability::TargetRef;
-
     let controller = source.controller;
-    let mut current = Some(execute.as_ref());
-    while let Some(def) = current {
-        match &*def.effect {
-            Effect::Scry { .. } => {
-                let ability = build_resolved_from_def(def, rid.source, controller);
-                let _ = crate::game::effects::scry::resolve(state, &ability, events);
-            }
-            Effect::Explore => {
-                let ability = ResolvedAbility::new(
-                    Effect::Explore,
-                    vec![TargetRef::Object(object_id)],
-                    rid.source,
-                    controller,
-                );
-                let _ = crate::game::effects::explore::resolve_explore_effect(
-                    state, &ability, object_id, events,
-                );
-            }
-            _ => {
-                let mut ability = build_resolved_from_def(def, rid.source, controller);
-                ability.targets = vec![TargetRef::Object(object_id)];
-                let _ = crate::game::effects::resolve_ability_chain(state, &ability, events, 1);
-            }
-        }
-        current = def.sub_ability.as_deref();
-    }
+
+    // CR 701.44a + CR 614.5 + CR 616.1f: Resolve the replacement's execute chain
+    // (Twists and Turns' "scry 1, then it explores"; Topography Tracker's "it
+    // explores, then it explores again") through the standard interactive
+    // continuation machinery instead of a straight-line loop. An intermediate
+    // scry, or a nonland explore's DigChoice, parks a player choice; the
+    // following link is stashed on `pending_continuation` and resumes only after
+    // that choice resolves — so the two explores reveal sequentially rather than
+    // both firing against the same still-unmoved top card. `stamp_explore_chain`
+    // carries the already-applied replacement set (which the pipeline marked with
+    // this rid before invoking the applier) onto every link, so a re-proposed
+    // explore excludes THIS replacement (no self-loop) while other doublers still
+    // apply (CR 616.1f).
+    let mut chain = build_resolved_from_def(&execute, rid.source, controller);
+    stamp_explore_chain(&mut chain, object_id, &applied);
+    let _ = crate::game::effects::resolve_ability_chain(state, &chain, events, 1);
 
     ApplyResult::Prevented
 }
@@ -6199,6 +6213,17 @@ fn apply_single_replacement(
             // generic Template stash here does not drop the deferred connive.
             let post_effect =
                 post_effect.filter(|_| !matches!(proposed, ProposedEvent::Connive { .. }));
+            // CR 701.44a + CR 614.5: The explore applier runs the entire
+            // replacement `execute` chain itself — Twists and Turns' "scry 1,
+            // then it explores", Topography Tracker's "it explores, then it
+            // explores again" — through the interactive continuation machinery
+            // and returns `Prevented` (mirroring connive). Stashing the same
+            // chain as a post-replacement continuation would run it a SECOND
+            // time when the drain fires, exploring again on the replacement's
+            // own source instead of the exploring permanent. The applier is the
+            // single authority for this event, so suppress the generic stash.
+            let post_effect =
+                post_effect.filter(|_| !matches!(proposed, ProposedEvent::Explore { .. }));
             let mut modifiers = event_modifiers_for_ability(ability, state, rid.source, &proposed);
             // CR 110.2a: A self-ETB controller override is carried directly on the
             // replacement definition (not derived from `execute`), parallel to the

--- a/crates/engine/tests/integration/explore_all_doubler_ordering.rs
+++ b/crates/engine/tests/integration/explore_all_doubler_ordering.rs
@@ -1,0 +1,153 @@
+//! Issue #5272: `ExploreAll` ("each creature you control explores", Hakbal of
+//! the Surging Soul) under an explore doubler (Topography Tracker — "if a
+//! creature you control would explore, instead it explores, then it explores
+//! again") must (a) terminate and (b) keep each creature's two doubled explores
+//! CONSECUTIVE — the next creature must not explore between the two halves.
+//!
+//! This drives the REAL production continuation shape:
+//! `Explore(C1).sub(ExploreAll { TrackedSet = [C2] })` built by
+//! `explore::resolve_single_explorer`, which the unit tests only approximate
+//! with a plain `Explore(C2)` sub.
+use engine::game::scenario::GameScenario;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, ControllerRef, Effect, ReplacementDefinition, TargetFilter,
+    TriggerConstraint, TriggerDefinition, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::replacements::ReplacementEvent;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+use engine::types::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+
+/// Topography Tracker's replacement: "instead it explores, then it explores
+/// again" — execute = Explore, sub = Explore, over any creature you control.
+fn double_explore_replacement() -> ReplacementDefinition {
+    ReplacementDefinition::new(ReplacementEvent::Explore)
+        .execute(
+            AbilityDefinition::new(AbilityKind::Spell, Effect::Explore)
+                .sub_ability(AbilityDefinition::new(AbilityKind::Spell, Effect::Explore)),
+        )
+        .valid_card(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ))
+}
+
+fn plus_one_counters(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> u32 {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .and_then(|o| o.counters.get(&CounterType::Plus1Plus1).copied())
+        .unwrap_or(0)
+}
+
+#[test]
+fn explore_all_under_doubler_keeps_each_creatures_explores_consecutive() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Two Merfolk that will explore; the trigger source carries the ExploreAll
+    // and the double-explore replacement.
+    let m1 = scenario
+        .add_creature(P0, "Merfolk One", 2, 2)
+        .with_subtypes(vec!["Merfolk"])
+        .id();
+    let m2 = scenario
+        .add_creature(P0, "Merfolk Two", 2, 2)
+        .with_subtypes(vec!["Merfolk"])
+        .id();
+
+    let trigger = TriggerDefinition::new(TriggerMode::Phase)
+        .phase(Phase::BeginCombat)
+        .trigger_zones(vec![Zone::Battlefield])
+        .constraint(TriggerConstraint::OnlyDuringYourTurn)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ExploreAll {
+                filter: TargetFilter::Typed(
+                    TypedFilter::creature()
+                        .subtype("Merfolk".to_string())
+                        .controller(ControllerRef::You),
+                ),
+            },
+        ));
+
+    scenario
+        .add_creature(P0, "Topography Tracker", 2, 2)
+        .with_trigger_definition(trigger)
+        .with_replacement_definition(double_explore_replacement());
+
+    // Four nonlands on top so every one of the four explores (2 creatures × 2)
+    // takes the pausing DigChoice branch; a card beneath anchors the top.
+    scenario.with_library_top(
+        P0,
+        &[
+            "Lightning Bolt",
+            "Lightning Bolt",
+            "Lightning Bolt",
+            "Lightning Bolt",
+            "Lightning Bolt",
+        ],
+    );
+
+    let mut runner = scenario.build();
+    runner.advance_to_combat();
+
+    // The top-level ExploreChoice fixes which Merfolk explores first.
+    let (first, second) = match runner.state().waiting_for.clone() {
+        WaitingFor::ExploreChoice { choosable, .. } => {
+            let first = choosable[0];
+            let second = if first == m1 { m2 } else { m1 };
+            (first, second)
+        }
+        other => panic!("expected the ExploreAll to open an ExploreChoice, got {other:?}"),
+    };
+
+    // Drive every prompt to completion; the loop bound turns the historic
+    // self-renewing explore loop (unbounded counters) into a test failure.
+    for step in 0..64 {
+        // Invariant: the SECOND creature may not gain a +1/+1 counter until the
+        // FIRST has both of its doubled explores done (2 counters). Its two
+        // explores stay consecutive — no interleaving.
+        if plus_one_counters(&runner, second) > 0 {
+            assert_eq!(
+                plus_one_counters(&runner, first),
+                2,
+                "second creature explored before the first's doubled explore finished"
+            );
+        }
+        let action = match runner.state().waiting_for.clone() {
+            WaitingFor::ExploreChoice { choosable, .. } => GameAction::ChooseTarget {
+                target: Some(engine::types::ability::TargetRef::Object(choosable[0])),
+            },
+            // Send each revealed nonland to the graveyard so the next explore
+            // reveals a fresh card.
+            WaitingFor::DigChoice { .. } => GameAction::SelectCards { cards: vec![] },
+            WaitingFor::Priority { .. } | WaitingFor::DeclareAttackers { .. } => break,
+            other => panic!("unexpected prompt at step {step}: {other:?}"),
+        };
+        assert!(step < 63, "explore did not terminate — infinite loop");
+        if runner.act(action).is_err() {
+            break;
+        }
+    }
+
+    // Each Merfolk explored exactly twice → exactly two +1/+1 counters each,
+    // and the loop terminated.
+    assert_eq!(
+        plus_one_counters(&runner, first),
+        2,
+        "first creature must explore exactly twice"
+    );
+    assert_eq!(
+        plus_one_counters(&runner, second),
+        2,
+        "second creature must explore exactly twice"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -735,6 +735,7 @@ mod esper_terra_saga_token_lore;
 mod everything_comes_to_dust_convoke_exile;
 mod exhaust_keyword_once_per_permanent;
 mod expensive_taste_look_and_play;
+mod explore_all_doubler_ordering;
 mod explore_all_sub_runs_once;
 mod explore_spell_3315;
 mod extinction_event_3270;


### PR DESCRIPTION
## Summary
Fixes the explore-replacement double-run and interactive-sequencing bug behind Topography Tracker ("if a creature you control would explore, instead it explores, then it explores again") and Twists and Turns ("scry 1, then that creature explores"). The same top card was revealed twice, counters were mis-applied, and the replacement's execute chain ran a second time on the replacement's own source — surfacing as a stuck/"looping" board.

Closes #5272.

Root causes:
1. `explore_applier` ran the replacement's execute chain in a straight-line loop, ignoring the interactive DigChoice/ScryChoice pause. It now runs the chain through the standard interactive continuation machinery (`resolve_ability_chain` + `build_resolved_from_def`), carrying the already-applied replacement set (CR 614.5 — no self-invocation; CR 616.1f — other doublers still apply).
2. The execute chain was also stashed as a generic post-replacement continuation and run twice. Suppressed the generic stash for `ProposedEvent::Explore`, mirroring the existing Connive suppression.
3. Ordering bug this exposed: for a multi-creature explore under a doubler (Hakbal of the Surging Soul), the next creature's explore was prepended ahead of the doubled second explore. A single creature's two explores now stay consecutive (guarded append, mirroring the PayCost/clash per-effect precedent).

Also corrected two stale CR annotations (701.37a Monstrosity → 701.44a Explore).

## Files changed
- crates/engine/src/game/effects/explore.rs
- crates/engine/src/game/effects/mod.rs
- crates/engine/src/game/replacement.rs
- crates/engine/tests/integration/explore_all_doubler_ordering.rs (new)
- crates/engine/tests/integration/main.rs

## CR references
- CR 614.1a — replacement event self-application
- CR 614.5 — a replacement effect does not apply to the event it generates (no self-invocation)
- CR 616.1 / CR 616.1f — multiple applicable replacement effects; other doublers still apply
- CR 701.44a — Explore (corrected from stale 701.37a Monstrosity annotations)

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (exit 0, no violations)
- `cargo clippy-strict` — clean
- `cargo test -p engine` (lib) — 16057 pass / 0 fail
- Targeted suites: explore unit (12), connive/scry/replacement (215), explore integration (9, incl. new end-to-end ExploreAll+doubler ordering test)
- Adversarial `$review-impl` cross-check: APPROVE — a RULES bug (multi-creature ordering under a doubler) was found and fixed; all suggestions applied.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

## Gate A
```
$ ./scripts/check-parser-combinators.sh
(no output — exit 0)
```
This change touches only the engine effect/replacement resolution layer and its integration tests; no parser combinator code is modified, and the nom-mandate gate reports zero violations.

## Anchored on
- crates/engine/src/game/replacement.rs:2019 — existing Connive post-replacement continuation suppression; the Explore suppression mirrors this same re-entry-vs-stash pattern.
- crates/engine/src/game/effects/mod.rs:5826 — existing `resolve_ability_chain` interactive-continuation machinery, reused to run the explore replacement chain through the DigChoice/ScryChoice pause instead of a straight-line loop.
- crates/engine/src/game/effects/mod.rs:2224 — existing per-effect choice-outcome guard (FlipCoin/RollDie/Clash/Dig) that the guarded-append ordering fix follows.

Tier: Frontier
