### PR TITLE
Add Avatar Aang four-bend transform regression tests (#5326)

### DIFF
--- a/crates/engine/tests/integration/issue_5326_avatar_aang_transform.rs
+++ b/crates/engine/tests/integration/issue_5326_avatar_aang_transform.rs
@@ -1,0 +1,176 @@
+//! Regression for issue #5326: Avatar Aang must transform after performing all
+//! four bend types in the same turn.
+//!
+//! https://github.com/phase-rs/phase/issues/5326
+
+use engine::game::effects::register_bending::resolve as resolve_register_bending;
+use engine::game::game_object::BackFaceData;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::triggers::process_triggers;
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{AbilityKind, Effect, ResolvedAbility};
+use engine::types::actions::GameAction;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::events::BendingType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::triggers::TriggerMode;
+
+const AVATAR_AANG_ORACLE: &str = "Flying, firebending 2\nWhenever you waterbend, earthbend, \
+     firebend, or airbend, draw a card. Then if you've done all four this turn, transform \
+     Avatar Aang.";
+
+fn drain_to_priority(runner: &mut engine::game::scenario::GameRunner) {
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(
+            guard < 128,
+            "drain exceeded bound: {:?}, stack={}",
+            runner.state().waiting_for,
+            runner.state().stack.len()
+        );
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            _ => {
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+        }
+    }
+}
+
+fn register_bend(
+    runner: &mut engine::game::scenario::GameRunner,
+    kind: BendingType,
+    source: ObjectId,
+) {
+    let ability = ResolvedAbility::new(Effect::RegisterBending { kind }, vec![], source, P0)
+        .kind(AbilityKind::Spell);
+    let mut events = Vec::new();
+    resolve_register_bending(runner.state_mut(), &ability, &mut events).expect("register bend");
+    process_triggers(runner.state_mut(), &events);
+    drain_to_priority(runner);
+}
+
+fn attach_aang_back_face(runner: &mut engine::game::scenario::GameRunner, aang: ObjectId) {
+    let obj = runner.state_mut().objects.get_mut(&aang).unwrap();
+    obj.back_face = Some(BackFaceData {
+        name: "Avatar Aang, Master of Elements".to_string(),
+        power: Some(6),
+        toughness: Some(6),
+        loyalty: None,
+        defense: None,
+        card_types: CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Creature],
+            subtypes: vec!["Avatar".to_string()],
+        },
+        mana_cost: ManaCost::default(),
+        keywords: vec![],
+        abilities: vec![],
+        trigger_definitions: Default::default(),
+        replacement_definitions: Default::default(),
+        static_definitions: Default::default(),
+        color: vec![],
+        printed_ref: None,
+        modal: None,
+        additional_cost: None,
+        strive_cost: None,
+        casting_restrictions: vec![],
+        casting_options: vec![],
+        layout_kind: None,
+    });
+}
+
+fn seed_aang(scenario: &mut GameScenario) -> ObjectId {
+    scenario
+        .add_creature(P0, "Avatar Aang", 4, 4)
+        .from_oracle_text_with_keywords(&["Flying", "firebending"], AVATAR_AANG_ORACLE)
+        .id()
+}
+
+#[test]
+fn avatar_aang_parses_bend_trigger_with_transform_gate() {
+    let parsed = parse_oracle_text(
+        AVATAR_AANG_ORACLE,
+        "Avatar Aang",
+        &["Flying".to_string(), "firebending".to_string()],
+        &["Creature".to_string()],
+        &["Avatar".to_string()],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::ElementalBend)
+        .expect("ElementalBend trigger");
+    let draw = trigger.execute.as_ref().expect("execute");
+    let transform = draw.sub_ability.as_ref().expect("transform sub-ability");
+    assert!(
+        matches!(draw.effect.as_ref(), Effect::Draw { .. }),
+        "first effect must draw"
+    );
+    assert!(
+        matches!(transform.effect.as_ref(), Effect::Transform { .. }),
+        "second effect must transform"
+    );
+    assert!(
+        transform.condition.is_some(),
+        "transform must be gated by intervening-if (all four bends)"
+    );
+}
+
+#[test]
+fn avatar_aang_transforms_after_fourth_bend_in_same_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+    let aang = seed_aang(&mut scenario);
+    // One library card per bend trigger draw.
+    for i in 0..4 {
+        scenario.add_card_to_library_top(P0, &format!("Lib {i}"));
+    }
+    let mut runner = scenario.build();
+    attach_aang_back_face(&mut runner, aang);
+    assert!(!runner.state().objects[&aang].transformed);
+
+    for kind in [
+        BendingType::Water,
+        BendingType::Earth,
+        BendingType::Fire,
+        BendingType::Air,
+    ] {
+        register_bend(&mut runner, kind, aang);
+    }
+
+    assert!(
+        runner.state().objects[&aang].transformed,
+        "Avatar Aang must transform after all four bend types in one turn"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .bending_types_this_turn
+            .len(),
+        4
+    );
+}
+
+#[test]
+fn avatar_aang_does_not_transform_after_only_three_bends() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+    let aang = seed_aang(&mut scenario);
+    for i in 0..3 {
+        scenario.add_card_to_library_top(P0, &format!("Lib {i}"));
+    }
+    let mut runner = scenario.build();
+    attach_aang_back_face(&mut runner, aang);
+
+    for kind in [BendingType::Water, BendingType::Earth, BendingType::Fire] {
+        register_bend(&mut runner, kind, aang);
+    }
+
+    assert!(
+        !runner.state().objects[&aang].transformed,
+        "three bend types must not satisfy the all-four gate"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -440,6 +440,7 @@ mod issue_5283_hall_of_bandit_lord;
 mod issue_5285_senu_keen_eyed_protector;
 mod issue_5286_lulu_loyal_hollyphant;
 mod issue_5287_samwise_stouthearted;
+mod issue_5326_avatar_aang_transform;
 mod issue_5327_doctor_doom_land_discard;
 mod issue_5328_attacks_alone_observer;
 mod issue_5329_mana_echoes;


### PR DESCRIPTION
Closes #5326 

## Summary

Avatar Aang ("Whenever you waterbend, earthbend, firebend, or airbend, draw a card. Then if you've done all four this turn, transform Avatar Aang.") was reported as not flipping when all four bend types are performed in the same turn. Investigation on current `main` shows the full path already works:

1. **Parser** lowers the batched trigger to `TriggerMode::ElementalBend` and attaches `AbilityCondition::QuantityCheck { BendTypesThisTurn >= 4 }` to the `Transform` sub-ability (not unconditional transform on every bend).
2. **Bend tracking** (`record_bending`) inserts each `BendingType` into `Player::bending_types_this_turn` before the bend `GameEvent` is scanned by `process_triggers`.
3. **Resolution** evaluates the intervening-if at transform time via `evaluate_condition` + `QuantityRef::BendTypesThisTurn`.

No engine logic changes were required. This PR adds end-to-end regression coverage through the production trigger pipeline (`process_triggers` → stack drain) so a future regression in bend tracking, parser gating, or transform resolution is caught immediately.

## Root cause of the original report (triage)

| Layer | Finding |
|-------|---------|
| Parser AST | `Draw` → gated `Transform`; `BendTypesThisTurn >= 4` on transform sub-ability |
| Prior coverage | `std_s07_batch5b` unit-style tests seed all four bend types then resolve ability chain directly |
| Gap | No integration test drove four sequential bends through `process_triggers` + stack resolution |
| Integration | Fourth bend in same turn → `transformed == true`; three bends → no transform |

The issue is labeled `status:confirmed` / `classifier:unsupported-aspect` on GitHub — parser reports fully parsed; runtime was fixed in the S07 `BendTypesThisTurn` increment but lacked e2e lock-in.

## Changes

### Integration tests (`crates/engine/tests/integration/issue_5326_avatar_aang_transform.rs`)

- Parse assertion: `ElementalBend` trigger chains `Draw` → gated `Transform`.
- Runtime positive: four sequential `RegisterBending` effects (water/earth/fire/air) through `process_triggers` + priority drain → Aang transforms.
- Runtime negative: three bends → no transform.

### Registration

- `mod issue_5326_avatar_aang_transform;` in `crates/engine/tests/integration/main.rs`

## Verification

```bash
cargo fmt --all
cargo test -p engine avatar_aang
cargo test -p engine std_s07_batch5b
```

## Test plan

- [ ] `cargo test -p engine avatar_aang` — 8 related tests green (3 new + 5 existing)
- [ ] Manual: Avatar Aang on battlefield, perform all four bend types same turn → transforms to Master of Elements
- [ ] Manual: perform only three bend types → draws but stays front face
