### PR TITLE
feat(parser): grant soulbond-paired quoted activated/triggered abilities

### DIFF
--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -659,20 +659,43 @@ pub(crate) fn parse_soulbond_paired_static(
     tp: &TextPair<'_>,
     description: &str,
 ) -> Option<StaticDefinition> {
-    let parser = preceded(
-        tag("as long as "),
-        preceded(
-            terminated(parse_soulbond_paired_condition_nom, tag(", ")),
-            preceded(
-                alt((tag("each of those creatures "), tag("both creatures "))),
-                alt((terminated(take_until("."), tag(".")), rest)),
-            ),
-        ),
-    );
-    let (_, predicate) = all_consuming(parser).parse(tp.lower).ok()?;
-    let mut def = parse_continuous_gets_has(predicate, TargetFilter::SourceOrPaired, description)?;
+    // CR 702.95: Soulbond. The paired reminder-text grant — "As long as ~ is
+    // paired with another creature, each of those creatures <predicate>." — is a
+    // CR 613.1f layer-6 ability-adding effect applied to BOTH paired creatures
+    // (SourceOrPaired). Split the pairing frame off the granted predicate with
+    // TextPair so the predicate keeps its ORIGINAL case: a quoted granted
+    // ability's mana symbols (`{1}{U}`) must reach the cost parser un-lowercased.
+    let after = tp.strip_prefix("as long as ")?;
+    let (condition, predicate) = after
+        .split_around(", each of those creatures ")
+        .or_else(|| after.split_around(", both creatures "))?;
+    if !matches_soulbond_paired_condition(condition.lower) {
+        return None;
+    }
+    let predicate = strip_granted_predicate_period(&predicate);
+    let mut def = parse_continuous_gets_has(
+        predicate.original,
+        TargetFilter::SourceOrPaired,
+        description,
+    )?;
     def.condition = Some(StaticCondition::SourceIsPaired);
     Some(def)
+}
+
+/// Trim a granted predicate's sentence-ending period, but leave a quoted ability
+/// intact. A quoted activated (CR 602.1) or triggered (CR 603.1) granted ability
+/// terminates with its period INSIDE the closing quote (`has "{1}{U}: ... your
+/// control."`), so a predicate ending in `"` has no outside period to strip —
+/// only the bare keyword/P-T forms (`has flying.`, `gets +1/+1.`) carry an outer
+/// period. A period-terminated `take_until(".")` would instead sever the quote
+/// at that inner period and drop the whole granted ability.
+fn strip_granted_predicate_period<'a>(predicate: &TextPair<'a>) -> TextPair<'a> {
+    let predicate = predicate.trim_end();
+    if predicate.ends_with("\"") {
+        predicate
+    } else {
+        predicate.trim_end_matches('.')
+    }
 }
 
 pub(crate) fn bind_where_x_in_quantity_expr(

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -665,6 +665,7 @@ pub(crate) fn parse_soulbond_paired_static(
     // (SourceOrPaired). Split the pairing frame off the granted predicate with
     // TextPair so the predicate keeps its ORIGINAL case: a quoted granted
     // ability's mana symbols (`{1}{U}`) must reach the cost parser un-lowercased.
+    // allow-noncombinator: TextPair dual-string structural strip preserving original case
     let after = tp.strip_prefix("as long as ")?;
     let (condition, predicate) = after
         .split_around(", each of those creatures ")
@@ -691,6 +692,7 @@ pub(crate) fn parse_soulbond_paired_static(
 /// at that inner period and drop the whole granted ability.
 fn strip_granted_predicate_period<'a>(predicate: &TextPair<'a>) -> TextPair<'a> {
     let predicate = predicate.trim_end();
+    // allow-noncombinator: punctuation inspection on a pre-tokenized chunk, not parse dispatch
     if predicate.ends_with("\"") {
         predicate
     } else {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -9635,6 +9635,114 @@ fn tokens_you_control_grant_spans_all_token_permanents() {
     );
 }
 
+// CR 702.95 + CR 613.1f: A soulbond pair grants a QUOTED activated/triggered
+// ability to both paired creatures — "As long as ~ is paired with another
+// creature, each of those creatures has "<ability>."". The granted ability's own
+// sentence period sits INSIDE its closing quote, so the paired predicate
+// extraction must not sever the quote at that inner period (regression: the
+// whole grant used to drop to empty `modifications` with a wrong `SelfRef`
+// scope). Covers the quoted class: Deadeye Navigator, Galvanic Alchemist,
+// Stonewright, Stern Mentor, Doom Weaver, Breathkeeper Seraph, Thundering
+// Mightmare, Imperious Mindbreaker, Tandem Lookout, Mirage Phalanx.
+#[test]
+fn soulbond_grants_quoted_activated_mana_ability() {
+    let def = parse_static_line(
+        "As long as ~ is paired with another creature, each of those creatures has \"{1}{U}: Exile ~, then return it to the battlefield under your control.\"",
+    )
+    .expect("soulbond quoted-ability grant must parse");
+    // CR 613.1f: the grant applies to BOTH paired creatures, gated on the pairing.
+    assert_eq!(def.affected, Some(TargetFilter::SourceOrPaired));
+    assert_eq!(def.condition, Some(StaticCondition::SourceIsPaired));
+    let ContinuousModification::GrantAbility { definition } = def
+        .modifications
+        .iter()
+        .find(|m| matches!(m, ContinuousModification::GrantAbility { .. }))
+        .expect("must grant the quoted activated ability, not drop it")
+    else {
+        unreachable!()
+    };
+    assert_eq!(definition.kind, AbilityKind::Activated);
+    assert!(
+        definition.cost.is_some(),
+        "granted activated ability must keep its {{1}}{{U}} cost: {definition:?}"
+    );
+}
+
+#[test]
+fn soulbond_grants_quoted_tap_free_activated_ability() {
+    let def = parse_static_line(
+        "As long as ~ is paired with another creature, each of those creatures has \"{2}{U}: Untap ~.\"",
+    )
+    .expect("Galvanic Alchemist soulbond grant must parse");
+    assert_eq!(def.affected, Some(TargetFilter::SourceOrPaired));
+    assert_eq!(def.condition, Some(StaticCondition::SourceIsPaired));
+    assert!(
+        def.modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::GrantAbility { .. })),
+        "granted ability dropped: {:?}",
+        def.modifications
+    );
+}
+
+#[test]
+fn soulbond_grants_quoted_triggered_ability() {
+    let def = parse_static_line(
+        "As long as ~ is paired with another creature, each of those creatures has \"Whenever ~ deals damage to an opponent, draw a card.\"",
+    )
+    .expect("Tandem Lookout soulbond grant must parse");
+    assert_eq!(def.affected, Some(TargetFilter::SourceOrPaired));
+    assert_eq!(def.condition, Some(StaticCondition::SourceIsPaired));
+    // CR 603.1: a "Whenever ..." quoted body becomes a granted TRIGGER, not an
+    // activated ability, so trigger metadata is preserved.
+    assert!(
+        def.modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::GrantTrigger { .. })),
+        "quoted triggered ability must become a GrantTrigger: {:?}",
+        def.modifications
+    );
+}
+
+// Regression: the bare keyword/P-T soulbond grants (which never had a quoted
+// period) must still parse identically through the same paired seam.
+#[test]
+fn soulbond_paired_keyword_grant_still_parses() {
+    let def = parse_static_line(
+        "As long as ~ is paired with another creature, both creatures have flying.",
+    )
+    .expect("Wingcrafter soulbond keyword grant must parse");
+    assert_eq!(def.affected, Some(TargetFilter::SourceOrPaired));
+    assert_eq!(def.condition, Some(StaticCondition::SourceIsPaired));
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::AddKeyword {
+                keyword: Keyword::Flying
+            }),
+        "keyword grant regressed: {:?}",
+        def.modifications
+    );
+}
+
+#[test]
+fn soulbond_paired_pt_grant_still_parses() {
+    let def = parse_static_line(
+        "As long as ~ is paired with another creature, each of those creatures gets +4/+4.",
+    )
+    .expect("Wolfir Silverheart soulbond P/T grant must parse");
+    assert_eq!(def.affected, Some(TargetFilter::SourceOrPaired));
+    assert_eq!(def.condition, Some(StaticCondition::SourceIsPaired));
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::AddPower { value: 4 })
+            && def
+                .modifications
+                .contains(&ContinuousModification::AddToughness { value: 4 }),
+        "P/T grant regressed: {:?}",
+        def.modifications
+    );
+}
+
 // CR 111.6: "Creature tokens you control" reaches the same token-descriptor arm
 // via the optional "creature " prefix, narrowing to creature tokens only.
 #[test]


### PR DESCRIPTION
CR 702.95 + CR 613.1f

## Bug

`parse_soulbond_paired_static` extracted the granted predicate with `take_until(".")`, which stops at the **first** period. A soulbond card whose paired grant is a **quoted activated/triggered ability** carries that ability's own sentence-ending period **inside** its closing quote (`... under your control."`). `take_until(".")` therefore severed the closing quote, the leftover `"` failed `all_consuming`, the soulbond parse returned `None`, and a fallback produced a static with **empty `modifications`** and the **wrong `SelfRef` scope**. None of these cards granted their ability at runtime.

Fully-broken class (10 cards — the granted ability was entirely dropped):

- **Deadeye Navigator** — `... each of those creatures has "{1}{U}: Exile this creature, then return it to the battlefield under your control."`
- **Galvanic Alchemist** — `"{2}{U}: Untap this creature."`
- **Stonewright** — `"{R}: This creature gets +1/+0 until end of turn."`
- **Stern Mentor** — `"{T}: Target player mills two cards."`
- **Doom Weaver**, **Breathkeeper Seraph**, **Thundering Mightmare**, **Imperious Mindbreaker**, **Mirage Phalanx** — quoted triggered abilities
- **Tandem Lookout** — `"Whenever this creature deals damage to an opponent, draw a card."`

## Fix

Scoped to the existing paired seam in `parse_soulbond_paired_static`:

1. Split the pairing frame off the predicate with **`TextPair`** so the predicate keeps its **original case** — a quoted ability's mana symbols (`{1}{U}`) must reach the cost parser un-lowercased (the old path passed the lowercased slice, a latent second bug).
2. Reuse the existing **`matches_soulbond_paired_condition`** building block to validate the pairing clause.
3. Add one quote-aware helper **`strip_granted_predicate_period`** that trims the sentence-ending period only when it sits **outside** a quote.

The intact predicate then flows through the existing `parse_continuous_gets_has` → `parse_quoted_ability_modifications` seam, which already classifies quoted text into `GrantAbility` (CR 602.1) / `GrantTrigger` (CR 603.1). The grant is applied to **both** paired creatures (`SourceOrPaired`, CR 613.1f layer 6), gated on `SourceIsPaired`.

## Why it's the right seam / minimal blast radius

- No new sibling handler — the fix parameterizes the **one** paired-static path; the bare keyword/P-T soulbond grants (Wingcrafter, Wolfir Silverheart, …) route through the **same** seam and parse **identically** as before (regression-tested).
- Parse-diff limited to the 10 quoted-grant soulbond cards.
- Reuses `TextPair`, `matches_soulbond_paired_condition`, `parse_continuous_gets_has`, `parse_quoted_ability_modifications` — no new engine surface.

## Tests

Full-shape assertions on `affected` / `condition` / granted modification:

- `soulbond_grants_quoted_activated_mana_ability` — `GrantAbility` (Activated, cost preserved)
- `soulbond_grants_quoted_tap_free_activated_ability`
- `soulbond_grants_quoted_triggered_ability` — `GrantTrigger`
- `soulbond_paired_keyword_grant_still_parses` — regression: `AddKeyword(Flying)`
- `soulbond_paired_pt_grant_still_parses` — regression: `AddPower{4}` + `AddToughness{4}`

## CR verification

- **CR 702.95** — Soulbond (verified in `docs/MagicCompRules.txt`).
- **CR 613.1f** — Layer 6: ability-adding effects (the grant to both paired creatures).
- **CR 602.1 / CR 603.1** — the granted activated / triggered ability.

## AI-contributor notes

- **Rules-correct:** granted ability restored to both paired creatures with the correct `SourceOrPaired` scope; the previous `SelfRef` fallback was wrong on both scope and content.
- **Builds the class:** one seam covers all 10 quoted-grant soulbond cards plus any future soulbond quoted grant.
- **Verified:** live-parsed Deadeye Navigator, Galvanic Alchemist, Stonewright, Tandem Lookout before/after against Scryfall Oracle text; `cargo fmt`, CI-exact `clippy -p engine --all-targets --features proptest -D warnings`, and the full soulbond test set are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
