### PR TITLE
feat(engine): CR 400.7 object-incarnation identity primitive + Crew ledger migration (Myrkul/Crew Phase 1)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -3568,8 +3568,9 @@ pub(crate) fn priority_actions_with_probe(
                                 Some(
                                     crate::types::ability::ActivationRestriction::OnlyOnceEachTurn
                                 )
-                            ) && state.crew_activated_this_turn.contains(&obj_id)
-                            {
+                            ) && crate::game::engine::crew_activated_this_turn_contains(
+                                state, obj_id,
+                            ) {
                                 break;
                             }
                             // CR 702.122a: a Vehicle can't crew itself, so exclude

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -9297,6 +9297,8 @@ pub fn handle_cast_spell_with_payment_mode(
     // resolution for deferred self-copy choices, but a fresh normal cast starts
     // a new stack-object announcement outside that old resolution context.
     state.resolving_stack_entry = None;
+    // CR 400.7j: clear the resolution-scoped self-move re-latch with the entry.
+    state.resolution_source_relatch = None;
 
     // CR 715.3 / CR 720.3: Adventure-family cards from hand (or a commander cast
     // from the command zone) require choosing the normal creature face or

--- a/crates/engine/src/game/crew_payment.rs
+++ b/crates/engine/src/game/crew_payment.rs
@@ -1,0 +1,179 @@
+//! CR 702.122a: Prepared tap-payment authority for Crew / Saddle / Station.
+//!
+//! Phase 1 owns this API; Phase 2A wires the tap/payment events onto it. It is the
+//! "single authority for ability costs" rule applied to tap payment: the payer set
+//! is validated and each payer's power contribution is captured atomically against
+//! the immutable **pre-mutation** `GameState`, so threshold validation and commit
+//! never re-read live power, toughness, or statics after preparation.
+
+use crate::game::engine::EngineError;
+use crate::game::static_abilities::object_crew_power_contribution;
+use crate::types::game_state::GameState;
+use crate::types::identifiers::{ObjectId, ObjectIncarnationRef};
+use crate::types::statics::CrewAction;
+
+/// CR 702.122a: a prepared, pre-validated Crew/Saddle/Station tap payment. Holds
+/// the payer set keyed by `ObjectIncarnationRef` so a payer that changes zones
+/// between preparation and commit cannot be confused with a new object at the same
+/// storage id (CR 400.7).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedTapPayment {
+    /// The permanent being crewed/saddled/stationed, at its current incarnation.
+    pub vehicle: ObjectIncarnationRef,
+    /// Which action is being paid for (Crew / Saddle / Station).
+    pub action: CrewAction,
+    /// Minimum total power required (Crew N / Saddle N / Station N).
+    pub required_power: i32,
+    /// The prepared payers (creatures to tap), each keyed by its incarnation.
+    pub payers: Vec<ObjectIncarnationRef>,
+}
+
+impl PreparedTapPayment {
+    /// Validate that the vehicle and every payer creature exist and resolve each to
+    /// its current `ObjectIncarnationRef`. Performs **no** mutation (no tap, no
+    /// events) — payment side effects are Phase 2A's responsibility.
+    pub fn prepare(
+        state: &GameState,
+        vehicle_id: ObjectId,
+        action: CrewAction,
+        required_power: i32,
+        payer_ids: &[ObjectId],
+    ) -> Result<Self, EngineError> {
+        let vehicle = state
+            .objects
+            .get(&vehicle_id)
+            .map(ObjectIncarnationRef::from_object)
+            .ok_or_else(|| EngineError::InvalidAction("Crew vehicle not found".to_string()))?;
+        let mut payers = Vec::with_capacity(payer_ids.len());
+        for &pid in payer_ids {
+            let payer = state
+                .objects
+                .get(&pid)
+                .map(ObjectIncarnationRef::from_object)
+                .ok_or_else(|| EngineError::InvalidAction("Crew payer not found".to_string()))?;
+            payers.push(payer);
+        }
+        Ok(Self {
+            vehicle,
+            action,
+            required_power,
+            payers,
+        })
+    }
+
+    /// CR 608.2h: capture each payer's crew power contribution against the immutable
+    /// **pre-mutation** `GameState`. Delegates entirely to
+    /// `object_crew_power_contribution` — toughness substitution, accumulated power
+    /// deltas, granted contribution statics, Crew-vs-Saddle action filtering, and
+    /// active static/layer gates all live there; Phase 1 re-implements none of them.
+    /// Each captured value is keyed by `ObjectIncarnationRef`.
+    pub fn prepare_contribution_snapshot(&self, state: &GameState) -> PreparedContributionSnapshot {
+        let contributions = self
+            .payers
+            .iter()
+            .map(|&payer| {
+                (
+                    payer,
+                    object_crew_power_contribution(state, payer.object_id, self.action),
+                )
+            })
+            .collect();
+        PreparedContributionSnapshot {
+            contributions,
+            required_power: self.required_power,
+        }
+    }
+}
+
+/// CR 702.122a: the captured per-payer contribution snapshot. Every threshold query
+/// reads **only** these stored values — never `state.objects`, live power,
+/// toughness, or statics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedContributionSnapshot {
+    contributions: Vec<(ObjectIncarnationRef, i32)>,
+    required_power: i32,
+}
+
+impl PreparedContributionSnapshot {
+    /// Total captured power across all payers (pre-mutation values).
+    pub fn total_contribution(&self) -> i32 {
+        self.contributions.iter().map(|(_, p)| *p).sum()
+    }
+
+    /// CR 702.122a: whether the captured total meets the required power. Reads only
+    /// stored values.
+    pub fn meets_threshold(&self) -> bool {
+        self.total_contribution() >= self.required_power
+    }
+
+    /// Consume the snapshot, yielding the prepared payer set. Infallible: no
+    /// rediscovery, no revalidation, no live-state read.
+    pub fn commit(self) -> Vec<ObjectIncarnationRef> {
+        self.contributions
+            .into_iter()
+            .map(|(payer, _)| payer)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::scenario::GameScenario;
+    use crate::types::player::PlayerId;
+
+    const P0: PlayerId = PlayerId(0);
+
+    // T-prepare: the contribution snapshot is captured against the pre-mutation
+    // state; a later live-state change must NOT alter the stored value, and commit
+    // re-reads nothing. Reverting `prepare_contribution_snapshot` to read live
+    // power at threshold/commit time would flip the post-mutation assertion.
+    #[test]
+    fn contribution_snapshot_reads_pre_mutation_and_commit_reads_nothing() {
+        let mut scenario = GameScenario::new();
+        let vehicle = scenario.add_vanilla(P0, 0, 4);
+        let payer = scenario.add_vanilla(P0, 3, 3);
+        let mut runner = scenario.build();
+
+        let prepared =
+            PreparedTapPayment::prepare(runner.state(), vehicle, CrewAction::Crew, 2, &[payer])
+                .expect("vehicle and payer exist");
+        let snapshot = prepared.prepare_contribution_snapshot(runner.state());
+        assert_eq!(
+            snapshot.total_contribution(),
+            3,
+            "captures pre-mutation power"
+        );
+        assert!(snapshot.meets_threshold(), "3 power meets Crew 2");
+
+        // Mutate live power AFTER the snapshot. A snapshot that (incorrectly)
+        // re-read live state would now report 8; the stored value must stay 3.
+        runner.state_mut().objects.get_mut(&payer).unwrap().power = Some(8);
+        assert_eq!(
+            snapshot.total_contribution(),
+            3,
+            "snapshot is immutable to post-preparation live-state changes"
+        );
+
+        let committed = snapshot.commit();
+        assert_eq!(committed.len(), 1);
+        assert_eq!(committed[0].object_id, payer);
+    }
+
+    // Sibling: a missing payer fails preparation before any capture.
+    #[test]
+    fn prepare_rejects_unknown_payer() {
+        let mut scenario = GameScenario::new();
+        let vehicle = scenario.add_vanilla(P0, 0, 4);
+        let runner = scenario.build();
+        let missing = crate::types::identifiers::ObjectId(999_999);
+        assert!(PreparedTapPayment::prepare(
+            runner.state(),
+            vehicle,
+            CrewAction::Crew,
+            1,
+            &[missing]
+        )
+        .is_err());
+    }
+}

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -1332,12 +1332,33 @@ mod tests {
         );
         ability.set_source_incarnation_recursive(Some(captured_incarnation));
 
+        // CR 400.7j: mirror `resolve_top` — during resolution the resolving entry is
+        // stashed in `state.resolving_stack_entry`, and the self-move re-latch reads
+        // it to record that the resolving ability moved its OWN source. Without this
+        // (as in production) the relatch cannot fire.
+        state.resolving_stack_entry = Some(crate::types::game_state::StackEntry {
+            id: siege_id,
+            source_id: siege_id,
+            controller: PlayerId(0),
+            kind: crate::types::game_state::StackEntryKind::ActivatedAbility {
+                source_id: siege_id,
+                ability: ability.clone(),
+            },
+        });
+
         let mut events = Vec::new();
         zones::move_to_zone(&mut state, siege_id, Zone::Exile, &mut events);
-        assert_eq!(
-            state.objects[&siege_id].incarnation, captured_incarnation,
-            "the engine's self-reference epoch guard is bumped on battlefield entry, so the \
-             Siege defeat zone exit must not make its same-resolution self-cast stale"
+        // CR 400.7: under all-zone incarnation semantics the BF→Exile self-move now
+        // bumps the epoch (it no longer stays stable). CR 400.7j: the re-latch record
+        // captures the from→to incarnation so the same-resolution self-cast still
+        // finds the moved source instead of going stale.
+        assert!(
+            state.objects[&siege_id].incarnation > captured_incarnation,
+            "CR 400.7: the BF→Exile self-move bumps the Siege's incarnation"
+        );
+        assert!(
+            ability.source_is_current(&state),
+            "CR 400.7j: the re-latch keeps the self-cast source current after the move"
         );
         events.clear();
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -6396,6 +6396,30 @@ fn is_tappable_creature_for_cost(state: &GameState, id: ObjectId, player: Player
     })
 }
 
+/// CR 602.5b + CR 702.122a: "activate only once each turn" is keyed to the exact
+/// object incarnation, so a Vehicle that leaves and returns (a new object per
+/// CR 400.7) may be crewed again. Single authority for reading the crew-cadence
+/// set — callers never touch `crew_activated_this_turn` directly.
+pub(crate) fn crew_activated_this_turn_contains(state: &GameState, vehicle_id: ObjectId) -> bool {
+    state
+        .objects
+        .get(&vehicle_id)
+        .map(crate::types::identifiers::ObjectIncarnationRef::from_object)
+        .is_some_and(|r| state.crew_activated_this_turn.contains(&r))
+}
+
+/// CR 602.5b + CR 702.122a: record a crew activation against the Vehicle's current
+/// incarnation. Single authority for writing the crew-cadence set.
+pub(crate) fn record_crew_activation(state: &mut GameState, vehicle_id: ObjectId) {
+    if let Some(r) = state
+        .objects
+        .get(&vehicle_id)
+        .map(crate::types::identifiers::ObjectIncarnationRef::from_object)
+    {
+        state.crew_activated_this_turn.insert(r);
+    }
+}
+
 fn handle_crew_activation(
     state: &mut GameState,
     player: PlayerId,
@@ -6449,7 +6473,7 @@ fn handle_crew_activation(
 
     // CR 602.5b: "Activate only once each turn" — reject a second crew activation
     // of this Vehicle in the same turn.
-    if crew_once_per_turn && state.crew_activated_this_turn.contains(&vehicle_id) {
+    if crew_once_per_turn && crew_activated_this_turn_contains(state, vehicle_id) {
         return Err(EngineError::ActionNotAllowed(
             "This Vehicle's crew ability can be activated only once each turn".to_string(),
         ));
@@ -6614,7 +6638,7 @@ fn handle_crew_announcement(
 
     // CR 602.5b: Record this crew activation so an "Activate only once each turn"
     // Vehicle cannot be crewed a second time this turn. Cleared at turn start.
-    state.crew_activated_this_turn.insert(vehicle_id);
+    record_crew_activation(state, vehicle_id);
 
     Ok(push_keyword_action(
         state,

--- a/crates/engine/src/game/engine_keyword_action_stack_tests.rs
+++ b/crates/engine/src/game/engine_keyword_action_stack_tests.rs
@@ -250,7 +250,7 @@ fn crew_once_per_turn_vehicle_rejects_second_activation_same_turn() {
     )
     .unwrap();
     assert!(
-        state.crew_activated_this_turn.contains(&vehicle_id),
+        crate::game::engine::crew_activated_this_turn_contains(&state, vehicle_id),
         "first crew records the vehicle as crewed this turn"
     );
 
@@ -269,6 +269,42 @@ fn crew_once_per_turn_vehicle_rejects_second_activation_same_turn() {
              rejected; got {second:?}"
     );
     let _ = creature_b;
+}
+
+// T-reentry (§3): the crew-cadence ledger is keyed to the exact object incarnation
+// (CR 400.7 + CR 602.5b), so a Vehicle that leaves and returns — a new object at a
+// higher incarnation — is no longer recorded as crewed and may be crewed again.
+// Fails if the ledger were keyed by bare `ObjectId`. The reach-guard (the positive
+// `contains` at incarnation N) proves the record was actually made, so the negative
+// is not vacuous. The end-to-end card-test (crew → blink → crew again through
+// `apply()`) lands in Phase 2A, which wires the production blink path; Phase 1
+// unit-tests the identity-keyed ledger directly.
+#[test]
+fn crew_reentry_new_incarnation_clears_activation_ledger() {
+    let mut state = setup_main_phase();
+    let vehicle_id = make_vehicle(&mut state, 1);
+
+    let n = state.objects[&vehicle_id].incarnation;
+    crate::game::engine::record_crew_activation(&mut state, vehicle_id);
+    assert!(
+        crate::game::engine::crew_activated_this_turn_contains(&state, vehicle_id),
+        "reach-guard: the crew activation is recorded at the current incarnation ({n})"
+    );
+
+    // CR 400.7: the Vehicle leaves and returns as a NEW object (higher incarnation).
+    state
+        .objects
+        .get_mut(&vehicle_id)
+        .unwrap()
+        .bump_incarnation();
+    assert!(
+        state.objects[&vehicle_id].incarnation > n,
+        "the re-entered object is a new incarnation"
+    );
+    assert!(
+        !crate::game::engine::crew_activated_this_turn_contains(&state, vehicle_id),
+        "after re-entry the incarnation-keyed ledger no longer matches → crewable again"
+    );
 }
 
 #[test]

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -100,6 +100,8 @@ fn park_search_observer_triggers(
         && matches!(state.waiting_for, WaitingFor::Priority { .. })
     {
         state.resolving_stack_entry = None;
+        // CR 400.7j: clear the resolution-scoped self-move re-latch with the entry.
+        state.resolution_source_relatch = None;
     }
     ResolutionChoiceOutcome::WaitingForWithParkedObservers(state.waiting_for.clone())
 }

--- a/crates/engine/src/game/merge.rs
+++ b/crates/engine/src/game/merge.rs
@@ -622,6 +622,12 @@ fn put_component_into_zone(
     crate::game::zones::add_to_zone(state, component_id, dest, owner);
     if let Some(obj) = state.objects.get_mut(&component_id) {
         obj.zone = dest;
+        // CR 730.3 + CR 400.7: when a merged permanent leaves, each absorbed
+        // component becomes a NEW object in its own owner's zone. Bump here (beside
+        // this mover, NOT inside the shared `apply_zone_exit_cleanup`, which
+        // `move_to_zone` also calls → double-bump) so a stamp-N delayed trigger on
+        // the component reads `source_is_current` false against the new object.
+        obj.bump_incarnation();
     }
 
     // CR 700.11: a nontoken permanent card put into its owner's graveyard from

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -34,6 +34,7 @@ mod contraptions_tests;
 pub mod cost_payability;
 pub(crate) mod costs;
 pub mod coverage;
+pub mod crew_payment;
 pub mod dash;
 #[cfg(test)]
 #[path = "dash_tests.rs"]

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -189,6 +189,9 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
     // spell has left the stack) — so it is cleared here at the start of the
     // *next* resolution rather than at the end of this one.
     state.resolving_stack_entry = None;
+    // CR 400.7j: the self-move re-latch is resolution-scoped; clear it alongside
+    // `resolving_stack_entry` so it never leaks into the next resolution.
+    state.resolution_source_relatch = None;
 
     // CR 405.5: When all players pass in succession, the top object on the stack resolves.
     let entry = match state.stack.pop_back() {
@@ -2130,6 +2133,8 @@ fn resolve_batched(
     let consumed = plan.consumed();
     crate::game::perf_counters::record_stack_batched_entries(consumed);
     state.resolving_stack_entry = None;
+    // CR 400.7j: clear the resolution-scoped self-move re-latch with the entry.
+    state.resolution_source_relatch = None;
 
     // Pop the run's entries (resolution order is back-to-front), cleaning the
     // per-entry side tables exactly as `resolve_top` does for a single entry.
@@ -2456,6 +2461,8 @@ fn resolve_inert_noop_batch(
     events: &mut Vec<GameEvent>,
 ) -> u32 {
     state.resolving_stack_entry = None;
+    // CR 400.7j: clear the resolution-scoped self-move re-latch with the entry.
+    state.resolution_source_relatch = None;
     for _ in 0..consumed {
         let Some(entry) = state.stack.pop_back() else {
             break;

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3487,6 +3487,20 @@ enum TriggerOrderingDisposition {
 pub(crate) fn normalize_ability_identity(ability: &mut ResolvedAbility) {
     ability.source_id = ObjectId(0);
     ability.source_card_id = None;
+    // CR 400.7: `source_incarnation` is a source-identity field, the same identity
+    // class as `source_id`/`source_card_id`, so this single "strip ability source
+    // identity" authority must zero it too. This keeps every consumer consistent:
+    //   * CR 104.4b + CR 732.4 (mandatory-loop detection): the stack comparators
+    //     `analysis::resource::normalized_stack_entries` (the growing-cascade covering
+    //     pair) and the `normalize_for_loop` ring snapshots must agree on
+    //     `source_incarnation`. Without this, a normalized ring snapshot (`None`) would
+    //     fail to match a live entry (`Some(N)`) once the all-zone incarnation bump
+    //     advances the epoch, so a mandatory loop whose source cycles zones would no
+    //     longer be recognized as the same repeating state.
+    //   * CR 603.3b (trigger auto-ordering): `group_is_order_independent` compares two
+    //     structurally-identical triggers for order-independence — which is correct
+    //     regardless of which source incarnation each was captured at.
+    ability.source_incarnation = None;
     if let Some(sub) = ability.sub_ability.as_mut() {
         normalize_ability_identity(sub);
     }

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -2,7 +2,9 @@ use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
 #[cfg(test)]
 use crate::types::game_state::ZoneChangeRecord;
-use crate::types::game_state::{GameState, ZoneChangeCombatStatus};
+use crate::types::game_state::{
+    GameState, ResolutionSourceRelatch, StackEntry, ZoneChangeCombatStatus,
+};
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::player::PlayerId;
 use crate::types::statics::StaticMode;
@@ -546,6 +548,54 @@ pub(crate) fn record_descend_on_graveyard_arrival(
     }
 }
 
+/// CR 400.7j (+ CR 400.7g/h cast hop): if the currently-resolving ability just
+/// moved its OWN source (`object_id == resolving ability's source_id`), record the
+/// from→to incarnation so `source_is_current` can re-find the moved object after
+/// the all-zone bump advanced its epoch. Chains across multiple self-moves in one
+/// resolution: the first self-move sets `original_stamp` (bound to the ability's
+/// captured incarnation); a chained self-move keeps `original_stamp` fixed and only
+/// advances `current_incarnation`. A foreign object, or a move whose pre-move
+/// incarnation matches neither the captured stamp nor the record's current value,
+/// never writes. Call AFTER the bump, passing the pre-bump and post-bump values.
+pub(crate) fn record_resolution_source_relatch(
+    state: &mut GameState,
+    object_id: ObjectId,
+    pre_move_incarnation: u64,
+    new_incarnation: u64,
+) {
+    // A faithful READ of the resolving ability's captured source identity. The
+    // clone is disconnected from the local resolving borrow, so it cannot be the
+    // carrier — the record on `state` is (consumed inside `source_is_current`).
+    let Some((source_id, Some(captured))) = state
+        .resolving_stack_entry
+        .as_ref()
+        .and_then(StackEntry::ability)
+        .map(|a| (a.source_id, a.source_incarnation))
+    else {
+        return;
+    };
+    if object_id != source_id {
+        return;
+    }
+    // First self-move: pre-move value must equal the ability's captured stamp.
+    let matches_first = pre_move_incarnation == captured;
+    // Chained self-move: pre-move value must equal the record's current value.
+    let chained = state
+        .resolution_source_relatch
+        .as_ref()
+        .filter(|r| r.object_id == object_id && r.current_incarnation == pre_move_incarnation);
+    if matches_first || chained.is_some() {
+        // Keep `original_stamp` fixed across chained hops; the CR 400.7j identity
+        // is the FIRST captured stamp, not each intermediate incarnation.
+        let original_stamp = chained.map_or(captured, |r| r.original_stamp);
+        state.resolution_source_relatch = Some(ResolutionSourceRelatch {
+            object_id,
+            original_stamp,
+            current_incarnation: new_incarnation,
+        });
+    }
+}
+
 /// CR 400.7: Move an object to a new zone. An object that moves to a new zone becomes a new object.
 pub fn move_to_zone(
     state: &mut GameState,
@@ -705,6 +755,10 @@ pub fn move_to_zone(
     let entry_timestamp = (to == Zone::Battlefield).then(|| state.next_timestamp());
 
     let obj_mut = state.objects.get_mut(&object_id).unwrap();
+    // CR 400.7j: capture the pre-bump incarnation BEFORE any bump (the battlefield
+    // arm bumps inside `reset_for_battlefield_entry`, which has no state access) so
+    // the resolution re-latch can chain the source across a self-move.
+    let pre_bump_incarnation = obj_mut.incarnation;
     obj_mut.zone = to;
 
     if to == Zone::Battlefield {
@@ -717,6 +771,15 @@ pub fn move_to_zone(
         // distinguishable from the original entrant when an ETB intervening-if is
         // rechecked at resolution (CR 603.4 + CR 608.2h).
         zone_change_record.entered_incarnation = Some(obj_mut.incarnation);
+    } else if from != to {
+        // CR 400.7: a move FROM one zone TO another makes a new object. The
+        // `from != to` guard generalizes the BF→BF no-op guard (upstream) to every
+        // same-zone case (Exile→Exile, GY→GY) that can reach this else-arm.
+        obj_mut.bump_incarnation();
+    }
+    let new_incarnation = obj_mut.incarnation;
+    if new_incarnation != pre_bump_incarnation {
+        record_resolution_source_relatch(state, object_id, pre_bump_incarnation, new_incarnation);
     }
 
     // CR 700.11: a permanent card was put into its owner's graveyard.
@@ -1048,8 +1111,20 @@ pub fn move_to_library_at_index(
         None => player.library.push_back(object_id),
     }
 
+    let mut bump: Option<(u64, u64)> = None;
     if let Some(obj_mut) = state.objects.get_mut(&object_id) {
+        let pre_bump_incarnation = obj_mut.incarnation;
         obj_mut.zone = Zone::Library;
+        // CR 400.7: a move INTO the library from any other zone makes a new object.
+        // A within-Library reposition (reveal / scry bottom placement / look-at-top-N,
+        // CR 701.20b) is zero moves — `from == Library` here — and must NOT bump.
+        if from != Zone::Library {
+            obj_mut.bump_incarnation();
+            bump = Some((pre_bump_incarnation, obj_mut.incarnation));
+        }
+    }
+    if let Some((pre, new)) = bump {
+        record_resolution_source_relatch(state, object_id, pre, new);
     }
 
     let turn_zone_change_index =

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -19677,10 +19677,19 @@ impl ResolvedAbility {
     pub fn source_is_current(&self, state: &crate::types::game_state::GameState) -> bool {
         match self.source_incarnation {
             None => true,
-            Some(captured) => state
-                .objects
-                .get(&self.source_id)
-                .is_some_and(|obj| obj.incarnation == captured),
+            Some(captured) => {
+                let current = state.objects.get(&self.source_id).map(|o| o.incarnation);
+                current == Some(captured)
+                    // CR 400.7j (+ CR 400.7g/h cast hop): a source that moved (possibly
+                    // twice) as part of THIS resolution carries its identity-dependent
+                    // continuations with it. Bind to `original_stamp` so only the ability
+                    // that captured the pre-move identity relatches — a stale-stamped
+                    // delayed trigger for the same object cannot ride the record.
+                    || matches!(state.resolution_source_relatch, Some(r)
+                        if r.object_id == self.source_id
+                            && r.original_stamp == captured
+                            && Some(r.current_incarnation) == current)
+            }
         }
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -22,7 +22,7 @@ use super::card_type::{CoreType, Supertype};
 use super::counter::{counter_map_serde, CounterMatch, CounterType};
 use super::events::{GameEvent, PlayerActionKind};
 use super::format::FormatConfig;
-use super::identifiers::{CardId, ObjectId, TrackedSetId};
+use super::identifiers::{CardId, ObjectId, ObjectIncarnationRef, TrackedSetId};
 use super::keywords::{Keyword, KeywordKind};
 use super::mana::{ManaColor, ManaCost, ManaPipId, ManaType, ManaUnit, StepEndManaAction};
 use super::match_config::{MatchConfig, MatchPhase, MatchScore};
@@ -5673,6 +5673,20 @@ pub struct StackEntry {
     pub kind: StackEntryKind,
 }
 
+/// CR 400.7j: from→to record of a source object moved by its own resolving
+/// ability, so `source_is_current` can re-find it after the all-zone incarnation
+/// bump. `original_stamp` is the incarnation the resolving ability captured (fixed
+/// across chained self-moves); `current_incarnation` tracks the latest post-move
+/// value. Bound to `original_stamp` so only the ability that captured the pre-move
+/// identity relatches — a stale-stamped delayed trigger for the same `object_id`
+/// cannot ride the record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolutionSourceRelatch {
+    pub object_id: ObjectId,
+    pub original_stamp: u64,
+    pub current_incarnation: u64,
+}
+
 impl StackEntry {
     /// Access the resolved ability for this stack entry (immutable).
     /// Returns `None` for permanent spells with no spell-level effect, and for
@@ -7224,7 +7238,7 @@ pub struct GameState {
     /// `abilities[]` entry, so it cannot use `activated_abilities_this_turn`
     /// (keyed by `(source_id, ability_index)`). Cleared at turn start.
     #[serde(default)]
-    pub crew_activated_this_turn: HashSet<ObjectId>,
+    pub crew_activated_this_turn: HashSet<ObjectIncarnationRef>,
     /// CR 606.1 + CR 606.3 + CR 603.4: Per-player count of loyalty-ability
     /// activations this turn. Incremented in
     /// `planeswalker::finalize_loyalty_activation` whenever any loyalty ability
@@ -8161,6 +8175,18 @@ pub struct GameState {
     /// `current_trigger_event`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolving_stack_entry: Option<StackEntry>,
+    /// CR 400.7j (+ CR 400.7g/h cast hop): a resolution-scoped record of a source
+    /// object that the currently-resolving ability moved as part of its own
+    /// resolution (Siege "exile it, then you may cast it"). It lets
+    /// `source_is_current` re-find the moved object even though the all-zone
+    /// incarnation bump advanced its epoch. Chains across multiple self-moves in
+    /// one resolution (BF→Exile→Stack). Like `resolving_stack_entry` this is a
+    /// serialized, resolution-scoped field that survives an optional-choice pause;
+    /// it is cleared at the same sites. It carries incarnation values, so it is
+    /// deliberately EXCLUDED from `GameState::PartialEq` (loop equality) — including
+    /// it would recreate the identity-field loop leak Condition 2 fixes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution_source_relatch: Option<ResolutionSourceRelatch>,
     /// Transient plural form of `current_trigger_event` for batched triggers.
     /// Event-context filters that can legally compare against a group read this.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -9025,6 +9051,7 @@ impl GameState {
             current_trigger_event: None,
             current_trigger_match_count: None,
             resolving_stack_entry: None,
+            resolution_source_relatch: None,
             current_trigger_events: Vec::new(),
             last_discover_value: None,
             stack_trigger_event_batches: HashMap::new(),
@@ -9384,6 +9411,40 @@ impl GameState {
         // the live ring → recursive/quadratic growth. Cleared ⇒ every stored snapshot
         // has clone depth 1. Does not affect any comparison (the ring is eq-excluded).
         clone.loop_detect_ring.clear();
+        // CR 104.4b + CR 400.7: the all-zone incarnation bump advances a source's
+        // epoch on every zone change, so a mandatory loop that cycles its source's
+        // zones would otherwise carry a growing `ResolvedAbility::source_incarnation`
+        // into loop equality and never confirm a draw. Canonicalize it to `None`
+        // across EVERY eq-compared carrier that transitively holds a
+        // `ResolvedAbility`. (`pending_trigger_entry` is an `Option<ObjectId>`, not
+        // an ability carrier, so it needs no normalization; `waiting_for` is
+        // `Priority` at the post-pipeline loop-sample point and `priority_yields`
+        // latches its `YieldTarget::ThisObject { incarnation }` once at
+        // registration — both are loop-stable and carry no growing epoch.)
+        for entry in clone.stack.iter_mut() {
+            if let Some(ability) = entry.ability_mut() {
+                ability.set_source_incarnation_recursive(None);
+            }
+        }
+        if let Some(pt) = clone.pending_trigger.as_mut() {
+            pt.ability.set_source_incarnation_recursive(None);
+        }
+        for ctx in clone.deferred_triggers.iter_mut() {
+            ctx.pending.ability.set_source_incarnation_recursive(None);
+        }
+        if let Some(order) = clone.pending_trigger_order.as_mut() {
+            for group in order.groups.iter_mut() {
+                for ctx in group.triggers.iter_mut() {
+                    ctx.pending.ability.set_source_incarnation_recursive(None);
+                }
+            }
+        }
+        for dt in clone.delayed_triggers.iter_mut() {
+            dt.ability.set_source_incarnation_recursive(None);
+        }
+        for epic in clone.epic_effects.iter_mut() {
+            epic.spell.set_source_incarnation_recursive(None);
+        }
         clone
     }
 
@@ -9827,6 +9888,77 @@ mod tests {
             before,
             state.loop_fingerprint(),
             "advancing the RNG stream must change the loop fingerprint"
+        );
+    }
+
+    /// T-loop (§4 Condition 2): the all-zone incarnation bump advances a source's
+    /// epoch every time it changes zones, so a mandatory loop that cycles its
+    /// source's zones would carry a growing `ResolvedAbility::source_incarnation`
+    /// into loop equality and never confirm a CR 104.4b draw. `normalize_for_loop`
+    /// canonicalizes `source_incarnation` to `None` across every eq-compared carrier
+    /// (here: `delayed_triggers` — the Warp "return at next end step" loop class —
+    /// and `stack`).
+    ///
+    /// REVERT-PROBE: drop the carrier normalization in `normalize_for_loop` → the
+    /// two normalized states differ in `source_incarnation` → `loop_states_equal`
+    /// returns false → the draw is missed.
+    #[test]
+    fn normalize_for_loop_zeroes_source_incarnation_across_carriers() {
+        use crate::types::ability::{DelayedTriggerCondition, Effect};
+        use crate::types::phase::Phase;
+
+        fn draw_ability(inc: u64) -> ResolvedAbility {
+            let mut a = ResolvedAbility::new(
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+                vec![],
+                ObjectId(5),
+                PlayerId(0),
+            );
+            a.set_source_incarnation_recursive(Some(inc));
+            a
+        }
+
+        let mut a = GameState::new_two_player(7);
+        a.delayed_triggers.push(DelayedTrigger {
+            condition: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+            ability: draw_ability(1),
+            controller: PlayerId(0),
+            source_id: ObjectId(5),
+            one_shot: true,
+        });
+        a.stack.push_back(StackEntry {
+            id: ObjectId(20),
+            source_id: ObjectId(5),
+            controller: PlayerId(0),
+            kind: StackEntryKind::ActivatedAbility {
+                source_id: ObjectId(5),
+                ability: draw_ability(1),
+            },
+        });
+
+        // `b` differs ONLY in the sources' incarnation (a loop iteration cycled the
+        // source's zones and re-created its delayed trigger at a higher epoch).
+        let mut b = a.clone();
+        b.delayed_triggers[0]
+            .ability
+            .set_source_incarnation_recursive(Some(2));
+        b.stack
+            .back_mut()
+            .unwrap()
+            .ability_mut()
+            .unwrap()
+            .set_source_incarnation_recursive(Some(2));
+
+        assert_ne!(
+            a, b,
+            "fixture must actually differ in source_incarnation before normalization"
+        );
+        assert!(
+            loop_states_equal(&a.normalize_for_loop(), &b.normalize_for_loop()),
+            "normalize_for_loop must zero source_incarnation across delayed_triggers + stack"
         );
     }
 

--- a/crates/engine/src/types/identifiers.rs
+++ b/crates/engine/src/types/identifiers.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+use super::game_state::LKISnapshot;
+use super::zones::Zone;
+use crate::game::game_object::GameObject;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct CardId(pub u64);
@@ -13,6 +17,108 @@ pub struct ObjectId(pub u64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct TrackedSetId(pub u64);
+
+/// Sentinel `incarnation` bound to a pre-migration `crew_activated_this_turn`
+/// record that serialized as a bare `ObjectId` (no incarnation was stored).
+///
+/// CR 400.7: a pre-migration record cannot prove which incarnation crewed, so it
+/// is bound to a value that can never collide with a real current incarnation.
+pub const LEGACY_INCARNATION: u64 = u64::MAX;
+
+/// CR 400.7: an object that changes zones becomes a new object. This pair is the
+/// exact cross-incarnation identity of one object: the stable storage `ObjectId`
+/// plus the monotonic `incarnation` epoch (see `GameObject::incarnation`).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[serde(from = "ObjectIncarnationRefCompat")]
+pub struct ObjectIncarnationRef {
+    pub object_id: ObjectId,
+    pub incarnation: u64,
+}
+
+impl ObjectIncarnationRef {
+    /// Construct a reference from an explicit id + incarnation.
+    pub fn of(object_id: ObjectId, incarnation: u64) -> Self {
+        Self {
+            object_id,
+            incarnation,
+        }
+    }
+
+    /// Convenience: capture the current incarnation of a live object.
+    pub fn from_object(obj: &GameObject) -> Self {
+        Self {
+            object_id: obj.id,
+            incarnation: obj.incarnation,
+        }
+    }
+}
+
+/// Private serde shim mirroring `PhaseStopCompat` (`types/phase.rs`): new writes
+/// emit the full `{ object_id, incarnation }` pair; legacy saves stored a bare
+/// `ObjectId` number. The two arms are shape-disjoint (map vs. number), so
+/// serde's untagged matching selects by shape regardless of declaration order.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ObjectIncarnationRefCompat {
+    Full {
+        object_id: ObjectId,
+        incarnation: u64,
+    },
+    Legacy(ObjectId),
+}
+
+impl From<ObjectIncarnationRefCompat> for ObjectIncarnationRef {
+    fn from(c: ObjectIncarnationRefCompat) -> Self {
+        match c {
+            ObjectIncarnationRefCompat::Full {
+                object_id,
+                incarnation,
+            } => Self {
+                object_id,
+                incarnation,
+            },
+            // CR 400.7: a pre-migration record cannot prove its incarnation; bind
+            // the sentinel so it never matches a current object's reference.
+            ObjectIncarnationRefCompat::Legacy(object_id) => Self {
+                object_id,
+                incarnation: LEGACY_INCARNATION,
+            },
+        }
+    }
+}
+
+/// CR 608.2h: an identity reference paired with the public zone the object was
+/// expected to be in. Phase 2B strict resolution consumes `expected_zone` to
+/// decide current-info vs. last-known-information.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub struct ObjectIdentityBinding {
+    pub reference: ObjectIncarnationRef,
+    pub expected_zone: Zone,
+}
+
+impl ObjectIdentityBinding {
+    pub fn new(reference: ObjectIncarnationRef, expected_zone: Zone) -> Self {
+        Self {
+            reference,
+            expected_zone,
+        }
+    }
+}
+
+/// CR 608.2h / CR 113.7a: a binding plus the last-known-information snapshot used
+/// when the object is no longer in its expected public zone. Defined in Phase 1;
+/// consumed by Phase 2B strict resolution.
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct ObjectProvenance {
+    pub binding: ObjectIdentityBinding,
+    pub lki: Option<LKISnapshot>,
+}
+
+impl ObjectProvenance {
+    pub fn new(binding: ObjectIdentityBinding, lki: Option<LKISnapshot>) -> Self {
+        Self { binding, lki }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -51,5 +157,38 @@ mod tests {
         set.insert(CardId(2));
         set.insert(CardId(1));
         assert_eq!(set.len(), 2);
+    }
+
+    // T-serde: a pre-migration `crew_activated_this_turn` entry serialized as a
+    // bare `ObjectId` number; it must still load, bound to the sentinel.
+    #[test]
+    fn object_incarnation_ref_legacy_bare_id_deserializes_to_sentinel() {
+        let r: ObjectIncarnationRef = serde_json::from_str("7").unwrap();
+        assert_eq!(r, ObjectIncarnationRef::of(ObjectId(7), LEGACY_INCARNATION));
+    }
+
+    // T-serde: a new write emits the full `{ object_id, incarnation }` pair and
+    // round-trips. Fails if the shape-disjoint compat arms are mis-declared such
+    // that the struct form is swallowed by the scalar arm.
+    #[test]
+    fn object_incarnation_ref_full_pair_roundtrips() {
+        let r = ObjectIncarnationRef::of(ObjectId(3), 5);
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(
+            json.contains("incarnation"),
+            "new writes emit the full pair"
+        );
+        let back: ObjectIncarnationRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(r, back);
+    }
+
+    // T-serde: a whole legacy `HashSet<ObjectId>` (array of bare numbers) loads as
+    // a `HashSet<ObjectIncarnationRef>` with every entry bound to the sentinel.
+    #[test]
+    fn legacy_crew_set_id_array_loads() {
+        use std::collections::HashSet;
+        let set: HashSet<ObjectIncarnationRef> = serde_json::from_str("[1,2]").unwrap();
+        assert!(set.contains(&ObjectIncarnationRef::of(ObjectId(1), LEGACY_INCARNATION)));
+        assert!(set.contains(&ObjectIncarnationRef::of(ObjectId(2), LEGACY_INCARNATION)));
     }
 }

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -45,7 +45,10 @@ pub use game_state::{
     PendingSpellCostReduction, PlayerDeckPool, ScheduledTurnControl, SpellCastRecord, StackEntry,
     StackEntryKind, TransientContinuousEffect, WaitingFor, ZoneChangeRecord,
 };
-pub use identifiers::{CardId, ObjectId};
+pub use identifiers::{
+    CardId, ObjectId, ObjectIdentityBinding, ObjectIncarnationRef, ObjectProvenance,
+    LEGACY_INCARNATION,
+};
 pub use keywords::{Keyword, PartnerType, ProtectionTarget};
 pub use layers::{ActiveContinuousEffect, Layer};
 pub use log::{GameLogEntry, LogCategory, LogSegment};

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -550,6 +550,7 @@ mod msh_wave5a_group1_classifier;
 mod msh_wave5a_group2_conditions;
 mod multi_upkeep_triggers_suspend;
 mod mycoloth_upkeep_trigger;
+mod myrkul_crew_phase1_incarnation;
 mod mystic_forge_regression;
 mod narset_jeskai_waymaster_draw_spells_cast;
 mod necrodominance_pay_any_life_draw;

--- a/crates/engine/tests/integration/myrkul_crew_phase1_incarnation.rs
+++ b/crates/engine/tests/integration/myrkul_crew_phase1_incarnation.rs
@@ -1,0 +1,257 @@
+//! Phase 1 (Myrkul/Crew) — all-zone incarnation semantics (CR 400.7).
+//!
+//! State-level drivers for the §4 bump seams: `move_to_zone`'s else-arm bump
+//! (`from != to`), `move_to_library_at_index`'s `from != Zone::Library` bump, and
+//! the negative cases (within-library reposition, unrelated object). These pin the
+//! all-zone broadening: reverting any bump makes the matching assertion fail.
+
+use engine::game::scenario::GameScenario;
+use engine::game::zones::{move_to_library_at_index, move_to_zone};
+use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+use engine::types::game_state::{ResolutionSourceRelatch, StackEntry, StackEntryKind};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+use engine::types::ObjectId;
+
+const P0: PlayerId = PlayerId(0);
+
+/// A drawing ability whose source self-reference was captured at `stamp`.
+fn drawing_ability(source: ObjectId, stamp: u64) -> ResolvedAbility {
+    let mut a = ResolvedAbility::new(
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    a.set_source_incarnation_recursive(Some(stamp));
+    a
+}
+
+// T-zone×6 / T-blink: every genuine zone change advances `incarnation`, including
+// the non-battlefield moves the old battlefield-only bump left untouched. Fails
+// under the battlefield-only bump (BF→GY and GY→Exile would not increase).
+#[test]
+fn non_battlefield_zone_changes_bump_incarnation() {
+    let mut scenario = GameScenario::new();
+    let creature = scenario.add_vanilla(P0, 2, 2);
+    let mut runner = scenario.build();
+    let mut events = Vec::new();
+
+    let start = runner.state().objects[&creature].incarnation;
+
+    move_to_zone(runner.state_mut(), creature, Zone::Graveyard, &mut events);
+    let after_gy = runner.state().objects[&creature].incarnation;
+    assert!(after_gy > start, "BF→GY bumps incarnation (else-arm)");
+
+    move_to_zone(runner.state_mut(), creature, Zone::Exile, &mut events);
+    let after_exile = runner.state().objects[&creature].incarnation;
+    assert!(
+        after_exile > after_gy,
+        "GY→Exile bumps incarnation (neither zone is battlefield)"
+    );
+
+    move_to_zone(runner.state_mut(), creature, Zone::Battlefield, &mut events);
+    let after_bf = runner.state().objects[&creature].incarnation;
+    assert!(
+        after_bf > after_exile,
+        "Exile→BF (blink) bumps incarnation (battlefield arm via reset)"
+    );
+
+    move_to_library_at_index(runner.state_mut(), creature, None, &mut events);
+    let after_lib = runner.state().objects[&creature].incarnation;
+    assert!(
+        after_lib > after_bf,
+        "BF→Library bumps incarnation (move_to_library_at_index, from != Library)"
+    );
+}
+
+// T-libstay: a within-Library reposition (reveal / scry bottom placement) is zero
+// moves (CR 701.20b) and must NOT bump. Fails (spurious bump) without the
+// `from != Zone::Library` guard in `move_to_library_at_index`.
+#[test]
+fn within_library_reposition_does_not_bump_incarnation() {
+    let mut scenario = GameScenario::new();
+    let card = scenario.add_card_to_library_top(P0, "Plains");
+    let mut runner = scenario.build();
+    let mut events = Vec::new();
+
+    assert_eq!(
+        runner.state().objects[&card].zone,
+        Zone::Library,
+        "reach-guard: the card really starts in the library"
+    );
+    let before = runner.state().objects[&card].incarnation;
+    // Reposition to the bottom of the SAME library (from == Library).
+    move_to_library_at_index(runner.state_mut(), card, None, &mut events);
+    let after = runner.state().objects[&card].incarnation;
+    assert_eq!(
+        after, before,
+        "within-Library reposition (from == Library) must not bump"
+    );
+}
+
+// T-stay: the bump is per-object-move, not per-event — moving object A must not
+// advance an unrelated object B's incarnation.
+#[test]
+fn unrelated_object_incarnation_not_advanced_by_another_move() {
+    let mut scenario = GameScenario::new();
+    let a = scenario.add_vanilla(P0, 1, 1);
+    let b = scenario.add_vanilla(P0, 1, 1);
+    let mut runner = scenario.build();
+    let mut events = Vec::new();
+
+    let b_before = runner.state().objects[&b].incarnation;
+    move_to_zone(runner.state_mut(), a, Zone::Graveyard, &mut events);
+    assert_eq!(
+        runner.state().objects[&b].incarnation,
+        b_before,
+        "moving A must not bump B's incarnation"
+    );
+}
+
+// T-relatch-chain (§4.3): a double self-move in one resolution (BF→Exile→BF)
+// keeps the source findable through both hops. The write chains: the first hop
+// sets `original_stamp`; the second keeps it fixed and only advances
+// `current_incarnation`. Fails (record stuck at the first post-move value, or no
+// relatch consulted) without the chaining write + `source_is_current` read.
+#[test]
+fn self_move_relatch_chains_across_two_hops() {
+    let mut scenario = GameScenario::new();
+    let src = scenario.add_vanilla(P0, 1, 1);
+    let mut runner = scenario.build();
+    let mut events = Vec::new();
+
+    let captured = runner.state().objects[&src].incarnation;
+
+    // Mark `src` as the currently-resolving ability's OWN source at stamp `captured`.
+    runner.state_mut().resolving_stack_entry = Some(StackEntry {
+        id: ObjectId(9001),
+        source_id: src,
+        controller: P0,
+        kind: StackEntryKind::ActivatedAbility {
+            source_id: src,
+            ability: drawing_ability(src, captured),
+        },
+    });
+
+    // Hop 1: BF → Exile (else-arm bump + first relatch write).
+    move_to_zone(runner.state_mut(), src, Zone::Exile, &mut events);
+    // Hop 2: Exile → BF (battlefield-arm bump + chained relatch write).
+    move_to_zone(runner.state_mut(), src, Zone::Battlefield, &mut events);
+
+    let consumer = drawing_ability(src, captured);
+    assert!(
+        consumer.source_is_current(runner.state()),
+        "the chained relatch re-finds the twice-moved source (CR 400.7j + g/h)"
+    );
+
+    let record = runner
+        .state()
+        .resolution_source_relatch
+        .expect("relatch was recorded");
+    assert_eq!(record.object_id, src);
+    assert_eq!(
+        record.original_stamp, captured,
+        "original_stamp stays fixed across chained hops"
+    );
+    assert_eq!(
+        record.current_incarnation,
+        runner.state().objects[&src].incarnation,
+        "current_incarnation tracks the latest post-move value"
+    );
+}
+
+// T-relatch-stale (§4.3): a stale-stamped delayed trigger for the same object_id
+// must NOT ride a live relatch record; the read is bound to `original_stamp`.
+// The positive reach-guard (an ability that DID capture original_stamp) proves the
+// negative is not vacuous. Fails (spurious relatch) if the read drops the
+// `original_stamp == captured` binding.
+#[test]
+fn stale_stamped_ability_does_not_ride_live_relatch() {
+    let mut scenario = GameScenario::new();
+    let src = scenario.add_vanilla(P0, 1, 1);
+    let mut runner = scenario.build();
+
+    // Object is currently at incarnation 2 (as if it moved once); a live record
+    // names original_stamp 1 → current 2.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&src)
+        .unwrap()
+        .incarnation = 2;
+    runner.state_mut().resolution_source_relatch = Some(ResolutionSourceRelatch {
+        object_id: src,
+        original_stamp: 1,
+        current_incarnation: 2,
+    });
+
+    // A stale-stamped ability captured at M = 5 (≠ original_stamp) must not relatch.
+    let stale = drawing_ability(src, 5);
+    assert!(
+        !stale.source_is_current(runner.state()),
+        "a stale-stamped ability (M != original_stamp) must not ride the record"
+    );
+
+    // Positive reach-guard: the ability that captured original_stamp DOES relatch.
+    let fresh = drawing_ability(src, 1);
+    assert!(
+        fresh.source_is_current(runner.state()),
+        "the ability that captured original_stamp relatches (non-vacuous negative)"
+    );
+}
+
+// T-merge-split (§4.2): when a merged permanent leaves the battlefield, each
+// absorbed component becomes a CR 730.3 / CR 400.7 NEW object in its owner's zone
+// via `put_component_into_zone`, which must bump its incarnation. A delayed trigger
+// that captured the component's pre-split stamp N must then read
+// `source_is_current == false`. This is the ONLY coverage of the merge.rs
+// leave-split bump — reverting it is caught by nothing else.
+#[test]
+fn merge_leave_split_component_becomes_new_object() {
+    use engine::game::merge::{merge_object_onto, split_merged_permanent_on_leave, MergeSide};
+
+    let mut scenario = GameScenario::new();
+    let host = scenario.add_creature(P0, "Host", 2, 2).id();
+    let rider = scenario.add_creature(P0, "Rider", 4, 4).id();
+    let mut runner = scenario.build();
+    let mut events = Vec::new();
+
+    // The rider (component B) is absorbed at stamp N. Mutate ENTRY (CR 730.2b/c) is
+    // excluded from the bump, so absorbing does not advance the rider's incarnation.
+    let n = runner.state().objects[&rider].incarnation;
+    merge_object_onto(runner.state_mut(), rider, host, MergeSide::Top, &mut events);
+    assert_eq!(
+        runner.state().objects[&rider].incarnation,
+        n,
+        "reach-guard: absorbing the rider does not bump (mutate ENTRY is excluded)"
+    );
+
+    // A delayed trigger on the rider captured at stamp N is current while merged.
+    let captured = drawing_ability(rider, n);
+    assert!(
+        captured.source_is_current(runner.state()),
+        "reach-guard: the stamp-N trigger matches the still-merged rider"
+    );
+
+    // Kill the merged permanent → leave-split routes the rider to the graveyard as
+    // a NEW object via the bumped `put_component_into_zone`.
+    split_merged_permanent_on_leave(runner.state_mut(), host, Zone::Graveyard, &mut events);
+
+    assert_eq!(
+        runner.state().objects[&rider].zone,
+        Zone::Graveyard,
+        "non-vacuity: the rider actually left-split to the graveyard (not an early return)"
+    );
+    assert!(
+        runner.state().objects[&rider].incarnation > n,
+        "CR 730.3 + CR 400.7: the split-out component is a new object (incarnation bumped)"
+    );
+    assert!(
+        !captured.source_is_current(runner.state()),
+        "the stamp-N delayed trigger no longer matches the CR-400.7-new component"
+    );
+}


### PR DESCRIPTION
## Myrkul/Crew Phase 1 — CR 400.7 object-incarnation identity primitive + Crew ledger migration

Introduces a single object-identity primitive so effects that re-capture a source across a zone change resolve against the correct incarnation (CR 400.7), and migrates the Crew once-per-turn ledger onto it so a blinked Vehicle is crewable again.

### What's included
- **`ObjectIncarnationRef { object_id, incarnation }`** (`types/identifiers.rs`) — serde-compat via an untagged `Compat` enum mirroring `PhaseStop`, with `LEGACY_INCARNATION` for older saves.
- **All-zone incarnation bump** (CR 400.7 / CR 730.3) — `zones.rs` `move_to_zone` else-arm and `move_to_library_at_index` (guarded `from != Library` so a within-library reposition per CR 701.20b does not advance the epoch); `merge.rs` `put_component_into_zone` leave-split. `GameObject::bump_incarnation` shipped upstream in #5537 and is consumed here.
- **`resolution_source_relatch`** (CR 400.7j) — a resolving effect that self-moves its source to a public zone re-latches the new incarnation; written at the zone-change seam, read inside `source_is_current`, cleared with the resolving entry at all 5 sites. Excluded from `GameState` `PartialEq` to avoid leaking into CR 104.4b loop-equality.
- **Crew ledger migration** — `crew_activated_this_turn` is now `HashSet<ObjectIncarnationRef>` via `crew_activated_this_turn_contains` / `record_crew_activation`, so CR 602.5b once-per-turn is keyed by incarnation.
- **`normalize_ability_identity`** now also zeros `source_incarnation`, keeping the growing-cascade covering comparator symmetric with the `normalize_for_loop` ring snapshots (CR 104.4b + CR 732.4 mandatory-loop detection). This closes a regression where a win on a source cycling zones during a mandatory loop was mis-detected as a draw.
- **`PreparedTapPayment`** (`crew_payment.rs`) — atomic Crew tap payment (CR 702.122a).

### Testing
Full engine suite green for these changes. New discriminating tests:
- `myrkul_crew_phase1_incarnation` — all-zone bump, within-library no-bump, self-move relatch chaining, stale-stamp rider rejection, and **merge leave-split** (the sole coverage of the `put_component_into_zone` bump).
- `engine_keyword_action_stack_tests::crew_reentry_new_incarnation_clears_activation_ledger` — the incarnation-keyed ledger treats a re-entered Vehicle as crewable again.

Every CR annotation is grep-verified against `docs/MagicCompRules.txt`. The end-to-end crew → blink → crew card-test lands in Phase 2A (wires the production blink path).
