### PR TITLE
fix(engine): recognize bare (unlabeled) Strive-shaped cost surcharge (Fireball)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3009,15 +3009,43 @@ fn apply_etb_exile_ltb_return(
     }
 }
 
+/// CR 207.2c + CR 601.2f: Extract the per-target cost-increase clause,
+/// "[Strive — ]This spell costs {N} more to cast for each target beyond
+/// the first." Two surface forms exist for the identical CR 601.2f cost
+/// increase.
+///
+/// Labeled (~17 cards since Strive was introduced in 2014, e.g. Aerial
+/// Formation, Ajani's Presence, Twinflame): "Strive — This spell costs…".
+///
+/// Bare, no ability-word label (Fireball, Alpha 1993 — predates Strive by
+/// 21 years; Officious Interrogation, MKM 2024 — WotC printed this nine
+/// years after Strive existed and chose not to apply the label): "This
+/// spell costs…" with no em-dash prefix at all.
+///
+/// Try the labeled form first (unchanged behavior for existing Strive
+/// cards); on `None`, fall back to the same cost-pattern pipeline run
+/// directly on the un-stripped line. If a DIFFERENT ability word labels the
+/// line, the labeled branch's `ability_word != "strive"` guard still
+/// correctly returns `None` without ever reaching the bare fallback.
 fn parse_strive_cost_line(line: &str) -> Option<ManaCost> {
     let stripped = strip_reminder_text(line.trim());
-    let (ability_word, effect_text) = strip_ability_word_with_name(&stripped)?;
-    if ability_word != "strive" {
-        return None;
+
+    if let Some((ability_word, effect_text)) = strip_ability_word_with_name(&stripped) {
+        if ability_word != "strive" {
+            return None;
+        }
+        return parse_strive_cost_body(&effect_text);
     }
 
+    parse_strive_cost_body(&stripped)
+}
+
+/// Shared nom pipeline for the cost-increase clause body, used by both the
+/// labeled and bare entry points in `parse_strive_cost_line` so the two
+/// surface forms parse identically.
+fn parse_strive_cost_body(effect_text: &str) -> Option<ManaCost> {
     let effect_lower = effect_text.to_lowercase();
-    let ((), rest_original) = nom_on_lower(&effect_text, &effect_lower, |i| {
+    let ((), rest_original) = nom_on_lower(effect_text, &effect_lower, |i| {
         value((), tag("this spell costs ")).parse(i)
     })?;
     let (cost, rest_original) = parse_mana_symbols(rest_original)?;

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -13897,6 +13897,105 @@ fn strive_cost_parsed_from_oracle_text() {
     assert_eq!(r.strive_cost.unwrap().mana_value(), 3);
 }
 
+/// CR 207.2c + CR 601.2f: Fireball (Alpha 1993) carries the identical
+/// per-target cost-increase clause 21 years before the "Strive" ability word
+/// existed, so its line is BARE (no em-dash label). The bare fallback in
+/// `parse_strive_cost_line` must populate `strive_cost` just like the labeled
+/// path does for modern Strive cards.
+#[test]
+fn strive_cost_parsed_from_bare_clause_fireball() {
+    use crate::types::ability::Effect;
+    use crate::types::mana::ManaCost;
+    let r = parse(
+        "This spell costs {1} more to cast for each target beyond the first.\nFireball deals X damage divided evenly, rounded down, among any number of targets.",
+        "Fireball",
+        &[],
+        &["Sorcery"],
+        &[],
+    );
+    let cost = r
+        .strive_cost
+        .as_ref()
+        .expect("bare (unlabeled) cost-increase clause must set strive_cost");
+    match cost {
+        ManaCost::Cost { shards, generic } => {
+            assert_eq!(
+                *generic, 1,
+                "Fireball's per-target surcharge is {{1}} generic"
+            );
+            assert!(shards.is_empty(), "no colored shards in {{1}}: {shards:?}");
+        }
+        other => panic!("expected a concrete Cost, got {other:?}"),
+    }
+    // Positive reach-guard: the second (damage-division) clause still parses to
+    // a real DealDamage effect — proving the bare-fallback fix does not regress
+    // the already-correct second clause and that this test reaches real parsing.
+    assert!(
+        !r.abilities.is_empty(),
+        "Fireball's damage clause must produce a spell ability"
+    );
+    let has_damage = r
+        .abilities
+        .iter()
+        .any(|a| matches!(&*a.effect, Effect::DealDamage { .. }));
+    assert!(
+        has_damage,
+        "Fireball's damage-division clause must parse to DealDamage: {:#?}",
+        r.abilities
+    );
+}
+
+/// CR 207.2c + CR 601.2f: Officious Interrogation (Murders at Karlov Manor,
+/// 2024) also carries a BARE cost-increase clause — printed nine years after
+/// Strive existed, WotC chose not to apply the label. This is the class-
+/// coverage proof: a different colored surcharge ({W}{U}) on the same pattern.
+#[test]
+fn strive_cost_parsed_from_bare_clause_officious_interrogation() {
+    use crate::types::mana::{ManaCost, ManaCostShard};
+    let r = parse(
+        "This spell costs {W}{U} more to cast for each target beyond the first.\nChoose any number of target players. Investigate X times, where X is the total number of creatures those players control.",
+        "Officious Interrogation",
+        &[],
+        &["Instant"],
+        &[],
+    );
+    let cost = r
+        .strive_cost
+        .as_ref()
+        .expect("bare (unlabeled) cost-increase clause must set strive_cost");
+    match cost {
+        ManaCost::Cost { shards, generic } => {
+            assert_eq!(*generic, 0, "{{W}}{{U}} carries no generic component");
+            assert_eq!(
+                shards,
+                &vec![ManaCostShard::White, ManaCostShard::Blue],
+                "surcharge must be {{W}}{{U}}: {shards:?}"
+            );
+        }
+        other => panic!("expected a concrete Cost, got {other:?}"),
+    }
+}
+
+/// Precision guard: the bare fallback must NOT over-match ordinary cost-
+/// modification text. A line with no "for each target beyond the first"
+/// suffix must return `None`, because `parse_strive_cost_body`'s
+/// `all_consuming` tail requires the full suffix.
+#[test]
+fn strive_cost_bare_clause_requires_full_suffix_match() {
+    let r = parse(
+        "This spell costs {1} more to cast.\nDraw a card.",
+        "Not A Strive Card",
+        &[],
+        &["Sorcery"],
+        &[],
+    );
+    assert!(
+        r.strive_cost.is_none(),
+        "bare fallback must not match a cost line lacking the per-target suffix: {:?}",
+        r.strive_cost
+    );
+}
+
 #[test]
 fn strive_cost_parsed_different_cost() {
     let r = parse(

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -567,6 +567,7 @@ mod no_witnesses_most_creatures_investigate;
 mod ob_nixilis_captive_kingpin_life_loss;
 mod obeka_splitter_additional_phases;
 mod obliterate_regression;
+mod officious_interrogation_bare_strive_surcharge;
 mod old_growth_troll_return_as_aura;
 mod omo_queen_of_vesuva;
 mod oracle_parser;

--- a/crates/engine/tests/integration/officious_interrogation_bare_strive_surcharge.rs
+++ b/crates/engine/tests/integration/officious_interrogation_bare_strive_surcharge.rs
@@ -1,0 +1,156 @@
+//! Officious Interrogation (Murders at Karlov Manor, 2024) carries a BARE,
+//! unlabeled per-target cost-increase clause — "This spell costs {W}{U} more
+//! to cast for each target beyond the first." — printed nine years after the
+//! "Strive" ability word existed, but WotC chose not to apply the label. The
+//! parser's `parse_strive_cost_line` previously required an em-dash ability-
+//! word label and silently dropped this clause (the CR 601.2f cost increase),
+//! so the per-target surcharge was never applied at cast time.
+//!
+//! This test drives the REAL cast pipeline. Officious targets "any number of
+//! target players" (no {X} in its mana cost, no damage-distribution step), so
+//! its cast route is: cast → slot-by-slot `ChooseTarget` → target-dependent
+//! cost determination (CR 601.2f, `apply_target_dependent_cost_modifiers`) →
+//! auto-payment. Each target beyond the first adds a {W}{U} surcharge, so
+//! casting at two targets must consume exactly two more mana (one white, one
+//! blue) than casting at one target.
+//!
+//! Reverting the parser fix makes `strive_cost` `None`, the surcharge vanishes,
+//! the residual pool stops depending on the target count, and the
+//! discriminating assertions below fail.
+//!
+//! NOTE (see implementation report): Fireball — the OTHER bare-clause card —
+//! cannot be used for this runtime proof. Its "divided evenly … among any
+//! number of targets" + {X} cost routes through a DistributeAmong pause that
+//! occurs BEFORE the CR 601.2f surcharge seam, so its surcharge is dropped at
+//! runtime by an INDEPENDENT engine gap unrelated to this parser fix. Officious
+//! exercises the same parser fix on a route that actually reaches the surcharge.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const OFFICIOUS_ORACLE: &str = "This spell costs {W}{U} more to cast for each target beyond the first.\nChoose any number of target players. Investigate X times, where X is the total number of creatures those players control.";
+
+/// White + blue units seeded to each side of the pool. Must comfortably cover
+/// the base {1} plus, for the two-target case, an extra {W}{U} surcharge.
+const COLOR_UNITS: usize = 5;
+
+fn p0_pool_total(runner: &GameRunner) -> usize {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .expect("P0 must exist")
+        .mana_pool
+        .total()
+}
+
+/// Cast Officious Interrogation at the given player targets, drive the full
+/// announce→pay pipeline, and return P0's residual mana pool count.
+fn residual_pool_after_cast(player_targets: &[engine::types::PlayerId]) -> usize {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Base cost {1} generic — the surcharge, not the base, is under test.
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Officious Interrogation", true, OFFICIOUS_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: Vec::new(),
+            generic: 1,
+        })
+        .id();
+
+    // Abundant white + blue so auto-payment can always satisfy the colored
+    // {W}{U} surcharge without starving the {1} generic base.
+    let mut pool: Vec<ManaUnit> = Vec::new();
+    for _ in 0..COLOR_UNITS {
+        pool.push(ManaUnit::new(ManaType::White, ObjectId(0), false, vec![]));
+        pool.push(ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]));
+    }
+    let seeded = pool.len();
+    scenario.with_mana_pool(P0, pool);
+
+    let mut runner = scenario.build();
+
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Officious Interrogation should be accepted");
+
+    // Reach-guard: target selection is the announced-cast follow-up (no {X} to
+    // announce first — Officious's "X" is a resolution-time dynamic count).
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::TargetSelection { .. }
+        ),
+        "expected TargetSelection after cast announcement, got {:?}",
+        runner.state().waiting_for
+    );
+
+    for &target in player_targets {
+        runner
+            .act(GameAction::ChooseTarget {
+                target: Some(TargetRef::Player(target)),
+            })
+            .expect("choosing a player target should succeed");
+    }
+    // Terminate optional target selection if we didn't exhaust the legal set.
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::TargetSelection { .. }
+    ) {
+        runner
+            .act(GameAction::ChooseTarget { target: None })
+            .expect("terminating optional target selection should succeed");
+    }
+
+    // Reach-guard: payment (CR 601.2f) must have consumed mana — a full pool
+    // here would mean we never reached the paid path.
+    let residual = p0_pool_total(&runner);
+    assert!(
+        residual < seeded,
+        "payment must have consumed mana; residual={residual} seeded={seeded}, waiting_for={:?}",
+        runner.state().waiting_for
+    );
+    residual
+}
+
+/// CR 601.2c + CR 601.2f: Officious Interrogation's bare per-target surcharge
+/// must apply at cast time. Casting at two players must consume exactly two
+/// more mana (one white + one blue = {W}{U}) than casting at one player.
+#[test]
+fn officious_bare_strive_surcharge_adds_wu_per_extra_target() {
+    let residual_one_target = residual_pool_after_cast(&[P1]);
+    let residual_two_targets = residual_pool_after_cast(&[P0, P1]);
+
+    let seeded = COLOR_UNITS * 2;
+    // One target: pays only the {1} base.
+    assert_eq!(
+        residual_one_target,
+        seeded - 1,
+        "single-target Officious pays only its {{1}} base"
+    );
+    // Two targets: pays {1} base + one {W}{U} surcharge = 3 mana.
+    assert_eq!(
+        residual_two_targets,
+        seeded - 3,
+        "two-target Officious pays {{1}} base plus a {{W}}{{U}} surcharge = 3 mana"
+    );
+    assert_eq!(
+        residual_one_target - residual_two_targets,
+        2,
+        "the second target must add a {{W}}{{U}} surcharge (CR 601.2f): \
+         residual@1={residual_one_target}, residual@2={residual_two_targets}"
+    );
+}

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -16,7 +16,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 2 | Dropped intervening-if / gating condition (condition: null) | 606 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
 | 3 | Anaphor bound to wrong referent | 404 | oracle_quantity.rs context-ref resolution + game/ability_utils.rs forward_result wiring |
 | 4 | Conjoined / chained second effect clause dropped | 387 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
-| 5 | Dropped 'for each' / dynamic count collapsed to Fixed | 333 | oracle_quantity.rs parse_for_each_clause / parse_quantity_ref — thread ForEach/ObjectCount into the effect count field |
+| 5 | Dropped 'for each' / dynamic count collapsed to Fixed | 330 | oracle_quantity.rs parse_for_each_clause / parse_quantity_ref — thread ForEach/ObjectCount into the effect count field |
 | 6 | Disjunctive (or-list) collapsed to first branch | 247 | oracle_nom/filter.rs + oracle_target.rs — build TargetFilter::Or across all alt() branches |
 | 7 | Wrong / dropped zone parameters on zone-change effect | 211 | game/zones.rs + oracle parser zone routing — derive correct origin/destination/owner from Oracle |
 | 8 | Additional / alternative casting cost dropped | 210 | oracle_cost.rs — parse additional/alternative cost clauses into Spell.cost / AdditionalCost |
@@ -2234,7 +2234,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 5. Dropped 'for each' / dynamic count collapsed to Fixed  (333 cards)
+### 5. Dropped 'for each' / dynamic count collapsed to Fixed  (330 cards)
 
 **Signature.** Effect quantity (count/amount/P-T) parses as Fixed(1)/constant instead of a dynamic QuantityExpr::Ref over a 'for each X' / 'that many' / 'equal to' clause; the multiplier is dropped.
 


### PR DESCRIPTION
## Summary

Fixes a parser misparse in `docs/parser-misparse-backlog.md`'s Category #5 ("Dropped 'for each' / dynamic count collapsed to Fixed", 333 cards).

[[Fireball]] ({X}{R}, Sorcery, Limited Edition Alpha 1993 — verified via [Scryfall](https://scryfall.com/card/lea/64/fireball)): `"This spell costs {1} more to cast for each target beyond the first.\nFireball deals X damage divided evenly, rounded down, among any number of targets."`

The first line is a genuine CR 601.2f cost increase — mechanically identical to the "Strive" ability word (CR 207.2c, introduced in Journey into Nyx 2014, purely flavor-text with no independent rules meaning). `parse_strive_cost_line` already handles this cost shape fully and correctly for ~17 Strive-labeled cards, but it unconditionally requires an em-dash `"Strive — "` label before attempting the cost-pattern match. Fireball's clause predates the label by 21 years, so it's bare — the function returns `None` immediately, and the clause is silently dropped (a separate, unrelated catch-all for lines starting with `"this spell costs "` suppresses any `Unimplemented` warning, so the bug produces zero signal — exactly the "looks done, is wrong" class this backlog exists to catch).

[[Officious Interrogation]] (Murders at Karlov Manor, 2024 — verified via Scryfall) has the identical bare, unlabeled shape: `"This spell costs {W}{U} more to cast for each target beyond the first.\nChoose any number of target players. Investigate X times..."` — printed nine years after Strive existed, WotC simply chose not to apply the label. This confirms the bare form is a real, recurring grammatical variant of the mechanic, not a one-off pre-2014 artifact, so the fix is scoped to the class, not just Fireball.

## Fix

`parse_strive_cost_line` now tries the labeled form first (unchanged behavior for existing Strive cards), and on no label, falls back to running the identical nom pipeline directly on the un-stripped line (factored into a shared `parse_strive_cost_body` helper so neither path duplicates the cost-matching logic). Every downstream consumer of the resulting `strive_cost: Option<ManaCost>` (IR lowering, `CardFace`/`GameObject` field-copy, and `game/casting.rs`'s `apply_target_dependent_cost_modifiers`/`concrete_cost_for_x`) already consumes it generically regardless of population path, so the parser function is the sole fix point — confirmed by direct trace, not assumption.

## Important scope note — Fireball's own gameplay cost is not fully fixed by this PR

While implementing this, I found a **separate, independent engine bug**: Fireball's specific casting route ({X} cost + "divided evenly among any number of targets", which pauses at a pre-payment `DistributeAmong` step) bypasses the cost-surcharge mechanism entirely — the total cost gets locked in back at `ChooseXValue` time, before targets are known, and is never re-derived once targets are actually chosen. So even with this parser fix, **Fireball's actual in-game cost still won't scale with target count** — that's a shared casting-pipeline bug (affects ~15 cards' payment-mode/convoke/assist access on the `{X}` + distribute-among-targets route, not just Fireball's surcharge), scoped to its own follow-up rather than this PR. The runtime discriminating test here uses Officious Interrogation instead, whose casting route does reach the surcharge seam correctly, to prove the parser fix reaches real production payment for at least one card in the class.

## Files changed

- `crates/engine/src/parser/oracle.rs` — the fix
- `crates/engine/src/parser/oracle_tests.rs` — 3 new unit tests (Fireball's real text, Officious Interrogation's real text as class-coverage proof, a precision guard against over-matching)
- `crates/engine/tests/integration/officious_interrogation_bare_strive_surcharge.rs` (new) — discriminating runtime test driving the real cast pipeline
- `crates/engine/tests/integration/main.rs` — registers the new test module
- `docs/parser-misparse-backlog.md` — list hygiene: removes Fireball, Officious Interrogation, and Ajani's Presence (a Strive-*labeled* card also listed in this category — confirmed via direct test execution, not inference, that it already parses correctly today; a stale entry unrelated to this fix)

## CR references

CR 207.2c, CR 601.2c, CR 601.2f

## Verification

- [x] Verified both cards' Oracle text via Scryfall (not paraphrases)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p engine --lib -- -D warnings` clean
- [x] `./scripts/check-parser-combinators.sh` (Gate A): 0 violations
- [x] `cargo test -p engine --lib`: 15976 passed, 0 failed
- [x] `cargo test -p engine --test integration`: 2569 passed, 0 failed
- [x] Live-revert-and-rerun: reverting the bare-fallback confirms the new unit + integration tests fail; restored and re-confirmed green
- [x] Two rounds of independent plan review (closed: a fabricated citation, a by-analogy-only stale-backlog claim later confirmed via direct execution, and an under-specified test design) plus a review-impl pass (closed: a leftover debug test, an Instant/Sorcery type-line mismatch on Officious Interrogation)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01XbgwGxbU9NHN9kou9isp8K