### PR TITLE
feat(parser): resolve "Permanents you control" anthem subject to any permanent

### DIFF
--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -223,6 +223,12 @@ pub(crate) fn parse_typed_you_control(
                     parse_token_you_control_descriptor(&TextPair::new(descriptor, &desc_lower))
                 {
                     filter
+                // CR 205.2a + CR 110.1: "Permanents you control" (and the bare
+                // "Creature" card-type word) name a type, not a subtype — resolve
+                // to the all-permanents base before the capitalized-subtype
+                // fallback fabricates a zero-match `Subtype("Permanent")`.
+                } else if let Some(base) = bulk_type_subject_base(descriptor) {
+                    TargetFilter::Typed(base.controller(ControllerRef::You))
                 } else if is_capitalized_words(descriptor) {
                     // CR 205.3m: Normalize plural subtypes to canonical singular form
                     let subtype_name = parse_subtype(descriptor)
@@ -234,6 +240,11 @@ pub(crate) fn parse_typed_you_control(
                 } else {
                     return None;
                 }
+            } else if let Some(base) = bulk_type_subject_base(desc_remaining) {
+                // CR 205.2a + CR 110.1: bulk permanent/creature noun after a
+                // combat-status prefix ("Untapped permanents you control") — base
+                // type, not a subtype.
+                TargetFilter::Typed(base.controller(ControllerRef::You).properties(extra_props))
             } else if is_capitalized_words(desc_remaining) {
                 // CR 205.3m: Normalize plural subtypes to canonical singular form
                 let subtype_name = parse_subtype(desc_remaining)

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3738,6 +3738,38 @@ fn strip_subject_controller_suffix<'a>(
     (original, None)
 }
 
+/// CR 205.2a + CR 110.1: A bulk card-type / permanent noun — "creature(s)" (the
+/// creature card type) or "permanent(s)" (any permanent on the battlefield) —
+/// names a type, NOT a creature subtype. Returns the base `TypedFilter` for the
+/// noun so the subject parser never fabricates a `Subtype("Permanent")` (which
+/// matches no real card) or `Subtype("Creature")`.
+pub(crate) fn bulk_type_subject_base(word: &str) -> Option<TypedFilter> {
+    if word.eq_ignore_ascii_case("creature") || word.eq_ignore_ascii_case("creatures") {
+        Some(TypedFilter::creature())
+    } else if word.eq_ignore_ascii_case("permanent") || word.eq_ignore_ascii_case("permanents") {
+        Some(TypedFilter::permanent())
+    } else {
+        None
+    }
+}
+
+/// Apply the shared subject scope to a base subject filter: the controller
+/// suffix ("you control" → `ControllerRef`, CR 109.5) and the leading "Other "
+/// exclusion (`FilterProp::Another`).
+fn scoped_subject_filter(
+    mut typed: TypedFilter,
+    controller: Option<ControllerRef>,
+    has_other: bool,
+) -> TargetFilter {
+    if let Some(controller) = controller {
+        typed = typed.controller(controller);
+    }
+    if has_other {
+        typed = typed.properties(vec![FilterProp::Another]);
+    }
+    TargetFilter::Typed(typed)
+}
+
 pub(crate) fn parse_creature_subject_filter(subject: &str) -> Option<TargetFilter> {
     let trimmed = subject.trim();
     let lower = trimmed.to_lowercase();
@@ -3769,43 +3801,29 @@ pub(crate) fn parse_creature_subject_filter(subject: &str) -> Option<TargetFilte
         // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
         prefix.trim()
     } else if !descriptor_text.contains(' ') && descriptor_text.to_lowercase().ends_with('s') {
-        if descriptor_text.eq_ignore_ascii_case("creatures") {
-            // CR 205.2a: "creatures" names the creature card type, not a creature subtype.
-            let mut typed = TypedFilter::creature();
-            if let Some(controller) = controller {
-                typed = typed.controller(controller);
-            }
-            if has_other {
-                typed = typed.properties(vec![FilterProp::Another]);
-            }
-            return Some(TargetFilter::Typed(typed));
+        // CR 205.2a + CR 110.1: a bulk card-type / permanent noun ("creatures",
+        // "permanents") names a type, not a creature subtype — checked BEFORE the
+        // subtype fallback so "Permanents you control" spans every permanent
+        // rather than fabricating a zero-match Subtype("Permanent").
+        if let Some(base) = bulk_type_subject_base(descriptor_text) {
+            return Some(scoped_subject_filter(base, controller, has_other));
         }
         // CR 205.3m: Use parse_subtype for irregular plurals (Elves→Elf, Dwarves→Dwarf)
         if let Some((canonical, _)) = parse_subtype(descriptor_text) {
-            let mut typed = TypedFilter::creature().subtype(canonical);
-            if let Some(controller) = controller {
-                typed = typed.controller(controller);
-            }
-            if has_other {
-                typed = typed.properties(vec![FilterProp::Another]);
-            }
-            return Some(TargetFilter::Typed(typed));
+            return Some(scoped_subject_filter(
+                TypedFilter::creature().subtype(canonical),
+                controller,
+                has_other,
+            ));
         }
         descriptor_text.trim_end_matches('s').trim()
     } else {
         return None;
     };
 
-    if descriptor.eq_ignore_ascii_case("creature") {
-        // CR 205.2a: "creature" names the creature card type, not a creature subtype.
-        let mut typed = TypedFilter::creature();
-        if let Some(controller) = controller {
-            typed = typed.controller(controller);
-        }
-        if has_other {
-            typed = typed.properties(vec![FilterProp::Another]);
-        }
-        return Some(TargetFilter::Typed(typed));
+    // CR 205.2a + CR 110.1: bare "creature" / "permanent" name a type, not a subtype.
+    if let Some(base) = bulk_type_subject_base(descriptor) {
+        return Some(scoped_subject_filter(base, controller, has_other));
     }
 
     if descriptor.is_empty() {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -13023,6 +13023,82 @@ fn parse_creature_subject_filter_generic_and_irregular_plurals() {
     }
 }
 
+// CR 205.2a + CR 110.1: "Permanents you control" names ANY permanent, not a
+// creature named subtype "Permanent". The old parse fabricated
+// [Creature, Subtype("Permanent")] (matching no real card), so anthems like
+// Wondrous Crucible, Mishra Tamer of Mak Fawa, Cursed Wombat and Innkeeper's
+// Talent applied to nothing.
+#[test]
+fn permanents_you_control_subject_is_any_permanent_not_creature_subtype() {
+    assert_eq!(
+        parse_creature_subject_filter("Permanents you control"),
+        Some(TargetFilter::Typed(
+            TypedFilter::permanent().controller(ControllerRef::You)
+        ))
+    );
+    // The leading "Other " exclusion still attaches on the all-permanents base.
+    assert_eq!(
+        parse_creature_subject_filter("Other permanents you control"),
+        Some(TargetFilter::Typed(
+            TypedFilter::permanent()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::Another])
+        ))
+    );
+}
+
+#[test]
+fn permanents_you_control_ward_anthem_applies_to_all_permanents() {
+    let def = parse_static_line("Permanents you control have ward {2}.")
+        .expect("permanents-you-control ward anthem must parse");
+    assert_eq!(
+        def.affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::permanent().controller(ControllerRef::You)
+        ))
+    );
+    assert!(
+        def.modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Ward(_)
+            }
+        )),
+        "ward grant dropped: {:?}",
+        def.modifications
+    );
+}
+
+#[test]
+fn permanents_you_control_with_counters_keeps_qualifier_on_permanent_base() {
+    // Innkeeper's Talent: the trailing "with counters on them" qualifier still
+    // attaches as a FilterProp on top of the corrected all-permanents base.
+    let def = parse_static_line("Permanents you control with counters on them have ward {1}.")
+        .expect("permanents-with-counters anthem must parse");
+    let Some(TargetFilter::Typed(tf)) = &def.affected else {
+        panic!("expected typed permanent filter, got {:?}", def.affected);
+    };
+    assert!(
+        tf.type_filters.contains(&TypeFilter::Permanent),
+        "must be the any-permanent base, got {:?}",
+        tf.type_filters
+    );
+    assert!(
+        !tf.type_filters.contains(&TypeFilter::Creature),
+        "must not narrow to Creature, got {:?}",
+        tf.type_filters
+    );
+    assert_eq!(tf.controller, Some(ControllerRef::You));
+    assert!(tf.get_subtype().is_none(), "must not fabricate a subtype");
+    assert!(
+        tf.properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::Counters { .. })),
+        "counter qualifier dropped: {:?}",
+        tf.properties
+    );
+}
+
 #[test]
 fn continuous_subject_filter_nontoken_is_negation_not_subtype() {
     // CR 111.1 / CR 205.3: "Nontoken creatures you control" (Ashaya, Soul of


### PR DESCRIPTION
CR 205.2a + CR 110.1

## Bug

"Permanents you control" names **any permanent** on the battlefield (CR 110.1), not a creature with a fabricated subtype `"Permanent"`. But both subject parsers fell through to the capitalized-subtype fallback and produced `[Creature, Subtype("Permanent")]` — a filter that matches **no real card**. So anthems/grants over "permanents you control" applied to nothing at runtime:

- **Wondrous Crucible** — `Permanents you control have ward {2}.`
- **Mishra, Tamer of Mak Fawa** — `Permanents you control have "Ward—Sacrifice a permanent."`
- **Cursed Wombat** — `Permanents you control have "Whenever one or more +1/+1 counters are put on this permanent, put an additional +1/+1 counter on it. ..."`
- **Innkeeper's Talent** — `Permanents you control with counters on them have ward {1}.`

Two independent seams had the same defect: `parse_creature_subject_filter` (shared.rs) and `parse_typed_you_control`'s "Xs you control" arm (anthem.rs), each calling `typed_filter_for_subtype("Permanent")`.

## Fix

One shared authority — **`bulk_type_subject_base`** — maps a bulk card-type / permanent noun (`"creature(s)"` → the creature card type, `"permanent(s)"` → any permanent) to its base `TypedFilter`, checked **before** the subtype fallback in both parsers. The pre-existing `"creatures"`/`"creature"` special-cases now route through the same helper (via `scoped_subject_filter`, which applies the `"you control"` controller and `"Other "` exclusion), so the two seams share **one** core-type-vs-subtype discrimination instead of duplicating it.

## Why it's the right seam / minimal blast radius

- Not a new sibling handler — it **collapses** the existing duplicated `"creatures"`/`"creature"` core-type checks into one authority and extends that authority to `"permanent(s)"`.
- Subtype anthems (`"Zombies you control"`, `"Elves"`), core-type anthems (`"Artifacts you control"` via `try_parse_core_type_descriptor`), commander/token designations, and negation/supertype descriptors are all untouched — the permanent arm sits after them and before the subtype fabrication.
- Parse-diff limited to the `"permanent(s)"` subject class.

## Tests

- `permanents_you_control_subject_is_any_permanent_not_creature_subtype` — full-shape: `parse_creature_subject_filter` yields `TypedFilter::permanent().controller(You)`, and `"Other permanents you control"` adds `FilterProp::Another`.
- `permanents_you_control_ward_anthem_applies_to_all_permanents` — end-to-end via `parse_static_line`: affected = all-permanents base, ward grant preserved.
- `permanents_you_control_with_counters_keeps_qualifier_on_permanent_base` — Innkeeper's Talent: the `"with counters on them"` qualifier still attaches on the corrected base.
- Existing `parse_creature_subject_filter_generic_and_irregular_plurals` (creatures / Elves / Wolves) still green.

## CR verification

- **CR 110.1** — "A permanent is a card or token on the battlefield." (verified in `docs/MagicCompRules.txt`)
- **CR 205.2a** — the card types (creature is a card type, not a subtype).
- **CR 109.5** — a static's "you"/"your" refers to the object's controller.

## AI-contributor notes

- **Rules-correct:** the ward/quoted-ability grants now apply to every permanent you control, per CR 110.1.
- **Builds the class:** one seam fixes Wondrous Crucible, Mishra Tamer of Mak Fawa, Cursed Wombat, Innkeeper's Talent, and any future `"permanents you control"` anthem.
- **Verified:** live-parsed all four cards before/after against Scryfall Oracle text; `cargo fmt`, CI-exact `clippy -p engine --all-targets --features proptest -D warnings`, and the full `parser::oracle_static::tests` module (1032 passed, 0 failed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
