### PR TITLE
feat(parser): peel a leading supertype off "<Supertype> <Subtype>" subjects

### DIFF
--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -285,6 +285,19 @@ pub(crate) fn try_parse_core_type_descriptor(descriptor_lower: &str) -> Option<T
 /// to their parent type instead of defaulting everything to Creature.
 pub(crate) fn typed_filter_for_subtype(subtype: &str) -> TypedFilter {
     use crate::types::ability::TypeFilter;
+    // CR 205.4a + CR 205.3m: a compound "<supertype> <subtype>" descriptor
+    // ("Legendary Human", "Snow Elf") peels its leading supertype word into a
+    // `HasSupertype` property so the remainder resolves to the REAL subtype —
+    // rather than fabricating a zero-match `Subtype("Legendary Human")` (General's
+    // Enforcer "Legendary Humans you control", Kashi-Tribe Elite "Legendary
+    // Snakes you control").
+    if let Some((supertype, rest)) = split_leading_supertype(subtype) {
+        let mut filter = typed_filter_for_subtype(rest);
+        filter
+            .properties
+            .push(FilterProp::HasSupertype { value: supertype });
+        return filter;
+    }
     if let Some(core_type) = infer_core_type_for_subtype(subtype) {
         let type_filter = match core_type {
             crate::types::card_type::CoreType::Artifact => TypeFilter::Artifact,
@@ -296,6 +309,19 @@ pub(crate) fn typed_filter_for_subtype(subtype: &str) -> TypedFilter {
     } else {
         TypedFilter::creature().subtype(subtype.to_string())
     }
+}
+
+/// CR 205.4a: Peel a leading supertype word off a compound "<supertype>
+/// <subtype>" subject descriptor ("Legendary Human", "Snow Elf"), returning the
+/// supertype and the original-case remainder. Returns `None` for a bare
+/// supertype (no following subtype) or a descriptor with no leading supertype,
+/// so a plain subtype falls through to the subtype path unchanged.
+fn split_leading_supertype(descriptor: &str) -> Option<(Supertype, &str)> {
+    let lower = descriptor.to_lowercase();
+    let (rest_lower, supertype) = nom_target::parse_supertype_word(&lower).ok()?;
+    let rest_lower = rest_lower.strip_prefix(' ')?;
+    let rest = descriptor[descriptor.len() - rest_lower.len()..].trim();
+    (!rest.is_empty()).then_some((supertype, rest))
 }
 
 pub(crate) fn is_capitalized_words(s: &str) -> bool {

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -8,7 +8,7 @@ use super::support::*;
 use crate::types::ability::PlayerFilter;
 use nom::character::complete::{alphanumeric1, char, digit1, one_of};
 use nom::combinator::{all_consuming, map_res, not, opt, peek, recognize};
-use nom::sequence::{delimited, pair};
+use nom::sequence::{delimited, pair, terminated};
 
 /// Lower a parsed rule-static predicate into the runtime static mode.
 pub(crate) fn lower_rule_static(
@@ -318,8 +318,15 @@ pub(crate) fn typed_filter_for_subtype(subtype: &str) -> TypedFilter {
 /// so a plain subtype falls through to the subtype path unchanged.
 fn split_leading_supertype(descriptor: &str) -> Option<(Supertype, &str)> {
     let lower = descriptor.to_lowercase();
-    let (rest_lower, supertype) = nom_target::parse_supertype_word(&lower).ok()?;
-    let rest_lower = rest_lower.strip_prefix(' ')?;
+    // Consume the supertype word AND its separating space atomically: a bare
+    // supertype (no following subtype) fails the trailing ` ` and declines here,
+    // so a plain subtype falls through to the subtype path unchanged.
+    let (rest_lower, supertype) = terminated(
+        nom_target::parse_supertype_word,
+        tag::<_, _, OracleError<'_>>(" "),
+    )
+    .parse(&lower)
+    .ok()?;
     let rest = descriptor[descriptor.len() - rest_lower.len()..].trim();
     (!rest.is_empty()).then_some((supertype, rest))
 }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -13267,6 +13267,60 @@ fn continuous_subject_filter_legendary_is_supertype_not_subtype() {
     assert_eq!(tf.controller, Some(ControllerRef::You));
 }
 
+// CR 205.4a + CR 205.3m: "Legendary Humans you control" is a compound
+// supertype + subtype subject — the legendary supertype plus the Human subtype,
+// NOT a fabricated subtype named "Legendary Human" (which matches no card).
+// General's Enforcer / Kashi-Tribe Elite anthems previously applied to nothing.
+#[test]
+fn legendary_subtype_subject_peels_supertype_and_keeps_subtype() {
+    let def = parse_static_line("Legendary Humans you control have indestructible.")
+        .expect("legendary-subtype anthem should parse");
+    let Some(TargetFilter::Typed(tf)) = &def.affected else {
+        panic!("Expected Typed affected filter, got {:?}", def.affected);
+    };
+    assert_eq!(
+        tf.get_subtype(),
+        Some("Human"),
+        "remainder must be the real subtype, not a fabricated 'Legendary Human'"
+    );
+    assert!(tf.type_filters.contains(&TypeFilter::Creature));
+    assert!(
+        tf.properties.contains(&FilterProp::HasSupertype {
+            value: Supertype::Legendary,
+        }),
+        "expected HasSupertype(Legendary), got {:?}",
+        tf.properties
+    );
+    assert_eq!(tf.controller, Some(ControllerRef::You));
+    assert!(def
+        .modifications
+        .contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Indestructible
+        }));
+}
+
+#[test]
+fn typed_filter_for_subtype_peels_leading_supertype() {
+    // Building-block: the single subtype-filter authority peels a leading
+    // supertype word into a HasSupertype property.
+    let filter = typed_filter_for_subtype("Legendary Human");
+    assert_eq!(filter.get_subtype(), Some("Human"));
+    assert!(filter.properties.contains(&FilterProp::HasSupertype {
+        value: Supertype::Legendary,
+    }));
+    // Regression: a plain subtype gains no supertype property.
+    let plain = typed_filter_for_subtype("Goblin");
+    assert_eq!(plain.get_subtype(), Some("Goblin"));
+    assert!(
+        !plain
+            .properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::HasSupertype { .. })),
+        "plain subtype must not gain a supertype, got {:?}",
+        plain.properties
+    );
+}
+
 #[test]
 fn static_jodah_anthem_affected_filter_uses_legendary_supertype() {
     // CR 205.4a + CR 613.4c: Jodah, the Unifier's anthem affects


### PR DESCRIPTION
CR 205.4a + CR 205.3m

## Bug

A subject phrase like "Legendary Humans you control" names the **legendary supertype** plus the **Human subtype** — but the shared subtype authority `typed_filter_for_subtype` treated the whole two-word string as one subtype and fabricated `Subtype("Legendary Human")`, a filter that matches **no card in existence**. The anthems therefore applied to nothing at runtime:

- **General's Enforcer** — `Legendary Humans you control have indestructible.`
- **Kashi-Tribe Elite** — `Legendary Snakes you control have shroud.`

Before: `affected = [Creature, Subtype("Legendary Human")]` (zero matches).
After: `affected = [Creature, Subtype("Human")] + HasSupertype(Legendary)`.

## Fix

At the single authority `typed_filter_for_subtype` (`grammar.rs`): peel a leading supertype word ("Legendary"/"Snow"/"Basic"/…) via a new `split_leading_supertype` helper, attach it as `FilterProp::HasSupertype`, and resolve the remainder as the real subtype (recursing so the core-type inference still runs on the true subtype).

Because **every** capitalized-subtype fallback in the subject parsers routes through this one function, all four call sites — `parse_typed_you_control`'s creature-arm and combat-status-prefix arm, plus the `parse_creature_subject_filter` fallback — inherit the fix from one place.

## Why it's the right seam / minimal blast radius

- One authority, not four sibling patches — the fix lands where the fabrication happens, so the whole `<supertype> <subtype>` subject class is covered in a single change.
- A **bare** supertype ("Legendary creatures") already routes through its own path (`descriptor_is_supertype`) and is untouched; a plain subtype ("Goblins") gains no supertype property (regression-tested).
- `split_leading_supertype` returns `None` for a bare supertype (no following subtype), so it never strips a legitimate lone supertype.

## Tests

- `legendary_subtype_subject_peels_supertype_and_keeps_subtype` — end-to-end via `parse_static_line`: General's Enforcer → `Subtype("Human")` + `HasSupertype(Legendary)` + `AddKeyword(Indestructible)`.
- `typed_filter_for_subtype_peels_leading_supertype` — building-block: "Legendary Human" → Human + HasSupertype(Legendary); "Goblin" → Goblin, no supertype (regression).
- Full `parser::oracle_static::tests` (1039 passed, 0 failed), including the existing bare-supertype "Legendary creatures" / Jodah tests.

## CR verification

- **CR 205.4a** — the supertypes (basic, legendary, ongoing, snow, world) — verified in `docs/MagicCompRules.txt`.
- **CR 205.3m** — subtype recognition on the remainder.

## AI-contributor notes

- **Rules-correct:** the anthem now targets legendary creatures of the named subtype per CR 205.4a; the enchanted/controlled set is real, not empty.
- **Builds the class:** the fix is at the shared subtype authority, so any `<supertype> <subtype>` subject (current or future) is covered.
- **Verified:** live-parsed General's Enforcer and Kashi-Tribe Elite before/after against Scryfall Oracle text; `cargo fmt`, CI-exact `clippy -p engine --all-targets --features proptest -D warnings`, and the full oracle_static test module are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
