### PR TITLE
fix(parser): "share a type with it" in a mana-amount count binds to the triggering object

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -15,7 +15,7 @@ use super::lower::{
     parse_for_each_multiplier_prefix, parse_multi_target_count_expr,
     parse_where_x_quantity_expression, strip_trailing_where_x,
 };
-use super::mana::{try_parse_activate_only_condition, try_parse_add_mana_effect};
+use super::mana::{try_parse_activate_only_condition, try_parse_add_mana_effect_with_context};
 use super::token::try_parse_token;
 use super::{
     attach_controller_if_absent, is_bare_object_pronoun, resolve_it_pronoun, ParseContext,
@@ -8270,7 +8270,7 @@ pub(super) fn parse_cost_resource_ast(
     })
     .is_some()
     {
-        return match try_parse_add_mana_effect(text) {
+        return match try_parse_add_mana_effect_with_context(text, ctx) {
             Some(Effect::Mana {
                 produced,
                 restrictions,

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -21,9 +21,12 @@ use crate::types::mana::{
 use crate::types::zones::Zone;
 
 use super::super::oracle_keyword::parse_keyword_from_oracle;
-use super::super::oracle_quantity::{parse_cda_quantity, parse_event_context_quantity};
+use super::super::oracle_quantity::{
+    parse_cda_quantity, parse_cda_quantity_with_context, parse_event_context_quantity,
+};
 use super::super::oracle_target::parse_type_phrase;
 use super::super::oracle_util::{parse_mana_production, parse_number, TextPair};
+use crate::parser::oracle_ir::context::ParseContext;
 use crate::types::ability::TargetFilter;
 
 /// Bridge: run a nom combinator on a lowercase copy, mapping the consumed length
@@ -160,13 +163,26 @@ fn parse_object_colors_scope(text: &str) -> Option<ObjectScope> {
     parser.parse(lower.as_str()).ok().map(|(_, scope)| scope)
 }
 
+#[cfg(test)]
 pub(super) fn try_parse_add_mana_effect(text: &str) -> Option<Effect> {
+    try_parse_add_mana_effect_with_context(text, &mut ParseContext::default())
+}
+
+/// Context-aware `try_parse_add_mana_effect`. The `ctx` carries the trigger
+/// subject so a count clause referencing the triggering object ("… equal to the
+/// number of creatures you control that share a creature type with it", Mana
+/// Echoes) resolves "it" to `TriggeringSource` rather than an empty
+/// `ParentTarget`.
+pub(super) fn try_parse_add_mana_effect_with_context(
+    text: &str,
+    ctx: &mut ParseContext,
+) -> Option<Effect> {
     // CR 505.1 + CR 106.4: A subject-led mana clause routes the produced mana
     // to the named player. Strip the subject, parse the bare "add …" clause,
     // and stamp the recipient onto the resulting `Effect::Mana.target`.
     if let Some((recipient, rest)) = strip_mana_subject_prefix(text.trim()) {
         let synthetic = format!("add {rest}");
-        let mut effect = try_parse_add_mana_effect(&synthetic)?;
+        let mut effect = try_parse_add_mana_effect_with_context(&synthetic, ctx)?;
         if let Effect::Mana { target, .. } = &mut effect {
             if target.is_none() {
                 *target = Some(recipient);
@@ -275,7 +291,7 @@ pub(super) fn try_parse_add_mana_effect(text: &str) -> Option<Effect> {
 
     // CR 106.1 / CR 106.3: "an amount of {color} equal to [quantity]"
     // e.g. "an amount of {G} equal to ~'s power"
-    if let Some(effect) = try_parse_amount_equal_to(clause, contribution) {
+    if let Some(effect) = try_parse_amount_equal_to_with_context(clause, contribution, ctx) {
         return Some(effect);
     }
 
@@ -2639,7 +2655,11 @@ fn parse_pure_color_symbol(
 
 /// CR 106.1 / CR 106.3: Parse "an amount of {color} equal to [quantity]"
 /// e.g. "an amount of {G} equal to ~'s power" -> AnyOneColor { count: SelfPower, [Green] }
-fn try_parse_amount_equal_to(clause: &str, contribution: ManaContribution) -> Option<Effect> {
+fn try_parse_amount_equal_to_with_context(
+    clause: &str,
+    contribution: ManaContribution,
+    ctx: &mut ParseContext,
+) -> Option<Effect> {
     let clause_lower = clause.to_lowercase();
     let (_, rest) = nom_on_lower(clause, &clause_lower, |i| {
         value((), tag("an amount of ")).parse(i)
@@ -2658,7 +2678,7 @@ fn try_parse_amount_equal_to(clause: &str, contribution: ManaContribution) -> Op
     }) {
         let quantity_text = quantity_text.trim().trim_end_matches(['.', '"']);
         let count = parse_event_context_quantity(quantity_text)
-            .or_else(|| parse_cda_quantity(quantity_text))?;
+            .or_else(|| parse_cda_quantity_with_context(quantity_text, ctx))?;
         return Some(Effect::Mana {
             produced: ManaProduction::ChosenColor {
                 count,
@@ -2688,7 +2708,7 @@ fn try_parse_amount_equal_to(clause: &str, contribution: ManaContribution) -> Op
         // triggering-spell spent-mana ref; fall back to `parse_cda_quantity` for
         // non-event quantities (e.g. "~'s power").
         let count = parse_event_context_quantity(quantity_text)
-            .or_else(|| parse_cda_quantity(quantity_text))?;
+            .or_else(|| parse_cda_quantity_with_context(quantity_text, ctx))?;
         return Some(Effect::Mana {
             produced: ManaProduction::Colorless { count },
             restrictions: vec![],
@@ -2733,6 +2753,51 @@ fn try_parse_amount_equal_to(clause: &str, contribution: ManaContribution) -> Op
 mod tests {
     use super::*;
     use crate::types::ability::{ControllerRef, TypeFilter};
+
+    #[test]
+    fn shares_type_with_it_in_trigger_context_uses_triggering_source() {
+        // #5329 Mana Echoes: with a trigger subject in context, "the number of
+        // creatures you control that share a creature type with it" must resolve
+        // "it" to `TriggeringSource`, not an empty `ParentTarget` (which counts
+        // nothing → adds no mana).
+        use crate::types::ability::{
+            FilterProp, QuantityExpr, QuantityRef, TargetFilter, TypedFilter,
+        };
+        let mut ctx = ParseContext {
+            subject: Some(TargetFilter::Typed(TypedFilter::default())),
+            ..ParseContext::default()
+        };
+        let effect = try_parse_add_mana_effect_with_context(
+            "Add an amount of {C} equal to the number of creatures you control that share a creature type with it.",
+            &mut ctx,
+        )
+        .expect("mana amount clause must parse");
+        let Effect::Mana {
+            produced:
+                ManaProduction::Colorless {
+                    count:
+                        QuantityExpr::Ref {
+                            qty: QuantityRef::ObjectCount { filter },
+                        },
+                },
+            ..
+        } = effect
+        else {
+            panic!("expected Colorless ObjectCount, got {effect:?}");
+        };
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        let reference = tf.properties.iter().find_map(|p| match p {
+            FilterProp::SharesQuality { reference, .. } => reference.as_deref(),
+            _ => None,
+        });
+        assert_eq!(
+            reference,
+            Some(&TargetFilter::TriggeringSource),
+            "\"share a creature type with it\" must reference the triggering object, got {reference:?}",
+        );
+    }
 
     fn extract_combinations(oracle: &str) -> Option<Vec<Vec<ManaColor>>> {
         match try_parse_add_mana_effect(oracle) {


### PR DESCRIPTION
Fixes #5329 (Mana Echoes). CR 106.1 + CR 608.2c.

"Whenever a creature enters, you may add an amount of {C} equal to the number of creatures you control that share a creature type with **it**." **added no mana.**

## Root cause

The mana-amount count parser dropped the parse context. The count filter `… that share a creature type with it` resolves "it" via `resolve_pronoun_target`, which needs `ctx.subject` (the trigger subject) to bind "it" to `TriggeringSource`. With no context it fell back to **`ParentTarget`** — but a triggered ability has no target, so the `ObjectCount` was always **0** → no mana.

The trigger effect parser *does* set the subject (`extract_trigger_subject_for_context`), but `try_parse_add_mana_effect` / `try_parse_amount_equal_to` took only `&str`, so the context never reached the count.

## Fix

Thread the context through the mana-amount path. `parse_cost_resource_ast` already holds the trigger `ctx`, so it now calls `try_parse_add_mana_effect_with_context` → `try_parse_amount_equal_to_with_context` → the existing ctx-aware `parse_cda_quantity_with_context`. "it" now binds to `TriggeringSource`, so the shared-type count sees the entering creature (verified: reference is now `TriggeringSource`, was `ParentTarget`).

This is a **class-fix** for any "add mana equal to `<count referencing the triggering object>`" trigger.

## Verification

- Fix confirmed via parse probe: the `SharesQuality` reference is now `TriggeringSource` (was `ParentTarget`).
- New test `shares_type_with_it_in_trigger_context_uses_triggering_source` (exercises the threaded context directly).
- `cargo check --tests` clean, clippy clean, parser-combinator gate exit 0, parser gap analysis unchanged (3977). The non-trigger callers keep a default context, so all existing mana parses are unchanged.

_Note: the full engine test-binary link is RAM-bound on my box, so the runtime end-to-end is left to CI._