### PR TITLE
refactor(parser): typed clause provenance via ClauseIrBuilder + ClauseDisposition (U5-M1)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -25,7 +25,9 @@ use super::super::oracle_util::{parse_comparator_prefix, parse_count_expr, strip
 use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
-use crate::parser::oracle_ir::effect_chain::{ClauseIr, EffectChainIr, SpecialClause};
+use crate::parser::oracle_ir::effect_chain::{
+    ClauseDisposition, ClauseIr, EffectChainIr, SpecialClause,
+};
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
     AttackSubject, CastFromZoneDriver, CastingPermission, Comparator, ConjureSource,
@@ -893,7 +895,11 @@ fn is_spend_mana_as_any_color_rider(clause: &ClauseIr) -> bool {
         return false;
     }
 
-    let lower = clause.source_text.to_ascii_lowercase();
+    let lower = clause
+        .source
+        .fragment()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
     let parsed = all_consuming((
         opt(alt((
             tag::<_, _, OracleError<'_>>("if you cast a spell this way, "),
@@ -1002,15 +1008,23 @@ fn attach_graveyard_redirect_rider_to_prior_cast_from_zone(
 /// printed increase (`{1}`, `{2}`, …); the mana symbols are case-insensitive
 /// digits in the common generic case.
 fn cast_cost_raise_rider(clause: &ClauseIr) -> Option<ManaCost> {
-    let lower = clause.source_text.to_ascii_lowercase();
-    nom_on_lower(clause.source_text.trim(), lower.trim(), |i| {
-        let (i, _) = tag("each spell cast this way costs ").parse(i)?;
-        let (i, cost) = nom_primitives::parse_mana_cost(i)?;
-        let (i, _) = tag(" more to cast").parse(i)?;
-        let (i, _) = opt(tag(".")).parse(i)?;
-        eof(i)?;
-        Ok((i, cost))
-    })
+    let lower = clause
+        .source
+        .fragment()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    nom_on_lower(
+        clause.source.fragment().unwrap_or_default().trim(),
+        lower.trim(),
+        |i| {
+            let (i, _) = tag("each spell cast this way costs ").parse(i)?;
+            let (i, cost) = nom_primitives::parse_mana_cost(i)?;
+            let (i, _) = tag(" more to cast").parse(i)?;
+            let (i, _) = opt(tag(".")).parse(i)?;
+            eof(i)?;
+            Ok((i, cost))
+        },
+    )
     .map(|(cost, _)| cost)
 }
 
@@ -1028,7 +1042,11 @@ fn parses_land_enters_tapped_rider(input: &str) -> bool {
 /// preceding `PlayFromExile` grant ("this way"), so it folds into the grant's
 /// `land_enter_tapped` rather than emitting a board-wide ETB-tapped replacement.
 fn is_land_enters_tapped_rider(clause: &ClauseIr) -> bool {
-    let lower = clause.source_text.to_ascii_lowercase();
+    let lower = clause
+        .source
+        .fragment()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
     let trimmed = lower.trim().trim_end_matches('.').trim();
     parses_land_enters_tapped_rider(trimmed)
 }
@@ -1048,10 +1066,16 @@ fn parse_until_next_same_source_exile_invalidation(input: &str) -> OracleResult<
 }
 
 fn is_until_next_same_source_exile_rider(clause: &ClauseIr) -> bool {
-    let lower = clause.source_text.to_ascii_lowercase();
-    nom_on_lower(clause.source_text.trim(), lower.trim(), |i| {
-        all_consuming(parse_until_next_same_source_exile_invalidation).parse(i)
-    })
+    let lower = clause
+        .source
+        .fragment()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    nom_on_lower(
+        clause.source.fragment().unwrap_or_default().trim(),
+        lower.trim(),
+        |i| all_consuming(parse_until_next_same_source_exile_invalidation).parse(i),
+    )
     .is_some()
 }
 
@@ -1311,14 +1335,19 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
         // evaluates to `true`; the boundary advance below then runs uniformly so
         // a following normal clause stamps `sub_link` from the correct boundary.
         let handled_as_special: bool = {
-            if clause_ir.absorbed_by_followup {
-                // Apply the followup continuation to the defs built so far.
-                if let Some(ref continuation) = clause_ir.followup_continuation {
+            if matches!(clause_ir.disposition, ClauseDisposition::Continue { .. }) {
+                // Apply the Continue clause's continuation to the defs built so far
+                // (formerly the absorbed `followup_continuation` path).
+                if let Some(continuation) = clause_ir.disposition.followup() {
                     apply_clause_continuation(&mut defs, continuation.clone(), kind);
                     apply_where_x_to_latest_def(&mut defs, clause_ir.where_x_expression.as_deref());
                 }
                 true
-            } else if let Some(ref special) = clause_ir.special {
+            } else if let ClauseDisposition::Special {
+                action: special,
+                intrinsic,
+            } = &clause_ir.disposition
+            {
                 match special {
                     SpecialClause::AltCostRider(cost) => {
                         attach_alt_cost_to_prior_cast_from_zone(&mut defs, cost.clone());
@@ -1597,7 +1626,7 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                         }
                         defs.push(def);
                         // Apply intrinsic continuation for THIS SearchLibrary (e.g., reveal flag, ChangeZone).
-                        if let Some(ref continuation) = clause_ir.intrinsic_continuation {
+                        if let Some(continuation) = intrinsic {
                             apply_clause_continuation(&mut defs, continuation.clone(), kind);
                         }
                         true
@@ -1663,9 +1692,13 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
         // before the generic chain assembly mistakes a `PutAtLibraryPosition{
         // Bottom}` for the Sanwell free-cast bottom-cleanup. Exile is left to its
         // existing clean path (the helper declines it).
-        if let Some(dest) =
-            parse_spell_graveyard_replacement_rider(&clause_ir.source_text.to_lowercase())
-        {
+        if let Some(dest) = parse_spell_graveyard_replacement_rider(
+            &clause_ir
+                .source
+                .fragment()
+                .unwrap_or_default()
+                .to_lowercase(),
+        ) {
             if attach_graveyard_redirect_rider_to_prior_cast_from_zone(&mut defs, dest) {
                 prev_boundary = clause_ir.boundary;
                 continue;
@@ -1699,8 +1732,8 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
         }
 
         // Non-absorbed, non-special followup continuation — apply it to the
-        // previous defs before building this clause's def.
-        if let Some(ref continuation) = clause_ir.followup_continuation {
+        // previous defs before building this clause's def (`Emit.followup`).
+        if let Some(continuation) = clause_ir.disposition.followup() {
             apply_clause_continuation(&mut defs, continuation.clone(), kind);
             apply_where_x_to_latest_def(&mut defs, clause_ir.where_x_expression.as_deref());
         }
@@ -1719,7 +1752,7 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                 ..
             }
         ) {
-            def.description = Some(clause_ir.source_text.clone());
+            def.description = Some(clause_ir.source.fragment().unwrap_or_default().to_string());
         }
         // CR 608.2c: This clause's link to its parent = the boundary that
         // SEPARATED the previous clause from this one. A `Sentence` boundary
@@ -1798,7 +1831,11 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
             );
         let is_pay_to_end_effect_termination =
             crate::parser::clause_shell::is_you_may_pay_to_end_effect_phrase(
-                &clause_ir.source_text.to_ascii_lowercase(),
+                &clause_ir
+                    .source
+                    .fragment()
+                    .unwrap_or_default()
+                    .to_ascii_lowercase(),
             );
         if clause_ir.is_optional
             && !matches!(&clause_ir.parsed.effect, Effect::SearchOutsideGame { .. })
@@ -1947,26 +1984,40 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
         }
         // CR 115.1d: Apply multi-target spec — prefer explicit choose-count text,
         // then strip result, then clause-level propagation.
-        if let Some(spec) = extract_exact_target_multi_target(&clause_ir.source_text) {
+        if let Some(spec) =
+            extract_exact_target_multi_target(clause_ir.source.fragment().unwrap_or_default())
+        {
             def = def.multi_target(spec);
-        } else if let Some(spec) = extract_bounded_target_multi_target(&clause_ir.source_text) {
+        } else if let Some(spec) =
+            extract_bounded_target_multi_target(clause_ir.source.fragment().unwrap_or_default())
+        {
             def = def.multi_target(spec);
-        } else if let Some(spec) = extract_optional_target_multi_target(&clause_ir.source_text) {
+        } else if let Some(spec) =
+            extract_optional_target_multi_target(clause_ir.source.fragment().unwrap_or_default())
+        {
             def = def.multi_target(spec);
-        } else if let Some(spec) = extract_verb_up_to_multi_target(&clause_ir.source_text) {
+        } else if let Some(spec) =
+            extract_verb_up_to_multi_target(clause_ir.source.fragment().unwrap_or_default())
+        {
             def = def.multi_target(spec);
         } else if let Some(ref spec) = clause_ir.multi_target {
             def = def.multi_target(spec.clone());
         } else if let Some(ref spec) = clause_ir.parsed.multi_target {
             def = def.multi_target(spec.clone());
         }
-        if parse_controlled_by_different_players_target_constraint(&clause_ir.source_text) {
+        if parse_controlled_by_different_players_target_constraint(
+            clause_ir.source.fragment().unwrap_or_default(),
+        ) {
             def = def.target_constraint(TargetSelectionConstraint::DifferentObjectControllers);
         }
-        if let Some(constraint) = parse_same_zone_owner_target_constraint(&clause_ir.source_text) {
+        if let Some(constraint) =
+            parse_same_zone_owner_target_constraint(clause_ir.source.fragment().unwrap_or_default())
+        {
             def = def.target_constraint(constraint);
         }
-        if let Some(constraint) = parse_total_mana_value_target_constraint(&clause_ir.source_text) {
+        if let Some(constraint) = parse_total_mana_value_target_constraint(
+            clause_ir.source.fragment().unwrap_or_default(),
+        ) {
             def = def.target_constraint(constraint);
         }
         // CR 601.2d: Propagate distribute flag.
@@ -2023,7 +2074,11 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
         // CR 603.7: Cross-clause pronoun → mark uses_tracked_set on delayed trigger
         // and bind direct follow-up ParentTarget references to the affected set.
         if !current_defs.is_empty() {
-            let source_text_lower = clause_ir.source_text.to_lowercase();
+            let source_text_lower = clause_ir
+                .source
+                .fragment()
+                .unwrap_or_default()
+                .to_lowercase();
             // CR 603.7: Scan ALL prior clauses for a tracked-set publisher — an
             // intermediate non-publishing clause (e.g. Investigate) must not
             // shadow an earlier exile clause. Example: Disorder in the Court
@@ -2074,8 +2129,9 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
 
         defs.extend(current_defs);
 
-        // Apply intrinsic continuation after extending defs with current clause's defs.
-        if let Some(ref continuation) = clause_ir.intrinsic_continuation {
+        // Apply intrinsic continuation after extending defs with current clause's
+        // defs (`Emit.intrinsic`).
+        if let Some(continuation) = clause_ir.disposition.intrinsic() {
             apply_clause_continuation(&mut defs, continuation.clone(), kind);
             apply_where_x_to_latest_def(&mut defs, clause_ir.where_x_expression.as_deref());
         }
@@ -2599,7 +2655,11 @@ fn filter_mentions_exiled_by_source(filter: &TargetFilter) -> bool {
 
 fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetChoiceTiming {
     if let Effect::PutCounter { target, .. } = &clause_ir.parsed.effect {
-        let lower = clause_ir.source_text.to_ascii_lowercase();
+        let lower = clause_ir
+            .source
+            .fragment()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
         if !nom_primitives::scan_contains(&lower, "target ")
             && target.contains_source_attachment_host()
         {
@@ -2607,7 +2667,11 @@ fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetChoiceTiming {
         }
     }
     if matches!(clause_ir.parsed.effect, Effect::MultiplyCounter { .. }) {
-        let lower = clause_ir.source_text.to_ascii_lowercase();
+        let lower = clause_ir
+            .source
+            .fragment()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
         if !nom_primitives::scan_contains(&lower, "target ") {
             return TargetChoiceTiming::Resolution;
         }
@@ -2622,7 +2686,11 @@ fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetChoiceTiming {
         }
     ) && clause_ir.multi_target.is_some()
     {
-        let lower = clause_ir.source_text.to_ascii_lowercase();
+        let lower = clause_ir
+            .source
+            .fragment()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
         if !nom_primitives::scan_contains(&lower, "target ") {
             return TargetChoiceTiming::Resolution;
         }
@@ -2639,7 +2707,11 @@ fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetChoiceTiming {
         return TargetChoiceTiming::Stack;
     }
 
-    let lower = clause_ir.source_text.to_ascii_lowercase();
+    let lower = clause_ir
+        .source
+        .fragment()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
     if nom_primitives::scan_contains(&lower, "target ") {
         TargetChoiceTiming::Stack
     } else {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -149,7 +149,8 @@ use self::subject::{
 use crate::parser::oracle_ir::ast::*;
 pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup};
 use crate::parser::oracle_ir::effect_chain::{
-    AbilityIr, AbilityShellIr, ClauseIr, EffectChainIr, SpecialClause,
+    AbilityIr, AbilityShellIr, ClauseDisposition, ClauseIr, ClauseIrBuilder, EffectChainIr,
+    SpecialClause,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -274,7 +275,7 @@ fn if_you_do_object_anchor(
     clauses
         .iter()
         .rev()
-        .find(|clause| !clause.absorbed_by_followup)
+        .find(|clause| !matches!(clause.disposition, ClauseDisposition::Continue { .. }))
         .and_then(|clause| match &clause.parsed.effect {
             Effect::GenericEffect {
                 static_abilities,
@@ -331,7 +332,7 @@ fn rewrite_cant_rider_for_non_zone_change_parent(
     let prev_is_turn_face_up = clauses
         .iter()
         .rev()
-        .find(|clause| !clause.absorbed_by_followup)
+        .find(|clause| !matches!(clause.disposition, ClauseDisposition::Continue { .. }))
         .is_some_and(|clause| matches!(clause.parsed.effect, Effect::TurnFaceUp { .. }));
     if prev_is_turn_face_up {
         return Some(AbilityCondition::Not {
@@ -23924,60 +23925,35 @@ fn clause_has_anaphoric_control_condition(clause: &ClauseIr) -> bool {
 /// CR 701.42a: Build the single `ClauseIr` for an atomic meld effect clause.
 /// All chain-assembly fields are inert (no condition/continuation/scope) — the
 /// own/control gate rides the trigger's intervening-if, not the effect chain.
-fn meld_single_clause(effect: Effect, source_text: &str) -> ClauseIr {
-    ClauseIr {
-        parsed: parsed_clause(effect),
-        boundary: Some(ClauseBoundary::Sentence),
-        condition: None,
-        is_optional: false,
-        opponent_may_scope: None,
-        repeat_for: None,
-        player_scope: None,
-        starting_with: None,
-        delayed_condition: None,
-        prefix_delayed_condition: None,
-        intrinsic_continuation: None,
-        followup_continuation: None,
-        absorbed_by_followup: false,
-        multi_target: None,
-        where_x_expression: None,
-        is_otherwise: false,
-        unless_pay: None,
-        special: None,
-        source_text: source_text.to_string(),
-        target_selection_mode: TargetSelectionMode::Chosen,
-        target_chooser: None,
-    }
+fn meld_clause(b: &mut ClauseIrBuilder, effect: Effect, source_text: &str) {
+    b.clause(
+        source_text,
+        parsed_clause(effect),
+        Some(ClauseBoundary::Sentence),
+        ClauseDisposition::Emit {
+            followup: None,
+            intrinsic: None,
+        },
+    )
+    .push();
 }
 
-fn unimplemented_clause_ir(
+fn unimplemented_clause(
+    b: &mut ClauseIrBuilder,
     name: &str,
     source_text: &str,
     boundary: Option<ClauseBoundary>,
-) -> ClauseIr {
-    ClauseIr {
-        parsed: parsed_clause(Effect::unimplemented(name, source_text)),
+) {
+    b.clause(
+        source_text,
+        parsed_clause(Effect::unimplemented(name, source_text)),
         boundary,
-        condition: None,
-        is_optional: false,
-        opponent_may_scope: None,
-        repeat_for: None,
-        player_scope: None,
-        starting_with: None,
-        delayed_condition: None,
-        prefix_delayed_condition: None,
-        intrinsic_continuation: None,
-        followup_continuation: None,
-        absorbed_by_followup: false,
-        multi_target: None,
-        where_x_expression: None,
-        is_otherwise: false,
-        unless_pay: None,
-        special: None,
-        source_text: source_text.to_string(),
-        target_selection_mode: TargetSelectionMode::Chosen,
-        target_chooser: None,
-    }
+        ClauseDisposition::Emit {
+            followup: None,
+            intrinsic: None,
+        },
+    )
+    .push();
 }
 
 pub(crate) fn parse_effect_chain_ir(
@@ -24070,8 +24046,10 @@ pub(crate) fn parse_effect_chain_ir(
         .is_some_and(|lower| lower.contains(meld::MELD_EFFECT_MARKER))
     {
         if let Some(effect) = meld::parse_meld_effect_clause(full_text.trim(), ctx) {
+            let mut meld_builder = ClauseIrBuilder::new(full_text);
+            meld_clause(&mut meld_builder, effect, full_text);
             return EffectChainIr {
-                clauses: vec![meld_single_clause(effect, full_text)],
+                clauses: meld_builder.finish(),
                 kind,
                 chain_rounding,
                 actor: ctx.actor.clone(),
@@ -24089,7 +24067,7 @@ pub(crate) fn parse_effect_chain_ir(
     // sibling clauses in the same sentence ("Target player loses X life")
     // substitute X with the same expression. Delimited by ClauseBoundary::Sentence.
     let sentence_where_x = compute_sentence_where_x(&chunks);
-    let mut clauses: Vec<ClauseIr> = Vec::new();
+    let mut builder = ClauseIrBuilder::new(full_text);
 
     // CR 608.2c + CR 117.3a: "Anchor subject" for chain-level anaphoric
     // inheritance. When a clause in the chain declares an explicit player-scope
@@ -24238,32 +24216,21 @@ pub(crate) fn parse_effect_chain_ir(
                     // RemoveAllAbilities first.
                     grants.insert(0, ContinuousModification::RemoveAllAbilities);
                 }
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::ReturnAsAura {
-                        enchant_filter,
-                        grants,
-                    }),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: starting_with.clone(),
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: None,
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        parsed_clause(Effect::ReturnAsAura {
+                            enchant_filter,
+                            grants,
+                        }),
+                        chunk.boundary_after,
+                        ClauseDisposition::Emit {
+                            followup: None,
+                            intrinsic: None,
+                        },
+                    )
+                    .starting_with(starting_with.clone())
+                    .push();
                 continue;
             }
         }
@@ -24298,33 +24265,22 @@ pub(crate) fn parse_effect_chain_ir(
                     }),
                     minimum: 0,
                 };
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::GivePlayerCounter {
-                        counter_kind: kind,
-                        count,
-                        target,
-                    }),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: starting_with.clone(),
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: None,
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        parsed_clause(Effect::GivePlayerCounter {
+                            counter_kind: kind,
+                            count,
+                            target,
+                        }),
+                        chunk.boundary_after,
+                        ClauseDisposition::Emit {
+                            followup: None,
+                            intrinsic: None,
+                        },
+                    )
+                    .starting_with(starting_with.clone())
+                    .push();
                 continue;
             }
         }
@@ -24339,10 +24295,11 @@ pub(crate) fn parse_effect_chain_ir(
         // folds this into the put's `sub_ability`; `rewire_result_anchored_subchain`
         // then re-affirms `forward_result` (moved card -> Attach source; original
         // source -> injected target).
-        let prev_moves_to_battlefield = clauses
+        let prev_moves_to_battlefield = builder
+            .clauses()
             .iter()
             .rev()
-            .find(|c| !c.absorbed_by_followup)
+            .find(|c| !matches!(c.disposition, ClauseDisposition::Continue { .. }))
             .is_some_and(|c| {
                 matches!(
                     &c.parsed.effect,
@@ -24359,11 +24316,19 @@ pub(crate) fn parse_effect_chain_ir(
             if let Some((condition, attach, is_optional)) =
                 try_parse_moved_card_subtype_attach_followup(normalized_text)
             {
-                let mut clause = meld_single_clause(attach, normalized_text);
-                clause.boundary = chunk.boundary_after;
-                clause.condition = Some(condition);
-                clause.is_optional = is_optional;
-                clauses.push(clause);
+                builder
+                    .clause(
+                        normalized_text,
+                        parsed_clause(attach),
+                        chunk.boundary_after,
+                        ClauseDisposition::Emit {
+                            followup: None,
+                            intrinsic: None,
+                        },
+                    )
+                    .condition(Some(condition))
+                    .is_optional(is_optional)
+                    .push();
                 continue;
             }
         }
@@ -24377,40 +24342,24 @@ pub(crate) fn parse_effect_chain_ir(
         // Sage's Scion: the granted card is cast by paying life equal to its
         // mana value instead of paying its mana cost.
         if let Some(cost) = try_parse_alt_cost_rider(normalized_text) {
-            clauses.push(ClauseIr {
-                parsed: parsed_clause(Effect::Unimplemented {
-                    name: "alt_cost_rider_placeholder".to_string(),
-                    description: None,
-                }),
-                boundary: chunk.boundary_after,
-                // CR 118.9: `condition: None` is intentional. The chunk's
-                // "If you do," gate (`OptionalEffectPerformed`) is deliberately
-                // discarded: the alternative cost is inherently conditional on the
-                // cast occurring, and `attach_alt_cost_to_prior_cast_from_zone`
-                // ties it to the `CastFromZone` permission, which only charges the
-                // cost when a card is actually picked and cast. Propagating the
-                // condition would double-gate (the folded `alt_ability_cost` has no
-                // condition field to carry it anyway).
-                condition: None,
-                is_optional: false,
-                opponent_may_scope: None,
-                repeat_for: None,
-                player_scope: None,
-                starting_with: None,
-                delayed_condition: None,
-                prefix_delayed_condition: None,
-                intrinsic_continuation: None,
-                followup_continuation: None,
-                absorbed_by_followup: false,
-                multi_target: None,
-                where_x_expression: None,
-                is_otherwise: false,
-                unless_pay: None,
-                special: Some(SpecialClause::AltCostRider(cost)),
-                source_text: normalized_text.to_string(),
-                target_selection_mode: TargetSelectionMode::Chosen,
-                target_chooser: None,
-            });
+            // CR 118.9: The chunk's "If you do," gate (`OptionalEffectPerformed`)
+            // is deliberately discarded (no `condition`): the alternative cost is
+            // inherently conditional on the cast occurring, and
+            // `attach_alt_cost_to_prior_cast_from_zone` ties it to the
+            // `CastFromZone` permission, which only charges the cost when a card is
+            // actually picked and cast. Propagating the condition would double-gate
+            // (the folded `alt_ability_cost` has no condition field to carry it).
+            builder
+                .clause(
+                    normalized_text,
+                    placeholder_parsed_clause("alt_cost_rider_placeholder"),
+                    chunk.boundary_after,
+                    ClauseDisposition::Special {
+                        action: SpecialClause::AltCostRider(cost),
+                        intrinsic: None,
+                    },
+                )
+                .push();
             continue;
         }
 
@@ -24425,17 +24374,20 @@ pub(crate) fn parse_effect_chain_ir(
         {
             let foretell_lower = normalized_text.to_lowercase();
             if sequence::is_foretell_cost_override_sentence(&foretell_lower) {
-                if let Some(absorbed) = clauses.iter_mut().rev().find(|c| {
-                    c.absorbed_by_followup
-                        && matches!(
-                            c.followup_continuation,
-                            Some(ContinuationAst::BecomesForetold)
-                        )
+                if let Some(absorbed) = builder.clauses_mut().iter_mut().rev().find(|c| {
+                    matches!(
+                        c.disposition,
+                        ClauseDisposition::Continue {
+                            continuation: Some(ContinuationAst::BecomesForetold)
+                        }
+                    )
                 }) {
                     // Suppress the grant: clear the BecomesForetold
                     // continuation so lowering does not emit the wrong {0}
                     // permission (strict failure until cost is representable).
-                    absorbed.followup_continuation = None;
+                    // The clause stays absorbed (Continue) — it must NOT fall
+                    // back to emitting its parsed effect.
+                    absorbed.disposition = ClauseDisposition::Continue { continuation: None };
                 }
                 // Fall through: parses as Unimplemented, accurately
                 // documenting that effect-defined foretell costs are
@@ -24444,33 +24396,18 @@ pub(crate) fn parse_effect_chain_ir(
         }
 
         if let Some(expiry) = try_parse_mana_retention_rider(normalized_text) {
-            if !clauses.is_empty() {
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::Unimplemented {
-                        name: "mana_retention_placeholder".to_string(),
-                        description: None,
-                    }),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: Some(SpecialClause::ManaRetention(expiry)),
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+            if !builder.is_empty() {
+                builder
+                    .clause(
+                        normalized_text,
+                        placeholder_parsed_clause("mana_retention_placeholder"),
+                        chunk.boundary_after,
+                        ClauseDisposition::Special {
+                            action: SpecialClause::ManaRetention(expiry),
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 continue;
             }
         }
@@ -24483,38 +24420,27 @@ pub(crate) fn parse_effect_chain_ir(
         // either fire both branches or neither (issue #1510, Auntie Ool). Requires a
         // prior clause to carry an anaphoric-control condition so this only engages
         // as a genuine else over a matching positive antecedent.
-        if clauses.iter().any(clause_has_anaphoric_control_condition) {
+        if builder
+            .clauses()
+            .iter()
+            .any(clause_has_anaphoric_control_condition)
+        {
             if let Some(else_text) = strip_inverse_control_otherwise_connector(normalized_text) {
                 let else_def = {
                     let ir = parse_effect_chain_ir(&else_text, kind, ctx);
                     lower_effect_chain_ir(&ir)
                 };
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::Unimplemented {
-                        name: "otherwise_placeholder".to_string(),
-                        description: None,
-                    }),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: true,
-                    unless_pay: None,
-                    special: Some(SpecialClause::Otherwise(Box::new(else_def))),
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        placeholder_parsed_clause("otherwise_placeholder"),
+                        chunk.boundary_after,
+                        ClauseDisposition::Special {
+                            action: SpecialClause::Otherwise(Box::new(else_def)),
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 continue;
             }
         }
@@ -24544,7 +24470,7 @@ pub(crate) fn parse_effect_chain_ir(
             // `ctx.parent_target_available` so the recursive parse binds the else
             // anaphor ("... and it's a 3/3 Robot ...") to `ParentTarget`. Saved and
             // restored so sibling outer chunks are unaffected.
-            let else_inherits_parent = chain_has_prior_typed_referent(&clauses, true);
+            let else_inherits_parent = chain_has_prior_typed_referent(builder.clauses(), true);
             let saved_parent_target_available = ctx.parent_target_available;
             ctx.parent_target_available = saved_parent_target_available || else_inherits_parent;
             let mut else_def = {
@@ -24557,7 +24483,7 @@ pub(crate) fn parse_effect_chain_ir(
             // lifetime, not `Permanent` (see helper doc).
             rebind_reanimate_animation_until_leaves(&mut else_def);
             // Check whether a prior clause has a condition — lowering will attach as else_ability
-            let has_condition = clauses.iter().any(|c| c.condition.is_some());
+            let has_condition = builder.clauses().iter().any(|c| c.condition.is_some());
             // CR 608.2d + CR 101.4: a standalone "If no one does, X" reward on an
             // "any opponent/player may" head (Browbeat, Book Burning) has no
             // explicit "if a player does" condition clause, but the may-head IS a
@@ -24566,38 +24492,26 @@ pub(crate) fn parse_effect_chain_ir(
             // OptionalEffectPerformed sub the runtime decline path walks, instead
             // of the unconditional `OtherwiseFallback` (which would fire the
             // reward ALWAYS and emit an Unimplemented placeholder).
-            let has_optional_may_head = clauses.iter().any(|c| c.opponent_may_scope.is_some());
+            let has_optional_may_head = builder
+                .clauses()
+                .iter()
+                .any(|c| c.opponent_may_scope.is_some());
             let special = if has_condition || has_optional_may_head {
                 SpecialClause::Otherwise(Box::new(else_def))
             } else {
                 SpecialClause::OtherwiseFallback(Box::new(else_def))
             };
-            clauses.push(ClauseIr {
-                parsed: parsed_clause(Effect::Unimplemented {
-                    name: "otherwise_placeholder".to_string(),
-                    description: None,
-                }),
-                boundary: chunk.boundary_after,
-                condition: None,
-                is_optional: false,
-                opponent_may_scope: None,
-                repeat_for: None,
-                player_scope: None,
-                starting_with: None,
-                delayed_condition: None,
-                prefix_delayed_condition: None,
-                intrinsic_continuation: None,
-                followup_continuation: None,
-                absorbed_by_followup: false,
-                multi_target: None,
-                where_x_expression: None,
-                is_otherwise: true,
-                unless_pay: None,
-                special: Some(special),
-                source_text: normalized_text.to_string(),
-                target_selection_mode: TargetSelectionMode::Chosen,
-                target_chooser: None,
-            });
+            builder
+                .clause(
+                    normalized_text,
+                    placeholder_parsed_clause("otherwise_placeholder"),
+                    chunk.boundary_after,
+                    ClauseDisposition::Special {
+                        action: special,
+                        intrinsic: None,
+                    },
+                )
+                .push();
             continue;
         }
 
@@ -24606,34 +24520,19 @@ pub(crate) fn parse_effect_chain_ir(
         // additional keyword. Recorded as a `SpecialClause`; lowering reads
         // the antecedent grant template and emits one `StaticDefinition` per
         // keyword. Requires a prior clause to attach to.
-        if !clauses.is_empty() {
+        if !builder.is_empty() {
             if let Some(keywords) = try_parse_same_is_true_continuation(normalized_text) {
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::Unimplemented {
-                        name: "same_is_true_for_placeholder".to_string(),
-                        description: None,
-                    }),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: Some(SpecialClause::SameIsTrueFor(keywords)),
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        placeholder_parsed_clause("same_is_true_for_placeholder"),
+                        chunk.boundary_after,
+                        ClauseDisposition::Special {
+                            action: SpecialClause::SameIsTrueFor(keywords),
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 continue;
             }
         }
@@ -24643,34 +24542,19 @@ pub(crate) fn parse_effect_chain_ir(
         // whose `tag("repeat this process")` would otherwise swallow the prefix
         // and discard the keyword list. Replicates the antecedent conditional
         // keyword-counter clause once per listed keyword during lowering.
-        if !clauses.is_empty() {
+        if !builder.is_empty() {
             if let Some(keywords) = try_parse_repeat_process_for_keywords(normalized_text) {
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::Unimplemented {
-                        name: "repeat_process_for_keywords_placeholder".to_string(),
-                        description: None,
-                    }),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: Some(SpecialClause::RepeatProcessForKeywords(keywords)),
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        placeholder_parsed_clause("repeat_process_for_keywords_placeholder"),
+                        chunk.boundary_after,
+                        ClauseDisposition::Special {
+                            action: SpecialClause::RepeatProcessForKeywords(keywords),
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 continue;
             }
         }
@@ -24686,33 +24570,21 @@ pub(crate) fn parse_effect_chain_ir(
         // `try_parse_exiled_this_way_keyword_grant` for the full explanation.
         // Requires a prior exile clause to publish the tracked set it broadcasts
         // to.
-        if !clauses.is_empty() {
+        if !builder.is_empty() {
             if let Some(parsed) =
                 subject::try_parse_exiled_this_way_keyword_grant(normalized_text, ctx)
             {
-                clauses.push(ClauseIr {
-                    parsed,
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: None,
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        parsed,
+                        chunk.boundary_after,
+                        ClauseDisposition::Emit {
+                            followup: None,
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 continue;
             }
         }
@@ -24730,36 +24602,26 @@ pub(crate) fn parse_effect_chain_ir(
         // that player gains 2 life"), requiring no new engine variant, resolver,
         // or scope. Placed before the targeted-opponent form so the scoped
         // fan-out wins (the two subjects are disjoint: "each …" vs "target …").
-        if let Some(prev_effect) = clauses
+        if let Some(prev_effect) = builder
+            .clauses()
             .iter()
             .rev()
-            .find(|clause| !clause.absorbed_by_followup)
+            .find(|clause| !matches!(clause.disposition, ClauseDisposition::Continue { .. }))
             .map(|clause| clause.parsed.effect.clone())
         {
             if let Some(scope) = sequence::try_parse_scoped_does_the_same(normalized_text) {
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(prev_effect),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: Some(scope),
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: None,
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        parsed_clause(prev_effect),
+                        chunk.boundary_after,
+                        ClauseDisposition::Emit {
+                            followup: None,
+                            intrinsic: None,
+                        },
+                    )
+                    .player_scope(Some(scope))
+                    .push();
                 continue;
             }
         }
@@ -24776,34 +24638,22 @@ pub(crate) fn parse_effect_chain_ir(
         // misparse: a flagged gap beats a wrong parse (CLAUDE.md #1 hard rule).
         // The `DoesTheSameSubject` typing is preserved so the eventual fix and
         // the deferred "each opponent … does the same" fanout slot in cleanly.
-        if !clauses.is_empty() {
+        if !builder.is_empty() {
             if let Some(subject) = sequence::try_parse_does_the_same_clause(normalized_text) {
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::unimplemented(
-                        sequence::does_the_same_unimplemented_name(subject),
-                        normalized_text.to_string(),
-                    )),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: None,
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        parsed_clause(Effect::unimplemented(
+                            sequence::does_the_same_unimplemented_name(subject),
+                            normalized_text.to_string(),
+                        )),
+                        chunk.boundary_after,
+                        ClauseDisposition::Emit {
+                            followup: None,
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 continue;
             }
         }
@@ -24839,7 +24689,7 @@ pub(crate) fn parse_effect_chain_ir(
                 // ability, and the ungated whole-chain driver (effects/mod.rs
                 // `repeated_full_chain`) then loops the exile→return process.
                 RepeatProcessOutcome::FixedCount(qty) => {
-                    if let Some(first) = clauses.first_mut() {
+                    if let Some(first) = builder.clauses_mut().first_mut() {
                         first.repeat_for = Some(qty);
                     }
                 }
@@ -24899,33 +24749,18 @@ pub(crate) fn parse_effect_chain_ir(
         if let Some(rider_def) =
             try_parse_die_exile_rider(rider_lower.trim_end_matches('.').trim(), kind)
         {
-            if !clauses.is_empty() {
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::Unimplemented {
-                        name: "die_exile_rider_placeholder".to_string(),
-                        description: None,
-                    }),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: Some(SpecialClause::DieExileRider(Box::new(rider_def))),
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+            if !builder.is_empty() {
+                builder
+                    .clause(
+                        normalized_text,
+                        placeholder_parsed_clause("die_exile_rider_placeholder"),
+                        chunk.boundary_after,
+                        ClauseDisposition::Special {
+                            action: SpecialClause::DieExileRider(Box::new(rider_def)),
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 continue;
             }
         }
@@ -24938,10 +24773,11 @@ pub(crate) fn parse_effect_chain_ir(
         // static binds to via `TrackedSet`. Guarded on a preceding damage clause
         // so the targeted/anaphor regen forms (Hurr Jackal, Lim-Dûl's Cohort)
         // keep their standalone in-chain dispatch.
-        if clauses
+        if builder
+            .clauses()
             .iter()
             .rev()
-            .find(|clause| !clause.absorbed_by_followup)
+            .find(|clause| !matches!(clause.disposition, ClauseDisposition::Continue { .. }))
             .is_some_and(|clause| {
                 matches!(
                     &clause.parsed.effect,
@@ -25020,58 +24856,34 @@ pub(crate) fn parse_effect_chain_ir(
                     &subject::cant_be_regenerated_tracked_set_application(),
                 );
                 regen_def.condition = Some(creature_match.clone());
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::unimplemented(
-                        "cant_be_regenerated_rider_placeholder",
-                        "",
-                    )),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: Some(SpecialClause::CantBeRegeneratedRider(Box::new(regen_def))),
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        parsed_clause(Effect::unimplemented(
+                            "cant_be_regenerated_rider_placeholder",
+                            "",
+                        )),
+                        chunk.boundary_after,
+                        ClauseDisposition::Special {
+                            action: SpecialClause::CantBeRegeneratedRider(Box::new(regen_def)),
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 // Stamp the same creature-gate condition on the die-exile rider
                 // (it swallowed the leading "if " during parse) and push it second.
                 exile_def.condition = Some(creature_match);
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::unimplemented("die_exile_rider_placeholder", "")),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: Some(SpecialClause::DieExileRider(Box::new(exile_def))),
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        parsed_clause(Effect::unimplemented("die_exile_rider_placeholder", "")),
+                        chunk.boundary_after,
+                        ClauseDisposition::Special {
+                            action: SpecialClause::DieExileRider(Box::new(exile_def)),
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 true
             };
             if conditional_regen_matched {
@@ -25081,41 +24893,29 @@ pub(crate) fn parse_effect_chain_ir(
                 normalized_text.trim_end_matches('.').trim(),
                 kind,
             ) {
-                clauses.push(ClauseIr {
-                    // Structural sentinel: replaced during lowering by the
-                    // SpecialClause attach (mirrors the DieExileRider placeholder).
-                    parsed: parsed_clause(Effect::unimplemented(
-                        "cant_be_regenerated_rider_placeholder",
-                        "",
-                    )),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: Some(SpecialClause::CantBeRegeneratedRider(Box::new(rider_def))),
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                // Structural sentinel: replaced during lowering by the
+                // SpecialClause attach (mirrors the DieExileRider placeholder).
+                builder
+                    .clause(
+                        normalized_text,
+                        parsed_clause(Effect::unimplemented(
+                            "cant_be_regenerated_rider_placeholder",
+                            "",
+                        )),
+                        chunk.boundary_after,
+                        ClauseDisposition::Special {
+                            action: SpecialClause::CantBeRegeneratedRider(Box::new(rider_def)),
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 continue;
             }
         }
 
         if is_free_cast_exile_instead_rider(rider_lower.trim_end_matches('.').trim()) {
-            if let Some(previous) = clauses.iter_mut().rev().find(|clause| {
-                !clause.absorbed_by_followup
+            if let Some(previous) = builder.clauses_mut().iter_mut().rev().find(|clause| {
+                !matches!(clause.disposition, ClauseDisposition::Continue { .. })
                     && matches!(&clause.parsed.effect, Effect::FreeCastFromZones { .. })
             }) {
                 if let Effect::FreeCastFromZones {
@@ -25132,33 +24932,18 @@ pub(crate) fn parse_effect_chain_ir(
         if let Some(life_payment) =
             try_parse_drawn_this_turn_pay_or_topdeck_followup(normalized_text)
         {
-            if !clauses.is_empty() {
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::Unimplemented {
-                        name: "drawn_this_turn_pay_or_topdeck_placeholder".to_string(),
-                        description: None,
-                    }),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: Some(SpecialClause::DrawnThisTurnPayOrTopdeck { life_payment }),
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+            if !builder.is_empty() {
+                builder
+                    .clause(
+                        normalized_text,
+                        placeholder_parsed_clause("drawn_this_turn_pay_or_topdeck_placeholder"),
+                        chunk.boundary_after,
+                        ClauseDisposition::Special {
+                            action: SpecialClause::DrawnThisTurnPayOrTopdeck { life_payment },
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 continue;
             }
         }
@@ -25174,7 +24959,11 @@ pub(crate) fn parse_effect_chain_ir(
             // effect to pass to try_parse_dig_instead_alternative (which inspects the
             // previous effect to check it's a Dig). Must skip absorbed clauses — in the
             // old code, absorbed chunks are not in `defs`, so `defs.last()` is the Dig.
-            let prev_clause = clauses.iter().rev().find(|c| !c.absorbed_by_followup);
+            let prev_clause = builder
+                .clauses()
+                .iter()
+                .rev()
+                .find(|c| !matches!(c.disposition, ClauseDisposition::Continue { .. }));
             let prev_temp =
                 prev_clause.map(|c| AbilityDefinition::new(kind, c.parsed.effect.clone()));
             let inherited_where_x_expression =
@@ -25182,34 +24971,23 @@ pub(crate) fn parse_effect_chain_ir(
             if let Some(alt_def) =
                 try_parse_dig_instead_alternative(normalized_text, prev_temp.as_ref(), kind, ctx)
             {
-                if !clauses.is_empty() {
+                if !builder.is_empty() {
                     // Store the alt_def's effect as `parsed.effect` so followup continuation
                     // matching (e.g., PutRest for "put the rest on the bottom") can see that
                     // the effective last clause is a Dig. In the old code, `defs.last()` was
                     // the alt_def (a Dig) after the DigInsteadAlt was processed.
-                    clauses.push(ClauseIr {
-                        parsed: parsed_clause((*alt_def.effect).clone()),
-                        boundary: chunk.boundary_after,
-                        condition: None,
-                        is_optional: false,
-                        opponent_may_scope: None,
-                        repeat_for: None,
-                        player_scope: None,
-                        starting_with: None,
-                        delayed_condition: None,
-                        prefix_delayed_condition: None,
-                        intrinsic_continuation: None,
-                        followup_continuation: None,
-                        absorbed_by_followup: false,
-                        multi_target: None,
-                        where_x_expression: inherited_where_x_expression,
-                        is_otherwise: false,
-                        unless_pay: None,
-                        special: Some(SpecialClause::DigInsteadAlt(Box::new(alt_def))),
-                        source_text: normalized_text.to_string(),
-                        target_selection_mode: TargetSelectionMode::Chosen,
-                        target_chooser: None,
-                    });
+                    builder
+                        .clause(
+                            normalized_text,
+                            parsed_clause((*alt_def.effect).clone()),
+                            chunk.boundary_after,
+                            ClauseDisposition::Special {
+                                action: SpecialClause::DigInsteadAlt(Box::new(alt_def)),
+                                intrinsic: None,
+                            },
+                        )
+                        .where_x_expression(inherited_where_x_expression)
+                        .push();
                     continue;
                 }
             }
@@ -25236,29 +25014,17 @@ pub(crate) fn parse_effect_chain_ir(
                     flipper: TargetFilter::Controller,
                 }
             };
-            clauses.push(ClauseIr {
-                parsed: parsed_clause(flip_effect),
-                boundary: chunk.boundary_after,
-                condition: None,
-                is_optional: false,
-                opponent_may_scope: None,
-                repeat_for: None,
-                player_scope: None,
-                starting_with: None,
-                delayed_condition: None,
-                prefix_delayed_condition: None,
-                intrinsic_continuation: None,
-                followup_continuation: None,
-                absorbed_by_followup: false,
-                multi_target: None,
-                where_x_expression: None,
-                is_otherwise: false,
-                unless_pay: None,
-                special: None,
-                source_text: normalized_text.to_string(),
-                target_selection_mode: TargetSelectionMode::Chosen,
-                target_chooser: None,
-            });
+            builder
+                .clause(
+                    normalized_text,
+                    parsed_clause(flip_effect),
+                    chunk.boundary_after,
+                    ClauseDisposition::Emit {
+                        followup: None,
+                        intrinsic: None,
+                    },
+                )
+                .push();
             continue;
         }
 
@@ -25272,58 +25038,34 @@ pub(crate) fn parse_effect_chain_ir(
         // antecedent.
         if let Some(parsed) = try_parse_conditional_damage_prevention_with_followup(normalized_text)
         {
-            clauses.push(ClauseIr {
-                parsed,
-                boundary: chunk.boundary_after,
-                condition: None,
-                is_optional: false,
-                opponent_may_scope: None,
-                repeat_for: None,
-                player_scope: None,
-                starting_with: None,
-                delayed_condition: None,
-                prefix_delayed_condition: None,
-                intrinsic_continuation: None,
-                followup_continuation: None,
-                absorbed_by_followup: false,
-                multi_target: None,
-                where_x_expression: None,
-                is_otherwise: false,
-                unless_pay: None,
-                special: None,
-                source_text: normalized_text.to_string(),
-                target_selection_mode: TargetSelectionMode::Chosen,
-                target_chooser: None,
-            });
+            builder
+                .clause(
+                    normalized_text,
+                    parsed,
+                    chunk.boundary_after,
+                    ClauseDisposition::Emit {
+                        followup: None,
+                        intrinsic: None,
+                    },
+                )
+                .push();
             continue;
         }
 
         if let Some(effect) =
             try_parse_next_time_source_damage_replacement(&normalized_text.to_lowercase())
         {
-            clauses.push(ClauseIr {
-                parsed: parsed_clause(effect),
-                boundary: chunk.boundary_after,
-                condition: None,
-                is_optional: false,
-                opponent_may_scope: None,
-                repeat_for: None,
-                player_scope: None,
-                starting_with: None,
-                delayed_condition: None,
-                prefix_delayed_condition: None,
-                intrinsic_continuation: None,
-                followup_continuation: None,
-                absorbed_by_followup: false,
-                multi_target: None,
-                where_x_expression: None,
-                is_otherwise: false,
-                unless_pay: None,
-                special: None,
-                source_text: normalized_text.to_string(),
-                target_selection_mode: TargetSelectionMode::Chosen,
-                target_chooser: None,
-            });
+            builder
+                .clause(
+                    normalized_text,
+                    parsed_clause(effect),
+                    chunk.boundary_after,
+                    ClauseDisposition::Emit {
+                        followup: None,
+                        intrinsic: None,
+                    },
+                )
+                .push();
             continue;
         }
 
@@ -25331,38 +25073,23 @@ pub(crate) fn parse_effect_chain_ir(
         // is replaced when the condition holds. Keep the base effect as the root so
         // target collection stays anchored on the printed target-bearing clause.
         if let Some(instead_def) = try_parse_generic_instead_clause(normalized_text, kind, ctx) {
-            if !clauses.is_empty() {
-                clauses.push(ClauseIr {
-                    parsed: parsed_clause(Effect::Unimplemented {
-                        name: "instead_clause_placeholder".to_string(),
-                        description: None,
-                    }),
-                    boundary: chunk.boundary_after,
-                    condition: None,
-                    is_optional: false,
-                    opponent_may_scope: None,
-                    repeat_for: None,
-                    player_scope: None,
-                    starting_with: None,
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target: None,
-                    where_x_expression: None,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: Some(SpecialClause::InsteadClause(Box::new(instead_def))),
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+            if !builder.is_empty() {
+                builder
+                    .clause(
+                        normalized_text,
+                        placeholder_parsed_clause("instead_clause_placeholder"),
+                        chunk.boundary_after,
+                        ClauseDisposition::Special {
+                            action: SpecialClause::InsteadClause(Box::new(instead_def)),
+                            intrinsic: None,
+                        },
+                    )
+                    .push();
                 continue;
             }
         }
 
-        let has_card_predicate_guess = chain_has_card_predicate_guess(&clauses);
+        let has_card_predicate_guess = chain_has_card_predicate_guess(builder.clauses());
         let (predicate_guess_cond, predicate_guess_text) = if has_card_predicate_guess {
             conditions::strip_card_predicate_guess_result_conditional(normalized_text)
                 .map(|(cond, body)| (Some(cond), body))
@@ -25374,15 +25101,16 @@ pub(crate) fn parse_effect_chain_ir(
             && predicate_guess_cond.is_none()
             && conditions::is_card_predicate_guess_result_conditional(normalized_text)
         {
-            clauses.push(unimplemented_clause_ir(
+            unimplemented_clause(
+                &mut builder,
                 "card_predicate_guess_result_condition",
                 normalized_text,
                 chunk.boundary_after,
-            ));
+            );
             continue;
         }
 
-        let has_guess_outcome_authority = chain_has_guess_outcome_authority(&clauses);
+        let has_guess_outcome_authority = chain_has_guess_outcome_authority(builder.clauses());
         if predicate_guess_cond.is_none()
             && !has_guess_outcome_authority
             && matches!(
@@ -25390,11 +25118,12 @@ pub(crate) fn parse_effect_chain_ir(
                 (Some(_), _)
             )
         {
-            clauses.push(unimplemented_clause_ir(
+            unimplemented_clause(
+                &mut builder,
                 "guess_result_condition",
                 normalized_text,
                 chunk.boundary_after,
-            ));
+            );
             continue;
         }
         // CR 608.2d: "if they guessed wrong/right, ..." — the OpponentGuess
@@ -25439,7 +25168,7 @@ pub(crate) fn parse_effect_chain_ir(
         // preceding `TurnFaceUp` must read the performed-signal, not the
         // zone-change ledger (a successful turn-up changes no zone). See the
         // helper for the full rationale (Etrata, Deadly Fugitive).
-        let condition = rewrite_cant_rider_for_non_zone_change_parent(condition, &clauses);
+        let condition = rewrite_cant_rider_for_non_zone_change_parent(condition, builder.clauses());
         // CR 608.2c: "[effect] a number of times equal to the difference" — when
         // a leading comparison condition was just stripped, a trailing
         // difference-repeat suffix repeats the effect by the unsigned magnitude
@@ -25633,7 +25362,9 @@ pub(crate) fn parse_effect_chain_ir(
                 for clause in &mut body_ir.clauses {
                     apply_outer_condition_to_clause(outer_condition, clause);
                 }
-                clauses.extend(body_ir.clauses);
+                for c in body_ir.clauses {
+                    builder.absorb_clause(c);
+                }
                 continue;
             }
         }
@@ -25646,7 +25377,7 @@ pub(crate) fn parse_effect_chain_ir(
             if condition.is_some()
                 && nom_primitives::scan_contains(&enters_lower, "enter tapped and attacking")
             {
-                if let Some(prev) = clauses.last() {
+                if let Some(prev) = builder.clauses().last() {
                     let can_patch = matches!(
                         prev.parsed.effect,
                         Effect::CopyTokenOf { .. }
@@ -25654,32 +25385,18 @@ pub(crate) fn parse_effect_chain_ir(
                             | Effect::ChangeZone { .. }
                     );
                     if can_patch {
-                        clauses.push(ClauseIr {
-                            parsed: parsed_clause(Effect::Unimplemented {
-                                name: "enters_tapped_attacking_placeholder".to_string(),
-                                description: None,
-                            }),
-                            boundary: chunk.boundary_after,
-                            condition,
-                            is_optional: false,
-                            opponent_may_scope: None,
-                            repeat_for: None,
-                            player_scope: None,
-                            starting_with: None,
-                            delayed_condition: None,
-                            prefix_delayed_condition: None,
-                            intrinsic_continuation: None,
-                            followup_continuation: None,
-                            absorbed_by_followup: false,
-                            multi_target: None,
-                            where_x_expression: None,
-                            is_otherwise: false,
-                            unless_pay: None,
-                            special: Some(SpecialClause::EntersTappedAttacking),
-                            source_text: normalized_text.to_string(),
-                            target_selection_mode: TargetSelectionMode::Chosen,
-                            target_chooser: None,
-                        });
+                        builder
+                            .clause(
+                                normalized_text,
+                                placeholder_parsed_clause("enters_tapped_attacking_placeholder"),
+                                chunk.boundary_after,
+                                ClauseDisposition::Special {
+                                    action: SpecialClause::EntersTappedAttacking,
+                                    intrinsic: None,
+                                },
+                            )
+                            .condition(condition)
+                            .push();
                         continue;
                     }
                 }
@@ -25761,10 +25478,11 @@ pub(crate) fn parse_effect_chain_ir(
             && !sequence::starts_clause_text(&text)
             && sequence::starts_clause_text_or_conjugated(&text)
         {
-            clauses
+            builder
+                .clauses()
                 .iter()
                 .rev()
-                .find(|clause| !clause.absorbed_by_followup)
+                .find(|clause| !matches!(clause.disposition, ClauseDisposition::Continue { .. }))
                 .and_then(|clause| clause.player_scope.clone())
         } else {
             None
@@ -25811,7 +25529,7 @@ pub(crate) fn parse_effect_chain_ir(
                 //     (Refurbished-Familiar-class, mandatory parent — CR 101.3
                 //     + CR 118.12 mandatory-cost branch).
                 // Recipient rebinds resolve "that player"/"you".
-                if let Some(prev) = clauses.last_mut() {
+                if let Some(prev) = builder.last_mut() {
                     if prev.boundary == Some(ClauseBoundary::Sentence) {
                         prev.boundary = Some(ClauseBoundary::Then);
                     }
@@ -25863,7 +25581,7 @@ pub(crate) fn parse_effect_chain_ir(
                 // and decline share the scope) the `ScopedPlayerMatches`
                 // conjunct is trivially true for every iteration and acts as
                 // a no-op, so this is uniformly safe for the whole class.
-                if let Some(prev) = clauses.last_mut() {
+                if let Some(prev) = builder.last_mut() {
                     if prev.boundary == Some(ClauseBoundary::Sentence) {
                         prev.boundary = Some(ClauseBoundary::Then);
                     }
@@ -25900,7 +25618,7 @@ pub(crate) fn parse_effect_chain_ir(
                 // ScopedPlayerMatches conjunct is rules-correct for the same-scope
                 // Wernog class: parent and decline both iterate `Opponent`, so the
                 // scope conjunct would be a trivial no-op (CR 109.5).
-                if let Some(prev) = clauses.last_mut() {
+                if let Some(prev) = builder.last_mut() {
                     if prev.boundary == Some(ClauseBoundary::Sentence) {
                         prev.boundary = Some(ClauseBoundary::Then);
                     }
@@ -25940,7 +25658,7 @@ pub(crate) fn parse_effect_chain_ir(
                 // within-action ContinuationStep that stays inside the scoped
                 // template (no-op when the boundary is already Then, e.g. Turtles
                 // in Time's "…, then each player who does draws seven cards").
-                if let Some(prev) = clauses.last_mut() {
+                if let Some(prev) = builder.last_mut() {
                     if prev.boundary == Some(ClauseBoundary::Sentence) {
                         prev.boundary = Some(ClauseBoundary::Then);
                     }
@@ -25992,7 +25710,7 @@ pub(crate) fn parse_effect_chain_ir(
             _ => None,
         }
         .or_else(|| ctx.actor.clone());
-        let if_you_do_anchor = if_you_do_object_anchor(&clauses, &condition);
+        let if_you_do_anchor = if_you_do_object_anchor(builder.clauses(), &condition);
         let chunk_subject = if condition.as_ref().is_some_and(condition_refs_source_object) {
             Some(TargetFilter::SelfRef)
         } else {
@@ -26008,13 +25726,13 @@ pub(crate) fn parse_effect_chain_ir(
         // no-op for all pre-existing cards.
         let parent_target_available = ctx.parent_target_available
             || if_you_do_anchor.is_some()
-            || chain_has_prior_typed_referent(&clauses, false);
+            || chain_has_prior_typed_referent(builder.clauses(), false);
         // CR 608.2c + CR 601.2a: a strict subset of `parent_target_available`
         // restricted to chosen-target referents (Emry), excluding impulse
         // publishers (Territorial Bruntar's `ExileFromTopUntil`). An "if you
         // do" object anchor is a created/tracked referent, not a target
         // selection, so it does not count here.
-        let parent_target_is_chosen = chain_prior_referent_is_chosen_target(&clauses);
+        let parent_target_is_chosen = chain_prior_referent_is_chosen_target(builder.clauses());
         // CR 608.2c (issue #1670): Consumption signal for the body "its
         // controller may" antecedent. True only when the rung ladder below
         // falls through to `chain_parent_target_controller_scope` for THIS
@@ -26089,7 +25807,7 @@ pub(crate) fn parse_effect_chain_ir(
             // token created by an earlier clause when that token is the chain's
             // most-recent object referent (Esper Terra's "put up to three lore
             // counters on it"). Cleared by an intervening explicit typed target.
-            token_created_in_chain: chain_prior_referent_is_created_token(&clauses),
+            token_created_in_chain: chain_prior_referent_is_created_token(builder.clauses()),
             effect_chain_full_lower: ctx.effect_chain_full_lower.clone(),
             parent_target_is_chosen,
             // CR 608.2c + CR 400.7: seed the zone published by an earlier
@@ -26235,29 +25953,27 @@ pub(crate) fn parse_effect_chain_ir(
                     ctx.push_diagnostic(d);
                 }
             }
-            clauses.push(ClauseIr {
-                parsed: parsed_clause(delayed_effect),
-                boundary: chunk.boundary_after,
-                condition: condition.clone(),
-                is_optional,
-                opponent_may_scope,
-                repeat_for: repeat_for.clone(),
-                player_scope,
-                starting_with: starting_with.clone(),
-                delayed_condition: None,
-                prefix_delayed_condition: Some(prefix_condition),
-                intrinsic_continuation: None,
-                followup_continuation: None,
-                absorbed_by_followup: false,
-                multi_target: None,
-                where_x_expression: where_x_expression.clone(),
-                is_otherwise: false,
-                unless_pay: None,
-                special: None,
-                source_text: normalized_text.to_string(),
-                target_selection_mode: chunk_ctx.target_selection_mode,
-                target_chooser: chunk_ctx.target_chooser.clone(),
-            });
+            builder
+                .clause(
+                    normalized_text,
+                    parsed_clause(delayed_effect),
+                    chunk.boundary_after,
+                    ClauseDisposition::Emit {
+                        followup: None,
+                        intrinsic: None,
+                    },
+                )
+                .condition(condition.clone())
+                .is_optional(is_optional)
+                .opponent_may_scope(opponent_may_scope)
+                .repeat_for(repeat_for.clone())
+                .player_scope(player_scope)
+                .starting_with(starting_with.clone())
+                .prefix_delayed_condition(Some(prefix_condition))
+                .where_x_expression(where_x_expression.clone())
+                .target_selection_mode(chunk_ctx.target_selection_mode)
+                .target_chooser(chunk_ctx.target_chooser.clone())
+                .push();
             continue;
         }
 
@@ -26271,29 +25987,24 @@ pub(crate) fn parse_effect_chain_ir(
             ctx.relative_player_scope = Some(chosen_scope.clone());
             chain_chosen_player_count = ctx.chosen_player_count;
             chain_chosen_player_scope = Some(chosen_scope);
-            clauses.push(ClauseIr {
-                parsed: clause,
-                boundary: chunk.boundary_after,
-                condition: condition.clone(),
-                is_optional,
-                opponent_may_scope,
-                repeat_for: repeat_for.clone(),
-                player_scope,
-                starting_with: starting_with.clone(),
-                delayed_condition: None,
-                prefix_delayed_condition: None,
-                intrinsic_continuation: None,
-                followup_continuation: None,
-                absorbed_by_followup: false,
-                multi_target: None,
-                where_x_expression: where_x_expression.clone(),
-                is_otherwise: false,
-                unless_pay: None,
-                special: None,
-                source_text: normalized_text.to_string(),
-                target_selection_mode: TargetSelectionMode::Chosen,
-                target_chooser: None,
-            });
+            builder
+                .clause(
+                    normalized_text,
+                    clause,
+                    chunk.boundary_after,
+                    ClauseDisposition::Emit {
+                        followup: None,
+                        intrinsic: None,
+                    },
+                )
+                .condition(condition.clone())
+                .is_optional(is_optional)
+                .opponent_may_scope(opponent_may_scope)
+                .repeat_for(repeat_for.clone())
+                .player_scope(player_scope)
+                .starting_with(starting_with.clone())
+                .where_x_expression(where_x_expression.clone())
+                .push();
             continue;
         }
 
@@ -26323,38 +26034,32 @@ pub(crate) fn parse_effect_chain_ir(
                     ctx.push_diagnostic(d);
                 }
             }
-            clauses.push(ClauseIr {
-                parsed: ParsedEffectClause {
-                    effect: (*animate_def.effect).clone(),
-                    duration: animate_def.duration.clone(),
-                    sub_ability: animate_def.sub_ability.clone(),
-                    distribute: animate_def.distribute,
-                    multi_target: animate_def.multi_target.clone(),
-                    condition: animate_def.condition.clone(),
-                    optional: animate_def.optional,
-                    unless_pay: animate_def.unless_pay.clone(),
-                },
-                boundary: chunk.boundary_after,
-                condition: condition.clone(),
-                is_optional,
-                opponent_may_scope,
-                repeat_for: repeat_for.clone(),
-                player_scope,
-                starting_with: starting_with.clone(),
-                delayed_condition: None,
-                prefix_delayed_condition: None,
-                intrinsic_continuation: None,
-                followup_continuation: None,
-                absorbed_by_followup: false,
-                multi_target: None,
-                where_x_expression: None,
-                is_otherwise: false,
-                unless_pay: None,
-                special: None,
-                source_text: normalized_text.to_string(),
-                target_selection_mode: TargetSelectionMode::Chosen,
-                target_chooser: None,
-            });
+            builder
+                .clause(
+                    normalized_text,
+                    ParsedEffectClause {
+                        effect: (*animate_def.effect).clone(),
+                        duration: animate_def.duration.clone(),
+                        sub_ability: animate_def.sub_ability.clone(),
+                        distribute: animate_def.distribute,
+                        multi_target: animate_def.multi_target.clone(),
+                        condition: animate_def.condition.clone(),
+                        optional: animate_def.optional,
+                        unless_pay: animate_def.unless_pay.clone(),
+                    },
+                    chunk.boundary_after,
+                    ClauseDisposition::Emit {
+                        followup: None,
+                        intrinsic: None,
+                    },
+                )
+                .condition(condition.clone())
+                .is_optional(is_optional)
+                .opponent_may_scope(opponent_may_scope)
+                .repeat_for(repeat_for.clone())
+                .player_scope(player_scope)
+                .starting_with(starting_with.clone())
+                .push();
             continue;
         }
 
@@ -26485,7 +26190,8 @@ pub(crate) fn parse_effect_chain_ir(
                 .parse(text_no_qty_lower.as_str())
                 .is_ok()
         {
-            if let Some(verb) = clauses
+            if let Some(verb) = builder
+                .clauses()
                 .last()
                 .and_then(|prev| extract_effect_verb(&prev.parsed.effect))
             {
@@ -26656,7 +26362,7 @@ pub(crate) fn parse_effect_chain_ir(
         if condition.is_some()
             && !is_distributed_chunk
             && !condition.as_ref().is_some_and(condition_refs_source_object)
-            && !clauses.is_empty()
+            && !builder.is_empty()
             && has_anaphoric_reference(&text_lower)
             && !matches!(if_you_do_anchor, Some(TargetFilter::SelfRef))
             && !typed_trigger_subject
@@ -26671,7 +26377,7 @@ pub(crate) fn parse_effect_chain_ir(
         // CR 608.2c: Pronoun clause following a conditional targeted effect.
         if condition.is_none()
             && !is_distributed_chunk
-            && clauses.last().is_some_and(|prev| {
+            && builder.clauses().last().is_some_and(|prev| {
                 prev.condition.is_some() && has_typed_target(&prev.parsed.effect)
             })
             && has_anaphoric_reference(&text_lower)
@@ -26695,7 +26401,7 @@ pub(crate) fn parse_effect_chain_ir(
         // (Nissa, Who Shakes the World).
         if condition.is_none()
             && !is_distributed_chunk
-            && chain_has_prior_typed_referent(&clauses, false)
+            && chain_has_prior_typed_referent(builder.clauses(), false)
             && has_anaphoric_reference(&text_lower)
             && !typed_trigger_subject
             && !explicit_any_target_clause(&clause.effect, &text_lower)
@@ -26711,12 +26417,13 @@ pub(crate) fn parse_effect_chain_ir(
         {
             replace_target_with_parent(&mut clause.effect);
         }
-        if chain_has_prior_player_target_referent(&clauses)
+        if chain_has_prior_player_target_referent(builder.clauses())
             && has_player_anaphoric_reference(&text_lower)
         {
             replace_player_anaphor_with_parent_target(&mut clause.effect);
         }
-        if clauses
+        if builder
+            .clauses()
             .last()
             .is_some_and(|prev| matches!(&prev.parsed.effect, Effect::Counter { .. }))
         {
@@ -26736,7 +26443,7 @@ pub(crate) fn parse_effect_chain_ir(
         if typed_trigger_subject
             && !is_distributed_chunk
             && parse_spell_graveyard_replacement_rider(&text_lower).is_some()
-            && clauses.last().is_some_and(|prev| {
+            && builder.clauses().last().is_some_and(|prev| {
                 matches!(
                     &prev.parsed.effect,
                     Effect::CastFromZone { .. } | Effect::Counter { .. }
@@ -26783,7 +26490,7 @@ pub(crate) fn parse_effect_chain_ir(
                 enter_transformed: true,
                 ..
             }
-        ) && clauses.last().is_some_and(|prev| {
+        ) && builder.clauses().last().is_some_and(|prev| {
             matches!(
                 &prev.parsed.effect,
                 Effect::ChangeZone {
@@ -26795,7 +26502,8 @@ pub(crate) fn parse_effect_chain_ir(
         });
         if (typed_trigger_subject || exile_then_return_transformed)
             && has_anaphoric_reference(&text_lower)
-            && clauses
+            && builder
+                .clauses()
                 .last()
                 .is_some_and(|prev| parsed_clause_targets_self_ref(&prev.parsed))
         {
@@ -26837,29 +26545,25 @@ pub(crate) fn parse_effect_chain_ir(
             if let Some(ref cond) = condition {
                 instead_def = instead_def.condition(cond.clone());
             }
-            clauses.push(ClauseIr {
-                parsed: clause,
-                boundary: chunk.boundary_after,
-                condition,
-                is_optional,
-                opponent_may_scope,
-                repeat_for,
-                player_scope,
-                starting_with: starting_with.clone(),
-                delayed_condition: None,
-                prefix_delayed_condition: None,
-                intrinsic_continuation: None,
-                followup_continuation: None,
-                absorbed_by_followup: false,
-                multi_target,
-                where_x_expression,
-                is_otherwise: false,
-                unless_pay: None,
-                special: Some(SpecialClause::KeywordInsteadOverride),
-                source_text: normalized_text.to_string(),
-                target_selection_mode: TargetSelectionMode::Chosen,
-                target_chooser: None,
-            });
+            builder
+                .clause(
+                    normalized_text,
+                    clause,
+                    chunk.boundary_after,
+                    ClauseDisposition::Special {
+                        action: SpecialClause::KeywordInsteadOverride,
+                        intrinsic: None,
+                    },
+                )
+                .condition(condition)
+                .is_optional(is_optional)
+                .opponent_may_scope(opponent_may_scope)
+                .repeat_for(repeat_for)
+                .player_scope(player_scope)
+                .starting_with(starting_with.clone())
+                .multi_target(multi_target)
+                .where_x_expression(where_x_expression)
+                .push();
             continue;
         }
 
@@ -26874,15 +26578,19 @@ pub(crate) fn parse_effect_chain_ir(
             effective_condition,
             Some(AbilityCondition::AdditionalCostPaidInstead)
         ) && matches!(clause.effect, Effect::SearchLibrary { .. })
-            && !clauses.is_empty()
+            && !builder.is_empty()
         {
             // Find the last non-absorbed clause — it should be a SearchLibrary with
             // a SearchDestination(Hand) intrinsic continuation.
-            let prev_non_absorbed = clauses.iter().rev().find(|c| !c.absorbed_by_followup);
+            let prev_non_absorbed = builder
+                .clauses()
+                .iter()
+                .rev()
+                .find(|c| !matches!(c.disposition, ClauseDisposition::Continue { .. }));
             let previous_is_search_with_hand_dest = prev_non_absorbed.is_some_and(|c| {
                 matches!(c.parsed.effect, Effect::SearchLibrary { .. })
                     && matches!(
-                        c.intrinsic_continuation,
+                        c.disposition.intrinsic(),
                         Some(ContinuationAst::SearchDestination {
                             destination: Zone::Hand,
                             ..
@@ -26898,29 +26606,25 @@ pub(crate) fn parse_effect_chain_ir(
                     intrinsic_continuation_effect(&temp_def),
                     full_text,
                 );
-                clauses.push(ClauseIr {
-                    parsed: clause,
-                    boundary: chunk.boundary_after,
-                    condition,
-                    is_optional,
-                    opponent_may_scope,
-                    repeat_for,
-                    player_scope,
-                    starting_with: starting_with.clone(),
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: ic,
-                    followup_continuation: None,
-                    absorbed_by_followup: false,
-                    multi_target,
-                    where_x_expression,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: Some(SpecialClause::AdditionalCostInsteadSearch),
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: TargetSelectionMode::Chosen,
-                    target_chooser: None,
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        clause,
+                        chunk.boundary_after,
+                        ClauseDisposition::Special {
+                            action: SpecialClause::AdditionalCostInsteadSearch,
+                            intrinsic: ic,
+                        },
+                    )
+                    .condition(condition)
+                    .is_optional(is_optional)
+                    .opponent_may_scope(opponent_may_scope)
+                    .repeat_for(repeat_for)
+                    .player_scope(player_scope)
+                    .starting_with(starting_with.clone())
+                    .multi_target(multi_target)
+                    .where_x_expression(where_x_expression)
+                    .push();
                 continue;
             }
         }
@@ -26931,8 +26635,9 @@ pub(crate) fn parse_effect_chain_ir(
         // CR 603.7: Scan ALL prior non-absorbed clauses for a tracked-set
         // publisher, not just the nearest. An intermediate non-publishing
         // clause (e.g. Investigate) must not shadow an earlier exile.
-        let any_prior_publishes = clauses.iter().any(|c| {
-            !c.absorbed_by_followup && publishes_tracked_set_from_resolution(&c.parsed.effect)
+        let any_prior_publishes = builder.clauses().iter().any(|c| {
+            !matches!(c.disposition, ClauseDisposition::Continue { .. })
+                && publishes_tracked_set_from_resolution(&c.parsed.effect)
         });
         let needs_tracked_set = any_prior_publishes
             && (contains_explicit_tracked_set_pronoun(&lower_check)
@@ -26953,9 +26658,9 @@ pub(crate) fn parse_effect_chain_ir(
         //    ChangeZone) that become `defs.last()`. We must simulate this to match followup
         //    patterns that absorb paraphrase chunks (e.g., "put it onto the battlefield"
         //    after SearchLibrary).
-        let absorbed_choice_prev = clauses.last().and_then(|previous| {
-            if previous.absorbed_by_followup {
-                match previous.followup_continuation.as_ref() {
+        let absorbed_choice_prev = builder.clauses().last().and_then(|previous| {
+            if matches!(previous.disposition, ClauseDisposition::Continue { .. }) {
+                match previous.disposition.followup() {
                     Some(ContinuationAst::ChooseFromExile { count, chooser }) => {
                         Some(Effect::ChooseFromZone {
                             count: *count,
@@ -26979,17 +26684,17 @@ pub(crate) fn parse_effect_chain_ir(
         // be after intrinsic/followup continuation application. Shared by the
         // nearest-clause lookback and the CR 608.2c deeper-clause lookback.
         let effective_effect_of = |previous: &ClauseIr| -> Effect {
-            if let Some(ref ic) = previous.intrinsic_continuation {
+            if let Some(ic) = previous.disposition.intrinsic() {
                 // Build a temporary defs list, apply the continuation, and use the last effect.
                 let mut temp_defs =
                     vec![AbilityDefinition::new(kind, previous.parsed.effect.clone())];
                 apply_clause_continuation(&mut temp_defs, ic.clone(), kind);
                 (*temp_defs.last().unwrap().effect).clone()
-            } else if let Some(ref _fc) = previous.followup_continuation {
+            } else if previous.disposition.followup().is_some() {
                 // A non-absorbed clause with a followup continuation means the continuation
                 // was applied to the clause BEFORE it. Simulate to get patched effect.
                 // Find the clause before `previous` (skip absorbed), apply the followup.
-                match previous.followup_continuation.as_ref() {
+                match previous.disposition.followup() {
                     Some(ContinuationAst::ChooseFromExile { count, chooser }) => {
                         Effect::ChooseFromZone {
                             count: *count,
@@ -27012,10 +26717,11 @@ pub(crate) fn parse_effect_chain_ir(
             }
         };
         // Non-absorbed clauses, nearest-first — the lookback search space.
-        let non_absorbed: Vec<&ClauseIr> = clauses
+        let non_absorbed: Vec<&ClauseIr> = builder
+            .clauses()
             .iter()
             .rev()
-            .filter(|c| !c.absorbed_by_followup)
+            .filter(|c| !matches!(c.disposition, ClauseDisposition::Continue { .. }))
             .collect();
         let effective_prev_effect =
             absorbed_choice_prev.or_else(|| non_absorbed.first().map(|c| effective_effect_of(c)));
@@ -27179,29 +26885,26 @@ pub(crate) fn parse_effect_chain_ir(
             // Store the followup continuation — it applies to the previous clause.
             // We handle this by pushing an absorbed marker clause.
             if let Some(continuation) = followup_continuation {
-                clauses.push(ClauseIr {
-                    parsed: clause,
-                    boundary: chunk.boundary_after,
-                    condition,
-                    is_optional,
-                    opponent_may_scope,
-                    repeat_for,
-                    player_scope,
-                    starting_with: starting_with.clone(),
-                    delayed_condition: None,
-                    prefix_delayed_condition: None,
-                    intrinsic_continuation: None,
-                    followup_continuation: Some(continuation),
-                    absorbed_by_followup: true,
-                    multi_target,
-                    where_x_expression,
-                    is_otherwise: false,
-                    unless_pay: None,
-                    special: None,
-                    source_text: normalized_text.to_string(),
-                    target_selection_mode: chunk_ctx.target_selection_mode,
-                    target_chooser: chunk_ctx.target_chooser.clone(),
-                });
+                builder
+                    .clause(
+                        normalized_text,
+                        clause,
+                        chunk.boundary_after,
+                        ClauseDisposition::Continue {
+                            continuation: Some(continuation),
+                        },
+                    )
+                    .condition(condition)
+                    .is_optional(is_optional)
+                    .opponent_may_scope(opponent_may_scope)
+                    .repeat_for(repeat_for)
+                    .player_scope(player_scope)
+                    .starting_with(starting_with.clone())
+                    .multi_target(multi_target)
+                    .where_x_expression(where_x_expression)
+                    .target_selection_mode(chunk_ctx.target_selection_mode)
+                    .target_chooser(chunk_ctx.target_chooser.clone())
+                    .push();
             }
             continue;
         }
@@ -27227,32 +26930,32 @@ pub(crate) fn parse_effect_chain_ir(
             restore_this_way_trigger_anaphor(&mut clause.effect);
         }
 
-        clauses.push(ClauseIr {
-            parsed: clause,
-            boundary: chunk.boundary_after,
-            condition,
-            is_optional,
-            opponent_may_scope,
-            repeat_for,
-            player_scope,
-            starting_with: starting_with.clone(),
-            delayed_condition,
-            prefix_delayed_condition: None,
-            intrinsic_continuation,
-            followup_continuation: followup_for_this,
-            absorbed_by_followup: false,
-            multi_target,
-            where_x_expression,
-            is_otherwise: false,
-            unless_pay,
-            special: None,
-            source_text: normalized_text.to_string(),
-            // CR 115.1 + CR 701.9b: snapshot the parser's per-chunk selection
-            // mode. Set to `Random` by `parse_target_with_ctx` when "random "
-            // was stripped from this chunk's target phrase.
-            target_selection_mode: chunk_ctx.target_selection_mode,
-            target_chooser: chunk_ctx.target_chooser.clone(),
-        });
+        // CR 115.1 + CR 701.9b: `target_selection_mode` snapshots the parser's
+        // per-chunk selection mode. Set to `Random` by `parse_target_with_ctx`
+        // when "random " was stripped from this chunk's target phrase.
+        builder
+            .clause(
+                normalized_text,
+                clause,
+                chunk.boundary_after,
+                ClauseDisposition::Emit {
+                    followup: followup_for_this,
+                    intrinsic: intrinsic_continuation,
+                },
+            )
+            .condition(condition)
+            .is_optional(is_optional)
+            .opponent_may_scope(opponent_may_scope)
+            .repeat_for(repeat_for)
+            .player_scope(player_scope)
+            .starting_with(starting_with.clone())
+            .delayed_condition(delayed_condition)
+            .multi_target(multi_target)
+            .where_x_expression(where_x_expression)
+            .unless_pay(unless_pay)
+            .target_selection_mode(chunk_ctx.target_selection_mode)
+            .target_chooser(chunk_ctx.target_chooser.clone())
+            .push();
 
         // Drain chunk-ctx diagnostics into the accumulator (the outer `ctx` is
         // shadowed inside the loop, so we collect here and extend after the loop).
@@ -27324,6 +27027,7 @@ pub(crate) fn parse_effect_chain_ir(
     // default to `Duration::UntilEndOfTurn` (engine convention for
     // `GenericEffect` whose duration field is `None`; the CR baseline per
     // CR 611.2a is "until end of the game", which is not what we want either).
+    let mut clauses = builder.finish();
     try_fold_loses_other_sibling(&mut clauses);
 
     // CR 611.2b: stamp the stripped leading "for as long as" duration onto every

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -23,6 +23,20 @@ pub(crate) struct ParsedEffectClause {
     pub(crate) effect: Effect,
     pub(crate) duration: Option<Duration>,
     /// Compound "and" remainder parsed into a sub_ability chain.
+    ///
+    /// **#13 / gate-9 residual (DEFERRED, not closed by Unit 5).** This holds a
+    /// fully-lowered `AbilityDefinition` with NO clause identity of its own. It is
+    /// constructed deep in imperative/subject parsing (e.g. `imperative.rs`), long
+    /// before the enclosing clause reaches `ClauseIrBuilder`, so no `ClauseId` is
+    /// in scope at construction. The enclosing `ClauseIr` IS addressed (it carries
+    /// a `ClauseId` + `OracleUnitSource`), so this nested def is covered
+    /// transitively by its parent clause's id — but it has no INDEPENDENT clause
+    /// identity. Minting one requires U6's `ClauseId`-keyed assembly arena
+    /// (Plan 01 §6, line 823), which owns the nested sub-clause id-space; a bespoke
+    /// nested id-space here would preempt that decision. The `rg 'ClauseIr {'`
+    /// removal gate does not cover this field (it holds an `AbilityDefinition`, not
+    /// a `ClauseIr`), so this doc comment is the honest marker: independent
+    /// sub-clause identity upgrades in U6.
     pub(crate) sub_ability: Option<Box<AbilityDefinition>>,
     /// CR 601.2d: When set, this effect requires distribution among targets at cast time.
     pub(crate) distribute: Option<DistributionUnit>,
@@ -1595,6 +1609,22 @@ pub(crate) fn parsed_clause(effect: Effect) -> ParsedEffectClause {
         optional: false,
         unless_pay: None,
     }
+}
+
+/// A `.parsed` placeholder for a clause whose real semantics live in its
+/// `ClauseDisposition` (e.g. a `Special` action), not in its effect. Distinct
+/// from `Effect::unimplemented`: it carries no fragment (`description: None`)
+/// because it marks an intentional structural non-effect, not an unparsed gap —
+/// a `Some(fragment)` here would leak into the coverage report as a false parse
+/// gap. `name` is a stable snake_case pattern-class key.
+pub(crate) fn placeholder_parsed_clause(name: &str) -> ParsedEffectClause {
+    // Structural placeholder for a disposition-carried clause; the None fragment is
+    // load-bearing (a Some(_) would surface as a false parse gap in coverage).
+    // allow-noncombinator: intentional Effect::Unimplemented placeholder, not parse dispatch.
+    parsed_clause(Effect::Unimplemented {
+        name: name.to_string(),
+        description: None,
+    })
 }
 
 pub(crate) fn with_clause_duration(

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -84,6 +84,23 @@ pub(crate) enum SpanPrecision {
     ///
     /// UNIT-3B DEBT — emitted only by `OracleSourceSpan::whole_document`.
     WholeDocument,
+    /// The span's byte range is exact **within the effect chain** it was parsed
+    /// from, but NOT card-absolute: it is an offset into a single
+    /// `parse_effect_chain_ir` invocation's text, not into the whole Oracle
+    /// document. Minted by the item-scoped `ClauseIrBuilder`, whose local
+    /// allocator is seeded over the chain text because the document allocator is
+    /// not yet threaded through `ParseContext` (same wall `AbilityIr` documents).
+    ///
+    /// It is HONEST, not fabricated: the offset is truthful relative to the
+    /// chain, and the verbatim `fragment` is retained so a later
+    /// allocator-threading unit can upgrade it to a card-absolute
+    /// `SpanPrecision::Exact` by adding the chain's base offset — or, if
+    /// preprocessing was not offset-linear, by re-locating the fragment in the
+    /// card text. A renderer must NOT print `first_line`/`start_byte` as a
+    /// card-absolute position, exactly as for `WholeDocument`.
+    ///
+    /// U5 DEBT — upgrades to `Exact` when the allocator is threaded.
+    ChainRelative,
 }
 
 /// Position of a unit within the original Oracle text, plus how precisely that
@@ -159,12 +176,57 @@ impl OracleSourceSpan {
         }
     }
 
-    /// True when this span's bounds locate the unit exactly. A position renderer
-    /// must consult this before printing a line number or byte offset.
+    /// A span whose byte range is exact **within one effect chain** but not
+    /// card-absolute. See `SpanPrecision::ChainRelative`. Minted by
+    /// `ClauseIrBuilder` for per-clause provenance; carries a verbatim fragment
+    /// (the guard in `check_fragment_precision` requires it) so the eventual
+    /// allocator-threading unit can upgrade it to `Exact`.
+    pub(crate) fn chain_relative(
+        first_line: usize,
+        last_line: usize,
+        start_byte: usize,
+        end_byte: usize,
+        ordinal_within_span: u32,
+    ) -> Self {
+        Self {
+            first_line,
+            last_line,
+            start_byte,
+            end_byte,
+            precision: SpanPrecision::ChainRelative,
+            ordinal_within_span,
+        }
+    }
+
+    /// True when this span's bounds locate the unit exactly **card-absolutely**.
+    /// A position renderer must consult this before printing a line number or
+    /// byte offset as a card position. `ChainRelative` is deliberately NOT exact:
+    /// its offsets are truthful only within a single chain.
     ///
-    /// Live in production today: `check_fragment_precision` <- `emit`.
+    /// The fragment-precision guard now consults the widened `carries_fragment`
+    /// (which admits `ChainRelative`), so this exact-only accessor has no
+    /// production caller in M1 — it is retained solely as the card-absolute
+    /// distinction the precision-tier tests assert on, hence `#[cfg(test)]`
+    /// rather than a dead-code allow.
+    #[cfg(test)]
     pub(crate) fn is_exact(&self) -> bool {
         matches!(self.precision, SpanPrecision::Exact)
+    }
+
+    /// True when this precision tier is allowed to carry a verbatim `fragment`.
+    ///
+    /// Both `Exact` (card-absolute) and `ChainRelative` (chain-local honest)
+    /// address a concrete byte range and therefore have a real verbatim
+    /// fragment; only `WholeDocument`, whose sole honest "fragment" would be the
+    /// entire card, must not. This is the single authority the fail-closed
+    /// `check_fragment_precision` guard consults — widened (not loosened) from
+    /// `is_exact` so the ChainRelative tier can carry its fragment without
+    /// reopening the whole-document-fragment hole `SpanPrecision` closed.
+    pub(crate) fn carries_fragment(&self) -> bool {
+        matches!(
+            self.precision,
+            SpanPrecision::Exact | SpanPrecision::ChainRelative
+        )
     }
 
     /// True when `self` and `other` cover overlapping bytes *and* claim the same
@@ -235,7 +297,7 @@ impl OracleUnitSource {
     /// A unit whose fragment presence contradicts its span precision is a parser
     /// contract violation, not an Oracle-text problem. Fail closed.
     fn check_fragment_precision(&self) -> Result<(), DocBuilderError> {
-        if self.fragment.is_some() == self.span.is_exact() {
+        if self.fragment.is_some() == self.span.carries_fragment() {
             Ok(())
         } else {
             Err(DocBuilderError::FragmentPrecisionMismatch {

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -9,6 +9,7 @@
 use serde::Serialize;
 
 use super::ast::{ClauseBoundary, ContinuationAst, ParsedEffectClause};
+use super::doc::{OracleDocBuilder, OracleSourceSpan, OracleUnitSource};
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ControllerRef,
     DelayedTriggerCondition, MultiTargetSpec, OpponentMayScope, PlayerFilter, QuantityExpr,
@@ -161,14 +162,128 @@ pub(crate) enum SpecialClause {
     RepeatProcessForKeywords(Vec<Keyword>),
 }
 
+// ===========================================================================
+// Typed clause provenance (Plan 01 §5) — Unit 5, milestone M1
+// ===========================================================================
+//
+// A clause carries a stable chain-local `ClauseId`, an honest chain-relative
+// `OracleUnitSource`, and exactly one `ClauseDisposition`.
+//
+// **Antecedent/reference layer JIT-DEFERRED to U6.** Plan 01 §5 also specifies a
+// typed antecedent-declaration / reference-consumption vocabulary
+// (`AntecedentValue`, `AntecedentSelector`, `ReferenceUse`, `ReferenceProjection`,
+// `BindingLifetime`, `ReferenceSurface`). An audit of every field the pre-U5
+// `ClauseIr` carried found NONE is an antecedent or a reference — the old
+// cross-clause binding is implicit (via `ParseContext` threading + the
+// continuation mechanism), so M1's faithful migration has ZERO producers of that
+// vocabulary and its only consumer is U6's assembler (not yet built). Landing it
+// now would be dead code under `-D warnings` and forcing empty per-site
+// declarations would be vacuous. Per "build for the class, not the card" and the
+// plan's multi-authority rule (Plan 01 §5, line 413), it is added in U6 where the
+// assembler binds references to antecedents by typed id/selector rather than by
+// lowered-tree shape search.
+
+/// Chain-local identity for one parsed clause, assigned in source order by the
+/// item-scoped [`ClauseIrBuilder`].
+///
+/// Distinct from the document-global `OracleUnitId`: a `ClauseId` is unique only
+/// within one `parse_effect_chain_ir` invocation. Unit 6's assembly arena keys
+/// its output nodes by `ClauseId` within a chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub(crate) struct ClauseId(pub(crate) u32);
+
+/// The single explicit disposition of a clause: what it does relative to the
+/// rest of the chain. Replaces the former ad-hoc `absorbed_by_followup` boolean,
+/// `intrinsic_continuation`/`followup_continuation` options, `is_otherwise`
+/// boolean, and `special` marker.
+///
+/// A continuation clause STAYS in the IR with its own id/source even when it
+/// emits no independent definition (Plan 01 §5). The explicit antecedent SELECTOR
+/// a `Continue` binds to is JIT-deferred to U6 (see the module note above); in M1
+/// the bound antecedent is the prior emitted def, exactly as the pre-U5 lowering
+/// applied it.
+///
+/// The three arms are the top-level XOR discriminant of the pre-U5 lower.rs loop
+/// (`if absorbed_by_followup … else if special … else …`, lower.rs:1314/1321).
+/// The two continuation channels ride ORTHOGONALLY on the arms — they are applied
+/// in multiple paths — so each arm carries the channels its path actually uses:
+/// - normal/`Emit`: `followup` patches PRIOR defs (lower.rs:1703), then the def is
+///   emitted, then `intrinsic` patches SELF (lower.rs:2078).
+/// - absorbed/`Continue`: `continuation` patches PRIOR defs; no self def is
+///   emitted (lower.rs:1314).
+/// - `special`: some arms apply `intrinsic` to the special-built def
+///   (lower.rs:1600, `AdditionalCostInsteadSearch`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum ClauseDisposition {
+    /// CR 608.2c: this clause emits its own definition(s). `followup` is a
+    /// continuation from THIS chunk that patches the PRIOR defs before this clause
+    /// emits (formerly `followup_continuation` on the non-absorbed path,
+    /// lower.rs:1703); `intrinsic` patches this clause's OWN lowered def after it
+    /// emits (formerly `intrinsic_continuation`, lower.rs:2078).
+    Emit {
+        followup: Option<ContinuationAst>,
+        intrinsic: Option<ContinuationAst>,
+    },
+    /// CR 608.2c: this clause continues/patches the prior emitted clause rather
+    /// than emitting an independent def. Folds the former `absorbed_by_followup`
+    /// and `followup_continuation` pair (absorbed path, lower.rs:1314). The clause
+    /// remains addressable (its own id/source) even though it produces no sibling
+    /// def. The explicit antecedent selector is JIT-deferred to U6 (module note);
+    /// in M1 the target is the prior emitted def, as the pre-U5 lowering applied it.
+    ///
+    /// `continuation` is `Option` because the absorbed-but-inert state
+    /// (`absorbed_by_followup: true, followup_continuation: None`) is reachable:
+    /// the foretell-cost-override suppression clears the continuation while the
+    /// clause stays absorbed (must NOT fall back to emitting its parsed effect).
+    /// `None` = absorbed no-op.
+    Continue {
+        continuation: Option<ContinuationAst>,
+    },
+    /// A special-case adjacency action that modifies an adjacent clause during
+    /// lowering (folds the former `special: Option<SpecialClause>`). `intrinsic`
+    /// carries the self-patch some special arms apply (lower.rs:1600).
+    ///
+    // TEMPORARY: faithful carry; decomposed into typed dispositions in U5-M2.
+    /// This wraps the existing `SpecialClause` value AS-IS — zero information
+    /// reconstructed or re-derived (it MOVES the value, unlike a projection
+    /// shim). This is not a generic "patch previous" collapse (Plan 01 §5, line
+    /// 811): the distinct concepts stay distinct inside `SpecialClause`. U5-M2
+    /// promotes each variant to its own typed disposition/attribute with a
+    /// snapshot + lowered-parity test, then deletes the `SpecialClause` enum.
+    Special {
+        action: SpecialClause,
+        intrinsic: Option<ContinuationAst>,
+    },
+}
+
 /// Per-clause IR: captures everything about a single parsed chunk before chain assembly.
 ///
 /// Each field corresponds to a local variable extracted during the chunk loop's
 /// "strip cascade" in `parse_effect_chain_ir`. All assembly logic (continuation
 /// patching, condition lifting, sub_ability wiring) is deferred to lowering.
+///
+/// **Construction is sealed to [`ClauseIrBuilder`].** The private `_sealed`
+/// field makes a struct literal outside this module a compile error, so a clause
+/// cannot exist without a `ClauseId`, an `OracleUnitSource`, and an explicit
+/// `ClauseDisposition` — the construction gate's teeth (Plan 01 §5, line 343).
+/// (The typed antecedent/reference declarations of Plan 01 §5 are JIT-deferred to
+/// U6; see the module note above.)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct ClauseIr {
     /// The parsed effect clause (effect, duration, sub_ability from parse_effect_clause).
+    /// Chain-local identity, assigned in source order by [`ClauseIrBuilder`].
+    pub(crate) id: ClauseId,
+    /// Honest chain-relative source (`SpanPrecision::ChainRelative`): exact byte
+    /// range within this chain + verbatim fragment. Replaces the former
+    /// unaddressed `source_text` string (Plan 01 §5, line 341). Upgrades to a
+    /// card-absolute `OracleUnitSource` in the allocator-threading unit; the
+    /// verbatim fragment is retained so that upgrade can re-locate it.
+    pub(crate) source: OracleUnitSource,
+    /// The one explicit disposition of this clause (Plan 01 §5). Folds the former
+    /// `absorbed_by_followup`, `followup_continuation`, `intrinsic_continuation`,
+    /// `is_otherwise`, and `special` fields. The typed antecedent/reference
+    /// declarations of Plan 01 §5 are JIT-deferred to U6 (see the module note).
+    pub(crate) disposition: ClauseDisposition,
     pub(crate) parsed: ParsedEffectClause,
     /// Clause boundary from split_clause_sequence.
     pub(crate) boundary: Option<ClauseBoundary>,
@@ -192,25 +307,13 @@ pub(crate) struct ClauseIr {
     pub(crate) delayed_condition: Option<DelayedTriggerCondition>,
     /// CR 603.7a: Temporal prefix delayed trigger condition.
     pub(crate) prefix_delayed_condition: Option<DelayedTriggerCondition>,
-    /// Intrinsic continuation marker (parsed from this chunk's text, applies to self).
-    pub(crate) intrinsic_continuation: Option<ContinuationAst>,
-    /// Followup continuation marker (parsed from this chunk's text, applies to previous clause).
-    pub(crate) followup_continuation: Option<ContinuationAst>,
-    /// Whether this clause was absorbed by a followup continuation.
-    pub(crate) absorbed_by_followup: bool,
     /// CR 115.1d: Multi-target spec.
     pub(crate) multi_target: Option<MultiTargetSpec>,
     /// CR 107.3i: "where X is <expr>" binding.
     pub(crate) where_x_expression: Option<String>,
-    /// Special-case: "otherwise" clause that attaches to prior conditional.
-    pub(crate) is_otherwise: bool,
     /// CR 118.12: Resolution-time "unless [player] pays" modifier carried by
     /// this clause.
     pub(crate) unless_pay: Option<UnlessPayModifier>,
-    /// Special-case action that modifies adjacent clauses during lowering.
-    pub(crate) special: Option<SpecialClause>,
-    /// The raw normalized text (for debug/diagnostic purposes).
-    pub(crate) source_text: String,
     /// CR 115.1 + CR 701.9b: Target selection mode captured from `ParseContext`
     /// after this chunk was parsed. Stamped onto the produced `AbilityDefinition`
     /// during lowering. `Chosen` (default) for ordinary "target X" phrases;
@@ -223,6 +326,329 @@ pub(crate) struct ClauseIr {
     /// targeted "of their choice" controlled by the phase-trigger active player.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) target_chooser: Option<TargetFilter>,
+    /// Construction seal: a private field forces all construction through
+    /// [`ClauseIrBuilder`], so no call site can mint a clause without identity,
+    /// source, disposition, and provenance (Plan 01 §5 construction gate).
+    #[serde(skip)]
+    _sealed: (),
+}
+
+impl ClauseDisposition {
+    /// The self-patch continuation parsed from a clause's own text (formerly the
+    /// `intrinsic_continuation` field): applied to this clause's own lowered def
+    /// after it emits. `Emit`/`Special` carry it; `Continue` never does.
+    pub(crate) fn intrinsic(&self) -> Option<&ContinuationAst> {
+        match self {
+            ClauseDisposition::Emit { intrinsic, .. }
+            | ClauseDisposition::Special { intrinsic, .. } => intrinsic.as_ref(),
+            ClauseDisposition::Continue { .. } => None,
+        }
+    }
+
+    /// The prior-patch continuation (formerly the `followup_continuation` field):
+    /// a normal (`Emit`) clause's followup that patches the PRIOR def, or a
+    /// `Continue` clause's continuation. `None` for `Special` clauses.
+    pub(crate) fn followup(&self) -> Option<&ContinuationAst> {
+        match self {
+            ClauseDisposition::Emit { followup, .. }
+            | ClauseDisposition::Continue {
+                continuation: followup,
+            } => followup.as_ref(),
+            ClauseDisposition::Special { .. } => None,
+        }
+    }
+}
+
+/// Item-scoped builder that is the single authority for `ClauseIr` construction.
+///
+/// It owns a LOCAL source-unit allocator seeded over the chain text, because the
+/// document allocator is not yet threaded through `ParseContext` (the same wall
+/// `AbilityIr` documents). Each clause therefore receives an honest
+/// `SpanPrecision::ChainRelative` `OracleUnitSource`: a byte range exact *within
+/// this chain* plus its verbatim fragment, upgradeable to card-absolute when the
+/// allocator is threaded.
+///
+/// `ClauseId`s are minted in source order. Construction of a clause is possible
+/// only through [`ClauseIrBuilder::clause`], which requires the disposition up
+/// front — the construction gate (Plan 01 §5, line 343).
+pub(crate) struct ClauseIrBuilder {
+    /// The chain-item slot whose `UnitAllocator` mints per-clause child units.
+    slot: super::doc::ItemSlot,
+    /// The chain text, for monotonic offset resolution of each clause fragment.
+    chain_text: String,
+    /// Monotonic byte cursor into `chain_text`: each located fragment advances it,
+    /// so repeated identical fragments resolve to distinct, source-ordered spans.
+    cursor: usize,
+    /// Next `ClauseId` to assign (source order within this chain).
+    next_clause_id: u32,
+    /// Accumulated clauses in source order.
+    clauses: Vec<ClauseIr>,
+}
+
+impl ClauseIrBuilder {
+    /// Create a builder scoped to one `parse_effect_chain_ir` invocation's text.
+    pub(crate) fn new(chain_text: &str) -> Self {
+        let mut doc = OracleDocBuilder::new();
+        let last_line = chain_text.lines().count().saturating_sub(1);
+        // The chain item itself is chain-relative: offsets 0..len into its own
+        // text, verbatim fragment = the whole chain. Children (clauses) are
+        // sub-ranges validated for containment by `allocate_with_span`.
+        let span = OracleSourceSpan::chain_relative(0, last_line, 0, chain_text.len(), 0);
+        let slot = doc.begin_item(span, Some(chain_text));
+        Self {
+            slot,
+            chain_text: chain_text.to_string(),
+            cursor: 0,
+            next_clause_id: 0,
+            clauses: Vec::new(),
+        }
+    }
+
+    /// Resolve `fragment`'s honest chain-relative byte span, advancing the cursor.
+    ///
+    /// A monotonic forward search keeps repeated identical clause fragments
+    /// distinct and source-ordered. When the fragment cannot be located — the
+    /// chunk text was normalized/derived and no longer appears verbatim in the
+    /// chain — it falls back to a zero-width span at the cursor. That is honest,
+    /// not fabricated: `ChainRelative` already disclaims card-absolute precision,
+    /// and the verbatim fragment is still carried for the later upgrade.
+    fn locate(&mut self, fragment: &str) -> OracleSourceSpan {
+        let (start, end) = match self.chain_text.get(self.cursor..).and_then(|tail| {
+            // allow-noncombinator: byte-offset provenance bookkeeping, not parsing dispatch
+            tail.find(fragment)
+        }) {
+            Some(rel) => {
+                let start = self.cursor + rel;
+                let end = start + fragment.len();
+                self.cursor = end;
+                (start, end)
+            }
+            None => (self.cursor, self.cursor),
+        };
+        let first_line = self
+            .chain_text
+            .get(..start)
+            .map_or(0, |p| p.matches('\n').count());
+        let last_line = self
+            .chain_text
+            .get(..end)
+            .map_or(first_line, |p| p.matches('\n').count());
+        // Ordinal within span disambiguates co-located units; each clause is a
+        // distinct unit, so the monotonically-increasing clause id doubles as a
+        // per-span ordinal that never collides.
+        OracleSourceSpan::chain_relative(first_line, last_line, start, end, self.next_clause_id)
+    }
+
+    /// Begin a clause. The `disposition` is REQUIRED here (not an optional
+    /// setter) so a clause cannot be built without one — the construction gate's
+    /// teeth. `source_text` is the verbatim clause fragment that becomes the
+    /// `ChainRelative` `OracleUnitSource`. (Typed antecedent/reference
+    /// declarations are JIT-deferred to U6; see the module note.)
+    pub(crate) fn clause(
+        &mut self,
+        source_text: &str,
+        parsed: ParsedEffectClause,
+        boundary: Option<ClauseBoundary>,
+        disposition: ClauseDisposition,
+    ) -> ClauseDraft<'_> {
+        ClauseDraft {
+            builder: self,
+            source_text: source_text.to_string(),
+            parsed,
+            boundary,
+            disposition,
+            condition: None,
+            is_optional: false,
+            opponent_may_scope: None,
+            repeat_for: None,
+            player_scope: None,
+            starting_with: None,
+            delayed_condition: None,
+            prefix_delayed_condition: None,
+            multi_target: None,
+            where_x_expression: None,
+            unless_pay: None,
+            target_selection_mode: TargetSelectionMode::Chosen,
+            target_chooser: None,
+        }
+    }
+
+    /// Whether any clause has been pushed yet.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.clauses.is_empty()
+    }
+
+    /// Read the already-built clauses for mid-chain lookback (prior-referent
+    /// checks, condition/opponent-may scans). Returns already-constructed
+    /// clauses — it constructs nothing, so the single-construction gate holds.
+    pub(crate) fn clauses(&self) -> &[ClauseIr] {
+        &self.clauses
+    }
+
+    /// Mutate already-built clauses for mid-chain patching (e.g. absorbing a
+    /// continuation into a prior clause, suppressing a continuation). Mutates
+    /// existing clauses only — constructs nothing, so the gate holds.
+    pub(crate) fn clauses_mut(&mut self) -> &mut [ClauseIr] {
+        &mut self.clauses
+    }
+
+    /// The most recently pushed clause, mutably. `None` before the first push.
+    pub(crate) fn last_mut(&mut self) -> Option<&mut ClauseIr> {
+        self.clauses.last_mut()
+    }
+
+    /// Absorb an already-built clause from a NESTED chain: re-mint a fresh
+    /// source-order `ClauseId` + `ChainRelative` span (re-locating its fragment in
+    /// THIS chain), preserving all content. Keeps single-construction — still
+    /// routes through [`ClauseIrBuilder::clause`] + [`ClauseDraft::push`].
+    pub(crate) fn absorb_clause(&mut self, c: ClauseIr) {
+        self.clause(
+            c.source.fragment().unwrap_or_default(),
+            c.parsed,
+            c.boundary,
+            c.disposition,
+        )
+        .condition(c.condition)
+        .is_optional(c.is_optional)
+        .opponent_may_scope(c.opponent_may_scope)
+        .repeat_for(c.repeat_for)
+        .player_scope(c.player_scope)
+        .starting_with(c.starting_with)
+        .delayed_condition(c.delayed_condition)
+        .prefix_delayed_condition(c.prefix_delayed_condition)
+        .multi_target(c.multi_target)
+        .where_x_expression(c.where_x_expression)
+        .unless_pay(c.unless_pay)
+        .target_selection_mode(c.target_selection_mode)
+        .target_chooser(c.target_chooser)
+        .push();
+    }
+
+    /// Consume the builder, yielding the source-ordered clause list.
+    pub(crate) fn finish(self) -> Vec<ClauseIr> {
+        self.clauses
+    }
+}
+
+/// A clause under construction: mandatory provenance was supplied to
+/// [`ClauseIrBuilder::clause`]; optional local attributes are set by chaining,
+/// then [`ClauseDraft::push`] mints identity + source and commits it.
+#[must_use = "a ClauseDraft does nothing until `.push()` commits it"]
+pub(crate) struct ClauseDraft<'a> {
+    builder: &'a mut ClauseIrBuilder,
+    source_text: String,
+    parsed: ParsedEffectClause,
+    boundary: Option<ClauseBoundary>,
+    disposition: ClauseDisposition,
+    condition: Option<AbilityCondition>,
+    is_optional: bool,
+    opponent_may_scope: Option<OpponentMayScope>,
+    repeat_for: Option<QuantityExpr>,
+    player_scope: Option<PlayerFilter>,
+    starting_with: Option<ControllerRef>,
+    delayed_condition: Option<DelayedTriggerCondition>,
+    prefix_delayed_condition: Option<DelayedTriggerCondition>,
+    multi_target: Option<MultiTargetSpec>,
+    where_x_expression: Option<String>,
+    unless_pay: Option<UnlessPayModifier>,
+    target_selection_mode: TargetSelectionMode,
+    target_chooser: Option<TargetFilter>,
+}
+
+impl ClauseDraft<'_> {
+    pub(crate) fn condition(mut self, v: Option<AbilityCondition>) -> Self {
+        self.condition = v;
+        self
+    }
+    // Consuming builder setter mirroring the `is_optional` field name; the
+    // `is_*`-takes-`&self` convention does not apply to a chainable builder.
+    #[allow(clippy::wrong_self_convention)]
+    pub(crate) fn is_optional(mut self, v: bool) -> Self {
+        self.is_optional = v;
+        self
+    }
+    pub(crate) fn opponent_may_scope(mut self, v: Option<OpponentMayScope>) -> Self {
+        self.opponent_may_scope = v;
+        self
+    }
+    pub(crate) fn repeat_for(mut self, v: Option<QuantityExpr>) -> Self {
+        self.repeat_for = v;
+        self
+    }
+    pub(crate) fn player_scope(mut self, v: Option<PlayerFilter>) -> Self {
+        self.player_scope = v;
+        self
+    }
+    pub(crate) fn starting_with(mut self, v: Option<ControllerRef>) -> Self {
+        self.starting_with = v;
+        self
+    }
+    pub(crate) fn delayed_condition(mut self, v: Option<DelayedTriggerCondition>) -> Self {
+        self.delayed_condition = v;
+        self
+    }
+    pub(crate) fn prefix_delayed_condition(mut self, v: Option<DelayedTriggerCondition>) -> Self {
+        self.prefix_delayed_condition = v;
+        self
+    }
+    pub(crate) fn multi_target(mut self, v: Option<MultiTargetSpec>) -> Self {
+        self.multi_target = v;
+        self
+    }
+    pub(crate) fn where_x_expression(mut self, v: Option<String>) -> Self {
+        self.where_x_expression = v;
+        self
+    }
+    pub(crate) fn unless_pay(mut self, v: Option<UnlessPayModifier>) -> Self {
+        self.unless_pay = v;
+        self
+    }
+    pub(crate) fn target_selection_mode(mut self, v: TargetSelectionMode) -> Self {
+        self.target_selection_mode = v;
+        self
+    }
+    pub(crate) fn target_chooser(mut self, v: Option<TargetFilter>) -> Self {
+        self.target_chooser = v;
+        self
+    }
+
+    /// Mint the `ClauseId` + `ChainRelative` `OracleUnitSource` and commit the
+    /// clause into the builder's source-ordered list.
+    pub(crate) fn push(self) {
+        let id = ClauseId(self.builder.next_clause_id);
+        let span = self.builder.locate(&self.source_text);
+        // `allocate_with_span` validates containment + fragment/precision. A
+        // ChainRelative child of the chain item always satisfies both by
+        // construction; the fallback zero-width span is contained too.
+        let source = self
+            .builder
+            .slot
+            .allocator()
+            .allocate_with_span(span, Some(&self.source_text))
+            .expect("chain-relative clause span is contained by its chain item");
+        self.builder.next_clause_id += 1;
+        self.builder.clauses.push(ClauseIr {
+            id,
+            source,
+            disposition: self.disposition,
+            parsed: self.parsed,
+            boundary: self.boundary,
+            condition: self.condition,
+            is_optional: self.is_optional,
+            opponent_may_scope: self.opponent_may_scope,
+            repeat_for: self.repeat_for,
+            player_scope: self.player_scope,
+            starting_with: self.starting_with,
+            delayed_condition: self.delayed_condition,
+            prefix_delayed_condition: self.prefix_delayed_condition,
+            multi_target: self.multi_target,
+            where_x_expression: self.where_x_expression,
+            unless_pay: self.unless_pay,
+            target_selection_mode: self.target_selection_mode,
+            target_chooser: self.target_chooser,
+            _sealed: (),
+        });
+    }
 }
 
 #[cfg(test)]
@@ -244,68 +670,111 @@ mod tests {
     }
 
     #[test]
-    fn clause_ir_default_fields() {
-        let clause = ClauseIr {
-            parsed: parsed_clause(Effect::Draw {
+    fn builder_mints_source_order_ids_and_chain_relative_spans() {
+        let chain = "draw a card. draw two cards";
+        let mut b = ClauseIrBuilder::new(chain);
+        assert!(b.is_empty());
+        assert!(b.clauses().last().is_none());
+        b.clause(
+            "draw a card",
+            parsed_clause(Effect::Draw {
                 count: QuantityExpr::Fixed { value: 1 },
                 target: TargetFilter::Controller,
             }),
-            boundary: None,
-            condition: None,
-            is_optional: false,
-            opponent_may_scope: None,
-            repeat_for: None,
-            player_scope: None,
-            starting_with: None,
-            delayed_condition: None,
-            prefix_delayed_condition: None,
-            intrinsic_continuation: None,
-            followup_continuation: None,
-            absorbed_by_followup: false,
-            multi_target: None,
-            where_x_expression: None,
-            is_otherwise: false,
-            unless_pay: None,
-            special: None,
-            source_text: "draw a card".to_string(),
-            target_selection_mode: TargetSelectionMode::Chosen,
-            target_chooser: None,
-        };
-        assert_eq!(clause.source_text, "draw a card");
-        assert!(!clause.is_optional);
-        assert!(!clause.is_otherwise);
-        assert!(!clause.absorbed_by_followup);
+            Some(ClauseBoundary::Sentence),
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
+        assert_eq!(b.clauses().last().map(|c| c.id), Some(ClauseId(0)));
+        b.clause(
+            "draw two cards",
+            parsed_clause(Effect::Draw {
+                count: QuantityExpr::Fixed { value: 2 },
+                target: TargetFilter::Controller,
+            }),
+            None,
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .is_optional(true)
+        .push();
+        let clauses = b.finish();
+        assert_eq!(clauses.len(), 2);
+        // Source-order ids.
+        assert_eq!(clauses[0].id, ClauseId(0));
+        assert_eq!(clauses[1].id, ClauseId(1));
+        // Verbatim fragment carried; span is chain-relative (not card-absolute).
+        assert_eq!(clauses[0].source.fragment(), Some("draw a card"));
+        assert!(!clauses[0].source.span().is_exact());
+        // Monotonic cursor keeps the second "draw" distinct from the first.
+        assert_eq!(clauses[1].source.fragment(), Some("draw two cards"));
+        assert!(clauses[1].source.span().start_byte > clauses[0].source.span().start_byte);
+        assert!(clauses[1].is_optional);
+    }
+
+    #[test]
+    fn builder_continue_disposition_stays_in_ir_with_own_id() {
+        let chain = "exile the top card. play that card";
+        let mut b = ClauseIrBuilder::new(chain);
+        b.clause(
+            "exile the top card",
+            parsed_clause(Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            }),
+            Some(ClauseBoundary::Sentence),
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
+        let prior = b.clauses().last().expect("prior clause").id;
+        // A continuation clause STAYS in the IR with its own id even though it
+        // emits no independent def — the honest replacement for the old
+        // `absorbed_by_followup` boolean.
+        b.clause(
+            "play that card",
+            parsed_clause(Effect::NoOp),
+            None,
+            ClauseDisposition::Continue {
+                continuation: Some(ContinuationAst::SearchResultClauseHandled),
+            },
+        )
+        .push();
+        let clauses = b.finish();
+        assert_eq!(clauses.len(), 2);
+        assert_eq!(prior, ClauseId(0));
+        assert_eq!(clauses[1].id, ClauseId(1));
+        assert!(matches!(
+            clauses[1].disposition,
+            ClauseDisposition::Continue { .. }
+        ));
     }
 
     #[test]
     fn effect_chain_ir_with_single_clause() {
+        let mut b = ClauseIrBuilder::new("draw two cards");
+        b.clause(
+            "draw two cards",
+            parsed_clause(Effect::Draw {
+                count: QuantityExpr::Fixed { value: 2 },
+                target: TargetFilter::Controller,
+            }),
+            Some(ClauseBoundary::Sentence),
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
         let ir = EffectChainIr {
-            clauses: vec![ClauseIr {
-                parsed: parsed_clause(Effect::Draw {
-                    count: QuantityExpr::Fixed { value: 2 },
-                    target: TargetFilter::Controller,
-                }),
-                boundary: Some(ClauseBoundary::Sentence),
-                condition: None,
-                is_optional: false,
-                opponent_may_scope: None,
-                repeat_for: None,
-                player_scope: None,
-                starting_with: None,
-                delayed_condition: None,
-                prefix_delayed_condition: None,
-                intrinsic_continuation: None,
-                followup_continuation: None,
-                absorbed_by_followup: false,
-                multi_target: None,
-                where_x_expression: None,
-                is_otherwise: false,
-                unless_pay: None,
-                special: None,
-                source_text: "draw two cards".to_string(),
-                target_selection_mode: TargetSelectionMode::Chosen,
-                target_chooser: None,
-            }],
+            clauses: b.finish(),
             kind: AbilityKind::Spell,
             chain_rounding: None,
             actor: None,

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -17283,37 +17283,30 @@ fn trigger_copy_token_suffix_condition_attaches_otherwise() {
 #[test]
 fn lower_effect_chain_ir_advances_boundary_past_special_clause() {
     use crate::parser::oracle_ir::ast::{parsed_clause, ClauseBoundary};
-    use crate::parser::oracle_ir::effect_chain::{ClauseIr, EffectChainIr, SpecialClause};
+    use crate::parser::oracle_ir::effect_chain::{
+        ClauseDisposition, ClauseIrBuilder, EffectChainIr, SpecialClause,
+    };
     use crate::types::ability::SubAbilityLink;
 
-    fn make_clause(
+    fn push_clause(
+        builder: &mut ClauseIrBuilder,
         effect: Effect,
         boundary: Option<ClauseBoundary>,
         special: Option<SpecialClause>,
-    ) -> ClauseIr {
-        ClauseIr {
-            parsed: parsed_clause(effect),
-            boundary,
-            condition: None,
-            is_optional: false,
-            opponent_may_scope: None,
-            repeat_for: None,
-            player_scope: None,
-            starting_with: None,
-            delayed_condition: None,
-            prefix_delayed_condition: None,
-            intrinsic_continuation: None,
-            followup_continuation: None,
-            absorbed_by_followup: false,
-            multi_target: None,
-            where_x_expression: None,
-            is_otherwise: false,
-            unless_pay: None,
-            special,
-            source_text: String::new(),
-            target_selection_mode: Default::default(),
-            target_chooser: None,
-        }
+    ) {
+        let disposition = match special {
+            Some(action) => ClauseDisposition::Special {
+                action,
+                intrinsic: None,
+            },
+            None => ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        };
+        builder
+            .clause("", parsed_clause(effect), boundary, disposition)
+            .push();
     }
 
     let draw_one = || Effect::Draw {
@@ -17327,19 +17320,20 @@ fn lower_effect_chain_ir_advances_boundary_past_special_clause() {
         draw_one(),
     ));
 
+    let mut builder = ClauseIrBuilder::new("");
+    // clause 0: normal, trailing boundary = Comma
+    push_clause(&mut builder, draw_one(), Some(ClauseBoundary::Comma), None);
+    // clause 1: SpecialClause::Otherwise, trailing boundary = Sentence
+    push_clause(
+        &mut builder,
+        draw_one(),
+        Some(ClauseBoundary::Sentence),
+        Some(SpecialClause::Otherwise(otherwise_def)),
+    );
+    // clause 2: normal — must stamp sub_link from clause 1's Sentence
+    push_clause(&mut builder, draw_one(), None, None);
     let ir = EffectChainIr {
-        clauses: vec![
-            // clause 0: normal, trailing boundary = Comma
-            make_clause(draw_one(), Some(ClauseBoundary::Comma), None),
-            // clause 1: SpecialClause::Otherwise, trailing boundary = Sentence
-            make_clause(
-                draw_one(),
-                Some(ClauseBoundary::Sentence),
-                Some(SpecialClause::Otherwise(otherwise_def)),
-            ),
-            // clause 2: normal — must stamp sub_link from clause 1's Sentence
-            make_clause(draw_one(), None, None),
-        ],
+        clauses: builder.finish(),
         kind: AbilityKind::Spell,
         chain_rounding: None,
         actor: None,


### PR DESCRIPTION
Replace the ad-hoc `Vec<ClauseIr>` accumulation in `parse_effect_chain_ir`
with an item-scoped `ClauseIrBuilder` that is the single authority for
`ClauseIr` construction — a `_sealed` field makes every external struct
literal a compile error, so the builder's one internal `push` is the sole
construction site. Each clause now carries a typed identity + provenance:

- `ClauseId(u32)`: source-order identity minted by the builder.
- `source: OracleUnitSource` at the new honest `SpanPrecision::ChainRelative`
  tier — byte-exact within the effect chain and carrying the verbatim
  fragment, upgradeable to card-absolute once the document allocator is
  threaded through `ParseContext` (a later unit). The fragment-precision
  guard consults a widened `carries_fragment` (Exact | ChainRelative) rather
  than `is_exact`, so the new tier can carry its fragment without reopening
  the whole-document-fragment hole.
- `ClauseDisposition` (Emit / Continue / Special): folds the former
  `absorbed_by_followup` + `special` discriminants into one typed enum. The
  two continuations are orthogonal to the discriminant, so they are exposed
  as role-named accessors that span variants: `followup()` (prior-patch;
  carried by Emit + Continue) and `intrinsic()` (self-patch; carried by
  Emit + Special).

`absorb_clause` re-mints a nested chain's clauses through the same
`.clause(...).push()` path, preserving the single-construction invariant.
The dead `is_otherwise` field is dropped (zero readers, verified).

Ten identical `Effect::Unimplemented { description: None }` placeholders (the
`.parsed` field of `Special`-disposition clauses, where the real semantics
live in the disposition) are folded into one `placeholder_parsed_clause`
helper — byte-identical, but DRY and distinct from the `Effect::unimplemented`
parse-gap constructor (which forces `description: Some`).

Faithful-by-intent, no behavior change: the IR snapshot parity tests hold
with zero `_lowered.snap` movement (63 snapshot tests + the full parser
suite green under `-D warnings`). locate() verbatim-fragment fallback rate:
1/4859 (0.02%) over the 568-card fixture.
