### PR TITLE
feat(engine): Captain America, First Avenger via UnattachFrom cost + divided damage

### DIFF
--- a/crates/engine/src/analysis/ability_graph.rs
+++ b/crates/engine/src/analysis/ability_graph.rs
@@ -1539,6 +1539,7 @@ fn fold_cost(acc: &mut NodeAcc, cost: &AbilityCost) {
         | AbilityCost::PaySpeed { .. }
         | AbilityCost::ReturnToHand { .. }
         | AbilityCost::Unattach
+        | AbilityCost::UnattachFrom { .. }
         | AbilityCost::Mill { .. }
         | AbilityCost::Exert
         | AbilityCost::Reveal { .. }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13695,6 +13695,20 @@ pub(super) fn find_non_self_exile(
     }
 }
 
+/// CR 701.3d + CR 608.2k: Detect a non-self `UnattachFrom` activation cost
+/// (Captain America's Throw) requiring an interactive "unattach a matching
+/// attachment from the source" selection. Returns `(count, filter)`. The
+/// source-self `Unattach` unit variant returns `None` — it detaches the source
+/// Equipment itself and is auto-paid, never surfaced interactively. Recurses
+/// into `Composite`, mirroring `find_non_self_exile`.
+pub(super) fn find_unattach_from_cost(cost: &AbilityCost) -> Option<(u32, &TargetFilter)> {
+    match cost {
+        AbilityCost::UnattachFrom { filter, count } => Some((*count, filter)),
+        AbilityCost::Composite { costs } => costs.iter().find_map(find_unattach_from_cost),
+        _ => None,
+    }
+}
+
 /// CR 117.1 + CR 601.2b: Detect an `ExileWithAggregate` activation cost (Baron
 /// Helmut Zemo's Boast) requiring an interactive "exile any number reaching the
 /// aggregate threshold" selection. Returns a borrowed view of its parameters.
@@ -13868,6 +13882,38 @@ pub(crate) fn find_eligible_exile_for_cost_targets(
                 .unwrap_or_default()
         }
     }
+}
+
+/// CR 701.3d + CR 601.2b + CR 202.3: Battlefield attachments controlled by
+/// `player`, currently attached to `source`, matching `filter`, whose mana value
+/// is at least `n`. Mirrors `find_eligible_exile_for_cost_targets`. The `n`
+/// mana-value floor implements the divided-damage legality gate (CR 601.2c/M1):
+/// the chosen Equipment's mana value is the total damage divided among the
+/// announced targets, so it must be >= the target count. Pass `n = 0` for the
+/// generic eligibility count (no floor).
+pub(crate) fn find_eligible_unattach_for_cost_targets(
+    state: &GameState,
+    player: PlayerId,
+    source: ObjectId,
+    filter: &TargetFilter,
+    n: u32,
+) -> Vec<ObjectId> {
+    let ctx = super::filter::FilterContext::from_source(state, source);
+    state
+        .battlefield
+        .iter()
+        .copied()
+        .filter(|&id| {
+            let Some(obj) = state.objects.get(&id) else {
+                return false;
+            };
+            // CR 701.3d: only attachments currently attached to the source host.
+            obj.controller == player
+                && obj.attached_to.and_then(|t| t.as_object()) == Some(source)
+                && obj.effective_mana_value() >= n
+                && super::filter::matches_target_filter(state, id, filter, &ctx)
+        })
+        .collect()
 }
 
 fn find_one_of_cost(cost: &AbilityCost) -> Option<&Vec<AbilityCost>> {
@@ -15464,6 +15510,11 @@ pub fn handle_activate_ability(
         pending_target.activation_cost = ability_def.cost.clone();
         pending_target.activation_ability_index = Some(ability_index);
         pending_target.target_constraints = target_constraints;
+        // CR 601.2d: propagate the divided-effect flag so a targeted activated
+        // ability that divides damage/counters among its targets (Captain
+        // America's Throw) reaches the `DistributeAmong` step after its costs are
+        // paid. Mirrors the spell target-selection path (`pending_targets.distribute`).
+        pending_target.distribute = ability_def.distribute.clone();
         return Ok(WaitingFor::TargetSelection {
             player,
             pending_cast: Box::new(pending_target),

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1795,6 +1795,117 @@ pub(crate) fn handle_sacrifice_for_cost(
     Ok(waiting_for)
 }
 
+/// CR 701.3d + CR 608.2k + CR 601.2d: Complete a non-self `UnattachFrom` cost
+/// (Captain America's Throw) after the player selects which attachment(s) to
+/// unattach. Validates each chosen object is still a controlled battlefield
+/// attachment on the source matching `filter`, snapshots the first as the
+/// cost-referent BEFORE detaching (CR 608.2k — "that Equipment's mana value"),
+/// detaches them (CR 701.3d — the Equipment stays on the battlefield), then
+/// re-surfaces the deferred damage division now that the divided total is known
+/// (CR 601.2d). Mirrors `handle_sacrifice_for_cost`, but the object is detached
+/// rather than destroyed and stays on the battlefield.
+pub(crate) fn handle_unattach_for_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    filter: &TargetFilter,
+    mut pending: PendingCast,
+    choices: &[ObjectId],
+    chosen: &[ObjectId],
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    // CR 601.2h: at least one attachment must be chosen (the detour sets
+    // min_count == count, so an empty selection is an illegal partial payment).
+    if chosen.is_empty() {
+        return Err(EngineError::InvalidAction(
+            "Must unattach at least one attachment to pay the cost".to_string(),
+        ));
+    }
+    let ctx = super::filter::FilterContext::from_source(state, pending.object_id);
+    for &id in chosen {
+        if !choices.contains(&id) {
+            return Err(EngineError::InvalidAction(
+                "Selected attachment not eligible to unattach".to_string(),
+            ));
+        }
+        let Some(obj) = state.objects.get(&id) else {
+            return Err(EngineError::InvalidAction(
+                "Attachment not found for unattach cost".to_string(),
+            ));
+        };
+        // CR 701.3d: must still be a controlled battlefield attachment on the
+        // source that matches the cost's filter.
+        if obj.zone != Zone::Battlefield
+            || obj.controller != player
+            || obj.attached_to.and_then(|t| t.as_object()) != Some(pending.object_id)
+            || !super::filter::matches_target_filter(state, id, filter, &ctx)
+        {
+            return Err(EngineError::InvalidAction(
+                "Attachment no longer eligible to unattach".to_string(),
+            ));
+        }
+    }
+
+    // CR 608.2k + CR 400.7j: capture the detached object's public characteristics
+    // BEFORE it leaves the source, stamping it onto the resolving ability as the
+    // cost-paid-object referent for "that Equipment's mana value".
+    if let Some(&first) = chosen.first() {
+        if let Some(snapshot) = state.objects.get(&first).map(|obj| CostPaidObjectSnapshot {
+            object_id: first,
+            lki: obj.snapshot_for_mana_spent(),
+        }) {
+            pending
+                .ability
+                .set_cost_paid_object_recursive(snapshot.clone());
+            // Gated to spell casts only (same guard as `handle_sacrifice_for_cost`):
+            // an activation's `object_id` is the source permanent, whose own cast
+            // provenance must not be overwritten. Captain America's Throw is an
+            // activation, so this stamp is skipped.
+            if pending.activation_ability_index.is_none() {
+                if let Some(spell_obj) = state.objects.get_mut(&pending.object_id) {
+                    spell_obj.cast_cost_paid_object = Some(snapshot);
+                }
+            }
+        }
+    }
+
+    // CR 701.3d: detach each chosen attachment; the Equipment stays on the
+    // battlefield (only the attachment link is cleared).
+    for &id in chosen {
+        if let Some(old_target) = super::effects::attach::unattach(state, id) {
+            events.push(GameEvent::Unattached {
+                attachment_id: id,
+                old_target,
+            });
+        }
+    }
+
+    // CR 601.2d + CR 608.2k: if this ability divides an effect among targets
+    // (Captain America's Throw), the divided total (the unattached Equipment's
+    // mana value) is only knowable now, after the cost is paid. Re-surface the
+    // division with the resolved total; the pending cast — with its activation
+    // index intact — resumes via the DistributeAmong handler, which pays the
+    // residual mana leg. Mirrors `maybe_pause_for_cast_distribution`.
+    if let Some(unit) = pending.distribute.clone() {
+        if let Some(total) = super::casting_targets::extract_distribution_total(
+            state,
+            &pending.ability,
+            &pending.ability.effect,
+        ) {
+            let targets = super::ability_utils::distribution_targets(&pending.ability);
+            state.pending_cast = Some(Box::new(pending));
+            return Ok(WaitingFor::DistributeAmong {
+                player,
+                total,
+                targets,
+                unit,
+            });
+        }
+    }
+
+    // Generic `UnattachFrom` with no division: finish the cost/cast normally.
+    finish_pending_cost_or_cast(state, player, pending, events)
+}
+
 /// CR 118.3 + CR 601.2b: Complete return-to-hand-as-cost after player selection.
 pub(crate) fn handle_return_to_hand_for_cost(
     state: &mut GameState,
@@ -2971,7 +3082,15 @@ pub(super) fn push_activated_ability_to_stack(
     // before target selection in handle_activate_ability.
     let target_slots = build_target_slots(state, &resolved)?;
     let assigned_targets = flatten_targets_in_chain(&resolved);
-    if !target_slots.is_empty() && assigned_targets.len() >= target_slots.len() {
+    // CR 601.2d: A divided-effect ability whose `distribution` is already
+    // announced has finalized its targets (a legal "up to N" division may fill
+    // fewer target slots than exist — Captain America's Throw picks 1 of 3), so
+    // it is ready to go on the stack even though `assigned_targets.len()` is below
+    // `target_slots.len()`. Without this the re-check would wrongly re-open target
+    // selection and drop the announced division.
+    if !target_slots.is_empty()
+        && (assigned_targets.len() >= target_slots.len() || resolved.distribution.is_some())
+    {
         emit_targeting_events(state, &assigned_targets, source_id, player, events);
         return push_ability_entry(state, player, source_id, ability_index, resolved, events);
     }

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -569,6 +569,46 @@ fn pay_activation_costs_after_target_selection(
             }));
         }
 
+        // CR 701.3d + CR 601.2c/601.2h: a targeted "unattach a matching
+        // attachment from ~" ability chooses its targets first, then surfaces the
+        // Unattach cost interactively (Captain America's Throw). The chosen
+        // Equipment's mana value drives the divided damage (CR 202.3 + CR 608.2k),
+        // so eligibility narrows to attachments whose mana value is at least the
+        // announced target count (CR 601.2c). Modeled on the non-self exile detour.
+        if let Some((count, filter)) = super::casting::find_unattach_from_cost(activation_cost) {
+            let n = distribution_targets(&assigned_ability).len() as u32;
+            let eligible = super::casting::find_eligible_unattach_for_cost_targets(
+                state,
+                player,
+                pending.object_id,
+                filter,
+                n,
+            );
+            if eligible.is_empty() {
+                // CR 733 / CR 601.2h: unpayable cost — nothing has been detached
+                // (pre-commit revert), so the activation is simply illegal.
+                return Err(EngineError::ActionNotAllowed(
+                    "No eligible Equipment to unattach with mana value >= target count".into(),
+                ));
+            }
+            let mut pending = pending.clone();
+            pending.ability = assigned_ability;
+            // CR 601.2h: unattach-from is a required cost — no decline, exactly
+            // `count` selections.
+            return Ok(Some(WaitingFor::PayCost {
+                player,
+                kind: PayCostKind::UnattachFrom {
+                    filter: filter.clone(),
+                },
+                choices: eligible,
+                count: count as usize,
+                min_count: count as usize,
+                resume: CostResume::Spell {
+                    spell: Box::new(pending),
+                },
+            }));
+        }
+
         let should_record_loyalty = crate::types::ability::is_loyalty_ability_cost(activation_cost)
             && super::planeswalker::can_activate_loyalty_ability(
                 state,

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -530,6 +530,18 @@ impl AbilityCost {
                         .any(|subtype| subtype == "Equipment")
                     && obj.attached_to.is_some()
             }),
+            // CR 701.3d + CR 601.2b: An unattach-from cost is payable iff the
+            // source controls >= `count` battlefield attachments matching `filter`
+            // currently attached to it. The generic eligibility count uses `n = 0`
+            // (no mana-value floor); the divided-damage MV>=N narrowing lives in
+            // the interactive detour (`find_eligible_unattach_for_cost_targets`).
+            AbilityCost::UnattachFrom { filter, count } => {
+                super::casting::find_eligible_unattach_for_cost_targets(
+                    state, player, source, filter, 0,
+                )
+                .len()
+                    >= *count as usize
+            }
             // CR 701.13b: A player can mill fewer than N cards if their library
             // has fewer than N; the cost is always payable.
             AbilityCost::Mill { .. } => true,

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1009,6 +1009,11 @@ fn pay_ability_cost_inner(
         | AbilityCost::Mill { .. }
         | AbilityCost::Blight { .. }
         | AbilityCost::Reveal { .. }
+        // CR 701.3d + CR 601.2h: A non-self unattach cost is paid by the
+        // interactive `WaitingFor::PayCost { kind: UnattachFrom }` detour before
+        // this resume runs, so this arm is an idempotent no-op (mirrors the
+        // non-self Exile/Sacrifice interactive-cost arms).
+        | AbilityCost::UnattachFrom { .. }
         | AbilityCost::Behold { .. } => {}
         AbilityCost::Discard { .. } | AbilityCost::NinjutsuFamily { .. } => {
             // At Activation these shapes are intercepted by the interactive
@@ -1187,6 +1192,9 @@ fn supported_at_resolution(cost: &AbilityCost) -> bool {
         | AbilityCost::ReturnToHand { .. }
         | AbilityCost::Mill { .. }
         | AbilityCost::Unattach
+        // CR 701.3d: an unattach-from cost is paid at activation via the
+        // interactive `PayCost { UnattachFrom }` detour, never at resolution.
+        | AbilityCost::UnattachFrom { .. }
         | AbilityCost::Exert
         | AbilityCost::Blight { .. }
         | AbilityCost::Reveal { .. }
@@ -1318,6 +1326,9 @@ fn can_pay_resolution(
         | AbilityCost::Tap
         | AbilityCost::Untap
         | AbilityCost::Unattach
+        // CR 701.3d: an unattach-from cost is an activation cost, not a
+        // resolution-time cost; refuse here like the unit `Unattach`.
+        | AbilityCost::UnattachFrom { .. }
         | AbilityCost::Loyalty { .. }
         | AbilityCost::Sacrifice(_)
         | AbilityCost::Exile { .. }
@@ -1429,6 +1440,10 @@ mod tests {
                 from_zone: None,
             },
             AbilityCost::Unattach => AbilityCost::Unattach,
+            AbilityCost::UnattachFrom { .. } => AbilityCost::UnattachFrom {
+                filter: TargetFilter::Any,
+                count: 1,
+            },
             AbilityCost::Mill { .. } => AbilityCost::Mill { count: 1 },
             AbilityCost::Exert => AbilityCost::Exert,
             AbilityCost::Blight { .. } => AbilityCost::Blight { count: 1 },
@@ -1544,6 +1559,10 @@ mod tests {
                 from_zone: None,
             },
             AbilityCost::Unattach,
+            AbilityCost::UnattachFrom {
+                filter: TargetFilter::Any,
+                count: 1,
+            },
             AbilityCost::Mill { count: 0 },
             AbilityCost::Exert,
             AbilityCost::Blight { count: 0 },

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -2158,6 +2158,21 @@ fn apply_action(
                         &mut events,
                     )?
                 }
+                // CR 701.3d + CR 608.2k: Unattach a matching attachment from the
+                // source as an activation cost (Captain America's Throw). The
+                // handler snapshots the detached Equipment as the cost-referent,
+                // then re-surfaces the deferred damage division.
+                PayCostKind::UnattachFrom { filter } => {
+                    casting_costs::handle_unattach_for_cost(
+                        state,
+                        *player,
+                        filter,
+                        *pending_cast.clone(),
+                        choices,
+                        &chosen,
+                        &mut events,
+                    )?
+                }
                 // CR 702.167a/b: Craft materials exile across the
                 // battlefield/graveyard union.
                 PayCostKind::ExileMaterials { materials } => {
@@ -2297,7 +2312,15 @@ fn apply_action(
                 | PayCostKind::ExilePermanent { .. }
                 | PayCostKind::ExileAggregate { .. }
                 | PayCostKind::RemoveCounter { .. }
+                // CR 701.3d: an unattach-from cost is only ever surfaced via
+                // `CostResume::Spell` (targeted activation), never as a mana
+                // ability — unreachable here.
+                | PayCostKind::UnattachFrom { .. }
                 | PayCostKind::Behold { .. } => {
+                    debug_assert!(
+                        !matches!(kind, PayCostKind::UnattachFrom { .. }),
+                        "UnattachFrom cost cannot resume a mana ability",
+                    );
                     return Err(EngineError::InvalidAction(
                         "Cost kind cannot resume a mana ability".into(),
                     ));
@@ -4833,43 +4856,66 @@ fn apply_action(
 
             // CR 601.2d: Resume casting pipeline after distribution.
             if state.pending_cast.is_some() {
-                // CR 601.2c + CR 601.2d + CR 601.2f: Targets and their division are now
-                // committed, so the total cost — including any target-dependent
-                // surcharge (Strive, CR 207.2c) — is finally determinable. Route through
-                // the single cost-determination authority every other post-target-
-                // selection path uses (`casting_targets::handle_select_targets` /
-                // `handle_choose_target`) instead of calling `finalize_cast` directly
-                // with the stale cost that was locked in at `ChooseXValue` time, before
-                // targets (and hence any per-target surcharge) were known.
                 let pending = state.pending_cast.take().unwrap();
-                // CR 601.2h ("Unpayable costs can't be paid"): mirror
-                // `finalize_mana_payment`'s `pending_for_restore` pattern
-                // (casting_costs.rs ~8623-8627/8778-8787) — `finish_pending_cast_cost_or_pay`'s
-                // downstream chain has no restore-on-error wrapper of its own, and
-                // `state.pending_cast` is already `None` here (unlike
-                // `handle_select_targets`, whose `pending_cast` lives inside the
-                // `WaitingFor::TargetSelection` variant and so is never destructively
-                // taken). Without this clone-and-restore, a recomputed cost that turns
-                // out unpayable would return `Err` with `state.pending_cast` gone while
-                // `state.waiting_for` still reports `DistributeAmong` — a resubmitted
-                // `DistributeAmong` action would then fall through to the
-                // resolution-time continuation branch below instead of being cleanly
-                // rejected.
-                let pending_for_restore = pending.clone();
-                let ability = pending.ability.clone();
-                let cost = pending.cost.clone();
-                match casting_costs::finish_pending_cast_cost_or_pay(
-                    state,
-                    p,
-                    *pending,
-                    ability,
-                    cost,
-                    &mut events,
-                ) {
-                    Ok(waiting_for) => waiting_for,
-                    Err(err) => {
-                        state.pending_cast = Some(pending_for_restore);
-                        return Err(err);
+                if let Some(ability_index) = pending.activation_ability_index {
+                    // CR 602.2b + CR 601.2d: an activated ability that divides
+                    // damage among targets goes on the stack as an ActivatedAbility
+                    // after the division is announced — not as a spell (Captain
+                    // America's Throw). `push_activated_ability_to_stack` pays the
+                    // residual mana leg and no-ops the already-paid UnattachFrom.
+                    // The spell-only cost-determination authority used in the `else`
+                    // branch (`finish_pending_cast_cost_or_pay`) must NOT be reached
+                    // here: it routes into `finalize_cast`, which would commit the
+                    // source permanent to the stack as a spell.
+                    casting_costs::push_activated_ability_to_stack(
+                        state,
+                        p,
+                        pending.object_id,
+                        ability_index,
+                        pending.ability,
+                        pending.activation_cost.as_ref(),
+                        pending.activation_residual,
+                        &mut events,
+                    )?
+                } else {
+                    // CR 601.2c + CR 601.2d + CR 601.2f: Targets and their division are now
+                    // committed, so the total cost — including any target-dependent
+                    // surcharge (Strive, CR 207.2c) — is finally determinable. Route through
+                    // the single cost-determination authority every other post-target-
+                    // selection path uses (`casting_targets::handle_select_targets` /
+                    // `handle_choose_target`) instead of calling `finalize_cast` directly
+                    // with the stale cost that was locked in at `ChooseXValue` time, before
+                    // targets (and hence any per-target surcharge) were known.
+                    //
+                    // CR 601.2h ("Unpayable costs can't be paid"): mirror
+                    // `finalize_mana_payment`'s `pending_for_restore` pattern
+                    // (casting_costs.rs ~8623-8627/8778-8787) — `finish_pending_cast_cost_or_pay`'s
+                    // downstream chain has no restore-on-error wrapper of its own, and
+                    // `state.pending_cast` is already `None` here (unlike
+                    // `handle_select_targets`, whose `pending_cast` lives inside the
+                    // `WaitingFor::TargetSelection` variant and so is never destructively
+                    // taken). Without this clone-and-restore, a recomputed cost that turns
+                    // out unpayable would return `Err` with `state.pending_cast` gone while
+                    // `state.waiting_for` still reports `DistributeAmong` — a resubmitted
+                    // `DistributeAmong` action would then fall through to the
+                    // resolution-time continuation branch below instead of being cleanly
+                    // rejected.
+                    let pending_for_restore = pending.clone();
+                    let ability = pending.ability.clone();
+                    let cost = pending.cost.clone();
+                    match casting_costs::finish_pending_cast_cost_or_pay(
+                        state,
+                        p,
+                        *pending,
+                        ability,
+                        cost,
+                        &mut events,
+                    ) {
+                        Ok(waiting_for) => waiting_for,
+                        Err(err) => {
+                            state.pending_cast = Some(pending_for_restore);
+                            return Err(err);
+                        }
                     }
                 }
             } else if let Some(mut pending_trigger) = state.pending_trigger.take() {

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -1031,6 +1031,7 @@ pub(super) fn handle_unless_payment(
             AbilityCost::Tap
             | AbilityCost::Untap
             | AbilityCost::Unattach
+            | AbilityCost::UnattachFrom { .. }
             | AbilityCost::Loyalty { .. }
             | AbilityCost::PaySpeed { .. }
             | AbilityCost::Exile { .. }

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -845,6 +845,7 @@ fn walk_cost(cost: &AbilityCost, out: &mut Vec<String>) {
         | AbilityCost::PaySpeed { .. }
         | AbilityCost::ReturnToHand { .. }
         | AbilityCost::Unattach
+        | AbilityCost::UnattachFrom { .. }
         | AbilityCost::Mill { .. }
         | AbilityCost::Exert
         | AbilityCost::Blight { .. }

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -612,6 +612,7 @@ fn replacement_cost_description(cost: &AbilityCost) -> String {
         | AbilityCost::PaySpeed { .. }
         | AbilityCost::ReturnToHand { .. }
         | AbilityCost::Unattach
+        | AbilityCost::UnattachFrom { .. }
         | AbilityCost::Mill { .. }
         | AbilityCost::Exert
         | AbilityCost::Blight { .. }

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -1080,6 +1080,28 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
         return AbilityCost::Unattach;
     }
 
+    // CR 701.3d + CR 608.2k: "Unattach a[n] <type> from ~" — unattach a matching
+    // attachment from the source host as a cost (Captain America's Throw). The
+    // detached object stays on the battlefield and becomes this ability's
+    // cost-referent. Kept AFTER the more-specific self-unattach branch above.
+    // The "from ~" recipient is normalized from the card name upstream
+    // (`normalize_card_name_refs`).
+    if let Some(((), after_article)) = nom_on_lower(text, &lower, |i| {
+        let (i, _) = tag("unattach ").parse(i)?;
+        value((), alt((tag("an "), tag("a ")))).parse(i)
+    }) {
+        let (filter, remainder) = parse_type_phrase(after_article);
+        let rem_lower = remainder.to_lowercase();
+        if let Some(((), tail)) = nom_on_lower(remainder, &rem_lower, |i| {
+            value((), preceded(tag(" from "), parse_cost_self_reference)).parse(i)
+        }) {
+            if tail.is_empty() {
+                // Only count == 1 has Oracle support today ("a[n] <type>").
+                return AbilityCost::UnattachFrom { filter, count: 1 };
+            }
+        }
+    }
+
     // "reveal your hand" — reveal the controller's entire hand.
     // CR 701.20a: Reveal means show to all players. Used as alternative cost
     // (Land Grant class). Modeled as EffectCost wrapping Effect::RevealHand.
@@ -2172,6 +2194,36 @@ mod tests {
             AbilityCost::Unattach
         );
         assert_eq!(parse_oracle_cost("Unattach ~"), AbilityCost::Unattach);
+    }
+
+    #[test]
+    fn cost_unattach_a_type_from_self() {
+        // CR 701.3d + CR 608.2k: Captain America's Throw cost. The recipient
+        // "from Captain America, First Avenger" is normalized to "from ~"
+        // upstream by `normalize_card_name_refs`.
+        let (expected_filter, remainder) = super::parse_type_phrase("Equipment from ~");
+        assert_eq!(remainder, " from ~");
+        assert_eq!(
+            parse_oracle_cost("Unattach an Equipment from ~"),
+            AbilityCost::UnattachFrom {
+                filter: expected_filter,
+                count: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn cost_unattach_self_still_unit_variant() {
+        // Negative: the more-specific self-unattach branch must win; it must NOT
+        // be captured by the new "unattach a[n] <type> from ~" branch.
+        assert_eq!(
+            parse_oracle_cost("Unattach this Equipment"),
+            AbilityCost::Unattach
+        );
+        assert!(!matches!(
+            parse_oracle_cost("Unattach this Equipment"),
+            AbilityCost::UnattachFrom { .. }
+        ));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -8062,6 +8062,7 @@ fn apply_where_x_to_ability_cost(cost: &mut AbilityCost, where_x_expression: Opt
         | AbilityCost::RemoveCounter { .. }
         | AbilityCost::ReturnToHand { .. }
         | AbilityCost::Unattach
+        | AbilityCost::UnattachFrom { .. }
         | AbilityCost::Mill { .. }
         | AbilityCost::Exert
         | AbilityCost::Blight { .. }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5761,6 +5761,27 @@ fn multi_target_for_distribute_among(distribution_amount: &QuantityExpr) -> Mult
     MultiTargetSpec::bounded_expr(min, inner.clone())
 }
 
+/// CR 601.2d: The keywords that introduce a divided/distributed *damage* effect.
+/// Single authority for the "is this a distribution clause?" membership test —
+/// extend here, never inline at a call site.
+///
+/// Two callers must agree on this set. `try_parse_distribute_damage` bounds its
+/// Pattern-B quantity slice with it, and `try_parse_choose_one_of_inline` bails out
+/// of the generic binary-choice splitter for any clause containing one, because the
+/// target-count list embeds a bare " or " ("among one, two, or three targets") that
+/// is a cardinality list, not a disjunction of clauses. If the two sets were allowed
+/// to drift, a newly supported distribution phrasing would parse correctly here yet
+/// still be split there — re-entering the clause cascade and overflowing the stack.
+///
+/// SCOPE: damage templating only. CR 601.2d also covers dividing *counters*
+/// ("such as damage or counters"), and the counter templating ("Distribute three
+/// +1/+1 counters among one, two, or three target creatures") carries the same bare
+/// " or " and is NOT guarded here — it is a pre-existing hazard on `main`, tracked
+/// separately. The durable fix keys the bail on the target-cardinality list rather
+/// than on the distribution verb, which covers both halves of the rule at once.
+pub(super) const DISTRIBUTION_KEYWORDS: [&str; 2] =
+    ["divided as you choose among", "divided evenly"];
+
 /// CR 601.2d: Parse "deal N damage divided as you choose among [targets]" and
 /// "deal N damage distributed among [targets]" → Effect::DealDamage with distribute flag.
 ///
@@ -5808,18 +5829,14 @@ pub(super) fn try_parse_distribute_damage(lower: &str, text: &str) -> Option<Par
         // as in Pattern A.
         let after_prefix_offset = after_tp.lower.len() - after_prefix.len();
         let (_, rest) = after_tp.split_at(after_prefix_offset);
-        let qty_end = [
-            "divided as you choose among",
-            "distributed among",
-            "divided evenly",
-        ]
-        .iter()
-        // allow-noncombinator: structural slice bound, not parsing dispatch — locate
-        // the earliest distribution keyword so `parse_cda_quantity` receives only the
-        // quantity phrase. The dispatch on *which* distribution kind applies is done
-        // by the `distribute_kind` combinator block below; this only bounds the slice.
-        .filter_map(|kw| rest.lower.find(kw))
-        .min()?;
+        let qty_end = DISTRIBUTION_KEYWORDS
+            .iter()
+            // allow-noncombinator: structural slice bound, not parsing dispatch — locate
+            // the earliest distribution keyword so `parse_cda_quantity` receives only the
+            // quantity phrase. The dispatch on *which* distribution kind applies is done
+            // by the `distribute_kind` combinator block below; this only bounds the slice.
+            .filter_map(|kw| rest.lower.find(kw))
+            .min()?;
         let qty_text = rest.lower[..qty_end].trim();
         let qty = parse_cda_quantity(qty_text)?;
         (qty, rest)

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -4971,6 +4971,38 @@ fn try_parse_choose_one_of_inline(
     {
         return None;
     }
+
+    // CR 601.2d: The divided/distributed-damage target-count quantifier
+    // ("divided as you choose among one, two, or three targets") embeds a bare
+    // " or " inside the cardinality list "one, two, or three", NOT a disjunction
+    // of two imperative clauses. Splitting there hands the orphan tail
+    // ("three targets") back through the full effect→subject→static→imperative
+    // recognizer cascade as a trial parse; because that tail is not a standalone
+    // effect, the cascade re-enters this clause parser several levels deep, and
+    // the parser's large per-frame AST locals overflow small (~1-2 MB) thread
+    // stacks. The dedicated `try_parse_distribute_damage` handler
+    // (`oracle_effect::lower`) owns this whole clause and reads the count list
+    // via `strip_distribute_among_target_quantifier`, so skip the generic binary
+    // splitter for any distribution clause and let that handler claim it.
+    //
+    // The keyword set is owned by `lower::DISTRIBUTION_KEYWORDS` — the same set the
+    // handler bounds its quantity slice with. Both must agree: a phrasing the handler
+    // learned but this guard did not would parse there and still split here.
+    //
+    // KNOWN GAP (pre-existing on `main`, not introduced here): this keys on the
+    // distribution *verb*, but the hazard is the target-cardinality list. CR 601.2d
+    // covers dividing "damage or counters", and the counter templating ("Distribute
+    // three +1/+1 counters among one, two, or three target creatures") carries the
+    // same bare " or " and is still split. The durable fix keys the bail on the
+    // cardinality list (`lower::BOUNDED_TARGET_PHRASES`), covering both halves at
+    // once; and the underlying cause is that a failed trial parse re-enters the
+    // clause cascade with no depth bound. Both are tracked as follow-ups.
+    if lower::DISTRIBUTION_KEYWORDS
+        .iter()
+        .any(|needle| nom_primitives::scan_contains(tp.lower, needle))
+    {
+        return None;
+    }
     let (before_lower, after_lower) =
         split_around(tp.lower, ", or ").or_else(|| split_around(tp.lower, " or "))?;
 

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -669,6 +669,9 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
             parse_cost_paid_object_ref,
             parse_cost_paid_object_prepositional_ref,
             parse_cost_paid_object_chosen_revealed_ref,
+            // CR 608.2k + CR 202.3: "that Equipment's mana value" (Captain
+            // America's Throw) — demonstrative back-reference to the paid attachment.
+            parse_cost_paid_object_demonstrative_ref,
         )),
         parse_event_context_refs,
     ))
@@ -2644,6 +2647,34 @@ fn parse_cost_paid_object_chosen_revealed_ref(input: &str) -> OracleResult<'_, Q
         ObjectProperty::ManaValue | ObjectProperty::ManaSymbolCount(_) => {
             return Err(oracle_err(input))
         }
+    };
+    Ok((rest, qty))
+}
+
+/// CR 608.2k + CR 202.3: Demonstrative back-reference to the attachment paid as
+/// this ability's cost. "that Equipment's mana value" / "that Aura's power" —
+/// "that <attachment-type>" points at the object unattached (or otherwise paid)
+/// as the cost (Captain America's Throw: "Unattach an Equipment from ~ … that
+/// Equipment's mana value"). Restricted to attachment subtypes (Equipment / Aura
+/// / Fortification) so it never collides with target demonstratives like "that
+/// creature". Resolves against the same `ObjectScope::CostPaidObject` referent as
+/// the participle possessive form above.
+fn parse_cost_paid_object_demonstrative_ref(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = tag("that ").parse(input)?;
+    let (rest, _) = alt((tag("equipment"), tag("aura"), tag("fortification"))).parse(rest)?;
+    let (rest, property) = parse_object_property_possessive_suffix(rest)?;
+    let qty = match property {
+        ObjectProperty::ManaValue => QuantityRef::ObjectManaValue {
+            scope: ObjectScope::CostPaidObject,
+        },
+        ObjectProperty::Power => QuantityRef::Power {
+            scope: ObjectScope::CostPaidObject,
+        },
+        ObjectProperty::Toughness => QuantityRef::Toughness {
+            scope: ObjectScope::CostPaidObject,
+        },
+        // `parse_object_property_possessive_suffix` never emits ManaSymbolCount.
+        ObjectProperty::ManaSymbolCount(_) => return Err(oracle_err(input)),
     };
     Ok((rest, qty))
 }
@@ -9515,5 +9546,40 @@ mod tests {
             panic!("expected typed filter");
         };
         assert!(tf.properties.contains(&FilterProp::NonToken));
+    }
+
+    #[test]
+    fn parse_that_equipments_mana_value_is_cost_paid_object() {
+        // CR 608.2k + CR 202.3: Captain America's Throw — "that Equipment's mana
+        // value" back-references the unattached (cost-paid) Equipment.
+        let (rest, q) = parse_quantity_ref("that equipment's mana value").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            q,
+            QuantityRef::ObjectManaValue {
+                scope: ObjectScope::CostPaidObject,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_that_creature_is_not_cost_paid_demonstrative() {
+        // Negative: the demonstrative cost-paid ref is restricted to attachment
+        // subtypes, so "that creature's mana value" must NOT resolve to a
+        // CostPaidObject demonstrative (it would otherwise shadow target refs).
+        let parsed = parse_quantity_ref("that creature's mana value");
+        assert!(
+            parsed.is_err()
+                || !matches!(
+                    parsed,
+                    Ok((
+                        _,
+                        QuantityRef::ObjectManaValue {
+                            scope: ObjectScope::CostPaidObject
+                        }
+                    ))
+                ),
+            "\"that creature\" must not become a cost-paid demonstrative: {parsed:?}"
+        );
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7765,6 +7765,15 @@ pub enum AbilityCost {
     /// CR 701.3d: Unattach this Equipment from the object it is equipping.
     /// Used by activated costs such as Sunforger's "Unattach this Equipment".
     Unattach,
+    /// CR 701.3d + CR 608.2k: Unattach `count` attachments matching `filter`
+    /// from the source host as a cost; the detached object stays on the
+    /// battlefield and becomes this ability's cost-referent (Captain America's
+    /// "Unattach an Equipment from ~" → "that Equipment's mana value"). Distinct
+    /// from the unit `Unattach` (which detaches the source Equipment itself).
+    UnattachFrom {
+        filter: TargetFilter,
+        count: u32,
+    },
     Mill {
         count: u32,
     },
@@ -7945,6 +7954,7 @@ impl AbilityCost {
             | AbilityCost::PaySpeed { .. }
             | AbilityCost::ReturnToHand { .. }
             | AbilityCost::Unattach
+            | AbilityCost::UnattachFrom { .. }
             | AbilityCost::Mill { .. }
             | AbilityCost::Exert
             | AbilityCost::Blight { .. }
@@ -8029,6 +8039,7 @@ impl AbilityCost {
             AbilityCost::PaySpeed { .. } => vec![CostCategory::PaysSpeed],
             AbilityCost::ReturnToHand { .. } => vec![CostCategory::ReturnsToHand],
             AbilityCost::Unattach => vec![CostCategory::Unattaches],
+            AbilityCost::UnattachFrom { .. } => vec![CostCategory::Unattaches],
             AbilityCost::Mill { .. } => vec![CostCategory::Mills],
             AbilityCost::Exert => vec![CostCategory::Exerts],
             AbilityCost::Blight { .. } => vec![CostCategory::PutsCounters],
@@ -8133,6 +8144,7 @@ impl AbilityCost {
             | AbilityCost::PaySpeed { .. }
             | AbilityCost::ReturnToHand { .. }
             | AbilityCost::Unattach
+            | AbilityCost::UnattachFrom { .. }
             | AbilityCost::Mill { .. }
             | AbilityCost::Exert
             | AbilityCost::Blight { .. }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3033,6 +3033,16 @@ pub enum PayCostKind {
     ExileFromManaZone {
         zone: Zone,
     },
+    /// CR 701.3d + CR 601.2h: Unattach a matching attachment from the source
+    /// host as an activation cost (Captain America's Throw). `filter` is the
+    /// attachment-implying `TargetFilter` the choices were drawn from; the
+    /// handler re-validates that each chosen object is still on the battlefield,
+    /// controlled by the player, and attached to the source before detaching it.
+    /// The Equipment stays on the battlefield (CR 701.3d) and its snapshot
+    /// becomes the resolving ability's cost-referent (CR 608.2k).
+    UnattachFrom {
+        filter: TargetFilter,
+    },
     RemoveCounter {
         counter_type: CounterMatch,
         /// CR 118.3 + CR 122.1: number of counters to remove from the one

--- a/crates/engine/tests/captain_america_throw.rs
+++ b/crates/engine/tests/captain_america_throw.rs
@@ -1,0 +1,764 @@
+//! Captain America, First Avenger (MAR) — the "Throw"/"Catch" pair.
+//!
+//! Throw — {3}, Unattach an Equipment from Captain America, First Avenger:
+//!   Captain America, First Avenger deals damage equal to that Equipment's mana
+//!   value divided as you choose among one, two, or three targets.
+//! Catch — At the beginning of combat on your turn, attach up to one target
+//!   Equipment you control to Captain America, First Avenger.
+//!
+//! These drive the REAL pipeline (parser → `ActivateAbility` → target selection
+//! → interactive `PayCost { UnattachFrom }` → deferred `DistributeAmong` →
+//! `push_activated_ability_to_stack`) so every seam of the `UnattachFrom`
+//! cost, the cost-paid-object mana-value provenance, and the Change B-1
+//! activated-vs-spell resume split is covered. MAR is release-gated and not in
+//! the local fixture, so the tests parse the real Oracle text.
+
+use engine::game::game_object::AttachTarget;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle::{parse_oracle_text, ParsedAbilities};
+use engine::types::ability::{
+    AbilityCost, Effect, ObjectScope, QuantityExpr, QuantityRef, TargetRef,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{CastPaymentMode, StackEntryKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const CAP: &str = "Throw — {3}, Unattach an Equipment from Captain America, First Avenger: Captain America, First Avenger deals damage equal to that Equipment's mana value divided as you choose among one, two, or three targets.\nCatch — At the beginning of combat on your turn, attach up to one target Equipment you control to Captain America, First Avenger.";
+
+fn cap_parse() -> ParsedAbilities {
+    parse_oracle_text(
+        CAP,
+        "Captain America, First Avenger",
+        &["Throw".to_string(), "Catch".to_string()],
+        &["Creature".to_string()],
+        &[
+            "Human".to_string(),
+            "Soldier".to_string(),
+            "Hero".to_string(),
+        ],
+    )
+}
+
+/// Create an Equipment on the battlefield with mana value `mv`, attached to
+/// `host` and controlled by `controller`.
+fn attach_equipment(
+    runner: &mut GameRunner,
+    controller: engine::types::player::PlayerId,
+    host: ObjectId,
+    name: &str,
+    mv: u32,
+) -> ObjectId {
+    let card_id = engine::types::identifiers::CardId(runner.state().next_object_id);
+    let id = engine::game::zones::create_object(
+        runner.state_mut(),
+        card_id,
+        controller,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Artifact];
+    obj.card_types.subtypes = vec!["Equipment".to_string()];
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = None;
+    obj.toughness = None;
+    obj.mana_cost = ManaCost::Cost {
+        shards: vec![],
+        generic: mv,
+    };
+    obj.attached_to = Some(AttachTarget::Object(host));
+    if let Some(h) = runner.state_mut().objects.get_mut(&host) {
+        h.attachments.push(id);
+    }
+    engine::game::layers::mark_layers_full(runner.state_mut());
+    engine::game::layers::flush_layers(runner.state_mut());
+    id
+}
+
+/// Index of Captain America's Throw activated ability.
+fn throw_index(runner: &GameRunner, cap: ObjectId) -> usize {
+    runner.state().objects[&cap]
+        .abilities
+        .iter()
+        .position(|a| matches!(a.effect.as_ref(), Effect::DealDamage { .. }))
+        .expect("Captain America must carry a DealDamage (Throw) activated ability")
+}
+
+fn give_generic_mana(runner: &mut GameRunner, player: engine::types::player::PlayerId, n: usize) {
+    for _ in 0..n {
+        runner.state_mut().add_mana_to_pool(
+            player,
+            ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![]),
+        );
+    }
+}
+
+/// Total floating mana in a player's pool (CR 106.4). `GameRunner` exposes no
+/// pool accessor, so read it off the state directly.
+fn pool_total(runner: &GameRunner, player: engine::types::player::PlayerId) -> usize {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| p.mana_pool.total())
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Parser — the load-bearing AST shape the runtime consumes.
+// ---------------------------------------------------------------------------
+
+/// Both abilities must parse to non-`Unimplemented` AST: the Throw activated
+/// ability with a `Composite[Mana, UnattachFrom]` cost and a
+/// `DealDamage { ObjectManaValue { CostPaidObject } }` effect, and the Catch
+/// combat trigger with an `Attach` effect.
+///
+/// Revert probe: without the parser branch, the cost falls to the unit
+/// `Unattach` (or `Unimplemented`) and the effect's amount is not a
+/// `CostPaidObject` mana-value reference — every assertion below flips.
+#[test]
+fn captain_america_both_abilities_parse() {
+    let parsed = cap_parse();
+
+    // Throw — activated DealDamage.
+    let throw = parsed
+        .abilities
+        .iter()
+        .find(|a| matches!(a.effect.as_ref(), Effect::DealDamage { .. }))
+        .expect("Throw activated ability");
+
+    let mut has_unattach_from = false;
+    match throw.cost.as_ref().expect("Throw has a cost") {
+        AbilityCost::Composite { costs } => {
+            for c in costs {
+                if let AbilityCost::UnattachFrom { count, .. } = c {
+                    assert_eq!(*count, 1);
+                    has_unattach_from = true;
+                }
+            }
+        }
+        AbilityCost::UnattachFrom { count, .. } => {
+            assert_eq!(*count, 1);
+            has_unattach_from = true;
+        }
+        other => panic!("expected Composite/UnattachFrom cost, got {other:?}"),
+    }
+    assert!(
+        has_unattach_from,
+        "Throw cost must contain an UnattachFrom leg, got {:?}",
+        throw.cost
+    );
+
+    match throw.effect.as_ref() {
+        Effect::DealDamage { amount, .. } => {
+            assert!(
+                quantity_reads_cost_paid_mana_value(amount),
+                "damage amount must read the cost-paid Equipment's mana value, got {amount:?}"
+            );
+        }
+        other => panic!("expected DealDamage, got {other:?}"),
+    }
+
+    // CR 601.2d: the divided-damage flag must be set on the activated ability so
+    // the activation pipeline surfaces the DistributeAmong step.
+    assert_eq!(
+        throw.distribute,
+        Some(engine::types::game_state::DistributionUnit::Damage),
+        "Throw must carry a Damage distribute flag"
+    );
+    assert!(
+        throw.multi_target.is_some(),
+        "Throw must divide among 1-3 targets"
+    );
+
+    // Catch — combat trigger that attaches.
+    assert!(
+        parsed.triggers.iter().any(|t| matches!(
+            t.execute.as_ref().map(|e| e.effect.as_ref()),
+            Some(Effect::Attach { .. })
+        )),
+        "Catch must parse to a trigger whose effect is Attach, got {:?}",
+        parsed.triggers
+    );
+
+    // No parse warning should be emitted for these two abilities.
+    assert!(
+        parsed.parse_warnings.is_empty(),
+        "expected zero parse warnings, got {:?}",
+        parsed.parse_warnings
+    );
+}
+
+fn quantity_reads_cost_paid_mana_value(expr: &QuantityExpr) -> bool {
+    match expr {
+        QuantityExpr::Ref {
+            qty:
+                QuantityRef::ObjectManaValue {
+                    scope: ObjectScope::CostPaidObject,
+                },
+        } => true,
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::ClampMin { inner, .. }
+        | QuantityExpr::Multiply { inner, .. } => quantity_reads_cost_paid_mana_value(inner),
+        _ => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Runtime — full activation pipeline.
+// ---------------------------------------------------------------------------
+
+/// Build Captain America on the battlefield with `mv`-valued Equipment attached,
+/// a P1 wall to take the damage, {3} in P0's pool, and P0 holding priority.
+fn setup(equip_mvs: &[u32]) -> (GameRunner, ObjectId, Vec<ObjectId>, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PostCombatMain);
+    let cap = scenario
+        .add_creature_from_oracle(P0, "Captain America, First Avenger", 4, 4, CAP)
+        .id();
+    // A big P1 wall so 1-3 damage never kills it (keeps the target legal and the
+    // damage observable).
+    let wall = scenario.add_creature(P1, "Wall", 0, 20).id();
+    let mut runner = scenario.build();
+
+    let equips: Vec<ObjectId> = equip_mvs
+        .iter()
+        .enumerate()
+        .map(|(i, &mv)| attach_equipment(&mut runner, P0, cap, &format!("Equip{i}"), mv))
+        .collect();
+
+    give_generic_mana(&mut runner, P0, 3);
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+    (runner, cap, equips, wall)
+}
+
+/// Throw resolves onto the stack as an ActivatedAbility (not a Spell) after the
+/// division is announced, and the chosen Equipment stays on the battlefield,
+/// detached, while the target takes damage equal to that Equipment's mana value.
+///
+/// Revert probe (Change B-1): reverting the DistributeAmong split makes the
+/// resume call `finalize_cast`, which pushes a `StackEntryKind::Spell` for an
+/// activation — the `ActivatedAbility` assertion flips (and the cast desyncs).
+#[test]
+fn throw_resolves_as_activated_ability_not_spell() {
+    let (mut runner, cap, equips, wall) = setup(&[3]);
+    let equip = equips[0];
+    let idx = throw_index(&runner, cap);
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: cap,
+            ability_index: idx,
+        })
+        .expect("activate Throw");
+
+    // Target selection (1..=3 targets); choose exactly the wall.
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::TargetSelection { .. }
+        ),
+        "expected target selection, got {:?}",
+        runner.state().waiting_for
+    );
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(wall)],
+        })
+        .expect("select one target");
+
+    // The Unattach cost surfaces AFTER targets are chosen.
+    match runner.state().waiting_for.clone() {
+        WaitingFor::PayCost {
+            kind: engine::types::game_state::PayCostKind::UnattachFrom { .. },
+            choices,
+            count,
+            min_count,
+            ..
+        } => {
+            assert_eq!(count, 1);
+            assert_eq!(min_count, 1, "unattach-from is a required cost");
+            assert!(choices.contains(&equip));
+        }
+        other => panic!("expected PayCost UnattachFrom, got {other:?}"),
+    }
+    runner
+        .act(GameAction::SelectCards { cards: vec![equip] })
+        .expect("unattach the equipment");
+
+    // The deferred division re-surfaces now that the MV (=3) is known.
+    match runner.state().waiting_for.clone() {
+        WaitingFor::DistributeAmong { total, targets, .. } => {
+            assert_eq!(
+                total, 3,
+                "divided total must equal the Equipment's mana value"
+            );
+            assert_eq!(targets, vec![TargetRef::Object(wall)]);
+        }
+        other => panic!("expected DistributeAmong after unattach, got {other:?}"),
+    }
+    runner
+        .act(GameAction::DistributeAmong {
+            distribution: vec![(TargetRef::Object(wall), 3)],
+        })
+        .expect("distribute all 3 to the wall");
+
+    // CR 602.2b + CR 601.2d (Change B-1): the ability is on the stack as an
+    // ActivatedAbility, never a Spell.
+    assert_eq!(runner.state().stack.len(), 1, "one stack object");
+    assert!(
+        matches!(
+            runner.state().stack[0].kind,
+            StackEntryKind::ActivatedAbility { .. }
+        ),
+        "Throw must resolve as an ActivatedAbility, got {:?}",
+        runner.state().stack[0].kind
+    );
+
+    // CR 601.2g: the `{3}` mana leg was actually charged. The shared `setup`
+    // grants exactly {3} and P0 has no mana sources, so a fully-paid activation
+    // leaves the pool empty. Revert probe: if the `{3}` leg were silently
+    // skipped (Throw free), the three floating mana would remain and this flips.
+    assert_eq!(
+        pool_total(&runner, P0),
+        0,
+        "the {{3}} activation cost must consume P0's whole pool"
+    );
+
+    // CR 701.3d: the Equipment stayed on the battlefield, detached.
+    let eq = &runner.state().objects[&equip];
+    assert_eq!(eq.zone, Zone::Battlefield);
+    assert!(eq.attached_to.is_none(), "equipment must be unattached");
+
+    runner.advance_until_stack_empty();
+
+    // CR 120.1: the wall took damage equal to the Equipment's mana value (3).
+    assert_eq!(
+        runner.state().objects[&wall].damage_marked,
+        3,
+        "wall must take 3 damage (the unattached Equipment's mana value)"
+    );
+}
+
+/// Provenance: with two attached Equipment of differing mana value, the CHOSEN
+/// one's mana value drives the divided damage — not the sibling, not the sum.
+///
+/// Revert probe: if the snapshot read the wrong object (or summed both), the
+/// MV-1 branch would deal 3 or 4 instead of 1.
+#[test]
+fn chosen_equipment_mana_value_drives_damage() {
+    for (pick_index, expected) in [(0usize, 3u32), (1usize, 1u32)] {
+        let (mut runner, cap, equips, wall) = setup(&[3, 1]);
+        let chosen = equips[pick_index];
+        let idx = throw_index(&runner, cap);
+
+        runner
+            .act(GameAction::ActivateAbility {
+                source_id: cap,
+                ability_index: idx,
+            })
+            .expect("activate Throw");
+        runner
+            .act(GameAction::SelectTargets {
+                targets: vec![TargetRef::Object(wall)],
+            })
+            .expect("select one target");
+        runner
+            .act(GameAction::SelectCards {
+                cards: vec![chosen],
+            })
+            .expect("unattach chosen equipment");
+
+        match runner.state().waiting_for.clone() {
+            WaitingFor::DistributeAmong { total, .. } => {
+                assert_eq!(
+                    total, expected,
+                    "divided total must equal the CHOSEN Equipment's mana value"
+                );
+            }
+            other => panic!("expected DistributeAmong, got {other:?}"),
+        }
+        runner
+            .act(GameAction::DistributeAmong {
+                distribution: vec![(TargetRef::Object(wall), expected)],
+            })
+            .expect("distribute");
+        runner.advance_until_stack_empty();
+        assert_eq!(
+            runner.state().objects[&wall].damage_marked,
+            expected,
+            "wall must take exactly the chosen Equipment's mana value"
+        );
+        // The sibling Equipment is untouched (still attached).
+        let sibling = equips[1 - pick_index];
+        assert!(
+            runner.state().objects[&sibling].attached_to.is_some(),
+            "the non-chosen Equipment must stay attached"
+        );
+    }
+}
+
+/// MV < announced target count: announce two targets, but the only attached
+/// Equipment has mana value 1 — the activation is unpayable and nothing detaches.
+///
+/// Revert probe: dropping the `mana_value >= n` floor in
+/// `find_eligible_unattach_for_cost_targets` makes the cost payable and the
+/// activation succeed — the `Err` assertion flips and the equipment detaches.
+#[test]
+fn unpayable_when_mana_value_below_target_count() {
+    let (mut runner, cap, equips, wall) = setup(&[1]);
+    let equip = equips[0];
+    let wall2 = {
+        let w_card = engine::types::identifiers::CardId(runner.state().next_object_id);
+        let w = engine::game::zones::create_object(
+            runner.state_mut(),
+            w_card,
+            P1,
+            "Wall2".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = runner.state_mut().objects.get_mut(&w).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.toughness = Some(20);
+        w
+    };
+    let idx = throw_index(&runner, cap);
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: cap,
+            ability_index: idx,
+        })
+        .expect("activate Throw");
+    // Announce TWO targets: division requires the MV to be at least 2.
+    let result = runner.act(GameAction::SelectTargets {
+        targets: vec![TargetRef::Object(wall), TargetRef::Object(wall2)],
+    });
+    assert!(
+        result.is_err(),
+        "announcing 2 targets with only a MV-1 Equipment must be an unpayable cost"
+    );
+    // CR 733: pre-commit revert — the Equipment is still attached, nothing detached.
+    assert!(
+        runner.state().objects[&equip].attached_to.is_some(),
+        "no Equipment may be detached when the cost was unpayable"
+    );
+}
+
+/// The `{3}` mana leg is a REAL cost: with only {2} floating and no mana
+/// sources, a Throw activation whose non-mana legs (target, unattach) are all
+/// otherwise legal cannot complete — the `{3}` leg is unpayable, so the ability
+/// never reaches the stack and no damage is dealt.
+///
+/// Revert probe: this is the discriminating negative for the `{3}` leg. If the
+/// `{3}` were dropped from the cost, this activation would finish for free —
+/// the `is_err()` assertion flips and the wall takes 3 damage. Paired with
+/// `throw_resolves_as_activated_ability_not_spell`'s empty-pool assertion (the
+/// positive reach-guard proving the same input completes with {3} available),
+/// this makes the negative non-vacuous.
+#[test]
+fn throw_unpayable_with_insufficient_mana() {
+    let (mut runner, cap, equips, wall) = setup(&[3]);
+    let equip = equips[0];
+    // Reduce P0's pool from the shared {3} down to only {2} — one short of
+    // Throw's {3} mana leg. P0 has no lands, so the leg cannot be funded.
+    if let Some(p) = runner.state_mut().players.iter_mut().find(|p| p.id == P0) {
+        p.mana_pool.clear();
+    }
+    give_generic_mana(&mut runner, P0, 2);
+    assert_eq!(pool_total(&runner, P0), 2, "start with only {{2}} floating");
+
+    let idx = throw_index(&runner, cap);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: cap,
+            ability_index: idx,
+        })
+        .expect("activate Throw");
+    // One target — MV-3 Equipment covers the division, so the unattach leg is
+    // legal; only the mana leg can fail.
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(wall)],
+        })
+        .expect("select one target");
+    runner
+        .act(GameAction::SelectCards { cards: vec![equip] })
+        .expect("unattach the equipment");
+
+    // The division re-surfaces (total 3). The `{3}` mana leg is paid when this
+    // is announced (CR 601.2g), and there is not enough mana to pay it.
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::DistributeAmong { .. }
+        ),
+        "expected DistributeAmong before the mana leg is charged, got {:?}",
+        runner.state().waiting_for
+    );
+    let result = runner.act(GameAction::DistributeAmong {
+        distribution: vec![(TargetRef::Object(wall), 3)],
+    });
+    // CR 601.2h: an unpayable cost can't be paid — the activation is illegal.
+    assert!(
+        result.is_err(),
+        "the {{3}} leg must be unpayable with only {{2}} floating"
+    );
+    // The ability never reached the stack and dealt no damage.
+    assert_eq!(
+        runner.state().stack.len(),
+        0,
+        "no ability on the stack when the mana leg is unpayable"
+    );
+    assert_eq!(
+        runner.state().objects[&wall].damage_marked,
+        0,
+        "the wall takes no damage when Throw's mana leg is unpayable"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Change B-1 regression — an existing X-divide damage spell still resolves as a
+// Spell. Shatterskull Smashing is an X-divide sorcery (no activation index), so
+// the DistributeAmong resume must still land on `finalize_cast`.
+// ---------------------------------------------------------------------------
+
+const SHATTERSKULL: &str = "Shatterskull Smashing deals X damage divided as you choose among up to two target creatures and/or planeswalkers.";
+
+/// Revert probe: if the Change B-1 split mis-routed spells through
+/// `push_activated_ability_to_stack`, this X-divide spell would panic or push an
+/// ActivatedAbility — the `Spell` assertion flips.
+#[test]
+fn x_divide_spell_still_finalizes_as_spell() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PostCombatMain);
+    let wall = scenario.add_creature(P1, "Wall", 0, 20).id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Shatterskull Smashing", false, SHATTERSKULL)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::X, ManaCostShard::Red],
+            generic: 0,
+        })
+        .id();
+    let card_id = engine::types::identifiers::CardId(spell.0);
+    let mut runner = scenario.build();
+    give_generic_mana(&mut runner, P0, 6); // {X}{R} with X=2 → pay from pool
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Shatterskull");
+
+    // Drive through X-choice, targets, and division to the stack.
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(guard < 30, "cast pipeline did not converge");
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ChooseXValue { .. } => {
+                runner
+                    .act(GameAction::ChooseX { value: 2 })
+                    .expect("choose X=2");
+            }
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .act(GameAction::SelectTargets {
+                        targets: vec![TargetRef::Object(wall)],
+                    })
+                    .expect("select target");
+            }
+            WaitingFor::DistributeAmong { total, .. } => {
+                runner
+                    .act(GameAction::DistributeAmong {
+                        distribution: vec![(TargetRef::Object(wall), total)],
+                    })
+                    .expect("distribute");
+                break;
+            }
+            other => panic!("unexpected wait during Shatterskull cast: {other:?}"),
+        }
+    }
+
+    assert_eq!(runner.state().stack.len(), 1, "one stack object");
+    assert!(
+        matches!(runner.state().stack[0].kind, StackEntryKind::Spell { .. }),
+        "an X-divide spell must remain a Spell on the stack, got {:?}",
+        runner.state().stack[0].kind
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Catch — begin-combat trigger, your turn only, attaches to self.
+// ---------------------------------------------------------------------------
+
+/// Build Captain America (P0) with a free-floating Equipment P0 controls, with
+/// `active` the active player, at the pre-combat main phase.
+fn catch_setup(active: engine::types::player::PlayerId) -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let cap = scenario
+        .add_creature_from_oracle(P0, "Captain America, First Avenger", 4, 4, CAP)
+        .id();
+    let mut runner = scenario.build();
+    // A loose Equipment P0 controls, not attached to anything.
+    let card_id = engine::types::identifiers::CardId(runner.state().next_object_id);
+    let equip = engine::game::zones::create_object(
+        runner.state_mut(),
+        card_id,
+        P0,
+        "Loose Equip".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = runner.state_mut().objects.get_mut(&equip).unwrap();
+        obj.card_types.core_types = vec![CoreType::Artifact];
+        obj.card_types.subtypes = vec!["Equipment".to_string()];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = None;
+        obj.toughness = None;
+    }
+    engine::game::layers::mark_layers_full(runner.state_mut());
+    engine::game::layers::flush_layers(runner.state_mut());
+    runner.state_mut().active_player = active;
+    runner.state_mut().priority_player = active;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: active };
+    (runner, cap, equip)
+}
+
+/// On your turn, Catch's begin-combat trigger attaches a chosen Equipment you
+/// control to Captain America itself.
+///
+/// Revert probe: if the trigger's target were not `SelfRef`, or the trigger did
+/// not fire, the Equipment would remain unattached (attached_to None).
+#[test]
+fn catch_attaches_equipment_to_self_on_your_turn() {
+    let (mut runner, cap, equip) = catch_setup(P0);
+    // With a single legal Equipment, the begin-combat trigger auto-targets and
+    // resolves it during combat advancement.
+    runner.advance_to_combat();
+    runner.advance_until_stack_empty();
+
+    // CR 301.5: the Equipment is now attached to Captain America itself.
+    assert_eq!(
+        runner.state().objects[&equip].attached_to,
+        Some(AttachTarget::Object(cap)),
+        "Catch must attach the chosen Equipment to Captain America"
+    );
+}
+
+/// Catch is "up to one target Equipment" (min 0, max 1). With ZERO Equipment
+/// the controller controls, the begin-combat trigger must resolve as a no-op —
+/// it may target nothing — and must NOT soft-lock on a stuck target-selection
+/// `WaitingFor`. The game must reach a stable, stack-empty state.
+///
+/// Revert probe: if the min-0 slot were mis-modeled as required-1, the trigger
+/// could not resolve with 0 legal targets and `advance_until_stack_empty` would
+/// leave a stuck `TriggerTargetSelection` / `TargetSelection` — the wait-state
+/// and stack-empty assertions flip.
+#[test]
+fn catch_resolves_with_no_equipment() {
+    // Captain America on P0's battlefield, but P0 controls NO Equipment.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let cap = scenario
+        .add_creature_from_oracle(P0, "Captain America, First Avenger", 4, 4, CAP)
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    runner.advance_to_combat();
+
+    // CR 115.6: an "up to one target" trigger may choose zero targets, so with
+    // no legal Equipment it resolves choosing none — it must not surface a stuck
+    // target-selection wait.
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. } | WaitingFor::TargetSelection { .. }
+        ),
+        "Catch with 0 legal Equipment must not soft-lock on target selection, got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().stack.len(),
+        0,
+        "the Catch trigger must resolve to a stable, stack-empty state"
+    );
+    // CR 301.5: nothing was attached — Captain America has no attachments.
+    assert!(
+        runner.state().objects[&cap].attachments.is_empty(),
+        "Catch must attach nothing when the controller controls no Equipment"
+    );
+}
+
+/// Catch's target must parse as an optional "up to one" (min 0, max 1), so a
+/// player may decline. The runtime decline path itself is governed by the
+/// shared trigger target-slot infrastructure (unchanged by this card).
+#[test]
+fn catch_target_is_optional_up_to_one() {
+    let parsed = cap_parse();
+    let catch = parsed
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_ref())
+        .filter(|e| matches!(e.effect.as_ref(), Effect::Attach { .. }))
+        .expect("Catch attach trigger");
+    let spec = catch
+        .multi_target
+        .as_ref()
+        .expect("Catch must carry an up-to-one multi-target spec");
+    assert_eq!(
+        spec.min,
+        QuantityExpr::Fixed { value: 0 },
+        "\"up to one\" must allow declining (min 0)"
+    );
+    assert_eq!(
+        spec.max,
+        Some(QuantityExpr::Fixed { value: 1 }),
+        "\"up to one\" caps at one target"
+    );
+}
+
+/// On an opponent's turn, Catch's "on your turn" trigger must not fire.
+///
+/// Revert probe: dropping the OnlyDuringYourTurn scope would fire the trigger on
+/// P1's turn and the Equipment could attach — the unattached assertion flips.
+#[test]
+fn catch_does_not_trigger_on_opponents_turn() {
+    let (mut runner, _cap, equip) = catch_setup(P1);
+    runner.advance_to_combat();
+
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ),
+        "Catch must not surface a target choice on the opponent's turn, got {:?}",
+        runner.state().waiting_for
+    );
+    runner.advance_until_stack_empty();
+    assert!(
+        runner.state().objects[&equip].attached_to.is_none(),
+        "Catch must not attach on the opponent's turn"
+    );
+}

--- a/crates/engine/tests/integration/captain_america_throw.rs
+++ b/crates/engine/tests/integration/captain_america_throw.rs
@@ -10,8 +10,9 @@
 //! → interactive `PayCost { UnattachFrom }` → deferred `DistributeAmong` →
 //! `push_activated_ability_to_stack`) so every seam of the `UnattachFrom`
 //! cost, the cost-paid-object mana-value provenance, and the Change B-1
-//! activated-vs-spell resume split is covered. MAR is release-gated and not in
-//! the local fixture, so the tests parse the real Oracle text.
+//! activated-vs-spell resume split is covered. The tests parse the real Oracle
+//! text directly so they are hermetic — independent of the generated card
+//! corpus (the MAR set is released and ungated; see `set_gating.rs`).
 
 use engine::game::game_object::AttachTarget;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
@@ -640,24 +641,52 @@ fn catch_setup(active: engine::types::player::PlayerId) -> (GameRunner, ObjectId
     (runner, cap, equip)
 }
 
-/// On your turn, Catch's begin-combat trigger attaches a chosen Equipment you
-/// control to Captain America itself.
+/// On your turn, Catch's begin-combat trigger attaches the single legal
+/// Equipment you control to Captain America itself (its `SelfRef` recipient).
 ///
-/// Revert probe: if the trigger's target were not `SelfRef`, or the trigger did
-/// not fire, the Equipment would remain unattached (attached_to None).
+/// Parse-path regression (this issue): parsing Captain America's Throw line —
+/// "…divided as you choose among one, two, or three targets" — used to route
+/// the count-list " or " through the generic `try_parse_choose_one_of_inline`
+/// binary splitter, whose trial parse of the orphan "three targets" tail
+/// re-entered the clause parser deeply and overflowed the test thread's stack
+/// (nondeterministically, depending on stack headroom). This test drives the
+/// real `add_creature_from_oracle` parse path, so a revert of the
+/// `try_parse_choose_one_of_inline` distribution-clause guard re-introduces the
+/// overflow at setup here.
 #[test]
 fn catch_attaches_equipment_to_self_on_your_turn() {
     let (mut runner, cap, equip) = catch_setup(P0);
-    // With a single legal Equipment, the begin-combat trigger auto-targets and
-    // resolves it during combat advancement.
     runner.advance_to_combat();
+
+    // CR 603.3d + CR 601.2c: Catch targets "up to one target Equipment you
+    // control" (min 0, max 1). Because "target the Equipment" is a legal
+    // completion, the engine either auto-selects the single legal Equipment
+    // during advancement or surfaces the optional target choice — both are
+    // rules-legal, and which one happens can vary with the auto-target policy.
+    // Answer the prompt if it is offered so the controller attaches the
+    // Equipment either way; there is no auto-decline outcome here because
+    // targeting the Equipment is always a valid completion.
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::TriggerTargetSelection { .. } | WaitingFor::TargetSelection { .. }
+    ) {
+        runner
+            .act(GameAction::ChooseTarget {
+                target: Some(TargetRef::Object(equip)),
+            })
+            .expect("choose the Equipment as Catch's optional target");
+    }
     runner.advance_until_stack_empty();
 
-    // CR 301.5: the Equipment is now attached to Captain America itself.
+    // CR 701.3a + CR 301.5: the Equipment is attached to Captain America itself.
     assert_eq!(
         runner.state().objects[&equip].attached_to,
         Some(AttachTarget::Object(cap)),
-        "Catch must attach the chosen Equipment to Captain America"
+        "Catch must attach the loose Equipment to Captain America on your turn"
+    );
+    assert!(
+        runner.state().objects[&cap].attachments.contains(&equip),
+        "Captain America must carry the attached Equipment"
     );
 }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -35,6 +35,7 @@ mod breeches_blastmaker_coin_flip_copy;
 mod brigid_mana_ability;
 mod bring_to_light_free_cast_2880;
 mod call_damage_control_modal_return;
+mod captain_america_throw;
 mod cascade_intervening_if_pipeline;
 mod case_solve_condition;
 mod cast_during_resolution_pipeline;

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -391,6 +391,7 @@ fn rewrite_bound_x_in_ability_cost(cost: &mut AbilityCost, binding: &QuantityExp
         | AbilityCost::RemoveCounter { .. }
         | AbilityCost::ReturnToHand { .. }
         | AbilityCost::Unattach
+        | AbilityCost::UnattachFrom { .. }
         | AbilityCost::Mill { .. }
         | AbilityCost::Exert
         | AbilityCost::Blight { .. }

--- a/crates/phase-ai/src/policies/payment_selection.rs
+++ b/crates/phase-ai/src/policies/payment_selection.rs
@@ -290,6 +290,10 @@ fn payment_cost(
             _ => card_value(state, obj_id) * 0.5,
         },
         PayCostKind::Behold { .. } => card_value(state, obj_id) * 0.1,
+        // CR 701.3d: Unattaching an Equipment as a cost keeps it on the
+        // battlefield (only the attachment link is removed), so the real resource
+        // cost is ~0 — the AI should treat the chosen Equipment as free to detach.
+        PayCostKind::UnattachFrom { .. } => 0.0,
         PayCostKind::Sacrifice => sacrifice_cost(state, obj_id, penalties),
     }
 }


### PR DESCRIPTION
Implements MAR #88 (Captain America, First Avenger, {R}{W}{U} 4/4). Adds a
reusable "unattach an attachment from the source as a cost" building block, not
a one-off:

- New AbilityCost::UnattachFrom { filter, count } + PayCostKind::UnattachFrom.
  The detached Equipment stays on the battlefield (CR 701.3d) and becomes the
  ability's cost-referent, captured as a CostPaidObjectSnapshot before detach
  (CR 608.2k / 400.7j) so "that Equipment's mana value" resolves via
  QuantityRef::ObjectManaValue { scope: CostPaidObject }.
- Throw: {3}, unattach an Equipment -> deal its mana value divided among 1-3
  targets. The divided total is unknown until the cost is paid, so distribution
  defers (extract_distribution_total None while MV=0) and re-fires after payment
  (CR 601.2c/601.2d/601.2h).
- Change B-1: the DistributeAmong resume was spell-only; it now routes activated
  abilities to push_activated_ability_to_stack vs spells to finalize_cast
  (CR 602.2b), so a divided-damage activated ability resolves as an
  ActivatedAbility, not a Spell. Also propagates distribute onto the targeted
  activation pending and guards the post-cost target re-check against re-opening
  an already-announced division.
- Catch: begin-combat-your-turn trigger attaches up to one target Equipment you
  control to the source, reusing existing Attach + trigger primitives.
- Interactive unattach choice surfaced from pay_activation_costs_after_target_selection
  (targeted-activation post-target path), mirroring the non-self exile detour;
  eligible choices bounded to MV >= announced target count so no impossible
  distribution is reachable and nothing is detached on an unpayable activation.
- AI values the unattach cost ~0 (Equipment is not lost). Single authorized
  mechanical no-op arm added to the dormant mtgish-import crate to keep the
  workspace compiling as AbilityCost grows.

Tests: 10 cast-pipeline tests (activation resolves as ActivatedAbility;
X-divide spell still resolves as Spell; chosen Equipment's MV drives damage;
unpayable-when-MV<targets; {3} charged; Catch attach/no-op/opponent-turn) plus
parser unit tests for the cost combinator and the "that Equipment's mana value"
demonstrative quantity.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
