### PR TITLE
feat(parser): filter "Legendary spells you cast cost {N} less" by supertype

### DIFF
--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -38,6 +38,21 @@ pub(crate) fn parse_chosen_name_source_filter(subject_lower: &str) -> Option<Tar
 /// CR 601.2f: Parse the spell-type prefix of a cost-modification line before
 /// `"cost"`. Handles compound subjects such as Goblin Anarchomancer's
 /// "Each spell you cast that's red or green" via `parse_that_clause_suffix`.
+/// CR 205.4a: A bare supertype spell subject ("Legendary spells you cast cost
+/// {1} less", Kethis, the Hidden Hand) — `parse_type_phrase` doesn't consume a
+/// lone supertype word (it requires a following type noun), so the restriction
+/// would otherwise drop and reduce the cost of EVERY spell. Emit a `HasSupertype`
+/// card filter instead.
+fn parse_bare_supertype_spell_filter(base: &str) -> Option<TargetFilter> {
+    let lower = base.to_lowercase();
+    let (_, supertype) = all_consuming(nom_target::parse_supertype_word)
+        .parse(lower.as_str())
+        .ok()?;
+    Some(TargetFilter::Typed(TypedFilter::card().properties(vec![
+        FilterProp::HasSupertype { value: supertype },
+    ])))
+}
+
 fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
     let base = type_desc.trim();
     let base = tag::<_, _, OracleError<'_>>("each ")
@@ -108,14 +123,17 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
             TargetFilter::Or { filters } if !filters.is_empty() && remainder.is_empty() => {
                 Some(filter)
             }
-            // Bare color words ("white", "red") are not consumed by parse_type_phrase
-            // because color prefixes require a trailing type word ("white creature").
+            // Bare color words ("white", "red") and bare supertype words
+            // ("legendary") are not consumed by parse_type_phrase, which requires
+            // a trailing type noun ("white creature", "legendary permanent").
             _ if remainder.is_empty() || remainder.eq_ignore_ascii_case(base_part) => {
-                parse_named_color(base_part).map(|color| {
-                    TargetFilter::Typed(
-                        TypedFilter::card().properties(vec![FilterProp::HasColor { color }]),
-                    )
-                })
+                parse_named_color(base_part)
+                    .map(|color| {
+                        TargetFilter::Typed(
+                            TypedFilter::card().properties(vec![FilterProp::HasColor { color }]),
+                        )
+                    })
+                    .or_else(|| parse_bare_supertype_spell_filter(base_part))
             }
             _ => None,
         }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5425,6 +5425,48 @@ fn static_spells_cost_less() {
     ));
 }
 
+// CR 205.4a: Kethis, the Hidden Hand — "Legendary spells you cast cost {1} less
+// to cast" must restrict to legendary spells via a HasSupertype filter, not drop
+// the restriction (spell_filter: None) and cheapen EVERY spell. `parse_type_phrase`
+// doesn't consume a lone supertype word, so it needed an explicit arm.
+#[test]
+fn static_legendary_spells_cost_less_keeps_supertype_filter() {
+    let def = parse_static_line("Legendary spells you cast cost {1} less to cast.").unwrap();
+    let StaticMode::ModifyCost {
+        spell_filter: Some(TargetFilter::Typed(tf)),
+        ..
+    } = &def.mode
+    else {
+        panic!("expected a filtered ModifyCost, got {:?}", def.mode);
+    };
+    assert!(
+        tf.properties.contains(&FilterProp::HasSupertype {
+            value: crate::types::card_type::Supertype::Legendary,
+        }),
+        "expected HasSupertype(Legendary), got {:?}",
+        tf.properties
+    );
+}
+
+// Regression: a card-TYPE spell subject ("Artifact spells") still resolves to its
+// type filter — the new supertype arm only fires for bare supertype words.
+#[test]
+fn static_artifact_spells_cost_less_keeps_type_filter() {
+    let def = parse_static_line("Artifact spells you cast cost {1} less to cast.").unwrap();
+    let StaticMode::ModifyCost {
+        spell_filter: Some(TargetFilter::Typed(tf)),
+        ..
+    } = &def.mode
+    else {
+        panic!("expected a filtered ModifyCost, got {:?}", def.mode);
+    };
+    assert!(
+        tf.type_filters.contains(&TypeFilter::Artifact),
+        "expected Artifact type filter, got {:?}",
+        tf.type_filters
+    );
+}
+
 #[test]
 fn static_opponent_spells_cost_more() {
     let def = parse_static_line("Spells your opponents cast cost {1} more to cast.").unwrap();


### PR DESCRIPTION
CR 205.4a

## Bug

"Legendary spells you cast cost {1} less to cast" (**Kethis, the Hidden Hand**) must restrict the reduction to *legendary* spells. But `parse_cost_mod_spell_type_prefix` built its filter with `parse_type_phrase`, which doesn't consume a lone **supertype** word ("legendary" requires a following type noun) — so the type prefix fell through to `None` and the static reduced the cost of **every** spell the controller cast.

- Before: `ModifyCost { spell_filter: None, .. }` (all spells cheaper).
- After: `ModifyCost { spell_filter: Some([Card] + HasSupertype(Legendary)), .. }`.

Card-**type** prefixes ("Artifact spells", "Creature spells") already worked — only bare-supertype prefixes dropped.

## Fix

Add a `parse_bare_supertype_spell_filter` arm alongside the existing bare-**color** fallback (both are words `parse_type_phrase` leaves unconsumed), emitting a `HasSupertype` card filter. It generalizes to every supertype — "Snow spells" → `HasSupertype(Snow)` — mirroring the bare-color handling already in this seam.

## Why it's the right seam / minimal blast radius

- The fix sits exactly where the bare-color fallback already lives (`parse_cost_mod_spell_type_prefix`), so it composes with the existing color / "of the chosen type" / "that's a …" qualifiers rather than adding a parallel path.
- Card-type and bare-spell subjects are untouched (regression-tested): "Artifact spells" still → `[Artifact]`, "Spells you cast" still → `None`.

## Tests

- `static_legendary_spells_cost_less_keeps_supertype_filter` — Kethis → `HasSupertype(Legendary)` on the spell filter.
- `static_artifact_spells_cost_less_keeps_type_filter` — regression: "Artifact spells" still resolves to `[Artifact]`.
- Existing `static_spells_cost_less` (bare → `None`) unchanged. Full `parser::oracle_static::tests` (1042 passed, 0 failed).

## CR verification

- **CR 205.4a** — the supertypes (basic, legendary, ongoing, snow, world) — verified in `docs/MagicCompRules.txt`.

## AI-contributor notes

- **Rules-correct:** only legendary spells are discounted per CR 205.4a; other spells pay full cost.
- **Builds the class:** the arm covers any bare-supertype spell-cost subject, current or future.
- **Verified:** live-parsed Kethis and an Artifact/Snow control before/after; `cargo fmt`, CI-exact `clippy -p engine --all-targets --features proptest -D warnings`, and the full oracle_static module are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
