### PR TITLE
Card/tromokratis

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1577,6 +1577,11 @@ pub fn validate_blockers_for_player(
     // controls that could legally block it must also be assigned as a blocker.
     // Unblocked (zero blockers) is always legal — the restriction only fires when
     // at least one creature is declared as a blocker.
+    //
+    // NOTE: In shared-team-turn games (CR 802), `player` is the one declaring
+    // blockers and may be a teammate rather than the attacked player. We look up
+    // `defending_player` from `AttackerInfo` to correctly scope the "all creatures"
+    // requirement to the player being attacked.
     for (attacker_id, blockers) in &blockers_per_attacker {
         let has_unless_all = block_restriction_statics_against_from_precomputed(
             state,
@@ -1587,6 +1592,19 @@ pub fn validate_blockers_for_player(
         if !has_unless_all {
             continue;
         }
+        // Determine the defending player from combat state (falls back to `player`
+        // when combat state is unavailable, e.g. in unit tests).
+        let defending = state
+            .combat
+            .as_ref()
+            .and_then(|combat| {
+                combat
+                    .attackers
+                    .iter()
+                    .find(|a| a.object_id == *attacker_id)
+                    .map(|a| a.defending_player)
+            })
+            .unwrap_or(player);
         // At least one blocker is assigned — verify every able creature also blocks.
         for &obj_id in &state.battlefield {
             // Skip creatures already assigned to this attacker.
@@ -1596,7 +1614,7 @@ pub fn validate_blockers_for_player(
             let Some(obj) = state.objects.get(&obj_id) else {
                 continue;
             };
-            if obj.controller != player
+            if obj.controller != defending
                 || !obj.card_types.core_types.contains(&CoreType::Creature)
                 || obj.tapped
             {

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1578,9 +1578,12 @@ pub fn validate_blockers_for_player(
     // Unblocked (zero blockers) is always legal — the restriction only fires when
     // at least one creature is declared as a blocker.
     for (attacker_id, blockers) in &blockers_per_attacker {
-        let has_unless_all =
-            block_restriction_statics_against(state, *attacker_id, &block_restriction)
-                .any(|(def, _src_id)| def.mode == StaticMode::CantBeBlockedUnlessAllBlock);
+        let has_unless_all = block_restriction_statics_against_from_precomputed(
+            state,
+            *attacker_id,
+            &block_restriction,
+        )
+        .any(|(def, _src_id)| def.mode == StaticMode::CantBeBlockedUnlessAllBlock);
         if !has_unless_all {
             continue;
         }

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -751,7 +751,8 @@ pub fn collect_block_restriction_statics(state: &GameState) -> Vec<(ObjectId, St
     if !(static_kind_present(state, StaticModeKind::CantBeBlocked)
         || static_kind_present(state, StaticModeKind::CantBeBlockedExceptBy)
         || static_kind_present(state, StaticModeKind::CantBeBlockedBy)
-        || static_kind_present(state, StaticModeKind::CantBeBlockedByMoreThan))
+        || static_kind_present(state, StaticModeKind::CantBeBlockedByMoreThan)
+        || static_kind_present(state, StaticModeKind::CantBeBlockedUnlessAllBlock))
     {
         return Vec::new();
     }
@@ -763,6 +764,7 @@ pub fn collect_block_restriction_statics(state: &GameState) -> Vec<(ObjectId, St
                     | StaticMode::CantBeBlockedExceptBy { .. }
                     | StaticMode::CantBeBlockedBy { .. }
                     | StaticMode::CantBeBlockedByMoreThan { .. }
+                    | StaticMode::CantBeBlockedUnlessAllBlock
             )
         })
         .map(|(src, def)| (src.id, def.clone()))
@@ -1564,6 +1566,68 @@ pub fn validate_blockers_for_player(
                 return Err(format!(
                     "{:?} can't be blocked by more than {} creature(s)",
                     attacker_id, max
+                ));
+            }
+        }
+    }
+
+    // CR 509.1b (Tromokratis): "can't be blocked unless all creatures defending
+    // player controls block it." If the attacker carries this static and has at
+    // least one blocker assigned, then EVERY untapped creature the defending player
+    // controls that could legally block it must also be assigned as a blocker.
+    // Unblocked (zero blockers) is always legal — the restriction only fires when
+    // at least one creature is declared as a blocker.
+    for (attacker_id, blockers) in &blockers_per_attacker {
+        let has_unless_all =
+            block_restriction_statics_against(state, *attacker_id, &block_restriction)
+                .any(|(def, _src_id)| def.mode == StaticMode::CantBeBlockedUnlessAllBlock);
+        if !has_unless_all {
+            continue;
+        }
+        // At least one blocker is assigned — verify every able creature also blocks.
+        for &obj_id in &state.battlefield {
+            // Skip creatures already assigned to this attacker.
+            if blockers.contains(&obj_id) {
+                continue;
+            }
+            let Some(obj) = state.objects.get(&obj_id) else {
+                continue;
+            };
+            if obj.controller != player
+                || !obj.card_types.core_types.contains(&CoreType::Creature)
+                || obj.tapped
+            {
+                continue;
+            }
+            // CR 702.26b: phased-out can't block.
+            if obj.is_phased_out() {
+                continue;
+            }
+            // CR 702.147a: Decayed can't block.
+            if obj.has_keyword(&Keyword::Decayed) {
+                continue;
+            }
+            // CR 701.35a: Detained can't block.
+            if !obj.detained_by.is_empty() {
+                continue;
+            }
+            // CantBlock static on the potential blocker.
+            if blocker_has_cant_block_static_from_precomputed(state, obj_id, &blocker_restriction) {
+                continue;
+            }
+            // Check if this creature could legally form a block pair.
+            if can_block_pair_with_precomputed(
+                state,
+                obj_id,
+                *attacker_id,
+                &blocker_restriction,
+                &block_restriction,
+                &blocker_allowed,
+                can_block_shadow_exists,
+            ) {
+                return Err(format!(
+                    "{:?} can't be blocked unless all creatures defending player controls block it (CR 509.1b)",
+                    attacker_id
                 ));
             }
         }

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -1764,6 +1764,11 @@ pub(crate) fn cant_be_blocked_mode(clause: &str) -> Option<(StaticMode, Option<S
     // "as long as …" condition fallthrough so the "unless" form is classified
     // explicitly rather than mis-handled by the generic condition parser.
     if let Some(after) = nom_tag_lower(rest, rest, " unless ") {
+        // CR 509.1b (Tromokratis): "can't be blocked unless all creatures defending
+        // player controls block it" — aggregate blocking restriction.
+        if parse_block_unless_all_block_nom(after) {
+            return Some((StaticMode::CantBeBlockedUnlessAllBlock, None));
+        }
         if let Some(target) = parse_block_unless_attacking_owner_nom(after) {
             return Some((
                 StaticMode::CantBeBlocked,
@@ -1811,6 +1816,18 @@ fn parse_block_unless_attacking_owner_nom(
     .parse(input)
     .ok()?;
     rest.trim().is_empty().then_some(target)
+}
+
+/// CR 509.1b (Tromokratis): recognize "all creatures defending player controls
+/// block it" (or "block ~") as the aggregate blocking restriction tail. Uses
+/// nom `tag_no_case` combinators to avoid verbatim string equality.
+fn parse_block_unless_all_block_nom(input: &str) -> bool {
+    let result: Result<(&str, &str), nom::Err<OracleError<'_>>> = alt((
+        tag_no_case("all creatures defending player controls block it"),
+        tag_no_case("all creatures defending player controls block ~"),
+    ))
+    .parse(input);
+    result.is_ok_and(|(rest, _)| rest.trim().is_empty())
 }
 
 /// CR 509.1b: Attach a trailing "as long as …" condition to the evasion

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2632,6 +2632,35 @@ fn self_keyword_grant_unless_source_combat_state_gate() {
     );
 }
 
+/// CR 509.1b (Tromokratis): "~ can't be blocked unless all creatures defending
+/// player controls block it." must parse to a dedicated
+/// `CantBeBlockedUnlessAllBlock` static with no condition.
+#[test]
+fn cant_be_blocked_unless_all_block_tromokratis() {
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        "~ can't be blocked unless all creatures defending player controls block it.",
+        "Tromokratis",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let block_static = parsed
+        .statics
+        .iter()
+        .find(|d| d.mode == StaticMode::CantBeBlockedUnlessAllBlock)
+        .expect("expected CantBeBlockedUnlessAllBlock static");
+    assert!(
+        block_static.condition.is_none(),
+        "CantBeBlockedUnlessAllBlock should have no condition"
+    );
+    assert!(
+        !serde_json::to_string(&parsed)
+            .unwrap()
+            .contains("Unrecognized"),
+        "must not leave an Unrecognized residue"
+    );
+}
+
 /// CR 509.1b + CR 506.2 + CR 108.3: The compound "+N/+N and can't be blocked
 /// unless it's attacking its owner or a permanent its owner controls" must
 /// decompose into BOTH the P/T grant AND a `CantBeBlocked` static whose

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1539,6 +1539,13 @@ pub enum StaticMode {
     CantBeBlockedByMoreThan {
         max: u32,
     },
+    /// CR 509.1b: This creature can't be blocked unless all creatures the
+    /// defending player controls block it (Tromokratis). A structural blocking
+    /// restriction enforced in `validate_blockers_for_player`: if any creature
+    /// is declared as a blocker of this attacker, then EVERY creature the
+    /// defending player controls that is able to block it must also be declared
+    /// as a blocker. Partial blocks are illegal.
+    CantBeBlockedUnlessAllBlock,
     /// CR 301.5 + CR 303.4 + CR 701.3a: Positive attachment restriction — this
     /// Aura/Equipment "can be attached only to" a permanent matching `filter`.
     /// The complement of the negative `Other("CantBeEquipped" | "CantBeEnchanted"
@@ -2000,6 +2007,7 @@ pub enum StaticModeKind {
     CantBeBlockedExceptBy,
     CantBeBlockedBy,
     CantBeBlockedByMoreThan,
+    CantBeBlockedUnlessAllBlock,
     AttachmentRestriction,
     Protection,
     Indestructible,
@@ -2137,6 +2145,7 @@ impl StaticMode {
             StaticMode::CantBeBlockedExceptBy { .. } => StaticModeKind::CantBeBlockedExceptBy,
             StaticMode::CantBeBlockedBy { .. } => StaticModeKind::CantBeBlockedBy,
             StaticMode::CantBeBlockedByMoreThan { .. } => StaticModeKind::CantBeBlockedByMoreThan,
+            StaticMode::CantBeBlockedUnlessAllBlock => StaticModeKind::CantBeBlockedUnlessAllBlock,
             StaticMode::AttachmentRestriction { .. } => StaticModeKind::AttachmentRestriction,
             StaticMode::Protection => StaticModeKind::Protection,
             StaticMode::Indestructible => StaticModeKind::Indestructible,
@@ -2487,6 +2496,7 @@ impl StaticMode {
             | StaticMode::CantBeBlockedExceptBy { .. }
             | StaticMode::CantBeBlockedBy { .. }
             | StaticMode::CantBeBlockedByMoreThan { .. }
+            | StaticMode::CantBeBlockedUnlessAllBlock
             | StaticMode::AttachmentRestriction { .. }
             | StaticMode::Protection
             | StaticMode::CantBeDestroyed
@@ -2810,6 +2820,9 @@ impl fmt::Display for StaticMode {
             StaticMode::CantBeBlockedByMoreThan { max } => {
                 write!(f, "CantBeBlockedByMoreThan({max})")
             }
+            StaticMode::CantBeBlockedUnlessAllBlock => {
+                write!(f, "CantBeBlockedUnlessAllBlock")
+            }
             StaticMode::Protection => write!(f, "Protection"),
             StaticMode::Indestructible => write!(f, "Indestructible"),
             StaticMode::CantBeDestroyed => write!(f, "CantBeDestroyed"),
@@ -2973,6 +2986,7 @@ impl FromStr for StaticMode {
                     max: parse_static_mode_u32_arg(s, "CantBeBlockedByMoreThan").unwrap(),
                 }
             }
+            "CantBeBlockedUnlessAllBlock" => StaticMode::CantBeBlockedUnlessAllBlock,
             "CantBeTargeted" => StaticMode::CantBeTargeted,
             "CantBeCast" => StaticMode::CantBeCast {
                 who: ProhibitionScope::Controller,

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -887,6 +887,7 @@ mod tomb_sandfall_cell_life_loss_runtime;
 mod tomb_veils_of_fear_life_loss_runtime;
 mod trench_behemoth_landfall_force_attack;
 mod triumphant_chomp;
+mod tromokratis;
 mod umbra_stalker_graveyard_chroma_4066;
 mod unless_pay_routes_through_authority;
 mod valakut_fireboar_switch_pt_on_attack;

--- a/crates/engine/tests/integration/tromokratis.rs
+++ b/crates/engine/tests/integration/tromokratis.rs
@@ -9,7 +9,7 @@
 //! to confirm the restriction is enforced at the declare-blockers step.
 
 use engine::game::combat::{validate_blockers, AttackerInfo, CombatState};
-use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::scenario::{GameScenario, P0, P1};
 use engine::game::zones::create_object;
 use engine::types::ability::StaticDefinition;
 use engine::types::actions::GameAction;
@@ -17,7 +17,6 @@ use engine::types::card_type::CoreType;
 use engine::types::format::FormatConfig;
 use engine::types::game_state::{GameState, WaitingFor};
 use engine::types::identifiers::{CardId, ObjectId};
-use engine::types::keywords::Keyword;
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
 use engine::types::statics::StaticMode;
@@ -273,7 +272,7 @@ fn e2e_hexproof_unless_attacking() {
     // layer evaluation.
     let has_hexproof_static = obj
         .static_definitions
-        .iter()
+        .iter_unchecked()
         .any(|sd| sd.mode == StaticMode::Continuous && sd.condition.is_some());
     assert!(
         has_hexproof_static,

--- a/crates/engine/tests/integration/tromokratis.rs
+++ b/crates/engine/tests/integration/tromokratis.rs
@@ -31,7 +31,6 @@ const TROMOKRATIS_BLOCK_ORACLE: &str =
 /// Oracle text for Tromokratis's hexproof ability (line 1).
 const TROMOKRATIS_HEXPROOF_ORACLE: &str = "~ has hexproof unless it's attacking or blocking.";
 
-
 fn create_creature(
     state: &mut GameState,
     controller: PlayerId,

--- a/crates/engine/tests/integration/tromokratis.rs
+++ b/crates/engine/tests/integration/tromokratis.rs
@@ -1,0 +1,282 @@
+//! Tromokratis — end-to-end integration tests.
+//!
+//! Validates both abilities:
+//! 1. Hexproof unless attacking or blocking (conditional keyword grant).
+//! 2. Can't be blocked unless all creatures defending player controls block it
+//!    (aggregate blocking restriction, CR 509.1b).
+//!
+//! Tests drive the real combat pipeline via `GameScenario` and `validate_blockers`
+//! to confirm the restriction is enforced at the declare-blockers step.
+
+use engine::game::combat::{validate_blockers, AttackerInfo, CombatState};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::zones::create_object;
+use engine::types::ability::StaticDefinition;
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::format::FormatConfig;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::statics::StaticMode;
+use engine::types::zones::Zone;
+
+use super::rules::AttackTarget;
+
+/// Oracle text for Tromokratis's blocking restriction ability (line 2).
+const TROMOKRATIS_BLOCK_ORACLE: &str =
+    "~ can't be blocked unless all creatures defending player controls block it.";
+
+/// Oracle text for Tromokratis's hexproof ability (line 1).
+const TROMOKRATIS_HEXPROOF_ORACLE: &str = "~ has hexproof unless it's attacking or blocking.";
+
+/// Full oracle text combining both abilities.
+const TROMOKRATIS_FULL_ORACLE: &str =
+    "Tromokratis has hexproof unless it's attacking or blocking.\n\
+     Tromokratis can't be blocked unless all creatures defending player controls block it.";
+
+fn create_creature(
+    state: &mut GameState,
+    controller: PlayerId,
+    name: &str,
+    power: i32,
+    toughness: i32,
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(state.next_object_id),
+        controller,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Creature];
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = Some(power);
+    obj.toughness = Some(toughness);
+    obj.base_power = Some(power);
+    obj.base_toughness = Some(toughness);
+    obj.summoning_sick = false;
+    obj.entered_battlefield_turn = Some(1);
+    id
+}
+
+/// CR 509.1b (Tromokratis): partial block is illegal — if any creature blocks
+/// Tromokratis, ALL creatures the defending player controls must block it.
+#[test]
+fn partial_block_is_illegal() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    state.turn_number = 2;
+    state.active_player = PlayerId(0);
+
+    let tromokratis = create_creature(&mut state, PlayerId(0), "Tromokratis", 8, 8);
+    state
+        .objects
+        .get_mut(&tromokratis)
+        .unwrap()
+        .static_definitions
+        .push(StaticDefinition::new(
+            StaticMode::CantBeBlockedUnlessAllBlock,
+        ));
+
+    let b1 = create_creature(&mut state, PlayerId(1), "Blocker A", 2, 2);
+    let b2 = create_creature(&mut state, PlayerId(1), "Blocker B", 2, 2);
+    let _b3 = create_creature(&mut state, PlayerId(1), "Blocker C", 2, 2);
+
+    state.combat = Some(CombatState {
+        attackers: vec![AttackerInfo::attacking_player(tromokratis, PlayerId(1))],
+        ..Default::default()
+    });
+
+    // Only two of three creatures block → illegal.
+    let result = validate_blockers(&state, &[(b1, tromokratis), (b2, tromokratis)]);
+    assert!(
+        result.is_err(),
+        "partial block should be illegal: {result:?}"
+    );
+}
+
+/// CR 509.1b: all creatures blocking Tromokratis is legal.
+#[test]
+fn all_creatures_block_is_legal() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    state.turn_number = 2;
+    state.active_player = PlayerId(0);
+
+    let tromokratis = create_creature(&mut state, PlayerId(0), "Tromokratis", 8, 8);
+    state
+        .objects
+        .get_mut(&tromokratis)
+        .unwrap()
+        .static_definitions
+        .push(StaticDefinition::new(
+            StaticMode::CantBeBlockedUnlessAllBlock,
+        ));
+
+    let b1 = create_creature(&mut state, PlayerId(1), "Blocker A", 2, 2);
+    let b2 = create_creature(&mut state, PlayerId(1), "Blocker B", 2, 2);
+    let b3 = create_creature(&mut state, PlayerId(1), "Blocker C", 2, 2);
+
+    state.combat = Some(CombatState {
+        attackers: vec![AttackerInfo::attacking_player(tromokratis, PlayerId(1))],
+        ..Default::default()
+    });
+
+    // All three creatures block → legal.
+    let result = validate_blockers(
+        &state,
+        &[(b1, tromokratis), (b2, tromokratis), (b3, tromokratis)],
+    );
+    assert!(result.is_ok(), "all-block should be legal: {result:?}");
+}
+
+/// CR 509.1b: choosing not to block at all (unblocked) is always legal.
+#[test]
+fn unblocked_is_legal() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    state.turn_number = 2;
+    state.active_player = PlayerId(0);
+
+    let tromokratis = create_creature(&mut state, PlayerId(0), "Tromokratis", 8, 8);
+    state
+        .objects
+        .get_mut(&tromokratis)
+        .unwrap()
+        .static_definitions
+        .push(StaticDefinition::new(
+            StaticMode::CantBeBlockedUnlessAllBlock,
+        ));
+
+    let _b1 = create_creature(&mut state, PlayerId(1), "Blocker A", 2, 2);
+    let _b2 = create_creature(&mut state, PlayerId(1), "Blocker B", 2, 2);
+
+    state.combat = Some(CombatState {
+        attackers: vec![AttackerInfo::attacking_player(tromokratis, PlayerId(1))],
+        ..Default::default()
+    });
+
+    // No blockers declared → legal.
+    let result = validate_blockers(&state, &[]);
+    assert!(result.is_ok(), "unblocked should be legal: {result:?}");
+}
+
+/// CR 509.1b: tapped creatures are unable to block, so they are excluded from
+/// the "all creatures" requirement. If the only non-blocking creature is tapped,
+/// a partial block is legal.
+#[test]
+fn tapped_creature_excluded_from_all_requirement() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    state.turn_number = 2;
+    state.active_player = PlayerId(0);
+
+    let tromokratis = create_creature(&mut state, PlayerId(0), "Tromokratis", 8, 8);
+    state
+        .objects
+        .get_mut(&tromokratis)
+        .unwrap()
+        .static_definitions
+        .push(StaticDefinition::new(
+            StaticMode::CantBeBlockedUnlessAllBlock,
+        ));
+
+    let b1 = create_creature(&mut state, PlayerId(1), "Blocker A", 2, 2);
+    let b2 = create_creature(&mut state, PlayerId(1), "Blocker B", 2, 2);
+    let tapped = create_creature(&mut state, PlayerId(1), "Tapped Creature", 3, 3);
+    // Tap the third creature so it can't block.
+    state.objects.get_mut(&tapped).unwrap().tapped = true;
+
+    state.combat = Some(CombatState {
+        attackers: vec![AttackerInfo::attacking_player(tromokratis, PlayerId(1))],
+        ..Default::default()
+    });
+
+    // Two untapped creatures both block → legal (tapped creature excluded).
+    let result = validate_blockers(&state, &[(b1, tromokratis), (b2, tromokratis)]);
+    assert!(
+        result.is_ok(),
+        "block with all untapped creatures should be legal: {result:?}"
+    );
+}
+
+/// End-to-end: Tromokratis parsed from oracle text gets both abilities.
+/// The blocking restriction rejects a partial block via the real pipeline.
+#[test]
+fn e2e_parsed_tromokratis_rejects_partial_block() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let tromokratis = scenario
+        .add_creature_from_oracle(P0, "Tromokratis", 8, 8, TROMOKRATIS_BLOCK_ORACLE)
+        .id();
+    let b1 = scenario.add_creature(P1, "Blocker A", 2, 2).id();
+    let _b2 = scenario.add_creature(P1, "Blocker B", 2, 2).id();
+    let _b3 = scenario.add_creature(P1, "Blocker C", 2, 2).id();
+
+    let mut runner = scenario.build();
+
+    // Advance to DeclareAttackers.
+    runner.advance_to_combat();
+
+    // Declare Tromokratis as attacker.
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(tromokratis, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("DeclareAttackers should succeed");
+
+    // Pass priority after attackers declared.
+    if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+        runner.pass_both_players();
+    }
+
+    // We should be at DeclareBlockers now.
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::DeclareBlockers { .. }
+        ),
+        "expected DeclareBlockers, got {:?}",
+        runner.state().waiting_for
+    );
+
+    // Partial block: only b1 blocks → should be rejected.
+    let result = runner.act(GameAction::DeclareBlockers {
+        assignments: vec![(b1, tromokratis)],
+    });
+    assert!(
+        result.is_err(),
+        "partial block of parsed Tromokratis should be rejected: {result:?}"
+    );
+}
+
+/// End-to-end: hexproof unless attacking or blocking — Tromokratis has hexproof
+/// when not in combat, loses it when attacking.
+#[test]
+fn e2e_hexproof_unless_attacking() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let tromokratis = scenario
+        .add_creature_from_oracle(P0, "Tromokratis", 8, 8, TROMOKRATIS_HEXPROOF_ORACLE)
+        .id();
+
+    let runner = scenario.build();
+
+    // Before combat: Tromokratis should have hexproof (not attacking/blocking).
+    let obj = runner.state().objects.get(&tromokratis).unwrap();
+    // The hexproof is granted via a Continuous static with condition
+    // Not(Or([SourceIsAttacking, SourceIsBlocking])). Since the creature is not
+    // attacking, the condition is satisfied and hexproof should be active after
+    // layer evaluation.
+    let has_hexproof_static = obj
+        .static_definitions
+        .iter()
+        .any(|sd| sd.mode == StaticMode::Continuous && sd.condition.is_some());
+    assert!(
+        has_hexproof_static,
+        "Tromokratis should have a conditional hexproof static definition"
+    );
+}

--- a/crates/engine/tests/integration/tromokratis.rs
+++ b/crates/engine/tests/integration/tromokratis.rs
@@ -31,10 +31,6 @@ const TROMOKRATIS_BLOCK_ORACLE: &str =
 /// Oracle text for Tromokratis's hexproof ability (line 1).
 const TROMOKRATIS_HEXPROOF_ORACLE: &str = "~ has hexproof unless it's attacking or blocking.";
 
-/// Full oracle text combining both abilities.
-const TROMOKRATIS_FULL_ORACLE: &str =
-    "Tromokratis has hexproof unless it's attacking or blocking.\n\
-     Tromokratis can't be blocked unless all creatures defending player controls block it.";
 
 fn create_creature(
     state: &mut GameState,


### PR DESCRIPTION
## Implement Tromokratis (CR 509.1b aggregate blocking restriction)

### Card

| Field | Value |
|-------|-------|
| Name | Tromokratis |
| Mana Cost | {5}{U}{U} |
| Type | Legendary Creature — Kraken |
| P/T | 8/8 |
| Oracle | Tromokratis has hexproof unless it's attacking or blocking. |
| | Tromokratis can't be blocked unless all creatures defending player controls block it. |
| Set | Born of the Gods (BNG) |
| Scryfall | https://scryfall.com/card/bng/55/tromokratis |

### Summary

Adds `StaticMode::CantBeBlockedUnlessAllBlock` — a structural blocking restriction (CR 509.1b) that requires ALL creatures the defending player controls to block the attacker, or none at all. Partial blocks are illegal; unblocked is always legal.

**Ability 1** (hexproof unless attacking or blocking) was already fully parsed and tested — no changes needed.

**Ability 2** (can't be blocked unless all creatures defending player controls block it) is the new mechanic implemented here.

### Changes

#### Types (`statics.rs`)
- New `StaticMode::CantBeBlockedUnlessAllBlock` variant
- Corresponding `StaticModeKind` entry
- `mode_kind()`, `as_keyword()`, `Display`, `FromStr` match arms

#### Parser (`evasion.rs`)
- `cant_be_blocked_mode`: recognize "unless all creatures defending player controls block it" (and the `~` variant) via `nom::tag_no_case` combinators
- New helper `parse_block_unless_all_block_nom` using `alt((tag_no_case(...), tag_no_case(...)))` — no verbatim string equality

#### Parser test (`oracle_static/tests.rs`)
- `cant_be_blocked_unless_all_block_tromokratis`: confirms the oracle text maps to `CantBeBlockedUnlessAllBlock` with no condition and no `Unrecognized` residue

#### Combat enforcement (`combat.rs`)
- `collect_block_restriction_statics`: gate + filter updated to include the new variant
- `validate_blockers_for_player`: after the per-attacker count checks (menace, max-blockers), iterates `blockers_per_attacker` and for each attacker carrying `CantBeBlockedUnlessAllBlock`, verifies that every untapped, non-detained, non-decayed, non-phased-out creature the defending player controls that could legally form a block pair is also assigned as a blocker. Returns `Err` if any able creature is missing.
- `can_block_pair_with_precomputed`: the existing `_ => {}` catch-all naturally skips the new variant (aggregate restriction, not per-pair)

#### Integration tests (`tromokratis.rs`)
| Test | Scenario |
|------|----------|
| `partial_block_is_illegal` | 2 of 3 creatures block → rejected |
| `all_creatures_block_is_legal` | All 3 block → accepted |
| `unblocked_is_legal` | No blockers → accepted |
| `tapped_creature_excluded_from_all_requirement` | Tapped creature excluded from "all" set |
| `e2e_parsed_tromokratis_rejects_partial_block` | Full parse→scenario→DeclareBlockers pipeline rejects partial block |
| `e2e_hexproof_unless_attacking` | Conditional hexproof static definition present |

### Comprehensive Rules References
- **CR 509.1b**: A creature can't be blocked unless all creatures the defending player controls block it (aggregate restriction)
- **CR 702.11**: Hexproof (conditional: unless attacking or blocking)
- **CR 509.1a**: A creature must be able to block in order to be declared as a blocker
