### PR TITLE
fix(parser): honor "if it dealt combat damage this turn" intervening-if on dies triggers

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -399,8 +399,22 @@ fn parse_player_dealt_combat_damage_by_source_this_turn(
 fn parse_source_dealt_damage_to_opponent_this_turn(
     input: &str,
 ) -> OracleResult<'_, StaticCondition> {
-    let (rest, _) = alt((tag("~"), tag("this creature"))).parse(input)?;
-    let (rest, _) = tag(" dealt damage to ").parse(rest)?;
+    // CR 120.1 + CR 120.2a + CR 603.4: "<source-anaphor> dealt [combat] damage to a
+    // player/opponent this turn" — the *dealing* direction (source = the ability's
+    // own permanent). "it" is the source anaphor for triggered-ability
+    // intervening-ifs (Wave of Rats' dies trigger); "~"/"this creature"/"this
+    // permanent" cover the self-ref forms. The optional "combat" qualifier narrows
+    // the damage channel (CR 120.2a) so combat-only history is required.
+    let (rest, _) = alt((
+        tag("~"),
+        tag("this creature"),
+        tag("this permanent"),
+        tag("it"),
+    ))
+    .parse(input)?;
+    let (rest, _) = tag(" dealt ").parse(rest)?;
+    let (rest, combat) = opt(tag("combat ")).parse(rest)?;
+    let (rest, _) = tag("damage to ").parse(rest)?;
     let (rest, target) = alt((
         value(
             TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
@@ -410,6 +424,11 @@ fn parse_source_dealt_damage_to_opponent_this_turn(
     ))
     .parse(rest)?;
     let (rest, _) = tag(" this turn").parse(rest)?;
+    let damage_kind = if combat.is_some() {
+        DamageKindFilter::CombatOnly
+    } else {
+        DamageKindFilter::Any
+    };
     Ok((
         rest,
         make_quantity_ge(
@@ -418,8 +437,7 @@ fn parse_source_dealt_damage_to_opponent_this_turn(
                 target: Box::new(target),
                 aggregate: AggregateFunction::Sum,
                 group_by: None,
-                damage_kind: DamageKindFilter::Any,
-
+                damage_kind,
                 channel: DamageChannel::Total,
             },
             1,
@@ -14466,6 +14484,37 @@ mod tests {
                 assert_eq!(typed.controller, Some(ControllerRef::Opponent));
             }
             other => panic!("expected opponent damage threshold quantity, got {other:?}"),
+        }
+    }
+
+    /// CR 120.1 + CR 120.2a + CR 603.4: the "it" source anaphor + the "combat"
+    /// qualifier — Wave of Rats' dies intervening-if. Distinct from the no-"combat"
+    /// sibling below (which stays `DamageKindFilter::Any`).
+    #[test]
+    fn parse_it_dealt_combat_damage_to_a_player_this_turn() {
+        let (rest, c) =
+            parse_inner_condition("it dealt combat damage to a player this turn").unwrap();
+        assert_eq!(rest, "");
+        match c {
+            StaticCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::DamageDealtThisTurn {
+                                source,
+                                target,
+                                damage_kind: DamageKindFilter::CombatOnly,
+                                channel: DamageChannel::Total,
+                                ..
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
+            } => {
+                assert_eq!(*source, TargetFilter::SelfRef);
+                assert_eq!(*target, TargetFilter::Player);
+            }
+            other => panic!("expected SelfRef->Player CombatOnly GE 1, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -1499,6 +1499,57 @@ fn trigger_dies_if_it_was_enchanted_attaches_attachment_lookback() {
 /// - Trigger-level `condition` is a `QuantityComparison` on Power(Source) >= 3.
 /// - The execute effect is Token creation (the Zombie Berserker), not Unimplemented.
 #[test]
+fn parse_wave_of_rats_dies_dealt_combat_damage_intervening_if() {
+    // CR 603.4 + CR 120.1 + CR 120.2a: Wave of Rats returns ONLY if it dealt
+    // combat damage to a player this turn. Pre-fix the intervening-if was
+    // swallowed (`condition: None`) and the creature returned unconditionally.
+    let def = parse_trigger_line(
+        "When this creature dies, if it dealt combat damage to a player this turn, \
+         return it to the battlefield under its owner's control.",
+        "Wave of Rats",
+    );
+
+    // Revert-guard: pre-fix `def.condition` is None.
+    assert_eq!(
+        def.condition,
+        Some(TriggerCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::DamageDealtThisTurn {
+                    source: Box::new(TargetFilter::SelfRef),
+                    target: Box::new(TargetFilter::Player),
+                    aggregate: AggregateFunction::Sum,
+                    group_by: None,
+                    damage_kind: crate::types::ability::DamageKindFilter::CombatOnly,
+                    channel: DamageChannel::Total,
+                },
+            },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 1 },
+        }),
+        "dies intervening-if must lift to DamageDealtThisTurn(SelfRef->Player, CombatOnly) >= 1, got {:?}",
+        def.condition,
+    );
+
+    // The return effect must be preserved (positive reach-guard for the negative below).
+    let execute = def.execute.as_deref().expect("execute must be Some");
+    assert!(
+        matches!(
+            *execute.effect,
+            Effect::ChangeZone {
+                destination: Zone::Battlefield,
+                ..
+            }
+        ),
+        "execute must be ChangeZone->Battlefield (return it), got {:?}",
+        execute.effect,
+    );
+    assert!(
+        !matches!(*execute.effect, Effect::Unimplemented { .. }),
+        "execute must not be Unimplemented",
+    );
+}
+
+#[test]
 fn parse_deathknell_berserker_dies_power_lki_intervening_if() {
     let def = parse_trigger_line(
         "When this creature dies, if its power was 3 or greater, create a 2/2 black Zombie Berserker creature token.",


### PR DESCRIPTION
**Bug:** Wave of Rats ("When this creature dies, if it dealt combat damage to a player this turn, return it to the battlefield under its owner's control.") parsed with `condition: null` — the intervening-if was **silently swallowed**, so the creature returned **unconditionally**.

**Fix:** The source-referential condition combinator `parse_source_dealt_damage_to_opponent_this_turn` only accepted the `"~"`/`"this creature"` subject and lacked a `"combat"` qualifier. Extend it with two leaf axes:
- the `"it"`/`"this permanent"` source anaphor, and
- an optional `"combat "` qualifier → `DamageKindFilter::CombatOnly` vs `Any`.

The clause now lifts through the existing bridge to `TriggerCondition::QuantityComparison` over `QuantityRef::DamageDealtThisTurn(SelfRef → Player, CombatOnly) ≥ 1`.

**No new variant, no runtime change** — a pure generalization of one existing combinator. Covers a class: Wave of Rats is fixed, and the two already-supported cards (Dunerider Outlaw, Whirling Dervish, "this creature dealt damage to an opponent") stay green (the no-`combat` path still yields `Any`). Verified locally: both new parser tests pass, the 19 `dealt_combat` sibling tests stay green, clippy clean.

CR 603.4 (intervening-if), CR 120.1 (source of damage), CR 120.2a (combat damage).
