### PR TITLE
fix(engine): re-derive target-dependent cost surcharge on the X+distribute casting route

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -8671,6 +8671,20 @@ pub fn finalize_mana_payment(
             );
         }
 
+        // NOTE: This branch is provably unreachable for every currently-implemented
+        // distribute-unit + {X}-cost card (Fireball and siblings) — the CR 601.2c/d
+        // gate in `ability_utils::ability_distribution_pool_needs_chosen_x` (added by
+        // issue #2856) forces `WaitingFor::ChooseXValue` before target selection
+        // whenever the divided amount is `Effect::DealDamage`/`Effect::PutCounter`
+        // with an unresolved X reference, which makes `chosen_x` always already set
+        // by the time `maybe_pause_for_cast_distribution` runs in
+        // `casting_targets::handle_select_targets`/`handle_choose_target` — so THAT
+        // path always wins first. If a future card's distribute-unit amount is
+        // neither `DealDamage` nor `PutCounter` (the one shape this gate does not
+        // cover), re-verify whether it also needs the CR 601.2f target-dependent
+        // cost recompute this branch currently skips (see
+        // `casting::apply_target_dependent_cost_modifiers`) before assuming this
+        // code path is exercised by existing coverage.
         if let Some(unit) = pending.distribute {
             // CR 601.2d: X-spell distribution — pay mana first to determine X, then
             // trigger DistributeAmong with total = X.
@@ -8863,6 +8877,20 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
             );
         }
 
+        // NOTE: This branch is provably unreachable for every currently-implemented
+        // distribute-unit + {X}-cost card (Fireball and siblings) — the CR 601.2c/d
+        // gate in `ability_utils::ability_distribution_pool_needs_chosen_x` (added by
+        // issue #2856) forces `WaitingFor::ChooseXValue` before target selection
+        // whenever the divided amount is `Effect::DealDamage`/`Effect::PutCounter`
+        // with an unresolved X reference, which makes `chosen_x` always already set
+        // by the time `maybe_pause_for_cast_distribution` runs in
+        // `casting_targets::handle_select_targets`/`handle_choose_target` — so THAT
+        // path always wins first. If a future card's distribute-unit amount is
+        // neither `DealDamage` nor `PutCounter` (the one shape this gate does not
+        // cover), re-verify whether it also needs the CR 601.2f target-dependent
+        // cost recompute this branch currently skips (see
+        // `casting::apply_target_dependent_cost_modifiers`) before assuming this
+        // code path is exercised by existing coverage.
         if let Some(unit) = pending.distribute {
             // CR 601.2d: X + distribution + Phyrexian is extremely rare (no known current cards).
             // Fall through to the auto-decision distribution path for safety — the Phyrexian

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -4833,20 +4833,45 @@ fn apply_action(
 
             // CR 601.2d: Resume casting pipeline after distribution.
             if state.pending_cast.is_some() {
-                // Mid-cast distribution: resume finalize_cast to commit the spell.
+                // CR 601.2c + CR 601.2d + CR 601.2f: Targets and their division are now
+                // committed, so the total cost — including any target-dependent
+                // surcharge (Strive, CR 207.2c) — is finally determinable. Route through
+                // the single cost-determination authority every other post-target-
+                // selection path uses (`casting_targets::handle_select_targets` /
+                // `handle_choose_target`) instead of calling `finalize_cast` directly
+                // with the stale cost that was locked in at `ChooseXValue` time, before
+                // targets (and hence any per-target surcharge) were known.
                 let pending = state.pending_cast.take().unwrap();
-                casting_costs::finalize_cast(
+                // CR 601.2h ("Unpayable costs can't be paid"): mirror
+                // `finalize_mana_payment`'s `pending_for_restore` pattern
+                // (casting_costs.rs ~8623-8627/8778-8787) — `finish_pending_cast_cost_or_pay`'s
+                // downstream chain has no restore-on-error wrapper of its own, and
+                // `state.pending_cast` is already `None` here (unlike
+                // `handle_select_targets`, whose `pending_cast` lives inside the
+                // `WaitingFor::TargetSelection` variant and so is never destructively
+                // taken). Without this clone-and-restore, a recomputed cost that turns
+                // out unpayable would return `Err` with `state.pending_cast` gone while
+                // `state.waiting_for` still reports `DistributeAmong` — a resubmitted
+                // `DistributeAmong` action would then fall through to the
+                // resolution-time continuation branch below instead of being cleanly
+                // rejected.
+                let pending_for_restore = pending.clone();
+                let ability = pending.ability.clone();
+                let cost = pending.cost.clone();
+                match casting_costs::finish_pending_cast_cost_or_pay(
                     state,
                     p,
-                    pending.object_id,
-                    pending.card_id,
-                    pending.ability,
-                    &pending.cost,
-                    pending.casting_variant,
-                    pending.cast_timing_permission,
-                    pending.origin_zone,
+                    *pending,
+                    ability,
+                    cost,
                     &mut events,
-                )?
+                ) {
+                    Ok(waiting_for) => waiting_for,
+                    Err(err) => {
+                        state.pending_cast = Some(pending_for_restore);
+                        return Err(err);
+                    }
+                }
             } else if let Some(mut pending_trigger) = state.pending_trigger.take() {
                 // CR 601.2d + CR 603.3d: Triggered abilities divide effects
                 // while being put on the stack. The chosen per-target amounts

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -3967,18 +3967,33 @@ pub(super) fn handle_resolution_choice(
                         events,
                     )?;
                 } else {
-                    state.waiting_for = casting_costs::finalize_cast(
-                        state,
-                        player,
-                        pending.object_id,
-                        pending.card_id,
-                        pending.ability,
-                        &pending.cost,
-                        pending.casting_variant,
-                        pending.cast_timing_permission,
-                        pending.origin_zone,
-                        events,
-                    )?;
+                    // CR 601.2c + CR 601.2f (mirrors the identical fix for
+                    // GameAction::DistributeAmong in engine.rs): a NamedChoice
+                    // pause can occur after targets are already known, so the
+                    // total cost — including any target-dependent surcharge
+                    // (Strive, CR 207.2c) — must be re-derived through the
+                    // single cost-determination authority
+                    // (`finish_pending_cast_cost_or_pay`) rather than paying
+                    // the cost that was locked in earlier in the casting
+                    // sequence, before this resumption point. The
+                    // clone-and-restore-on-Err mirrors
+                    // `finalize_mana_payment`'s `pending_for_restore` pattern
+                    // (CR 601.2h, "unpayable costs can't be paid") since
+                    // `state.pending_cast` is already taken (`None`) here and
+                    // `finish_pending_cast_cost_or_pay`'s downstream chain has
+                    // no restore-on-error wrapper of its own.
+                    let pending_for_restore = pending.clone();
+                    let ability = pending.ability.clone();
+                    let cost = pending.cost.clone();
+                    state.waiting_for = match casting_costs::finish_pending_cast_cost_or_pay(
+                        state, player, *pending, ability, cost, events,
+                    ) {
+                        Ok(waiting_for) => waiting_for,
+                        Err(err) => {
+                            state.pending_cast = Some(pending_for_restore);
+                            return Err(err);
+                        }
+                    };
                 }
             } else if let Some(source) =
                 source_id.filter(|_| !state.deferred_entry_events.is_empty())

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1056,6 +1056,15 @@ impl<'a> CardBuilder<'a> {
         self
     }
 
+    /// Pin a Strive-style per-target cost surcharge (CR 207.2c + CR 601.2f) on
+    /// this card directly, bypassing Oracle-text parsing. Use when the parser's
+    /// recognition of the surcharge clause is out of scope for the test (e.g. a
+    /// card whose printed text predates the "Strive —" ability-word template).
+    pub fn with_strive_cost(&mut self, cost: crate::types::mana::ManaCost) -> &mut Self {
+        self.obj().strive_cost = Some(cost);
+        self
+    }
+
     /// Pre-mark damage on this permanent (for SBA / deathtouch tests).
     pub fn with_damage_marked(&mut self, damage: u32) -> &mut Self {
         self.obj().damage_marked = damage;

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5051,7 +5051,16 @@ pub struct DamageSlot {
 pub enum DistributionUnit {
     Damage,
     /// CR 601.2d: Even split — engine auto-computes `total / num_targets` (rounded down).
-    /// No player choice needed; bypasses `WaitingFor::DistributeAmong`.
+    /// No player *choice* in HOW it's split, but whether the flow pauses at
+    /// `WaitingFor::DistributeAmong` depends on the casting route:
+    /// - Non-deferred-target-selection flow (inside `finalize_mana_payment`):
+    ///   the split is applied inline and `WaitingFor::DistributeAmong` is bypassed.
+    /// - Deferred-target-selection flow (e.g. Fireball, gated by
+    ///   `ability_utils::ability_distribution_pool_needs_chosen_x`): the cast still
+    ///   pauses at `WaitingFor::DistributeAmong` via
+    ///   `casting_targets::maybe_pause_for_cast_distribution` — the split itself is
+    ///   automatic, but the pause is needed so cost (CR 601.2f) and target legality
+    ///   can re-resolve once targets are known.
     EvenSplitDamage,
     Counters(String),
     Life,

--- a/crates/engine/tests/integration/fireball_x_cost_surcharge_timing.rs
+++ b/crates/engine/tests/integration/fireball_x_cost_surcharge_timing.rs
@@ -120,21 +120,17 @@ fn cast_fireball(runner: &mut GameRunner, spell: ObjectId, card_id: CardId) {
 
 /// CR 601.2b: X is announced before targets for a distribute-among spell.
 fn drive_choose_x(runner: &mut GameRunner, x: u32) {
-    for _ in 0..40 {
-        match runner.state().waiting_for.clone() {
-            WaitingFor::ChooseXValue { .. } => {
-                runner
-                    .act(GameAction::ChooseX { value: x })
-                    .expect("ChooseX should succeed");
-                return;
-            }
-            WaitingFor::TargetSelection { .. } => {
-                panic!("X must be announced before targets for Fireball's distribute route");
-            }
-            _ => return,
+    match runner.state().waiting_for.clone() {
+        WaitingFor::ChooseXValue { .. } => {
+            runner
+                .act(GameAction::ChooseX { value: x })
+                .expect("ChooseX should succeed");
         }
+        WaitingFor::TargetSelection { .. } => {
+            panic!("X must be announced before targets for Fireball's distribute route");
+        }
+        other => panic!("expected ChooseXValue immediately after CastSpell, got {other:?}"),
     }
-    panic!("never reached ChooseXValue");
 }
 
 /// CR 601.2c: choose the given targets slot-by-slot (mirrors the production
@@ -189,7 +185,10 @@ fn drive_to_distribute(
 /// engine's `DistributeAmong` validator only requires sum == total and each ≥ 1.
 fn even_distribution(total: u32, targets: &[TargetRef]) -> Vec<(TargetRef, u32)> {
     let n = targets.len() as u32;
-    assert!(n > 0 && total % n == 0, "test uses evenly divisible X");
+    assert!(
+        n > 0 && total.is_multiple_of(n),
+        "test uses evenly divisible X"
+    );
     let share = total / n;
     targets.iter().map(|t| (t.clone(), share)).collect()
 }

--- a/crates/engine/tests/integration/fireball_x_cost_surcharge_timing.rs
+++ b/crates/engine/tests/integration/fireball_x_cost_surcharge_timing.rs
@@ -1,0 +1,323 @@
+//! Fireball — runtime cost must scale with target count on the {X}+distribute
+//! casting route.
+//!
+//! Real Oracle: "This spell costs {1} more to cast for each target beyond the
+//! first. / Fireball deals X damage divided evenly, rounded down, among any
+//! number of targets."
+//!
+//! Fireball is the one real card combining an `{X}` cost + a Strive-shaped
+//! per-target surcharge (CR 207.2c + CR 601.2f) + a distribute-among-targets
+//! effect. Because its distribution defers target selection until AFTER `{X}`
+//! is announced (CR 601.2b, gated by
+//! `ability_utils::ability_distribution_pool_needs_chosen_x`), it commits its
+//! division through `WaitingFor::DistributeAmong`. The pre-fix
+//! `GameAction::DistributeAmong` mid-cast handler called
+//! `casting_costs::finalize_cast` directly with `pending.cost` — the cost
+//! locked in at `ChooseXValue` time (CR 601.2b), BEFORE targets were known — so
+//! the per-target surcharge (CR 601.2f, computed by
+//! `casting::apply_target_dependent_cost_modifiers`) was never applied: the
+//! spell always cost as if it had a single target. The fix routes that handler
+//! through `casting_costs::finish_pending_cast_cost_or_pay`, the same
+//! post-target-selection cost authority every other casting route uses.
+//!
+//! FIXTURE NOTE (scope isolation): the surcharge is pinned directly with
+//! `with_strive_cost` (CR 207.2c + CR 601.2f) rather than parsed from Oracle
+//! text, exactly as this branch's plan directs (the runtime timing fix must not
+//! depend on the separate parser fix, PR #5545). The card's effect text is the
+//! VERBATIM distribution clause only ("Fireball deals X damage divided evenly,
+//! rounded down, among any number of targets"), which is already parsed
+//! correctly today and drives the real EvenSplitDamage distribute-among branch.
+//! The printed surcharge line ("This spell costs {1} more to cast for each
+//! target beyond the first") is deliberately EXCLUDED from the fixture text:
+//! today's parser mis-lowers that "for each" clause into a self-spell cost
+//! increase that evaluates to +{1} per battlefield permanent (the exact PR
+//! #5545 defect), which would swamp this test with an unrelated, out-of-scope
+//! cost inflation. Including it verbatim was verified to make the spell cost
+//! `{X + battlefield-creature-count}{R}` — a parser bug this branch does not
+//! own. Excluding one printed line while pinning its true effect keeps this
+//! test focused strictly on the runtime distribute-route timing seam.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::PlayerId;
+
+const FIREBALL_ORACLE: &str =
+    "Fireball deals X damage divided evenly, rounded down, among any number of targets.";
+
+/// {X}{R} — one red plus the variable generic.
+fn fireball_cost() -> ManaCost {
+    ManaCost::Cost {
+        shards: vec![ManaCostShard::X, ManaCostShard::Red],
+        generic: 0,
+    }
+}
+
+/// "{1} more per target beyond the first" — one generic per extra target.
+fn strive_one_generic() -> ManaCost {
+    ManaCost::Cost {
+        shards: vec![],
+        generic: 1,
+    }
+}
+
+fn red_pool(amount: usize) -> Vec<ManaUnit> {
+    (0..amount)
+        .map(|_| ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn pool_total(runner: &GameRunner, player: PlayerId) -> usize {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| p.mana_pool.total())
+        .unwrap_or(0)
+}
+
+/// Build a fresh Fireball scenario: three opposing creatures to target, a
+/// pinned `{1}`-per-extra-target surcharge, and a red mana pool of `pool` mana.
+fn fireball_scenario(pool: usize) -> (GameRunner, ObjectId, CardId, Vec<ObjectId>) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let creatures: Vec<ObjectId> = (0..3)
+        .map(|i| {
+            scenario
+                .add_creature(P1, &format!("Grizzly {i}"), 3, 3)
+                .id()
+        })
+        .collect();
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Fireball", false, FIREBALL_ORACLE)
+        .with_mana_cost(fireball_cost())
+        .with_strive_cost(strive_one_generic())
+        .id();
+    let card_id = CardId(spell.0);
+
+    scenario.with_mana_pool(P0, red_pool(pool));
+
+    (scenario.build(), spell, card_id, creatures)
+}
+
+fn cast_fireball(runner: &mut GameRunner, spell: ObjectId, card_id: CardId) {
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("Fireball cast announcement should be accepted");
+}
+
+/// CR 601.2b: X is announced before targets for a distribute-among spell.
+fn drive_choose_x(runner: &mut GameRunner, x: u32) {
+    for _ in 0..40 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ChooseXValue { .. } => {
+                runner
+                    .act(GameAction::ChooseX { value: x })
+                    .expect("ChooseX should succeed");
+                return;
+            }
+            WaitingFor::TargetSelection { .. } => {
+                panic!("X must be announced before targets for Fireball's distribute route");
+            }
+            _ => return,
+        }
+    }
+    panic!("never reached ChooseXValue");
+}
+
+/// CR 601.2c: choose the given targets slot-by-slot (mirrors the production
+/// client), then finish any remaining optional "any number of targets" slots.
+fn drive_targets(runner: &mut GameRunner, targets: &[ObjectId]) {
+    for &t in targets {
+        assert!(
+            matches!(
+                runner.state().waiting_for,
+                WaitingFor::TargetSelection { .. }
+            ),
+            "expected TargetSelection while choosing targets, got {:?}",
+            runner.state().waiting_for
+        );
+        runner
+            .act(GameAction::ChooseTarget {
+                target: Some(TargetRef::Object(t)),
+            })
+            .expect("ChooseTarget should succeed");
+    }
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::TargetSelection { .. }
+    ) {
+        runner
+            .act(GameAction::ChooseTarget { target: None })
+            .expect("finishing optional target slots should succeed");
+    }
+}
+
+/// Reach `WaitingFor::DistributeAmong` for `x` damage over the chosen targets,
+/// asserting the buggy seam is actually driven, and return `(total, targets)`.
+fn drive_to_distribute(
+    runner: &mut GameRunner,
+    spell: ObjectId,
+    card_id: CardId,
+    x: u32,
+    targets: &[ObjectId],
+) -> (u32, Vec<TargetRef>) {
+    cast_fireball(runner, spell, card_id);
+    drive_choose_x(runner, x);
+    drive_targets(runner, targets);
+
+    match runner.state().waiting_for.clone() {
+        WaitingFor::DistributeAmong { total, targets, .. } => (total, targets),
+        other => panic!("expected DistributeAmong after target selection, got {other:?}"),
+    }
+}
+
+/// Split `total` as evenly as the submitted targets allow (each ≥ 1). For the
+/// X-divisible-by-count cases used here this is the rounded-even split; the
+/// engine's `DistributeAmong` validator only requires sum == total and each ≥ 1.
+fn even_distribution(total: u32, targets: &[TargetRef]) -> Vec<(TargetRef, u32)> {
+    let n = targets.len() as u32;
+    assert!(n > 0 && total % n == 0, "test uses evenly divisible X");
+    let share = total / n;
+    targets.iter().map(|t| (t.clone(), share)).collect()
+}
+
+/// Primary fix: on the {X}+distribute route the final paid cost must include the
+/// CR 601.2f per-target surcharge. Same X, same starting pool, different target
+/// counts ⇒ the 3-target cast must pay {1}×2 more than the 1-target cast.
+#[test]
+fn fireball_surcharge_scales_with_target_count_on_distribute_route() {
+    const POOL: usize = 20;
+    const X: u32 = 3;
+
+    // 1 target: {X}{R} = {3}{R} = 4 mana, no surcharge (0 targets beyond first).
+    let (mut runner, spell, card_id, creatures) = fireball_scenario(POOL);
+    let (total, targets) = drive_to_distribute(&mut runner, spell, card_id, X, &creatures[..1]);
+    assert_eq!(total, X, "damage pool equals announced X");
+    assert_eq!(targets.len(), 1, "single-target reach guard");
+    runner
+        .act(GameAction::DistributeAmong {
+            distribution: even_distribution(total, &targets),
+        })
+        .expect("1-target distribution + payment should succeed");
+    let residual_one = pool_total(&runner, P0);
+    assert_eq!(
+        residual_one,
+        POOL - 4,
+        "1 target pays only {{X}}{{R}} = {{3}}{{R}} = 4 mana (no surcharge)"
+    );
+
+    // 3 targets: {3}{R} + {1}×2 surcharge = 6 mana. Pre-fix this stayed at 4.
+    let (mut runner, spell, card_id, creatures) = fireball_scenario(POOL);
+    let (total, targets) = drive_to_distribute(&mut runner, spell, card_id, X, &creatures[..3]);
+    assert_eq!(total, X, "damage pool equals announced X");
+    assert_eq!(
+        targets.len(),
+        3,
+        "three-target reach guard drives the buggy seam"
+    );
+    runner
+        .act(GameAction::DistributeAmong {
+            distribution: even_distribution(total, &targets),
+        })
+        .expect("3-target distribution + payment should succeed");
+    let residual_three = pool_total(&runner, P0);
+    // Revert-failing assertion: pre-fix (finalize_cast with stale cost) drops
+    // the surcharge, leaving residual at POOL - 4 == 16. The fix charges the
+    // two extra targets' {1} each, so residual == POOL - 6 == 14.
+    assert_eq!(
+        residual_three,
+        POOL - 6,
+        "3 targets must pay {{3}}{{R}} + {{1}}x2 surcharge = 6 mana (CR 601.2f)"
+    );
+    assert_eq!(
+        residual_one - residual_three,
+        2,
+        "the 2 targets beyond the first each add {{1}} to the paid cost"
+    );
+}
+
+/// Rollback wrapper: when the recomputed (correctly higher) cost is unpayable,
+/// the handler must leave a clean, retryable state — `pending_cast` restored and
+/// `waiting_for` unchanged — rather than dropping `pending_cast` while
+/// `waiting_for` still reports `DistributeAmong` (CR 601.2h).
+#[test]
+fn fireball_unpayable_recomputed_cost_rolls_back_cleanly() {
+    // Fund EXACTLY the 1-target cost ({3}{R} = 4). Choosing 3 targets raises the
+    // real cost to 6 (surcharge), which this pool cannot afford.
+    const X: u32 = 3;
+    let (mut runner, spell, card_id, creatures) = fireball_scenario(4);
+    let (total, targets) = drive_to_distribute(&mut runner, spell, card_id, X, &creatures[..3]);
+    assert_eq!(targets.len(), 3, "three-target reach guard");
+    assert_eq!(
+        pool_total(&runner, P0),
+        4,
+        "pool funded for the 1-target cost only"
+    );
+
+    // Snapshot the exact pre-failure state (reach guard: pending_cast is Some).
+    let pre_pending = runner.state().pending_cast.clone();
+    let pre_waiting = runner.state().waiting_for.clone();
+    assert!(
+        pre_pending.is_some(),
+        "reach guard: a pending cast must exist before the failing distribution"
+    );
+
+    // CR 601.2d: the handler stashes the announced division into
+    // `pending.ability.distribution` BEFORE it clones `pending_for_restore`, so a
+    // correct clean restore carries exactly that stash (and nothing else changes).
+    // Build the expected post-failure pending from the pre-failure snapshot plus
+    // that one stash — a full structural check that both (i) proves the restore is
+    // not a subtly-wrong `Some(_)`, and (ii) proves the distribution stash is
+    // present (a restore that dropped it would fail here just as a bare
+    // pre-snapshot compare would).
+    let distribution = even_distribution(total, &targets);
+    let mut expected_pending = pre_pending.clone();
+    expected_pending
+        .as_mut()
+        .expect("reach guard set above")
+        .ability
+        .distribution = Some(distribution.clone());
+
+    let result = runner.act(GameAction::DistributeAmong { distribution });
+
+    // (a) the unpayable recomputed cost is rejected.
+    assert!(
+        result.is_err(),
+        "recomputed 6-mana cost must be unpayable from a 4-mana pool (CR 601.2h)"
+    );
+    // (b) full structural restore of pending_cast — not just is_some(): catches a
+    // restore that pushes back a subtly-wrong PendingCast (e.g. a dropped
+    // `.ability.distribution` stash, or a cost/target field mutated in place).
+    assert_eq!(
+        runner.state().pending_cast,
+        expected_pending,
+        "pending_cast must be restored exactly (pre-failure state + the CR 601.2d distribution stash)"
+    );
+    // (c) waiting_for is unchanged — a clean, retryable/cancellable DistributeAmong
+    // state, not a corrupted stale one.
+    assert_eq!(
+        runner.state().waiting_for,
+        pre_waiting,
+        "waiting_for must still be the same DistributeAmong after the failed payment"
+    );
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::DistributeAmong { .. }
+        ),
+        "state must remain at DistributeAmong for a clean retry/cancel"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -111,6 +111,7 @@ mod fact_or_fiction_pile_separation;
 mod fateful_handoff_target_mana_value_draw;
 mod festival_of_embers_graveyard_additional_cost;
 mod field_marshal_soldier_anthem_first_strike;
+mod fireball_x_cost_surcharge_timing;
 mod flickerwisp_delayed_return;
 mod floodpits_drowner;
 mod flowstone_surge_mixed_anthem;


### PR DESCRIPTION
## Summary

Follow-up to #5545 (Fireball's parser misparse — that PR makes `strive_cost` correctly get populated). This PR fixes a separate, independent runtime bug: even with `strive_cost` populated, [[Fireball]]'s ({X}{R}: "This spell costs {1} more to cast for each target beyond the first.\nFireball deals X damage divided evenly, rounded down, among any number of targets.") actual in-game cost never scaled with target count.

## Root cause

Fireball's specific casting shape — an `{X}` cost combined with "divided evenly among any number of targets" — triggers a sequence where:

1. `{X}` is announced first (CR 601.2b) and the cost gets locked in via `apply_post_x_cost_modifiers` **before any targets exist**, so the per-target surcharge loop (`for _ in 1..target_count`) is a no-op at that point (`target_count == 0`).
2. Targets are chosen after (CR 601.2c).
3. Because the spell needs to "divide" its effect among the now-known targets, the engine pauses at `WaitingFor::DistributeAmong` (CR 601.2d) rather than proceeding straight to payment.
4. The `GameAction::DistributeAmong` handler resumes by calling `casting_costs::finalize_cast` **directly** with the stale, pre-target cost — completely skipping `check_additional_cost_or_pay_with_distribute`, the only place `apply_target_dependent_cost_modifiers` (the CR 601.2f surcharge authority) actually runs.

## Fix

Route through `casting_costs::finish_pending_cast_cost_or_pay` — the same cost-determination authority every other casting route already uses to go from "targets known" to "cost determined, locked in, paid" — instead of calling `finalize_cast` directly. This is a general seam fix, not hardcoded to Fireball: **Fireball is currently the only real card in Magic combining an `{X}` cost, a strive-shaped per-target surcharge, and a distribute-among-targets effect** (verified via Scryfall across two rounds of review), so the fix automatically covers any future card with this shape.

This requires a rollback wrapper. `state.pending_cast` is `.take()`n (set to `None`) before the call, and `finish_pending_cast_cost_or_pay`'s downstream chain has no restore-on-error of its own. If the recomputed (correctly higher) cost turns out unpayable, a bare `Err` would leave `state.waiting_for` stale as `DistributeAmong` while `pending_cast` is gone — a resubmitted `DistributeAmong` action would then silently fall through to an unrelated resolution-time-continuation branch instead of being cleanly rejected. The fix mirrors `finalize_mana_payment`'s existing `pending_for_restore` clone-and-restore-on-`Err` pattern (CR 601.2h: "Unpayable costs can't be paid").

**Extended defensively to a second call site found during review**: `engine_resolution_choices.rs`'s `NamedChoice` handler has the identical anti-pattern in its spell-cast resume branch (`activation_ability_index == None`) — also calls `finalize_cast` directly with a stale cost. No currently-shipped card was confirmed to reach it with a target-dependent cost modifier, but the fix is mechanical and the pattern is exactly the same, so it's fixed rather than left as a known latent gap.

A second near-miss (`finalize_mana_payment`'s two `pending.distribute`-gated blocks) was investigated and found **provably unreachable** for every real card today — git-verified that the #2856 divide-softlock gate (`ability_distribution_pool_needs_chosen_x`) predates and is an ancestor of the commits shaping those blocks. Documented with a cross-reference comment; no functional change needed there.

Also corrects `DistributionUnit::EvenSplitDamage`'s doc comment, which incorrectly claimed it always bypasses `WaitingFor::DistributeAmong` — true only for the non-deferred-target-selection flow, not for a deferred-selection card like Fireball.

## Test note

The new test pins the surcharge via a new `with_strive_cost` test builder rather than parsing Fireball's full real Oracle text, because that text currently mis-parses on `origin/main` into an unrelated, separate bug (a spurious static cost modifier) — that's PR #5545's territory, not this branch's job, and is documented in the test module doc.

## Files changed

- `crates/engine/src/game/engine.rs` — the primary fix (`DistributeAmong` handler)
- `crates/engine/src/game/engine_resolution_choices.rs` — the identical fix applied to the `NamedChoice` handler's spell-cast resume branch
- `crates/engine/src/game/casting_costs.rs` — documentation-only cross-reference comments (no functional change)
- `crates/engine/src/types/game_state.rs` — `DistributionUnit::EvenSplitDamage` doc correction
- `crates/engine/src/game/scenario.rs` — `with_strive_cost` test builder
- `crates/engine/tests/integration/fireball_x_cost_surcharge_timing.rs` (new) — discriminating runtime tests
- `crates/engine/tests/integration/main.rs` — registers the new test module

## CR references

CR 207.2c, CR 601.2b, CR 601.2c, CR 601.2d, CR 601.2f, CR 601.2h

## Verification

- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p engine --lib -- -D warnings` clean
- [x] `./scripts/check-parser-combinators.sh`: no-op (no parser files touched)
- [x] `cargo test -p engine --lib`: 16104 passed, 0 failed
- [x] `cargo test -p engine --test integration`: 2665 passed, 0 failed
- [x] Live-revert-and-rerun performed independently twice (by the implementer and by an independent reviewer): reverting the cost-authority swap fails the surcharge test; reverting *only* the rollback wrapper (keeping the swap) fails the state-coherence assertions specifically, proving the wrapper is load-bearing, not decorative
- [x] Three rounds of independent plan review (closed: a test-file dependency mixup later clarified as belonging to a separate not-yet-merged PR, a genuinely-investigated near-miss call site proven unreachable via git history, a corrected card-class table, and a traced-and-fixed state-corruption risk in the naive version of this fix) plus a review-impl pass (found the second `NamedChoice` call site, since fixed)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01XbgwGxbU9NHN9kou9isp8K