### PR TITLE
fix(engine): return cards exiled with a self-exiled source (Mechtitan Core)

### DIFF
--- a/crates/engine/src/game/exile_links.rs
+++ b/crates/engine/src/game/exile_links.rs
@@ -250,14 +250,21 @@ mod tests {
     /// CR 702.167a/c: a `CraftMaterial` link must survive the craft source's
     /// battlefield exit (it self-exiles mid-activation and returns with the same
     /// ObjectId), so the returned permanent can still read what it was crafted
-    /// with. A plain `TrackedBySource` link from the same source is pruned on
-    /// that exit — the contrast that motivates the dedicated kind.
+    /// with. The contrast that motivates the dedicated kind is now a NON-exile
+    /// exit: on a death (battlefield -> graveyard) `CraftMaterial` survives but a
+    /// plain `TrackedBySource` link from the same source is pruned.
+    ///
+    /// CR 607.2a + CR 400.7: `TrackedBySource` links are NOT pruned on an exit TO
+    /// EXILE — a self-exiled source stays the linked-ability referent for its
+    /// pile (Mechtitan Core). The exile-exit arm below asserts that survival so a
+    /// regression that reinstates the old blanket prune fails here.
     #[test]
     fn craft_material_link_survives_source_battlefield_exit() {
         use crate::game::zones::{create_object, move_to_zone};
         use crate::types::game_state::{ExileLinkKind, GameState};
         use crate::types::identifiers::CardId;
 
+        // --- Non-exile exit (death): CraftMaterial survives, TrackedBySource pruned.
         let mut state = GameState::new_two_player(1);
         let source = create_object(
             &mut state,
@@ -283,9 +290,8 @@ mod tests {
         );
         push_with_kind(&mut state, tracked, source, ExileLinkKind::TrackedBySource);
 
-        // The craft source self-exiles mid-activation (battlefield -> exile).
         let mut events = Vec::new();
-        move_to_zone(&mut state, source, Zone::Exile, &mut events);
+        move_to_zone(&mut state, source, Zone::Graveyard, &mut events);
 
         assert!(
             state.exile_links.iter().any(|l| l.exiled_id == material
@@ -298,7 +304,36 @@ mod tests {
                 .exile_links
                 .iter()
                 .any(|l| l.exiled_id == tracked && l.source_id == source),
-            "TrackedBySource link must be pruned on the source's battlefield exit"
+            "TrackedBySource link must be pruned on a non-exile battlefield exit (death)"
+        );
+
+        // --- Exit TO EXILE (self-exile cost): TrackedBySource survives (CR 607.2a).
+        let mut state = GameState::new_two_player(1);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Mechtitan Core".to_string(),
+            Zone::Battlefield,
+        );
+        let tracked = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Exiled With Source".to_string(),
+            Zone::Exile,
+        );
+        push_with_kind(&mut state, tracked, source, ExileLinkKind::TrackedBySource);
+
+        let mut events = Vec::new();
+        move_to_zone(&mut state, source, Zone::Exile, &mut events);
+
+        assert!(
+            state
+                .exile_links
+                .iter()
+                .any(|l| l.exiled_id == tracked && l.source_id == source),
+            "TrackedBySource link must survive the source's self-exile (CR 607.2a)"
         );
     }
 

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -6279,9 +6279,16 @@ mod tests {
 
     #[test]
     fn pit_of_offerings_blink_clears_exile_links() {
-        // CR 400.7 + CR 610.3: When Pit of Offerings leaves the battlefield,
-        // its `TrackedBySource` exile links are dropped. A blink (LTB then
-        // re-ETB) creates a new object that inherits no linkage.
+        // CR 400.7: A blink (LTB then re-ETB) creates a new object that inherits
+        // no linkage — the re-entered Pit's mana ability must not read the old
+        // incarnation's exiled cards.
+        //
+        // CR 607.2a: `TrackedBySource` links now SURVIVE the leg into exile (a
+        // self-exiled source stays the linked-ability referent for its pile —
+        // Mechtitan Core); the blink reset happens on RE-ENTRY, not on the exit.
+        // While Pit sits in exile the preserved link is inert (its "{T}: add mana
+        // among cards exiled with ~" ability can only be activated on the
+        // battlefield), so this staged blink still ends with no stale linkage.
         let mut state = GameState::new_two_player(42);
         let (pit, _exiled) = pit_of_offerings_with_exiled_card(
             &mut state,
@@ -6292,14 +6299,20 @@ mod tests {
 
         assert_eq!(state.exile_links.len(), 1, "precondition: link was created");
 
+        // LTB into exile: the link is preserved (CR 607.2a durability), not yet cleared.
         let mut events = Vec::new();
         crate::game::zones::move_to_zone(&mut state, pit, Zone::Exile, &mut events);
+        assert!(
+            state.exile_links.iter().any(|link| link.source_id == pit),
+            "an exit into exile preserves the TrackedBySource link (CR 607.2a)"
+        );
 
-        // The TrackedBySource link keyed to the (departed) Pit object must be gone.
+        // Re-ETB (the blink completes): the new object sheds the stale linkage.
+        crate::game::zones::move_to_zone(&mut state, pit, Zone::Battlefield, &mut events);
         assert!(
             state.exile_links.iter().all(|link| link.source_id != pit),
-            "TrackedBySource exile links must be pruned when the source leaves \
-             the battlefield (CR 400.7)"
+            "TrackedBySource exile links must be cleared when the source re-enters \
+             the battlefield as a new object (CR 400.7)"
         );
     }
 

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -479,6 +479,18 @@ pub(crate) fn apply_zone_exit_cleanup(
         // source self-exiles mid-activation and returns with the same ObjectId,
         // so the material links must survive its battlefield exit for the
         // returned permanent to still read what it was crafted with.
+        // CR 607.2a + CR 400.7: `TrackedBySource` links are preserved when the
+        // source leaves the battlefield TO EXILE. A source that self-exiles
+        // (typically as its own activation cost — Mechtitan Core: "Exile this
+        // Vehicle and four other …: … return all cards exiled with this Vehicle
+        // …") keeps a stable ObjectId in exile and remains the linked-ability
+        // referent (CR 607.2a: the second ability refers to the cards put in exile
+        // by the first). Preserve its links so a deferred `ExiledBySource` return
+        // still finds the pile turns later — the blink-identity reset instead
+        // happens if that source RE-ENTERS the battlefield (paired entry prune
+        // below). Narrowed to the exile-exit so ordinary death/bounce (to
+        // graveyard/hand) still prunes.
+        let source_exits_to_exile = to == Zone::Exile;
         state.exile_links.retain(|link| {
             link.source_id != object_id
                 || matches!(
@@ -487,6 +499,11 @@ pub(crate) fn apply_zone_exit_cleanup(
                         | crate::types::game_state::ExileLinkKind::Haunt
                         | crate::types::game_state::ExileLinkKind::CraftMaterial
                 )
+                || (source_exits_to_exile
+                    && matches!(
+                        link.kind,
+                        crate::types::game_state::ExileLinkKind::TrackedBySource
+                    ))
         });
     }
 }
@@ -785,6 +802,26 @@ pub fn move_to_zone(
     // CR 700.11: a permanent card was put into its owner's graveyard.
     if to == Zone::Graveyard {
         record_descend_on_graveyard_arrival(state, object_id, owner);
+    }
+
+    // CR 400.7: A permanent that re-enters the battlefield is a new object with no
+    // relation to its previous existence, so it sheds the "exiled with it"
+    // associations of its prior incarnation. The battlefield-EXIT cleanup above
+    // now preserves a source's `TrackedBySource` links when it leaves TO EXILE
+    // (so a self-exiled source's pending linked return still finds its pile —
+    // Mechtitan Core); this paired entry prune is the blink-back reset that drops
+    // those stale links if that same source is later returned to the battlefield,
+    // preventing `ExiledBySource` from reading a prior incarnation's pile. Scoped
+    // to `TrackedBySource`: `CraftMaterial` links must survive re-entry (the craft
+    // source returns transformed and must still read its materials).
+    if to == Zone::Battlefield {
+        state.exile_links.retain(|link| {
+            link.source_id != object_id
+                || !matches!(
+                    link.kind,
+                    crate::types::game_state::ExileLinkKind::TrackedBySource
+                )
+        });
     }
 
     // CR 611.3a + CR 400.3: Hand size affects continuous effects gated on the
@@ -2728,6 +2765,95 @@ mod tests {
                 .iter()
                 .all(|link| link.source_id != source),
             "TrackedBySource links should still be pruned immediately after LTB"
+        );
+    }
+
+    /// CR 607.2a + CR 400.7: A source that leaves the battlefield TO EXILE
+    /// (self-exile as an activation cost — Mechtitan Core) keeps a stable
+    /// ObjectId in exile and stays the linked-ability referent for its
+    /// "exiled with ~" pile, so its `TrackedBySource` links must survive the
+    /// exit. The sibling above (exit to graveyard) proves the survival is
+    /// exile-scoped, not a blanket "never prune".
+    #[test]
+    fn tracked_by_source_links_survive_source_exit_to_exile() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(60),
+            PlayerId(0),
+            "Mechtitan Core".to_string(),
+            Zone::Battlefield,
+        );
+        let exiled = create_object(
+            &mut state,
+            CardId(61),
+            PlayerId(1),
+            "Exiled With Source".to_string(),
+            Zone::Exile,
+        );
+        state.exile_links.push(crate::types::game_state::ExileLink {
+            source_id: source,
+            exiled_id: exiled,
+            kind: crate::types::game_state::ExileLinkKind::TrackedBySource,
+        });
+
+        let mut events = Vec::new();
+        move_to_zone(&mut state, source, Zone::Exile, &mut events);
+
+        assert!(
+            state
+                .exile_links
+                .iter()
+                .any(|link| link.source_id == source && link.exiled_id == exiled),
+            "TrackedBySource link must survive the source's self-exile"
+        );
+        // Reach-guard: the deferred `ExiledBySource` lookup keyed to the now-exiled
+        // source still resolves the pile (the property the Mechtitan return relies on).
+        assert!(
+            crate::game::players::linked_exile_cards_for_source(&state, source)
+                .iter()
+                .any(|snap| snap.exiled_id == exiled),
+            "linked_exile_cards_for_source must return the pile after the source self-exiles"
+        );
+    }
+
+    /// CR 400.7: A source that self-exiled (keeping its `TrackedBySource` links)
+    /// and is then returned to the battlefield is a new object and sheds those
+    /// stale links, so a later "cards exiled with ~" reference cannot read a
+    /// prior incarnation's pile. This is the blink-back reset paired with the
+    /// exit-to-exile preservation above.
+    #[test]
+    fn tracked_by_source_links_reset_on_battlefield_reentry() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(62),
+            PlayerId(0),
+            "Blinked Source".to_string(),
+            Zone::Exile,
+        );
+        let exiled = create_object(
+            &mut state,
+            CardId(63),
+            PlayerId(1),
+            "Old Pile Card".to_string(),
+            Zone::Exile,
+        );
+        state.exile_links.push(crate::types::game_state::ExileLink {
+            source_id: source,
+            exiled_id: exiled,
+            kind: crate::types::game_state::ExileLinkKind::TrackedBySource,
+        });
+
+        let mut events = Vec::new();
+        move_to_zone(&mut state, source, Zone::Battlefield, &mut events);
+
+        assert!(
+            state
+                .exile_links
+                .iter()
+                .all(|link| link.source_id != source),
+            "TrackedBySource links keyed to a re-entering source must be dropped (CR 400.7)"
         );
     }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -533,6 +533,7 @@ mod mass_phase_out_1792_repro;
 mod master_of_ceremonies;
 mod mauhur_swarming_of_moria;
 mod maze_of_ith_untap_bidirectional_prevent;
+mod mechtitan_core_return_exiled;
 mod memory_plunder_free_cast_2884;
 mod militant_angel_attacked_opponents;
 mod mill_double_redirect_choice_continuation;

--- a/crates/engine/tests/integration/mechtitan_core_return_exiled.rs
+++ b/crates/engine/tests/integration/mechtitan_core_return_exiled.rs
@@ -1,0 +1,213 @@
+//! Regression for **Mechtitan Core** (no linked GitHub issue) —
+//!
+//! > {5}, Exile this Vehicle and four other artifact creatures and/or Vehicles
+//! > you control: Create Mechtitan, a legendary 10/10 Construct artifact creature
+//! > token … When that token leaves the battlefield, return all cards exiled with
+//! > this Vehicle except this card to the battlefield tapped under their owners'
+//! > control.
+//!
+//! At runtime the activated ability exiles the 4 others with `TrackedBySource`
+//! links (`source_id = Mechtitan Core`) — the self-exiled Core is NOT self-linked,
+//! so "except this card" falls out for free — and installs a delayed trigger
+//! `WhenLeavesPlayFiltered{token} → ChangeZoneAll{ Exile→Battlefield,
+//! ExiledBySource, enter_tapped: Tapped }` whose `source_id` is Core.
+//!
+//! THE BUG: Core self-exiles paying its own cost. Before the fix,
+//! `apply_zone_exit_cleanup` pruned every `TrackedBySource` link keyed to Core the
+//! instant Core left the battlefield, and the only fallback (`linked_exile_lki`)
+//! is cleared on every phase/step transition. So when the token left many turns
+//! later, `linked_exile_cards_for_source(Core)` returned `[]` and NOTHING came
+//! back. This test reproduces that exact runtime shape (source self-exiles → a
+//! phase passes → the token leaves) and asserts the pile returns TAPPED.
+//!
+//! THE FIX (`game/zones.rs`): preserve `TrackedBySource` links when a source
+//! leaves the battlefield TO EXILE (CR 607.2a: the pile stays the linked-ability
+//! referent while the source sits in exile with a stable ObjectId per CR 400.7),
+//! and reset them only if that source RE-ENTERS the battlefield.
+//!
+//! DISCRIMINATOR: revert the exit-prune change → Core's self-exile drops the
+//! links → the `== Battlefield` / `tapped` assertions flip to "still in Exile".
+//!
+//! CR references (verified against `docs/MagicCompRules.txt`):
+//!   - CR 607.2a: an "exile …" ability and a "cards exiled with [this object]"
+//!     ability are linked; the second refers to the exile-zone cards the first put
+//!     there — the association does not depend on where the source now is.
+//!   - CR 400.7: an object that changes zones becomes a new object; ObjectId is
+//!     stable storage, so the self-exiled Core keeps its id in exile.
+//!   - CR 614.12: an effect that modifies how a permanent enters the battlefield
+//!     (here, tapped) — the mass return honors `enter_tapped`.
+
+use engine::game::players::linked_exile_cards_for_source;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::triggers::check_delayed_triggers;
+use engine::game::zones::{create_object, move_to_zone};
+use engine::types::ability::{DelayedTriggerCondition, Effect, ResolvedAbility, TargetFilter};
+use engine::types::game_state::{DelayedTrigger, ExileLink, ExileLinkKind, GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::phase::Phase;
+use engine::types::zones::{EtbTapState, Zone};
+
+/// Build the delayed trigger the parser produces for Mechtitan Core, bound to a
+/// concrete `token` (condition) and `core` (effect source). Mirrors the stored
+/// AST observed in a real game-state export.
+fn install_mechtitan_return_trigger(state: &mut GameState, core: ObjectId, token: ObjectId) {
+    let ability = ResolvedAbility::new(
+        Effect::ChangeZoneAll {
+            origin: Some(Zone::Exile),
+            destination: Zone::Battlefield,
+            target: TargetFilter::ExiledBySource,
+            enters_under: None,
+            enter_tapped: EtbTapState::Tapped,
+            enter_with_counters: vec![],
+            face_down_profile: None,
+            library_position: None,
+            random_order: false,
+        },
+        vec![],
+        core,
+        P0,
+    );
+    state.delayed_triggers.push(DelayedTrigger {
+        condition: DelayedTriggerCondition::WhenLeavesPlayFiltered {
+            filter: TargetFilter::SpecificObject { id: token },
+        },
+        ability,
+        controller: P0,
+        source_id: core,
+        one_shot: true,
+    });
+}
+
+/// Drive priority passes until the stack drains so the fired delayed trigger's
+/// mass return resolves onto the battlefield.
+fn drain_stack(runner: &mut GameRunner) {
+    for _ in 0..200 {
+        if matches!(runner.state().waiting_for, WaitingFor::OrderTriggers { .. }) {
+            engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            continue;
+        }
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            _ => {
+                if runner
+                    .act(engine::types::actions::GameAction::PassPriority)
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn mechtitan_core_returns_exiled_pile_tapped_after_token_leaves() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Mechtitan Core on the battlefield (the exile source / delayed-trigger source).
+    let core = scenario.add_creature(P0, "Mechtitan Core", 2, 4).id();
+    // The Mechtitan token on the battlefield.
+    let token = scenario.add_creature(P0, "Mechtitan", 10, 10).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+    let state = runner.state_mut();
+
+    // The four "other" cards exiled with Core (two per owner — proves per-owner
+    // routing on the return). All carry `TrackedBySource` links keyed to Core,
+    // exactly as the activation cost's `EffectZoneChoice` produces them.
+    let p0_a = create_object(state, CardId(900), P0, "Ally A".to_string(), Zone::Exile);
+    let p0_b = create_object(state, CardId(901), P0, "Ally B".to_string(), Zone::Exile);
+    let p1_a = create_object(state, CardId(902), P1, "Foe A".to_string(), Zone::Exile);
+    let p1_b = create_object(state, CardId(903), P1, "Foe B".to_string(), Zone::Exile);
+    let pile = [p0_a, p0_b, p1_a, p1_b];
+    for exiled in pile {
+        state.exile_links.push(ExileLink {
+            exiled_id: exiled,
+            source_id: core,
+            kind: ExileLinkKind::TrackedBySource,
+        });
+    }
+    // A control card exiled by a DIFFERENT source must never come back.
+    let unrelated = create_object(state, CardId(904), P0, "Unrelated".to_string(), Zone::Exile);
+    let other_source = create_object(
+        state,
+        CardId(905),
+        P0,
+        "Other Source".to_string(),
+        Zone::Battlefield,
+    );
+    state.exile_links.push(ExileLink {
+        exiled_id: unrelated,
+        source_id: other_source,
+        kind: ExileLinkKind::TrackedBySource,
+    });
+
+    install_mechtitan_return_trigger(state, core, token);
+
+    // 1) Core self-exiles paying its own cost (battlefield -> exile). The fix must
+    //    preserve Core's TrackedBySource links here.
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), core, Zone::Exile, &mut events);
+    assert_eq!(
+        runner.state().objects[&core].zone,
+        Zone::Exile,
+        "precondition: Core self-exiled"
+    );
+    // DISCRIMINATOR (revert the exit-prune → this is empty): the linked pile
+    // survives Core's departure and is still resolvable from exile.
+    assert_eq!(
+        linked_exile_cards_for_source(runner.state(), core).len(),
+        4,
+        "all four exiled-with-Core cards must survive Core's self-exile (CR 607.2a)"
+    );
+
+    // 2) A phase passes — proves the (turn-scoped) linked_exile_lki fallback is
+    //    irrelevant; durability comes from the preserved live links.
+    let mut phase_events = Vec::new();
+    engine::game::turns::advance_phase(runner.state_mut(), &mut phase_events);
+
+    // 3) The token leaves the battlefield → fire the delayed return trigger.
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), token, Zone::Graveyard, &mut events);
+    check_delayed_triggers(runner.state_mut(), &events);
+    drain_stack(&mut runner);
+
+    // DISCRIMINATORS: the four exiled cards return to the battlefield, TAPPED,
+    // under their own owners' control; Core (this card) stays in exile.
+    for exiled in pile {
+        assert_eq!(
+            runner.state().objects[&exiled].zone,
+            Zone::Battlefield,
+            "exiled-with-Core card {exiled:?} must return to the battlefield"
+        );
+        assert!(
+            runner.state().objects[&exiled].tapped,
+            "returned card {exiled:?} must enter tapped"
+        );
+    }
+    assert_eq!(runner.state().objects[&p0_a].controller, P0);
+    assert_eq!(runner.state().objects[&p0_b].controller, P0);
+    assert_eq!(
+        runner.state().objects[&p1_a].controller,
+        P1,
+        "return is under each card's OWNER's control"
+    );
+    assert_eq!(runner.state().objects[&p1_b].controller, P1);
+
+    // "except this card": Core itself is not linked to itself, so it stays exiled.
+    assert_eq!(
+        runner.state().objects[&core].zone,
+        Zone::Exile,
+        "Mechtitan Core itself must NOT return (\"except this card\")"
+    );
+    // NEGATIVE: a card exiled by a different source is untouched.
+    assert_eq!(
+        runner.state().objects[&unrelated].zone,
+        Zone::Exile,
+        "a card exiled by a different source must not be returned"
+    );
+}


### PR DESCRIPTION
## Problem

**Mechtitan Core** never returned its exiled cards when the Mechtitan token left the battlefield. It presents as "the returned cards weren't tapped," but the cards were not returned **at all** (so they were never tapped).

Root cause, confirmed against a real game-state export:

- The activated ability exiles the 4 other permanents with `TrackedBySource` exile-links keyed to Core, and installs a delayed trigger `WhenLeavesPlayFiltered{token} → ChangeZoneAll{ Exile→Battlefield, ExiledBySource, enter_tapped: Tapped }` whose `source_id` is Core. The AST is correct — `enter_tapped` is `Tapped`.
- Core self-exiles paying its own cost. `apply_zone_exit_cleanup` (`game/zones.rs`) pruned every `TrackedBySource` link keyed to Core the instant Core left the battlefield, and the only fallback (`linked_exile_lki`) is cleared on every phase/step transition.
- So when the token left (typically turns later), `linked_exile_cards_for_source(Core)` returned `[]` and nothing came back.

Per Scryfall, the real text is "return all cards exiled with this Vehicle **except this card**" — Core does not return itself. That already falls out for free: the self-exile of "this Vehicle" never self-links Core, so `ExiledBySource(Core)` yields only the 4 others.

## Fix (`crates/engine/src/game/zones.rs`)

1. **Preserve** `TrackedBySource` links when a source leaves the battlefield **to exile** (CR 607.2a: the pile stays the linked-ability referent while the source keeps its stable ObjectId in exile per CR 400.7). Mirrors the existing `CraftMaterial` exemption; narrowed to exit-to-exile so ordinary death/bounce still prunes.
2. **Paired reset**: clear those links if that source **re-enters** the battlefield (CR 400.7 blink-identity reset).

Blast radius is small: `should_track_exiled_by_source` already gates link creation to sources whose ability consumes `ExiledBySource`, so cards like Bojuka Bog / Pit of Offerings never create these links in the first place.

## Tests

- `crates/engine/tests/integration/mechtitan_core_return_exiled.rs` — end-to-end regression: source self-exiles → a phase passes → the token leaves → all 4 exiled cards return **tapped** under their owners' control, Core stays in exile, a card exiled by a different source is untouched. Revert-failing on the exit-prune change.
- Two seam unit tests in `game/zones.rs` (links survive exit-to-exile; links reset on battlefield re-entry).
- Updated two pre-existing tests (`craft_material_link_survives_source_battlefield_exit`, `pit_of_offerings_blink_clears_exile_links`) that encoded the old prune-on-exile behavior to the new blink-on-reentry semantics.

Full engine lib suite (16132) and integration suite (2676) pass; `cargo fmt` and `clippy --tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
