### PR TITLE
feat(parser): recognize "Players may spend mana as though it were mana of any color"

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -90,6 +90,28 @@ pub(crate) fn is_speed_unlock_sentence(lower: &str) -> bool {
     .is_ok()
 }
 
+/// CR 609.4b: Match a board-wide "[you|players] may spend mana as though it were
+/// mana of any color" static (Chromatic Orrery / Mycosynth Lattice / Mycosynthwave),
+/// with no activation-source or spell-class qualifier tail. Both subject prefixes
+/// map to the same all-players concession — the runtime scopes
+/// `TargetFilter::Player` to every player — so they share one recognizer. Replaces
+/// a verbatim-string `==` match; the tailed forms ("... to activate abilities of
+/// X", "... to cast it") are consumed by earlier arms and never reach here.
+fn parse_board_wide_spend_any_color(lower: &str) -> bool {
+    all_consuming(terminated(
+        preceded(
+            alt((
+                tag::<_, _, OracleError<'_>>("you may "),
+                tag("players may "),
+            )),
+            tag("spend mana as though it were mana of any color"),
+        ),
+        opt(tag(".")),
+    ))
+    .parse(lower)
+    .is_ok()
+}
+
 /// CR 305.2: static land-play permissions with an explicit additional-drop
 /// count greater than the ordinary +1 grant. `u8::MAX` represents "any
 /// number"; runtime summing saturates so it stays effectively unbounded when
@@ -1049,8 +1071,14 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
-    // CR 609.4b: "You may spend mana as though it were mana of any color."
-    if tp.lower.trim_end_matches('.') == "you may spend mana as though it were mana of any color" {
+    // CR 609.4b: "[You|Players] may spend mana as though it were mana of any
+    // color." The controller form (Chromatic Orrery, "You may ...") and the
+    // all-players form (Mycosynth Lattice / Mycosynthwave, "Players may ...")
+    // both grant the board-wide any-color concession with no activation-source
+    // or spell-class qualifier tail. The runtime scopes
+    // `affected: TargetFilter::Player` to every player (`check_static_ability`),
+    // so the two phrasings share one static shape.
+    if parse_board_wide_spend_any_color(tp.lower) {
         return Some(
             StaticDefinition::new(StaticMode::SpendManaAsAnyColor {
                 spell_filter: None,

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -20049,6 +20049,38 @@ fn parser_shape_evelyn_collection_counter_play_permission_static_is_not_unimplem
     assert_eq!(def.mode, StaticMode::LinkedCollectionCounterPlayPermission);
 }
 
+// CR 609.4b: Mycosynth Lattice / Mycosynthwave — "Players may spend mana as
+// though it were mana of any color" grants the board-wide any-color concession to
+// every player (affected: TargetFilter::Player, which the runtime scopes to all
+// players). Previously the "Players may" subject dropped the whole static — only
+// the "You may" form was matched (by a verbatim string == check).
+#[test]
+fn static_players_may_spend_mana_as_any_color() {
+    let def =
+        parse_static_line("Players may spend mana as though it were mana of any color.").unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::SpendManaAsAnyColor {
+            spell_filter: None,
+            activation_source_filter: None,
+        }
+    );
+    assert_eq!(def.affected, Some(TargetFilter::Player));
+}
+
+#[test]
+fn static_you_may_spend_mana_as_any_color_still_parses() {
+    // Regression: the controller "You may" form still parses to the same shape.
+    let def = parse_static_line("You may spend mana as though it were mana of any color.").unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::SpendManaAsAnyColor {
+            spell_filter: None,
+            activation_source_filter: None,
+        }
+    );
+}
+
 // --- Group B: Generic activated ability cost reduction ---
 
 #[test]


### PR DESCRIPTION
CR 609.4b

## Bug

Mycosynth Lattice and Mycosynthwave read "**Players** may spend mana as though it were mana of any color" — the all-players form of the board-wide any-color concession. But the dispatcher only matched the controller form ("**You** may spend mana …") via a verbatim string `==` check, so the "Players may" subject **dropped the entire static** and no player gained the permission.

## Fix

Replace the verbatim `==` match with a nom recognizer `parse_board_wide_spend_any_color` (mirroring the existing `is_speed_unlock_sentence` helper) that accepts **both** the "You may" and "Players may" subject prefixes on the bare form. Both map to the same `SpendManaAsAnyColor` static with `affected: TargetFilter::Player`, which `check_static_ability` already scopes to *every* player — so no runtime change is needed.

## Why it's the right seam / minimal blast radius

- Removes a prohibited verbatim-string dispatch (`tp.lower.trim_end_matches('.') == "…"`) in favor of a combinator — the same idiom the sibling `is_speed_unlock_sentence` uses.
- `all_consuming` keeps the recognizer to the **bare** form; the qualified tails ("… to activate abilities of X", "… to cast it") are consumed by earlier arms (`try_parse_spend_any_color_to_activate_abilities`, the type_change "to cast it" grant) and never reach here — verified unchanged.

## Tests

- `static_players_may_spend_mana_as_any_color` — "Players may …" → `SpendManaAsAnyColor { .. }` with `affected: Some(TargetFilter::Player)`.
- `static_you_may_spend_mana_as_any_color_still_parses` — regression: the "You may" form still parses to the same shape.
- Full `parser::oracle_static::tests` (1047 passed, 0 failed), including the "… to activate abilities of creatures you control" activation-source-filtered case.

## CR verification

- **CR 609.4b** — spending mana as though it were another type/color — verified in `docs/MagicCompRules.txt`.

## AI-contributor notes

- **Rules-correct:** every player gains the any-color concession per CR 609.4b; the runtime already broadcasts `TargetFilter::Player` to all players.
- **Builds the class:** Mycosynth Lattice + Mycosynthwave, and any future "Players may spend mana …" board-wide static.
- **Verified:** live-parsed "Players may" / "You may" / "You may … to activate abilities of X" before/after; `cargo fmt`, CI-exact `clippy -p engine --all-targets --features proptest -D warnings`, and the full oracle_static module are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
