### PR TITLE
refactor(parser): promote rider SpecialClause variants to ClauseDisposition::Absorb (U5-M2)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1343,6 +1343,16 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                     apply_where_x_to_latest_def(&mut defs, clause_ir.where_x_expression.as_deref());
                 }
                 true
+            } else if let ClauseDisposition::Absorb { rider, kind: _ } = &clause_ir.disposition {
+                // CR 614.1a / CR 701.19c: attach the rider as the tail of the prior
+                // def's sub_ability chain instead of overwriting it — multi-target
+                // damage spells (Serpentine Spike) populate the chain with
+                // continuation events, so the rider must attach AFTER them. Both
+                // `AbsorbKind`s share this mechanic (`kind` is provenance only).
+                if let Some(last_def) = defs.last_mut() {
+                    append_to_deepest_sub_ability(last_def, Some(rider.clone()));
+                }
+                true
             } else if let ClauseDisposition::Special {
                 action: special,
                 intrinsic,
@@ -1423,32 +1433,6 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                             },
                         ));
                         defs.push(*else_def.clone());
-                        true
-                    }
-                    SpecialClause::DieExileRider(rider_def) => {
-                        if let Some(last_def) = defs.last_mut() {
-                            // CR 614.1a + CR 608.2c: Append the rider as the
-                            // tail of the existing sub_ability chain instead of
-                            // overwriting it. Multi-target damage spells
-                            // (Serpentine Spike) populate the sub_ability chain
-                            // with continuation damage events; the rider must
-                            // attach AFTER the chain so all continuation events
-                            // resolve before the replacement attaches.
-                            append_to_deepest_sub_ability(last_def, Some(rider_def.clone()));
-                        }
-                        true
-                    }
-                    SpecialClause::CantBeRegeneratedRider(rider_def) => {
-                        // CR 608.2c + CR 701.19c: Attach the "<noun> dealt damage
-                        // this way can't be regenerated" rider as the tail of the
-                        // preceding damage clause's sub_ability chain. The rider's
-                        // `GenericEffect{target: TrackedSet}` then trips
-                        // `next_sub_needs_tracked_set` on that damage clause, so it
-                        // publishes the damaged object ids the rider's
-                        // CantBeRegenerated static binds to.
-                        if let Some(last_def) = defs.last_mut() {
-                            append_to_deepest_sub_ability(last_def, Some(rider_def.clone()));
-                        }
                         true
                     }
                     SpecialClause::DigInsteadAlt(alt_def) => {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -149,8 +149,8 @@ use self::subject::{
 use crate::parser::oracle_ir::ast::*;
 pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup};
 use crate::parser::oracle_ir::effect_chain::{
-    AbilityIr, AbilityShellIr, ClauseDisposition, ClauseIr, ClauseIrBuilder, EffectChainIr,
-    SpecialClause,
+    AbilityIr, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr, ClauseIrBuilder,
+    EffectChainIr, SpecialClause,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -24755,9 +24755,9 @@ pub(crate) fn parse_effect_chain_ir(
                         normalized_text,
                         placeholder_parsed_clause("die_exile_rider_placeholder"),
                         chunk.boundary_after,
-                        ClauseDisposition::Special {
-                            action: SpecialClause::DieExileRider(Box::new(rider_def)),
-                            intrinsic: None,
+                        ClauseDisposition::Absorb {
+                            rider: Box::new(rider_def),
+                            kind: AbsorbKind::DieExile,
                         },
                     )
                     .push();
@@ -24864,9 +24864,9 @@ pub(crate) fn parse_effect_chain_ir(
                             "",
                         )),
                         chunk.boundary_after,
-                        ClauseDisposition::Special {
-                            action: SpecialClause::CantBeRegeneratedRider(Box::new(regen_def)),
-                            intrinsic: None,
+                        ClauseDisposition::Absorb {
+                            rider: Box::new(regen_def),
+                            kind: AbsorbKind::CantBeRegenerated,
                         },
                     )
                     .push();
@@ -24878,9 +24878,9 @@ pub(crate) fn parse_effect_chain_ir(
                         normalized_text,
                         parsed_clause(Effect::unimplemented("die_exile_rider_placeholder", "")),
                         chunk.boundary_after,
-                        ClauseDisposition::Special {
-                            action: SpecialClause::DieExileRider(Box::new(exile_def)),
-                            intrinsic: None,
+                        ClauseDisposition::Absorb {
+                            rider: Box::new(exile_def),
+                            kind: AbsorbKind::DieExile,
                         },
                     )
                     .push();
@@ -24893,8 +24893,8 @@ pub(crate) fn parse_effect_chain_ir(
                 normalized_text.trim_end_matches('.').trim(),
                 kind,
             ) {
-                // Structural sentinel: replaced during lowering by the
-                // SpecialClause attach (mirrors the DieExileRider placeholder).
+                // Structural sentinel: replaced during lowering by the Absorb
+                // rider attach (mirrors the DieExile placeholder).
                 builder
                     .clause(
                         normalized_text,
@@ -24903,9 +24903,9 @@ pub(crate) fn parse_effect_chain_ir(
                             "",
                         )),
                         chunk.boundary_after,
-                        ClauseDisposition::Special {
-                            action: SpecialClause::CantBeRegeneratedRider(Box::new(rider_def)),
-                            intrinsic: None,
+                        ClauseDisposition::Absorb {
+                            rider: Box::new(rider_def),
+                            kind: AbsorbKind::CantBeRegenerated,
                         },
                     )
                     .push();

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -125,14 +125,6 @@ pub(crate) enum SpecialClause {
     Otherwise(Box<AbilityDefinition>),
     /// CR 608.2c: "Otherwise" fallback — no conditional found, emit as Unimplemented + def.
     OtherwiseFallback(Box<AbilityDefinition>),
-    /// CR 614.1a + CR 514.2: Die-exile-rider — attach as sub_ability on previous def.
-    DieExileRider(Box<AbilityDefinition>),
-    /// CR 608.2c + CR 701.19c: "[noun] dealt damage this way can't be
-    /// regenerated this turn." — a separate-sentence regen rider that attaches
-    /// as a sub_ability on the previous damage clause (Incinerate, Flamebreak,
-    /// Jaya Ballard, Task Mage). Carries a `GenericEffect{CantBeRegenerated}`
-    /// whose `target: TrackedSet` binds to the damage clause's published set.
-    CantBeRegeneratedRider(Box<AbilityDefinition>),
     /// CR 608.2c: Dig-instead alternative — replace previous Dig with conditional alternative.
     DigInsteadAlt(Box<AbilityDefinition>),
     /// CR 608.2e: Generic instead clause — attach to previous def as sub_ability.
@@ -239,6 +231,17 @@ pub(crate) enum ClauseDisposition {
     Continue {
         continuation: Option<ContinuationAst>,
     },
+    /// CR 608.2c: this clause's def attaches as a sub_ability RIDER on the tail of
+    /// the prior emitted def's sub_ability chain, emitting no sibling def. Promoted
+    /// from the former `SpecialClause::{DieExileRider, CantBeRegeneratedRider}`
+    /// (U5-M2). `kind` preserves the distinct rules concept (they share the
+    /// `append_to_deepest_sub_ability` mechanic — Plan 01 §5 line 811). The bound
+    /// antecedent is the prior emitted def (implicit, as M1's `Continue`); the
+    /// explicit antecedent selector is JIT-deferred to U6.
+    Absorb {
+        rider: Box<AbilityDefinition>,
+        kind: AbsorbKind,
+    },
     /// A special-case adjacency action that modifies an adjacent clause during
     /// lowering (folds the former `special: Option<SpecialClause>`). `intrinsic`
     /// carries the self-patch some special arms apply (lower.rs:1600).
@@ -254,6 +257,17 @@ pub(crate) enum ClauseDisposition {
         action: SpecialClause,
         intrinsic: Option<ContinuationAst>,
     },
+}
+
+/// The distinct sub_ability-rider concepts that fold onto the prior emitted def.
+/// Both share the `append_to_deepest_sub_ability` mechanic; `kind` keeps the CR
+/// concept typed rather than collapsing it (Plan 01 §5 line 811).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum AbsorbKind {
+    /// CR 614.1a + CR 514.2: die-exile rider (attach as sub_ability tail).
+    DieExile,
+    /// CR 608.2c + CR 701.19c: "dealt damage this way can't be regenerated" rider.
+    CantBeRegenerated,
 }
 
 /// Per-clause IR: captures everything about a single parsed chunk before chain assembly.
@@ -336,25 +350,25 @@ pub(crate) struct ClauseIr {
 impl ClauseDisposition {
     /// The self-patch continuation parsed from a clause's own text (formerly the
     /// `intrinsic_continuation` field): applied to this clause's own lowered def
-    /// after it emits. `Emit`/`Special` carry it; `Continue` never does.
+    /// after it emits. `Emit`/`Special` carry it; `Continue`/`Absorb` never do.
     pub(crate) fn intrinsic(&self) -> Option<&ContinuationAst> {
         match self {
             ClauseDisposition::Emit { intrinsic, .. }
             | ClauseDisposition::Special { intrinsic, .. } => intrinsic.as_ref(),
-            ClauseDisposition::Continue { .. } => None,
+            ClauseDisposition::Continue { .. } | ClauseDisposition::Absorb { .. } => None,
         }
     }
 
     /// The prior-patch continuation (formerly the `followup_continuation` field):
     /// a normal (`Emit`) clause's followup that patches the PRIOR def, or a
-    /// `Continue` clause's continuation. `None` for `Special` clauses.
+    /// `Continue` clause's continuation. `None` for `Special`/`Absorb` clauses.
     pub(crate) fn followup(&self) -> Option<&ContinuationAst> {
         match self {
             ClauseDisposition::Emit { followup, .. }
             | ClauseDisposition::Continue {
                 continuation: followup,
             } => followup.as_ref(),
-            ClauseDisposition::Special { .. } => None,
+            ClauseDisposition::Special { .. } | ClauseDisposition::Absorb { .. } => None,
         }
     }
 }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -506,6 +506,59 @@ fn snapcaster_mage() {
 }
 
 // ---------------------------------------------------------------------------
+// Damage sub_ability riders (U5-M2 Absorb parity: die-exile / can't-regenerate)
+// ---------------------------------------------------------------------------
+
+// CR 608.2c + CR 701.19c: unconditional "can't be regenerated" rider on a
+// separate sentence after a damage clause (SpecialClause::CantBeRegeneratedRider
+// → ClauseDisposition::Absorb { kind: CantBeRegenerated }). Verified verbatim
+// against Scryfall.
+#[test]
+fn incinerate() {
+    let (ir, lowered) = parse_two_layer(
+        "Incinerate deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn.",
+        "Incinerate",
+        &["Instant"],
+        &[],
+    );
+    insta::assert_json_snapshot!("incinerate_ir", &ir);
+    insta::assert_json_snapshot!("incinerate_lowered", &lowered);
+}
+
+// CR 614.1a + CR 514.2: standalone "if [it] would die this turn, exile it
+// instead" die-exile rider on a separate sentence after a damage clause
+// (SpecialClause::DieExileRider → ClauseDisposition::Absorb { kind: DieExile }).
+// Verified verbatim against Scryfall (includes the printed Devoid keyword line).
+#[test]
+fn touch_of_the_void() {
+    let (ir, lowered) = parse_two_layer(
+        "Devoid (This card has no color.)\nTouch of the Void deals 3 damage to any target. If a creature dealt damage this way would die this turn, exile it instead.",
+        "Touch of the Void",
+        &["Sorcery"],
+        &[],
+    );
+    insta::assert_json_snapshot!("touch_of_the_void_ir", &ir);
+    insta::assert_json_snapshot!("touch_of_the_void_lowered", &lowered);
+}
+
+// CR 109.2 + CR 608.2c: the conditional two-rider form ("If it's a creature, it
+// can't be regenerated this turn, and if it would die this turn, exile it
+// instead.") emits BOTH Absorb kinds from the conditional-regen block —
+// CantBeRegenerated then DieExile, each stamped with the creature-gate
+// condition. Verified verbatim against Scryfall.
+#[test]
+fn carbonize() {
+    let (ir, lowered) = parse_two_layer(
+        "Carbonize deals 3 damage to any target. If it's a creature, it can't be regenerated this turn, and if it would die this turn, exile it instead.",
+        "Carbonize",
+        &["Instant"],
+        &[],
+    );
+    insta::assert_json_snapshot!("carbonize_ir", &ir);
+    insta::assert_json_snapshot!("carbonize_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
 // Triggers (various patterns)
 // ---------------------------------------------------------------------------
 

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__carbonize_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__carbonize_ir.snap
@@ -1,0 +1,170 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 135,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "~ deals 3 damage to any target. If it's a creature, it can't be regenerated this turn, and if it would die this turn, exile it instead."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "DealDamage",
+            "amount": {
+              "type": "Fixed",
+              "value": 3
+            },
+            "target": {
+              "type": "Any"
+            }
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GenericEffect",
+              "static_abilities": [
+                {
+                  "mode": "CantBeRegenerated",
+                  "affected": {
+                    "type": "ParentTarget"
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddStaticMode",
+                      "mode": "CantBeRegenerated"
+                    }
+                  ],
+                  "condition": null,
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": null
+                }
+              ],
+              "duration": "UntilEndOfTurn",
+              "target": {
+                "type": "TrackedSet",
+                "id": 0
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "AddTargetReplacement",
+                "replacement": {
+                  "event": "Moved",
+                  "execute": {
+                    "kind": "Spell",
+                    "effect": {
+                      "type": "ChangeZone",
+                      "origin": "Battlefield",
+                      "destination": "Exile",
+                      "target": {
+                        "type": "SelfRef"
+                      },
+                      "owner_library": false,
+                      "enter_transformed": false,
+                      "enter_tapped": false,
+                      "enters_attacking": false
+                    },
+                    "cost": null,
+                    "sub_ability": null,
+                    "duration": null,
+                    "description": null,
+                    "target_prompt": null,
+                    "condition": null,
+                    "optional_targeting": false,
+                    "optional": false,
+                    "forward_result": false
+                  },
+                  "mode": {
+                    "type": "Mandatory"
+                  },
+                  "valid_card": {
+                    "type": "SelfRef"
+                  },
+                  "description": null,
+                  "condition": null,
+                  "destination_zone": "Graveyard",
+                  "consume_on_apply": true,
+                  "expiry": {
+                    "type": "EndOfTurn"
+                  }
+                },
+                "target": {
+                  "type": "Any"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": {
+                "type": "TargetMatchesFilter",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": null,
+                  "properties": []
+                },
+                "use_lki": true
+              },
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": {
+              "type": "TargetMatchesFilter",
+              "filter": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": null,
+                "properties": []
+              },
+              "use_lki": true
+            },
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": "~ deals 3 damage to any target. If it's a creature, it can't be regenerated this turn, and if it would die this turn, exile it instead.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Carbonize deals 3 damage to any target. If it's a creature, it can't be regenerated this turn, and if it would die this turn, exile it instead.",
+  "card_name": "Carbonize"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__carbonize_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__carbonize_lowered.snap
@@ -1,0 +1,152 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "DealDamage",
+        "amount": {
+          "type": "Fixed",
+          "value": 3
+        },
+        "target": {
+          "type": "Any"
+        }
+      },
+      "cost": null,
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "GenericEffect",
+          "static_abilities": [
+            {
+              "mode": "CantBeRegenerated",
+              "affected": {
+                "type": "ParentTarget"
+              },
+              "modifications": [
+                {
+                  "type": "AddStaticMode",
+                  "mode": "CantBeRegenerated"
+                }
+              ],
+              "condition": null,
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": null
+            }
+          ],
+          "duration": "UntilEndOfTurn",
+          "target": {
+            "type": "TrackedSet",
+            "id": 0
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "AddTargetReplacement",
+            "replacement": {
+              "event": "Moved",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "ChangeZone",
+                  "origin": "Battlefield",
+                  "destination": "Exile",
+                  "target": {
+                    "type": "SelfRef"
+                  },
+                  "owner_library": false,
+                  "enter_transformed": false,
+                  "enter_tapped": false,
+                  "enters_attacking": false
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "mode": {
+                "type": "Mandatory"
+              },
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "description": null,
+              "condition": null,
+              "destination_zone": "Graveyard",
+              "consume_on_apply": true,
+              "expiry": {
+                "type": "EndOfTurn"
+              }
+            },
+            "target": {
+              "type": "Any"
+            }
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": {
+            "type": "TargetMatchesFilter",
+            "filter": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            "use_lki": true
+          },
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "duration": "UntilEndOfTurn",
+        "description": null,
+        "target_prompt": null,
+        "condition": {
+          "type": "TargetMatchesFilter",
+          "filter": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": null,
+            "properties": []
+          },
+          "use_lki": true
+        },
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "duration": null,
+      "description": "~ deals 3 damage to any target. If it's a creature, it can't be regenerated this turn, and if it would die this turn, exile it instead.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__incinerate_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__incinerate_ir.snap
@@ -1,0 +1,91 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 96,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "~ deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "DealDamage",
+            "amount": {
+              "type": "Fixed",
+              "value": 3
+            },
+            "target": {
+              "type": "Any"
+            }
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GenericEffect",
+              "static_abilities": [
+                {
+                  "mode": "CantBeRegenerated",
+                  "affected": {
+                    "type": "ParentTarget"
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddStaticMode",
+                      "mode": "CantBeRegenerated"
+                    }
+                  ],
+                  "condition": null,
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": null
+                }
+              ],
+              "duration": "UntilEndOfTurn",
+              "target": {
+                "type": "TrackedSet",
+                "id": 0
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": "~ deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Incinerate deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn.",
+  "card_name": "Incinerate"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__incinerate_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__incinerate_lowered.snap
@@ -1,0 +1,73 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "DealDamage",
+        "amount": {
+          "type": "Fixed",
+          "value": 3
+        },
+        "target": {
+          "type": "Any"
+        }
+      },
+      "cost": null,
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "GenericEffect",
+          "static_abilities": [
+            {
+              "mode": "CantBeRegenerated",
+              "affected": {
+                "type": "ParentTarget"
+              },
+              "modifications": [
+                {
+                  "type": "AddStaticMode",
+                  "mode": "CantBeRegenerated"
+                }
+              ],
+              "condition": null,
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": null
+            }
+          ],
+          "duration": "UntilEndOfTurn",
+          "target": {
+            "type": "TrackedSet",
+            "id": 0
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": "UntilEndOfTurn",
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "duration": null,
+      "description": "~ deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__touch_of_the_void_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__touch_of_the_void_ir.snap
@@ -1,0 +1,130 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 32,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Devoid (This card has no color.)"
+      },
+      "node": {
+        "Keyword": "Devoid"
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 33,
+          "end_byte": 139,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "~ deals 3 damage to any target. If a creature dealt damage this way would die this turn, exile it instead."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "DealDamage",
+            "amount": {
+              "type": "Fixed",
+              "value": 3
+            },
+            "target": {
+              "type": "Any"
+            }
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "AddTargetReplacement",
+              "replacement": {
+                "event": "Moved",
+                "execute": {
+                  "kind": "Spell",
+                  "effect": {
+                    "type": "ChangeZone",
+                    "origin": "Battlefield",
+                    "destination": "Exile",
+                    "target": {
+                      "type": "SelfRef"
+                    },
+                    "owner_library": false,
+                    "enter_transformed": false,
+                    "enter_tapped": false,
+                    "enters_attacking": false
+                  },
+                  "cost": null,
+                  "sub_ability": null,
+                  "duration": null,
+                  "description": null,
+                  "target_prompt": null,
+                  "condition": null,
+                  "optional_targeting": false,
+                  "optional": false,
+                  "forward_result": false
+                },
+                "mode": {
+                  "type": "Mandatory"
+                },
+                "valid_card": {
+                  "type": "SelfRef"
+                },
+                "description": null,
+                "condition": null,
+                "destination_zone": "Graveyard",
+                "consume_on_apply": true,
+                "expiry": {
+                  "type": "EndOfTurn"
+                }
+              },
+              "target": {
+                "type": "Any"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": "~ deals 3 damage to any target. If a creature dealt damage this way would die this turn, exile it instead.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Devoid (This card has no color.)\nTouch of the Void deals 3 damage to any target. If a creature dealt damage this way would die this turn, exile it instead.",
+  "card_name": "Touch of the Void"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__touch_of_the_void_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__touch_of_the_void_lowered.snap
@@ -1,0 +1,93 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "DealDamage",
+        "amount": {
+          "type": "Fixed",
+          "value": 3
+        },
+        "target": {
+          "type": "Any"
+        }
+      },
+      "cost": null,
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "AddTargetReplacement",
+          "replacement": {
+            "event": "Moved",
+            "execute": {
+              "kind": "Spell",
+              "effect": {
+                "type": "ChangeZone",
+                "origin": "Battlefield",
+                "destination": "Exile",
+                "target": {
+                  "type": "SelfRef"
+                },
+                "owner_library": false,
+                "enter_transformed": false,
+                "enter_tapped": false,
+                "enters_attacking": false
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "mode": {
+              "type": "Mandatory"
+            },
+            "valid_card": {
+              "type": "SelfRef"
+            },
+            "description": null,
+            "condition": null,
+            "destination_zone": "Graveyard",
+            "consume_on_apply": true,
+            "expiry": {
+              "type": "EndOfTurn"
+            }
+          },
+          "target": {
+            "type": "Any"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "duration": null,
+      "description": "~ deals 3 damage to any target. If a creature dealt damage this way would die this turn, exile it instead.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": [
+    "Devoid"
+  ]
+}


### PR DESCRIPTION
First U5-M2 increment: decompose the temporary `ClauseDisposition::Special
{ action: SpecialClause }` catch-all (M1 left it as a faithful carry) into
typed dispositions, one coherent family per change, each with a parity test.

`DieExileRider` + `CantBeRegeneratedRider` share the `append_to_deepest_sub_ability`
mechanic (attach a rider as the tail of the prior def's sub_ability chain) but are
distinct CR concepts (614.1a die-exile vs 701.19c can't-regenerate). They fold into
`ClauseDisposition::Absorb { rider, kind: AbsorbKind }`, where `kind` keeps the
concept typed rather than collapsing it into a generic patch-previous action
(Plan 01 §5 line 811). Both `SpecialClause` variants are deleted; the accessors'
exhaustive matches force `Absorb` to be handled.

Faithful-by-construction: `ClauseDisposition` is consumed inside
`lower_effect_chain_ir` and never reaches a serialized snapshot (the `*_ir.snap`
layer serializes the already-lowered `AbilityDefinition`), so the promotion is
byte-identical to both layers. Parity tests — Incinerate, Touch of the Void,
Carbonize (all Oracle text verified on Scryfall) — cover both `AbsorbKind`s and
all four emit sites; their ir + lowered snapshots pass with zero drift.
