### PR TITLE
refactor(parser): promote Otherwise SpecialClause variants to ClauseDisposition::BranchOtherwise (U5-M2)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -26,7 +26,7 @@ use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::effect_chain::{
-    ClauseDisposition, ClauseIr, EffectChainIr, SpecialClause,
+    ClauseDisposition, ClauseIr, EffectChainIr, OtherwiseKind, SpecialClause,
 };
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
@@ -1353,17 +1353,16 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                     append_to_deepest_sub_ability(last_def, Some(rider.clone()));
                 }
                 true
-            } else if let ClauseDisposition::Special {
-                action: special,
-                intrinsic,
+            } else if let ClauseDisposition::BranchOtherwise {
+                else_def,
+                kind: otherwise_kind,
             } = &clause_ir.disposition
             {
-                match special {
-                    SpecialClause::AltCostRider(cost) => {
-                        attach_alt_cost_to_prior_cast_from_zone(&mut defs, cost.clone());
-                        true
-                    }
-                    SpecialClause::Otherwise(else_def) => {
+                // CR 608.2c: `otherwise_kind` was determined at PARSE time (whether
+                // a prior conditional / opponent-may head existed) — it is NOT
+                // recomputed here, so parse-time and lower-time views cannot diverge.
+                match otherwise_kind {
+                    OtherwiseKind::Bound => {
                         // Walk defs backward to find the most recent conditional
                         let mut attached = false;
                         for d in defs.iter_mut().rev() {
@@ -1422,9 +1421,8 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                                 }
                             }
                         }
-                        true
                     }
-                    SpecialClause::OtherwiseFallback(else_def) => {
+                    OtherwiseKind::Fallback => {
                         defs.push(AbilityDefinition::new(
                             kind,
                             Effect::Unimplemented {
@@ -1433,6 +1431,17 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                             },
                         ));
                         defs.push(*else_def.clone());
+                    }
+                }
+                true
+            } else if let ClauseDisposition::Special {
+                action: special,
+                intrinsic,
+            } = &clause_ir.disposition
+            {
+                match special {
+                    SpecialClause::AltCostRider(cost) => {
+                        attach_alt_cost_to_prior_cast_from_zone(&mut defs, cost.clone());
                         true
                     }
                     SpecialClause::DigInsteadAlt(alt_def) => {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -150,7 +150,7 @@ use crate::parser::oracle_ir::ast::*;
 pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup};
 use crate::parser::oracle_ir::effect_chain::{
     AbilityIr, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr, ClauseIrBuilder,
-    EffectChainIr, SpecialClause,
+    EffectChainIr, OtherwiseKind, SpecialClause,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -24430,14 +24430,18 @@ pub(crate) fn parse_effect_chain_ir(
                     let ir = parse_effect_chain_ir(&else_text, kind, ctx);
                     lower_effect_chain_ir(&ir)
                 };
+                // Bound by construction: this arm is reached only inside
+                // `builder.clauses().any(clause_has_anaphoric_control_condition)`,
+                // so a prior clause carries a control condition that lowers to a
+                // conditional def the Bound handler attaches the else-branch to.
                 builder
                     .clause(
                         normalized_text,
                         placeholder_parsed_clause("otherwise_placeholder"),
                         chunk.boundary_after,
-                        ClauseDisposition::Special {
-                            action: SpecialClause::Otherwise(Box::new(else_def)),
-                            intrinsic: None,
+                        ClauseDisposition::BranchOtherwise {
+                            else_def: Box::new(else_def),
+                            kind: OtherwiseKind::Bound,
                         },
                     )
                     .push();
@@ -24496,19 +24500,22 @@ pub(crate) fn parse_effect_chain_ir(
                 .clauses()
                 .iter()
                 .any(|c| c.opponent_may_scope.is_some());
-            let special = if has_condition || has_optional_may_head {
-                SpecialClause::Otherwise(Box::new(else_def))
+            // PARSE-TIME Bound/Fallback determination — this predicate MUST stay
+            // exactly here (parse time). Recomputing "prior conditional present?"
+            // at lowering could diverge from this state and move output.
+            let kind = if has_condition || has_optional_may_head {
+                OtherwiseKind::Bound
             } else {
-                SpecialClause::OtherwiseFallback(Box::new(else_def))
+                OtherwiseKind::Fallback
             };
             builder
                 .clause(
                     normalized_text,
                     placeholder_parsed_clause("otherwise_placeholder"),
                     chunk.boundary_after,
-                    ClauseDisposition::Special {
-                        action: special,
-                        intrinsic: None,
+                    ClauseDisposition::BranchOtherwise {
+                        else_def: Box::new(else_def),
+                        kind,
                     },
                 )
                 .push();

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -121,10 +121,6 @@ pub(crate) enum DoesTheSameSubject {
 pub(crate) enum SpecialClause {
     /// CR 118.9 + CR 119.4: Alternative-cost rider — fold cost onto previous CastFromZone.
     AltCostRider(AbilityCost),
-    /// CR 608.2c: "Otherwise, [effect]" — attach as else_ability on previous conditional.
-    Otherwise(Box<AbilityDefinition>),
-    /// CR 608.2c: "Otherwise" fallback — no conditional found, emit as Unimplemented + def.
-    OtherwiseFallback(Box<AbilityDefinition>),
     /// CR 608.2c: Dig-instead alternative — replace previous Dig with conditional alternative.
     DigInsteadAlt(Box<AbilityDefinition>),
     /// CR 608.2e: Generic instead clause — attach to previous def as sub_ability.
@@ -242,6 +238,15 @@ pub(crate) enum ClauseDisposition {
         rider: Box<AbilityDefinition>,
         kind: AbsorbKind,
     },
+    /// CR 608.2c: an "Otherwise, [effect]" else-branch. Promoted from
+    /// `SpecialClause::{Otherwise, OtherwiseFallback}` (U5-M2). `kind` carries the
+    /// PARSE-TIME determination of whether a prior conditional exists — do NOT
+    /// recompute it at lowering (parse-time and lower-time "prior conditional
+    /// present?" states could diverge and move output).
+    BranchOtherwise {
+        else_def: Box<AbilityDefinition>,
+        kind: OtherwiseKind,
+    },
     /// A special-case adjacency action that modifies an adjacent clause during
     /// lowering (folds the former `special: Option<SpecialClause>`). `intrinsic`
     /// carries the self-patch some special arms apply (lower.rs:1600).
@@ -268,6 +273,20 @@ pub(crate) enum AbsorbKind {
     DieExile,
     /// CR 608.2c + CR 701.19c: "dealt damage this way can't be regenerated" rider.
     CantBeRegenerated,
+}
+
+/// CR 608.2c: whether the "Otherwise" else-branch binds to a prior conditional or
+/// self-emits. The determination is made at PARSE time (whether a prior
+/// conditional / opponent-may head was found) and carried here — never recomputed
+/// at lowering.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum OtherwiseKind {
+    /// A prior conditional def (or opponent-may head) was found at parse time:
+    /// attach the else-branch as its `else_ability` / synthesized reward.
+    Bound,
+    /// No prior conditional at parse time: self-emit (an Unimplemented "otherwise"
+    /// marker def followed by the else def).
+    Fallback,
 }
 
 /// Per-clause IR: captures everything about a single parsed chunk before chain assembly.
@@ -355,7 +374,9 @@ impl ClauseDisposition {
         match self {
             ClauseDisposition::Emit { intrinsic, .. }
             | ClauseDisposition::Special { intrinsic, .. } => intrinsic.as_ref(),
-            ClauseDisposition::Continue { .. } | ClauseDisposition::Absorb { .. } => None,
+            ClauseDisposition::Continue { .. }
+            | ClauseDisposition::Absorb { .. }
+            | ClauseDisposition::BranchOtherwise { .. } => None,
         }
     }
 
@@ -368,7 +389,9 @@ impl ClauseDisposition {
             | ClauseDisposition::Continue {
                 continuation: followup,
             } => followup.as_ref(),
-            ClauseDisposition::Special { .. } | ClauseDisposition::Absorb { .. } => None,
+            ClauseDisposition::Special { .. }
+            | ClauseDisposition::Absorb { .. }
+            | ClauseDisposition::BranchOtherwise { .. } => None,
         }
     }
 }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -559,6 +559,60 @@ fn carbonize() {
 }
 
 // ---------------------------------------------------------------------------
+// "Otherwise" else-branches (U5-M2 BranchOtherwise parity)
+// ---------------------------------------------------------------------------
+// All three exercise the Bound kind (prior conditional / opponent-may head
+// present at parse time); Fallback has no real corpus card (0/568 fixture
+// cards). Oracle text verified verbatim against Scryfall.
+
+// CR 608.2c + CR 205.3a: Bound → attach-to-conditional + self-ref rebind
+// (`definition_targets_self_source` → `rewrite_else_parent_target_to_self_ref`,
+// so the else "it" binds to the source rather than an empty target list).
+#[test]
+fn repeat_offender() {
+    let (ir, lowered) = parse_two_layer(
+        "{2}{B}: If this creature is suspected, put a +1/+1 counter on it. Otherwise, suspect it. (A suspected creature has menace and can't block.)",
+        "Repeat Offender",
+        &["Creature"],
+        &["Human", "Assassin"],
+    );
+    insta::assert_json_snapshot!("repeat_offender_ir", &ir);
+    insta::assert_json_snapshot!("repeat_offender_lowered", &lowered);
+}
+
+// CR 608.2c: Bound → attach-to-conditional + event-context "that much" rebind
+// (`rewrite_else_event_context_to_stable`, so the else's "that much" reads the
+// if-branch's stable magnitude instead of a per-instruction 0).
+#[test]
+fn caustic_bronco() {
+    let (ir, lowered) = parse_two_layer(
+        "Whenever this creature attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if this creature isn't saddled. Otherwise, each opponent loses that much life.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
+        "Caustic Bronco",
+        &["Creature"],
+        &["Snake", "Horse", "Mount"],
+    );
+    insta::assert_json_snapshot!("caustic_bronco_ir", &ir);
+    insta::assert_json_snapshot!("caustic_bronco_lowered", &lowered);
+}
+
+// CR 608.2d + CR 101.4: Bound → opponent-may reward branch (no explicit
+// condition, but the "any player may" head sets `opponent_may_scope`, so
+// `has_optional_may_head` routes it Bound; the handler's `!attached` fallback
+// synthesizes the `Not(OptionalEffectPerformed)`-gated reward on the may-head).
+// The "If no one does, …" connector is one of the recognized otherwise forms.
+#[test]
+fn browbeat() {
+    let (ir, lowered) = parse_two_layer(
+        "Any player may have Browbeat deal 5 damage to them. If no one does, target player draws three cards.",
+        "Browbeat",
+        &["Sorcery"],
+        &[],
+    );
+    insta::assert_json_snapshot!("browbeat_ir", &ir);
+    insta::assert_json_snapshot!("browbeat_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
 // Triggers (various patterns)
 // ---------------------------------------------------------------------------
 

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__browbeat_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__browbeat_ir.snap
@@ -1,0 +1,80 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 93,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Any player may have ~ deal 5 damage to them. If no one does, target player draws three cards."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "DealDamage",
+            "amount": {
+              "type": "Fixed",
+              "value": 5
+            },
+            "target": {
+              "type": "Player"
+            }
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Draw",
+              "count": {
+                "type": "Fixed",
+                "value": 3
+              },
+              "target": {
+                "type": "Player"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": {
+              "type": "Not",
+              "condition": {
+                "type": "EffectOutcome",
+                "signal": "OptionalEffectPerformed"
+              }
+            },
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": "Any player may have ~ deal 5 damage to them. If no one does, target player draws three cards.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": true,
+          "optional_for": "AnyPlayer",
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Any player may have Browbeat deal 5 damage to them. If no one does, target player draws three cards.",
+  "card_name": "Browbeat"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__browbeat_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__browbeat_lowered.snap
@@ -1,0 +1,62 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "DealDamage",
+        "amount": {
+          "type": "Fixed",
+          "value": 5
+        },
+        "target": {
+          "type": "Player"
+        }
+      },
+      "cost": null,
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Draw",
+          "count": {
+            "type": "Fixed",
+            "value": 3
+          },
+          "target": {
+            "type": "Player"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": {
+          "type": "Not",
+          "condition": {
+            "type": "EffectOutcome",
+            "signal": "OptionalEffectPerformed"
+          }
+        },
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "duration": null,
+      "description": "Any player may have ~ deal 5 damage to them. If no one does, target player draws three cards.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": true,
+      "optional_for": "AnyPlayer",
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__caustic_bronco_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__caustic_bronco_ir.snap
@@ -1,0 +1,185 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 195,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever ~ attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if ~ isn't saddled. Otherwise, each opponent loses that much life."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Attacks",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "RevealTop",
+              "player": {
+                "type": "Controller"
+              },
+              "count": 1
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "ChangeZone",
+                "origin": null,
+                "destination": "Hand",
+                "target": {
+                  "type": "ParentTarget"
+                },
+                "owner_library": false,
+                "enter_transformed": false,
+                "enter_tapped": false,
+                "enters_attacking": false
+              },
+              "cost": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "LoseLife",
+                  "amount": {
+                    "type": "Ref",
+                    "qty": {
+                      "type": "ObjectManaValue",
+                      "scope": {
+                        "type": "Demonstrative"
+                      }
+                    }
+                  },
+                  "target": {
+                    "type": "Controller"
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "else_ability": {
+                  "kind": "Spell",
+                  "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                      "type": "Ref",
+                      "qty": {
+                        "type": "ObjectManaValue",
+                        "scope": {
+                          "type": "Demonstrative"
+                        }
+                      }
+                    }
+                  },
+                  "cost": null,
+                  "sub_ability": null,
+                  "duration": null,
+                  "description": null,
+                  "target_prompt": null,
+                  "condition": null,
+                  "optional_targeting": false,
+                  "optional": false,
+                  "forward_result": false,
+                  "player_scope": {
+                    "type": "Opponent"
+                  }
+                },
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": {
+                  "type": "Not",
+                  "condition": {
+                    "type": "SourceMatchesFilter",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [],
+                      "controller": null,
+                      "properties": [
+                        {
+                          "type": "IsSaddled"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false,
+                "sub_link": "SequentialSibling"
+              },
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever ~ attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if ~ isn't saddled. Otherwise, each opponent loses that much life.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 196,
+          "end_byte": 352,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Saddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)"
+      },
+      "node": {
+        "Keyword": {
+          "Saddle": 3
+        }
+      }
+    }
+  ],
+  "source_text": "Whenever this creature attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if this creature isn't saddled. Otherwise, each opponent loses that much life.\nSaddle 3 (Tap any number of other creatures you control with total power 3 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
+  "card_name": "Caustic Bronco"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__caustic_bronco_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__caustic_bronco_lowered.snap
@@ -1,0 +1,148 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "Attacks",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "RevealTop",
+          "player": {
+            "type": "Controller"
+          },
+          "count": 1
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "ChangeZone",
+            "origin": null,
+            "destination": "Hand",
+            "target": {
+              "type": "ParentTarget"
+            },
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "LoseLife",
+              "amount": {
+                "type": "Ref",
+                "qty": {
+                  "type": "ObjectManaValue",
+                  "scope": {
+                    "type": "Demonstrative"
+                  }
+                }
+              },
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "else_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "LoseLife",
+                "amount": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "ObjectManaValue",
+                    "scope": {
+                      "type": "Demonstrative"
+                    }
+                  }
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false,
+              "player_scope": {
+                "type": "Opponent"
+              }
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": {
+              "type": "Not",
+              "condition": {
+                "type": "SourceMatchesFilter",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [],
+                  "controller": null,
+                  "properties": [
+                    {
+                      "type": "IsSaddled"
+                    }
+                  ]
+                }
+              }
+            },
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
+          },
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "Whenever ~ attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if ~ isn't saddled. Otherwise, each opponent loses that much life.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": [
+    {
+      "Saddle": 3
+    }
+  ]
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__repeat_offender_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__repeat_offender_ir.snap
@@ -1,0 +1,95 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 127,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{2}{B}: If ~ is suspected, put a +1/+1 counter on it. Otherwise, suspect it. (A suspected creature has menace and can't block.)"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "PutCounter",
+            "counter_type": "P1P1",
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "target": {
+              "type": "SelfRef"
+            }
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Black"
+              ],
+              "generic": 2
+            }
+          },
+          "sub_ability": null,
+          "else_ability": {
+            "kind": "Activated",
+            "effect": {
+              "type": "Suspect",
+              "target": {
+                "type": "SelfRef"
+              },
+              "scope": {
+                "type": "Single"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": "{2}{B}: If ~ is suspected, put a +1/+1 counter on it. Otherwise, suspect it.",
+          "target_prompt": null,
+          "condition": {
+            "type": "SourceMatchesFilter",
+            "filter": {
+              "type": "Typed",
+              "type_filters": [],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "Suspected"
+                }
+              ]
+            }
+          },
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "{2}{B}: If this creature is suspected, put a +1/+1 counter on it. Otherwise, suspect it. (A suspected creature has menace and can't block.)",
+  "card_name": "Repeat Offender"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__repeat_offender_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__repeat_offender_lowered.snap
@@ -1,0 +1,77 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "PutCounter",
+        "counter_type": "P1P1",
+        "count": {
+          "type": "Fixed",
+          "value": 1
+        },
+        "target": {
+          "type": "SelfRef"
+        }
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Black"
+          ],
+          "generic": 2
+        }
+      },
+      "sub_ability": null,
+      "else_ability": {
+        "kind": "Activated",
+        "effect": {
+          "type": "Suspect",
+          "target": {
+            "type": "SelfRef"
+          },
+          "scope": {
+            "type": "Single"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "duration": null,
+      "description": "{2}{B}: If ~ is suspected, put a +1/+1 counter on it. Otherwise, suspect it.",
+      "target_prompt": null,
+      "condition": {
+        "type": "SourceMatchesFilter",
+        "filter": {
+          "type": "Typed",
+          "type_filters": [],
+          "controller": null,
+          "properties": [
+            {
+              "type": "Suspected"
+            }
+          ]
+        }
+      },
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -17328,14 +17328,15 @@ fn trigger_copy_token_suffix_condition_attaches_otherwise() {
 ///
 /// Direct-IR construction tests the boundary-advance building block in
 /// isolation: clause 0 normal (`boundary: Comma`), clause 1
-/// `SpecialClause::Otherwise` (`boundary: Sentence`), clause 2 normal.
-/// With the bug, clause 2 inherits clause 0's `Comma` → `ContinuationStep`;
-/// with the fix it inherits clause 1's `Sentence` → `SequentialSibling`.
+/// `BranchOtherwise { kind: Bound }` (a no-op with no prior conditional,
+/// `boundary: Sentence`), clause 2 normal. With the bug, clause 2 inherits
+/// clause 0's `Comma` → `ContinuationStep`; with the fix it inherits clause 1's
+/// `Sentence` → `SequentialSibling`.
 #[test]
 fn lower_effect_chain_ir_advances_boundary_past_special_clause() {
     use crate::parser::oracle_ir::ast::{parsed_clause, ClauseBoundary};
     use crate::parser::oracle_ir::effect_chain::{
-        ClauseDisposition, ClauseIrBuilder, EffectChainIr, SpecialClause,
+        ClauseDisposition, ClauseIrBuilder, EffectChainIr, OtherwiseKind,
     };
     use crate::types::ability::SubAbilityLink;
 
@@ -17343,18 +17344,8 @@ fn lower_effect_chain_ir_advances_boundary_past_special_clause() {
         builder: &mut ClauseIrBuilder,
         effect: Effect,
         boundary: Option<ClauseBoundary>,
-        special: Option<SpecialClause>,
+        disposition: ClauseDisposition,
     ) {
-        let disposition = match special {
-            Some(action) => ClauseDisposition::Special {
-                action,
-                intrinsic: None,
-            },
-            None => ClauseDisposition::Emit {
-                followup: None,
-                intrinsic: None,
-            },
-        };
         builder
             .clause("", parsed_clause(effect), boundary, disposition)
             .push();
@@ -17364,8 +17355,13 @@ fn lower_effect_chain_ir_advances_boundary_past_special_clause() {
         count: QuantityExpr::Fixed { value: 1 },
         target: TargetFilter::Controller,
     };
-    // `SpecialClause::Otherwise` is a silent no-op when no prior conditional
-    // def exists, so clause 0 needs no condition.
+    let emit = || ClauseDisposition::Emit {
+        followup: None,
+        intrinsic: None,
+    };
+    // A `BranchOtherwise { kind: Bound }` with no prior conditional def is a
+    // silent no-op (attaches nowhere) — the same boundary-advancing behavior the
+    // former `SpecialClause::Otherwise` had, so clause 0 needs no condition.
     let otherwise_def = Box::new(crate::types::ability::AbilityDefinition::new(
         AbilityKind::Spell,
         draw_one(),
@@ -17373,16 +17369,24 @@ fn lower_effect_chain_ir_advances_boundary_past_special_clause() {
 
     let mut builder = ClauseIrBuilder::new("");
     // clause 0: normal, trailing boundary = Comma
-    push_clause(&mut builder, draw_one(), Some(ClauseBoundary::Comma), None);
-    // clause 1: SpecialClause::Otherwise, trailing boundary = Sentence
+    push_clause(
+        &mut builder,
+        draw_one(),
+        Some(ClauseBoundary::Comma),
+        emit(),
+    );
+    // clause 1: BranchOtherwise (no-op), trailing boundary = Sentence
     push_clause(
         &mut builder,
         draw_one(),
         Some(ClauseBoundary::Sentence),
-        Some(SpecialClause::Otherwise(otherwise_def)),
+        ClauseDisposition::BranchOtherwise {
+            else_def: otherwise_def,
+            kind: OtherwiseKind::Bound,
+        },
     );
     // clause 2: normal — must stamp sub_link from clause 1's Sentence
-    push_clause(&mut builder, draw_one(), None, None);
+    push_clause(&mut builder, draw_one(), None, emit());
     let ir = EffectChainIr {
         clauses: builder.finish(),
         kind: AbilityKind::Spell,
@@ -17407,6 +17411,88 @@ fn lower_effect_chain_ir_advances_boundary_past_special_clause() {
         trailing.sub_link,
         SubAbilityLink::ContinuationStep,
         "regression guard: must NOT inherit clause 0's stale Comma boundary"
+    );
+}
+
+/// CR 608.2c: direct handler coverage for `ClauseDisposition::BranchOtherwise {
+/// kind: Fallback }`. No real card in the fixture corpus produces Fallback
+/// (0/568 — it is the degenerate strict-failure branch that fires only when the
+/// parser fails to recognize the antecedent condition), so this constructs the
+/// disposition directly to pin the verbatim-moved Fallback body: it self-emits an
+/// `Unimplemented { name: "otherwise" }` marker def followed by the else def.
+#[test]
+fn branch_otherwise_fallback_self_emits_unimplemented_marker_and_else() {
+    use crate::parser::oracle_ir::ast::{parsed_clause, ClauseBoundary};
+    use crate::parser::oracle_ir::effect_chain::{
+        ClauseDisposition, ClauseIrBuilder, EffectChainIr, OtherwiseKind,
+    };
+
+    let draw_one = || Effect::Draw {
+        count: QuantityExpr::Fixed { value: 1 },
+        target: TargetFilter::Controller,
+    };
+    let gain_life = || Effect::GainLife {
+        amount: QuantityExpr::Fixed { value: 2 },
+        player: TargetFilter::Controller,
+    };
+    let else_def = Box::new(crate::types::ability::AbilityDefinition::new(
+        AbilityKind::Spell,
+        gain_life(),
+    ));
+
+    let mut builder = ClauseIrBuilder::new("");
+    // clause 0: a normal emitted def (the "prior" clause).
+    builder
+        .clause(
+            "",
+            parsed_clause(draw_one()),
+            Some(ClauseBoundary::Sentence),
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
+    // clause 1: Fallback — no prior conditional, so self-emit marker + else.
+    builder
+        .clause(
+            "",
+            parsed_clause(draw_one()),
+            None,
+            ClauseDisposition::BranchOtherwise {
+                else_def,
+                kind: OtherwiseKind::Fallback,
+            },
+        )
+        .push();
+    let ir = EffectChainIr {
+        clauses: builder.finish(),
+        kind: AbilityKind::Spell,
+        chain_rounding: None,
+        actor: None,
+        repeat_until: None,
+    };
+
+    // Walk the lowered sub_ability chain and collect every effect.
+    let root = lower_effect_chain_ir(&ir);
+    let mut effects: Vec<&Effect> = Vec::new();
+    let mut cur = Some(&root);
+    while let Some(def) = cur {
+        effects.push(&def.effect);
+        cur = def.sub_ability.as_deref();
+    }
+    // Fallback self-emits the Unimplemented "otherwise" marker …
+    assert!(
+        effects.iter().any(|e| matches!(
+            e,
+            Effect::Unimplemented { name, .. } if name == "otherwise"
+        )),
+        "Fallback must self-emit the Unimplemented 'otherwise' marker, chain: {effects:?}"
+    );
+    // … followed by the else def (GainLife).
+    assert!(
+        effects.iter().any(|e| matches!(e, Effect::GainLife { .. })),
+        "Fallback must emit the else def after the marker, chain: {effects:?}"
     );
 }
 


### PR DESCRIPTION
Second U5-M2 increment. `Otherwise` + `OtherwiseFallback` (CR 608.2c "Otherwise,
[effect]") fold into `ClauseDisposition::BranchOtherwise { else_def, kind:
OtherwiseKind }`. `kind` carries the PARSE-TIME determination of whether a prior
conditional exists (Bound = attach as its `else_ability`; Fallback = self-emit) —
the `if has_condition || has_optional_may_head` predicate stays exactly where it
was, so the Bound/Fallback decision is unmoved and output is byte-identical. Both
`SpecialClause` variants are deleted; the accessors' exhaustive matches force
`BranchOtherwise` to be handled.

Faithful-by-construction: `ClauseDisposition` never reaches a serialized snapshot
(consumed inside `lower_effect_chain_ir`). Bound parity tests — Repeat Offender
(self-ref rebind), Caustic Bronco (event-context "that much" rebind), Browbeat
(opponent-may reward) — cover all three handler sub-branches with zero snapshot
drift. Fallback has no positive card in the 568-card corpus (it is a strict-
failure defensive branch), so its verbatim-moved handler body is covered by a
direct unit test instead of a fabricated parity card.
