### PR TITLE
refactor(parser): promote replicator SpecialClause variants to ClauseDisposition::ReplicatePerKeyword (U5-M2)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -26,7 +26,7 @@ use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::effect_chain::{
-    ClauseDisposition, ClauseIr, EffectChainIr, OtherwiseKind, SpecialClause,
+    ClauseDisposition, ClauseIr, EffectChainIr, OtherwiseKind, ReplicateKind, SpecialClause,
 };
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
@@ -1434,6 +1434,19 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                     }
                 }
                 true
+            } else if let ClauseDisposition::ReplicatePerKeyword { keywords, kind } =
+                &clause_ir.disposition
+            {
+                // CR 702 / CR 608.2c: replicate the antecedent template clause once
+                // per listed keyword. `kind` selects which template shape (and thus
+                // helper); the keyword-swap logic lives unchanged in the helpers.
+                match kind {
+                    ReplicateKind::StaticGrant => attach_same_is_true_keywords(&mut defs, keywords),
+                    ReplicateKind::CounterPlacement => {
+                        attach_repeat_process_keywords(&mut defs, keywords)
+                    }
+                }
+                true
             } else if let ClauseDisposition::Special {
                 action: special,
                 intrinsic,
@@ -1638,14 +1651,6 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                     }
                     SpecialClause::ManaRetention(expiry) => {
                         attach_mana_retention_to_prior_mana(&mut defs, *expiry);
-                        true
-                    }
-                    SpecialClause::SameIsTrueFor(keywords) => {
-                        attach_same_is_true_keywords(&mut defs, keywords);
-                        true
-                    }
-                    SpecialClause::RepeatProcessForKeywords(keywords) => {
-                        attach_repeat_process_keywords(&mut defs, keywords);
                         true
                     }
                 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -150,7 +150,7 @@ use crate::parser::oracle_ir::ast::*;
 pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup};
 use crate::parser::oracle_ir::effect_chain::{
     AbilityIr, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr, ClauseIrBuilder,
-    EffectChainIr, OtherwiseKind, SpecialClause,
+    EffectChainIr, OtherwiseKind, ReplicateKind, SpecialClause,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -24534,9 +24534,9 @@ pub(crate) fn parse_effect_chain_ir(
                         normalized_text,
                         placeholder_parsed_clause("same_is_true_for_placeholder"),
                         chunk.boundary_after,
-                        ClauseDisposition::Special {
-                            action: SpecialClause::SameIsTrueFor(keywords),
-                            intrinsic: None,
+                        ClauseDisposition::ReplicatePerKeyword {
+                            keywords,
+                            kind: ReplicateKind::StaticGrant,
                         },
                     )
                     .push();
@@ -24556,9 +24556,9 @@ pub(crate) fn parse_effect_chain_ir(
                         normalized_text,
                         placeholder_parsed_clause("repeat_process_for_keywords_placeholder"),
                         chunk.boundary_after,
-                        ClauseDisposition::Special {
-                            action: SpecialClause::RepeatProcessForKeywords(keywords),
-                            intrinsic: None,
+                        ClauseDisposition::ReplicatePerKeyword {
+                            keywords,
+                            kind: ReplicateKind::CounterPlacement,
                         },
                     )
                     .push();

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -7051,8 +7051,9 @@ pub(super) fn parse_keyword_grant_list(input: &str) -> Option<(Vec<Keyword>, &st
 /// each additional listed keyword.
 ///
 /// Returns the parsed keyword list. The chunk loop wraps this in
-/// `SpecialClause::SameIsTrueFor`; lowering reads the antecedent
-/// `GenericEffect` clause and clones its grant template once per keyword.
+/// `ClauseDisposition::ReplicatePerKeyword { kind: StaticGrant }`; lowering reads
+/// the antecedent `GenericEffect` clause and clones its grant template once per
+/// keyword.
 /// Generalized over the whole evergreen-keyword vocabulary — covers every card
 /// of this "the same is true for …" class, not Odric alone.
 pub(crate) fn try_parse_same_is_true_continuation(text: &str) -> Option<Vec<Keyword>> {
@@ -7074,8 +7075,9 @@ pub(crate) fn try_parse_same_is_true_continuation(text: &str) -> Option<Vec<Keyw
 /// CR 608.2c: Parse a counter-class keyword-list continuation —
 /// "Repeat this process for <keyword list>." (Kathril, Aspect Warper) or
 /// "Do the same for <keyword list>." (Super-Adaptoid). Returns the keyword
-/// list; the chunk loop wraps it in `SpecialClause::RepeatProcessForKeywords`
-/// and lowering replicates the antecedent conditional keyword-counter clause
+/// list; the chunk loop wraps it in
+/// `ClauseDisposition::ReplicatePerKeyword { kind: CounterPlacement }` and
+/// lowering replicates the antecedent conditional keyword-counter clause
 /// once per keyword. Both phrasings are leaf-level variants of the same
 /// "replicate the prior keyword-counter clause for each listed keyword"
 /// directive, so they share one combinator and one `SpecialClause`. Mirrors

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -136,18 +136,6 @@ pub(crate) enum SpecialClause {
     DrawnThisTurnPayOrTopdeck { life_payment: QuantityExpr },
     /// CR 106.4: Mana-retention rider — fold expiry onto the previous Mana effect.
     ManaRetention(ManaExpiry),
-    /// CR 702: "The same is true for <keyword list>." — Odric, Lunarch Marshal.
-    /// Each listed keyword extends the previous `GenericEffect` clause with one
-    /// additional `StaticDefinition` cloned from the antecedent grant template,
-    /// with both the granted keyword and the gating condition's keyword swapped.
-    SameIsTrueFor(Vec<Keyword>),
-    /// CR 608.2c: "Repeat this process for <keyword list>." — Kathril, Aspect
-    /// Warper. Replicates the antecedent conditional keyword-counter clause
-    /// (`PutCounter { counter_type: Keyword(..) }` gated by a graveyard-keyword
-    /// condition) once per listed keyword, swapping both the placed counter's
-    /// keyword and the gating condition's keyword. The counters-class analogue
-    /// of `SameIsTrueFor` (which handles static keyword grants).
-    RepeatProcessForKeywords(Vec<Keyword>),
 }
 
 // ===========================================================================
@@ -247,6 +235,15 @@ pub(crate) enum ClauseDisposition {
         else_def: Box<AbilityDefinition>,
         kind: OtherwiseKind,
     },
+    /// CR 608.2c / CR 702: replicate an antecedent template clause once per listed
+    /// keyword, swapping the keyword in both the granted ability/counter and its
+    /// gating condition. Promoted from `SpecialClause::{SameIsTrueFor,
+    /// RepeatProcessForKeywords}` (U5-M2). `kind` selects the replication helper;
+    /// the bound antecedent is the prior emitted clause (implicit, as `Continue`).
+    ReplicatePerKeyword {
+        keywords: Vec<Keyword>,
+        kind: ReplicateKind,
+    },
     /// A special-case adjacency action that modifies an adjacent clause during
     /// lowering (folds the former `special: Option<SpecialClause>`). `intrinsic`
     /// carries the self-patch some special arms apply (lower.rs:1600).
@@ -287,6 +284,19 @@ pub(crate) enum OtherwiseKind {
     /// No prior conditional at parse time: self-emit (an Unimplemented "otherwise"
     /// marker def followed by the else def).
     Fallback,
+}
+
+/// CR 608.2c / CR 702: which per-keyword replication is performed. Both replicate
+/// an antecedent template per listed keyword; `kind` selects which template shape
+/// (static grant vs. counter placement) and thus which lowering helper runs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum ReplicateKind {
+    /// CR 702: "The same is true for <keywords>." — replicate the antecedent static
+    /// keyword-GRANT clause per keyword (Odric, Lunarch Marshal).
+    StaticGrant,
+    /// CR 608.2c: "Repeat this process for <keywords>." — replicate the antecedent
+    /// conditional keyword-COUNTER clause per keyword (Kathril, Aspect Warper).
+    CounterPlacement,
 }
 
 /// Per-clause IR: captures everything about a single parsed chunk before chain assembly.
@@ -376,7 +386,8 @@ impl ClauseDisposition {
             | ClauseDisposition::Special { intrinsic, .. } => intrinsic.as_ref(),
             ClauseDisposition::Continue { .. }
             | ClauseDisposition::Absorb { .. }
-            | ClauseDisposition::BranchOtherwise { .. } => None,
+            | ClauseDisposition::BranchOtherwise { .. }
+            | ClauseDisposition::ReplicatePerKeyword { .. } => None,
         }
     }
 
@@ -391,7 +402,8 @@ impl ClauseDisposition {
             } => followup.as_ref(),
             ClauseDisposition::Special { .. }
             | ClauseDisposition::Absorb { .. }
-            | ClauseDisposition::BranchOtherwise { .. } => None,
+            | ClauseDisposition::BranchOtherwise { .. }
+            | ClauseDisposition::ReplicatePerKeyword { .. } => None,
         }
     }
 }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -613,6 +613,42 @@ fn browbeat() {
 }
 
 // ---------------------------------------------------------------------------
+// Per-keyword replication (U5-M2 ReplicatePerKeyword parity)
+// ---------------------------------------------------------------------------
+// Oracle text verified verbatim against Scryfall.
+
+// CR 702: StaticGrant — "The same is true for <keywords>." replicates the
+// antecedent static keyword-grant clause once per listed keyword, swapping the
+// keyword in both the grant and its gating condition (Odric, Lunarch Marshal).
+#[test]
+fn odric_lunarch_marshal() {
+    let (ir, lowered) = parse_two_layer(
+        "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.",
+        "Odric, Lunarch Marshal",
+        &["Creature"],
+        &["Human", "Soldier"],
+    );
+    insta::assert_json_snapshot!("odric_lunarch_marshal_ir", &ir);
+    insta::assert_json_snapshot!("odric_lunarch_marshal_lowered", &lowered);
+}
+
+// CR 608.2c: CounterPlacement — "Repeat this process for <keywords>." replicates
+// the antecedent conditional keyword-counter clause once per listed keyword,
+// swapping the keyword in both the placed counter and the graveyard-keyword gate
+// (Kathril, Aspect Warper).
+#[test]
+fn kathril_aspect_warper() {
+    let (ir, lowered) = parse_two_layer(
+        "When Kathril enters, put a flying counter on any creature you control if a creature card in your graveyard has flying. Repeat this process for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance. Then put a +1/+1 counter on Kathril for each counter put on a creature this way.",
+        "Kathril, Aspect Warper",
+        &["Creature"],
+        &["Nightmare", "Insect"],
+    );
+    insta::assert_json_snapshot!("kathril_aspect_warper_ir", &ir);
+    insta::assert_json_snapshot!("kathril_aspect_warper_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
 // Triggers (various patterns)
 // ---------------------------------------------------------------------------
 

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kathril_aspect_warper_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kathril_aspect_warper_ir.snap
@@ -1,0 +1,667 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 327,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "When ~ enters, put a flying counter on any creature you control if a creature card in your graveyard has flying. Repeat this process for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance. Then put a +1/+1 counter on ~ for each counter put on a creature this way."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "flying",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "Any"
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "PutCounter",
+                "counter_type": "first strike",
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                },
+                "target": {
+                  "type": "Any"
+                }
+              },
+              "cost": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "PutCounter",
+                  "counter_type": "double strike",
+                  "count": {
+                    "type": "Fixed",
+                    "value": 1
+                  },
+                  "target": {
+                    "type": "Any"
+                  }
+                },
+                "cost": null,
+                "sub_ability": {
+                  "kind": "Spell",
+                  "effect": {
+                    "type": "PutCounter",
+                    "counter_type": "deathtouch",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "target": {
+                      "type": "Any"
+                    }
+                  },
+                  "cost": null,
+                  "sub_ability": {
+                    "kind": "Spell",
+                    "effect": {
+                      "type": "PutCounter",
+                      "counter_type": "hexproof",
+                      "count": {
+                        "type": "Fixed",
+                        "value": 1
+                      },
+                      "target": {
+                        "type": "Any"
+                      }
+                    },
+                    "cost": null,
+                    "sub_ability": {
+                      "kind": "Spell",
+                      "effect": {
+                        "type": "PutCounter",
+                        "counter_type": "indestructible",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "target": {
+                          "type": "Any"
+                        }
+                      },
+                      "cost": null,
+                      "sub_ability": {
+                        "kind": "Spell",
+                        "effect": {
+                          "type": "PutCounter",
+                          "counter_type": "lifelink",
+                          "count": {
+                            "type": "Fixed",
+                            "value": 1
+                          },
+                          "target": {
+                            "type": "Any"
+                          }
+                        },
+                        "cost": null,
+                        "sub_ability": {
+                          "kind": "Spell",
+                          "effect": {
+                            "type": "PutCounter",
+                            "counter_type": "menace",
+                            "count": {
+                              "type": "Fixed",
+                              "value": 1
+                            },
+                            "target": {
+                              "type": "Any"
+                            }
+                          },
+                          "cost": null,
+                          "sub_ability": {
+                            "kind": "Spell",
+                            "effect": {
+                              "type": "PutCounter",
+                              "counter_type": "reach",
+                              "count": {
+                                "type": "Fixed",
+                                "value": 1
+                              },
+                              "target": {
+                                "type": "Any"
+                              }
+                            },
+                            "cost": null,
+                            "sub_ability": {
+                              "kind": "Spell",
+                              "effect": {
+                                "type": "PutCounter",
+                                "counter_type": "trample",
+                                "count": {
+                                  "type": "Fixed",
+                                  "value": 1
+                                },
+                                "target": {
+                                  "type": "Any"
+                                }
+                              },
+                              "cost": null,
+                              "sub_ability": {
+                                "kind": "Spell",
+                                "effect": {
+                                  "type": "PutCounter",
+                                  "counter_type": "vigilance",
+                                  "count": {
+                                    "type": "Fixed",
+                                    "value": 1
+                                  },
+                                  "target": {
+                                    "type": "Any"
+                                  }
+                                },
+                                "cost": null,
+                                "sub_ability": {
+                                  "kind": "Spell",
+                                  "effect": {
+                                    "type": "PutCounter",
+                                    "counter_type": "P1P1",
+                                    "count": {
+                                      "type": "Ref",
+                                      "qty": {
+                                        "type": "TrackedSetSize"
+                                      }
+                                    },
+                                    "target": {
+                                      "type": "SelfRef"
+                                    }
+                                  },
+                                  "cost": null,
+                                  "sub_ability": null,
+                                  "duration": null,
+                                  "description": null,
+                                  "target_prompt": null,
+                                  "condition": null,
+                                  "optional_targeting": false,
+                                  "optional": false,
+                                  "forward_result": false,
+                                  "sub_link": "SequentialSibling"
+                                },
+                                "duration": null,
+                                "description": null,
+                                "target_prompt": null,
+                                "condition": {
+                                  "type": "QuantityCheck",
+                                  "lhs": {
+                                    "type": "Ref",
+                                    "qty": {
+                                      "type": "ObjectCount",
+                                      "filter": {
+                                        "type": "Typed",
+                                        "type_filters": [
+                                          "Creature"
+                                        ],
+                                        "controller": "You",
+                                        "properties": [
+                                          {
+                                            "type": "InZone",
+                                            "zone": "Graveyard"
+                                          },
+                                          {
+                                            "type": "WithKeyword",
+                                            "value": "Vigilance"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "comparator": "GE",
+                                  "rhs": {
+                                    "type": "Fixed",
+                                    "value": 1
+                                  }
+                                },
+                                "optional_targeting": false,
+                                "optional": false,
+                                "forward_result": false,
+                                "sub_link": "SequentialSibling"
+                              },
+                              "duration": null,
+                              "description": null,
+                              "target_prompt": null,
+                              "condition": {
+                                "type": "QuantityCheck",
+                                "lhs": {
+                                  "type": "Ref",
+                                  "qty": {
+                                    "type": "ObjectCount",
+                                    "filter": {
+                                      "type": "Typed",
+                                      "type_filters": [
+                                        "Creature"
+                                      ],
+                                      "controller": "You",
+                                      "properties": [
+                                        {
+                                          "type": "InZone",
+                                          "zone": "Graveyard"
+                                        },
+                                        {
+                                          "type": "WithKeyword",
+                                          "value": "Trample"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                "comparator": "GE",
+                                "rhs": {
+                                  "type": "Fixed",
+                                  "value": 1
+                                }
+                              },
+                              "optional_targeting": false,
+                              "optional": false,
+                              "forward_result": false,
+                              "sub_link": "SequentialSibling"
+                            },
+                            "duration": null,
+                            "description": null,
+                            "target_prompt": null,
+                            "condition": {
+                              "type": "QuantityCheck",
+                              "lhs": {
+                                "type": "Ref",
+                                "qty": {
+                                  "type": "ObjectCount",
+                                  "filter": {
+                                    "type": "Typed",
+                                    "type_filters": [
+                                      "Creature"
+                                    ],
+                                    "controller": "You",
+                                    "properties": [
+                                      {
+                                        "type": "InZone",
+                                        "zone": "Graveyard"
+                                      },
+                                      {
+                                        "type": "WithKeyword",
+                                        "value": "Reach"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              "comparator": "GE",
+                              "rhs": {
+                                "type": "Fixed",
+                                "value": 1
+                              }
+                            },
+                            "optional_targeting": false,
+                            "optional": false,
+                            "forward_result": false,
+                            "sub_link": "SequentialSibling"
+                          },
+                          "duration": null,
+                          "description": null,
+                          "target_prompt": null,
+                          "condition": {
+                            "type": "QuantityCheck",
+                            "lhs": {
+                              "type": "Ref",
+                              "qty": {
+                                "type": "ObjectCount",
+                                "filter": {
+                                  "type": "Typed",
+                                  "type_filters": [
+                                    "Creature"
+                                  ],
+                                  "controller": "You",
+                                  "properties": [
+                                    {
+                                      "type": "InZone",
+                                      "zone": "Graveyard"
+                                    },
+                                    {
+                                      "type": "WithKeyword",
+                                      "value": "Menace"
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "comparator": "GE",
+                            "rhs": {
+                              "type": "Fixed",
+                              "value": 1
+                            }
+                          },
+                          "optional_targeting": false,
+                          "optional": false,
+                          "forward_result": false,
+                          "sub_link": "SequentialSibling"
+                        },
+                        "duration": null,
+                        "description": null,
+                        "target_prompt": null,
+                        "condition": {
+                          "type": "QuantityCheck",
+                          "lhs": {
+                            "type": "Ref",
+                            "qty": {
+                              "type": "ObjectCount",
+                              "filter": {
+                                "type": "Typed",
+                                "type_filters": [
+                                  "Creature"
+                                ],
+                                "controller": "You",
+                                "properties": [
+                                  {
+                                    "type": "InZone",
+                                    "zone": "Graveyard"
+                                  },
+                                  {
+                                    "type": "WithKeyword",
+                                    "value": "Lifelink"
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "comparator": "GE",
+                          "rhs": {
+                            "type": "Fixed",
+                            "value": 1
+                          }
+                        },
+                        "optional_targeting": false,
+                        "optional": false,
+                        "forward_result": false,
+                        "sub_link": "SequentialSibling"
+                      },
+                      "duration": null,
+                      "description": null,
+                      "target_prompt": null,
+                      "condition": {
+                        "type": "QuantityCheck",
+                        "lhs": {
+                          "type": "Ref",
+                          "qty": {
+                            "type": "ObjectCount",
+                            "filter": {
+                              "type": "Typed",
+                              "type_filters": [
+                                "Creature"
+                              ],
+                              "controller": "You",
+                              "properties": [
+                                {
+                                  "type": "InZone",
+                                  "zone": "Graveyard"
+                                },
+                                {
+                                  "type": "WithKeyword",
+                                  "value": "Indestructible"
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "comparator": "GE",
+                        "rhs": {
+                          "type": "Fixed",
+                          "value": 1
+                        }
+                      },
+                      "optional_targeting": false,
+                      "optional": false,
+                      "forward_result": false,
+                      "sub_link": "SequentialSibling"
+                    },
+                    "duration": null,
+                    "description": null,
+                    "target_prompt": null,
+                    "condition": {
+                      "type": "QuantityCheck",
+                      "lhs": {
+                        "type": "Ref",
+                        "qty": {
+                          "type": "ObjectCount",
+                          "filter": {
+                            "type": "Typed",
+                            "type_filters": [
+                              "Creature"
+                            ],
+                            "controller": "You",
+                            "properties": [
+                              {
+                                "type": "InZone",
+                                "zone": "Graveyard"
+                              },
+                              {
+                                "type": "WithKeyword",
+                                "value": "Hexproof"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "comparator": "GE",
+                      "rhs": {
+                        "type": "Fixed",
+                        "value": 1
+                      }
+                    },
+                    "optional_targeting": false,
+                    "optional": false,
+                    "forward_result": false,
+                    "sub_link": "SequentialSibling"
+                  },
+                  "duration": null,
+                  "description": null,
+                  "target_prompt": null,
+                  "condition": {
+                    "type": "QuantityCheck",
+                    "lhs": {
+                      "type": "Ref",
+                      "qty": {
+                        "type": "ObjectCount",
+                        "filter": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Creature"
+                          ],
+                          "controller": "You",
+                          "properties": [
+                            {
+                              "type": "InZone",
+                              "zone": "Graveyard"
+                            },
+                            {
+                              "type": "WithKeyword",
+                              "value": "Deathtouch"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "comparator": "GE",
+                    "rhs": {
+                      "type": "Fixed",
+                      "value": 1
+                    }
+                  },
+                  "optional_targeting": false,
+                  "optional": false,
+                  "forward_result": false,
+                  "sub_link": "SequentialSibling"
+                },
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": {
+                  "type": "QuantityCheck",
+                  "lhs": {
+                    "type": "Ref",
+                    "qty": {
+                      "type": "ObjectCount",
+                      "filter": {
+                        "type": "Typed",
+                        "type_filters": [
+                          "Creature"
+                        ],
+                        "controller": "You",
+                        "properties": [
+                          {
+                            "type": "InZone",
+                            "zone": "Graveyard"
+                          },
+                          {
+                            "type": "WithKeyword",
+                            "value": "DoubleStrike"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "comparator": "GE",
+                  "rhs": {
+                    "type": "Fixed",
+                    "value": 1
+                  }
+                },
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false,
+                "sub_link": "SequentialSibling"
+              },
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": {
+                "type": "QuantityCheck",
+                "lhs": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "ObjectCount",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "InZone",
+                          "zone": "Graveyard"
+                        },
+                        {
+                          "type": "WithKeyword",
+                          "value": "FirstStrike"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "comparator": "GE",
+                "rhs": {
+                  "type": "Fixed",
+                  "value": 1
+                }
+              },
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false,
+              "sub_link": "SequentialSibling"
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": {
+              "type": "QuantityCheck",
+              "lhs": {
+                "type": "Ref",
+                "qty": {
+                  "type": "ObjectCount",
+                  "filter": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "InZone",
+                        "zone": "Graveyard"
+                      },
+                      {
+                        "type": "WithKeyword",
+                        "value": "Flying"
+                      }
+                    ]
+                  }
+                }
+              },
+              "comparator": "GE",
+              "rhs": {
+                "type": "Fixed",
+                "value": 1
+              }
+            },
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When ~ enters, put a flying counter on any creature you control if a creature card in your graveyard has flying. Repeat this process for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance. Then put a +1/+1 counter on ~ for each counter put on a creature this way.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "When Kathril enters, put a flying counter on any creature you control if a creature card in your graveyard has flying. Repeat this process for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance. Then put a +1/+1 counter on Kathril for each counter put on a creature this way.",
+  "card_name": "Kathril, Aspect Warper",
+  "diagnostics": [
+    {
+      "type": "TargetFallback",
+      "context": "parse_target could not classify",
+      "text": "any creature you control",
+      "line_index": 0
+    }
+  ]
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kathril_aspect_warper_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kathril_aspect_warper_lowered.snap
@@ -1,0 +1,649 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "ChangesZone",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "PutCounter",
+          "counter_type": "flying",
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "target": {
+            "type": "Any"
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "PutCounter",
+            "counter_type": "first strike",
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "target": {
+              "type": "Any"
+            }
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "double strike",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "Any"
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "PutCounter",
+                "counter_type": "deathtouch",
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                },
+                "target": {
+                  "type": "Any"
+                }
+              },
+              "cost": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "PutCounter",
+                  "counter_type": "hexproof",
+                  "count": {
+                    "type": "Fixed",
+                    "value": 1
+                  },
+                  "target": {
+                    "type": "Any"
+                  }
+                },
+                "cost": null,
+                "sub_ability": {
+                  "kind": "Spell",
+                  "effect": {
+                    "type": "PutCounter",
+                    "counter_type": "indestructible",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "target": {
+                      "type": "Any"
+                    }
+                  },
+                  "cost": null,
+                  "sub_ability": {
+                    "kind": "Spell",
+                    "effect": {
+                      "type": "PutCounter",
+                      "counter_type": "lifelink",
+                      "count": {
+                        "type": "Fixed",
+                        "value": 1
+                      },
+                      "target": {
+                        "type": "Any"
+                      }
+                    },
+                    "cost": null,
+                    "sub_ability": {
+                      "kind": "Spell",
+                      "effect": {
+                        "type": "PutCounter",
+                        "counter_type": "menace",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "target": {
+                          "type": "Any"
+                        }
+                      },
+                      "cost": null,
+                      "sub_ability": {
+                        "kind": "Spell",
+                        "effect": {
+                          "type": "PutCounter",
+                          "counter_type": "reach",
+                          "count": {
+                            "type": "Fixed",
+                            "value": 1
+                          },
+                          "target": {
+                            "type": "Any"
+                          }
+                        },
+                        "cost": null,
+                        "sub_ability": {
+                          "kind": "Spell",
+                          "effect": {
+                            "type": "PutCounter",
+                            "counter_type": "trample",
+                            "count": {
+                              "type": "Fixed",
+                              "value": 1
+                            },
+                            "target": {
+                              "type": "Any"
+                            }
+                          },
+                          "cost": null,
+                          "sub_ability": {
+                            "kind": "Spell",
+                            "effect": {
+                              "type": "PutCounter",
+                              "counter_type": "vigilance",
+                              "count": {
+                                "type": "Fixed",
+                                "value": 1
+                              },
+                              "target": {
+                                "type": "Any"
+                              }
+                            },
+                            "cost": null,
+                            "sub_ability": {
+                              "kind": "Spell",
+                              "effect": {
+                                "type": "PutCounter",
+                                "counter_type": "P1P1",
+                                "count": {
+                                  "type": "Ref",
+                                  "qty": {
+                                    "type": "TrackedSetSize"
+                                  }
+                                },
+                                "target": {
+                                  "type": "SelfRef"
+                                }
+                              },
+                              "cost": null,
+                              "sub_ability": null,
+                              "duration": null,
+                              "description": null,
+                              "target_prompt": null,
+                              "condition": null,
+                              "optional_targeting": false,
+                              "optional": false,
+                              "forward_result": false,
+                              "sub_link": "SequentialSibling"
+                            },
+                            "duration": null,
+                            "description": null,
+                            "target_prompt": null,
+                            "condition": {
+                              "type": "QuantityCheck",
+                              "lhs": {
+                                "type": "Ref",
+                                "qty": {
+                                  "type": "ObjectCount",
+                                  "filter": {
+                                    "type": "Typed",
+                                    "type_filters": [
+                                      "Creature"
+                                    ],
+                                    "controller": "You",
+                                    "properties": [
+                                      {
+                                        "type": "InZone",
+                                        "zone": "Graveyard"
+                                      },
+                                      {
+                                        "type": "WithKeyword",
+                                        "value": "Vigilance"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              "comparator": "GE",
+                              "rhs": {
+                                "type": "Fixed",
+                                "value": 1
+                              }
+                            },
+                            "optional_targeting": false,
+                            "optional": false,
+                            "forward_result": false,
+                            "sub_link": "SequentialSibling"
+                          },
+                          "duration": null,
+                          "description": null,
+                          "target_prompt": null,
+                          "condition": {
+                            "type": "QuantityCheck",
+                            "lhs": {
+                              "type": "Ref",
+                              "qty": {
+                                "type": "ObjectCount",
+                                "filter": {
+                                  "type": "Typed",
+                                  "type_filters": [
+                                    "Creature"
+                                  ],
+                                  "controller": "You",
+                                  "properties": [
+                                    {
+                                      "type": "InZone",
+                                      "zone": "Graveyard"
+                                    },
+                                    {
+                                      "type": "WithKeyword",
+                                      "value": "Trample"
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "comparator": "GE",
+                            "rhs": {
+                              "type": "Fixed",
+                              "value": 1
+                            }
+                          },
+                          "optional_targeting": false,
+                          "optional": false,
+                          "forward_result": false,
+                          "sub_link": "SequentialSibling"
+                        },
+                        "duration": null,
+                        "description": null,
+                        "target_prompt": null,
+                        "condition": {
+                          "type": "QuantityCheck",
+                          "lhs": {
+                            "type": "Ref",
+                            "qty": {
+                              "type": "ObjectCount",
+                              "filter": {
+                                "type": "Typed",
+                                "type_filters": [
+                                  "Creature"
+                                ],
+                                "controller": "You",
+                                "properties": [
+                                  {
+                                    "type": "InZone",
+                                    "zone": "Graveyard"
+                                  },
+                                  {
+                                    "type": "WithKeyword",
+                                    "value": "Reach"
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "comparator": "GE",
+                          "rhs": {
+                            "type": "Fixed",
+                            "value": 1
+                          }
+                        },
+                        "optional_targeting": false,
+                        "optional": false,
+                        "forward_result": false,
+                        "sub_link": "SequentialSibling"
+                      },
+                      "duration": null,
+                      "description": null,
+                      "target_prompt": null,
+                      "condition": {
+                        "type": "QuantityCheck",
+                        "lhs": {
+                          "type": "Ref",
+                          "qty": {
+                            "type": "ObjectCount",
+                            "filter": {
+                              "type": "Typed",
+                              "type_filters": [
+                                "Creature"
+                              ],
+                              "controller": "You",
+                              "properties": [
+                                {
+                                  "type": "InZone",
+                                  "zone": "Graveyard"
+                                },
+                                {
+                                  "type": "WithKeyword",
+                                  "value": "Menace"
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "comparator": "GE",
+                        "rhs": {
+                          "type": "Fixed",
+                          "value": 1
+                        }
+                      },
+                      "optional_targeting": false,
+                      "optional": false,
+                      "forward_result": false,
+                      "sub_link": "SequentialSibling"
+                    },
+                    "duration": null,
+                    "description": null,
+                    "target_prompt": null,
+                    "condition": {
+                      "type": "QuantityCheck",
+                      "lhs": {
+                        "type": "Ref",
+                        "qty": {
+                          "type": "ObjectCount",
+                          "filter": {
+                            "type": "Typed",
+                            "type_filters": [
+                              "Creature"
+                            ],
+                            "controller": "You",
+                            "properties": [
+                              {
+                                "type": "InZone",
+                                "zone": "Graveyard"
+                              },
+                              {
+                                "type": "WithKeyword",
+                                "value": "Lifelink"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "comparator": "GE",
+                      "rhs": {
+                        "type": "Fixed",
+                        "value": 1
+                      }
+                    },
+                    "optional_targeting": false,
+                    "optional": false,
+                    "forward_result": false,
+                    "sub_link": "SequentialSibling"
+                  },
+                  "duration": null,
+                  "description": null,
+                  "target_prompt": null,
+                  "condition": {
+                    "type": "QuantityCheck",
+                    "lhs": {
+                      "type": "Ref",
+                      "qty": {
+                        "type": "ObjectCount",
+                        "filter": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Creature"
+                          ],
+                          "controller": "You",
+                          "properties": [
+                            {
+                              "type": "InZone",
+                              "zone": "Graveyard"
+                            },
+                            {
+                              "type": "WithKeyword",
+                              "value": "Indestructible"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "comparator": "GE",
+                    "rhs": {
+                      "type": "Fixed",
+                      "value": 1
+                    }
+                  },
+                  "optional_targeting": false,
+                  "optional": false,
+                  "forward_result": false,
+                  "sub_link": "SequentialSibling"
+                },
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": {
+                  "type": "QuantityCheck",
+                  "lhs": {
+                    "type": "Ref",
+                    "qty": {
+                      "type": "ObjectCount",
+                      "filter": {
+                        "type": "Typed",
+                        "type_filters": [
+                          "Creature"
+                        ],
+                        "controller": "You",
+                        "properties": [
+                          {
+                            "type": "InZone",
+                            "zone": "Graveyard"
+                          },
+                          {
+                            "type": "WithKeyword",
+                            "value": "Hexproof"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "comparator": "GE",
+                  "rhs": {
+                    "type": "Fixed",
+                    "value": 1
+                  }
+                },
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false,
+                "sub_link": "SequentialSibling"
+              },
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": {
+                "type": "QuantityCheck",
+                "lhs": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "ObjectCount",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "InZone",
+                          "zone": "Graveyard"
+                        },
+                        {
+                          "type": "WithKeyword",
+                          "value": "Deathtouch"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "comparator": "GE",
+                "rhs": {
+                  "type": "Fixed",
+                  "value": 1
+                }
+              },
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false,
+              "sub_link": "SequentialSibling"
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": {
+              "type": "QuantityCheck",
+              "lhs": {
+                "type": "Ref",
+                "qty": {
+                  "type": "ObjectCount",
+                  "filter": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "InZone",
+                        "zone": "Graveyard"
+                      },
+                      {
+                        "type": "WithKeyword",
+                        "value": "DoubleStrike"
+                      }
+                    ]
+                  }
+                }
+              },
+              "comparator": "GE",
+              "rhs": {
+                "type": "Fixed",
+                "value": 1
+              }
+            },
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
+          },
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": {
+            "type": "QuantityCheck",
+            "lhs": {
+              "type": "Ref",
+              "qty": {
+                "type": "ObjectCount",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "InZone",
+                      "zone": "Graveyard"
+                    },
+                    {
+                      "type": "WithKeyword",
+                      "value": "FirstStrike"
+                    }
+                  ]
+                }
+              }
+            },
+            "comparator": "GE",
+            "rhs": {
+              "type": "Fixed",
+              "value": 1
+            }
+          },
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false,
+          "sub_link": "SequentialSibling"
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": {
+          "type": "QuantityCheck",
+          "lhs": {
+            "type": "Ref",
+            "qty": {
+              "type": "ObjectCount",
+              "filter": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": [
+                  {
+                    "type": "InZone",
+                    "zone": "Graveyard"
+                  },
+                  {
+                    "type": "WithKeyword",
+                    "value": "Flying"
+                  }
+                ]
+              }
+            }
+          },
+          "comparator": "GE",
+          "rhs": {
+            "type": "Fixed",
+            "value": 1
+          }
+        },
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": "Battlefield",
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "When ~ enters, put a flying counter on any creature you control if a creature card in your graveyard has flying. Repeat this process for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance. Then put a +1/+1 counter on ~ for each counter put on a creature this way.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": [],
+  "parseWarnings": [
+    {
+      "type": "TargetFallback",
+      "context": "parse_target could not classify",
+      "text": "any creature you control",
+      "line_index": 0
+    }
+  ]
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__odric_lunarch_marshal_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__odric_lunarch_marshal_ir.snap
@@ -1,0 +1,562 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 279,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Phase",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GenericEffect",
+              "static_abilities": [
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "FirstStrike"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "FirstStrike"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Flying"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "Flying"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Deathtouch"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "Deathtouch"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "DoubleStrike"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "DoubleStrike"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Haste"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "Haste"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Hexproof"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "Hexproof"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Indestructible"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "Indestructible"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Lifelink"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "Lifelink"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Menace"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "Menace"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Reach"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "Reach"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Skulk"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "Skulk"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Trample"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "Trample"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                },
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Vigilance"
+                    }
+                  ],
+                  "condition": {
+                    "type": "IsPresent",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "WithKeyword",
+                          "value": "Vigilance"
+                        }
+                      ]
+                    }
+                  },
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain first strike"
+                }
+              ],
+              "duration": "UntilEndOfTurn",
+              "target": null
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": "BeginCombat",
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.",
+  "card_name": "Odric, Lunarch Marshal"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__odric_lunarch_marshal_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__odric_lunarch_marshal_lowered.snap
@@ -1,0 +1,544 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "Phase",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "GenericEffect",
+          "static_abilities": [
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "FirstStrike"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "FirstStrike"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Flying"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Flying"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Deathtouch"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Deathtouch"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "DoubleStrike"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "DoubleStrike"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Haste"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Haste"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Hexproof"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Hexproof"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Indestructible"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Indestructible"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Lifelink"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Lifelink"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Menace"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Menace"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Reach"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Reach"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Skulk"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Skulk"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Trample"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Trample"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            },
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Vigilance"
+                }
+              ],
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Vigilance"
+                    }
+                  ]
+                }
+              },
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain first strike"
+            }
+          ],
+          "duration": "UntilEndOfTurn",
+          "target": null
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": "UntilEndOfTurn",
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": null,
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": "BeginCombat",
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}


### PR DESCRIPTION
Third U5-M2 increment. SameIsTrueFor + RepeatProcessForKeywords (CR 702 / CR
608.2c per-keyword template replication) fold into
`ClauseDisposition::ReplicatePerKeyword { keywords, kind: ReplicateKind }`, where
`kind` (StaticGrant | CounterPlacement) selects the replication helper — the two
handlers share the same call shape but distinct rules concepts, kept typed rather
than collapsed. Both SpecialClause variants are deleted.

Faithful-by-construction (ClauseDisposition never reaches a serialized snapshot).
Parity tests — Odric, Lunarch Marshal (StaticGrant, 12-keyword grant) and Kathril,
Aspect Warper (CounterPlacement) — exercise the multi-keyword replication loop with
zero snapshot drift.
