### PR TITLE
refactor(parser): promote rider SpecialClause variants to ClauseDisposition::ModifyPrior (U5-M2)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -26,7 +26,8 @@ use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::effect_chain::{
-    ClauseDisposition, ClauseIr, EffectChainIr, OtherwiseKind, ReplicateKind, SpecialClause,
+    ClauseDisposition, ClauseIr, EffectChainIr, OtherwiseKind, PriorModifier, ReplicateKind,
+    SpecialClause,
 };
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
@@ -1447,72 +1448,17 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                     }
                 }
                 true
-            } else if let ClauseDisposition::Special {
-                action: special,
-                intrinsic,
-            } = &clause_ir.disposition
-            {
-                match special {
-                    SpecialClause::AltCostRider(cost) => {
+            } else if let ClauseDisposition::ModifyPrior { modifier } = &clause_ir.disposition {
+                // CR 608.2c: fold a field-level modification onto the prior emitted
+                // def; emit no sibling. `modifier` selects which field/aspect.
+                match modifier {
+                    PriorModifier::AltCost(cost) => {
                         attach_alt_cost_to_prior_cast_from_zone(&mut defs, cost.clone());
-                        true
                     }
-                    SpecialClause::DigInsteadAlt(alt_def) => {
-                        if let Some(last_def) = defs.pop() {
-                            let mut new_def = *alt_def.clone();
-                            apply_where_x_ability_expression(
-                                &mut new_def,
-                                clause_ir.where_x_expression.as_deref(),
-                            );
-                            new_def.else_ability = Some(Box::new(last_def));
-                            defs.push(new_def);
-                        }
-                        true
+                    PriorModifier::ManaRetention(expiry) => {
+                        attach_mana_retention_to_prior_mana(&mut defs, *expiry);
                     }
-                    SpecialClause::InsteadClause(instead_def) => {
-                        // CR 614.1a + CR 608.2c: assemble a multi-clause base + an
-                        // "instead" override so the runtime can produce both
-                        // branches. Clause 1 becomes the root and is the Cow-swap
-                        // target — when the override's `ConditionInstead` fires,
-                        // `effects/mod.rs` swaps the root's effect with the
-                        // override's at parent resolution, and the override branch
-                        // returns terminally (see the `ConditionInstead` arm at
-                        // ~line 2713 in `effects/mod.rs`). To make the tail clauses
-                        // (2..N) conditional on the override NOT firing, we stash
-                        // them in the override's `else_ability`: the runtime only
-                        // walks `else_ability` when the swap did not happen. Net:
-                        // condition true → only the override's effect runs (clause
-                        // 1 swapped away, tail bypassed); condition false → clause
-                        // 1 runs as printed, then the tail runs from
-                        // `else_ability`. Single-clause bases collapse to the
-                        // prior shape (empty tail → no `else_ability`).
-                        if !defs.is_empty() {
-                            let mut chain_defs = std::mem::take(&mut defs);
-                            let mut root = chain_defs.remove(0);
-                            for next in chain_defs {
-                                append_to_deepest_sub_ability(&mut root, Some(Box::new(next)));
-                            }
-                            let mut instead = *instead_def.clone();
-                            // CR 702.33d + CR 707.10: Resolve "create N of those
-                            // tokens" anaphor against the root (the antecedent
-                            // for a multi-clause base is the first printed clause).
-                            rewrite_those_tokens_from_antecedent(&mut instead.effect, &root.effect);
-                            if rewrite_counter_instead_target_from_antecedent(
-                                &mut instead.effect,
-                                &root.effect,
-                            ) {
-                                instead.target_choice_timing = root.target_choice_timing;
-                            }
-                            if has_explicit_player_target(root.effect.as_ref()) {
-                                rewrite_player_anaphor_targets_in_definition(&mut instead);
-                            }
-                            instead.else_ability = root.sub_ability.take();
-                            root.sub_ability = Some(Box::new(instead));
-                            defs.push(root);
-                        }
-                        true
-                    }
-                    SpecialClause::EntersTappedAttacking => {
+                    PriorModifier::EntersTappedAttacking => {
                         // CR 508.4 / CR 614.1: Conditional enters-tapped-attacking modifier
                         if let Some(prev) = defs.last() {
                             let can_patch = matches!(
@@ -1587,6 +1533,68 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                                 defs.push(patched);
                             }
                         }
+                    }
+                }
+                true
+            } else if let ClauseDisposition::Special {
+                action: special,
+                intrinsic,
+            } = &clause_ir.disposition
+            {
+                match special {
+                    SpecialClause::DigInsteadAlt(alt_def) => {
+                        if let Some(last_def) = defs.pop() {
+                            let mut new_def = *alt_def.clone();
+                            apply_where_x_ability_expression(
+                                &mut new_def,
+                                clause_ir.where_x_expression.as_deref(),
+                            );
+                            new_def.else_ability = Some(Box::new(last_def));
+                            defs.push(new_def);
+                        }
+                        true
+                    }
+                    SpecialClause::InsteadClause(instead_def) => {
+                        // CR 614.1a + CR 608.2c: assemble a multi-clause base + an
+                        // "instead" override so the runtime can produce both
+                        // branches. Clause 1 becomes the root and is the Cow-swap
+                        // target — when the override's `ConditionInstead` fires,
+                        // `effects/mod.rs` swaps the root's effect with the
+                        // override's at parent resolution, and the override branch
+                        // returns terminally (see the `ConditionInstead` arm at
+                        // ~line 2713 in `effects/mod.rs`). To make the tail clauses
+                        // (2..N) conditional on the override NOT firing, we stash
+                        // them in the override's `else_ability`: the runtime only
+                        // walks `else_ability` when the swap did not happen. Net:
+                        // condition true → only the override's effect runs (clause
+                        // 1 swapped away, tail bypassed); condition false → clause
+                        // 1 runs as printed, then the tail runs from
+                        // `else_ability`. Single-clause bases collapse to the
+                        // prior shape (empty tail → no `else_ability`).
+                        if !defs.is_empty() {
+                            let mut chain_defs = std::mem::take(&mut defs);
+                            let mut root = chain_defs.remove(0);
+                            for next in chain_defs {
+                                append_to_deepest_sub_ability(&mut root, Some(Box::new(next)));
+                            }
+                            let mut instead = *instead_def.clone();
+                            // CR 702.33d + CR 707.10: Resolve "create N of those
+                            // tokens" anaphor against the root (the antecedent
+                            // for a multi-clause base is the first printed clause).
+                            rewrite_those_tokens_from_antecedent(&mut instead.effect, &root.effect);
+                            if rewrite_counter_instead_target_from_antecedent(
+                                &mut instead.effect,
+                                &root.effect,
+                            ) {
+                                instead.target_choice_timing = root.target_choice_timing;
+                            }
+                            if has_explicit_player_target(root.effect.as_ref()) {
+                                rewrite_player_anaphor_targets_in_definition(&mut instead);
+                            }
+                            instead.else_ability = root.sub_ability.take();
+                            root.sub_ability = Some(Box::new(instead));
+                            defs.push(root);
+                        }
                         true
                     }
                     SpecialClause::KeywordInsteadOverride => {
@@ -1647,10 +1655,6 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                                 *current = life_payment.clone();
                             }
                         }
-                        true
-                    }
-                    SpecialClause::ManaRetention(expiry) => {
-                        attach_mana_retention_to_prior_mana(&mut defs, *expiry);
                         true
                     }
                 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -150,7 +150,7 @@ use crate::parser::oracle_ir::ast::*;
 pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup};
 use crate::parser::oracle_ir::effect_chain::{
     AbilityIr, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr, ClauseIrBuilder,
-    EffectChainIr, OtherwiseKind, ReplicateKind, SpecialClause,
+    EffectChainIr, OtherwiseKind, PriorModifier, ReplicateKind, SpecialClause,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -24354,9 +24354,8 @@ pub(crate) fn parse_effect_chain_ir(
                     normalized_text,
                     placeholder_parsed_clause("alt_cost_rider_placeholder"),
                     chunk.boundary_after,
-                    ClauseDisposition::Special {
-                        action: SpecialClause::AltCostRider(cost),
-                        intrinsic: None,
+                    ClauseDisposition::ModifyPrior {
+                        modifier: PriorModifier::AltCost(cost),
                     },
                 )
                 .push();
@@ -24402,9 +24401,8 @@ pub(crate) fn parse_effect_chain_ir(
                         normalized_text,
                         placeholder_parsed_clause("mana_retention_placeholder"),
                         chunk.boundary_after,
-                        ClauseDisposition::Special {
-                            action: SpecialClause::ManaRetention(expiry),
-                            intrinsic: None,
+                        ClauseDisposition::ModifyPrior {
+                            modifier: PriorModifier::ManaRetention(expiry),
                         },
                     )
                     .push();
@@ -25397,9 +25395,8 @@ pub(crate) fn parse_effect_chain_ir(
                                 normalized_text,
                                 placeholder_parsed_clause("enters_tapped_attacking_placeholder"),
                                 chunk.boundary_after,
-                                ClauseDisposition::Special {
-                                    action: SpecialClause::EntersTappedAttacking,
-                                    intrinsic: None,
+                                ClauseDisposition::ModifyPrior {
+                                    modifier: PriorModifier::EntersTappedAttacking,
                                 },
                             )
                             .condition(condition)

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -119,14 +119,10 @@ pub(crate) enum DoesTheSameSubject {
 /// become markers that lowering processes when building the def list.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) enum SpecialClause {
-    /// CR 118.9 + CR 119.4: Alternative-cost rider — fold cost onto previous CastFromZone.
-    AltCostRider(AbilityCost),
     /// CR 608.2c: Dig-instead alternative — replace previous Dig with conditional alternative.
     DigInsteadAlt(Box<AbilityDefinition>),
     /// CR 608.2e: Generic instead clause — attach to previous def as sub_ability.
     InsteadClause(Box<AbilityDefinition>),
-    /// CR 508.4 / CR 614.1: Conditional enters-tapped-attacking modifier on previous clause.
-    EntersTappedAttacking,
     /// CR 608.2e: TargetHasKeywordInstead — attach to previous def as sub_ability.
     KeywordInsteadOverride,
     /// CR 608.2e: AdditionalCostPaidInstead + SearchLibrary — fold else_ability from previous.
@@ -134,8 +130,6 @@ pub(crate) enum SpecialClause {
     /// Follow-up to a drawn-this-turn choice: sets the life payment and
     /// confirms the topdeck branch without emitting a separate effect.
     DrawnThisTurnPayOrTopdeck { life_payment: QuantityExpr },
-    /// CR 106.4: Mana-retention rider — fold expiry onto the previous Mana effect.
-    ManaRetention(ManaExpiry),
 }
 
 // ===========================================================================
@@ -189,6 +183,10 @@ pub(crate) struct ClauseId(pub(crate) u32);
 ///   emitted (lower.rs:1314).
 /// - `special`: some arms apply `intrinsic` to the special-built def
 ///   (lower.rs:1600, `AdditionalCostInsteadSearch`).
+// Intentional: variants carry parser IR directly (the `Emit` channels hold two
+// `ContinuationAst` options). Mirrors `oracle_ir::doc.rs`. This IR enum is
+// short-lived per-clause and Vec-allocated, so the size gap is acceptable.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) enum ClauseDisposition {
     /// CR 608.2c: this clause emits its own definition(s). `followup` is a
@@ -244,6 +242,10 @@ pub(crate) enum ClauseDisposition {
         keywords: Vec<Keyword>,
         kind: ReplicateKind,
     },
+    /// CR 608.2c: fold a `PriorModifier` onto the prior emitted def; emits no
+    /// sibling. Promoted from the three rider `SpecialClause` variants (U5-M2). The
+    /// bound antecedent is the prior emitted def (implicit, as `Continue`).
+    ModifyPrior { modifier: PriorModifier },
     /// A special-case adjacency action that modifies an adjacent clause during
     /// lowering (folds the former `special: Option<SpecialClause>`). `intrinsic`
     /// carries the self-patch some special arms apply (lower.rs:1600).
@@ -270,6 +272,22 @@ pub(crate) enum AbsorbKind {
     DieExile,
     /// CR 608.2c + CR 701.19c: "dealt damage this way can't be regenerated" rider.
     CantBeRegenerated,
+}
+
+/// CR 608.2c: a field-level modification folded onto the prior emitted def
+/// (emits no sibling). Promoted from `SpecialClause::{AltCostRider, ManaRetention,
+/// EntersTappedAttacking}` (U5-M2). Each variant is a distinct rules concept that
+/// modifies a different field/aspect of the prior def.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum PriorModifier {
+    /// CR 118.9 + CR 119.4: fold an alternative cost onto the prior CastFromZone.
+    AltCost(AbilityCost),
+    /// CR 106.4: fold a mana-retention expiry onto the prior Mana effect.
+    ManaRetention(ManaExpiry),
+    /// CR 508.4 / CR 614.1: mark the prior token/copy/zone-change to enter tapped
+    /// and attacking (conditional modifier; carries the gate on the clause's
+    /// `condition`, with the unpatched original stashed in `else_ability`).
+    EntersTappedAttacking,
 }
 
 /// CR 608.2c: whether the "Otherwise" else-branch binds to a prior conditional or
@@ -387,7 +405,8 @@ impl ClauseDisposition {
             ClauseDisposition::Continue { .. }
             | ClauseDisposition::Absorb { .. }
             | ClauseDisposition::BranchOtherwise { .. }
-            | ClauseDisposition::ReplicatePerKeyword { .. } => None,
+            | ClauseDisposition::ReplicatePerKeyword { .. }
+            | ClauseDisposition::ModifyPrior { .. } => None,
         }
     }
 
@@ -403,7 +422,8 @@ impl ClauseDisposition {
             ClauseDisposition::Special { .. }
             | ClauseDisposition::Absorb { .. }
             | ClauseDisposition::BranchOtherwise { .. }
-            | ClauseDisposition::ReplicatePerKeyword { .. } => None,
+            | ClauseDisposition::ReplicatePerKeyword { .. }
+            | ClauseDisposition::ModifyPrior { .. } => None,
         }
     }
 }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -649,6 +649,44 @@ fn kathril_aspect_warper() {
 }
 
 // ---------------------------------------------------------------------------
+// Prior-def modifiers (U5-M2 ModifyPrior parity)
+// ---------------------------------------------------------------------------
+// Oracle text verified verbatim against Scryfall. AltCost + ManaRetention have
+// real cards below; the third ModifyPrior kind (EntersTappedAttacking) has no
+// card in the 568-card fixture and a complex pop+patch body — it is covered by a
+// direct handler unit test in oracle_trigger_tests.rs instead.
+
+// CR 118.9 + CR 119.4: AltCost — "pay <cost> rather than paying its mana cost."
+// folds an `alt_ability_cost` onto the prior CastFromZone play grant (Nashi,
+// Moon Sage's Scion).
+#[test]
+fn nashi_moon_sages_scion() {
+    let (ir, lowered) = parse_two_layer(
+        "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Nashi deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
+        "Nashi, Moon Sage's Scion",
+        &["Creature"],
+        &["Rat", "Ninja"],
+    );
+    insta::assert_json_snapshot!("nashi_moon_sages_scion_ir", &ir);
+    insta::assert_json_snapshot!("nashi_moon_sages_scion_lowered", &lowered);
+}
+
+// CR 106.4: ManaRetention — "you don't lose this mana as steps and phases end."
+// folds a mana-retention expiry onto the prior mana-production effect (Karn,
+// Legacy Reforged).
+#[test]
+fn karn_legacy_reforged() {
+    let (ir, lowered) = parse_two_layer(
+        "Karn's power and toughness are each equal to the greatest mana value among artifacts you control.\nAt the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
+        "Karn, Legacy Reforged",
+        &["Artifact", "Creature"],
+        &["Golem"],
+    );
+    insta::assert_json_snapshot!("karn_legacy_reforged_ir", &ir);
+    insta::assert_json_snapshot!("karn_legacy_reforged_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
 // Triggers (various patterns)
 // ---------------------------------------------------------------------------
 

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_ir.snap
@@ -1,0 +1,165 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 94,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "~'s power and toughness are each equal to the greatest mana value among artifacts you control."
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
+            "type": "SelfRef"
+          },
+          "modifications": [
+            {
+              "type": "SetDynamicPower",
+              "value": {
+                "type": "Ref",
+                "qty": {
+                  "type": "Aggregate",
+                  "function": "Max",
+                  "property": "ManaValue",
+                  "filter": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Artifact"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  }
+                }
+              }
+            },
+            {
+              "type": "SetDynamicToughness",
+              "value": {
+                "type": "Ref",
+                "qty": {
+                  "type": "Aggregate",
+                  "function": "Max",
+                  "property": "ManaValue",
+                  "filter": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Artifact"
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  }
+                }
+              }
+            }
+          ],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": true,
+          "description": "~'s power and toughness are each equal to the greatest mana value among artifacts you control."
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 95,
+          "end_byte": 288,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "At the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Phase",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Mana",
+              "produced": {
+                "type": "Colorless",
+                "count": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "ObjectCount",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Artifact"
+                      ],
+                      "controller": "You",
+                      "properties": []
+                    }
+                  }
+                }
+              },
+              "restrictions": [
+                {
+                  "SpellTypeOrAbilityActivation": {
+                    "spell_type": "Artifact",
+                    "ability": "Any"
+                  }
+                }
+              ],
+              "expiry": "EndOfTurn"
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "is_mana_ability": true
+          },
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": "Upkeep",
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "At the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
+          "constraint": {
+            "type": "OnlyDuringYourTurn"
+          },
+          "condition": null,
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "Karn's power and toughness are each equal to the greatest mana value among artifacts you control.\nAt the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
+  "card_name": "Karn, Legacy Reforged"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_lowered.snap
@@ -1,0 +1,128 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "Phase",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Mana",
+          "produced": {
+            "type": "Colorless",
+            "count": {
+              "type": "Ref",
+              "qty": {
+                "type": "ObjectCount",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Artifact"
+                  ],
+                  "controller": "You",
+                  "properties": []
+                }
+              }
+            }
+          },
+          "restrictions": [
+            {
+              "SpellTypeOrAbilityActivation": {
+                "spell_type": "Artifact",
+                "ability": "Any"
+              }
+            }
+          ],
+          "expiry": "EndOfTurn"
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false,
+        "is_mana_ability": true
+      },
+      "valid_card": null,
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": "Upkeep",
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "At the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
+      "constraint": {
+        "type": "OnlyDuringYourTurn"
+      },
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "SelfRef"
+      },
+      "modifications": [
+        {
+          "type": "SetDynamicPower",
+          "value": {
+            "type": "Ref",
+            "qty": {
+              "type": "Aggregate",
+              "function": "Max",
+              "property": "ManaValue",
+              "filter": {
+                "type": "Typed",
+                "type_filters": [
+                  "Artifact"
+                ],
+                "controller": "You",
+                "properties": []
+              }
+            }
+          }
+        },
+        {
+          "type": "SetDynamicToughness",
+          "value": {
+            "type": "Ref",
+            "qty": {
+              "type": "Aggregate",
+              "function": "Max",
+              "property": "ManaValue",
+              "filter": {
+                "type": "Typed",
+                "type_filters": [
+                  "Artifact"
+                ],
+                "controller": "You",
+                "properties": []
+              }
+            }
+          }
+        }
+      ],
+      "condition": null,
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": true,
+      "description": "~'s power and toughness are each equal to the greatest mana value among artifacts you control."
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__nashi_moon_sages_scion_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__nashi_moon_sages_scion_ir.snap
@@ -1,0 +1,138 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 147,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)"
+      },
+      "node": {
+        "Keyword": {
+          "Ninjutsu": {
+            "type": "Cost",
+            "shards": [
+              "Black"
+            ],
+            "generic": 3
+          }
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 148,
+          "end_byte": 385,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever ~ deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "DamageDone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "ExileTop",
+              "player": {
+                "type": "Controller"
+              },
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "CastFromZone",
+                "target": {
+                  "type": "TrackedSet",
+                  "id": 0
+                },
+                "without_paying_mana_cost": false,
+                "mode": "Play",
+                "alt_ability_cost": {
+                  "type": "PayLife",
+                  "amount": {
+                    "type": "Ref",
+                    "qty": {
+                      "type": "SelfManaValue"
+                    }
+                  }
+                },
+                "duration": "UntilEndOfTurn"
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": "UntilEndOfTurn",
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false,
+              "sub_link": "SequentialSibling"
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "player_scope": {
+              "type": "All"
+            }
+          },
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "CombatOnly",
+          "secondary": false,
+          "valid_target": {
+            "type": "Player"
+          },
+          "valid_source": {
+            "type": "SelfRef"
+          },
+          "description": "Whenever ~ deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Nashi deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
+  "card_name": "Nashi, Moon Sage's Scion"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__nashi_moon_sages_scion_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__nashi_moon_sages_scion_lowered.snap
@@ -1,0 +1,101 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "DamageDone",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "ExileTop",
+          "player": {
+            "type": "Controller"
+          },
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "CastFromZone",
+            "target": {
+              "type": "TrackedSet",
+              "id": 0
+            },
+            "without_paying_mana_cost": false,
+            "mode": "Play",
+            "alt_ability_cost": {
+              "type": "PayLife",
+              "amount": {
+                "type": "Ref",
+                "qty": {
+                  "type": "SelfManaValue"
+                }
+              }
+            },
+            "duration": "UntilEndOfTurn"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false,
+          "sub_link": "SequentialSibling"
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false,
+        "player_scope": {
+          "type": "All"
+        }
+      },
+      "valid_card": null,
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "CombatOnly",
+      "secondary": false,
+      "valid_target": {
+        "type": "Player"
+      },
+      "valid_source": {
+        "type": "SelfRef"
+      },
+      "description": "Whenever ~ deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": [
+    {
+      "Ninjutsu": {
+        "type": "Cost",
+        "shards": [
+          "Black"
+        ],
+        "generic": 3
+      }
+    }
+  ]
+}

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -17496,6 +17496,109 @@ fn branch_otherwise_fallback_self_emits_unimplemented_marker_and_else() {
     );
 }
 
+/// CR 508.4 / CR 614.1: direct handler coverage for `ClauseDisposition::ModifyPrior
+/// { modifier: EntersTappedAttacking }`. No card in the 568-card fixture produces
+/// it, and its lowering body (pop the prior token/copy/zone-change, set
+/// enters-tapped-attacking, stash the unpatched original as `else_ability` gated
+/// on the clause condition) is the most involved of the three ModifyPrior kinds —
+/// so this constructs the disposition directly to pin the verbatim-moved body.
+/// The Token effect is sourced from the real parser to avoid hand-listing every
+/// `Effect::Token` field.
+#[test]
+fn modify_prior_enters_tapped_attacking_patches_prior_token_with_condition_else() {
+    use crate::parser::oracle_effect::parse_effect_chain;
+    use crate::parser::oracle_ir::ast::{parsed_clause, ClauseBoundary};
+    use crate::parser::oracle_ir::effect_chain::{
+        ClauseDisposition, ClauseIrBuilder, EffectChainIr, PriorModifier,
+    };
+
+    let token_def = parse_effect_chain(
+        "Create a 1/1 white Soldier creature token.",
+        AbilityKind::Spell,
+    );
+    let token_effect = (*token_def.effect).clone();
+    // Precondition: a Token that does NOT yet enter tapped/attacking.
+    assert!(
+        matches!(
+            &token_effect,
+            Effect::Token {
+                enters_attacking: false,
+                tapped: false,
+                ..
+            }
+        ),
+        "fixture must be a plain Token, got {token_effect:?}"
+    );
+
+    let gate = AbilityCondition::effect_performed();
+
+    let mut builder = ClauseIrBuilder::new("");
+    // clause 0: the token creation (normal Emit).
+    builder
+        .clause(
+            "",
+            parsed_clause(token_effect),
+            Some(ClauseBoundary::Sentence),
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
+    // clause 1: the conditional enters-tapped-attacking modifier on the prior token.
+    builder
+        .clause(
+            "",
+            parsed_clause(Effect::NoOp),
+            None,
+            ClauseDisposition::ModifyPrior {
+                modifier: PriorModifier::EntersTappedAttacking,
+            },
+        )
+        .condition(Some(gate.clone()))
+        .push();
+    let ir = EffectChainIr {
+        clauses: builder.finish(),
+        kind: AbilityKind::Spell,
+        chain_rounding: None,
+        actor: None,
+        repeat_until: None,
+    };
+
+    let root = lower_effect_chain_ir(&ir);
+    // The prior token is patched to enter tapped + attacking, gated by the condition …
+    assert!(
+        matches!(
+            &*root.effect,
+            Effect::Token {
+                enters_attacking: true,
+                tapped: true,
+                ..
+            }
+        ),
+        "patched token must enter tapped+attacking, got {:?}",
+        root.effect
+    );
+    assert_eq!(root.condition.as_ref(), Some(&gate));
+    // … with the UNPATCHED original stashed as the else_ability.
+    let original = root
+        .else_ability
+        .as_deref()
+        .expect("else_ability must carry the unpatched original token");
+    assert!(
+        matches!(
+            &*original.effect,
+            Effect::Token {
+                enters_attacking: false,
+                tapped: false,
+                ..
+            }
+        ),
+        "else_ability must be the unpatched token, got {:?}",
+        original.effect
+    );
+}
+
 #[test]
 fn trigger_subject_predicate_it_gains() {
     // "it gains haste" — subject-predicate with "it" as subject.


### PR DESCRIPTION
Fourth U5-M2 increment. AltCostRider + ManaRetention + EntersTappedAttacking
(CR 118.9 / CR 106.4 / CR 508.4) share the structural role "modify a field of the
prior emitted def, emit no sibling" and fold into
`ClauseDisposition::ModifyPrior { modifier: PriorModifier }`, where `PriorModifier`
(AltCost | ManaRetention | EntersTappedAttacking) keeps each distinct rules concept
typed. The three lower.rs handler bodies (including the EntersTappedAttacking
pop+patch that stashes the unpatched original in else_ability) move verbatim under
`match modifier`. All three SpecialClause variants are deleted.

Faithful-by-construction (ClauseDisposition never reaches a serialized snapshot).
Parity: Nashi, Moon Sage's Scion (AltCost, alt_ability_cost folded onto the prior
CastFromZone) and Karn, Legacy Reforged (ManaRetention, expiry folded onto the mana
effect), zero snapshot drift. The third kind (EntersTappedAttacking) has no card in
the 568-card fixture, so its verbatim-moved pop+patch body is pinned by a direct
handler unit test instead.

clippy::large_enum_variant is allowed on ClauseDisposition (matching the sibling
oracle_ir/doc.rs convention): shrinking SpecialClause exposed the pre-existing large
`Emit` variant (two ContinuationAst option channels); the per-clause IR enum is
short-lived and Vec-allocated, so the size gap is acceptable.
