### PR TITLE
Fix Grave Sifter per-player creature-type graveyard return (#5279)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2475,6 +2475,19 @@ fn is_player_scope_local_continuation(parent: &Effect, child: &Effect) -> bool {
                 },
                 Effect::Shuffle { .. }
             )
+            // CR 608.2c + CR 101.4: "each player chooses [value] and returns
+            // [cards] from their graveyard to their hand" (Grave Sifter) — the
+            // persisting `Choose` and the graveyard `ChangeZone` are one
+            // per-player instruction. Detaching the return as an unscoped tail
+            // would run every player's return only after ALL players chose,
+            // skipping each player's return after their own choice (#5279).
+            | (
+                Effect::Choose { persist: true, .. },
+                Effect::ChangeZone {
+                    origin: Some(_),
+                    ..
+                }
+            )
     )
 }
 
@@ -2644,6 +2657,15 @@ fn detach_after_player_scope_local_chain(
         || next_is_optional_clause_continuation
         || is_player_scope_local_continuation(&node.effect, &next.effect)
     {
+        // CR 608.2c: co-scoped continuations kept inside the scoped template
+        // inherit the outer iteration — redundant `player_scope` on the child
+        // would re-enter the fan-out driver mid-instruction (Grave Sifter:
+        // Choose → graveyard ChangeZone must run once per outer iteration).
+        if next_is_co_scoped_anaphoric_consumer
+            || is_player_scope_local_continuation(&node.effect, &next.effect)
+        {
+            next.player_scope = None;
+        }
         let tail = detach_after_player_scope_local_chain(&mut next, scope, referent_in_scope);
         node.sub_ability = Some(next);
         tail
@@ -9610,12 +9632,12 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{
         AbilityCondition, AbilityDefinition, AbilityKind, AggregateFunction, BounceSelection,
-        CardPredicateChoice, CastingPermission, ChoiceValue, Chooser, ChosenAttribute, Comparator,
-        ContinuousModification, ControllerRef, DelayedTriggerCondition, Duration, EffectScope,
-        FilterProp, ManaSpendPermission, ObjectProperty, PermissionGrantee, PlayerFilter,
-        PlayerScope, PtValue, QuantityExpr, QuantityRef, SpellContext, StaticDefinition,
-        TapStateChange, TargetFilter, TargetRef, TypeFilter, TypedFilter, UnlessPayModifier,
-        UntilCondition, ZoneOwner,
+        CardPredicateChoice, CastingPermission, ChoiceType, ChoiceValue, Chooser, ChosenAttribute,
+        Comparator, ContinuousModification, ControllerRef, DelayedTriggerCondition, Duration,
+        EffectScope, FilterProp, ManaSpendPermission, ObjectProperty, PermissionGrantee,
+        PlayerFilter, PlayerScope, PtValue, QuantityExpr, QuantityRef, SpellContext,
+        StaticDefinition, TapStateChange, TargetFilter, TargetRef, TargetSelectionMode, TypeFilter,
+        TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
     };
     use crate::types::actions::GameAction;
     use crate::types::card::CardFace;
@@ -17520,6 +17542,64 @@ mod tests {
             detached.player_scope,
             Some(PlayerFilter::All),
             "the detached Draw keeps its own player_scope so it fans out post-all-reveals"
+        );
+
+        // Choose(CreatureType) → ChangeZone(graveyard return), all scope=All
+        // (Grave Sifter, issue #5279). The return must stay inside each outer
+        // iteration and must not re-enter the fan-out driver mid-instruction.
+        let mut choose_return = ResolvedAbility::new(
+            Effect::Choose {
+                choice_type: ChoiceType::creature_type(),
+                persist: true,
+                selection: TargetSelectionMode::Chosen,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        );
+        choose_return.player_scope = Some(PlayerFilter::All);
+        let mut graveyard_return = ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: Some(Zone::Graveyard),
+                destination: Zone::Hand,
+                target: TargetFilter::Typed(
+                    TypedFilter::card().properties(vec![FilterProp::IsChosenCreatureType]),
+                ),
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: true,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        );
+        graveyard_return.player_scope = Some(PlayerFilter::All);
+        choose_return.sub_ability = Some(Box::new(graveyard_return));
+
+        let (scoped_choose, tail_choose) =
+            split_player_scope_chain(&choose_return, &PlayerFilter::All);
+        assert!(
+            tail_choose.is_none(),
+            "the graveyard return stays inside the choose iteration"
+        );
+        let return_in_scope = scoped_choose
+            .sub_ability
+            .as_ref()
+            .expect("ChangeZone stays attached");
+        assert!(
+            matches!(return_in_scope.effect, Effect::ChangeZone { .. }),
+            "ChangeZone is the kept sub-clause"
+        );
+        assert!(
+            return_in_scope.player_scope.is_none(),
+            "the kept ChangeZone's redundant player_scope is cleared"
         );
     }
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2661,9 +2661,7 @@ fn detach_after_player_scope_local_chain(
         // inherit the outer iteration — redundant `player_scope` on the child
         // would re-enter the fan-out driver mid-instruction (Grave Sifter:
         // Choose → graveyard ChangeZone must run once per outer iteration).
-        if next_is_co_scoped_anaphoric_consumer
-            || is_player_scope_local_continuation(&node.effect, &next.effect)
-        {
+        if is_player_scope_local_continuation(&node.effect, &next.effect) {
             next.player_scope = None;
         }
         let tail = detach_after_player_scope_local_chain(&mut next, scope, referent_in_scope);

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1775,6 +1775,17 @@ pub(super) fn parse_targeted_action_ast(
         } else {
             (is_mass, target_text)
         };
+        // CR 107.1c: "return any number of [filter] cards" — strip the quantifier
+        // before target parsing and carry `up_to` onto `ReturnToZone` (Grave Sifter).
+        let target_lower = target_text.to_ascii_lowercase();
+        let any_number_prefix = tag::<_, _, OracleError<'_>>("any number of ")
+            .parse(target_lower.as_str())
+            .ok()
+            .map(|(rest, _)| target_lower.len() - rest.len());
+        let (target_text, return_up_to) = match any_number_prefix {
+            Some(consumed) => (&target_text[consumed..], true),
+            None => (target_text, false),
+        };
         let counted_return = parse_count_expr(target_text).and_then(|(mut count, after_count)| {
             let filter = extract_object_count_filter(&count)?;
             if nom_primitives::scan_contains(rest_lower, "rounded up") {
@@ -1907,6 +1918,7 @@ pub(super) fn parse_targeted_action_ast(
                         target,
                         origin,
                         destination: Zone::Hand,
+                        up_to: return_up_to,
                     })
                 } else {
                     Some(TargetedImperativeAst::Return { target, selection })
@@ -1927,6 +1939,7 @@ pub(super) fn parse_targeted_action_ast(
                         target,
                         origin,
                         destination: d.zone,
+                        up_to: return_up_to,
                     })
                 }
             }
@@ -2160,6 +2173,7 @@ pub(super) fn lower_targeted_action_ast(ast: TargetedImperativeAst) -> Effect {
             target,
             origin,
             destination,
+            up_to,
         } => Effect::ChangeZone {
             origin,
             destination,
@@ -2169,7 +2183,7 @@ pub(super) fn lower_targeted_action_ast(ast: TargetedImperativeAst) -> Effect {
             enters_under: None,
             enter_tapped: crate::types::zones::EtbTapState::Unspecified,
             enters_attacking: false,
-            up_to: false,
+            up_to,
             enter_with_counters: vec![],
             conditional_enter_with_counters: vec![],
             face_down_profile: None,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13957,6 +13957,7 @@ fn try_parse_verb_and_target<'a>(
                             target,
                             origin,
                             destination: Zone::Hand,
+                            up_to: false,
                         },
                         rem,
                     ))
@@ -13983,6 +13984,7 @@ fn try_parse_verb_and_target<'a>(
                             target,
                             origin,
                             destination: d.zone,
+                            up_to: false,
                         },
                         rem,
                     ))

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -968,6 +968,9 @@ pub(crate) enum TargetedImperativeAst {
         target: TargetFilter,
         origin: Option<Zone>,
         destination: Zone,
+        /// CR 107.1c: "return any number of [filter] cards" — zero-or-more
+        /// resolution-time zone selection (Grave Sifter class).
+        up_to: bool,
     },
     /// CR 400.7 + CR 608.2c: Mass return to a non-default zone. Lowers to
     /// `ChangeZoneAll` so the resolver scans every matching object instead of

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -9,11 +9,11 @@ use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
 use crate::types::ability::{
-    AggregateFunction, AttachmentKind, CombatRelation, CombatRelationSubject, Comparator,
-    ControllerRef, CountScope, DamageKindFilter, FilterProp, ObjectProperty, ObjectScope,
-    ParitySource, PlayerFilter, PtStat, PtValueScope, QuantityExpr, QuantityRef, SeatDirection,
-    SharedQuality, SharedQualityRelation, TargetFilter, TargetSelectionMode, TypeFilter,
-    TypedFilter,
+    AggregateFunction, AttachmentKind, ChoiceType, CombatRelation, CombatRelationSubject,
+    Comparator, ControllerRef, CountScope, DamageKindFilter, FilterProp, ObjectProperty,
+    ObjectScope, ParitySource, PlayerFilter, PtStat, PtValueScope, QuantityExpr, QuantityRef,
+    SeatDirection, SharedQuality, SharedQualityRelation, TargetFilter, TargetSelectionMode,
+    TypeFilter, TypedFilter,
 };
 use crate::types::card_type::Supertype;
 use crate::types::counter::{CounterMatch, CounterType};
@@ -2983,8 +2983,17 @@ pub fn parse_type_phrase_with_ctx<'a>(
                     | TypeFilter::Battle
             )
         );
+        // CR 205.2a + CR 608.2c: When a preceding `Choose` committed
+        // `CreatureType`, "cards of that type" still refers to the chosen
+        // creature subtype (Grave Sifter), not a card type — even though the
+        // head noun is `Card`. Without this override, `IsChosenCardType` reads
+        // the wrong `ChosenAttribute` axis and the graveyard return finds no
+        // eligible cards.
         let chosen_prop = if is_card_typed_base {
-            FilterProp::IsChosenCardType
+            match ctx.pending_choice_type.as_ref() {
+                Some(ChoiceType::CreatureType { .. }) => FilterProp::IsChosenCreatureType,
+                _ => FilterProp::IsChosenCardType,
+            }
         } else {
             FilterProp::IsChosenCreatureType
         };

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2983,7 +2983,7 @@ pub fn parse_type_phrase_with_ctx<'a>(
                     | TypeFilter::Battle
             )
         );
-        // CR 205.2a + CR 608.2c: When a preceding `Choose` committed
+        // CR 205.3m + CR 608.2c: When a preceding `Choose` committed
         // `CreatureType`, "cards of that type" still refers to the chosen
         // creature subtype (Grave Sifter), not a card type — even though the
         // head noun is `Card`. Without this override, `IsChosenCardType` reads

--- a/crates/engine/tests/integration/issue_5279_grave_sifter.rs
+++ b/crates/engine/tests/integration/issue_5279_grave_sifter.rs
@@ -1,0 +1,210 @@
+//! Issue #5279: Grave Sifter (Discord report title "Grace Sifter") — each player
+//! chooses a creature type and returns any number of matching cards from their
+//! graveyard to their hand.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{ChoiceType, Effect, FilterProp, PlayerFilter, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const GRAVE_SIFTER_ORACLE: &str =
+    "When this creature enters, each player chooses a creature type and returns any number of cards of that type from their graveyard to their hand.";
+
+fn parsed_grave_sifter() -> engine::parser::oracle::ParsedAbilities {
+    parse_oracle_text(
+        GRAVE_SIFTER_ORACLE,
+        "Grave Sifter",
+        &[],
+        &["Creature".to_string()],
+        &["Elemental".to_string(), "Beast".to_string()],
+    )
+}
+
+fn setup_grave_sifter_cast() -> (engine::game::scenario::GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let bears = scenario
+        .add_creature_to_graveyard(P0, "Grizzly Bears", 2, 2)
+        .with_subtypes(vec!["Bear"])
+        .id();
+    let _hill_giant = scenario
+        .add_creature_to_graveyard(P1, "Hill Giant", 3, 3)
+        .with_subtypes(vec!["Giant"])
+        .id();
+
+    let grave_sifter = scenario
+        .add_creature_to_hand_from_oracle(P0, "Grave Sifter", 5, 7, GRAVE_SIFTER_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 5,
+            shards: vec![ManaCostShard::Green],
+        })
+        .id();
+
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Green, ObjectId(9_990), false, vec![]),
+            ManaUnit::new(ManaType::Green, ObjectId(9_991), false, vec![]),
+            ManaUnit::new(ManaType::Green, ObjectId(9_992), false, vec![]),
+            ManaUnit::new(ManaType::Green, ObjectId(9_993), false, vec![]),
+            ManaUnit::new(ManaType::Green, ObjectId(9_994), false, vec![]),
+            ManaUnit::new(ManaType::Green, ObjectId(9_995), false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+    runner.state_mut().all_creature_types = vec![
+        "Bear".to_string(),
+        "Giant".to_string(),
+        "Elemental".to_string(),
+        "Beast".to_string(),
+    ];
+
+    (runner, grave_sifter, bears)
+}
+
+#[test]
+fn grave_sifter_etb_parses_choose_creature_type_per_player() {
+    let parsed = parsed_grave_sifter();
+    let trigger = parsed.triggers.first().expect("ETB trigger");
+    let execute = trigger.execute.as_ref().expect("execute");
+    assert!(
+        matches!(
+            execute.effect.as_ref(),
+            Effect::Choose {
+                choice_type,
+                persist: true,
+                ..
+            } if matches!(choice_type, ChoiceType::CreatureType { .. })
+        ),
+        "top effect must be persisting CreatureType Choose, got {:?}",
+        execute.effect
+    );
+    assert_eq!(
+        execute.player_scope,
+        Some(PlayerFilter::All),
+        "each player chooses must set player_scope: All"
+    );
+    let sub = execute.sub_ability.as_ref().expect("return sub");
+    if let Effect::ChangeZone {
+        target,
+        origin,
+        up_to,
+        ..
+    } = sub.effect.as_ref()
+    {
+        assert_eq!(
+            *origin,
+            Some(Zone::Graveyard),
+            "graveyard return must set origin"
+        );
+        assert!(*up_to, "any number of cards must set up_to on ChangeZone");
+        if let TargetFilter::Typed(tf) = target {
+            assert!(
+                tf.properties
+                    .iter()
+                    .any(|p| matches!(p, FilterProp::IsChosenCreatureType)),
+                "creature-type choice must filter with IsChosenCreatureType, got {:?}",
+                tf.properties
+            );
+        } else {
+            panic!("expected Typed target on graveyard return, got {target:?}");
+        }
+    } else {
+        panic!(
+            "sub must return graveyard cards to hand, got {:?}",
+            sub.effect
+        );
+    }
+}
+
+#[test]
+fn grave_sifter_etb_prompts_creature_type_choice() {
+    let (mut runner, grave_sifter, _bears) = setup_grave_sifter_cast();
+
+    runner.cast(grave_sifter).resolve();
+
+    match &runner.state().waiting_for {
+        WaitingFor::NamedChoice {
+            player,
+            choice_type,
+            options,
+            ..
+        } => {
+            assert_eq!(
+                *player, P0,
+                "APNAP: active player chooses creature type first"
+            );
+            assert!(
+                matches!(choice_type, ChoiceType::CreatureType { .. }),
+                "prompt must be creature type choice, got {choice_type:?}"
+            );
+            assert!(
+                options.iter().any(|o| o.eq_ignore_ascii_case("Bear")),
+                "Bear must be a legal creature type option: {options:?}"
+            );
+        }
+        other => {
+            panic!("Grave Sifter ETB must surface NamedChoice for creature type, got {other:?}")
+        }
+    }
+}
+
+#[test]
+fn grave_sifter_each_player_creature_type_return_from_graveyard() {
+    let (mut runner, grave_sifter, bears) = setup_grave_sifter_cast();
+
+    runner.cast(grave_sifter).resolve();
+
+    runner
+        .act(GameAction::ChooseOption {
+            choice: "Bear".to_string(),
+        })
+        .expect("P0 chooses Bear");
+
+    match &runner.state().waiting_for {
+        WaitingFor::EffectZoneChoice {
+            player,
+            cards,
+            up_to,
+            ..
+        } => {
+            assert_eq!(*player, P0, "P0 must choose cards from their graveyard");
+            assert!(cards.contains(&bears), "Grizzly Bears must be eligible");
+            assert!(*up_to, "any number of cards must allow up-to selection");
+        }
+        other => panic!(
+            "after P0 chooses Bear, expected EffectZoneChoice for graveyard return, got {other:?}"
+        ),
+    }
+
+    runner
+        .act(GameAction::SelectCards { cards: vec![bears] })
+        .expect("P0 returns Grizzly Bears");
+
+    match &runner.state().waiting_for {
+        WaitingFor::NamedChoice { player, .. } => {
+            assert_eq!(*player, P1, "APNAP: opponent chooses creature type next");
+        }
+        other => panic!("expected P1 NamedChoice after P0 return, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::ChooseOption {
+            choice: "Giant".to_string(),
+        })
+        .expect("P1 chooses Giant");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&bears].zone,
+        Zone::Hand,
+        "Grizzly Bears must return to P0's hand"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -437,6 +437,7 @@ mod issue_4962_volo_guide_to_monsters;
 mod issue_4999_treasure_cruise_delve_tokens;
 mod issue_5145_violent_eruption_choose_target_distribution;
 mod issue_5159_attacks_alone_investigate;
+mod issue_5279_grave_sifter;
 mod issue_5282_nissa_ultimate_emblem_search;
 mod issue_5283_hall_of_bandit_lord;
 mod issue_5285_senu_keen_eyed_protector;


### PR DESCRIPTION

Closes #5279

## Summary

Discord report title "Grace Sifter" maps to **Grave Sifter** (C14). Oracle: each player chooses a creature type, then returns any number of matching cards from their graveyard to their hand.

Three bugs blocked the ETB:

1. **Wrong chosen-type filter** — after a `CreatureType` choice, `"cards of that type"` parsed as `IsChosenCardType` (card-typed base). Runtime stores the choice on `ChosenAttribute::CreatureType`, so no graveyard cards matched and the return step was skipped.
2. **Missing up-to** — `"returns any number of"` did not set `up_to: true` on the graveyard `ChangeZone`.
3. **Player-scope chain split** — parser stamps `player_scope: All` on both `Choose` and `ChangeZone`. Keeping the return inside the scoped template without clearing the child's redundant `player_scope` re-entered the fan-out driver mid-instruction, skipping P0's graveyard return and jumping to P1's creature-type choice.

## Files changed

- `crates/engine/src/parser/oracle_target.rs` — `IsChosenCreatureType` when pending choice is `CreatureType`
- `crates/engine/src/parser/oracle_effect/imperative.rs` — strip `"any number of "`, thread `up_to`
- `crates/engine/src/parser/oracle_ir/ast.rs` — `up_to` on `ReturnToZone`
- `crates/engine/src/parser/oracle_effect/mod.rs` — `ReturnToZone` lowering sites
- `crates/engine/src/game/effects/mod.rs` — `is_player_scope_local_continuation` + clear redundant child `player_scope`
- `crates/engine/tests/integration/issue_5279_grave_sifter.rs` — regression tests
- `crates/engine/tests/integration/main.rs` — mod registration

## Test plan

- [x] `grave_sifter_etb_parses_choose_creature_type_per_player` — `Choose(CreatureType)` + `player_scope: All`, sub `ChangeZone` with `IsChosenCreatureType`, `origin: Graveyard`, `up_to: true`
- [x] `grave_sifter_etb_prompts_creature_type_choice` — APNAP `NamedChoice` with Bear in options
- [x] `grave_sifter_each_player_creature_type_return_from_graveyard` — P0 chooses Bear → `EffectZoneChoice` for Grizzly Bears → P1 chooses Giant → bear returns to hand
- [x] `split_player_scope_keeps_reveal_anaphora_chain_but_detaches_aggregate` — Choose → ChangeZone stays inside scoped template; child `player_scope` cleared

## Verification

```bash
cargo fmt --all
cargo test -p engine --lib split_player_scope_keeps_reveal
cargo test -p engine issue_5279 -- --nocapture
```

- [x] `cargo fmt --all`
- [x] `cargo test -p engine --lib split_player_scope_keeps_reveal`
- [x] `cargo test -p engine issue_5279 -- --nocapture`
- [ ] `tilt logs clippy` / `tilt logs test-engine` (when Tilt is up)

