### PR TITLE
refactor(parser): promote instead-override SpecialClause variants to ClauseDisposition::ReplaceMeaning (U5-M2)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -26,8 +26,8 @@ use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::effect_chain::{
-    ClauseDisposition, ClauseIr, EffectChainIr, OtherwiseKind, PriorModifier, ReplicateKind,
-    SpecialClause,
+    ClauseDisposition, ClauseIr, EffectChainIr, OtherwiseKind, PriorModifier, ReplaceMeaningKind,
+    ReplicateKind, SpecialClause,
 };
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
@@ -1536,13 +1536,14 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                     }
                 }
                 true
-            } else if let ClauseDisposition::Special {
-                action: special,
-                intrinsic,
-            } = &clause_ir.disposition
+            } else if let ClauseDisposition::ReplaceMeaning { kind: replace_kind } =
+                &clause_ir.disposition
             {
-                match special {
-                    SpecialClause::DigInsteadAlt(alt_def) => {
+                // CR 608.2c / CR 614.1a: replace/override the meaning of the prior
+                // emitted def(s); `kind` selects which (moved verbatim from the old
+                // SpecialClause arms).
+                match replace_kind {
+                    ReplaceMeaningKind::DigAlt(alt_def) => {
                         if let Some(last_def) = defs.pop() {
                             let mut new_def = *alt_def.clone();
                             apply_where_x_ability_expression(
@@ -1554,7 +1555,7 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                         }
                         true
                     }
-                    SpecialClause::InsteadClause(instead_def) => {
+                    ReplaceMeaningKind::Instead(instead_def) => {
                         // CR 614.1a + CR 608.2c: assemble a multi-clause base + an
                         // "instead" override so the runtime can produce both
                         // branches. Clause 1 becomes the root and is the Cow-swap
@@ -1597,7 +1598,7 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                         }
                         true
                     }
-                    SpecialClause::KeywordInsteadOverride => {
+                    ReplaceMeaningKind::KeywordOverride => {
                         // Build the def for this clause and attach to previous as sub_ability
                         let mut def = AbilityDefinition::new(kind, clause_ir.parsed.effect.clone());
                         let effective_cond = clause_ir
@@ -1612,6 +1613,13 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                         }
                         true
                     }
+                }
+            } else if let ClauseDisposition::Special {
+                action: special,
+                intrinsic,
+            } = &clause_ir.disposition
+            {
+                match special {
                     SpecialClause::AdditionalCostInsteadSearch => {
                         // Build this clause's def and fold else_ability from the trailing clause.
                         // The trailing ChangeZone was produced by the previous SearchLibrary's

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -150,7 +150,7 @@ use crate::parser::oracle_ir::ast::*;
 pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup};
 use crate::parser::oracle_ir::effect_chain::{
     AbilityIr, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr, ClauseIrBuilder,
-    EffectChainIr, OtherwiseKind, PriorModifier, ReplicateKind, SpecialClause,
+    EffectChainIr, OtherwiseKind, PriorModifier, ReplaceMeaningKind, ReplicateKind, SpecialClause,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -24986,9 +24986,8 @@ pub(crate) fn parse_effect_chain_ir(
                             normalized_text,
                             parsed_clause((*alt_def.effect).clone()),
                             chunk.boundary_after,
-                            ClauseDisposition::Special {
-                                action: SpecialClause::DigInsteadAlt(Box::new(alt_def)),
-                                intrinsic: None,
+                            ClauseDisposition::ReplaceMeaning {
+                                kind: ReplaceMeaningKind::DigAlt(Box::new(alt_def)),
                             },
                         )
                         .where_x_expression(inherited_where_x_expression)
@@ -25084,9 +25083,8 @@ pub(crate) fn parse_effect_chain_ir(
                         normalized_text,
                         placeholder_parsed_clause("instead_clause_placeholder"),
                         chunk.boundary_after,
-                        ClauseDisposition::Special {
-                            action: SpecialClause::InsteadClause(Box::new(instead_def)),
-                            intrinsic: None,
+                        ClauseDisposition::ReplaceMeaning {
+                            kind: ReplaceMeaningKind::Instead(Box::new(instead_def)),
                         },
                     )
                     .push();
@@ -26554,9 +26552,8 @@ pub(crate) fn parse_effect_chain_ir(
                     normalized_text,
                     clause,
                     chunk.boundary_after,
-                    ClauseDisposition::Special {
-                        action: SpecialClause::KeywordInsteadOverride,
-                        intrinsic: None,
+                    ClauseDisposition::ReplaceMeaning {
+                        kind: ReplaceMeaningKind::KeywordOverride,
                     },
                 )
                 .condition(condition)

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -119,12 +119,6 @@ pub(crate) enum DoesTheSameSubject {
 /// become markers that lowering processes when building the def list.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) enum SpecialClause {
-    /// CR 608.2c: Dig-instead alternative — replace previous Dig with conditional alternative.
-    DigInsteadAlt(Box<AbilityDefinition>),
-    /// CR 608.2e: Generic instead clause — attach to previous def as sub_ability.
-    InsteadClause(Box<AbilityDefinition>),
-    /// CR 608.2e: TargetHasKeywordInstead — attach to previous def as sub_ability.
-    KeywordInsteadOverride,
     /// CR 608.2e: AdditionalCostPaidInstead + SearchLibrary — fold else_ability from previous.
     AdditionalCostInsteadSearch,
     /// Follow-up to a drawn-this-turn choice: sets the life payment and
@@ -246,6 +240,13 @@ pub(crate) enum ClauseDisposition {
     /// sibling. Promoted from the three rider `SpecialClause` variants (U5-M2). The
     /// bound antecedent is the prior emitted def (implicit, as `Continue`).
     ModifyPrior { modifier: PriorModifier },
+    /// CR 608.2c / CR 614.1a: this clause replaces or overrides the meaning of the
+    /// prior emitted def(s) rather than emitting an independent sibling. Promoted
+    /// from `SpecialClause::{DigInsteadAlt, InsteadClause, KeywordInsteadOverride}`
+    /// (U5-M2). `kind` carries each variant's payload and keeps the distinct rules
+    /// concept typed (Plan 01 §5 line 811). Bound antecedent is the prior emitted
+    /// def(s) (implicit, as `Continue`).
+    ReplaceMeaning { kind: ReplaceMeaningKind },
     /// A special-case adjacency action that modifies an adjacent clause during
     /// lowering (folds the former `special: Option<SpecialClause>`). `intrinsic`
     /// carries the self-patch some special arms apply (lower.rs:1600).
@@ -288,6 +289,21 @@ pub(crate) enum PriorModifier {
     /// and attacking (conditional modifier; carries the gate on the clause's
     /// `condition`, with the unpatched original stashed in `else_ability`).
     EntersTappedAttacking,
+}
+
+/// CR 608.2c / CR 614.1a: which meaning-replacement the clause performs on the
+/// prior emitted def(s). Each variant carries its own payload and rules concept.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum ReplaceMeaningKind {
+    /// CR 608.2c: pop the prior def; wrap this alternative def with the prior as its
+    /// `else_ability` (dig-instead alternative).
+    DigAlt(Box<AbilityDefinition>),
+    /// CR 614.1a + CR 608.2c: multi-clause base + "instead" override via Cow-swap;
+    /// tail clauses stashed in the override's `else_ability`.
+    Instead(Box<AbilityDefinition>),
+    /// CR 608.2e: build this clause's def from `parsed` + condition, attach as the
+    /// prior def's `sub_ability` (keyword-instead override).
+    KeywordOverride,
 }
 
 /// CR 608.2c: whether the "Otherwise" else-branch binds to a prior conditional or
@@ -406,7 +422,8 @@ impl ClauseDisposition {
             | ClauseDisposition::Absorb { .. }
             | ClauseDisposition::BranchOtherwise { .. }
             | ClauseDisposition::ReplicatePerKeyword { .. }
-            | ClauseDisposition::ModifyPrior { .. } => None,
+            | ClauseDisposition::ModifyPrior { .. }
+            | ClauseDisposition::ReplaceMeaning { .. } => None,
         }
     }
 
@@ -423,7 +440,8 @@ impl ClauseDisposition {
             | ClauseDisposition::Absorb { .. }
             | ClauseDisposition::BranchOtherwise { .. }
             | ClauseDisposition::ReplicatePerKeyword { .. }
-            | ClauseDisposition::ModifyPrior { .. } => None,
+            | ClauseDisposition::ModifyPrior { .. }
+            | ClauseDisposition::ReplaceMeaning { .. } => None,
         }
     }
 }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -687,6 +687,58 @@ fn karn_legacy_reforged() {
 }
 
 // ---------------------------------------------------------------------------
+// Meaning-replacement overrides (U5-M2 ReplaceMeaning parity)
+// ---------------------------------------------------------------------------
+// All three kinds have real cards in the 568-card fixture (DigAlt 2, Instead 24,
+// KeywordOverride 1). Oracle text verified verbatim against Scryfall.
+
+// CR 608.2c: DigAlt — "you may instead <alternative dig disposition>" pops the
+// prior dig def and wraps the alternative with the prior as its `else_ability`
+// (Follow the Lumarets). "Infusion —" is an ability word (stripped like Landfall).
+#[test]
+fn follow_the_lumarets() {
+    let (ir, lowered) = parse_two_layer(
+        "Infusion — Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. If you gained life this turn, you may instead reveal two creature and/or land cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
+        "Follow the Lumarets",
+        &["Sorcery"],
+        &[],
+    );
+    insta::assert_json_snapshot!("follow_the_lumarets_ir", &ir);
+    insta::assert_json_snapshot!("follow_the_lumarets_lowered", &lowered);
+}
+
+// CR 614.1a + CR 608.2c: Instead — the multi-clause Cow-swap. Clause 1 ("gain
+// control … until end of turn") is the root/swap target; the "… instead" override
+// carries the `ConditionInstead`, and the TAIL clauses ("Untap that creature. It
+// gains haste …") are stashed in the override's `else_ability` (Evil's Thrall).
+#[test]
+fn evils_thrall() {
+    let (ir, lowered) = parse_two_layer(
+        "Gain control of target creature until end of turn. If you control a Villain with greater mana value than that creature, gain control of that creature until the end of your next turn instead. Untap that creature. It gains haste until end of turn.",
+        "Evil's Thrall",
+        &["Sorcery"],
+        &[],
+    );
+    insta::assert_json_snapshot!("evils_thrall_ir", &ir);
+    insta::assert_json_snapshot!("evils_thrall_lowered", &lowered);
+}
+
+// CR 608.2e: KeywordOverride — a "TargetHasKeywordInstead"-conditioned clause
+// builds its def from the parsed effect + condition and attaches as the prior
+// def's `sub_ability` (Conformer Shuriken's granted attack trigger).
+#[test]
+fn conformer_shuriken() {
+    let (ir, lowered) = parse_two_layer(
+        "Equipped creature has \"Whenever this creature attacks, tap target creature defending player controls. If that creature has greater power than this creature, put a number of +1/+1 counters on this creature equal to the difference.\"\nEquip {2}",
+        "Conformer Shuriken",
+        &["Artifact"],
+        &["Equipment"],
+    );
+    insta::assert_json_snapshot!("conformer_shuriken_ir", &ir);
+    insta::assert_json_snapshot!("conformer_shuriken_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
 // Triggers (various patterns)
 // ---------------------------------------------------------------------------
 

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conformer_shuriken_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conformer_shuriken_ir.snap
@@ -1,0 +1,185 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 194,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Equipped creature has \"Whenever ~ attacks, tap target creature defending player controls. If that creature has greater power than ~, put a number of +1/+1 counters on ~ equal to the difference.\""
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": null,
+            "properties": [
+              {
+                "type": "EquippedBy"
+              }
+            ]
+          },
+          "modifications": [
+            {
+              "type": "GrantTrigger",
+              "trigger": {
+                "mode": "Attacks",
+                "execute": {
+                  "kind": "Spell",
+                  "effect": {
+                    "type": "SetTapState",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "DefendingPlayer",
+                      "properties": []
+                    },
+                    "scope": {
+                      "type": "Single"
+                    },
+                    "state": {
+                      "type": "Tap"
+                    }
+                  },
+                  "cost": null,
+                  "sub_ability": {
+                    "kind": "Spell",
+                    "effect": {
+                      "type": "Unimplemented",
+                      "name": "put",
+                      "description": "counters equal to the difference"
+                    },
+                    "cost": null,
+                    "sub_ability": null,
+                    "duration": null,
+                    "description": null,
+                    "target_prompt": null,
+                    "condition": {
+                      "type": "TargetHasKeywordInstead",
+                      "keyword": {
+                        "Unknown": "greater power than ~"
+                      }
+                    },
+                    "optional_targeting": false,
+                    "optional": false,
+                    "forward_result": false
+                  },
+                  "duration": null,
+                  "description": null,
+                  "target_prompt": null,
+                  "condition": null,
+                  "optional_targeting": false,
+                  "optional": false,
+                  "forward_result": false
+                },
+                "valid_card": {
+                  "type": "SelfRef"
+                },
+                "origin": null,
+                "destination": null,
+                "trigger_zones": [
+                  "Battlefield"
+                ],
+                "phase": null,
+                "optional": false,
+                "damage_kind": "Any",
+                "secondary": false,
+                "valid_target": null,
+                "valid_source": null,
+                "description": "Whenever ~ attacks, tap target creature defending player controls. If that creature has greater power than ~, put a number of +1/+1 counters on ~ equal to the difference.",
+                "constraint": null,
+                "condition": null,
+                "batched": false
+              }
+            }
+          ],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "Equipped creature has \"Whenever ~ attacks, tap target creature defending player controls. If that creature has greater power than ~, put a number of +1/+1 counters on ~ equal to the difference.\""
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 195,
+          "end_byte": 204,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Equip {2}"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Attach",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": []
+            }
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 2
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "Equip {2}",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
+          "ability_tag": {
+            "type": "Equip"
+          },
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Equipped creature has \"Whenever this creature attacks, tap target creature defending player controls. If that creature has greater power than this creature, put a number of +1/+1 counters on this creature equal to the difference.\"\nEquip {2}",
+  "card_name": "Conformer Shuriken"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conformer_shuriken_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conformer_shuriken_lowered.snap
@@ -1,0 +1,148 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "Attach",
+        "target": {
+          "type": "Typed",
+          "type_filters": [
+            "Creature"
+          ],
+          "controller": "You",
+          "properties": []
+        }
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [],
+          "generic": 2
+        }
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "Equip {2}",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        }
+      ],
+      "ability_tag": {
+        "type": "Equip"
+      },
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "Typed",
+        "type_filters": [
+          "Creature"
+        ],
+        "controller": null,
+        "properties": [
+          {
+            "type": "EquippedBy"
+          }
+        ]
+      },
+      "modifications": [
+        {
+          "type": "GrantTrigger",
+          "trigger": {
+            "mode": "Attacks",
+            "execute": {
+              "kind": "Spell",
+              "effect": {
+                "type": "SetTapState",
+                "target": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "DefendingPlayer",
+                  "properties": []
+                },
+                "scope": {
+                  "type": "Single"
+                },
+                "state": {
+                  "type": "Tap"
+                }
+              },
+              "cost": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "Unimplemented",
+                  "name": "put",
+                  "description": "counters equal to the difference"
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": {
+                  "type": "TargetHasKeywordInstead",
+                  "keyword": {
+                    "Unknown": "greater power than ~"
+                  }
+                },
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "valid_card": {
+              "type": "SelfRef"
+            },
+            "origin": null,
+            "destination": null,
+            "trigger_zones": [
+              "Battlefield"
+            ],
+            "phase": null,
+            "optional": false,
+            "damage_kind": "Any",
+            "secondary": false,
+            "valid_target": null,
+            "valid_source": null,
+            "description": "Whenever ~ attacks, tap target creature defending player controls. If that creature has greater power than ~, put a number of +1/+1 counters on ~ equal to the difference.",
+            "constraint": null,
+            "condition": null,
+            "batched": false
+          }
+        }
+      ],
+      "condition": null,
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Equipped creature has \"Whenever ~ attacks, tap target creature defending player controls. If that creature has greater power than ~, put a number of +1/+1 counters on ~ equal to the difference.\""
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__evils_thrall_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__evils_thrall_ir.snap
@@ -1,0 +1,181 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 245,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Gain control of target creature until end of turn. If you control a Villain with greater mana value than that creature, gain control of that creature until the end of your next turn instead. Untap that creature. It gains haste until end of turn."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "GainControl",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            }
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GainControl",
+              "target": {
+                "type": "ParentTarget"
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "SetTapState",
+                "target": {
+                  "type": "ParentTarget"
+                },
+                "scope": {
+                  "type": "Single"
+                },
+                "state": {
+                  "type": "Untap"
+                }
+              },
+              "cost": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "GenericEffect",
+                  "static_abilities": [
+                    {
+                      "mode": "Continuous",
+                      "affected": {
+                        "type": "SelfRef"
+                      },
+                      "modifications": [
+                        {
+                          "type": "AddKeyword",
+                          "keyword": "Haste"
+                        }
+                      ],
+                      "condition": null,
+                      "affected_zone": null,
+                      "effect_zone": null,
+                      "active_zones": [],
+                      "characteristic_defining": false,
+                      "description": "gain haste"
+                    }
+                  ],
+                  "duration": "UntilEndOfTurn",
+                  "target": null
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": "UntilEndOfTurn",
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false,
+                "sub_link": "SequentialSibling"
+              },
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false,
+              "sub_link": "SequentialSibling"
+            },
+            "duration": {
+              "UntilEndOfNextTurnOf": {
+                "player": {
+                  "type": "Controller"
+                }
+              }
+            },
+            "description": null,
+            "target_prompt": null,
+            "condition": {
+              "type": "ConditionInstead",
+              "inner": {
+                "type": "QuantityCheck",
+                "lhs": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "ObjectCount",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        {
+                          "Subtype": "Villain"
+                        }
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "Cmc",
+                          "comparator": "GT",
+                          "value": {
+                            "type": "Ref",
+                            "qty": {
+                              "type": "ObjectManaValue",
+                              "scope": {
+                                "type": "Target"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "type": "InZone",
+                          "zone": "Battlefield"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "comparator": "GE",
+                "rhs": {
+                  "type": "Fixed",
+                  "value": 1
+                }
+              }
+            },
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": "UntilEndOfTurn",
+          "description": "Gain control of target creature until end of turn. If you control a Villain with greater mana value than that creature, gain control of that creature until the end of your next turn instead. Untap that creature. It gains haste until end of turn.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Gain control of target creature until end of turn. If you control a Villain with greater mana value than that creature, gain control of that creature until the end of your next turn instead. Untap that creature. It gains haste until end of turn.",
+  "card_name": "Evil's Thrall"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__evils_thrall_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__evils_thrall_lowered.snap
@@ -1,0 +1,163 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "GainControl",
+        "target": {
+          "type": "Typed",
+          "type_filters": [
+            "Creature"
+          ],
+          "controller": null,
+          "properties": []
+        }
+      },
+      "cost": null,
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "GainControl",
+          "target": {
+            "type": "ParentTarget"
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "SetTapState",
+            "target": {
+              "type": "ParentTarget"
+            },
+            "scope": {
+              "type": "Single"
+            },
+            "state": {
+              "type": "Untap"
+            }
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GenericEffect",
+              "static_abilities": [
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "SelfRef"
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Haste"
+                    }
+                  ],
+                  "condition": null,
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain haste"
+                }
+              ],
+              "duration": "UntilEndOfTurn",
+              "target": null
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
+          },
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false,
+          "sub_link": "SequentialSibling"
+        },
+        "duration": {
+          "UntilEndOfNextTurnOf": {
+            "player": {
+              "type": "Controller"
+            }
+          }
+        },
+        "description": null,
+        "target_prompt": null,
+        "condition": {
+          "type": "ConditionInstead",
+          "inner": {
+            "type": "QuantityCheck",
+            "lhs": {
+              "type": "Ref",
+              "qty": {
+                "type": "ObjectCount",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    {
+                      "Subtype": "Villain"
+                    }
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "Cmc",
+                      "comparator": "GT",
+                      "value": {
+                        "type": "Ref",
+                        "qty": {
+                          "type": "ObjectManaValue",
+                          "scope": {
+                            "type": "Target"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "InZone",
+                      "zone": "Battlefield"
+                    }
+                  ]
+                }
+              }
+            },
+            "comparator": "GE",
+            "rhs": {
+              "type": "Fixed",
+              "value": 1
+            }
+          }
+        },
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "duration": "UntilEndOfTurn",
+      "description": "Gain control of target creature until end of turn. If you control a Villain with greater mana value than that creature, gain control of that creature until the end of your next turn instead. Untap that creature. It gains haste until end of turn.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__follow_the_lumarets_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__follow_the_lumarets_ir.snap
@@ -1,0 +1,144 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 329,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Infusion — Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. If you gained life this turn, you may instead reveal two creature and/or land cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Dig",
+            "player": {
+              "type": "Controller"
+            },
+            "count": {
+              "type": "Fixed",
+              "value": 4
+            },
+            "destination": "Hand",
+            "keep_count": 2,
+            "up_to": false,
+            "filter": {
+              "type": "Or",
+              "filters": [
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": null,
+                  "properties": []
+                },
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Land"
+                  ],
+                  "controller": null,
+                  "properties": []
+                }
+              ]
+            },
+            "rest_destination": "Library",
+            "reveal": false,
+            "enter_tapped": false
+          },
+          "cost": null,
+          "sub_ability": null,
+          "else_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Dig",
+              "player": {
+                "type": "Controller"
+              },
+              "count": {
+                "type": "Fixed",
+                "value": 4
+              },
+              "destination": "Hand",
+              "keep_count": 1,
+              "up_to": true,
+              "filter": {
+                "type": "Or",
+                "filters": [
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": null,
+                    "properties": []
+                  },
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Land"
+                    ],
+                    "controller": null,
+                    "properties": []
+                  }
+                ]
+              },
+              "rest_destination": "Library",
+              "reveal": true,
+              "enter_tapped": false
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": "Infusion — Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. If you gained life this turn, you may instead reveal two creature and/or land cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
+          "target_prompt": null,
+          "condition": {
+            "type": "QuantityCheck",
+            "lhs": {
+              "type": "Ref",
+              "qty": {
+                "type": "LifeGainedThisTurn",
+                "player": {
+                  "type": "Controller"
+                }
+              }
+            },
+            "comparator": "GE",
+            "rhs": {
+              "type": "Fixed",
+              "value": 1
+            }
+          },
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Infusion — Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. If you gained life this turn, you may instead reveal two creature and/or land cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
+  "card_name": "Follow the Lumarets"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__follow_the_lumarets_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__follow_the_lumarets_lowered.snap
@@ -1,0 +1,126 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "Dig",
+        "player": {
+          "type": "Controller"
+        },
+        "count": {
+          "type": "Fixed",
+          "value": 4
+        },
+        "destination": "Hand",
+        "keep_count": 2,
+        "up_to": false,
+        "filter": {
+          "type": "Or",
+          "filters": [
+            {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            {
+              "type": "Typed",
+              "type_filters": [
+                "Land"
+              ],
+              "controller": null,
+              "properties": []
+            }
+          ]
+        },
+        "rest_destination": "Library",
+        "reveal": false,
+        "enter_tapped": false
+      },
+      "cost": null,
+      "sub_ability": null,
+      "else_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Dig",
+          "player": {
+            "type": "Controller"
+          },
+          "count": {
+            "type": "Fixed",
+            "value": 4
+          },
+          "destination": "Hand",
+          "keep_count": 1,
+          "up_to": true,
+          "filter": {
+            "type": "Or",
+            "filters": [
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": null,
+                "properties": []
+              },
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Land"
+                ],
+                "controller": null,
+                "properties": []
+              }
+            ]
+          },
+          "rest_destination": "Library",
+          "reveal": true,
+          "enter_tapped": false
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "duration": null,
+      "description": "Infusion — Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. If you gained life this turn, you may instead reveal two creature and/or land cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
+      "target_prompt": null,
+      "condition": {
+        "type": "QuantityCheck",
+        "lhs": {
+          "type": "Ref",
+          "qty": {
+            "type": "LifeGainedThisTurn",
+            "player": {
+              "type": "Controller"
+            }
+          }
+        },
+        "comparator": "GE",
+        "rhs": {
+          "type": "Fixed",
+          "value": 1
+        }
+      },
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}


### PR DESCRIPTION
Fifth U5-M2 increment. DigInsteadAlt + InsteadClause + KeywordInsteadOverride
(CR 608.2c / CR 614.1a / CR 608.2e — all `intrinsic: None`) share the structural
role "replace/override the meaning of the prior emitted def(s), emit no sibling"
and fold into `ClauseDisposition::ReplaceMeaning { kind: ReplaceMeaningKind }`,
where `kind` (DigAlt | Instead | KeywordOverride) carries each variant's payload
and keeps the distinct rules concept typed. AdditionalCostInsteadSearch
(intrinsic-carrier) and DrawnThisTurnPayOrTopdeck are deliberately left for inc6.

The three lower.rs handler bodies — including InsteadClause's intricate multi-clause
Cow-swap (mem::take the def chain, build the base, stash the tail in the override's
else_ability) — move byte-for-byte under `match kind`; only the arm pattern names
change (the else-if block evaluates to the match's bool, so the per-arm `true`
bodies are untouched). All three SpecialClause variants are deleted.

Faithful-by-construction (ClauseDisposition never reaches a serialized snapshot).
All three kinds have real fixture cards (DigAlt 2, Instead 24, KeywordOverride 1);
parity: Follow the Lumarets (DigAlt — else_ability + Dig), Evil's Thrall (Instead —
ConditionInstead override + Untap/Haste tail in else_ability), Conformer Shuriken
(KeywordOverride — sub_ability + counters). Zero snapshot drift.
