### PR TITLE
refactor(parser): promote final SpecialClause variants and delete the enum (U5-M2)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -27,7 +27,7 @@ use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::effect_chain::{
     ClauseDisposition, ClauseIr, EffectChainIr, OtherwiseKind, PriorModifier, ReplaceMeaningKind,
-    ReplicateKind, SpecialClause,
+    ReplicateKind,
 };
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
@@ -1541,7 +1541,7 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
             {
                 // CR 608.2c / CR 614.1a: replace/override the meaning of the prior
                 // emitted def(s); `kind` selects which (moved verbatim from the old
-                // SpecialClause arms).
+                // special-clause arms).
                 match replace_kind {
                     ReplaceMeaningKind::DigAlt(alt_def) => {
                         if let Some(last_def) = defs.pop() {
@@ -1614,58 +1614,57 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                         true
                     }
                 }
-            } else if let ClauseDisposition::Special {
-                action: special,
-                intrinsic,
-            } = &clause_ir.disposition
+            } else if let ClauseDisposition::FoldSearchIntoElse { intrinsic } =
+                &clause_ir.disposition
             {
-                match special {
-                    SpecialClause::AdditionalCostInsteadSearch => {
-                        // Build this clause's def and fold else_ability from the trailing clause.
-                        // The trailing ChangeZone was produced by the previous SearchLibrary's
-                        // intrinsic continuation (SearchDestination).
-                        let mut def = AbilityDefinition::new(kind, clause_ir.parsed.effect.clone());
-                        let effective_cond = clause_ir
-                            .condition
-                            .as_ref()
-                            .or(clause_ir.parsed.condition.as_ref());
-                        if let Some(cond) = effective_cond {
-                            def = def.condition(cond.clone());
+                // CR 608.2c + CR 601.2b: later text ("if this spell was kicked, instead
+                // search …") modifies the meaning of the earlier search, gated on an
+                // additional cost announced at cast. Build this clause's def and fold
+                // else_ability from the trailing clause. The trailing ChangeZone was
+                // produced by the previous SearchLibrary's intrinsic continuation
+                // (SearchDestination).
+                let mut def = AbilityDefinition::new(kind, clause_ir.parsed.effect.clone());
+                let effective_cond = clause_ir
+                    .condition
+                    .as_ref()
+                    .or(clause_ir.parsed.condition.as_ref());
+                if let Some(cond) = effective_cond {
+                    def = def.condition(cond.clone());
+                }
+                // Pop trailing search-destination ChangeZone and attach as else_ability
+                if defs.len() >= 2 {
+                    let trailing_is_search_destination = matches!(
+                        &*defs.last().unwrap().effect,
+                        Effect::ChangeZone {
+                            origin: Some(Zone::Library),
+                            destination: Zone::Hand,
+                            ..
                         }
-                        // Pop trailing search-destination ChangeZone and attach as else_ability
-                        if defs.len() >= 2 {
-                            let trailing_is_search_destination = matches!(
-                                &*defs.last().unwrap().effect,
-                                Effect::ChangeZone {
-                                    origin: Some(Zone::Library),
-                                    destination: Zone::Hand,
-                                    ..
-                                }
-                            );
-                            if trailing_is_search_destination {
-                                def.else_ability = Some(Box::new(defs.pop().unwrap()));
-                            }
-                        }
-                        defs.push(def);
-                        // Apply intrinsic continuation for THIS SearchLibrary (e.g., reveal flag, ChangeZone).
-                        if let Some(continuation) = intrinsic {
-                            apply_clause_continuation(&mut defs, continuation.clone(), kind);
-                        }
-                        true
-                    }
-                    SpecialClause::DrawnThisTurnPayOrTopdeck { life_payment } => {
-                        if let Some(last_def) = defs.last_mut() {
-                            if let Effect::ChooseDrawnThisTurnPayOrTopdeck {
-                                life_payment: current,
-                                ..
-                            } = &mut *last_def.effect
-                            {
-                                *current = life_payment.clone();
-                            }
-                        }
-                        true
+                    );
+                    if trailing_is_search_destination {
+                        def.else_ability = Some(Box::new(defs.pop().unwrap()));
                     }
                 }
+                defs.push(def);
+                // Apply intrinsic continuation for THIS SearchLibrary (e.g., reveal flag, ChangeZone).
+                if let Some(continuation) = intrinsic {
+                    apply_clause_continuation(&mut defs, continuation.clone(), kind);
+                }
+                true
+            } else if let ClauseDisposition::DrawnThisTurnFollowup { life_payment } =
+                &clause_ir.disposition
+            {
+                // Set the life payment on the prior drawn-this-turn choice; emits no def.
+                if let Some(last_def) = defs.last_mut() {
+                    if let Effect::ChooseDrawnThisTurnPayOrTopdeck {
+                        life_payment: current,
+                        ..
+                    } = &mut *last_def.effect
+                    {
+                        *current = life_payment.clone();
+                    }
+                }
+                true
             } else {
                 false
             }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -150,7 +150,7 @@ use crate::parser::oracle_ir::ast::*;
 pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup};
 use crate::parser::oracle_ir::effect_chain::{
     AbilityIr, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr, ClauseIrBuilder,
-    EffectChainIr, OtherwiseKind, PriorModifier, ReplaceMeaningKind, ReplicateKind, SpecialClause,
+    EffectChainIr, OtherwiseKind, PriorModifier, ReplaceMeaningKind, ReplicateKind,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -24524,7 +24524,8 @@ pub(crate) fn parse_effect_chain_ir(
 
         // CR 702: "The same is true for <keyword list>." — Odric, Lunarch
         // Marshal. Extends the previous `GenericEffect` keyword grant to each
-        // additional keyword. Recorded as a `SpecialClause`; lowering reads
+        // additional keyword. Recorded as a `ReplicatePerKeyword` disposition;
+        // lowering reads
         // the antecedent grant template and emits one `StaticDefinition` per
         // keyword. Requires a prior clause to attach to.
         if !builder.is_empty() {
@@ -24818,7 +24819,7 @@ pub(crate) fn parse_effect_chain_ir(
             // `AbilityDefinition.condition` (evaluated per sub_ability at
             // resolution; skipped when false; the empty-target sub inherits the
             // parent's chosen targets so `TargetMatchesFilter` resolves the damage
-            // target). The SpecialClause lowering arms move the def as-is, so the
+            // target). The `Absorb` lowering arms move the def as-is, so the
             // condition must be stamped on the DEF, not the ClauseIr.
             let conditional_regen_matched = 'conditional_regen: {
                 let regen_body = normalized_text.trim_end_matches('.').trim();
@@ -24945,10 +24946,7 @@ pub(crate) fn parse_effect_chain_ir(
                         normalized_text,
                         placeholder_parsed_clause("drawn_this_turn_pay_or_topdeck_placeholder"),
                         chunk.boundary_after,
-                        ClauseDisposition::Special {
-                            action: SpecialClause::DrawnThisTurnPayOrTopdeck { life_payment },
-                            intrinsic: None,
-                        },
+                        ClauseDisposition::DrawnThisTurnFollowup { life_payment },
                     )
                     .push();
                 continue;
@@ -26614,10 +26612,7 @@ pub(crate) fn parse_effect_chain_ir(
                         normalized_text,
                         clause,
                         chunk.boundary_after,
-                        ClauseDisposition::Special {
-                            action: SpecialClause::AdditionalCostInsteadSearch,
-                            intrinsic: ic,
-                        },
+                        ClauseDisposition::FoldSearchIntoElse { intrinsic: ic },
                     )
                     .condition(condition)
                     .is_optional(is_optional)

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -7080,7 +7080,8 @@ pub(crate) fn try_parse_same_is_true_continuation(text: &str) -> Option<Vec<Keyw
 /// lowering replicates the antecedent conditional keyword-counter clause
 /// once per keyword. Both phrasings are leaf-level variants of the same
 /// "replicate the prior keyword-counter clause for each listed keyword"
-/// directive, so they share one combinator and one `SpecialClause`. Mirrors
+/// directive, so they share one combinator and one `ReplicatePerKeyword`
+/// disposition kind. Mirrors
 /// `try_parse_same_is_true_continuation`; covers every card of this class, not
 /// Kathril or Super-Adaptoid alone.
 pub(super) fn try_parse_repeat_process_for_keywords(text: &str) -> Option<Vec<Keyword>> {
@@ -7107,11 +7108,11 @@ pub(super) fn try_parse_repeat_process_for_keywords(text: &str) -> Option<Vec<Ke
 /// — an effect-replication directive (The Wedding of River Song). The clause has
 /// no effect of its own; it *would* replicate the immediately-preceding sibling
 /// clause for a targeted opponent. NOT YET IMPLEMENTED: there is no
-/// `SpecialClause::DoesTheSame` variant and no antecedent-cloning lowering. The
+/// `DoesTheSame` clause disposition and no antecedent-cloning lowering. The
 /// chunk loop instead emits a *documented* `Effect::Unimplemented` (keyed by
 /// `does_the_same_unimplemented_name`) for a recognized match — a typed
 /// strict-failure, never a silent misparse. The future fix (a `DoesTheSame`
-/// special clause whose lowering clones the antecedent action and retargets it
+/// disposition whose lowering clones the antecedent action and retargets it
 /// onto the opponent's own objects, CR 608.2d) is tracked as backlog work; the
 /// typed `DoesTheSameSubject` return is preserved so it can slot in cleanly.
 ///

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -43420,3 +43420,163 @@ fn dance_of_the_manse_targets_graveyard_not_battlefield() {
         );
     }
 }
+// ===========================================================================
+// U5-M2 capstone: reach-guards for the two final typed dispositions
+// ===========================================================================
+// `ClauseDisposition` is consumed inside `lower_effect_chain_ir` and never
+// serialized, so the parity snapshots in `oracle_ir::snapshot_tests` cannot show
+// WHICH arm a card takes. These assert the route directly: if an emit site stops
+// producing the disposition (or drops its payload), they fail even though the
+// lowered tree might still look plausible.
+
+/// CR 608.2c + CR 601.2b: Aang's Journey's "instead, search …" clause must land
+/// on `FoldSearchIntoElse` AND carry its own `SearchDestination` intrinsic. The
+/// intrinsic is the load-bearing part: it is the SECOND search's self-patch
+/// (destination/reveal), so dropping it silently strips the search's destination.
+#[test]
+fn aangs_journey_reaches_fold_search_into_else() {
+    let mut ctx = ParseContext::default();
+    let ir = parse_effect_chain_ir(
+        "Search your library for a basic land card. If this spell was kicked, instead search your library for a basic land card and a Shrine card. Reveal those cards, put them into your hand, then shuffle.",
+        AbilityKind::Spell,
+        &mut ctx,
+    );
+    let fold = ir
+        .clauses
+        .iter()
+        .find(|c| matches!(c.disposition, ClauseDisposition::FoldSearchIntoElse { .. }))
+        .expect("the kicked 'instead search' clause must lower via FoldSearchIntoElse");
+    assert!(
+        matches!(
+            fold.disposition.intrinsic(),
+            Some(ContinuationAst::SearchDestination {
+                destination: Zone::Hand,
+                ..
+            })
+        ),
+        "FoldSearchIntoElse must preserve the second search's own SearchDestination \
+         intrinsic, got {:?}",
+        fold.disposition.intrinsic()
+    );
+}
+
+/// CR 608.2c + CR 601.2b: same disposition via a DIFFERENT additional cost (collect
+/// evidence, not kicker) with a revealing search — the class, not the card.
+#[test]
+fn analyze_the_pollen_reaches_fold_search_into_else() {
+    let mut ctx = ParseContext::default();
+    let ir = parse_effect_chain_ir(
+        "Search your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle.",
+        AbilityKind::Spell,
+        &mut ctx,
+    );
+    let fold = ir
+        .clauses
+        .iter()
+        .find(|c| matches!(c.disposition, ClauseDisposition::FoldSearchIntoElse { .. }))
+        .expect("the evidence 'instead search' clause must lower via FoldSearchIntoElse");
+    assert!(
+        matches!(
+            fold.disposition.intrinsic(),
+            Some(ContinuationAst::SearchDestination {
+                destination: Zone::Hand,
+                reveal: true,
+                ..
+            })
+        ),
+        "revealing search must preserve `reveal: true` in its intrinsic, got {:?}",
+        fold.disposition.intrinsic()
+    );
+}
+
+/// Sylvan Library's "For each of those cards, pay 4 life …" clause must land on
+/// `DrawnThisTurnFollowup` carrying the parsed payment.
+#[test]
+fn sylvan_library_reaches_drawn_this_turn_followup() {
+    let mut ctx = ParseContext::default();
+    let ir = parse_effect_chain_ir(
+        "You may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
+        AbilityKind::Spell,
+        &mut ctx,
+    );
+    let followup = ir
+        .clauses
+        .iter()
+        .find_map(|c| match &c.disposition {
+            ClauseDisposition::DrawnThisTurnFollowup { life_payment } => Some(life_payment),
+            _ => None,
+        })
+        .expect(
+            "the 'for each of those cards, pay N life' clause must lower via DrawnThisTurnFollowup",
+        );
+    assert_eq!(*followup, QuantityExpr::Fixed { value: 4 });
+}
+
+/// Direct handler coverage for `ClauseDisposition::DrawnThisTurnFollowup`: it
+/// WRITES the disposition's `life_payment` onto the prior
+/// `ChooseDrawnThisTurnPayOrTopdeck` def and emits no def of its own.
+///
+/// Constructed directly with a NON-default payment (3, vs the parser's hardcoded
+/// default of 4) because Sylvan Library — the only card of this class — parses a
+/// payment identical to that default, so a card-level assertion of `4` would pass
+/// even if this handler never ran. Here, if the arm is dropped or mis-wired, the
+/// payment stays 4 and this fails.
+#[test]
+fn drawn_this_turn_followup_overwrites_prior_life_payment() {
+    use crate::parser::oracle_ir::ast::{parsed_clause, ClauseBoundary};
+    use crate::parser::oracle_ir::effect_chain::{ClauseIrBuilder, EffectChainIr};
+
+    let choose = || Effect::ChooseDrawnThisTurnPayOrTopdeck {
+        count: QuantityExpr::Fixed { value: 2 },
+        life_payment: QuantityExpr::Fixed { value: 4 },
+        player: TargetFilter::Controller,
+    };
+
+    let mut builder = ClauseIrBuilder::new("");
+    // clause 0: the prior emitted choice def the follow-up patches.
+    builder
+        .clause(
+            "",
+            parsed_clause(choose()),
+            Some(ClauseBoundary::Sentence),
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
+    // clause 1: the follow-up — sets the payment, emits nothing.
+    builder
+        .clause(
+            "",
+            parsed_clause(choose()),
+            None,
+            ClauseDisposition::DrawnThisTurnFollowup {
+                life_payment: QuantityExpr::Fixed { value: 3 },
+            },
+        )
+        .push();
+    let ir = EffectChainIr {
+        clauses: builder.finish(),
+        kind: AbilityKind::Spell,
+        chain_rounding: None,
+        actor: None,
+        repeat_until: None,
+    };
+
+    let root = lower_effect_chain_ir(&ir);
+    let Effect::ChooseDrawnThisTurnPayOrTopdeck { life_payment, .. } = &*root.effect else {
+        panic!("expected the choice def as root, got {:?}", root.effect);
+    };
+    assert_eq!(
+        *life_payment,
+        QuantityExpr::Fixed { value: 3 },
+        "DrawnThisTurnFollowup must overwrite the prior def's life_payment (3), \
+         not leave the parsed default (4)"
+    );
+    assert!(
+        root.sub_ability.is_none(),
+        "the follow-up clause must emit no def of its own, got {:?}",
+        root.sub_ability
+    );
+}

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -112,20 +112,6 @@ pub(crate) enum DoesTheSameSubject {
     TargetOpponent,
 }
 
-/// Special-case clause actions that modify or attach to adjacent clauses during lowering.
-///
-/// The chunk loop's special-case handlers (otherwise, instead, alt-cost rider, etc.)
-/// currently modify `defs: Vec<AbilityDefinition>` inline. In the IR split, these
-/// become markers that lowering processes when building the def list.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) enum SpecialClause {
-    /// CR 608.2e: AdditionalCostPaidInstead + SearchLibrary — fold else_ability from previous.
-    AdditionalCostInsteadSearch,
-    /// Follow-up to a drawn-this-turn choice: sets the life payment and
-    /// confirms the topdeck branch without emitting a separate effect.
-    DrawnThisTurnPayOrTopdeck { life_payment: QuantityExpr },
-}
-
 // ===========================================================================
 // Typed clause provenance (Plan 01 §5) — Unit 5, milestone M1
 // ===========================================================================
@@ -159,7 +145,8 @@ pub(crate) struct ClauseId(pub(crate) u32);
 /// The single explicit disposition of a clause: what it does relative to the
 /// rest of the chain. Replaces the former ad-hoc `absorbed_by_followup` boolean,
 /// `intrinsic_continuation`/`followup_continuation` options, `is_otherwise`
-/// boolean, and `special` marker.
+/// boolean, and the `special` marker enum (fully decomposed into typed
+/// dispositions by U5-M2; the marker enum no longer exists).
 ///
 /// A continuation clause STAYS in the IR with its own id/source even when it
 /// emits no independent definition (Plan 01 §5). The explicit antecedent SELECTOR
@@ -175,8 +162,8 @@ pub(crate) struct ClauseId(pub(crate) u32);
 ///   emitted, then `intrinsic` patches SELF (lower.rs:2078).
 /// - absorbed/`Continue`: `continuation` patches PRIOR defs; no self def is
 ///   emitted (lower.rs:1314).
-/// - `special`: some arms apply `intrinsic` to the special-built def
-///   (lower.rs:1600, `AdditionalCostInsteadSearch`).
+/// - `FoldSearchIntoElse`: applies `intrinsic` to the def it builds, inline at its
+///   own tail (the former `special` path's only intrinsic carrier).
 // Intentional: variants carry parser IR directly (the `Emit` channels hold two
 // `ContinuationAst` options). Mirrors `oracle_ir::doc.rs`. This IR enum is
 // short-lived per-clause and Vec-allocated, so the size gap is acceptable.
@@ -209,7 +196,7 @@ pub(crate) enum ClauseDisposition {
     },
     /// CR 608.2c: this clause's def attaches as a sub_ability RIDER on the tail of
     /// the prior emitted def's sub_ability chain, emitting no sibling def. Promoted
-    /// from the former `SpecialClause::{DieExileRider, CantBeRegeneratedRider}`
+    /// from the former special-clause markers `DieExileRider` / `CantBeRegeneratedRider`
     /// (U5-M2). `kind` preserves the distinct rules concept (they share the
     /// `append_to_deepest_sub_ability` mechanic — Plan 01 §5 line 811). The bound
     /// antecedent is the prior emitted def (implicit, as M1's `Continue`); the
@@ -219,7 +206,8 @@ pub(crate) enum ClauseDisposition {
         kind: AbsorbKind,
     },
     /// CR 608.2c: an "Otherwise, [effect]" else-branch. Promoted from
-    /// `SpecialClause::{Otherwise, OtherwiseFallback}` (U5-M2). `kind` carries the
+    /// the former special-clause markers `Otherwise` / `OtherwiseFallback` (U5-M2).
+    /// `kind` carries the
     /// PARSE-TIME determination of whether a prior conditional exists — do NOT
     /// recompute it at lowering (parse-time and lower-time "prior conditional
     /// present?" states could diverge and move output).
@@ -229,39 +217,53 @@ pub(crate) enum ClauseDisposition {
     },
     /// CR 608.2c / CR 702: replicate an antecedent template clause once per listed
     /// keyword, swapping the keyword in both the granted ability/counter and its
-    /// gating condition. Promoted from `SpecialClause::{SameIsTrueFor,
-    /// RepeatProcessForKeywords}` (U5-M2). `kind` selects the replication helper;
+    /// gating condition. Promoted from the former special-clause markers
+    /// `SameIsTrueFor` / `RepeatProcessForKeywords` (U5-M2). `kind` selects the
+    /// replication helper;
     /// the bound antecedent is the prior emitted clause (implicit, as `Continue`).
     ReplicatePerKeyword {
         keywords: Vec<Keyword>,
         kind: ReplicateKind,
     },
     /// CR 608.2c: fold a `PriorModifier` onto the prior emitted def; emits no
-    /// sibling. Promoted from the three rider `SpecialClause` variants (U5-M2). The
+    /// sibling. Promoted from the three former rider special-clause markers (U5-M2). The
     /// bound antecedent is the prior emitted def (implicit, as `Continue`).
     ModifyPrior { modifier: PriorModifier },
     /// CR 608.2c / CR 614.1a: this clause replaces or overrides the meaning of the
     /// prior emitted def(s) rather than emitting an independent sibling. Promoted
-    /// from `SpecialClause::{DigInsteadAlt, InsteadClause, KeywordInsteadOverride}`
-    /// (U5-M2). `kind` carries each variant's payload and keeps the distinct rules
+    /// from the former special-clause markers `DigInsteadAlt` / `InsteadClause` /
+    /// `KeywordInsteadOverride` (U5-M2). `kind` carries each variant's payload and
+    /// keeps the distinct rules
     /// concept typed (Plan 01 §5 line 811). Bound antecedent is the prior emitted
     /// def(s) (implicit, as `Continue`).
     ReplaceMeaning { kind: ReplaceMeaningKind },
-    /// A special-case adjacency action that modifies an adjacent clause during
-    /// lowering (folds the former `special: Option<SpecialClause>`). `intrinsic`
-    /// carries the self-patch some special arms apply (lower.rs:1600).
+    /// CR 608.2c + CR 601.2b: an "if <additional cost was paid>, instead search …"
+    /// clause — later text that modifies the meaning of earlier text (CR 608.2c),
+    /// gated on an additional cost announced at cast (CR 601.2b). Build this clause's
+    /// def, fold the PRIOR `SearchLibrary`'s trailing search-destination `ChangeZone`
+    /// into this def's `else_ability`, then apply this clause's own intrinsic
+    /// continuation. Promoted from the former special-clause marker
+    /// `AdditionalCostInsteadSearch` (U5-M2).
     ///
-    // TEMPORARY: faithful carry; decomposed into typed dispositions in U5-M2.
-    /// This wraps the existing `SpecialClause` value AS-IS — zero information
-    /// reconstructed or re-derived (it MOVES the value, unlike a projection
-    /// shim). This is not a generic "patch previous" collapse (Plan 01 §5, line
-    /// 811): the distinct concepts stay distinct inside `SpecialClause`. U5-M2
-    /// promotes each variant to its own typed disposition/attribute with a
-    /// snapshot + lowered-parity test, then deletes the `SpecialClause` enum.
-    Special {
-        action: SpecialClause,
-        intrinsic: Option<ContinuationAst>,
-    },
+    /// NOTE: the deleted marker's doc cited CR 608.2e; that rule is APNAP ordering for
+    /// multi-player multi-step actions and does not describe this fold. Re-derived to
+    /// CR 608.2c, which names this exact shape ("later text … may modify the meaning of
+    /// earlier text").
+    ///
+    /// The sole intrinsic-carrying disposition besides `Emit`: the second
+    /// `SearchLibrary` of an "additional cost … instead, search your library" chain
+    /// needs its OWN `SearchDestination` self-patch, which the handler applies inline
+    /// at its tail. It is also read by the parse-time `previous_is_search_with_hand_dest`
+    /// guard (`oracle_effect/mod.rs`), so the `intrinsic()` accessor must expose it.
+    FoldSearchIntoElse { intrinsic: Option<ContinuationAst> },
+    /// CR 608.2c: follow-up to a drawn-this-turn choice ("For each of those cards,
+    /// pay N life or put the card on top of your library") — later text that
+    /// parameterizes earlier text. Sets the life payment on the prior
+    /// `ChooseDrawnThisTurnPayOrTopdeck` effect and confirms the topdeck branch,
+    /// emitting no separate def. Promoted from the former special-clause marker
+    /// `DrawnThisTurnPayOrTopdeck` (U5-M2). The bound antecedent is the prior
+    /// emitted def (implicit, as `Continue`).
+    DrawnThisTurnFollowup { life_payment: QuantityExpr },
 }
 
 /// The distinct sub_ability-rider concepts that fold onto the prior emitted def.
@@ -276,8 +278,9 @@ pub(crate) enum AbsorbKind {
 }
 
 /// CR 608.2c: a field-level modification folded onto the prior emitted def
-/// (emits no sibling). Promoted from `SpecialClause::{AltCostRider, ManaRetention,
-/// EntersTappedAttacking}` (U5-M2). Each variant is a distinct rules concept that
+/// (emits no sibling). Promoted from the former special-clause markers
+/// `AltCostRider` / `ManaRetention` / `EntersTappedAttacking` (U5-M2). Each
+/// variant is a distinct rules concept that
 /// modifies a different field/aspect of the prior def.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) enum PriorModifier {
@@ -413,35 +416,38 @@ pub(crate) struct ClauseIr {
 impl ClauseDisposition {
     /// The self-patch continuation parsed from a clause's own text (formerly the
     /// `intrinsic_continuation` field): applied to this clause's own lowered def
-    /// after it emits. `Emit`/`Special` carry it; `Continue`/`Absorb` never do.
+    /// after it emits. `Emit`/`FoldSearchIntoElse` carry it; the other dispositions
+    /// never do.
     pub(crate) fn intrinsic(&self) -> Option<&ContinuationAst> {
         match self {
             ClauseDisposition::Emit { intrinsic, .. }
-            | ClauseDisposition::Special { intrinsic, .. } => intrinsic.as_ref(),
+            | ClauseDisposition::FoldSearchIntoElse { intrinsic } => intrinsic.as_ref(),
             ClauseDisposition::Continue { .. }
             | ClauseDisposition::Absorb { .. }
             | ClauseDisposition::BranchOtherwise { .. }
             | ClauseDisposition::ReplicatePerKeyword { .. }
             | ClauseDisposition::ModifyPrior { .. }
-            | ClauseDisposition::ReplaceMeaning { .. } => None,
+            | ClauseDisposition::ReplaceMeaning { .. }
+            | ClauseDisposition::DrawnThisTurnFollowup { .. } => None,
         }
     }
 
     /// The prior-patch continuation (formerly the `followup_continuation` field):
     /// a normal (`Emit`) clause's followup that patches the PRIOR def, or a
-    /// `Continue` clause's continuation. `None` for `Special`/`Absorb` clauses.
+    /// `Continue` clause's continuation. `None` for every other disposition.
     pub(crate) fn followup(&self) -> Option<&ContinuationAst> {
         match self {
             ClauseDisposition::Emit { followup, .. }
             | ClauseDisposition::Continue {
                 continuation: followup,
             } => followup.as_ref(),
-            ClauseDisposition::Special { .. }
-            | ClauseDisposition::Absorb { .. }
+            ClauseDisposition::Absorb { .. }
             | ClauseDisposition::BranchOtherwise { .. }
             | ClauseDisposition::ReplicatePerKeyword { .. }
             | ClauseDisposition::ModifyPrior { .. }
-            | ClauseDisposition::ReplaceMeaning { .. } => None,
+            | ClauseDisposition::ReplaceMeaning { .. }
+            | ClauseDisposition::FoldSearchIntoElse { .. }
+            | ClauseDisposition::DrawnThisTurnFollowup { .. } => None,
         }
     }
 }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -510,8 +510,8 @@ fn snapcaster_mage() {
 // ---------------------------------------------------------------------------
 
 // CR 608.2c + CR 701.19c: unconditional "can't be regenerated" rider on a
-// separate sentence after a damage clause (SpecialClause::CantBeRegeneratedRider
-// → ClauseDisposition::Absorb { kind: CantBeRegenerated }). Verified verbatim
+// separate sentence after a damage clause
+// (ClauseDisposition::Absorb { kind: CantBeRegenerated }). Verified verbatim
 // against Scryfall.
 #[test]
 fn incinerate() {
@@ -527,7 +527,7 @@ fn incinerate() {
 
 // CR 614.1a + CR 514.2: standalone "if [it] would die this turn, exile it
 // instead" die-exile rider on a separate sentence after a damage clause
-// (SpecialClause::DieExileRider → ClauseDisposition::Absorb { kind: DieExile }).
+// (ClauseDisposition::Absorb { kind: DieExile }).
 // Verified verbatim against Scryfall (includes the printed Devoid keyword line).
 #[test]
 fn touch_of_the_void() {
@@ -736,6 +736,69 @@ fn conformer_shuriken() {
     );
     insta::assert_json_snapshot!("conformer_shuriken_ir", &ir);
     insta::assert_json_snapshot!("conformer_shuriken_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
+// Search-fold + drawn-this-turn follow-up (U5-M2 capstone parity)
+// ---------------------------------------------------------------------------
+// The last two special-clause markers, now typed dispositions. Oracle text
+// verified verbatim against Scryfall. Reach-guards asserting these texts really
+// land on the new dispositions live in `oracle_effect::tests`
+// (`*_reaches_fold_search_into_else`, `sylvan_library_reaches_drawn_this_turn_followup`) —
+// `ClauseDisposition` is never serialized, so a snapshot alone cannot show which
+// arm ran.
+
+// CR 608.2c + CR 601.2b: FoldSearchIntoElse — an "instead, search your library …"
+// clause whose additional cost was paid (CR 601.2b) is later text modifying the
+// meaning of the earlier search (CR 608.2c). It builds its own def and folds the
+// PRIOR search's trailing search-destination `ChangeZone` into its `else_ability`,
+// then applies its OWN intrinsic `SearchDestination` continuation. Kicker variant.
+#[test]
+fn aangs_journey() {
+    let (ir, lowered) = parse_two_layer(
+        "Kicker {2} (You may pay an additional {2} as you cast this spell.)\nSearch your library for a basic land card. If this spell was kicked, instead search your library for a basic land card and a Shrine card. Reveal those cards, put them into your hand, then shuffle.\nYou gain 2 life.",
+        "Aang's Journey",
+        &["Sorcery"],
+        &["Lesson"],
+    );
+    insta::assert_json_snapshot!("aangs_journey_ir", &ir);
+    insta::assert_json_snapshot!("aangs_journey_lowered", &lowered);
+}
+
+// CR 608.2c + CR 601.2b: FoldSearchIntoElse, second card of the class — the cost
+// is `collect evidence` rather than kicker, and the search reveals (the intrinsic
+// carries `reveal: true`). Same disposition, different cost + intrinsic payload:
+// this is the class, not the card.
+#[test]
+fn analyze_the_pollen() {
+    let (ir, lowered) = parse_two_layer(
+        "As an additional cost to cast this spell, you may collect evidence 8. (Exile cards with total mana value 8 or greater from your graveyard.)\nSearch your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle.",
+        "Analyze the Pollen",
+        &["Sorcery"],
+        &[],
+    );
+    insta::assert_json_snapshot!("analyze_the_pollen_ir", &ir);
+    insta::assert_json_snapshot!("analyze_the_pollen_lowered", &lowered);
+}
+
+// DrawnThisTurnFollowup — "For each of those cards, pay N life or put the card on
+// top of your library" sets the life payment on the prior
+// `ChooseDrawnThisTurnPayOrTopdeck` and emits no def of its own (Sylvan Library).
+// NOTE: this is the only card of its class and it is NOT in the 568-card fixture
+// corpus, so the payment write is additionally pinned by a direct handler test
+// (`drawn_this_turn_followup_overwrites_prior_life_payment`) using a NON-default
+// payment — Sylvan Library's parsed default is already 4, so asserting 4 here
+// would be vacuous.
+#[test]
+fn sylvan_library() {
+    let (ir, lowered) = parse_two_layer(
+        "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
+        "Sylvan Library",
+        &["Enchantment"],
+        &[],
+    );
+    insta::assert_json_snapshot!("sylvan_library_ir", &ir);
+    insta::assert_json_snapshot!("sylvan_library_lowered", &lowered);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aangs_journey_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aangs_journey_ir.snap
@@ -1,0 +1,370 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 763
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 66,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Kicker {2} (You may pay an additional {2} as you cast this spell.)"
+      },
+      "node": {
+        "Keyword": {
+          "Kicker": {
+            "type": "Cost",
+            "shards": [],
+            "generic": 2
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 66,
+          "precision": "Exact",
+          "ordinal_within_span": 1
+        },
+        "fragment": "Kicker {2} (You may pay an additional {2} as you cast this spell.)"
+      },
+      "node": {
+        "AdditionalCost": {
+          "type": "Kicker",
+          "data": {
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [],
+                  "generic": 2
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 67,
+          "end_byte": 263,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Search your library for a basic land card. If this spell was kicked, instead search your library for a basic land card and a Shrine card. Reveal those cards, put them into your hand, then shuffle."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "SearchLibrary",
+            "filter": {
+              "type": "Typed",
+              "type_filters": [
+                "Land"
+              ],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "HasSupertype",
+                  "value": "Basic"
+                }
+              ]
+            },
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "reveal": false
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "SearchLibrary",
+              "filter": {
+                "type": "Or",
+                "filters": [
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Land"
+                    ],
+                    "controller": null,
+                    "properties": [
+                      {
+                        "type": "HasSupertype",
+                        "value": "Basic"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Enchantment",
+                      {
+                        "Subtype": "Shrine"
+                      }
+                    ],
+                    "controller": null,
+                    "properties": []
+                  }
+                ]
+              },
+              "count": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "reveal": false,
+              "selection_constraint": {
+                "type": "MatchEachFilter",
+                "filters": [
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Land"
+                    ],
+                    "controller": null,
+                    "properties": [
+                      {
+                        "type": "HasSupertype",
+                        "value": "Basic"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Enchantment",
+                      {
+                        "Subtype": "Shrine"
+                      }
+                    ],
+                    "controller": null,
+                    "properties": []
+                  }
+                ]
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "ChangeZone",
+                "origin": "Library",
+                "destination": "Hand",
+                "target": {
+                  "type": "Any"
+                },
+                "owner_library": false,
+                "enter_transformed": false,
+                "enter_tapped": false,
+                "enters_attacking": false
+              },
+              "cost": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "ChangeZone",
+                  "origin": null,
+                  "destination": "Hand",
+                  "target": {
+                    "type": "ParentTarget"
+                  },
+                  "owner_library": false,
+                  "enter_transformed": false,
+                  "enter_tapped": false,
+                  "enters_attacking": false
+                },
+                "cost": null,
+                "sub_ability": {
+                  "kind": "Spell",
+                  "effect": {
+                    "type": "Shuffle",
+                    "target": {
+                      "type": "Controller"
+                    }
+                  },
+                  "cost": null,
+                  "sub_ability": {
+                    "kind": "Spell",
+                    "effect": {
+                      "type": "GainLife",
+                      "amount": {
+                        "type": "Fixed",
+                        "value": 2
+                      }
+                    },
+                    "cost": null,
+                    "sub_ability": null,
+                    "duration": null,
+                    "description": null,
+                    "target_prompt": null,
+                    "condition": null,
+                    "optional_targeting": false,
+                    "optional": false,
+                    "forward_result": false,
+                    "sub_link": "SequentialSibling"
+                  },
+                  "duration": null,
+                  "description": null,
+                  "target_prompt": null,
+                  "condition": null,
+                  "optional_targeting": false,
+                  "optional": false,
+                  "forward_result": false
+                },
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "else_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "ChangeZone",
+                "origin": "Library",
+                "destination": "Hand",
+                "target": {
+                  "type": "Any"
+                },
+                "owner_library": false,
+                "enter_transformed": false,
+                "enter_tapped": false,
+                "enters_attacking": false
+              },
+              "cost": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "ChangeZone",
+                  "origin": null,
+                  "destination": "Hand",
+                  "target": {
+                    "type": "ParentTarget"
+                  },
+                  "owner_library": false,
+                  "enter_transformed": false,
+                  "enter_tapped": false,
+                  "enters_attacking": false
+                },
+                "cost": null,
+                "sub_ability": {
+                  "kind": "Spell",
+                  "effect": {
+                    "type": "Shuffle",
+                    "target": {
+                      "type": "Controller"
+                    }
+                  },
+                  "cost": null,
+                  "sub_ability": {
+                    "kind": "Spell",
+                    "effect": {
+                      "type": "GainLife",
+                      "amount": {
+                        "type": "Fixed",
+                        "value": 2
+                      }
+                    },
+                    "cost": null,
+                    "sub_ability": null,
+                    "duration": null,
+                    "description": null,
+                    "target_prompt": null,
+                    "condition": null,
+                    "optional_targeting": false,
+                    "optional": false,
+                    "forward_result": false,
+                    "sub_link": "SequentialSibling"
+                  },
+                  "duration": null,
+                  "description": null,
+                  "target_prompt": null,
+                  "condition": null,
+                  "optional_targeting": false,
+                  "optional": false,
+                  "forward_result": false
+                },
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": {
+              "type": "AdditionalCostPaidInstead"
+            },
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": "Search your library for a basic land card. If this spell was kicked, instead search your library for a basic land card and a Shrine card. Reveal those cards, put them into your hand, then shuffle.\nYou gain 2 life.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Kicker {2} (You may pay an additional {2} as you cast this spell.)\nSearch your library for a basic land card. If this spell was kicked, instead search your library for a basic land card and a Shrine card. Reveal those cards, put them into your hand, then shuffle.\nYou gain 2 life.",
+  "card_name": "Aang's Journey"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aangs_journey_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aangs_journey_lowered.snap
@@ -1,0 +1,313 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 764
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "SearchLibrary",
+        "filter": {
+          "type": "Typed",
+          "type_filters": [
+            "Land"
+          ],
+          "controller": null,
+          "properties": [
+            {
+              "type": "HasSupertype",
+              "value": "Basic"
+            }
+          ]
+        },
+        "count": {
+          "type": "Fixed",
+          "value": 1
+        },
+        "reveal": false
+      },
+      "cost": null,
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "SearchLibrary",
+          "filter": {
+            "type": "Or",
+            "filters": [
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Land"
+                ],
+                "controller": null,
+                "properties": [
+                  {
+                    "type": "HasSupertype",
+                    "value": "Basic"
+                  }
+                ]
+              },
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Enchantment",
+                  {
+                    "Subtype": "Shrine"
+                  }
+                ],
+                "controller": null,
+                "properties": []
+              }
+            ]
+          },
+          "count": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "reveal": false,
+          "selection_constraint": {
+            "type": "MatchEachFilter",
+            "filters": [
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Land"
+                ],
+                "controller": null,
+                "properties": [
+                  {
+                    "type": "HasSupertype",
+                    "value": "Basic"
+                  }
+                ]
+              },
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Enchantment",
+                  {
+                    "Subtype": "Shrine"
+                  }
+                ],
+                "controller": null,
+                "properties": []
+              }
+            ]
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "ChangeZone",
+            "origin": "Library",
+            "destination": "Hand",
+            "target": {
+              "type": "Any"
+            },
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "ChangeZone",
+              "origin": null,
+              "destination": "Hand",
+              "target": {
+                "type": "ParentTarget"
+              },
+              "owner_library": false,
+              "enter_transformed": false,
+              "enter_tapped": false,
+              "enters_attacking": false
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "Shuffle",
+                "target": {
+                  "type": "Controller"
+                }
+              },
+              "cost": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "GainLife",
+                  "amount": {
+                    "type": "Fixed",
+                    "value": 2
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false,
+                "sub_link": "SequentialSibling"
+              },
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "else_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "ChangeZone",
+            "origin": "Library",
+            "destination": "Hand",
+            "target": {
+              "type": "Any"
+            },
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "ChangeZone",
+              "origin": null,
+              "destination": "Hand",
+              "target": {
+                "type": "ParentTarget"
+              },
+              "owner_library": false,
+              "enter_transformed": false,
+              "enter_tapped": false,
+              "enters_attacking": false
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "Shuffle",
+                "target": {
+                  "type": "Controller"
+                }
+              },
+              "cost": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "GainLife",
+                  "amount": {
+                    "type": "Fixed",
+                    "value": 2
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false,
+                "sub_link": "SequentialSibling"
+              },
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": {
+          "type": "AdditionalCostPaidInstead"
+        },
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "duration": null,
+      "description": "Search your library for a basic land card. If this spell was kicked, instead search your library for a basic land card and a Shrine card. Reveal those cards, put them into your hand, then shuffle.\nYou gain 2 life.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": [
+    {
+      "Kicker": {
+        "type": "Cost",
+        "shards": [],
+        "generic": 2
+      }
+    }
+  ],
+  "additionalCost": {
+    "type": "Kicker",
+    "data": {
+      "costs": [
+        {
+          "type": "Mana",
+          "cost": {
+            "type": "Cost",
+            "shards": [],
+            "generic": 2
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__analyze_the_pollen_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__analyze_the_pollen_ir.snap
@@ -1,0 +1,216 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 779
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 139,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "As an additional cost to cast this spell, you may collect evidence 8. (Exile cards with total mana value 8 or greater from your graveyard.)"
+      },
+      "node": {
+        "AdditionalCost": {
+          "type": "Optional",
+          "data": {
+            "cost": {
+              "type": "CollectEvidence",
+              "amount": 8
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 140,
+          "end_byte": 321,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Search your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "SearchLibrary",
+            "filter": {
+              "type": "Typed",
+              "type_filters": [
+                "Land"
+              ],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "HasSupertype",
+                  "value": "Basic"
+                }
+              ]
+            },
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "reveal": true
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "SearchLibrary",
+              "filter": {
+                "type": "Or",
+                "filters": [
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": null,
+                    "properties": []
+                  },
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Land"
+                    ],
+                    "controller": null,
+                    "properties": []
+                  }
+                ]
+              },
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "reveal": true
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "ChangeZone",
+                "origin": "Library",
+                "destination": "Hand",
+                "target": {
+                  "type": "Any"
+                },
+                "owner_library": false,
+                "enter_transformed": false,
+                "enter_tapped": false,
+                "enters_attacking": false
+              },
+              "cost": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "Shuffle",
+                  "target": {
+                    "type": "Controller"
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "else_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "ChangeZone",
+                "origin": "Library",
+                "destination": "Hand",
+                "target": {
+                  "type": "Any"
+                },
+                "owner_library": false,
+                "enter_transformed": false,
+                "enter_tapped": false,
+                "enters_attacking": false
+              },
+              "cost": null,
+              "sub_ability": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "Shuffle",
+                  "target": {
+                    "type": "Controller"
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": {
+              "type": "AdditionalCostPaidInstead"
+            },
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": "Search your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "As an additional cost to cast this spell, you may collect evidence 8. (Exile cards with total mana value 8 or greater from your graveyard.)\nSearch your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle.",
+  "card_name": "Analyze the Pollen"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__analyze_the_pollen_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__analyze_the_pollen_lowered.snap
@@ -1,0 +1,178 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 780
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "SearchLibrary",
+        "filter": {
+          "type": "Typed",
+          "type_filters": [
+            "Land"
+          ],
+          "controller": null,
+          "properties": [
+            {
+              "type": "HasSupertype",
+              "value": "Basic"
+            }
+          ]
+        },
+        "count": {
+          "type": "Fixed",
+          "value": 1
+        },
+        "reveal": true
+      },
+      "cost": null,
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "SearchLibrary",
+          "filter": {
+            "type": "Or",
+            "filters": [
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": null,
+                "properties": []
+              },
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Land"
+                ],
+                "controller": null,
+                "properties": []
+              }
+            ]
+          },
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "reveal": true
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "ChangeZone",
+            "origin": "Library",
+            "destination": "Hand",
+            "target": {
+              "type": "Any"
+            },
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Shuffle",
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "else_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "ChangeZone",
+            "origin": "Library",
+            "destination": "Hand",
+            "target": {
+              "type": "Any"
+            },
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Shuffle",
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": {
+          "type": "AdditionalCostPaidInstead"
+        },
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "duration": null,
+      "description": "Search your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": [],
+  "additionalCost": {
+    "type": "Optional",
+    "data": {
+      "cost": {
+        "type": "CollectEvidence",
+        "amount": 8
+      }
+    }
+  }
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_library_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_library_ir.snap
@@ -1,0 +1,103 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 799
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 204,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Phase",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Draw",
+              "count": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "ChooseDrawnThisTurnPayOrTopdeck",
+                "count": {
+                  "type": "Fixed",
+                  "value": 2
+                },
+                "life_payment": {
+                  "type": "Fixed",
+                  "value": 4
+                },
+                "player": {
+                  "type": "Controller"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": {
+                "type": "EffectOutcome",
+                "signal": "OptionalEffectPerformed"
+              },
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false,
+              "sub_link": "SequentialSibling"
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": true,
+            "forward_result": false
+          },
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": "Draw",
+          "optional": true,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
+          "constraint": {
+            "type": "OnlyDuringYourTurn"
+          },
+          "condition": null,
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
+  "card_name": "Sylvan Library"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_library_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_library_lowered.snap
@@ -1,0 +1,85 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 800
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "Phase",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Draw",
+          "count": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "target": {
+            "type": "Controller"
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "ChooseDrawnThisTurnPayOrTopdeck",
+            "count": {
+              "type": "Fixed",
+              "value": 2
+            },
+            "life_payment": {
+              "type": "Fixed",
+              "value": 4
+            },
+            "player": {
+              "type": "Controller"
+            }
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": {
+            "type": "EffectOutcome",
+            "signal": "OptionalEffectPerformed"
+          },
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false,
+          "sub_link": "SequentialSibling"
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": true,
+        "forward_result": false
+      },
+      "valid_card": null,
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": "Draw",
+      "optional": true,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
+      "constraint": {
+        "type": "OnlyDuringYourTurn"
+      },
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -17361,7 +17361,7 @@ fn lower_effect_chain_ir_advances_boundary_past_special_clause() {
     };
     // A `BranchOtherwise { kind: Bound }` with no prior conditional def is a
     // silent no-op (attaches nowhere) — the same boundary-advancing behavior the
-    // former `SpecialClause::Otherwise` had, so clause 0 needs no condition.
+    // former `Otherwise` special-clause marker had, so clause 0 needs no condition.
     let otherwise_def = Box::new(crate::types::ability::AbilityDefinition::new(
         AbilityKind::Spell,
         draw_one(),


### PR DESCRIPTION
Sixth and final U5-M2 increment; completes U5. The last two SpecialClause
variants become typed dispositions, and the SpecialClause enum plus the
ClauseDisposition::Special variant are DELETED outright.

- AdditionalCostInsteadSearch -> ClauseDisposition::FoldSearchIntoElse
  { intrinsic }. The only intrinsic-carrier: the second SearchLibrary of an
  "additional cost ... instead, search your library" chain needs its OWN
  SearchDestination self-patch, which the handler applies inline at its tail.
  The intrinsic is also read by the parse-time previous_is_search_with_hand_dest
  guard, so the intrinsic() accessor keeps an arm for it.
- DrawnThisTurnPayOrTopdeck -> ClauseDisposition::DrawnThisTurnFollowup
  { life_payment } (emit-site intrinsic verified None, so no intrinsic field).
- enum SpecialClause, ClauseDisposition::Special, its accessor arms, and the
  now-empty `else if let Special` block are gone. Gate:
  `rg 'enum SpecialClause|ClauseDisposition::Special\b|SpecialClause::'
  crates/engine/src` returns ZERO; so does a bare `rg SpecialClause`.

Both handler bodies move statement-for-statement (only the match pattern names
and one dedent level change). ClauseDisposition is consumed inside
lower_effect_chain_ir and never serialized, so the promotion is faithful by
construction: zero snapshot drift across the 76 pre-existing snapshots.

Parity: Aang's Journey + Analyze the Pollen (FoldSearchIntoElse via kicker and
collect-evidence -- the class, not the card) and Sylvan Library
(DrawnThisTurnFollowup). Because dispositions never reach a snapshot, reach-guards
in oracle_effect::tests assert each card really lands on the new arm and that
FoldSearchIntoElse preserves its SearchDestination intrinsic. Sylvan Library's
parsed life payment (4) equals the handler's default, so its card-level snapshot
is vacuous for the payment write -- a direct handler test pins it with a
non-default payment (3) instead.

CR fix: the deleted marker's doc cited CR 608.2e for the search fold. CR 608.2e is
APNAP ordering for multi-player multi-step actions and does not describe it. The
new dispositions cite CR 608.2c ("later text ... may modify the meaning of earlier
text") + CR 601.2b (additional costs announced at cast), both grep-verified.
