### PR TITLE
docs(engine): correct miscited CR 608.2e annotations to CR 608.2c

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -121,7 +121,7 @@ pub fn build_resolved_from_def_with_targets(
     resolved
 }
 
-/// CR 608.2c + CR 608.2e: Apply an "instead" swap from a sub-ability override
+/// CR 608.2c: Apply an "instead" swap from a sub-ability override
 /// onto a parent `ResolvedAbility`. Produces a new `ResolvedAbility` whose
 /// **identity / runtime context** comes from the parent (controller, source,
 /// already-announced targets, kicker context, chosen-X, etc.) but whose

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -6315,18 +6315,18 @@ fn resolve_chain_body(
         }
     }
 
-    // CR 608.2e: "Instead" kicker — check if a sub overrides the parent.
+    // CR 608.2c: "Instead" kicker — check if a sub overrides the parent.
     // When condition is met, replace the current ability's effect with the sub's
     // effect, preserving the full resolution flow (tracked sets, continuations).
     let ability = if let Some(ref sub) = ability.sub_ability {
-        // CR 608.2e: "Instead" kicker — swap parent effect with override sub's effect.
+        // CR 608.2c: "Instead" kicker — swap parent effect with override sub's effect.
         let should_swap = if matches!(
             sub.condition,
             Some(AbilityCondition::AdditionalCostPaidInstead)
         ) {
             ability.context.additional_cost_paid
         } else if let Some(AbilityCondition::CastVariantPaidInstead { variant }) = sub.condition {
-            // CR 608.2e + CR 702.49 + CR 702.190a: Read from GameObject, not SpellContext
+            // CR 608.2c + CR 702.49 + CR 702.190a: Read from GameObject, not SpellContext
             state
                 .objects
                 .get(&ability.source_id)
@@ -6335,7 +6335,7 @@ fn resolve_chain_body(
         } else if let Some(AbilityCondition::TargetHasKeywordInstead { ref keyword }) =
             sub.condition
         {
-            // CR 608.2e: Check if the first resolved object target has the keyword.
+            // CR 608.2c: Check if the first resolved object target has the keyword.
             ability
                 .targets
                 .iter()
@@ -6351,7 +6351,7 @@ fn resolve_chain_body(
             false
         };
         if should_swap {
-            // CR 608.2c + CR 608.2e: Single-authority swap helper preserves
+            // CR 608.2c: Single-authority swap helper preserves
             // every effect-shape field on the sub (player_scope, optional,
             // multi_target, repeat_for, …) and every runtime-context field on
             // the parent (controller, targets, chosen_x, …). See
@@ -7636,7 +7636,7 @@ fn resolve_chain_body(
         // Check if the sub_ability has a condition that gates its execution.
         // Casting-time conditions are evaluated against the parent's SpellContext.
         if let Some(ref condition) = sub.condition {
-            // CR 608.2e: "Instead" overrides are terminal — the Cow swap above either
+            // CR 608.2c: "Instead" overrides are terminal — the Cow swap above either
             // replaced the parent's effect (condition met) or didn't (condition not met).
             // For kicker/ninjutsu/keyword-instead, the base has no continuation chain.
             // For ConditionInstead, the base chain (else_ability) must run when NOT swapped.
@@ -14676,7 +14676,7 @@ mod tests {
 
     #[test]
     fn override_instead_condition_met_swaps_effect() {
-        // CR 608.2e: When AdditionalCostPaidInstead condition is met,
+        // CR 608.2c: When AdditionalCostPaidInstead condition is met,
         // the sub's effect replaces the parent's effect.
         let mut state = GameState::new_two_player(42);
 
@@ -14724,7 +14724,7 @@ mod tests {
 
     #[test]
     fn override_instead_condition_not_met_runs_parent() {
-        // CR 608.2e: When AdditionalCostPaidInstead condition is NOT met,
+        // CR 608.2c: When AdditionalCostPaidInstead condition is NOT met,
         // the parent runs normally and the override sub is skipped.
         let mut state = GameState::new_two_player(42);
 

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2323,7 +2323,7 @@ pub(super) fn strip_player_property_superlative_conditional(
     )
 }
 
-/// CR 608.2e + CR 122.1b: Parse "if that creature has <keyword>[ and ~ doesn't], <effect>".
+/// CR 608.2c + CR 122.1b: Parse "if that creature has <keyword>[ and ~ doesn't], <effect>".
 ///
 /// The optional " and ~ doesn't" conjunct (Super-Adaptoid: "If that creature
 /// has haste and Super-Adaptoid doesn't, put a haste counter on
@@ -3764,7 +3764,7 @@ fn build_instead_def(
     kind: AbilityKind,
     ctx: &mut ParseContext,
 ) -> Option<AbilityDefinition> {
-    // CR 608.2e: An additional-cost-paid "instead" fold ("if it/this spell was
+    // CR 608.2c: An additional-cost-paid "instead" fold ("if it/this spell was
     // kicked, ... instead") is owned by `strip_additional_cost_conditional`,
     // which folds it to the dedicated `AdditionalCostPaidInstead`. Defer here so
     // the generic `parse_condition_text` recognizer (which now classifies "was
@@ -9085,7 +9085,7 @@ mod tests {
         ));
     }
 
-    /// CR 608.2e: Full instead-clause assembly for Fblthp's ETB draw rider.
+    /// CR 608.2c: Full instead-clause assembly for Fblthp's ETB draw rider.
     #[test]
     fn fblthp_library_origin_instead_clause() {
         let instead = try_parse_generic_instead_clause(
@@ -9108,7 +9108,7 @@ mod tests {
         ));
     }
 
-    /// CR 608.2e: ETB base draw + library-origin instead override chain.
+    /// CR 608.2c: ETB base draw + library-origin instead override chain.
     #[test]
     fn fblthp_etb_draw_chain_with_library_instead() {
         let def = parse_effect_chain(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23377,7 +23377,7 @@ pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
     let mut def = lower_effect_chain_ir(&ir.body);
     finalize_effect_chain(&mut def);
     apply_owner_library_reveal_anchor_from_text(&mut def, &ir.source_text);
-    // CR 608.2e: a root the chain cannot describe (it has no previous boundary).
+    // CR 608.2c: a root the chain cannot describe (it has no previous boundary).
     if let Some(sub_link) = ir.shell.sub_link {
         def.sub_link = sub_link;
     }
@@ -25074,7 +25074,7 @@ pub(crate) fn parse_effect_chain_ir(
             continue;
         }
 
-        // CR 608.2e: "if [condition], [effect] instead" — the preceding ability's effect
+        // CR 608.2c: "if [condition], [effect] instead" — the preceding ability's effect
         // is replaced when the condition holds. Keep the base effect as the root so
         // target collection stays anchored on the printed target-bearing clause.
         if let Some(instead_def) = try_parse_generic_instead_clause(normalized_text, kind, ctx) {
@@ -25270,7 +25270,7 @@ pub(crate) fn parse_effect_chain_ir(
         } else {
             (None, text)
         };
-        // CR 608.2e: "If that creature has [keyword], [effect] instead"
+        // CR 608.2c: "If that creature has [keyword], [effect] instead"
         let (keyword_instead_cond, text) = if condition.is_none()
             && if_you_do.is_none()
             && counter_cond.is_none()
@@ -25341,7 +25341,7 @@ pub(crate) fn parse_effect_chain_ir(
             UnlessSuffixStrip::Parsed(c) => Some(c),
             _ => condition,
         };
-        // CR 608.2e: Strip leading "instead " when a condition was extracted.
+        // CR 608.2c: Strip leading "instead " when a condition was extracted.
         // The condition already encodes the replacement gate; "instead" is a
         // textual marker that the effect parser doesn't need.
         let text = if condition.is_some() {
@@ -26537,7 +26537,7 @@ pub(crate) fn parse_effect_chain_ir(
             is_optional
         };
 
-        // CR 608.2e: "Instead" overrides — marker for lowering to attach as
+        // CR 608.2c: "Instead" overrides — marker for lowering to attach as
         // sub_ability on the previous def.
         if matches!(
             condition,
@@ -26569,7 +26569,7 @@ pub(crate) fn parse_effect_chain_ir(
             continue;
         }
 
-        // CR 608.2e: AdditionalCostPaidInstead + SearchLibrary pattern.
+        // CR 608.2c: AdditionalCostPaidInstead + SearchLibrary pattern.
         // In the old code, the trailing ChangeZone was an explicit def produced by the
         // SearchDestination intrinsic continuation. In the IR, the ChangeZone is implicit
         // in the SearchLibrary clause's intrinsic_continuation field. We check for either:

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -16715,7 +16715,7 @@ fn kicker_instead_chain_produces_correct_condition() {
 
 #[test]
 fn kicker_leading_instead_produces_correct_condition() {
-    // CR 608.2e: "if kicked, instead [effect]" — leading "instead" variant.
+    // CR 608.2c: "if kicked, instead [effect]" — leading "instead" variant.
     // Must produce AdditionalCostPaidInstead, same as trailing "instead".
     let ability = parse_effect_chain(
             "Destroy target creature or planeswalker with mana value 2 or less. If this spell was kicked, instead destroy target creature or planeswalker",
@@ -16816,7 +16816,7 @@ fn rite_of_replication_kicker_creates_five_copies() {
 
 #[test]
 fn general_condition_leading_instead_strips_prefix() {
-    // CR 608.2e: Ability-word / general condition with leading "instead"
+    // CR 608.2c: Ability-word / general condition with leading "instead"
     // (cross-line pattern like Traverse the Ulvenwald's delirium).
     let ability = parse_effect_chain(
         "If you control three or more creatures, instead draw two cards",

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -723,7 +723,7 @@ fn evils_thrall() {
     insta::assert_json_snapshot!("evils_thrall_lowered", &lowered);
 }
 
-// CR 608.2e: KeywordOverride — a "TargetHasKeywordInstead"-conditioned clause
+// CR 608.2c: KeywordOverride — a "TargetHasKeywordInstead"-conditioned clause
 // builds its def from the parsed effect + condition and attaches as the prior
 // def's `sub_ability` (Conformer Shuriken's granted attack trigger).
 #[test]

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -13387,7 +13387,7 @@ fn strip_counter_conditional_demonstrative_target_non_trigger() {
 /// `strip_counter_conditional` (offered only in the trailing form), so
 /// `strip_counter_conditional` returns no condition here and this
 /// replacement-class clause stays on the same inert deferral path as upstream
-/// `main` (CR 608.2e). Discriminating: under the pre-fix over-acceptance the
+/// `main` (CR 608.2c). Discriminating: under the pre-fix over-acceptance the
 /// leading demonstrative matched and the condition became
 /// `QuantityCheck(Target, GE 1)`, with the "instead" replacement wrongly lowered
 /// as an additive 5-damage sibling (target with a counter → 3+5=8 instead of the

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -16323,7 +16323,7 @@ pub enum AbilityCondition {
         )]
         subject: ObjectScope,
     },
-    /// CR 608.2e + CR 702.49 + CR 702.190a: "Instead" override gated on the source
+    /// CR 608.2c + CR 702.49 + CR 702.190a: "Instead" override gated on the source
     /// permanent having entered via a specified cast/activation variant this turn.
     /// Unlike AdditionalCostPaidInstead (which reads SpellContext.additional_cost_paid),
     /// this reads GameObject.cast_variant_paid from the game state.
@@ -16367,7 +16367,7 @@ pub enum AbilityCondition {
     /// CR 701.54a: True when the ability's source permanent is its controller's
     /// Ring-bearer. For "unless ~ is your Ring-bearer", wrap with `Not`.
     IsRingBearer,
-    /// CR 608.2e: "If [target] has [keyword], [override effect] instead"
+    /// CR 608.2c: "If [target] has [keyword], [override effect] instead"
     /// Checked at resolution time against the first resolved object target's keywords.
     /// Uses "Instead" override semantics: swaps the parent effect when condition is met.
     TargetHasKeywordInstead { keyword: Keyword },

--- a/crates/engine/tests/integration/s07_b3_target_identity.rs
+++ b/crates/engine/tests/integration/s07_b3_target_identity.rs
@@ -270,7 +270,7 @@ fn steer_clear_deals_four_with_mount_two_without() {
     assert_eq!(
         run_steer(true),
         4,
-        "controlled a Mount as you cast → 4 damage instead (CR 608.2e)"
+        "controlled a Mount as you cast → 4 damage instead (CR 608.2c)"
     );
     assert_eq!(
         run_steer(false),


### PR DESCRIPTION
## What

`CR 608.2e` was being used across the engine to mean *"later text on the card modifies the meaning of earlier text"* / `instead` semantics. That is the wrong rule.

Grep-verified against `docs/MagicCompRules.txt`:

- **608.2c** — "…However, replacement effects may modify these actions. **In some cases, later text on the card may modify the meaning of earlier text** (for example, *'Destroy target creature. It can't be regenerated'* …)"
- **608.2e** — "Some spells and abilities have multiple steps or actions … **that involve multiple players**. In these cases, the choices for the first action are made in **APNAP order**…"

So sites reasoning about `AdditionalCostPaidInstead`, `ConditionInstead` overrides, and later-text-modifies-earlier are miscited and are corrected to **608.2c**.

## What is deliberately NOT changed

The genuinely multi-player sites keep **608.2e**, because there it is the correct rule:

- `opponent_guess.rs` — a player other than the controller makes a choice (608.2d + 608.2e)
- the `player_scope` equalization cluster (Balance, Syphon Mind) — clause-local snapshots across players
- APNAP discard accumulation, catch-up-draw ordering

Each site was decided by reading the code, not by pattern-matching the comment text.

## Scope

Comment-only. The sole non-comment line is a test *assertion label* string. No behavior change, no snapshot movement.

Citations inside `parser/oracle_effect/{assembly,lower}.rs` and `parser/oracle_ir/effect_chain.rs` are intentionally left for the in-flight U6 refactor to correct as it moves them, to avoid conflicting with that stack.