### PR TITLE
refactor(parser): convert the remaining continuation scans to arena bindings (U6-C2b)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -348,6 +348,12 @@ pub(super) struct AssemblyEnv {
     search_destination_nodes: Vec<usize>,
     /// Every `Dig`/`Mill` node, in emission order (the `DigFromAmong` anchor set).
     dig_or_mill_nodes: Vec<usize>,
+    /// Every `Dig`/`RevealUntil` node (the `RestDestination` patchable set).
+    dig_or_reveal_until_nodes: Vec<usize>,
+    /// Every `Destroy`/`DestroyAll` node (the can't-be-regenerated antecedent set).
+    destroy_like_nodes: Vec<usize>,
+    /// Every node already carrying a face-down profile (CR 708.2a spec antecedent).
+    face_down_profile_nodes: Vec<usize>,
 }
 
 /// Which antecedent a handler is binding to. Point selectors only (U6-C2);
@@ -393,6 +399,18 @@ pub(super) enum AntecedentRole {
     Conditional,
     /// An "any player may" head (`optional_for`).
     OptionalHead,
+    /// A `Dig` or `RevealUntil` — the set `patch_rest_destination_recursively`
+    /// can patch, which a `RestDestination` ("put the rest ...") clause binds back
+    /// to. Deliberately a DIFFERENT set from `DigOrMill`.
+    DigOrRevealUntil,
+    /// A `Destroy` or `DestroyAll` — the antecedent of a "can't be regenerated"
+    /// rider, which may be non-adjacent (Kirtar's Wrath puts a Token between them).
+    DestroyLike,
+    /// A move/manifest/turn-face-down node that ALREADY carries a face-down
+    /// profile — the antecedent a "They're N/M ... creatures." spec refines
+    /// (CR 708.2a). "Already carries one" is the binding condition itself, not a
+    /// guard: a node with no profile is not this antecedent at all.
+    FaceDownProfileHolder,
     /// A `Dig` or `Mill` — the "look at / mill N cards" anchor a `DigFromAmong`
     /// continuation binds back to.
     ///
@@ -492,6 +510,9 @@ impl AssemblyEnv {
         self.optional_head_nodes.clear();
         self.search_destination_nodes.clear();
         self.dig_or_mill_nodes.clear();
+        self.dig_or_reveal_until_nodes.clear();
+        self.destroy_like_nodes.clear();
+        self.face_down_profile_nodes.clear();
 
         for (index, def) in defs.iter().enumerate() {
             let provenance = self.prov.get(index).copied().unwrap_or(NodeProvenance {
@@ -533,6 +554,38 @@ impl AssemblyEnv {
             }
             if matches!(&*def.effect, Effect::Dig { .. } | Effect::Mill { .. }) {
                 self.dig_or_mill_nodes.push(index);
+            }
+            if matches!(
+                &*def.effect,
+                Effect::Dig { .. } | Effect::RevealUntil { .. }
+            ) {
+                self.dig_or_reveal_until_nodes.push(index);
+            }
+            if matches!(
+                &*def.effect,
+                Effect::Destroy { .. } | Effect::DestroyAll { .. }
+            ) {
+                self.destroy_like_nodes.push(index);
+            }
+            if matches!(
+                &*def.effect,
+                Effect::ChangeZoneAll {
+                    face_down_profile: Some(_),
+                    library_position: None,
+                    random_order: false,
+                    ..
+                } | Effect::ChangeZone {
+                    face_down_profile: Some(_),
+                    ..
+                } | Effect::Manifest {
+                    profile: Some(_),
+                    ..
+                } | Effect::TurnFaceDown {
+                    profile: Some(_),
+                    ..
+                }
+            ) {
+                self.face_down_profile_nodes.push(index);
             }
             match &*def.effect {
                 Effect::Dig { .. } | Effect::Mill { .. } | Effect::RevealUntil { .. } => {
@@ -625,6 +678,15 @@ impl AssemblyEnv {
                 &self.search_destination_nodes
             }
             AntecedentSelector::LastWithRole(AntecedentRole::DigOrMill) => &self.dig_or_mill_nodes,
+            AntecedentSelector::LastWithRole(AntecedentRole::DigOrRevealUntil) => {
+                &self.dig_or_reveal_until_nodes
+            }
+            AntecedentSelector::LastWithRole(AntecedentRole::DestroyLike) => {
+                &self.destroy_like_nodes
+            }
+            AntecedentSelector::LastWithRole(AntecedentRole::FaceDownProfileHolder) => {
+                &self.face_down_profile_nodes
+            }
             AntecedentSelector::Between { anchor } => {
                 // Walk FORWARD over emission order from the anchor and take the
                 // FIRST qualifying node. Reads `order` only — never the output tree.

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3550,12 +3550,16 @@ pub(super) fn apply_clause_continuation(
             // adjacent — e.g. Kirtar's Wrath threshold has a Token creation
             // between the DestroyAll and "Creatures destroyed this way can't
             // be regenerated."
-            if let Some(def) = defs.iter_mut().rev().find(|d| {
-                matches!(
-                    &*d.effect,
-                    Effect::Destroy { .. } | Effect::DestroyAll { .. }
-                )
-            }) {
+            let bound = env.resolve(
+                defs,
+                super::assembly::AntecedentSelector::LastWithRole(
+                    super::assembly::AntecedentRole::DestroyLike,
+                ),
+                None,
+                super::assembly::OnMiss::Ignore,
+            );
+            if let Some(bound_index) = bound {
+                let def = &mut defs[bound_index];
                 match &mut *def.effect {
                     Effect::Destroy {
                         cant_regenerate, ..
@@ -3599,14 +3603,18 @@ pub(super) fn apply_clause_continuation(
             // clause, `defs.last()` is the intervening clause. Search back for
             // the nearest rest-patchable def (`Dig`/`RevealUntil` — what
             // `patch_rest_destination_recursively` handles).
-            let Some(previous) = defs
-                .iter_mut()
-                .rev()
-                .find(|d| matches!(&*d.effect, Effect::Dig { .. } | Effect::RevealUntil { .. }))
-            else {
+            let bound = env.resolve(
+                defs,
+                super::assembly::AntecedentSelector::LastWithRole(
+                    super::assembly::AntecedentRole::DigOrRevealUntil,
+                ),
+                None,
+                super::assembly::OnMiss::Ignore,
+            );
+            let Some(bound_index) = bound else {
                 return;
             };
-            patch_rest_destination_recursively(previous, destination, reorder_all);
+            patch_rest_destination_recursively(&mut defs[bound_index], destination, reorder_all);
         }
         ContinuationAst::DigFromAmong {
             quantity,
@@ -3915,7 +3923,18 @@ pub(super) fn apply_clause_continuation(
             // `face_down_profile` (set by the "... face down ..." put-clause) and
             // overwrite it with the specified profile. Mirror the DigFromAmong /
             // PutRest backward-walk idiom.
-            for def in defs.iter_mut().rev() {
+            // U6-C2b: bind the profile-holder by ROLE. "Already carries a profile"
+            // is the binding condition itself — a node without one is not this
+            // antecedent at all — so it lives in the registry, not in a guard.
+            let bound = env.resolve(
+                defs,
+                super::assembly::AntecedentSelector::LastWithRole(
+                    super::assembly::AntecedentRole::FaceDownProfileHolder,
+                ),
+                None,
+                super::assembly::OnMiss::Ignore,
+            );
+            for def in bound.map(|i| &mut defs[i]).into_iter() {
                 match &mut *def.effect {
                     Effect::ChangeZoneAll {
                         face_down_profile: fdp @ Some(_),


### PR DESCRIPTION
Continues the U6 assembly-arena work (A → B1 → C1 → C2 → C3). Converts the remaining top-level positional backward scans in `apply_clause_continuation` into explicit arena antecedent bindings.

## Converted

| site | role | binds (full 35k pool) | divergences | fires when forced wrong |
|------|------|-----------------------|-------------|-------------------------|
| `RestDestination` | `LastWithRole(DigOrRevealUntil)` | 283 | 0 | 283/283 |
| `CantRegenerate` | `LastWithRole(DestroyLike)` | 135 | 0 | 133/135 |
| `FaceDownProfileSpec` | `LastWithRole(FaceDownProfileHolder)` | 8 | 0 | 6/8 |

`DigOrRevealUntil` is deliberately a **different set** from C3's `DigOrMill`. The old `last_dig` registry was a `Dig|Mill|RevealUntil` union, but its two consumers want different subsets — binding `RestDestination` to the union would have silently mis-bound on any chain containing a `Mill`. A role names a set, not a vibe.

`FaceDownProfileHolder` registers only nodes that *already* carry a profile. "Already has one" is the binding condition itself — a node without a profile is not this antecedent at all — so it belongs in the registry rather than in a guard at the use site.

A **fifth** scan turned up that the original 69-site audit missed (`FaceDownProfileSpec`, CR 708.2a). Converted, rather than shipping a four-of-four completeness claim that wasn't true.

## Deliberately deferred to C5 — `CopyRetarget` (186 binds; well-covered, not rare)

`set_copy_retarget_in_ability` **recurses into `sub_ability` and mutates as it walks** — its "predicate" *is* the patch. That is the same recursive first-vacant-slot class as `attach_alt_cost_to_prior_cast_from_zone`, `attach_mana_retention_to_prior_mana`, and `find_prev_play_from_exile_permission_mut`, which a **top-level** arena structurally cannot serve. It needs the node-granularity change; binding it to a top-level registry now would silently mis-bind. It is the one positional scan left in the assembly path, and it is left on purpose.

## Verification

Dual-run old-vs-new over the **full `data/card-data.json` (35,396 cards)**, not the 2,410-face fixture — every binding here is rare enough that the fixture is systematically blind to it. Per-site fire counts taken with each selector perturbed **independently** (a chained perturbation makes a downstream site report a phantom 0 because it is never *reached*). Legacy scans deleted only after each site was individually proven clean.

16,111 lib tests pass · 79 snapshots, zero drift, zero `.snap.new` · `clippy -D warnings` clean · combinator gate clean.