### PR TITLE
Fix Call the Spirit Dragons upkeep counters and win rider (#5274)

### DIFF
--- a/crates/engine/data/known-tokens.toml
+++ b/crates/engine/data/known-tokens.toml
@@ -3023,11 +3023,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Giant Opportunity"
 scryfall_oracle_id = "395aa62e-0786-4bd8-a88f-998e4700742e"
-scryfall_id = "6d284306-3365-45b4-8539-c2af7b3e16c4"
-
-[[token.source_card_refs]]
-card_name = "Giant Opportunity"
-scryfall_oracle_id = "395aa62e-0786-4bd8-a88f-998e4700742e"
 scryfall_id = "40383646-3fc4-4267-b9ad-bf90a85972fc"
 
 [token.token_image_ref]
@@ -4006,11 +4001,6 @@ keywords = ["Flying"]
 card_name = "Aven Initiate"
 scryfall_oracle_id = "c872012d-b598-4076-8385-2e3771c0306f"
 scryfall_id = "e078dfbe-ebdf-4ea8-aed7-cb2c986e7656"
-
-[[token.source_card_refs]]
-card_name = "Aven Initiate"
-scryfall_oracle_id = "c872012d-b598-4076-8385-2e3771c0306f"
-scryfall_id = "eba15599-ba74-4506-847a-4472214d8d33"
 
 [token.token_image_ref]
 scryfall_id = "12feaabf-7b3e-4cef-8d45-1b9bbe2baaf6"
@@ -6199,11 +6189,6 @@ scryfall_oracle_id = "4a0cc2a2-3711-473a-b2c5-b1e52b34e4fb"
 scryfall_id = "8c0f9306-2058-476d-a711-bd37a6e15e42"
 
 [[token.source_card_refs]]
-card_name = "Waylay"
-scryfall_oracle_id = "f0db78c7-09b5-4981-8ca8-6dbab597c5d9"
-scryfall_id = "867a33ee-0340-413a-8243-9d6bc2d944e2"
-
-[[token.source_card_refs]]
 card_name = "Battle Menu"
 scryfall_oracle_id = "8af57b80-bbc6-47ce-83f6-34ae8e2f5bd5"
 scryfall_id = "240e1466-bd02-423d-b829-234dcd2bfab2"
@@ -6299,7 +6284,6 @@ source_card_names = [
     "Death Mutation",
     "Deathbloom Thallid",
     "Deathspore Thallid",
-    "Demand",
     "Dreampod Druid",
     "Druidic Satchel",
     "Elvish Farmer",
@@ -6359,7 +6343,6 @@ source_card_names = [
     "Sprout",
     "Sprout Swarm",
     "Sprouting Thrinax",
-    "Supply",
     "Supply // Demand",
     "Tana, the Bloodsower",
     "Tendershoot Dryad",
@@ -6398,95 +6381,9 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Shroofus Sproutsire"
-scryfall_oracle_id = "e0cebb09-d10d-4b70-96be-82df0e5d52d3"
-scryfall_id = "d29839f0-afe0-4caa-9628-655738aecce4"
-
-[[token.source_card_refs]]
-card_name = "Saproling Infestation"
-scryfall_oracle_id = "dd257eb3-4112-41e5-9c7d-00d1f683dbdb"
-scryfall_id = "8642e530-914c-4149-944a-c4966ee27299"
-
-[[token.source_card_refs]]
-card_name = "Tribune of Rot"
-scryfall_oracle_id = "cd1b3ef3-73ac-4f06-8cfb-5f2388481379"
-scryfall_id = "e60890ef-daf7-4542-9813-6c6a6e0ab222"
-
-[[token.source_card_refs]]
-card_name = "Night Soil"
-scryfall_oracle_id = "3165fe8f-52d7-40f7-bb14-8f4300a564e6"
-scryfall_id = "4f25a497-46dc-47aa-8586-d514578a6d25"
-
-[[token.source_card_refs]]
-card_name = "Elvish Farmer"
-scryfall_oracle_id = "91fe1075-e170-4575-ae28-8d692f051637"
-scryfall_id = "9e37a5d9-2b6f-4412-aec2-0d6161e2a7d2"
-
-[[token.source_card_refs]]
-card_name = "Verdant Force"
-scryfall_oracle_id = "7a21ea22-3cd7-4c11-8895-5943c0d93a0d"
-scryfall_id = "d5a5533f-d24d-4cca-a47e-0676c6061a35"
-
-[[token.source_card_refs]]
-card_name = "Aether Mutation"
-scryfall_oracle_id = "6697fe5b-90ac-4321-aa2f-cdc6ec283cb4"
-scryfall_id = "a9507116-ede8-40a1-8fa3-705e6f6f64c0"
-
-[[token.source_card_refs]]
-card_name = "Fertile Imagination"
-scryfall_oracle_id = "8808595b-5d77-4382-ae1e-9609e1da65ef"
-scryfall_id = "e5c879af-a092-4cc4-a53d-760553d94864"
-
-[[token.source_card_refs]]
-card_name = "Spontaneous Generation"
-scryfall_oracle_id = "d5b021e3-a0c1-471b-9088-a76816806354"
-scryfall_id = "ce5765cb-00cd-4920-9fe8-68791048ec4a"
-
-[[token.source_card_refs]]
-card_name = "Night Soil"
-scryfall_oracle_id = "3165fe8f-52d7-40f7-bb14-8f4300a564e6"
-scryfall_id = "ee3eb61b-698c-42b1-8a33-0ce7c3829e07"
-
-[[token.source_card_refs]]
 card_name = "Tendershoot Dryad"
 scryfall_oracle_id = "a336c10a-b5bd-47ff-ba2d-31e27af1e15a"
 scryfall_id = "def3571c-01dd-4eee-8f60-0ac4d1928d33"
-
-[[token.source_card_refs]]
-card_name = "Last Stand"
-scryfall_oracle_id = "4d2a465e-9ebd-4002-b6cd-e0eab08bad54"
-scryfall_id = "7dc3d054-6266-4ce0-89ed-f8b170794f2e"
-
-[[token.source_card_refs]]
-card_name = "Saproling Symbiosis"
-scryfall_oracle_id = "69d22037-fbf7-44d2-81a7-7ce8e32f06ec"
-scryfall_id = "2bb63748-5c84-43a0-8f17-a2a17f658337"
-
-[[token.source_card_refs]]
-card_name = "Thallid"
-scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
-scryfall_id = "ba7b31c0-45d0-44e6-961b-fa8108e571e3"
-
-[[token.source_card_refs]]
-card_name = "Supply // Demand"
-face_name = "Supply"
-scryfall_oracle_id = "d7158101-f6ac-4d61-9570-a3adc3c8b583"
-scryfall_id = "d4628887-bda4-47e4-84d1-d31a8298f9e5"
-
-[[token.source_card_refs]]
-card_name = "Thallid Devourer"
-scryfall_oracle_id = "b7326fd9-7648-4db3-b506-61a7de8a4094"
-scryfall_id = "1a392801-bdc8-4342-8cdd-48f874e22afa"
-
-[[token.source_card_refs]]
-card_name = "Rith's Charm"
-scryfall_oracle_id = "9dbccdc5-61f7-4a7d-bbbc-5cab393e24f7"
-scryfall_id = "dd30f389-bac8-4b82-a8a7-6948d43a9f60"
-
-[[token.source_card_refs]]
-card_name = "Spore Swarm"
-scryfall_oracle_id = "8fb599a7-2c61-446b-a7a7-cd5367f9b796"
-scryfall_id = "f5a9ab6c-d4e6-461b-b760-037b7c2b7f42"
 
 [[token.source_card_refs]]
 card_name = "Selesnya Evangel"
@@ -6494,120 +6391,9 @@ scryfall_oracle_id = "4a2fea39-99d6-4766-9f2c-0a63925349cb"
 scryfall_id = "3afd9bc0-442b-4e0f-bb5e-821c1070b213"
 
 [[token.source_card_refs]]
-card_name = "Deathbloom Thallid"
-scryfall_oracle_id = "ce873790-de4d-4ba3-8023-c44306ba3ff8"
-scryfall_id = "bbe74b50-a2a9-4ace-95ed-4ad5d12e3f2e"
-
-[[token.source_card_refs]]
-card_name = "Sporesower Thallid"
-scryfall_oracle_id = "dd840d84-bc4a-4420-b8ac-99093a5aa253"
-scryfall_id = "2f834b1f-9f05-4553-a9b5-828a8348ed30"
-
-[[token.source_card_refs]]
-card_name = "Vitaspore Thallid"
-scryfall_oracle_id = "8940f80b-9c8d-48c0-97c0-c18d77797911"
-scryfall_id = "cad14bc9-b90e-48e0-9e72-173874dab6bc"
-
-[[token.source_card_refs]]
-card_name = "Verdeloth the Ancient"
-scryfall_oracle_id = "8222321f-b74d-4f74-9ee7-79455433345a"
-scryfall_id = "4b3e632e-21dc-4cc3-9c80-4b3d8b8e5795"
-
-[[token.source_card_refs]]
-card_name = "Verdant Force"
-scryfall_oracle_id = "7a21ea22-3cd7-4c11-8895-5943c0d93a0d"
-scryfall_id = "0b4e67cf-3c49-480c-b960-128b1ab2a716"
-
-[[token.source_card_refs]]
-card_name = "Rith, the Awakener"
-scryfall_oracle_id = "97e5d788-2dd3-4c8e-9ab6-f4ea9c7a9a3d"
-scryfall_id = "c30be387-280d-49bd-a3d1-c1636ee931ce"
-
-[[token.source_card_refs]]
-card_name = "Verdant Embrace"
-scryfall_oracle_id = "f0bbd988-50b7-476c-9183-dfabd4a95079"
-scryfall_id = "3dd1d130-98e7-4898-9f13-2bb58fa4777b"
-
-[[token.source_card_refs]]
-card_name = "Selesnya Guildmage"
-scryfall_oracle_id = "8fbdca3a-7aa3-4b5a-98d7-9168856045ac"
-scryfall_id = "954b8e86-284a-4a6f-ac35-896afd414f8a"
-
-[[token.source_card_refs]]
-card_name = "Tukatongue Thallid"
-scryfall_oracle_id = "c7dbd008-e941-497e-8305-80c53b1dffe2"
-scryfall_id = "d90794bf-2d48-4a53-8197-b931d26292fb"
-
-[[token.source_card_refs]]
-card_name = "Fungal Plots"
-scryfall_oracle_id = "0a85402a-e3be-4ebb-8001-9d9a20dde7e8"
-scryfall_id = "cc306b05-d991-4048-8390-6f404268d249"
-
-[[token.source_card_refs]]
-card_name = "Saproling Migration"
-scryfall_oracle_id = "bbbb80bd-76fa-4155-929b-4a3565d1cb35"
-scryfall_id = "52589a1d-bb98-4af2-8813-8598fb20b4f2"
-
-[[token.source_card_refs]]
-card_name = "Deathspore Thallid"
-scryfall_oracle_id = "3a2a6904-219a-4d16-b11a-1e0e2826814e"
-scryfall_id = "44ee5ee3-11f8-4a4e-bfa3-10ff45ed6d1b"
-
-[[token.source_card_refs]]
 card_name = "Pollenbright Wings"
 scryfall_oracle_id = "582c8030-1d41-4c63-8ed6-06aad398a96c"
 scryfall_id = "e190a22c-31d3-4c16-81c2-735e58348df1"
-
-[[token.source_card_refs]]
-card_name = "Vitu-Ghazi, the City-Tree"
-scryfall_oracle_id = "88fb9e82-28b9-4275-a1e2-cb3a9bfda127"
-scryfall_id = "afc35026-a29e-4fb0-931f-5e90faf41802"
-
-[[token.source_card_refs]]
-card_name = "Supply // Demand"
-face_name = "Demand"
-scryfall_oracle_id = "d7158101-f6ac-4d61-9570-a3adc3c8b583"
-scryfall_id = "d4628887-bda4-47e4-84d1-d31a8298f9e5"
-
-[[token.source_card_refs]]
-card_name = "Undercellar Myconid"
-scryfall_oracle_id = "127f5b7e-79bc-4fe0-b9d4-1a267a6a4d46"
-scryfall_id = "fbd215e0-0de9-4382-9d8f-9b8d1ec5449d"
-
-[[token.source_card_refs]]
-card_name = "Thallid"
-scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
-scryfall_id = "80f8f778-ae31-45cd-b27f-f93a07853ede"
-
-[[token.source_card_refs]]
-card_name = "Selesnya Guildmage"
-scryfall_oracle_id = "8fbdca3a-7aa3-4b5a-98d7-9168856045ac"
-scryfall_id = "21061ce3-d098-4057-b341-c5db6ee1b6d4"
-
-[[token.source_card_refs]]
-card_name = "Flash Foliage"
-scryfall_oracle_id = "ee79b00d-9b2a-454d-a20c-edb073ef69cf"
-scryfall_id = "b71c63da-dfe3-475f-88d9-20008c01163a"
-
-[[token.source_card_refs]]
-card_name = "Scatter the Seeds"
-scryfall_oracle_id = "c17d5153-cc74-4fbb-9d75-f7ee7b557b0a"
-scryfall_id = "c4415070-4304-482b-b8e5-2bf689af0843"
-
-[[token.source_card_refs]]
-card_name = "Verdeloth the Ancient"
-scryfall_oracle_id = "8222321f-b74d-4f74-9ee7-79455433345a"
-scryfall_id = "72d5fab1-fa20-4006-b19d-179d36238c9b"
-
-[[token.source_card_refs]]
-card_name = "Thallid"
-scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
-scryfall_id = "2cf2f3da-9101-439d-8caa-910ff40bfbb3"
-
-[[token.source_card_refs]]
-card_name = "Thallid"
-scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
-scryfall_id = "6d4d2d63-3552-4e9c-8862-84a3ca3456d7"
 
 [[token.source_card_refs]]
 card_name = "Mycoloth"
@@ -6615,109 +6401,9 @@ scryfall_oracle_id = "d7fd16ce-282d-49cd-b2b4-0d25935e7a72"
 scryfall_id = "924976cf-9b46-4cbf-ab27-07ca72a21608"
 
 [[token.source_card_refs]]
-card_name = "Night Soil"
-scryfall_oracle_id = "3165fe8f-52d7-40f7-bb14-8f4300a564e6"
-scryfall_id = "4cda6d18-d4b1-4b8a-a72e-f90115adf4c3"
-
-[[token.source_card_refs]]
-card_name = "Sprout Swarm"
-scryfall_oracle_id = "8b33d890-7d67-44a8-a253-e2b171d7ca9d"
-scryfall_id = "0b915355-4e98-44df-81bd-961a3d3c86b8"
-
-[[token.source_card_refs]]
-card_name = "Sporoloth Ancient"
-scryfall_oracle_id = "071e15b5-6d21-4695-9ad0-69f40eb8f4ef"
-scryfall_id = "cdc8f3f3-4ff4-4943-8ae0-c1af78a5ae16"
-
-[[token.source_card_refs]]
-card_name = "Savage Thallid"
-scryfall_oracle_id = "309a57cb-cc08-4892-bc63-c424ca9c5b43"
-scryfall_id = "a87cbbdb-3bbc-48da-b5e3-fcdbddebec81"
-
-[[token.source_card_refs]]
 card_name = "Verdant Force"
 scryfall_oracle_id = "7a21ea22-3cd7-4c11-8895-5943c0d93a0d"
 scryfall_id = "c75ebe25-f0cd-4e44-b488-06edb0cacb5a"
-
-[[token.source_card_refs]]
-card_name = "Fists of Ironwood"
-scryfall_oracle_id = "2f6a5278-23bf-47b2-a2b9-dfff7d96f3dd"
-scryfall_id = "7193c00f-0398-485c-974d-346ee59cd4c7"
-
-[[token.source_card_refs]]
-card_name = "Fungal Infection"
-scryfall_oracle_id = "04a8858e-9033-403e-9346-5a2ad1bdf680"
-scryfall_id = "727a589a-2248-478f-825f-932bfb456675"
-
-[[token.source_card_refs]]
-card_name = "Mycologist"
-scryfall_oracle_id = "af0bf083-0624-4ccd-b282-a35937e925fe"
-scryfall_id = "56d8e9fa-e241-4a11-99b8-ffced81eb38b"
-
-[[token.source_card_refs]]
-card_name = "Nemata, Grove Guardian"
-scryfall_oracle_id = "5ce58279-7f1e-4ef7-a352-ecbaee31b6ff"
-scryfall_id = "8c6a0ca4-5006-4c9b-91cd-e01d77e4fdc2"
-
-[[token.source_card_refs]]
-card_name = "Dreampod Druid"
-scryfall_oracle_id = "db2af2b0-a5aa-4e4a-b5bc-52a5ac3968fc"
-scryfall_id = "1e35f72d-a62e-490b-a3b2-a56af22f8ff7"
-
-[[token.source_card_refs]]
-card_name = "Night Soil"
-scryfall_oracle_id = "3165fe8f-52d7-40f7-bb14-8f4300a564e6"
-scryfall_id = "64bde90c-afe9-44a0-b7ae-d0588e425c18"
-
-[[token.source_card_refs]]
-card_name = "Death Mutation"
-scryfall_oracle_id = "6f705338-b00b-4a6d-924f-443e7c5670b7"
-scryfall_id = "4c643d87-50bc-4380-b1d6-0a465eef5dbf"
-
-[[token.source_card_refs]]
-card_name = "Selesnya Evangel"
-scryfall_oracle_id = "4a2fea39-99d6-4766-9f2c-0a63925349cb"
-scryfall_id = "18bc93c1-f236-4d1b-bb54-5041b3cae5a6"
-
-[[token.source_card_refs]]
-card_name = "Ulasht, the Hate Seed"
-scryfall_oracle_id = "796f1e1f-7fec-429d-82ae-125f541d6cc7"
-scryfall_id = "a0ba043a-d508-49dd-9bf3-a7ae8d26ac9b"
-
-[[token.source_card_refs]]
-card_name = "Sporogenesis"
-scryfall_oracle_id = "33005c63-fe9f-4051-b781-eacf1ca5eec6"
-scryfall_id = "839d969b-b1f7-4978-b00c-db0766161f63"
-
-[[token.source_card_refs]]
-card_name = "Aura Mutation"
-scryfall_oracle_id = "19bb51dd-2b93-45f0-927d-bbafddadd0a3"
-scryfall_id = "38421179-615e-4aba-91a4-503bfee05403"
-
-[[token.source_card_refs]]
-card_name = "Psychotrope Thallid"
-scryfall_oracle_id = "384c61f2-17ed-4c7a-8722-e0a05e9dcaf9"
-scryfall_id = "e2803fdc-2ae1-438c-b5b1-559817e85fdb"
-
-[[token.source_card_refs]]
-card_name = "Thallid"
-scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
-scryfall_id = "01827286-b104-41c5-bac9-7c38414bc40e"
-
-[[token.source_card_refs]]
-card_name = "Thallid Devourer"
-scryfall_oracle_id = "b7326fd9-7648-4db3-b506-61a7de8a4094"
-scryfall_id = "aa533845-4c4b-4072-aa39-8e56ce7ec325"
-
-[[token.source_card_refs]]
-card_name = "Sarpadian Empires, Vol. VII"
-scryfall_oracle_id = "f71d55f5-f220-4cb0-9468-b8d339ab8535"
-scryfall_id = "b37a6cf7-f239-4bca-b4c3-a48932ef56b5"
-
-[[token.source_card_refs]]
-card_name = "Fungal Rebirth"
-scryfall_oracle_id = "b917f39a-3176-47ad-afda-08d09b873c02"
-scryfall_id = "52abf994-78d6-40dd-9d43-19ae8176e3bd"
 
 [[token.source_card_refs]]
 card_name = "Saproling Cluster"
@@ -6730,124 +6416,9 @@ scryfall_oracle_id = "c17d5153-cc74-4fbb-9d75-f7ee7b557b0a"
 scryfall_id = "17359989-ef90-46f5-a4cd-f40bfac5e59f"
 
 [[token.source_card_refs]]
-card_name = "Thallid"
-scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
-scryfall_id = "4caaf31b-86a9-485b-8da7-d5b526ed1233"
-
-[[token.source_card_refs]]
-card_name = "Thelonite Hermit"
-scryfall_oracle_id = "69d2e5f3-2f4d-4a36-bcd5-181164ecd894"
-scryfall_id = "be95b6b0-ff20-405f-81ae-87f5cce45fb2"
-
-[[token.source_card_refs]]
-card_name = "Golgari Germination"
-scryfall_oracle_id = "3f9cf871-7df6-49d5-aab3-ad945571b707"
-scryfall_id = "24a1db16-d936-4f92-9611-327a988ce04c"
-
-[[token.source_card_refs]]
-card_name = "Saproling Cluster"
-scryfall_oracle_id = "3b64051e-d320-4991-bc9e-6e1435a23c17"
-scryfall_id = "5f50072b-aedd-4074-b1f7-f9ce477c26c2"
-
-[[token.source_card_refs]]
-card_name = "Thallid Germinator"
-scryfall_oracle_id = "262bc269-3e70-46ae-b0a3-5f8030a6971a"
-scryfall_id = "ac526fb0-e6d0-4ee0-9888-15098c1704df"
-
-[[token.source_card_refs]]
-card_name = "Verdant Force"
-scryfall_oracle_id = "7a21ea22-3cd7-4c11-8895-5943c0d93a0d"
-scryfall_id = "29bd094c-fcc1-4abf-ba3e-03a5b9b6d1c2"
-
-[[token.source_card_refs]]
-card_name = "Greener Pastures"
-scryfall_oracle_id = "f9e1346a-af72-4644-b384-8f7b0a35ec31"
-scryfall_id = "55c3222e-ac18-4f57-9c9e-50deb0a69db3"
-
-[[token.source_card_refs]]
-card_name = "Elvish Farmer"
-scryfall_oracle_id = "91fe1075-e170-4575-ae28-8d692f051637"
-scryfall_id = "40a9710e-b2f8-4746-8640-d450f58a6e49"
-
-[[token.source_card_refs]]
-card_name = "Sporemound"
-scryfall_oracle_id = "1be56a3d-a6c0-4b65-ae71-3d90ceefc6c0"
-scryfall_id = "90594c9c-95a5-4d3c-9005-863fa710cdbd"
-
-[[token.source_card_refs]]
-card_name = "Thallid Shell-Dweller"
-scryfall_oracle_id = "481e3a30-fbe9-4ed3-a982-8a73f0dca33b"
-scryfall_id = "4ee36256-022f-49b3-8914-9b1c2f4dc506"
-
-[[token.source_card_refs]]
-card_name = "Verdant Force"
-scryfall_oracle_id = "7a21ea22-3cd7-4c11-8895-5943c0d93a0d"
-scryfall_id = "baa4749b-1c1b-4e07-8926-c5f12681140b"
-
-[[token.source_card_refs]]
 card_name = "Selesnya Guildmage"
 scryfall_oracle_id = "8fbdca3a-7aa3-4b5a-98d7-9168856045ac"
 scryfall_id = "aa4c6ee5-c4dd-4b60-a6fc-5992f663c20e"
-
-[[token.source_card_refs]]
-card_name = "Sporemound"
-scryfall_oracle_id = "1be56a3d-a6c0-4b65-ae71-3d90ceefc6c0"
-scryfall_id = "f2799310-c77a-47b2-b1a5-50c029600020"
-
-[[token.source_card_refs]]
-card_name = "Saurian Symbiote"
-scryfall_oracle_id = "14b180d2-5701-452d-8deb-cf0845c95df5"
-scryfall_id = "b32224ef-cfd4-42ef-857a-24386590c360"
-
-[[token.source_card_refs]]
-card_name = "Pollenbright Wings"
-scryfall_oracle_id = "582c8030-1d41-4c63-8ed6-06aad398a96c"
-scryfall_id = "3ca4f3b9-c952-4fd3-a586-3e063b62b23d"
-
-[[token.source_card_refs]]
-card_name = "Verdant Embrace"
-scryfall_oracle_id = "f0bbd988-50b7-476c-9183-dfabd4a95079"
-scryfall_id = "50c915a4-a75f-40e7-b78a-9c304dcdd83e"
-
-[[token.source_card_refs]]
-card_name = "Bramble Elemental"
-scryfall_oracle_id = "ac5c0078-e2f1-4ac1-8748-575d69e09cf8"
-scryfall_id = "470665e5-fa48-4772-ba71-5d4008d042f3"
-
-[[token.source_card_refs]]
-card_name = "Aether Mutation"
-scryfall_oracle_id = "6697fe5b-90ac-4321-aa2f-cdc6ec283cb4"
-scryfall_id = "5386a61c-4928-4bd1-babe-5b089ab8b2d9"
-
-[[token.source_card_refs]]
-card_name = "Artifact Mutation"
-scryfall_oracle_id = "e77e8768-3ea8-44f9-aba6-1e023e006946"
-scryfall_id = "d5eef49c-a80f-4622-ba77-999f9151c841"
-
-[[token.source_card_refs]]
-card_name = "Sprout"
-scryfall_oracle_id = "424c6f5e-b386-47e9-b3fe-25b263097d40"
-scryfall_id = "6967363f-1e05-4484-8790-47f7be68455c"
-
-[[token.source_card_refs]]
-card_name = "Pallid Mycoderm"
-scryfall_oracle_id = "e76a1371-76c8-46dd-ba43-87fb0ab940d4"
-scryfall_id = "3a11b639-a5a3-424d-80c6-42d7252472a1"
-
-[[token.source_card_refs]]
-card_name = "Verdeloth the Ancient"
-scryfall_oracle_id = "8222321f-b74d-4f74-9ee7-79455433345a"
-scryfall_id = "ef6b08e0-6e5f-40e5-8c2a-c10c6e5beddc"
-
-[[token.source_card_refs]]
-card_name = "Seed Spark"
-scryfall_oracle_id = "fc2e441c-bc0b-439f-af71-daba3b033381"
-scryfall_id = "33af31cf-d730-4f54-a0be-3229cdccf60c"
-
-[[token.source_card_refs]]
-card_name = "Utopia Mycon"
-scryfall_oracle_id = "492dafd8-0393-4151-845c-d9ca10bda03e"
-scryfall_id = "b9d3d285-8327-4dba-911b-ff03b186f6b8"
 
 [[token.source_card_refs]]
 card_name = "Korozda Guildmage"
@@ -7031,11 +6602,6 @@ scryfall_id = "4df7b253-6107-47d6-b650-cb4d3e0aec6b"
 card_name = "Dalkovan Encampment"
 scryfall_oracle_id = "33a90122-7280-4481-9b97-5879194cae40"
 scryfall_id = "98ad5f0c-8775-4e89-8e92-84a6ade93e35"
-
-[[token.source_card_refs]]
-card_name = "Rally the Horde"
-scryfall_oracle_id = "fd9aeda1-9e44-4bc6-aa0d-19d58918d1f4"
-scryfall_id = "b292a8d2-44b1-4c20-8035-0f5912cc09a4"
 
 [[token.source_card_refs]]
 card_name = "Within Range"
@@ -7882,16 +7448,6 @@ subtypes = ["Cat"]
 supertypes = []
 colors = ["Green"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Waiting in the Weeds"
-scryfall_oracle_id = "5a61d51e-1a3f-49f6-9a94-a708dd6f69df"
-scryfall_id = "5f91ec4e-6818-46f4-94da-f3f8c4489fb2"
-
-[[token.source_card_refs]]
-card_name = "Waiting in the Weeds"
-scryfall_oracle_id = "5a61d51e-1a3f-49f6-9a94-a708dd6f69df"
-scryfall_id = "7e2d5a77-6ee8-463d-9e6a-fdb1cc6d70e6"
 
 [token.token_image_ref]
 scryfall_id = "7ebd7482-0f67-4afa-ba82-bf12e7e07b30"
@@ -10036,34 +9592,9 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Dwynen's Elite"
-scryfall_oracle_id = "3d4a7dd3-9258-4bd1-adc4-08f0205e196a"
-scryfall_id = "31eee7a7-af13-4de5-9f4b-5f803335cfc5"
-
-[[token.source_card_refs]]
-card_name = "Elderleaf Mentor"
-scryfall_oracle_id = "3795fc31-2369-47d0-b9c9-120f44b8f114"
-scryfall_id = "a175c5cf-b33d-481d-b093-57072f6f671e"
-
-[[token.source_card_refs]]
-card_name = "Elven Bow"
-scryfall_oracle_id = "43daed96-2216-4f17-82ce-3eccd5d69936"
-scryfall_id = "d986c6e3-dabc-4422-94b9-f7154935a355"
-
-[[token.source_card_refs]]
 card_name = "Tyvar Kell"
 scryfall_oracle_id = "14c8a590-88ec-4982-ad7b-36a219ff6de7"
 scryfall_id = "9a46a0f5-390c-4d5f-9d1f-38031b68aa25"
-
-[[token.source_card_refs]]
-card_name = "Lys Alana Huntmaster"
-scryfall_oracle_id = "3f3439e1-75ce-482d-881f-836492dca6e9"
-scryfall_id = "42df23b1-7d28-403f-bf12-d4ec81500c36"
-
-[[token.source_card_refs]]
-card_name = "Wolverine Riders"
-scryfall_oracle_id = "09070db6-01f6-4a8a-b167-a7825e6959f4"
-scryfall_id = "575d407c-c37e-4664-b2e3-217dfd5a78a2"
 
 [[token.source_card_refs]]
 card_name = "Sylvan Offering"
@@ -10076,9 +9607,9 @@ scryfall_oracle_id = "3f3439e1-75ce-482d-881f-836492dca6e9"
 scryfall_id = "c5fc9e54-8fc4-4de4-be74-e925a85187b4"
 
 [[token.source_card_refs]]
-card_name = "Ambassador Oak"
-scryfall_oracle_id = "4045c24e-098f-4582-8c50-576a94c7b705"
-scryfall_id = "b8664d29-dacc-49cb-949f-e00ceeb75ff6"
+card_name = "Lathril, Blade of the Elves"
+scryfall_oracle_id = "9b568c34-ba0a-44a7-a0ee-bee3a37b3396"
+scryfall_id = "f7f00791-de5e-4f10-9931-8694afcd580c"
 
 [[token.source_card_refs]]
 card_name = "Presence of Gond"
@@ -10091,24 +9622,9 @@ scryfall_oracle_id = "3fa71348-fa4d-4f39-a451-cf1570591991"
 scryfall_id = "084d98ec-9978-4386-972a-4cbddde7109e"
 
 [[token.source_card_refs]]
-card_name = "Elvish Warmaster"
-scryfall_oracle_id = "bda83ef4-e345-495d-878c-4da171f997ba"
-scryfall_id = "3bc94b52-1cb1-4c1e-8b17-5632abc2490d"
-
-[[token.source_card_refs]]
-card_name = "Presence of Gond"
-scryfall_oracle_id = "ab42398c-f0a1-4b94-ac5f-b8768e1b4e05"
-scryfall_id = "37fcba6c-c078-4a0d-be68-984536d91831"
-
-[[token.source_card_refs]]
 card_name = "Imperious Perfect"
 scryfall_oracle_id = "3fa71348-fa4d-4f39-a451-cf1570591991"
 scryfall_id = "3b2e604b-5ca5-4b17-834c-9067f1605147"
-
-[[token.source_card_refs]]
-card_name = "Imperious Perfect"
-scryfall_oracle_id = "3fa71348-fa4d-4f39-a451-cf1570591991"
-scryfall_id = "525cf980-275e-423e-9470-e782ce4796dd"
 
 [[token.source_card_refs]]
 card_name = "Ambassador Oak"
@@ -10116,19 +9632,9 @@ scryfall_oracle_id = "4045c24e-098f-4582-8c50-576a94c7b705"
 scryfall_id = "fb619508-67a2-426d-819b-57e21bf61d66"
 
 [[token.source_card_refs]]
-card_name = "Presence of Gond"
-scryfall_oracle_id = "ab42398c-f0a1-4b94-ac5f-b8768e1b4e05"
-scryfall_id = "bba661af-c4a8-4230-830e-a9ee22b25d6b"
-
-[[token.source_card_refs]]
 card_name = "Flourishing Defenses"
 scryfall_oracle_id = "f1b26eb1-6337-42d6-a475-53ad6427f00f"
 scryfall_id = "37a678b3-53ba-48c7-9846-6454f8b34127"
-
-[[token.source_card_refs]]
-card_name = "Dwynen's Elite"
-scryfall_oracle_id = "3d4a7dd3-9258-4bd1-adc4-08f0205e196a"
-scryfall_id = "d95d4f15-613c-42f1-a49b-f4f604e69feb"
 
 [[token.source_card_refs]]
 card_name = "Elven Bow"
@@ -12166,17 +11672,7 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Ovinomancer"
 scryfall_oracle_id = "98026d30-a29f-4590-968f-b1b36926a275"
-scryfall_id = "ae4f0988-4194-4481-a6b7-27753261174a"
-
-[[token.source_card_refs]]
-card_name = "Ovinomancer"
-scryfall_oracle_id = "98026d30-a29f-4590-968f-b1b36926a275"
 scryfall_id = "20af3166-6338-4fac-bfa6-cea19daefc62"
-
-[[token.source_card_refs]]
-card_name = "Ovinomancer"
-scryfall_oracle_id = "98026d30-a29f-4590-968f-b1b36926a275"
-scryfall_id = "5573470a-7192-4f1e-aafd-517c494875a8"
 
 [[token.source_card_refs]]
 card_name = "Ovinomancer"
@@ -13639,11 +13135,6 @@ card_name = "Cloudseeder"
 scryfall_oracle_id = "4ba75d9e-e3f1-424a-95ca-37784b8d9479"
 scryfall_id = "a9adcc82-0754-4cb7-ac28-e5624f563b7f"
 
-[[token.source_card_refs]]
-card_name = "Cloudseeder"
-scryfall_oracle_id = "4ba75d9e-e3f1-424a-95ca-37784b8d9479"
-scryfall_id = "727f9f4b-a8b6-47bd-9830-e69d118fe671"
-
 [token.token_image_ref]
 scryfall_id = "4a2144f2-d4be-419e-bfca-116cedfdf18b"
 scryfall_oracle_id = "5b04de5c-19b7-4767-a38f-d5420d5da472"
@@ -13685,16 +13176,6 @@ scryfall_id = "d0904640-40e8-45bf-ac9c-94b1dd0bab8f"
 card_name = "Hallowed Haunting"
 scryfall_oracle_id = "e310ab58-180e-4840-bc8d-9f9b06f1b478"
 scryfall_id = "674c0a50-9c37-4c29-84d8-eb3e34f34d37"
-
-[[token.source_card_refs]]
-card_name = "Hallowed Haunting"
-scryfall_oracle_id = "e310ab58-180e-4840-bc8d-9f9b06f1b478"
-scryfall_id = "1948c865-fd0a-423c-9911-44a95a03c71f"
-
-[[token.source_card_refs]]
-card_name = "Hallowed Haunting"
-scryfall_oracle_id = "e310ab58-180e-4840-bc8d-9f9b06f1b478"
-scryfall_id = "6f85bf51-4eca-4428-9a17-a85b5c2dd741"
 
 [token.token_image_ref]
 scryfall_id = "5212bae5-d768-45ab-aba8-94c4f9fabc79"
@@ -14019,11 +13500,6 @@ card_name = "Scouring Swarm"
 scryfall_oracle_id = "aa64f830-b9b6-4d5e-9a5d-f9e120089335"
 scryfall_id = "1a9318ca-2974-4d3f-8951-205ba3f9c64a"
 
-[[token.source_card_refs]]
-card_name = "Fumulus, the Infestation"
-scryfall_oracle_id = "c75f8365-71f1-415f-8bbc-9bacb8ddba0b"
-scryfall_id = "ee5e47c2-7648-4218-b42c-ed9650e12914"
-
 [token.token_image_ref]
 scryfall_id = "2172a126-2ea6-4b5c-84c2-7879c1982a3a"
 scryfall_oracle_id = "b9f1e3ec-dffa-442b-a38a-1e76e59ee146"
@@ -14210,17 +13686,7 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Penumbra Bobcat"
 scryfall_oracle_id = "f0787397-8edb-4794-8ee1-22f97a057be8"
-scryfall_id = "496cce86-ff61-4d24-8d37-8c27acaff21c"
-
-[[token.source_card_refs]]
-card_name = "Penumbra Bobcat"
-scryfall_oracle_id = "f0787397-8edb-4794-8ee1-22f97a057be8"
 scryfall_id = "359fbd40-0f61-4ec7-872c-228a476c7ad5"
-
-[[token.source_card_refs]]
-card_name = "Penumbra Bobcat"
-scryfall_oracle_id = "f0787397-8edb-4794-8ee1-22f97a057be8"
-scryfall_id = "21049fee-a748-4856-99ae-3a225a168532"
 
 [token.token_image_ref]
 scryfall_id = "05a61555-ddb9-4d55-b637-a219d772033d"
@@ -14260,11 +13726,6 @@ keywords = []
 card_name = "Creakwood Liege"
 scryfall_oracle_id = "1e67b4eb-e5d2-4368-8284-4ba5c4c42455"
 scryfall_id = "9a05c8f9-e810-498d-ab51-632661dd000d"
-
-[[token.source_card_refs]]
-card_name = "Wriggling Grub"
-scryfall_oracle_id = "d25e8f54-1915-4d0b-b4b1-93ee40da2cfa"
-scryfall_id = "e02aa086-13b2-42cf-acf4-086ba406e886"
 
 [token.token_image_ref]
 scryfall_id = "9f5ddcda-dcf0-468d-a5db-011e1b6ccab1"
@@ -14899,11 +14360,6 @@ keywords = ["Lifelink"]
 [[token.source_card_refs]]
 card_name = "Sorin, Grim Nemesis"
 scryfall_oracle_id = "0a01dd05-e289-489f-b3ad-88e15e157bd0"
-scryfall_id = "829fba64-6708-40a9-b134-3cdfbf2c648f"
-
-[[token.source_card_refs]]
-card_name = "Sorin, Grim Nemesis"
-scryfall_oracle_id = "0a01dd05-e289-489f-b3ad-88e15e157bd0"
 scryfall_id = "d25c3609-a200-4532-9df8-8e92c24544bc"
 
 [[token.source_card_refs]]
@@ -14915,11 +14371,6 @@ scryfall_id = "c8896833-843c-437f-a9d5-7352b7ea6d3b"
 card_name = "Call the Bloodline"
 scryfall_oracle_id = "8e90300b-c0da-4484-b065-e2fafa4e1b15"
 scryfall_id = "6fae65ac-be15-4d05-83aa-83f872d807fe"
-
-[[token.source_card_refs]]
-card_name = "Call the Bloodline"
-scryfall_oracle_id = "8e90300b-c0da-4484-b065-e2fafa4e1b15"
-scryfall_id = "543eb8f7-1e24-4810-91de-debeb7d1d0ba"
 
 [[token.source_card_refs]]
 card_name = "Elenda and Azor"
@@ -15812,34 +15263,9 @@ colors = ["Black"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
-card_name = "Priest of the Blood Rite"
-scryfall_oracle_id = "441cdd7d-6c4c-4a91-a118-7eaa35276660"
-scryfall_id = "7f49d2da-af70-482c-ac9a-5987ca7a0802"
-
-[[token.source_card_refs]]
-card_name = "Skirsdag High Priest"
-scryfall_oracle_id = "c6064c08-e4e0-49f4-9f0b-55cdecf443af"
-scryfall_id = "1265ed45-2954-4fca-b13f-5c1afd1ef134"
-
-[[token.source_card_refs]]
 card_name = "Skirsdag High Priest"
 scryfall_oracle_id = "c6064c08-e4e0-49f4-9f0b-55cdecf443af"
 scryfall_id = "7a329b20-4e6e-45c9-aee0-51fe81dce543"
-
-[[token.source_card_refs]]
-card_name = "Skirsdag High Priest"
-scryfall_oracle_id = "c6064c08-e4e0-49f4-9f0b-55cdecf443af"
-scryfall_id = "02e4faab-c26b-4d76-b747-8dc3f6b2fe9a"
-
-[[token.source_card_refs]]
-card_name = "Archfiend's Vessel"
-scryfall_oracle_id = "62c240ac-f2dd-4e39-9e82-50307efa833e"
-scryfall_id = "b20e33cb-202f-4973-8c83-c75faf908672"
-
-[[token.source_card_refs]]
-card_name = "Priest of the Blood Rite"
-scryfall_oracle_id = "441cdd7d-6c4c-4a91-a118-7eaa35276660"
-scryfall_id = "87f77674-dd03-4f19-bd87-aec2359b620e"
 
 [token.token_image_ref]
 scryfall_id = "1f75f7a3-b4d2-40e1-9721-cbe6a63971ba"
@@ -16149,17 +15575,7 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Stangg"
 scryfall_oracle_id = "739eac91-3029-4ce7-9885-0af3ddea472e"
-scryfall_id = "a277775a-6b48-4238-a618-3ae94c4cc85c"
-
-[[token.source_card_refs]]
-card_name = "Stangg"
-scryfall_oracle_id = "739eac91-3029-4ce7-9885-0af3ddea472e"
 scryfall_id = "b9510aef-0516-4d42-8aa7-f83bec809932"
-
-[[token.source_card_refs]]
-card_name = "Stangg"
-scryfall_oracle_id = "739eac91-3029-4ce7-9885-0af3ddea472e"
-scryfall_id = "4e9df135-4449-42ff-868b-56b1f702aca6"
 
 [[token.source_card_refs]]
 card_name = "Stangg, Echo Warrior"
@@ -16170,11 +15586,6 @@ scryfall_id = "9385b40f-79a7-4d9c-b253-54587a1f28b4"
 card_name = "Stangg, Echo Warrior"
 scryfall_oracle_id = "aaf2a587-ced7-4615-b10f-164e7384b073"
 scryfall_id = "7722a9a1-2ff9-4a39-b56e-c7eef2ff9dcd"
-
-[[token.source_card_refs]]
-card_name = "Stangg"
-scryfall_oracle_id = "739eac91-3029-4ce7-9885-0af3ddea472e"
-scryfall_id = "71cc6ef5-401a-4125-9765-74905f6c3551"
 
 [token.token_image_ref]
 scryfall_id = "edc84f49-86e9-43a2-b98c-a59b1e0c72ed"
@@ -16706,24 +16117,9 @@ colors = ["Red"]
 keywords = ["Haste"]
 
 [[token.source_card_refs]]
-card_name = "Lightning Coils"
-scryfall_oracle_id = "bbb16f23-fdb1-444b-bef8-ce3e177c2678"
-scryfall_id = "a800f326-3416-4917-a1cf-0f90255777d3"
-
-[[token.source_card_refs]]
-card_name = "Feral Lightning"
-scryfall_oracle_id = "acd17fbf-645b-4c4d-b2c6-44127e3b743d"
-scryfall_id = "2391265f-ef0c-463f-9371-5a0b71dbbb49"
-
-[[token.source_card_refs]]
 card_name = "Chandra, Flamecaller"
 scryfall_oracle_id = "0c2a9131-f3d7-4f71-8bcc-3c169574b2e3"
 scryfall_id = "a77b4416-61da-4cd5-b3f1-79238a8e2503"
-
-[[token.source_card_refs]]
-card_name = "Chandra, Flamecaller"
-scryfall_oracle_id = "0c2a9131-f3d7-4f71-8bcc-3c169574b2e3"
-scryfall_id = "507ea0e3-6b8c-4c0d-8a4b-5386f70ea8d1"
 
 [[token.source_card_refs]]
 card_name = "Chandra, Flamecaller"
@@ -16817,11 +16213,6 @@ keywords = ["Flying"]
 card_name = "Seraphic Steed"
 scryfall_oracle_id = "51622e89-aa5e-4dd6-a078-eb45e8ebb434"
 scryfall_id = "7ada7ab4-0dee-4ff3-9817-1e61ca3f2ccf"
-
-[[token.source_card_refs]]
-card_name = "Linvala, the Preserver"
-scryfall_oracle_id = "64f5689d-504d-40e9-bdb5-36dcefd257e2"
-scryfall_id = "b9231958-cfe7-461b-9ce7-a5225657b205"
 
 [[token.source_card_refs]]
 card_name = "Seraphic Steed"
@@ -17495,24 +16886,9 @@ scryfall_oracle_id = "4e93b23c-a7f7-4bdd-bbca-0dc48bb5c223"
 scryfall_id = "36633f10-ea38-421c-ab80-9862eb18d6da"
 
 [[token.source_card_refs]]
-card_name = "Goblin Rabblemaster"
-scryfall_oracle_id = "24661b81-6bee-4ad8-b3ab-53cb65005c51"
-scryfall_id = "28ecbe76-5118-4844-9a20-b227c924189d"
-
-[[token.source_card_refs]]
-card_name = "Goblin Warrens"
-scryfall_oracle_id = "c1161505-1623-4475-a88e-2e48072cc2f1"
-scryfall_id = "2d8ce8ad-2bb9-4c53-8e36-9690e8a118f1"
-
-[[token.source_card_refs]]
 card_name = "Krenko, Tin Street Kingpin"
 scryfall_oracle_id = "e8065e1d-e937-4b56-8011-78f0d07328a0"
 scryfall_id = "3f779348-693c-4e7a-82b1-02172304f06b"
-
-[[token.source_card_refs]]
-card_name = "Beetleback Chief"
-scryfall_oracle_id = "f5c5f64c-6911-430c-a825-b32b96d39c7d"
-scryfall_id = "a4a514b9-8a67-47aa-8218-8d6fe8040128"
 
 [[token.source_card_refs]]
 card_name = "Krenko, Mob Boss"
@@ -17525,34 +16901,14 @@ scryfall_oracle_id = "7b8f4879-578e-40e4-863a-41d0c32c6bdd"
 scryfall_id = "4ebce261-3a53-48f2-a173-0d98c68aff2c"
 
 [[token.source_card_refs]]
-card_name = "Siege-Gang Commander"
-scryfall_oracle_id = "ddc7f59a-bbb1-4ba1-82c8-6813fd191940"
-scryfall_id = "92e78cec-aaf9-4fe8-887b-b7e356d63315"
-
-[[token.source_card_refs]]
 card_name = "Mogg War Marshal"
 scryfall_oracle_id = "7b8f4879-578e-40e4-863a-41d0c32c6bdd"
 scryfall_id = "fd170aa1-18be-470e-aa36-bfb11e9f92c1"
 
 [[token.source_card_refs]]
-card_name = "Ardoz, Cobbler of War"
-scryfall_oracle_id = "bcd5e175-2ef0-48f4-b9bd-14383dd234e0"
-scryfall_id = "2a012f05-0009-42cf-8a69-07140b2a2aef"
-
-[[token.source_card_refs]]
 card_name = "Goblinslide"
 scryfall_oracle_id = "4885354f-0b77-47b6-b8f7-00753804436f"
 scryfall_id = "b0e81bcf-d2f1-4ce0-9c1e-730632caa328"
-
-[[token.source_card_refs]]
-card_name = "Goblin Marshal"
-scryfall_oracle_id = "4bc91d7d-37aa-475c-8fe9-763975d51add"
-scryfall_id = "6a85b2f9-c12c-46dd-ae04-470ebf5ec6d9"
-
-[[token.source_card_refs]]
-card_name = "Mogg Infestation"
-scryfall_oracle_id = "cfd61b53-83c6-4886-8503-ddcb92dc7f85"
-scryfall_id = "bfeb1145-3729-481e-a314-c325ed2f2a35"
 
 [[token.source_card_refs]]
 card_name = "Goblin Gang Leader"
@@ -17565,11 +16921,6 @@ scryfall_oracle_id = "f5c5f64c-6911-430c-a825-b32b96d39c7d"
 scryfall_id = "16b8a76e-5ad9-42b6-ba03-819b2491c0c2"
 
 [[token.source_card_refs]]
-card_name = "Mogg War Marshal"
-scryfall_oracle_id = "7b8f4879-578e-40e4-863a-41d0c32c6bdd"
-scryfall_id = "8b9e0bdb-b615-447a-b80d-d7244c25c56e"
-
-[[token.source_card_refs]]
 card_name = "Empty the Warrens"
 scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
 scryfall_id = "41d728ed-9fdf-4d92-bd97-66e27c139423"
@@ -17580,29 +16931,9 @@ scryfall_oracle_id = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617"
 scryfall_id = "2b1c0405-bfcd-4c5f-ab74-50bc27271377"
 
 [[token.source_card_refs]]
-card_name = "Mogg Alarm"
-scryfall_oracle_id = "1c2117d5-4600-489c-be5b-dc0ed69b30ca"
-scryfall_id = "f246e128-0a43-478a-a232-51020fab76d5"
-
-[[token.source_card_refs]]
-card_name = "Goblin Offensive"
-scryfall_oracle_id = "25cb5c86-83cd-4a06-b0d1-a0f6fc9158a6"
-scryfall_id = "e9813857-5527-4499-af86-758a5971e21a"
-
-[[token.source_card_refs]]
-card_name = "Dragon Fodder"
-scryfall_oracle_id = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617"
-scryfall_id = "686d43eb-ea91-4ae1-bdc4-dcd885688acd"
-
-[[token.source_card_refs]]
 card_name = "Goblin Negotiation"
 scryfall_oracle_id = "79824266-bffa-476c-bdd3-976e9d789a42"
 scryfall_id = "2470167c-acee-4de3-b762-a7ade6fc284e"
-
-[[token.source_card_refs]]
-card_name = "Dragon Fodder"
-scryfall_oracle_id = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617"
-scryfall_id = "cdb5eab0-5397-4c00-8cef-7d3baf38a171"
 
 [[token.source_card_refs]]
 card_name = "Goblin Rally"
@@ -17615,44 +16946,14 @@ scryfall_oracle_id = "f451b8f0-1ff5-4e8d-9f30-9352d83ed687"
 scryfall_id = "8fd0fdb6-3a6d-4831-8d1b-0b1b69304c36"
 
 [[token.source_card_refs]]
-card_name = "Warbreak Trumpeter"
-scryfall_oracle_id = "40e5c7fe-4d7a-41c0-8b90-ea0b46a01c9d"
-scryfall_id = "fc942957-1067-428c-8ee1-01f9e260efe1"
-
-[[token.source_card_refs]]
-card_name = "Empty the Warrens"
-scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
-scryfall_id = "952bb27c-c58a-478a-b637-eb4f7e1e0ab4"
-
-[[token.source_card_refs]]
 card_name = "Empty the Warrens"
 scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
 scryfall_id = "07e5e725-c482-4dbc-9612-d3155ed71a75"
 
 [[token.source_card_refs]]
-card_name = "Beetleback Chief"
-scryfall_oracle_id = "f5c5f64c-6911-430c-a825-b32b96d39c7d"
-scryfall_id = "c042844a-7291-45f9-92c9-482842228777"
-
-[[token.source_card_refs]]
-card_name = "Ib Halfheart, Goblin Tactician"
-scryfall_oracle_id = "6742c4b9-8fa6-439f-844d-04a09fa20c45"
-scryfall_id = "d09f9597-c2a9-4c1a-8375-ab06b1a21ee3"
-
-[[token.source_card_refs]]
-card_name = "Goblin Warrens"
-scryfall_oracle_id = "c1161505-1623-4475-a88e-2e48072cc2f1"
-scryfall_id = "57218245-5e0f-4233-896a-00ec0cc34fcc"
-
-[[token.source_card_refs]]
 card_name = "Howlsquad Heavy"
 scryfall_oracle_id = "cd45a29f-73bc-435c-9d50-09a4ecaa77be"
 scryfall_id = "cc43b129-06e9-4b17-8320-2699bfc67d0e"
-
-[[token.source_card_refs]]
-card_name = "Sarpadian Empires, Vol. VII"
-scryfall_oracle_id = "f71d55f5-f220-4cb0-9468-b8d339ab8535"
-scryfall_id = "b37a6cf7-f239-4bca-b4c3-a48932ef56b5"
 
 [[token.source_card_refs]]
 card_name = "Mogg War Marshal"
@@ -17665,34 +16966,14 @@ scryfall_oracle_id = "8b022754-6d16-470e-b754-4df6e4f4709e"
 scryfall_id = "71c818eb-3846-471f-967a-76e1cb809b9f"
 
 [[token.source_card_refs]]
-card_name = "Goblin Rally"
-scryfall_oracle_id = "9ccb6ce8-ccb6-4809-a1cc-cebd38744815"
-scryfall_id = "60b0a697-e901-42d9-9833-fedfcb6db9b3"
-
-[[token.source_card_refs]]
 card_name = "Dragon Fodder"
 scryfall_oracle_id = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617"
 scryfall_id = "ebb84e38-57cd-4539-99e7-c4e319d16314"
 
 [[token.source_card_refs]]
-card_name = "Blast from the Past"
-scryfall_oracle_id = "08638828-ce88-44d4-a6b2-1effb68ccbdf"
-scryfall_id = "aa30bf92-5281-4b74-8d2a-dc7b0467cb0a"
-
-[[token.source_card_refs]]
 card_name = "Pashalik Mons"
 scryfall_oracle_id = "bdb94ccd-1bb5-4bb7-9539-e1b1c97c19c5"
 scryfall_id = "f66ca912-a7ec-4e51-9ae7-0d98b5be21b1"
-
-[[token.source_card_refs]]
-card_name = "Dragon Fodder"
-scryfall_oracle_id = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617"
-scryfall_id = "27238e0e-c676-44f5-841c-6e4a3a3f6374"
-
-[[token.source_card_refs]]
-card_name = "Goblin Warrens"
-scryfall_oracle_id = "c1161505-1623-4475-a88e-2e48072cc2f1"
-scryfall_id = "1255654b-f983-4862-9112-9e378ea5d9fe"
 
 [[token.source_card_refs]]
 card_name = "Goblin Goliath"
@@ -17710,16 +16991,6 @@ scryfall_oracle_id = "6a038dec-2d9c-4422-a0f3-94bf70e55217"
 scryfall_id = "24025e76-0016-46a6-93cd-366071953c36"
 
 [[token.source_card_refs]]
-card_name = "Goblin Instigator"
-scryfall_oracle_id = "8b022754-6d16-470e-b754-4df6e4f4709e"
-scryfall_id = "f32d7ce5-078b-40ff-8ecb-34309a0e3719"
-
-[[token.source_card_refs]]
-card_name = "Blast from the Past"
-scryfall_oracle_id = "08638828-ce88-44d4-a6b2-1effb68ccbdf"
-scryfall_id = "dc0741ad-83c2-4ee5-a712-529787e532ba"
-
-[[token.source_card_refs]]
 card_name = "Goblin Assault"
 scryfall_oracle_id = "d1255776-b88b-4f05-9b71-ff89a2eba453"
 scryfall_id = "26bccccc-f694-47a8-90fa-e3f1f62b9664"
@@ -17730,24 +17001,9 @@ scryfall_oracle_id = "da1c1c70-c2fa-4ba7-89fe-d9af3fb353b9"
 scryfall_id = "b44c7ba3-c90a-436d-a159-89dc9981e0c3"
 
 [[token.source_card_refs]]
-card_name = "Sling-Gang Lieutenant"
-scryfall_oracle_id = "4e93b23c-a7f7-4bdd-bbca-0dc48bb5c223"
-scryfall_id = "8d8d27af-e4cf-4e18-825e-8f6c972e64ba"
-
-[[token.source_card_refs]]
 card_name = "Kuldotha Rebirth"
 scryfall_oracle_id = "f3e28778-0149-4dbd-badb-ba5aeacacd76"
 scryfall_id = "1c7930aa-9556-487a-9e37-78c722dfb4bc"
-
-[[token.source_card_refs]]
-card_name = "Goblin Rabblemaster"
-scryfall_oracle_id = "24661b81-6bee-4ad8-b3ab-53cb65005c51"
-scryfall_id = "e9a1920f-43a9-456f-bc3e-517fee9023df"
-
-[[token.source_card_refs]]
-card_name = "Hunted Phantasm"
-scryfall_oracle_id = "ef4b334b-8407-4147-b434-602e59806906"
-scryfall_id = "faec8ab3-80c6-4b8f-a60d-50cc683e66b4"
 
 [[token.source_card_refs]]
 card_name = "Mogg Infestation"
@@ -17765,34 +17021,9 @@ scryfall_oracle_id = "9cfe86ae-eebe-44aa-a956-4b3e9e621105"
 scryfall_id = "edd9e8d3-6e30-43fc-8931-0f5c07a0e5b7"
 
 [[token.source_card_refs]]
-card_name = "Mogg Infestation"
-scryfall_oracle_id = "cfd61b53-83c6-4886-8503-ddcb92dc7f85"
-scryfall_id = "5a91aa6f-cb2f-4aad-9415-bba4eb9b76ca"
-
-[[token.source_card_refs]]
-card_name = "Sling-Gang Lieutenant"
-scryfall_oracle_id = "4e93b23c-a7f7-4bdd-bbca-0dc48bb5c223"
-scryfall_id = "b419c3d8-0ea5-4a78-a647-b7e16c7f7ec5"
-
-[[token.source_card_refs]]
-card_name = "Hordeling Outburst"
-scryfall_oracle_id = "a6450b8e-eb18-431c-9eb7-7daf107978b2"
-scryfall_id = "81b98d04-937e-47ee-8f97-775c77e33de9"
-
-[[token.source_card_refs]]
 card_name = "Hordeling Outburst"
 scryfall_oracle_id = "a6450b8e-eb18-431c-9eb7-7daf107978b2"
 scryfall_id = "5183ca53-dc90-4971-a610-38b4ba85dc83"
-
-[[token.source_card_refs]]
-card_name = "Sling-Gang Lieutenant"
-scryfall_oracle_id = "4e93b23c-a7f7-4bdd-bbca-0dc48bb5c223"
-scryfall_id = "01e68d4a-fd13-4172-8d71-9f25149b39e8"
-
-[[token.source_card_refs]]
-card_name = "Krenko, Mob Boss"
-scryfall_oracle_id = "68418069-f615-40ef-ae0d-764192acae00"
-scryfall_id = "cd9fec9d-23c8-4d35-97c1-9499527198fb"
 
 [[token.source_card_refs]]
 card_name = "Battle Cry Goblin"
@@ -17800,49 +17031,14 @@ scryfall_oracle_id = "e74c4001-d958-4d2b-b57d-c3601f01580c"
 scryfall_id = "2a17c97b-1195-4ca7-aa30-fe11585f180c"
 
 [[token.source_card_refs]]
-card_name = "Hordeling Outburst"
-scryfall_oracle_id = "a6450b8e-eb18-431c-9eb7-7daf107978b2"
-scryfall_id = "a22f186e-64dc-47c9-8bba-a78fda435fbe"
-
-[[token.source_card_refs]]
-card_name = "Empty the Warrens"
-scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
-scryfall_id = "622daabf-987d-4311-b3d3-b27d62cd5e6e"
-
-[[token.source_card_refs]]
-card_name = "Krenko's Command"
-scryfall_oracle_id = "9cfe86ae-eebe-44aa-a956-4b3e9e621105"
-scryfall_id = "d6379f3d-fe55-4c21-96d7-3796f5489e37"
-
-[[token.source_card_refs]]
 card_name = "Siege-Gang Commander"
 scryfall_oracle_id = "ddc7f59a-bbb1-4ba1-82c8-6813fd191940"
 scryfall_id = "7d67e614-03d2-4034-b82f-25962fc378d4"
 
 [[token.source_card_refs]]
-card_name = "Pashalik Mons"
-scryfall_oracle_id = "bdb94ccd-1bb5-4bb7-9539-e1b1c97c19c5"
-scryfall_id = "7515e5b3-5240-480d-8a0e-5a989c1a906d"
-
-[[token.source_card_refs]]
 card_name = "Krenko, Tin Street Kingpin"
 scryfall_oracle_id = "e8065e1d-e937-4b56-8011-78f0d07328a0"
 scryfall_id = "a762a954-1166-4c6c-bf87-0f68a5a24f3e"
-
-[[token.source_card_refs]]
-card_name = "Ib Halfheart, Goblin Tactician"
-scryfall_oracle_id = "6742c4b9-8fa6-439f-844d-04a09fa20c45"
-scryfall_id = "38134389-b471-4f58-a9ae-26bf9dc1557a"
-
-[[token.source_card_refs]]
-card_name = "Goblin Rally"
-scryfall_oracle_id = "9ccb6ce8-ccb6-4809-a1cc-cebd38744815"
-scryfall_id = "34d6a2d0-d855-4b87-9f4c-58dda0b81c82"
-
-[[token.source_card_refs]]
-card_name = "Goblin Warrens"
-scryfall_oracle_id = "c1161505-1623-4475-a88e-2e48072cc2f1"
-scryfall_id = "bbec4aa5-3319-43dc-8347-5633edbd7018"
 
 [[token.source_card_refs]]
 card_name = "Searslicer Goblin"
@@ -17860,11 +17056,6 @@ scryfall_oracle_id = "24661b81-6bee-4ad8-b3ab-53cb65005c51"
 scryfall_id = "aab03d01-ec92-473d-b983-18cf5f06ff39"
 
 [[token.source_card_refs]]
-card_name = "Blast from the Past"
-scryfall_oracle_id = "08638828-ce88-44d4-a6b2-1effb68ccbdf"
-scryfall_id = "5ca23782-80d3-4656-afba-f8440c813253"
-
-[[token.source_card_refs]]
 card_name = "Siege-Gang Lieutenant"
 scryfall_oracle_id = "9e9d538b-a9e5-4d59-b7c1-208fe18110e3"
 scryfall_id = "76049160-69f7-4114-81f3-dfab8242ac15"
@@ -17873,11 +17064,6 @@ scryfall_id = "76049160-69f7-4114-81f3-dfab8242ac15"
 card_name = "Krenko's Command"
 scryfall_oracle_id = "9cfe86ae-eebe-44aa-a956-4b3e9e621105"
 scryfall_id = "80979d0c-d833-46d8-9f7c-b188801fe336"
-
-[[token.source_card_refs]]
-card_name = "Krenko, Mob Boss"
-scryfall_oracle_id = "68418069-f615-40ef-ae0d-764192acae00"
-scryfall_id = "0b9c68ff-1fe4-42ef-8d1f-43120de5c1ff"
 
 [[token.source_card_refs]]
 card_name = "Siege-Gang Commander"
@@ -17942,11 +17128,6 @@ subtypes = ["Zombie"]
 supertypes = []
 colors = ["Blue"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Geralf, Visionary Stitcher"
-scryfall_oracle_id = "0a0743b0-07c2-4e11-8b30-6b1b8156bdd0"
-scryfall_id = "cd93a0d6-b148-4252-9245-d2a2adcabf12"
 
 [[token.source_card_refs]]
 card_name = "Stitcher Geralf"
@@ -18109,11 +17290,6 @@ subtypes = ["Sliver"]
 supertypes = []
 colors = []
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Sliversmith"
-scryfall_oracle_id = "244443f0-c92b-4640-88b6-308b0312c8be"
-scryfall_id = "b242b7dd-a632-4024-a69a-179a63fb93a8"
 
 [[token.source_card_refs]]
 card_name = "Sliversmith"
@@ -18333,7 +17509,7 @@ toughness = 2
 core_types = ["Creature"]
 subtypes = ["Hero"]
 supertypes = []
-colors = []
+colors = ["White"]
 keywords = ["Vigilance"]
 
 [[token.source_card_refs]]
@@ -18801,11 +17977,6 @@ scryfall_oracle_id = "e7dfe47f-41fc-4071-9ad3-96cd8d9be52e"
 scryfall_id = "79e4242c-a53a-4287-976b-8e545888a1fa"
 
 [[token.source_card_refs]]
-card_name = "Royal Treatment"
-scryfall_oracle_id = "fd0f8fdc-4065-41f4-b8fb-ecb8f185774d"
-scryfall_id = "009bad41-5e96-4bb3-9f5e-66500fb8af29"
-
-[[token.source_card_refs]]
 card_name = "Besotted Knight // Betroth the Beast"
 face_name = "Betroth the Beast"
 scryfall_oracle_id = "c7b6d2cd-9105-404b-88f0-a67037fb2120"
@@ -18942,11 +18113,6 @@ keywords = [
     "Flying",
     "Haste",
 ]
-
-[[token.source_card_refs]]
-card_name = "The Locust God"
-scryfall_oracle_id = "e025a714-02da-4b0c-8021-cf3e8dc9b19e"
-scryfall_id = "8e0b820b-1f20-4e2e-ba75-af6d30621dc8"
 
 [[token.source_card_refs]]
 card_name = "The Locust God"
@@ -19298,11 +18464,6 @@ scryfall_id = "626db678-2dec-4026-af5a-83e834692ba0"
 card_name = "Dragon Egg"
 scryfall_oracle_id = "8f561498-66e7-4cbf-8cb9-e6fd4717993d"
 scryfall_id = "166e3f73-07f0-4c59-a48f-01b830fb9898"
-
-[[token.source_card_refs]]
-card_name = "Dragon Egg"
-scryfall_oracle_id = "8f561498-66e7-4cbf-8cb9-e6fd4717993d"
-scryfall_id = "58d31ba0-6cec-4d8b-950f-f0b70bb8b0dd"
 
 [token.token_image_ref]
 scryfall_id = "1e2aaaca-6563-406f-b1bc-6849ba555da8"
@@ -20140,11 +19301,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Kher Keep"
 scryfall_oracle_id = "79638767-fbc7-451a-b29f-d93f2ac6f102"
-scryfall_id = "dde3b332-5bc3-47bc-ba24-5437f04c21a0"
-
-[[token.source_card_refs]]
-card_name = "Kher Keep"
-scryfall_oracle_id = "79638767-fbc7-451a-b29f-d93f2ac6f102"
 scryfall_id = "4d559369-59eb-4c8f-8bc1-987a529037b8"
 
 [[token.source_card_refs]]
@@ -20227,11 +19383,6 @@ scryfall_oracle_id = "5097f4e6-50af-4641-909f-db44abf0ce32"
 scryfall_id = "1fa981d3-4a41-4bf1-ba64-2cd7224a6059"
 
 [[token.source_card_refs]]
-card_name = "Lathliss, Dragon Queen"
-scryfall_oracle_id = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd"
-scryfall_id = "c7db2091-2888-46d4-8f4a-49f55dc80cd8"
-
-[[token.source_card_refs]]
 card_name = "Rite of the Dragoncaller"
 scryfall_oracle_id = "5097f4e6-50af-4641-909f-db44abf0ce32"
 scryfall_id = "3a99d9bc-da4e-488b-bc4a-90594c072b66"
@@ -20240,11 +19391,6 @@ scryfall_id = "3a99d9bc-da4e-488b-bc4a-90594c072b66"
 card_name = "Rite of the Dragoncaller"
 scryfall_oracle_id = "5097f4e6-50af-4641-909f-db44abf0ce32"
 scryfall_id = "5a73750c-ddd4-448e-94f3-f64bada20508"
-
-[[token.source_card_refs]]
-card_name = "Sarkhan, Fireblood"
-scryfall_oracle_id = "074cbe14-a0c8-4772-955a-b4052333d6ce"
-scryfall_id = "8818250f-a844-4430-853e-0a034aa97485"
 
 [[token.source_card_refs]]
 card_name = "Dragonmaster Outcast"
@@ -20276,11 +19422,6 @@ subtypes = ["Insect"]
 supertypes = []
 colors = ["Black"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Nest of Scarabs"
-scryfall_oracle_id = "1f21cf59-6390-44b4-ab2e-ef290dfd8c85"
-scryfall_id = "d849dc0a-4122-497c-a2a7-e5a21dc809f5"
 
 [[token.source_card_refs]]
 card_name = "Nest of Scarabs"
@@ -21583,16 +20724,6 @@ colors = ["Red"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Flurry of Horns"
-scryfall_oracle_id = "0c8ab7bf-7b6a-4a34-b988-9f3f4d84a9ea"
-scryfall_id = "be522ae8-9cf4-4c63-9a1c-0010d482c00a"
-
-[[token.source_card_refs]]
-card_name = "Sethron, Hurloon General"
-scryfall_oracle_id = "561c1ce9-41e7-474a-9476-bb9a7d24f0d5"
-scryfall_id = "274cdb39-1454-4c9b-acd8-4f762a48e71f"
-
-[[token.source_card_refs]]
 card_name = "Sethron, Hurloon General"
 scryfall_oracle_id = "561c1ce9-41e7-474a-9476-bb9a7d24f0d5"
 scryfall_id = "e075bbdc-822f-4549-bfd5-ce4a2a4354f1"
@@ -21645,8 +20776,6 @@ source_card_names = [
     "Desperate Sentry",
     "Emrakul's Evangel",
     "Enlightened Maniac",
-    "Extricator of Flesh",
-    "Extricator of Sin",
     "Extricator of Sin // Extricator of Flesh",
     "Foul Emissary",
     "Hanweir, the Writhing Township",
@@ -21681,12 +20810,6 @@ scryfall_oracle_id = "4310524d-dc0e-48ad-ae66-4c64aaa39340"
 scryfall_id = "7f186ffa-b914-45cc-bf25-1306842a2ad5"
 
 [[token.source_card_refs]]
-card_name = "Hanweir, the Writhing Township"
-face_name = "Hanweir, the Writhing Township"
-scryfall_oracle_id = "f4905c40-003e-4992-b8d7-3f07ba09c686"
-scryfall_id = "5e42bb55-6fe3-4d0a-9634-43e41837aa5d"
-
-[[token.source_card_refs]]
 card_name = "Shrill Howler // Howling Chorus"
 face_name = "Howling Chorus"
 scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
@@ -21699,22 +20822,10 @@ scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
 scryfall_id = "e414e208-2e90-4b0d-b107-7a387b3f779b"
 
 [[token.source_card_refs]]
-card_name = "Shrill Howler // Howling Chorus"
-face_name = "Shrill Howler"
-scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
-scryfall_id = "b7408d54-e15d-4975-8f30-8cd36fca9429"
-
-[[token.source_card_refs]]
 card_name = "Hanweir, the Writhing Township"
 face_name = "Hanweir, the Writhing Township"
 scryfall_oracle_id = "f4905c40-003e-4992-b8d7-3f07ba09c686"
 scryfall_id = "ddad5b2a-0575-4b44-9fbc-107ee4d10f24"
-
-[[token.source_card_refs]]
-card_name = "Extricator of Sin // Extricator of Flesh"
-face_name = "Extricator of Flesh"
-scryfall_oracle_id = "08b3328c-1d96-4a05-ae8b-f1b654084faa"
-scryfall_id = "1d2ec933-cfc9-4ca4-b47b-f82109d89f0a"
 
 [[token.source_card_refs]]
 card_name = "Desperate Sentry"
@@ -21728,27 +20839,10 @@ scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
 scryfall_id = "e414e208-2e90-4b0d-b107-7a387b3f779b"
 
 [[token.source_card_refs]]
-card_name = "Wharf Infiltrator"
-scryfall_oracle_id = "ac88975c-fb2c-441a-bdd4-e7de6ba865e7"
-scryfall_id = "dc8c14a0-15aa-49e0-b0ba-cb658f1b4854"
-
-[[token.source_card_refs]]
-card_name = "Extricator of Sin // Extricator of Flesh"
-face_name = "Extricator of Sin"
-scryfall_oracle_id = "08b3328c-1d96-4a05-ae8b-f1b654084faa"
-scryfall_id = "1d2ec933-cfc9-4ca4-b47b-f82109d89f0a"
-
-[[token.source_card_refs]]
 card_name = "Shrill Howler // Howling Chorus"
 face_name = "Shrill Howler"
 scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
 scryfall_id = "246885ac-4e8e-4856-b796-5d72dfb7fb29"
-
-[[token.source_card_refs]]
-card_name = "Shrill Howler // Howling Chorus"
-face_name = "Howling Chorus"
-scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
-scryfall_id = "b7408d54-e15d-4975-8f30-8cd36fca9429"
 
 [token.token_image_ref]
 scryfall_id = "a106fc38-c321-4afa-8e66-ea6a9e594a55"
@@ -21953,11 +21047,6 @@ colors = ["Black"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Nettlecyst"
-scryfall_oracle_id = "04c7f4fe-2098-4311-866d-6733c08d5178"
-scryfall_id = "466df5af-f5ec-45ec-bba0-838cc3f387dd"
-
-[[token.source_card_refs]]
 card_name = "Bonehoard"
 scryfall_oracle_id = "83c69c05-173d-4c1b-9541-1dde474fef5f"
 scryfall_id = "75dc1b48-7d49-45ac-b345-988392183ff0"
@@ -22021,11 +21110,6 @@ scryfall_id = "8c418159-b5d1-48e9-9a31-707f49d6733b"
 card_name = "Bonehoard"
 scryfall_oracle_id = "83c69c05-173d-4c1b-9541-1dde474fef5f"
 scryfall_id = "1b146240-2899-43b6-adc6-930905a0d5b7"
-
-[[token.source_card_refs]]
-card_name = "Batterbone"
-scryfall_oracle_id = "389d459d-446a-4b84-82b2-a30fe6ced11f"
-scryfall_id = "5a148abb-e9fd-469c-b18b-9def75d3b783"
 
 [[token.source_card_refs]]
 card_name = "Sickleslicer"
@@ -22447,11 +21531,6 @@ card_name = "Sandwurm Convergence"
 scryfall_oracle_id = "429eff2b-635b-43f6-b20f-82e25992c0b9"
 scryfall_id = "3ad9cb61-4072-449b-9b32-83e2192cb292"
 
-[[token.source_card_refs]]
-card_name = "Sandwurm Convergence"
-scryfall_oracle_id = "429eff2b-635b-43f6-b20f-82e25992c0b9"
-scryfall_id = "3b579409-0129-4f44-b594-d7611ef12472"
-
 [token.token_image_ref]
 scryfall_id = "983253f0-fcf1-4c57-81eb-101f3495b6ae"
 scryfall_oracle_id = "1adf3c28-58c0-4239-ba4a-c53d345709b4"
@@ -22621,11 +21700,6 @@ keywords = ["Flying"]
 card_name = "Angel of Sanctions"
 scryfall_oracle_id = "3c49e98d-d33b-47fa-8b07-b38b367de2c7"
 scryfall_id = "546b6ffc-44e3-4994-b84b-6282c6474a1a"
-
-[[token.source_card_refs]]
-card_name = "Angel of Sanctions"
-scryfall_oracle_id = "3c49e98d-d33b-47fa-8b07-b38b367de2c7"
-scryfall_id = "41b282de-e204-47be-99ea-2596c12bd81c"
 
 [token.token_image_ref]
 scryfall_id = "eee11a08-6cdc-4c47-9ad4-26b766e4a839"
@@ -23901,6 +22975,11 @@ scryfall_id = "610a4f3d-3d92-4b7f-bc6e-89a87b7c7717"
 [[token.source_card_refs]]
 card_name = "Titania, Protector of Argoth"
 scryfall_oracle_id = "d0ade00d-a496-441d-9b7e-7dc033d3292c"
+scryfall_id = "711f4094-9a78-42f7-8f75-f57af921dd2f"
+
+[[token.source_card_refs]]
+card_name = "Titania, Protector of Argoth"
+scryfall_oracle_id = "d0ade00d-a496-441d-9b7e-7dc033d3292c"
 scryfall_id = "b02605cf-ef0b-467c-a6e8-064c2e260cd6"
 
 [[token.source_card_refs]]
@@ -24139,11 +23218,6 @@ card_name = "Vizier of Many Faces"
 scryfall_oracle_id = "55bceb83-bbba-477f-98ce-6e0a80b91080"
 scryfall_id = "b8385f76-3057-4f8f-af84-f70214364870"
 
-[[token.source_card_refs]]
-card_name = "Vizier of Many Faces"
-scryfall_oracle_id = "55bceb83-bbba-477f-98ce-6e0a80b91080"
-scryfall_id = "e28ebe21-5447-45f5-97e4-c9bf1905b4bc"
-
 [token.token_image_ref]
 scryfall_id = "208b09fc-985b-49f5-8af8-27cb590946ae"
 scryfall_oracle_id = "c97e158a-a1be-446c-b9aa-cae931735b9d"
@@ -24215,11 +23289,6 @@ keywords = []
 card_name = "Hunted Horror"
 scryfall_oracle_id = "3469463e-ed4d-44bb-81f3-42bbe09d34ad"
 scryfall_id = "02f74866-d0ea-42ce-bc44-500219fb73d4"
-
-[[token.source_card_refs]]
-card_name = "Hunted Horror"
-scryfall_oracle_id = "3469463e-ed4d-44bb-81f3-42bbe09d34ad"
-scryfall_id = "0ca680e3-2d10-4a32-8b0c-8b0c6be96540"
 
 [token.token_image_ref]
 scryfall_id = "dcd41697-6fe6-423c-a04a-035a3d4f8fd2"
@@ -24555,11 +23624,6 @@ keywords = ["Vigilance"]
 card_name = "Finale of Glory"
 scryfall_oracle_id = "68273453-1059-4eab-8c27-5d96f998f3b1"
 scryfall_id = "9b6b5cb7-26aa-43d6-ae97-24e5efd3c636"
-
-[[token.source_card_refs]]
-card_name = "Finale of Glory"
-scryfall_oracle_id = "68273453-1059-4eab-8c27-5d96f998f3b1"
-scryfall_id = "1e71b0fb-2d36-4b81-bd5b-c3fd083e3e97"
 
 [token.token_image_ref]
 scryfall_id = "f1684175-6e03-4934-92e3-e2a32725f7f9"
@@ -25924,11 +24988,6 @@ colors = ["Blue"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
-card_name = "Ojutai's Summons"
-scryfall_oracle_id = "def45f3a-dba0-4d08-b086-5236d6e0edb1"
-scryfall_id = "fd7fb80c-9cc3-45a9-8144-7559bd320efd"
-
-[[token.source_card_refs]]
 card_name = "Skywise Teachings"
 scryfall_oracle_id = "95a5e444-39f6-4f42-a83f-befa76350bc1"
 scryfall_id = "e55ba092-abc0-49ba-b756-6cb714165fec"
@@ -26008,11 +25067,6 @@ keywords = []
 card_name = "Ajani's Chosen"
 scryfall_oracle_id = "9c77eb0a-543a-41db-ba1f-aa0163837ae0"
 scryfall_id = "bc20cca0-303f-4463-85ae-26b80ff26211"
-
-[[token.source_card_refs]]
-card_name = "Ajani's Chosen"
-scryfall_oracle_id = "9c77eb0a-543a-41db-ba1f-aa0163837ae0"
-scryfall_id = "8ea009c1-505e-4307-b8f3-2d37e36507a6"
 
 [token.token_image_ref]
 scryfall_id = "7d400b41-813d-4a63-848f-5eb4db4bf3bb"
@@ -26588,11 +25642,6 @@ scryfall_oracle_id = "0156c94b-e64c-49de-a46c-a203c5e05e98"
 scryfall_id = "fa23ced5-0baa-4a8d-9263-ec2d94233a84"
 
 [[token.source_card_refs]]
-card_name = "Triplicate Spirits"
-scryfall_oracle_id = "48090c64-f41a-447b-ad7a-54e3194f759b"
-scryfall_id = "3c83a6e2-2c4e-40fb-b954-f78cd1553687"
-
-[[token.source_card_refs]]
 card_name = "Kykar, Zephyr Awakener"
 scryfall_oracle_id = "0156c94b-e64c-49de-a46c-a203c5e05e98"
 scryfall_id = "1f8ec6f1-4889-46e2-b681-59bf7b581195"
@@ -26606,11 +25655,6 @@ scryfall_id = "a1763648-802f-4178-a46a-a0c19142fd67"
 card_name = "Kykar, Zephyr Awakener"
 scryfall_oracle_id = "0156c94b-e64c-49de-a46c-a203c5e05e98"
 scryfall_id = "6c980998-7124-4ec6-a0b6-e8d9a2364925"
-
-[[token.source_card_refs]]
-card_name = "Sandsteppe Outcast"
-scryfall_oracle_id = "fccd17b1-ca0f-4649-a002-5cbf9666b510"
-scryfall_id = "3e2137fe-5e92-442e-b22a-473c5a669308"
 
 [token.token_image_ref]
 scryfall_id = "278adad2-49a6-4baa-8dbe-93474545eef7"
@@ -27143,11 +26187,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Tezzeret the Schemer"
 scryfall_oracle_id = "49d64ecb-3a4f-4013-9a34-8b1539a91e96"
-scryfall_id = "c10e9fdf-8a51-4bc2-95bf-b88f6969f959"
-
-[[token.source_card_refs]]
-card_name = "Tezzeret the Schemer"
-scryfall_oracle_id = "49d64ecb-3a4f-4013-9a34-8b1539a91e96"
 scryfall_id = "58265203-bc16-41d2-875c-2ff3b4870824"
 
 [token.token_image_ref]
@@ -27508,7 +26547,6 @@ id = "1fcde5b3-a6ba-52e8-a46f-d41809973467"
 category = "Creature"
 fidelity = "Full"
 source_card_names = [
-    "Alive",
     "Alive // Well",
     "Call of the Conclave",
     "Centaur Glade",
@@ -27517,7 +26555,6 @@ source_card_names = [
     "Rampage of the Clans",
     "Trostani's Summoner",
     "Vitu-Ghazi Guildmage",
-    "Well",
 ]
 set_code = "RVR"
 set_name = "Ravnica Remastered"
@@ -27534,17 +26571,6 @@ subtypes = ["Centaur"]
 supertypes = []
 colors = ["Green"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Alive // Well"
-face_name = "Alive"
-scryfall_oracle_id = "57ad3c3a-6ac7-4a35-bc07-00f6ea0988c5"
-scryfall_id = "1bc8966b-8c95-4e8e-993c-d536727599b7"
-
-[[token.source_card_refs]]
-card_name = "Centaur Glade"
-scryfall_oracle_id = "369c3b6c-6715-4b6a-89d2-e7542400ba8f"
-scryfall_id = "1c75f9c8-9640-4f64-b32a-916436e461fc"
 
 [[token.source_card_refs]]
 card_name = "Vitu-Ghazi Guildmage"
@@ -27570,12 +26596,6 @@ scryfall_id = "476f0994-10a0-422b-8031-069d5b06064f"
 card_name = "Call of the Conclave"
 scryfall_oracle_id = "e1635acd-ed1e-4038-a11a-6518df285253"
 scryfall_id = "88cacc67-5b0e-4cd5-a552-f64934578930"
-
-[[token.source_card_refs]]
-card_name = "Alive // Well"
-face_name = "Well"
-scryfall_oracle_id = "57ad3c3a-6ac7-4a35-bc07-00f6ea0988c5"
-scryfall_id = "1bc8966b-8c95-4e8e-993c-d536727599b7"
 
 [token.token_image_ref]
 scryfall_id = "5f657b65-67fc-4b7d-bc9e-840190f69362"
@@ -28517,11 +27537,6 @@ scryfall_id = "2d7687d1-d168-4279-b21d-fcfc7573c7b5"
 card_name = "Underworld Hermit"
 scryfall_oracle_id = "f7f4ddc9-cea0-42f9-bbca-2ad87a24bfc8"
 scryfall_id = "735a5082-72f4-4812-adcc-d8095d8eee51"
-
-[[token.source_card_refs]]
-card_name = "Deep Forest Hermit"
-scryfall_oracle_id = "80e9a42e-f4f4-4bfc-91a2-ad124737dca2"
-scryfall_id = "96c5607b-55fe-43c2-93fe-0084d84499d9"
 
 [[token.source_card_refs]]
 card_name = "Chatterfang, Squirrel General"
@@ -31859,16 +30874,6 @@ colors = ["White"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
-card_name = "Angelic Favor"
-scryfall_oracle_id = "37162c6e-ac31-4386-9d1e-76aa66070b35"
-scryfall_id = "871ad2f3-1dd2-45ea-881d-529aad3b76ec"
-
-[[token.source_card_refs]]
-card_name = "Decree of Justice"
-scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
-scryfall_id = "1d347ffc-5542-485c-8fc7-327c1c68b7aa"
-
-[[token.source_card_refs]]
 card_name = "Entreat the Angels"
 scryfall_oracle_id = "b349f018-c20b-48b0-9e65-d5fd56b24b88"
 scryfall_id = "ff4411bc-ed4e-4d54-9e1b-21fc77b0e415"
@@ -31879,11 +30884,6 @@ scryfall_oracle_id = "b349f018-c20b-48b0-9e65-d5fd56b24b88"
 scryfall_id = "0659529d-1328-47de-9910-cce5b744aedf"
 
 [[token.source_card_refs]]
-card_name = "Geist of Saint Traft"
-scryfall_oracle_id = "4304035c-c3e4-4a19-aa1f-92a83d8aed1f"
-scryfall_id = "42eac2d9-3f41-47f9-a3ae-7cfdcd4c945c"
-
-[[token.source_card_refs]]
 card_name = "Decree of Justice"
 scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
 scryfall_id = "bcb7e629-5600-499f-9dc7-144085b4a1b7"
@@ -31892,16 +30892,6 @@ scryfall_id = "bcb7e629-5600-499f-9dc7-144085b4a1b7"
 card_name = "Angelic Accord"
 scryfall_oracle_id = "aa95501f-bb59-494a-bcae-b74ca10ad57e"
 scryfall_id = "b2cb986c-2a8e-4a24-b5d4-4393edc0c347"
-
-[[token.source_card_refs]]
-card_name = "Decree of Justice"
-scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
-scryfall_id = "5e8a7e5c-f252-4de8-94d7-e7327210bf26"
-
-[[token.source_card_refs]]
-card_name = "Speaker of the Heavens"
-scryfall_oracle_id = "e4bacf1b-0a45-4c73-857d-dffadb7e6fa5"
-scryfall_id = "4a7c3dd3-a2e3-400a-8d2e-242bb8de39c1"
 
 [[token.source_card_refs]]
 card_name = "Decree of Justice"
@@ -31929,29 +30919,9 @@ scryfall_oracle_id = "f63c2438-27d4-449a-828f-f0a2ea86ff16"
 scryfall_id = "f89995b9-5409-4d3a-9518-7a4354b9d02f"
 
 [[token.source_card_refs]]
-card_name = "Decree of Justice"
-scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
-scryfall_id = "c2cecbd0-87a7-45e5-bf10-e97b298803fd"
-
-[[token.source_card_refs]]
-card_name = "Descend upon the Sinful"
-scryfall_oracle_id = "9cbf95f4-3510-420b-9355-645450f4493d"
-scryfall_id = "73f518c3-b679-40cf-ae2e-1de4470c514e"
-
-[[token.source_card_refs]]
 card_name = "Sigil of the Empty Throne"
 scryfall_oracle_id = "3b9b5b22-5a7d-4e37-a870-ca0f0efa4f36"
 scryfall_id = "6875be24-1515-488f-a899-929c8e480dfd"
-
-[[token.source_card_refs]]
-card_name = "Urbis Protector"
-scryfall_oracle_id = "564dd5e7-6c1e-4959-a594-60e08552aec9"
-scryfall_id = "8771abc9-e1f2-4d4f-8492-3209866cdc05"
-
-[[token.source_card_refs]]
-card_name = "Sigil of the Empty Throne"
-scryfall_oracle_id = "3b9b5b22-5a7d-4e37-a870-ca0f0efa4f36"
-scryfall_id = "733e1156-39a3-49a2-af5d-75c978107b2a"
 
 [[token.source_card_refs]]
 card_name = "Decree of Justice"
@@ -32048,11 +31018,6 @@ scryfall_oracle_id = "53fc09e1-1e5d-4f22-b623-2c5c770183ab"
 scryfall_id = "85050609-baf0-430a-ab33-83a6ea6d4741"
 
 [[token.source_card_refs]]
-card_name = "Monstrous Rage"
-scryfall_oracle_id = "646a2371-54c0-4492-ac2f-20f109d6108c"
-scryfall_id = "4b2e000b-a147-443b-9138-9ff2d16c0422"
-
-[[token.source_card_refs]]
 card_name = "Living Lectern"
 scryfall_oracle_id = "061e7fb2-2c04-4845-b60a-0e2512a2dec1"
 scryfall_id = "169afcaf-7ebf-4590-9e51-2a1a5eb3ac76"
@@ -32083,11 +31048,6 @@ scryfall_id = "79e4242c-a53a-4287-976b-8e545888a1fa"
 card_name = "Unassuming Sage"
 scryfall_oracle_id = "1cf4e16b-2273-41c7-9bcd-0cdc78e12198"
 scryfall_id = "a66fbaeb-1624-43b3-83e2-a37ce7588a5a"
-
-[[token.source_card_refs]]
-card_name = "Monstrous Rage"
-scryfall_oracle_id = "646a2371-54c0-4492-ac2f-20f109d6108c"
-scryfall_id = "9ebf25f9-844c-40c6-b0f0-d5c82ee04656"
 
 [[token.source_card_refs]]
 card_name = "Become Brutes"
@@ -33339,11 +32299,6 @@ card_name = "Ajani, Strength of the Pride"
 scryfall_oracle_id = "c3974ec7-7af0-4b65-baf6-4c1c4fe8a5c4"
 scryfall_id = "49109f9f-c3df-4694-9c80-32fc28169442"
 
-[[token.source_card_refs]]
-card_name = "Ajani, Strength of the Pride"
-scryfall_oracle_id = "c3974ec7-7af0-4b65-baf6-4c1c4fe8a5c4"
-scryfall_id = "a58deb8a-1c4b-4e3d-9c00-63f615f358c0"
-
 [token.token_image_ref]
 scryfall_id = "6740f7cb-e21b-41ca-acf0-93d63f1f8c54"
 scryfall_oracle_id = "9fcff433-c6f7-44c6-8279-04625703cb3e"
@@ -33614,11 +32569,6 @@ scryfall_oracle_id = "bf30b8ae-0125-4a00-bae8-ac1aa7703a08"
 scryfall_id = "7c54fe0b-56f6-4cff-adde-56aa5326194d"
 
 [[token.source_card_refs]]
-card_name = "Vernal Sovereign"
-scryfall_oracle_id = "bf30b8ae-0125-4a00-bae8-ac1aa7703a08"
-scryfall_id = "8d4ebe8b-8d2f-4534-994e-e387f23cbe1d"
-
-[[token.source_card_refs]]
 card_name = "Voice of Resurgence"
 scryfall_oracle_id = "5cbbb3f3-63a4-4983-81ea-8c405b10e63f"
 scryfall_id = "a1dacda4-ed81-4daf-8718-cc59bffd95fc"
@@ -33780,21 +32730,6 @@ scryfall_id = "53f91325-e95a-4b68-9491-4249c2e940b4"
 [[token.source_card_refs]]
 card_name = "Giant Caterpillar"
 scryfall_oracle_id = "43a515f2-b53a-4bb4-bb6e-0d79c9162359"
-scryfall_id = "2abf3c63-2f8c-4f43-b08b-35a974214ad3"
-
-[[token.source_card_refs]]
-card_name = "Giant Caterpillar"
-scryfall_oracle_id = "43a515f2-b53a-4bb4-bb6e-0d79c9162359"
-scryfall_id = "b7f602a6-3d35-49a3-b5cb-d754e03a9573"
-
-[[token.source_card_refs]]
-card_name = "Giant Caterpillar"
-scryfall_oracle_id = "43a515f2-b53a-4bb4-bb6e-0d79c9162359"
-scryfall_id = "bdc5eb8a-4531-4408-90fe-9b352d71a052"
-
-[[token.source_card_refs]]
-card_name = "Giant Caterpillar"
-scryfall_oracle_id = "43a515f2-b53a-4bb4-bb6e-0d79c9162359"
 scryfall_id = "e5392f2f-8762-4a06-8f1d-7af8dfb7408d"
 
 [token.token_image_ref]
@@ -33828,11 +32763,6 @@ keywords = ["Flying"]
 card_name = "Sword of Dungeons & Dragons"
 scryfall_oracle_id = "8e0b725c-b27a-4aa2-8e4b-6ab47e73927d"
 scryfall_id = "bf451d4b-0884-4ab5-8d85-312d9db82e76"
-
-[[token.source_card_refs]]
-card_name = "Sword of Dungeons & Dragons"
-scryfall_oracle_id = "8e0b725c-b27a-4aa2-8e4b-6ab47e73927d"
-scryfall_id = "541640e3-4b45-41b3-b2b0-090ea5bb1e57"
 
 [token.token_image_ref]
 scryfall_id = "6819b8c9-73a3-4e8e-ad7a-95cffabf873a"
@@ -33945,16 +32875,6 @@ keywords = ["Flying"]
 card_name = "Pride of the Clouds"
 scryfall_oracle_id = "7d595158-73a8-4ebf-aac5-0b5193cef9b7"
 scryfall_id = "48e6b67f-ebf5-4413-9417-ed45a576a390"
-
-[[token.source_card_refs]]
-card_name = "Pride of the Clouds"
-scryfall_oracle_id = "7d595158-73a8-4ebf-aac5-0b5193cef9b7"
-scryfall_id = "ecc2a029-6e64-4b6d-9d82-afc319dbc57a"
-
-[[token.source_card_refs]]
-card_name = "Dovescape"
-scryfall_oracle_id = "d9f4af37-c85e-44ab-9fea-3c67e2f3cf27"
-scryfall_id = "b6e3d6e6-ac17-4d73-acac-089442de4af6"
 
 [[token.source_card_refs]]
 card_name = "Dovescape"
@@ -34387,11 +33307,6 @@ scryfall_oracle_id = "1ed9e351-0000-4b75-8ecb-d15bd88df68a"
 scryfall_id = "2a717b98-cdac-416d-bf6c-f6b6638e65d1"
 
 [[token.source_card_refs]]
-card_name = "Hard Evidence"
-scryfall_oracle_id = "0728b195-2dfe-4d73-91ae-e658a97b0b9a"
-scryfall_id = "c55901dc-3f5a-490d-8496-5b844530d410"
-
-[[token.source_card_refs]]
 card_name = "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar"
 face_name = "Tamiyo, Seasoned Scholar"
 scryfall_oracle_id = "1ed9e351-0000-4b75-8ecb-d15bd88df68a"
@@ -34538,32 +33453,12 @@ keywords = ["Deathtouch"]
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
 scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
-scryfall_id = "dcdbecfc-fc37-4327-9469-7139e16f7fbd"
-
-[[token.source_card_refs]]
-card_name = "Wurmcoil Engine"
-scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
-scryfall_id = "6927d6d4-93fe-4ded-b091-a0c671c1716b"
-
-[[token.source_card_refs]]
-card_name = "Wurmcoil Engine"
-scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
 scryfall_id = "efc01aa1-55f3-4557-a5b0-734f3b9ed050"
 
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
 scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
 scryfall_id = "5d275f04-cc60-4e3f-95cc-3d02bc916b82"
-
-[[token.source_card_refs]]
-card_name = "Wurmcoil Engine"
-scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
-scryfall_id = "219f1f03-e882-40ca-8854-1e466e37b8cd"
-
-[[token.source_card_refs]]
-card_name = "Wurmcoil Engine"
-scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
-scryfall_id = "b045a766-73ee-4109-bede-2e1d71b80f2f"
 
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
@@ -35035,21 +33930,9 @@ scryfall_id = "a47070a0-fd05-4ed9-a175-847a864478da"
 
 [[token.source_card_refs]]
 card_name = "Mouth // Feed"
-face_name = "Mouth"
-scryfall_oracle_id = "980f6341-3c13-4405-8550-b838b228f788"
-scryfall_id = "f5e94e39-4104-4b88-ae2b-a2dd5d2589cb"
-
-[[token.source_card_refs]]
-card_name = "Mouth // Feed"
 face_name = "Feed"
 scryfall_oracle_id = "980f6341-3c13-4405-8550-b838b228f788"
 scryfall_id = "a47070a0-fd05-4ed9-a175-847a864478da"
-
-[[token.source_card_refs]]
-card_name = "Mouth // Feed"
-face_name = "Feed"
-scryfall_oracle_id = "980f6341-3c13-4405-8550-b838b228f788"
-scryfall_id = "f5e94e39-4104-4b88-ae2b-a2dd5d2589cb"
 
 [token.token_image_ref]
 scryfall_id = "1aea5e0b-dc4e-4055-9e13-1dfbc25a2f00"
@@ -35094,11 +33977,6 @@ scryfall_id = "95acdbfc-ec40-4ecd-bd0b-0908ed5d31bc"
 card_name = "Felidar Retreat"
 scryfall_oracle_id = "16629f59-bae8-4c19-bf50-443eb0ed6856"
 scryfall_id = "89e3cc09-5057-4c05-88fc-d6cda809fc74"
-
-[[token.source_card_refs]]
-card_name = "Felidar Retreat"
-scryfall_oracle_id = "16629f59-bae8-4c19-bf50-443eb0ed6856"
-scryfall_id = "34b3b925-743d-4f88-97d6-d0847c0d7d6a"
 
 [token.token_image_ref]
 scryfall_id = "322ef76e-e0f0-48d7-a6ad-5d4c1c9ccb2e"
@@ -35331,11 +34209,6 @@ keywords = []
 card_name = "Tooth and Claw"
 scryfall_oracle_id = "587368eb-068c-44a3-ba8c-5ad0f59f880f"
 scryfall_id = "a8c77d9f-22bd-4676-b594-8499369c449c"
-
-[[token.source_card_refs]]
-card_name = "Tooth and Claw"
-scryfall_oracle_id = "587368eb-068c-44a3-ba8c-5ad0f59f880f"
-scryfall_id = "71696093-0867-4889-8fb4-56fa143f9b27"
 
 [token.token_image_ref]
 scryfall_id = "8437b125-6057-4d17-9f2c-28ea56553f84"
@@ -36082,11 +34955,6 @@ card_name = "The Locust God"
 scryfall_oracle_id = "e025a714-02da-4b0c-8021-cf3e8dc9b19e"
 scryfall_id = "4e0c1d0a-2651-4961-8b70-ff78093732ce"
 
-[[token.source_card_refs]]
-card_name = "The Locust God"
-scryfall_oracle_id = "e025a714-02da-4b0c-8021-cf3e8dc9b19e"
-scryfall_id = "cba0603a-37aa-47b5-bfda-6be2c0138f03"
-
 [token.token_image_ref]
 scryfall_id = "ae56d9e8-de05-456b-af32-b5992992ee15"
 scryfall_oracle_id = "6f80811b-fdc7-4fb9-ac61-d8b51c28fe7f"
@@ -36212,36 +35080,6 @@ subtypes = ["Rukh"]
 supertypes = []
 colors = ["Red"]
 keywords = ["Flying"]
-
-[[token.source_card_refs]]
-card_name = "Rukh Egg"
-scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
-scryfall_id = "d805f1f4-ac45-404d-b52c-4d5eb019e24a"
-
-[[token.source_card_refs]]
-card_name = "Rukh Egg"
-scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
-scryfall_id = "b28f9e63-e5e4-44b5-a17e-8301ff17c623"
-
-[[token.source_card_refs]]
-card_name = "Rukh Egg"
-scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
-scryfall_id = "9c4defc2-b1a2-4ae2-bda0-24ecd4ff8181"
-
-[[token.source_card_refs]]
-card_name = "Rukh Egg"
-scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
-scryfall_id = "33e1098d-6d6e-444d-8307-508ffb2a9b4a"
-
-[[token.source_card_refs]]
-card_name = "Rukh Egg"
-scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
-scryfall_id = "e4bfc662-edfb-43ff-8022-1db971b1de22"
-
-[[token.source_card_refs]]
-card_name = "Rukh Egg"
-scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
-scryfall_id = "99a2fbef-a340-4c08-9c77-a157948cacdf"
 
 [token.token_image_ref]
 scryfall_id = "b5489e26-6aec-4706-9c3e-8454878fa6c3"
@@ -36869,8 +35707,6 @@ source_card_names = [
     "Breya's Apprentice",
     "Broadcast Rambler",
     "Camera Launcher",
-    "Deploy",
-    "Depose",
     "Depose // Deploy",
     "Detective's Satchel",
     "Deviant Skytech",
@@ -36948,12 +35784,6 @@ scryfall_oracle_id = "9be5a350-c38e-425f-9d6a-8eb111132a89"
 scryfall_id = "19529568-c759-4ae0-b2e4-ab5a11d421a4"
 
 [[token.source_card_refs]]
-card_name = "Depose // Deploy"
-face_name = "Deploy"
-scryfall_oracle_id = "c547c9ab-a303-48fb-9579-37f9de9a558b"
-scryfall_id = "0bda0b80-8a41-4001-9f60-06b1d7f9b1fa"
-
-[[token.source_card_refs]]
 card_name = "Fuss // Bother"
 face_name = "Fuss"
 scryfall_oracle_id = "88e9006a-cfdf-40f3-80d5-23465f3dceca"
@@ -36963,12 +35793,6 @@ scryfall_id = "269a031e-0b89-40e1-b11b-ae870d72161c"
 card_name = "Whirler Rogue"
 scryfall_oracle_id = "7060f2c8-fca0-4b7a-bddf-37682f434596"
 scryfall_id = "31dec9a8-714f-4e28-9781-d0a8c6775298"
-
-[[token.source_card_refs]]
-card_name = "Depose // Deploy"
-face_name = "Depose"
-scryfall_oracle_id = "c547c9ab-a303-48fb-9579-37f9de9a558b"
-scryfall_id = "0bda0b80-8a41-4001-9f60-06b1d7f9b1fa"
 
 [[token.source_card_refs]]
 card_name = "Surveillance Monitor"
@@ -37966,16 +36790,6 @@ scryfall_id = "a4dfb147-10f6-49f1-b777-12125e87189b"
 [[token.source_card_refs]]
 card_name = "Gutter Grime"
 scryfall_oracle_id = "0b8adb9e-97a5-43d9-87d6-993f22edaf3b"
-scryfall_id = "29dcc6ad-3f7d-41d3-9a94-de4b63620763"
-
-[[token.source_card_refs]]
-card_name = "Miming Slime"
-scryfall_oracle_id = "50e7f705-c347-440b-8159-81a52bbfbdfb"
-scryfall_id = "bbf8f4c9-3d1d-4fc9-b852-0890af674916"
-
-[[token.source_card_refs]]
-card_name = "Gutter Grime"
-scryfall_oracle_id = "0b8adb9e-97a5-43d9-87d6-993f22edaf3b"
 scryfall_id = "cf3f3913-86d8-4b1c-9d2e-942102e7fac3"
 
 [token.token_image_ref]
@@ -38183,11 +36997,6 @@ subtypes = ["Horror"]
 supertypes = []
 colors = ["Black"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Hunted Lammasu"
-scryfall_oracle_id = "a76667b5-2144-4395-a5c1-57cb3c29a99e"
-scryfall_id = "b84de052-65e5-4723-a746-5c554fa1612d"
 
 [[token.source_card_refs]]
 card_name = "Hunted Lammasu"
@@ -38883,11 +37692,6 @@ subtypes = ["Bird"]
 supertypes = []
 colors = ["White"]
 keywords = ["Flying"]
-
-[[token.source_card_refs]]
-card_name = "Roc Egg"
-scryfall_oracle_id = "16dfd80a-9847-45b8-954f-2af9b7cfa21d"
-scryfall_id = "ed945e1a-977a-4de8-9962-828388bafc3e"
 
 [[token.source_card_refs]]
 card_name = "Roc Egg"
@@ -39880,11 +38684,6 @@ scryfall_oracle_id = "66950068-adf4-42d7-ad72-fdb4a0e58922"
 scryfall_id = "9fb292a4-cf71-4aeb-b92e-eab2e3177653"
 
 [[token.source_card_refs]]
-card_name = "Crashing Footfalls"
-scryfall_oracle_id = "2b166d97-c2c1-4642-b151-9bb1ad32e362"
-scryfall_id = "564eb8e2-e3fb-44b6-a36d-a74e2374f9ff"
-
-[[token.source_card_refs]]
 card_name = "W'Kabi, Shield of the Nation"
 scryfall_oracle_id = "66950068-adf4-42d7-ad72-fdb4a0e58922"
 scryfall_id = "f74ec2db-bcf2-46f4-a002-f3c1c8f4f976"
@@ -39969,17 +38768,7 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Urza's Factory"
 scryfall_oracle_id = "5a620d20-f14e-43d0-8e57-c2a197e2ec51"
-scryfall_id = "73d9f428-8ce0-4a73-ac38-2dcbdcf12584"
-
-[[token.source_card_refs]]
-card_name = "Urza's Factory"
-scryfall_oracle_id = "5a620d20-f14e-43d0-8e57-c2a197e2ec51"
 scryfall_id = "c02a54a6-9247-4460-83e5-d10fbd1554e6"
-
-[[token.source_card_refs]]
-card_name = "Urza's Factory"
-scryfall_oracle_id = "5a620d20-f14e-43d0-8e57-c2a197e2ec51"
-scryfall_id = "b22d97f3-08cf-4c19-bbe2-5a36096187cd"
 
 [[token.source_card_refs]]
 card_name = "Urza's Factory"
@@ -40317,52 +39106,12 @@ keywords = ["Flying"]
 [[token.source_card_refs]]
 card_name = "The Hive"
 scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
-scryfall_id = "fa3aa493-3801-400e-965e-e518c38eb770"
-
-[[token.source_card_refs]]
-card_name = "The Hive"
-scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
 scryfall_id = "7fb40127-8aba-4a20-b03e-983ddaa605d5"
 
 [[token.source_card_refs]]
 card_name = "The Hive"
 scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
-scryfall_id = "09b82c6b-9b14-4607-95d5-2964b926ec37"
-
-[[token.source_card_refs]]
-card_name = "The Hive"
-scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
-scryfall_id = "f9d01a2e-2687-4b37-aed6-63202cd81231"
-
-[[token.source_card_refs]]
-card_name = "The Hive"
-scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
-scryfall_id = "84b83106-a10d-469a-99eb-56110ef34ba1"
-
-[[token.source_card_refs]]
-card_name = "The Hive"
-scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
 scryfall_id = "51027e4f-de9b-43d9-8b73-98e723aa65f2"
-
-[[token.source_card_refs]]
-card_name = "The Hive"
-scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
-scryfall_id = "544a7138-eae8-4ff9-9e17-680bfa717183"
-
-[[token.source_card_refs]]
-card_name = "The Hive"
-scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
-scryfall_id = "af5534f0-485e-41f2-bcfa-d65c1a9b86bd"
-
-[[token.source_card_refs]]
-card_name = "The Hive"
-scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
-scryfall_id = "dc052e94-1574-4e79-9b1b-288180901dea"
-
-[[token.source_card_refs]]
-card_name = "The Hive"
-scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
-scryfall_id = "885c72d8-cee1-4a67-a394-b7dfe89bbd2e"
 
 [token.token_image_ref]
 scryfall_id = "09921372-126f-4c81-b6d8-ea50b1d0eb44"
@@ -41308,11 +40057,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Nadir Kraken"
 scryfall_oracle_id = "5a73d439-bd78-42e1-90ae-eedd30536881"
-scryfall_id = "be7b276f-2351-4f56-a104-13e3ec3f0890"
-
-[[token.source_card_refs]]
-card_name = "Nadir Kraken"
-scryfall_oracle_id = "5a73d439-bd78-42e1-90ae-eedd30536881"
 scryfall_id = "3bd63804-d538-471f-b57f-e1023f7e14a8"
 
 [token.token_image_ref]
@@ -41444,11 +40188,6 @@ keywords = ["Deathtouch"]
 card_name = "Pharika, God of Affliction"
 scryfall_oracle_id = "b7d05d00-1e69-4d11-bff0-c1ca2026aad6"
 scryfall_id = "109bfa3d-02e0-4395-bd6e-edaad77f25f7"
-
-[[token.source_card_refs]]
-card_name = "Pharika, God of Affliction"
-scryfall_oracle_id = "b7d05d00-1e69-4d11-bff0-c1ca2026aad6"
-scryfall_id = "0bcaa988-7485-461b-a3ae-764e1f4531df"
 
 [[token.source_card_refs]]
 card_name = "Pharika, God of Affliction"
@@ -41794,11 +40533,6 @@ card_name = "Kessig Wolfrider"
 scryfall_oracle_id = "d9c42e56-1818-4b73-9cd6-1c5aaf6a5b56"
 scryfall_id = "9d54673a-2147-474c-9bcb-ef89dbe54456"
 
-[[token.source_card_refs]]
-card_name = "Kessig Wolfrider"
-scryfall_oracle_id = "d9c42e56-1818-4b73-9cd6-1c5aaf6a5b56"
-scryfall_id = "f76bddc3-f62e-4504-9703-8ed57acb90fa"
-
 [token.token_image_ref]
 scryfall_id = "001cc57e-f3fc-4790-a9e5-171b2e3e8739"
 scryfall_oracle_id = "04139d92-67d3-4e3c-a97f-158f24115044"
@@ -41888,16 +40622,6 @@ scryfall_oracle_id = "ca68f436-2522-4007-87bf-2669c7743db0"
 scryfall_id = "ac37ca6f-a6ee-4dfb-949f-2562f98d09d0"
 
 [[token.source_card_refs]]
-card_name = "Spider-Slayer, Hatred Honed"
-scryfall_oracle_id = "ca68f436-2522-4007-87bf-2669c7743db0"
-scryfall_id = "a8874e6e-400f-48ff-a9da-6bce557bde78"
-
-[[token.source_card_refs]]
-card_name = "Robotics Mastery"
-scryfall_oracle_id = "855318cb-9382-4183-87c7-93bdfac86431"
-scryfall_id = "b9be8e17-7304-4df9-bdeb-8f31c604056c"
-
-[[token.source_card_refs]]
 card_name = "Robotics Mastery"
 scryfall_oracle_id = "855318cb-9382-4183-87c7-93bdfac86431"
 scryfall_id = "b5ed3c76-946a-4140-8c7b-2011e72a7d54"
@@ -41978,11 +40702,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Wolf's Quarry"
 scryfall_oracle_id = "c6fead73-0473-4b57-899a-9f8c5b4f896d"
-scryfall_id = "84c2f778-2ad0-4b80-9296-f37c6090f8ff"
-
-[[token.source_card_refs]]
-card_name = "Wolf's Quarry"
-scryfall_oracle_id = "c6fead73-0473-4b57-899a-9f8c5b4f896d"
 scryfall_id = "5d21c15f-378e-4abf-992f-9743aa6ab6b8"
 
 [token.token_image_ref]
@@ -42057,18 +40776,6 @@ card_name = "Nissa, Vastwood Seer // Nissa, Sage Animist"
 face_name = "Nissa, Sage Animist"
 scryfall_oracle_id = "35754a21-9fba-4370-a254-292918a777ba"
 scryfall_id = "aa4103ef-4778-41da-99f5-fa590074cd52"
-
-[[token.source_card_refs]]
-card_name = "Nissa, Vastwood Seer // Nissa, Sage Animist"
-face_name = "Nissa, Sage Animist"
-scryfall_oracle_id = "35754a21-9fba-4370-a254-292918a777ba"
-scryfall_id = "332f7ad3-33b0-4b03-9c86-73917f8db29a"
-
-[[token.source_card_refs]]
-card_name = "Nissa, Vastwood Seer // Nissa, Sage Animist"
-face_name = "Nissa, Vastwood Seer"
-scryfall_oracle_id = "35754a21-9fba-4370-a254-292918a777ba"
-scryfall_id = "332f7ad3-33b0-4b03-9c86-73917f8db29a"
 
 [token.token_image_ref]
 scryfall_id = "2c3775c8-2d3d-47b0-b262-8b86d649c087"
@@ -44793,11 +43500,6 @@ keywords = ["Haste"]
 [[token.source_card_refs]]
 card_name = "Riftmarked Knight"
 scryfall_oracle_id = "a20093c6-b8b4-4051-808f-febd030f7fe4"
-scryfall_id = "d503b565-a3c8-4b57-9e30-fb97d2a49afa"
-
-[[token.source_card_refs]]
-card_name = "Riftmarked Knight"
-scryfall_oracle_id = "a20093c6-b8b4-4051-808f-febd030f7fe4"
 scryfall_id = "20c4cb76-c895-4862-8099-d306b1bb06e9"
 
 [token.token_image_ref]
@@ -45570,11 +44272,6 @@ keywords = [
 [[token.source_card_refs]]
 card_name = "Hornet Cannon"
 scryfall_oracle_id = "595ae6f1-e66a-4774-943a-9d5368f4a3b4"
-scryfall_id = "51e9afeb-4d27-441c-b379-3dfe974053b8"
-
-[[token.source_card_refs]]
-card_name = "Hornet Cannon"
-scryfall_oracle_id = "595ae6f1-e66a-4774-943a-9d5368f4a3b4"
 scryfall_id = "a3ea39a8-48d1-4a58-8662-88841eabec92"
 
 [token.token_image_ref]
@@ -46201,19 +44898,9 @@ colors = ["Red"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Seasoned Pyromancer"
-scryfall_oracle_id = "02238355-9c84-4ae0-b850-269f460144a8"
-scryfall_id = "11754da2-dc6a-47f7-9744-4db71ea9d336"
-
-[[token.source_card_refs]]
 card_name = "Molten Birth"
 scryfall_oracle_id = "aeaae9cc-f30f-4d7e-86f3-3132ef47e987"
 scryfall_id = "910098bb-c909-47c5-b2ef-0dd4e5a8346a"
-
-[[token.source_card_refs]]
-card_name = "Young Pyromancer"
-scryfall_oracle_id = "5fac139a-07d3-4e6c-98e3-d98b199f7a6f"
-scryfall_id = "9b53aa90-f8d6-4cbc-9836-9e4d95ea74f7"
 
 [[token.source_card_refs]]
 card_name = "Young Pyromancer"
@@ -46233,17 +44920,7 @@ scryfall_id = "96ff0ce1-9737-452a-9ecb-b32a3e926283"
 [[token.source_card_refs]]
 card_name = "Young Pyromancer"
 scryfall_oracle_id = "5fac139a-07d3-4e6c-98e3-d98b199f7a6f"
-scryfall_id = "218af707-cc60-407e-af20-e21879a0e902"
-
-[[token.source_card_refs]]
-card_name = "Young Pyromancer"
-scryfall_oracle_id = "5fac139a-07d3-4e6c-98e3-d98b199f7a6f"
 scryfall_id = "e63195ed-5c3e-40e8-9cc2-5cbc1faf7f7f"
-
-[[token.source_card_refs]]
-card_name = "Young Pyromancer"
-scryfall_oracle_id = "5fac139a-07d3-4e6c-98e3-d98b199f7a6f"
-scryfall_id = "8afb19df-b96a-4736-81ab-3561e2767d2d"
 
 [[token.source_card_refs]]
 card_name = "Young Pyromancer"
@@ -46283,11 +44960,6 @@ keywords = ["Flying"]
 card_name = "Sengir Nosferatu"
 scryfall_oracle_id = "2efdfcae-c3ad-4c6b-8a60-45a203bd14c6"
 scryfall_id = "71dc9f1e-b889-402d-a5a1-fa0d7d493246"
-
-[[token.source_card_refs]]
-card_name = "Sengir Nosferatu"
-scryfall_oracle_id = "2efdfcae-c3ad-4c6b-8a60-45a203bd14c6"
-scryfall_id = "3cd9cc4c-708b-41cb-9cac-fd6d8ce9922d"
 
 [token.token_image_ref]
 scryfall_id = "4c532e0f-8934-4ad3-bb1a-640abe946e10"
@@ -48168,9 +46840,7 @@ source_card_names = [
     "Blood Fountain",
     "Blood Petal Celebrant",
     "Blood Servitor",
-    "Bloodbat Summoner",
     "Bloodcrazed Socialite",
-    "Bloodsoaked Reveler",
     "Bloodtithe Harvester",
     "Bloodvial Purveyor",
     "Bloody Betrayal",
@@ -48191,7 +46861,6 @@ source_card_names = [
     "Old Rutstein",
     "Olivia's Attendants",
     "Pointed Discussion",
-    "Restless Bloodseeker",
     "Restless Bloodseeker // Bloodsoaked Reveler",
     "Sanguine Brushstroke",
     "Sanguine Statuette",
@@ -48202,7 +46871,6 @@ source_card_names = [
     "Transmutation Font",
     "Vampire's Kiss",
     "Vampires' Vengeance",
-    "Voldaren Bloodcaster",
     "Voldaren Bloodcaster // Bloodbat Summoner",
     "Voldaren Epicure",
     "Voldaren Estate",
@@ -48226,55 +46894,9 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Sanguine Statuette"
-scryfall_oracle_id = "35553c2a-0150-49e4-81da-f356c6a17253"
-scryfall_id = "b40a143a-afa0-4fe2-802b-abcf09d7b145"
-
-[[token.source_card_refs]]
 card_name = "Voldaren Estate"
 scryfall_oracle_id = "fb0c0426-f1a6-4e52-9242-627786d3119a"
 scryfall_id = "dd0ee2f1-d5be-4f60-a128-7011eef71f11"
-
-[[token.source_card_refs]]
-card_name = "Vampire's Kiss"
-scryfall_oracle_id = "105cea6e-18e9-4dec-a533-0dca4d41320b"
-scryfall_id = "02f210ed-b40b-44c8-9424-fbefb31e9c3c"
-
-[[token.source_card_refs]]
-card_name = "Pointed Discussion"
-scryfall_oracle_id = "aff9a568-2848-4614-a28b-b1ea84f7f0b7"
-scryfall_id = "0bed9878-8662-433e-8786-3a66e8f668ed"
-
-[[token.source_card_refs]]
-card_name = "Restless Bloodseeker // Bloodsoaked Reveler"
-face_name = "Bloodsoaked Reveler"
-scryfall_oracle_id = "7aef5d2e-b66d-4822-b563-44d21d008272"
-scryfall_id = "0c6c01a9-67f7-4e96-b44e-b28379b41cc2"
-
-[[token.source_card_refs]]
-card_name = "Falkenrath Celebrants"
-scryfall_oracle_id = "3c0be888-0d66-4bad-84f4-90c3934915d7"
-scryfall_id = "8fa79e35-1a83-431e-bf70-71860c288210"
-
-[[token.source_card_refs]]
-card_name = "Blood Petal Celebrant"
-scryfall_oracle_id = "219cf182-0942-4569-91e9-9bc9bb1d06d0"
-scryfall_id = "03e5159b-0575-4ae1-b04b-ab812207cbdf"
-
-[[token.source_card_refs]]
-card_name = "Blood Fountain"
-scryfall_oracle_id = "abfa5753-8c02-4e2f-8f98-b0636907293a"
-scryfall_id = "1b0c4931-3260-411a-9c7d-b67c87e7aecc"
-
-[[token.source_card_refs]]
-card_name = "Ivora, Insatiable Heir"
-scryfall_oracle_id = "d847542b-7522-43ec-91b0-f0aba5d7dddd"
-scryfall_id = "2ba70366-b6ae-423a-a8d8-29d2b8afd939"
-
-[[token.source_card_refs]]
-card_name = "Blood Fountain"
-scryfall_oracle_id = "abfa5753-8c02-4e2f-8f98-b0636907293a"
-scryfall_id = "3499687b-5dd3-4a0c-96a3-7db227abcaf2"
 
 [[token.source_card_refs]]
 card_name = "Jaws, Relentless Predator"
@@ -48284,78 +46906,7 @@ scryfall_id = "c6d16a9e-98c0-46e0-987c-f0de0915a204"
 [[token.source_card_refs]]
 card_name = "Bloody Betrayal"
 scryfall_oracle_id = "a2743cb6-564d-43f1-99cc-4ba3ceb2e282"
-scryfall_id = "dd678a9b-95a3-4abb-b845-0e998144c3f6"
-
-[[token.source_card_refs]]
-card_name = "Syphon Essence"
-scryfall_oracle_id = "e6e7b5ba-ea10-4f53-8afc-045aa1906c6b"
-scryfall_id = "bd07eb9f-4817-45f4-a5eb-3d1842d43301"
-
-[[token.source_card_refs]]
-card_name = "Odric, Blood-Cursed"
-scryfall_oracle_id = "690f79f3-e6a5-4542-8401-61a9bf645d55"
-scryfall_id = "e3a463f6-975c-4bba-8dc1-5cf0ff874bb4"
-
-[[token.source_card_refs]]
-card_name = "Old Rutstein"
-scryfall_oracle_id = "8f5ffb0b-0585-4a37-8048-eda53990d1dd"
-scryfall_id = "2bda3765-c56f-4b27-83f8-d01e16265328"
-
-[[token.source_card_refs]]
-card_name = "Bloody Betrayal"
-scryfall_oracle_id = "a2743cb6-564d-43f1-99cc-4ba3ceb2e282"
 scryfall_id = "9460ca4f-aea4-4c38-8e36-7467178986cc"
-
-[[token.source_card_refs]]
-card_name = "Belligerent Guest"
-scryfall_oracle_id = "417e798d-9ca6-4cd0-adb4-f61d3becb201"
-scryfall_id = "23430e0e-521d-412d-92ed-082e569d760c"
-
-[[token.source_card_refs]]
-card_name = "Anje, Maid of Dishonor"
-scryfall_oracle_id = "1829f1dc-1fa9-4361-b318-d4dee280e6fd"
-scryfall_id = "b81584cd-0624-4524-9426-35f1a1ef60ea"
-
-[[token.source_card_refs]]
-card_name = "Voldaren Epicure"
-scryfall_oracle_id = "cef82674-1f61-407b-801b-a76a3803e598"
-scryfall_id = "b9706fd5-04d2-4dff-9e59-ac822df5b7e0"
-
-[[token.source_card_refs]]
-card_name = "Sigarda's Imprisonment"
-scryfall_oracle_id = "574230c7-b949-4c90-b107-c26458a6e469"
-scryfall_id = "1fc02a0f-d555-40ba-8bcd-00a0c1d56038"
-
-[[token.source_card_refs]]
-card_name = "Voldaren Bloodcaster // Bloodbat Summoner"
-face_name = "Bloodbat Summoner"
-scryfall_oracle_id = "a720f3d3-c2d7-4e50-8cc6-600120380e9c"
-scryfall_id = "5299eaa4-9223-4180-8339-8cf9af3a41b1"
-
-[[token.source_card_refs]]
-card_name = "Bloodcrazed Socialite"
-scryfall_oracle_id = "7e165b4e-4c8f-4a0f-bd6e-7b0a15b12d1d"
-scryfall_id = "35deff8c-14d7-4b24-bce8-97ca041c72fd"
-
-[[token.source_card_refs]]
-card_name = "Blood Servitor"
-scryfall_oracle_id = "5a3f9c4d-20a8-46aa-9cf3-3916f56a7906"
-scryfall_id = "4adef77b-c17f-4573-b6e1-d6ca82b4c94f"
-
-[[token.source_card_refs]]
-card_name = "Markov Enforcer"
-scryfall_oracle_id = "e262ea6f-c8c7-45c7-a9a6-29dcbe6300a4"
-scryfall_id = "768e4488-1c3b-4ccb-abf8-fd168655d7de"
-
-[[token.source_card_refs]]
-card_name = "Falkenrath Celebrants"
-scryfall_oracle_id = "3c0be888-0d66-4bad-84f4-90c3934915d7"
-scryfall_id = "8813702a-3311-423a-ab71-263a0ff10d6e"
-
-[[token.source_card_refs]]
-card_name = "Ceremonial Knife"
-scryfall_oracle_id = "db221948-fcb9-4ef9-ae69-70266235dd04"
-scryfall_id = "779fa44a-444b-47fc-882b-d9da7714bd02"
 
 [[token.source_card_refs]]
 card_name = "Voldaren Epicure"
@@ -48363,55 +46914,9 @@ scryfall_oracle_id = "cef82674-1f61-407b-801b-a76a3803e598"
 scryfall_id = "cc9e4323-50a7-4b6d-9bf4-6d5820c52261"
 
 [[token.source_card_refs]]
-card_name = "Blood Petal Celebrant"
-scryfall_oracle_id = "219cf182-0942-4569-91e9-9bc9bb1d06d0"
-scryfall_id = "f25a585e-4f8c-4ed3-8cd3-624c6e3da1d6"
-
-[[token.source_card_refs]]
-card_name = "Bloodvial Purveyor"
-scryfall_oracle_id = "7292272d-6511-466b-aadd-c4fe7ed8df09"
-scryfall_id = "58996f26-f751-47bd-be42-8b7e07f31db0"
-
-[[token.source_card_refs]]
-card_name = "Voldaren Estate"
-scryfall_oracle_id = "fb0c0426-f1a6-4e52-9242-627786d3119a"
-scryfall_id = "1dd9238b-0de6-4552-980b-44d4f5911cec"
-
-[[token.source_card_refs]]
-card_name = "Vampires' Vengeance"
-scryfall_oracle_id = "3a82e724-28f6-430f-a474-ab4276197963"
-scryfall_id = "40af466b-6506-4dca-abfc-15963b5e3d31"
-
-[[token.source_card_refs]]
-card_name = "Bloodtithe Harvester"
-scryfall_oracle_id = "419a8ab2-cff6-4811-a559-8791c9bb3d8e"
-scryfall_id = "13c555ad-44c9-458c-8f65-6b7b4b5d70ea"
-
-[[token.source_card_refs]]
-card_name = "Gluttonous Guest"
-scryfall_oracle_id = "2d338aa5-22bc-4cc4-a1e0-cc5018ce001e"
-scryfall_id = "1670ccb8-0127-4f22-af3a-a6a47283b7fe"
-
-[[token.source_card_refs]]
-card_name = "Belligerent Guest"
-scryfall_oracle_id = "417e798d-9ca6-4cd0-adb4-f61d3becb201"
-scryfall_id = "801741b8-b3a6-4f4a-9955-f3c29408b919"
-
-[[token.source_card_refs]]
-card_name = "Voldaren Bloodcaster // Bloodbat Summoner"
-face_name = "Voldaren Bloodcaster"
-scryfall_oracle_id = "a720f3d3-c2d7-4e50-8cc6-600120380e9c"
-scryfall_id = "5299eaa4-9223-4180-8339-8cf9af3a41b1"
-
-[[token.source_card_refs]]
 card_name = "Bloodtithe Harvester"
 scryfall_oracle_id = "419a8ab2-cff6-4811-a559-8791c9bb3d8e"
 scryfall_id = "0c95e4b1-2fa8-420d-8c55-f74badb2bafa"
-
-[[token.source_card_refs]]
-card_name = "Grisly Ritual"
-scryfall_oracle_id = "56c78349-e4fa-48ba-ae8e-d2312ae6edc6"
-scryfall_id = "f91ab125-a0f4-4c85-8433-8b0ba8865c93"
 
 [[token.source_card_refs]]
 card_name = "Strefan, Maurer Progenitor"
@@ -48424,50 +46929,14 @@ scryfall_oracle_id = "abfa5753-8c02-4e2f-8f98-b0636907293a"
 scryfall_id = "edd57db1-9a72-4ae4-bb40-26bc57fb2972"
 
 [[token.source_card_refs]]
-card_name = "Bloodtithe Harvester"
-scryfall_oracle_id = "419a8ab2-cff6-4811-a559-8791c9bb3d8e"
-scryfall_id = "ce8c5a87-deef-4c81-88ab-6817b8e4b000"
-
-[[token.source_card_refs]]
-card_name = "Gluttonous Guest"
-scryfall_oracle_id = "2d338aa5-22bc-4cc4-a1e0-cc5018ce001e"
-scryfall_id = "9fb5acb2-8a28-4b8b-8538-ebc0e1d06f27"
-
-[[token.source_card_refs]]
 card_name = "Sanguine Brushstroke"
 scryfall_oracle_id = "d2c6502d-fefd-4c9f-9d7b-6dfcc43316e1"
 scryfall_id = "b7c08707-9467-452c-96ee-2e9d3661dcb4"
 
 [[token.source_card_refs]]
-card_name = "Falkenrath Forebear"
-scryfall_oracle_id = "940080ce-c504-48c8-a763-326fef907217"
-scryfall_id = "edc71a2f-853e-4c61-b2d3-b767158d71a3"
-
-[[token.source_card_refs]]
-card_name = "Lacerate Flesh"
-scryfall_oracle_id = "201c8de7-9675-475b-8f9e-7b1935234488"
-scryfall_id = "780bc65a-4dd1-4321-b0f6-d26ecca4a9fe"
-
-[[token.source_card_refs]]
-card_name = "Restless Bloodseeker // Bloodsoaked Reveler"
-face_name = "Restless Bloodseeker"
-scryfall_oracle_id = "7aef5d2e-b66d-4822-b563-44d21d008272"
-scryfall_id = "0c6c01a9-67f7-4e96-b44e-b28379b41cc2"
-
-[[token.source_card_refs]]
 card_name = "Falkenrath Celebrants"
 scryfall_oracle_id = "3c0be888-0d66-4bad-84f4-90c3934915d7"
 scryfall_id = "3eafd571-9364-44d9-8da5-1d93c07f0300"
-
-[[token.source_card_refs]]
-card_name = "Voldaren Epicure"
-scryfall_oracle_id = "cef82674-1f61-407b-801b-a76a3803e598"
-scryfall_id = "74053281-6581-4a8d-b8bd-4352c78b1de6"
-
-[[token.source_card_refs]]
-card_name = "Olivia's Attendants"
-scryfall_oracle_id = "6b384c3c-0d6b-4bba-b4c7-5af8b32bdf1c"
-scryfall_id = "f401ae72-1e0b-405f-8e15-fa309d9e35ba"
 
 [token.token_image_ref]
 scryfall_id = "6b563165-b97f-42c6-82a8-65d8ee69e381"
@@ -49182,11 +47651,6 @@ scryfall_oracle_id = "4c6a0c30-b547-4eff-8ff4-0ca25803c076"
 scryfall_id = "2138dfbb-a4e3-49db-b908-95d0b2b7e82f"
 
 [[token.source_card_refs]]
-card_name = "Urza, Lord High Artificer"
-scryfall_oracle_id = "e87906d2-db1a-4e19-b910-adb4eb339945"
-scryfall_id = "86d744cd-225c-4279-898a-858dc316cf7f"
-
-[[token.source_card_refs]]
 card_name = "Urza's Saga"
 scryfall_oracle_id = "4c6a0c30-b547-4eff-8ff4-0ca25803c076"
 scryfall_id = "c1e0f201-42cb-46a1-901a-65bb4fc18f6c"
@@ -49795,21 +48259,6 @@ scryfall_id = "f88e1bb5-dd3a-46e9-a52d-ec42002c4a05"
 card_name = "Emmara, Soul of the Accord"
 scryfall_oracle_id = "c65ba242-3369-48a9-864f-1b1f85238f67"
 scryfall_id = "07c42262-6291-43df-ba34-83e462ab56b6"
-
-[[token.source_card_refs]]
-card_name = "Dawn of Hope"
-scryfall_oracle_id = "d7a38484-2acc-49a6-b32d-d54dddb14d31"
-scryfall_id = "6f66cf2f-191d-4cbf-a340-a516973a7751"
-
-[[token.source_card_refs]]
-card_name = "Dawn of Hope"
-scryfall_oracle_id = "d7a38484-2acc-49a6-b32d-d54dddb14d31"
-scryfall_id = "de36ecaa-62e0-4f1c-b07f-837a786dc897"
-
-[[token.source_card_refs]]
-card_name = "Trostani Discordant"
-scryfall_oracle_id = "9a2fdc0e-e0de-47fc-95e4-04e725ddf060"
-scryfall_id = "79d61bba-4404-4336-8290-51d1576f728d"
 
 [token.token_image_ref]
 scryfall_id = "20a9bda0-5673-4071-9201-83670a317f8a"
@@ -50542,11 +48991,6 @@ keywords = []
 card_name = "The Big Idea"
 scryfall_oracle_id = "976fb4c7-f330-4b8b-8f87-e6839d9a2880"
 scryfall_id = "2ec4563d-1a83-402c-b209-0e1f740a6523"
-
-[[token.source_card_refs]]
-card_name = "The Big Idea"
-scryfall_oracle_id = "976fb4c7-f330-4b8b-8f87-e6839d9a2880"
-scryfall_id = "93500a3f-86a6-4eab-9fa3-d1ec2c224a49"
 
 [token.token_image_ref]
 scryfall_id = "af1a8115-127d-4268-a4d0-95360862e5fb"
@@ -52322,11 +50766,6 @@ scryfall_oracle_id = "533767ca-7208-4c88-b160-375479b68285"
 scryfall_id = "3052eb74-496d-41eb-ace6-84a4ace4d7da"
 
 [[token.source_card_refs]]
-card_name = "Caller of the Claw"
-scryfall_oracle_id = "ec79255f-4b4d-4a0a-89d8-c59ba640275b"
-scryfall_id = "a073459e-1f00-47e0-a1b3-d30203aa35d1"
-
-[[token.source_card_refs]]
 card_name = "Fade from History"
 scryfall_oracle_id = "533767ca-7208-4c88-b160-375479b68285"
 scryfall_id = "e8eea4aa-e538-42d8-a3f2-b21d17e61654"
@@ -52336,16 +50775,6 @@ card_name = "Argoth, Sanctum of Nature // Titania, Gaea Incarnate"
 face_name = "Argoth, Sanctum of Nature"
 scryfall_oracle_id = "62648946-1708-48f4-ba40-c057563ab11b"
 scryfall_id = "79a840ed-91cf-45ea-bad2-757856e88544"
-
-[[token.source_card_refs]]
-card_name = "Grizzly Fate"
-scryfall_oracle_id = "f3073e4f-ca7e-4fde-88a4-bd7b6ebfbc8c"
-scryfall_id = "92d23432-6181-44c3-8d36-d7632a8a329f"
-
-[[token.source_card_refs]]
-card_name = "Bearscape"
-scryfall_oracle_id = "7e481e22-4122-4259-8978-4727eb307195"
-scryfall_id = "3284b61a-bd95-4846-ad3f-903cd1158867"
 
 [[token.source_card_refs]]
 card_name = "Fade from History"
@@ -52375,27 +50804,7 @@ scryfall_id = "a158c1c7-5a03-42b8-ba94-92b11af3d89e"
 [[token.source_card_refs]]
 card_name = "Grizzly Fate"
 scryfall_oracle_id = "f3073e4f-ca7e-4fde-88a4-bd7b6ebfbc8c"
-scryfall_id = "004e1457-d951-4029-8bb6-17a290793e79"
-
-[[token.source_card_refs]]
-card_name = "Grizzly Fate"
-scryfall_oracle_id = "f3073e4f-ca7e-4fde-88a4-bd7b6ebfbc8c"
 scryfall_id = "75d22bb3-824e-4699-8352-42392af307d1"
-
-[[token.source_card_refs]]
-card_name = "Words of Wilding"
-scryfall_oracle_id = "888582df-4fe2-4d05-9b62-10c90aaa76f2"
-scryfall_id = "fdb9565f-5b09-4127-b169-3146079dab84"
-
-[[token.source_card_refs]]
-card_name = "Kamahl's Summons"
-scryfall_oracle_id = "8b6ef0a2-cd90-44c8-8f11-e1983f2b1dfd"
-scryfall_id = "0edc37c6-b6a8-424f-95dd-928d03c28542"
-
-[[token.source_card_refs]]
-card_name = "Mother Bear"
-scryfall_oracle_id = "fe742976-ef13-4c25-972f-254b1ed436de"
-scryfall_id = "ce2c30dd-f28a-4400-b6ea-f26462e45afc"
 
 [token.token_image_ref]
 scryfall_id = "772dac39-269b-4a35-aad3-320279af833f"
@@ -52472,11 +50881,6 @@ subtypes = ["Dragon"]
 supertypes = []
 colors = ["Red"]
 keywords = ["Flying"]
-
-[[token.source_card_refs]]
-card_name = "Sarkhan Unbroken"
-scryfall_oracle_id = "1d37b453-f10c-42f2-8390-626a8a8eb27c"
-scryfall_id = "35ef90e4-86ac-4995-b327-0ae34ae1ebf3"
 
 [[token.source_card_refs]]
 card_name = "Sarkhan the Masterless"
@@ -52791,11 +51195,6 @@ keywords = []
 card_name = "Stroke of Midnight"
 scryfall_oracle_id = "9a107e48-3d50-4941-95b1-10f2b29a4245"
 scryfall_id = "ab135925-d924-456d-851a-6ccdaaf27271"
-
-[[token.source_card_refs]]
-card_name = "Adeline, Resplendent Cathar"
-scryfall_oracle_id = "38515f89-348b-4cf3-b7bd-1f6fe4ce2fba"
-scryfall_id = "21a0e852-7855-4a6b-8eca-191a8e83023a"
 
 [token.token_image_ref]
 scryfall_id = "06af3d5a-7b38-42f6-822f-da4e04a7f265"
@@ -53363,22 +51762,12 @@ keywords = [
 [[token.source_card_refs]]
 card_name = "Hornet Nest"
 scryfall_oracle_id = "123d2b6e-114e-4767-860d-50790382ca4a"
-scryfall_id = "27bf526c-d22a-4164-b26f-57c370f9feef"
-
-[[token.source_card_refs]]
-card_name = "Hornet Nest"
-scryfall_oracle_id = "123d2b6e-114e-4767-860d-50790382ca4a"
 scryfall_id = "cc4693c6-f532-4726-b51a-21b04f820448"
 
 [[token.source_card_refs]]
 card_name = "Hornet Nest"
 scryfall_oracle_id = "123d2b6e-114e-4767-860d-50790382ca4a"
 scryfall_id = "c7b3c3de-6e12-4b93-830f-cae5b1b40ac4"
-
-[[token.source_card_refs]]
-card_name = "Hornet Queen"
-scryfall_oracle_id = "3b1f8108-6911-49e9-8f78-f950bb58cb6c"
-scryfall_id = "4068158e-39ea-4acc-889c-e9fad93d482f"
 
 [token.token_image_ref]
 scryfall_id = "e17b804f-4dca-4101-ba8f-b732504ac488"
@@ -53450,16 +51839,6 @@ colors = [
     "White",
 ]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Goblin Trenches"
-scryfall_oracle_id = "b43f40e6-c0ad-4a12-b75d-f2ba12629bfe"
-scryfall_id = "2100844c-6a41-40f5-b7f8-9b426d5a6945"
-
-[[token.source_card_refs]]
-card_name = "Goblin Trenches"
-scryfall_oracle_id = "b43f40e6-c0ad-4a12-b75d-f2ba12629bfe"
-scryfall_id = "73744225-d432-495e-916d-b18e6d042dff"
 
 [[token.source_card_refs]]
 card_name = "Goblin Trenches"
@@ -53735,19 +52114,9 @@ scryfall_oracle_id = "0cee5539-d10b-4de2-aee8-e02f0e24ac26"
 scryfall_id = "8cae1953-0142-4510-99cf-1d7250c36f63"
 
 [[token.source_card_refs]]
-card_name = "Imperious Oligarch"
-scryfall_oracle_id = "b0381c2a-40e2-4002-82e3-ae2d687daed3"
-scryfall_id = "81758315-e863-4338-8157-e3601ad1ce99"
-
-[[token.source_card_refs]]
 card_name = "Indebted Spirit"
 scryfall_oracle_id = "c4c0a622-7325-4024-8b2e-6335f9a729e9"
 scryfall_id = "bfdbef00-bc1b-4dd6-aef5-aeb5ce454344"
-
-[[token.source_card_refs]]
-card_name = "Syndicate Messenger"
-scryfall_oracle_id = "f5f4d78b-ed2b-471b-9ece-237fb55adc13"
-scryfall_id = "183530b1-a4c1-4124-b91f-9b5619bf7905"
 
 [[token.source_card_refs]]
 card_name = "Knight of Sorrows"
@@ -53834,11 +52203,6 @@ scryfall_id = "215b4632-adce-4357-bfcf-b6014ed2a24b"
 card_name = "Riku of Many Paths"
 scryfall_oracle_id = "1cfe6e3a-f8c9-4105-ad03-0faf1fcc4626"
 scryfall_id = "21b63544-4c31-4f38-9907-0407719a60b1"
-
-[[token.source_card_refs]]
-card_name = "Ordered Migration"
-scryfall_oracle_id = "ee0a59ba-8d34-43d5-b9a5-42015588e3d5"
-scryfall_id = "04d83a07-6054-45f1-bdf9-07f2006238d2"
 
 [token.token_image_ref]
 scryfall_id = "000d9280-a79a-4f9f-822c-7aaecbff3337"
@@ -53947,11 +52311,6 @@ keywords = [
 card_name = "Dark Depths"
 scryfall_oracle_id = "c9b82110-7dfd-4617-9399-9510be449043"
 scryfall_id = "e00d16f9-ea27-4aa3-a134-4e04f934d020"
-
-[[token.source_card_refs]]
-card_name = "Dark Depths"
-scryfall_oracle_id = "c9b82110-7dfd-4617-9399-9510be449043"
-scryfall_id = "e8fa97f8-2f52-426a-84f3-a7b85fda1344"
 
 [token.token_image_ref]
 scryfall_id = "105e687e-7196-4010-a6b7-cfa42d998fa4"
@@ -55211,11 +53570,6 @@ keywords = ["Reach"]
 [[token.source_card_refs]]
 card_name = "Penumbra Spider"
 scryfall_oracle_id = "47678f44-b595-492e-af00-4e73f941e24e"
-scryfall_id = "6a989ac1-df69-45e7-98bf-564cc7c38973"
-
-[[token.source_card_refs]]
-card_name = "Penumbra Spider"
-scryfall_oracle_id = "47678f44-b595-492e-af00-4e73f941e24e"
 scryfall_id = "5bdec240-39e5-4abd-bf8d-3d26a788dc9d"
 
 [[token.source_card_refs]]
@@ -55650,16 +54004,6 @@ subtypes = ["Goblin"]
 supertypes = []
 colors = ["Red"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Empty the Warrens"
-scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
-scryfall_id = "9618ad79-bca0-47c7-85f5-e620a3ce6225"
-
-[[token.source_card_refs]]
-card_name = "Empty the Warrens"
-scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
-scryfall_id = "05af8b37-6588-42dc-a5e5-e81ccd0abb91"
 
 [token.token_image_ref]
 scryfall_id = "ccfc021b-6bcf-4c5e-a0ea-a5ce379fcbee"
@@ -56444,11 +54788,6 @@ keywords = ["Lifelink"]
 [[token.source_card_refs]]
 card_name = "Sacred Cat"
 scryfall_oracle_id = "d85ea576-a794-44bf-b405-1f1c49477409"
-scryfall_id = "4c8e85ef-d5ef-4be0-a13f-bd3715d41561"
-
-[[token.source_card_refs]]
-card_name = "Sacred Cat"
-scryfall_oracle_id = "d85ea576-a794-44bf-b405-1f1c49477409"
 scryfall_id = "6d21c5f3-64bb-4ae7-a946-1522930b6e56"
 
 [[token.source_card_refs]]
@@ -56553,11 +54892,6 @@ keywords = ["Flying"]
 [[token.source_card_refs]]
 card_name = "Lathliss, Dragon Queen"
 scryfall_oracle_id = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd"
-scryfall_id = "9460e3c6-e745-41d3-8e17-0b92fb126a16"
-
-[[token.source_card_refs]]
-card_name = "Lathliss, Dragon Queen"
-scryfall_oracle_id = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd"
 scryfall_id = "0f0cdff4-c81e-4e53-8721-748eb71d9e81"
 
 [[token.source_card_refs]]
@@ -56593,22 +54927,7 @@ scryfall_id = "17373240-6edf-4b51-a6a8-7fe4f718a51e"
 [[token.source_card_refs]]
 card_name = "Lathliss, Dragon Queen"
 scryfall_oracle_id = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd"
-scryfall_id = "8435c03c-b9a2-40fa-a979-879bd120a011"
-
-[[token.source_card_refs]]
-card_name = "Dragon Roost"
-scryfall_oracle_id = "6dc98143-7c4c-4b75-9bbb-5226d800b1d6"
-scryfall_id = "95e4f28b-c7a7-4450-b477-73e4559f0276"
-
-[[token.source_card_refs]]
-card_name = "Lathliss, Dragon Queen"
-scryfall_oracle_id = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd"
 scryfall_id = "0cb48015-627b-49cd-8dc3-d446e82b8172"
-
-[[token.source_card_refs]]
-card_name = "Day of the Dragons"
-scryfall_oracle_id = "c4df259a-cdd4-420a-8e3d-7b69da5c9f6f"
-scryfall_id = "366a934c-eb01-48c6-8393-c2fe0708ff91"
 
 [[token.source_card_refs]]
 card_name = "Sarkhan, Fireblood"
@@ -56658,16 +54977,6 @@ keywords = []
 card_name = "Jedit Ojanen, Mercenary"
 scryfall_oracle_id = "3d80fa33-9032-4c16-8355-2f18a71af67c"
 scryfall_id = "914a4923-18a6-4aa5-8510-b02e9dc7bb41"
-
-[[token.source_card_refs]]
-card_name = "Lord Windgrace"
-scryfall_oracle_id = "38a55562-1e2d-4240-9454-219a4a25d38d"
-scryfall_id = "a135d779-d223-4274-8d7f-d7b12842d93b"
-
-[[token.source_card_refs]]
-card_name = "Jedit Ojanen of Efrava"
-scryfall_oracle_id = "c065a7c0-272b-4b7e-a41c-7164352cd189"
-scryfall_id = "1685676c-19be-4220-993f-494c53f60499"
 
 [[token.source_card_refs]]
 card_name = "Jedit Ojanen, Mercenary"
@@ -57065,11 +55374,6 @@ card_name = "Subterranean Tremors"
 scryfall_oracle_id = "f0881756-de74-43b1-a9fe-c2fde93faf5a"
 scryfall_id = "1b9510b8-6601-4116-8713-ff7649c000eb"
 
-[[token.source_card_refs]]
-card_name = "Subterranean Tremors"
-scryfall_oracle_id = "f0881756-de74-43b1-a9fe-c2fde93faf5a"
-scryfall_id = "02a20564-90af-4dbd-bf5c-debc49e4f391"
-
 [token.token_image_ref]
 scryfall_id = "70345006-5cde-44f8-ab66-9d8163d4c4f6"
 scryfall_oracle_id = "49db8af8-de3b-4503-acc6-04cac2f87a2e"
@@ -57258,11 +55562,6 @@ scryfall_id = "bcb484b4-d004-4cf0-9930-a79d03e95aae"
 card_name = "Vital Splicer"
 scryfall_oracle_id = "e1899133-635d-46ff-b90d-6f8d46a1ffe1"
 scryfall_id = "d13cf68c-b54c-46e1-a720-af57aac9e570"
-
-[[token.source_card_refs]]
-card_name = "Blade Splicer"
-scryfall_oracle_id = "194166ad-0179-42a3-86b9-ba7f322ec576"
-scryfall_id = "34c0e3a0-672f-40c9-be66-8b916a4588f2"
 
 [[token.source_card_refs]]
 card_name = "Sensor Splicer"
@@ -57841,11 +56140,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Heart-Piercer Manticore"
 scryfall_oracle_id = "253bec96-108c-4880-9c04-8bc99ceafa64"
-scryfall_id = "0c4b41be-793c-4dcc-9c0d-16fbdfece30b"
-
-[[token.source_card_refs]]
-card_name = "Heart-Piercer Manticore"
-scryfall_oracle_id = "253bec96-108c-4880-9c04-8bc99ceafa64"
 scryfall_id = "6cd213a1-92f6-49dd-9ea9-41a00879faaa"
 
 [token.token_image_ref]
@@ -57947,11 +56241,6 @@ keywords = []
 card_name = "Release the Dogs"
 scryfall_oracle_id = "b97d21b4-d730-479f-872f-3e1645b66751"
 scryfall_id = "67283aec-f8ee-4275-bf5e-58cea852956a"
-
-[[token.source_card_refs]]
-card_name = "Release the Dogs"
-scryfall_oracle_id = "b97d21b4-d730-479f-872f-3e1645b66751"
-scryfall_id = "7df3cd89-02c9-4a1c-9a8a-d17a0b1030c9"
 
 [token.token_image_ref]
 scryfall_id = "8031f333-c818-4793-8cf8-232bf9088a96"
@@ -62584,11 +60873,6 @@ scryfall_oracle_id = "e7dfe47f-41fc-4071-9ad3-96cd8d9be52e"
 scryfall_id = "79e4242c-a53a-4287-976b-8e545888a1fa"
 
 [[token.source_card_refs]]
-card_name = "Royal Treatment"
-scryfall_oracle_id = "fd0f8fdc-4065-41f4-b8fb-ecb8f185774d"
-scryfall_id = "009bad41-5e96-4bb3-9f5e-66500fb8af29"
-
-[[token.source_card_refs]]
 card_name = "Besotted Knight // Betroth the Beast"
 face_name = "Betroth the Beast"
 scryfall_oracle_id = "c7b6d2cd-9105-404b-88f0-a67037fb2120"
@@ -62877,11 +61161,6 @@ colors = [
     "White",
 ]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Tolsimir Wolfblood"
-scryfall_oracle_id = "30ee2790-1f5d-4073-aae7-5e7ae30421d2"
-scryfall_id = "069ac859-e0ef-4685-bad3-5c741102b5b9"
 
 [[token.source_card_refs]]
 card_name = "Tolsimir Wolfblood"
@@ -64026,9 +62305,7 @@ source_card_names = [
     "Benevolent Offering",
     "Bishop of Wings",
     "Blessed Defiance",
-    "Brine Comber",
     "Brine Comber // Brinebound Gift",
-    "Brinebound Gift",
     "Clarion Spirit",
     "Confront the Assault",
     "Court of Grace",
@@ -64116,26 +62393,6 @@ scryfall_oracle_id = "0c4e2c90-c17b-42cc-b4d7-cf75970fbe90"
 scryfall_id = "67083aca-b077-4b12-8218-876e22476f85"
 
 [[token.source_card_refs]]
-card_name = "Kirtar's Wrath"
-scryfall_oracle_id = "4f66d82a-492f-4638-9f77-190d4a33ad7f"
-scryfall_id = "b5a0c4e6-d50e-42e8-b062-8f6ef5950ab7"
-
-[[token.source_card_refs]]
-card_name = "Spirit Cairn"
-scryfall_oracle_id = "ae896d87-59c7-4d8d-a137-9e471d3e174e"
-scryfall_id = "d8baf60f-c20b-4b2f-9fe1-df008a9273c6"
-
-[[token.source_card_refs]]
-card_name = "Avacyn's Collar"
-scryfall_oracle_id = "842e3835-fff3-4684-bfd1-e7064a1fd2e6"
-scryfall_id = "219dd7c5-0d8f-46a2-9181-3ed30d489397"
-
-[[token.source_card_refs]]
-card_name = "Triplicate Spirits"
-scryfall_oracle_id = "48090c64-f41a-447b-ad7a-54e3194f759b"
-scryfall_id = "05c90b56-6e4b-43d1-886d-a6d78da7a586"
-
-[[token.source_card_refs]]
 card_name = "Lingering Souls"
 scryfall_oracle_id = "0b8c3337-04dd-4798-8203-6d8b8cfb936b"
 scryfall_id = "1d371239-b231-455f-a724-5025284ee023"
@@ -64144,16 +62401,6 @@ scryfall_id = "1d371239-b231-455f-a724-5025284ee023"
 card_name = "Blessed Defiance"
 scryfall_oracle_id = "04e3d36f-5dec-422c-a371-15e135fdface"
 scryfall_id = "184e5208-edbe-417f-8ff8-1950d08071ab"
-
-[[token.source_card_refs]]
-card_name = "Lingering Souls"
-scryfall_oracle_id = "0b8c3337-04dd-4798-8203-6d8b8cfb936b"
-scryfall_id = "f11908e8-8c85-4eb7-b29d-b97712be42ee"
-
-[[token.source_card_refs]]
-card_name = "Haunted Dead"
-scryfall_oracle_id = "03259490-a789-4f96-8c5b-b410425bdd02"
-scryfall_id = "66210a3f-010b-4a9b-a08f-97d3ca962b0c"
 
 [[token.source_card_refs]]
 card_name = "Afterlife"
@@ -64166,75 +62413,9 @@ scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
 scryfall_id = "ab2ff619-b82a-45c1-b25a-5b6ece2afdc4"
 
 [[token.source_card_refs]]
-card_name = "Dauntless Cathar"
-scryfall_oracle_id = "c14bd133-ff17-48b3-a1c8-56c93d8c6e43"
-scryfall_id = "bf6570e3-f245-4556-89b4-a48f26b6dc4f"
-
-[[token.source_card_refs]]
-card_name = "Transluminant"
-scryfall_oracle_id = "f4d54a89-8409-4fbc-b01f-3b03f352820f"
-scryfall_id = "2f28187b-2c99-4502-99d5-3a53ff3fa008"
-
-[[token.source_card_refs]]
-card_name = "Doomed Traveler"
-scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
-scryfall_id = "32f2065f-1aff-4d6c-af4b-2c2cfb2e0595"
-
-[[token.source_card_refs]]
-card_name = "Field of Souls"
-scryfall_oracle_id = "4d7a5b14-8fce-41f2-a0d5-fff3d15f41f6"
-scryfall_id = "9816a3ef-e2a8-4d97-afbf-d190a62265bf"
-
-[[token.source_card_refs]]
-card_name = "Spirit Cairn"
-scryfall_oracle_id = "ae896d87-59c7-4d8d-a137-9e471d3e174e"
-scryfall_id = "e92c30d9-d09b-461c-a715-b33f8f5c78c8"
-
-[[token.source_card_refs]]
-card_name = "Haunted Dead"
-scryfall_oracle_id = "03259490-a789-4f96-8c5b-b410425bdd02"
-scryfall_id = "68e5693f-8414-4e1d-8a05-8bd920969f30"
-
-[[token.source_card_refs]]
-card_name = "Brine Comber // Brinebound Gift"
-face_name = "Brine Comber"
-scryfall_oracle_id = "8845ba0d-c2f4-49e4-b06e-54a06a8297e0"
-scryfall_id = "4205f8f8-7b18-4999-ac51-860fab376d79"
-
-[[token.source_card_refs]]
 card_name = "Bishop of Wings"
 scryfall_oracle_id = "af4684cf-f109-44be-adfb-7c551a36635e"
 scryfall_id = "c369d381-b48e-43cf-a032-8bcb120f443e"
-
-[[token.source_card_refs]]
-card_name = "Afterlife"
-scryfall_oracle_id = "4c13e2b5-961a-4031-84b1-15bd19b94286"
-scryfall_id = "4644694d-52e6-4d00-8cad-748899eeea84"
-
-[[token.source_card_refs]]
-card_name = "Sandsteppe Outcast"
-scryfall_oracle_id = "fccd17b1-ca0f-4649-a002-5cbf9666b510"
-scryfall_id = "b34a7501-4afc-4467-b0d6-b32d7657064e"
-
-[[token.source_card_refs]]
-card_name = "Whispering Wizard"
-scryfall_oracle_id = "321e101c-a426-4d18-be0b-c26c5348b70d"
-scryfall_id = "a3f29cbb-d802-4085-a236-86775764bc9e"
-
-[[token.source_card_refs]]
-card_name = "Doomed Traveler"
-scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
-scryfall_id = "e98c3007-c45f-4502-ae4b-693bd64f23ba"
-
-[[token.source_card_refs]]
-card_name = "Heron-Blessed Geist"
-scryfall_oracle_id = "9c5897cd-f209-4e51-adc2-d791e5671029"
-scryfall_id = "3a79a435-9b58-4bcd-8544-79d9a71d85a2"
-
-[[token.source_card_refs]]
-card_name = "Triplicate Spirits"
-scryfall_oracle_id = "48090c64-f41a-447b-ad7a-54e3194f759b"
-scryfall_id = "d7cf5453-f8b8-4f86-a2f0-fdc79f7c977f"
 
 [[token.source_card_refs]]
 card_name = "Lingering Souls"
@@ -64249,47 +62430,7 @@ scryfall_id = "5e1ae45c-ac55-468d-8e27-e72b5954ce94"
 [[token.source_card_refs]]
 card_name = "Field of Souls"
 scryfall_oracle_id = "4d7a5b14-8fce-41f2-a0d5-fff3d15f41f6"
-scryfall_id = "5faea9ff-4260-4b83-a5fb-5169bc017b14"
-
-[[token.source_card_refs]]
-card_name = "Mausoleum Guard"
-scryfall_oracle_id = "64f3af46-f8ab-4ba4-9dff-7412cefb4eea"
-scryfall_id = "43227caf-f902-46b4-936f-125d879eb54a"
-
-[[token.source_card_refs]]
-card_name = "Field of Souls"
-scryfall_oracle_id = "4d7a5b14-8fce-41f2-a0d5-fff3d15f41f6"
 scryfall_id = "a264d5f2-9e27-4c41-a76e-0dc944c6dc74"
-
-[[token.source_card_refs]]
-card_name = "Blessed Defiance"
-scryfall_oracle_id = "04e3d36f-5dec-422c-a371-15e135fdface"
-scryfall_id = "d333e35c-ca90-4aaa-950a-48b5623c31a6"
-
-[[token.source_card_refs]]
-card_name = "Teysa, Orzhov Scion"
-scryfall_oracle_id = "8191342b-b25e-4c4d-8f69-aee662148ff4"
-scryfall_id = "9eb856e6-8f63-4048-9818-cc3e65748855"
-
-[[token.source_card_refs]]
-card_name = "Kaya, Geist Hunter"
-scryfall_oracle_id = "e0edb2fc-2533-407c-85e5-4337f4233f05"
-scryfall_id = "9135b501-82be-43cb-9aa5-9cf08789c636"
-
-[[token.source_card_refs]]
-card_name = "Nearheath Chaplain"
-scryfall_oracle_id = "16c587db-d07b-47ab-8b03-c3b2cc7144f5"
-scryfall_id = "a4861c8d-5e4a-4c4b-854c-410aad2d49cb"
-
-[[token.source_card_refs]]
-card_name = "Doomed Traveler"
-scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
-scryfall_id = "8a03d414-bff9-4aba-8b0a-0ed57982251e"
-
-[[token.source_card_refs]]
-card_name = "Doomed Traveler"
-scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
-scryfall_id = "52c3f3f5-47b7-46bf-a5a8-b7a79f41236e"
 
 [[token.source_card_refs]]
 card_name = "Court of Grace"
@@ -64297,34 +62438,9 @@ scryfall_oracle_id = "f63c2438-27d4-449a-828f-f0a2ea86ff16"
 scryfall_id = "f89995b9-5409-4d3a-9518-7a4354b9d02f"
 
 [[token.source_card_refs]]
-card_name = "Luminous Angel"
-scryfall_oracle_id = "8d7cf56c-94fd-47d8-9e0f-cd3163688983"
-scryfall_id = "9b4f880d-6262-429f-91b7-def417aa13bd"
-
-[[token.source_card_refs]]
 card_name = "Clarion Spirit"
 scryfall_oracle_id = "dec20b18-afe6-405e-b47d-a757a5645c63"
 scryfall_id = "55882138-83a2-4a0a-96b0-6d5150edc4e3"
-
-[[token.source_card_refs]]
-card_name = "March of Souls"
-scryfall_oracle_id = "bca7101b-e74b-42af-ac63-1b3defb4137d"
-scryfall_id = "f07dd0f1-b80b-4af0-ae76-907ec55ec7d5"
-
-[[token.source_card_refs]]
-card_name = "Transluminant"
-scryfall_oracle_id = "f4d54a89-8409-4fbc-b01f-3b03f352820f"
-scryfall_id = "318ce4ef-38bd-4360-895f-457587164197"
-
-[[token.source_card_refs]]
-card_name = "Slayer's Plate"
-scryfall_oracle_id = "05004b4a-2e2c-4a88-a994-8576684fb64a"
-scryfall_id = "f0ad0796-0357-4e74-9d65-c7761a3f223c"
-
-[[token.source_card_refs]]
-card_name = "Afterlife"
-scryfall_oracle_id = "4c13e2b5-961a-4031-84b1-15bd19b94286"
-scryfall_id = "061ccd50-aff0-445b-9151-8fee6b3b4df4"
 
 [[token.source_card_refs]]
 card_name = "Dauntless Cathar"
@@ -64332,19 +62448,9 @@ scryfall_oracle_id = "c14bd133-ff17-48b3-a1c8-56c93d8c6e43"
 scryfall_id = "fc3b97d0-8245-48de-aa05-e6800c0339ad"
 
 [[token.source_card_refs]]
-card_name = "Not Forgotten"
-scryfall_oracle_id = "e0fa6d08-1808-4a29-b1e4-5cec9d31d798"
-scryfall_id = "05860b72-fb1b-44d8-9275-12863724a9ef"
-
-[[token.source_card_refs]]
 card_name = "Alharu, Solemn Ritualist"
 scryfall_oracle_id = "c8deef08-fcf2-41e1-8aeb-aa4e0af147ca"
 scryfall_id = "f699f8d9-8708-44ca-8d14-1ca93aa68c9e"
-
-[[token.source_card_refs]]
-card_name = "Nurturing Presence"
-scryfall_oracle_id = "3f03c834-2cb3-4c54-bee6-c64f3a5fce47"
-scryfall_id = "1b302947-5d66-425d-b67e-bf1d5846d490"
 
 [[token.source_card_refs]]
 card_name = "Lingering Souls"
@@ -64352,50 +62458,14 @@ scryfall_oracle_id = "0b8c3337-04dd-4798-8203-6d8b8cfb936b"
 scryfall_id = "278e97cf-312d-4e9e-bc39-023f4e547121"
 
 [[token.source_card_refs]]
-card_name = "Twilight Drover"
-scryfall_oracle_id = "b0d60856-80f9-4c64-9768-28a0a690ecb1"
-scryfall_id = "bbc33bb6-d71c-45f9-9030-bdef3d40a08a"
-
-[[token.source_card_refs]]
-card_name = "Seize the Soul"
-scryfall_oracle_id = "91557f08-15b1-4e3e-90fd-cec35ed0868a"
-scryfall_id = "29bf245f-e8e0-4d32-8cd7-06d832609910"
-
-[[token.source_card_refs]]
-card_name = "Blessed Defiance"
-scryfall_oracle_id = "04e3d36f-5dec-422c-a371-15e135fdface"
-scryfall_id = "a2713730-fe6b-46b6-9189-de349c712fee"
-
-[[token.source_card_refs]]
 card_name = "Doomed Traveler"
 scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
 scryfall_id = "9c5b6837-2381-4563-861c-73ef3b5341cd"
 
 [[token.source_card_refs]]
-card_name = "Funeral Pyre"
-scryfall_oracle_id = "02af53c1-83e6-447f-908b-2757c8aa445c"
-scryfall_id = "4d8542f6-ee34-42c6-acd5-07b0c7cc2f63"
-
-[[token.source_card_refs]]
 card_name = "Triplicate Spirits"
 scryfall_oracle_id = "48090c64-f41a-447b-ad7a-54e3194f759b"
 scryfall_id = "9d258bcc-3379-4f56-b584-be25979e5244"
-
-[[token.source_card_refs]]
-card_name = "Afterlife"
-scryfall_oracle_id = "4c13e2b5-961a-4031-84b1-15bd19b94286"
-scryfall_id = "8fa2ecf9-b53c-4f1d-9028-ca3820d043cb"
-
-[[token.source_card_refs]]
-card_name = "Brine Comber // Brinebound Gift"
-face_name = "Brinebound Gift"
-scryfall_oracle_id = "8845ba0d-c2f4-49e4-b06e-54a06a8297e0"
-scryfall_id = "4205f8f8-7b18-4999-ac51-860fab376d79"
-
-[[token.source_card_refs]]
-card_name = "Requiem Angel"
-scryfall_oracle_id = "59f10ddb-8287-4d2c-8c60-1080b108fa78"
-scryfall_id = "ddcb90f4-82c0-412c-9e90-9fffc8c5df10"
 
 [token.token_image_ref]
 scryfall_id = "6f5a5786-e2be-4bb0-b971-81d1d5cc8f52"
@@ -64667,11 +62737,6 @@ scryfall_oracle_id = "a4b37d16-95b3-4143-a0b2-ad9f2aba91f8"
 scryfall_id = "6d84e2d4-38bf-4d46-99a6-37c2dda66b16"
 
 [[token.source_card_refs]]
-card_name = "Thundering Spineback"
-scryfall_oracle_id = "c9db31d7-00cf-4200-a11f-74cc2d9e843e"
-scryfall_id = "a2e40ded-6daf-423e-8d74-2c6d448e0853"
-
-[[token.source_card_refs]]
 card_name = "Regisaur Alpha"
 scryfall_oracle_id = "0673f4e0-66ff-458c-b4ba-eb067e560cce"
 scryfall_id = "38a51e82-cbfc-4487-9a81-6e793e93f545"
@@ -64691,11 +62756,6 @@ scryfall_id = "dd6e6088-6c8d-45cc-a03f-67d7b8d3aa67"
 card_name = "Regisaur Alpha"
 scryfall_oracle_id = "0673f4e0-66ff-458c-b4ba-eb067e560cce"
 scryfall_id = "d22585cf-f84e-4c3d-a219-bd493d1122b3"
-
-[[token.source_card_refs]]
-card_name = "Thundering Spineback"
-scryfall_oracle_id = "c9db31d7-00cf-4200-a11f-74cc2d9e843e"
-scryfall_id = "51269cfb-e4a9-4dc2-a412-8fc1664f465e"
 
 [[token.source_card_refs]]
 card_name = "Baffling End"
@@ -65097,22 +63157,7 @@ scryfall_id = "6a5b3a64-3664-45c1-b6ba-47d16f71a333"
 [[token.source_card_refs]]
 card_name = "Murmuring Mystic"
 scryfall_oracle_id = "dcd4da46-5438-4454-8b1b-43ca51bda1f9"
-scryfall_id = "5dc95208-2b3a-44cd-9782-b303379b8174"
-
-[[token.source_card_refs]]
-card_name = "Murmuring Mystic"
-scryfall_oracle_id = "dcd4da46-5438-4454-8b1b-43ca51bda1f9"
-scryfall_id = "e550c890-bf16-4831-87bc-a07a4dc673ac"
-
-[[token.source_card_refs]]
-card_name = "Murmuring Mystic"
-scryfall_oracle_id = "dcd4da46-5438-4454-8b1b-43ca51bda1f9"
 scryfall_id = "9e68dcc2-bba4-4efa-97bb-3ed892037595"
-
-[[token.source_card_refs]]
-card_name = "Murmuring Mystic"
-scryfall_oracle_id = "dcd4da46-5438-4454-8b1b-43ca51bda1f9"
-scryfall_id = "d3fbbf86-d784-4dd0-b3f1-818c2a74a940"
 
 [token.token_image_ref]
 scryfall_id = "95970f74-0f28-4d81-9fbd-cb49f5d5eebc"
@@ -66530,11 +64575,6 @@ scryfall_oracle_id = "aae76e5c-f5e0-4d18-b465-e6a829be908a"
 scryfall_id = "71bcf8d7-cc70-4d52-9607-09ed7e08d61b"
 
 [[token.source_card_refs]]
-card_name = "Malik, Grim Manipulator"
-scryfall_oracle_id = "416608a1-89a4-44ce-8fd0-fab6b023d3d4"
-scryfall_id = "5cf4fee3-3059-4ca4-a47d-0848410b294d"
-
-[[token.source_card_refs]]
 card_name = "Sonic the Hedgehog"
 scryfall_oracle_id = "b07a7b00-9394-48a9-a597-17f391495909"
 scryfall_id = "072a0e6f-e636-4ce1-a253-580ab956410e"
@@ -66600,6 +64640,11 @@ scryfall_oracle_id = "3d1b09a3-f151-4218-974b-02bb6159247a"
 scryfall_id = "4156e1cc-ee40-4753-adf8-47b948cf7eb8"
 
 [[token.source_card_refs]]
+card_name = "Tireless Provisioner"
+scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
+scryfall_id = "6d2e2e8d-8382-4d98-9e25-2dff1b1d0ff8"
+
+[[token.source_card_refs]]
 card_name = "Prosper, Tome-Bound"
 scryfall_oracle_id = "1e9b0fd6-5aae-401a-8df5-d94ce6442696"
 scryfall_id = "8213f299-0f6e-499f-ba8e-7e297965d482"
@@ -66653,11 +64698,6 @@ scryfall_id = "9a6f8a6e-cc77-41d8-b753-bb3c5a5c4f48"
 card_name = "Professional Face-Breaker"
 scryfall_oracle_id = "04152e7a-969c-4858-841b-0a569a9fc1bf"
 scryfall_id = "7e7c8626-3c82-43f1-98a7-db165b30cf3b"
-
-[[token.source_card_refs]]
-card_name = "Evin, Waterdeep Opportunist"
-scryfall_oracle_id = "f688f839-c7c2-45a9-8c60-9fdb030803e6"
-scryfall_id = "c35accd3-92ee-4b0b-a30a-4dcd3252d1b8"
 
 [[token.source_card_refs]]
 card_name = "Reckoner Bankbuster // Reckoner Bankbuster"
@@ -68108,32 +66148,7 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Promise of Bunrei"
 scryfall_oracle_id = "6158ab85-a929-472c-9618-8e76d2d4b228"
-scryfall_id = "1250735d-d43b-488f-bddf-ed10261a6382"
-
-[[token.source_card_refs]]
-card_name = "Sekki, Seasons' Guide"
-scryfall_oracle_id = "1b92501c-80fe-4ae7-834e-72f57ba41a6a"
-scryfall_id = "9883e973-54c3-4bec-91d8-22f2829cdfa2"
-
-[[token.source_card_refs]]
-card_name = "Dripping-Tongue Zubera"
-scryfall_oracle_id = "78b1cb2d-1b48-4068-b6f3-8727ef9e8080"
-scryfall_id = "e752b762-38b7-463c-aa09-37fecfe71a53"
-
-[[token.source_card_refs]]
-card_name = "Promise of Bunrei"
-scryfall_oracle_id = "6158ab85-a929-472c-9618-8e76d2d4b228"
 scryfall_id = "c20c138d-e32c-4544-a2e5-a2d1adf3dc0c"
-
-[[token.source_card_refs]]
-card_name = "Gods' Eye, Gate to the Reikai"
-scryfall_oracle_id = "a66008c9-1ede-4dcf-8d35-6c0ed2390996"
-scryfall_id = "bdc33a21-d196-4c17-a296-87ff08e7ef69"
-
-[[token.source_card_refs]]
-card_name = "Honden of Life's Web"
-scryfall_oracle_id = "a1fdfcc6-4b3c-40f8-a9e4-dff9ace74a59"
-scryfall_id = "3c618af6-b02e-448f-9131-3c50ef0d433b"
 
 [[token.source_card_refs]]
 card_name = "Release to Memory"
@@ -68141,29 +66156,9 @@ scryfall_oracle_id = "3ae456e4-cb35-47be-b654-051e288622fe"
 scryfall_id = "3d609e89-cbb0-4715-bfcc-d4cbf1c303f9"
 
 [[token.source_card_refs]]
-card_name = "Baku Altar"
-scryfall_oracle_id = "8443b8c2-d0ab-4fb1-ad35-7e5e4cb345b6"
-scryfall_id = "81e1dbb8-3df8-4e7e-b74b-baab7d6f97c1"
-
-[[token.source_card_refs]]
-card_name = "Forbidden Orchard"
-scryfall_oracle_id = "cfd60d1f-9832-4408-b84e-0fd3018b015b"
-scryfall_id = "c13bea32-5dac-4338-b570-bed58109273d"
-
-[[token.source_card_refs]]
-card_name = "Spiritual Visit"
-scryfall_oracle_id = "40759025-91e1-4755-a8cf-0b68c8e9220f"
-scryfall_id = "c4e4866e-13a8-4130-9895-60e762b7efea"
-
-[[token.source_card_refs]]
 card_name = "Forbidden Orchard"
 scryfall_oracle_id = "cfd60d1f-9832-4408-b84e-0fd3018b015b"
 scryfall_id = "3f79add5-6c23-4a36-86d3-8647605d2a71"
-
-[[token.source_card_refs]]
-card_name = "Forbidden Orchard"
-scryfall_oracle_id = "cfd60d1f-9832-4408-b84e-0fd3018b015b"
-scryfall_id = "88d78261-c8c9-4e0e-b157-f70ed46c3a25"
 
 [token.token_image_ref]
 scryfall_id = "3e55bca3-43a3-44a8-b673-b1d0cf3f203f"
@@ -68733,11 +66728,6 @@ keywords = []
 card_name = "Sunscourge Champion"
 scryfall_oracle_id = "f5e9c69f-b949-4e9a-91d8-e0d52f8d8d3e"
 scryfall_id = "f0bb41cc-6edb-4a31-92cb-b17850b49432"
-
-[[token.source_card_refs]]
-card_name = "Sunscourge Champion"
-scryfall_oracle_id = "f5e9c69f-b949-4e9a-91d8-e0d52f8d8d3e"
-scryfall_id = "281bd31f-a4ae-4554-8944-fbc14db21dfd"
 
 [token.token_image_ref]
 scryfall_id = "289a9593-151e-47d0-b0de-5eb9f061515a"
@@ -70362,17 +68352,7 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Phyrexian Processor"
 scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
-scryfall_id = "6875ce99-badd-44da-8e5d-509600efa1d0"
-
-[[token.source_card_refs]]
-card_name = "Phyrexian Processor"
-scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
 scryfall_id = "04789161-f0a8-4ba5-832f-4d585c5117a6"
-
-[[token.source_card_refs]]
-card_name = "Phyrexian Processor"
-scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
-scryfall_id = "6bbb83f8-09bf-4c61-b871-e48917e61073"
 
 [[token.source_card_refs]]
 card_name = "Phyrexian Processor"
@@ -70393,16 +68373,6 @@ scryfall_id = "56df1833-4c93-499b-9f40-f8c2d0f29342"
 card_name = "Phyrexian Processor"
 scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
 scryfall_id = "86238bde-8a82-4e85-bd64-2fdce77fb72b"
-
-[[token.source_card_refs]]
-card_name = "Phyrexian Processor"
-scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
-scryfall_id = "a1d31c43-7d50-4eaf-9016-a679e92abcc9"
-
-[[token.source_card_refs]]
-card_name = "Phyrexian Processor"
-scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
-scryfall_id = "66dac1f1-451b-4137-9c2e-b43b937c2edc"
 
 [[token.source_card_refs]]
 card_name = "Phyrexian Processor"
@@ -71317,11 +69287,6 @@ scryfall_oracle_id = "188656d8-4ea8-4e58-88da-b010a16eb6f2"
 scryfall_id = "e2449311-a705-4a31-a345-a36d436ae561"
 
 [[token.source_card_refs]]
-card_name = "Aquatic Incursion"
-scryfall_oracle_id = "e4212b05-d397-49fb-af8b-9e52a60e6d1e"
-scryfall_id = "4e7566ac-e9b3-4220-9b25-84d5b33f5842"
-
-[[token.source_card_refs]]
 card_name = "Deeproot Pilgrimage"
 scryfall_oracle_id = "188656d8-4ea8-4e58-88da-b010a16eb6f2"
 scryfall_id = "790d70a9-ff02-4676-a804-ee0e030dfe3b"
@@ -71550,11 +69515,6 @@ keywords = ["Haste"]
 card_name = "Earthshaker Khenra"
 scryfall_oracle_id = "df660a8e-39c2-455d-8860-522e2998a95e"
 scryfall_id = "0d60eabe-b281-4eba-9c26-287364ed2067"
-
-[[token.source_card_refs]]
-card_name = "Earthshaker Khenra"
-scryfall_oracle_id = "df660a8e-39c2-455d-8860-522e2998a95e"
-scryfall_id = "cd8f78c8-9cb6-464a-ba0e-6a3fa31cfe1d"
 
 [token.token_image_ref]
 scryfall_id = "c4bb3bd7-5aef-495e-81ba-f5d287981dbd"
@@ -72279,11 +70239,6 @@ scryfall_oracle_id = "79a1783f-ea7e-4cdf-95f5-53b383d38c66"
 scryfall_id = "2f68b4de-271b-415f-ad8f-104981bb12ab"
 
 [[token.source_card_refs]]
-card_name = "Breeding Pit"
-scryfall_oracle_id = "ddc83b35-cf7c-495b-bd30-e409b622e299"
-scryfall_id = "37c9b663-5c02-4221-9efb-59841dfd2188"
-
-[[token.source_card_refs]]
 card_name = "Szat's Will"
 scryfall_oracle_id = "f0d8bde1-76db-4bd2-ae90-3e3a3418de0b"
 scryfall_id = "9828be7b-1eae-4718-9e71-2f625121b00b"
@@ -72292,16 +70247,6 @@ scryfall_id = "9828be7b-1eae-4718-9e71-2f625121b00b"
 card_name = "Szat's Will"
 scryfall_oracle_id = "f0d8bde1-76db-4bd2-ae90-3e3a3418de0b"
 scryfall_id = "a4eaff0d-678b-47ab-915d-12e4fa43bb6b"
-
-[[token.source_card_refs]]
-card_name = "Breeding Pit"
-scryfall_oracle_id = "ddc83b35-cf7c-495b-bd30-e409b622e299"
-scryfall_id = "376dce6f-6fb8-4262-bc79-3c12656d6f08"
-
-[[token.source_card_refs]]
-card_name = "Breeding Pit"
-scryfall_oracle_id = "ddc83b35-cf7c-495b-bd30-e409b622e299"
-scryfall_id = "a0d7e85f-eba5-4fc5-9fc0-109109d368aa"
 
 [[token.source_card_refs]]
 card_name = "Tevesh Szat, Doom of Fools"
@@ -72669,11 +70614,6 @@ colors = ["White"]
 keywords = ["Lifelink"]
 
 [[token.source_card_refs]]
-card_name = "Ajani, Adversary of Tyrants"
-scryfall_oracle_id = "b25bea73-7444-4ee2-8022-611461506117"
-scryfall_id = "5a6facfa-d73c-4f10-a3b7-d2653823423d"
-
-[[token.source_card_refs]]
 card_name = "Regal Caracal"
 scryfall_oracle_id = "aa571676-b390-4b8a-baea-4c4cd60c01f6"
 scryfall_id = "b6310a82-73db-40cb-ae64-6f07f869024c"
@@ -72842,11 +70782,6 @@ subtypes = [
 supertypes = []
 colors = ["Blue"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Mysterio, Master of Illusion"
-scryfall_oracle_id = "40f664d8-4c73-44aa-8fb1-d38771a42520"
-scryfall_id = "ffca39eb-f611-46b1-9d6b-a5c90c722fb9"
 
 [[token.source_card_refs]]
 card_name = "Mysterio's Mirage"
@@ -73666,22 +71601,7 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Icatian Town"
 scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
-scryfall_id = "f7582903-57b0-42e6-991c-0f93ab9172d0"
-
-[[token.source_card_refs]]
-card_name = "Icatian Town"
-scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
-scryfall_id = "cbb7c28d-0366-4d01-84a2-f1bc9f38aa4a"
-
-[[token.source_card_refs]]
-card_name = "Icatian Town"
-scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
 scryfall_id = "fa779cce-f112-4a58-b87d-46445848793b"
-
-[[token.source_card_refs]]
-card_name = "Sarpadian Empires, Vol. VII"
-scryfall_oracle_id = "f71d55f5-f220-4cb0-9468-b8d339ab8535"
-scryfall_id = "b37a6cf7-f239-4bca-b4c3-a48932ef56b5"
 
 [[token.source_card_refs]]
 card_name = "Icatian Crier"
@@ -73692,21 +71612,6 @@ scryfall_id = "c5ba6543-ede7-45a5-8e8d-e17d3f545d3f"
 card_name = "Icatian Town"
 scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
 scryfall_id = "e6ebd5ea-df3f-4cea-bdd1-97ff1776630a"
-
-[[token.source_card_refs]]
-card_name = "Icatian Crier"
-scryfall_oracle_id = "668312dd-7b6e-46bf-9c6a-bfb03dd75b8f"
-scryfall_id = "523ab784-c77e-4b78-99fc-b5d7ed985d76"
-
-[[token.source_card_refs]]
-card_name = "Icatian Town"
-scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
-scryfall_id = "582044a0-0f4e-4de4-8bea-bc64757db198"
-
-[[token.source_card_refs]]
-card_name = "Icatian Town"
-scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
-scryfall_id = "6e06788f-e87b-4071-ba7d-e0253a52132d"
 
 [token.token_image_ref]
 scryfall_id = "165164e7-5693-4d65-b789-8ed8a222365b"
@@ -73889,11 +71794,6 @@ keywords = ["Shroud"]
 card_name = "Deadly Grub"
 scryfall_oracle_id = "093112dd-ebfd-4983-9357-0a9b07e10bb1"
 scryfall_id = "44e872ae-2e41-49f5-9015-e8f9fa7da987"
-
-[[token.source_card_refs]]
-card_name = "Deadly Grub"
-scryfall_oracle_id = "093112dd-ebfd-4983-9357-0a9b07e10bb1"
-scryfall_id = "cde915a3-9c85-4365-bab9-87d446f85794"
 
 [token.token_image_ref]
 scryfall_id = "0ff2e2bd-b8e9-4563-85ad-fdbb0607fb7c"
@@ -74402,19 +72302,9 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Metrognome"
-scryfall_oracle_id = "57fe5c94-ee93-45c6-bf7e-89d177d0fe70"
-scryfall_id = "d71f153d-2d07-4a8a-b725-747bb96afe00"
-
-[[token.source_card_refs]]
 card_name = "Threefold Thunderhulk"
 scryfall_oracle_id = "b8020a8b-557b-465d-865d-b59fecd7abc1"
 scryfall_id = "699d1222-f150-46aa-9004-87b45f07eb42"
-
-[[token.source_card_refs]]
-card_name = "By Gnome Means"
-scryfall_oracle_id = "bc827191-e7ed-45ae-a084-a19d16b936e3"
-scryfall_id = "e63f29cd-5c93-47dc-acdf-37f3b12e9328"
 
 [token.token_image_ref]
 scryfall_id = "e32673cc-bec9-49b3-bc34-e2b3982ca245"
@@ -74616,11 +72506,6 @@ scryfall_id = "d9357606-e192-47e8-b9cd-e1a567903754"
 card_name = "Soul Separator"
 scryfall_oracle_id = "f1da52a4-08a0-4427-a461-a1dc6627b98e"
 scryfall_id = "9e1e52fe-bceb-416b-bd7f-2887f25c7b20"
-
-[[token.source_card_refs]]
-card_name = "Soul Separator"
-scryfall_oracle_id = "f1da52a4-08a0-4427-a461-a1dc6627b98e"
-scryfall_id = "ce861750-08b6-4c22-b9ce-da0048cb673c"
 
 [token.token_image_ref]
 scryfall_id = "ae290b7e-8ff2-4262-8ac7-8481283e2a02"
@@ -75049,11 +72934,6 @@ subtypes = [
 supertypes = []
 colors = ["White"]
 keywords = ["Flying"]
-
-[[token.source_card_refs]]
-card_name = "Oketra's Attendant"
-scryfall_oracle_id = "c45d1df1-92a7-4b36-8e27-1f88c3737bf9"
-scryfall_id = "28ee2a16-58d3-4548-85ee-c7b3a7e57d0a"
 
 [[token.source_card_refs]]
 card_name = "Oketra's Attendant"
@@ -75670,11 +73550,6 @@ keywords = [
 ]
 
 [[token.source_card_refs]]
-card_name = "Marit Lage's Slumber"
-scryfall_oracle_id = "a11d890e-38d4-467c-bc04-948979c142e0"
-scryfall_id = "a8538685-e36b-43ee-b756-7a89bc24f330"
-
-[[token.source_card_refs]]
 card_name = "Dark Depths"
 scryfall_oracle_id = "c9b82110-7dfd-4617-9399-9510be449043"
 scryfall_id = "09c224c7-418d-4b64-9d56-a87e4ff631ab"
@@ -76009,65 +73884,13 @@ scryfall_id = "baddb39b-c31f-48e4-8d43-1cc46a713416"
 [[token.source_card_refs]]
 card_name = "Bestial Menace"
 scryfall_oracle_id = "ef08d371-9d6c-4a2d-a444-d475fbf1b633"
-scryfall_id = "f0dd5077-7a1f-4a9c-8a86-9e87da909f0c"
-
-[[token.source_card_refs]]
-card_name = "Endless Swarm"
-scryfall_oracle_id = "c62a9e10-cfc6-48cc-a3f7-68d624182a5a"
-scryfall_id = "f64d9404-9685-495d-a591-63d6164a88a9"
-
-[[token.source_card_refs]]
-card_name = "Orochi Hatchery"
-scryfall_oracle_id = "65fb1945-ed7a-4f1b-bc6b-166cbec1d8ec"
-scryfall_id = "7e662e2e-f706-4d79-86ed-48b60787a5d0"
-
-[[token.source_card_refs]]
-card_name = "Snake Pit"
-scryfall_oracle_id = "115bd33d-4875-4014-ae9f-0052f5acdbb2"
-scryfall_id = "059a70a5-d4fb-445e-af98-e81821df2c59"
-
-[[token.source_card_refs]]
-card_name = "Bestial Menace"
-scryfall_oracle_id = "ef08d371-9d6c-4a2d-a444-d475fbf1b633"
 scryfall_id = "f9540288-9aef-49a2-a5da-3e42ba9dbbcd"
-
-[[token.source_card_refs]]
-card_name = "Snake Basket"
-scryfall_oracle_id = "12236231-7c6e-4edc-87dc-737115843185"
-scryfall_id = "bfda9a16-9cdb-494a-b662-ac24e3b89d0c"
-
-[[token.source_card_refs]]
-card_name = "Snake Basket"
-scryfall_oracle_id = "12236231-7c6e-4edc-87dc-737115843185"
-scryfall_id = "3a9bc174-1d10-49bf-af4f-2f6061b1796e"
-
-[[token.source_card_refs]]
-card_name = "Sosuke's Summons"
-scryfall_oracle_id = "6be663a5-70e2-435a-91ae-16168402787b"
-scryfall_id = "42359e94-9f57-45ae-ae39-d4b939813015"
-
-[[token.source_card_refs]]
-card_name = "Orochi Eggwatcher // Shidako, Broodmistress"
-face_name = "Shidako, Broodmistress"
-scryfall_oracle_id = "e448e27c-f66d-4369-8215-7f7275e456e1"
-scryfall_id = "a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22"
 
 [[token.source_card_refs]]
 card_name = "Orochi Eggwatcher // Shidako, Broodmistress"
 face_name = "Orochi Eggwatcher"
 scryfall_oracle_id = "e448e27c-f66d-4369-8215-7f7275e456e1"
 scryfall_id = "a2a0181f-44bf-487d-a685-f92a8a43afe3"
-
-[[token.source_card_refs]]
-card_name = "Orochi Eggwatcher // Shidako, Broodmistress"
-face_name = "Orochi Eggwatcher"
-scryfall_oracle_id = "e448e27c-f66d-4369-8215-7f7275e456e1"
-scryfall_id = "a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22"
-
-[[token.source_card_refs]]
-card_name = "Seed the Land"
-scryfall_oracle_id = "75b39a67-6720-482f-935a-c142ca0f7891"
-scryfall_id = "ec1b0a4e-e52e-4d4e-9b12-24676d8571b1"
 
 [[token.source_card_refs]]
 card_name = "Xyris, the Writhing Storm"
@@ -76630,11 +74453,6 @@ keywords = ["Flying"]
 card_name = "Leafdrake Roost"
 scryfall_oracle_id = "b5ff42a1-1ac4-472b-8479-5e3749845305"
 scryfall_id = "5f74cf11-8deb-4623-9c1e-1e86e98bd831"
-
-[[token.source_card_refs]]
-card_name = "Leafdrake Roost"
-scryfall_oracle_id = "b5ff42a1-1ac4-472b-8479-5e3749845305"
-scryfall_id = "aa9cb544-fa42-4671-917d-e08c582f7657"
 
 [token.token_image_ref]
 scryfall_id = "c06d2c07-7d3e-46e3-86f0-7ceba3b0aee0"
@@ -78875,11 +76693,6 @@ scryfall_id = "dc04312f-3838-4e5e-bb9e-52bcf8049d09"
 [[token.source_card_refs]]
 card_name = "Toxrill, the Corrosive"
 scryfall_oracle_id = "c71b2325-bde6-4364-a93b-8477ffeb25d8"
-scryfall_id = "3bf11c3b-53ff-4b22-97a4-45b5f00cc7a3"
-
-[[token.source_card_refs]]
-card_name = "Toxrill, the Corrosive"
-scryfall_oracle_id = "c71b2325-bde6-4364-a93b-8477ffeb25d8"
 scryfall_id = "78808d46-a3a7-4598-bddf-a302977808fb"
 
 [token.token_image_ref]
@@ -79341,11 +77154,6 @@ scryfall_oracle_id = "6f6cbcd4-7a4b-4a38-bf29-995e82e658ce"
 scryfall_id = "9515329a-0738-4b23-a326-ff417f47da77"
 
 [[token.source_card_refs]]
-card_name = "Expendable Lackey"
-scryfall_oracle_id = "6f6cbcd4-7a4b-4a38-bf29-995e82e658ce"
-scryfall_id = "9e671b0f-55b9-4bff-b02a-0be1f6db193f"
-
-[[token.source_card_refs]]
 card_name = "Exotic Pets"
 scryfall_oracle_id = "497cb281-e057-42fc-937d-512855b74159"
 scryfall_id = "902f1ed8-5c10-45e4-8f2f-182e800faab4"
@@ -79427,11 +77235,6 @@ scryfall_id = "da8b764a-4de9-4c29-8f75-2babf904c1de"
 card_name = "Heliod, God of the Sun"
 scryfall_oracle_id = "4ea488b2-5ba0-4565-b928-570c8e03b926"
 scryfall_id = "f6365e12-c470-40a2-95b0-827ec4404c38"
-
-[[token.source_card_refs]]
-card_name = "Heliod, God of the Sun"
-scryfall_oracle_id = "4ea488b2-5ba0-4565-b928-570c8e03b926"
-scryfall_id = "97b40941-d43d-487d-a418-6ada2ec24b5c"
 
 [[token.source_card_refs]]
 card_name = "Heliod, God of the Sun"
@@ -81884,11 +79687,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Llanowar Mentor"
 scryfall_oracle_id = "bc7b6508-6522-4772-93b0-3985e7e75048"
-scryfall_id = "b23f0074-40ad-4057-a672-42ed4f9564c0"
-
-[[token.source_card_refs]]
-card_name = "Llanowar Mentor"
-scryfall_oracle_id = "bc7b6508-6522-4772-93b0-3985e7e75048"
 scryfall_id = "e0f894e7-adf7-4fe5-811a-8e2d8c8a88d6"
 
 [token.token_image_ref]
@@ -81910,10 +79708,8 @@ source_card_names = [
     "Crawling Sensation",
     "Dragonlair Spider",
     "Hiveheart Shaman",
-    "Infestation Expert",
     "Infestation Expert // Infested Werewolf",
     "Infested Roothold",
-    "Infested Werewolf",
     "Iridescent Hornbeetle",
     "It of the Horrid Swarm",
     "Living Hive",
@@ -81953,55 +79749,9 @@ scryfall_oracle_id = "50de88d4-0beb-45e5-9664-d4f0e280e652"
 scryfall_id = "565438a2-3b2f-4bfa-9af0-69fbcbcef99d"
 
 [[token.source_card_refs]]
-card_name = "Iridescent Hornbeetle"
-scryfall_oracle_id = "3270265f-fa9f-4ef0-a1a3-a68fc2349bf1"
-scryfall_id = "424f3f1e-f61d-4130-8f1c-52698074cc90"
-
-[[token.source_card_refs]]
-card_name = "Swarm Shambler"
-scryfall_oracle_id = "f46c72b8-e2e8-42e6-a2e7-ffa5810a9bf3"
-scryfall_id = "63ccad14-ec2b-4235-a917-c0355c16599a"
-
-[[token.source_card_refs]]
 card_name = "Scute Swarm"
 scryfall_oracle_id = "aa854d50-444c-49d9-bfb1-5476b33c1c0b"
 scryfall_id = "62c19f87-1bbc-4309-8781-4519db8b91a2"
-
-[[token.source_card_refs]]
-card_name = "Vitality Charm"
-scryfall_oracle_id = "74f5b4a9-8358-40b1-b38a-e034e2b916ac"
-scryfall_id = "e1abae21-ed8f-4e21-b227-f721b840c11f"
-
-[[token.source_card_refs]]
-card_name = "Infestation Expert // Infested Werewolf"
-face_name = "Infested Werewolf"
-scryfall_oracle_id = "bf69dc2a-9aec-4181-bbe9-70875055ec03"
-scryfall_id = "e7e246b5-9c21-45d1-951b-ab5a47b4e7e4"
-
-[[token.source_card_refs]]
-card_name = "Old Rutstein"
-scryfall_oracle_id = "8f5ffb0b-0585-4a37-8048-eda53990d1dd"
-scryfall_id = "2bda3765-c56f-4b27-83f8-d01e16265328"
-
-[[token.source_card_refs]]
-card_name = "Beacon of Creation"
-scryfall_oracle_id = "55f31c9c-a015-4965-a0c4-788b861dba21"
-scryfall_id = "5bc629de-18a3-4780-9df6-28ee54a34b81"
-
-[[token.source_card_refs]]
-card_name = "Symbiotic Wurm"
-scryfall_oracle_id = "99e3b8ee-29e3-41de-af31-a4e8800c4619"
-scryfall_id = "a60313ca-10cc-4c33-a557-1401c5721e3b"
-
-[[token.source_card_refs]]
-card_name = "Crawling Sensation"
-scryfall_oracle_id = "98441834-7da0-4d9f-88a4-a342a9b2a4c3"
-scryfall_id = "83e4d626-5017-4243-bafa-36e1cedcfb76"
-
-[[token.source_card_refs]]
-card_name = "Symbiotic Elf"
-scryfall_oracle_id = "cfaa0d5d-d9f1-4586-a7b1-6576a58c0f1e"
-scryfall_id = "33af35c6-7802-4366-ad20-1e330b4957ef"
 
 [[token.source_card_refs]]
 card_name = "The Astonishing Ant-Man"
@@ -82009,65 +79759,9 @@ scryfall_oracle_id = "6c7e4e51-099a-4398-a4b7-e2f0ddd36429"
 scryfall_id = "5d98073e-2828-4365-a8d6-f631aac0cca9"
 
 [[token.source_card_refs]]
-card_name = "Broodhatch Nantuko"
-scryfall_oracle_id = "b0a54050-3493-4ff6-8eca-e43b92c1f3d3"
-scryfall_id = "38315ba3-57a0-4aa0-b1bc-4b1fcdd763d4"
-
-[[token.source_card_refs]]
 card_name = "Saber Ants"
 scryfall_oracle_id = "9c3c9a22-e092-4845-b661-047590746498"
 scryfall_id = "58f0a2f9-5c5e-4477-ae7e-a52cf5778962"
-
-[[token.source_card_refs]]
-card_name = "Living Hive"
-scryfall_oracle_id = "1aa5df06-a61d-47e8-b12d-34009854d088"
-scryfall_id = "407dad3c-d721-412a-8b29-bc15be56d2fe"
-
-[[token.source_card_refs]]
-card_name = "Crawling Infestation"
-scryfall_oracle_id = "a42262b8-8a26-4570-a6ee-24b239d095fc"
-scryfall_id = "5a624ef1-eb3e-47b5-99b1-809766eaba93"
-
-[[token.source_card_refs]]
-card_name = "Symbiotic Wurm"
-scryfall_oracle_id = "99e3b8ee-29e3-41de-af31-a4e8800c4619"
-scryfall_id = "e0671bd0-5d81-4c15-869c-1c61d66fa767"
-
-[[token.source_card_refs]]
-card_name = "Saber Ants"
-scryfall_oracle_id = "9c3c9a22-e092-4845-b661-047590746498"
-scryfall_id = "e9269f52-1002-475d-a0f3-d652630591ca"
-
-[[token.source_card_refs]]
-card_name = "Infested Roothold"
-scryfall_oracle_id = "86ebaaf1-82eb-439e-bfca-68521ca199eb"
-scryfall_id = "f9fc7bf3-fa3f-450a-875e-05a022794181"
-
-[[token.source_card_refs]]
-card_name = "Vilespawn Spider"
-scryfall_oracle_id = "3e969073-76cc-4a2c-9abd-3a4094488fe5"
-scryfall_id = "1db5bb0b-af35-4040-9b26-4375ff656fe2"
-
-[[token.source_card_refs]]
-card_name = "One Dozen Eyes"
-scryfall_oracle_id = "b1fbf818-6699-4f05-9a91-19aa296526bf"
-scryfall_id = "c3216148-f64e-434b-80b8-772f6eb831ca"
-
-[[token.source_card_refs]]
-card_name = "Symbiotic Beast"
-scryfall_oracle_id = "70ecc25b-2004-4a3c-80c3-6d97bf0711eb"
-scryfall_id = "bb61443d-e47a-4fe1-b777-67a3670a5a56"
-
-[[token.source_card_refs]]
-card_name = "Wirewood Hivemaster"
-scryfall_oracle_id = "20339b68-b617-45a6-b569-cc6231641e88"
-scryfall_id = "ea55b4fc-366f-4906-9eaa-9085f6a22612"
-
-[[token.source_card_refs]]
-card_name = "Infestation Expert // Infested Werewolf"
-face_name = "Infestation Expert"
-scryfall_oracle_id = "bf69dc2a-9aec-4181-bbe9-70875055ec03"
-scryfall_id = "e7e246b5-9c21-45d1-951b-ab5a47b4e7e4"
 
 [[token.source_card_refs]]
 card_name = "The Astonishing Ant-Man"
@@ -82080,11 +79774,6 @@ scryfall_oracle_id = "b0a54050-3493-4ff6-8eca-e43b92c1f3d3"
 scryfall_id = "ffc29f3a-bf26-4db4-ac8e-48be4862dd11"
 
 [[token.source_card_refs]]
-card_name = "Hiveheart Shaman"
-scryfall_oracle_id = "c3780529-d47e-48dc-86f6-c1a282c3b656"
-scryfall_id = "79cacec9-af89-45ee-9f63-f3b4ca5ea280"
-
-[[token.source_card_refs]]
 card_name = "Ant-Man, Colony Commander"
 scryfall_oracle_id = "b0ed9fbe-324d-467a-a326-c6f85a4c688a"
 scryfall_id = "26faf2db-ad86-462f-b61f-c1893c9aebbf"
@@ -82093,11 +79782,6 @@ scryfall_id = "26faf2db-ad86-462f-b61f-c1893c9aebbf"
 card_name = "Dragonlair Spider"
 scryfall_oracle_id = "f17d3aa4-6e88-4973-b2a4-942098a1c463"
 scryfall_id = "7ebddcdb-9bcb-4355-9bcf-232608fb678e"
-
-[[token.source_card_refs]]
-card_name = "Crawling Sensation"
-scryfall_oracle_id = "98441834-7da0-4d9f-88a4-a342a9b2a4c3"
-scryfall_id = "aedb008c-c89b-4093-8622-ee18e217de15"
 
 [[token.source_card_refs]]
 card_name = "Symbiotic Beast"
@@ -82495,11 +80179,6 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Professional Wrestler"
-scryfall_oracle_id = "3dd92eea-02ca-4e55-8f69-8c8059dd7ee6"
-scryfall_id = "5e1bc145-8e4b-484a-bf29-4b46089d9300"
-
-[[token.source_card_refs]]
 card_name = "J. Jonah Jameson"
 scryfall_oracle_id = "de861715-fd0b-493e-9a7c-c470a23044c0"
 scryfall_id = "9ee905d6-b647-4eb1-a8d9-89add9bafc31"
@@ -82527,32 +80206,12 @@ scryfall_id = "e1ec41d4-0180-42f7-9c54-f3c39b4ffb8d"
 [[token.source_card_refs]]
 card_name = "Common Crook"
 scryfall_oracle_id = "ebcbfdba-34c7-40eb-91a9-d306ff5ae8b9"
-scryfall_id = "7d7b5a4a-5dc0-46f0-94dc-35723423f8b9"
-
-[[token.source_card_refs]]
-card_name = "Common Crook"
-scryfall_oracle_id = "ebcbfdba-34c7-40eb-91a9-d306ff5ae8b9"
 scryfall_id = "6f5872df-e692-44aa-b18d-22447f5f274c"
 
 [[token.source_card_refs]]
 card_name = "Ultimate Green Goblin"
 scryfall_oracle_id = "b5b43d01-fce6-4a00-9c19-7a7e2a09d833"
 scryfall_id = "e82d3f71-8404-40e7-b7fa-35713d1b384e"
-
-[[token.source_card_refs]]
-card_name = "Ultimate Green Goblin"
-scryfall_oracle_id = "b5b43d01-fce6-4a00-9c19-7a7e2a09d833"
-scryfall_id = "9905b88b-4b4d-4a14-8032-7f23d4517d8b"
-
-[[token.source_card_refs]]
-card_name = "Pictures of Spider-Man"
-scryfall_oracle_id = "4fd74a8c-a4e7-4988-ae02-9a73ab6ec89e"
-scryfall_id = "42b0bd7b-38a6-465c-badf-ea72989160b9"
-
-[[token.source_card_refs]]
-card_name = "J. Jonah Jameson"
-scryfall_oracle_id = "de861715-fd0b-493e-9a7c-c470a23044c0"
-scryfall_id = "380ab614-e46d-476b-bce9-fd2a8c074906"
 
 [token.token_image_ref]
 scryfall_id = "d52efeb3-661d-45e9-97c3-af167f889684"
@@ -83167,11 +80826,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Temmet, Vizier of Naktamun"
 scryfall_oracle_id = "e245d5c9-ae3a-4246-bd74-c6fed76b9fad"
-scryfall_id = "1024c07a-8764-4a78-8f82-1b1dd943e06f"
-
-[[token.source_card_refs]]
-card_name = "Temmet, Vizier of Naktamun"
-scryfall_oracle_id = "e245d5c9-ae3a-4246-bd74-c6fed76b9fad"
 scryfall_id = "6af12a34-52a1-4940-a8d5-9e9811fcd59f"
 
 [token.token_image_ref]
@@ -83618,11 +81272,6 @@ card_name = "Patagia Viper"
 scryfall_oracle_id = "b9985370-d908-431c-ad33-ec532fe07d1f"
 scryfall_id = "c9dc1daf-24bc-4564-8955-abc5989e6156"
 
-[[token.source_card_refs]]
-card_name = "Patagia Viper"
-scryfall_oracle_id = "b9985370-d908-431c-ad33-ec532fe07d1f"
-scryfall_id = "78031831-f773-489f-b1c2-c8f5537f2286"
-
 [token.token_image_ref]
 scryfall_id = "153f01ac-8601-488f-8da7-72f392c0a3c6"
 scryfall_oracle_id = "b54d7c25-6de9-4782-9336-1bf27dc8c046"
@@ -83662,11 +81311,6 @@ scryfall_id = "9cb587e1-1243-4422-8ee3-198bd247b42c"
 card_name = "Water Gun Balloon Game"
 scryfall_oracle_id = "3d190316-138e-45f5-b6f0-11667bd0630b"
 scryfall_id = "242e7c36-8f1a-4614-86c2-07d97cf516fc"
-
-[[token.source_card_refs]]
-card_name = "Water Gun Balloon Game"
-scryfall_oracle_id = "3d190316-138e-45f5-b6f0-11667bd0630b"
-scryfall_id = "3002ffee-28ec-4aa4-8433-a009273a4ada"
 
 [token.token_image_ref]
 scryfall_id = "628c542b-7579-4070-9143-6f1f7221468f"
@@ -84133,12 +81777,6 @@ scryfall_id = "e71df56a-c27f-4983-a2c7-c2412a0345b0"
 card_name = "Bloodline Keeper // Lord of Lineage"
 face_name = "Bloodline Keeper"
 scryfall_oracle_id = "434e82b5-abd4-41ac-a5b1-2dd01c667374"
-scryfall_id = "25f42544-79d1-48d1-884b-de3c0ccfce79"
-
-[[token.source_card_refs]]
-card_name = "Bloodline Keeper // Lord of Lineage"
-face_name = "Bloodline Keeper"
-scryfall_oracle_id = "434e82b5-abd4-41ac-a5b1-2dd01c667374"
 scryfall_id = "b8a289a6-a310-48c2-8162-792d6d3c4fa9"
 
 [[token.source_card_refs]]
@@ -84152,12 +81790,6 @@ card_name = "Bloodline Keeper // Lord of Lineage"
 face_name = "Lord of Lineage"
 scryfall_oracle_id = "434e82b5-abd4-41ac-a5b1-2dd01c667374"
 scryfall_id = "e71df56a-c27f-4983-a2c7-c2412a0345b0"
-
-[[token.source_card_refs]]
-card_name = "Bloodline Keeper // Lord of Lineage"
-face_name = "Lord of Lineage"
-scryfall_oracle_id = "434e82b5-abd4-41ac-a5b1-2dd01c667374"
-scryfall_id = "25f42544-79d1-48d1-884b-de3c0ccfce79"
 
 [token.token_image_ref]
 scryfall_id = "c5cb4398-e180-472e-8662-2a5902bafb4f"
@@ -85156,11 +82788,6 @@ scryfall_id = "ac8819ff-cd97-440c-8256-f3e3b4fc3c41"
 [[token.source_card_refs]]
 card_name = "Consuming Blob"
 scryfall_oracle_id = "818292cc-6261-47e4-b573-d92f03da6ded"
-scryfall_id = "56798b63-2905-4e64-a81a-87b376c08ec4"
-
-[[token.source_card_refs]]
-card_name = "Consuming Blob"
-scryfall_oracle_id = "818292cc-6261-47e4-b573-d92f03da6ded"
 scryfall_id = "4540fa4b-93e8-4749-a839-9a6e816c1145"
 
 [token.token_image_ref]
@@ -85419,11 +83046,6 @@ keywords = []
 card_name = "Oath of Gideon"
 scryfall_oracle_id = "ea168acc-22a1-4ba5-affd-fb813b93535a"
 scryfall_id = "b8a3f02b-9408-46a5-8d25-f5cec553d600"
-
-[[token.source_card_refs]]
-card_name = "Oath of Gideon"
-scryfall_oracle_id = "ea168acc-22a1-4ba5-affd-fb813b93535a"
-scryfall_id = "a8e60cdc-6480-4e0a-b45b-24585707c5a6"
 
 [[token.source_card_refs]]
 card_name = "Retreat to Emeria"
@@ -86510,44 +84132,9 @@ scryfall_oracle_id = "d3e1848a-c236-4352-a7be-b0b4699af968"
 scryfall_id = "33bdda6c-d32c-4666-b885-039eccc5a2ef"
 
 [[token.source_card_refs]]
-card_name = "Hunting Pack"
-scryfall_oracle_id = "d3e1848a-c236-4352-a7be-b0b4699af968"
-scryfall_id = "d5bd5788-1201-497b-93cf-d638b9cf5e7b"
-
-[[token.source_card_refs]]
-card_name = "Hunting Pack"
-scryfall_oracle_id = "d3e1848a-c236-4352-a7be-b0b4699af968"
-scryfall_id = "8b0f5d29-5342-4591-bdc9-c2bc9289ed41"
-
-[[token.source_card_refs]]
-card_name = "Beast Attack"
-scryfall_oracle_id = "3f5acd90-199c-4ed3-9c8a-eeac4670d876"
-scryfall_id = "6a5ebe27-2083-400e-8943-b506be470e3f"
-
-[[token.source_card_refs]]
-card_name = "Shadowbeast Sighting"
-scryfall_oracle_id = "f05d5632-0a82-45bf-b66e-22cf4080ed5e"
-scryfall_id = "c419455e-2ede-430f-84cc-4d1164898cb5"
-
-[[token.source_card_refs]]
-card_name = "Combine Chrysalis"
-scryfall_oracle_id = "a1cee8d7-f619-47b4-ba8c-faf3106d4e41"
-scryfall_id = "bfeabcc4-98cf-41ab-a304-ed3070ca6c5e"
-
-[[token.source_card_refs]]
 card_name = "Rampaging Baloths"
 scryfall_oracle_id = "2d3e6549-6cc6-434f-a189-ba3b55e64c34"
 scryfall_id = "23bc2161-50f0-4c42-9a38-824f8c0c0015"
-
-[[token.source_card_refs]]
-card_name = "Herd Baloth"
-scryfall_oracle_id = "03873314-6e64-43ab-95c0-3d8692a57a03"
-scryfall_id = "523262d4-0508-4f29-9169-da2fe69d4083"
-
-[[token.source_card_refs]]
-card_name = "Rampaging Baloths"
-scryfall_oracle_id = "2d3e6549-6cc6-434f-a189-ba3b55e64c34"
-scryfall_id = "455f4de4-c6f5-43f5-b9f0-f1e9414b7748"
 
 [[token.source_card_refs]]
 card_name = "Baloth Prime"
@@ -87323,11 +84910,6 @@ card_name = "Crested Sunmare"
 scryfall_oracle_id = "054fedbb-062e-491e-9a94-594fda33094f"
 scryfall_id = "6b17f101-0df2-4b33-b818-90c77c69ef23"
 
-[[token.source_card_refs]]
-card_name = "Crested Sunmare"
-scryfall_oracle_id = "054fedbb-062e-491e-9a94-594fda33094f"
-scryfall_id = "73e43044-c76f-410b-b7f6-8e5c2d0d9094"
-
 [token.token_image_ref]
 scryfall_id = "f3dd4d92-6471-4f4b-9c70-cbd2196e8c7b"
 scryfall_oracle_id = "e8ca1b87-27c4-41a7-ba45-ee1873712019"
@@ -87415,11 +84997,6 @@ keywords = ["Flying"]
 card_name = "Abhorrent Overlord"
 scryfall_oracle_id = "13f63240-a6bb-4333-a3dd-818725c6fb73"
 scryfall_id = "4415d050-7a76-4f8b-bf78-e33dd21fe4f1"
-
-[[token.source_card_refs]]
-card_name = "Abhorrent Overlord"
-scryfall_oracle_id = "13f63240-a6bb-4333-a3dd-818725c6fb73"
-scryfall_id = "f0c1ada8-f69c-4f84-ba66-4ac76f24cadd"
 
 [token.token_image_ref]
 scryfall_id = "26b24bbe-f5bc-44d3-b716-6612d39b07bc"
@@ -89834,21 +87411,6 @@ scryfall_id = "41f18f42-b86b-4a12-9f0d-76b761571195"
 card_name = "Hot Dog Cart"
 scryfall_oracle_id = "cf27f1f8-2d95-4a00-97f8-72a244837f08"
 scryfall_id = "6ee3b883-e9f5-426f-a2ea-96fe9ff3aba9"
-
-[[token.source_card_refs]]
-card_name = "Spider-Ham, Peter Porker"
-scryfall_oracle_id = "00b50215-e832-417f-9c80-2bc3050b6ebb"
-scryfall_id = "b1c95ee4-b60d-4868-b7e3-204849a8f544"
-
-[[token.source_card_refs]]
-card_name = "Hot Dog Cart"
-scryfall_oracle_id = "cf27f1f8-2d95-4a00-97f8-72a244837f08"
-scryfall_id = "38812303-9c39-4bc3-ab60-5a845f66e5e9"
-
-[[token.source_card_refs]]
-card_name = "City Pigeon"
-scryfall_oracle_id = "ac8cae63-270c-4f73-b29b-50f8f2395fd9"
-scryfall_id = "5303956a-87ce-4193-8bf5-5c58beab31fa"
 
 [[token.source_card_refs]]
 card_name = "City Pigeon"
@@ -95274,11 +92836,6 @@ scryfall_oracle_id = "47f221a4-b51a-46b9-a4fc-46bc8ec7ddd3"
 scryfall_id = "962dc573-612d-434b-82fb-af9c3e3c9aca"
 
 [[token.source_card_refs]]
-card_name = "Hangarback Walker"
-scryfall_oracle_id = "dde55256-5259-44e7-a267-fca45a7f0d04"
-scryfall_id = "c246b845-dfca-47a3-aa56-074d30590320"
-
-[[token.source_card_refs]]
 card_name = "Maverick Thopterist"
 scryfall_oracle_id = "71ba6f1b-2fa6-4d4c-8778-f0765b1a5d8e"
 scryfall_id = "cad17d67-538e-4c60-a582-a394032a5112"
@@ -96624,7 +94181,6 @@ source_card_names = [
     "Necromaster Dragon",
     "Necromentia",
     "Necrotic Hex",
-    "Never",
     "Never // Return",
     "Nevinyrral, Urborg Tyrant",
     "Noosegraf Mob",
@@ -96636,7 +94192,6 @@ source_card_names = [
     "Rakshasa Gravecaller",
     "Rank Officer",
     "Reap the Seagraf",
-    "Return",
     "Rise from the Tides",
     "Risen Necroregent",
     "Rotlung Reanimator",
@@ -96684,90 +94239,15 @@ colors = ["Black"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Rotlung Reanimator"
-scryfall_oracle_id = "de7f1725-833c-4784-94b1-7a33e36aec94"
-scryfall_id = "87b29d1e-9c06-4ad1-8178-b3eaa212f6f1"
-
-[[token.source_card_refs]]
-card_name = "Maalfeld Twins"
-scryfall_oracle_id = "dda4b515-49c0-43fe-9f6a-36defa326bb1"
-scryfall_id = "7c8cce8a-43b4-42aa-abbd-0835583e74bd"
-
-[[token.source_card_refs]]
-card_name = "Sarcomancy"
-scryfall_oracle_id = "bd1e93da-7524-4bdd-9738-accd76bda7f7"
-scryfall_id = "5e26f693-4e62-4925-923f-f46376a8a179"
-
-[[token.source_card_refs]]
-card_name = "Hour of Promise"
-scryfall_oracle_id = "51ff3e53-90bb-41bf-80e4-bb3fd51d574a"
-scryfall_id = "a023e08d-7a47-4897-b14b-743269b96ae9"
-
-[[token.source_card_refs]]
-card_name = "Sarcomancy"
-scryfall_oracle_id = "bd1e93da-7524-4bdd-9738-accd76bda7f7"
-scryfall_id = "76c3887a-7c26-4ec8-b522-b511fe1d67d3"
-
-[[token.source_card_refs]]
-card_name = "Bone Miser"
-scryfall_oracle_id = "3984e5f6-8643-4104-aa9c-18d474e07801"
-scryfall_id = "76dd0716-2aa0-4d57-8ead-3e48cbdf5ea9"
-
-[[token.source_card_refs]]
-card_name = "Ghoulcaller's Accomplice"
-scryfall_oracle_id = "16616aa2-5490-4fab-9de4-f37ca8c8be08"
-scryfall_id = "0dadc9ea-fd6b-449e-82cc-ca7cab7da1ce"
-
-[[token.source_card_refs]]
-card_name = "Oath of Liliana"
-scryfall_oracle_id = "0bd7fd12-a0b7-4b4e-8a33-cace6e6bd6d1"
-scryfall_id = "bc40bbd8-5624-4f76-ad25-78f997bce7cd"
-
-[[token.source_card_refs]]
-card_name = "Necromancer's Stockpile"
-scryfall_oracle_id = "dc47a97b-f511-4b97-97b2-e0309055544b"
-scryfall_id = "5fdec536-d233-40f1-9448-82c3c845ead6"
-
-[[token.source_card_refs]]
-card_name = "Skull Skaab"
-scryfall_oracle_id = "c73839bf-7500-4fd4-aa2b-e2e2e157784d"
-scryfall_id = "0e0904c0-4d9a-4c60-a6ce-5ba2fde8abea"
-
-[[token.source_card_refs]]
 card_name = "Grim Reaper's Scythe"
 scryfall_oracle_id = "91b1db8c-4bce-43d1-94ab-14b1435686c7"
 scryfall_id = "16e47e94-4bab-4818-8197-47435af7dab2"
-
-[[token.source_card_refs]]
-card_name = "Liliana, Death's Majesty"
-scryfall_oracle_id = "7fca595e-1902-40fd-a359-622caa612b6a"
-scryfall_id = "193b9060-3b1b-4f62-86db-b1a9e37d654b"
-
-[[token.source_card_refs]]
-card_name = "Gisa's Bidding"
-scryfall_oracle_id = "0abc993b-18c7-4bb8-aa58-0d06a41cb48f"
-scryfall_id = "6a6619b7-429d-4855-9d8a-0a4a1486f18e"
-
-[[token.source_card_refs]]
-card_name = "Midnight Ritual"
-scryfall_oracle_id = "389ad507-8a14-4856-8d19-c90e3104aca8"
-scryfall_id = "0e98c4f7-b0f4-48c6-b502-3dc5802d827f"
-
-[[token.source_card_refs]]
-card_name = "Doomed Dissenter"
-scryfall_oracle_id = "11cb509d-21af-48f1-b355-135ebd3e4bd1"
-scryfall_id = "a53d3ce5-3e71-44f1-ab0e-98d399287722"
 
 [[token.source_card_refs]]
 card_name = "Liliana, Heretical Healer // Liliana, Defiant Necromancer"
 face_name = "Liliana, Heretical Healer"
 scryfall_oracle_id = "b96a8ad2-3d86-459b-a34f-19c9dc07c3c4"
 scryfall_id = "d8b718d8-fca3-4b3e-9448-6067c8656a9a"
-
-[[token.source_card_refs]]
-card_name = "Dark Salvation"
-scryfall_oracle_id = "f5c2b700-da52-4436-b234-e32ba7759e17"
-scryfall_id = "d38bf566-d2f6-4f86-9e16-f39c85f8b947"
 
 [[token.source_card_refs]]
 card_name = "Rise from the Tides"
@@ -96780,50 +94260,9 @@ scryfall_oracle_id = "485f710d-5bc2-4c8f-b7e9-eed6caa261a6"
 scryfall_id = "92105bc6-b64a-4bdc-99fe-7a2ccdbd4486"
 
 [[token.source_card_refs]]
-card_name = "Liliana, Heretical Healer // Liliana, Defiant Necromancer"
-face_name = "Liliana, Defiant Necromancer"
-scryfall_oracle_id = "b96a8ad2-3d86-459b-a34f-19c9dc07c3c4"
-scryfall_id = "e1760e5f-d5f4-485f-b0ff-34e6a0c7a707"
-
-[[token.source_card_refs]]
-card_name = "Bone Miser"
-scryfall_oracle_id = "3984e5f6-8643-4104-aa9c-18d474e07801"
-scryfall_id = "2dd78806-621a-4f9f-936c-527ec9659667"
-
-[[token.source_card_refs]]
-card_name = "Havengul Runebinder"
-scryfall_oracle_id = "e91e7f62-0788-445e-ba93-2c9d233ec3ab"
-scryfall_id = "f917afb6-992d-4eb1-bf7e-8fe4af56c9bd"
-
-[[token.source_card_refs]]
-card_name = "Dying to Serve"
-scryfall_oracle_id = "2b719057-1bc0-4c3a-97c3-8377844570dd"
-scryfall_id = "8a054853-12d3-4a3b-b037-7b0ad0e9a7a1"
-
-[[token.source_card_refs]]
-card_name = "Bridge from Below"
-scryfall_oracle_id = "0f071f64-b69b-4fa0-999c-5028429e3cfb"
-scryfall_id = "52c44610-6d4b-4c14-839f-2c085badec90"
-
-[[token.source_card_refs]]
 card_name = "Grave Titan"
 scryfall_oracle_id = "f3abd4d1-a975-4e85-8684-aa0fce029670"
 scryfall_id = "3b4faa6e-5013-4c59-80f5-662a386672eb"
-
-[[token.source_card_refs]]
-card_name = "Liliana's Mastery"
-scryfall_oracle_id = "bd104c7e-311e-4b03-98d3-5f20f3a99d26"
-scryfall_id = "e28b5fce-ac73-44ec-be2c-c95d8d3579fe"
-
-[[token.source_card_refs]]
-card_name = "Zombie Infestation"
-scryfall_oracle_id = "bdce1af0-3643-4e77-88f9-320206a191d4"
-scryfall_id = "ccd5f98a-7ab5-44b3-850c-b50963dace66"
-
-[[token.source_card_refs]]
-card_name = "Liliana's Reaver"
-scryfall_oracle_id = "97332d4e-a55c-4e4f-9040-bf426a7c8e39"
-scryfall_id = "fa9396f3-a93c-47ee-91da-78af864c86c3"
 
 [[token.source_card_refs]]
 card_name = "Overseer of the Damned"
@@ -96831,152 +94270,9 @@ scryfall_oracle_id = "c1f085ce-5b52-45b3-aef0-f77f36b3da36"
 scryfall_id = "c76dc426-e538-4f72-9556-3231ad49c88d"
 
 [[token.source_card_refs]]
-card_name = "Wakedancer"
-scryfall_oracle_id = "e850743e-e4c4-4a09-b797-d5f688b51451"
-scryfall_id = "e0fd24ce-6b37-4801-b10f-5e2dbada7a41"
-
-[[token.source_card_refs]]
-card_name = "Doomed Dissenter"
-scryfall_oracle_id = "11cb509d-21af-48f1-b355-135ebd3e4bd1"
-scryfall_id = "8e2af405-63b2-4774-9ed3-d62f9f4f26e3"
-
-[[token.source_card_refs]]
-card_name = "Bridge from Below"
-scryfall_oracle_id = "0f071f64-b69b-4fa0-999c-5028429e3cfb"
-scryfall_id = "5feaed81-008e-4ec1-852d-907c0897dff6"
-
-[[token.source_card_refs]]
-card_name = "Waste Not"
-scryfall_oracle_id = "00fdcc19-88ed-46c3-91f0-095806228105"
-scryfall_id = "f5dd0247-f6a0-4f1d-ac27-a49a7e022e5b"
-
-[[token.source_card_refs]]
-card_name = "Xathrid Necromancer"
-scryfall_oracle_id = "a6b38874-c8be-47f7-a656-ba49ec9e967f"
-scryfall_id = "624b8dd3-41b5-4211-b644-b03f47c5d87f"
-
-[[token.source_card_refs]]
-card_name = "Graf Harvest"
-scryfall_oracle_id = "d3ba6922-c2f7-45ab-87a3-d4bbd770d1ba"
-scryfall_id = "ed0e46f8-5094-4e67-ad77-67e81c269657"
-
-[[token.source_card_refs]]
-card_name = "Never // Return"
-face_name = "Never"
-scryfall_oracle_id = "bf276236-18a6-4a48-b47d-5227832d26e6"
-scryfall_id = "4f4fa62a-8297-4565-9ff5-68ba4c5b91e4"
-
-[[token.source_card_refs]]
-card_name = "Rise from the Tides"
-scryfall_oracle_id = "390b862a-2a85-44bd-832c-f5bbd3eb4ea0"
-scryfall_id = "84646b55-a986-4781-8c40-319ba4c94f3a"
-
-[[token.source_card_refs]]
-card_name = "Graf Harvest"
-scryfall_oracle_id = "d3ba6922-c2f7-45ab-87a3-d4bbd770d1ba"
-scryfall_id = "83f2413f-987f-4eab-96c1-f662821546a5"
-
-[[token.source_card_refs]]
-card_name = "Diregraf Colossus"
-scryfall_oracle_id = "fd62ad01-601f-4250-bc2a-8ef3982e45c4"
-scryfall_id = "3a40e938-5528-4aa1-843b-4193dd69c698"
-
-[[token.source_card_refs]]
-card_name = "Diregraf Colossus"
-scryfall_oracle_id = "fd62ad01-601f-4250-bc2a-8ef3982e45c4"
-scryfall_id = "d0f7808b-fc76-4108-a8d5-43b38b18f8a1"
-
-[[token.source_card_refs]]
-card_name = "Ghoulcaller Gisa"
-scryfall_oracle_id = "0dd894cb-1968-471c-af08-ea7ec5ce8428"
-scryfall_id = "0bcba8d3-725b-49f9-8281-eafac15208c5"
-
-[[token.source_card_refs]]
-card_name = "Noosegraf Mob"
-scryfall_oracle_id = "f27fb53f-a983-410a-821b-e48cd8c01f2e"
-scryfall_id = "a297304e-0034-4686-bad4-c6e6527453e8"
-
-[[token.source_card_refs]]
-card_name = "Liliana, the Last Hope"
-scryfall_oracle_id = "64a9a6b4-26b5-4d23-be86-85c54e9c4727"
-scryfall_id = "8abee671-86a3-4e26-ad6a-1059c87922b0"
-
-[[token.source_card_refs]]
-card_name = "Doomed Dissenter"
-scryfall_oracle_id = "11cb509d-21af-48f1-b355-135ebd3e4bd1"
-scryfall_id = "318e58cf-31f0-460d-b456-86c0bd2220e2"
-
-[[token.source_card_refs]]
-card_name = "Liliana, Heretical Healer // Liliana, Defiant Necromancer"
-face_name = "Liliana, Heretical Healer"
-scryfall_oracle_id = "b96a8ad2-3d86-459b-a34f-19c9dc07c3c4"
-scryfall_id = "e1760e5f-d5f4-485f-b0ff-34e6a0c7a707"
-
-[[token.source_card_refs]]
-card_name = "Endless Ranks of the Dead"
-scryfall_oracle_id = "69d4ecac-4735-4667-bfc1-c8800b436d08"
-scryfall_id = "d920b00c-d4ed-4d21-abfa-da270a1ae94f"
-
-[[token.source_card_refs]]
-card_name = "Feast or Famine"
-scryfall_oracle_id = "485f710d-5bc2-4c8f-b7e9-eed6caa261a6"
-scryfall_id = "f4ac1586-c3d5-4add-bade-b527dcf4a391"
-
-[[token.source_card_refs]]
-card_name = "Sarcomancy"
-scryfall_oracle_id = "bd1e93da-7524-4bdd-9738-accd76bda7f7"
-scryfall_id = "eb5730f5-a44c-4f75-a26f-90815cfcd31e"
-
-[[token.source_card_refs]]
-card_name = "Feast or Famine"
-scryfall_oracle_id = "485f710d-5bc2-4c8f-b7e9-eed6caa261a6"
-scryfall_id = "7c185b4d-8da5-4b8a-85f0-5f0622c7bade"
-
-[[token.source_card_refs]]
-card_name = "Liliana, Death's Majesty"
-scryfall_oracle_id = "7fca595e-1902-40fd-a359-622caa612b6a"
-scryfall_id = "f42b0052-0758-489f-b7e2-208686ad82af"
-
-[[token.source_card_refs]]
-card_name = "Ghoulcaller's Accomplice"
-scryfall_oracle_id = "16616aa2-5490-4fab-9de4-f37ca8c8be08"
-scryfall_id = "63b62aaf-cc36-4235-b802-828b2c4d6341"
-
-[[token.source_card_refs]]
-card_name = "Field of the Dead"
-scryfall_oracle_id = "aa959340-c869-4caa-92c7-572bd8d23eef"
-scryfall_id = "2cf97898-1e05-4c0e-896f-ba6713bf6a7b"
-
-[[token.source_card_refs]]
 card_name = "Waste Not"
 scryfall_oracle_id = "00fdcc19-88ed-46c3-91f0-095806228105"
 scryfall_id = "fd3e5359-97c4-41ec-b18e-4abcd2205886"
-
-[[token.source_card_refs]]
-card_name = "Suspicious Shambler"
-scryfall_oracle_id = "ea6ee33f-0cba-4e96-817f-dc89c9064ead"
-scryfall_id = "ff36347c-1fc1-4493-8e45-ef3372ecce45"
-
-[[token.source_card_refs]]
-card_name = "Zombie Infestation"
-scryfall_oracle_id = "bdce1af0-3643-4e77-88f9-320206a191d4"
-scryfall_id = "c9ce5007-56ab-4361-8130-df48add1492b"
-
-[[token.source_card_refs]]
-card_name = "Liliana's Mastery"
-scryfall_oracle_id = "bd104c7e-311e-4b03-98d3-5f20f3a99d26"
-scryfall_id = "6ec0e486-c726-4e5d-807f-6d7474f2f061"
-
-[[token.source_card_refs]]
-card_name = "Endless Ranks of the Dead"
-scryfall_oracle_id = "69d4ecac-4735-4667-bfc1-c8800b436d08"
-scryfall_id = "4070b947-1d40-4f86-bfed-59de52ddcb66"
-
-[[token.source_card_refs]]
-card_name = "Never // Return"
-face_name = "Return"
-scryfall_oracle_id = "bf276236-18a6-4a48-b47d-5227832d26e6"
-scryfall_id = "4f4fa62a-8297-4565-9ff5-68ba4c5b91e4"
 
 [[token.source_card_refs]]
 card_name = "Liliana, Heretical Healer // Liliana, Defiant Necromancer"
@@ -96990,34 +94286,9 @@ scryfall_oracle_id = "bd104c7e-311e-4b03-98d3-5f20f3a99d26"
 scryfall_id = "f1c1c21f-fbbd-442d-b79f-6c42db9072e7"
 
 [[token.source_card_refs]]
-card_name = "Dark Salvation"
-scryfall_oracle_id = "f5c2b700-da52-4436-b234-e32ba7759e17"
-scryfall_id = "44290703-7988-4ef8-8277-807190a02bd5"
-
-[[token.source_card_refs]]
-card_name = "Cellar Door"
-scryfall_oracle_id = "a2f79037-86c0-430c-ba91-62ac807a44ce"
-scryfall_id = "ea1b217c-c3d4-4cdb-9ee7-2cf7c8d0eb7b"
-
-[[token.source_card_refs]]
 card_name = "Ghoulcaller Gisa"
 scryfall_oracle_id = "0dd894cb-1968-471c-af08-ea7ec5ce8428"
 scryfall_id = "779e3944-4342-4151-9963-87e8d41fd2ff"
-
-[[token.source_card_refs]]
-card_name = "Headless Rider"
-scryfall_oracle_id = "d4fdacd7-3101-44e2-a880-dde7326137a4"
-scryfall_id = "8804973b-b733-417e-9bee-828efbcb4453"
-
-[[token.source_card_refs]]
-card_name = "Drunau Corpse Trawler"
-scryfall_oracle_id = "870ca989-0e72-4e74-9570-57e129298f2e"
-scryfall_id = "b06a3112-a27e-44ba-872a-c7fb5e0b29ad"
-
-[[token.source_card_refs]]
-card_name = "Feast or Famine"
-scryfall_oracle_id = "485f710d-5bc2-4c8f-b7e9-eed6caa261a6"
-scryfall_id = "302ec21d-bb10-4651-80da-11852768165d"
 
 [token.token_image_ref]
 scryfall_id = "17f001ab-514b-49e7-a657-b2872ad7a1de"
@@ -97481,11 +94752,6 @@ subtypes = ["Goblin"]
 supertypes = []
 colors = ["Red"]
 keywords = ["Haste"]
-
-[[token.source_card_refs]]
-card_name = "Rakdos Guildmage"
-scryfall_oracle_id = "650949ca-609b-46c5-bc6b-6f782cdcb6d2"
-scryfall_id = "0e01fef8-5563-4dec-ab8e-e486e19e202c"
 
 [[token.source_card_refs]]
 card_name = "Rakdos Guildmage"
@@ -98436,19 +95702,9 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Big Score"
-scryfall_oracle_id = "a5cbd257-c836-493e-bb1a-76242619dea2"
-scryfall_id = "9cf2452d-17af-4bb2-8a52-348d6e5e08b9"
-
-[[token.source_card_refs]]
 card_name = "Gala Greeters"
 scryfall_oracle_id = "cce081eb-8820-415a-a7b2-3c5b9d4a2601"
 scryfall_id = "da271d69-f086-4267-b044-5dbc01e5c6de"
-
-[[token.source_card_refs]]
-card_name = "Big Score"
-scryfall_oracle_id = "a5cbd257-c836-493e-bb1a-76242619dea2"
-scryfall_id = "8721dca7-9b24-4e66-a51f-7100988310e8"
 
 [token.token_image_ref]
 scryfall_id = "96103710-10a8-4457-bd7d-b14445196397"
@@ -98780,17 +96036,6 @@ colors = ["Blue"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Euroakus"
-scryfall_oracle_id = "e11a022c-140d-4b7f-84b0-17885f76faa6"
-scryfall_id = "4a4039bd-ed03-4eef-8a3d-97f134475974"
-
-[[token.source_card_refs]]
-card_name = "Docent of Perfection // Final Iteration"
-face_name = "Final Iteration"
-scryfall_oracle_id = "85e797de-da27-4cd5-8fa4-4aef948988b2"
-scryfall_id = "2c983363-f900-45f5-b906-d56b91d5c260"
-
-[[token.source_card_refs]]
 card_name = "Docent of Perfection // Final Iteration"
 face_name = "Final Iteration"
 scryfall_oracle_id = "85e797de-da27-4cd5-8fa4-4aef948988b2"
@@ -98801,12 +96046,6 @@ card_name = "Docent of Perfection // Final Iteration"
 face_name = "Docent of Perfection"
 scryfall_oracle_id = "85e797de-da27-4cd5-8fa4-4aef948988b2"
 scryfall_id = "96658239-3169-42ef-9983-cd4da24e0f4c"
-
-[[token.source_card_refs]]
-card_name = "Docent of Perfection // Final Iteration"
-face_name = "Docent of Perfection"
-scryfall_oracle_id = "85e797de-da27-4cd5-8fa4-4aef948988b2"
-scryfall_id = "2c983363-f900-45f5-b906-d56b91d5c260"
 
 [token.token_image_ref]
 scryfall_id = "547ba2bc-2520-4d79-b9c9-a17f921df1bd"
@@ -99533,24 +96772,9 @@ scryfall_oracle_id = "9b568c34-ba0a-44a7-a0ee-bee3a37b3396"
 scryfall_id = "61f766b8-a92e-4353-b457-ac62fc470713"
 
 [[token.source_card_refs]]
-card_name = "Tyvar Kell"
-scryfall_oracle_id = "14c8a590-88ec-4982-ad7b-36a219ff6de7"
-scryfall_id = "3c772bcf-2468-42d0-a671-f57814ba8cbb"
-
-[[token.source_card_refs]]
-card_name = "Ambassador Oak"
-scryfall_oracle_id = "4045c24e-098f-4582-8c50-576a94c7b705"
-scryfall_id = "5be17ab1-a94d-4ba5-9468-a1df345a1eda"
-
-[[token.source_card_refs]]
 card_name = "Lathril, Blade of the Elves"
 scryfall_oracle_id = "9b568c34-ba0a-44a7-a0ee-bee3a37b3396"
 scryfall_id = "8d4e5480-a287-4a25-b855-a26dae555b1c"
-
-[[token.source_card_refs]]
-card_name = "Dwynen's Elite"
-scryfall_oracle_id = "3d4a7dd3-9258-4bd1-adc4-08f0205e196a"
-scryfall_id = "2e70732f-68c1-4341-879e-5c9c68ea8503"
 
 [token.token_image_ref]
 scryfall_id = "315c45f4-7bc9-45d5-bbf5-2533cf80af60"
@@ -102591,21 +99815,6 @@ scryfall_oracle_id = "a5656dab-5ce6-48fd-9eae-2c06969bb8df"
 scryfall_id = "c8c0be82-6448-4ae9-aed6-147b8e2988f0"
 
 [[token.source_card_refs]]
-card_name = "Ogre Slumlord"
-scryfall_oracle_id = "0a5e3748-2e58-4e53-9653-8af4e21cf223"
-scryfall_id = "9342052f-6b6b-40b9-bbc9-7ba3e8365fe1"
-
-[[token.source_card_refs]]
-card_name = "Ogre Slumlord"
-scryfall_oracle_id = "0a5e3748-2e58-4e53-9653-8af4e21cf223"
-scryfall_id = "b1f176f9-d353-479e-a808-54dc5e8ff746"
-
-[[token.source_card_refs]]
-card_name = "Lab Rats"
-scryfall_oracle_id = "c53d6d3e-64e3-48b9-afab-3bde3164888f"
-scryfall_id = "3132c128-e0bd-4524-9526-914b3c7181fc"
-
-[[token.source_card_refs]]
 card_name = "Mad Ratter"
 scryfall_oracle_id = "779fa24d-e9d2-475d-b3aa-dc0388b18307"
 scryfall_id = "d78fd600-d6ed-4f16-8aeb-02945044d235"
@@ -102621,19 +99830,9 @@ scryfall_oracle_id = "a5656dab-5ce6-48fd-9eae-2c06969bb8df"
 scryfall_id = "be464d88-8933-46e8-97b0-3be05f1976a3"
 
 [[token.source_card_refs]]
-card_name = "Lab Rats"
-scryfall_oracle_id = "c53d6d3e-64e3-48b9-afab-3bde3164888f"
-scryfall_id = "6fd5d79e-cfd8-484b-bbc8-785177922e30"
-
-[[token.source_card_refs]]
 card_name = "Marrow-Gnawer"
 scryfall_oracle_id = "2b934761-5720-477b-94b7-d1d91dc581a6"
 scryfall_id = "3ce0ce55-bf61-491e-9136-6f62b5aa5795"
-
-[[token.source_card_refs]]
-card_name = "Marrow-Gnawer"
-scryfall_oracle_id = "2b934761-5720-477b-94b7-d1d91dc581a6"
-scryfall_id = "72e4548b-c171-4f10-b896-af37543dcf0f"
 
 [[token.source_card_refs]]
 card_name = "Rat King, Pale Piper"
@@ -102644,21 +99843,6 @@ scryfall_id = "9b215ce4-a085-4627-99b1-f4f1344ad41b"
 card_name = "Big Apple, 3 a.m."
 scryfall_oracle_id = "dd01ef1f-f6be-498f-82e0-dc04833e685f"
 scryfall_id = "b9cc16f9-fea3-4527-9b81-3c84ce9c5e01"
-
-[[token.source_card_refs]]
-card_name = "Marrow-Gnawer"
-scryfall_oracle_id = "2b934761-5720-477b-94b7-d1d91dc581a6"
-scryfall_id = "03648d6b-01a2-4de0-8d2a-c49f45d3d803"
-
-[[token.source_card_refs]]
-card_name = "Mad Ratter"
-scryfall_oracle_id = "779fa24d-e9d2-475d-b3aa-dc0388b18307"
-scryfall_id = "36b15eb3-ad86-48cd-b414-b8a06f61635d"
-
-[[token.source_card_refs]]
-card_name = "Plague of Vermin"
-scryfall_oracle_id = "efc12acf-ffef-40a6-b2ce-fe93e89ad840"
-scryfall_id = "6c6aca69-1624-420f-b83e-290a2c38291e"
 
 [[token.source_card_refs]]
 card_name = "Piper of the Swarm"
@@ -102917,34 +100101,14 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Deranged Hermit"
-scryfall_oracle_id = "b9cd714b-2ad8-4fdb-a8aa-82b17730e071"
-scryfall_id = "bf0e94c9-61c4-4cc0-b5ce-db62bc2660ee"
-
-[[token.source_card_refs]]
 card_name = "Specimen Collector"
 scryfall_oracle_id = "fdb51cc1-ce0e-4920-b123-1cdd570fc38b"
 scryfall_id = "e0b291b4-1e90-40f6-b282-5c6c0c1dc7af"
 
 [[token.source_card_refs]]
-card_name = "Squirrel Sanctuary"
-scryfall_oracle_id = "693d20e9-ad92-44ad-9190-d247c94660eb"
-scryfall_id = "919ae9b1-cd82-4c54-923e-689e16b6bad6"
-
-[[token.source_card_refs]]
-card_name = "Nut Collector"
-scryfall_oracle_id = "4e1bc03c-e131-4422-beba-0a45a26fdf43"
-scryfall_id = "f4eec210-5df0-4fb8-8eb1-e616d9995acc"
-
-[[token.source_card_refs]]
 card_name = "Nut Collector"
 scryfall_oracle_id = "4e1bc03c-e131-4422-beba-0a45a26fdf43"
 scryfall_id = "1b866327-a857-485b-9399-4e61828e1d76"
-
-[[token.source_card_refs]]
-card_name = "Acorn Harvest"
-scryfall_oracle_id = "6aeba615-2d37-4eb8-a377-41a517e95aa3"
-scryfall_id = "32987720-cc0c-416b-b79b-217d3b37542d"
 
 [[token.source_card_refs]]
 card_name = "Chatter of the Squirrel"
@@ -102957,29 +100121,9 @@ scryfall_oracle_id = "80312910-5d53-44f1-9982-e46dc7532abb"
 scryfall_id = "d8b94ebb-0b3a-4e68-8c0c-3a61ac32f3ef"
 
 [[token.source_card_refs]]
-card_name = "Liege of the Hollows"
-scryfall_oracle_id = "bef7441e-5a44-46bc-8141-8e02ecd06fce"
-scryfall_id = "dff4512b-8244-4e38-bffb-0062a97d9531"
-
-[[token.source_card_refs]]
-card_name = "Verdant Command"
-scryfall_oracle_id = "5a5d426b-e5eb-44f0-b5fe-c258bec6d59e"
-scryfall_id = "6d3beeda-ae1d-4215-8318-f5670b5bfbc5"
-
-[[token.source_card_refs]]
-card_name = "Chatterfang, Squirrel General"
-scryfall_oracle_id = "f15b3b76-d38a-48db-bb44-3296183c8641"
-scryfall_id = "30310d1c-27b5-4d49-95ea-aad530190974"
-
-[[token.source_card_refs]]
 card_name = "Squirrel Nest"
 scryfall_oracle_id = "2d584333-b25e-4291-a2c9-80c6d9f8732a"
 scryfall_id = "29788426-7a12-4a04-8dbe-c434445b8e0f"
-
-[[token.source_card_refs]]
-card_name = "Chatter of the Squirrel"
-scryfall_oracle_id = "b0aaa4b1-5188-43a6-997d-7a9b2ad452bc"
-scryfall_id = "84273844-7fab-4ff7-afb3-c82153132daf"
 
 [[token.source_card_refs]]
 card_name = "Druid's Call"
@@ -102987,24 +100131,9 @@ scryfall_oracle_id = "e71f4fe8-2ecd-450b-8c41-5e38d749f59d"
 scryfall_id = "7390d66f-9924-466a-9f32-0dff83c82d9e"
 
 [[token.source_card_refs]]
-card_name = "Nested Shambler"
-scryfall_oracle_id = "bfa882ee-de18-4ef8-8957-3e04ed6e3c1e"
-scryfall_id = "d9a0ff44-e7c6-4347-a222-0598e2b4ecf7"
-
-[[token.source_card_refs]]
 card_name = "The Unbeatable Squirrel Girl"
 scryfall_oracle_id = "80312910-5d53-44f1-9982-e46dc7532abb"
 scryfall_id = "ef518e5b-7942-4e66-aee0-a1c2aa1f9754"
-
-[[token.source_card_refs]]
-card_name = "Nantuko Shrine"
-scryfall_oracle_id = "fc32ec2b-5432-41cc-ab4c-d9f986126392"
-scryfall_id = "4b66bab3-ee6f-4f74-bbc1-8099c9c4904b"
-
-[[token.source_card_refs]]
-card_name = "Form of the Squirrel"
-scryfall_oracle_id = "4cdea12f-f221-4afa-9a41-21007bbbacc8"
-scryfall_id = "2241203c-1219-4e75-9973-7e1a44885341"
 
 [[token.source_card_refs]]
 card_name = "Squirrel Nest"
@@ -103017,34 +100146,9 @@ scryfall_oracle_id = "56d13879-2dc5-4d84-918b-4bd1a5fc2a33"
 scryfall_id = "9fed5706-d7bd-4c8c-b301-4909b3167d06"
 
 [[token.source_card_refs]]
-card_name = "Chatter of the Squirrel"
-scryfall_oracle_id = "b0aaa4b1-5188-43a6-997d-7a9b2ad452bc"
-scryfall_id = "1f9b9720-d15a-4d07-af8c-a26409043696"
-
-[[token.source_card_refs]]
 card_name = "Scurry Oak"
 scryfall_oracle_id = "eee6c02b-7d6a-4445-ad27-8b03176147d4"
 scryfall_id = "91323e4a-4fd3-44c6-b124-277901fb8aae"
-
-[[token.source_card_refs]]
-card_name = "Squirrel Wrangler"
-scryfall_oracle_id = "4021b6b4-9b87-4dd5-a5df-79540bedbe87"
-scryfall_id = "7094be2a-454e-4e4d-a540-c5c80e37468a"
-
-[[token.source_card_refs]]
-card_name = "Deranged Hermit"
-scryfall_oracle_id = "b9cd714b-2ad8-4fdb-a8aa-82b17730e071"
-scryfall_id = "c25df202-0dd4-448d-8cb3-11fd7df0d505"
-
-[[token.source_card_refs]]
-card_name = "Scurry Oak"
-scryfall_oracle_id = "eee6c02b-7d6a-4445-ad27-8b03176147d4"
-scryfall_id = "c98a3c11-9761-4037-a6bf-f5d41108b738"
-
-[[token.source_card_refs]]
-card_name = "Chatterstorm"
-scryfall_oracle_id = "7e6c7b57-bd6a-4ac8-bcab-c3a879f479c2"
-scryfall_id = "aa2bb6af-ba3d-410a-9cc7-85ac0f5b5f5b"
 
 [[token.source_card_refs]]
 card_name = "Comet, Stellar Pup"
@@ -103052,49 +100156,14 @@ scryfall_oracle_id = "e7c67480-1816-4071-9eab-a1d1b535a344"
 scryfall_id = "c3385549-0342-4c51-9bae-888d34cf0087"
 
 [[token.source_card_refs]]
-card_name = "Chitterspitter"
-scryfall_oracle_id = "4a338863-d599-46e7-9c30-e11b898ae1b0"
-scryfall_id = "c85d9cd2-8de4-47b1-81e8-8f0301c83bfc"
-
-[[token.source_card_refs]]
 card_name = "Underworld Hermit"
 scryfall_oracle_id = "f7f4ddc9-cea0-42f9-bbca-2ad87a24bfc8"
 scryfall_id = "a66dbfed-34e7-4872-87d7-5ddae5d98b5b"
 
 [[token.source_card_refs]]
-card_name = "Squirrel Nest"
-scryfall_oracle_id = "2d584333-b25e-4291-a2c9-80c6d9f8732a"
-scryfall_id = "22eccb27-1723-4c5a-96b8-85e6e5739c30"
-
-[[token.source_card_refs]]
-card_name = "Drey Keeper"
-scryfall_oracle_id = "7223ef44-0bfb-4108-810d-134174ff26b0"
-scryfall_id = "5c2d77ee-73d5-4eba-b188-4a0f298c1642"
-
-[[token.source_card_refs]]
-card_name = "Specimen Collector"
-scryfall_oracle_id = "fdb51cc1-ce0e-4920-b123-1cdd570fc38b"
-scryfall_id = "a325b3f1-67f6-4b56-8572-94e9970a5acc"
-
-[[token.source_card_refs]]
-card_name = "Earl of Squirrel"
-scryfall_oracle_id = "edc4d1fb-f482-4f2b-985e-1e4d5941e574"
-scryfall_id = "acf8fa0e-fab4-468b-a32b-c8be9347f4d8"
-
-[[token.source_card_refs]]
-card_name = "Druid's Call"
-scryfall_oracle_id = "e71f4fe8-2ecd-450b-8c41-5e38d749f59d"
-scryfall_id = "e22318a5-80c8-4fa3-ad05-8d3035caf336"
-
-[[token.source_card_refs]]
 card_name = "Squirrel Wrangler"
 scryfall_oracle_id = "4021b6b4-9b87-4dd5-a5df-79540bedbe87"
 scryfall_id = "feb48ab0-5f7e-44f2-896e-1cd8c4afac7e"
-
-[[token.source_card_refs]]
-card_name = "Squirrel Wrangler"
-scryfall_oracle_id = "4021b6b4-9b87-4dd5-a5df-79540bedbe87"
-scryfall_id = "97033651-05dc-4078-831d-5ea6a37e6ae3"
 
 [token.token_image_ref]
 scryfall_id = "fd0474f3-682d-4c6d-b902-84f3250aa269"
@@ -103873,11 +100942,6 @@ card_name = "Resilient Khenra"
 scryfall_oracle_id = "eb23f999-e7f9-4082-b322-5b00ba64b458"
 scryfall_id = "033a69fb-2af9-426c-b1d6-3e5b18c78c9a"
 
-[[token.source_card_refs]]
-card_name = "Resilient Khenra"
-scryfall_oracle_id = "eb23f999-e7f9-4082-b322-5b00ba64b458"
-scryfall_id = "0e0a3128-b25d-402a-a13c-e0677ad43468"
-
 [token.token_image_ref]
 scryfall_id = "c1326c5d-b5a5-4942-b15d-37830ac62c7d"
 scryfall_oracle_id = "5bbd780b-cc80-4000-a357-7c341a9d45f1"
@@ -104443,11 +101507,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Secure the Wastes"
 scryfall_oracle_id = "b2347910-d6c6-4681-8316-7ef27056485c"
-scryfall_id = "aadf5e24-1ac0-40b4-8702-cd0e077c17e0"
-
-[[token.source_card_refs]]
-card_name = "Secure the Wastes"
-scryfall_oracle_id = "b2347910-d6c6-4681-8316-7ef27056485c"
 scryfall_id = "44f0da2e-3513-4891-bea2-27dd138064b3"
 
 [[token.source_card_refs]]
@@ -104456,19 +101515,9 @@ scryfall_oracle_id = "09619943-6aec-4080-ace5-a0c6ebb23f1c"
 scryfall_id = "be898edb-35dd-4896-96d9-323aca64a2ce"
 
 [[token.source_card_refs]]
-card_name = "Najeela, the Blade-Blossom"
-scryfall_oracle_id = "09619943-6aec-4080-ace5-a0c6ebb23f1c"
-scryfall_id = "08eb1bef-b00d-490b-a631-2849e0d1fd8e"
-
-[[token.source_card_refs]]
 card_name = "Mardu Hordechief"
 scryfall_oracle_id = "f9ea5b9e-a23d-48cf-8601-56e79ca844f9"
 scryfall_id = "6cd635fe-0ea2-4b9f-8bd7-86180a98cfad"
-
-[[token.source_card_refs]]
-card_name = "Najeela, the Blade-Blossom"
-scryfall_oracle_id = "09619943-6aec-4080-ace5-a0c6ebb23f1c"
-scryfall_id = "5aa5bec9-904f-42fb-9511-4706d6e6767e"
 
 [[token.source_card_refs]]
 card_name = "Najeela, the Blade-Blossom"
@@ -104479,11 +101528,6 @@ scryfall_id = "a84d0c3c-7382-46f9-a826-44100ac7cb41"
 card_name = "Najeela, the Blade-Blossom"
 scryfall_oracle_id = "09619943-6aec-4080-ace5-a0c6ebb23f1c"
 scryfall_id = "385bd474-fb4b-4c19-b583-ac2fa2e18475"
-
-[[token.source_card_refs]]
-card_name = "Najeela, the Blade-Blossom"
-scryfall_oracle_id = "09619943-6aec-4080-ace5-a0c6ebb23f1c"
-scryfall_id = "cc30e027-8cb8-4b06-a24a-6ad49d6a2cf3"
 
 [token.token_image_ref]
 scryfall_id = "3053e02b-7157-4fb6-9427-d64a68ea29c3"
@@ -104635,16 +101679,6 @@ keywords = []
 card_name = "Desert Warfare"
 scryfall_oracle_id = "de301ef8-8ba0-423d-9117-a8492a58d01b"
 scryfall_id = "bc7778d4-f1b6-4295-adb9-78ba7c185e9d"
-
-[[token.source_card_refs]]
-card_name = "Hazezon Tamar"
-scryfall_oracle_id = "d298df4e-7b60-4495-9773-cc81954b7dd9"
-scryfall_id = "4cd43773-2a6f-4f03-bcee-de32049561e5"
-
-[[token.source_card_refs]]
-card_name = "Hazezon Tamar"
-scryfall_oracle_id = "d298df4e-7b60-4495-9773-cc81954b7dd9"
-scryfall_id = "17fc3a85-c6b9-4fd2-a6a2-d3210708e5ea"
 
 [[token.source_card_refs]]
 card_name = "Desert Warfare"
@@ -104895,11 +101929,6 @@ keywords = [
     "Flying",
     "Vigilance",
 ]
-
-[[token.source_card_refs]]
-card_name = "Aven Wind Guide"
-scryfall_oracle_id = "bb813ffa-2615-4177-a7fb-6e0dfb819fc2"
-scryfall_id = "878d4576-8079-4555-938b-1e318c5f332e"
 
 [[token.source_card_refs]]
 card_name = "Aven Wind Guide"
@@ -106959,11 +103988,6 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Beast Within"
-scryfall_oracle_id = "7735eeba-693b-47e2-bd51-414379cf1016"
-scryfall_id = "7f419a04-7a18-4ea4-9581-bbc35bec4f16"
-
-[[token.source_card_refs]]
 card_name = "Garruk Wildspeaker"
 scryfall_oracle_id = "186b4def-4fff-4a2b-bcbf-5318b0ac5fa9"
 scryfall_id = "fbbd5627-2f55-4101-981b-49f5f45db578"
@@ -106982,42 +104006,12 @@ scryfall_id = "c30267b1-a7ea-45cd-99a8-6b0e6ddbc395"
 [[token.source_card_refs]]
 card_name = "Beast Within"
 scryfall_oracle_id = "7735eeba-693b-47e2-bd51-414379cf1016"
-scryfall_id = "b6b6c66f-e3e0-4904-ae41-2ecc786f70c5"
-
-[[token.source_card_refs]]
-card_name = "Midsummer Revel"
-scryfall_oracle_id = "d3579282-5045-4b37-9998-9a282e9932b9"
-scryfall_id = "b40a7f65-10fe-4ce5-ad1c-be53a635d7a9"
-
-[[token.source_card_refs]]
-card_name = "Beast Within"
-scryfall_oracle_id = "7735eeba-693b-47e2-bd51-414379cf1016"
-scryfall_id = "da5775cc-7df2-4494-866e-216446ffddff"
-
-[[token.source_card_refs]]
-card_name = "Primeval Bounty"
-scryfall_oracle_id = "f633c16d-d943-421c-ad18-af35db9ec9fc"
-scryfall_id = "c8123d01-da65-4d03-9f23-3842fba5fc28"
-
-[[token.source_card_refs]]
-card_name = "Bringer of the Green Dawn"
-scryfall_oracle_id = "f0548af1-d1cc-44d1-b5a0-f013563f29de"
-scryfall_id = "bc208f3e-5a6a-4fae-8a7c-2bed28ad0c41"
-
-[[token.source_card_refs]]
-card_name = "Beast Within"
-scryfall_oracle_id = "7735eeba-693b-47e2-bd51-414379cf1016"
 scryfall_id = "12666334-5c82-4228-bc33-4db2bba127f5"
 
 [[token.source_card_refs]]
 card_name = "Beast Within"
 scryfall_oracle_id = "7735eeba-693b-47e2-bd51-414379cf1016"
 scryfall_id = "299f1f93-ecee-4ed8-a77e-6ebc4b85328d"
-
-[[token.source_card_refs]]
-card_name = "Thragtusk"
-scryfall_oracle_id = "0dd0e91a-d16b-4718-8d11-1a3fcf8e0753"
-scryfall_id = "d0594c41-0361-4a3b-a9cd-60f4e3b0cffe"
 
 [[token.source_card_refs]]
 card_name = "Garruk Wildspeaker // Garruk Wildspeaker"
@@ -107046,11 +104040,6 @@ card_name = "Garruk Wildspeaker // Garruk Wildspeaker"
 face_name = "Garruk Wildspeaker"
 scryfall_oracle_id = "186b4def-4fff-4a2b-bcbf-5318b0ac5fa9"
 scryfall_id = "c05c6c38-d204-458c-af17-4cf5efd2c7fc"
-
-[[token.source_card_refs]]
-card_name = "Pulse of the Tangle"
-scryfall_oracle_id = "26f034b1-9a96-4371-a28e-be00b02d9d60"
-scryfall_id = "88cf1c67-9edc-42dd-ba7f-96baab25813a"
 
 [[token.source_card_refs]]
 card_name = "Beast Within"
@@ -107655,11 +104644,6 @@ card_name = "Master of Waves"
 scryfall_oracle_id = "07d40173-53e7-4328-a3b0-6214d93855b6"
 scryfall_id = "6cca3f7c-f0b1-4a0e-a2b9-ffb4a00e2ac6"
 
-[[token.source_card_refs]]
-card_name = "Master of Waves"
-scryfall_oracle_id = "07d40173-53e7-4328-a3b0-6214d93855b6"
-scryfall_id = "fde1e8a0-7e25-4ef1-a394-c6eb58c8b5a6"
-
 [token.token_image_ref]
 scryfall_id = "ae196fbc-c9ee-4dba-9eb3-52209908b898"
 scryfall_oracle_id = "cb78f496-a5db-4d23-b63d-04584e8f3bb1"
@@ -108107,11 +105091,6 @@ scryfall_oracle_id = "ace86e56-efde-4eb7-8815-71456a4c3abe"
 scryfall_id = "17fd4d15-413f-41c5-b3e0-71bbb52851bc"
 
 [[token.source_card_refs]]
-card_name = "Strike It Rich"
-scryfall_oracle_id = "c34c17c7-3827-49a2-be25-67f44fdfe150"
-scryfall_id = "2099f819-d504-447a-a390-75267d8a7e55"
-
-[[token.source_card_refs]]
 card_name = "Warren Soultrader"
 scryfall_oracle_id = "ace86e56-efde-4eb7-8815-71456a4c3abe"
 scryfall_id = "5c18591d-a8e2-49ea-b31e-7358e4143024"
@@ -108120,11 +105099,6 @@ scryfall_id = "5c18591d-a8e2-49ea-b31e-7358e4143024"
 card_name = "Warren Soultrader"
 scryfall_oracle_id = "ace86e56-efde-4eb7-8815-71456a4c3abe"
 scryfall_id = "b334e4c6-d316-4141-8889-f95afcc04701"
-
-[[token.source_card_refs]]
-card_name = "Tireless Provisioner"
-scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
-scryfall_id = "3cf04e55-b266-46cd-a79a-d87f5ceba469"
 
 [[token.source_card_refs]]
 card_name = "Ziatora, the Incinerator"
@@ -108140,11 +105114,6 @@ scryfall_id = "d9a42082-615c-4387-a77c-97ee94153c57"
 card_name = "The Reaver Cleaver"
 scryfall_oracle_id = "37a2a31d-51e6-4c07-b4c2-b206ad40eb42"
 scryfall_id = "1d671d06-5881-41c4-a4ff-79c8733bebf5"
-
-[[token.source_card_refs]]
-card_name = "Ragavan, Nimble Pilferer"
-scryfall_oracle_id = "37108cd4-bbab-4ce3-9ed6-f60e8422e703"
-scryfall_id = "8d27e717-8bda-44dc-90b9-a6f7029c7b93"
 
 [token.token_image_ref]
 scryfall_id = "79a7e037-9f56-4a77-a09e-caeafbb86d7c"
@@ -109196,19 +106165,9 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Apothecary White"
-scryfall_oracle_id = "7bf8bb41-6f46-492c-b6cf-5cfb29f973a4"
-scryfall_id = "4fedf84e-55ca-4334-a2c1-6e991112bb68"
-
-[[token.source_card_refs]]
 card_name = "Tippy-Toe, Terrific Partner"
 scryfall_oracle_id = "6a1bce89-0c11-4d8d-aacb-c0a5a5effffc"
 scryfall_id = "6082ab9f-290e-4230-84a0-46c7f8ed712d"
-
-[[token.source_card_refs]]
-card_name = "Rocco, Street Chef"
-scryfall_oracle_id = "071f5b4b-6a1e-4dc3-9c08-b79713191811"
-scryfall_id = "421c2ed3-be60-4814-a82c-a0e3fbb97e63"
 
 [[token.source_card_refs]]
 card_name = "City Pigeon"
@@ -109221,34 +106180,9 @@ scryfall_oracle_id = "34c0f75d-10a9-428d-b202-3defb3949090"
 scryfall_id = "61a89566-06c1-404f-8217-e5276e2dc5a2"
 
 [[token.source_card_refs]]
-card_name = "Rocco, Street Chef"
-scryfall_oracle_id = "071f5b4b-6a1e-4dc3-9c08-b79713191811"
-scryfall_id = "8102736a-220d-41d8-acea-79971d73db9a"
-
-[[token.source_card_refs]]
-card_name = "Rocco, Street Chef"
-scryfall_oracle_id = "071f5b4b-6a1e-4dc3-9c08-b79713191811"
-scryfall_id = "d9808e72-4143-421f-a498-dbebbd598544"
-
-[[token.source_card_refs]]
-card_name = "Late to Dinner"
-scryfall_oracle_id = "31bf199b-dfb1-428e-96a5-eb25104e2b43"
-scryfall_id = "2de018c5-9772-4fc6-a778-7eb4d9a16e6e"
-
-[[token.source_card_refs]]
-card_name = "Tireless Provisioner"
-scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
-scryfall_id = "5590a3a5-e0bd-451a-b98e-00a492487c46"
-
-[[token.source_card_refs]]
 card_name = "Heroic Feast"
 scryfall_oracle_id = "31cae00a-3a74-4a59-80b0-a656f524e878"
 scryfall_id = "dd9b6b3f-07b1-42d2-8aff-8da3113b9d88"
-
-[[token.source_card_refs]]
-card_name = "Tempting Witch"
-scryfall_oracle_id = "82284fe4-ecb3-4b27-bb03-27290ad15b17"
-scryfall_id = "8adbd4a5-3171-495a-a540-0ecf280b77fc"
 
 [[token.source_card_refs]]
 card_name = "Lucky the Pizza Dog"
@@ -109256,29 +106190,9 @@ scryfall_oracle_id = "3a429a1e-62c0-4f01-b09e-2bbf63e56a98"
 scryfall_id = "5fc454a5-39af-421d-a494-727ac7b6115e"
 
 [[token.source_card_refs]]
-card_name = "Rocco, Street Chef"
-scryfall_oracle_id = "071f5b4b-6a1e-4dc3-9c08-b79713191811"
-scryfall_id = "cdb53ce7-845c-4c62-98a9-4fc33c67a07b"
-
-[[token.source_card_refs]]
 card_name = "Heroic Feast"
 scryfall_oracle_id = "31cae00a-3a74-4a59-80b0-a656f524e878"
 scryfall_id = "32d05c3d-cf03-492e-a956-2e77c36e36c4"
-
-[[token.source_card_refs]]
-card_name = "Fierce Witchstalker"
-scryfall_oracle_id = "ad69f48e-c387-4376-a04f-37d3992c7946"
-scryfall_id = "797744c0-cfcc-43cb-baeb-bc2be3f7523d"
-
-[[token.source_card_refs]]
-card_name = "Bake into a Pie"
-scryfall_oracle_id = "1b9ec782-0ba1-41f1-bc39-d3302494ecb3"
-scryfall_id = "2c6e5b25-b721-45ee-894a-697de1310b8c"
-
-[[token.source_card_refs]]
-card_name = "Rocco, Street Chef"
-scryfall_oracle_id = "071f5b4b-6a1e-4dc3-9c08-b79713191811"
-scryfall_id = "dc25ce46-9d1a-4d5d-b35d-ea7abb8c5e5c"
 
 [token.token_image_ref]
 scryfall_id = "39389acc-cfa7-4a44-9d46-45be7dd72564"
@@ -113072,22 +109986,12 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Kari Zev, Skyship Raider"
 scryfall_oracle_id = "786baa29-afd4-40f0-95c8-920a972b9175"
-scryfall_id = "9638a43f-6b61-4455-8e0f-4142652c4b54"
-
-[[token.source_card_refs]]
-card_name = "Kari Zev, Skyship Raider"
-scryfall_oracle_id = "786baa29-afd4-40f0-95c8-920a972b9175"
 scryfall_id = "48765efe-bcb5-4a15-acd0-607ead64ae6d"
 
 [[token.source_card_refs]]
 card_name = "Kari Zev, Skyship Raider"
 scryfall_oracle_id = "786baa29-afd4-40f0-95c8-920a972b9175"
 scryfall_id = "1a9e43d4-41ff-468c-b817-7e8467fadb1a"
-
-[[token.source_card_refs]]
-card_name = "Kari Zev, Skyship Raider"
-scryfall_oracle_id = "786baa29-afd4-40f0-95c8-920a972b9175"
-scryfall_id = "f9b7d945-0c34-4576-abb0-a6e2a816c052"
 
 [token.token_image_ref]
 scryfall_id = "ef2891b2-56a0-40f4-a992-d9866451f946"
@@ -113304,11 +110208,6 @@ keywords = [
 card_name = "Manaform Hellkite"
 scryfall_oracle_id = "f426aa1a-e1dc-4563-b450-2e23d6bd980b"
 scryfall_id = "0a559655-0967-41b9-8248-170f95c05f84"
-
-[[token.source_card_refs]]
-card_name = "Manaform Hellkite"
-scryfall_oracle_id = "f426aa1a-e1dc-4563-b450-2e23d6bd980b"
-scryfall_id = "0087f7de-7065-4492-8fe9-f9a22c32a05d"
 
 [token.token_image_ref]
 scryfall_id = "44b7c73d-80a0-4a27-b0a2-317164362449"
@@ -114163,29 +111062,14 @@ colors = ["Black"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Enkira, Hostile Scavenger"
-scryfall_oracle_id = "558fd7a9-9b39-4c82-b909-5febf55dc010"
-scryfall_id = "f7cad73d-312c-4ea5-93c7-8a422b16f207"
-
-[[token.source_card_refs]]
 card_name = "Hansk, Slayer Zealot"
 scryfall_oracle_id = "d818f863-17ee-4387-94bf-d7e6e8ab590c"
 scryfall_id = "0bffb892-e5dc-413d-924e-b9bda7bf7100"
 
 [[token.source_card_refs]]
-card_name = "Hansk, Slayer Zealot"
-scryfall_oracle_id = "d818f863-17ee-4387-94bf-d7e6e8ab590c"
-scryfall_id = "f6ea7c19-71ec-44ff-affc-fc76fe3146a7"
-
-[[token.source_card_refs]]
 card_name = "Gisa's Favorite Shovel"
 scryfall_oracle_id = "9c298c7b-9c63-4a66-a0fc-977491b623c7"
 scryfall_id = "d92f06af-47bd-4ede-a174-21be69387c1b"
-
-[[token.source_card_refs]]
-card_name = "Gisa's Favorite Shovel"
-scryfall_oracle_id = "9c298c7b-9c63-4a66-a0fc-977491b623c7"
-scryfall_id = "8139bb44-47e8-4076-99ed-ad3623198ad9"
 
 [[token.source_card_refs]]
 card_name = "Enkira, Hostile Scavenger"
@@ -114310,11 +111194,6 @@ scryfall_oracle_id = "3acef3dc-61ee-48e0-9b2e-a8e29d5f4ac7"
 scryfall_id = "2632c821-513f-4059-b073-98ff691c1117"
 
 [[token.source_card_refs]]
-card_name = "Aether Channeler"
-scryfall_oracle_id = "fb220f46-f8b8-4804-baa4-e7d50b4871f7"
-scryfall_id = "d5859a42-5a82-47db-9f1d-ffe3f2b61a02"
-
-[[token.source_card_refs]]
 card_name = "Falcon and Redwing"
 scryfall_oracle_id = "0f7c7035-e395-4da5-8536-9f192d03e3ba"
 scryfall_id = "a2f3d58c-ad5c-4d1a-bda6-fbc55635e946"
@@ -114326,49 +111205,9 @@ scryfall_oracle_id = "5b8472c8-a7e7-46f2-aecf-e954082a5ef5"
 scryfall_id = "66b3f745-055b-4338-b6f0-7b7281d63afd"
 
 [[token.source_card_refs]]
-card_name = "Battle Screech"
-scryfall_oracle_id = "e73131cd-b454-405b-9539-9d777e232b9e"
-scryfall_id = "70e0261c-80a2-406d-8afe-109c87cb9c4c"
-
-[[token.source_card_refs]]
 card_name = "Emeria Angel"
 scryfall_oracle_id = "ea6616e4-db8d-4905-80f8-cb0162906850"
 scryfall_id = "9df8f833-72c2-4169-915b-ae54925b2271"
-
-[[token.source_card_refs]]
-card_name = "Jötun Owl Keeper"
-scryfall_oracle_id = "3acef3dc-61ee-48e0-9b2e-a8e29d5f4ac7"
-scryfall_id = "1566c8a2-aaca-4ce0-a36b-620ea6f135cb"
-
-[[token.source_card_refs]]
-card_name = "Scour the Desert"
-scryfall_oracle_id = "86c9e08a-397a-4c24-8f4c-48a648889399"
-scryfall_id = "d19d87ed-2b5d-4f93-a197-9d0267949e12"
-
-[[token.source_card_refs]]
-card_name = "Seller of Songbirds"
-scryfall_oracle_id = "87e4c6ff-f83f-412b-9d23-aac7a57ef6db"
-scryfall_id = "4f3b2176-958a-42e0-b88e-5b3416b40150"
-
-[[token.source_card_refs]]
-card_name = "Battle Screech"
-scryfall_oracle_id = "e73131cd-b454-405b-9539-9d777e232b9e"
-scryfall_id = "ea11071d-ac7f-453a-b24a-8ea008b9bf67"
-
-[[token.source_card_refs]]
-card_name = "Soul of Migration"
-scryfall_oracle_id = "f90ebf35-08f9-4277-92d9-75165f32a84e"
-scryfall_id = "34e0433a-e8a1-442e-93cf-93a25c1eb765"
-
-[[token.source_card_refs]]
-card_name = "Seller of Songbirds"
-scryfall_oracle_id = "87e4c6ff-f83f-412b-9d23-aac7a57ef6db"
-scryfall_id = "df84d9ce-9ff0-438a-96e1-2aadd60dcaba"
-
-[[token.source_card_refs]]
-card_name = "Battle Screech"
-scryfall_oracle_id = "e73131cd-b454-405b-9539-9d777e232b9e"
-scryfall_id = "c3c38264-0d79-47d4-bca2-a20a991bbac9"
 
 [[token.source_card_refs]]
 card_name = "Migratory Route"
@@ -114483,19 +111322,7 @@ keywords = ["Deathtouch"]
 card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
 face_name = "Garruk, the Veil-Cursed"
 scryfall_oracle_id = "7cec9021-6f25-4fd8-b40e-adf4ffd3a7b8"
-scryfall_id = "c340ad6b-aa09-4d12-a947-33b29b875158"
-
-[[token.source_card_refs]]
-card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
-face_name = "Garruk, the Veil-Cursed"
-scryfall_oracle_id = "7cec9021-6f25-4fd8-b40e-adf4ffd3a7b8"
 scryfall_id = "6897514f-e396-46d6-91e3-158366c741bb"
-
-[[token.source_card_refs]]
-card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
-face_name = "Garruk Relentless"
-scryfall_oracle_id = "7cec9021-6f25-4fd8-b40e-adf4ffd3a7b8"
-scryfall_id = "c340ad6b-aa09-4d12-a947-33b29b875158"
 
 [[token.source_card_refs]]
 card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
@@ -115145,11 +111972,6 @@ subtypes = [
 supertypes = []
 colors = ["Black"]
 keywords = ["Flying"]
-
-[[token.source_card_refs]]
-card_name = "Bitterblossom"
-scryfall_oracle_id = "fb868840-09fa-49b1-85cb-b08ad065e972"
-scryfall_id = "25dd861f-ee63-4d79-b31b-173c9c336426"
 
 [[token.source_card_refs]]
 card_name = "Bitterblossom"
@@ -116834,32 +113656,12 @@ keywords = ["Lifelink"]
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
 scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
-scryfall_id = "dcdbecfc-fc37-4327-9469-7139e16f7fbd"
-
-[[token.source_card_refs]]
-card_name = "Wurmcoil Engine"
-scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
-scryfall_id = "6927d6d4-93fe-4ded-b091-a0c671c1716b"
-
-[[token.source_card_refs]]
-card_name = "Wurmcoil Engine"
-scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
 scryfall_id = "efc01aa1-55f3-4557-a5b0-734f3b9ed050"
 
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
 scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
 scryfall_id = "5d275f04-cc60-4e3f-95cc-3d02bc916b82"
-
-[[token.source_card_refs]]
-card_name = "Wurmcoil Engine"
-scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
-scryfall_id = "219f1f03-e882-40ca-8854-1e466e37b8cd"
-
-[[token.source_card_refs]]
-card_name = "Wurmcoil Engine"
-scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
-scryfall_id = "b045a766-73ee-4109-bede-2e1d71b80f2f"
 
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
@@ -117360,21 +114162,6 @@ card_name = "Avenger of Zendikar"
 scryfall_oracle_id = "4ba5b3f6-503b-43e6-b66e-4f8c55cffed7"
 scryfall_id = "5c43add9-f948-41fe-b40c-e1d357db5f05"
 
-[[token.source_card_refs]]
-card_name = "Avenger of Zendikar"
-scryfall_oracle_id = "4ba5b3f6-503b-43e6-b66e-4f8c55cffed7"
-scryfall_id = "4b5f7be6-c30a-43f0-a371-e93a24cc5636"
-
-[[token.source_card_refs]]
-card_name = "Nissa, Voice of Zendikar"
-scryfall_oracle_id = "b0f36bf7-bdde-4576-9eca-ec02d41326ab"
-scryfall_id = "8474716e-c73e-4292-a177-7eb553ba5e76"
-
-[[token.source_card_refs]]
-card_name = "Khalni Garden"
-scryfall_oracle_id = "b2d5ba45-8674-4428-89db-c2bbbf0bf5c5"
-scryfall_id = "a1dbe0cd-46ff-4728-92e9-0cfa7cc8620a"
-
 [token.token_image_ref]
 scryfall_id = "3db07715-d315-4361-8af5-ce68d20e6c08"
 scryfall_oracle_id = "bcd346a7-4d96-4a0c-9725-fb740e32b730"
@@ -117443,11 +114230,6 @@ keywords = ["Vigilance"]
 card_name = "Brimaz, King of Oreskos"
 scryfall_oracle_id = "49471b65-be9d-4ded-b2e5-dfc81b306b54"
 scryfall_id = "25e475d2-a813-43d0-aa6b-4a16e92d7375"
-
-[[token.source_card_refs]]
-card_name = "Brimaz, King of Oreskos"
-scryfall_oracle_id = "49471b65-be9d-4ded-b2e5-dfc81b306b54"
-scryfall_id = "f2fd4bf5-7ed6-4a90-b0ba-ba886342859a"
 
 [[token.source_card_refs]]
 card_name = "Brimaz, King of Oreskos"
@@ -117670,11 +114452,6 @@ scryfall_id = "f94db3a7-ae06-494c-8af5-824dee6f23f0"
 card_name = "Tidal Wave"
 scryfall_oracle_id = "c5f5b7e5-af1e-4c8a-8d44-3e2152955d4e"
 scryfall_id = "9898c19f-7341-4be9-b592-bac884e55c84"
-
-[[token.source_card_refs]]
-card_name = "Tidal Wave"
-scryfall_oracle_id = "c5f5b7e5-af1e-4c8a-8d44-3e2152955d4e"
-scryfall_id = "49a9689b-bf1e-404e-ba08-0b04de4288fb"
 
 [token.token_image_ref]
 scryfall_id = "353aaec9-79fb-4b83-b4f4-8c7dc2a6b1c1"
@@ -118058,11 +114835,6 @@ keywords = [
     "Haste",
     "Trample",
 ]
-
-[[token.source_card_refs]]
-card_name = "Sparkspitter"
-scryfall_oracle_id = "0fbec99f-0e49-4211-a06e-edd783cf47da"
-scryfall_id = "91431126-05b3-4c2e-aff7-41c2866265f6"
 
 [[token.source_card_refs]]
 card_name = "Sparkspitter"
@@ -118989,26 +115761,6 @@ supertypes = []
 colors = ["Black"]
 keywords = ["Flying"]
 
-[[token.source_card_refs]]
-card_name = "Bitterblossom"
-scryfall_oracle_id = "fb868840-09fa-49b1-85cb-b08ad065e972"
-scryfall_id = "07ed5249-ac56-4f56-a8ca-f1808460dac6"
-
-[[token.source_card_refs]]
-card_name = "Bitterblossom"
-scryfall_oracle_id = "fb868840-09fa-49b1-85cb-b08ad065e972"
-scryfall_id = "4c2fd7bd-6528-453b-b55d-a708967b14e8"
-
-[[token.source_card_refs]]
-card_name = "Bitterblossom"
-scryfall_oracle_id = "fb868840-09fa-49b1-85cb-b08ad065e972"
-scryfall_id = "bdf9661d-b581-4496-9004-f292d9ac03ef"
-
-[[token.source_card_refs]]
-card_name = "Bitterblossom"
-scryfall_oracle_id = "fb868840-09fa-49b1-85cb-b08ad065e972"
-scryfall_id = "4d6c0dc6-ab2e-4ab5-951a-1ddd6698e80e"
-
 [token.token_image_ref]
 scryfall_id = "096cbccf-cd00-49d6-9885-54ba68667c27"
 scryfall_oracle_id = "741b9f0d-8c0d-4865-b177-fb64b687ad11"
@@ -119469,8 +116221,6 @@ id = "89078c71-1e5f-5362-b049-a34bdf309172"
 category = "Creature"
 fidelity = "Full"
 source_card_names = [
-    "Edgar Markov's Coffin",
-    "Edgar, Charmed Groom",
     "Edgar, Charmed Groom // Edgar Markov's Coffin",
     "Glass-Cast Heart",
 ]
@@ -119498,18 +116248,6 @@ keywords = ["Lifelink"]
 card_name = "Glass-Cast Heart"
 scryfall_oracle_id = "3edd6272-20fa-4c3a-bf34-2f253cc8ac9e"
 scryfall_id = "f36a4054-903c-468a-877b-0ba43a403cc1"
-
-[[token.source_card_refs]]
-card_name = "Edgar, Charmed Groom // Edgar Markov's Coffin"
-face_name = "Edgar Markov's Coffin"
-scryfall_oracle_id = "96cb97ca-4ce0-4d33-86fb-4db4ce1956be"
-scryfall_id = "78f57a41-e9a6-4f71-92a0-46c4534c8fca"
-
-[[token.source_card_refs]]
-card_name = "Edgar, Charmed Groom // Edgar Markov's Coffin"
-face_name = "Edgar, Charmed Groom"
-scryfall_oracle_id = "96cb97ca-4ce0-4d33-86fb-4db4ce1956be"
-scryfall_id = "78f57a41-e9a6-4f71-92a0-46c4534c8fca"
 
 [token.token_image_ref]
 scryfall_id = "788a024d-4945-4ac0-b29c-31a327c3b5b5"
@@ -121855,11 +118593,6 @@ scryfall_oracle_id = "3b583358-d0d5-4f53-b06c-c6439156e684"
 scryfall_id = "d4ba75be-2428-45aa-bf02-75c379a5dfa2"
 
 [[token.source_card_refs]]
-card_name = "Chandra, Gremlin Wrangler"
-scryfall_oracle_id = "486757df-23c0-4b53-97c3-c38c4eb32a56"
-scryfall_id = "d7ee8f1a-76ca-48a5-b71c-bc787cf66a09"
-
-[[token.source_card_refs]]
 card_name = "Release the Gremlins"
 scryfall_oracle_id = "3b583358-d0d5-4f53-b06c-c6439156e684"
 scryfall_id = "a2f36565-2a11-48fd-8280-feaff5b8765a"
@@ -123255,11 +119988,6 @@ keywords = ["Flying"]
 [[token.source_card_refs]]
 card_name = "Griffin Guide"
 scryfall_oracle_id = "c5323a43-82de-4340-8578-b3ffcc66f8fa"
-scryfall_id = "e19a15d9-5899-4b84-9c00-345b19df53ae"
-
-[[token.source_card_refs]]
-card_name = "Griffin Guide"
-scryfall_oracle_id = "c5323a43-82de-4340-8578-b3ffcc66f8fa"
 scryfall_id = "344c8ece-80d7-4efc-badb-985fecb11761"
 
 [[token.source_card_refs]]
@@ -123271,11 +119999,6 @@ scryfall_id = "ba8e0599-082d-4252-a579-c773466347a2"
 card_name = "Griffin Aerie"
 scryfall_oracle_id = "7cab62dc-a256-4da8-a3ea-b3903ec37077"
 scryfall_id = "2a64a64f-55d2-41e2-aa33-31daba8344c8"
-
-[[token.source_card_refs]]
-card_name = "Griffin Aerie"
-scryfall_oracle_id = "7cab62dc-a256-4da8-a3ea-b3903ec37077"
-scryfall_id = "b0c1cd62-aa6e-4120-ba70-1f12c8efe389"
 
 [token.token_image_ref]
 scryfall_id = "f20992a9-7ea7-454d-aac6-ff6928eb80b5"
@@ -123976,21 +120699,6 @@ card_name = "Sek'Kuar, Deathkeeper"
 scryfall_oracle_id = "94426127-65c2-435e-ba92-423a3c102061"
 scryfall_id = "245d86df-388d-421d-b904-d563e81727ad"
 
-[[token.source_card_refs]]
-card_name = "Sek'Kuar, Deathkeeper"
-scryfall_oracle_id = "94426127-65c2-435e-ba92-423a3c102061"
-scryfall_id = "9257bb20-de32-460c-96cf-375acb6a0b1d"
-
-[[token.source_card_refs]]
-card_name = "Balduvian Dead"
-scryfall_oracle_id = "18d6b89a-3588-43d9-a247-4747a7d784fc"
-scryfall_id = "c9aee135-65f6-4abb-b0ca-ee5ceb958a24"
-
-[[token.source_card_refs]]
-card_name = "Balduvian Dead"
-scryfall_oracle_id = "18d6b89a-3588-43d9-a247-4747a7d784fc"
-scryfall_id = "fac1875a-feab-4213-aa15-69892b7df58b"
-
 [token.token_image_ref]
 scryfall_id = "07ab0fbc-293e-4917-9792-fdc9b512713d"
 scryfall_oracle_id = "3b2ccc79-67d6-437d-9696-fbd887c7d8b6"
@@ -124547,11 +121255,6 @@ scryfall_id = "372d0c0b-439c-413f-aac4-5174c75aadb0"
 [[token.source_card_refs]]
 card_name = "Big Score"
 scryfall_oracle_id = "a5cbd257-c836-493e-bb1a-76242619dea2"
-scryfall_id = "c7b698a1-dff1-413f-ba4f-0298c686999a"
-
-[[token.source_card_refs]]
-card_name = "Big Score"
-scryfall_oracle_id = "a5cbd257-c836-493e-bb1a-76242619dea2"
 scryfall_id = "8b2699d2-2057-4fbf-8e52-736fcfe2759d"
 
 [[token.source_card_refs]]
@@ -124981,35 +121684,15 @@ colors = ["White"]
 keywords = ["Vigilance"]
 
 [[token.source_card_refs]]
-card_name = "Valorous Steed"
-scryfall_oracle_id = "4b5f30a6-b0fb-4dcb-85d5-1db1bba73737"
-scryfall_id = "637c80b7-6cbb-4f3f-b279-55048b90ad1c"
-
-[[token.source_card_refs]]
 card_name = "Virtue of Loyalty // Ardenvale Fealty"
 face_name = "Virtue of Loyalty"
 scryfall_oracle_id = "f61f4307-4eec-476a-97e5-d4d3da2b54c3"
 scryfall_id = "ea7e7daf-7c06-4c74-8bcf-e42c1f611861"
 
 [[token.source_card_refs]]
-card_name = "Knightly Valor"
-scryfall_oracle_id = "9ba6cec6-97bf-4a83-9ffa-77e187d0945b"
-scryfall_id = "844b8b36-6c45-445c-92a3-f1058669d66a"
-
-[[token.source_card_refs]]
-card_name = "Selesnya Charm"
-scryfall_oracle_id = "a1a49639-bcc4-4522-8862-c9fb13d40880"
-scryfall_id = "f616ef56-51ed-47d2-910c-fa4e0bca0823"
-
-[[token.source_card_refs]]
 card_name = "Selesnya Charm"
 scryfall_oracle_id = "a1a49639-bcc4-4522-8862-c9fb13d40880"
 scryfall_id = "30284c06-4477-4dde-8b28-9646324303d5"
-
-[[token.source_card_refs]]
-card_name = "Knightly Valor"
-scryfall_oracle_id = "9ba6cec6-97bf-4a83-9ffa-77e187d0945b"
-scryfall_id = "39232813-d1d5-402f-a0c8-92acbf72ff51"
 
 [[token.source_card_refs]]
 card_name = "Lonesome Unicorn // Rider in Need"
@@ -125034,35 +121717,15 @@ scryfall_oracle_id = "9ba6cec6-97bf-4a83-9ffa-77e187d0945b"
 scryfall_id = "5ca1bf37-b372-400d-ba2d-3d456bcec393"
 
 [[token.source_card_refs]]
-card_name = "Gallant Cavalry"
-scryfall_oracle_id = "b500c460-2814-47a4-b307-17ca519f3565"
-scryfall_id = "38f370a9-1401-4018-bbd3-0a8737f9fbea"
-
-[[token.source_card_refs]]
 card_name = "Valorous Steed"
 scryfall_oracle_id = "4b5f30a6-b0fb-4dcb-85d5-1db1bba73737"
 scryfall_id = "19e8e7dd-4bbb-48a7-9427-f7557d670f74"
-
-[[token.source_card_refs]]
-card_name = "Knightly Valor"
-scryfall_oracle_id = "9ba6cec6-97bf-4a83-9ffa-77e187d0945b"
-scryfall_id = "c6f463b5-188f-4ecc-8cbf-0f200515bb09"
-
-[[token.source_card_refs]]
-card_name = "Basri's Lieutenant"
-scryfall_oracle_id = "57d0c688-6206-4c83-9fcb-27fd29e2a9ed"
-scryfall_id = "d38f37d7-4aa7-43bf-ad15-9a8a31d42594"
 
 [[token.source_card_refs]]
 card_name = "Lonesome Unicorn // Rider in Need"
 face_name = "Rider in Need"
 scryfall_oracle_id = "c8f6cc1f-b7e4-470d-8d48-ef848d7c1116"
 scryfall_id = "68fe8de1-8c3b-4e05-9d4a-67d979184980"
-
-[[token.source_card_refs]]
-card_name = "The Circle of Loyalty"
-scryfall_oracle_id = "fd1b4523-2399-4771-89bf-1d65f5d67056"
-scryfall_id = "29a37ed7-223e-4e19-b318-83cac54f6b16"
 
 [[token.source_card_refs]]
 card_name = "Virtue of Loyalty // Ardenvale Fealty"
@@ -125499,17 +122162,7 @@ keywords = ["Flying"]
 [[token.source_card_refs]]
 card_name = "Archon of Sun's Grace"
 scryfall_oracle_id = "48a99dce-0aa9-4aac-81df-cec5f94c639d"
-scryfall_id = "895da74d-26ce-4e0c-baef-6eabc40bf0de"
-
-[[token.source_card_refs]]
-card_name = "Archon of Sun's Grace"
-scryfall_oracle_id = "48a99dce-0aa9-4aac-81df-cec5f94c639d"
 scryfall_id = "0d3af89d-d22c-45e8-9fec-170ac9bb0a34"
-
-[[token.source_card_refs]]
-card_name = "Archon of Sun's Grace"
-scryfall_oracle_id = "48a99dce-0aa9-4aac-81df-cec5f94c639d"
-scryfall_id = "5c3f9a15-02ee-4d83-ab4c-6cec9071b841"
 
 [token.token_image_ref]
 scryfall_id = "f130171f-a3e2-4dac-806a-1f2c428ac9fc"
@@ -126375,11 +123028,6 @@ card_name = "Timeless Witness"
 scryfall_oracle_id = "a52a06aa-56fc-4845-bbcd-a54f16369b34"
 scryfall_id = "8b63ec86-670b-4acd-b14c-3d90acbde087"
 
-[[token.source_card_refs]]
-card_name = "Timeless Witness"
-scryfall_oracle_id = "a52a06aa-56fc-4845-bbcd-a54f16369b34"
-scryfall_id = "3483a95e-1b06-4973-a0f7-ff5b5f9c0e79"
-
 [token.token_image_ref]
 scryfall_id = "0902163b-9a92-4df3-afdd-396db24c7fd4"
 scryfall_oracle_id = "e292b492-1918-4c92-af43-3bfbe39dcea4"
@@ -126846,11 +123494,6 @@ scryfall_oracle_id = "e6f59807-eaf6-4889-8c89-2ac915afefff"
 scryfall_id = "fab7646a-61e8-446b-9dba-ac6e0db82f10"
 
 [[token.source_card_refs]]
-card_name = "Smothering Tithe"
-scryfall_oracle_id = "153376c9-dffd-458c-8ce3-a4c8269bc4e9"
-scryfall_id = "58178dd4-c61e-4017-b2e6-2d8308ded4fd"
-
-[[token.source_card_refs]]
 card_name = "Discerning Financier"
 scryfall_oracle_id = "734a5186-caa6-4811-b6d7-91b7b32fc403"
 scryfall_id = "584774b5-640f-45e0-810b-f5faf119645b"
@@ -126860,11 +123503,6 @@ card_name = "Decadent Dragon // Expensive Taste"
 face_name = "Decadent Dragon"
 scryfall_oracle_id = "5df44b8d-b337-49d8-8427-34253f52cb47"
 scryfall_id = "8a717d27-596d-4341-b592-4f9777f778e5"
-
-[[token.source_card_refs]]
-card_name = "Smothering Tithe"
-scryfall_oracle_id = "153376c9-dffd-458c-8ce3-a4c8269bc4e9"
-scryfall_id = "f6c69c2f-729b-49ed-909d-57190a728e11"
 
 [[token.source_card_refs]]
 card_name = "Redcap Thief"
@@ -126881,11 +123519,6 @@ scryfall_id = "315cbbf7-a2ad-4565-9877-1e903d7fd797"
 card_name = "Charming Scoundrel"
 scryfall_oracle_id = "9eec304d-ffcb-4287-b877-280ac1e4f496"
 scryfall_id = "c8090bcf-e17a-4110-a518-77ccd045b18f"
-
-[[token.source_card_refs]]
-card_name = "Smothering Tithe"
-scryfall_oracle_id = "153376c9-dffd-458c-8ce3-a4c8269bc4e9"
-scryfall_id = "a095e47e-8f02-45cf-a9d2-677fe171258d"
 
 [token.token_image_ref]
 scryfall_id = "73cbf189-a79b-4dca-8b29-33aef6306b5a"
@@ -128506,11 +125139,6 @@ scryfall_oracle_id = "b9176173-c4a1-45ae-8f34-bd6b31c141fe"
 scryfall_id = "90eaf94e-85a7-4958-aa58-8e2fe44db58d"
 
 [[token.source_card_refs]]
-card_name = "Oketra the True"
-scryfall_oracle_id = "646e68c8-cc42-4d6c-8363-a18b10a10eae"
-scryfall_id = "b3aa8c17-e37e-430e-a940-d016c4ab5852"
-
-[[token.source_card_refs]]
 card_name = "Supply Caravan"
 scryfall_oracle_id = "1abcfe8d-4beb-4910-b353-1227e1256329"
 scryfall_id = "d247bd88-9593-462c-8f9e-28e29c064c10"
@@ -129136,11 +125764,6 @@ subtypes = [
 supertypes = []
 colors = ["Red"]
 keywords = ["Prowess"]
-
-[[token.source_card_refs]]
-card_name = "Goblin Wizardry"
-scryfall_oracle_id = "f621dcaa-c500-4a17-a65a-60d9b5516a3b"
-scryfall_id = "04d250d6-7ab1-4b30-85a4-acb0b620629c"
 
 [[token.source_card_refs]]
 card_name = "Goblin Wizardry"
@@ -131639,21 +128262,6 @@ card_name = "Heroic Reinforcements"
 scryfall_oracle_id = "c442e8b0-a0a4-4839-8049-125b91b15c99"
 scryfall_id = "6a05e8d5-c2ad-489a-888d-22622886b620"
 
-[[token.source_card_refs]]
-card_name = "Raise the Alarm"
-scryfall_oracle_id = "5b2364d7-a811-4595-a1b4-224c70555ffa"
-scryfall_id = "81d3e5c5-6531-48e7-9dd6-2db519dd61b1"
-
-[[token.source_card_refs]]
-card_name = "Ancestral Blade"
-scryfall_oracle_id = "ab28a801-6ab1-4db2-8ae2-c24bb4c10ebb"
-scryfall_id = "7902956b-8d64-4320-89b0-6f369ce1f410"
-
-[[token.source_card_refs]]
-card_name = "Memorial to Glory"
-scryfall_oracle_id = "eb8ec34c-ae07-4a09-940f-ee965146a787"
-scryfall_id = "edad3735-0cf3-471d-9731-8118aa4dce68"
-
 [token.token_image_ref]
 scryfall_id = "d093322e-a717-4e2d-8199-fa560792bcf6"
 scryfall_oracle_id = "eac25f12-6459-438c-a09e-93e23d2cf80d"
@@ -131974,13 +128582,11 @@ source_card_names = [
     "Hero of Precinct One",
     "Increasing Devotion",
     "Inquisitive Puppet",
-    "Jerren, Corrupted Bishop",
     "Jerren, Corrupted Bishop // Ormendahl, the Corrupter",
     "Join the Dance",
     "Kharis & The Beholder",
     "Lovestruck Beast // Heart's Desire",
     "Oakhame Ranger // Bring Back",
-    "Ormendahl, the Corrupter",
     "Rally for the Throne",
     "Return from the Wilds",
     "Slaughter Specialist",
@@ -131990,9 +128596,7 @@ source_card_names = [
     "Visions of Glory",
     "Voice of the Provinces",
     "Watchful Giant",
-    "Wedding Announcement",
     "Wedding Announcement // Wedding Festivity",
-    "Wedding Festivity",
     "Welcome to Sweettooth",
     "Worthy Knight",
 ]
@@ -132018,72 +128622,9 @@ scryfall_oracle_id = "9a107e48-3d50-4941-95b1-10f2b29a4245"
 scryfall_id = "b000f605-177f-459d-a197-fcf54efec2fb"
 
 [[token.source_card_refs]]
-card_name = "Jerren, Corrupted Bishop // Ormendahl, the Corrupter"
-face_name = "Ormendahl, the Corrupter"
-scryfall_oracle_id = "20d0df30-013c-47c0-b70b-d628d427d30b"
-scryfall_id = "439d4cd6-afca-46d3-8850-898cb9212a26"
-
-[[token.source_card_refs]]
-card_name = "Adeline, Resplendent Cathar"
-scryfall_oracle_id = "38515f89-348b-4cf3-b7bd-1f6fe4ce2fba"
-scryfall_id = "0b9579d8-bc8f-4d74-bfc1-dcdd42568f79"
-
-[[token.source_card_refs]]
-card_name = "Stroke of Midnight"
-scryfall_oracle_id = "9a107e48-3d50-4941-95b1-10f2b29a4245"
-scryfall_id = "711135d0-7769-4154-873a-e2505f8795f0"
-
-[[token.source_card_refs]]
 card_name = "Voice of the Provinces"
 scryfall_oracle_id = "81b15ed1-7069-4f8b-96b9-f6d67298afef"
 scryfall_id = "c2599730-fc82-468b-bb5c-7e722dbabbe7"
-
-[[token.source_card_refs]]
-card_name = "Voice of the Provinces"
-scryfall_oracle_id = "81b15ed1-7069-4f8b-96b9-f6d67298afef"
-scryfall_id = "30a78066-c52e-48fd-bcf9-d0b60f00fddc"
-
-[[token.source_card_refs]]
-card_name = "Dawnhart Mentor"
-scryfall_oracle_id = "e12fb44a-524e-4603-a89c-fad8204fdb2b"
-scryfall_id = "d0c50047-013f-4a14-8cdd-08c6d5b89e8b"
-
-[[token.source_card_refs]]
-card_name = "Adeline, Resplendent Cathar"
-scryfall_oracle_id = "38515f89-348b-4cf3-b7bd-1f6fe4ce2fba"
-scryfall_id = "9c5743e9-7fae-483a-b591-496afdd905f2"
-
-[[token.source_card_refs]]
-card_name = "Cathar's Call"
-scryfall_oracle_id = "433e92d2-899a-4eed-98b9-80de5d25494b"
-scryfall_id = "8e9721c2-ca45-452b-9694-16cc8651a35b"
-
-[[token.source_card_refs]]
-card_name = "Kharis & The Beholder"
-scryfall_oracle_id = "329f84dd-889c-4d03-a0bb-d96712ebcad8"
-scryfall_id = "8dd4d771-366c-4d81-875d-7ba9f1f00320"
-
-[[token.source_card_refs]]
-card_name = "Clarion Cathars"
-scryfall_oracle_id = "193f9b12-ee34-40c2-9315-6794416a4f62"
-scryfall_id = "3937d712-e944-4540-bc38-812096977059"
-
-[[token.source_card_refs]]
-card_name = "Wedding Announcement // Wedding Festivity"
-face_name = "Wedding Festivity"
-scryfall_oracle_id = "259ac30c-cc05-4c04-9b23-71283f84b808"
-scryfall_id = "f56277ed-1c80-48c8-8fe0-e2e3a05e7caf"
-
-[[token.source_card_refs]]
-card_name = "Cemetery Protector"
-scryfall_oracle_id = "34c8fffd-1b23-4f40-ad29-1f0acb519e7e"
-scryfall_id = "efde8248-90ad-46ae-968d-9c6b252fa2a2"
-
-[[token.source_card_refs]]
-card_name = "Wedding Announcement // Wedding Festivity"
-face_name = "Wedding Announcement"
-scryfall_oracle_id = "259ac30c-cc05-4c04-9b23-71283f84b808"
-scryfall_id = "f56277ed-1c80-48c8-8fe0-e2e3a05e7caf"
 
 [[token.source_card_refs]]
 card_name = "Castle Ardenvale"
@@ -132091,30 +128632,9 @@ scryfall_oracle_id = "f8f4fc60-725d-46d8-8e8f-e68e00d20589"
 scryfall_id = "65e4de2e-47d2-4967-be31-9df0057a9c74"
 
 [[token.source_card_refs]]
-card_name = "Sunset Revelry"
-scryfall_oracle_id = "65779f3b-7fc5-4847-99d7-78f697d34c3d"
-scryfall_id = "b982565f-f2ca-453d-99f6-9560123f7448"
-
-[[token.source_card_refs]]
-card_name = "Join the Dance"
-scryfall_oracle_id = "d8fc015c-7e6d-441d-bbeb-98ca74b21314"
-scryfall_id = "d403fbce-132a-41d2-b3ed-82420d14ed55"
-
-[[token.source_card_refs]]
 card_name = "Join the Dance"
 scryfall_oracle_id = "d8fc015c-7e6d-441d-bbeb-98ca74b21314"
 scryfall_id = "e6dde9fc-def0-422f-94d0-e6d09101d543"
-
-[[token.source_card_refs]]
-card_name = "Slaughter Specialist"
-scryfall_oracle_id = "ab431f93-73bb-49d9-9321-a0712f096ed7"
-scryfall_id = "18386c30-b2c1-41b4-a3a6-90493d1c9c2d"
-
-[[token.source_card_refs]]
-card_name = "Jerren, Corrupted Bishop // Ormendahl, the Corrupter"
-face_name = "Jerren, Corrupted Bishop"
-scryfall_oracle_id = "20d0df30-013c-47c0-b70b-d628d427d30b"
-scryfall_id = "439d4cd6-afca-46d3-8850-898cb9212a26"
 
 [[token.source_card_refs]]
 card_name = "Adeline, Resplendent Cathar"
@@ -133125,11 +129645,6 @@ keywords = []
 card_name = "Labyrinth Guardian"
 scryfall_oracle_id = "867ee3e7-88df-4e4b-b199-f441a8460573"
 scryfall_id = "132c19f0-3b75-49a9-b3a9-501031fe3f50"
-
-[[token.source_card_refs]]
-card_name = "Labyrinth Guardian"
-scryfall_oracle_id = "867ee3e7-88df-4e4b-b199-f441a8460573"
-scryfall_id = "38013d49-a9cd-4398-bb6f-f985ec81301d"
 
 [[token.source_card_refs]]
 card_name = "Labyrinth Guardian"
@@ -134958,11 +131473,6 @@ card_name = "Rampaging Baloths"
 scryfall_oracle_id = "2d3e6549-6cc6-434f-a189-ba3b55e64c34"
 scryfall_id = "c25ee47b-d099-4788-9c2b-73d151bf56fb"
 
-[[token.source_card_refs]]
-card_name = "Somberwald Beastmaster"
-scryfall_oracle_id = "df35bf19-4cbf-4624-925d-ceca6bff596e"
-scryfall_id = "6488d613-59fa-4e26-a48c-eecab8754808"
-
 [token.token_image_ref]
 scryfall_id = "21bd6fb3-f60c-49cc-8854-6a20a1e1d9c7"
 scryfall_oracle_id = "695b14a0-920a-47bd-bd4a-7989862cdd0a"
@@ -135364,11 +131874,6 @@ scryfall_id = "b30fd369-68db-41f1-bb1e-eabfe4eb5356"
 card_name = "Dreadhorde Invasion"
 scryfall_oracle_id = "01deabbb-af6a-4998-99a7-35b7cfa9ef77"
 scryfall_id = "ccd2fc83-7fbe-45c4-a5f3-18a105ce6f09"
-
-[[token.source_card_refs]]
-card_name = "Lazotep Chancellor"
-scryfall_oracle_id = "c3e67b8f-1c91-4a2f-b924-35bbaff4bab9"
-scryfall_id = "2583c3c4-4238-4136-9020-37d46bff73d0"
 
 [[token.source_card_refs]]
 card_name = "Angrath, Captain of Chaos"
@@ -136114,11 +132619,7 @@ preset_id = "99859c93-5f3d-5dc3-ace1-f8c1802706f8"
 id = "99a2d3f7-bda1-5a31-8a8f-c11d0c7a2437"
 category = "Creature"
 fidelity = "Full"
-source_card_names = [
-    "Development",
-    "Research",
-    "Research // Development",
-]
+source_card_names = ["Research // Development"]
 set_code = "C20"
 set_name = "Commander 2020"
 collector_number = "10"
@@ -136134,18 +132635,6 @@ subtypes = ["Elemental"]
 supertypes = []
 colors = ["Red"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Research // Development"
-face_name = "Development"
-scryfall_oracle_id = "fa38394b-6ac4-460c-ae3a-54d50037715b"
-scryfall_id = "5d48ee48-aaeb-4907-b9dc-32f22e95ae4c"
-
-[[token.source_card_refs]]
-card_name = "Research // Development"
-face_name = "Research"
-scryfall_oracle_id = "fa38394b-6ac4-460c-ae3a-54d50037715b"
-scryfall_id = "5d48ee48-aaeb-4907-b9dc-32f22e95ae4c"
 
 [token.token_image_ref]
 scryfall_id = "9d952cde-4b40-4a05-833e-029da3554c6d"
@@ -137065,11 +133554,6 @@ scryfall_oracle_id = "2e18ee5b-cda3-428b-be91-939c410256ac"
 scryfall_id = "f082111b-9b1c-4a25-8c5d-d6ef77533a9b"
 
 [[token.source_card_refs]]
-card_name = "Conservatory"
-scryfall_oracle_id = "8f88b0bf-81bd-4223-9dad-d8c49ff4b87a"
-scryfall_id = "8bab22c5-4742-4f2e-bda1-26c72b09cd9c"
-
-[[token.source_card_refs]]
 card_name = "Morska, Undersea Sleuth"
 scryfall_oracle_id = "80ea3e65-946d-42c3-a26f-3d74e81d70b4"
 scryfall_id = "d6e8a859-92bf-452e-bcc2-3975bf1d6217"
@@ -137113,11 +133597,6 @@ scryfall_id = "e8578839-046f-4afd-a0e7-4737ded9e6eb"
 card_name = "Follow the Bodies"
 scryfall_oracle_id = "2d6a0d89-7ebd-420e-9892-be1506ab3714"
 scryfall_id = "387f3f54-d26c-4b2c-ab8b-8bdba0b11b1a"
-
-[[token.source_card_refs]]
-card_name = "Syndicate Heavy"
-scryfall_oracle_id = "01becf76-aa53-4fd5-94c1-665c64674219"
-scryfall_id = "251e36f1-1bfd-4c04-8c61-1c2bc18beb8a"
 
 [[token.source_card_refs]]
 card_name = "No Witnesses"
@@ -137166,11 +133645,6 @@ scryfall_oracle_id = "2d16d51b-47e0-4cdc-83dd-a805ba50bd83"
 scryfall_id = "aabfada0-3c1b-4237-b06c-573071ccd68d"
 
 [[token.source_card_refs]]
-card_name = "Secret Passage"
-scryfall_oracle_id = "c6a46fc2-fc8f-4dcd-bca7-682abfbf303d"
-scryfall_id = "6b35ede8-e882-46fd-9eda-9d6f64c73ea1"
-
-[[token.source_card_refs]]
 card_name = "Confirm Suspicions"
 scryfall_oracle_id = "a30d076b-c942-45e4-b943-3749ce955291"
 scryfall_id = "1d1463af-8f22-4771-af19-3799ffe706b8"
@@ -137205,11 +133679,6 @@ scryfall_id = "c1500cbf-5619-465e-a97b-75e676ce789b"
 card_name = "Erdwal Illuminator"
 scryfall_oracle_id = "5ff4ef34-acb9-46c3-8530-f4b093807066"
 scryfall_id = "5c39fa19-ca75-49f4-8e1e-8b59bc9b664a"
-
-[[token.source_card_refs]]
-card_name = "Dining Room"
-scryfall_oracle_id = "0880461e-8943-443b-90e7-ff84eef46550"
-scryfall_id = "1bf8dcb2-6fe7-4ab3-b290-fb427d116c74"
 
 [[token.source_card_refs]]
 card_name = "Teysa, Opulent Oligarch"
@@ -137272,11 +133741,6 @@ scryfall_oracle_id = "4ec0b64d-c793-47a6-9c26-9ad4d9e9c182"
 scryfall_id = "32a701da-47d6-4c85-a428-adeb4a20678d"
 
 [[token.source_card_refs]]
-card_name = "Ballroom"
-scryfall_oracle_id = "cb91e842-9f06-4863-a328-2cabe1bcfe27"
-scryfall_id = "6e982bf8-382f-4987-bc39-28e1ce290340"
-
-[[token.source_card_refs]]
 card_name = "Alquist Proft, Master Sleuth"
 scryfall_oracle_id = "dd79a994-7dad-49d4-8d8f-62dbedde4a38"
 scryfall_id = "e528424e-a3b1-4902-b42d-1ba9ac412e73"
@@ -137285,11 +133749,6 @@ scryfall_id = "e528424e-a3b1-4902-b42d-1ba9ac412e73"
 card_name = "Merchant of Truth"
 scryfall_oracle_id = "84275aab-f718-4896-b61c-63bf49fb483b"
 scryfall_id = "0f47e29e-54c5-4b1a-b9b9-d5e267a0203a"
-
-[[token.source_card_refs]]
-card_name = "Lavinia, Foil to Conspiracy"
-scryfall_oracle_id = "b5b26cea-9be3-46f7-9603-a6eee0dd107e"
-scryfall_id = "1f1b47ed-e935-44a4-b654-a32c0bf5dd19"
 
 [[token.source_card_refs]]
 card_name = "Novice Inspector"
@@ -137320,11 +133779,6 @@ scryfall_id = "7cbb17af-e17e-438a-ad72-0c942e6706b6"
 card_name = "Foreboding Steamboat"
 scryfall_oracle_id = "d97a0e41-9dd7-4466-afb7-3d8bd6cd0eed"
 scryfall_id = "dc8f50a0-d5a2-46c1-8f09-4c43f174dca7"
-
-[[token.source_card_refs]]
-card_name = "Lavinia, Foil to Conspiracy"
-scryfall_oracle_id = "b5b26cea-9be3-46f7-9603-a6eee0dd107e"
-scryfall_id = "d5435866-d48b-496a-ba07-438163b71ae8"
 
 [[token.source_card_refs]]
 card_name = "Torch the Witness"
@@ -137367,16 +133821,6 @@ scryfall_oracle_id = "dc4d5602-47cb-47c8-8a43-3b840e12b79c"
 scryfall_id = "21d6accd-167a-4b21-a488-44d54cdfa608"
 
 [[token.source_card_refs]]
-card_name = "Billiard Room"
-scryfall_oracle_id = "a4fc174e-7fa6-41a8-ae03-255f226840f9"
-scryfall_id = "dc2a3de1-01ac-4425-8534-e5019e01f2cd"
-
-[[token.source_card_refs]]
-card_name = "Lounge"
-scryfall_oracle_id = "98a22879-d0b2-441f-bcf6-a67b4552b73c"
-scryfall_id = "4b197079-488d-47c6-a494-8baf36c48667"
-
-[[token.source_card_refs]]
 card_name = "Sharp-Eyed Rookie"
 scryfall_oracle_id = "0642fb0d-73cb-4989-852c-3233fe36c3b4"
 scryfall_id = "be2b1b18-179d-48e1-ab8a-9374eb1ae429"
@@ -137407,19 +133851,9 @@ scryfall_oracle_id = "0232418d-1c52-4573-b488-c62345ca1c8d"
 scryfall_id = "08877e2c-79ac-4a4d-a7dd-60652c5eb5f6"
 
 [[token.source_card_refs]]
-card_name = "Resonance Technician"
-scryfall_oracle_id = "ec8a4b26-633a-4e88-aa8a-82e9704b3439"
-scryfall_id = "1e7c9ff3-9db9-41c0-9c8b-067e694973c5"
-
-[[token.source_card_refs]]
 card_name = "They Went This Way"
 scryfall_oracle_id = "47951720-9584-4ca3-a73d-3d259102b2f8"
 scryfall_id = "f4a31d4a-34bc-46b4-b20f-a5460191b35d"
-
-[[token.source_card_refs]]
-card_name = "Study"
-scryfall_oracle_id = "7ffadb3f-0b88-416f-b1a1-876383c22720"
-scryfall_id = "c694bc39-3eae-4b40-8f85-34785f9e75f1"
 
 [[token.source_card_refs]]
 card_name = "Kellan, Inquisitive Prodigy // Tail the Suspect"
@@ -137448,11 +133882,6 @@ scryfall_oracle_id = "b401179f-eded-4973-8182-df4627133886"
 scryfall_id = "6c134956-ba18-415e-b101-c1254415ea04"
 
 [[token.source_card_refs]]
-card_name = "Hall"
-scryfall_oracle_id = "949e455d-6a9e-491a-892f-826cc8be0fd9"
-scryfall_id = "ab3d0e50-630a-4ccc-aa79-1db912ea801e"
-
-[[token.source_card_refs]]
 card_name = "Chalk Outline"
 scryfall_oracle_id = "af335eb3-f60a-44b3-a1ed-1e165f3e3605"
 scryfall_id = "b3ff56c1-4153-4e15-9ac6-06d93fa2ae50"
@@ -137476,11 +133905,6 @@ scryfall_id = "9daf962d-f48d-4c93-98d1-ec32d3c758a1"
 card_name = "Deduce"
 scryfall_oracle_id = "eeae4161-9f35-45df-8b3c-c55e37f49cd1"
 scryfall_id = "5ad92dbd-828e-425f-8cab-819a04ea9020"
-
-[[token.source_card_refs]]
-card_name = "Kitchen"
-scryfall_oracle_id = "47f71408-5509-4651-9121-fd0867adae00"
-scryfall_id = "4388ae8f-a2c4-4e0d-a6a1-0204ff3f469b"
 
 [[token.source_card_refs]]
 card_name = "Flotsam // Jetsam"
@@ -137515,11 +133939,6 @@ scryfall_oracle_id = "24038629-7c12-45ef-8ec4-0d2bb3e2265c"
 scryfall_id = "c675428b-2dc4-408d-9632-81c1a700090f"
 
 [[token.source_card_refs]]
-card_name = "Library"
-scryfall_oracle_id = "33a7d29a-ebc0-4606-91b6-7381e2a16016"
-scryfall_id = "442cf173-8042-40fa-98d6-6ca93caa3e03"
-
-[[token.source_card_refs]]
 card_name = "Loxodon Eavesdropper"
 scryfall_oracle_id = "141a2757-8f20-4e10-9866-bb5d612ed62d"
 scryfall_id = "bbbf8c3a-6c74-42fd-bb8d-61e3f0a77848"
@@ -137550,11 +133969,6 @@ scryfall_oracle_id = "d4f5748f-bb0e-4c48-8802-45a7ad5a80a4"
 scryfall_id = "ba0870d4-b5b8-4fd7-a21b-417f832e0d7e"
 
 [[token.source_card_refs]]
-card_name = "Carnage Interpreter"
-scryfall_oracle_id = "4bc79fb3-81bb-42ed-9bbb-93f8cede3094"
-scryfall_id = "f6fb576e-a4a4-496b-b553-3f81cc651210"
-
-[[token.source_card_refs]]
 card_name = "Wojek Investigator"
 scryfall_oracle_id = "ab41243d-b178-4ebe-a7ac-bea37427be99"
 scryfall_id = "58eccc85-bdfe-48f4-a79e-76d9ef122815"
@@ -137579,11 +133993,6 @@ scryfall_id = "66660f7c-9e1c-4e88-856a-98fab1f1364d"
 card_name = "Homicide Investigator"
 scryfall_oracle_id = "dc4d5602-47cb-47c8-8a43-3b840e12b79c"
 scryfall_id = "b9106abf-f589-48a2-90f8-d606a7367377"
-
-[[token.source_card_refs]]
-card_name = "Lonis, Genetics Expert"
-scryfall_oracle_id = "52d8e492-b7b7-4ad4-8f1f-5c50993e55e0"
-scryfall_id = "59813845-48c9-4af2-8beb-91d58aac09ee"
 
 [[token.source_card_refs]]
 card_name = "Lazav, Wearer of Faces"
@@ -137828,11 +134237,6 @@ scryfall_oracle_id = "91b2520e-85b6-4e1f-88cf-a585feeb8e65"
 scryfall_id = "5524b712-c67d-4d2e-9344-9e85a6ce3227"
 
 [[token.source_card_refs]]
-card_name = "Krenko's Command"
-scryfall_oracle_id = "9cfe86ae-eebe-44aa-a956-4b3e9e621105"
-scryfall_id = "b07d96a1-87a0-45ff-ae6e-230deaf44dca"
-
-[[token.source_card_refs]]
 card_name = "A Killer Among Us"
 scryfall_oracle_id = "79d577a8-53c0-4220-bc0e-70764d72d5fd"
 scryfall_id = "2c1392c5-91a5-4e6e-803d-ed032e4d594b"
@@ -137964,11 +134368,6 @@ scryfall_id = "c77d9454-a78c-4063-ad66-46b2f5a030aa"
 card_name = "Kasmina, Enigmatic Mentor"
 scryfall_oracle_id = "df561b38-fe2a-4db9-a9d4-ec25b1c7572a"
 scryfall_id = "bf793e51-1e92-41ab-8516-dd78df5e1ca0"
-
-[[token.source_card_refs]]
-card_name = "Kasmina, Enigmatic Mentor"
-scryfall_oracle_id = "df561b38-fe2a-4db9-a9d4-ec25b1c7572a"
-scryfall_id = "ca2b53e2-aa6a-4cb2-899c-8e022e822ffc"
 
 [[token.source_card_refs]]
 card_name = "Kasmina, Enigmatic Mentor"
@@ -138410,44 +134809,9 @@ scryfall_oracle_id = "c1624d10-8838-4af8-aea1-a96c0fe6fd6b"
 scryfall_id = "a241317d-2277-467e-a8f9-aa71c944e244"
 
 [[token.source_card_refs]]
-card_name = "Dire Fleet Hoarder"
-scryfall_oracle_id = "7d48ad95-d428-4e2d-b697-56907c3ce579"
-scryfall_id = "9cd2e253-db7c-4c34-8cd5-8aca28752a60"
-
-[[token.source_card_refs]]
-card_name = "Grim Bounty"
-scryfall_oracle_id = "8060dc97-9868-4846-85f4-0ef70da2b021"
-scryfall_id = "eb485579-49c4-4834-9fba-a8ae2dde86e9"
-
-[[token.source_card_refs]]
-card_name = "Shambling Ghast"
-scryfall_oracle_id = "e5e6229a-3422-4afd-9a87-86daa2d31d3a"
-scryfall_id = "856e95de-792d-478a-91cf-fe0df549abdb"
-
-[[token.source_card_refs]]
-card_name = "Fake Your Own Death"
-scryfall_oracle_id = "ad01df89-29fe-44c7-a133-91425f8ff09c"
-scryfall_id = "271ac37f-305c-4918-8761-1779caa19f36"
-
-[[token.source_card_refs]]
 card_name = "Rapacious Dragon"
 scryfall_oracle_id = "0944ec2e-1dd9-459f-8f1d-667242cf52fe"
 scryfall_id = "5eaddac1-d8ca-4949-8140-c9193e3df921"
-
-[[token.source_card_refs]]
-card_name = "Prosperous Thief"
-scryfall_oracle_id = "6d03971a-8365-449a-8fbe-07b5b9bb42dc"
-scryfall_id = "5dea029b-ffc9-49d1-925c-b55a944d3439"
-
-[[token.source_card_refs]]
-card_name = "Pitiless Plunderer"
-scryfall_oracle_id = "a784481f-eccb-4112-bb38-04a659319660"
-scryfall_id = "1ac61e84-94d6-4ff7-a00f-29de93f09a38"
-
-[[token.source_card_refs]]
-card_name = "Undercity Scrounger"
-scryfall_oracle_id = "2750451f-348e-452f-88d0-bc921c46e8cc"
-scryfall_id = "ad8f033f-2626-44f0-b549-f0b2777731c3"
 
 [[token.source_card_refs]]
 card_name = "Involuntary Employment"
@@ -138465,39 +134829,9 @@ scryfall_oracle_id = "234a734b-ba28-4f1b-9d01-3c3e7d516590"
 scryfall_id = "a829747f-cf9b-4d81-ba66-9f0630ed4565"
 
 [[token.source_card_refs]]
-card_name = "Rev, Tithe Extractor"
-scryfall_oracle_id = "8345eb05-c04e-4c1d-9776-5ab7d91a7842"
-scryfall_id = "8bf88010-799d-4217-8e79-308bec7ad2ff"
-
-[[token.source_card_refs]]
-card_name = "Thieves' Tools"
-scryfall_oracle_id = "7fe361ef-a168-4847-92a2-21c1661aac06"
-scryfall_id = "7c3faae3-a117-4d59-bc19-c85ceffe6021"
-
-[[token.source_card_refs]]
 card_name = "Gleaming Barrier"
 scryfall_oracle_id = "1eb9e401-8975-447b-839d-f7cd23897465"
 scryfall_id = "1b49b009-e6f2-494a-9235-f5c25c2d70a9"
-
-[[token.source_card_refs]]
-card_name = "Ruthless Technomancer"
-scryfall_oracle_id = "4e58ad76-37c7-4531-b207-6890b39a2679"
-scryfall_id = "5a9832da-b790-47a7-b19a-360e5f90dc25"
-
-[[token.source_card_refs]]
-card_name = "Scion of Opulence"
-scryfall_oracle_id = "5818b31e-2e86-4230-937e-478e14534f91"
-scryfall_id = "d5af4995-f29f-4c4a-a2ed-a0e6ba94f334"
-
-[[token.source_card_refs]]
-card_name = "Tireless Provisioner"
-scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
-scryfall_id = "5dbc2162-238d-492b-b629-94f771230d92"
-
-[[token.source_card_refs]]
-card_name = "Seize the Spoils"
-scryfall_oracle_id = "58f83528-9110-4895-b5ea-51b90af30a8d"
-scryfall_id = "eecfce55-f288-40e6-887d-75bd0e065e28"
 
 [[token.source_card_refs]]
 card_name = "Brass's Bounty"
@@ -138505,29 +134839,9 @@ scryfall_oracle_id = "63b0538e-aa94-4e23-adf1-704cbf5bc3e5"
 scryfall_id = "65fe7127-b0ec-400f-97f1-6e17ab8e319d"
 
 [[token.source_card_refs]]
-card_name = "Contract Killing"
-scryfall_oracle_id = "a7a0e473-77c1-4a85-b6d7-b0dfdadb696f"
-scryfall_id = "b4e0debd-0157-4a7f-ac84-b322a821d88e"
-
-[[token.source_card_refs]]
-card_name = "Rapacious Dragon"
-scryfall_oracle_id = "0944ec2e-1dd9-459f-8f1d-667242cf52fe"
-scryfall_id = "5e4f1666-7df7-455d-85fc-03c117baa319"
-
-[[token.source_card_refs]]
-card_name = "Ruthless Knave"
-scryfall_oracle_id = "00225c40-27ff-410f-a591-5c788c6a2bd6"
-scryfall_id = "f679da19-5dac-4be6-983d-fee7e80cdb9c"
-
-[[token.source_card_refs]]
 card_name = "Seize the Spoils"
 scryfall_oracle_id = "58f83528-9110-4895-b5ea-51b90af30a8d"
 scryfall_id = "efcf7e75-5de2-45cc-9275-caccd73214fa"
-
-[[token.source_card_refs]]
-card_name = "Deadly Dispute"
-scryfall_oracle_id = "457af74a-02b3-4659-846d-63e482667f34"
-scryfall_id = "a788df2d-75e7-4a3b-a046-7e264e40cbfa"
 
 [[token.source_card_refs]]
 card_name = "An Offer You Can't Refuse"
@@ -139526,32 +135840,12 @@ scryfall_id = "a12cf50b-12f1-454a-b3cd-b3a30ee75585"
 [[token.source_card_refs]]
 card_name = "Wurmweaver Coil"
 scryfall_oracle_id = "83419229-c266-4022-8297-d1b05ec5ee20"
-scryfall_id = "661580bc-b5e5-48ce-b855-c177f1c61742"
-
-[[token.source_card_refs]]
-card_name = "Roar of the Wurm"
-scryfall_oracle_id = "b8b9e6fd-b3ed-4fbc-8753-74018fa33caa"
-scryfall_id = "3e282e0e-6462-40de-9abf-44385413fce9"
-
-[[token.source_card_refs]]
-card_name = "Wurmweaver Coil"
-scryfall_oracle_id = "83419229-c266-4022-8297-d1b05ec5ee20"
 scryfall_id = "37a71160-aa29-4662-8d7b-590771b42635"
 
 [[token.source_card_refs]]
 card_name = "Roar of the Wurm"
 scryfall_oracle_id = "b8b9e6fd-b3ed-4fbc-8753-74018fa33caa"
 scryfall_id = "0c315523-a023-42f3-9906-690d90eb99dd"
-
-[[token.source_card_refs]]
-card_name = "Crush of Wurms"
-scryfall_oracle_id = "6c12cd05-b673-453c-9f6b-f3aa022467c1"
-scryfall_id = "32a924b3-3bd6-43ad-acbd-1303dd670db4"
-
-[[token.source_card_refs]]
-card_name = "Roar of the Wurm"
-scryfall_oracle_id = "b8b9e6fd-b3ed-4fbc-8753-74018fa33caa"
-scryfall_id = "ddf54317-4c08-4a66-9fd2-9983384e2374"
 
 [[token.source_card_refs]]
 card_name = "Roar of the Wurm"
@@ -140096,11 +136390,6 @@ card_name = "Hare Apparent"
 scryfall_oracle_id = "3c1619bd-db5e-4df6-a196-0a9d62374f6d"
 scryfall_id = "9fc6f0e9-eb5f-4bc0-b3d7-756644b66d12"
 
-[[token.source_card_refs]]
-card_name = "Hop to It"
-scryfall_oracle_id = "e8a9350a-07c1-47ed-8c4f-88e4b3b17545"
-scryfall_id = "16fabbbf-e35b-468c-9aea-09aa6a388dee"
-
 [token.token_image_ref]
 scryfall_id = "63ae4f9c-ad6e-4d6a-89f1-653916bf5373"
 scryfall_oracle_id = "fee35fc4-a5b5-4c2c-8c6a-62dad166ea72"
@@ -140327,6 +136616,11 @@ scryfall_id = "7a832060-ecc6-406a-ab06-b371aa952e13"
 card_name = "Tippy-Toe, Terrific Partner"
 scryfall_oracle_id = "6a1bce89-0c11-4d8d-aacb-c0a5a5effffc"
 scryfall_id = "d3154e82-3497-47ad-99e5-369cb40ac869"
+
+[[token.source_card_refs]]
+card_name = "Tireless Provisioner"
+scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
+scryfall_id = "6d2e2e8d-8382-4d98-9e25-2dff1b1d0ff8"
 
 [[token.source_card_refs]]
 card_name = "Academy Manufactor"
@@ -141239,11 +137533,6 @@ card_name = "Chasm Skulker"
 scryfall_oracle_id = "69facbc7-3859-4716-b627-5199571fb3cf"
 scryfall_id = "92a08fad-56ad-4437-9bb8-6d016c1c714f"
 
-[[token.source_card_refs]]
-card_name = "Chasm Skulker"
-scryfall_oracle_id = "69facbc7-3859-4716-b627-5199571fb3cf"
-scryfall_id = "dd7619c0-bb4e-41ed-929b-7d6e0cc9fca0"
-
 [token.token_image_ref]
 scryfall_id = "660d8e43-13e1-464b-b251-c7c2d77732ca"
 scryfall_oracle_id = "dd85fcd6-9bfd-4deb-a56a-77c6bca8eb97"
@@ -141892,16 +138181,6 @@ subtypes = ["Beast"]
 supertypes = []
 colors = ["Green"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Primeval Bounty"
-scryfall_oracle_id = "f633c16d-d943-421c-ad18-af35db9ec9fc"
-scryfall_id = "f1623228-0935-4a8d-863c-249d613bd3ab"
-
-[[token.source_card_refs]]
-card_name = "Somberwald Beastmaster"
-scryfall_oracle_id = "df35bf19-4cbf-4624-925d-ceca6bff596e"
-scryfall_id = "6488d613-59fa-4e26-a48c-eecab8754808"
 
 [[token.source_card_refs]]
 card_name = "Primeval Bounty"
@@ -144523,11 +140802,6 @@ scryfall_oracle_id = "8e62d05a-6efd-4764-bca8-97895e0cb613"
 scryfall_id = "faac5cd1-ce93-4b98-97ad-8bdce2862b3b"
 
 [[token.source_card_refs]]
-card_name = "Assemble the Legion"
-scryfall_oracle_id = "6f81bef3-6ca0-4cf4-aa99-7b2813eeef04"
-scryfall_id = "a71c666d-a03b-4f2b-80ad-e1ecf0df1d10"
-
-[[token.source_card_refs]]
 card_name = "Sunhome Guildmage"
 scryfall_oracle_id = "f211d21f-7d78-4435-a592-a6896023af3b"
 scryfall_id = "d1d2de3e-5885-45df-8570-69d2d3e0e25c"
@@ -145287,11 +141561,6 @@ card_name = "Wrenn and Seven"
 scryfall_oracle_id = "63a509ea-cedc-40e9-b4e8-0ff4fc356485"
 scryfall_id = "302f0dc1-88ab-4961-b78c-fbe7980dca18"
 
-[[token.source_card_refs]]
-card_name = "Wrenn and Seven"
-scryfall_oracle_id = "63a509ea-cedc-40e9-b4e8-0ff4fc356485"
-scryfall_id = "365d2ecc-24ef-41fb-a1ee-055e99e1d94f"
-
 [token.token_image_ref]
 scryfall_id = "26981595-edf3-4f22-b2f0-fe0052408f8c"
 scryfall_oracle_id = "46e30c03-15cd-46ed-a122-c47cbca87368"
@@ -145456,17 +141725,7 @@ keywords = ["Trample"]
 [[token.source_card_refs]]
 card_name = "Voice of the Woods"
 scryfall_oracle_id = "12da8ba3-ca60-44c8-8627-1b4af2a2c4a3"
-scryfall_id = "1ebb4668-eebf-4b7e-ae29-75fff5963868"
-
-[[token.source_card_refs]]
-card_name = "Voice of the Woods"
-scryfall_oracle_id = "12da8ba3-ca60-44c8-8627-1b4af2a2c4a3"
 scryfall_id = "d7a6315c-aa6f-4be1-a002-d7824bfad622"
-
-[[token.source_card_refs]]
-card_name = "Voice of the Woods"
-scryfall_oracle_id = "12da8ba3-ca60-44c8-8627-1b4af2a2c4a3"
-scryfall_id = "30582551-8236-41d5-bedf-818f4af97d3f"
 
 [token.token_image_ref]
 scryfall_id = "7737cbbf-659e-4a8d-9918-50652d6c0863"
@@ -145797,19 +142056,9 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Sliver Hive"
-scryfall_oracle_id = "e7286688-ffbe-4d25-ad55-27990f005368"
-scryfall_id = "61d4a8e0-edbf-43b1-8047-8235f803c3aa"
-
-[[token.source_card_refs]]
 card_name = "Brood Sliver"
 scryfall_oracle_id = "6b1d178f-9713-4dcf-920b-ddf2c94cc427"
 scryfall_id = "c5bffc93-1162-49e5-a38b-8a7271915d0c"
-
-[[token.source_card_refs]]
-card_name = "Brood Sliver"
-scryfall_oracle_id = "6b1d178f-9713-4dcf-920b-ddf2c94cc427"
-scryfall_id = "33803c12-1d78-49fe-a3a3-7f47c60a96b6"
 
 [[token.source_card_refs]]
 card_name = "Sliver Hive"
@@ -145817,24 +142066,9 @@ scryfall_oracle_id = "e7286688-ffbe-4d25-ad55-27990f005368"
 scryfall_id = "04541650-6ee7-4825-984e-4794b306c274"
 
 [[token.source_card_refs]]
-card_name = "Hive Stirrings"
-scryfall_oracle_id = "c7dd0614-e11e-4b6b-a2cb-9904e457148f"
-scryfall_id = "93fa40de-1bf2-46ef-8cb8-7331386990d1"
-
-[[token.source_card_refs]]
 card_name = "Thrumming Hivepool"
 scryfall_oracle_id = "04ea21b3-084b-4746-9b49-99b6ef4f0885"
 scryfall_id = "85caf659-7b43-462e-a342-34703d46eb57"
-
-[[token.source_card_refs]]
-card_name = "Sliver Queen"
-scryfall_oracle_id = "b8376cca-ea96-478a-8e98-c4482031300a"
-scryfall_id = "235c0ece-aed0-4120-99cc-5d0e28fa70ab"
-
-[[token.source_card_refs]]
-card_name = "Sliver Queen"
-scryfall_oracle_id = "b8376cca-ea96-478a-8e98-c4482031300a"
-scryfall_id = "096cff82-28eb-4096-be1d-a02b9a56e682"
 
 [[token.source_card_refs]]
 card_name = "Thrumming Hivepool"
@@ -148201,11 +144435,6 @@ scryfall_oracle_id = "dfec65a0-6fb6-463d-aa62-e84a427db217"
 scryfall_id = "524a5d93-26ed-436d-a437-dc9460acce98"
 
 [[token.source_card_refs]]
-card_name = "Attended Healer"
-scryfall_oracle_id = "9442a18b-9093-4a10-ab61-6962f5af3bb6"
-scryfall_id = "1eae2fa8-032a-49d5-8e5f-de742cded9c2"
-
-[[token.source_card_refs]]
 card_name = "Arahbo, the First Fang"
 scryfall_oracle_id = "dfec65a0-6fb6-463d-aa62-e84a427db217"
 scryfall_id = "2507fddd-2dc0-45f0-ac47-1ddd8690be46"
@@ -148311,19 +144540,9 @@ colors = ["Blue"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
-card_name = "Moonblade Shinobi"
-scryfall_oracle_id = "046e25ee-c96d-4cff-93be-f7e3379d713c"
-scryfall_id = "ebfbb4fe-a415-44fa-9a5b-cd6c05251723"
-
-[[token.source_card_refs]]
 card_name = "Meloku the Clouded Mirror"
 scryfall_oracle_id = "3b96b8c3-b9c8-4712-a3b1-243a67cc013a"
 scryfall_id = "60b9db96-a6ab-454b-99a7-910ef77560d7"
-
-[[token.source_card_refs]]
-card_name = "Meloku the Clouded Mirror"
-scryfall_oracle_id = "3b96b8c3-b9c8-4712-a3b1-243a67cc013a"
-scryfall_id = "1caaa733-6d4c-4e18-a64e-f95851c7063b"
 
 [token.token_image_ref]
 scryfall_id = "7274e711-42fd-489e-809d-77d3bce24422"
@@ -149730,11 +145949,6 @@ card_name = "Witch's Mark"
 scryfall_oracle_id = "00807825-88e5-4b88-8527-a49f553a91be"
 scryfall_id = "7120f534-cc20-453a-8ddd-ebd6f64235e7"
 
-[[token.source_card_refs]]
-card_name = "Witch's Mark"
-scryfall_oracle_id = "00807825-88e5-4b88-8527-a49f553a91be"
-scryfall_id = "03c6aae5-f85a-4083-b880-71c0e141cc22"
-
 [token.token_image_ref]
 scryfall_id = "6929750f-cf08-4e3e-83b0-076e1f6fa8e0"
 scryfall_oracle_id = "0664dcc8-fa68-4802-936f-ecd2979ebf3c"
@@ -149926,7 +146140,6 @@ source_card_names = [
     "Auspicious Arrival",
     "Azula, On the Hunt",
     "Ballroom",
-    "Bearer of Overwhelming Truths",
     "Billiard Room",
     "Blink",
     "Briarbridge Patrol",
@@ -149944,12 +146157,9 @@ source_card_names = [
     "Conservatory",
     "Cunning Maneuver",
     "Curious Inquiry",
-    "Daring Sleuth",
     "Daring Sleuth // Bearer of Overwhelming Truths",
     "Declaration in Stone",
     "Deduce",
-    "Dennick, Pious Apparition",
-    "Dennick, Pious Apprentice",
     "Dennick, Pious Apprentice // Dennick, Pious Apparition",
     "Detective's Satchel",
     "Dining Room",
@@ -150102,258 +146312,14 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Press for Answers"
-scryfall_oracle_id = "4960c3a0-77ca-48d8-b565-6c5f1e6522cf"
-scryfall_id = "e7854c3f-8c89-4ac6-8cfe-3b5b3b651918"
-
-[[token.source_card_refs]]
-card_name = "Erdwal Illuminator"
-scryfall_oracle_id = "5ff4ef34-acb9-46c3-8530-f4b093807066"
-scryfall_id = "bba1f355-4aa0-421f-86fc-25de52f47d74"
-
-[[token.source_card_refs]]
-card_name = "Magnifying Glass"
-scryfall_oracle_id = "f2ce9e55-07c0-4f36-a59e-127693fc0f62"
-scryfall_id = "46881c84-d20f-4e9d-bd58-d11c349de83b"
-
-[[token.source_card_refs]]
-card_name = "Fleeting Memories"
-scryfall_oracle_id = "fbb0173d-7ec9-4f43-b457-f8de6703497e"
-scryfall_id = "14ee271d-f545-4fde-a859-f8a1bb92d512"
-
-[[token.source_card_refs]]
-card_name = "Tireless Tracker"
-scryfall_oracle_id = "e6555cca-e608-4c87-b835-9cd47fd1f543"
-scryfall_id = "e7fe81de-a81f-4226-9067-4d6598b82016"
-
-[[token.source_card_refs]]
-card_name = "Declaration in Stone"
-scryfall_oracle_id = "49554441-bb48-4829-b8d6-55e687a6c2e2"
-scryfall_id = "99822609-bba8-44da-8f86-54960b566522"
-
-[[token.source_card_refs]]
-card_name = "Deduce"
-scryfall_oracle_id = "eeae4161-9f35-45df-8b3c-c55e37f49cd1"
-scryfall_id = "a6813cd2-7151-459a-a2f1-52808584de53"
-
-[[token.source_card_refs]]
-card_name = "Briarbridge Tracker"
-scryfall_oracle_id = "8fe6e954-f19b-4d11-83d3-74c634d51bad"
-scryfall_id = "facfdada-406a-4b7f-8d59-7b740619394d"
-
-[[token.source_card_refs]]
-card_name = "Drownyard Explorers"
-scryfall_oracle_id = "c1ebbe89-8976-4ed7-a68a-8b08aac4616c"
-scryfall_id = "bb4e2569-7e5c-44d0-8d41-79d4a8e47d1d"
-
-[[token.source_card_refs]]
-card_name = "Erdwal Illuminator"
-scryfall_oracle_id = "5ff4ef34-acb9-46c3-8530-f4b093807066"
-scryfall_id = "d4fbfd62-0318-4f77-ab91-37e56233e493"
-
-[[token.source_card_refs]]
-card_name = "Ulvenwald Mysteries"
-scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
-scryfall_id = "749aafbf-9d17-4341-a137-dba1cc4d09da"
-
-[[token.source_card_refs]]
-card_name = "Briarbridge Tracker"
-scryfall_oracle_id = "8fe6e954-f19b-4d11-83d3-74c634d51bad"
-scryfall_id = "444abc67-ee3a-45ba-a4ce-95a22e139c64"
-
-[[token.source_card_refs]]
 card_name = "Agent 13, Sharon Carter"
 scryfall_oracle_id = "ddf7201a-6672-416d-be6b-202dafbeccab"
 scryfall_id = "107cb521-9806-47dc-92d8-b43112b63caa"
 
 [[token.source_card_refs]]
-card_name = "Fateful Absence"
-scryfall_oracle_id = "35bba442-1aec-4d33-b502-4c580d61644b"
-scryfall_id = "ea9e80c6-92b1-4c06-bf7e-b5e9f6c73418"
-
-[[token.source_card_refs]]
 card_name = "Thraben Inspector"
 scryfall_oracle_id = "caa02547-66e3-4e27-a2d3-5e94f3e7a069"
 scryfall_id = "ec18fa41-6948-4d94-8dcc-31fb63fb53ec"
-
-[[token.source_card_refs]]
-card_name = "Floodhound"
-scryfall_oracle_id = "6dd8ba09-f117-4514-9e09-f9f9f5fb5025"
-scryfall_id = "c0ca694c-f0ee-4994-92a2-be2a840c7e07"
-
-[[token.source_card_refs]]
-card_name = "Dennick, Pious Apprentice // Dennick, Pious Apparition"
-face_name = "Dennick, Pious Apparition"
-scryfall_oracle_id = "45802eb2-6848-416c-95e0-c1c1ea0620d0"
-scryfall_id = "4df8d711-09e3-43e5-b59e-ea6a92cae726"
-
-[[token.source_card_refs]]
-card_name = "Hard Evidence"
-scryfall_oracle_id = "0728b195-2dfe-4d73-91ae-e658a97b0b9a"
-scryfall_id = "204114ed-0d8e-460f-b7ce-9266536d4399"
-
-[[token.source_card_refs]]
-card_name = "Tireless Tracker"
-scryfall_oracle_id = "e6555cca-e608-4c87-b835-9cd47fd1f543"
-scryfall_id = "b3364018-aeba-4f58-8233-b0026c488dd0"
-
-[[token.source_card_refs]]
-card_name = "Foul Play"
-scryfall_oracle_id = "773c7a1e-0f59-4606-a2fc-c47bda760ecd"
-scryfall_id = "61639281-9a2d-4921-bed4-ce3ce9220b17"
-
-[[token.source_card_refs]]
-card_name = "Drownyard Explorers"
-scryfall_oracle_id = "c1ebbe89-8976-4ed7-a68a-8b08aac4616c"
-scryfall_id = "aa7a4792-0d24-47d7-a1df-818d97d40904"
-
-[[token.source_card_refs]]
-card_name = "Wavesifter"
-scryfall_oracle_id = "d1ec1e4e-faa6-4afc-9e00-a3327105c11b"
-scryfall_id = "c8d0613d-82eb-4400-9a24-902a9fd5ad80"
-
-[[token.source_card_refs]]
-card_name = "Floodhound"
-scryfall_oracle_id = "6dd8ba09-f117-4514-9e09-f9f9f5fb5025"
-scryfall_id = "50b2a8a0-93a3-4e83-8f14-efbce07d2d3a"
-
-[[token.source_card_refs]]
-card_name = "Jace's Scrutiny"
-scryfall_oracle_id = "8578c462-7b2d-4b69-ad10-a2eab44ac98d"
-scryfall_id = "4f6fa6db-c216-4973-96e7-4e10348e0aa8"
-
-[[token.source_card_refs]]
-card_name = "Tamiyo's Journal"
-scryfall_oracle_id = "20591a83-7138-4876-b088-035bd3788be3"
-scryfall_id = "b623e860-febb-4e30-9423-e8b1fadd5ee2"
-
-[[token.source_card_refs]]
-card_name = "Byway Courier"
-scryfall_oracle_id = "e186cc6f-8c11-4475-a704-0b4c3a9eade9"
-scryfall_id = "5b1c4e0f-734a-442a-b0b0-e26a2937c3f8"
-
-[[token.source_card_refs]]
-card_name = "Magnifying Glass"
-scryfall_oracle_id = "f2ce9e55-07c0-4f36-a59e-127693fc0f62"
-scryfall_id = "5db997a7-d54c-4821-9e9f-56292f9e7e5a"
-
-[[token.source_card_refs]]
-card_name = "Hold for Questioning"
-scryfall_oracle_id = "1095fcd9-8127-4345-9052-fccb350296d3"
-scryfall_id = "74004b11-53dc-475c-8d29-cf52403456cf"
-
-[[token.source_card_refs]]
-card_name = "Ongoing Investigation"
-scryfall_oracle_id = "68227832-2916-49b9-92bb-c09b8a0c13f5"
-scryfall_id = "c464b2f5-54e0-45a7-a58c-750f587ca339"
-
-[[token.source_card_refs]]
-card_name = "Foul Play"
-scryfall_oracle_id = "773c7a1e-0f59-4606-a2fc-c47bda760ecd"
-scryfall_id = "8e8fd73b-942a-44f1-85e3-bb599bccb05b"
-
-[[token.source_card_refs]]
-card_name = "Lonis, Cryptozoologist"
-scryfall_oracle_id = "0ee06ed0-717a-4bfa-b634-d00e013c1f16"
-scryfall_id = "e4b2e6f3-bba8-4ee5-b100-a5d89bd76253"
-
-[[token.source_card_refs]]
-card_name = "Dennick, Pious Apprentice // Dennick, Pious Apparition"
-face_name = "Dennick, Pious Apprentice"
-scryfall_oracle_id = "45802eb2-6848-416c-95e0-c1c1ea0620d0"
-scryfall_id = "4df8d711-09e3-43e5-b59e-ea6a92cae726"
-
-[[token.source_card_refs]]
-card_name = "Confirm Suspicions"
-scryfall_oracle_id = "a30d076b-c942-45e4-b943-3749ce955291"
-scryfall_id = "510df438-4ed3-4542-864e-0c23eacc4c30"
-
-[[token.source_card_refs]]
-card_name = "Daring Sleuth // Bearer of Overwhelming Truths"
-face_name = "Bearer of Overwhelming Truths"
-scryfall_oracle_id = "69ca69c7-403b-4b5d-be08-d9dce8ce410e"
-scryfall_id = "a7e2eed8-9a2d-4a6e-8bb2-53dc3022a4ac"
-
-[[token.source_card_refs]]
-card_name = "Funnel-Web Recluse"
-scryfall_oracle_id = "6148fcf5-466a-43aa-a0f3-d3d9fae4d883"
-scryfall_id = "bedd5fac-b7b1-46db-99af-41edc28663ef"
-
-[[token.source_card_refs]]
-card_name = "Tamiyo's Journal"
-scryfall_oracle_id = "20591a83-7138-4876-b088-035bd3788be3"
-scryfall_id = "de5c1782-e2bb-40f2-b3df-9b74a9166c73"
-
-[[token.source_card_refs]]
-card_name = "Weirding Wood"
-scryfall_oracle_id = "9ce5cc2f-e223-4c3b-adc1-c0109fd31762"
-scryfall_id = "65b73086-30f0-44c6-bf83-a0faeb91e885"
-
-[[token.source_card_refs]]
-card_name = "Secrets of the Key"
-scryfall_oracle_id = "55c7ce94-3cd3-42f3-9dd8-0c118fa626c8"
-scryfall_id = "c136e3ee-5134-480e-a322-69c9ed9b4677"
-
-[[token.source_card_refs]]
-card_name = "Jace's Scrutiny"
-scryfall_oracle_id = "8578c462-7b2d-4b69-ad10-a2eab44ac98d"
-scryfall_id = "a7e8e533-350b-4558-98d3-b7fcab3770f5"
-
-[[token.source_card_refs]]
-card_name = "Byway Courier"
-scryfall_oracle_id = "e186cc6f-8c11-4475-a704-0b4c3a9eade9"
-scryfall_id = "5d705a2b-9370-4f73-829c-823918f55c19"
-
-[[token.source_card_refs]]
-card_name = "Ulvenwald Mysteries"
-scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
-scryfall_id = "c6079979-8613-4613-a5bd-6b1fab382767"
-
-[[token.source_card_refs]]
-card_name = "Ulvenwald Mysteries"
-scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
-scryfall_id = "fd02c995-0a77-460c-9fa3-34f74b14b119"
-
-[[token.source_card_refs]]
-card_name = "Thraben Inspector"
-scryfall_oracle_id = "caa02547-66e3-4e27-a2d3-5e94f3e7a069"
-scryfall_id = "9b65852b-b748-4263-a5aa-7a44e891c582"
-
-[[token.source_card_refs]]
-card_name = "Daring Sleuth // Bearer of Overwhelming Truths"
-face_name = "Daring Sleuth"
-scryfall_oracle_id = "69ca69c7-403b-4b5d-be08-d9dce8ce410e"
-scryfall_id = "a7e2eed8-9a2d-4a6e-8bb2-53dc3022a4ac"
-
-[[token.source_card_refs]]
-card_name = "Thraben Inspector"
-scryfall_oracle_id = "caa02547-66e3-4e27-a2d3-5e94f3e7a069"
-scryfall_id = "6c727d20-51a0-443a-9d40-6efe7b91193a"
-
-[[token.source_card_refs]]
-card_name = "Confront the Unknown"
-scryfall_oracle_id = "221240c5-3c97-438c-b906-2508eacf190f"
-scryfall_id = "856c3be0-afe1-40c3-b84f-b50235246216"
-
-[[token.source_card_refs]]
-card_name = "Briarbridge Patrol"
-scryfall_oracle_id = "784f0ca3-efe1-4e22-aedd-57cba7996fa5"
-scryfall_id = "003b5fe1-4e9e-49ae-9af4-04eefb96398f"
-
-[[token.source_card_refs]]
-card_name = "Bygone Bishop"
-scryfall_oracle_id = "a47d9ea3-95fe-4774-8e72-30e7f56756f4"
-scryfall_id = "3fc53890-be06-42f0-9a78-eb0d62d0fffe"
-
-[[token.source_card_refs]]
-card_name = "Humble the Brute"
-scryfall_oracle_id = "bea6606c-ea9a-4199-a8cd-b35d7c47fd7b"
-scryfall_id = "65970840-0c4d-47b1-96d6-7d5c7a3411d9"
-
-[[token.source_card_refs]]
-card_name = "Tireless Tracker"
-scryfall_oracle_id = "e6555cca-e608-4c87-b835-9cd47fd1f543"
-scryfall_id = "5015b027-de1c-4e1e-8cf3-d946b8a3a4a3"
 
 [[token.source_card_refs]]
 card_name = "Panther Pounce"
@@ -150701,22 +146667,12 @@ keywords = ["Deathtouch"]
 [[token.source_card_refs]]
 card_name = "Ophiomancer"
 scryfall_oracle_id = "55eca80c-dcd8-4c2f-aa0f-fb0aec7b80f7"
-scryfall_id = "6c44fca9-3a41-41c3-aa74-f0f5a81e8b7d"
-
-[[token.source_card_refs]]
-card_name = "Ophiomancer"
-scryfall_oracle_id = "55eca80c-dcd8-4c2f-aa0f-fb0aec7b80f7"
 scryfall_id = "0ef8d3a2-5c6b-41e2-aa7d-81e4a5d04421"
 
 [[token.source_card_refs]]
 card_name = "Ophiomancer"
 scryfall_oracle_id = "55eca80c-dcd8-4c2f-aa0f-fb0aec7b80f7"
 scryfall_id = "baf793b6-9612-43f3-9f1b-2e53e81cb89f"
-
-[[token.source_card_refs]]
-card_name = "Aphelia, Viper Whisperer"
-scryfall_oracle_id = "191e003f-1a78-4d85-9c70-2ae132a5f9cc"
-scryfall_id = "1a0867be-a861-4fb4-b8ff-cb2966193755"
 
 [token.token_image_ref]
 scryfall_id = "62340bbb-cff0-48c1-8854-235340e80477"
@@ -152720,11 +148676,6 @@ scryfall_id = "cce2fce1-8172-43ed-937d-a543a474ef46"
 [[token.source_card_refs]]
 card_name = "Champion of Wits"
 scryfall_oracle_id = "3fd8ba0c-75ec-43ea-8706-f71e6cf1d236"
-scryfall_id = "b685b930-3201-4eb1-ac29-9c926651d118"
-
-[[token.source_card_refs]]
-card_name = "Champion of Wits"
-scryfall_oracle_id = "3fd8ba0c-75ec-43ea-8706-f71e6cf1d236"
 scryfall_id = "cf76d414-9424-4fd5-a1ff-2ff345ad6b0a"
 
 [[token.source_card_refs]]
@@ -154688,16 +150639,6 @@ scryfall_oracle_id = "936ae5dc-9838-47f3-ba1f-66523a7f5b76"
 scryfall_id = "31c99a7d-a70b-4599-9bd2-be7a5cac28ff"
 
 [[token.source_card_refs]]
-card_name = "Stolen by the Fae"
-scryfall_oracle_id = "5bafd0e0-8bf8-4e06-a54a-81cc6cc4bdb7"
-scryfall_id = "857d00b7-af88-483c-a209-6dde97d6e3c8"
-
-[[token.source_card_refs]]
-card_name = "Hunted Troll"
-scryfall_oracle_id = "1f789fcf-3df6-45a6-a732-9f43e33718d6"
-scryfall_id = "fd9d891e-ae8c-485a-b999-d1e08fffd164"
-
-[[token.source_card_refs]]
 card_name = "Alela, Artful Provocateur"
 scryfall_oracle_id = "936ae5dc-9838-47f3-ba1f-66523a7f5b76"
 scryfall_id = "80a94f62-2060-494b-924a-792b728dcf99"
@@ -154706,16 +150647,6 @@ scryfall_id = "80a94f62-2060-494b-924a-792b728dcf99"
 card_name = "Faebloom Trick"
 scryfall_oracle_id = "903d114b-1899-4e67-bee3-af0673850388"
 scryfall_id = "0c3bee8f-f5be-4404-a696-c902637799c3"
-
-[[token.source_card_refs]]
-card_name = "Faerie Formation"
-scryfall_oracle_id = "0366c2f6-6e78-4526-808c-fa7bace6006e"
-scryfall_id = "86682959-6720-44e0-8fe3-982f0b3e94ce"
-
-[[token.source_card_refs]]
-card_name = "Stolen by the Fae"
-scryfall_oracle_id = "5bafd0e0-8bf8-4e06-a54a-81cc6cc4bdb7"
-scryfall_id = "85d4af60-a143-42d1-a580-b4ba197ca1ea"
 
 [[token.source_card_refs]]
 card_name = "Alela, Artful Provocateur"
@@ -156697,34 +152628,9 @@ scryfall_oracle_id = "688e5e19-8f28-45c4-ace4-a38144f494f1"
 scryfall_id = "f824d5b6-259b-467b-93b5-e93db8b15359"
 
 [[token.source_card_refs]]
-card_name = "Scion Summoner"
-scryfall_oracle_id = "fa60f3a6-5834-4059-adea-dd17366b7885"
-scryfall_id = "e709bf1f-9bbb-4da7-a1ea-7deb94858b8c"
-
-[[token.source_card_refs]]
 card_name = "Eldrazi Skyspawner"
 scryfall_oracle_id = "b5661289-a03c-40fc-a1e4-f602adb56f81"
 scryfall_id = "1e1a05a1-8c66-4df9-8b57-f15b5d268973"
-
-[[token.source_card_refs]]
-card_name = "Blisterpod"
-scryfall_oracle_id = "2a62b226-d317-4212-9781-9c1d72056f11"
-scryfall_id = "8db1cc35-8901-4528-9100-38f12d89540c"
-
-[[token.source_card_refs]]
-card_name = "Brood Monitor"
-scryfall_oracle_id = "9a08bb4b-46df-4b99-8f86-670d07e900ba"
-scryfall_id = "0c6de7f2-fcc2-4a08-b49c-b50bb195a252"
-
-[[token.source_card_refs]]
-card_name = "Brood Monitor"
-scryfall_oracle_id = "9a08bb4b-46df-4b99-8f86-670d07e900ba"
-scryfall_id = "cf5a6be1-f706-4681-9f95-512381be123e"
-
-[[token.source_card_refs]]
-card_name = "Catacomb Sifter"
-scryfall_oracle_id = "4c2c5f3b-61f3-4772-9ade-f5be80719e9f"
-scryfall_id = "fcfb168b-86df-4e60-aee3-5e9976158edb"
 
 [[token.source_card_refs]]
 card_name = "Spawning Bed"
@@ -156752,21 +152658,6 @@ scryfall_oracle_id = "9a08bb4b-46df-4b99-8f86-670d07e900ba"
 scryfall_id = "cef68b13-74b6-4a8a-8f81-1427d18044a4"
 
 [[token.source_card_refs]]
-card_name = "Carrier Thrall"
-scryfall_oracle_id = "b3e0b8a6-5de4-4988-b042-2641b1ed3e32"
-scryfall_id = "755c5d2e-6f82-49e2-981c-d21567e2dbe6"
-
-[[token.source_card_refs]]
-card_name = "Warping Wail"
-scryfall_oracle_id = "c8b9fa02-0a0c-4a87-9a00-3c1c7e2f4bfd"
-scryfall_id = "f461d613-518f-41cf-b08f-0778d40d3cf7"
-
-[[token.source_card_refs]]
-card_name = "Spawning Bed"
-scryfall_oracle_id = "49e43de3-460b-4562-aef6-da43bd56debc"
-scryfall_id = "2c1059b9-99da-47ce-a013-84ad755fda11"
-
-[[token.source_card_refs]]
 card_name = "Vile Redeemer"
 scryfall_oracle_id = "a7a88bcc-eac2-4f74-804f-b49d16560184"
 scryfall_id = "7a08e28c-dee2-4ab8-bc72-1498a7dd3a40"
@@ -156782,10 +152673,8 @@ category = "Creature"
 fidelity = "Full"
 source_card_names = [
     "Cartouche of Solidarity",
-    "Finish",
     "Oketra the True",
     "Oketra's Monument",
-    "Start",
     "Start // Finish",
     "Steward of Solidarity",
     "Supply Caravan",
@@ -156808,27 +152697,6 @@ colors = ["White"]
 keywords = ["Vigilance"]
 
 [[token.source_card_refs]]
-card_name = "Start // Finish"
-face_name = "Finish"
-scryfall_oracle_id = "4ae2750e-3650-42df-a539-ea4cb72fa136"
-scryfall_id = "10cb9813-0c4b-40e7-a883-90737116a417"
-
-[[token.source_card_refs]]
-card_name = "Supply Caravan"
-scryfall_oracle_id = "1abcfe8d-4beb-4910-b353-1227e1256329"
-scryfall_id = "71899431-c397-4031-b01a-d8bd960bbe2d"
-
-[[token.source_card_refs]]
-card_name = "Cartouche of Solidarity"
-scryfall_oracle_id = "b9176173-c4a1-45ae-8f34-bd6b31c141fe"
-scryfall_id = "c0848afc-fc62-44d3-82be-5de86a12a630"
-
-[[token.source_card_refs]]
-card_name = "Oketra's Monument"
-scryfall_oracle_id = "0370afa0-07d3-4787-8a5b-10272cb3a486"
-scryfall_id = "f86bc112-4744-4310-a3a8-df5c6c9421b3"
-
-[[token.source_card_refs]]
 card_name = "Oketra's Monument"
 scryfall_oracle_id = "0370afa0-07d3-4787-8a5b-10272cb3a486"
 scryfall_id = "01bdc760-a5c9-45a9-9d83-dd3780f8ed6f"
@@ -156837,32 +152705,6 @@ scryfall_id = "01bdc760-a5c9-45a9-9d83-dd3780f8ed6f"
 card_name = "Cartouche of Solidarity"
 scryfall_oracle_id = "b9176173-c4a1-45ae-8f34-bd6b31c141fe"
 scryfall_id = "1ef605df-6dc5-4c1d-9cc3-14353ad15989"
-
-[[token.source_card_refs]]
-card_name = "Start // Finish"
-face_name = "Start"
-scryfall_oracle_id = "4ae2750e-3650-42df-a539-ea4cb72fa136"
-scryfall_id = "10cb9813-0c4b-40e7-a883-90737116a417"
-
-[[token.source_card_refs]]
-card_name = "Steward of Solidarity"
-scryfall_oracle_id = "dcaf3c6f-06e2-4762-82aa-625113e375a1"
-scryfall_id = "92f0245a-3784-4972-8322-7bd8a0e06f7f"
-
-[[token.source_card_refs]]
-card_name = "Oketra the True"
-scryfall_oracle_id = "646e68c8-cc42-4d6c-8363-a18b10a10eae"
-scryfall_id = "e6a94f2b-5b18-4e7e-b47f-185e6a8a40b3"
-
-[[token.source_card_refs]]
-card_name = "Steward of Solidarity"
-scryfall_oracle_id = "dcaf3c6f-06e2-4762-82aa-625113e375a1"
-scryfall_id = "6898c5d9-ac25-4ec8-94a8-6fb3df2700b3"
-
-[[token.source_card_refs]]
-card_name = "Cartouche of Solidarity"
-scryfall_oracle_id = "b9176173-c4a1-45ae-8f34-bd6b31c141fe"
-scryfall_id = "4d2bc626-7104-4995-bf29-6cba08cbaf9d"
 
 [token.token_image_ref]
 scryfall_id = "7728b4ea-4288-4699-b45f-21beb327d4ce"
@@ -156955,11 +152797,6 @@ scryfall_id = "90450177-4ed6-41e6-9917-70a0720bb84c"
 card_name = "Pentavus"
 scryfall_oracle_id = "1c0d4f28-2494-45b0-acb8-921fee602c01"
 scryfall_id = "a39ab7f7-c22f-4cf7-ae1f-d40b84996177"
-
-[[token.source_card_refs]]
-card_name = "Pentavus"
-scryfall_oracle_id = "1c0d4f28-2494-45b0-acb8-921fee602c01"
-scryfall_id = "32a11f0a-7547-4fda-a8ed-caf76ce98f10"
 
 [[token.source_card_refs]]
 card_name = "Pentavus"
@@ -157154,11 +152991,6 @@ subtypes = ["Spirit"]
 supertypes = []
 colors = ["White"]
 keywords = ["Flying"]
-
-[[token.source_card_refs]]
-card_name = "Oyobi, Who Split the Heavens"
-scryfall_oracle_id = "df5c1f34-94e4-4f89-b1af-943c430862d0"
-scryfall_id = "313bd276-2f69-447e-a2b1-240cf839614a"
 
 [[token.source_card_refs]]
 card_name = "Oyobi, Who Split the Heavens"
@@ -158649,11 +154481,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Stitcher's Apprentice"
 scryfall_oracle_id = "14bf3049-faa3-4c1f-a613-603e977a50a4"
-scryfall_id = "24e39028-a930-4751-91e9-0e91fa7f91ec"
-
-[[token.source_card_refs]]
-card_name = "Stitcher's Apprentice"
-scryfall_oracle_id = "14bf3049-faa3-4c1f-a613-603e977a50a4"
 scryfall_id = "717e34b9-161e-4b11-afb1-f41ee8027433"
 
 [token.token_image_ref]
@@ -159648,34 +155475,9 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Cavalier of Dawn"
-scryfall_oracle_id = "7c520355-1ab8-4d6d-9a29-0f63d6b60024"
-scryfall_id = "aea6ac4a-9e4a-4360-b87b-637a621aef1a"
-
-[[token.source_card_refs]]
-card_name = "Precursor Golem"
-scryfall_oracle_id = "668fc293-1b8f-4870-9784-4ac660925e30"
-scryfall_id = "d1b840bb-a772-40e3-97f0-92a27dc0fe2d"
-
-[[token.source_card_refs]]
-card_name = "Cavalier of Dawn"
-scryfall_oracle_id = "7c520355-1ab8-4d6d-9a29-0f63d6b60024"
-scryfall_id = "0d650ea3-2e80-4bcf-b800-7f2063d2acd9"
-
-[[token.source_card_refs]]
 card_name = "Precursor Golem"
 scryfall_oracle_id = "668fc293-1b8f-4870-9784-4ac660925e30"
 scryfall_id = "730c68d1-b218-43a6-831f-fe9f6b55c503"
-
-[[token.source_card_refs]]
-card_name = "Precursor Golem"
-scryfall_oracle_id = "668fc293-1b8f-4870-9784-4ac660925e30"
-scryfall_id = "13d8e349-e843-4460-92dc-5f4cbc9c1e92"
-
-[[token.source_card_refs]]
-card_name = "Precursor Golem"
-scryfall_oracle_id = "668fc293-1b8f-4870-9784-4ac660925e30"
-scryfall_id = "182c80d0-3ce2-42cd-8dd7-e28b10e2a9a1"
 
 [[token.source_card_refs]]
 card_name = "Golem Foundry"
@@ -161402,11 +157204,6 @@ card_name = "Firja's Retribution"
 scryfall_oracle_id = "fea32d4e-ceef-4954-a84d-e7e2509e4a13"
 scryfall_id = "e7d1bbe5-c63e-4a8d-b79a-0dcca221a726"
 
-[[token.source_card_refs]]
-card_name = "Valkyrie's Sword"
-scryfall_oracle_id = "236c4ff1-8c3f-4763-8df9-925021e65726"
-scryfall_id = "705c275e-bf42-4941-a1f6-c1dc3dcedc46"
-
 [token.token_image_ref]
 scryfall_id = "a2db6fe1-b6ec-43ca-933f-dbab4cd08064"
 scryfall_oracle_id = "8c5015a4-35ac-43ab-b5f7-20bd2e5fbe3c"
@@ -162597,11 +158394,6 @@ colors = [
     "Blue",
 ]
 keywords = ["Menace"]
-
-[[token.source_card_refs]]
-card_name = "Corpse Cobble"
-scryfall_oracle_id = "5b0b6c8f-472a-4ee2-8368-3b17a2df498d"
-scryfall_id = "5fac9235-9e9f-47ee-b8c2-9ebce780c930"
 
 [[token.source_card_refs]]
 card_name = "Corpse Cobble"
@@ -165470,11 +161262,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Pact of the Titan"
 scryfall_oracle_id = "cf4959bf-92ae-4c9b-b631-724ce100cbb8"
-scryfall_id = "8f332ef3-335a-494d-a90f-61a9e9834ccd"
-
-[[token.source_card_refs]]
-card_name = "Pact of the Titan"
-scryfall_oracle_id = "cf4959bf-92ae-4c9b-b631-724ce100cbb8"
 scryfall_id = "4612effe-8ca2-4c27-90d2-d9255acc80d9"
 
 [token.token_image_ref]
@@ -165970,11 +161757,6 @@ scryfall_id = "91eb9067-0bc7-4497-ba9c-c1ea41e5a379"
 card_name = "Contraband Livestock"
 scryfall_oracle_id = "fbafe993-8118-40cc-9cb7-ee3f62a2c888"
 scryfall_id = "d170361f-11f6-480e-8927-c63f00c7f331"
-
-[[token.source_card_refs]]
-card_name = "Stampede Surfer"
-scryfall_oracle_id = "22640b75-8db6-4264-a4aa-9174c159a228"
-scryfall_id = "7e782e90-d6e5-4a55-87a8-3bd6dce1b67a"
 
 [[token.source_card_refs]]
 card_name = "Curse of the Swine"
@@ -167940,11 +163722,6 @@ scryfall_id = "63e3de28-d6e9-4f27-a544-0434fb4b55bb"
 [[token.source_card_refs]]
 card_name = "Simulacrum Synthesizer"
 scryfall_oracle_id = "eb7a1f21-a66d-415b-8520-710b44890bb6"
-scryfall_id = "c201946b-0746-4f8b-bd7b-84dc0fa60395"
-
-[[token.source_card_refs]]
-card_name = "Simulacrum Synthesizer"
-scryfall_oracle_id = "eb7a1f21-a66d-415b-8520-710b44890bb6"
 scryfall_id = "28a11489-11c5-4018-aab8-c9d036638414"
 
 [[token.source_card_refs]]
@@ -167971,11 +163748,6 @@ scryfall_id = "c7658ec0-3207-4c7e-b31a-30a2a9249595"
 card_name = "Urza, Lord High Artificer"
 scryfall_oracle_id = "e87906d2-db1a-4e19-b910-adb4eb339945"
 scryfall_id = "f531402e-681f-4439-837c-4e184efd5a49"
-
-[[token.source_card_refs]]
-card_name = "Urza, Lord High Artificer"
-scryfall_oracle_id = "e87906d2-db1a-4e19-b910-adb4eb339945"
-scryfall_id = "98294441-b5a1-4b59-9325-80d0ff913ebd"
 
 [token.token_image_ref]
 scryfall_id = "3877d2d1-61f2-4295-b0fc-827965eaaefc"
@@ -168439,8 +164211,6 @@ source_card_names = [
     "Hobbling Zombie",
     "Jadar, Ghoulcaller of Nephalia",
     "No Way Out",
-    "Poppet Factory",
-    "Poppet Stitcher",
     "Poppet Stitcher // Poppet Factory",
     "Revenge of the Drowned",
     "Rotten Reunion",
@@ -168466,40 +164236,9 @@ colors = ["Black"]
 keywords = ["Decayed"]
 
 [[token.source_card_refs]]
-card_name = "Flip the Switch"
-scryfall_oracle_id = "a28eb946-c7f2-4c90-ab6c-b194e290e33d"
-scryfall_id = "78198be2-41e4-4e0b-ac21-9e2db577af01"
-
-[[token.source_card_refs]]
-card_name = "Falcon Abomination"
-scryfall_oracle_id = "21eea63f-72b2-4155-bfad-f9937a8f8614"
-scryfall_id = "40e5e0e9-bc54-4a23-b880-a1b5ec740a8c"
-
-[[token.source_card_refs]]
-card_name = "Poppet Stitcher // Poppet Factory"
-face_name = "Poppet Stitcher"
-scryfall_oracle_id = "bc2d0702-b140-4b78-8a8f-3a6d19073b59"
-scryfall_id = "f033f980-ddc5-4dea-a682-5a823be99aa5"
-
-[[token.source_card_refs]]
-card_name = "Rotten Reunion"
-scryfall_oracle_id = "1bde8eaa-9beb-4529-b540-5e0155c09713"
-scryfall_id = "b13cc06c-5f5e-4feb-8a44-a468d6e6c07d"
-
-[[token.source_card_refs]]
 card_name = "Wilhelt, the Rotcleaver"
 scryfall_oracle_id = "eada96a1-4964-4ad0-b0e3-2df08d6ae188"
 scryfall_id = "82471687-46fa-4ccf-a792-180db0a5dd22"
-
-[[token.source_card_refs]]
-card_name = "Diregraf Horde"
-scryfall_oracle_id = "d7947858-f11d-438c-8ad3-991afe950a11"
-scryfall_id = "4ac94b24-630d-4808-8603-e776f16bc7ca"
-
-[[token.source_card_refs]]
-card_name = "Tainted Adversary"
-scryfall_oracle_id = "8bed92cc-b3f8-4201-bcbc-44535ff1bd96"
-scryfall_id = "88e07d94-93fe-4827-b4e0-f73dc1962b9a"
 
 [[token.source_card_refs]]
 card_name = "Startle"
@@ -168517,50 +164256,9 @@ scryfall_oracle_id = "fb3defc0-c93a-4423-9ff9-c399f8a8ef1f"
 scryfall_id = "49d5d62b-72ed-446a-b280-ad04c38bdd0c"
 
 [[token.source_card_refs]]
-card_name = "Ghoulish Procession"
-scryfall_oracle_id = "39e20898-cf01-48dc-8972-7ac500c3fa79"
-scryfall_id = "e2c94193-85e2-4df6-a450-2d254a3b2ac0"
-
-[[token.source_card_refs]]
-card_name = "Hobbling Zombie"
-scryfall_oracle_id = "9d1c3ec1-00a4-4890-93a3-e3cf137ca7e4"
-scryfall_id = "83052fa8-bfb5-4d09-8235-a0e112ff3b4a"
-
-[[token.source_card_refs]]
-card_name = "Revenge of the Drowned"
-scryfall_oracle_id = "d5d869bc-8996-4d19-9e32-d1cfb968875c"
-scryfall_id = "401edb61-83f1-4a8d-ae91-58b62a9ced9c"
-
-[[token.source_card_refs]]
-card_name = "No Way Out"
-scryfall_oracle_id = "8cbbb1f4-4654-4865-a14c-0c94cd5d8b19"
-scryfall_id = "90cd492a-dbe6-49a5-92fd-ee2fa1b2f115"
-
-[[token.source_card_refs]]
-card_name = "Poppet Stitcher // Poppet Factory"
-face_name = "Poppet Factory"
-scryfall_oracle_id = "bc2d0702-b140-4b78-8a8f-3a6d19073b59"
-scryfall_id = "f033f980-ddc5-4dea-a682-5a823be99aa5"
-
-[[token.source_card_refs]]
 card_name = "Diregraf Horde"
 scryfall_oracle_id = "d7947858-f11d-438c-8ad3-991afe950a11"
 scryfall_id = "5f969e42-fd00-4bda-801a-7930d5ef67d5"
-
-[[token.source_card_refs]]
-card_name = "Ghoulcaller's Harvest"
-scryfall_oracle_id = "bbef4d8e-5861-4d50-9589-14b46c71e9af"
-scryfall_id = "1166c45b-292a-4441-8f73-266055de12c7"
-
-[[token.source_card_refs]]
-card_name = "Jadar, Ghoulcaller of Nephalia"
-scryfall_oracle_id = "fb3defc0-c93a-4423-9ff9-c399f8a8ef1f"
-scryfall_id = "92218f51-5b3f-4c4f-b472-7c03daaccc03"
-
-[[token.source_card_refs]]
-card_name = "Startle"
-scryfall_oracle_id = "7996222e-68c8-4a5c-9531-c60cdd88ae05"
-scryfall_id = "350b885a-5e09-45a2-b71e-c86d22f38758"
 
 [token.token_image_ref]
 scryfall_id = "b0d6fd21-48f0-4151-9671-762c25d95592"
@@ -169023,34 +164721,9 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Aether Chaser"
-scryfall_oracle_id = "8aab0b55-2779-43c7-a3ee-151b8e5c72f3"
-scryfall_id = "4139592c-6f0c-44ac-9de0-ebd639cd893d"
-
-[[token.source_card_refs]]
-card_name = "Glint-Sleeve Artisan"
-scryfall_oracle_id = "b5f35577-3d94-4835-bfca-3090cb0c63ff"
-scryfall_id = "e8a03ab1-29a2-4186-86da-09fa7ff469e6"
-
-[[token.source_card_refs]]
-card_name = "Marionette Master"
-scryfall_oracle_id = "dabbf796-3b88-499e-8839-06fa36fe01ac"
-scryfall_id = "09b3b0f5-5532-4367-9967-cd68ff869c7e"
-
-[[token.source_card_refs]]
 card_name = "Weaponcraft Enthusiast"
 scryfall_oracle_id = "7c27136a-bf9d-4f42-9c37-abe347fad1bb"
 scryfall_id = "4f096976-20a0-419b-9249-1cf0cccd2eb5"
-
-[[token.source_card_refs]]
-card_name = "Servo Schematic"
-scryfall_oracle_id = "6b8c6104-c537-4025-83e2-e89c8668f3ba"
-scryfall_id = "0acf747f-7ade-486c-b3b2-b48193a364fd"
-
-[[token.source_card_refs]]
-card_name = "Servo Exhibition"
-scryfall_oracle_id = "76a6ddc2-f894-4331-89a9-87ca16efd0c0"
-scryfall_id = "3727b70d-bee0-432d-863d-a319dd14a9fb"
 
 [[token.source_card_refs]]
 card_name = "Hidden Stockpile"
@@ -169063,29 +164736,9 @@ scryfall_oracle_id = "4b77479e-8d49-46f6-b774-d8caf151c15c"
 scryfall_id = "056b4bd0-1794-4319-9f72-8aad1298b8ca"
 
 [[token.source_card_refs]]
-card_name = "Cogworker's Puzzleknot"
-scryfall_oracle_id = "2065e9d0-c6e9-4270-898e-9822b532d467"
-scryfall_id = "4c0401df-6eb4-4eeb-b666-4384b5b739f4"
-
-[[token.source_card_refs]]
 card_name = "Saheeli, Sublime Artificer"
 scryfall_oracle_id = "ab655810-f67e-4576-9174-35b16f5e3235"
 scryfall_id = "5662d0a5-3222-4ab9-9e15-f06477730b75"
-
-[[token.source_card_refs]]
-card_name = "Hidden Stockpile"
-scryfall_oracle_id = "f5ded323-75c8-471e-a516-238b9d6b06d3"
-scryfall_id = "7a39586b-a31e-4a3d-8ff8-09897d307e06"
-
-[[token.source_card_refs]]
-card_name = "Aether Swooper"
-scryfall_oracle_id = "f7ed301a-dce7-49d0-a68a-d3a099201f65"
-scryfall_id = "d0a0595f-b98d-4593-a25f-3cfc5db14668"
-
-[[token.source_card_refs]]
-card_name = "Peema Outrider"
-scryfall_oracle_id = "7747e94c-35a7-4e3b-956b-339a16634502"
-scryfall_id = "ac1d4572-ce2e-4040-bd8e-e3d3a850ca05"
 
 [[token.source_card_refs]]
 card_name = "Saheeli, Sublime Artificer"
@@ -169093,54 +164746,9 @@ scryfall_oracle_id = "ab655810-f67e-4576-9174-35b16f5e3235"
 scryfall_id = "c8bbc692-8d2e-4487-bd19-1a5c78fd3d53"
 
 [[token.source_card_refs]]
-card_name = "Oviya Pashiri, Sage Lifecrafter"
-scryfall_oracle_id = "41e03224-bcdd-4127-a19a-fe66196339b9"
-scryfall_id = "e1c2b1b4-6439-4203-967d-c8a40a2e701e"
-
-[[token.source_card_refs]]
-card_name = "Visionary Augmenter"
-scryfall_oracle_id = "1782bfd7-7d8f-4ed2-9d45-ba9adb41e996"
-scryfall_id = "a77979b6-100a-40ed-ac40-6ed4941e4ca3"
-
-[[token.source_card_refs]]
-card_name = "Maulfist Squad"
-scryfall_oracle_id = "2a8ec988-b513-4e66-b7f5-b2196b4bbff2"
-scryfall_id = "da615e0c-09dd-439e-a874-993b0f2a3097"
-
-[[token.source_card_refs]]
-card_name = "Highspire Artisan"
-scryfall_oracle_id = "fc8c54c4-a436-43cc-888b-f4ba3e751c16"
-scryfall_id = "b335fda4-8611-41d9-b320-d96cd3ff01dc"
-
-[[token.source_card_refs]]
-card_name = "Propeller Pioneer"
-scryfall_oracle_id = "d17a9750-a89f-4ad1-9c15-7ccffc554ee5"
-scryfall_id = "0b916b0e-bb83-44b5-8fcc-88df4a4b3e77"
-
-[[token.source_card_refs]]
 card_name = "Glint-Sleeve Artisan"
 scryfall_oracle_id = "b5f35577-3d94-4835-bfca-3090cb0c63ff"
 scryfall_id = "bea3b945-ae35-4cf0-a5dd-b2398d192c2f"
-
-[[token.source_card_refs]]
-card_name = "Aether Poisoner"
-scryfall_oracle_id = "73757d44-7889-416b-94d2-e730e601ace3"
-scryfall_id = "9503d214-7268-4617-b1a8-51b6d520a029"
-
-[[token.source_card_refs]]
-card_name = "Master Trinketeer"
-scryfall_oracle_id = "aa57f607-c5eb-45a7-bfb1-adce0aef49c7"
-scryfall_id = "902e0fc2-cfec-4bc7-8b9a-d349e74e0b56"
-
-[[token.source_card_refs]]
-card_name = "Angel of Invention"
-scryfall_oracle_id = "28c7f2b6-ba67-4ccf-9e1b-99c89a9d1f72"
-scryfall_id = "d0bc9fc4-b343-431d-a756-0caa2c56c01a"
-
-[[token.source_card_refs]]
-card_name = "Countless Gears Renegade"
-scryfall_oracle_id = "9d1f9036-a466-46b6-ab7c-2de487876978"
-scryfall_id = "87eca36f-5d7c-46ed-bd13-914dad179743"
 
 [[token.source_card_refs]]
 card_name = "Angel of Invention"
@@ -169148,39 +164756,14 @@ scryfall_oracle_id = "28c7f2b6-ba67-4ccf-9e1b-99c89a9d1f72"
 scryfall_id = "98c42f02-6eda-4ef7-929f-b3a2ece9f650"
 
 [[token.source_card_refs]]
-card_name = "Aether Inspector"
-scryfall_oracle_id = "9373a176-a5e9-4fdc-906b-bc6aef657e5b"
-scryfall_id = "e0ae3458-4231-478f-9209-50ab70cf1eea"
-
-[[token.source_card_refs]]
-card_name = "Sram's Expertise"
-scryfall_oracle_id = "5cd17347-5558-46f9-b8bb-ae5deeb1f229"
-scryfall_id = "d4cad3d4-36e5-4df3-a7b3-09c73c86f3bc"
-
-[[token.source_card_refs]]
 card_name = "Servo Exhibition"
 scryfall_oracle_id = "76a6ddc2-f894-4331-89a9-87ca16efd0c0"
 scryfall_id = "256f0b63-ff50-4b4b-9598-d76c4aa9ee4e"
 
 [[token.source_card_refs]]
-card_name = "Sly Requisitioner"
-scryfall_oracle_id = "15ea4698-86b4-47c5-a9a7-60af16063a61"
-scryfall_id = "5f0fd407-8674-49fc-833a-783132cf7264"
-
-[[token.source_card_refs]]
 card_name = "Countless Gears Renegade"
 scryfall_oracle_id = "9d1f9036-a466-46b6-ab7c-2de487876978"
 scryfall_id = "5c7cebae-6ba2-4cf1-a442-2c7a4fbc58da"
-
-[[token.source_card_refs]]
-card_name = "Weaponcraft Enthusiast"
-scryfall_oracle_id = "7c27136a-bf9d-4f42-9c37-abe347fad1bb"
-scryfall_id = "c6323a7b-e640-4f68-92bb-ca01e575f730"
-
-[[token.source_card_refs]]
-card_name = "Animation Module"
-scryfall_oracle_id = "af42079b-a3c0-448c-9bb2-b915252e87a9"
-scryfall_id = "296ee786-b4f5-4e65-8e09-a0231aaed3b3"
 
 [[token.source_card_refs]]
 card_name = "Peema Outrider"
@@ -169338,11 +164921,6 @@ scryfall_oracle_id = "ce35f262-b93f-4409-8b33-26a7ed7abac8"
 scryfall_id = "41c42be7-84fe-4d9d-bf5c-e75e4d5635fa"
 
 [[token.source_card_refs]]
-card_name = "Paladin of the Bloodstained"
-scryfall_oracle_id = "f340018d-8b68-45d5-a72e-a922be68365d"
-scryfall_id = "ccd69b22-dc31-4af3-b0e2-ef75e1fe0e26"
-
-[[token.source_card_refs]]
 card_name = "Legion's Landing // Adanto, the First Fort"
 face_name = "Adanto, the First Fort"
 scryfall_oracle_id = "f7d8b91b-6541-4d3e-af51-7e000eac69c1"
@@ -169481,19 +165059,9 @@ colors = ["Red"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "General Kreat, the Boltbringer"
-scryfall_oracle_id = "da1c1c70-c2fa-4ba7-89fe-d9af3fb353b9"
-scryfall_id = "226fc101-abcc-4ed4-8c0b-3677dc8d8f0a"
-
-[[token.source_card_refs]]
 card_name = "Searslicer Goblin"
 scryfall_oracle_id = "86ec0b56-497f-481c-a03a-c4e64e8e7404"
 scryfall_id = "58deba9d-5c95-4633-a86c-2637a8bb7ce2"
-
-[[token.source_card_refs]]
-card_name = "Goblin Goliath"
-scryfall_oracle_id = "131069a6-8f30-4caf-8934-3588837b5f7f"
-scryfall_id = "86b29f57-010e-4b32-b49f-c5af989b8281"
 
 [[token.source_card_refs]]
 card_name = "Dragon Fodder"
@@ -169506,34 +165074,14 @@ scryfall_oracle_id = "68418069-f615-40ef-ae0d-764192acae00"
 scryfall_id = "824b2d73-2151-4e5e-9f05-8f63e2bdcaa9"
 
 [[token.source_card_refs]]
-card_name = "Goblin Surprise"
-scryfall_oracle_id = "79cd09e8-d738-47c0-9473-b6281bec6935"
-scryfall_id = "f092806d-b2de-44a8-85cd-0ab2b16e344e"
-
-[[token.source_card_refs]]
 card_name = "Searslicer Goblin"
 scryfall_oracle_id = "86ec0b56-497f-481c-a03a-c4e64e8e7404"
 scryfall_id = "0523f8d8-4324-4e1d-9a88-4fd871e93bb8"
 
 [[token.source_card_refs]]
-card_name = "Krenko's Command"
-scryfall_oracle_id = "9cfe86ae-eebe-44aa-a956-4b3e9e621105"
-scryfall_id = "699295ea-edf4-46f4-972e-82359c80bb2e"
-
-[[token.source_card_refs]]
-card_name = "Battle Cry Goblin"
-scryfall_oracle_id = "e74c4001-d958-4d2b-b57d-c3601f01580c"
-scryfall_id = "ba41ec1b-e631-4882-b897-df26e26ada04"
-
-[[token.source_card_refs]]
 card_name = "Goblin Negotiation"
 scryfall_oracle_id = "79824266-bffa-476c-bdd3-976e9d789a42"
 scryfall_id = "f2016585-e26c-4d13-b09f-af6383c192f7"
-
-[[token.source_card_refs]]
-card_name = "Goblin Rabblemaster"
-scryfall_oracle_id = "24661b81-6bee-4ad8-b3ab-53cb65005c51"
-scryfall_id = "9962cf82-a8ed-4984-adeb-b08b7c54751b"
 
 [[token.source_card_refs]]
 card_name = "Searslicer Goblin"
@@ -169549,16 +165097,6 @@ scryfall_id = "527dd5d4-5f72-40bb-8a9d-1f5ac3f81e2e"
 card_name = "Searslicer Goblin"
 scryfall_oracle_id = "86ec0b56-497f-481c-a03a-c4e64e8e7404"
 scryfall_id = "9e3059e4-b198-4eba-98e8-f0f9f83d1928"
-
-[[token.source_card_refs]]
-card_name = "Krenko, Tin Street Kingpin"
-scryfall_oracle_id = "e8065e1d-e937-4b56-8011-78f0d07328a0"
-scryfall_id = "0c7d8714-a0ef-4ae8-909b-60f3319c646c"
-
-[[token.source_card_refs]]
-card_name = "Beetleback Chief"
-scryfall_oracle_id = "f5c5f64c-6911-430c-a825-b32b96d39c7d"
-scryfall_id = "fe276be5-bc54-4fb7-82af-a2312c76f1d2"
 
 [token.token_image_ref]
 scryfall_id = "70f8a1de-cd4c-4afa-bf03-0245d375d42e"
@@ -169594,27 +165132,7 @@ scryfall_id = "698a050c-6828-4bb0-8dde-85b41e657034"
 [[token.source_card_refs]]
 card_name = "Sengir Autocrat"
 scryfall_oracle_id = "0561043a-3896-4bb1-8ff5-ee674ddfea2a"
-scryfall_id = "234a5401-bbe4-40ab-9204-12d944fbd2b1"
-
-[[token.source_card_refs]]
-card_name = "Sengir Autocrat"
-scryfall_oracle_id = "0561043a-3896-4bb1-8ff5-ee674ddfea2a"
-scryfall_id = "647b0f86-8ec1-4506-9a31-a8495232094e"
-
-[[token.source_card_refs]]
-card_name = "Sengir Autocrat"
-scryfall_oracle_id = "0561043a-3896-4bb1-8ff5-ee674ddfea2a"
 scryfall_id = "83fa8a17-ff86-465e-9092-0968081f4e28"
-
-[[token.source_card_refs]]
-card_name = "Sengir Autocrat"
-scryfall_oracle_id = "0561043a-3896-4bb1-8ff5-ee674ddfea2a"
-scryfall_id = "bac17237-778d-4551-9a92-8be546e233dc"
-
-[[token.source_card_refs]]
-card_name = "Sengir Autocrat"
-scryfall_oracle_id = "0561043a-3896-4bb1-8ff5-ee674ddfea2a"
-scryfall_id = "0d16e024-7865-43d0-8cd8-8933ef741d05"
 
 [token.token_image_ref]
 scryfall_id = "c98dbedd-b1f1-4a9c-af37-8ce2ae07a247"
@@ -173172,11 +168690,6 @@ card_name = "Hungry for More"
 scryfall_oracle_id = "3eaf1e6b-bf4c-4ea8-83ea-6827470fd802"
 scryfall_id = "ce09c0df-d022-4ebf-8f7f-8a913249e75f"
 
-[[token.source_card_refs]]
-card_name = "Hungry for More"
-scryfall_oracle_id = "3eaf1e6b-bf4c-4ea8-83ea-6827470fd802"
-scryfall_id = "e7e74cfe-d573-482c-87df-804551667aad"
-
 [token.token_image_ref]
 scryfall_id = "0f8fe08d-b469-4471-8a7d-cf75850ba312"
 scryfall_oracle_id = "e45c5c4e-2226-4c77-9480-8cc80a47e5a3"
@@ -173419,11 +168932,6 @@ scryfall_id = "1925dc45-4dee-4772-aa16-3b4ca54be6c7"
 card_name = "Grist, the Hunger Tide"
 scryfall_oracle_id = "0efb0d7e-dea0-4817-a243-15066e9ef333"
 scryfall_id = "a10b0238-fe30-4543-ae8a-ed834a0930b1"
-
-[[token.source_card_refs]]
-card_name = "Amzu, Swarm's Hunger"
-scryfall_oracle_id = "6777863c-e52c-4a7c-b8d2-a16b1438b3d2"
-scryfall_id = "634f6f70-347e-436f-abf9-4a573472e2c8"
 
 [[token.source_card_refs]]
 card_name = "Izoni, Thousand-Eyed"
@@ -173906,11 +169414,6 @@ colors = [
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Courier's Briefcase"
-scryfall_oracle_id = "00cd3bf9-0dd6-4ec0-a841-1839a71604ab"
-scryfall_id = "4960fa74-c0bf-4f1d-82a7-d5da5aa3e00a"
-
-[[token.source_card_refs]]
 card_name = "Master of Ceremonies"
 scryfall_oracle_id = "18ed0c8a-db8f-4247-87c4-544b833f01bd"
 scryfall_id = "ac736037-113f-4e4b-8b97-7b2300b0d276"
@@ -173955,24 +169458,9 @@ colors = ["Red"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Akroan Crusader"
-scryfall_oracle_id = "d981d85c-e97b-4fe7-b415-6e73a3e7e35c"
-scryfall_id = "45158565-dacd-4892-b51a-40da7d1da778"
-
-[[token.source_card_refs]]
-card_name = "Akroan Crusader"
-scryfall_oracle_id = "d981d85c-e97b-4fe7-b415-6e73a3e7e35c"
-scryfall_id = "b8569043-16b2-480f-b4d0-ba2fe6e19b46"
-
-[[token.source_card_refs]]
 card_name = "Frontline Heroism"
 scryfall_oracle_id = "4c340b82-22e1-445a-b236-82471b442031"
 scryfall_id = "7fb34149-5e09-47cb-bd1f-f2f9ee14dce3"
-
-[[token.source_card_refs]]
-card_name = "Frontline Heroism"
-scryfall_oracle_id = "4c340b82-22e1-445a-b236-82471b442031"
-scryfall_id = "e78eda51-255a-4421-9b6f-025a432e9df9"
 
 [token.token_image_ref]
 scryfall_id = "dfb0ae06-9a02-4cd6-bc1d-423662d7a1bd"
@@ -175025,11 +170513,6 @@ scryfall_oracle_id = "84e84532-498b-40ea-9510-46fb2403939b"
 scryfall_id = "4018dda4-c78b-4e8e-ab8b-391e16c4e0f7"
 
 [[token.source_card_refs]]
-card_name = "Tireless Provisioner"
-scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
-scryfall_id = "3cf04e55-b266-46cd-a79a-d87f5ceba469"
-
-[[token.source_card_refs]]
 card_name = "Sorin of House Markov // Sorin, Ravenous Neonate"
 face_name = "Sorin, Ravenous Neonate"
 scryfall_oracle_id = "84e84532-498b-40ea-9510-46fb2403939b"
@@ -175949,16 +171432,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Brindle Shoat"
 scryfall_oracle_id = "d385c2e1-a62e-43ad-80ef-a6178deac82c"
-scryfall_id = "318a41e3-1c5a-467e-9ffb-e6a5f817f8fe"
-
-[[token.source_card_refs]]
-card_name = "Brindle Shoat"
-scryfall_oracle_id = "d385c2e1-a62e-43ad-80ef-a6178deac82c"
-scryfall_id = "03eea9a2-3129-47f5-88cc-8295d0039cb7"
-
-[[token.source_card_refs]]
-card_name = "Brindle Shoat"
-scryfall_oracle_id = "d385c2e1-a62e-43ad-80ef-a6178deac82c"
 scryfall_id = "0a005933-e206-4b14-9a0f-755fae6c5a2a"
 
 [token.token_image_ref]
@@ -176050,19 +171523,9 @@ scryfall_oracle_id = "26ae37ab-91f8-4113-beb0-1154f9b62d28"
 scryfall_id = "7849b360-afad-4f50-b455-3d118f7bfcd0"
 
 [[token.source_card_refs]]
-card_name = "Varchild's War-Riders"
-scryfall_oracle_id = "258921f2-df26-4d8a-ad34-8f44d0158ae7"
-scryfall_id = "e879b457-dffa-4b3b-a3cd-717a60c1e586"
-
-[[token.source_card_refs]]
 card_name = "Varchild, Betrayer of Kjeldor"
 scryfall_oracle_id = "26ae37ab-91f8-4113-beb0-1154f9b62d28"
 scryfall_id = "2c67b70f-4090-4b1c-b4c9-804b6f90054b"
-
-[[token.source_card_refs]]
-card_name = "Varchild's War-Riders"
-scryfall_oracle_id = "258921f2-df26-4d8a-ad34-8f44d0158ae7"
-scryfall_id = "ee1d41da-aa72-434b-811f-95d4bae4ba5c"
 
 [token.token_image_ref]
 scryfall_id = "f4478979-19b6-4524-bbbd-519594c38f5a"
@@ -177010,11 +172473,6 @@ scryfall_oracle_id = "325b3469-531e-4ca2-bccb-bb95258c1b54"
 scryfall_id = "308fbcf8-0475-4c0b-a365-418588f84b5a"
 
 [[token.source_card_refs]]
-card_name = "Everythingamajig"
-scryfall_oracle_id = "7123b355-8606-4666-a8a8-9560cfea9e86"
-scryfall_id = "e9600f0b-c182-40fc-a0da-77f7758c94a9"
-
-[[token.source_card_refs]]
 card_name = "Trading Post"
 scryfall_oracle_id = "63788566-e25a-44bb-bb55-197e1b93b3e8"
 scryfall_id = "03499a72-e865-46ff-bcb2-75e53e4b600e"
@@ -177279,11 +172737,6 @@ subtypes = [
 supertypes = []
 colors = ["Blue"]
 keywords = ["Flying"]
-
-[[token.source_card_refs]]
-card_name = "Mu Yanling, Sky Dancer"
-scryfall_oracle_id = "1e825298-7c99-40cc-81c9-280cc7ed98d3"
-scryfall_id = "483f5d0c-26d1-467c-b5d8-96e8aa259a7e"
 
 [[token.source_card_refs]]
 card_name = "Mu Yanling, Sky Dancer"
@@ -178042,22 +173495,12 @@ keywords = ["Changeling"]
 [[token.source_card_refs]]
 card_name = "Irregular Cohort"
 scryfall_oracle_id = "c0636d16-671c-4e80-af8c-67d80d2cd979"
-scryfall_id = "1a578419-020e-4b54-be89-62eb186bfce4"
-
-[[token.source_card_refs]]
-card_name = "Irregular Cohort"
-scryfall_oracle_id = "c0636d16-671c-4e80-af8c-67d80d2cd979"
 scryfall_id = "b1ec325a-31bb-4df8-8b88-6d28c85907ce"
 
 [[token.source_card_refs]]
 card_name = "Irregular Cohort"
 scryfall_oracle_id = "c0636d16-671c-4e80-af8c-67d80d2cd979"
 scryfall_id = "61775227-34ad-469a-a4d4-ee8ce69dd10f"
-
-[[token.source_card_refs]]
-card_name = "Birthing Boughs"
-scryfall_oracle_id = "c6836d78-ca71-4413-aced-d4de19976221"
-scryfall_id = "3a3be8f6-8301-4389-876c-69fa42b7a9cc"
 
 [[token.source_card_refs]]
 card_name = "Birthing Boughs"
@@ -179268,11 +174711,6 @@ colors = ["Black"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
-card_name = "Tivash, Gloom Summoner"
-scryfall_oracle_id = "b5641fcf-135e-43e7-a547-344fac61e279"
-scryfall_id = "f930f102-ad69-4b70-ae0f-641f5c05f40c"
-
-[[token.source_card_refs]]
 card_name = "Reign of the Pit"
 scryfall_oracle_id = "3e1a6337-bb29-450f-bf29-ff71b357a983"
 scryfall_id = "098c7cd1-5f20-437d-9b81-f480f3f02833"
@@ -179280,17 +174718,7 @@ scryfall_id = "098c7cd1-5f20-437d-9b81-f480f3f02833"
 [[token.source_card_refs]]
 card_name = "Promise of Power"
 scryfall_oracle_id = "fde459b2-f45f-40d2-b328-58f65440f494"
-scryfall_id = "d96c3947-0eec-48a1-ba69-59734b4ac9da"
-
-[[token.source_card_refs]]
-card_name = "Promise of Power"
-scryfall_oracle_id = "fde459b2-f45f-40d2-b328-58f65440f494"
 scryfall_id = "ad5c6863-da34-4d5a-8782-ddaf3ccb498f"
-
-[[token.source_card_refs]]
-card_name = "Reign of the Pit"
-scryfall_oracle_id = "3e1a6337-bb29-450f-bf29-ff71b357a983"
-scryfall_id = "a74dd700-a326-4add-b563-01707f79df93"
 
 [token.token_image_ref]
 scryfall_id = "2c0e7faf-43cb-4a96-ac3c-9533f957ee28"
@@ -179467,11 +174895,6 @@ scryfall_oracle_id = "93c2b91d-7d4e-483c-a11f-4a525f881503"
 scryfall_id = "85e160f7-a641-4d39-8b47-7e27478d9e84"
 
 [[token.source_card_refs]]
-card_name = "Hexgold Hoverwings"
-scryfall_oracle_id = "63018d1c-f7fb-44c8-bcd2-292e74ab5b54"
-scryfall_id = "c8d4e0dd-a7fb-410b-9170-d8ebb161a9a5"
-
-[[token.source_card_refs]]
 card_name = "Barret, Avalanche Leader"
 scryfall_oracle_id = "83f776d9-f3b6-40c2-8008-1ace4d110825"
 scryfall_id = "2e37fd36-84f0-4869-bfae-da4b97c9725d"
@@ -179480,11 +174903,6 @@ scryfall_id = "2e37fd36-84f0-4869-bfae-da4b97c9725d"
 card_name = "Barret, Avalanche Leader"
 scryfall_oracle_id = "83f776d9-f3b6-40c2-8008-1ace4d110825"
 scryfall_id = "6ee716c6-a4be-4237-bdef-f812baffa6d5"
-
-[[token.source_card_refs]]
-card_name = "Mirran Bardiche"
-scryfall_oracle_id = "1fd04d9e-cf89-49ba-a932-5d278f65bf77"
-scryfall_id = "e8835209-c4ce-4c1b-8bd9-6a7d2c39f814"
 
 [token.token_image_ref]
 scryfall_id = "6afbbdad-aeed-428a-b840-c33f59a18d0b"
@@ -179578,11 +174996,6 @@ scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
 scryfall_id = "97fcf5a5-54e1-43f3-95e3-edc6215bf973"
 
 [[token.source_card_refs]]
-card_name = "Wall Crawl"
-scryfall_oracle_id = "4a09536e-dfc1-4b15-adc1-07ef866ebda0"
-scryfall_id = "c37e8b36-00bc-4fc0-89e1-dfd8a3188465"
-
-[[token.source_card_refs]]
 card_name = "Peter Parker // Amazing Spider-Man"
 face_name = "Amazing Spider-Man"
 scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
@@ -179592,18 +175005,7 @@ scryfall_id = "98912aae-4e42-4434-b979-9c85f09f8d6d"
 card_name = "Peter Parker // Amazing Spider-Man"
 face_name = "Peter Parker"
 scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
-scryfall_id = "2ec821c3-3e5c-4af8-a6ef-e2e77aa8668c"
-
-[[token.source_card_refs]]
-card_name = "Peter Parker // Amazing Spider-Man"
-face_name = "Peter Parker"
-scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
 scryfall_id = "3ce33422-5dba-4a42-8375-dd8ccc692a7b"
-
-[[token.source_card_refs]]
-card_name = "Origin of Spider-Man"
-scryfall_oracle_id = "7fbe9056-190f-40a1-bee9-59ebd6f981f5"
-scryfall_id = "1bb9f52a-8edc-4ca5-bc63-ac6f93874219"
 
 [[token.source_card_refs]]
 card_name = "Origin of Spider-Man"
@@ -179630,18 +175032,7 @@ scryfall_id = "1183262e-1f02-46b3-8cfa-fe30e0016c11"
 card_name = "Peter Parker // Amazing Spider-Man"
 face_name = "Amazing Spider-Man"
 scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
-scryfall_id = "2ec821c3-3e5c-4af8-a6ef-e2e77aa8668c"
-
-[[token.source_card_refs]]
-card_name = "Peter Parker // Amazing Spider-Man"
-face_name = "Amazing Spider-Man"
-scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
 scryfall_id = "97fcf5a5-54e1-43f3-95e3-edc6215bf973"
-
-[[token.source_card_refs]]
-card_name = "Spiders-Man, Heroic Horde"
-scryfall_oracle_id = "d21d7557-9702-46c1-8277-42a3442084c2"
-scryfall_id = "29f7f242-57fa-4714-84fa-3e65c7101985"
 
 [token.token_image_ref]
 scryfall_id = "4a40f6e1-3545-4503-af3e-f0acfb735e3a"
@@ -181074,11 +176465,6 @@ scryfall_oracle_id = "3d01c351-6dbd-4d63-9843-3aa1a3c039a6"
 scryfall_id = "f9d25b34-990d-416c-aef7-1b5a73f19dd4"
 
 [[token.source_card_refs]]
-card_name = "Deadly Dispute"
-scryfall_oracle_id = "457af74a-02b3-4659-846d-63e482667f34"
-scryfall_id = "a4e0b297-6d33-4e2b-b497-aa952dcf2141"
-
-[[token.source_card_refs]]
 card_name = "Zidane, Tantalus Thief"
 scryfall_oracle_id = "f267fb54-1881-464c-81af-9e03c3f3b41d"
 scryfall_id = "2eaffe7a-0e04-4c19-942b-695a0c350ef0"
@@ -181092,11 +176478,6 @@ scryfall_id = "af4481b1-43b0-43e6-a9ea-f4ec0a551e61"
 card_name = "Kain, Traitorous Dragoon"
 scryfall_oracle_id = "70fbb378-d905-47cf-8c54-cc166a7867b3"
 scryfall_id = "28eb294b-4cab-4c34-ae29-20aac9799471"
-
-[[token.source_card_refs]]
-card_name = "Ancient Copper Dragon"
-scryfall_oracle_id = "48daee9d-ddaf-410f-8c3a-12fa1064ab56"
-scryfall_id = "f6cbc754-8aed-4c32-857c-ea639943b5d2"
 
 [[token.source_card_refs]]
 card_name = "Magic Pot"
@@ -181123,11 +176504,6 @@ card_name = "Sidequest: Hunt the Mark // Yiazmat, Ultimate Mark"
 face_name = "Sidequest: Hunt the Mark"
 scryfall_oracle_id = "d74f9a18-8dab-4549-be3f-9697ff68d73c"
 scryfall_id = "de8067cc-3de3-43b2-8fcf-6dce6f4f7db1"
-
-[[token.source_card_refs]]
-card_name = "Ragavan, Nimble Pilferer"
-scryfall_oracle_id = "37108cd4-bbab-4ce3-9ed6-f60e8422e703"
-scryfall_id = "a71d1ec3-2d7a-4749-8936-8bf7a8b83d84"
 
 [[token.source_card_refs]]
 card_name = "Sidequest: Hunt the Mark // Yiazmat, Ultimate Mark"
@@ -181174,11 +176550,6 @@ scryfall_id = "545c98b3-dc78-4070-8dcb-f6a246abce09"
 card_name = "Undercity Dire Rat"
 scryfall_oracle_id = "f09811d0-c5da-4061-aaa7-835ccee3b05a"
 scryfall_id = "274788f4-fbf3-4a15-bdc0-f513a2fde30d"
-
-[[token.source_card_refs]]
-card_name = "Captain Lannery Storm"
-scryfall_oracle_id = "235bf0ba-658c-463f-b112-7478ba27bd7b"
-scryfall_id = "7c3aeedd-d41b-44c9-9b0a-e5952202f632"
 
 [[token.source_card_refs]]
 card_name = "Prompto Argentum"
@@ -181867,11 +177238,6 @@ keywords = []
 card_name = "Torens, Fist of the Angels"
 scryfall_oracle_id = "2cb96408-9195-4e41-ad9a-f8c74fbad083"
 scryfall_id = "f8566528-ba96-4425-8831-b5d6197da9ae"
-
-[[token.source_card_refs]]
-card_name = "Torens, Fist of the Angels"
-scryfall_oracle_id = "2cb96408-9195-4e41-ad9a-f8c74fbad083"
-scryfall_id = "e52fbb3a-f366-4c78-a617-3abbe08c4f47"
 
 [token.token_image_ref]
 scryfall_id = "e35e232f-e98b-49c7-a68c-d8e3339e90b5"
@@ -182983,16 +178349,6 @@ scryfall_id = "217201eb-3340-4aa2-8d38-5d9ff2997b39"
 [[token.source_card_refs]]
 card_name = "Seize the Storm"
 scryfall_oracle_id = "d3455e93-3a05-42db-945d-c4c85f4ac827"
-scryfall_id = "e3bd712f-e62e-46ff-bf3a-05a55573edea"
-
-[[token.source_card_refs]]
-card_name = "Seize the Storm"
-scryfall_oracle_id = "d3455e93-3a05-42db-945d-c4c85f4ac827"
-scryfall_id = "024b3bfd-3d2b-4f45-b015-2d94fe2f2bb3"
-
-[[token.source_card_refs]]
-card_name = "Seize the Storm"
-scryfall_oracle_id = "d3455e93-3a05-42db-945d-c4c85f4ac827"
 scryfall_id = "45ec2af6-8397-429f-900f-846a5056f8e0"
 
 [token.token_image_ref]
@@ -183074,26 +178430,9 @@ scryfall_oracle_id = "cb952c81-c7bb-4670-938d-296d35551986"
 scryfall_id = "e7fcfcba-6547-4617-a301-47e1d7523dae"
 
 [[token.source_card_refs]]
-card_name = "Seed Guardian"
-scryfall_oracle_id = "728045bf-0959-44ff-8de9-16ec35fd248f"
-scryfall_id = "e05367ee-9d50-4963-a317-81a2f663c35a"
-
-[[token.source_card_refs]]
 card_name = "Tumbleweed Rising"
 scryfall_oracle_id = "ef574346-1d98-447d-acb6-4d8d53c5f651"
 scryfall_id = "275d2d2a-ef85-48c9-919d-bc62cdad8a10"
-
-[[token.source_card_refs]]
-card_name = "Budoka Gardener // Dokai, Weaver of Life"
-face_name = "Dokai, Weaver of Life"
-scryfall_oracle_id = "cb952c81-c7bb-4670-938d-296d35551986"
-scryfall_id = "49999b95-5e62-414c-b975-4191b9c1ab39"
-
-[[token.source_card_refs]]
-card_name = "Budoka Gardener // Dokai, Weaver of Life"
-face_name = "Budoka Gardener"
-scryfall_oracle_id = "cb952c81-c7bb-4670-938d-296d35551986"
-scryfall_id = "49999b95-5e62-414c-b975-4191b9c1ab39"
 
 [[token.source_card_refs]]
 card_name = "Dance of the Tumbleweeds"
@@ -183883,11 +179222,6 @@ keywords = ["Flying"]
 [[token.source_card_refs]]
 card_name = "Ominous Roost"
 scryfall_oracle_id = "745fc118-ffab-45c6-b51a-7bef2f6931e8"
-scryfall_id = "cd643429-ba1f-4dec-a8a6-eb0a85597e60"
-
-[[token.source_card_refs]]
-card_name = "Ominous Roost"
-scryfall_oracle_id = "745fc118-ffab-45c6-b51a-7bef2f6931e8"
 scryfall_id = "daf2b49a-56f9-4093-960f-9ec7af8983b5"
 
 [token.token_image_ref]
@@ -184015,11 +179349,6 @@ scryfall_id = "4184638c-bfb8-424d-b106-ed7b3d80b668"
 card_name = "Hunted Dragon"
 scryfall_oracle_id = "39a4416f-9b40-432e-aeb6-cc7bf519b37a"
 scryfall_id = "f454ae09-6ad3-4ef5-b640-c09908ba3625"
-
-[[token.source_card_refs]]
-card_name = "Hunted Dragon"
-scryfall_oracle_id = "39a4416f-9b40-432e-aeb6-cc7bf519b37a"
-scryfall_id = "d2b9cc6e-47db-47d5-84c9-975e4b618261"
 
 [[token.source_card_refs]]
 card_name = "Hunted Dragon"
@@ -184231,11 +179560,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Tah-Crop Skirmisher"
 scryfall_oracle_id = "6fab0fa0-d082-414e-9bcf-edc0fc1f6211"
-scryfall_id = "2178f185-db23-41e8-b52b-a734f9d2344f"
-
-[[token.source_card_refs]]
-card_name = "Tah-Crop Skirmisher"
-scryfall_oracle_id = "6fab0fa0-d082-414e-9bcf-edc0fc1f6211"
 scryfall_id = "ab0429ec-0809-4e68-9790-8c21bde201a2"
 
 [token.token_image_ref]
@@ -184360,16 +179684,6 @@ scryfall_oracle_id = "0728b195-2dfe-4d73-91ae-e658a97b0b9a"
 scryfall_id = "501599d6-1072-4124-b05d-01f96de153f3"
 
 [[token.source_card_refs]]
-card_name = "Hard Evidence"
-scryfall_oracle_id = "0728b195-2dfe-4d73-91ae-e658a97b0b9a"
-scryfall_id = "204114ed-0d8e-460f-b7ce-9266536d4399"
-
-[[token.source_card_refs]]
-card_name = "Scuttletide"
-scryfall_oracle_id = "2be9c1e6-0226-497a-b548-21bf1cfbc286"
-scryfall_id = "d9b34ec1-8aa5-4cfd-b15e-1c479f82cfd0"
-
-[[token.source_card_refs]]
 card_name = "Scuttletide"
 scryfall_oracle_id = "2be9c1e6-0226-497a-b548-21bf1cfbc286"
 scryfall_id = "38e4ce27-aba2-4a3f-8de7-d442323d8be2"
@@ -184378,16 +179692,6 @@ scryfall_id = "38e4ce27-aba2-4a3f-8de7-d442323d8be2"
 card_name = "Specimen Collector"
 scryfall_oracle_id = "fdb51cc1-ce0e-4920-b123-1cdd570fc38b"
 scryfall_id = "bdfaed69-bc4c-4c73-abc3-00dce5e0177e"
-
-[[token.source_card_refs]]
-card_name = "Hard Evidence"
-scryfall_oracle_id = "0728b195-2dfe-4d73-91ae-e658a97b0b9a"
-scryfall_id = "c55901dc-3f5a-490d-8496-5b844530d410"
-
-[[token.source_card_refs]]
-card_name = "Specimen Collector"
-scryfall_oracle_id = "fdb51cc1-ce0e-4920-b123-1cdd570fc38b"
-scryfall_id = "a325b3f1-67f6-4b56-8572-94e9970a5acc"
 
 [token.token_image_ref]
 scryfall_id = "7ef7f37a-b7f5-45a1-8f2b-7097089ca2e5"
@@ -184450,17 +179754,7 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Thunderheads"
 scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
-scryfall_id = "56de9727-021e-4b37-b80b-08dcd898aec0"
-
-[[token.source_card_refs]]
-card_name = "Thunderheads"
-scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
 scryfall_id = "bf0a2851-946d-4f10-b43b-7444daa54ae1"
-
-[[token.source_card_refs]]
-card_name = "Thunderheads"
-scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
-scryfall_id = "381a7aaa-6cb8-47db-a381-6d1102e2338e"
 
 [[token.source_card_refs]]
 card_name = "Thunderheads"
@@ -184836,11 +180130,6 @@ scryfall_id = "067f24df-7018-45c8-bd67-1336b3672bb3"
 card_name = "Ominous Seas"
 scryfall_oracle_id = "58ea9b0a-1bef-4ccb-acb7-f03c8daf3df3"
 scryfall_id = "ce8965f2-756a-4461-a643-db024a11c2de"
-
-[[token.source_card_refs]]
-card_name = "Kiora, the Tide's Fury"
-scryfall_oracle_id = "6918a8b7-ced8-4f32-8780-69dfc8b9d11b"
-scryfall_id = "b42c67ad-847b-43af-b885-f55a8d859434"
 
 [token.token_image_ref]
 scryfall_id = "ca17c7b2-180a-4bd1-9ab2-152f8f656dba"
@@ -185474,11 +180763,6 @@ subtypes = ["Boar"]
 supertypes = []
 colors = ["Green"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Rural Recruit"
-scryfall_oracle_id = "fda06d9e-d17f-4bb6-916b-06116e47c8e8"
-scryfall_id = "428e7ae9-f299-4514-a225-ba8bbaa810f7"
 
 [[token.source_card_refs]]
 card_name = "Rural Recruit"
@@ -188584,16 +183868,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Endrek Sahr, Master Breeder"
 scryfall_oracle_id = "47a0079f-3544-45bc-a32a-bd93844c8c43"
-scryfall_id = "dac6faba-59f2-436f-addb-c53db2b0cc17"
-
-[[token.source_card_refs]]
-card_name = "Sarpadian Empires, Vol. VII"
-scryfall_oracle_id = "f71d55f5-f220-4cb0-9468-b8d339ab8535"
-scryfall_id = "b37a6cf7-f239-4bca-b4c3-a48932ef56b5"
-
-[[token.source_card_refs]]
-card_name = "Endrek Sahr, Master Breeder"
-scryfall_oracle_id = "47a0079f-3544-45bc-a32a-bd93844c8c43"
 scryfall_id = "22a14b34-c575-471b-b636-b25cb269196c"
 
 [[token.source_card_refs]]
@@ -189851,11 +185125,6 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Elmar, Ulvenwald Informant"
-scryfall_oracle_id = "5a35201d-e9b1-433a-bb70-3280ceedbcd6"
-scryfall_id = "95d197b3-fc56-43a2-981f-b5b905222b5c"
-
-[[token.source_card_refs]]
 card_name = "Havengul Laboratory // Havengul Mystery"
 face_name = "Havengul Laboratory"
 scryfall_oracle_id = "e71ac446-02a4-4468-8d29-f28b21617665"
@@ -189865,23 +185134,6 @@ scryfall_id = "83a86763-c3fe-4cff-8b65-22cb329d112c"
 card_name = "Wernog, Rider's Chaplain"
 scryfall_oracle_id = "6cd03270-54cc-43e1-9b86-70c76960c841"
 scryfall_id = "25a4af68-6e5e-4b44-9c1c-25ecdbd555b5"
-
-[[token.source_card_refs]]
-card_name = "Havengul Laboratory // Havengul Mystery"
-face_name = "Havengul Mystery"
-scryfall_oracle_id = "e71ac446-02a4-4468-8d29-f28b21617665"
-scryfall_id = "823b019e-10c0-4712-8167-d4f37a71e782"
-
-[[token.source_card_refs]]
-card_name = "Sophina, Spearsage Deserter"
-scryfall_oracle_id = "095dabda-4570-4764-8d62-4a29eb19d3e6"
-scryfall_id = "e0a64924-068e-483f-91a6-d450b67b3c75"
-
-[[token.source_card_refs]]
-card_name = "Havengul Laboratory // Havengul Mystery"
-face_name = "Havengul Laboratory"
-scryfall_oracle_id = "e71ac446-02a4-4468-8d29-f28b21617665"
-scryfall_id = "823b019e-10c0-4712-8167-d4f37a71e782"
 
 [[token.source_card_refs]]
 card_name = "Tireless Tracker"
@@ -189907,11 +185159,6 @@ scryfall_id = "c88eb33d-efba-4ad9-878f-f051079c9bce"
 card_name = "Elmar, Ulvenwald Informant"
 scryfall_oracle_id = "5a35201d-e9b1-433a-bb70-3280ceedbcd6"
 scryfall_id = "abb04ab1-2a74-432f-b3d3-d4f5b2534066"
-
-[[token.source_card_refs]]
-card_name = "Wernog, Rider's Chaplain"
-scryfall_oracle_id = "6cd03270-54cc-43e1-9b86-70c76960c841"
-scryfall_id = "39491011-bdf6-4e61-8534-fe26c1571f8f"
 
 [[token.source_card_refs]]
 card_name = "Tireless Tracker"
@@ -190008,22 +185255,12 @@ scryfall_id = "11ba43d1-e879-40e0-b49c-e009deb7e3aa"
 [[token.source_card_refs]]
 card_name = "Myr Sire"
 scryfall_oracle_id = "25794033-bd17-4056-b116-68d3acf52569"
-scryfall_id = "a3f2e2e5-5ed2-4040-92ba-ad1ac13f03f6"
-
-[[token.source_card_refs]]
-card_name = "Myr Sire"
-scryfall_oracle_id = "25794033-bd17-4056-b116-68d3acf52569"
 scryfall_id = "8e289d6c-1dcd-4431-9ed4-62b48eb207e1"
 
 [[token.source_card_refs]]
 card_name = "Parasitic Implant"
 scryfall_oracle_id = "4fc0f58c-5f7f-4a32-8f14-cae696672beb"
 scryfall_id = "e34f1bf3-9f3a-47f0-9761-8b2356328a39"
-
-[[token.source_card_refs]]
-card_name = "Parasitic Implant"
-scryfall_oracle_id = "4fc0f58c-5f7f-4a32-8f14-cae696672beb"
-scryfall_id = "43296ce8-f055-4778-a187-363a642001e4"
 
 [[token.source_card_refs]]
 card_name = "Myr Sire"
@@ -190754,12 +185991,9 @@ source_card_names = [
     "Arlinn Kord // Arlinn, Embraced by the Moon",
     "Arlinn, Embraced by the Moon",
     "Arlinn, Voice of the Pack",
-    "Arlinn, the Moon's Fury",
-    "Arlinn, the Pack's Hope",
     "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
     "Bestial Menace",
     "Bird",
-    "Child of the Pack",
     "Child of the Pack // Savage Packmate",
     "Cult of the Waxing Moon",
     "Elturgard Ranger",
@@ -190789,13 +186023,10 @@ source_card_names = [
     "Raised by Wolves",
     "Ranger Class",
     "Ravager of the Fells",
-    "Savage Packmate",
     "Silverfur Partisan",
     "Somberwald Beastmaster",
     "Sword of Body and Mind",
-    "Tovolar's Huntmaster",
     "Tovolar's Huntmaster // Tovolar's Packleader",
-    "Tovolar's Packleader",
     "Turntimber Ranger",
     "Varis, Silverymoon Ranger",
     "Wolf-Skull Shaman",
@@ -190823,66 +186054,16 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Nightpack Ambusher"
-scryfall_oracle_id = "4d67357c-5939-45c8-a656-aaf76728a5a6"
-scryfall_id = "4cd67241-6ff1-41bc-9bda-4a87fd4f6bdd"
-
-[[token.source_card_refs]]
 card_name = "Huntmaster of the Fells // Ravager of the Fells"
 face_name = "Ravager of the Fells"
 scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
 scryfall_id = "86da891f-08d0-459c-9d20-358032c6411a"
 
 [[token.source_card_refs]]
-card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
-face_name = "Garruk, the Veil-Cursed"
-scryfall_oracle_id = "7cec9021-6f25-4fd8-b40e-adf4ffd3a7b8"
-scryfall_id = "c340ad6b-aa09-4d12-a947-33b29b875158"
-
-[[token.source_card_refs]]
-card_name = "Arlinn Kord // Arlinn, Embraced by the Moon"
-face_name = "Arlinn, Embraced by the Moon"
-scryfall_oracle_id = "6bb7d0df-7a9f-4e17-8c31-7628c4b12356"
-scryfall_id = "49ed8050-1c98-47a0-82dd-ce08ee372387"
-
-[[token.source_card_refs]]
-card_name = "Child of the Pack // Savage Packmate"
-face_name = "Child of the Pack"
-scryfall_oracle_id = "a9c5b155-7c09-4100-9679-8fca2b5e9222"
-scryfall_id = "79fbd424-8668-4e36-8e2f-780362c9915e"
-
-[[token.source_card_refs]]
-card_name = "Sword of Body and Mind"
-scryfall_oracle_id = "fac42229-4f5f-4d04-85dd-5031d4e435aa"
-scryfall_id = "57c976cc-db75-4293-9ea4-a777d9ab426c"
-
-[[token.source_card_refs]]
-card_name = "Howling Moon"
-scryfall_oracle_id = "a814d4c7-2ec0-4278-8704-23b39dcead4e"
-scryfall_id = "37cad74a-df5c-467f-b8f6-7e8497d37d83"
-
-[[token.source_card_refs]]
-card_name = "Child of the Pack // Savage Packmate"
-face_name = "Savage Packmate"
-scryfall_oracle_id = "a9c5b155-7c09-4100-9679-8fca2b5e9222"
-scryfall_id = "79fbd424-8668-4e36-8e2f-780362c9915e"
-
-[[token.source_card_refs]]
 card_name = "Huntmaster of the Fells // Ravager of the Fells"
 face_name = "Huntmaster of the Fells"
 scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
 scryfall_id = "b3819a11-2f3e-4304-a1b0-6abf893c89c5"
-
-[[token.source_card_refs]]
-card_name = "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury"
-face_name = "Arlinn, the Moon's Fury"
-scryfall_oracle_id = "f227ce07-7e96-4a36-ab7c-9be6e777d649"
-scryfall_id = "5be8204f-8bb3-466c-a0c5-52b25bcdb7ba"
-
-[[token.source_card_refs]]
-card_name = "Somberwald Beastmaster"
-scryfall_oracle_id = "df35bf19-4cbf-4624-925d-ceca6bff596e"
-scryfall_id = "6488d613-59fa-4e26-a48c-eecab8754808"
 
 [[token.source_card_refs]]
 card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
@@ -190897,20 +186078,10 @@ scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
 scryfall_id = "b3819a11-2f3e-4304-a1b0-6abf893c89c5"
 
 [[token.source_card_refs]]
-card_name = "Feed the Pack"
-scryfall_oracle_id = "48981194-6465-4900-8cea-206f8ab5d00e"
-scryfall_id = "81df4f6c-fa65-43cd-bad1-4f255d75d1aa"
-
-[[token.source_card_refs]]
 card_name = "Arlinn Kord // Arlinn, Embraced by the Moon"
 face_name = "Arlinn Kord"
 scryfall_oracle_id = "6bb7d0df-7a9f-4e17-8c31-7628c4b12356"
 scryfall_id = "49825631-2498-41fe-a1df-f152ec05d1a8"
-
-[[token.source_card_refs]]
-card_name = "Bestial Menace"
-scryfall_oracle_id = "ef08d371-9d6c-4a2d-a444-d475fbf1b633"
-scryfall_id = "f0dd5077-7a1f-4a9c-8a86-9e87da909f0c"
 
 [[token.source_card_refs]]
 card_name = "Huntmaster of the Fells // Ravager of the Fells"
@@ -190925,48 +186096,10 @@ scryfall_oracle_id = "6e638587-30b3-4c4b-b463-fb415ea048f7"
 scryfall_id = "ef84540b-a132-4169-b3c0-b0edeb395c9b"
 
 [[token.source_card_refs]]
-card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
-face_name = "Garruk Relentless"
-scryfall_oracle_id = "7cec9021-6f25-4fd8-b40e-adf4ffd3a7b8"
-scryfall_id = "c340ad6b-aa09-4d12-a947-33b29b875158"
-
-[[token.source_card_refs]]
-card_name = "Huntmaster of the Fells // Ravager of the Fells"
-face_name = "Huntmaster of the Fells"
-scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
-scryfall_id = "6c37fcdc-6187-4ed1-908a-74e2f9e188bf"
-
-[[token.source_card_refs]]
 card_name = "Arlinn Kord // Arlinn, Embraced by the Moon"
 face_name = "Arlinn Kord"
 scryfall_oracle_id = "6bb7d0df-7a9f-4e17-8c31-7628c4b12356"
 scryfall_id = "e72d7c11-2165-4c72-80f3-3c1a7b4b5572"
-
-[[token.source_card_refs]]
-card_name = "Mayor of Avabruck // Howlpack Alpha"
-face_name = "Mayor of Avabruck"
-scryfall_oracle_id = "6e638587-30b3-4c4b-b463-fb415ea048f7"
-scryfall_id = "af4bf1fc-19fe-4300-9842-9828178c419a"
-
-[[token.source_card_refs]]
-card_name = "Pack Guardian"
-scryfall_oracle_id = "61ad6bd2-c079-44e7-a1d9-8089f086ec69"
-scryfall_id = "8d1e8eb8-115e-41c4-bf49-7aa7ebd1c4e2"
-
-[[token.source_card_refs]]
-card_name = "Wolfkin Bond"
-scryfall_oracle_id = "49e22e88-d4d9-4781-81e3-bf77b76b132b"
-scryfall_id = "d8bb1b11-bf65-46a1-acb4-c7708a75e041"
-
-[[token.source_card_refs]]
-card_name = "Wolfwillow Haven"
-scryfall_oracle_id = "7579f57d-c76e-4703-a030-34fb7160cb23"
-scryfall_id = "7d135a17-2d93-41d9-be1d-80aa55f1050a"
-
-[[token.source_card_refs]]
-card_name = "Kessig Cagebreakers"
-scryfall_oracle_id = "d7407920-7596-497a-a135-b9343909a0cb"
-scryfall_id = "3d305e7c-81b2-460e-8f56-63cfbb018f15"
 
 [[token.source_card_refs]]
 card_name = "Mayor of Avabruck // Howlpack Alpha"
@@ -190993,70 +186126,9 @@ scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
 scryfall_id = "86da891f-08d0-459c-9d20-358032c6411a"
 
 [[token.source_card_refs]]
-card_name = "Ferocious Pup"
-scryfall_oracle_id = "a1112750-8d38-49e0-ab1c-77110b2bbc4d"
-scryfall_id = "eee53763-7344-4627-93c3-b4a5b26b1f16"
-
-[[token.source_card_refs]]
-card_name = "Huntmaster of the Fells // Ravager of the Fells"
-face_name = "Ravager of the Fells"
-scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
-scryfall_id = "6c37fcdc-6187-4ed1-908a-74e2f9e188bf"
-
-[[token.source_card_refs]]
-card_name = "Arlinn, Voice of the Pack"
-scryfall_oracle_id = "a15b83df-91b7-49f0-9bec-5776a3dac8bd"
-scryfall_id = "98bee15d-6868-4dfc-9dd9-b437c5f3d6db"
-
-[[token.source_card_refs]]
-card_name = "Tovolar's Huntmaster // Tovolar's Packleader"
-face_name = "Tovolar's Packleader"
-scryfall_oracle_id = "18563bc9-6090-4629-b304-89a67d93f635"
-scryfall_id = "47f1be55-1a95-49e0-8943-4b8fa2f2f987"
-
-[[token.source_card_refs]]
 card_name = "Pack Guardian"
 scryfall_oracle_id = "61ad6bd2-c079-44e7-a1d9-8089f086ec69"
 scryfall_id = "7a40a06d-83ad-47d8-81ff-fbeafd92eafe"
-
-[[token.source_card_refs]]
-card_name = "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury"
-face_name = "Arlinn, the Pack's Hope"
-scryfall_oracle_id = "f227ce07-7e96-4a36-ab7c-9be6e777d649"
-scryfall_id = "5be8204f-8bb3-466c-a0c5-52b25bcdb7ba"
-
-[[token.source_card_refs]]
-card_name = "Tovolar's Huntmaster // Tovolar's Packleader"
-face_name = "Tovolar's Huntmaster"
-scryfall_oracle_id = "18563bc9-6090-4629-b304-89a67d93f635"
-scryfall_id = "47f1be55-1a95-49e0-8943-4b8fa2f2f987"
-
-[[token.source_card_refs]]
-card_name = "Master of the Wild Hunt"
-scryfall_oracle_id = "dd25cab9-15cc-40f5-9b68-8f345dd7e952"
-scryfall_id = "0cace1a3-34df-45d0-b653-b120b3617d40"
-
-[[token.source_card_refs]]
-card_name = "Wolfrider's Saddle"
-scryfall_oracle_id = "d0eeb863-6c1b-4e84-9199-e77f15724626"
-scryfall_id = "b66e1b92-194b-4efc-9bac-f15d7ee648a6"
-
-[[token.source_card_refs]]
-card_name = "Mayor of Avabruck // Howlpack Alpha"
-face_name = "Howlpack Alpha"
-scryfall_oracle_id = "6e638587-30b3-4c4b-b463-fb415ea048f7"
-scryfall_id = "af4bf1fc-19fe-4300-9842-9828178c419a"
-
-[[token.source_card_refs]]
-card_name = "Arlinn Kord // Arlinn, Embraced by the Moon"
-face_name = "Arlinn Kord"
-scryfall_oracle_id = "6bb7d0df-7a9f-4e17-8c31-7628c4b12356"
-scryfall_id = "49ed8050-1c98-47a0-82dd-ce08ee372387"
-
-[[token.source_card_refs]]
-card_name = "Predator's Howl"
-scryfall_oracle_id = "a1180796-6e26-4b45-9263-130620d702e5"
-scryfall_id = "f0976212-1e3f-4a31-ac56-15827fdbe28d"
 
 [[token.source_card_refs]]
 card_name = "Pack Guardian"
@@ -191074,11 +186146,6 @@ card_name = "Arlinn Kord // Arlinn, Embraced by the Moon"
 face_name = "Arlinn, Embraced by the Moon"
 scryfall_oracle_id = "6bb7d0df-7a9f-4e17-8c31-7628c4b12356"
 scryfall_id = "e72d7c11-2165-4c72-80f3-3c1a7b4b5572"
-
-[[token.source_card_refs]]
-card_name = "Wolfkin Bond"
-scryfall_oracle_id = "49e22e88-d4d9-4781-81e3-bf77b76b132b"
-scryfall_id = "40101dc6-4354-4f0a-aa90-946ed78d731e"
 
 [token.token_image_ref]
 scryfall_id = "89b89a55-3ea2-4186-b946-06831bc16169"
@@ -192949,17 +188016,7 @@ keywords = [
 [[token.source_card_refs]]
 card_name = "Thunderheads"
 scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
-scryfall_id = "56de9727-021e-4b37-b80b-08dcd898aec0"
-
-[[token.source_card_refs]]
-card_name = "Thunderheads"
-scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
 scryfall_id = "bf0a2851-946d-4f10-b43b-7444daa54ae1"
-
-[[token.source_card_refs]]
-card_name = "Thunderheads"
-scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
-scryfall_id = "381a7aaa-6cb8-47db-a381-6d1102e2338e"
 
 [[token.source_card_refs]]
 card_name = "Thunderheads"
@@ -193515,22 +188572,7 @@ scryfall_id = "6a03d849-67ef-47a8-babb-8a71c1f19d17"
 [[token.source_card_refs]]
 card_name = "Serra the Benevolent"
 scryfall_oracle_id = "8b0e2382-dd91-42e6-aba3-5e8a15418a49"
-scryfall_id = "fb89414e-ba6d-4d6f-957c-4f1946364331"
-
-[[token.source_card_refs]]
-card_name = "Serra the Benevolent"
-scryfall_oracle_id = "8b0e2382-dd91-42e6-aba3-5e8a15418a49"
 scryfall_id = "8e3c139e-fcd5-4a23-bcac-b887c6e198e5"
-
-[[token.source_card_refs]]
-card_name = "Finale of Glory"
-scryfall_oracle_id = "68273453-1059-4eab-8c27-5d96f998f3b1"
-scryfall_id = "1e71b0fb-2d36-4b81-bd5b-c3fd083e3e97"
-
-[[token.source_card_refs]]
-card_name = "Valkyrie Harbinger"
-scryfall_oracle_id = "18a5e71e-eb75-4ac7-bedd-2220aaa24f78"
-scryfall_id = "e9828a61-bc29-4a6d-8a41-e439dcb822db"
 
 [[token.source_card_refs]]
 card_name = "Valkyrie Harbinger"
@@ -193541,11 +188583,6 @@ scryfall_id = "edab83a9-35b5-4312-b8ee-1c042c02aa31"
 card_name = "Valkyrie Harbinger"
 scryfall_oracle_id = "18a5e71e-eb75-4ac7-bedd-2220aaa24f78"
 scryfall_id = "a79ecdf5-2167-4590-a964-e9d7eb32dfe6"
-
-[[token.source_card_refs]]
-card_name = "Valkyrie Harbinger"
-scryfall_oracle_id = "18a5e71e-eb75-4ac7-bedd-2220aaa24f78"
-scryfall_id = "e976523b-55cf-4cc0-b537-bb7c629004b4"
 
 [[token.source_card_refs]]
 card_name = "Parhelion II // Parhelion II"
@@ -193729,29 +188766,9 @@ scryfall_oracle_id = "0b768f8f-2213-45b9-bced-8fb1bbb441c3"
 scryfall_id = "1f20a82f-512e-47e7-9813-842cd5db1898"
 
 [[token.source_card_refs]]
-card_name = "Devils' Playground"
-scryfall_oracle_id = "ab9e2045-860a-40ab-bec1-0dffced003ef"
-scryfall_id = "336977de-7ece-40c1-8257-60bf0ffa32b4"
-
-[[token.source_card_refs]]
-card_name = "Make Mischief"
-scryfall_oracle_id = "5de50aa5-3b30-4d7d-9203-bc8fc0f8fb34"
-scryfall_id = "aeb6a7ca-b4ad-414b-9e1e-62dd87359451"
-
-[[token.source_card_refs]]
 card_name = "You Exist Only to Amuse"
 scryfall_oracle_id = "def8c0a9-ccf9-46e6-9027-6c841a0e146a"
 scryfall_id = "0fea7f06-f607-42a2-bb2f-50af43a0ff3a"
-
-[[token.source_card_refs]]
-card_name = "Dance with Devils"
-scryfall_oracle_id = "caeb508a-c1fd-45b5-a14e-e0ac7321c9a9"
-scryfall_id = "606f0b72-fc78-415c-9999-4ce362ed037d"
-
-[[token.source_card_refs]]
-card_name = "Zurzoth, Chaos Rider"
-scryfall_oracle_id = "a7da9ec5-f82f-4a6d-9737-06a1556e2dd6"
-scryfall_id = "3d94b4c3-7944-41b6-8c92-78fd6e50658d"
 
 [[token.source_card_refs]]
 card_name = "Spiked Corridor // Torture Pit"
@@ -193760,19 +188777,9 @@ scryfall_oracle_id = "e49b902f-a556-4dab-8928-93caf0a3f609"
 scryfall_id = "b90164a1-8b0a-4445-a0ad-43e4c3324925"
 
 [[token.source_card_refs]]
-card_name = "Dance with Devils"
-scryfall_oracle_id = "caeb508a-c1fd-45b5-a14e-e0ac7321c9a9"
-scryfall_id = "9189fafa-f30f-49a1-b07d-e432640d2bc5"
-
-[[token.source_card_refs]]
 card_name = "Tibalt, Rakish Instigator"
 scryfall_oracle_id = "0b768f8f-2213-45b9-bced-8fb1bbb441c3"
 scryfall_id = "7fcd6cc0-91b5-47ca-8f3d-c25cf26b81d7"
-
-[[token.source_card_refs]]
-card_name = "Burn Down the House"
-scryfall_oracle_id = "0ec54683-a65c-461d-862e-585b6499d6a5"
-scryfall_id = "4b73cbec-3c03-453f-903e-9a948cd40a8b"
 
 [[token.source_card_refs]]
 card_name = "Spiked Corridor // Torture Pit"
@@ -195824,11 +190831,6 @@ scryfall_oracle_id = "53fc09e1-1e5d-4f22-b623-2c5c770183ab"
 scryfall_id = "85050609-baf0-430a-ab33-83a6ea6d4741"
 
 [[token.source_card_refs]]
-card_name = "Monstrous Rage"
-scryfall_oracle_id = "646a2371-54c0-4492-ac2f-20f109d6108c"
-scryfall_id = "4b2e000b-a147-443b-9138-9ff2d16c0422"
-
-[[token.source_card_refs]]
 card_name = "Living Lectern"
 scryfall_oracle_id = "061e7fb2-2c04-4845-b60a-0e2512a2dec1"
 scryfall_id = "169afcaf-7ebf-4590-9e51-2a1a5eb3ac76"
@@ -195859,11 +190861,6 @@ scryfall_id = "79e4242c-a53a-4287-976b-8e545888a1fa"
 card_name = "Unassuming Sage"
 scryfall_oracle_id = "1cf4e16b-2273-41c7-9bcd-0cdc78e12198"
 scryfall_id = "a66fbaeb-1624-43b3-83e2-a37ce7588a5a"
-
-[[token.source_card_refs]]
-card_name = "Monstrous Rage"
-scryfall_oracle_id = "646a2371-54c0-4492-ac2f-20f109d6108c"
-scryfall_id = "9ebf25f9-844c-40c6-b0f0-d5c82ee04656"
 
 [[token.source_card_refs]]
 card_name = "Become Brutes"
@@ -196953,12 +191950,6 @@ scryfall_id = "4957bf8f-75ff-473e-9235-5441643a7c7b"
 card_name = "Incubation // Incongruity"
 face_name = "Incubation"
 scryfall_oracle_id = "363edb16-009f-4cc2-99e3-2b15db84e7af"
-scryfall_id = "2c1ace2e-b3eb-4e60-adfd-9f40b8cd4416"
-
-[[token.source_card_refs]]
-card_name = "Incubation // Incongruity"
-face_name = "Incubation"
-scryfall_oracle_id = "363edb16-009f-4cc2-99e3-2b15db84e7af"
 scryfall_id = "4957bf8f-75ff-473e-9235-5441643a7c7b"
 
 [[token.source_card_refs]]
@@ -196970,22 +191961,6 @@ scryfall_id = "917df0f5-af77-4e8a-af81-2f78a432b520"
 card_name = "Rapid Hybridization"
 scryfall_oracle_id = "06692cd9-ac2f-4a32-8fd1-043ba3c0fe71"
 scryfall_id = "ccda5bda-5afd-4548-bd48-12c780bfa68b"
-
-[[token.source_card_refs]]
-card_name = "Incubation // Incongruity"
-face_name = "Incongruity"
-scryfall_oracle_id = "363edb16-009f-4cc2-99e3-2b15db84e7af"
-scryfall_id = "2c1ace2e-b3eb-4e60-adfd-9f40b8cd4416"
-
-[[token.source_card_refs]]
-card_name = "Rapid Hybridization"
-scryfall_oracle_id = "06692cd9-ac2f-4a32-8fd1-043ba3c0fe71"
-scryfall_id = "49420431-0595-4525-b751-3d119fcaca22"
-
-[[token.source_card_refs]]
-card_name = "Rapid Hybridization"
-scryfall_oracle_id = "06692cd9-ac2f-4a32-8fd1-043ba3c0fe71"
-scryfall_id = "00f91207-c877-4911-8bb6-d8c5272b412d"
 
 [token.token_image_ref]
 scryfall_id = "42e98a20-325e-476f-8297-cbe8e09d85b2"
@@ -197924,11 +192899,6 @@ colors = ["Blue"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Crush of Tentacles"
-scryfall_oracle_id = "4ede153c-89cb-4121-bf23-a1d213d6f238"
-scryfall_id = "f8e07c79-8838-4df6-9554-661f535f0da0"
-
-[[token.source_card_refs]]
 card_name = "Octomancer"
 scryfall_oracle_id = "1cf7e5a0-cc8f-4bf7-9767-2f3bcae26339"
 scryfall_id = "f260197a-0297-4673-96de-dee915d79353"
@@ -198330,11 +193300,6 @@ scryfall_oracle_id = "58f12f0d-e2c1-48f9-9e27-d1de8db743cb"
 scryfall_id = "0f852937-381d-4445-99d3-2ecb8af6bb6a"
 
 [[token.source_card_refs]]
-card_name = "Orzhov Racketeers"
-scryfall_oracle_id = "4f6c9cee-5af7-4b00-a2a4-2770dab0a2dc"
-scryfall_id = "acb7c9c9-fad0-4394-9b4f-7ef3db765fea"
-
-[[token.source_card_refs]]
 card_name = "Teysa, Opulent Oligarch"
 scryfall_oracle_id = "d4f5748f-bb0e-4c48-8802-45a7ad5a80a4"
 scryfall_id = "9b5a13dd-c2fd-432e-bc49-cc62d94d62a0"
@@ -198350,11 +193315,6 @@ scryfall_oracle_id = "d4f5748f-bb0e-4c48-8802-45a7ad5a80a4"
 scryfall_id = "536f271e-5daa-4ffe-9dd4-0ccc48d6fb66"
 
 [[token.source_card_refs]]
-card_name = "Afterlife Insurance"
-scryfall_oracle_id = "05501e88-d4c3-4474-92a9-c02ab15b107b"
-scryfall_id = "2fa47810-ba83-4a6e-9940-7315ee7e44a5"
-
-[[token.source_card_refs]]
 card_name = "Teysa, Opulent Oligarch"
 scryfall_oracle_id = "d4f5748f-bb0e-4c48-8802-45a7ad5a80a4"
 scryfall_id = "ba0870d4-b5b8-4fd7-a21b-417f832e0d7e"
@@ -198365,19 +193325,9 @@ scryfall_oracle_id = "0a094c5f-cefb-4ba1-90c8-dd78ae8efe95"
 scryfall_id = "a2827593-4951-4ba7-b73e-c27de56f2606"
 
 [[token.source_card_refs]]
-card_name = "Syndicate Messenger"
-scryfall_oracle_id = "f5f4d78b-ed2b-471b-9ece-237fb55adc13"
-scryfall_id = "672b88fa-250b-4f8f-878e-ce3446c92ea9"
-
-[[token.source_card_refs]]
 card_name = "Teysa, Opulent Oligarch"
 scryfall_oracle_id = "d4f5748f-bb0e-4c48-8802-45a7ad5a80a4"
 scryfall_id = "4193a7bd-bba3-44f2-acf3-685847b8be27"
-
-[[token.source_card_refs]]
-card_name = "Seraph of the Scales"
-scryfall_oracle_id = "4a3acbf7-0699-4d7c-b4fa-aa15c7cde189"
-scryfall_id = "e1eb4816-2f33-4800-a9f0-11fec4ac4cd0"
 
 [token.token_image_ref]
 scryfall_id = "f4588570-bde4-4c2f-8469-81a3e15fb57b"
@@ -198717,11 +193667,6 @@ scryfall_oracle_id = "67f0cef6-8ef4-4c39-b306-2b580036894e"
 scryfall_id = "949ce545-4d5b-4329-a44e-5486fd3bebe6"
 
 [[token.source_card_refs]]
-card_name = "Awaken the Woods"
-scryfall_oracle_id = "3cc79d36-1a24-4395-8ad1-915a65db8a60"
-scryfall_id = "914e582c-978f-46fd-b06b-1ff2c20e5506"
-
-[[token.source_card_refs]]
 card_name = "Jyoti, Moag Ancient"
 scryfall_oracle_id = "67f0cef6-8ef4-4c39-b306-2b580036894e"
 scryfall_id = "f8a1f0ff-8680-41fb-bddb-e2ed071a166b"
@@ -198918,29 +193863,9 @@ scryfall_oracle_id = "7f2ba562-8d5e-4915-967e-54916c3c5876"
 scryfall_id = "a6e8433d-eb2a-43d1-b59b-7d70ff97c8e7"
 
 [[token.source_card_refs]]
-card_name = "Giant Opportunity"
-scryfall_oracle_id = "395aa62e-0786-4bd8-a88f-998e4700742e"
-scryfall_id = "6d284306-3365-45b4-8539-c2af7b3e16c4"
-
-[[token.source_card_refs]]
-card_name = "Fierce Witchstalker"
-scryfall_oracle_id = "ad69f48e-c387-4376-a04f-37d3992c7946"
-scryfall_id = "207788a7-c6aa-4aad-b2d1-f1b20355ae7b"
-
-[[token.source_card_refs]]
-card_name = "Hurska Sweet-Tooth"
-scryfall_oracle_id = "8d49b6a1-4ae2-4443-a6b3-9ef806cb6fc4"
-scryfall_id = "00841818-d46a-4865-a41c-daf627d10d1b"
-
-[[token.source_card_refs]]
 card_name = "Cat Collector"
 scryfall_oracle_id = "52f1b5a4-62ff-44de-80da-503d4e52d312"
 scryfall_id = "526fe356-bff1-4211-9e88-bf913ac76b1d"
-
-[[token.source_card_refs]]
-card_name = "Tough Cookie"
-scryfall_oracle_id = "8a1a5862-c027-4c15-99a7-1795d0da96da"
-scryfall_id = "09ffe48f-abfa-4110-805e-35671b42386d"
 
 [[token.source_card_refs]]
 card_name = "Midnight Snack"
@@ -198948,24 +193873,9 @@ scryfall_oracle_id = "3ddcaee9-a11e-477a-bd19-f5ee10512549"
 scryfall_id = "c9b7543f-2a45-4db6-b560-d15507a58c91"
 
 [[token.source_card_refs]]
-card_name = "Orchard Strider"
-scryfall_oracle_id = "c6906032-e08b-478f-bc71-cb1184f60bad"
-scryfall_id = "acdab158-3e36-42cd-9fda-e8282dbafeb2"
-
-[[token.source_card_refs]]
 card_name = "Bake into a Pie"
 scryfall_oracle_id = "1b9ec782-0ba1-41f1-bc39-d3302494ecb3"
 scryfall_id = "2ab0e660-86a3-4b92-82fa-77dcb5db947d"
-
-[[token.source_card_refs]]
-card_name = "Tireless Provisioner"
-scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
-scryfall_id = "5dbc2162-238d-492b-b629-94f771230d92"
-
-[[token.source_card_refs]]
-card_name = "Trail of Crumbs"
-scryfall_oracle_id = "185d6356-8f8d-4b32-8259-b4eb0a95866c"
-scryfall_id = "198be33b-d6d1-4c96-bdfa-4b4098079042"
 
 [token.token_image_ref]
 scryfall_id = "6f1077f8-9e2a-4155-a7f0-4604bc0f94e8"
@@ -199049,11 +193959,6 @@ scryfall_id = "ea1ab937-8647-4c83-99d5-6a40dffa4c9b"
 card_name = "Magma Opus"
 scryfall_oracle_id = "985f9dd7-e693-48ff-9dd6-a1a3cbaa236b"
 scryfall_id = "0fd4a0f7-ba03-4158-95cd-4effe798aec0"
-
-[[token.source_card_refs]]
-card_name = "Multiple Choice"
-scryfall_oracle_id = "b4d23acf-ff1f-4a6a-9ede-2667a99e9665"
-scryfall_id = "b71b23e7-4f4c-46bc-a512-4e2e6ff303cd"
 
 [[token.source_card_refs]]
 card_name = "Zaffai, Thunder Conductor"
@@ -199648,184 +194553,14 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Captain Lannery Storm"
-scryfall_oracle_id = "235bf0ba-658c-463f-b112-7478ba27bd7b"
-scryfall_id = "d33d910f-f378-4b55-9587-2101faefe0fa"
-
-[[token.source_card_refs]]
-card_name = "Rapacious Dragon"
-scryfall_oracle_id = "0944ec2e-1dd9-459f-8f1d-667242cf52fe"
-scryfall_id = "6d5d5f0b-7574-43d9-b9ab-b4d0fa419212"
-
-[[token.source_card_refs]]
-card_name = "Strike It Rich"
-scryfall_oracle_id = "c34c17c7-3827-49a2-be25-67f44fdfe150"
-scryfall_id = "d2e5d72a-5ef4-4578-8595-66eeef762c21"
-
-[[token.source_card_refs]]
-card_name = "Corsair Captain"
-scryfall_oracle_id = "a7ec13c6-7ade-433a-b5a2-047854eef486"
-scryfall_id = "a9b016d4-ddf6-47d6-b934-a0b979b60680"
-
-[[token.source_card_refs]]
-card_name = "Pitiless Plunderer"
-scryfall_oracle_id = "a784481f-eccb-4112-bb38-04a659319660"
-scryfall_id = "e8da4daa-1441-4d15-b9dc-7732343b38f1"
-
-[[token.source_card_refs]]
-card_name = "Brazen Freebooter"
-scryfall_oracle_id = "13e8d063-eece-4f38-83f6-02403130defa"
-scryfall_id = "60a1e6e9-5e5f-4431-9732-fd313df843df"
-
-[[token.source_card_refs]]
-card_name = "Unexpected Windfall"
-scryfall_oracle_id = "498c10c9-253d-4b15-b48c-1509381b17e8"
-scryfall_id = "b272df7e-f94c-4a57-a3dd-27d53525e726"
-
-[[token.source_card_refs]]
-card_name = "Gadrak, the Crown-Scourge"
-scryfall_oracle_id = "42d7ec93-0943-43e2-9b65-b7edc3349410"
-scryfall_id = "cbb13721-e6f7-439c-8993-a896de5d6892"
-
-[[token.source_card_refs]]
-card_name = "Old Rutstein"
-scryfall_oracle_id = "8f5ffb0b-0585-4a37-8048-eda53990d1dd"
-scryfall_id = "2bda3765-c56f-4b27-83f8-d01e16265328"
-
-[[token.source_card_refs]]
-card_name = "Trove of Temptation"
-scryfall_oracle_id = "f624c0f1-1c09-4b7a-b140-11329f27e3c7"
-scryfall_id = "faf67f7a-00da-422b-b517-fb55990a1999"
-
-[[token.source_card_refs]]
-card_name = "Tireless Provisioner"
-scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
-scryfall_id = "5590a3a5-e0bd-451a-b98e-00a492487c46"
-
-[[token.source_card_refs]]
-card_name = "Emissary Green"
-scryfall_oracle_id = "c43e7fa5-ff93-42d9-af79-ee417a8e41a7"
-scryfall_id = "323e9430-b87c-4b02-9ade-c4c65343147b"
-
-[[token.source_card_refs]]
-card_name = "Malcolm, Keen-Eyed Navigator"
-scryfall_oracle_id = "a66f8b44-0163-4456-b152-4acefab896a4"
-scryfall_id = "cfcb3051-161f-42f8-bfec-db03b349ff00"
-
-[[token.source_card_refs]]
-card_name = "Goldvein Pick"
-scryfall_oracle_id = "c1624d10-8838-4af8-aea1-a96c0fe6fd6b"
-scryfall_id = "bd33b5fc-9901-493b-8d7f-5e98223fdcad"
-
-[[token.source_card_refs]]
-card_name = "Sailor of Means"
-scryfall_oracle_id = "c4efae03-99de-4439-925b-504602623bfd"
-scryfall_id = "10c1e6ad-1227-4049-89bf-69ace48c3076"
-
-[[token.source_card_refs]]
-card_name = "Prosperous Pirates"
-scryfall_oracle_id = "9dc6281b-08e0-4c66-9aef-abc7184ca36a"
-scryfall_id = "f6db054e-8303-44c7-8c96-d031a8c85b34"
-
-[[token.source_card_refs]]
-card_name = "Big Score"
-scryfall_oracle_id = "a5cbd257-c836-493e-bb1a-76242619dea2"
-scryfall_id = "5fbb7413-af44-4038-a56c-8cc3ca645a58"
-
-[[token.source_card_refs]]
-card_name = "Unexpected Windfall"
-scryfall_oracle_id = "498c10c9-253d-4b15-b48c-1509381b17e8"
-scryfall_id = "33ba9e5a-d078-4a47-b181-0ca7d1596919"
-
-[[token.source_card_refs]]
-card_name = "Improvised Weaponry"
-scryfall_oracle_id = "fa5dad0b-8e23-4b88-b383-849f7318e01f"
-scryfall_id = "828a5005-0b19-49a2-bc9a-5b32c719c74c"
-
-[[token.source_card_refs]]
-card_name = "Professional Face-Breaker"
-scryfall_oracle_id = "04152e7a-969c-4858-841b-0a569a9fc1bf"
-scryfall_id = "9c2561e6-c5b6-4c88-896e-67b33b8cf6bc"
-
-[[token.source_card_refs]]
-card_name = "Jewel-Eyed Cobra"
-scryfall_oracle_id = "bbfee53c-30a6-4ed0-beef-5c254be75fc5"
-scryfall_id = "56607174-63aa-415b-8511-1abe17689e78"
-
-[[token.source_card_refs]]
 card_name = "Pitiless Plunderer"
 scryfall_oracle_id = "a784481f-eccb-4112-bb38-04a659319660"
 scryfall_id = "6a4b4679-6ca9-49e1-a7ee-2b7a30e3e06c"
 
 [[token.source_card_refs]]
-card_name = "Iron Man, Titan of Innovation"
-scryfall_oracle_id = "67ab82de-1167-42f5-90bd-21c63edcc712"
-scryfall_id = "20d54b22-62e8-48ac-ba65-0bdbf42d6cad"
-
-[[token.source_card_refs]]
-card_name = "Vault Robber"
-scryfall_oracle_id = "68c90a32-d6ee-4595-8517-5f4cb0e4062d"
-scryfall_id = "e1f67518-b5ea-4b9b-96b5-e01de054b348"
-
-[[token.source_card_refs]]
-card_name = "Goldspan Dragon"
-scryfall_oracle_id = "716b3ea2-45b7-4a8f-af72-de7f4e510eff"
-scryfall_id = "0c67a683-4e1d-4a64-952d-a1c27a34ed1d"
-
-[[token.source_card_refs]]
-card_name = "Mastermind Plum"
-scryfall_oracle_id = "4605d8b3-b714-4717-8ff3-155fabfc1999"
-scryfall_id = "df81568b-c66a-49c6-bd48-7df98ea00117"
-
-[[token.source_card_refs]]
-card_name = "Burdened Aerialist"
-scryfall_oracle_id = "dd39cccb-095c-4ef4-8423-f4d328849295"
-scryfall_id = "d8cc9f89-4758-4236-ac08-638cbd8c107a"
-
-[[token.source_card_refs]]
 card_name = "Hullbreacher"
 scryfall_oracle_id = "2f533667-e29b-4bec-897a-e7a9eee08314"
 scryfall_id = "c2a0530f-7b72-4a33-8eec-bcd75d9c3045"
-
-[[token.source_card_refs]]
-card_name = "Covetous Elegy"
-scryfall_oracle_id = "dd69ef80-d30c-4b15-aec8-4154dc20cb25"
-scryfall_id = "f8f1f5e8-c1bf-405f-b8e3-655d5558e18d"
-
-[[token.source_card_refs]]
-card_name = "Shiny Impetus"
-scryfall_oracle_id = "aae76e5c-f5e0-4d18-b465-e6a829be908a"
-scryfall_id = "d91896ea-e0fd-4113-a3c6-a7811e16be46"
-
-[[token.source_card_refs]]
-card_name = "Gleaming Barrier"
-scryfall_oracle_id = "1eb9e401-8975-447b-839d-f7cd23897465"
-scryfall_id = "bf4ba8a3-77b0-4da8-9bdd-0950d0fe8401"
-
-[[token.source_card_refs]]
-card_name = "Halo Scarab"
-scryfall_oracle_id = "1201c146-54af-4668-a544-cde3ece23f2e"
-scryfall_id = "573857cf-2afe-455e-a0e3-b67a465d4f4e"
-
-[[token.source_card_refs]]
-card_name = "Deadly Dispute"
-scryfall_oracle_id = "457af74a-02b3-4659-846d-63e482667f34"
-scryfall_id = "e0f658ff-323e-4e32-beaa-1d5753b4f081"
-
-[[token.source_card_refs]]
-card_name = "Rapacious Dragon"
-scryfall_oracle_id = "0944ec2e-1dd9-459f-8f1d-667242cf52fe"
-scryfall_id = "495c0dbf-1671-40f9-809c-98ef6d588512"
-
-[[token.source_card_refs]]
-card_name = "Sudden Breakthrough"
-scryfall_oracle_id = "f5576cd4-6b21-4b29-902c-9c1fbdd7b2be"
-scryfall_id = "c78dd917-7748-41dd-b294-943302bdab34"
-
-[[token.source_card_refs]]
-card_name = "Deadly Dispute"
-scryfall_oracle_id = "457af74a-02b3-4659-846d-63e482667f34"
-scryfall_id = "1d3df7bd-b0ca-4f51-99e5-d259246196e8"
 
 [token.token_image_ref]
 scryfall_id = "c6e096bb-ad9e-4a8b-8b42-26852fa32c1d"
@@ -201263,11 +195998,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Gideon, Ally of Zendikar"
 scryfall_oracle_id = "51eae7ff-fed9-4afe-8053-7690379449dd"
-scryfall_id = "d5908dce-f02d-4cff-b793-0a97ee928823"
-
-[[token.source_card_refs]]
-card_name = "Gideon, Ally of Zendikar"
-scryfall_oracle_id = "51eae7ff-fed9-4afe-8053-7690379449dd"
 scryfall_id = "187e887c-c39d-4d25-a506-cdc95fc70316"
 
 [[token.source_card_refs]]
@@ -201853,16 +196583,6 @@ scryfall_id = "cf99efef-aec7-41e7-bde5-542421a03072"
 card_name = "Penumbra Wurm"
 scryfall_oracle_id = "abccb19f-098b-4453-b7bc-838ad5914ebe"
 scryfall_id = "de4ce98d-0a19-42c5-9ef9-32408da1d2a1"
-
-[[token.source_card_refs]]
-card_name = "Penumbra Wurm"
-scryfall_oracle_id = "abccb19f-098b-4453-b7bc-838ad5914ebe"
-scryfall_id = "ae3dffe7-ecaf-4cf0-a43e-8e2746282992"
-
-[[token.source_card_refs]]
-card_name = "Penumbra Wurm"
-scryfall_oracle_id = "abccb19f-098b-4453-b7bc-838ad5914ebe"
-scryfall_id = "a66be186-ccd3-4b51-b3fb-5a1116b189e4"
 
 [token.token_image_ref]
 scryfall_id = "31107acf-5969-42ff-a805-9152f439b7fa"
@@ -204689,19 +199409,9 @@ colors = ["White"]
 keywords = ["Lifelink"]
 
 [[token.source_card_refs]]
-card_name = "Regal Caracal"
-scryfall_oracle_id = "aa571676-b390-4b8a-baea-4c4cd60c01f6"
-scryfall_id = "c4b80710-0057-4b7e-aa50-4d4d67dfbae2"
-
-[[token.source_card_refs]]
 card_name = "Liberated Livestock"
 scryfall_oracle_id = "d080cb03-b3e5-42e8-b289-2ce2151b4cb8"
 scryfall_id = "890e8f0d-07c2-47bb-af99-944289c6ea56"
-
-[[token.source_card_refs]]
-card_name = "Pride Sovereign"
-scryfall_oracle_id = "a131c32d-2b4f-4ee4-aab2-ab05ab010978"
-scryfall_id = "4a8c3161-ccfd-456b-8453-5f77496892e4"
 
 [[token.source_card_refs]]
 card_name = "Basri, Tomorrow's Champion"
@@ -204714,11 +199424,6 @@ scryfall_oracle_id = "d8e1e9ba-708c-4f54-abc3-817004a2f2ac"
 scryfall_id = "991270fa-a391-4c2e-bd9a-19151386fb67"
 
 [[token.source_card_refs]]
-card_name = "Leonin Warleader"
-scryfall_oracle_id = "8b1351e6-165e-4ca3-96d5-4774b3176362"
-scryfall_id = "b24820fa-7cef-4396-920c-810dd06e3887"
-
-[[token.source_card_refs]]
 card_name = "Liberated Livestock"
 scryfall_oracle_id = "d080cb03-b3e5-42e8-b289-2ce2151b4cb8"
 scryfall_id = "f22f4c5a-fe42-4511-be96-78e0e807e704"
@@ -204727,11 +199432,6 @@ scryfall_id = "f22f4c5a-fe42-4511-be96-78e0e807e704"
 card_name = "Basri, Tomorrow's Champion"
 scryfall_oracle_id = "d8e1e9ba-708c-4f54-abc3-817004a2f2ac"
 scryfall_id = "440766a6-5820-4248-ad91-4d946235e136"
-
-[[token.source_card_refs]]
-card_name = "Regal Caracal"
-scryfall_oracle_id = "aa571676-b390-4b8a-baea-4c4cd60c01f6"
-scryfall_id = "8511fb74-dd0c-492d-87f6-7d27d39d101a"
 
 [token.token_image_ref]
 scryfall_id = "902fba98-92b7-461b-ac6e-29cb2c4e307f"
@@ -205317,11 +200017,6 @@ scryfall_oracle_id = "ea1eb902-a23c-44ff-9169-19baf71de238"
 scryfall_id = "0ea31d56-3530-41b4-8d31-c6ee16e87ae6"
 
 [[token.source_card_refs]]
-card_name = "Drake Haven"
-scryfall_oracle_id = "86d3def3-53fa-4cad-bb25-d3275af1e3f5"
-scryfall_id = "4cfe0645-79ec-4e94-a6eb-b38b920d2dab"
-
-[[token.source_card_refs]]
 card_name = "Drake Hatcher"
 scryfall_oracle_id = "4de0ccab-bb5d-4c7c-827e-36aa1d00b182"
 scryfall_id = "c4c31f0d-b77f-4cf9-8350-2dde15d427a7"
@@ -205340,21 +200035,6 @@ scryfall_id = "bcaf4196-6bf3-47fa-b5c7-0e77f45cf820"
 card_name = "Drake Hatcher"
 scryfall_oracle_id = "4de0ccab-bb5d-4c7c-827e-36aa1d00b182"
 scryfall_id = "b60cf418-b927-49b6-9613-41eae6296902"
-
-[[token.source_card_refs]]
-card_name = "Alandra, Sky Dreamer"
-scryfall_oracle_id = "97bb1589-2941-4a75-a5f6-916871e51e9e"
-scryfall_id = "61561585-f4fb-4e47-a65a-0c43a855ebcf"
-
-[[token.source_card_refs]]
-card_name = "Talrand's Invocation"
-scryfall_oracle_id = "43355ac4-bf8c-48f6-a322-fafbc9d132d1"
-scryfall_id = "4b153c2f-fc87-49bc-9d1e-d5e7e25b2142"
-
-[[token.source_card_refs]]
-card_name = "Talrand, Sky Summoner"
-scryfall_oracle_id = "ea1eb902-a23c-44ff-9169-19baf71de238"
-scryfall_id = "3d89c1a1-1896-4360-b123-52d82a6871d4"
 
 [[token.source_card_refs]]
 card_name = "Talrand, Sky Summoner"
@@ -205434,11 +200114,6 @@ scryfall_id = "34ec1216-1b8c-418f-bc25-c3f5ad4fda00"
 card_name = "Breya, Etherium Shaper"
 scryfall_oracle_id = "d460a9e2-5a7d-4562-880e-45174be19a9d"
 scryfall_id = "581591f0-b3c7-4fca-b4b9-1d1d098ca7fb"
-
-[[token.source_card_refs]]
-card_name = "Sharding Sphinx"
-scryfall_oracle_id = "9ebc0144-fc45-4de7-b3d8-ef8cf2e211ae"
-scryfall_id = "4df1ce35-1f1c-40ab-8e4d-cb087b4656d8"
 
 [token.token_image_ref]
 scryfall_id = "e0a7adb3-8e66-4e63-95f2-1a5f5827b676"
@@ -205574,11 +200249,6 @@ colors = ["Black"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Wakedancer"
-scryfall_oracle_id = "e850743e-e4c4-4a09-b797-d5f688b51451"
-scryfall_id = "9e20cdcc-1580-4495-9627-2f799b05e359"
-
-[[token.source_card_refs]]
 card_name = "Dread Summons"
 scryfall_oracle_id = "642fa01d-025e-44dd-8360-5325e5a28282"
 scryfall_id = "dfb5dd33-6e5b-4d78-92fa-678c9f01c606"
@@ -205589,26 +200259,6 @@ scryfall_oracle_id = "ea6ee33f-0cba-4e96-817f-dc89c9064ead"
 scryfall_id = "3d2c5345-eb55-4bca-9183-b4e1404405f8"
 
 [[token.source_card_refs]]
-card_name = "Boneclad Necromancer"
-scryfall_oracle_id = "6494e3c4-5489-44a5-94b6-4ee2d7830896"
-scryfall_id = "39f8e986-30a5-4184-a717-e30b0bc2a419"
-
-[[token.source_card_refs]]
-card_name = "Liliana, Death's Majesty"
-scryfall_oracle_id = "7fca595e-1902-40fd-a359-622caa612b6a"
-scryfall_id = "69264ed3-b31f-4b92-aec1-e46f91b2068d"
-
-[[token.source_card_refs]]
-card_name = "Army of the Damned"
-scryfall_oracle_id = "75d667ec-86f4-4850-a3b6-e7a9fc7053b0"
-scryfall_id = "b46b0818-cd87-41b4-85d2-c474b995d4c0"
-
-[[token.source_card_refs]]
-card_name = "Doomed Dissenter"
-scryfall_oracle_id = "11cb509d-21af-48f1-b355-135ebd3e4bd1"
-scryfall_id = "f6a99641-1796-4263-bbbb-b4bac0b07dd4"
-
-[[token.source_card_refs]]
 card_name = "Maalfeld Twins"
 scryfall_oracle_id = "dda4b515-49c0-43fe-9f6a-36defa326bb1"
 scryfall_id = "c166df8f-9508-427a-8ec7-bc8541b6ed88"
@@ -205617,11 +200267,6 @@ scryfall_id = "c166df8f-9508-427a-8ec7-bc8541b6ed88"
 card_name = "Liliana, Dreadhorde General"
 scryfall_oracle_id = "5e958212-6a5b-4288-8d31-f1572619d7dc"
 scryfall_id = "7a097413-b77c-45e8-a4ac-5b2dc1d34e16"
-
-[[token.source_card_refs]]
-card_name = "Moan of the Unhallowed"
-scryfall_oracle_id = "ce87e5ed-2562-4563-9a5b-bd53c04ec4a5"
-scryfall_id = "d95f7af9-cabf-47e0-9ca4-e276ff6605b9"
 
 [[token.source_card_refs]]
 card_name = "Liliana, Dreadhorde General"
@@ -205835,47 +200480,12 @@ keywords = ["Reach"]
 [[token.source_card_refs]]
 card_name = "Ishkanah, Grafwidow"
 scryfall_oracle_id = "6f4861f4-1b3b-4dbc-b55b-196075d0a693"
-scryfall_id = "045b6009-6215-4d2b-acce-5d90f2d4e391"
-
-[[token.source_card_refs]]
-card_name = "Ishkanah, Grafwidow"
-scryfall_oracle_id = "6f4861f4-1b3b-4dbc-b55b-196075d0a693"
 scryfall_id = "851c729f-1c98-4962-9cc9-84872133ac02"
-
-[[token.source_card_refs]]
-card_name = "Rotwidow Pack"
-scryfall_oracle_id = "27b5d9d8-cc19-46be-9862-405cf7ef5408"
-scryfall_id = "ce62fa4e-f76d-4ff2-aa6d-bcae4f725696"
-
-[[token.source_card_refs]]
-card_name = "Twin-Silk Spider"
-scryfall_oracle_id = "a2193302-402a-4cf0-8014-5facecad647b"
-scryfall_id = "9adcf067-b08c-4e36-afab-be41d7659c56"
-
-[[token.source_card_refs]]
-card_name = "Arasta of the Endless Web"
-scryfall_oracle_id = "695eea46-1535-48c5-bbb6-0b8379e77bfc"
-scryfall_id = "255544be-db0f-4dcc-8787-f05652cd2684"
-
-[[token.source_card_refs]]
-card_name = "Arasta of the Endless Web"
-scryfall_oracle_id = "695eea46-1535-48c5-bbb6-0b8379e77bfc"
-scryfall_id = "de819fd7-0823-42da-99bc-db87bb71acc8"
 
 [[token.source_card_refs]]
 card_name = "Spider Spawning"
 scryfall_oracle_id = "da113cc9-bb2b-4af4-9c43-32c165b87363"
 scryfall_id = "d798227e-b098-4eff-931c-0bef642ccc81"
-
-[[token.source_card_refs]]
-card_name = "Arachnogenesis"
-scryfall_oracle_id = "b655bee5-52d3-467e-b16c-cfc2edf2b1a1"
-scryfall_id = "922f0e2f-a211-4ac1-b7bb-4dc46a5802a3"
-
-[[token.source_card_refs]]
-card_name = "Arachnogenesis"
-scryfall_oracle_id = "b655bee5-52d3-467e-b16c-cfc2edf2b1a1"
-scryfall_id = "77e2f5ac-5c0d-4503-b8ab-fee00eaaa4a3"
 
 [[token.source_card_refs]]
 card_name = "Twin-Silk Spider"
@@ -205886,16 +200496,6 @@ scryfall_id = "68e9ba91-9bab-4b2f-a82d-05b333b8deed"
 card_name = "Arasta of the Endless Web"
 scryfall_oracle_id = "695eea46-1535-48c5-bbb6-0b8379e77bfc"
 scryfall_id = "95a87b4e-f0ea-457c-9517-4acf313c4ca6"
-
-[[token.source_card_refs]]
-card_name = "Spider Spawning"
-scryfall_oracle_id = "da113cc9-bb2b-4af4-9c43-32c165b87363"
-scryfall_id = "97858ce1-bfb3-4307-a0d5-b2139fa09b8b"
-
-[[token.source_card_refs]]
-card_name = "Brood Weaver"
-scryfall_oracle_id = "f0a7ef59-7897-4e84-a85e-1fcbe3dc9f6a"
-scryfall_id = "2ec08f5a-0dcc-426b-94d9-cf8877071d6a"
 
 [token.token_image_ref]
 scryfall_id = "a351094c-2315-4e95-89ed-16a1866f67cb"
@@ -207424,16 +202024,6 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Myr Matrix"
-scryfall_oracle_id = "46a07fdd-0ca3-4654-9caa-a88fae80c414"
-scryfall_id = "4a1af62e-d566-4f39-a467-244602c9240b"
-
-[[token.source_card_refs]]
-card_name = "Myr Incubator"
-scryfall_oracle_id = "d0a493af-551e-4475-af5d-ec4e080728cb"
-scryfall_id = "31b0f9ef-7404-4e05-b759-aaf1ebcfcb31"
-
-[[token.source_card_refs]]
 card_name = "Myr Battlesphere"
 scryfall_oracle_id = "c53ba31a-ba27-4e17-9a92-311acb1cab29"
 scryfall_id = "0db4cf09-8cf0-4aa7-8bfe-fe600352032d"
@@ -207452,11 +202042,6 @@ scryfall_id = "18957d46-01e9-4ef0-97ba-ddbe5b34ea10"
 card_name = "Mirrodin Besieged"
 scryfall_oracle_id = "674e2683-31c0-4fee-95fb-98b1201e41e7"
 scryfall_id = "edf98768-c7dd-434e-8883-19b47ad45790"
-
-[[token.source_card_refs]]
-card_name = "Genesis Chamber"
-scryfall_oracle_id = "150ab025-5cc3-4468-a724-bbba8838445d"
-scryfall_id = "f0a66ded-c697-4bab-8abf-464185f32a70"
 
 [token.token_image_ref]
 scryfall_id = "9d54ed64-573d-45cc-9d5c-94c5d0fc88ec"
@@ -207575,11 +202160,6 @@ keywords = ["Trample"]
 card_name = "Honored Hydra"
 scryfall_oracle_id = "db63d999-97a6-4a62-83bd-e0677e6f8956"
 scryfall_id = "21c33902-a06a-4321-bdf4-cea5494fda63"
-
-[[token.source_card_refs]]
-card_name = "Honored Hydra"
-scryfall_oracle_id = "db63d999-97a6-4a62-83bd-e0677e6f8956"
-scryfall_id = "c430a165-3bbf-4ee4-81f7-fe45bd7a201e"
 
 [token.token_image_ref]
 scryfall_id = "7365ffff-b171-4275-9fdb-e622f8456858"
@@ -209372,11 +203952,6 @@ card_name = "Reef Worm"
 scryfall_oracle_id = "e3ad5cbc-4245-4e1e-8204-509381fa0c1c"
 scryfall_id = "25576181-a5a4-4baf-a2b4-fbfe13fb9df6"
 
-[[token.source_card_refs]]
-card_name = "Kiora, the Crashing Wave"
-scryfall_oracle_id = "58cc2097-f4b4-4695-9076-78666050cdb6"
-scryfall_id = "6ace0bfa-254f-46e0-8a14-277f080e013c"
-
 [token.token_image_ref]
 scryfall_id = "9155825a-6449-4b36-aa14-4c227075ed51"
 scryfall_oracle_id = "cd0f813b-1f9f-484d-adab-bc8d16d2b867"
@@ -209409,22 +203984,7 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Pongify"
 scryfall_oracle_id = "05849bd6-8f38-4031-be2b-e2aa03beb8cc"
-scryfall_id = "cce74a84-4441-4f2e-89d8-df0b096790ed"
-
-[[token.source_card_refs]]
-card_name = "Side to Side"
-scryfall_oracle_id = "5201143e-3305-456a-813e-a51a5901ad81"
-scryfall_id = "a8512b3c-9a44-4c15-8217-0f13898846cd"
-
-[[token.source_card_refs]]
-card_name = "Pongify"
-scryfall_oracle_id = "05849bd6-8f38-4031-be2b-e2aa03beb8cc"
 scryfall_id = "cb504714-b034-4938-93ad-7cb2ae320829"
-
-[[token.source_card_refs]]
-card_name = "Pongify"
-scryfall_oracle_id = "05849bd6-8f38-4031-be2b-e2aa03beb8cc"
-scryfall_id = "5780936e-629d-4737-9005-651234f5426d"
 
 [token.token_image_ref]
 scryfall_id = "4b2ee605-3c7a-4769-978d-3199bdc7c504"
@@ -209949,11 +204509,6 @@ colors = ["Black"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
-card_name = "Belfry Spirit"
-scryfall_oracle_id = "c171065f-7947-4161-a481-1ea2d3ce8422"
-scryfall_id = "556e4e71-b149-49c8-8a22-83660bef57bb"
-
-[[token.source_card_refs]]
 card_name = "Skeletal Vampire"
 scryfall_oracle_id = "7ed8a69b-fba0-4d4d-98b2-311a92373669"
 scryfall_id = "7cb8d6b0-13c1-4b04-9a92-1b87f2b7c1ea"
@@ -209964,19 +204519,9 @@ scryfall_oracle_id = "c171065f-7947-4161-a481-1ea2d3ce8422"
 scryfall_id = "c1f5854d-63cf-419f-990c-6f473e181a68"
 
 [[token.source_card_refs]]
-card_name = "Skeletal Vampire"
-scryfall_oracle_id = "7ed8a69b-fba0-4d4d-98b2-311a92373669"
-scryfall_id = "69251d44-3038-4b64-ab78-fc87f0406ba2"
-
-[[token.source_card_refs]]
 card_name = "Lunar Convocation"
 scryfall_oracle_id = "cb68d1e4-36aa-4a00-b671-8959e7d526d4"
 scryfall_id = "4396e4c7-660d-4055-bc94-4ccea95223b7"
-
-[[token.source_card_refs]]
-card_name = "Bat Whisperer"
-scryfall_oracle_id = "f20f6da9-d678-486b-99f9-7121669fef81"
-scryfall_id = "a57d2348-a05c-4d40-bb3e-68ebf396cd62"
 
 [[token.source_card_refs]]
 card_name = "Lunar Convocation"
@@ -209993,10 +204538,8 @@ id = "ee98a86d-1691-56eb-ab6f-337e3ec7cd1b"
 category = "Creature"
 fidelity = "Full"
 source_card_names = [
-    "Assault",
     "Assault // Battery",
     "Autarch Mammoth",
-    "Battery",
     "Bestial Menace",
     "Call of the Herd",
     "Elephant Ambush",
@@ -210026,23 +204569,6 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Elephant Ambush"
-scryfall_oracle_id = "09386931-59bd-481f-bccc-32e8a8abc0f9"
-scryfall_id = "b4abdf1c-a0a9-4e1d-b448-58742830f767"
-
-[[token.source_card_refs]]
-card_name = "Assault // Battery"
-face_name = "Assault"
-scryfall_oracle_id = "fcdeb83f-531c-4087-9254-7f19eb065f00"
-scryfall_id = "4a9f1e99-9de8-45cb-b035-4f920477e2e5"
-
-[[token.source_card_refs]]
-card_name = "Assault // Battery"
-face_name = "Assault"
-scryfall_oracle_id = "fcdeb83f-531c-4087-9254-7f19eb065f00"
-scryfall_id = "0ec6a889-c941-4898-a2f6-4d3863faf535"
-
-[[token.source_card_refs]]
 card_name = "Generous Gift"
 scryfall_oracle_id = "fae37e28-e137-4177-b973-fa8b4dd8f409"
 scryfall_id = "c3f9b454-97e9-4c77-b37a-e974221ae385"
@@ -210051,37 +204577,6 @@ scryfall_id = "c3f9b454-97e9-4c77-b37a-e974221ae385"
 card_name = "Trumpeting Herd"
 scryfall_oracle_id = "69501650-ed48-4ebf-9287-b0338c5bc5d5"
 scryfall_id = "a9b998c9-ff41-45b6-baf7-0fc456daf978"
-
-[[token.source_card_refs]]
-card_name = "Call of the Herd"
-scryfall_oracle_id = "ee243f81-f51c-4d9a-a396-f7cef84b46c1"
-scryfall_id = "ebff1b5d-b948-48fa-9fa7-690b13ab5d71"
-
-[[token.source_card_refs]]
-card_name = "Trumpeting Herd"
-scryfall_oracle_id = "69501650-ed48-4ebf-9287-b0338c5bc5d5"
-scryfall_id = "8f439a94-c3fa-4813-abbb-a39200a88bc7"
-
-[[token.source_card_refs]]
-card_name = "Bestial Menace"
-scryfall_oracle_id = "ef08d371-9d6c-4a2d-a444-d475fbf1b633"
-scryfall_id = "f0dd5077-7a1f-4a9c-8a86-9e87da909f0c"
-
-[[token.source_card_refs]]
-card_name = "Assault // Battery"
-face_name = "Battery"
-scryfall_oracle_id = "fcdeb83f-531c-4087-9254-7f19eb065f00"
-scryfall_id = "4a9f1e99-9de8-45cb-b035-4f920477e2e5"
-
-[[token.source_card_refs]]
-card_name = "Call of the Herd"
-scryfall_oracle_id = "ee243f81-f51c-4d9a-a396-f7cef84b46c1"
-scryfall_id = "429a88cc-53db-4c5e-a061-f0f49a38c675"
-
-[[token.source_card_refs]]
-card_name = "Elephant Guide"
-scryfall_oracle_id = "c138bd7f-8751-4e96-b54a-d5082e1a491f"
-scryfall_id = "7d3a7226-f574-430e-9b8f-4e531a21540f"
 
 [[token.source_card_refs]]
 card_name = "Elephant Guide"
@@ -210102,17 +204597,6 @@ scryfall_id = "4de50769-8cae-4eff-913b-0ebb6dde4f9c"
 card_name = "Terastodon"
 scryfall_oracle_id = "17975a20-2c13-4325-be1e-0bcda5063a2d"
 scryfall_id = "48783dc1-0976-4955-b7e3-afa311160d68"
-
-[[token.source_card_refs]]
-card_name = "Assault // Battery"
-face_name = "Battery"
-scryfall_oracle_id = "fcdeb83f-531c-4087-9254-7f19eb065f00"
-scryfall_id = "0ec6a889-c941-4898-a2f6-4d3863faf535"
-
-[[token.source_card_refs]]
-card_name = "Elephant Guide"
-scryfall_oracle_id = "c138bd7f-8751-4e96-b54a-d5082e1a491f"
-scryfall_id = "cc09ab3d-16ad-4d78-8d6c-5211104b41cf"
 
 [[token.source_card_refs]]
 card_name = "Generous Gift"
@@ -210143,11 +204627,6 @@ scryfall_id = "cd1383d8-fdc4-4830-a05b-a69ee15e3cd0"
 card_name = "Generous Gift"
 scryfall_oracle_id = "fae37e28-e137-4177-b973-fa8b4dd8f409"
 scryfall_id = "96d4e224-e630-4696-85ef-cf42f9d03ca5"
-
-[[token.source_card_refs]]
-card_name = "Generous Gift"
-scryfall_oracle_id = "fae37e28-e137-4177-b973-fa8b4dd8f409"
-scryfall_id = "47f44d5a-f3d6-4a9a-8bd3-b17a88565c51"
 
 [token.token_image_ref]
 scryfall_id = "e96f22c0-b9c8-418a-8224-e7d0b2841bd2"
@@ -210448,11 +204927,6 @@ keywords = []
 card_name = "Witch's Mark"
 scryfall_oracle_id = "00807825-88e5-4b88-8527-a49f553a91be"
 scryfall_id = "7120f534-cc20-453a-8ddd-ebd6f64235e7"
-
-[[token.source_card_refs]]
-card_name = "Witch's Mark"
-scryfall_oracle_id = "00807825-88e5-4b88-8527-a49f553a91be"
-scryfall_id = "03c6aae5-f85a-4083-b880-71c0e141cc22"
 
 [token.token_image_ref]
 scryfall_id = "6929750f-cf08-4e3e-83b0-076e1f6fa8e0"
@@ -211496,22 +205970,12 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "News Helicopter"
 scryfall_oracle_id = "192dd1e2-b6c2-432a-a1b4-e52ff39b3db2"
-scryfall_id = "cfe529d7-4418-4068-8f9d-6d74a74fd291"
-
-[[token.source_card_refs]]
-card_name = "News Helicopter"
-scryfall_oracle_id = "192dd1e2-b6c2-432a-a1b4-e52ff39b3db2"
 scryfall_id = "15717af0-30cd-4417-947a-c27cca06d93a"
 
 [[token.source_card_refs]]
 card_name = "Friendly Neighborhood"
 scryfall_oracle_id = "10fe402e-8d6f-4058-9f42-86f229055359"
 scryfall_id = "2e7c80af-4841-4e5f-a3c9-8448b63b3788"
-
-[[token.source_card_refs]]
-card_name = "Friendly Neighborhood"
-scryfall_oracle_id = "10fe402e-8d6f-4058-9f42-86f229055359"
-scryfall_id = "10e0dff7-8923-4e47-bf28-c6d0af78ce24"
 
 [[token.source_card_refs]]
 card_name = "Spider-Girl, Legacy Hero"
@@ -211529,19 +205993,9 @@ scryfall_oracle_id = "50477dc8-9a2a-41eb-984d-c9e1e78e08a2"
 scryfall_id = "f6ff59e4-c7b7-4fdc-a49e-2d7aab859474"
 
 [[token.source_card_refs]]
-card_name = "Spider-Girl, Legacy Hero"
-scryfall_oracle_id = "d459b3f5-a18c-4c17-a855-dc147f7c2161"
-scryfall_id = "ebc534ac-c33b-4059-9d11-82645f8fead1"
-
-[[token.source_card_refs]]
 card_name = "Friendly Neighborhood"
 scryfall_oracle_id = "10fe402e-8d6f-4058-9f42-86f229055359"
 scryfall_id = "17a18e2f-221f-4fc2-8dab-25bf12fb8756"
-
-[[token.source_card_refs]]
-card_name = "Silk, Web Weaver"
-scryfall_oracle_id = "50477dc8-9a2a-41eb-984d-c9e1e78e08a2"
-scryfall_id = "458cd7a1-7437-493b-b7b7-42ef489e77df"
 
 [token.token_image_ref]
 scryfall_id = "398fbcd8-fac7-4396-9c69-5c72695121a9"
@@ -211639,11 +206093,6 @@ keywords = ["Deathtouch"]
 card_name = "Hapatra, Vizier of Poisons"
 scryfall_oracle_id = "a8ddea1c-8d80-49c1-a5b4-630d5e51d66e"
 scryfall_id = "d19e17fc-ae3e-4533-ab94-70d5f2e1b8cd"
-
-[[token.source_card_refs]]
-card_name = "Hapatra, Vizier of Poisons"
-scryfall_oracle_id = "a8ddea1c-8d80-49c1-a5b4-630d5e51d66e"
-scryfall_id = "b43ba233-30c4-4b18-8489-4df76551aa73"
 
 [token.token_image_ref]
 scryfall_id = "9a9380a8-8f38-47cd-8648-20626c06b9b3"
@@ -212273,18 +206722,6 @@ card_name = "Dorothea, Vengeful Victim // Dorothea's Retribution"
 face_name = "Dorothea's Retribution"
 scryfall_oracle_id = "2cef4171-8151-4ee9-83a7-bcb5116451bf"
 scryfall_id = "ff66ee02-6b68-405e-a5c0-f59bb8020865"
-
-[[token.source_card_refs]]
-card_name = "Dorothea, Vengeful Victim // Dorothea's Retribution"
-face_name = "Dorothea's Retribution"
-scryfall_oracle_id = "2cef4171-8151-4ee9-83a7-bcb5116451bf"
-scryfall_id = "680ce9a3-b47a-4f79-8254-f0935266b467"
-
-[[token.source_card_refs]]
-card_name = "Dorothea, Vengeful Victim // Dorothea's Retribution"
-face_name = "Dorothea, Vengeful Victim"
-scryfall_oracle_id = "2cef4171-8151-4ee9-83a7-bcb5116451bf"
-scryfall_id = "680ce9a3-b47a-4f79-8254-f0935266b467"
 
 [[token.source_card_refs]]
 card_name = "Dorothea, Vengeful Victim // Dorothea's Retribution"
@@ -213462,16 +207899,6 @@ card_name = "Zendikar's Roil"
 scryfall_oracle_id = "a842cc2b-52eb-4dc5-86c6-6575c2ed913d"
 scryfall_id = "79298a0f-50ca-4bf5-b863-a60f07846970"
 
-[[token.source_card_refs]]
-card_name = "Zendikar's Roil"
-scryfall_oracle_id = "a842cc2b-52eb-4dc5-86c6-6575c2ed913d"
-scryfall_id = "3f0768ee-aa58-48ca-91e8-64332af5dcfe"
-
-[[token.source_card_refs]]
-card_name = "Zendikar's Roil"
-scryfall_oracle_id = "a842cc2b-52eb-4dc5-86c6-6575c2ed913d"
-scryfall_id = "180aa3d6-8475-4c98-a140-af736a9c135e"
-
 [token.token_image_ref]
 scryfall_id = "5dc134da-51b8-452d-b515-54def56fe0c7"
 scryfall_oracle_id = "e3c32eb9-508a-41d3-b85f-cb85ab2f2716"
@@ -213702,29 +208129,9 @@ scryfall_oracle_id = "792da586-a687-428c-a10e-75431249df5b"
 scryfall_id = "c08c7bf9-a2ed-45c6-8b48-15122d9d9e37"
 
 [[token.source_card_refs]]
-card_name = "Strength of Arms"
-scryfall_oracle_id = "40ff84c7-cd72-49a6-86ba-a8d23c819ee7"
-scryfall_id = "3e021db5-982b-457c-958f-951ba3be317d"
-
-[[token.source_card_refs]]
-card_name = "Bastion of Remembrance"
-scryfall_oracle_id = "c7f33cea-2ec8-4081-9208-a5b1d86721b3"
-scryfall_id = "0c9a8ae0-af8b-41e5-b841-314106e40eaf"
-
-[[token.source_card_refs]]
 card_name = "Omen of the Sun"
 scryfall_oracle_id = "08740dda-0629-4b6f-bbcc-c8088105b5e7"
 scryfall_id = "b3733812-32e5-407d-82f0-089983777e09"
-
-[[token.source_card_refs]]
-card_name = "Thraben Standard Bearer"
-scryfall_oracle_id = "679d5a1d-8da8-4142-924b-97b359f55309"
-scryfall_id = "0229a5ce-196b-494e-bc6f-a71daedf05cc"
-
-[[token.source_card_refs]]
-card_name = "Ulvenwald Mysteries"
-scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
-scryfall_id = "749aafbf-9d17-4341-a137-dba1cc4d09da"
 
 [[token.source_card_refs]]
 card_name = "Bastion of Remembrance"
@@ -213772,24 +208179,9 @@ scryfall_oracle_id = "8e953251-aa5c-4aa3-8e69-1ff1f609f3ff"
 scryfall_id = "3fa2050a-711f-4c6e-8b01-5353bd2a4234"
 
 [[token.source_card_refs]]
-card_name = "Ulvenwald Mysteries"
-scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
-scryfall_id = "c6079979-8613-4613-a5bd-6b1fab382767"
-
-[[token.source_card_refs]]
-card_name = "Ulvenwald Mysteries"
-scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
-scryfall_id = "fd02c995-0a77-460c-9fa3-34f74b14b119"
-
-[[token.source_card_refs]]
 card_name = "Bastion of Remembrance"
 scryfall_oracle_id = "c7f33cea-2ec8-4081-9208-a5b1d86721b3"
 scryfall_id = "7ad20d37-575d-490e-bf04-91323a35e89d"
-
-[[token.source_card_refs]]
-card_name = "Sigarda, Heron's Grace"
-scryfall_oracle_id = "79b56cf8-d573-40cf-b797-6b4eef2bed23"
-scryfall_id = "f1b34868-c8f0-4e55-beac-8068af672618"
 
 [token.token_image_ref]
 scryfall_id = "631c2c16-132d-4607-ab7e-207a6af188e5"
@@ -213986,17 +208378,6 @@ subtypes = ["Human"]
 supertypes = []
 colors = ["Red"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Stensia Uprising"
-scryfall_oracle_id = "a881bf6e-6247-4adb-9f9c-e4b928692573"
-scryfall_id = "2ea95b64-9c5f-4f0d-ab7e-e4412a3cdadf"
-
-[[token.source_card_refs]]
-card_name = "Hanweir Garrison // Hanweir, the Writhing Township"
-face_name = "Hanweir Garrison"
-scryfall_oracle_id = "7cb29569-48e1-4782-9906-fad155ebfafe"
-scryfall_id = "85822129-ee39-4239-ba88-807435170f94"
 
 [[token.source_card_refs]]
 card_name = "Hanweir Garrison // Hanweir, the Writhing Township"
@@ -214969,11 +209350,6 @@ card_name = "Garruk, Apex Predator"
 scryfall_oracle_id = "ef9a8bdc-3361-440d-89f6-0bf5ff7a09e8"
 scryfall_id = "07dd9bfc-b6d2-493d-b825-941556018dbd"
 
-[[token.source_card_refs]]
-card_name = "Garruk, Apex Predator"
-scryfall_oracle_id = "ef9a8bdc-3361-440d-89f6-0bf5ff7a09e8"
-scryfall_id = "3ebd3fd3-d629-4e14-876f-55342a3a97d2"
-
 [token.token_image_ref]
 scryfall_id = "b56fd392-17c2-43d5-a92d-3f91beb8adfb"
 scryfall_oracle_id = "3c27a325-4490-44e6-aa9a-b591697486c8"
@@ -215332,21 +209708,6 @@ card_name = "Oviya Pashiri, Sage Lifecrafter"
 scryfall_oracle_id = "41e03224-bcdd-4127-a19a-fe66196339b9"
 scryfall_id = "b7938b15-7585-43fb-897f-a57e820665b3"
 
-[[token.source_card_refs]]
-card_name = "Metallurgic Summonings"
-scryfall_oracle_id = "7d5149c6-0e7e-438c-a554-5235c85e2426"
-scryfall_id = "77dbf358-0f4f-4b7a-aede-a7fc13619f24"
-
-[[token.source_card_refs]]
-card_name = "Oviya Pashiri, Sage Lifecrafter"
-scryfall_oracle_id = "41e03224-bcdd-4127-a19a-fe66196339b9"
-scryfall_id = "e1c2b1b4-6439-4203-967d-c8a40a2e701e"
-
-[[token.source_card_refs]]
-card_name = "Gemini Engine"
-scryfall_oracle_id = "eab4241d-a0d8-4914-85a4-56bc4ff718f2"
-scryfall_id = "2e03e05b-011b-4695-950b-98dd7643b8a0"
-
 [token.token_image_ref]
 scryfall_id = "0f3954f9-776d-4a8d-a032-724c4eae0e13"
 scryfall_oracle_id = "63ff850d-df4a-4903-95cb-cc04dfacc3f1"
@@ -215377,11 +209738,6 @@ keywords = []
 card_name = "Trial of Strength"
 scryfall_oracle_id = "b272cb56-dcba-479e-9fba-5b31e616a95f"
 scryfall_id = "acadb754-4a3b-4633-b784-252c0e1ab650"
-
-[[token.source_card_refs]]
-card_name = "Trial of Strength"
-scryfall_oracle_id = "b272cb56-dcba-479e-9fba-5b31e616a95f"
-scryfall_id = "fb8484a4-3ee1-4104-b22a-8a2f1401fbdc"
 
 [token.token_image_ref]
 scryfall_id = "29b7ecd1-c70e-467c-a9ea-99c2668c3405"
@@ -215550,11 +209906,6 @@ subtypes = ["Human"]
 supertypes = []
 colors = ["White"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Apothecary White"
-scryfall_oracle_id = "7bf8bb41-6f46-492c-b6cf-5cfb29f973a4"
-scryfall_id = "4fedf84e-55ca-4334-a2c1-6e991112bb68"
 
 [[token.source_card_refs]]
 card_name = "Castle Ardenvale"
@@ -216470,11 +210821,6 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Rise of the Ants"
 scryfall_oracle_id = "d9d33dcd-3352-478e-afc4-40f2ff369c39"
-scryfall_id = "7fb63465-4fb4-429c-8ff5-f6527e0a0b16"
-
-[[token.source_card_refs]]
-card_name = "Rise of the Ants"
-scryfall_oracle_id = "d9d33dcd-3352-478e-afc4-40f2ff369c39"
 scryfall_id = "7b00ea7e-da6e-4ebd-b39a-eb4657a1f9a5"
 
 [[token.source_card_refs]]
@@ -217274,24 +211620,9 @@ colors = ["White"]
 keywords = []
 
 [[token.source_card_refs]]
-card_name = "Security Detail"
-scryfall_oracle_id = "2a26dee4-b4b6-489d-99e5-6dbd8d19419d"
-scryfall_id = "5b89d34b-1a67-4f5c-a731-54b56c5233ff"
-
-[[token.source_card_refs]]
 card_name = "Midnight Angel Armor"
 scryfall_oracle_id = "cdcfc66d-3d3a-4311-b864-937e7b624d61"
 scryfall_id = "a3881ae9-f6c4-4b35-b767-351a8cb4e7c4"
-
-[[token.source_card_refs]]
-card_name = "Elspeth, Sun's Champion"
-scryfall_oracle_id = "05e6b243-48a6-4a42-bc5f-413441de9c33"
-scryfall_id = "8f8bdb2a-d6be-4a9c-bfa8-de00ccf3ca06"
-
-[[token.source_card_refs]]
-card_name = "Even the Odds"
-scryfall_oracle_id = "6cd3605c-7885-4d32-8585-3b0b0f733702"
-scryfall_id = "f704cd76-dca8-4526-b03f-7e3753d8fbb5"
 
 [[token.source_card_refs]]
 card_name = "S.H.I.E.L.D. Deployment Drone"
@@ -217309,16 +211640,6 @@ scryfall_oracle_id = "d6f36172-d3ef-49e9-a55f-ce2983bb2439"
 scryfall_id = "e94da91d-6c76-4909-91e3-2f8d97398654"
 
 [[token.source_card_refs]]
-card_name = "Ironroot Warlord"
-scryfall_oracle_id = "abc49dc3-03b3-48a4-afe1-5fc435b65d0f"
-scryfall_id = "b78765aa-f952-47f5-b6fc-8aca93fc4104"
-
-[[token.source_card_refs]]
-card_name = "Decree of Justice"
-scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
-scryfall_id = "1d347ffc-5542-485c-8fc7-327c1c68b7aa"
-
-[[token.source_card_refs]]
 card_name = "Kimoyo Beads"
 scryfall_oracle_id = "c7bdbf7a-8054-4e91-bb32-84f47e98553c"
 scryfall_id = "e8f6d489-44d2-4613-a1bb-bd435577e16a"
@@ -217327,16 +211648,6 @@ scryfall_id = "e8f6d489-44d2-4613-a1bb-bd435577e16a"
 card_name = "Martial Coup"
 scryfall_oracle_id = "2b7c4dab-e432-4b34-b058-3cec5c0d72df"
 scryfall_id = "b6e7563a-a613-49f4-98a0-dd0f5c00f299"
-
-[[token.source_card_refs]]
-card_name = "Lena, Selfless Champion"
-scryfall_oracle_id = "a8a8407c-d0e3-4311-82ed-1ab1f75159d9"
-scryfall_id = "da1fb1a6-7f64-45a6-9fc0-a325b7600afa"
-
-[[token.source_card_refs]]
-card_name = "Evangel of Heliod"
-scryfall_oracle_id = "4fbe1c02-f5bf-47c7-80de-09a32d01e5db"
-scryfall_id = "403597f8-12c7-40be-bb06-4468f547b80c"
 
 [[token.source_card_refs]]
 card_name = "Decree of Justice"
@@ -217357,16 +211668,6 @@ scryfall_id = "9e308f77-206b-4c9d-bfba-f4c476ea574a"
 card_name = "Okoye, Dora Milaje Leader"
 scryfall_oracle_id = "6d397d26-7e52-47b2-9880-2c10e90cfba4"
 scryfall_id = "2c89acf5-20f0-4441-b96f-2c5cacd685fb"
-
-[[token.source_card_refs]]
-card_name = "Benalish Commander"
-scryfall_oracle_id = "3a1e85fe-7064-4df7-bc3b-24131cd15d06"
-scryfall_id = "44814da0-3bc8-423d-9b22-3fea123048fa"
-
-[[token.source_card_refs]]
-card_name = "Decree of Justice"
-scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
-scryfall_id = "5e8a7e5c-f252-4de8-94d7-e7327210bf26"
 
 [[token.source_card_refs]]
 card_name = "Secure Detention"
@@ -217399,29 +211700,9 @@ scryfall_oracle_id = "26e92eb8-7a23-4e7e-be83-244bb6078606"
 scryfall_id = "bfa75d51-307f-45da-8fac-81bb32830ee9"
 
 [[token.source_card_refs]]
-card_name = "Decree of Justice"
-scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
-scryfall_id = "c2cecbd0-87a7-45e5-bf10-e97b298803fd"
-
-[[token.source_card_refs]]
-card_name = "Mobilization"
-scryfall_oracle_id = "6b8119e9-a9a9-4349-be32-adcb84b8eb79"
-scryfall_id = "653cc07b-0f53-4b5b-9c5f-885b8b4a6e5f"
-
-[[token.source_card_refs]]
 card_name = "Wakandan Shield Guard"
 scryfall_oracle_id = "a9268e61-2697-46ff-b219-4f2be646cbe4"
 scryfall_id = "47eba4f9-8276-4367-8ff5-53a066e8c729"
-
-[[token.source_card_refs]]
-card_name = "Kjeldoran Outpost"
-scryfall_oracle_id = "8b370db5-dfb9-4ea0-9017-bae3e767b041"
-scryfall_id = "db90c357-26e3-4ab2-a280-0d8d74b95048"
-
-[[token.source_card_refs]]
-card_name = "Kjeldoran Outpost"
-scryfall_oracle_id = "8b370db5-dfb9-4ea0-9017-bae3e767b041"
-scryfall_id = "e0769fc7-50b5-4b49-8aff-af04536288fb"
 
 [[token.source_card_refs]]
 card_name = "Elspeth, Sun's Champion"
@@ -217429,24 +211710,9 @@ scryfall_oracle_id = "05e6b243-48a6-4a42-bc5f-413441de9c33"
 scryfall_id = "97f8d1ca-bc82-453a-b237-ef75ce027b8f"
 
 [[token.source_card_refs]]
-card_name = "Kjeldoran Outpost"
-scryfall_oracle_id = "8b370db5-dfb9-4ea0-9017-bae3e767b041"
-scryfall_id = "3aaf73be-ef08-43fb-af8c-7c2536f743e0"
-
-[[token.source_card_refs]]
-card_name = "Raise the Alarm"
-scryfall_oracle_id = "5b2364d7-a811-4595-a1b4-224c70555ffa"
-scryfall_id = "f552f9b6-0a60-44d8-985e-249617e04866"
-
-[[token.source_card_refs]]
 card_name = "Kimoyo Beads"
 scryfall_oracle_id = "c7bdbf7a-8054-4e91-bb32-84f47e98553c"
 scryfall_id = "1138096a-0d7c-461b-af83-3c90f681722d"
-
-[[token.source_card_refs]]
-card_name = "Murder Investigation"
-scryfall_oracle_id = "42ca56c5-a9c4-4a2c-ae05-bce47aa6e16c"
-scryfall_id = "612da129-c8dd-4f89-a505-548ad5c2f7e1"
 
 [[token.source_card_refs]]
 card_name = "Decree of Justice"
@@ -217467,21 +211733,6 @@ scryfall_id = "0cb5f2df-9a5c-4fdf-8bb3-24d4d670768b"
 card_name = "Martial Coup"
 scryfall_oracle_id = "2b7c4dab-e432-4b34-b058-3cec5c0d72df"
 scryfall_id = "a0660e74-6973-41d7-a20b-8d71fed1495a"
-
-[[token.source_card_refs]]
-card_name = "Darien, King of Kjeldor"
-scryfall_oracle_id = "d05336cb-6157-47e7-942f-43becd67a5bf"
-scryfall_id = "5ea571ae-b9bd-4bd2-9357-52915f0d2f15"
-
-[[token.source_card_refs]]
-card_name = "Stormfront Riders"
-scryfall_oracle_id = "9df318b9-16c6-42f1-9f81-6f73ca01e5c1"
-scryfall_id = "de5e892e-d321-436f-81a6-73975e65b45c"
-
-[[token.source_card_refs]]
-card_name = "Raise the Alarm"
-scryfall_oracle_id = "5b2364d7-a811-4595-a1b4-224c70555ffa"
-scryfall_id = "4be510c8-fc01-4374-ac04-7968d24480fe"
 
 [[token.source_card_refs]]
 card_name = "Darien, King of Kjeldor"
@@ -220087,11 +214338,6 @@ keywords = [
     "Indestructible",
 ]
 
-[[token.source_card_refs]]
-card_name = "Dark Depths"
-scryfall_oracle_id = "c9b82110-7dfd-4617-9399-9510be449043"
-scryfall_id = "92409c3a-fb1a-4205-9fe1-0f5affc7b21d"
-
 [token.token_image_ref]
 scryfall_id = "8f5c3863-c876-48a8-9bc8-be20cd61074c"
 scryfall_oracle_id = "48e9147e-59f7-4693-83d7-7f514be871bc"
@@ -221641,11 +215887,6 @@ scryfall_id = "3aecfe99-9c4b-4087-84ee-fb208fd22820"
 [[token.source_card_refs]]
 card_name = "Xenagos, the Reveler"
 scryfall_oracle_id = "942a318e-90eb-4f10-bb30-2e10f5cc922a"
-scryfall_id = "e7848a59-14f1-49ea-981e-8436acb70d85"
-
-[[token.source_card_refs]]
-card_name = "Xenagos, the Reveler"
-scryfall_oracle_id = "942a318e-90eb-4f10-bb30-2e10f5cc922a"
 scryfall_id = "edfd90ee-a142-4a80-b383-802bbee2cef1"
 
 [[token.source_card_refs]]
@@ -222095,11 +216336,6 @@ card_name = "B.O.B. (Bevy of Beebles)"
 scryfall_oracle_id = "c33af24f-3371-4af9-af33-940078d3cef2"
 scryfall_id = "7e41ecd9-8875-4765-a9a9-372f948b5ad7"
 
-[[token.source_card_refs]]
-card_name = "B.O.B. (Bevy of Beebles)"
-scryfall_oracle_id = "c33af24f-3371-4af9-af33-940078d3cef2"
-scryfall_id = "de1d5bfb-953f-4ce0-88ee-721e69254228"
-
 [token.token_image_ref]
 scryfall_id = "9bbfa4d4-106b-4fec-86ac-b81b71a8f432"
 scryfall_oracle_id = "2de03d67-1b55-4abc-9a64-4f59658b9e97"
@@ -222136,11 +216372,6 @@ colors = ["White"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
-card_name = "Sacred Mesa"
-scryfall_oracle_id = "8776d14f-a5a2-4ef3-98d0-e1148e579e4d"
-scryfall_id = "6622f325-6bc3-49dc-ba8e-154e70772dd5"
-
-[[token.source_card_refs]]
 card_name = "Pegasus Stampede"
 scryfall_oracle_id = "16b4a48a-fec2-433c-948d-e0b16c961172"
 scryfall_id = "a5301a1b-5fa1-4311-a515-ff1b64c98945"
@@ -222149,11 +216380,6 @@ scryfall_id = "a5301a1b-5fa1-4311-a515-ff1b64c98945"
 card_name = "Storm Herd"
 scryfall_oracle_id = "30aa362b-7ab1-486e-9802-1171e0dc2416"
 scryfall_id = "62a3fc08-6d95-43da-8479-4289018c2d58"
-
-[[token.source_card_refs]]
-card_name = "Storm Herd"
-scryfall_oracle_id = "30aa362b-7ab1-486e-9802-1171e0dc2416"
-scryfall_id = "c8c86398-2cbc-4ad7-a231-6802e3b4d1c0"
 
 [[token.source_card_refs]]
 card_name = "Storm Herd"
@@ -222172,30 +216398,10 @@ scryfall_oracle_id = "e71863a7-0de1-4ab5-95e8-c39e6810d899"
 scryfall_id = "d32dcd09-8542-4135-8955-e29ee63e3589"
 
 [[token.source_card_refs]]
-card_name = "Pegasus Refuge"
-scryfall_oracle_id = "07462467-e4a3-409e-bcef-9cc92ca4c299"
-scryfall_id = "a2bce334-0ae6-4a7d-85db-99ee205ce546"
-
-[[token.source_card_refs]]
 card_name = "Pegasus Guardian // Rescue the Foal"
 face_name = "Rescue the Foal"
 scryfall_oracle_id = "e71863a7-0de1-4ab5-95e8-c39e6810d899"
 scryfall_id = "d32dcd09-8542-4135-8955-e29ee63e3589"
-
-[[token.source_card_refs]]
-card_name = "Sacred Mesa"
-scryfall_oracle_id = "8776d14f-a5a2-4ef3-98d0-e1148e579e4d"
-scryfall_id = "c76e4cc6-6e69-4787-9425-7a35e06c0b69"
-
-[[token.source_card_refs]]
-card_name = "Pegasus Stampede"
-scryfall_oracle_id = "16b4a48a-fec2-433c-948d-e0b16c961172"
-scryfall_id = "3b941576-8254-4d69-85ae-c748c7921ce5"
-
-[[token.source_card_refs]]
-card_name = "Pegasus Stampede"
-scryfall_oracle_id = "16b4a48a-fec2-433c-948d-e0b16c961172"
-scryfall_id = "7418d65f-1017-4f98-b039-db4228769454"
 
 [token.token_image_ref]
 scryfall_id = "ebd8f43d-7e54-46d4-9fe9-ac818a9fd91f"
@@ -222975,12 +217181,10 @@ id = "fb4ee9b2-1eb8-5465-9fcc-7c7089627d36"
 category = "Creature"
 fidelity = "Full"
 source_card_names = [
-    "Hanweir Militia Captain",
     "Hanweir Militia Captain // Westvale Cult Leader",
     "Ormendahl, Profane Prince",
     "Westvale Abbey",
     "Westvale Abbey // Ormendahl, Profane Prince",
-    "Westvale Cult Leader",
 ]
 set_code = "INR"
 set_name = "Innistrad Remastered"
@@ -223036,12 +217240,6 @@ scryfall_id = "d3182b40-a731-4957-9d6e-a1f69c3aeb5e"
 
 [[token.source_card_refs]]
 card_name = "Westvale Abbey // Ormendahl, Profane Prince"
-face_name = "Ormendahl, Profane Prince"
-scryfall_oracle_id = "04eeb9ad-5c59-411b-8809-db8349838588"
-scryfall_id = "20c2c22f-5115-4a66-bcad-e70619d43448"
-
-[[token.source_card_refs]]
-card_name = "Westvale Abbey // Ormendahl, Profane Prince"
 face_name = "Westvale Abbey"
 scryfall_oracle_id = "04eeb9ad-5c59-411b-8809-db8349838588"
 scryfall_id = "5fbc6091-a161-45b0-9932-543b569caaee"
@@ -223057,24 +217255,6 @@ card_name = "Westvale Abbey // Ormendahl, Profane Prince"
 face_name = "Ormendahl, Profane Prince"
 scryfall_oracle_id = "04eeb9ad-5c59-411b-8809-db8349838588"
 scryfall_id = "5fbc6091-a161-45b0-9932-543b569caaee"
-
-[[token.source_card_refs]]
-card_name = "Westvale Abbey // Ormendahl, Profane Prince"
-face_name = "Westvale Abbey"
-scryfall_oracle_id = "04eeb9ad-5c59-411b-8809-db8349838588"
-scryfall_id = "20c2c22f-5115-4a66-bcad-e70619d43448"
-
-[[token.source_card_refs]]
-card_name = "Hanweir Militia Captain // Westvale Cult Leader"
-face_name = "Hanweir Militia Captain"
-scryfall_oracle_id = "2d8eba16-cfca-4a38-bde0-6ee36c67231a"
-scryfall_id = "7e6b3fb3-897b-4665-b053-a29f25850b25"
-
-[[token.source_card_refs]]
-card_name = "Hanweir Militia Captain // Westvale Cult Leader"
-face_name = "Westvale Cult Leader"
-scryfall_oracle_id = "2d8eba16-cfca-4a38-bde0-6ee36c67231a"
-scryfall_id = "7e6b3fb3-897b-4665-b053-a29f25850b25"
 
 [token.token_image_ref]
 scryfall_id = "7081602e-84a3-45b0-87f6-f0f236a5264e"
@@ -223942,11 +218122,6 @@ subtypes = ["Skeleton"]
 supertypes = []
 colors = ["Black"]
 keywords = []
-
-[[token.source_card_refs]]
-card_name = "Drudge Spell"
-scryfall_oracle_id = "d63f4eeb-3fa5-4e65-8414-e3fd3c03c128"
-scryfall_id = "52b352de-e989-4ad5-963c-818092fc9f1a"
 
 [[token.source_card_refs]]
 card_name = "Skeletonize"
@@ -227507,159 +221682,9 @@ scryfall_oracle_id = "7c4e3a25-6b72-45ab-bcb0-9c4a67a4c7b1"
 scryfall_id = "833f4412-98eb-4ba5-8ae7-f3c973291db7"
 
 [[token.source_card_refs]]
-card_name = "Thopter Squadron"
-scryfall_oracle_id = "f1482ca4-610b-48fe-ac23-4526637bb72a"
-scryfall_id = "5fd13ac2-9642-4d59-a5c6-cc13c86991f0"
-
-[[token.source_card_refs]]
-card_name = "Ghirapur Gearcrafter"
-scryfall_oracle_id = "710dc9b1-7d32-4330-95a8-3e91a668202a"
-scryfall_id = "b9ec4def-3f9a-436e-aa7b-d1e03c7dbc6a"
-
-[[token.source_card_refs]]
-card_name = "Experimental Aviator"
-scryfall_oracle_id = "47f221a4-b51a-46b9-a4fc-46bc8ec7ddd3"
-scryfall_id = "9ddd283c-643a-449c-8cb6-178526d5476e"
-
-[[token.source_card_refs]]
-card_name = "Breya's Apprentice"
-scryfall_oracle_id = "8fb9ff2d-1e90-4a26-8397-bb981fda2f7b"
-scryfall_id = "7d4cc438-d93d-4fe9-8162-c7271c9d15b3"
-
-[[token.source_card_refs]]
-card_name = "Thopter Mechanic"
-scryfall_oracle_id = "a7e7be75-646d-4c99-8388-15bb422c8e25"
-scryfall_id = "282e630c-5d4a-469b-9b51-1127616dda34"
-
-[[token.source_card_refs]]
-card_name = "Pia Nalaar"
-scryfall_oracle_id = "715336f5-a708-488b-9f30-5702a9013af0"
-scryfall_id = "ba07c7db-9ec7-47c1-96a4-fa67492870f0"
-
-[[token.source_card_refs]]
-card_name = "Pia Nalaar, Consul of Revival"
-scryfall_oracle_id = "65d4ebdb-8757-4e5e-9411-d78597e20d57"
-scryfall_id = "413eedd5-ea42-4b6f-9282-3040e517d936"
-
-[[token.source_card_refs]]
-card_name = "Pia Nalaar, Consul of Revival"
-scryfall_oracle_id = "65d4ebdb-8757-4e5e-9411-d78597e20d57"
-scryfall_id = "613ed071-7672-44c4-bd19-66954ea0c83c"
-
-[[token.source_card_refs]]
-card_name = "Whirlermaker"
-scryfall_oracle_id = "bdf28770-0962-4317-822f-c187bc6706d1"
-scryfall_id = "48e02966-ff20-4e5e-b27d-adc6156c802d"
-
-[[token.source_card_refs]]
-card_name = "Launch Mishap"
-scryfall_oracle_id = "5d4ed768-0a37-4604-8121-43920ed9fb4a"
-scryfall_id = "abc561d3-9e52-41fd-8311-60cc9dfffdd1"
-
-[[token.source_card_refs]]
-card_name = "Thopter Squadron"
-scryfall_oracle_id = "f1482ca4-610b-48fe-ac23-4526637bb72a"
-scryfall_id = "25af067f-436c-4835-875a-3b2c2557104c"
-
-[[token.source_card_refs]]
-card_name = "Whirlermaker"
-scryfall_oracle_id = "bdf28770-0962-4317-822f-c187bc6706d1"
-scryfall_id = "f4acd88d-fc44-4ff8-81d7-5a8350fd6731"
-
-[[token.source_card_refs]]
-card_name = "Maverick Thopterist"
-scryfall_oracle_id = "71ba6f1b-2fa6-4d4c-8778-f0765b1a5d8e"
-scryfall_id = "8f5dc3c8-2a3c-42fc-9d88-55520af29f84"
-
-[[token.source_card_refs]]
-card_name = "Pia Nalaar, Consul of Revival"
-scryfall_oracle_id = "65d4ebdb-8757-4e5e-9411-d78597e20d57"
-scryfall_id = "0ae89461-4bce-4b49-b875-03afc2469fe7"
-
-[[token.source_card_refs]]
-card_name = "Pia and Kiran Nalaar"
-scryfall_oracle_id = "86084ed9-b8bb-4289-9579-6056194787bc"
-scryfall_id = "c8562d6b-25af-4d6b-9eb8-6ab08fa12dd1"
-
-[[token.source_card_refs]]
-card_name = "Pia Nalaar, Consul of Revival"
-scryfall_oracle_id = "65d4ebdb-8757-4e5e-9411-d78597e20d57"
-scryfall_id = "28216a47-709f-41fc-834c-7e4c99c806f7"
-
-[[token.source_card_refs]]
-card_name = "Sai, Master Thopterist"
-scryfall_oracle_id = "52241b9c-7a69-4176-9234-8bdab09d8e64"
-scryfall_id = "a1091e0e-a179-4241-8be0-ea92d86f4c08"
-
-[[token.source_card_refs]]
-card_name = "Thopter Spy Network"
-scryfall_oracle_id = "49be65fd-3755-410d-b0dc-2e5861ea2552"
-scryfall_id = "dc605d26-417f-4ef6-a3c4-8482ea05ee12"
-
-[[token.source_card_refs]]
-card_name = "Tezzeret, Artifice Master"
-scryfall_oracle_id = "e22824cf-07a1-4c83-b6c4-9d8fcff3892f"
-scryfall_id = "95b03fbb-10e9-4bf8-8fd3-e99e8c1cd84f"
-
-[[token.source_card_refs]]
 card_name = "Hangarback Walker"
 scryfall_oracle_id = "dde55256-5259-44e7-a267-fca45a7f0d04"
 scryfall_id = "cc387ccf-f746-4855-81e5-64f5a5e0fdda"
-
-[[token.source_card_refs]]
-card_name = "Etherium Spinner"
-scryfall_oracle_id = "b501128b-2797-401b-8aec-923050081cae"
-scryfall_id = "84130c94-f98c-4a66-9880-4b09fa663067"
-
-[[token.source_card_refs]]
-card_name = "Pia Nalaar, Consul of Revival"
-scryfall_oracle_id = "65d4ebdb-8757-4e5e-9411-d78597e20d57"
-scryfall_id = "7aafbdf8-b1cd-4dbb-863c-0d44494eec2b"
-
-[[token.source_card_refs]]
-card_name = "Barbed Spike"
-scryfall_oracle_id = "28b22709-3e69-4eb7-8a3d-b75b6e65f30e"
-scryfall_id = "227e37c6-1e5f-4b2b-b723-fcc6e8fa669d"
-
-[[token.source_card_refs]]
-card_name = "Thopter Squadron"
-scryfall_oracle_id = "f1482ca4-610b-48fe-ac23-4526637bb72a"
-scryfall_id = "d3ac2d30-7c9a-40b3-812e-e77e49229f48"
-
-[[token.source_card_refs]]
-card_name = "Whirlermaker"
-scryfall_oracle_id = "bdf28770-0962-4317-822f-c187bc6706d1"
-scryfall_id = "3624a056-2af8-4e55-8e19-f26c03701945"
-
-[[token.source_card_refs]]
-card_name = "Thopter Engineer"
-scryfall_oracle_id = "4ac53b34-20d2-4a53-bade-4f998fb6ae67"
-scryfall_id = "3ba40fc1-a92c-4676-90fa-66d0f7c0f9cf"
-
-[[token.source_card_refs]]
-card_name = "Hangarback Walker"
-scryfall_oracle_id = "dde55256-5259-44e7-a267-fca45a7f0d04"
-scryfall_id = "b46b2624-0396-4576-aedc-2b7980f76241"
-
-[[token.source_card_refs]]
-card_name = "Fairgrounds Patrol"
-scryfall_oracle_id = "8b0689b5-7c68-46b3-a72a-4f97ef1d0a15"
-scryfall_id = "21456767-bf7b-4813-b305-1bc3005f56b9"
-
-[[token.source_card_refs]]
-card_name = "Whirler Virtuoso"
-scryfall_oracle_id = "f82da236-e567-4221-a0bc-439a0c7e2b03"
-scryfall_id = "634c5d10-f71b-4673-b1d7-059f47717da9"
-
-[[token.source_card_refs]]
-card_name = "Whirler Rogue"
-scryfall_oracle_id = "7060f2c8-fca0-4b7a-bddf-37682f434596"
-scryfall_id = "c62a27a8-271c-4ac8-97a5-2efb192e3a15"
-
-[[token.source_card_refs]]
-card_name = "Aviation Pioneer"
-scryfall_oracle_id = "ad11ff81-acaa-4529-ba15-718dadbea259"
-scryfall_id = "4165233d-8651-4498-91b6-d3e5e6d613a5"
 
 [token.token_image_ref]
 scryfall_id = "b9d38c75-c69f-45cd-a745-03ac7513491b"
@@ -227721,11 +221746,6 @@ keywords = [
 card_name = "Sorin the Mirthless"
 scryfall_oracle_id = "fbffaf9f-40e7-4113-a037-533b733cebce"
 scryfall_id = "112394a6-7819-43b4-adad-f6900aff2936"
-
-[[token.source_card_refs]]
-card_name = "Sorin the Mirthless"
-scryfall_oracle_id = "fbffaf9f-40e7-4113-a037-533b733cebce"
-scryfall_id = "d1a38e25-297f-43e1-9455-73f00eb08cec"
 
 [[token.source_card_refs]]
 card_name = "Sorin the Mirthless"
@@ -229471,11 +223491,6 @@ card_name = "Triskelavus"
 scryfall_oracle_id = "e958f7bf-3011-4175-b467-ca225a9b7ad2"
 scryfall_id = "899eb19e-9932-4066-9de6-dfdbbab5e769"
 
-[[token.source_card_refs]]
-card_name = "Triskelavus"
-scryfall_oracle_id = "e958f7bf-3011-4175-b467-ca225a9b7ad2"
-scryfall_id = "978d11e7-cfb7-41bf-bb98-deb79549a074"
-
 [token.token_image_ref]
 scryfall_id = "b5ddb67c-82fb-42d6-a4c2-11cd38eb128d"
 scryfall_oracle_id = "80e72f55-b718-4442-93ee-f9175a739975"
@@ -230098,11 +224113,6 @@ card_name = "Sokenzan Smelter"
 scryfall_oracle_id = "dd645241-2992-4c4e-a6a8-c2215d2340ae"
 scryfall_id = "758724f9-93c9-4178-ae40-3fefc75a010e"
 
-[[token.source_card_refs]]
-card_name = "Sokenzan Smelter"
-scryfall_oracle_id = "dd645241-2992-4c4e-a6a8-c2215d2340ae"
-scryfall_id = "b4ec8275-80c0-4c1e-9432-a940a83756a0"
-
 [token.token_image_ref]
 scryfall_id = "cbafdfc0-380a-482b-b5f8-a7a00ecf8da6"
 scryfall_oracle_id = "74658c70-caa8-4172-8a65-055d327668f9"
@@ -230378,11 +224388,6 @@ keywords = []
 card_name = "Anointer Priest"
 scryfall_oracle_id = "4e0b9273-6614-41a8-9738-959349c0717b"
 scryfall_id = "46f810c2-310e-42f5-ab1f-d56396cf5124"
-
-[[token.source_card_refs]]
-card_name = "Anointer Priest"
-scryfall_oracle_id = "4e0b9273-6614-41a8-9738-959349c0717b"
-scryfall_id = "c1c4274b-4268-48af-bbf0-38349a317a99"
 
 [[token.source_card_refs]]
 card_name = "Anointer Priest"

--- a/crates/engine/data/known-tokens.toml
+++ b/crates/engine/data/known-tokens.toml
@@ -3023,6 +3023,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Giant Opportunity"
 scryfall_oracle_id = "395aa62e-0786-4bd8-a88f-998e4700742e"
+scryfall_id = "6d284306-3365-45b4-8539-c2af7b3e16c4"
+
+[[token.source_card_refs]]
+card_name = "Giant Opportunity"
+scryfall_oracle_id = "395aa62e-0786-4bd8-a88f-998e4700742e"
 scryfall_id = "40383646-3fc4-4267-b9ad-bf90a85972fc"
 
 [token.token_image_ref]
@@ -4001,6 +4006,11 @@ keywords = ["Flying"]
 card_name = "Aven Initiate"
 scryfall_oracle_id = "c872012d-b598-4076-8385-2e3771c0306f"
 scryfall_id = "e078dfbe-ebdf-4ea8-aed7-cb2c986e7656"
+
+[[token.source_card_refs]]
+card_name = "Aven Initiate"
+scryfall_oracle_id = "c872012d-b598-4076-8385-2e3771c0306f"
+scryfall_id = "eba15599-ba74-4506-847a-4472214d8d33"
 
 [token.token_image_ref]
 scryfall_id = "12feaabf-7b3e-4cef-8d45-1b9bbe2baaf6"
@@ -6189,6 +6199,11 @@ scryfall_oracle_id = "4a0cc2a2-3711-473a-b2c5-b1e52b34e4fb"
 scryfall_id = "8c0f9306-2058-476d-a711-bd37a6e15e42"
 
 [[token.source_card_refs]]
+card_name = "Waylay"
+scryfall_oracle_id = "f0db78c7-09b5-4981-8ca8-6dbab597c5d9"
+scryfall_id = "867a33ee-0340-413a-8243-9d6bc2d944e2"
+
+[[token.source_card_refs]]
 card_name = "Battle Menu"
 scryfall_oracle_id = "8af57b80-bbc6-47ce-83f6-34ae8e2f5bd5"
 scryfall_id = "240e1466-bd02-423d-b829-234dcd2bfab2"
@@ -6284,6 +6299,7 @@ source_card_names = [
     "Death Mutation",
     "Deathbloom Thallid",
     "Deathspore Thallid",
+    "Demand",
     "Dreampod Druid",
     "Druidic Satchel",
     "Elvish Farmer",
@@ -6343,6 +6359,7 @@ source_card_names = [
     "Sprout",
     "Sprout Swarm",
     "Sprouting Thrinax",
+    "Supply",
     "Supply // Demand",
     "Tana, the Bloodsower",
     "Tendershoot Dryad",
@@ -6381,9 +6398,95 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Shroofus Sproutsire"
+scryfall_oracle_id = "e0cebb09-d10d-4b70-96be-82df0e5d52d3"
+scryfall_id = "d29839f0-afe0-4caa-9628-655738aecce4"
+
+[[token.source_card_refs]]
+card_name = "Saproling Infestation"
+scryfall_oracle_id = "dd257eb3-4112-41e5-9c7d-00d1f683dbdb"
+scryfall_id = "8642e530-914c-4149-944a-c4966ee27299"
+
+[[token.source_card_refs]]
+card_name = "Tribune of Rot"
+scryfall_oracle_id = "cd1b3ef3-73ac-4f06-8cfb-5f2388481379"
+scryfall_id = "e60890ef-daf7-4542-9813-6c6a6e0ab222"
+
+[[token.source_card_refs]]
+card_name = "Night Soil"
+scryfall_oracle_id = "3165fe8f-52d7-40f7-bb14-8f4300a564e6"
+scryfall_id = "4f25a497-46dc-47aa-8586-d514578a6d25"
+
+[[token.source_card_refs]]
+card_name = "Elvish Farmer"
+scryfall_oracle_id = "91fe1075-e170-4575-ae28-8d692f051637"
+scryfall_id = "9e37a5d9-2b6f-4412-aec2-0d6161e2a7d2"
+
+[[token.source_card_refs]]
+card_name = "Verdant Force"
+scryfall_oracle_id = "7a21ea22-3cd7-4c11-8895-5943c0d93a0d"
+scryfall_id = "d5a5533f-d24d-4cca-a47e-0676c6061a35"
+
+[[token.source_card_refs]]
+card_name = "Aether Mutation"
+scryfall_oracle_id = "6697fe5b-90ac-4321-aa2f-cdc6ec283cb4"
+scryfall_id = "a9507116-ede8-40a1-8fa3-705e6f6f64c0"
+
+[[token.source_card_refs]]
+card_name = "Fertile Imagination"
+scryfall_oracle_id = "8808595b-5d77-4382-ae1e-9609e1da65ef"
+scryfall_id = "e5c879af-a092-4cc4-a53d-760553d94864"
+
+[[token.source_card_refs]]
+card_name = "Spontaneous Generation"
+scryfall_oracle_id = "d5b021e3-a0c1-471b-9088-a76816806354"
+scryfall_id = "ce5765cb-00cd-4920-9fe8-68791048ec4a"
+
+[[token.source_card_refs]]
+card_name = "Night Soil"
+scryfall_oracle_id = "3165fe8f-52d7-40f7-bb14-8f4300a564e6"
+scryfall_id = "ee3eb61b-698c-42b1-8a33-0ce7c3829e07"
+
+[[token.source_card_refs]]
 card_name = "Tendershoot Dryad"
 scryfall_oracle_id = "a336c10a-b5bd-47ff-ba2d-31e27af1e15a"
 scryfall_id = "def3571c-01dd-4eee-8f60-0ac4d1928d33"
+
+[[token.source_card_refs]]
+card_name = "Last Stand"
+scryfall_oracle_id = "4d2a465e-9ebd-4002-b6cd-e0eab08bad54"
+scryfall_id = "7dc3d054-6266-4ce0-89ed-f8b170794f2e"
+
+[[token.source_card_refs]]
+card_name = "Saproling Symbiosis"
+scryfall_oracle_id = "69d22037-fbf7-44d2-81a7-7ce8e32f06ec"
+scryfall_id = "2bb63748-5c84-43a0-8f17-a2a17f658337"
+
+[[token.source_card_refs]]
+card_name = "Thallid"
+scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
+scryfall_id = "ba7b31c0-45d0-44e6-961b-fa8108e571e3"
+
+[[token.source_card_refs]]
+card_name = "Supply // Demand"
+face_name = "Supply"
+scryfall_oracle_id = "d7158101-f6ac-4d61-9570-a3adc3c8b583"
+scryfall_id = "d4628887-bda4-47e4-84d1-d31a8298f9e5"
+
+[[token.source_card_refs]]
+card_name = "Thallid Devourer"
+scryfall_oracle_id = "b7326fd9-7648-4db3-b506-61a7de8a4094"
+scryfall_id = "1a392801-bdc8-4342-8cdd-48f874e22afa"
+
+[[token.source_card_refs]]
+card_name = "Rith's Charm"
+scryfall_oracle_id = "9dbccdc5-61f7-4a7d-bbbc-5cab393e24f7"
+scryfall_id = "dd30f389-bac8-4b82-a8a7-6948d43a9f60"
+
+[[token.source_card_refs]]
+card_name = "Spore Swarm"
+scryfall_oracle_id = "8fb599a7-2c61-446b-a7a7-cd5367f9b796"
+scryfall_id = "f5a9ab6c-d4e6-461b-b760-037b7c2b7f42"
 
 [[token.source_card_refs]]
 card_name = "Selesnya Evangel"
@@ -6391,9 +6494,120 @@ scryfall_oracle_id = "4a2fea39-99d6-4766-9f2c-0a63925349cb"
 scryfall_id = "3afd9bc0-442b-4e0f-bb5e-821c1070b213"
 
 [[token.source_card_refs]]
+card_name = "Deathbloom Thallid"
+scryfall_oracle_id = "ce873790-de4d-4ba3-8023-c44306ba3ff8"
+scryfall_id = "bbe74b50-a2a9-4ace-95ed-4ad5d12e3f2e"
+
+[[token.source_card_refs]]
+card_name = "Sporesower Thallid"
+scryfall_oracle_id = "dd840d84-bc4a-4420-b8ac-99093a5aa253"
+scryfall_id = "2f834b1f-9f05-4553-a9b5-828a8348ed30"
+
+[[token.source_card_refs]]
+card_name = "Vitaspore Thallid"
+scryfall_oracle_id = "8940f80b-9c8d-48c0-97c0-c18d77797911"
+scryfall_id = "cad14bc9-b90e-48e0-9e72-173874dab6bc"
+
+[[token.source_card_refs]]
+card_name = "Verdeloth the Ancient"
+scryfall_oracle_id = "8222321f-b74d-4f74-9ee7-79455433345a"
+scryfall_id = "4b3e632e-21dc-4cc3-9c80-4b3d8b8e5795"
+
+[[token.source_card_refs]]
+card_name = "Verdant Force"
+scryfall_oracle_id = "7a21ea22-3cd7-4c11-8895-5943c0d93a0d"
+scryfall_id = "0b4e67cf-3c49-480c-b960-128b1ab2a716"
+
+[[token.source_card_refs]]
+card_name = "Rith, the Awakener"
+scryfall_oracle_id = "97e5d788-2dd3-4c8e-9ab6-f4ea9c7a9a3d"
+scryfall_id = "c30be387-280d-49bd-a3d1-c1636ee931ce"
+
+[[token.source_card_refs]]
+card_name = "Verdant Embrace"
+scryfall_oracle_id = "f0bbd988-50b7-476c-9183-dfabd4a95079"
+scryfall_id = "3dd1d130-98e7-4898-9f13-2bb58fa4777b"
+
+[[token.source_card_refs]]
+card_name = "Selesnya Guildmage"
+scryfall_oracle_id = "8fbdca3a-7aa3-4b5a-98d7-9168856045ac"
+scryfall_id = "954b8e86-284a-4a6f-ac35-896afd414f8a"
+
+[[token.source_card_refs]]
+card_name = "Tukatongue Thallid"
+scryfall_oracle_id = "c7dbd008-e941-497e-8305-80c53b1dffe2"
+scryfall_id = "d90794bf-2d48-4a53-8197-b931d26292fb"
+
+[[token.source_card_refs]]
+card_name = "Fungal Plots"
+scryfall_oracle_id = "0a85402a-e3be-4ebb-8001-9d9a20dde7e8"
+scryfall_id = "cc306b05-d991-4048-8390-6f404268d249"
+
+[[token.source_card_refs]]
+card_name = "Saproling Migration"
+scryfall_oracle_id = "bbbb80bd-76fa-4155-929b-4a3565d1cb35"
+scryfall_id = "52589a1d-bb98-4af2-8813-8598fb20b4f2"
+
+[[token.source_card_refs]]
+card_name = "Deathspore Thallid"
+scryfall_oracle_id = "3a2a6904-219a-4d16-b11a-1e0e2826814e"
+scryfall_id = "44ee5ee3-11f8-4a4e-bfa3-10ff45ed6d1b"
+
+[[token.source_card_refs]]
 card_name = "Pollenbright Wings"
 scryfall_oracle_id = "582c8030-1d41-4c63-8ed6-06aad398a96c"
 scryfall_id = "e190a22c-31d3-4c16-81c2-735e58348df1"
+
+[[token.source_card_refs]]
+card_name = "Vitu-Ghazi, the City-Tree"
+scryfall_oracle_id = "88fb9e82-28b9-4275-a1e2-cb3a9bfda127"
+scryfall_id = "afc35026-a29e-4fb0-931f-5e90faf41802"
+
+[[token.source_card_refs]]
+card_name = "Supply // Demand"
+face_name = "Demand"
+scryfall_oracle_id = "d7158101-f6ac-4d61-9570-a3adc3c8b583"
+scryfall_id = "d4628887-bda4-47e4-84d1-d31a8298f9e5"
+
+[[token.source_card_refs]]
+card_name = "Undercellar Myconid"
+scryfall_oracle_id = "127f5b7e-79bc-4fe0-b9d4-1a267a6a4d46"
+scryfall_id = "fbd215e0-0de9-4382-9d8f-9b8d1ec5449d"
+
+[[token.source_card_refs]]
+card_name = "Thallid"
+scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
+scryfall_id = "80f8f778-ae31-45cd-b27f-f93a07853ede"
+
+[[token.source_card_refs]]
+card_name = "Selesnya Guildmage"
+scryfall_oracle_id = "8fbdca3a-7aa3-4b5a-98d7-9168856045ac"
+scryfall_id = "21061ce3-d098-4057-b341-c5db6ee1b6d4"
+
+[[token.source_card_refs]]
+card_name = "Flash Foliage"
+scryfall_oracle_id = "ee79b00d-9b2a-454d-a20c-edb073ef69cf"
+scryfall_id = "b71c63da-dfe3-475f-88d9-20008c01163a"
+
+[[token.source_card_refs]]
+card_name = "Scatter the Seeds"
+scryfall_oracle_id = "c17d5153-cc74-4fbb-9d75-f7ee7b557b0a"
+scryfall_id = "c4415070-4304-482b-b8e5-2bf689af0843"
+
+[[token.source_card_refs]]
+card_name = "Verdeloth the Ancient"
+scryfall_oracle_id = "8222321f-b74d-4f74-9ee7-79455433345a"
+scryfall_id = "72d5fab1-fa20-4006-b19d-179d36238c9b"
+
+[[token.source_card_refs]]
+card_name = "Thallid"
+scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
+scryfall_id = "2cf2f3da-9101-439d-8caa-910ff40bfbb3"
+
+[[token.source_card_refs]]
+card_name = "Thallid"
+scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
+scryfall_id = "6d4d2d63-3552-4e9c-8862-84a3ca3456d7"
 
 [[token.source_card_refs]]
 card_name = "Mycoloth"
@@ -6401,9 +6615,109 @@ scryfall_oracle_id = "d7fd16ce-282d-49cd-b2b4-0d25935e7a72"
 scryfall_id = "924976cf-9b46-4cbf-ab27-07ca72a21608"
 
 [[token.source_card_refs]]
+card_name = "Night Soil"
+scryfall_oracle_id = "3165fe8f-52d7-40f7-bb14-8f4300a564e6"
+scryfall_id = "4cda6d18-d4b1-4b8a-a72e-f90115adf4c3"
+
+[[token.source_card_refs]]
+card_name = "Sprout Swarm"
+scryfall_oracle_id = "8b33d890-7d67-44a8-a253-e2b171d7ca9d"
+scryfall_id = "0b915355-4e98-44df-81bd-961a3d3c86b8"
+
+[[token.source_card_refs]]
+card_name = "Sporoloth Ancient"
+scryfall_oracle_id = "071e15b5-6d21-4695-9ad0-69f40eb8f4ef"
+scryfall_id = "cdc8f3f3-4ff4-4943-8ae0-c1af78a5ae16"
+
+[[token.source_card_refs]]
+card_name = "Savage Thallid"
+scryfall_oracle_id = "309a57cb-cc08-4892-bc63-c424ca9c5b43"
+scryfall_id = "a87cbbdb-3bbc-48da-b5e3-fcdbddebec81"
+
+[[token.source_card_refs]]
 card_name = "Verdant Force"
 scryfall_oracle_id = "7a21ea22-3cd7-4c11-8895-5943c0d93a0d"
 scryfall_id = "c75ebe25-f0cd-4e44-b488-06edb0cacb5a"
+
+[[token.source_card_refs]]
+card_name = "Fists of Ironwood"
+scryfall_oracle_id = "2f6a5278-23bf-47b2-a2b9-dfff7d96f3dd"
+scryfall_id = "7193c00f-0398-485c-974d-346ee59cd4c7"
+
+[[token.source_card_refs]]
+card_name = "Fungal Infection"
+scryfall_oracle_id = "04a8858e-9033-403e-9346-5a2ad1bdf680"
+scryfall_id = "727a589a-2248-478f-825f-932bfb456675"
+
+[[token.source_card_refs]]
+card_name = "Mycologist"
+scryfall_oracle_id = "af0bf083-0624-4ccd-b282-a35937e925fe"
+scryfall_id = "56d8e9fa-e241-4a11-99b8-ffced81eb38b"
+
+[[token.source_card_refs]]
+card_name = "Nemata, Grove Guardian"
+scryfall_oracle_id = "5ce58279-7f1e-4ef7-a352-ecbaee31b6ff"
+scryfall_id = "8c6a0ca4-5006-4c9b-91cd-e01d77e4fdc2"
+
+[[token.source_card_refs]]
+card_name = "Dreampod Druid"
+scryfall_oracle_id = "db2af2b0-a5aa-4e4a-b5bc-52a5ac3968fc"
+scryfall_id = "1e35f72d-a62e-490b-a3b2-a56af22f8ff7"
+
+[[token.source_card_refs]]
+card_name = "Night Soil"
+scryfall_oracle_id = "3165fe8f-52d7-40f7-bb14-8f4300a564e6"
+scryfall_id = "64bde90c-afe9-44a0-b7ae-d0588e425c18"
+
+[[token.source_card_refs]]
+card_name = "Death Mutation"
+scryfall_oracle_id = "6f705338-b00b-4a6d-924f-443e7c5670b7"
+scryfall_id = "4c643d87-50bc-4380-b1d6-0a465eef5dbf"
+
+[[token.source_card_refs]]
+card_name = "Selesnya Evangel"
+scryfall_oracle_id = "4a2fea39-99d6-4766-9f2c-0a63925349cb"
+scryfall_id = "18bc93c1-f236-4d1b-bb54-5041b3cae5a6"
+
+[[token.source_card_refs]]
+card_name = "Ulasht, the Hate Seed"
+scryfall_oracle_id = "796f1e1f-7fec-429d-82ae-125f541d6cc7"
+scryfall_id = "a0ba043a-d508-49dd-9bf3-a7ae8d26ac9b"
+
+[[token.source_card_refs]]
+card_name = "Sporogenesis"
+scryfall_oracle_id = "33005c63-fe9f-4051-b781-eacf1ca5eec6"
+scryfall_id = "839d969b-b1f7-4978-b00c-db0766161f63"
+
+[[token.source_card_refs]]
+card_name = "Aura Mutation"
+scryfall_oracle_id = "19bb51dd-2b93-45f0-927d-bbafddadd0a3"
+scryfall_id = "38421179-615e-4aba-91a4-503bfee05403"
+
+[[token.source_card_refs]]
+card_name = "Psychotrope Thallid"
+scryfall_oracle_id = "384c61f2-17ed-4c7a-8722-e0a05e9dcaf9"
+scryfall_id = "e2803fdc-2ae1-438c-b5b1-559817e85fdb"
+
+[[token.source_card_refs]]
+card_name = "Thallid"
+scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
+scryfall_id = "01827286-b104-41c5-bac9-7c38414bc40e"
+
+[[token.source_card_refs]]
+card_name = "Thallid Devourer"
+scryfall_oracle_id = "b7326fd9-7648-4db3-b506-61a7de8a4094"
+scryfall_id = "aa533845-4c4b-4072-aa39-8e56ce7ec325"
+
+[[token.source_card_refs]]
+card_name = "Sarpadian Empires, Vol. VII"
+scryfall_oracle_id = "f71d55f5-f220-4cb0-9468-b8d339ab8535"
+scryfall_id = "b37a6cf7-f239-4bca-b4c3-a48932ef56b5"
+
+[[token.source_card_refs]]
+card_name = "Fungal Rebirth"
+scryfall_oracle_id = "b917f39a-3176-47ad-afda-08d09b873c02"
+scryfall_id = "52abf994-78d6-40dd-9d43-19ae8176e3bd"
 
 [[token.source_card_refs]]
 card_name = "Saproling Cluster"
@@ -6416,9 +6730,124 @@ scryfall_oracle_id = "c17d5153-cc74-4fbb-9d75-f7ee7b557b0a"
 scryfall_id = "17359989-ef90-46f5-a4cd-f40bfac5e59f"
 
 [[token.source_card_refs]]
+card_name = "Thallid"
+scryfall_oracle_id = "46abaabe-7015-4d82-a5aa-2706b1f51bed"
+scryfall_id = "4caaf31b-86a9-485b-8da7-d5b526ed1233"
+
+[[token.source_card_refs]]
+card_name = "Thelonite Hermit"
+scryfall_oracle_id = "69d2e5f3-2f4d-4a36-bcd5-181164ecd894"
+scryfall_id = "be95b6b0-ff20-405f-81ae-87f5cce45fb2"
+
+[[token.source_card_refs]]
+card_name = "Golgari Germination"
+scryfall_oracle_id = "3f9cf871-7df6-49d5-aab3-ad945571b707"
+scryfall_id = "24a1db16-d936-4f92-9611-327a988ce04c"
+
+[[token.source_card_refs]]
+card_name = "Saproling Cluster"
+scryfall_oracle_id = "3b64051e-d320-4991-bc9e-6e1435a23c17"
+scryfall_id = "5f50072b-aedd-4074-b1f7-f9ce477c26c2"
+
+[[token.source_card_refs]]
+card_name = "Thallid Germinator"
+scryfall_oracle_id = "262bc269-3e70-46ae-b0a3-5f8030a6971a"
+scryfall_id = "ac526fb0-e6d0-4ee0-9888-15098c1704df"
+
+[[token.source_card_refs]]
+card_name = "Verdant Force"
+scryfall_oracle_id = "7a21ea22-3cd7-4c11-8895-5943c0d93a0d"
+scryfall_id = "29bd094c-fcc1-4abf-ba3e-03a5b9b6d1c2"
+
+[[token.source_card_refs]]
+card_name = "Greener Pastures"
+scryfall_oracle_id = "f9e1346a-af72-4644-b384-8f7b0a35ec31"
+scryfall_id = "55c3222e-ac18-4f57-9c9e-50deb0a69db3"
+
+[[token.source_card_refs]]
+card_name = "Elvish Farmer"
+scryfall_oracle_id = "91fe1075-e170-4575-ae28-8d692f051637"
+scryfall_id = "40a9710e-b2f8-4746-8640-d450f58a6e49"
+
+[[token.source_card_refs]]
+card_name = "Sporemound"
+scryfall_oracle_id = "1be56a3d-a6c0-4b65-ae71-3d90ceefc6c0"
+scryfall_id = "90594c9c-95a5-4d3c-9005-863fa710cdbd"
+
+[[token.source_card_refs]]
+card_name = "Thallid Shell-Dweller"
+scryfall_oracle_id = "481e3a30-fbe9-4ed3-a982-8a73f0dca33b"
+scryfall_id = "4ee36256-022f-49b3-8914-9b1c2f4dc506"
+
+[[token.source_card_refs]]
+card_name = "Verdant Force"
+scryfall_oracle_id = "7a21ea22-3cd7-4c11-8895-5943c0d93a0d"
+scryfall_id = "baa4749b-1c1b-4e07-8926-c5f12681140b"
+
+[[token.source_card_refs]]
 card_name = "Selesnya Guildmage"
 scryfall_oracle_id = "8fbdca3a-7aa3-4b5a-98d7-9168856045ac"
 scryfall_id = "aa4c6ee5-c4dd-4b60-a6fc-5992f663c20e"
+
+[[token.source_card_refs]]
+card_name = "Sporemound"
+scryfall_oracle_id = "1be56a3d-a6c0-4b65-ae71-3d90ceefc6c0"
+scryfall_id = "f2799310-c77a-47b2-b1a5-50c029600020"
+
+[[token.source_card_refs]]
+card_name = "Saurian Symbiote"
+scryfall_oracle_id = "14b180d2-5701-452d-8deb-cf0845c95df5"
+scryfall_id = "b32224ef-cfd4-42ef-857a-24386590c360"
+
+[[token.source_card_refs]]
+card_name = "Pollenbright Wings"
+scryfall_oracle_id = "582c8030-1d41-4c63-8ed6-06aad398a96c"
+scryfall_id = "3ca4f3b9-c952-4fd3-a586-3e063b62b23d"
+
+[[token.source_card_refs]]
+card_name = "Verdant Embrace"
+scryfall_oracle_id = "f0bbd988-50b7-476c-9183-dfabd4a95079"
+scryfall_id = "50c915a4-a75f-40e7-b78a-9c304dcdd83e"
+
+[[token.source_card_refs]]
+card_name = "Bramble Elemental"
+scryfall_oracle_id = "ac5c0078-e2f1-4ac1-8748-575d69e09cf8"
+scryfall_id = "470665e5-fa48-4772-ba71-5d4008d042f3"
+
+[[token.source_card_refs]]
+card_name = "Aether Mutation"
+scryfall_oracle_id = "6697fe5b-90ac-4321-aa2f-cdc6ec283cb4"
+scryfall_id = "5386a61c-4928-4bd1-babe-5b089ab8b2d9"
+
+[[token.source_card_refs]]
+card_name = "Artifact Mutation"
+scryfall_oracle_id = "e77e8768-3ea8-44f9-aba6-1e023e006946"
+scryfall_id = "d5eef49c-a80f-4622-ba77-999f9151c841"
+
+[[token.source_card_refs]]
+card_name = "Sprout"
+scryfall_oracle_id = "424c6f5e-b386-47e9-b3fe-25b263097d40"
+scryfall_id = "6967363f-1e05-4484-8790-47f7be68455c"
+
+[[token.source_card_refs]]
+card_name = "Pallid Mycoderm"
+scryfall_oracle_id = "e76a1371-76c8-46dd-ba43-87fb0ab940d4"
+scryfall_id = "3a11b639-a5a3-424d-80c6-42d7252472a1"
+
+[[token.source_card_refs]]
+card_name = "Verdeloth the Ancient"
+scryfall_oracle_id = "8222321f-b74d-4f74-9ee7-79455433345a"
+scryfall_id = "ef6b08e0-6e5f-40e5-8c2a-c10c6e5beddc"
+
+[[token.source_card_refs]]
+card_name = "Seed Spark"
+scryfall_oracle_id = "fc2e441c-bc0b-439f-af71-daba3b033381"
+scryfall_id = "33af31cf-d730-4f54-a0be-3229cdccf60c"
+
+[[token.source_card_refs]]
+card_name = "Utopia Mycon"
+scryfall_oracle_id = "492dafd8-0393-4151-845c-d9ca10bda03e"
+scryfall_id = "b9d3d285-8327-4dba-911b-ff03b186f6b8"
 
 [[token.source_card_refs]]
 card_name = "Korozda Guildmage"
@@ -6602,6 +7031,11 @@ scryfall_id = "4df7b253-6107-47d6-b650-cb4d3e0aec6b"
 card_name = "Dalkovan Encampment"
 scryfall_oracle_id = "33a90122-7280-4481-9b97-5879194cae40"
 scryfall_id = "98ad5f0c-8775-4e89-8e92-84a6ade93e35"
+
+[[token.source_card_refs]]
+card_name = "Rally the Horde"
+scryfall_oracle_id = "fd9aeda1-9e44-4bc6-aa0d-19d58918d1f4"
+scryfall_id = "b292a8d2-44b1-4c20-8035-0f5912cc09a4"
 
 [[token.source_card_refs]]
 card_name = "Within Range"
@@ -7448,6 +7882,16 @@ subtypes = ["Cat"]
 supertypes = []
 colors = ["Green"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Waiting in the Weeds"
+scryfall_oracle_id = "5a61d51e-1a3f-49f6-9a94-a708dd6f69df"
+scryfall_id = "5f91ec4e-6818-46f4-94da-f3f8c4489fb2"
+
+[[token.source_card_refs]]
+card_name = "Waiting in the Weeds"
+scryfall_oracle_id = "5a61d51e-1a3f-49f6-9a94-a708dd6f69df"
+scryfall_id = "7e2d5a77-6ee8-463d-9e6a-fdb1cc6d70e6"
 
 [token.token_image_ref]
 scryfall_id = "7ebd7482-0f67-4afa-ba82-bf12e7e07b30"
@@ -9592,9 +10036,34 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Dwynen's Elite"
+scryfall_oracle_id = "3d4a7dd3-9258-4bd1-adc4-08f0205e196a"
+scryfall_id = "31eee7a7-af13-4de5-9f4b-5f803335cfc5"
+
+[[token.source_card_refs]]
+card_name = "Elderleaf Mentor"
+scryfall_oracle_id = "3795fc31-2369-47d0-b9c9-120f44b8f114"
+scryfall_id = "a175c5cf-b33d-481d-b093-57072f6f671e"
+
+[[token.source_card_refs]]
+card_name = "Elven Bow"
+scryfall_oracle_id = "43daed96-2216-4f17-82ce-3eccd5d69936"
+scryfall_id = "d986c6e3-dabc-4422-94b9-f7154935a355"
+
+[[token.source_card_refs]]
 card_name = "Tyvar Kell"
 scryfall_oracle_id = "14c8a590-88ec-4982-ad7b-36a219ff6de7"
 scryfall_id = "9a46a0f5-390c-4d5f-9d1f-38031b68aa25"
+
+[[token.source_card_refs]]
+card_name = "Lys Alana Huntmaster"
+scryfall_oracle_id = "3f3439e1-75ce-482d-881f-836492dca6e9"
+scryfall_id = "42df23b1-7d28-403f-bf12-d4ec81500c36"
+
+[[token.source_card_refs]]
+card_name = "Wolverine Riders"
+scryfall_oracle_id = "09070db6-01f6-4a8a-b167-a7825e6959f4"
+scryfall_id = "575d407c-c37e-4664-b2e3-217dfd5a78a2"
 
 [[token.source_card_refs]]
 card_name = "Sylvan Offering"
@@ -9607,9 +10076,9 @@ scryfall_oracle_id = "3f3439e1-75ce-482d-881f-836492dca6e9"
 scryfall_id = "c5fc9e54-8fc4-4de4-be74-e925a85187b4"
 
 [[token.source_card_refs]]
-card_name = "Lathril, Blade of the Elves"
-scryfall_oracle_id = "9b568c34-ba0a-44a7-a0ee-bee3a37b3396"
-scryfall_id = "f7f00791-de5e-4f10-9931-8694afcd580c"
+card_name = "Ambassador Oak"
+scryfall_oracle_id = "4045c24e-098f-4582-8c50-576a94c7b705"
+scryfall_id = "b8664d29-dacc-49cb-949f-e00ceeb75ff6"
 
 [[token.source_card_refs]]
 card_name = "Presence of Gond"
@@ -9622,9 +10091,24 @@ scryfall_oracle_id = "3fa71348-fa4d-4f39-a451-cf1570591991"
 scryfall_id = "084d98ec-9978-4386-972a-4cbddde7109e"
 
 [[token.source_card_refs]]
+card_name = "Elvish Warmaster"
+scryfall_oracle_id = "bda83ef4-e345-495d-878c-4da171f997ba"
+scryfall_id = "3bc94b52-1cb1-4c1e-8b17-5632abc2490d"
+
+[[token.source_card_refs]]
+card_name = "Presence of Gond"
+scryfall_oracle_id = "ab42398c-f0a1-4b94-ac5f-b8768e1b4e05"
+scryfall_id = "37fcba6c-c078-4a0d-be68-984536d91831"
+
+[[token.source_card_refs]]
 card_name = "Imperious Perfect"
 scryfall_oracle_id = "3fa71348-fa4d-4f39-a451-cf1570591991"
 scryfall_id = "3b2e604b-5ca5-4b17-834c-9067f1605147"
+
+[[token.source_card_refs]]
+card_name = "Imperious Perfect"
+scryfall_oracle_id = "3fa71348-fa4d-4f39-a451-cf1570591991"
+scryfall_id = "525cf980-275e-423e-9470-e782ce4796dd"
 
 [[token.source_card_refs]]
 card_name = "Ambassador Oak"
@@ -9632,9 +10116,19 @@ scryfall_oracle_id = "4045c24e-098f-4582-8c50-576a94c7b705"
 scryfall_id = "fb619508-67a2-426d-819b-57e21bf61d66"
 
 [[token.source_card_refs]]
+card_name = "Presence of Gond"
+scryfall_oracle_id = "ab42398c-f0a1-4b94-ac5f-b8768e1b4e05"
+scryfall_id = "bba661af-c4a8-4230-830e-a9ee22b25d6b"
+
+[[token.source_card_refs]]
 card_name = "Flourishing Defenses"
 scryfall_oracle_id = "f1b26eb1-6337-42d6-a475-53ad6427f00f"
 scryfall_id = "37a678b3-53ba-48c7-9846-6454f8b34127"
+
+[[token.source_card_refs]]
+card_name = "Dwynen's Elite"
+scryfall_oracle_id = "3d4a7dd3-9258-4bd1-adc4-08f0205e196a"
+scryfall_id = "d95d4f15-613c-42f1-a49b-f4f604e69feb"
 
 [[token.source_card_refs]]
 card_name = "Elven Bow"
@@ -11672,7 +12166,17 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Ovinomancer"
 scryfall_oracle_id = "98026d30-a29f-4590-968f-b1b36926a275"
+scryfall_id = "ae4f0988-4194-4481-a6b7-27753261174a"
+
+[[token.source_card_refs]]
+card_name = "Ovinomancer"
+scryfall_oracle_id = "98026d30-a29f-4590-968f-b1b36926a275"
 scryfall_id = "20af3166-6338-4fac-bfa6-cea19daefc62"
+
+[[token.source_card_refs]]
+card_name = "Ovinomancer"
+scryfall_oracle_id = "98026d30-a29f-4590-968f-b1b36926a275"
+scryfall_id = "5573470a-7192-4f1e-aafd-517c494875a8"
 
 [[token.source_card_refs]]
 card_name = "Ovinomancer"
@@ -13135,6 +13639,11 @@ card_name = "Cloudseeder"
 scryfall_oracle_id = "4ba75d9e-e3f1-424a-95ca-37784b8d9479"
 scryfall_id = "a9adcc82-0754-4cb7-ac28-e5624f563b7f"
 
+[[token.source_card_refs]]
+card_name = "Cloudseeder"
+scryfall_oracle_id = "4ba75d9e-e3f1-424a-95ca-37784b8d9479"
+scryfall_id = "727f9f4b-a8b6-47bd-9830-e69d118fe671"
+
 [token.token_image_ref]
 scryfall_id = "4a2144f2-d4be-419e-bfca-116cedfdf18b"
 scryfall_oracle_id = "5b04de5c-19b7-4767-a38f-d5420d5da472"
@@ -13176,6 +13685,16 @@ scryfall_id = "d0904640-40e8-45bf-ac9c-94b1dd0bab8f"
 card_name = "Hallowed Haunting"
 scryfall_oracle_id = "e310ab58-180e-4840-bc8d-9f9b06f1b478"
 scryfall_id = "674c0a50-9c37-4c29-84d8-eb3e34f34d37"
+
+[[token.source_card_refs]]
+card_name = "Hallowed Haunting"
+scryfall_oracle_id = "e310ab58-180e-4840-bc8d-9f9b06f1b478"
+scryfall_id = "1948c865-fd0a-423c-9911-44a95a03c71f"
+
+[[token.source_card_refs]]
+card_name = "Hallowed Haunting"
+scryfall_oracle_id = "e310ab58-180e-4840-bc8d-9f9b06f1b478"
+scryfall_id = "6f85bf51-4eca-4428-9a17-a85b5c2dd741"
 
 [token.token_image_ref]
 scryfall_id = "5212bae5-d768-45ab-aba8-94c4f9fabc79"
@@ -13500,6 +14019,11 @@ card_name = "Scouring Swarm"
 scryfall_oracle_id = "aa64f830-b9b6-4d5e-9a5d-f9e120089335"
 scryfall_id = "1a9318ca-2974-4d3f-8951-205ba3f9c64a"
 
+[[token.source_card_refs]]
+card_name = "Fumulus, the Infestation"
+scryfall_oracle_id = "c75f8365-71f1-415f-8bbc-9bacb8ddba0b"
+scryfall_id = "ee5e47c2-7648-4218-b42c-ed9650e12914"
+
 [token.token_image_ref]
 scryfall_id = "2172a126-2ea6-4b5c-84c2-7879c1982a3a"
 scryfall_oracle_id = "b9f1e3ec-dffa-442b-a38a-1e76e59ee146"
@@ -13686,7 +14210,17 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Penumbra Bobcat"
 scryfall_oracle_id = "f0787397-8edb-4794-8ee1-22f97a057be8"
+scryfall_id = "496cce86-ff61-4d24-8d37-8c27acaff21c"
+
+[[token.source_card_refs]]
+card_name = "Penumbra Bobcat"
+scryfall_oracle_id = "f0787397-8edb-4794-8ee1-22f97a057be8"
 scryfall_id = "359fbd40-0f61-4ec7-872c-228a476c7ad5"
+
+[[token.source_card_refs]]
+card_name = "Penumbra Bobcat"
+scryfall_oracle_id = "f0787397-8edb-4794-8ee1-22f97a057be8"
+scryfall_id = "21049fee-a748-4856-99ae-3a225a168532"
 
 [token.token_image_ref]
 scryfall_id = "05a61555-ddb9-4d55-b637-a219d772033d"
@@ -13726,6 +14260,11 @@ keywords = []
 card_name = "Creakwood Liege"
 scryfall_oracle_id = "1e67b4eb-e5d2-4368-8284-4ba5c4c42455"
 scryfall_id = "9a05c8f9-e810-498d-ab51-632661dd000d"
+
+[[token.source_card_refs]]
+card_name = "Wriggling Grub"
+scryfall_oracle_id = "d25e8f54-1915-4d0b-b4b1-93ee40da2cfa"
+scryfall_id = "e02aa086-13b2-42cf-acf4-086ba406e886"
 
 [token.token_image_ref]
 scryfall_id = "9f5ddcda-dcf0-468d-a5db-011e1b6ccab1"
@@ -14360,6 +14899,11 @@ keywords = ["Lifelink"]
 [[token.source_card_refs]]
 card_name = "Sorin, Grim Nemesis"
 scryfall_oracle_id = "0a01dd05-e289-489f-b3ad-88e15e157bd0"
+scryfall_id = "829fba64-6708-40a9-b134-3cdfbf2c648f"
+
+[[token.source_card_refs]]
+card_name = "Sorin, Grim Nemesis"
+scryfall_oracle_id = "0a01dd05-e289-489f-b3ad-88e15e157bd0"
 scryfall_id = "d25c3609-a200-4532-9df8-8e92c24544bc"
 
 [[token.source_card_refs]]
@@ -14371,6 +14915,11 @@ scryfall_id = "c8896833-843c-437f-a9d5-7352b7ea6d3b"
 card_name = "Call the Bloodline"
 scryfall_oracle_id = "8e90300b-c0da-4484-b065-e2fafa4e1b15"
 scryfall_id = "6fae65ac-be15-4d05-83aa-83f872d807fe"
+
+[[token.source_card_refs]]
+card_name = "Call the Bloodline"
+scryfall_oracle_id = "8e90300b-c0da-4484-b065-e2fafa4e1b15"
+scryfall_id = "543eb8f7-1e24-4810-91de-debeb7d1d0ba"
 
 [[token.source_card_refs]]
 card_name = "Elenda and Azor"
@@ -15263,9 +15812,34 @@ colors = ["Black"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
+card_name = "Priest of the Blood Rite"
+scryfall_oracle_id = "441cdd7d-6c4c-4a91-a118-7eaa35276660"
+scryfall_id = "7f49d2da-af70-482c-ac9a-5987ca7a0802"
+
+[[token.source_card_refs]]
+card_name = "Skirsdag High Priest"
+scryfall_oracle_id = "c6064c08-e4e0-49f4-9f0b-55cdecf443af"
+scryfall_id = "1265ed45-2954-4fca-b13f-5c1afd1ef134"
+
+[[token.source_card_refs]]
 card_name = "Skirsdag High Priest"
 scryfall_oracle_id = "c6064c08-e4e0-49f4-9f0b-55cdecf443af"
 scryfall_id = "7a329b20-4e6e-45c9-aee0-51fe81dce543"
+
+[[token.source_card_refs]]
+card_name = "Skirsdag High Priest"
+scryfall_oracle_id = "c6064c08-e4e0-49f4-9f0b-55cdecf443af"
+scryfall_id = "02e4faab-c26b-4d76-b747-8dc3f6b2fe9a"
+
+[[token.source_card_refs]]
+card_name = "Archfiend's Vessel"
+scryfall_oracle_id = "62c240ac-f2dd-4e39-9e82-50307efa833e"
+scryfall_id = "b20e33cb-202f-4973-8c83-c75faf908672"
+
+[[token.source_card_refs]]
+card_name = "Priest of the Blood Rite"
+scryfall_oracle_id = "441cdd7d-6c4c-4a91-a118-7eaa35276660"
+scryfall_id = "87f77674-dd03-4f19-bd87-aec2359b620e"
 
 [token.token_image_ref]
 scryfall_id = "1f75f7a3-b4d2-40e1-9721-cbe6a63971ba"
@@ -15575,7 +16149,17 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Stangg"
 scryfall_oracle_id = "739eac91-3029-4ce7-9885-0af3ddea472e"
+scryfall_id = "a277775a-6b48-4238-a618-3ae94c4cc85c"
+
+[[token.source_card_refs]]
+card_name = "Stangg"
+scryfall_oracle_id = "739eac91-3029-4ce7-9885-0af3ddea472e"
 scryfall_id = "b9510aef-0516-4d42-8aa7-f83bec809932"
+
+[[token.source_card_refs]]
+card_name = "Stangg"
+scryfall_oracle_id = "739eac91-3029-4ce7-9885-0af3ddea472e"
+scryfall_id = "4e9df135-4449-42ff-868b-56b1f702aca6"
 
 [[token.source_card_refs]]
 card_name = "Stangg, Echo Warrior"
@@ -15586,6 +16170,11 @@ scryfall_id = "9385b40f-79a7-4d9c-b253-54587a1f28b4"
 card_name = "Stangg, Echo Warrior"
 scryfall_oracle_id = "aaf2a587-ced7-4615-b10f-164e7384b073"
 scryfall_id = "7722a9a1-2ff9-4a39-b56e-c7eef2ff9dcd"
+
+[[token.source_card_refs]]
+card_name = "Stangg"
+scryfall_oracle_id = "739eac91-3029-4ce7-9885-0af3ddea472e"
+scryfall_id = "71cc6ef5-401a-4125-9765-74905f6c3551"
 
 [token.token_image_ref]
 scryfall_id = "edc84f49-86e9-43a2-b98c-a59b1e0c72ed"
@@ -16117,9 +16706,24 @@ colors = ["Red"]
 keywords = ["Haste"]
 
 [[token.source_card_refs]]
+card_name = "Lightning Coils"
+scryfall_oracle_id = "bbb16f23-fdb1-444b-bef8-ce3e177c2678"
+scryfall_id = "a800f326-3416-4917-a1cf-0f90255777d3"
+
+[[token.source_card_refs]]
+card_name = "Feral Lightning"
+scryfall_oracle_id = "acd17fbf-645b-4c4d-b2c6-44127e3b743d"
+scryfall_id = "2391265f-ef0c-463f-9371-5a0b71dbbb49"
+
+[[token.source_card_refs]]
 card_name = "Chandra, Flamecaller"
 scryfall_oracle_id = "0c2a9131-f3d7-4f71-8bcc-3c169574b2e3"
 scryfall_id = "a77b4416-61da-4cd5-b3f1-79238a8e2503"
+
+[[token.source_card_refs]]
+card_name = "Chandra, Flamecaller"
+scryfall_oracle_id = "0c2a9131-f3d7-4f71-8bcc-3c169574b2e3"
+scryfall_id = "507ea0e3-6b8c-4c0d-8a4b-5386f70ea8d1"
 
 [[token.source_card_refs]]
 card_name = "Chandra, Flamecaller"
@@ -16213,6 +16817,11 @@ keywords = ["Flying"]
 card_name = "Seraphic Steed"
 scryfall_oracle_id = "51622e89-aa5e-4dd6-a078-eb45e8ebb434"
 scryfall_id = "7ada7ab4-0dee-4ff3-9817-1e61ca3f2ccf"
+
+[[token.source_card_refs]]
+card_name = "Linvala, the Preserver"
+scryfall_oracle_id = "64f5689d-504d-40e9-bdb5-36dcefd257e2"
+scryfall_id = "b9231958-cfe7-461b-9ce7-a5225657b205"
 
 [[token.source_card_refs]]
 card_name = "Seraphic Steed"
@@ -16886,9 +17495,24 @@ scryfall_oracle_id = "4e93b23c-a7f7-4bdd-bbca-0dc48bb5c223"
 scryfall_id = "36633f10-ea38-421c-ab80-9862eb18d6da"
 
 [[token.source_card_refs]]
+card_name = "Goblin Rabblemaster"
+scryfall_oracle_id = "24661b81-6bee-4ad8-b3ab-53cb65005c51"
+scryfall_id = "28ecbe76-5118-4844-9a20-b227c924189d"
+
+[[token.source_card_refs]]
+card_name = "Goblin Warrens"
+scryfall_oracle_id = "c1161505-1623-4475-a88e-2e48072cc2f1"
+scryfall_id = "2d8ce8ad-2bb9-4c53-8e36-9690e8a118f1"
+
+[[token.source_card_refs]]
 card_name = "Krenko, Tin Street Kingpin"
 scryfall_oracle_id = "e8065e1d-e937-4b56-8011-78f0d07328a0"
 scryfall_id = "3f779348-693c-4e7a-82b1-02172304f06b"
+
+[[token.source_card_refs]]
+card_name = "Beetleback Chief"
+scryfall_oracle_id = "f5c5f64c-6911-430c-a825-b32b96d39c7d"
+scryfall_id = "a4a514b9-8a67-47aa-8218-8d6fe8040128"
 
 [[token.source_card_refs]]
 card_name = "Krenko, Mob Boss"
@@ -16901,14 +17525,34 @@ scryfall_oracle_id = "7b8f4879-578e-40e4-863a-41d0c32c6bdd"
 scryfall_id = "4ebce261-3a53-48f2-a173-0d98c68aff2c"
 
 [[token.source_card_refs]]
+card_name = "Siege-Gang Commander"
+scryfall_oracle_id = "ddc7f59a-bbb1-4ba1-82c8-6813fd191940"
+scryfall_id = "92e78cec-aaf9-4fe8-887b-b7e356d63315"
+
+[[token.source_card_refs]]
 card_name = "Mogg War Marshal"
 scryfall_oracle_id = "7b8f4879-578e-40e4-863a-41d0c32c6bdd"
 scryfall_id = "fd170aa1-18be-470e-aa36-bfb11e9f92c1"
 
 [[token.source_card_refs]]
+card_name = "Ardoz, Cobbler of War"
+scryfall_oracle_id = "bcd5e175-2ef0-48f4-b9bd-14383dd234e0"
+scryfall_id = "2a012f05-0009-42cf-8a69-07140b2a2aef"
+
+[[token.source_card_refs]]
 card_name = "Goblinslide"
 scryfall_oracle_id = "4885354f-0b77-47b6-b8f7-00753804436f"
 scryfall_id = "b0e81bcf-d2f1-4ce0-9c1e-730632caa328"
+
+[[token.source_card_refs]]
+card_name = "Goblin Marshal"
+scryfall_oracle_id = "4bc91d7d-37aa-475c-8fe9-763975d51add"
+scryfall_id = "6a85b2f9-c12c-46dd-ae04-470ebf5ec6d9"
+
+[[token.source_card_refs]]
+card_name = "Mogg Infestation"
+scryfall_oracle_id = "cfd61b53-83c6-4886-8503-ddcb92dc7f85"
+scryfall_id = "bfeb1145-3729-481e-a314-c325ed2f2a35"
 
 [[token.source_card_refs]]
 card_name = "Goblin Gang Leader"
@@ -16921,6 +17565,11 @@ scryfall_oracle_id = "f5c5f64c-6911-430c-a825-b32b96d39c7d"
 scryfall_id = "16b8a76e-5ad9-42b6-ba03-819b2491c0c2"
 
 [[token.source_card_refs]]
+card_name = "Mogg War Marshal"
+scryfall_oracle_id = "7b8f4879-578e-40e4-863a-41d0c32c6bdd"
+scryfall_id = "8b9e0bdb-b615-447a-b80d-d7244c25c56e"
+
+[[token.source_card_refs]]
 card_name = "Empty the Warrens"
 scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
 scryfall_id = "41d728ed-9fdf-4d92-bd97-66e27c139423"
@@ -16931,9 +17580,29 @@ scryfall_oracle_id = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617"
 scryfall_id = "2b1c0405-bfcd-4c5f-ab74-50bc27271377"
 
 [[token.source_card_refs]]
+card_name = "Mogg Alarm"
+scryfall_oracle_id = "1c2117d5-4600-489c-be5b-dc0ed69b30ca"
+scryfall_id = "f246e128-0a43-478a-a232-51020fab76d5"
+
+[[token.source_card_refs]]
+card_name = "Goblin Offensive"
+scryfall_oracle_id = "25cb5c86-83cd-4a06-b0d1-a0f6fc9158a6"
+scryfall_id = "e9813857-5527-4499-af86-758a5971e21a"
+
+[[token.source_card_refs]]
+card_name = "Dragon Fodder"
+scryfall_oracle_id = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617"
+scryfall_id = "686d43eb-ea91-4ae1-bdc4-dcd885688acd"
+
+[[token.source_card_refs]]
 card_name = "Goblin Negotiation"
 scryfall_oracle_id = "79824266-bffa-476c-bdd3-976e9d789a42"
 scryfall_id = "2470167c-acee-4de3-b762-a7ade6fc284e"
+
+[[token.source_card_refs]]
+card_name = "Dragon Fodder"
+scryfall_oracle_id = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617"
+scryfall_id = "cdb5eab0-5397-4c00-8cef-7d3baf38a171"
 
 [[token.source_card_refs]]
 card_name = "Goblin Rally"
@@ -16946,14 +17615,44 @@ scryfall_oracle_id = "f451b8f0-1ff5-4e8d-9f30-9352d83ed687"
 scryfall_id = "8fd0fdb6-3a6d-4831-8d1b-0b1b69304c36"
 
 [[token.source_card_refs]]
+card_name = "Warbreak Trumpeter"
+scryfall_oracle_id = "40e5c7fe-4d7a-41c0-8b90-ea0b46a01c9d"
+scryfall_id = "fc942957-1067-428c-8ee1-01f9e260efe1"
+
+[[token.source_card_refs]]
+card_name = "Empty the Warrens"
+scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
+scryfall_id = "952bb27c-c58a-478a-b637-eb4f7e1e0ab4"
+
+[[token.source_card_refs]]
 card_name = "Empty the Warrens"
 scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
 scryfall_id = "07e5e725-c482-4dbc-9612-d3155ed71a75"
 
 [[token.source_card_refs]]
+card_name = "Beetleback Chief"
+scryfall_oracle_id = "f5c5f64c-6911-430c-a825-b32b96d39c7d"
+scryfall_id = "c042844a-7291-45f9-92c9-482842228777"
+
+[[token.source_card_refs]]
+card_name = "Ib Halfheart, Goblin Tactician"
+scryfall_oracle_id = "6742c4b9-8fa6-439f-844d-04a09fa20c45"
+scryfall_id = "d09f9597-c2a9-4c1a-8375-ab06b1a21ee3"
+
+[[token.source_card_refs]]
+card_name = "Goblin Warrens"
+scryfall_oracle_id = "c1161505-1623-4475-a88e-2e48072cc2f1"
+scryfall_id = "57218245-5e0f-4233-896a-00ec0cc34fcc"
+
+[[token.source_card_refs]]
 card_name = "Howlsquad Heavy"
 scryfall_oracle_id = "cd45a29f-73bc-435c-9d50-09a4ecaa77be"
 scryfall_id = "cc43b129-06e9-4b17-8320-2699bfc67d0e"
+
+[[token.source_card_refs]]
+card_name = "Sarpadian Empires, Vol. VII"
+scryfall_oracle_id = "f71d55f5-f220-4cb0-9468-b8d339ab8535"
+scryfall_id = "b37a6cf7-f239-4bca-b4c3-a48932ef56b5"
 
 [[token.source_card_refs]]
 card_name = "Mogg War Marshal"
@@ -16966,14 +17665,34 @@ scryfall_oracle_id = "8b022754-6d16-470e-b754-4df6e4f4709e"
 scryfall_id = "71c818eb-3846-471f-967a-76e1cb809b9f"
 
 [[token.source_card_refs]]
+card_name = "Goblin Rally"
+scryfall_oracle_id = "9ccb6ce8-ccb6-4809-a1cc-cebd38744815"
+scryfall_id = "60b0a697-e901-42d9-9833-fedfcb6db9b3"
+
+[[token.source_card_refs]]
 card_name = "Dragon Fodder"
 scryfall_oracle_id = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617"
 scryfall_id = "ebb84e38-57cd-4539-99e7-c4e319d16314"
 
 [[token.source_card_refs]]
+card_name = "Blast from the Past"
+scryfall_oracle_id = "08638828-ce88-44d4-a6b2-1effb68ccbdf"
+scryfall_id = "aa30bf92-5281-4b74-8d2a-dc7b0467cb0a"
+
+[[token.source_card_refs]]
 card_name = "Pashalik Mons"
 scryfall_oracle_id = "bdb94ccd-1bb5-4bb7-9539-e1b1c97c19c5"
 scryfall_id = "f66ca912-a7ec-4e51-9ae7-0d98b5be21b1"
+
+[[token.source_card_refs]]
+card_name = "Dragon Fodder"
+scryfall_oracle_id = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617"
+scryfall_id = "27238e0e-c676-44f5-841c-6e4a3a3f6374"
+
+[[token.source_card_refs]]
+card_name = "Goblin Warrens"
+scryfall_oracle_id = "c1161505-1623-4475-a88e-2e48072cc2f1"
+scryfall_id = "1255654b-f983-4862-9112-9e378ea5d9fe"
 
 [[token.source_card_refs]]
 card_name = "Goblin Goliath"
@@ -16991,6 +17710,16 @@ scryfall_oracle_id = "6a038dec-2d9c-4422-a0f3-94bf70e55217"
 scryfall_id = "24025e76-0016-46a6-93cd-366071953c36"
 
 [[token.source_card_refs]]
+card_name = "Goblin Instigator"
+scryfall_oracle_id = "8b022754-6d16-470e-b754-4df6e4f4709e"
+scryfall_id = "f32d7ce5-078b-40ff-8ecb-34309a0e3719"
+
+[[token.source_card_refs]]
+card_name = "Blast from the Past"
+scryfall_oracle_id = "08638828-ce88-44d4-a6b2-1effb68ccbdf"
+scryfall_id = "dc0741ad-83c2-4ee5-a712-529787e532ba"
+
+[[token.source_card_refs]]
 card_name = "Goblin Assault"
 scryfall_oracle_id = "d1255776-b88b-4f05-9b71-ff89a2eba453"
 scryfall_id = "26bccccc-f694-47a8-90fa-e3f1f62b9664"
@@ -17001,9 +17730,24 @@ scryfall_oracle_id = "da1c1c70-c2fa-4ba7-89fe-d9af3fb353b9"
 scryfall_id = "b44c7ba3-c90a-436d-a159-89dc9981e0c3"
 
 [[token.source_card_refs]]
+card_name = "Sling-Gang Lieutenant"
+scryfall_oracle_id = "4e93b23c-a7f7-4bdd-bbca-0dc48bb5c223"
+scryfall_id = "8d8d27af-e4cf-4e18-825e-8f6c972e64ba"
+
+[[token.source_card_refs]]
 card_name = "Kuldotha Rebirth"
 scryfall_oracle_id = "f3e28778-0149-4dbd-badb-ba5aeacacd76"
 scryfall_id = "1c7930aa-9556-487a-9e37-78c722dfb4bc"
+
+[[token.source_card_refs]]
+card_name = "Goblin Rabblemaster"
+scryfall_oracle_id = "24661b81-6bee-4ad8-b3ab-53cb65005c51"
+scryfall_id = "e9a1920f-43a9-456f-bc3e-517fee9023df"
+
+[[token.source_card_refs]]
+card_name = "Hunted Phantasm"
+scryfall_oracle_id = "ef4b334b-8407-4147-b434-602e59806906"
+scryfall_id = "faec8ab3-80c6-4b8f-a60d-50cc683e66b4"
 
 [[token.source_card_refs]]
 card_name = "Mogg Infestation"
@@ -17021,9 +17765,34 @@ scryfall_oracle_id = "9cfe86ae-eebe-44aa-a956-4b3e9e621105"
 scryfall_id = "edd9e8d3-6e30-43fc-8931-0f5c07a0e5b7"
 
 [[token.source_card_refs]]
+card_name = "Mogg Infestation"
+scryfall_oracle_id = "cfd61b53-83c6-4886-8503-ddcb92dc7f85"
+scryfall_id = "5a91aa6f-cb2f-4aad-9415-bba4eb9b76ca"
+
+[[token.source_card_refs]]
+card_name = "Sling-Gang Lieutenant"
+scryfall_oracle_id = "4e93b23c-a7f7-4bdd-bbca-0dc48bb5c223"
+scryfall_id = "b419c3d8-0ea5-4a78-a647-b7e16c7f7ec5"
+
+[[token.source_card_refs]]
+card_name = "Hordeling Outburst"
+scryfall_oracle_id = "a6450b8e-eb18-431c-9eb7-7daf107978b2"
+scryfall_id = "81b98d04-937e-47ee-8f97-775c77e33de9"
+
+[[token.source_card_refs]]
 card_name = "Hordeling Outburst"
 scryfall_oracle_id = "a6450b8e-eb18-431c-9eb7-7daf107978b2"
 scryfall_id = "5183ca53-dc90-4971-a610-38b4ba85dc83"
+
+[[token.source_card_refs]]
+card_name = "Sling-Gang Lieutenant"
+scryfall_oracle_id = "4e93b23c-a7f7-4bdd-bbca-0dc48bb5c223"
+scryfall_id = "01e68d4a-fd13-4172-8d71-9f25149b39e8"
+
+[[token.source_card_refs]]
+card_name = "Krenko, Mob Boss"
+scryfall_oracle_id = "68418069-f615-40ef-ae0d-764192acae00"
+scryfall_id = "cd9fec9d-23c8-4d35-97c1-9499527198fb"
 
 [[token.source_card_refs]]
 card_name = "Battle Cry Goblin"
@@ -17031,14 +17800,49 @@ scryfall_oracle_id = "e74c4001-d958-4d2b-b57d-c3601f01580c"
 scryfall_id = "2a17c97b-1195-4ca7-aa30-fe11585f180c"
 
 [[token.source_card_refs]]
+card_name = "Hordeling Outburst"
+scryfall_oracle_id = "a6450b8e-eb18-431c-9eb7-7daf107978b2"
+scryfall_id = "a22f186e-64dc-47c9-8bba-a78fda435fbe"
+
+[[token.source_card_refs]]
+card_name = "Empty the Warrens"
+scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
+scryfall_id = "622daabf-987d-4311-b3d3-b27d62cd5e6e"
+
+[[token.source_card_refs]]
+card_name = "Krenko's Command"
+scryfall_oracle_id = "9cfe86ae-eebe-44aa-a956-4b3e9e621105"
+scryfall_id = "d6379f3d-fe55-4c21-96d7-3796f5489e37"
+
+[[token.source_card_refs]]
 card_name = "Siege-Gang Commander"
 scryfall_oracle_id = "ddc7f59a-bbb1-4ba1-82c8-6813fd191940"
 scryfall_id = "7d67e614-03d2-4034-b82f-25962fc378d4"
 
 [[token.source_card_refs]]
+card_name = "Pashalik Mons"
+scryfall_oracle_id = "bdb94ccd-1bb5-4bb7-9539-e1b1c97c19c5"
+scryfall_id = "7515e5b3-5240-480d-8a0e-5a989c1a906d"
+
+[[token.source_card_refs]]
 card_name = "Krenko, Tin Street Kingpin"
 scryfall_oracle_id = "e8065e1d-e937-4b56-8011-78f0d07328a0"
 scryfall_id = "a762a954-1166-4c6c-bf87-0f68a5a24f3e"
+
+[[token.source_card_refs]]
+card_name = "Ib Halfheart, Goblin Tactician"
+scryfall_oracle_id = "6742c4b9-8fa6-439f-844d-04a09fa20c45"
+scryfall_id = "38134389-b471-4f58-a9ae-26bf9dc1557a"
+
+[[token.source_card_refs]]
+card_name = "Goblin Rally"
+scryfall_oracle_id = "9ccb6ce8-ccb6-4809-a1cc-cebd38744815"
+scryfall_id = "34d6a2d0-d855-4b87-9f4c-58dda0b81c82"
+
+[[token.source_card_refs]]
+card_name = "Goblin Warrens"
+scryfall_oracle_id = "c1161505-1623-4475-a88e-2e48072cc2f1"
+scryfall_id = "bbec4aa5-3319-43dc-8347-5633edbd7018"
 
 [[token.source_card_refs]]
 card_name = "Searslicer Goblin"
@@ -17056,6 +17860,11 @@ scryfall_oracle_id = "24661b81-6bee-4ad8-b3ab-53cb65005c51"
 scryfall_id = "aab03d01-ec92-473d-b983-18cf5f06ff39"
 
 [[token.source_card_refs]]
+card_name = "Blast from the Past"
+scryfall_oracle_id = "08638828-ce88-44d4-a6b2-1effb68ccbdf"
+scryfall_id = "5ca23782-80d3-4656-afba-f8440c813253"
+
+[[token.source_card_refs]]
 card_name = "Siege-Gang Lieutenant"
 scryfall_oracle_id = "9e9d538b-a9e5-4d59-b7c1-208fe18110e3"
 scryfall_id = "76049160-69f7-4114-81f3-dfab8242ac15"
@@ -17064,6 +17873,11 @@ scryfall_id = "76049160-69f7-4114-81f3-dfab8242ac15"
 card_name = "Krenko's Command"
 scryfall_oracle_id = "9cfe86ae-eebe-44aa-a956-4b3e9e621105"
 scryfall_id = "80979d0c-d833-46d8-9f7c-b188801fe336"
+
+[[token.source_card_refs]]
+card_name = "Krenko, Mob Boss"
+scryfall_oracle_id = "68418069-f615-40ef-ae0d-764192acae00"
+scryfall_id = "0b9c68ff-1fe4-42ef-8d1f-43120de5c1ff"
 
 [[token.source_card_refs]]
 card_name = "Siege-Gang Commander"
@@ -17128,6 +17942,11 @@ subtypes = ["Zombie"]
 supertypes = []
 colors = ["Blue"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Geralf, Visionary Stitcher"
+scryfall_oracle_id = "0a0743b0-07c2-4e11-8b30-6b1b8156bdd0"
+scryfall_id = "cd93a0d6-b148-4252-9245-d2a2adcabf12"
 
 [[token.source_card_refs]]
 card_name = "Stitcher Geralf"
@@ -17290,6 +18109,11 @@ subtypes = ["Sliver"]
 supertypes = []
 colors = []
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Sliversmith"
+scryfall_oracle_id = "244443f0-c92b-4640-88b6-308b0312c8be"
+scryfall_id = "b242b7dd-a632-4024-a69a-179a63fb93a8"
 
 [[token.source_card_refs]]
 card_name = "Sliversmith"
@@ -17509,7 +18333,7 @@ toughness = 2
 core_types = ["Creature"]
 subtypes = ["Hero"]
 supertypes = []
-colors = ["White"]
+colors = []
 keywords = ["Vigilance"]
 
 [[token.source_card_refs]]
@@ -17977,6 +18801,11 @@ scryfall_oracle_id = "e7dfe47f-41fc-4071-9ad3-96cd8d9be52e"
 scryfall_id = "79e4242c-a53a-4287-976b-8e545888a1fa"
 
 [[token.source_card_refs]]
+card_name = "Royal Treatment"
+scryfall_oracle_id = "fd0f8fdc-4065-41f4-b8fb-ecb8f185774d"
+scryfall_id = "009bad41-5e96-4bb3-9f5e-66500fb8af29"
+
+[[token.source_card_refs]]
 card_name = "Besotted Knight // Betroth the Beast"
 face_name = "Betroth the Beast"
 scryfall_oracle_id = "c7b6d2cd-9105-404b-88f0-a67037fb2120"
@@ -18113,6 +18942,11 @@ keywords = [
     "Flying",
     "Haste",
 ]
+
+[[token.source_card_refs]]
+card_name = "The Locust God"
+scryfall_oracle_id = "e025a714-02da-4b0c-8021-cf3e8dc9b19e"
+scryfall_id = "8e0b820b-1f20-4e2e-ba75-af6d30621dc8"
 
 [[token.source_card_refs]]
 card_name = "The Locust God"
@@ -18464,6 +19298,11 @@ scryfall_id = "626db678-2dec-4026-af5a-83e834692ba0"
 card_name = "Dragon Egg"
 scryfall_oracle_id = "8f561498-66e7-4cbf-8cb9-e6fd4717993d"
 scryfall_id = "166e3f73-07f0-4c59-a48f-01b830fb9898"
+
+[[token.source_card_refs]]
+card_name = "Dragon Egg"
+scryfall_oracle_id = "8f561498-66e7-4cbf-8cb9-e6fd4717993d"
+scryfall_id = "58d31ba0-6cec-4d8b-950f-f0b70bb8b0dd"
 
 [token.token_image_ref]
 scryfall_id = "1e2aaaca-6563-406f-b1bc-6849ba555da8"
@@ -19301,6 +20140,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Kher Keep"
 scryfall_oracle_id = "79638767-fbc7-451a-b29f-d93f2ac6f102"
+scryfall_id = "dde3b332-5bc3-47bc-ba24-5437f04c21a0"
+
+[[token.source_card_refs]]
+card_name = "Kher Keep"
+scryfall_oracle_id = "79638767-fbc7-451a-b29f-d93f2ac6f102"
 scryfall_id = "4d559369-59eb-4c8f-8bc1-987a529037b8"
 
 [[token.source_card_refs]]
@@ -19383,6 +20227,11 @@ scryfall_oracle_id = "5097f4e6-50af-4641-909f-db44abf0ce32"
 scryfall_id = "1fa981d3-4a41-4bf1-ba64-2cd7224a6059"
 
 [[token.source_card_refs]]
+card_name = "Lathliss, Dragon Queen"
+scryfall_oracle_id = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd"
+scryfall_id = "c7db2091-2888-46d4-8f4a-49f55dc80cd8"
+
+[[token.source_card_refs]]
 card_name = "Rite of the Dragoncaller"
 scryfall_oracle_id = "5097f4e6-50af-4641-909f-db44abf0ce32"
 scryfall_id = "3a99d9bc-da4e-488b-bc4a-90594c072b66"
@@ -19391,6 +20240,11 @@ scryfall_id = "3a99d9bc-da4e-488b-bc4a-90594c072b66"
 card_name = "Rite of the Dragoncaller"
 scryfall_oracle_id = "5097f4e6-50af-4641-909f-db44abf0ce32"
 scryfall_id = "5a73750c-ddd4-448e-94f3-f64bada20508"
+
+[[token.source_card_refs]]
+card_name = "Sarkhan, Fireblood"
+scryfall_oracle_id = "074cbe14-a0c8-4772-955a-b4052333d6ce"
+scryfall_id = "8818250f-a844-4430-853e-0a034aa97485"
 
 [[token.source_card_refs]]
 card_name = "Dragonmaster Outcast"
@@ -19422,6 +20276,11 @@ subtypes = ["Insect"]
 supertypes = []
 colors = ["Black"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Nest of Scarabs"
+scryfall_oracle_id = "1f21cf59-6390-44b4-ab2e-ef290dfd8c85"
+scryfall_id = "d849dc0a-4122-497c-a2a7-e5a21dc809f5"
 
 [[token.source_card_refs]]
 card_name = "Nest of Scarabs"
@@ -20724,6 +21583,16 @@ colors = ["Red"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Flurry of Horns"
+scryfall_oracle_id = "0c8ab7bf-7b6a-4a34-b988-9f3f4d84a9ea"
+scryfall_id = "be522ae8-9cf4-4c63-9a1c-0010d482c00a"
+
+[[token.source_card_refs]]
+card_name = "Sethron, Hurloon General"
+scryfall_oracle_id = "561c1ce9-41e7-474a-9476-bb9a7d24f0d5"
+scryfall_id = "274cdb39-1454-4c9b-acd8-4f762a48e71f"
+
+[[token.source_card_refs]]
 card_name = "Sethron, Hurloon General"
 scryfall_oracle_id = "561c1ce9-41e7-474a-9476-bb9a7d24f0d5"
 scryfall_id = "e075bbdc-822f-4549-bfd5-ce4a2a4354f1"
@@ -20776,6 +21645,8 @@ source_card_names = [
     "Desperate Sentry",
     "Emrakul's Evangel",
     "Enlightened Maniac",
+    "Extricator of Flesh",
+    "Extricator of Sin",
     "Extricator of Sin // Extricator of Flesh",
     "Foul Emissary",
     "Hanweir, the Writhing Township",
@@ -20810,6 +21681,12 @@ scryfall_oracle_id = "4310524d-dc0e-48ad-ae66-4c64aaa39340"
 scryfall_id = "7f186ffa-b914-45cc-bf25-1306842a2ad5"
 
 [[token.source_card_refs]]
+card_name = "Hanweir, the Writhing Township"
+face_name = "Hanweir, the Writhing Township"
+scryfall_oracle_id = "f4905c40-003e-4992-b8d7-3f07ba09c686"
+scryfall_id = "5e42bb55-6fe3-4d0a-9634-43e41837aa5d"
+
+[[token.source_card_refs]]
 card_name = "Shrill Howler // Howling Chorus"
 face_name = "Howling Chorus"
 scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
@@ -20822,10 +21699,22 @@ scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
 scryfall_id = "e414e208-2e90-4b0d-b107-7a387b3f779b"
 
 [[token.source_card_refs]]
+card_name = "Shrill Howler // Howling Chorus"
+face_name = "Shrill Howler"
+scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
+scryfall_id = "b7408d54-e15d-4975-8f30-8cd36fca9429"
+
+[[token.source_card_refs]]
 card_name = "Hanweir, the Writhing Township"
 face_name = "Hanweir, the Writhing Township"
 scryfall_oracle_id = "f4905c40-003e-4992-b8d7-3f07ba09c686"
 scryfall_id = "ddad5b2a-0575-4b44-9fbc-107ee4d10f24"
+
+[[token.source_card_refs]]
+card_name = "Extricator of Sin // Extricator of Flesh"
+face_name = "Extricator of Flesh"
+scryfall_oracle_id = "08b3328c-1d96-4a05-ae8b-f1b654084faa"
+scryfall_id = "1d2ec933-cfc9-4ca4-b47b-f82109d89f0a"
 
 [[token.source_card_refs]]
 card_name = "Desperate Sentry"
@@ -20839,10 +21728,27 @@ scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
 scryfall_id = "e414e208-2e90-4b0d-b107-7a387b3f779b"
 
 [[token.source_card_refs]]
+card_name = "Wharf Infiltrator"
+scryfall_oracle_id = "ac88975c-fb2c-441a-bdd4-e7de6ba865e7"
+scryfall_id = "dc8c14a0-15aa-49e0-b0ba-cb658f1b4854"
+
+[[token.source_card_refs]]
+card_name = "Extricator of Sin // Extricator of Flesh"
+face_name = "Extricator of Sin"
+scryfall_oracle_id = "08b3328c-1d96-4a05-ae8b-f1b654084faa"
+scryfall_id = "1d2ec933-cfc9-4ca4-b47b-f82109d89f0a"
+
+[[token.source_card_refs]]
 card_name = "Shrill Howler // Howling Chorus"
 face_name = "Shrill Howler"
 scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
 scryfall_id = "246885ac-4e8e-4856-b796-5d72dfb7fb29"
+
+[[token.source_card_refs]]
+card_name = "Shrill Howler // Howling Chorus"
+face_name = "Howling Chorus"
+scryfall_oracle_id = "30c3f88f-11d3-4b5f-8936-bab1c65bd693"
+scryfall_id = "b7408d54-e15d-4975-8f30-8cd36fca9429"
 
 [token.token_image_ref]
 scryfall_id = "a106fc38-c321-4afa-8e66-ea6a9e594a55"
@@ -21047,6 +21953,11 @@ colors = ["Black"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Nettlecyst"
+scryfall_oracle_id = "04c7f4fe-2098-4311-866d-6733c08d5178"
+scryfall_id = "466df5af-f5ec-45ec-bba0-838cc3f387dd"
+
+[[token.source_card_refs]]
 card_name = "Bonehoard"
 scryfall_oracle_id = "83c69c05-173d-4c1b-9541-1dde474fef5f"
 scryfall_id = "75dc1b48-7d49-45ac-b345-988392183ff0"
@@ -21110,6 +22021,11 @@ scryfall_id = "8c418159-b5d1-48e9-9a31-707f49d6733b"
 card_name = "Bonehoard"
 scryfall_oracle_id = "83c69c05-173d-4c1b-9541-1dde474fef5f"
 scryfall_id = "1b146240-2899-43b6-adc6-930905a0d5b7"
+
+[[token.source_card_refs]]
+card_name = "Batterbone"
+scryfall_oracle_id = "389d459d-446a-4b84-82b2-a30fe6ced11f"
+scryfall_id = "5a148abb-e9fd-469c-b18b-9def75d3b783"
 
 [[token.source_card_refs]]
 card_name = "Sickleslicer"
@@ -21531,6 +22447,11 @@ card_name = "Sandwurm Convergence"
 scryfall_oracle_id = "429eff2b-635b-43f6-b20f-82e25992c0b9"
 scryfall_id = "3ad9cb61-4072-449b-9b32-83e2192cb292"
 
+[[token.source_card_refs]]
+card_name = "Sandwurm Convergence"
+scryfall_oracle_id = "429eff2b-635b-43f6-b20f-82e25992c0b9"
+scryfall_id = "3b579409-0129-4f44-b594-d7611ef12472"
+
 [token.token_image_ref]
 scryfall_id = "983253f0-fcf1-4c57-81eb-101f3495b6ae"
 scryfall_oracle_id = "1adf3c28-58c0-4239-ba4a-c53d345709b4"
@@ -21700,6 +22621,11 @@ keywords = ["Flying"]
 card_name = "Angel of Sanctions"
 scryfall_oracle_id = "3c49e98d-d33b-47fa-8b07-b38b367de2c7"
 scryfall_id = "546b6ffc-44e3-4994-b84b-6282c6474a1a"
+
+[[token.source_card_refs]]
+card_name = "Angel of Sanctions"
+scryfall_oracle_id = "3c49e98d-d33b-47fa-8b07-b38b367de2c7"
+scryfall_id = "41b282de-e204-47be-99ea-2596c12bd81c"
 
 [token.token_image_ref]
 scryfall_id = "eee11a08-6cdc-4c47-9ad4-26b766e4a839"
@@ -22975,11 +23901,6 @@ scryfall_id = "610a4f3d-3d92-4b7f-bc6e-89a87b7c7717"
 [[token.source_card_refs]]
 card_name = "Titania, Protector of Argoth"
 scryfall_oracle_id = "d0ade00d-a496-441d-9b7e-7dc033d3292c"
-scryfall_id = "711f4094-9a78-42f7-8f75-f57af921dd2f"
-
-[[token.source_card_refs]]
-card_name = "Titania, Protector of Argoth"
-scryfall_oracle_id = "d0ade00d-a496-441d-9b7e-7dc033d3292c"
 scryfall_id = "b02605cf-ef0b-467c-a6e8-064c2e260cd6"
 
 [[token.source_card_refs]]
@@ -23218,6 +24139,11 @@ card_name = "Vizier of Many Faces"
 scryfall_oracle_id = "55bceb83-bbba-477f-98ce-6e0a80b91080"
 scryfall_id = "b8385f76-3057-4f8f-af84-f70214364870"
 
+[[token.source_card_refs]]
+card_name = "Vizier of Many Faces"
+scryfall_oracle_id = "55bceb83-bbba-477f-98ce-6e0a80b91080"
+scryfall_id = "e28ebe21-5447-45f5-97e4-c9bf1905b4bc"
+
 [token.token_image_ref]
 scryfall_id = "208b09fc-985b-49f5-8af8-27cb590946ae"
 scryfall_oracle_id = "c97e158a-a1be-446c-b9aa-cae931735b9d"
@@ -23289,6 +24215,11 @@ keywords = []
 card_name = "Hunted Horror"
 scryfall_oracle_id = "3469463e-ed4d-44bb-81f3-42bbe09d34ad"
 scryfall_id = "02f74866-d0ea-42ce-bc44-500219fb73d4"
+
+[[token.source_card_refs]]
+card_name = "Hunted Horror"
+scryfall_oracle_id = "3469463e-ed4d-44bb-81f3-42bbe09d34ad"
+scryfall_id = "0ca680e3-2d10-4a32-8b0c-8b0c6be96540"
 
 [token.token_image_ref]
 scryfall_id = "dcd41697-6fe6-423c-a04a-035a3d4f8fd2"
@@ -23624,6 +24555,11 @@ keywords = ["Vigilance"]
 card_name = "Finale of Glory"
 scryfall_oracle_id = "68273453-1059-4eab-8c27-5d96f998f3b1"
 scryfall_id = "9b6b5cb7-26aa-43d6-ae97-24e5efd3c636"
+
+[[token.source_card_refs]]
+card_name = "Finale of Glory"
+scryfall_oracle_id = "68273453-1059-4eab-8c27-5d96f998f3b1"
+scryfall_id = "1e71b0fb-2d36-4b81-bd5b-c3fd083e3e97"
 
 [token.token_image_ref]
 scryfall_id = "f1684175-6e03-4934-92e3-e2a32725f7f9"
@@ -24988,6 +25924,11 @@ colors = ["Blue"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
+card_name = "Ojutai's Summons"
+scryfall_oracle_id = "def45f3a-dba0-4d08-b086-5236d6e0edb1"
+scryfall_id = "fd7fb80c-9cc3-45a9-8144-7559bd320efd"
+
+[[token.source_card_refs]]
 card_name = "Skywise Teachings"
 scryfall_oracle_id = "95a5e444-39f6-4f42-a83f-befa76350bc1"
 scryfall_id = "e55ba092-abc0-49ba-b756-6cb714165fec"
@@ -25067,6 +26008,11 @@ keywords = []
 card_name = "Ajani's Chosen"
 scryfall_oracle_id = "9c77eb0a-543a-41db-ba1f-aa0163837ae0"
 scryfall_id = "bc20cca0-303f-4463-85ae-26b80ff26211"
+
+[[token.source_card_refs]]
+card_name = "Ajani's Chosen"
+scryfall_oracle_id = "9c77eb0a-543a-41db-ba1f-aa0163837ae0"
+scryfall_id = "8ea009c1-505e-4307-b8f3-2d37e36507a6"
 
 [token.token_image_ref]
 scryfall_id = "7d400b41-813d-4a63-848f-5eb4db4bf3bb"
@@ -25642,6 +26588,11 @@ scryfall_oracle_id = "0156c94b-e64c-49de-a46c-a203c5e05e98"
 scryfall_id = "fa23ced5-0baa-4a8d-9263-ec2d94233a84"
 
 [[token.source_card_refs]]
+card_name = "Triplicate Spirits"
+scryfall_oracle_id = "48090c64-f41a-447b-ad7a-54e3194f759b"
+scryfall_id = "3c83a6e2-2c4e-40fb-b954-f78cd1553687"
+
+[[token.source_card_refs]]
 card_name = "Kykar, Zephyr Awakener"
 scryfall_oracle_id = "0156c94b-e64c-49de-a46c-a203c5e05e98"
 scryfall_id = "1f8ec6f1-4889-46e2-b681-59bf7b581195"
@@ -25655,6 +26606,11 @@ scryfall_id = "a1763648-802f-4178-a46a-a0c19142fd67"
 card_name = "Kykar, Zephyr Awakener"
 scryfall_oracle_id = "0156c94b-e64c-49de-a46c-a203c5e05e98"
 scryfall_id = "6c980998-7124-4ec6-a0b6-e8d9a2364925"
+
+[[token.source_card_refs]]
+card_name = "Sandsteppe Outcast"
+scryfall_oracle_id = "fccd17b1-ca0f-4649-a002-5cbf9666b510"
+scryfall_id = "3e2137fe-5e92-442e-b22a-473c5a669308"
 
 [token.token_image_ref]
 scryfall_id = "278adad2-49a6-4baa-8dbe-93474545eef7"
@@ -26187,6 +27143,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Tezzeret the Schemer"
 scryfall_oracle_id = "49d64ecb-3a4f-4013-9a34-8b1539a91e96"
+scryfall_id = "c10e9fdf-8a51-4bc2-95bf-b88f6969f959"
+
+[[token.source_card_refs]]
+card_name = "Tezzeret the Schemer"
+scryfall_oracle_id = "49d64ecb-3a4f-4013-9a34-8b1539a91e96"
 scryfall_id = "58265203-bc16-41d2-875c-2ff3b4870824"
 
 [token.token_image_ref]
@@ -26547,6 +27508,7 @@ id = "1fcde5b3-a6ba-52e8-a46f-d41809973467"
 category = "Creature"
 fidelity = "Full"
 source_card_names = [
+    "Alive",
     "Alive // Well",
     "Call of the Conclave",
     "Centaur Glade",
@@ -26555,6 +27517,7 @@ source_card_names = [
     "Rampage of the Clans",
     "Trostani's Summoner",
     "Vitu-Ghazi Guildmage",
+    "Well",
 ]
 set_code = "RVR"
 set_name = "Ravnica Remastered"
@@ -26571,6 +27534,17 @@ subtypes = ["Centaur"]
 supertypes = []
 colors = ["Green"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Alive // Well"
+face_name = "Alive"
+scryfall_oracle_id = "57ad3c3a-6ac7-4a35-bc07-00f6ea0988c5"
+scryfall_id = "1bc8966b-8c95-4e8e-993c-d536727599b7"
+
+[[token.source_card_refs]]
+card_name = "Centaur Glade"
+scryfall_oracle_id = "369c3b6c-6715-4b6a-89d2-e7542400ba8f"
+scryfall_id = "1c75f9c8-9640-4f64-b32a-916436e461fc"
 
 [[token.source_card_refs]]
 card_name = "Vitu-Ghazi Guildmage"
@@ -26596,6 +27570,12 @@ scryfall_id = "476f0994-10a0-422b-8031-069d5b06064f"
 card_name = "Call of the Conclave"
 scryfall_oracle_id = "e1635acd-ed1e-4038-a11a-6518df285253"
 scryfall_id = "88cacc67-5b0e-4cd5-a552-f64934578930"
+
+[[token.source_card_refs]]
+card_name = "Alive // Well"
+face_name = "Well"
+scryfall_oracle_id = "57ad3c3a-6ac7-4a35-bc07-00f6ea0988c5"
+scryfall_id = "1bc8966b-8c95-4e8e-993c-d536727599b7"
 
 [token.token_image_ref]
 scryfall_id = "5f657b65-67fc-4b7d-bc9e-840190f69362"
@@ -27537,6 +28517,11 @@ scryfall_id = "2d7687d1-d168-4279-b21d-fcfc7573c7b5"
 card_name = "Underworld Hermit"
 scryfall_oracle_id = "f7f4ddc9-cea0-42f9-bbca-2ad87a24bfc8"
 scryfall_id = "735a5082-72f4-4812-adcc-d8095d8eee51"
+
+[[token.source_card_refs]]
+card_name = "Deep Forest Hermit"
+scryfall_oracle_id = "80e9a42e-f4f4-4bfc-91a2-ad124737dca2"
+scryfall_id = "96c5607b-55fe-43c2-93fe-0084d84499d9"
 
 [[token.source_card_refs]]
 card_name = "Chatterfang, Squirrel General"
@@ -30874,6 +31859,16 @@ colors = ["White"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
+card_name = "Angelic Favor"
+scryfall_oracle_id = "37162c6e-ac31-4386-9d1e-76aa66070b35"
+scryfall_id = "871ad2f3-1dd2-45ea-881d-529aad3b76ec"
+
+[[token.source_card_refs]]
+card_name = "Decree of Justice"
+scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
+scryfall_id = "1d347ffc-5542-485c-8fc7-327c1c68b7aa"
+
+[[token.source_card_refs]]
 card_name = "Entreat the Angels"
 scryfall_oracle_id = "b349f018-c20b-48b0-9e65-d5fd56b24b88"
 scryfall_id = "ff4411bc-ed4e-4d54-9e1b-21fc77b0e415"
@@ -30884,6 +31879,11 @@ scryfall_oracle_id = "b349f018-c20b-48b0-9e65-d5fd56b24b88"
 scryfall_id = "0659529d-1328-47de-9910-cce5b744aedf"
 
 [[token.source_card_refs]]
+card_name = "Geist of Saint Traft"
+scryfall_oracle_id = "4304035c-c3e4-4a19-aa1f-92a83d8aed1f"
+scryfall_id = "42eac2d9-3f41-47f9-a3ae-7cfdcd4c945c"
+
+[[token.source_card_refs]]
 card_name = "Decree of Justice"
 scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
 scryfall_id = "bcb7e629-5600-499f-9dc7-144085b4a1b7"
@@ -30892,6 +31892,16 @@ scryfall_id = "bcb7e629-5600-499f-9dc7-144085b4a1b7"
 card_name = "Angelic Accord"
 scryfall_oracle_id = "aa95501f-bb59-494a-bcae-b74ca10ad57e"
 scryfall_id = "b2cb986c-2a8e-4a24-b5d4-4393edc0c347"
+
+[[token.source_card_refs]]
+card_name = "Decree of Justice"
+scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
+scryfall_id = "5e8a7e5c-f252-4de8-94d7-e7327210bf26"
+
+[[token.source_card_refs]]
+card_name = "Speaker of the Heavens"
+scryfall_oracle_id = "e4bacf1b-0a45-4c73-857d-dffadb7e6fa5"
+scryfall_id = "4a7c3dd3-a2e3-400a-8d2e-242bb8de39c1"
 
 [[token.source_card_refs]]
 card_name = "Decree of Justice"
@@ -30919,9 +31929,29 @@ scryfall_oracle_id = "f63c2438-27d4-449a-828f-f0a2ea86ff16"
 scryfall_id = "f89995b9-5409-4d3a-9518-7a4354b9d02f"
 
 [[token.source_card_refs]]
+card_name = "Decree of Justice"
+scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
+scryfall_id = "c2cecbd0-87a7-45e5-bf10-e97b298803fd"
+
+[[token.source_card_refs]]
+card_name = "Descend upon the Sinful"
+scryfall_oracle_id = "9cbf95f4-3510-420b-9355-645450f4493d"
+scryfall_id = "73f518c3-b679-40cf-ae2e-1de4470c514e"
+
+[[token.source_card_refs]]
 card_name = "Sigil of the Empty Throne"
 scryfall_oracle_id = "3b9b5b22-5a7d-4e37-a870-ca0f0efa4f36"
 scryfall_id = "6875be24-1515-488f-a899-929c8e480dfd"
+
+[[token.source_card_refs]]
+card_name = "Urbis Protector"
+scryfall_oracle_id = "564dd5e7-6c1e-4959-a594-60e08552aec9"
+scryfall_id = "8771abc9-e1f2-4d4f-8492-3209866cdc05"
+
+[[token.source_card_refs]]
+card_name = "Sigil of the Empty Throne"
+scryfall_oracle_id = "3b9b5b22-5a7d-4e37-a870-ca0f0efa4f36"
+scryfall_id = "733e1156-39a3-49a2-af5d-75c978107b2a"
 
 [[token.source_card_refs]]
 card_name = "Decree of Justice"
@@ -31018,6 +32048,11 @@ scryfall_oracle_id = "53fc09e1-1e5d-4f22-b623-2c5c770183ab"
 scryfall_id = "85050609-baf0-430a-ab33-83a6ea6d4741"
 
 [[token.source_card_refs]]
+card_name = "Monstrous Rage"
+scryfall_oracle_id = "646a2371-54c0-4492-ac2f-20f109d6108c"
+scryfall_id = "4b2e000b-a147-443b-9138-9ff2d16c0422"
+
+[[token.source_card_refs]]
 card_name = "Living Lectern"
 scryfall_oracle_id = "061e7fb2-2c04-4845-b60a-0e2512a2dec1"
 scryfall_id = "169afcaf-7ebf-4590-9e51-2a1a5eb3ac76"
@@ -31048,6 +32083,11 @@ scryfall_id = "79e4242c-a53a-4287-976b-8e545888a1fa"
 card_name = "Unassuming Sage"
 scryfall_oracle_id = "1cf4e16b-2273-41c7-9bcd-0cdc78e12198"
 scryfall_id = "a66fbaeb-1624-43b3-83e2-a37ce7588a5a"
+
+[[token.source_card_refs]]
+card_name = "Monstrous Rage"
+scryfall_oracle_id = "646a2371-54c0-4492-ac2f-20f109d6108c"
+scryfall_id = "9ebf25f9-844c-40c6-b0f0-d5c82ee04656"
 
 [[token.source_card_refs]]
 card_name = "Become Brutes"
@@ -32299,6 +33339,11 @@ card_name = "Ajani, Strength of the Pride"
 scryfall_oracle_id = "c3974ec7-7af0-4b65-baf6-4c1c4fe8a5c4"
 scryfall_id = "49109f9f-c3df-4694-9c80-32fc28169442"
 
+[[token.source_card_refs]]
+card_name = "Ajani, Strength of the Pride"
+scryfall_oracle_id = "c3974ec7-7af0-4b65-baf6-4c1c4fe8a5c4"
+scryfall_id = "a58deb8a-1c4b-4e3d-9c00-63f615f358c0"
+
 [token.token_image_ref]
 scryfall_id = "6740f7cb-e21b-41ca-acf0-93d63f1f8c54"
 scryfall_oracle_id = "9fcff433-c6f7-44c6-8279-04625703cb3e"
@@ -32569,6 +33614,11 @@ scryfall_oracle_id = "bf30b8ae-0125-4a00-bae8-ac1aa7703a08"
 scryfall_id = "7c54fe0b-56f6-4cff-adde-56aa5326194d"
 
 [[token.source_card_refs]]
+card_name = "Vernal Sovereign"
+scryfall_oracle_id = "bf30b8ae-0125-4a00-bae8-ac1aa7703a08"
+scryfall_id = "8d4ebe8b-8d2f-4534-994e-e387f23cbe1d"
+
+[[token.source_card_refs]]
 card_name = "Voice of Resurgence"
 scryfall_oracle_id = "5cbbb3f3-63a4-4983-81ea-8c405b10e63f"
 scryfall_id = "a1dacda4-ed81-4daf-8718-cc59bffd95fc"
@@ -32730,6 +33780,21 @@ scryfall_id = "53f91325-e95a-4b68-9491-4249c2e940b4"
 [[token.source_card_refs]]
 card_name = "Giant Caterpillar"
 scryfall_oracle_id = "43a515f2-b53a-4bb4-bb6e-0d79c9162359"
+scryfall_id = "2abf3c63-2f8c-4f43-b08b-35a974214ad3"
+
+[[token.source_card_refs]]
+card_name = "Giant Caterpillar"
+scryfall_oracle_id = "43a515f2-b53a-4bb4-bb6e-0d79c9162359"
+scryfall_id = "b7f602a6-3d35-49a3-b5cb-d754e03a9573"
+
+[[token.source_card_refs]]
+card_name = "Giant Caterpillar"
+scryfall_oracle_id = "43a515f2-b53a-4bb4-bb6e-0d79c9162359"
+scryfall_id = "bdc5eb8a-4531-4408-90fe-9b352d71a052"
+
+[[token.source_card_refs]]
+card_name = "Giant Caterpillar"
+scryfall_oracle_id = "43a515f2-b53a-4bb4-bb6e-0d79c9162359"
 scryfall_id = "e5392f2f-8762-4a06-8f1d-7af8dfb7408d"
 
 [token.token_image_ref]
@@ -32763,6 +33828,11 @@ keywords = ["Flying"]
 card_name = "Sword of Dungeons & Dragons"
 scryfall_oracle_id = "8e0b725c-b27a-4aa2-8e4b-6ab47e73927d"
 scryfall_id = "bf451d4b-0884-4ab5-8d85-312d9db82e76"
+
+[[token.source_card_refs]]
+card_name = "Sword of Dungeons & Dragons"
+scryfall_oracle_id = "8e0b725c-b27a-4aa2-8e4b-6ab47e73927d"
+scryfall_id = "541640e3-4b45-41b3-b2b0-090ea5bb1e57"
 
 [token.token_image_ref]
 scryfall_id = "6819b8c9-73a3-4e8e-ad7a-95cffabf873a"
@@ -32875,6 +33945,16 @@ keywords = ["Flying"]
 card_name = "Pride of the Clouds"
 scryfall_oracle_id = "7d595158-73a8-4ebf-aac5-0b5193cef9b7"
 scryfall_id = "48e6b67f-ebf5-4413-9417-ed45a576a390"
+
+[[token.source_card_refs]]
+card_name = "Pride of the Clouds"
+scryfall_oracle_id = "7d595158-73a8-4ebf-aac5-0b5193cef9b7"
+scryfall_id = "ecc2a029-6e64-4b6d-9d82-afc319dbc57a"
+
+[[token.source_card_refs]]
+card_name = "Dovescape"
+scryfall_oracle_id = "d9f4af37-c85e-44ab-9fea-3c67e2f3cf27"
+scryfall_id = "b6e3d6e6-ac17-4d73-acac-089442de4af6"
 
 [[token.source_card_refs]]
 card_name = "Dovescape"
@@ -33307,6 +34387,11 @@ scryfall_oracle_id = "1ed9e351-0000-4b75-8ecb-d15bd88df68a"
 scryfall_id = "2a717b98-cdac-416d-bf6c-f6b6638e65d1"
 
 [[token.source_card_refs]]
+card_name = "Hard Evidence"
+scryfall_oracle_id = "0728b195-2dfe-4d73-91ae-e658a97b0b9a"
+scryfall_id = "c55901dc-3f5a-490d-8496-5b844530d410"
+
+[[token.source_card_refs]]
 card_name = "Tamiyo, Inquisitive Student // Tamiyo, Seasoned Scholar"
 face_name = "Tamiyo, Seasoned Scholar"
 scryfall_oracle_id = "1ed9e351-0000-4b75-8ecb-d15bd88df68a"
@@ -33453,12 +34538,32 @@ keywords = ["Deathtouch"]
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
 scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
+scryfall_id = "dcdbecfc-fc37-4327-9469-7139e16f7fbd"
+
+[[token.source_card_refs]]
+card_name = "Wurmcoil Engine"
+scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
+scryfall_id = "6927d6d4-93fe-4ded-b091-a0c671c1716b"
+
+[[token.source_card_refs]]
+card_name = "Wurmcoil Engine"
+scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
 scryfall_id = "efc01aa1-55f3-4557-a5b0-734f3b9ed050"
 
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
 scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
 scryfall_id = "5d275f04-cc60-4e3f-95cc-3d02bc916b82"
+
+[[token.source_card_refs]]
+card_name = "Wurmcoil Engine"
+scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
+scryfall_id = "219f1f03-e882-40ca-8854-1e466e37b8cd"
+
+[[token.source_card_refs]]
+card_name = "Wurmcoil Engine"
+scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
+scryfall_id = "b045a766-73ee-4109-bede-2e1d71b80f2f"
 
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
@@ -33930,9 +35035,21 @@ scryfall_id = "a47070a0-fd05-4ed9-a175-847a864478da"
 
 [[token.source_card_refs]]
 card_name = "Mouth // Feed"
+face_name = "Mouth"
+scryfall_oracle_id = "980f6341-3c13-4405-8550-b838b228f788"
+scryfall_id = "f5e94e39-4104-4b88-ae2b-a2dd5d2589cb"
+
+[[token.source_card_refs]]
+card_name = "Mouth // Feed"
 face_name = "Feed"
 scryfall_oracle_id = "980f6341-3c13-4405-8550-b838b228f788"
 scryfall_id = "a47070a0-fd05-4ed9-a175-847a864478da"
+
+[[token.source_card_refs]]
+card_name = "Mouth // Feed"
+face_name = "Feed"
+scryfall_oracle_id = "980f6341-3c13-4405-8550-b838b228f788"
+scryfall_id = "f5e94e39-4104-4b88-ae2b-a2dd5d2589cb"
 
 [token.token_image_ref]
 scryfall_id = "1aea5e0b-dc4e-4055-9e13-1dfbc25a2f00"
@@ -33977,6 +35094,11 @@ scryfall_id = "95acdbfc-ec40-4ecd-bd0b-0908ed5d31bc"
 card_name = "Felidar Retreat"
 scryfall_oracle_id = "16629f59-bae8-4c19-bf50-443eb0ed6856"
 scryfall_id = "89e3cc09-5057-4c05-88fc-d6cda809fc74"
+
+[[token.source_card_refs]]
+card_name = "Felidar Retreat"
+scryfall_oracle_id = "16629f59-bae8-4c19-bf50-443eb0ed6856"
+scryfall_id = "34b3b925-743d-4f88-97d6-d0847c0d7d6a"
 
 [token.token_image_ref]
 scryfall_id = "322ef76e-e0f0-48d7-a6ad-5d4c1c9ccb2e"
@@ -34209,6 +35331,11 @@ keywords = []
 card_name = "Tooth and Claw"
 scryfall_oracle_id = "587368eb-068c-44a3-ba8c-5ad0f59f880f"
 scryfall_id = "a8c77d9f-22bd-4676-b594-8499369c449c"
+
+[[token.source_card_refs]]
+card_name = "Tooth and Claw"
+scryfall_oracle_id = "587368eb-068c-44a3-ba8c-5ad0f59f880f"
+scryfall_id = "71696093-0867-4889-8fb4-56fa143f9b27"
 
 [token.token_image_ref]
 scryfall_id = "8437b125-6057-4d17-9f2c-28ea56553f84"
@@ -34955,6 +36082,11 @@ card_name = "The Locust God"
 scryfall_oracle_id = "e025a714-02da-4b0c-8021-cf3e8dc9b19e"
 scryfall_id = "4e0c1d0a-2651-4961-8b70-ff78093732ce"
 
+[[token.source_card_refs]]
+card_name = "The Locust God"
+scryfall_oracle_id = "e025a714-02da-4b0c-8021-cf3e8dc9b19e"
+scryfall_id = "cba0603a-37aa-47b5-bfda-6be2c0138f03"
+
 [token.token_image_ref]
 scryfall_id = "ae56d9e8-de05-456b-af32-b5992992ee15"
 scryfall_oracle_id = "6f80811b-fdc7-4fb9-ac61-d8b51c28fe7f"
@@ -35080,6 +36212,36 @@ subtypes = ["Rukh"]
 supertypes = []
 colors = ["Red"]
 keywords = ["Flying"]
+
+[[token.source_card_refs]]
+card_name = "Rukh Egg"
+scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
+scryfall_id = "d805f1f4-ac45-404d-b52c-4d5eb019e24a"
+
+[[token.source_card_refs]]
+card_name = "Rukh Egg"
+scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
+scryfall_id = "b28f9e63-e5e4-44b5-a17e-8301ff17c623"
+
+[[token.source_card_refs]]
+card_name = "Rukh Egg"
+scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
+scryfall_id = "9c4defc2-b1a2-4ae2-bda0-24ecd4ff8181"
+
+[[token.source_card_refs]]
+card_name = "Rukh Egg"
+scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
+scryfall_id = "33e1098d-6d6e-444d-8307-508ffb2a9b4a"
+
+[[token.source_card_refs]]
+card_name = "Rukh Egg"
+scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
+scryfall_id = "e4bfc662-edfb-43ff-8022-1db971b1de22"
+
+[[token.source_card_refs]]
+card_name = "Rukh Egg"
+scryfall_oracle_id = "98116aec-2ab1-4bee-b727-9feff6274825"
+scryfall_id = "99a2fbef-a340-4c08-9c77-a157948cacdf"
 
 [token.token_image_ref]
 scryfall_id = "b5489e26-6aec-4706-9c3e-8454878fa6c3"
@@ -35707,6 +36869,8 @@ source_card_names = [
     "Breya's Apprentice",
     "Broadcast Rambler",
     "Camera Launcher",
+    "Deploy",
+    "Depose",
     "Depose // Deploy",
     "Detective's Satchel",
     "Deviant Skytech",
@@ -35784,6 +36948,12 @@ scryfall_oracle_id = "9be5a350-c38e-425f-9d6a-8eb111132a89"
 scryfall_id = "19529568-c759-4ae0-b2e4-ab5a11d421a4"
 
 [[token.source_card_refs]]
+card_name = "Depose // Deploy"
+face_name = "Deploy"
+scryfall_oracle_id = "c547c9ab-a303-48fb-9579-37f9de9a558b"
+scryfall_id = "0bda0b80-8a41-4001-9f60-06b1d7f9b1fa"
+
+[[token.source_card_refs]]
 card_name = "Fuss // Bother"
 face_name = "Fuss"
 scryfall_oracle_id = "88e9006a-cfdf-40f3-80d5-23465f3dceca"
@@ -35793,6 +36963,12 @@ scryfall_id = "269a031e-0b89-40e1-b11b-ae870d72161c"
 card_name = "Whirler Rogue"
 scryfall_oracle_id = "7060f2c8-fca0-4b7a-bddf-37682f434596"
 scryfall_id = "31dec9a8-714f-4e28-9781-d0a8c6775298"
+
+[[token.source_card_refs]]
+card_name = "Depose // Deploy"
+face_name = "Depose"
+scryfall_oracle_id = "c547c9ab-a303-48fb-9579-37f9de9a558b"
+scryfall_id = "0bda0b80-8a41-4001-9f60-06b1d7f9b1fa"
 
 [[token.source_card_refs]]
 card_name = "Surveillance Monitor"
@@ -36790,6 +37966,16 @@ scryfall_id = "a4dfb147-10f6-49f1-b777-12125e87189b"
 [[token.source_card_refs]]
 card_name = "Gutter Grime"
 scryfall_oracle_id = "0b8adb9e-97a5-43d9-87d6-993f22edaf3b"
+scryfall_id = "29dcc6ad-3f7d-41d3-9a94-de4b63620763"
+
+[[token.source_card_refs]]
+card_name = "Miming Slime"
+scryfall_oracle_id = "50e7f705-c347-440b-8159-81a52bbfbdfb"
+scryfall_id = "bbf8f4c9-3d1d-4fc9-b852-0890af674916"
+
+[[token.source_card_refs]]
+card_name = "Gutter Grime"
+scryfall_oracle_id = "0b8adb9e-97a5-43d9-87d6-993f22edaf3b"
 scryfall_id = "cf3f3913-86d8-4b1c-9d2e-942102e7fac3"
 
 [token.token_image_ref]
@@ -36997,6 +38183,11 @@ subtypes = ["Horror"]
 supertypes = []
 colors = ["Black"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Hunted Lammasu"
+scryfall_oracle_id = "a76667b5-2144-4395-a5c1-57cb3c29a99e"
+scryfall_id = "b84de052-65e5-4723-a746-5c554fa1612d"
 
 [[token.source_card_refs]]
 card_name = "Hunted Lammasu"
@@ -37692,6 +38883,11 @@ subtypes = ["Bird"]
 supertypes = []
 colors = ["White"]
 keywords = ["Flying"]
+
+[[token.source_card_refs]]
+card_name = "Roc Egg"
+scryfall_oracle_id = "16dfd80a-9847-45b8-954f-2af9b7cfa21d"
+scryfall_id = "ed945e1a-977a-4de8-9962-828388bafc3e"
 
 [[token.source_card_refs]]
 card_name = "Roc Egg"
@@ -38684,6 +39880,11 @@ scryfall_oracle_id = "66950068-adf4-42d7-ad72-fdb4a0e58922"
 scryfall_id = "9fb292a4-cf71-4aeb-b92e-eab2e3177653"
 
 [[token.source_card_refs]]
+card_name = "Crashing Footfalls"
+scryfall_oracle_id = "2b166d97-c2c1-4642-b151-9bb1ad32e362"
+scryfall_id = "564eb8e2-e3fb-44b6-a36d-a74e2374f9ff"
+
+[[token.source_card_refs]]
 card_name = "W'Kabi, Shield of the Nation"
 scryfall_oracle_id = "66950068-adf4-42d7-ad72-fdb4a0e58922"
 scryfall_id = "f74ec2db-bcf2-46f4-a002-f3c1c8f4f976"
@@ -38768,7 +39969,17 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Urza's Factory"
 scryfall_oracle_id = "5a620d20-f14e-43d0-8e57-c2a197e2ec51"
+scryfall_id = "73d9f428-8ce0-4a73-ac38-2dcbdcf12584"
+
+[[token.source_card_refs]]
+card_name = "Urza's Factory"
+scryfall_oracle_id = "5a620d20-f14e-43d0-8e57-c2a197e2ec51"
 scryfall_id = "c02a54a6-9247-4460-83e5-d10fbd1554e6"
+
+[[token.source_card_refs]]
+card_name = "Urza's Factory"
+scryfall_oracle_id = "5a620d20-f14e-43d0-8e57-c2a197e2ec51"
+scryfall_id = "b22d97f3-08cf-4c19-bbe2-5a36096187cd"
 
 [[token.source_card_refs]]
 card_name = "Urza's Factory"
@@ -39106,12 +40317,52 @@ keywords = ["Flying"]
 [[token.source_card_refs]]
 card_name = "The Hive"
 scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
+scryfall_id = "fa3aa493-3801-400e-965e-e518c38eb770"
+
+[[token.source_card_refs]]
+card_name = "The Hive"
+scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
 scryfall_id = "7fb40127-8aba-4a20-b03e-983ddaa605d5"
 
 [[token.source_card_refs]]
 card_name = "The Hive"
 scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
+scryfall_id = "09b82c6b-9b14-4607-95d5-2964b926ec37"
+
+[[token.source_card_refs]]
+card_name = "The Hive"
+scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
+scryfall_id = "f9d01a2e-2687-4b37-aed6-63202cd81231"
+
+[[token.source_card_refs]]
+card_name = "The Hive"
+scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
+scryfall_id = "84b83106-a10d-469a-99eb-56110ef34ba1"
+
+[[token.source_card_refs]]
+card_name = "The Hive"
+scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
 scryfall_id = "51027e4f-de9b-43d9-8b73-98e723aa65f2"
+
+[[token.source_card_refs]]
+card_name = "The Hive"
+scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
+scryfall_id = "544a7138-eae8-4ff9-9e17-680bfa717183"
+
+[[token.source_card_refs]]
+card_name = "The Hive"
+scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
+scryfall_id = "af5534f0-485e-41f2-bcfa-d65c1a9b86bd"
+
+[[token.source_card_refs]]
+card_name = "The Hive"
+scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
+scryfall_id = "dc052e94-1574-4e79-9b1b-288180901dea"
+
+[[token.source_card_refs]]
+card_name = "The Hive"
+scryfall_oracle_id = "87a77482-f286-4fb1-b179-85b2095bb768"
+scryfall_id = "885c72d8-cee1-4a67-a394-b7dfe89bbd2e"
 
 [token.token_image_ref]
 scryfall_id = "09921372-126f-4c81-b6d8-ea50b1d0eb44"
@@ -40057,6 +41308,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Nadir Kraken"
 scryfall_oracle_id = "5a73d439-bd78-42e1-90ae-eedd30536881"
+scryfall_id = "be7b276f-2351-4f56-a104-13e3ec3f0890"
+
+[[token.source_card_refs]]
+card_name = "Nadir Kraken"
+scryfall_oracle_id = "5a73d439-bd78-42e1-90ae-eedd30536881"
 scryfall_id = "3bd63804-d538-471f-b57f-e1023f7e14a8"
 
 [token.token_image_ref]
@@ -40188,6 +41444,11 @@ keywords = ["Deathtouch"]
 card_name = "Pharika, God of Affliction"
 scryfall_oracle_id = "b7d05d00-1e69-4d11-bff0-c1ca2026aad6"
 scryfall_id = "109bfa3d-02e0-4395-bd6e-edaad77f25f7"
+
+[[token.source_card_refs]]
+card_name = "Pharika, God of Affliction"
+scryfall_oracle_id = "b7d05d00-1e69-4d11-bff0-c1ca2026aad6"
+scryfall_id = "0bcaa988-7485-461b-a3ae-764e1f4531df"
 
 [[token.source_card_refs]]
 card_name = "Pharika, God of Affliction"
@@ -40533,6 +41794,11 @@ card_name = "Kessig Wolfrider"
 scryfall_oracle_id = "d9c42e56-1818-4b73-9cd6-1c5aaf6a5b56"
 scryfall_id = "9d54673a-2147-474c-9bcb-ef89dbe54456"
 
+[[token.source_card_refs]]
+card_name = "Kessig Wolfrider"
+scryfall_oracle_id = "d9c42e56-1818-4b73-9cd6-1c5aaf6a5b56"
+scryfall_id = "f76bddc3-f62e-4504-9703-8ed57acb90fa"
+
 [token.token_image_ref]
 scryfall_id = "001cc57e-f3fc-4790-a9e5-171b2e3e8739"
 scryfall_oracle_id = "04139d92-67d3-4e3c-a97f-158f24115044"
@@ -40622,6 +41888,16 @@ scryfall_oracle_id = "ca68f436-2522-4007-87bf-2669c7743db0"
 scryfall_id = "ac37ca6f-a6ee-4dfb-949f-2562f98d09d0"
 
 [[token.source_card_refs]]
+card_name = "Spider-Slayer, Hatred Honed"
+scryfall_oracle_id = "ca68f436-2522-4007-87bf-2669c7743db0"
+scryfall_id = "a8874e6e-400f-48ff-a9da-6bce557bde78"
+
+[[token.source_card_refs]]
+card_name = "Robotics Mastery"
+scryfall_oracle_id = "855318cb-9382-4183-87c7-93bdfac86431"
+scryfall_id = "b9be8e17-7304-4df9-bdeb-8f31c604056c"
+
+[[token.source_card_refs]]
 card_name = "Robotics Mastery"
 scryfall_oracle_id = "855318cb-9382-4183-87c7-93bdfac86431"
 scryfall_id = "b5ed3c76-946a-4140-8c7b-2011e72a7d54"
@@ -40702,6 +41978,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Wolf's Quarry"
 scryfall_oracle_id = "c6fead73-0473-4b57-899a-9f8c5b4f896d"
+scryfall_id = "84c2f778-2ad0-4b80-9296-f37c6090f8ff"
+
+[[token.source_card_refs]]
+card_name = "Wolf's Quarry"
+scryfall_oracle_id = "c6fead73-0473-4b57-899a-9f8c5b4f896d"
 scryfall_id = "5d21c15f-378e-4abf-992f-9743aa6ab6b8"
 
 [token.token_image_ref]
@@ -40776,6 +42057,18 @@ card_name = "Nissa, Vastwood Seer // Nissa, Sage Animist"
 face_name = "Nissa, Sage Animist"
 scryfall_oracle_id = "35754a21-9fba-4370-a254-292918a777ba"
 scryfall_id = "aa4103ef-4778-41da-99f5-fa590074cd52"
+
+[[token.source_card_refs]]
+card_name = "Nissa, Vastwood Seer // Nissa, Sage Animist"
+face_name = "Nissa, Sage Animist"
+scryfall_oracle_id = "35754a21-9fba-4370-a254-292918a777ba"
+scryfall_id = "332f7ad3-33b0-4b03-9c86-73917f8db29a"
+
+[[token.source_card_refs]]
+card_name = "Nissa, Vastwood Seer // Nissa, Sage Animist"
+face_name = "Nissa, Vastwood Seer"
+scryfall_oracle_id = "35754a21-9fba-4370-a254-292918a777ba"
+scryfall_id = "332f7ad3-33b0-4b03-9c86-73917f8db29a"
 
 [token.token_image_ref]
 scryfall_id = "2c3775c8-2d3d-47b0-b262-8b86d649c087"
@@ -43500,6 +44793,11 @@ keywords = ["Haste"]
 [[token.source_card_refs]]
 card_name = "Riftmarked Knight"
 scryfall_oracle_id = "a20093c6-b8b4-4051-808f-febd030f7fe4"
+scryfall_id = "d503b565-a3c8-4b57-9e30-fb97d2a49afa"
+
+[[token.source_card_refs]]
+card_name = "Riftmarked Knight"
+scryfall_oracle_id = "a20093c6-b8b4-4051-808f-febd030f7fe4"
 scryfall_id = "20c4cb76-c895-4862-8099-d306b1bb06e9"
 
 [token.token_image_ref]
@@ -44272,6 +45570,11 @@ keywords = [
 [[token.source_card_refs]]
 card_name = "Hornet Cannon"
 scryfall_oracle_id = "595ae6f1-e66a-4774-943a-9d5368f4a3b4"
+scryfall_id = "51e9afeb-4d27-441c-b379-3dfe974053b8"
+
+[[token.source_card_refs]]
+card_name = "Hornet Cannon"
+scryfall_oracle_id = "595ae6f1-e66a-4774-943a-9d5368f4a3b4"
 scryfall_id = "a3ea39a8-48d1-4a58-8662-88841eabec92"
 
 [token.token_image_ref]
@@ -44898,9 +46201,19 @@ colors = ["Red"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Seasoned Pyromancer"
+scryfall_oracle_id = "02238355-9c84-4ae0-b850-269f460144a8"
+scryfall_id = "11754da2-dc6a-47f7-9744-4db71ea9d336"
+
+[[token.source_card_refs]]
 card_name = "Molten Birth"
 scryfall_oracle_id = "aeaae9cc-f30f-4d7e-86f3-3132ef47e987"
 scryfall_id = "910098bb-c909-47c5-b2ef-0dd4e5a8346a"
+
+[[token.source_card_refs]]
+card_name = "Young Pyromancer"
+scryfall_oracle_id = "5fac139a-07d3-4e6c-98e3-d98b199f7a6f"
+scryfall_id = "9b53aa90-f8d6-4cbc-9836-9e4d95ea74f7"
 
 [[token.source_card_refs]]
 card_name = "Young Pyromancer"
@@ -44920,7 +46233,17 @@ scryfall_id = "96ff0ce1-9737-452a-9ecb-b32a3e926283"
 [[token.source_card_refs]]
 card_name = "Young Pyromancer"
 scryfall_oracle_id = "5fac139a-07d3-4e6c-98e3-d98b199f7a6f"
+scryfall_id = "218af707-cc60-407e-af20-e21879a0e902"
+
+[[token.source_card_refs]]
+card_name = "Young Pyromancer"
+scryfall_oracle_id = "5fac139a-07d3-4e6c-98e3-d98b199f7a6f"
 scryfall_id = "e63195ed-5c3e-40e8-9cc2-5cbc1faf7f7f"
+
+[[token.source_card_refs]]
+card_name = "Young Pyromancer"
+scryfall_oracle_id = "5fac139a-07d3-4e6c-98e3-d98b199f7a6f"
+scryfall_id = "8afb19df-b96a-4736-81ab-3561e2767d2d"
 
 [[token.source_card_refs]]
 card_name = "Young Pyromancer"
@@ -44960,6 +46283,11 @@ keywords = ["Flying"]
 card_name = "Sengir Nosferatu"
 scryfall_oracle_id = "2efdfcae-c3ad-4c6b-8a60-45a203bd14c6"
 scryfall_id = "71dc9f1e-b889-402d-a5a1-fa0d7d493246"
+
+[[token.source_card_refs]]
+card_name = "Sengir Nosferatu"
+scryfall_oracle_id = "2efdfcae-c3ad-4c6b-8a60-45a203bd14c6"
+scryfall_id = "3cd9cc4c-708b-41cb-9cac-fd6d8ce9922d"
 
 [token.token_image_ref]
 scryfall_id = "4c532e0f-8934-4ad3-bb1a-640abe946e10"
@@ -46840,7 +48168,9 @@ source_card_names = [
     "Blood Fountain",
     "Blood Petal Celebrant",
     "Blood Servitor",
+    "Bloodbat Summoner",
     "Bloodcrazed Socialite",
+    "Bloodsoaked Reveler",
     "Bloodtithe Harvester",
     "Bloodvial Purveyor",
     "Bloody Betrayal",
@@ -46861,6 +48191,7 @@ source_card_names = [
     "Old Rutstein",
     "Olivia's Attendants",
     "Pointed Discussion",
+    "Restless Bloodseeker",
     "Restless Bloodseeker // Bloodsoaked Reveler",
     "Sanguine Brushstroke",
     "Sanguine Statuette",
@@ -46871,6 +48202,7 @@ source_card_names = [
     "Transmutation Font",
     "Vampire's Kiss",
     "Vampires' Vengeance",
+    "Voldaren Bloodcaster",
     "Voldaren Bloodcaster // Bloodbat Summoner",
     "Voldaren Epicure",
     "Voldaren Estate",
@@ -46894,9 +48226,55 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Sanguine Statuette"
+scryfall_oracle_id = "35553c2a-0150-49e4-81da-f356c6a17253"
+scryfall_id = "b40a143a-afa0-4fe2-802b-abcf09d7b145"
+
+[[token.source_card_refs]]
 card_name = "Voldaren Estate"
 scryfall_oracle_id = "fb0c0426-f1a6-4e52-9242-627786d3119a"
 scryfall_id = "dd0ee2f1-d5be-4f60-a128-7011eef71f11"
+
+[[token.source_card_refs]]
+card_name = "Vampire's Kiss"
+scryfall_oracle_id = "105cea6e-18e9-4dec-a533-0dca4d41320b"
+scryfall_id = "02f210ed-b40b-44c8-9424-fbefb31e9c3c"
+
+[[token.source_card_refs]]
+card_name = "Pointed Discussion"
+scryfall_oracle_id = "aff9a568-2848-4614-a28b-b1ea84f7f0b7"
+scryfall_id = "0bed9878-8662-433e-8786-3a66e8f668ed"
+
+[[token.source_card_refs]]
+card_name = "Restless Bloodseeker // Bloodsoaked Reveler"
+face_name = "Bloodsoaked Reveler"
+scryfall_oracle_id = "7aef5d2e-b66d-4822-b563-44d21d008272"
+scryfall_id = "0c6c01a9-67f7-4e96-b44e-b28379b41cc2"
+
+[[token.source_card_refs]]
+card_name = "Falkenrath Celebrants"
+scryfall_oracle_id = "3c0be888-0d66-4bad-84f4-90c3934915d7"
+scryfall_id = "8fa79e35-1a83-431e-bf70-71860c288210"
+
+[[token.source_card_refs]]
+card_name = "Blood Petal Celebrant"
+scryfall_oracle_id = "219cf182-0942-4569-91e9-9bc9bb1d06d0"
+scryfall_id = "03e5159b-0575-4ae1-b04b-ab812207cbdf"
+
+[[token.source_card_refs]]
+card_name = "Blood Fountain"
+scryfall_oracle_id = "abfa5753-8c02-4e2f-8f98-b0636907293a"
+scryfall_id = "1b0c4931-3260-411a-9c7d-b67c87e7aecc"
+
+[[token.source_card_refs]]
+card_name = "Ivora, Insatiable Heir"
+scryfall_oracle_id = "d847542b-7522-43ec-91b0-f0aba5d7dddd"
+scryfall_id = "2ba70366-b6ae-423a-a8d8-29d2b8afd939"
+
+[[token.source_card_refs]]
+card_name = "Blood Fountain"
+scryfall_oracle_id = "abfa5753-8c02-4e2f-8f98-b0636907293a"
+scryfall_id = "3499687b-5dd3-4a0c-96a3-7db227abcaf2"
 
 [[token.source_card_refs]]
 card_name = "Jaws, Relentless Predator"
@@ -46906,7 +48284,78 @@ scryfall_id = "c6d16a9e-98c0-46e0-987c-f0de0915a204"
 [[token.source_card_refs]]
 card_name = "Bloody Betrayal"
 scryfall_oracle_id = "a2743cb6-564d-43f1-99cc-4ba3ceb2e282"
+scryfall_id = "dd678a9b-95a3-4abb-b845-0e998144c3f6"
+
+[[token.source_card_refs]]
+card_name = "Syphon Essence"
+scryfall_oracle_id = "e6e7b5ba-ea10-4f53-8afc-045aa1906c6b"
+scryfall_id = "bd07eb9f-4817-45f4-a5eb-3d1842d43301"
+
+[[token.source_card_refs]]
+card_name = "Odric, Blood-Cursed"
+scryfall_oracle_id = "690f79f3-e6a5-4542-8401-61a9bf645d55"
+scryfall_id = "e3a463f6-975c-4bba-8dc1-5cf0ff874bb4"
+
+[[token.source_card_refs]]
+card_name = "Old Rutstein"
+scryfall_oracle_id = "8f5ffb0b-0585-4a37-8048-eda53990d1dd"
+scryfall_id = "2bda3765-c56f-4b27-83f8-d01e16265328"
+
+[[token.source_card_refs]]
+card_name = "Bloody Betrayal"
+scryfall_oracle_id = "a2743cb6-564d-43f1-99cc-4ba3ceb2e282"
 scryfall_id = "9460ca4f-aea4-4c38-8e36-7467178986cc"
+
+[[token.source_card_refs]]
+card_name = "Belligerent Guest"
+scryfall_oracle_id = "417e798d-9ca6-4cd0-adb4-f61d3becb201"
+scryfall_id = "23430e0e-521d-412d-92ed-082e569d760c"
+
+[[token.source_card_refs]]
+card_name = "Anje, Maid of Dishonor"
+scryfall_oracle_id = "1829f1dc-1fa9-4361-b318-d4dee280e6fd"
+scryfall_id = "b81584cd-0624-4524-9426-35f1a1ef60ea"
+
+[[token.source_card_refs]]
+card_name = "Voldaren Epicure"
+scryfall_oracle_id = "cef82674-1f61-407b-801b-a76a3803e598"
+scryfall_id = "b9706fd5-04d2-4dff-9e59-ac822df5b7e0"
+
+[[token.source_card_refs]]
+card_name = "Sigarda's Imprisonment"
+scryfall_oracle_id = "574230c7-b949-4c90-b107-c26458a6e469"
+scryfall_id = "1fc02a0f-d555-40ba-8bcd-00a0c1d56038"
+
+[[token.source_card_refs]]
+card_name = "Voldaren Bloodcaster // Bloodbat Summoner"
+face_name = "Bloodbat Summoner"
+scryfall_oracle_id = "a720f3d3-c2d7-4e50-8cc6-600120380e9c"
+scryfall_id = "5299eaa4-9223-4180-8339-8cf9af3a41b1"
+
+[[token.source_card_refs]]
+card_name = "Bloodcrazed Socialite"
+scryfall_oracle_id = "7e165b4e-4c8f-4a0f-bd6e-7b0a15b12d1d"
+scryfall_id = "35deff8c-14d7-4b24-bce8-97ca041c72fd"
+
+[[token.source_card_refs]]
+card_name = "Blood Servitor"
+scryfall_oracle_id = "5a3f9c4d-20a8-46aa-9cf3-3916f56a7906"
+scryfall_id = "4adef77b-c17f-4573-b6e1-d6ca82b4c94f"
+
+[[token.source_card_refs]]
+card_name = "Markov Enforcer"
+scryfall_oracle_id = "e262ea6f-c8c7-45c7-a9a6-29dcbe6300a4"
+scryfall_id = "768e4488-1c3b-4ccb-abf8-fd168655d7de"
+
+[[token.source_card_refs]]
+card_name = "Falkenrath Celebrants"
+scryfall_oracle_id = "3c0be888-0d66-4bad-84f4-90c3934915d7"
+scryfall_id = "8813702a-3311-423a-ab71-263a0ff10d6e"
+
+[[token.source_card_refs]]
+card_name = "Ceremonial Knife"
+scryfall_oracle_id = "db221948-fcb9-4ef9-ae69-70266235dd04"
+scryfall_id = "779fa44a-444b-47fc-882b-d9da7714bd02"
 
 [[token.source_card_refs]]
 card_name = "Voldaren Epicure"
@@ -46914,9 +48363,55 @@ scryfall_oracle_id = "cef82674-1f61-407b-801b-a76a3803e598"
 scryfall_id = "cc9e4323-50a7-4b6d-9bf4-6d5820c52261"
 
 [[token.source_card_refs]]
+card_name = "Blood Petal Celebrant"
+scryfall_oracle_id = "219cf182-0942-4569-91e9-9bc9bb1d06d0"
+scryfall_id = "f25a585e-4f8c-4ed3-8cd3-624c6e3da1d6"
+
+[[token.source_card_refs]]
+card_name = "Bloodvial Purveyor"
+scryfall_oracle_id = "7292272d-6511-466b-aadd-c4fe7ed8df09"
+scryfall_id = "58996f26-f751-47bd-be42-8b7e07f31db0"
+
+[[token.source_card_refs]]
+card_name = "Voldaren Estate"
+scryfall_oracle_id = "fb0c0426-f1a6-4e52-9242-627786d3119a"
+scryfall_id = "1dd9238b-0de6-4552-980b-44d4f5911cec"
+
+[[token.source_card_refs]]
+card_name = "Vampires' Vengeance"
+scryfall_oracle_id = "3a82e724-28f6-430f-a474-ab4276197963"
+scryfall_id = "40af466b-6506-4dca-abfc-15963b5e3d31"
+
+[[token.source_card_refs]]
+card_name = "Bloodtithe Harvester"
+scryfall_oracle_id = "419a8ab2-cff6-4811-a559-8791c9bb3d8e"
+scryfall_id = "13c555ad-44c9-458c-8f65-6b7b4b5d70ea"
+
+[[token.source_card_refs]]
+card_name = "Gluttonous Guest"
+scryfall_oracle_id = "2d338aa5-22bc-4cc4-a1e0-cc5018ce001e"
+scryfall_id = "1670ccb8-0127-4f22-af3a-a6a47283b7fe"
+
+[[token.source_card_refs]]
+card_name = "Belligerent Guest"
+scryfall_oracle_id = "417e798d-9ca6-4cd0-adb4-f61d3becb201"
+scryfall_id = "801741b8-b3a6-4f4a-9955-f3c29408b919"
+
+[[token.source_card_refs]]
+card_name = "Voldaren Bloodcaster // Bloodbat Summoner"
+face_name = "Voldaren Bloodcaster"
+scryfall_oracle_id = "a720f3d3-c2d7-4e50-8cc6-600120380e9c"
+scryfall_id = "5299eaa4-9223-4180-8339-8cf9af3a41b1"
+
+[[token.source_card_refs]]
 card_name = "Bloodtithe Harvester"
 scryfall_oracle_id = "419a8ab2-cff6-4811-a559-8791c9bb3d8e"
 scryfall_id = "0c95e4b1-2fa8-420d-8c55-f74badb2bafa"
+
+[[token.source_card_refs]]
+card_name = "Grisly Ritual"
+scryfall_oracle_id = "56c78349-e4fa-48ba-ae8e-d2312ae6edc6"
+scryfall_id = "f91ab125-a0f4-4c85-8433-8b0ba8865c93"
 
 [[token.source_card_refs]]
 card_name = "Strefan, Maurer Progenitor"
@@ -46929,14 +48424,50 @@ scryfall_oracle_id = "abfa5753-8c02-4e2f-8f98-b0636907293a"
 scryfall_id = "edd57db1-9a72-4ae4-bb40-26bc57fb2972"
 
 [[token.source_card_refs]]
+card_name = "Bloodtithe Harvester"
+scryfall_oracle_id = "419a8ab2-cff6-4811-a559-8791c9bb3d8e"
+scryfall_id = "ce8c5a87-deef-4c81-88ab-6817b8e4b000"
+
+[[token.source_card_refs]]
+card_name = "Gluttonous Guest"
+scryfall_oracle_id = "2d338aa5-22bc-4cc4-a1e0-cc5018ce001e"
+scryfall_id = "9fb5acb2-8a28-4b8b-8538-ebc0e1d06f27"
+
+[[token.source_card_refs]]
 card_name = "Sanguine Brushstroke"
 scryfall_oracle_id = "d2c6502d-fefd-4c9f-9d7b-6dfcc43316e1"
 scryfall_id = "b7c08707-9467-452c-96ee-2e9d3661dcb4"
 
 [[token.source_card_refs]]
+card_name = "Falkenrath Forebear"
+scryfall_oracle_id = "940080ce-c504-48c8-a763-326fef907217"
+scryfall_id = "edc71a2f-853e-4c61-b2d3-b767158d71a3"
+
+[[token.source_card_refs]]
+card_name = "Lacerate Flesh"
+scryfall_oracle_id = "201c8de7-9675-475b-8f9e-7b1935234488"
+scryfall_id = "780bc65a-4dd1-4321-b0f6-d26ecca4a9fe"
+
+[[token.source_card_refs]]
+card_name = "Restless Bloodseeker // Bloodsoaked Reveler"
+face_name = "Restless Bloodseeker"
+scryfall_oracle_id = "7aef5d2e-b66d-4822-b563-44d21d008272"
+scryfall_id = "0c6c01a9-67f7-4e96-b44e-b28379b41cc2"
+
+[[token.source_card_refs]]
 card_name = "Falkenrath Celebrants"
 scryfall_oracle_id = "3c0be888-0d66-4bad-84f4-90c3934915d7"
 scryfall_id = "3eafd571-9364-44d9-8da5-1d93c07f0300"
+
+[[token.source_card_refs]]
+card_name = "Voldaren Epicure"
+scryfall_oracle_id = "cef82674-1f61-407b-801b-a76a3803e598"
+scryfall_id = "74053281-6581-4a8d-b8bd-4352c78b1de6"
+
+[[token.source_card_refs]]
+card_name = "Olivia's Attendants"
+scryfall_oracle_id = "6b384c3c-0d6b-4bba-b4c7-5af8b32bdf1c"
+scryfall_id = "f401ae72-1e0b-405f-8e15-fa309d9e35ba"
 
 [token.token_image_ref]
 scryfall_id = "6b563165-b97f-42c6-82a8-65d8ee69e381"
@@ -47651,6 +49182,11 @@ scryfall_oracle_id = "4c6a0c30-b547-4eff-8ff4-0ca25803c076"
 scryfall_id = "2138dfbb-a4e3-49db-b908-95d0b2b7e82f"
 
 [[token.source_card_refs]]
+card_name = "Urza, Lord High Artificer"
+scryfall_oracle_id = "e87906d2-db1a-4e19-b910-adb4eb339945"
+scryfall_id = "86d744cd-225c-4279-898a-858dc316cf7f"
+
+[[token.source_card_refs]]
 card_name = "Urza's Saga"
 scryfall_oracle_id = "4c6a0c30-b547-4eff-8ff4-0ca25803c076"
 scryfall_id = "c1e0f201-42cb-46a1-901a-65bb4fc18f6c"
@@ -48259,6 +49795,21 @@ scryfall_id = "f88e1bb5-dd3a-46e9-a52d-ec42002c4a05"
 card_name = "Emmara, Soul of the Accord"
 scryfall_oracle_id = "c65ba242-3369-48a9-864f-1b1f85238f67"
 scryfall_id = "07c42262-6291-43df-ba34-83e462ab56b6"
+
+[[token.source_card_refs]]
+card_name = "Dawn of Hope"
+scryfall_oracle_id = "d7a38484-2acc-49a6-b32d-d54dddb14d31"
+scryfall_id = "6f66cf2f-191d-4cbf-a340-a516973a7751"
+
+[[token.source_card_refs]]
+card_name = "Dawn of Hope"
+scryfall_oracle_id = "d7a38484-2acc-49a6-b32d-d54dddb14d31"
+scryfall_id = "de36ecaa-62e0-4f1c-b07f-837a786dc897"
+
+[[token.source_card_refs]]
+card_name = "Trostani Discordant"
+scryfall_oracle_id = "9a2fdc0e-e0de-47fc-95e4-04e725ddf060"
+scryfall_id = "79d61bba-4404-4336-8290-51d1576f728d"
 
 [token.token_image_ref]
 scryfall_id = "20a9bda0-5673-4071-9201-83670a317f8a"
@@ -48991,6 +50542,11 @@ keywords = []
 card_name = "The Big Idea"
 scryfall_oracle_id = "976fb4c7-f330-4b8b-8f87-e6839d9a2880"
 scryfall_id = "2ec4563d-1a83-402c-b209-0e1f740a6523"
+
+[[token.source_card_refs]]
+card_name = "The Big Idea"
+scryfall_oracle_id = "976fb4c7-f330-4b8b-8f87-e6839d9a2880"
+scryfall_id = "93500a3f-86a6-4eab-9fa3-d1ec2c224a49"
 
 [token.token_image_ref]
 scryfall_id = "af1a8115-127d-4268-a4d0-95360862e5fb"
@@ -50766,6 +52322,11 @@ scryfall_oracle_id = "533767ca-7208-4c88-b160-375479b68285"
 scryfall_id = "3052eb74-496d-41eb-ace6-84a4ace4d7da"
 
 [[token.source_card_refs]]
+card_name = "Caller of the Claw"
+scryfall_oracle_id = "ec79255f-4b4d-4a0a-89d8-c59ba640275b"
+scryfall_id = "a073459e-1f00-47e0-a1b3-d30203aa35d1"
+
+[[token.source_card_refs]]
 card_name = "Fade from History"
 scryfall_oracle_id = "533767ca-7208-4c88-b160-375479b68285"
 scryfall_id = "e8eea4aa-e538-42d8-a3f2-b21d17e61654"
@@ -50775,6 +52336,16 @@ card_name = "Argoth, Sanctum of Nature // Titania, Gaea Incarnate"
 face_name = "Argoth, Sanctum of Nature"
 scryfall_oracle_id = "62648946-1708-48f4-ba40-c057563ab11b"
 scryfall_id = "79a840ed-91cf-45ea-bad2-757856e88544"
+
+[[token.source_card_refs]]
+card_name = "Grizzly Fate"
+scryfall_oracle_id = "f3073e4f-ca7e-4fde-88a4-bd7b6ebfbc8c"
+scryfall_id = "92d23432-6181-44c3-8d36-d7632a8a329f"
+
+[[token.source_card_refs]]
+card_name = "Bearscape"
+scryfall_oracle_id = "7e481e22-4122-4259-8978-4727eb307195"
+scryfall_id = "3284b61a-bd95-4846-ad3f-903cd1158867"
 
 [[token.source_card_refs]]
 card_name = "Fade from History"
@@ -50804,7 +52375,27 @@ scryfall_id = "a158c1c7-5a03-42b8-ba94-92b11af3d89e"
 [[token.source_card_refs]]
 card_name = "Grizzly Fate"
 scryfall_oracle_id = "f3073e4f-ca7e-4fde-88a4-bd7b6ebfbc8c"
+scryfall_id = "004e1457-d951-4029-8bb6-17a290793e79"
+
+[[token.source_card_refs]]
+card_name = "Grizzly Fate"
+scryfall_oracle_id = "f3073e4f-ca7e-4fde-88a4-bd7b6ebfbc8c"
 scryfall_id = "75d22bb3-824e-4699-8352-42392af307d1"
+
+[[token.source_card_refs]]
+card_name = "Words of Wilding"
+scryfall_oracle_id = "888582df-4fe2-4d05-9b62-10c90aaa76f2"
+scryfall_id = "fdb9565f-5b09-4127-b169-3146079dab84"
+
+[[token.source_card_refs]]
+card_name = "Kamahl's Summons"
+scryfall_oracle_id = "8b6ef0a2-cd90-44c8-8f11-e1983f2b1dfd"
+scryfall_id = "0edc37c6-b6a8-424f-95dd-928d03c28542"
+
+[[token.source_card_refs]]
+card_name = "Mother Bear"
+scryfall_oracle_id = "fe742976-ef13-4c25-972f-254b1ed436de"
+scryfall_id = "ce2c30dd-f28a-4400-b6ea-f26462e45afc"
 
 [token.token_image_ref]
 scryfall_id = "772dac39-269b-4a35-aad3-320279af833f"
@@ -50881,6 +52472,11 @@ subtypes = ["Dragon"]
 supertypes = []
 colors = ["Red"]
 keywords = ["Flying"]
+
+[[token.source_card_refs]]
+card_name = "Sarkhan Unbroken"
+scryfall_oracle_id = "1d37b453-f10c-42f2-8390-626a8a8eb27c"
+scryfall_id = "35ef90e4-86ac-4995-b327-0ae34ae1ebf3"
 
 [[token.source_card_refs]]
 card_name = "Sarkhan the Masterless"
@@ -51195,6 +52791,11 @@ keywords = []
 card_name = "Stroke of Midnight"
 scryfall_oracle_id = "9a107e48-3d50-4941-95b1-10f2b29a4245"
 scryfall_id = "ab135925-d924-456d-851a-6ccdaaf27271"
+
+[[token.source_card_refs]]
+card_name = "Adeline, Resplendent Cathar"
+scryfall_oracle_id = "38515f89-348b-4cf3-b7bd-1f6fe4ce2fba"
+scryfall_id = "21a0e852-7855-4a6b-8eca-191a8e83023a"
 
 [token.token_image_ref]
 scryfall_id = "06af3d5a-7b38-42f6-822f-da4e04a7f265"
@@ -51762,12 +53363,22 @@ keywords = [
 [[token.source_card_refs]]
 card_name = "Hornet Nest"
 scryfall_oracle_id = "123d2b6e-114e-4767-860d-50790382ca4a"
+scryfall_id = "27bf526c-d22a-4164-b26f-57c370f9feef"
+
+[[token.source_card_refs]]
+card_name = "Hornet Nest"
+scryfall_oracle_id = "123d2b6e-114e-4767-860d-50790382ca4a"
 scryfall_id = "cc4693c6-f532-4726-b51a-21b04f820448"
 
 [[token.source_card_refs]]
 card_name = "Hornet Nest"
 scryfall_oracle_id = "123d2b6e-114e-4767-860d-50790382ca4a"
 scryfall_id = "c7b3c3de-6e12-4b93-830f-cae5b1b40ac4"
+
+[[token.source_card_refs]]
+card_name = "Hornet Queen"
+scryfall_oracle_id = "3b1f8108-6911-49e9-8f78-f950bb58cb6c"
+scryfall_id = "4068158e-39ea-4acc-889c-e9fad93d482f"
 
 [token.token_image_ref]
 scryfall_id = "e17b804f-4dca-4101-ba8f-b732504ac488"
@@ -51839,6 +53450,16 @@ colors = [
     "White",
 ]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Goblin Trenches"
+scryfall_oracle_id = "b43f40e6-c0ad-4a12-b75d-f2ba12629bfe"
+scryfall_id = "2100844c-6a41-40f5-b7f8-9b426d5a6945"
+
+[[token.source_card_refs]]
+card_name = "Goblin Trenches"
+scryfall_oracle_id = "b43f40e6-c0ad-4a12-b75d-f2ba12629bfe"
+scryfall_id = "73744225-d432-495e-916d-b18e6d042dff"
 
 [[token.source_card_refs]]
 card_name = "Goblin Trenches"
@@ -52114,9 +53735,19 @@ scryfall_oracle_id = "0cee5539-d10b-4de2-aee8-e02f0e24ac26"
 scryfall_id = "8cae1953-0142-4510-99cf-1d7250c36f63"
 
 [[token.source_card_refs]]
+card_name = "Imperious Oligarch"
+scryfall_oracle_id = "b0381c2a-40e2-4002-82e3-ae2d687daed3"
+scryfall_id = "81758315-e863-4338-8157-e3601ad1ce99"
+
+[[token.source_card_refs]]
 card_name = "Indebted Spirit"
 scryfall_oracle_id = "c4c0a622-7325-4024-8b2e-6335f9a729e9"
 scryfall_id = "bfdbef00-bc1b-4dd6-aef5-aeb5ce454344"
+
+[[token.source_card_refs]]
+card_name = "Syndicate Messenger"
+scryfall_oracle_id = "f5f4d78b-ed2b-471b-9ece-237fb55adc13"
+scryfall_id = "183530b1-a4c1-4124-b91f-9b5619bf7905"
 
 [[token.source_card_refs]]
 card_name = "Knight of Sorrows"
@@ -52203,6 +53834,11 @@ scryfall_id = "215b4632-adce-4357-bfcf-b6014ed2a24b"
 card_name = "Riku of Many Paths"
 scryfall_oracle_id = "1cfe6e3a-f8c9-4105-ad03-0faf1fcc4626"
 scryfall_id = "21b63544-4c31-4f38-9907-0407719a60b1"
+
+[[token.source_card_refs]]
+card_name = "Ordered Migration"
+scryfall_oracle_id = "ee0a59ba-8d34-43d5-b9a5-42015588e3d5"
+scryfall_id = "04d83a07-6054-45f1-bdf9-07f2006238d2"
 
 [token.token_image_ref]
 scryfall_id = "000d9280-a79a-4f9f-822c-7aaecbff3337"
@@ -52311,6 +53947,11 @@ keywords = [
 card_name = "Dark Depths"
 scryfall_oracle_id = "c9b82110-7dfd-4617-9399-9510be449043"
 scryfall_id = "e00d16f9-ea27-4aa3-a134-4e04f934d020"
+
+[[token.source_card_refs]]
+card_name = "Dark Depths"
+scryfall_oracle_id = "c9b82110-7dfd-4617-9399-9510be449043"
+scryfall_id = "e8fa97f8-2f52-426a-84f3-a7b85fda1344"
 
 [token.token_image_ref]
 scryfall_id = "105e687e-7196-4010-a6b7-cfa42d998fa4"
@@ -53570,6 +55211,11 @@ keywords = ["Reach"]
 [[token.source_card_refs]]
 card_name = "Penumbra Spider"
 scryfall_oracle_id = "47678f44-b595-492e-af00-4e73f941e24e"
+scryfall_id = "6a989ac1-df69-45e7-98bf-564cc7c38973"
+
+[[token.source_card_refs]]
+card_name = "Penumbra Spider"
+scryfall_oracle_id = "47678f44-b595-492e-af00-4e73f941e24e"
 scryfall_id = "5bdec240-39e5-4abd-bf8d-3d26a788dc9d"
 
 [[token.source_card_refs]]
@@ -54004,6 +55650,16 @@ subtypes = ["Goblin"]
 supertypes = []
 colors = ["Red"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Empty the Warrens"
+scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
+scryfall_id = "9618ad79-bca0-47c7-85f5-e620a3ce6225"
+
+[[token.source_card_refs]]
+card_name = "Empty the Warrens"
+scryfall_oracle_id = "3a59c882-8bb8-49ba-862f-125020dd5bec"
+scryfall_id = "05af8b37-6588-42dc-a5e5-e81ccd0abb91"
 
 [token.token_image_ref]
 scryfall_id = "ccfc021b-6bcf-4c5e-a0ea-a5ce379fcbee"
@@ -54788,6 +56444,11 @@ keywords = ["Lifelink"]
 [[token.source_card_refs]]
 card_name = "Sacred Cat"
 scryfall_oracle_id = "d85ea576-a794-44bf-b405-1f1c49477409"
+scryfall_id = "4c8e85ef-d5ef-4be0-a13f-bd3715d41561"
+
+[[token.source_card_refs]]
+card_name = "Sacred Cat"
+scryfall_oracle_id = "d85ea576-a794-44bf-b405-1f1c49477409"
 scryfall_id = "6d21c5f3-64bb-4ae7-a946-1522930b6e56"
 
 [[token.source_card_refs]]
@@ -54892,6 +56553,11 @@ keywords = ["Flying"]
 [[token.source_card_refs]]
 card_name = "Lathliss, Dragon Queen"
 scryfall_oracle_id = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd"
+scryfall_id = "9460e3c6-e745-41d3-8e17-0b92fb126a16"
+
+[[token.source_card_refs]]
+card_name = "Lathliss, Dragon Queen"
+scryfall_oracle_id = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd"
 scryfall_id = "0f0cdff4-c81e-4e53-8721-748eb71d9e81"
 
 [[token.source_card_refs]]
@@ -54927,7 +56593,22 @@ scryfall_id = "17373240-6edf-4b51-a6a8-7fe4f718a51e"
 [[token.source_card_refs]]
 card_name = "Lathliss, Dragon Queen"
 scryfall_oracle_id = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd"
+scryfall_id = "8435c03c-b9a2-40fa-a979-879bd120a011"
+
+[[token.source_card_refs]]
+card_name = "Dragon Roost"
+scryfall_oracle_id = "6dc98143-7c4c-4b75-9bbb-5226d800b1d6"
+scryfall_id = "95e4f28b-c7a7-4450-b477-73e4559f0276"
+
+[[token.source_card_refs]]
+card_name = "Lathliss, Dragon Queen"
+scryfall_oracle_id = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd"
 scryfall_id = "0cb48015-627b-49cd-8dc3-d446e82b8172"
+
+[[token.source_card_refs]]
+card_name = "Day of the Dragons"
+scryfall_oracle_id = "c4df259a-cdd4-420a-8e3d-7b69da5c9f6f"
+scryfall_id = "366a934c-eb01-48c6-8393-c2fe0708ff91"
 
 [[token.source_card_refs]]
 card_name = "Sarkhan, Fireblood"
@@ -54977,6 +56658,16 @@ keywords = []
 card_name = "Jedit Ojanen, Mercenary"
 scryfall_oracle_id = "3d80fa33-9032-4c16-8355-2f18a71af67c"
 scryfall_id = "914a4923-18a6-4aa5-8510-b02e9dc7bb41"
+
+[[token.source_card_refs]]
+card_name = "Lord Windgrace"
+scryfall_oracle_id = "38a55562-1e2d-4240-9454-219a4a25d38d"
+scryfall_id = "a135d779-d223-4274-8d7f-d7b12842d93b"
+
+[[token.source_card_refs]]
+card_name = "Jedit Ojanen of Efrava"
+scryfall_oracle_id = "c065a7c0-272b-4b7e-a41c-7164352cd189"
+scryfall_id = "1685676c-19be-4220-993f-494c53f60499"
 
 [[token.source_card_refs]]
 card_name = "Jedit Ojanen, Mercenary"
@@ -55374,6 +57065,11 @@ card_name = "Subterranean Tremors"
 scryfall_oracle_id = "f0881756-de74-43b1-a9fe-c2fde93faf5a"
 scryfall_id = "1b9510b8-6601-4116-8713-ff7649c000eb"
 
+[[token.source_card_refs]]
+card_name = "Subterranean Tremors"
+scryfall_oracle_id = "f0881756-de74-43b1-a9fe-c2fde93faf5a"
+scryfall_id = "02a20564-90af-4dbd-bf5c-debc49e4f391"
+
 [token.token_image_ref]
 scryfall_id = "70345006-5cde-44f8-ab66-9d8163d4c4f6"
 scryfall_oracle_id = "49db8af8-de3b-4503-acc6-04cac2f87a2e"
@@ -55562,6 +57258,11 @@ scryfall_id = "bcb484b4-d004-4cf0-9930-a79d03e95aae"
 card_name = "Vital Splicer"
 scryfall_oracle_id = "e1899133-635d-46ff-b90d-6f8d46a1ffe1"
 scryfall_id = "d13cf68c-b54c-46e1-a720-af57aac9e570"
+
+[[token.source_card_refs]]
+card_name = "Blade Splicer"
+scryfall_oracle_id = "194166ad-0179-42a3-86b9-ba7f322ec576"
+scryfall_id = "34c0e3a0-672f-40c9-be66-8b916a4588f2"
 
 [[token.source_card_refs]]
 card_name = "Sensor Splicer"
@@ -56140,6 +57841,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Heart-Piercer Manticore"
 scryfall_oracle_id = "253bec96-108c-4880-9c04-8bc99ceafa64"
+scryfall_id = "0c4b41be-793c-4dcc-9c0d-16fbdfece30b"
+
+[[token.source_card_refs]]
+card_name = "Heart-Piercer Manticore"
+scryfall_oracle_id = "253bec96-108c-4880-9c04-8bc99ceafa64"
 scryfall_id = "6cd213a1-92f6-49dd-9ea9-41a00879faaa"
 
 [token.token_image_ref]
@@ -56241,6 +57947,11 @@ keywords = []
 card_name = "Release the Dogs"
 scryfall_oracle_id = "b97d21b4-d730-479f-872f-3e1645b66751"
 scryfall_id = "67283aec-f8ee-4275-bf5e-58cea852956a"
+
+[[token.source_card_refs]]
+card_name = "Release the Dogs"
+scryfall_oracle_id = "b97d21b4-d730-479f-872f-3e1645b66751"
+scryfall_id = "7df3cd89-02c9-4a1c-9a8a-d17a0b1030c9"
 
 [token.token_image_ref]
 scryfall_id = "8031f333-c818-4793-8cf8-232bf9088a96"
@@ -60873,6 +62584,11 @@ scryfall_oracle_id = "e7dfe47f-41fc-4071-9ad3-96cd8d9be52e"
 scryfall_id = "79e4242c-a53a-4287-976b-8e545888a1fa"
 
 [[token.source_card_refs]]
+card_name = "Royal Treatment"
+scryfall_oracle_id = "fd0f8fdc-4065-41f4-b8fb-ecb8f185774d"
+scryfall_id = "009bad41-5e96-4bb3-9f5e-66500fb8af29"
+
+[[token.source_card_refs]]
 card_name = "Besotted Knight // Betroth the Beast"
 face_name = "Betroth the Beast"
 scryfall_oracle_id = "c7b6d2cd-9105-404b-88f0-a67037fb2120"
@@ -61161,6 +62877,11 @@ colors = [
     "White",
 ]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Tolsimir Wolfblood"
+scryfall_oracle_id = "30ee2790-1f5d-4073-aae7-5e7ae30421d2"
+scryfall_id = "069ac859-e0ef-4685-bad3-5c741102b5b9"
 
 [[token.source_card_refs]]
 card_name = "Tolsimir Wolfblood"
@@ -62305,7 +64026,9 @@ source_card_names = [
     "Benevolent Offering",
     "Bishop of Wings",
     "Blessed Defiance",
+    "Brine Comber",
     "Brine Comber // Brinebound Gift",
+    "Brinebound Gift",
     "Clarion Spirit",
     "Confront the Assault",
     "Court of Grace",
@@ -62393,6 +64116,26 @@ scryfall_oracle_id = "0c4e2c90-c17b-42cc-b4d7-cf75970fbe90"
 scryfall_id = "67083aca-b077-4b12-8218-876e22476f85"
 
 [[token.source_card_refs]]
+card_name = "Kirtar's Wrath"
+scryfall_oracle_id = "4f66d82a-492f-4638-9f77-190d4a33ad7f"
+scryfall_id = "b5a0c4e6-d50e-42e8-b062-8f6ef5950ab7"
+
+[[token.source_card_refs]]
+card_name = "Spirit Cairn"
+scryfall_oracle_id = "ae896d87-59c7-4d8d-a137-9e471d3e174e"
+scryfall_id = "d8baf60f-c20b-4b2f-9fe1-df008a9273c6"
+
+[[token.source_card_refs]]
+card_name = "Avacyn's Collar"
+scryfall_oracle_id = "842e3835-fff3-4684-bfd1-e7064a1fd2e6"
+scryfall_id = "219dd7c5-0d8f-46a2-9181-3ed30d489397"
+
+[[token.source_card_refs]]
+card_name = "Triplicate Spirits"
+scryfall_oracle_id = "48090c64-f41a-447b-ad7a-54e3194f759b"
+scryfall_id = "05c90b56-6e4b-43d1-886d-a6d78da7a586"
+
+[[token.source_card_refs]]
 card_name = "Lingering Souls"
 scryfall_oracle_id = "0b8c3337-04dd-4798-8203-6d8b8cfb936b"
 scryfall_id = "1d371239-b231-455f-a724-5025284ee023"
@@ -62401,6 +64144,16 @@ scryfall_id = "1d371239-b231-455f-a724-5025284ee023"
 card_name = "Blessed Defiance"
 scryfall_oracle_id = "04e3d36f-5dec-422c-a371-15e135fdface"
 scryfall_id = "184e5208-edbe-417f-8ff8-1950d08071ab"
+
+[[token.source_card_refs]]
+card_name = "Lingering Souls"
+scryfall_oracle_id = "0b8c3337-04dd-4798-8203-6d8b8cfb936b"
+scryfall_id = "f11908e8-8c85-4eb7-b29d-b97712be42ee"
+
+[[token.source_card_refs]]
+card_name = "Haunted Dead"
+scryfall_oracle_id = "03259490-a789-4f96-8c5b-b410425bdd02"
+scryfall_id = "66210a3f-010b-4a9b-a08f-97d3ca962b0c"
 
 [[token.source_card_refs]]
 card_name = "Afterlife"
@@ -62413,9 +64166,75 @@ scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
 scryfall_id = "ab2ff619-b82a-45c1-b25a-5b6ece2afdc4"
 
 [[token.source_card_refs]]
+card_name = "Dauntless Cathar"
+scryfall_oracle_id = "c14bd133-ff17-48b3-a1c8-56c93d8c6e43"
+scryfall_id = "bf6570e3-f245-4556-89b4-a48f26b6dc4f"
+
+[[token.source_card_refs]]
+card_name = "Transluminant"
+scryfall_oracle_id = "f4d54a89-8409-4fbc-b01f-3b03f352820f"
+scryfall_id = "2f28187b-2c99-4502-99d5-3a53ff3fa008"
+
+[[token.source_card_refs]]
+card_name = "Doomed Traveler"
+scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
+scryfall_id = "32f2065f-1aff-4d6c-af4b-2c2cfb2e0595"
+
+[[token.source_card_refs]]
+card_name = "Field of Souls"
+scryfall_oracle_id = "4d7a5b14-8fce-41f2-a0d5-fff3d15f41f6"
+scryfall_id = "9816a3ef-e2a8-4d97-afbf-d190a62265bf"
+
+[[token.source_card_refs]]
+card_name = "Spirit Cairn"
+scryfall_oracle_id = "ae896d87-59c7-4d8d-a137-9e471d3e174e"
+scryfall_id = "e92c30d9-d09b-461c-a715-b33f8f5c78c8"
+
+[[token.source_card_refs]]
+card_name = "Haunted Dead"
+scryfall_oracle_id = "03259490-a789-4f96-8c5b-b410425bdd02"
+scryfall_id = "68e5693f-8414-4e1d-8a05-8bd920969f30"
+
+[[token.source_card_refs]]
+card_name = "Brine Comber // Brinebound Gift"
+face_name = "Brine Comber"
+scryfall_oracle_id = "8845ba0d-c2f4-49e4-b06e-54a06a8297e0"
+scryfall_id = "4205f8f8-7b18-4999-ac51-860fab376d79"
+
+[[token.source_card_refs]]
 card_name = "Bishop of Wings"
 scryfall_oracle_id = "af4684cf-f109-44be-adfb-7c551a36635e"
 scryfall_id = "c369d381-b48e-43cf-a032-8bcb120f443e"
+
+[[token.source_card_refs]]
+card_name = "Afterlife"
+scryfall_oracle_id = "4c13e2b5-961a-4031-84b1-15bd19b94286"
+scryfall_id = "4644694d-52e6-4d00-8cad-748899eeea84"
+
+[[token.source_card_refs]]
+card_name = "Sandsteppe Outcast"
+scryfall_oracle_id = "fccd17b1-ca0f-4649-a002-5cbf9666b510"
+scryfall_id = "b34a7501-4afc-4467-b0d6-b32d7657064e"
+
+[[token.source_card_refs]]
+card_name = "Whispering Wizard"
+scryfall_oracle_id = "321e101c-a426-4d18-be0b-c26c5348b70d"
+scryfall_id = "a3f29cbb-d802-4085-a236-86775764bc9e"
+
+[[token.source_card_refs]]
+card_name = "Doomed Traveler"
+scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
+scryfall_id = "e98c3007-c45f-4502-ae4b-693bd64f23ba"
+
+[[token.source_card_refs]]
+card_name = "Heron-Blessed Geist"
+scryfall_oracle_id = "9c5897cd-f209-4e51-adc2-d791e5671029"
+scryfall_id = "3a79a435-9b58-4bcd-8544-79d9a71d85a2"
+
+[[token.source_card_refs]]
+card_name = "Triplicate Spirits"
+scryfall_oracle_id = "48090c64-f41a-447b-ad7a-54e3194f759b"
+scryfall_id = "d7cf5453-f8b8-4f86-a2f0-fdc79f7c977f"
 
 [[token.source_card_refs]]
 card_name = "Lingering Souls"
@@ -62430,7 +64249,47 @@ scryfall_id = "5e1ae45c-ac55-468d-8e27-e72b5954ce94"
 [[token.source_card_refs]]
 card_name = "Field of Souls"
 scryfall_oracle_id = "4d7a5b14-8fce-41f2-a0d5-fff3d15f41f6"
+scryfall_id = "5faea9ff-4260-4b83-a5fb-5169bc017b14"
+
+[[token.source_card_refs]]
+card_name = "Mausoleum Guard"
+scryfall_oracle_id = "64f3af46-f8ab-4ba4-9dff-7412cefb4eea"
+scryfall_id = "43227caf-f902-46b4-936f-125d879eb54a"
+
+[[token.source_card_refs]]
+card_name = "Field of Souls"
+scryfall_oracle_id = "4d7a5b14-8fce-41f2-a0d5-fff3d15f41f6"
 scryfall_id = "a264d5f2-9e27-4c41-a76e-0dc944c6dc74"
+
+[[token.source_card_refs]]
+card_name = "Blessed Defiance"
+scryfall_oracle_id = "04e3d36f-5dec-422c-a371-15e135fdface"
+scryfall_id = "d333e35c-ca90-4aaa-950a-48b5623c31a6"
+
+[[token.source_card_refs]]
+card_name = "Teysa, Orzhov Scion"
+scryfall_oracle_id = "8191342b-b25e-4c4d-8f69-aee662148ff4"
+scryfall_id = "9eb856e6-8f63-4048-9818-cc3e65748855"
+
+[[token.source_card_refs]]
+card_name = "Kaya, Geist Hunter"
+scryfall_oracle_id = "e0edb2fc-2533-407c-85e5-4337f4233f05"
+scryfall_id = "9135b501-82be-43cb-9aa5-9cf08789c636"
+
+[[token.source_card_refs]]
+card_name = "Nearheath Chaplain"
+scryfall_oracle_id = "16c587db-d07b-47ab-8b03-c3b2cc7144f5"
+scryfall_id = "a4861c8d-5e4a-4c4b-854c-410aad2d49cb"
+
+[[token.source_card_refs]]
+card_name = "Doomed Traveler"
+scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
+scryfall_id = "8a03d414-bff9-4aba-8b0a-0ed57982251e"
+
+[[token.source_card_refs]]
+card_name = "Doomed Traveler"
+scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
+scryfall_id = "52c3f3f5-47b7-46bf-a5a8-b7a79f41236e"
 
 [[token.source_card_refs]]
 card_name = "Court of Grace"
@@ -62438,9 +64297,34 @@ scryfall_oracle_id = "f63c2438-27d4-449a-828f-f0a2ea86ff16"
 scryfall_id = "f89995b9-5409-4d3a-9518-7a4354b9d02f"
 
 [[token.source_card_refs]]
+card_name = "Luminous Angel"
+scryfall_oracle_id = "8d7cf56c-94fd-47d8-9e0f-cd3163688983"
+scryfall_id = "9b4f880d-6262-429f-91b7-def417aa13bd"
+
+[[token.source_card_refs]]
 card_name = "Clarion Spirit"
 scryfall_oracle_id = "dec20b18-afe6-405e-b47d-a757a5645c63"
 scryfall_id = "55882138-83a2-4a0a-96b0-6d5150edc4e3"
+
+[[token.source_card_refs]]
+card_name = "March of Souls"
+scryfall_oracle_id = "bca7101b-e74b-42af-ac63-1b3defb4137d"
+scryfall_id = "f07dd0f1-b80b-4af0-ae76-907ec55ec7d5"
+
+[[token.source_card_refs]]
+card_name = "Transluminant"
+scryfall_oracle_id = "f4d54a89-8409-4fbc-b01f-3b03f352820f"
+scryfall_id = "318ce4ef-38bd-4360-895f-457587164197"
+
+[[token.source_card_refs]]
+card_name = "Slayer's Plate"
+scryfall_oracle_id = "05004b4a-2e2c-4a88-a994-8576684fb64a"
+scryfall_id = "f0ad0796-0357-4e74-9d65-c7761a3f223c"
+
+[[token.source_card_refs]]
+card_name = "Afterlife"
+scryfall_oracle_id = "4c13e2b5-961a-4031-84b1-15bd19b94286"
+scryfall_id = "061ccd50-aff0-445b-9151-8fee6b3b4df4"
 
 [[token.source_card_refs]]
 card_name = "Dauntless Cathar"
@@ -62448,9 +64332,19 @@ scryfall_oracle_id = "c14bd133-ff17-48b3-a1c8-56c93d8c6e43"
 scryfall_id = "fc3b97d0-8245-48de-aa05-e6800c0339ad"
 
 [[token.source_card_refs]]
+card_name = "Not Forgotten"
+scryfall_oracle_id = "e0fa6d08-1808-4a29-b1e4-5cec9d31d798"
+scryfall_id = "05860b72-fb1b-44d8-9275-12863724a9ef"
+
+[[token.source_card_refs]]
 card_name = "Alharu, Solemn Ritualist"
 scryfall_oracle_id = "c8deef08-fcf2-41e1-8aeb-aa4e0af147ca"
 scryfall_id = "f699f8d9-8708-44ca-8d14-1ca93aa68c9e"
+
+[[token.source_card_refs]]
+card_name = "Nurturing Presence"
+scryfall_oracle_id = "3f03c834-2cb3-4c54-bee6-c64f3a5fce47"
+scryfall_id = "1b302947-5d66-425d-b67e-bf1d5846d490"
 
 [[token.source_card_refs]]
 card_name = "Lingering Souls"
@@ -62458,14 +64352,50 @@ scryfall_oracle_id = "0b8c3337-04dd-4798-8203-6d8b8cfb936b"
 scryfall_id = "278e97cf-312d-4e9e-bc39-023f4e547121"
 
 [[token.source_card_refs]]
+card_name = "Twilight Drover"
+scryfall_oracle_id = "b0d60856-80f9-4c64-9768-28a0a690ecb1"
+scryfall_id = "bbc33bb6-d71c-45f9-9030-bdef3d40a08a"
+
+[[token.source_card_refs]]
+card_name = "Seize the Soul"
+scryfall_oracle_id = "91557f08-15b1-4e3e-90fd-cec35ed0868a"
+scryfall_id = "29bf245f-e8e0-4d32-8cd7-06d832609910"
+
+[[token.source_card_refs]]
+card_name = "Blessed Defiance"
+scryfall_oracle_id = "04e3d36f-5dec-422c-a371-15e135fdface"
+scryfall_id = "a2713730-fe6b-46b6-9189-de349c712fee"
+
+[[token.source_card_refs]]
 card_name = "Doomed Traveler"
 scryfall_oracle_id = "a30907c0-fbde-4fd3-a8c7-f304305fcea7"
 scryfall_id = "9c5b6837-2381-4563-861c-73ef3b5341cd"
 
 [[token.source_card_refs]]
+card_name = "Funeral Pyre"
+scryfall_oracle_id = "02af53c1-83e6-447f-908b-2757c8aa445c"
+scryfall_id = "4d8542f6-ee34-42c6-acd5-07b0c7cc2f63"
+
+[[token.source_card_refs]]
 card_name = "Triplicate Spirits"
 scryfall_oracle_id = "48090c64-f41a-447b-ad7a-54e3194f759b"
 scryfall_id = "9d258bcc-3379-4f56-b584-be25979e5244"
+
+[[token.source_card_refs]]
+card_name = "Afterlife"
+scryfall_oracle_id = "4c13e2b5-961a-4031-84b1-15bd19b94286"
+scryfall_id = "8fa2ecf9-b53c-4f1d-9028-ca3820d043cb"
+
+[[token.source_card_refs]]
+card_name = "Brine Comber // Brinebound Gift"
+face_name = "Brinebound Gift"
+scryfall_oracle_id = "8845ba0d-c2f4-49e4-b06e-54a06a8297e0"
+scryfall_id = "4205f8f8-7b18-4999-ac51-860fab376d79"
+
+[[token.source_card_refs]]
+card_name = "Requiem Angel"
+scryfall_oracle_id = "59f10ddb-8287-4d2c-8c60-1080b108fa78"
+scryfall_id = "ddcb90f4-82c0-412c-9e90-9fffc8c5df10"
 
 [token.token_image_ref]
 scryfall_id = "6f5a5786-e2be-4bb0-b971-81d1d5cc8f52"
@@ -62737,6 +64667,11 @@ scryfall_oracle_id = "a4b37d16-95b3-4143-a0b2-ad9f2aba91f8"
 scryfall_id = "6d84e2d4-38bf-4d46-99a6-37c2dda66b16"
 
 [[token.source_card_refs]]
+card_name = "Thundering Spineback"
+scryfall_oracle_id = "c9db31d7-00cf-4200-a11f-74cc2d9e843e"
+scryfall_id = "a2e40ded-6daf-423e-8d74-2c6d448e0853"
+
+[[token.source_card_refs]]
 card_name = "Regisaur Alpha"
 scryfall_oracle_id = "0673f4e0-66ff-458c-b4ba-eb067e560cce"
 scryfall_id = "38a51e82-cbfc-4487-9a81-6e793e93f545"
@@ -62756,6 +64691,11 @@ scryfall_id = "dd6e6088-6c8d-45cc-a03f-67d7b8d3aa67"
 card_name = "Regisaur Alpha"
 scryfall_oracle_id = "0673f4e0-66ff-458c-b4ba-eb067e560cce"
 scryfall_id = "d22585cf-f84e-4c3d-a219-bd493d1122b3"
+
+[[token.source_card_refs]]
+card_name = "Thundering Spineback"
+scryfall_oracle_id = "c9db31d7-00cf-4200-a11f-74cc2d9e843e"
+scryfall_id = "51269cfb-e4a9-4dc2-a412-8fc1664f465e"
 
 [[token.source_card_refs]]
 card_name = "Baffling End"
@@ -63157,7 +65097,22 @@ scryfall_id = "6a5b3a64-3664-45c1-b6ba-47d16f71a333"
 [[token.source_card_refs]]
 card_name = "Murmuring Mystic"
 scryfall_oracle_id = "dcd4da46-5438-4454-8b1b-43ca51bda1f9"
+scryfall_id = "5dc95208-2b3a-44cd-9782-b303379b8174"
+
+[[token.source_card_refs]]
+card_name = "Murmuring Mystic"
+scryfall_oracle_id = "dcd4da46-5438-4454-8b1b-43ca51bda1f9"
+scryfall_id = "e550c890-bf16-4831-87bc-a07a4dc673ac"
+
+[[token.source_card_refs]]
+card_name = "Murmuring Mystic"
+scryfall_oracle_id = "dcd4da46-5438-4454-8b1b-43ca51bda1f9"
 scryfall_id = "9e68dcc2-bba4-4efa-97bb-3ed892037595"
+
+[[token.source_card_refs]]
+card_name = "Murmuring Mystic"
+scryfall_oracle_id = "dcd4da46-5438-4454-8b1b-43ca51bda1f9"
+scryfall_id = "d3fbbf86-d784-4dd0-b3f1-818c2a74a940"
 
 [token.token_image_ref]
 scryfall_id = "95970f74-0f28-4d81-9fbd-cb49f5d5eebc"
@@ -64575,6 +66530,11 @@ scryfall_oracle_id = "aae76e5c-f5e0-4d18-b465-e6a829be908a"
 scryfall_id = "71bcf8d7-cc70-4d52-9607-09ed7e08d61b"
 
 [[token.source_card_refs]]
+card_name = "Malik, Grim Manipulator"
+scryfall_oracle_id = "416608a1-89a4-44ce-8fd0-fab6b023d3d4"
+scryfall_id = "5cf4fee3-3059-4ca4-a47d-0848410b294d"
+
+[[token.source_card_refs]]
 card_name = "Sonic the Hedgehog"
 scryfall_oracle_id = "b07a7b00-9394-48a9-a597-17f391495909"
 scryfall_id = "072a0e6f-e636-4ce1-a253-580ab956410e"
@@ -64640,11 +66600,6 @@ scryfall_oracle_id = "3d1b09a3-f151-4218-974b-02bb6159247a"
 scryfall_id = "4156e1cc-ee40-4753-adf8-47b948cf7eb8"
 
 [[token.source_card_refs]]
-card_name = "Tireless Provisioner"
-scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
-scryfall_id = "6d2e2e8d-8382-4d98-9e25-2dff1b1d0ff8"
-
-[[token.source_card_refs]]
 card_name = "Prosper, Tome-Bound"
 scryfall_oracle_id = "1e9b0fd6-5aae-401a-8df5-d94ce6442696"
 scryfall_id = "8213f299-0f6e-499f-ba8e-7e297965d482"
@@ -64698,6 +66653,11 @@ scryfall_id = "9a6f8a6e-cc77-41d8-b753-bb3c5a5c4f48"
 card_name = "Professional Face-Breaker"
 scryfall_oracle_id = "04152e7a-969c-4858-841b-0a569a9fc1bf"
 scryfall_id = "7e7c8626-3c82-43f1-98a7-db165b30cf3b"
+
+[[token.source_card_refs]]
+card_name = "Evin, Waterdeep Opportunist"
+scryfall_oracle_id = "f688f839-c7c2-45a9-8c60-9fdb030803e6"
+scryfall_id = "c35accd3-92ee-4b0b-a30a-4dcd3252d1b8"
 
 [[token.source_card_refs]]
 card_name = "Reckoner Bankbuster // Reckoner Bankbuster"
@@ -66148,7 +68108,32 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Promise of Bunrei"
 scryfall_oracle_id = "6158ab85-a929-472c-9618-8e76d2d4b228"
+scryfall_id = "1250735d-d43b-488f-bddf-ed10261a6382"
+
+[[token.source_card_refs]]
+card_name = "Sekki, Seasons' Guide"
+scryfall_oracle_id = "1b92501c-80fe-4ae7-834e-72f57ba41a6a"
+scryfall_id = "9883e973-54c3-4bec-91d8-22f2829cdfa2"
+
+[[token.source_card_refs]]
+card_name = "Dripping-Tongue Zubera"
+scryfall_oracle_id = "78b1cb2d-1b48-4068-b6f3-8727ef9e8080"
+scryfall_id = "e752b762-38b7-463c-aa09-37fecfe71a53"
+
+[[token.source_card_refs]]
+card_name = "Promise of Bunrei"
+scryfall_oracle_id = "6158ab85-a929-472c-9618-8e76d2d4b228"
 scryfall_id = "c20c138d-e32c-4544-a2e5-a2d1adf3dc0c"
+
+[[token.source_card_refs]]
+card_name = "Gods' Eye, Gate to the Reikai"
+scryfall_oracle_id = "a66008c9-1ede-4dcf-8d35-6c0ed2390996"
+scryfall_id = "bdc33a21-d196-4c17-a296-87ff08e7ef69"
+
+[[token.source_card_refs]]
+card_name = "Honden of Life's Web"
+scryfall_oracle_id = "a1fdfcc6-4b3c-40f8-a9e4-dff9ace74a59"
+scryfall_id = "3c618af6-b02e-448f-9131-3c50ef0d433b"
 
 [[token.source_card_refs]]
 card_name = "Release to Memory"
@@ -66156,9 +68141,29 @@ scryfall_oracle_id = "3ae456e4-cb35-47be-b654-051e288622fe"
 scryfall_id = "3d609e89-cbb0-4715-bfcc-d4cbf1c303f9"
 
 [[token.source_card_refs]]
+card_name = "Baku Altar"
+scryfall_oracle_id = "8443b8c2-d0ab-4fb1-ad35-7e5e4cb345b6"
+scryfall_id = "81e1dbb8-3df8-4e7e-b74b-baab7d6f97c1"
+
+[[token.source_card_refs]]
+card_name = "Forbidden Orchard"
+scryfall_oracle_id = "cfd60d1f-9832-4408-b84e-0fd3018b015b"
+scryfall_id = "c13bea32-5dac-4338-b570-bed58109273d"
+
+[[token.source_card_refs]]
+card_name = "Spiritual Visit"
+scryfall_oracle_id = "40759025-91e1-4755-a8cf-0b68c8e9220f"
+scryfall_id = "c4e4866e-13a8-4130-9895-60e762b7efea"
+
+[[token.source_card_refs]]
 card_name = "Forbidden Orchard"
 scryfall_oracle_id = "cfd60d1f-9832-4408-b84e-0fd3018b015b"
 scryfall_id = "3f79add5-6c23-4a36-86d3-8647605d2a71"
+
+[[token.source_card_refs]]
+card_name = "Forbidden Orchard"
+scryfall_oracle_id = "cfd60d1f-9832-4408-b84e-0fd3018b015b"
+scryfall_id = "88d78261-c8c9-4e0e-b157-f70ed46c3a25"
 
 [token.token_image_ref]
 scryfall_id = "3e55bca3-43a3-44a8-b673-b1d0cf3f203f"
@@ -66728,6 +68733,11 @@ keywords = []
 card_name = "Sunscourge Champion"
 scryfall_oracle_id = "f5e9c69f-b949-4e9a-91d8-e0d52f8d8d3e"
 scryfall_id = "f0bb41cc-6edb-4a31-92cb-b17850b49432"
+
+[[token.source_card_refs]]
+card_name = "Sunscourge Champion"
+scryfall_oracle_id = "f5e9c69f-b949-4e9a-91d8-e0d52f8d8d3e"
+scryfall_id = "281bd31f-a4ae-4554-8944-fbc14db21dfd"
 
 [token.token_image_ref]
 scryfall_id = "289a9593-151e-47d0-b0de-5eb9f061515a"
@@ -68352,7 +70362,17 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Phyrexian Processor"
 scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
+scryfall_id = "6875ce99-badd-44da-8e5d-509600efa1d0"
+
+[[token.source_card_refs]]
+card_name = "Phyrexian Processor"
+scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
 scryfall_id = "04789161-f0a8-4ba5-832f-4d585c5117a6"
+
+[[token.source_card_refs]]
+card_name = "Phyrexian Processor"
+scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
+scryfall_id = "6bbb83f8-09bf-4c61-b871-e48917e61073"
 
 [[token.source_card_refs]]
 card_name = "Phyrexian Processor"
@@ -68373,6 +70393,16 @@ scryfall_id = "56df1833-4c93-499b-9f40-f8c2d0f29342"
 card_name = "Phyrexian Processor"
 scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
 scryfall_id = "86238bde-8a82-4e85-bd64-2fdce77fb72b"
+
+[[token.source_card_refs]]
+card_name = "Phyrexian Processor"
+scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
+scryfall_id = "a1d31c43-7d50-4eaf-9016-a679e92abcc9"
+
+[[token.source_card_refs]]
+card_name = "Phyrexian Processor"
+scryfall_oracle_id = "36c800cb-b1ca-4432-ad3c-4d8b90337f4c"
+scryfall_id = "66dac1f1-451b-4137-9c2e-b43b937c2edc"
 
 [[token.source_card_refs]]
 card_name = "Phyrexian Processor"
@@ -69287,6 +71317,11 @@ scryfall_oracle_id = "188656d8-4ea8-4e58-88da-b010a16eb6f2"
 scryfall_id = "e2449311-a705-4a31-a345-a36d436ae561"
 
 [[token.source_card_refs]]
+card_name = "Aquatic Incursion"
+scryfall_oracle_id = "e4212b05-d397-49fb-af8b-9e52a60e6d1e"
+scryfall_id = "4e7566ac-e9b3-4220-9b25-84d5b33f5842"
+
+[[token.source_card_refs]]
 card_name = "Deeproot Pilgrimage"
 scryfall_oracle_id = "188656d8-4ea8-4e58-88da-b010a16eb6f2"
 scryfall_id = "790d70a9-ff02-4676-a804-ee0e030dfe3b"
@@ -69515,6 +71550,11 @@ keywords = ["Haste"]
 card_name = "Earthshaker Khenra"
 scryfall_oracle_id = "df660a8e-39c2-455d-8860-522e2998a95e"
 scryfall_id = "0d60eabe-b281-4eba-9c26-287364ed2067"
+
+[[token.source_card_refs]]
+card_name = "Earthshaker Khenra"
+scryfall_oracle_id = "df660a8e-39c2-455d-8860-522e2998a95e"
+scryfall_id = "cd8f78c8-9cb6-464a-ba0e-6a3fa31cfe1d"
 
 [token.token_image_ref]
 scryfall_id = "c4bb3bd7-5aef-495e-81ba-f5d287981dbd"
@@ -70239,6 +72279,11 @@ scryfall_oracle_id = "79a1783f-ea7e-4cdf-95f5-53b383d38c66"
 scryfall_id = "2f68b4de-271b-415f-ad8f-104981bb12ab"
 
 [[token.source_card_refs]]
+card_name = "Breeding Pit"
+scryfall_oracle_id = "ddc83b35-cf7c-495b-bd30-e409b622e299"
+scryfall_id = "37c9b663-5c02-4221-9efb-59841dfd2188"
+
+[[token.source_card_refs]]
 card_name = "Szat's Will"
 scryfall_oracle_id = "f0d8bde1-76db-4bd2-ae90-3e3a3418de0b"
 scryfall_id = "9828be7b-1eae-4718-9e71-2f625121b00b"
@@ -70247,6 +72292,16 @@ scryfall_id = "9828be7b-1eae-4718-9e71-2f625121b00b"
 card_name = "Szat's Will"
 scryfall_oracle_id = "f0d8bde1-76db-4bd2-ae90-3e3a3418de0b"
 scryfall_id = "a4eaff0d-678b-47ab-915d-12e4fa43bb6b"
+
+[[token.source_card_refs]]
+card_name = "Breeding Pit"
+scryfall_oracle_id = "ddc83b35-cf7c-495b-bd30-e409b622e299"
+scryfall_id = "376dce6f-6fb8-4262-bc79-3c12656d6f08"
+
+[[token.source_card_refs]]
+card_name = "Breeding Pit"
+scryfall_oracle_id = "ddc83b35-cf7c-495b-bd30-e409b622e299"
+scryfall_id = "a0d7e85f-eba5-4fc5-9fc0-109109d368aa"
 
 [[token.source_card_refs]]
 card_name = "Tevesh Szat, Doom of Fools"
@@ -70614,6 +72669,11 @@ colors = ["White"]
 keywords = ["Lifelink"]
 
 [[token.source_card_refs]]
+card_name = "Ajani, Adversary of Tyrants"
+scryfall_oracle_id = "b25bea73-7444-4ee2-8022-611461506117"
+scryfall_id = "5a6facfa-d73c-4f10-a3b7-d2653823423d"
+
+[[token.source_card_refs]]
 card_name = "Regal Caracal"
 scryfall_oracle_id = "aa571676-b390-4b8a-baea-4c4cd60c01f6"
 scryfall_id = "b6310a82-73db-40cb-ae64-6f07f869024c"
@@ -70782,6 +72842,11 @@ subtypes = [
 supertypes = []
 colors = ["Blue"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Mysterio, Master of Illusion"
+scryfall_oracle_id = "40f664d8-4c73-44aa-8fb1-d38771a42520"
+scryfall_id = "ffca39eb-f611-46b1-9d6b-a5c90c722fb9"
 
 [[token.source_card_refs]]
 card_name = "Mysterio's Mirage"
@@ -71601,7 +73666,22 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Icatian Town"
 scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
+scryfall_id = "f7582903-57b0-42e6-991c-0f93ab9172d0"
+
+[[token.source_card_refs]]
+card_name = "Icatian Town"
+scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
+scryfall_id = "cbb7c28d-0366-4d01-84a2-f1bc9f38aa4a"
+
+[[token.source_card_refs]]
+card_name = "Icatian Town"
+scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
 scryfall_id = "fa779cce-f112-4a58-b87d-46445848793b"
+
+[[token.source_card_refs]]
+card_name = "Sarpadian Empires, Vol. VII"
+scryfall_oracle_id = "f71d55f5-f220-4cb0-9468-b8d339ab8535"
+scryfall_id = "b37a6cf7-f239-4bca-b4c3-a48932ef56b5"
 
 [[token.source_card_refs]]
 card_name = "Icatian Crier"
@@ -71612,6 +73692,21 @@ scryfall_id = "c5ba6543-ede7-45a5-8e8d-e17d3f545d3f"
 card_name = "Icatian Town"
 scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
 scryfall_id = "e6ebd5ea-df3f-4cea-bdd1-97ff1776630a"
+
+[[token.source_card_refs]]
+card_name = "Icatian Crier"
+scryfall_oracle_id = "668312dd-7b6e-46bf-9c6a-bfb03dd75b8f"
+scryfall_id = "523ab784-c77e-4b78-99fc-b5d7ed985d76"
+
+[[token.source_card_refs]]
+card_name = "Icatian Town"
+scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
+scryfall_id = "582044a0-0f4e-4de4-8bea-bc64757db198"
+
+[[token.source_card_refs]]
+card_name = "Icatian Town"
+scryfall_oracle_id = "aa8b60b6-cf55-4aaa-9caa-2b17942d8269"
+scryfall_id = "6e06788f-e87b-4071-ba7d-e0253a52132d"
 
 [token.token_image_ref]
 scryfall_id = "165164e7-5693-4d65-b789-8ed8a222365b"
@@ -71794,6 +73889,11 @@ keywords = ["Shroud"]
 card_name = "Deadly Grub"
 scryfall_oracle_id = "093112dd-ebfd-4983-9357-0a9b07e10bb1"
 scryfall_id = "44e872ae-2e41-49f5-9015-e8f9fa7da987"
+
+[[token.source_card_refs]]
+card_name = "Deadly Grub"
+scryfall_oracle_id = "093112dd-ebfd-4983-9357-0a9b07e10bb1"
+scryfall_id = "cde915a3-9c85-4365-bab9-87d446f85794"
 
 [token.token_image_ref]
 scryfall_id = "0ff2e2bd-b8e9-4563-85ad-fdbb0607fb7c"
@@ -72302,9 +74402,19 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Metrognome"
+scryfall_oracle_id = "57fe5c94-ee93-45c6-bf7e-89d177d0fe70"
+scryfall_id = "d71f153d-2d07-4a8a-b725-747bb96afe00"
+
+[[token.source_card_refs]]
 card_name = "Threefold Thunderhulk"
 scryfall_oracle_id = "b8020a8b-557b-465d-865d-b59fecd7abc1"
 scryfall_id = "699d1222-f150-46aa-9004-87b45f07eb42"
+
+[[token.source_card_refs]]
+card_name = "By Gnome Means"
+scryfall_oracle_id = "bc827191-e7ed-45ae-a084-a19d16b936e3"
+scryfall_id = "e63f29cd-5c93-47dc-acdf-37f3b12e9328"
 
 [token.token_image_ref]
 scryfall_id = "e32673cc-bec9-49b3-bc34-e2b3982ca245"
@@ -72506,6 +74616,11 @@ scryfall_id = "d9357606-e192-47e8-b9cd-e1a567903754"
 card_name = "Soul Separator"
 scryfall_oracle_id = "f1da52a4-08a0-4427-a461-a1dc6627b98e"
 scryfall_id = "9e1e52fe-bceb-416b-bd7f-2887f25c7b20"
+
+[[token.source_card_refs]]
+card_name = "Soul Separator"
+scryfall_oracle_id = "f1da52a4-08a0-4427-a461-a1dc6627b98e"
+scryfall_id = "ce861750-08b6-4c22-b9ce-da0048cb673c"
 
 [token.token_image_ref]
 scryfall_id = "ae290b7e-8ff2-4262-8ac7-8481283e2a02"
@@ -72934,6 +75049,11 @@ subtypes = [
 supertypes = []
 colors = ["White"]
 keywords = ["Flying"]
+
+[[token.source_card_refs]]
+card_name = "Oketra's Attendant"
+scryfall_oracle_id = "c45d1df1-92a7-4b36-8e27-1f88c3737bf9"
+scryfall_id = "28ee2a16-58d3-4548-85ee-c7b3a7e57d0a"
 
 [[token.source_card_refs]]
 card_name = "Oketra's Attendant"
@@ -73550,6 +75670,11 @@ keywords = [
 ]
 
 [[token.source_card_refs]]
+card_name = "Marit Lage's Slumber"
+scryfall_oracle_id = "a11d890e-38d4-467c-bc04-948979c142e0"
+scryfall_id = "a8538685-e36b-43ee-b756-7a89bc24f330"
+
+[[token.source_card_refs]]
 card_name = "Dark Depths"
 scryfall_oracle_id = "c9b82110-7dfd-4617-9399-9510be449043"
 scryfall_id = "09c224c7-418d-4b64-9d56-a87e4ff631ab"
@@ -73884,13 +76009,65 @@ scryfall_id = "baddb39b-c31f-48e4-8d43-1cc46a713416"
 [[token.source_card_refs]]
 card_name = "Bestial Menace"
 scryfall_oracle_id = "ef08d371-9d6c-4a2d-a444-d475fbf1b633"
+scryfall_id = "f0dd5077-7a1f-4a9c-8a86-9e87da909f0c"
+
+[[token.source_card_refs]]
+card_name = "Endless Swarm"
+scryfall_oracle_id = "c62a9e10-cfc6-48cc-a3f7-68d624182a5a"
+scryfall_id = "f64d9404-9685-495d-a591-63d6164a88a9"
+
+[[token.source_card_refs]]
+card_name = "Orochi Hatchery"
+scryfall_oracle_id = "65fb1945-ed7a-4f1b-bc6b-166cbec1d8ec"
+scryfall_id = "7e662e2e-f706-4d79-86ed-48b60787a5d0"
+
+[[token.source_card_refs]]
+card_name = "Snake Pit"
+scryfall_oracle_id = "115bd33d-4875-4014-ae9f-0052f5acdbb2"
+scryfall_id = "059a70a5-d4fb-445e-af98-e81821df2c59"
+
+[[token.source_card_refs]]
+card_name = "Bestial Menace"
+scryfall_oracle_id = "ef08d371-9d6c-4a2d-a444-d475fbf1b633"
 scryfall_id = "f9540288-9aef-49a2-a5da-3e42ba9dbbcd"
+
+[[token.source_card_refs]]
+card_name = "Snake Basket"
+scryfall_oracle_id = "12236231-7c6e-4edc-87dc-737115843185"
+scryfall_id = "bfda9a16-9cdb-494a-b662-ac24e3b89d0c"
+
+[[token.source_card_refs]]
+card_name = "Snake Basket"
+scryfall_oracle_id = "12236231-7c6e-4edc-87dc-737115843185"
+scryfall_id = "3a9bc174-1d10-49bf-af4f-2f6061b1796e"
+
+[[token.source_card_refs]]
+card_name = "Sosuke's Summons"
+scryfall_oracle_id = "6be663a5-70e2-435a-91ae-16168402787b"
+scryfall_id = "42359e94-9f57-45ae-ae39-d4b939813015"
+
+[[token.source_card_refs]]
+card_name = "Orochi Eggwatcher // Shidako, Broodmistress"
+face_name = "Shidako, Broodmistress"
+scryfall_oracle_id = "e448e27c-f66d-4369-8215-7f7275e456e1"
+scryfall_id = "a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22"
 
 [[token.source_card_refs]]
 card_name = "Orochi Eggwatcher // Shidako, Broodmistress"
 face_name = "Orochi Eggwatcher"
 scryfall_oracle_id = "e448e27c-f66d-4369-8215-7f7275e456e1"
 scryfall_id = "a2a0181f-44bf-487d-a685-f92a8a43afe3"
+
+[[token.source_card_refs]]
+card_name = "Orochi Eggwatcher // Shidako, Broodmistress"
+face_name = "Orochi Eggwatcher"
+scryfall_oracle_id = "e448e27c-f66d-4369-8215-7f7275e456e1"
+scryfall_id = "a4f4aa3b-c64a-4430-b1a2-a7fca87d0a22"
+
+[[token.source_card_refs]]
+card_name = "Seed the Land"
+scryfall_oracle_id = "75b39a67-6720-482f-935a-c142ca0f7891"
+scryfall_id = "ec1b0a4e-e52e-4d4e-9b12-24676d8571b1"
 
 [[token.source_card_refs]]
 card_name = "Xyris, the Writhing Storm"
@@ -74453,6 +76630,11 @@ keywords = ["Flying"]
 card_name = "Leafdrake Roost"
 scryfall_oracle_id = "b5ff42a1-1ac4-472b-8479-5e3749845305"
 scryfall_id = "5f74cf11-8deb-4623-9c1e-1e86e98bd831"
+
+[[token.source_card_refs]]
+card_name = "Leafdrake Roost"
+scryfall_oracle_id = "b5ff42a1-1ac4-472b-8479-5e3749845305"
+scryfall_id = "aa9cb544-fa42-4671-917d-e08c582f7657"
 
 [token.token_image_ref]
 scryfall_id = "c06d2c07-7d3e-46e3-86f0-7ceba3b0aee0"
@@ -76693,6 +78875,11 @@ scryfall_id = "dc04312f-3838-4e5e-bb9e-52bcf8049d09"
 [[token.source_card_refs]]
 card_name = "Toxrill, the Corrosive"
 scryfall_oracle_id = "c71b2325-bde6-4364-a93b-8477ffeb25d8"
+scryfall_id = "3bf11c3b-53ff-4b22-97a4-45b5f00cc7a3"
+
+[[token.source_card_refs]]
+card_name = "Toxrill, the Corrosive"
+scryfall_oracle_id = "c71b2325-bde6-4364-a93b-8477ffeb25d8"
 scryfall_id = "78808d46-a3a7-4598-bddf-a302977808fb"
 
 [token.token_image_ref]
@@ -77154,6 +79341,11 @@ scryfall_oracle_id = "6f6cbcd4-7a4b-4a38-bf29-995e82e658ce"
 scryfall_id = "9515329a-0738-4b23-a326-ff417f47da77"
 
 [[token.source_card_refs]]
+card_name = "Expendable Lackey"
+scryfall_oracle_id = "6f6cbcd4-7a4b-4a38-bf29-995e82e658ce"
+scryfall_id = "9e671b0f-55b9-4bff-b02a-0be1f6db193f"
+
+[[token.source_card_refs]]
 card_name = "Exotic Pets"
 scryfall_oracle_id = "497cb281-e057-42fc-937d-512855b74159"
 scryfall_id = "902f1ed8-5c10-45e4-8f2f-182e800faab4"
@@ -77235,6 +79427,11 @@ scryfall_id = "da8b764a-4de9-4c29-8f75-2babf904c1de"
 card_name = "Heliod, God of the Sun"
 scryfall_oracle_id = "4ea488b2-5ba0-4565-b928-570c8e03b926"
 scryfall_id = "f6365e12-c470-40a2-95b0-827ec4404c38"
+
+[[token.source_card_refs]]
+card_name = "Heliod, God of the Sun"
+scryfall_oracle_id = "4ea488b2-5ba0-4565-b928-570c8e03b926"
+scryfall_id = "97b40941-d43d-487d-a418-6ada2ec24b5c"
 
 [[token.source_card_refs]]
 card_name = "Heliod, God of the Sun"
@@ -79687,6 +81884,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Llanowar Mentor"
 scryfall_oracle_id = "bc7b6508-6522-4772-93b0-3985e7e75048"
+scryfall_id = "b23f0074-40ad-4057-a672-42ed4f9564c0"
+
+[[token.source_card_refs]]
+card_name = "Llanowar Mentor"
+scryfall_oracle_id = "bc7b6508-6522-4772-93b0-3985e7e75048"
 scryfall_id = "e0f894e7-adf7-4fe5-811a-8e2d8c8a88d6"
 
 [token.token_image_ref]
@@ -79708,8 +81910,10 @@ source_card_names = [
     "Crawling Sensation",
     "Dragonlair Spider",
     "Hiveheart Shaman",
+    "Infestation Expert",
     "Infestation Expert // Infested Werewolf",
     "Infested Roothold",
+    "Infested Werewolf",
     "Iridescent Hornbeetle",
     "It of the Horrid Swarm",
     "Living Hive",
@@ -79749,9 +81953,55 @@ scryfall_oracle_id = "50de88d4-0beb-45e5-9664-d4f0e280e652"
 scryfall_id = "565438a2-3b2f-4bfa-9af0-69fbcbcef99d"
 
 [[token.source_card_refs]]
+card_name = "Iridescent Hornbeetle"
+scryfall_oracle_id = "3270265f-fa9f-4ef0-a1a3-a68fc2349bf1"
+scryfall_id = "424f3f1e-f61d-4130-8f1c-52698074cc90"
+
+[[token.source_card_refs]]
+card_name = "Swarm Shambler"
+scryfall_oracle_id = "f46c72b8-e2e8-42e6-a2e7-ffa5810a9bf3"
+scryfall_id = "63ccad14-ec2b-4235-a917-c0355c16599a"
+
+[[token.source_card_refs]]
 card_name = "Scute Swarm"
 scryfall_oracle_id = "aa854d50-444c-49d9-bfb1-5476b33c1c0b"
 scryfall_id = "62c19f87-1bbc-4309-8781-4519db8b91a2"
+
+[[token.source_card_refs]]
+card_name = "Vitality Charm"
+scryfall_oracle_id = "74f5b4a9-8358-40b1-b38a-e034e2b916ac"
+scryfall_id = "e1abae21-ed8f-4e21-b227-f721b840c11f"
+
+[[token.source_card_refs]]
+card_name = "Infestation Expert // Infested Werewolf"
+face_name = "Infested Werewolf"
+scryfall_oracle_id = "bf69dc2a-9aec-4181-bbe9-70875055ec03"
+scryfall_id = "e7e246b5-9c21-45d1-951b-ab5a47b4e7e4"
+
+[[token.source_card_refs]]
+card_name = "Old Rutstein"
+scryfall_oracle_id = "8f5ffb0b-0585-4a37-8048-eda53990d1dd"
+scryfall_id = "2bda3765-c56f-4b27-83f8-d01e16265328"
+
+[[token.source_card_refs]]
+card_name = "Beacon of Creation"
+scryfall_oracle_id = "55f31c9c-a015-4965-a0c4-788b861dba21"
+scryfall_id = "5bc629de-18a3-4780-9df6-28ee54a34b81"
+
+[[token.source_card_refs]]
+card_name = "Symbiotic Wurm"
+scryfall_oracle_id = "99e3b8ee-29e3-41de-af31-a4e8800c4619"
+scryfall_id = "a60313ca-10cc-4c33-a557-1401c5721e3b"
+
+[[token.source_card_refs]]
+card_name = "Crawling Sensation"
+scryfall_oracle_id = "98441834-7da0-4d9f-88a4-a342a9b2a4c3"
+scryfall_id = "83e4d626-5017-4243-bafa-36e1cedcfb76"
+
+[[token.source_card_refs]]
+card_name = "Symbiotic Elf"
+scryfall_oracle_id = "cfaa0d5d-d9f1-4586-a7b1-6576a58c0f1e"
+scryfall_id = "33af35c6-7802-4366-ad20-1e330b4957ef"
 
 [[token.source_card_refs]]
 card_name = "The Astonishing Ant-Man"
@@ -79759,9 +82009,65 @@ scryfall_oracle_id = "6c7e4e51-099a-4398-a4b7-e2f0ddd36429"
 scryfall_id = "5d98073e-2828-4365-a8d6-f631aac0cca9"
 
 [[token.source_card_refs]]
+card_name = "Broodhatch Nantuko"
+scryfall_oracle_id = "b0a54050-3493-4ff6-8eca-e43b92c1f3d3"
+scryfall_id = "38315ba3-57a0-4aa0-b1bc-4b1fcdd763d4"
+
+[[token.source_card_refs]]
 card_name = "Saber Ants"
 scryfall_oracle_id = "9c3c9a22-e092-4845-b661-047590746498"
 scryfall_id = "58f0a2f9-5c5e-4477-ae7e-a52cf5778962"
+
+[[token.source_card_refs]]
+card_name = "Living Hive"
+scryfall_oracle_id = "1aa5df06-a61d-47e8-b12d-34009854d088"
+scryfall_id = "407dad3c-d721-412a-8b29-bc15be56d2fe"
+
+[[token.source_card_refs]]
+card_name = "Crawling Infestation"
+scryfall_oracle_id = "a42262b8-8a26-4570-a6ee-24b239d095fc"
+scryfall_id = "5a624ef1-eb3e-47b5-99b1-809766eaba93"
+
+[[token.source_card_refs]]
+card_name = "Symbiotic Wurm"
+scryfall_oracle_id = "99e3b8ee-29e3-41de-af31-a4e8800c4619"
+scryfall_id = "e0671bd0-5d81-4c15-869c-1c61d66fa767"
+
+[[token.source_card_refs]]
+card_name = "Saber Ants"
+scryfall_oracle_id = "9c3c9a22-e092-4845-b661-047590746498"
+scryfall_id = "e9269f52-1002-475d-a0f3-d652630591ca"
+
+[[token.source_card_refs]]
+card_name = "Infested Roothold"
+scryfall_oracle_id = "86ebaaf1-82eb-439e-bfca-68521ca199eb"
+scryfall_id = "f9fc7bf3-fa3f-450a-875e-05a022794181"
+
+[[token.source_card_refs]]
+card_name = "Vilespawn Spider"
+scryfall_oracle_id = "3e969073-76cc-4a2c-9abd-3a4094488fe5"
+scryfall_id = "1db5bb0b-af35-4040-9b26-4375ff656fe2"
+
+[[token.source_card_refs]]
+card_name = "One Dozen Eyes"
+scryfall_oracle_id = "b1fbf818-6699-4f05-9a91-19aa296526bf"
+scryfall_id = "c3216148-f64e-434b-80b8-772f6eb831ca"
+
+[[token.source_card_refs]]
+card_name = "Symbiotic Beast"
+scryfall_oracle_id = "70ecc25b-2004-4a3c-80c3-6d97bf0711eb"
+scryfall_id = "bb61443d-e47a-4fe1-b777-67a3670a5a56"
+
+[[token.source_card_refs]]
+card_name = "Wirewood Hivemaster"
+scryfall_oracle_id = "20339b68-b617-45a6-b569-cc6231641e88"
+scryfall_id = "ea55b4fc-366f-4906-9eaa-9085f6a22612"
+
+[[token.source_card_refs]]
+card_name = "Infestation Expert // Infested Werewolf"
+face_name = "Infestation Expert"
+scryfall_oracle_id = "bf69dc2a-9aec-4181-bbe9-70875055ec03"
+scryfall_id = "e7e246b5-9c21-45d1-951b-ab5a47b4e7e4"
 
 [[token.source_card_refs]]
 card_name = "The Astonishing Ant-Man"
@@ -79774,6 +82080,11 @@ scryfall_oracle_id = "b0a54050-3493-4ff6-8eca-e43b92c1f3d3"
 scryfall_id = "ffc29f3a-bf26-4db4-ac8e-48be4862dd11"
 
 [[token.source_card_refs]]
+card_name = "Hiveheart Shaman"
+scryfall_oracle_id = "c3780529-d47e-48dc-86f6-c1a282c3b656"
+scryfall_id = "79cacec9-af89-45ee-9f63-f3b4ca5ea280"
+
+[[token.source_card_refs]]
 card_name = "Ant-Man, Colony Commander"
 scryfall_oracle_id = "b0ed9fbe-324d-467a-a326-c6f85a4c688a"
 scryfall_id = "26faf2db-ad86-462f-b61f-c1893c9aebbf"
@@ -79782,6 +82093,11 @@ scryfall_id = "26faf2db-ad86-462f-b61f-c1893c9aebbf"
 card_name = "Dragonlair Spider"
 scryfall_oracle_id = "f17d3aa4-6e88-4973-b2a4-942098a1c463"
 scryfall_id = "7ebddcdb-9bcb-4355-9bcf-232608fb678e"
+
+[[token.source_card_refs]]
+card_name = "Crawling Sensation"
+scryfall_oracle_id = "98441834-7da0-4d9f-88a4-a342a9b2a4c3"
+scryfall_id = "aedb008c-c89b-4093-8622-ee18e217de15"
 
 [[token.source_card_refs]]
 card_name = "Symbiotic Beast"
@@ -80179,6 +82495,11 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Professional Wrestler"
+scryfall_oracle_id = "3dd92eea-02ca-4e55-8f69-8c8059dd7ee6"
+scryfall_id = "5e1bc145-8e4b-484a-bf29-4b46089d9300"
+
+[[token.source_card_refs]]
 card_name = "J. Jonah Jameson"
 scryfall_oracle_id = "de861715-fd0b-493e-9a7c-c470a23044c0"
 scryfall_id = "9ee905d6-b647-4eb1-a8d9-89add9bafc31"
@@ -80206,12 +82527,32 @@ scryfall_id = "e1ec41d4-0180-42f7-9c54-f3c39b4ffb8d"
 [[token.source_card_refs]]
 card_name = "Common Crook"
 scryfall_oracle_id = "ebcbfdba-34c7-40eb-91a9-d306ff5ae8b9"
+scryfall_id = "7d7b5a4a-5dc0-46f0-94dc-35723423f8b9"
+
+[[token.source_card_refs]]
+card_name = "Common Crook"
+scryfall_oracle_id = "ebcbfdba-34c7-40eb-91a9-d306ff5ae8b9"
 scryfall_id = "6f5872df-e692-44aa-b18d-22447f5f274c"
 
 [[token.source_card_refs]]
 card_name = "Ultimate Green Goblin"
 scryfall_oracle_id = "b5b43d01-fce6-4a00-9c19-7a7e2a09d833"
 scryfall_id = "e82d3f71-8404-40e7-b7fa-35713d1b384e"
+
+[[token.source_card_refs]]
+card_name = "Ultimate Green Goblin"
+scryfall_oracle_id = "b5b43d01-fce6-4a00-9c19-7a7e2a09d833"
+scryfall_id = "9905b88b-4b4d-4a14-8032-7f23d4517d8b"
+
+[[token.source_card_refs]]
+card_name = "Pictures of Spider-Man"
+scryfall_oracle_id = "4fd74a8c-a4e7-4988-ae02-9a73ab6ec89e"
+scryfall_id = "42b0bd7b-38a6-465c-badf-ea72989160b9"
+
+[[token.source_card_refs]]
+card_name = "J. Jonah Jameson"
+scryfall_oracle_id = "de861715-fd0b-493e-9a7c-c470a23044c0"
+scryfall_id = "380ab614-e46d-476b-bce9-fd2a8c074906"
 
 [token.token_image_ref]
 scryfall_id = "d52efeb3-661d-45e9-97c3-af167f889684"
@@ -80826,6 +83167,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Temmet, Vizier of Naktamun"
 scryfall_oracle_id = "e245d5c9-ae3a-4246-bd74-c6fed76b9fad"
+scryfall_id = "1024c07a-8764-4a78-8f82-1b1dd943e06f"
+
+[[token.source_card_refs]]
+card_name = "Temmet, Vizier of Naktamun"
+scryfall_oracle_id = "e245d5c9-ae3a-4246-bd74-c6fed76b9fad"
 scryfall_id = "6af12a34-52a1-4940-a8d5-9e9811fcd59f"
 
 [token.token_image_ref]
@@ -81272,6 +83618,11 @@ card_name = "Patagia Viper"
 scryfall_oracle_id = "b9985370-d908-431c-ad33-ec532fe07d1f"
 scryfall_id = "c9dc1daf-24bc-4564-8955-abc5989e6156"
 
+[[token.source_card_refs]]
+card_name = "Patagia Viper"
+scryfall_oracle_id = "b9985370-d908-431c-ad33-ec532fe07d1f"
+scryfall_id = "78031831-f773-489f-b1c2-c8f5537f2286"
+
 [token.token_image_ref]
 scryfall_id = "153f01ac-8601-488f-8da7-72f392c0a3c6"
 scryfall_oracle_id = "b54d7c25-6de9-4782-9336-1bf27dc8c046"
@@ -81311,6 +83662,11 @@ scryfall_id = "9cb587e1-1243-4422-8ee3-198bd247b42c"
 card_name = "Water Gun Balloon Game"
 scryfall_oracle_id = "3d190316-138e-45f5-b6f0-11667bd0630b"
 scryfall_id = "242e7c36-8f1a-4614-86c2-07d97cf516fc"
+
+[[token.source_card_refs]]
+card_name = "Water Gun Balloon Game"
+scryfall_oracle_id = "3d190316-138e-45f5-b6f0-11667bd0630b"
+scryfall_id = "3002ffee-28ec-4aa4-8433-a009273a4ada"
 
 [token.token_image_ref]
 scryfall_id = "628c542b-7579-4070-9143-6f1f7221468f"
@@ -81777,6 +84133,12 @@ scryfall_id = "e71df56a-c27f-4983-a2c7-c2412a0345b0"
 card_name = "Bloodline Keeper // Lord of Lineage"
 face_name = "Bloodline Keeper"
 scryfall_oracle_id = "434e82b5-abd4-41ac-a5b1-2dd01c667374"
+scryfall_id = "25f42544-79d1-48d1-884b-de3c0ccfce79"
+
+[[token.source_card_refs]]
+card_name = "Bloodline Keeper // Lord of Lineage"
+face_name = "Bloodline Keeper"
+scryfall_oracle_id = "434e82b5-abd4-41ac-a5b1-2dd01c667374"
 scryfall_id = "b8a289a6-a310-48c2-8162-792d6d3c4fa9"
 
 [[token.source_card_refs]]
@@ -81790,6 +84152,12 @@ card_name = "Bloodline Keeper // Lord of Lineage"
 face_name = "Lord of Lineage"
 scryfall_oracle_id = "434e82b5-abd4-41ac-a5b1-2dd01c667374"
 scryfall_id = "e71df56a-c27f-4983-a2c7-c2412a0345b0"
+
+[[token.source_card_refs]]
+card_name = "Bloodline Keeper // Lord of Lineage"
+face_name = "Lord of Lineage"
+scryfall_oracle_id = "434e82b5-abd4-41ac-a5b1-2dd01c667374"
+scryfall_id = "25f42544-79d1-48d1-884b-de3c0ccfce79"
 
 [token.token_image_ref]
 scryfall_id = "c5cb4398-e180-472e-8662-2a5902bafb4f"
@@ -82788,6 +85156,11 @@ scryfall_id = "ac8819ff-cd97-440c-8256-f3e3b4fc3c41"
 [[token.source_card_refs]]
 card_name = "Consuming Blob"
 scryfall_oracle_id = "818292cc-6261-47e4-b573-d92f03da6ded"
+scryfall_id = "56798b63-2905-4e64-a81a-87b376c08ec4"
+
+[[token.source_card_refs]]
+card_name = "Consuming Blob"
+scryfall_oracle_id = "818292cc-6261-47e4-b573-d92f03da6ded"
 scryfall_id = "4540fa4b-93e8-4749-a839-9a6e816c1145"
 
 [token.token_image_ref]
@@ -83046,6 +85419,11 @@ keywords = []
 card_name = "Oath of Gideon"
 scryfall_oracle_id = "ea168acc-22a1-4ba5-affd-fb813b93535a"
 scryfall_id = "b8a3f02b-9408-46a5-8d25-f5cec553d600"
+
+[[token.source_card_refs]]
+card_name = "Oath of Gideon"
+scryfall_oracle_id = "ea168acc-22a1-4ba5-affd-fb813b93535a"
+scryfall_id = "a8e60cdc-6480-4e0a-b45b-24585707c5a6"
 
 [[token.source_card_refs]]
 card_name = "Retreat to Emeria"
@@ -84132,9 +86510,44 @@ scryfall_oracle_id = "d3e1848a-c236-4352-a7be-b0b4699af968"
 scryfall_id = "33bdda6c-d32c-4666-b885-039eccc5a2ef"
 
 [[token.source_card_refs]]
+card_name = "Hunting Pack"
+scryfall_oracle_id = "d3e1848a-c236-4352-a7be-b0b4699af968"
+scryfall_id = "d5bd5788-1201-497b-93cf-d638b9cf5e7b"
+
+[[token.source_card_refs]]
+card_name = "Hunting Pack"
+scryfall_oracle_id = "d3e1848a-c236-4352-a7be-b0b4699af968"
+scryfall_id = "8b0f5d29-5342-4591-bdc9-c2bc9289ed41"
+
+[[token.source_card_refs]]
+card_name = "Beast Attack"
+scryfall_oracle_id = "3f5acd90-199c-4ed3-9c8a-eeac4670d876"
+scryfall_id = "6a5ebe27-2083-400e-8943-b506be470e3f"
+
+[[token.source_card_refs]]
+card_name = "Shadowbeast Sighting"
+scryfall_oracle_id = "f05d5632-0a82-45bf-b66e-22cf4080ed5e"
+scryfall_id = "c419455e-2ede-430f-84cc-4d1164898cb5"
+
+[[token.source_card_refs]]
+card_name = "Combine Chrysalis"
+scryfall_oracle_id = "a1cee8d7-f619-47b4-ba8c-faf3106d4e41"
+scryfall_id = "bfeabcc4-98cf-41ab-a304-ed3070ca6c5e"
+
+[[token.source_card_refs]]
 card_name = "Rampaging Baloths"
 scryfall_oracle_id = "2d3e6549-6cc6-434f-a189-ba3b55e64c34"
 scryfall_id = "23bc2161-50f0-4c42-9a38-824f8c0c0015"
+
+[[token.source_card_refs]]
+card_name = "Herd Baloth"
+scryfall_oracle_id = "03873314-6e64-43ab-95c0-3d8692a57a03"
+scryfall_id = "523262d4-0508-4f29-9169-da2fe69d4083"
+
+[[token.source_card_refs]]
+card_name = "Rampaging Baloths"
+scryfall_oracle_id = "2d3e6549-6cc6-434f-a189-ba3b55e64c34"
+scryfall_id = "455f4de4-c6f5-43f5-b9f0-f1e9414b7748"
 
 [[token.source_card_refs]]
 card_name = "Baloth Prime"
@@ -84910,6 +87323,11 @@ card_name = "Crested Sunmare"
 scryfall_oracle_id = "054fedbb-062e-491e-9a94-594fda33094f"
 scryfall_id = "6b17f101-0df2-4b33-b818-90c77c69ef23"
 
+[[token.source_card_refs]]
+card_name = "Crested Sunmare"
+scryfall_oracle_id = "054fedbb-062e-491e-9a94-594fda33094f"
+scryfall_id = "73e43044-c76f-410b-b7f6-8e5c2d0d9094"
+
 [token.token_image_ref]
 scryfall_id = "f3dd4d92-6471-4f4b-9c70-cbd2196e8c7b"
 scryfall_oracle_id = "e8ca1b87-27c4-41a7-ba45-ee1873712019"
@@ -84997,6 +87415,11 @@ keywords = ["Flying"]
 card_name = "Abhorrent Overlord"
 scryfall_oracle_id = "13f63240-a6bb-4333-a3dd-818725c6fb73"
 scryfall_id = "4415d050-7a76-4f8b-bf78-e33dd21fe4f1"
+
+[[token.source_card_refs]]
+card_name = "Abhorrent Overlord"
+scryfall_oracle_id = "13f63240-a6bb-4333-a3dd-818725c6fb73"
+scryfall_id = "f0c1ada8-f69c-4f84-ba66-4ac76f24cadd"
 
 [token.token_image_ref]
 scryfall_id = "26b24bbe-f5bc-44d3-b716-6612d39b07bc"
@@ -87411,6 +89834,21 @@ scryfall_id = "41f18f42-b86b-4a12-9f0d-76b761571195"
 card_name = "Hot Dog Cart"
 scryfall_oracle_id = "cf27f1f8-2d95-4a00-97f8-72a244837f08"
 scryfall_id = "6ee3b883-e9f5-426f-a2ea-96fe9ff3aba9"
+
+[[token.source_card_refs]]
+card_name = "Spider-Ham, Peter Porker"
+scryfall_oracle_id = "00b50215-e832-417f-9c80-2bc3050b6ebb"
+scryfall_id = "b1c95ee4-b60d-4868-b7e3-204849a8f544"
+
+[[token.source_card_refs]]
+card_name = "Hot Dog Cart"
+scryfall_oracle_id = "cf27f1f8-2d95-4a00-97f8-72a244837f08"
+scryfall_id = "38812303-9c39-4bc3-ab60-5a845f66e5e9"
+
+[[token.source_card_refs]]
+card_name = "City Pigeon"
+scryfall_oracle_id = "ac8cae63-270c-4f73-b29b-50f8f2395fd9"
+scryfall_id = "5303956a-87ce-4193-8bf5-5c58beab31fa"
 
 [[token.source_card_refs]]
 card_name = "City Pigeon"
@@ -92836,6 +95274,11 @@ scryfall_oracle_id = "47f221a4-b51a-46b9-a4fc-46bc8ec7ddd3"
 scryfall_id = "962dc573-612d-434b-82fb-af9c3e3c9aca"
 
 [[token.source_card_refs]]
+card_name = "Hangarback Walker"
+scryfall_oracle_id = "dde55256-5259-44e7-a267-fca45a7f0d04"
+scryfall_id = "c246b845-dfca-47a3-aa56-074d30590320"
+
+[[token.source_card_refs]]
 card_name = "Maverick Thopterist"
 scryfall_oracle_id = "71ba6f1b-2fa6-4d4c-8778-f0765b1a5d8e"
 scryfall_id = "cad17d67-538e-4c60-a582-a394032a5112"
@@ -94181,6 +96624,7 @@ source_card_names = [
     "Necromaster Dragon",
     "Necromentia",
     "Necrotic Hex",
+    "Never",
     "Never // Return",
     "Nevinyrral, Urborg Tyrant",
     "Noosegraf Mob",
@@ -94192,6 +96636,7 @@ source_card_names = [
     "Rakshasa Gravecaller",
     "Rank Officer",
     "Reap the Seagraf",
+    "Return",
     "Rise from the Tides",
     "Risen Necroregent",
     "Rotlung Reanimator",
@@ -94239,15 +96684,90 @@ colors = ["Black"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Rotlung Reanimator"
+scryfall_oracle_id = "de7f1725-833c-4784-94b1-7a33e36aec94"
+scryfall_id = "87b29d1e-9c06-4ad1-8178-b3eaa212f6f1"
+
+[[token.source_card_refs]]
+card_name = "Maalfeld Twins"
+scryfall_oracle_id = "dda4b515-49c0-43fe-9f6a-36defa326bb1"
+scryfall_id = "7c8cce8a-43b4-42aa-abbd-0835583e74bd"
+
+[[token.source_card_refs]]
+card_name = "Sarcomancy"
+scryfall_oracle_id = "bd1e93da-7524-4bdd-9738-accd76bda7f7"
+scryfall_id = "5e26f693-4e62-4925-923f-f46376a8a179"
+
+[[token.source_card_refs]]
+card_name = "Hour of Promise"
+scryfall_oracle_id = "51ff3e53-90bb-41bf-80e4-bb3fd51d574a"
+scryfall_id = "a023e08d-7a47-4897-b14b-743269b96ae9"
+
+[[token.source_card_refs]]
+card_name = "Sarcomancy"
+scryfall_oracle_id = "bd1e93da-7524-4bdd-9738-accd76bda7f7"
+scryfall_id = "76c3887a-7c26-4ec8-b522-b511fe1d67d3"
+
+[[token.source_card_refs]]
+card_name = "Bone Miser"
+scryfall_oracle_id = "3984e5f6-8643-4104-aa9c-18d474e07801"
+scryfall_id = "76dd0716-2aa0-4d57-8ead-3e48cbdf5ea9"
+
+[[token.source_card_refs]]
+card_name = "Ghoulcaller's Accomplice"
+scryfall_oracle_id = "16616aa2-5490-4fab-9de4-f37ca8c8be08"
+scryfall_id = "0dadc9ea-fd6b-449e-82cc-ca7cab7da1ce"
+
+[[token.source_card_refs]]
+card_name = "Oath of Liliana"
+scryfall_oracle_id = "0bd7fd12-a0b7-4b4e-8a33-cace6e6bd6d1"
+scryfall_id = "bc40bbd8-5624-4f76-ad25-78f997bce7cd"
+
+[[token.source_card_refs]]
+card_name = "Necromancer's Stockpile"
+scryfall_oracle_id = "dc47a97b-f511-4b97-97b2-e0309055544b"
+scryfall_id = "5fdec536-d233-40f1-9448-82c3c845ead6"
+
+[[token.source_card_refs]]
+card_name = "Skull Skaab"
+scryfall_oracle_id = "c73839bf-7500-4fd4-aa2b-e2e2e157784d"
+scryfall_id = "0e0904c0-4d9a-4c60-a6ce-5ba2fde8abea"
+
+[[token.source_card_refs]]
 card_name = "Grim Reaper's Scythe"
 scryfall_oracle_id = "91b1db8c-4bce-43d1-94ab-14b1435686c7"
 scryfall_id = "16e47e94-4bab-4818-8197-47435af7dab2"
+
+[[token.source_card_refs]]
+card_name = "Liliana, Death's Majesty"
+scryfall_oracle_id = "7fca595e-1902-40fd-a359-622caa612b6a"
+scryfall_id = "193b9060-3b1b-4f62-86db-b1a9e37d654b"
+
+[[token.source_card_refs]]
+card_name = "Gisa's Bidding"
+scryfall_oracle_id = "0abc993b-18c7-4bb8-aa58-0d06a41cb48f"
+scryfall_id = "6a6619b7-429d-4855-9d8a-0a4a1486f18e"
+
+[[token.source_card_refs]]
+card_name = "Midnight Ritual"
+scryfall_oracle_id = "389ad507-8a14-4856-8d19-c90e3104aca8"
+scryfall_id = "0e98c4f7-b0f4-48c6-b502-3dc5802d827f"
+
+[[token.source_card_refs]]
+card_name = "Doomed Dissenter"
+scryfall_oracle_id = "11cb509d-21af-48f1-b355-135ebd3e4bd1"
+scryfall_id = "a53d3ce5-3e71-44f1-ab0e-98d399287722"
 
 [[token.source_card_refs]]
 card_name = "Liliana, Heretical Healer // Liliana, Defiant Necromancer"
 face_name = "Liliana, Heretical Healer"
 scryfall_oracle_id = "b96a8ad2-3d86-459b-a34f-19c9dc07c3c4"
 scryfall_id = "d8b718d8-fca3-4b3e-9448-6067c8656a9a"
+
+[[token.source_card_refs]]
+card_name = "Dark Salvation"
+scryfall_oracle_id = "f5c2b700-da52-4436-b234-e32ba7759e17"
+scryfall_id = "d38bf566-d2f6-4f86-9e16-f39c85f8b947"
 
 [[token.source_card_refs]]
 card_name = "Rise from the Tides"
@@ -94260,9 +96780,50 @@ scryfall_oracle_id = "485f710d-5bc2-4c8f-b7e9-eed6caa261a6"
 scryfall_id = "92105bc6-b64a-4bdc-99fe-7a2ccdbd4486"
 
 [[token.source_card_refs]]
+card_name = "Liliana, Heretical Healer // Liliana, Defiant Necromancer"
+face_name = "Liliana, Defiant Necromancer"
+scryfall_oracle_id = "b96a8ad2-3d86-459b-a34f-19c9dc07c3c4"
+scryfall_id = "e1760e5f-d5f4-485f-b0ff-34e6a0c7a707"
+
+[[token.source_card_refs]]
+card_name = "Bone Miser"
+scryfall_oracle_id = "3984e5f6-8643-4104-aa9c-18d474e07801"
+scryfall_id = "2dd78806-621a-4f9f-936c-527ec9659667"
+
+[[token.source_card_refs]]
+card_name = "Havengul Runebinder"
+scryfall_oracle_id = "e91e7f62-0788-445e-ba93-2c9d233ec3ab"
+scryfall_id = "f917afb6-992d-4eb1-bf7e-8fe4af56c9bd"
+
+[[token.source_card_refs]]
+card_name = "Dying to Serve"
+scryfall_oracle_id = "2b719057-1bc0-4c3a-97c3-8377844570dd"
+scryfall_id = "8a054853-12d3-4a3b-b037-7b0ad0e9a7a1"
+
+[[token.source_card_refs]]
+card_name = "Bridge from Below"
+scryfall_oracle_id = "0f071f64-b69b-4fa0-999c-5028429e3cfb"
+scryfall_id = "52c44610-6d4b-4c14-839f-2c085badec90"
+
+[[token.source_card_refs]]
 card_name = "Grave Titan"
 scryfall_oracle_id = "f3abd4d1-a975-4e85-8684-aa0fce029670"
 scryfall_id = "3b4faa6e-5013-4c59-80f5-662a386672eb"
+
+[[token.source_card_refs]]
+card_name = "Liliana's Mastery"
+scryfall_oracle_id = "bd104c7e-311e-4b03-98d3-5f20f3a99d26"
+scryfall_id = "e28b5fce-ac73-44ec-be2c-c95d8d3579fe"
+
+[[token.source_card_refs]]
+card_name = "Zombie Infestation"
+scryfall_oracle_id = "bdce1af0-3643-4e77-88f9-320206a191d4"
+scryfall_id = "ccd5f98a-7ab5-44b3-850c-b50963dace66"
+
+[[token.source_card_refs]]
+card_name = "Liliana's Reaver"
+scryfall_oracle_id = "97332d4e-a55c-4e4f-9040-bf426a7c8e39"
+scryfall_id = "fa9396f3-a93c-47ee-91da-78af864c86c3"
 
 [[token.source_card_refs]]
 card_name = "Overseer of the Damned"
@@ -94270,9 +96831,152 @@ scryfall_oracle_id = "c1f085ce-5b52-45b3-aef0-f77f36b3da36"
 scryfall_id = "c76dc426-e538-4f72-9556-3231ad49c88d"
 
 [[token.source_card_refs]]
+card_name = "Wakedancer"
+scryfall_oracle_id = "e850743e-e4c4-4a09-b797-d5f688b51451"
+scryfall_id = "e0fd24ce-6b37-4801-b10f-5e2dbada7a41"
+
+[[token.source_card_refs]]
+card_name = "Doomed Dissenter"
+scryfall_oracle_id = "11cb509d-21af-48f1-b355-135ebd3e4bd1"
+scryfall_id = "8e2af405-63b2-4774-9ed3-d62f9f4f26e3"
+
+[[token.source_card_refs]]
+card_name = "Bridge from Below"
+scryfall_oracle_id = "0f071f64-b69b-4fa0-999c-5028429e3cfb"
+scryfall_id = "5feaed81-008e-4ec1-852d-907c0897dff6"
+
+[[token.source_card_refs]]
+card_name = "Waste Not"
+scryfall_oracle_id = "00fdcc19-88ed-46c3-91f0-095806228105"
+scryfall_id = "f5dd0247-f6a0-4f1d-ac27-a49a7e022e5b"
+
+[[token.source_card_refs]]
+card_name = "Xathrid Necromancer"
+scryfall_oracle_id = "a6b38874-c8be-47f7-a656-ba49ec9e967f"
+scryfall_id = "624b8dd3-41b5-4211-b644-b03f47c5d87f"
+
+[[token.source_card_refs]]
+card_name = "Graf Harvest"
+scryfall_oracle_id = "d3ba6922-c2f7-45ab-87a3-d4bbd770d1ba"
+scryfall_id = "ed0e46f8-5094-4e67-ad77-67e81c269657"
+
+[[token.source_card_refs]]
+card_name = "Never // Return"
+face_name = "Never"
+scryfall_oracle_id = "bf276236-18a6-4a48-b47d-5227832d26e6"
+scryfall_id = "4f4fa62a-8297-4565-9ff5-68ba4c5b91e4"
+
+[[token.source_card_refs]]
+card_name = "Rise from the Tides"
+scryfall_oracle_id = "390b862a-2a85-44bd-832c-f5bbd3eb4ea0"
+scryfall_id = "84646b55-a986-4781-8c40-319ba4c94f3a"
+
+[[token.source_card_refs]]
+card_name = "Graf Harvest"
+scryfall_oracle_id = "d3ba6922-c2f7-45ab-87a3-d4bbd770d1ba"
+scryfall_id = "83f2413f-987f-4eab-96c1-f662821546a5"
+
+[[token.source_card_refs]]
+card_name = "Diregraf Colossus"
+scryfall_oracle_id = "fd62ad01-601f-4250-bc2a-8ef3982e45c4"
+scryfall_id = "3a40e938-5528-4aa1-843b-4193dd69c698"
+
+[[token.source_card_refs]]
+card_name = "Diregraf Colossus"
+scryfall_oracle_id = "fd62ad01-601f-4250-bc2a-8ef3982e45c4"
+scryfall_id = "d0f7808b-fc76-4108-a8d5-43b38b18f8a1"
+
+[[token.source_card_refs]]
+card_name = "Ghoulcaller Gisa"
+scryfall_oracle_id = "0dd894cb-1968-471c-af08-ea7ec5ce8428"
+scryfall_id = "0bcba8d3-725b-49f9-8281-eafac15208c5"
+
+[[token.source_card_refs]]
+card_name = "Noosegraf Mob"
+scryfall_oracle_id = "f27fb53f-a983-410a-821b-e48cd8c01f2e"
+scryfall_id = "a297304e-0034-4686-bad4-c6e6527453e8"
+
+[[token.source_card_refs]]
+card_name = "Liliana, the Last Hope"
+scryfall_oracle_id = "64a9a6b4-26b5-4d23-be86-85c54e9c4727"
+scryfall_id = "8abee671-86a3-4e26-ad6a-1059c87922b0"
+
+[[token.source_card_refs]]
+card_name = "Doomed Dissenter"
+scryfall_oracle_id = "11cb509d-21af-48f1-b355-135ebd3e4bd1"
+scryfall_id = "318e58cf-31f0-460d-b456-86c0bd2220e2"
+
+[[token.source_card_refs]]
+card_name = "Liliana, Heretical Healer // Liliana, Defiant Necromancer"
+face_name = "Liliana, Heretical Healer"
+scryfall_oracle_id = "b96a8ad2-3d86-459b-a34f-19c9dc07c3c4"
+scryfall_id = "e1760e5f-d5f4-485f-b0ff-34e6a0c7a707"
+
+[[token.source_card_refs]]
+card_name = "Endless Ranks of the Dead"
+scryfall_oracle_id = "69d4ecac-4735-4667-bfc1-c8800b436d08"
+scryfall_id = "d920b00c-d4ed-4d21-abfa-da270a1ae94f"
+
+[[token.source_card_refs]]
+card_name = "Feast or Famine"
+scryfall_oracle_id = "485f710d-5bc2-4c8f-b7e9-eed6caa261a6"
+scryfall_id = "f4ac1586-c3d5-4add-bade-b527dcf4a391"
+
+[[token.source_card_refs]]
+card_name = "Sarcomancy"
+scryfall_oracle_id = "bd1e93da-7524-4bdd-9738-accd76bda7f7"
+scryfall_id = "eb5730f5-a44c-4f75-a26f-90815cfcd31e"
+
+[[token.source_card_refs]]
+card_name = "Feast or Famine"
+scryfall_oracle_id = "485f710d-5bc2-4c8f-b7e9-eed6caa261a6"
+scryfall_id = "7c185b4d-8da5-4b8a-85f0-5f0622c7bade"
+
+[[token.source_card_refs]]
+card_name = "Liliana, Death's Majesty"
+scryfall_oracle_id = "7fca595e-1902-40fd-a359-622caa612b6a"
+scryfall_id = "f42b0052-0758-489f-b7e2-208686ad82af"
+
+[[token.source_card_refs]]
+card_name = "Ghoulcaller's Accomplice"
+scryfall_oracle_id = "16616aa2-5490-4fab-9de4-f37ca8c8be08"
+scryfall_id = "63b62aaf-cc36-4235-b802-828b2c4d6341"
+
+[[token.source_card_refs]]
+card_name = "Field of the Dead"
+scryfall_oracle_id = "aa959340-c869-4caa-92c7-572bd8d23eef"
+scryfall_id = "2cf97898-1e05-4c0e-896f-ba6713bf6a7b"
+
+[[token.source_card_refs]]
 card_name = "Waste Not"
 scryfall_oracle_id = "00fdcc19-88ed-46c3-91f0-095806228105"
 scryfall_id = "fd3e5359-97c4-41ec-b18e-4abcd2205886"
+
+[[token.source_card_refs]]
+card_name = "Suspicious Shambler"
+scryfall_oracle_id = "ea6ee33f-0cba-4e96-817f-dc89c9064ead"
+scryfall_id = "ff36347c-1fc1-4493-8e45-ef3372ecce45"
+
+[[token.source_card_refs]]
+card_name = "Zombie Infestation"
+scryfall_oracle_id = "bdce1af0-3643-4e77-88f9-320206a191d4"
+scryfall_id = "c9ce5007-56ab-4361-8130-df48add1492b"
+
+[[token.source_card_refs]]
+card_name = "Liliana's Mastery"
+scryfall_oracle_id = "bd104c7e-311e-4b03-98d3-5f20f3a99d26"
+scryfall_id = "6ec0e486-c726-4e5d-807f-6d7474f2f061"
+
+[[token.source_card_refs]]
+card_name = "Endless Ranks of the Dead"
+scryfall_oracle_id = "69d4ecac-4735-4667-bfc1-c8800b436d08"
+scryfall_id = "4070b947-1d40-4f86-bfed-59de52ddcb66"
+
+[[token.source_card_refs]]
+card_name = "Never // Return"
+face_name = "Return"
+scryfall_oracle_id = "bf276236-18a6-4a48-b47d-5227832d26e6"
+scryfall_id = "4f4fa62a-8297-4565-9ff5-68ba4c5b91e4"
 
 [[token.source_card_refs]]
 card_name = "Liliana, Heretical Healer // Liliana, Defiant Necromancer"
@@ -94286,9 +96990,34 @@ scryfall_oracle_id = "bd104c7e-311e-4b03-98d3-5f20f3a99d26"
 scryfall_id = "f1c1c21f-fbbd-442d-b79f-6c42db9072e7"
 
 [[token.source_card_refs]]
+card_name = "Dark Salvation"
+scryfall_oracle_id = "f5c2b700-da52-4436-b234-e32ba7759e17"
+scryfall_id = "44290703-7988-4ef8-8277-807190a02bd5"
+
+[[token.source_card_refs]]
+card_name = "Cellar Door"
+scryfall_oracle_id = "a2f79037-86c0-430c-ba91-62ac807a44ce"
+scryfall_id = "ea1b217c-c3d4-4cdb-9ee7-2cf7c8d0eb7b"
+
+[[token.source_card_refs]]
 card_name = "Ghoulcaller Gisa"
 scryfall_oracle_id = "0dd894cb-1968-471c-af08-ea7ec5ce8428"
 scryfall_id = "779e3944-4342-4151-9963-87e8d41fd2ff"
+
+[[token.source_card_refs]]
+card_name = "Headless Rider"
+scryfall_oracle_id = "d4fdacd7-3101-44e2-a880-dde7326137a4"
+scryfall_id = "8804973b-b733-417e-9bee-828efbcb4453"
+
+[[token.source_card_refs]]
+card_name = "Drunau Corpse Trawler"
+scryfall_oracle_id = "870ca989-0e72-4e74-9570-57e129298f2e"
+scryfall_id = "b06a3112-a27e-44ba-872a-c7fb5e0b29ad"
+
+[[token.source_card_refs]]
+card_name = "Feast or Famine"
+scryfall_oracle_id = "485f710d-5bc2-4c8f-b7e9-eed6caa261a6"
+scryfall_id = "302ec21d-bb10-4651-80da-11852768165d"
 
 [token.token_image_ref]
 scryfall_id = "17f001ab-514b-49e7-a657-b2872ad7a1de"
@@ -94752,6 +97481,11 @@ subtypes = ["Goblin"]
 supertypes = []
 colors = ["Red"]
 keywords = ["Haste"]
+
+[[token.source_card_refs]]
+card_name = "Rakdos Guildmage"
+scryfall_oracle_id = "650949ca-609b-46c5-bc6b-6f782cdcb6d2"
+scryfall_id = "0e01fef8-5563-4dec-ab8e-e486e19e202c"
 
 [[token.source_card_refs]]
 card_name = "Rakdos Guildmage"
@@ -95702,9 +98436,19 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Big Score"
+scryfall_oracle_id = "a5cbd257-c836-493e-bb1a-76242619dea2"
+scryfall_id = "9cf2452d-17af-4bb2-8a52-348d6e5e08b9"
+
+[[token.source_card_refs]]
 card_name = "Gala Greeters"
 scryfall_oracle_id = "cce081eb-8820-415a-a7b2-3c5b9d4a2601"
 scryfall_id = "da271d69-f086-4267-b044-5dbc01e5c6de"
+
+[[token.source_card_refs]]
+card_name = "Big Score"
+scryfall_oracle_id = "a5cbd257-c836-493e-bb1a-76242619dea2"
+scryfall_id = "8721dca7-9b24-4e66-a51f-7100988310e8"
 
 [token.token_image_ref]
 scryfall_id = "96103710-10a8-4457-bd7d-b14445196397"
@@ -96036,6 +98780,17 @@ colors = ["Blue"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Euroakus"
+scryfall_oracle_id = "e11a022c-140d-4b7f-84b0-17885f76faa6"
+scryfall_id = "4a4039bd-ed03-4eef-8a3d-97f134475974"
+
+[[token.source_card_refs]]
+card_name = "Docent of Perfection // Final Iteration"
+face_name = "Final Iteration"
+scryfall_oracle_id = "85e797de-da27-4cd5-8fa4-4aef948988b2"
+scryfall_id = "2c983363-f900-45f5-b906-d56b91d5c260"
+
+[[token.source_card_refs]]
 card_name = "Docent of Perfection // Final Iteration"
 face_name = "Final Iteration"
 scryfall_oracle_id = "85e797de-da27-4cd5-8fa4-4aef948988b2"
@@ -96046,6 +98801,12 @@ card_name = "Docent of Perfection // Final Iteration"
 face_name = "Docent of Perfection"
 scryfall_oracle_id = "85e797de-da27-4cd5-8fa4-4aef948988b2"
 scryfall_id = "96658239-3169-42ef-9983-cd4da24e0f4c"
+
+[[token.source_card_refs]]
+card_name = "Docent of Perfection // Final Iteration"
+face_name = "Docent of Perfection"
+scryfall_oracle_id = "85e797de-da27-4cd5-8fa4-4aef948988b2"
+scryfall_id = "2c983363-f900-45f5-b906-d56b91d5c260"
 
 [token.token_image_ref]
 scryfall_id = "547ba2bc-2520-4d79-b9c9-a17f921df1bd"
@@ -96772,9 +99533,24 @@ scryfall_oracle_id = "9b568c34-ba0a-44a7-a0ee-bee3a37b3396"
 scryfall_id = "61f766b8-a92e-4353-b457-ac62fc470713"
 
 [[token.source_card_refs]]
+card_name = "Tyvar Kell"
+scryfall_oracle_id = "14c8a590-88ec-4982-ad7b-36a219ff6de7"
+scryfall_id = "3c772bcf-2468-42d0-a671-f57814ba8cbb"
+
+[[token.source_card_refs]]
+card_name = "Ambassador Oak"
+scryfall_oracle_id = "4045c24e-098f-4582-8c50-576a94c7b705"
+scryfall_id = "5be17ab1-a94d-4ba5-9468-a1df345a1eda"
+
+[[token.source_card_refs]]
 card_name = "Lathril, Blade of the Elves"
 scryfall_oracle_id = "9b568c34-ba0a-44a7-a0ee-bee3a37b3396"
 scryfall_id = "8d4e5480-a287-4a25-b855-a26dae555b1c"
+
+[[token.source_card_refs]]
+card_name = "Dwynen's Elite"
+scryfall_oracle_id = "3d4a7dd3-9258-4bd1-adc4-08f0205e196a"
+scryfall_id = "2e70732f-68c1-4341-879e-5c9c68ea8503"
 
 [token.token_image_ref]
 scryfall_id = "315c45f4-7bc9-45d5-bbf5-2533cf80af60"
@@ -99815,6 +102591,21 @@ scryfall_oracle_id = "a5656dab-5ce6-48fd-9eae-2c06969bb8df"
 scryfall_id = "c8c0be82-6448-4ae9-aed6-147b8e2988f0"
 
 [[token.source_card_refs]]
+card_name = "Ogre Slumlord"
+scryfall_oracle_id = "0a5e3748-2e58-4e53-9653-8af4e21cf223"
+scryfall_id = "9342052f-6b6b-40b9-bbc9-7ba3e8365fe1"
+
+[[token.source_card_refs]]
+card_name = "Ogre Slumlord"
+scryfall_oracle_id = "0a5e3748-2e58-4e53-9653-8af4e21cf223"
+scryfall_id = "b1f176f9-d353-479e-a808-54dc5e8ff746"
+
+[[token.source_card_refs]]
+card_name = "Lab Rats"
+scryfall_oracle_id = "c53d6d3e-64e3-48b9-afab-3bde3164888f"
+scryfall_id = "3132c128-e0bd-4524-9526-914b3c7181fc"
+
+[[token.source_card_refs]]
 card_name = "Mad Ratter"
 scryfall_oracle_id = "779fa24d-e9d2-475d-b3aa-dc0388b18307"
 scryfall_id = "d78fd600-d6ed-4f16-8aeb-02945044d235"
@@ -99830,9 +102621,19 @@ scryfall_oracle_id = "a5656dab-5ce6-48fd-9eae-2c06969bb8df"
 scryfall_id = "be464d88-8933-46e8-97b0-3be05f1976a3"
 
 [[token.source_card_refs]]
+card_name = "Lab Rats"
+scryfall_oracle_id = "c53d6d3e-64e3-48b9-afab-3bde3164888f"
+scryfall_id = "6fd5d79e-cfd8-484b-bbc8-785177922e30"
+
+[[token.source_card_refs]]
 card_name = "Marrow-Gnawer"
 scryfall_oracle_id = "2b934761-5720-477b-94b7-d1d91dc581a6"
 scryfall_id = "3ce0ce55-bf61-491e-9136-6f62b5aa5795"
+
+[[token.source_card_refs]]
+card_name = "Marrow-Gnawer"
+scryfall_oracle_id = "2b934761-5720-477b-94b7-d1d91dc581a6"
+scryfall_id = "72e4548b-c171-4f10-b896-af37543dcf0f"
 
 [[token.source_card_refs]]
 card_name = "Rat King, Pale Piper"
@@ -99843,6 +102644,21 @@ scryfall_id = "9b215ce4-a085-4627-99b1-f4f1344ad41b"
 card_name = "Big Apple, 3 a.m."
 scryfall_oracle_id = "dd01ef1f-f6be-498f-82e0-dc04833e685f"
 scryfall_id = "b9cc16f9-fea3-4527-9b81-3c84ce9c5e01"
+
+[[token.source_card_refs]]
+card_name = "Marrow-Gnawer"
+scryfall_oracle_id = "2b934761-5720-477b-94b7-d1d91dc581a6"
+scryfall_id = "03648d6b-01a2-4de0-8d2a-c49f45d3d803"
+
+[[token.source_card_refs]]
+card_name = "Mad Ratter"
+scryfall_oracle_id = "779fa24d-e9d2-475d-b3aa-dc0388b18307"
+scryfall_id = "36b15eb3-ad86-48cd-b414-b8a06f61635d"
+
+[[token.source_card_refs]]
+card_name = "Plague of Vermin"
+scryfall_oracle_id = "efc12acf-ffef-40a6-b2ce-fe93e89ad840"
+scryfall_id = "6c6aca69-1624-420f-b83e-290a2c38291e"
 
 [[token.source_card_refs]]
 card_name = "Piper of the Swarm"
@@ -100101,14 +102917,34 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Deranged Hermit"
+scryfall_oracle_id = "b9cd714b-2ad8-4fdb-a8aa-82b17730e071"
+scryfall_id = "bf0e94c9-61c4-4cc0-b5ce-db62bc2660ee"
+
+[[token.source_card_refs]]
 card_name = "Specimen Collector"
 scryfall_oracle_id = "fdb51cc1-ce0e-4920-b123-1cdd570fc38b"
 scryfall_id = "e0b291b4-1e90-40f6-b282-5c6c0c1dc7af"
 
 [[token.source_card_refs]]
+card_name = "Squirrel Sanctuary"
+scryfall_oracle_id = "693d20e9-ad92-44ad-9190-d247c94660eb"
+scryfall_id = "919ae9b1-cd82-4c54-923e-689e16b6bad6"
+
+[[token.source_card_refs]]
+card_name = "Nut Collector"
+scryfall_oracle_id = "4e1bc03c-e131-4422-beba-0a45a26fdf43"
+scryfall_id = "f4eec210-5df0-4fb8-8eb1-e616d9995acc"
+
+[[token.source_card_refs]]
 card_name = "Nut Collector"
 scryfall_oracle_id = "4e1bc03c-e131-4422-beba-0a45a26fdf43"
 scryfall_id = "1b866327-a857-485b-9399-4e61828e1d76"
+
+[[token.source_card_refs]]
+card_name = "Acorn Harvest"
+scryfall_oracle_id = "6aeba615-2d37-4eb8-a377-41a517e95aa3"
+scryfall_id = "32987720-cc0c-416b-b79b-217d3b37542d"
 
 [[token.source_card_refs]]
 card_name = "Chatter of the Squirrel"
@@ -100121,9 +102957,29 @@ scryfall_oracle_id = "80312910-5d53-44f1-9982-e46dc7532abb"
 scryfall_id = "d8b94ebb-0b3a-4e68-8c0c-3a61ac32f3ef"
 
 [[token.source_card_refs]]
+card_name = "Liege of the Hollows"
+scryfall_oracle_id = "bef7441e-5a44-46bc-8141-8e02ecd06fce"
+scryfall_id = "dff4512b-8244-4e38-bffb-0062a97d9531"
+
+[[token.source_card_refs]]
+card_name = "Verdant Command"
+scryfall_oracle_id = "5a5d426b-e5eb-44f0-b5fe-c258bec6d59e"
+scryfall_id = "6d3beeda-ae1d-4215-8318-f5670b5bfbc5"
+
+[[token.source_card_refs]]
+card_name = "Chatterfang, Squirrel General"
+scryfall_oracle_id = "f15b3b76-d38a-48db-bb44-3296183c8641"
+scryfall_id = "30310d1c-27b5-4d49-95ea-aad530190974"
+
+[[token.source_card_refs]]
 card_name = "Squirrel Nest"
 scryfall_oracle_id = "2d584333-b25e-4291-a2c9-80c6d9f8732a"
 scryfall_id = "29788426-7a12-4a04-8dbe-c434445b8e0f"
+
+[[token.source_card_refs]]
+card_name = "Chatter of the Squirrel"
+scryfall_oracle_id = "b0aaa4b1-5188-43a6-997d-7a9b2ad452bc"
+scryfall_id = "84273844-7fab-4ff7-afb3-c82153132daf"
 
 [[token.source_card_refs]]
 card_name = "Druid's Call"
@@ -100131,9 +102987,24 @@ scryfall_oracle_id = "e71f4fe8-2ecd-450b-8c41-5e38d749f59d"
 scryfall_id = "7390d66f-9924-466a-9f32-0dff83c82d9e"
 
 [[token.source_card_refs]]
+card_name = "Nested Shambler"
+scryfall_oracle_id = "bfa882ee-de18-4ef8-8957-3e04ed6e3c1e"
+scryfall_id = "d9a0ff44-e7c6-4347-a222-0598e2b4ecf7"
+
+[[token.source_card_refs]]
 card_name = "The Unbeatable Squirrel Girl"
 scryfall_oracle_id = "80312910-5d53-44f1-9982-e46dc7532abb"
 scryfall_id = "ef518e5b-7942-4e66-aee0-a1c2aa1f9754"
+
+[[token.source_card_refs]]
+card_name = "Nantuko Shrine"
+scryfall_oracle_id = "fc32ec2b-5432-41cc-ab4c-d9f986126392"
+scryfall_id = "4b66bab3-ee6f-4f74-bbc1-8099c9c4904b"
+
+[[token.source_card_refs]]
+card_name = "Form of the Squirrel"
+scryfall_oracle_id = "4cdea12f-f221-4afa-9a41-21007bbbacc8"
+scryfall_id = "2241203c-1219-4e75-9973-7e1a44885341"
 
 [[token.source_card_refs]]
 card_name = "Squirrel Nest"
@@ -100146,9 +103017,34 @@ scryfall_oracle_id = "56d13879-2dc5-4d84-918b-4bd1a5fc2a33"
 scryfall_id = "9fed5706-d7bd-4c8c-b301-4909b3167d06"
 
 [[token.source_card_refs]]
+card_name = "Chatter of the Squirrel"
+scryfall_oracle_id = "b0aaa4b1-5188-43a6-997d-7a9b2ad452bc"
+scryfall_id = "1f9b9720-d15a-4d07-af8c-a26409043696"
+
+[[token.source_card_refs]]
 card_name = "Scurry Oak"
 scryfall_oracle_id = "eee6c02b-7d6a-4445-ad27-8b03176147d4"
 scryfall_id = "91323e4a-4fd3-44c6-b124-277901fb8aae"
+
+[[token.source_card_refs]]
+card_name = "Squirrel Wrangler"
+scryfall_oracle_id = "4021b6b4-9b87-4dd5-a5df-79540bedbe87"
+scryfall_id = "7094be2a-454e-4e4d-a540-c5c80e37468a"
+
+[[token.source_card_refs]]
+card_name = "Deranged Hermit"
+scryfall_oracle_id = "b9cd714b-2ad8-4fdb-a8aa-82b17730e071"
+scryfall_id = "c25df202-0dd4-448d-8cb3-11fd7df0d505"
+
+[[token.source_card_refs]]
+card_name = "Scurry Oak"
+scryfall_oracle_id = "eee6c02b-7d6a-4445-ad27-8b03176147d4"
+scryfall_id = "c98a3c11-9761-4037-a6bf-f5d41108b738"
+
+[[token.source_card_refs]]
+card_name = "Chatterstorm"
+scryfall_oracle_id = "7e6c7b57-bd6a-4ac8-bcab-c3a879f479c2"
+scryfall_id = "aa2bb6af-ba3d-410a-9cc7-85ac0f5b5f5b"
 
 [[token.source_card_refs]]
 card_name = "Comet, Stellar Pup"
@@ -100156,14 +103052,49 @@ scryfall_oracle_id = "e7c67480-1816-4071-9eab-a1d1b535a344"
 scryfall_id = "c3385549-0342-4c51-9bae-888d34cf0087"
 
 [[token.source_card_refs]]
+card_name = "Chitterspitter"
+scryfall_oracle_id = "4a338863-d599-46e7-9c30-e11b898ae1b0"
+scryfall_id = "c85d9cd2-8de4-47b1-81e8-8f0301c83bfc"
+
+[[token.source_card_refs]]
 card_name = "Underworld Hermit"
 scryfall_oracle_id = "f7f4ddc9-cea0-42f9-bbca-2ad87a24bfc8"
 scryfall_id = "a66dbfed-34e7-4872-87d7-5ddae5d98b5b"
 
 [[token.source_card_refs]]
+card_name = "Squirrel Nest"
+scryfall_oracle_id = "2d584333-b25e-4291-a2c9-80c6d9f8732a"
+scryfall_id = "22eccb27-1723-4c5a-96b8-85e6e5739c30"
+
+[[token.source_card_refs]]
+card_name = "Drey Keeper"
+scryfall_oracle_id = "7223ef44-0bfb-4108-810d-134174ff26b0"
+scryfall_id = "5c2d77ee-73d5-4eba-b188-4a0f298c1642"
+
+[[token.source_card_refs]]
+card_name = "Specimen Collector"
+scryfall_oracle_id = "fdb51cc1-ce0e-4920-b123-1cdd570fc38b"
+scryfall_id = "a325b3f1-67f6-4b56-8572-94e9970a5acc"
+
+[[token.source_card_refs]]
+card_name = "Earl of Squirrel"
+scryfall_oracle_id = "edc4d1fb-f482-4f2b-985e-1e4d5941e574"
+scryfall_id = "acf8fa0e-fab4-468b-a32b-c8be9347f4d8"
+
+[[token.source_card_refs]]
+card_name = "Druid's Call"
+scryfall_oracle_id = "e71f4fe8-2ecd-450b-8c41-5e38d749f59d"
+scryfall_id = "e22318a5-80c8-4fa3-ad05-8d3035caf336"
+
+[[token.source_card_refs]]
 card_name = "Squirrel Wrangler"
 scryfall_oracle_id = "4021b6b4-9b87-4dd5-a5df-79540bedbe87"
 scryfall_id = "feb48ab0-5f7e-44f2-896e-1cd8c4afac7e"
+
+[[token.source_card_refs]]
+card_name = "Squirrel Wrangler"
+scryfall_oracle_id = "4021b6b4-9b87-4dd5-a5df-79540bedbe87"
+scryfall_id = "97033651-05dc-4078-831d-5ea6a37e6ae3"
 
 [token.token_image_ref]
 scryfall_id = "fd0474f3-682d-4c6d-b902-84f3250aa269"
@@ -100942,6 +103873,11 @@ card_name = "Resilient Khenra"
 scryfall_oracle_id = "eb23f999-e7f9-4082-b322-5b00ba64b458"
 scryfall_id = "033a69fb-2af9-426c-b1d6-3e5b18c78c9a"
 
+[[token.source_card_refs]]
+card_name = "Resilient Khenra"
+scryfall_oracle_id = "eb23f999-e7f9-4082-b322-5b00ba64b458"
+scryfall_id = "0e0a3128-b25d-402a-a13c-e0677ad43468"
+
 [token.token_image_ref]
 scryfall_id = "c1326c5d-b5a5-4942-b15d-37830ac62c7d"
 scryfall_oracle_id = "5bbd780b-cc80-4000-a357-7c341a9d45f1"
@@ -101507,6 +104443,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Secure the Wastes"
 scryfall_oracle_id = "b2347910-d6c6-4681-8316-7ef27056485c"
+scryfall_id = "aadf5e24-1ac0-40b4-8702-cd0e077c17e0"
+
+[[token.source_card_refs]]
+card_name = "Secure the Wastes"
+scryfall_oracle_id = "b2347910-d6c6-4681-8316-7ef27056485c"
 scryfall_id = "44f0da2e-3513-4891-bea2-27dd138064b3"
 
 [[token.source_card_refs]]
@@ -101515,9 +104456,19 @@ scryfall_oracle_id = "09619943-6aec-4080-ace5-a0c6ebb23f1c"
 scryfall_id = "be898edb-35dd-4896-96d9-323aca64a2ce"
 
 [[token.source_card_refs]]
+card_name = "Najeela, the Blade-Blossom"
+scryfall_oracle_id = "09619943-6aec-4080-ace5-a0c6ebb23f1c"
+scryfall_id = "08eb1bef-b00d-490b-a631-2849e0d1fd8e"
+
+[[token.source_card_refs]]
 card_name = "Mardu Hordechief"
 scryfall_oracle_id = "f9ea5b9e-a23d-48cf-8601-56e79ca844f9"
 scryfall_id = "6cd635fe-0ea2-4b9f-8bd7-86180a98cfad"
+
+[[token.source_card_refs]]
+card_name = "Najeela, the Blade-Blossom"
+scryfall_oracle_id = "09619943-6aec-4080-ace5-a0c6ebb23f1c"
+scryfall_id = "5aa5bec9-904f-42fb-9511-4706d6e6767e"
 
 [[token.source_card_refs]]
 card_name = "Najeela, the Blade-Blossom"
@@ -101528,6 +104479,11 @@ scryfall_id = "a84d0c3c-7382-46f9-a826-44100ac7cb41"
 card_name = "Najeela, the Blade-Blossom"
 scryfall_oracle_id = "09619943-6aec-4080-ace5-a0c6ebb23f1c"
 scryfall_id = "385bd474-fb4b-4c19-b583-ac2fa2e18475"
+
+[[token.source_card_refs]]
+card_name = "Najeela, the Blade-Blossom"
+scryfall_oracle_id = "09619943-6aec-4080-ace5-a0c6ebb23f1c"
+scryfall_id = "cc30e027-8cb8-4b06-a24a-6ad49d6a2cf3"
 
 [token.token_image_ref]
 scryfall_id = "3053e02b-7157-4fb6-9427-d64a68ea29c3"
@@ -101679,6 +104635,16 @@ keywords = []
 card_name = "Desert Warfare"
 scryfall_oracle_id = "de301ef8-8ba0-423d-9117-a8492a58d01b"
 scryfall_id = "bc7778d4-f1b6-4295-adb9-78ba7c185e9d"
+
+[[token.source_card_refs]]
+card_name = "Hazezon Tamar"
+scryfall_oracle_id = "d298df4e-7b60-4495-9773-cc81954b7dd9"
+scryfall_id = "4cd43773-2a6f-4f03-bcee-de32049561e5"
+
+[[token.source_card_refs]]
+card_name = "Hazezon Tamar"
+scryfall_oracle_id = "d298df4e-7b60-4495-9773-cc81954b7dd9"
+scryfall_id = "17fc3a85-c6b9-4fd2-a6a2-d3210708e5ea"
 
 [[token.source_card_refs]]
 card_name = "Desert Warfare"
@@ -101929,6 +104895,11 @@ keywords = [
     "Flying",
     "Vigilance",
 ]
+
+[[token.source_card_refs]]
+card_name = "Aven Wind Guide"
+scryfall_oracle_id = "bb813ffa-2615-4177-a7fb-6e0dfb819fc2"
+scryfall_id = "878d4576-8079-4555-938b-1e318c5f332e"
 
 [[token.source_card_refs]]
 card_name = "Aven Wind Guide"
@@ -103988,6 +106959,11 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Beast Within"
+scryfall_oracle_id = "7735eeba-693b-47e2-bd51-414379cf1016"
+scryfall_id = "7f419a04-7a18-4ea4-9581-bbc35bec4f16"
+
+[[token.source_card_refs]]
 card_name = "Garruk Wildspeaker"
 scryfall_oracle_id = "186b4def-4fff-4a2b-bcbf-5318b0ac5fa9"
 scryfall_id = "fbbd5627-2f55-4101-981b-49f5f45db578"
@@ -104006,12 +106982,42 @@ scryfall_id = "c30267b1-a7ea-45cd-99a8-6b0e6ddbc395"
 [[token.source_card_refs]]
 card_name = "Beast Within"
 scryfall_oracle_id = "7735eeba-693b-47e2-bd51-414379cf1016"
+scryfall_id = "b6b6c66f-e3e0-4904-ae41-2ecc786f70c5"
+
+[[token.source_card_refs]]
+card_name = "Midsummer Revel"
+scryfall_oracle_id = "d3579282-5045-4b37-9998-9a282e9932b9"
+scryfall_id = "b40a7f65-10fe-4ce5-ad1c-be53a635d7a9"
+
+[[token.source_card_refs]]
+card_name = "Beast Within"
+scryfall_oracle_id = "7735eeba-693b-47e2-bd51-414379cf1016"
+scryfall_id = "da5775cc-7df2-4494-866e-216446ffddff"
+
+[[token.source_card_refs]]
+card_name = "Primeval Bounty"
+scryfall_oracle_id = "f633c16d-d943-421c-ad18-af35db9ec9fc"
+scryfall_id = "c8123d01-da65-4d03-9f23-3842fba5fc28"
+
+[[token.source_card_refs]]
+card_name = "Bringer of the Green Dawn"
+scryfall_oracle_id = "f0548af1-d1cc-44d1-b5a0-f013563f29de"
+scryfall_id = "bc208f3e-5a6a-4fae-8a7c-2bed28ad0c41"
+
+[[token.source_card_refs]]
+card_name = "Beast Within"
+scryfall_oracle_id = "7735eeba-693b-47e2-bd51-414379cf1016"
 scryfall_id = "12666334-5c82-4228-bc33-4db2bba127f5"
 
 [[token.source_card_refs]]
 card_name = "Beast Within"
 scryfall_oracle_id = "7735eeba-693b-47e2-bd51-414379cf1016"
 scryfall_id = "299f1f93-ecee-4ed8-a77e-6ebc4b85328d"
+
+[[token.source_card_refs]]
+card_name = "Thragtusk"
+scryfall_oracle_id = "0dd0e91a-d16b-4718-8d11-1a3fcf8e0753"
+scryfall_id = "d0594c41-0361-4a3b-a9cd-60f4e3b0cffe"
 
 [[token.source_card_refs]]
 card_name = "Garruk Wildspeaker // Garruk Wildspeaker"
@@ -104040,6 +107046,11 @@ card_name = "Garruk Wildspeaker // Garruk Wildspeaker"
 face_name = "Garruk Wildspeaker"
 scryfall_oracle_id = "186b4def-4fff-4a2b-bcbf-5318b0ac5fa9"
 scryfall_id = "c05c6c38-d204-458c-af17-4cf5efd2c7fc"
+
+[[token.source_card_refs]]
+card_name = "Pulse of the Tangle"
+scryfall_oracle_id = "26f034b1-9a96-4371-a28e-be00b02d9d60"
+scryfall_id = "88cf1c67-9edc-42dd-ba7f-96baab25813a"
 
 [[token.source_card_refs]]
 card_name = "Beast Within"
@@ -104644,6 +107655,11 @@ card_name = "Master of Waves"
 scryfall_oracle_id = "07d40173-53e7-4328-a3b0-6214d93855b6"
 scryfall_id = "6cca3f7c-f0b1-4a0e-a2b9-ffb4a00e2ac6"
 
+[[token.source_card_refs]]
+card_name = "Master of Waves"
+scryfall_oracle_id = "07d40173-53e7-4328-a3b0-6214d93855b6"
+scryfall_id = "fde1e8a0-7e25-4ef1-a394-c6eb58c8b5a6"
+
 [token.token_image_ref]
 scryfall_id = "ae196fbc-c9ee-4dba-9eb3-52209908b898"
 scryfall_oracle_id = "cb78f496-a5db-4d23-b63d-04584e8f3bb1"
@@ -105091,6 +108107,11 @@ scryfall_oracle_id = "ace86e56-efde-4eb7-8815-71456a4c3abe"
 scryfall_id = "17fd4d15-413f-41c5-b3e0-71bbb52851bc"
 
 [[token.source_card_refs]]
+card_name = "Strike It Rich"
+scryfall_oracle_id = "c34c17c7-3827-49a2-be25-67f44fdfe150"
+scryfall_id = "2099f819-d504-447a-a390-75267d8a7e55"
+
+[[token.source_card_refs]]
 card_name = "Warren Soultrader"
 scryfall_oracle_id = "ace86e56-efde-4eb7-8815-71456a4c3abe"
 scryfall_id = "5c18591d-a8e2-49ea-b31e-7358e4143024"
@@ -105099,6 +108120,11 @@ scryfall_id = "5c18591d-a8e2-49ea-b31e-7358e4143024"
 card_name = "Warren Soultrader"
 scryfall_oracle_id = "ace86e56-efde-4eb7-8815-71456a4c3abe"
 scryfall_id = "b334e4c6-d316-4141-8889-f95afcc04701"
+
+[[token.source_card_refs]]
+card_name = "Tireless Provisioner"
+scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
+scryfall_id = "3cf04e55-b266-46cd-a79a-d87f5ceba469"
 
 [[token.source_card_refs]]
 card_name = "Ziatora, the Incinerator"
@@ -105114,6 +108140,11 @@ scryfall_id = "d9a42082-615c-4387-a77c-97ee94153c57"
 card_name = "The Reaver Cleaver"
 scryfall_oracle_id = "37a2a31d-51e6-4c07-b4c2-b206ad40eb42"
 scryfall_id = "1d671d06-5881-41c4-a4ff-79c8733bebf5"
+
+[[token.source_card_refs]]
+card_name = "Ragavan, Nimble Pilferer"
+scryfall_oracle_id = "37108cd4-bbab-4ce3-9ed6-f60e8422e703"
+scryfall_id = "8d27e717-8bda-44dc-90b9-a6f7029c7b93"
 
 [token.token_image_ref]
 scryfall_id = "79a7e037-9f56-4a77-a09e-caeafbb86d7c"
@@ -106165,9 +109196,19 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Apothecary White"
+scryfall_oracle_id = "7bf8bb41-6f46-492c-b6cf-5cfb29f973a4"
+scryfall_id = "4fedf84e-55ca-4334-a2c1-6e991112bb68"
+
+[[token.source_card_refs]]
 card_name = "Tippy-Toe, Terrific Partner"
 scryfall_oracle_id = "6a1bce89-0c11-4d8d-aacb-c0a5a5effffc"
 scryfall_id = "6082ab9f-290e-4230-84a0-46c7f8ed712d"
+
+[[token.source_card_refs]]
+card_name = "Rocco, Street Chef"
+scryfall_oracle_id = "071f5b4b-6a1e-4dc3-9c08-b79713191811"
+scryfall_id = "421c2ed3-be60-4814-a82c-a0e3fbb97e63"
 
 [[token.source_card_refs]]
 card_name = "City Pigeon"
@@ -106180,9 +109221,34 @@ scryfall_oracle_id = "34c0f75d-10a9-428d-b202-3defb3949090"
 scryfall_id = "61a89566-06c1-404f-8217-e5276e2dc5a2"
 
 [[token.source_card_refs]]
+card_name = "Rocco, Street Chef"
+scryfall_oracle_id = "071f5b4b-6a1e-4dc3-9c08-b79713191811"
+scryfall_id = "8102736a-220d-41d8-acea-79971d73db9a"
+
+[[token.source_card_refs]]
+card_name = "Rocco, Street Chef"
+scryfall_oracle_id = "071f5b4b-6a1e-4dc3-9c08-b79713191811"
+scryfall_id = "d9808e72-4143-421f-a498-dbebbd598544"
+
+[[token.source_card_refs]]
+card_name = "Late to Dinner"
+scryfall_oracle_id = "31bf199b-dfb1-428e-96a5-eb25104e2b43"
+scryfall_id = "2de018c5-9772-4fc6-a778-7eb4d9a16e6e"
+
+[[token.source_card_refs]]
+card_name = "Tireless Provisioner"
+scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
+scryfall_id = "5590a3a5-e0bd-451a-b98e-00a492487c46"
+
+[[token.source_card_refs]]
 card_name = "Heroic Feast"
 scryfall_oracle_id = "31cae00a-3a74-4a59-80b0-a656f524e878"
 scryfall_id = "dd9b6b3f-07b1-42d2-8aff-8da3113b9d88"
+
+[[token.source_card_refs]]
+card_name = "Tempting Witch"
+scryfall_oracle_id = "82284fe4-ecb3-4b27-bb03-27290ad15b17"
+scryfall_id = "8adbd4a5-3171-495a-a540-0ecf280b77fc"
 
 [[token.source_card_refs]]
 card_name = "Lucky the Pizza Dog"
@@ -106190,9 +109256,29 @@ scryfall_oracle_id = "3a429a1e-62c0-4f01-b09e-2bbf63e56a98"
 scryfall_id = "5fc454a5-39af-421d-a494-727ac7b6115e"
 
 [[token.source_card_refs]]
+card_name = "Rocco, Street Chef"
+scryfall_oracle_id = "071f5b4b-6a1e-4dc3-9c08-b79713191811"
+scryfall_id = "cdb53ce7-845c-4c62-98a9-4fc33c67a07b"
+
+[[token.source_card_refs]]
 card_name = "Heroic Feast"
 scryfall_oracle_id = "31cae00a-3a74-4a59-80b0-a656f524e878"
 scryfall_id = "32d05c3d-cf03-492e-a956-2e77c36e36c4"
+
+[[token.source_card_refs]]
+card_name = "Fierce Witchstalker"
+scryfall_oracle_id = "ad69f48e-c387-4376-a04f-37d3992c7946"
+scryfall_id = "797744c0-cfcc-43cb-baeb-bc2be3f7523d"
+
+[[token.source_card_refs]]
+card_name = "Bake into a Pie"
+scryfall_oracle_id = "1b9ec782-0ba1-41f1-bc39-d3302494ecb3"
+scryfall_id = "2c6e5b25-b721-45ee-894a-697de1310b8c"
+
+[[token.source_card_refs]]
+card_name = "Rocco, Street Chef"
+scryfall_oracle_id = "071f5b4b-6a1e-4dc3-9c08-b79713191811"
+scryfall_id = "dc25ce46-9d1a-4d5d-b35d-ea7abb8c5e5c"
 
 [token.token_image_ref]
 scryfall_id = "39389acc-cfa7-4a44-9d46-45be7dd72564"
@@ -109986,12 +113072,22 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Kari Zev, Skyship Raider"
 scryfall_oracle_id = "786baa29-afd4-40f0-95c8-920a972b9175"
+scryfall_id = "9638a43f-6b61-4455-8e0f-4142652c4b54"
+
+[[token.source_card_refs]]
+card_name = "Kari Zev, Skyship Raider"
+scryfall_oracle_id = "786baa29-afd4-40f0-95c8-920a972b9175"
 scryfall_id = "48765efe-bcb5-4a15-acd0-607ead64ae6d"
 
 [[token.source_card_refs]]
 card_name = "Kari Zev, Skyship Raider"
 scryfall_oracle_id = "786baa29-afd4-40f0-95c8-920a972b9175"
 scryfall_id = "1a9e43d4-41ff-468c-b817-7e8467fadb1a"
+
+[[token.source_card_refs]]
+card_name = "Kari Zev, Skyship Raider"
+scryfall_oracle_id = "786baa29-afd4-40f0-95c8-920a972b9175"
+scryfall_id = "f9b7d945-0c34-4576-abb0-a6e2a816c052"
 
 [token.token_image_ref]
 scryfall_id = "ef2891b2-56a0-40f4-a992-d9866451f946"
@@ -110208,6 +113304,11 @@ keywords = [
 card_name = "Manaform Hellkite"
 scryfall_oracle_id = "f426aa1a-e1dc-4563-b450-2e23d6bd980b"
 scryfall_id = "0a559655-0967-41b9-8248-170f95c05f84"
+
+[[token.source_card_refs]]
+card_name = "Manaform Hellkite"
+scryfall_oracle_id = "f426aa1a-e1dc-4563-b450-2e23d6bd980b"
+scryfall_id = "0087f7de-7065-4492-8fe9-f9a22c32a05d"
 
 [token.token_image_ref]
 scryfall_id = "44b7c73d-80a0-4a27-b0a2-317164362449"
@@ -111062,14 +114163,29 @@ colors = ["Black"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Enkira, Hostile Scavenger"
+scryfall_oracle_id = "558fd7a9-9b39-4c82-b909-5febf55dc010"
+scryfall_id = "f7cad73d-312c-4ea5-93c7-8a422b16f207"
+
+[[token.source_card_refs]]
 card_name = "Hansk, Slayer Zealot"
 scryfall_oracle_id = "d818f863-17ee-4387-94bf-d7e6e8ab590c"
 scryfall_id = "0bffb892-e5dc-413d-924e-b9bda7bf7100"
 
 [[token.source_card_refs]]
+card_name = "Hansk, Slayer Zealot"
+scryfall_oracle_id = "d818f863-17ee-4387-94bf-d7e6e8ab590c"
+scryfall_id = "f6ea7c19-71ec-44ff-affc-fc76fe3146a7"
+
+[[token.source_card_refs]]
 card_name = "Gisa's Favorite Shovel"
 scryfall_oracle_id = "9c298c7b-9c63-4a66-a0fc-977491b623c7"
 scryfall_id = "d92f06af-47bd-4ede-a174-21be69387c1b"
+
+[[token.source_card_refs]]
+card_name = "Gisa's Favorite Shovel"
+scryfall_oracle_id = "9c298c7b-9c63-4a66-a0fc-977491b623c7"
+scryfall_id = "8139bb44-47e8-4076-99ed-ad3623198ad9"
 
 [[token.source_card_refs]]
 card_name = "Enkira, Hostile Scavenger"
@@ -111194,6 +114310,11 @@ scryfall_oracle_id = "3acef3dc-61ee-48e0-9b2e-a8e29d5f4ac7"
 scryfall_id = "2632c821-513f-4059-b073-98ff691c1117"
 
 [[token.source_card_refs]]
+card_name = "Aether Channeler"
+scryfall_oracle_id = "fb220f46-f8b8-4804-baa4-e7d50b4871f7"
+scryfall_id = "d5859a42-5a82-47db-9f1d-ffe3f2b61a02"
+
+[[token.source_card_refs]]
 card_name = "Falcon and Redwing"
 scryfall_oracle_id = "0f7c7035-e395-4da5-8536-9f192d03e3ba"
 scryfall_id = "a2f3d58c-ad5c-4d1a-bda6-fbc55635e946"
@@ -111205,9 +114326,49 @@ scryfall_oracle_id = "5b8472c8-a7e7-46f2-aecf-e954082a5ef5"
 scryfall_id = "66b3f745-055b-4338-b6f0-7b7281d63afd"
 
 [[token.source_card_refs]]
+card_name = "Battle Screech"
+scryfall_oracle_id = "e73131cd-b454-405b-9539-9d777e232b9e"
+scryfall_id = "70e0261c-80a2-406d-8afe-109c87cb9c4c"
+
+[[token.source_card_refs]]
 card_name = "Emeria Angel"
 scryfall_oracle_id = "ea6616e4-db8d-4905-80f8-cb0162906850"
 scryfall_id = "9df8f833-72c2-4169-915b-ae54925b2271"
+
+[[token.source_card_refs]]
+card_name = "Jötun Owl Keeper"
+scryfall_oracle_id = "3acef3dc-61ee-48e0-9b2e-a8e29d5f4ac7"
+scryfall_id = "1566c8a2-aaca-4ce0-a36b-620ea6f135cb"
+
+[[token.source_card_refs]]
+card_name = "Scour the Desert"
+scryfall_oracle_id = "86c9e08a-397a-4c24-8f4c-48a648889399"
+scryfall_id = "d19d87ed-2b5d-4f93-a197-9d0267949e12"
+
+[[token.source_card_refs]]
+card_name = "Seller of Songbirds"
+scryfall_oracle_id = "87e4c6ff-f83f-412b-9d23-aac7a57ef6db"
+scryfall_id = "4f3b2176-958a-42e0-b88e-5b3416b40150"
+
+[[token.source_card_refs]]
+card_name = "Battle Screech"
+scryfall_oracle_id = "e73131cd-b454-405b-9539-9d777e232b9e"
+scryfall_id = "ea11071d-ac7f-453a-b24a-8ea008b9bf67"
+
+[[token.source_card_refs]]
+card_name = "Soul of Migration"
+scryfall_oracle_id = "f90ebf35-08f9-4277-92d9-75165f32a84e"
+scryfall_id = "34e0433a-e8a1-442e-93cf-93a25c1eb765"
+
+[[token.source_card_refs]]
+card_name = "Seller of Songbirds"
+scryfall_oracle_id = "87e4c6ff-f83f-412b-9d23-aac7a57ef6db"
+scryfall_id = "df84d9ce-9ff0-438a-96e1-2aadd60dcaba"
+
+[[token.source_card_refs]]
+card_name = "Battle Screech"
+scryfall_oracle_id = "e73131cd-b454-405b-9539-9d777e232b9e"
+scryfall_id = "c3c38264-0d79-47d4-bca2-a20a991bbac9"
 
 [[token.source_card_refs]]
 card_name = "Migratory Route"
@@ -111322,7 +114483,19 @@ keywords = ["Deathtouch"]
 card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
 face_name = "Garruk, the Veil-Cursed"
 scryfall_oracle_id = "7cec9021-6f25-4fd8-b40e-adf4ffd3a7b8"
+scryfall_id = "c340ad6b-aa09-4d12-a947-33b29b875158"
+
+[[token.source_card_refs]]
+card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
+face_name = "Garruk, the Veil-Cursed"
+scryfall_oracle_id = "7cec9021-6f25-4fd8-b40e-adf4ffd3a7b8"
 scryfall_id = "6897514f-e396-46d6-91e3-158366c741bb"
+
+[[token.source_card_refs]]
+card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
+face_name = "Garruk Relentless"
+scryfall_oracle_id = "7cec9021-6f25-4fd8-b40e-adf4ffd3a7b8"
+scryfall_id = "c340ad6b-aa09-4d12-a947-33b29b875158"
 
 [[token.source_card_refs]]
 card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
@@ -111972,6 +115145,11 @@ subtypes = [
 supertypes = []
 colors = ["Black"]
 keywords = ["Flying"]
+
+[[token.source_card_refs]]
+card_name = "Bitterblossom"
+scryfall_oracle_id = "fb868840-09fa-49b1-85cb-b08ad065e972"
+scryfall_id = "25dd861f-ee63-4d79-b31b-173c9c336426"
 
 [[token.source_card_refs]]
 card_name = "Bitterblossom"
@@ -113656,12 +116834,32 @@ keywords = ["Lifelink"]
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
 scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
+scryfall_id = "dcdbecfc-fc37-4327-9469-7139e16f7fbd"
+
+[[token.source_card_refs]]
+card_name = "Wurmcoil Engine"
+scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
+scryfall_id = "6927d6d4-93fe-4ded-b091-a0c671c1716b"
+
+[[token.source_card_refs]]
+card_name = "Wurmcoil Engine"
+scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
 scryfall_id = "efc01aa1-55f3-4557-a5b0-734f3b9ed050"
 
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
 scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
 scryfall_id = "5d275f04-cc60-4e3f-95cc-3d02bc916b82"
+
+[[token.source_card_refs]]
+card_name = "Wurmcoil Engine"
+scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
+scryfall_id = "219f1f03-e882-40ca-8854-1e466e37b8cd"
+
+[[token.source_card_refs]]
+card_name = "Wurmcoil Engine"
+scryfall_oracle_id = "d1a60f44-7696-49ee-91fb-cab5b3102962"
+scryfall_id = "b045a766-73ee-4109-bede-2e1d71b80f2f"
 
 [[token.source_card_refs]]
 card_name = "Wurmcoil Engine"
@@ -114162,6 +117360,21 @@ card_name = "Avenger of Zendikar"
 scryfall_oracle_id = "4ba5b3f6-503b-43e6-b66e-4f8c55cffed7"
 scryfall_id = "5c43add9-f948-41fe-b40c-e1d357db5f05"
 
+[[token.source_card_refs]]
+card_name = "Avenger of Zendikar"
+scryfall_oracle_id = "4ba5b3f6-503b-43e6-b66e-4f8c55cffed7"
+scryfall_id = "4b5f7be6-c30a-43f0-a371-e93a24cc5636"
+
+[[token.source_card_refs]]
+card_name = "Nissa, Voice of Zendikar"
+scryfall_oracle_id = "b0f36bf7-bdde-4576-9eca-ec02d41326ab"
+scryfall_id = "8474716e-c73e-4292-a177-7eb553ba5e76"
+
+[[token.source_card_refs]]
+card_name = "Khalni Garden"
+scryfall_oracle_id = "b2d5ba45-8674-4428-89db-c2bbbf0bf5c5"
+scryfall_id = "a1dbe0cd-46ff-4728-92e9-0cfa7cc8620a"
+
 [token.token_image_ref]
 scryfall_id = "3db07715-d315-4361-8af5-ce68d20e6c08"
 scryfall_oracle_id = "bcd346a7-4d96-4a0c-9725-fb740e32b730"
@@ -114230,6 +117443,11 @@ keywords = ["Vigilance"]
 card_name = "Brimaz, King of Oreskos"
 scryfall_oracle_id = "49471b65-be9d-4ded-b2e5-dfc81b306b54"
 scryfall_id = "25e475d2-a813-43d0-aa6b-4a16e92d7375"
+
+[[token.source_card_refs]]
+card_name = "Brimaz, King of Oreskos"
+scryfall_oracle_id = "49471b65-be9d-4ded-b2e5-dfc81b306b54"
+scryfall_id = "f2fd4bf5-7ed6-4a90-b0ba-ba886342859a"
 
 [[token.source_card_refs]]
 card_name = "Brimaz, King of Oreskos"
@@ -114452,6 +117670,11 @@ scryfall_id = "f94db3a7-ae06-494c-8af5-824dee6f23f0"
 card_name = "Tidal Wave"
 scryfall_oracle_id = "c5f5b7e5-af1e-4c8a-8d44-3e2152955d4e"
 scryfall_id = "9898c19f-7341-4be9-b592-bac884e55c84"
+
+[[token.source_card_refs]]
+card_name = "Tidal Wave"
+scryfall_oracle_id = "c5f5b7e5-af1e-4c8a-8d44-3e2152955d4e"
+scryfall_id = "49a9689b-bf1e-404e-ba08-0b04de4288fb"
 
 [token.token_image_ref]
 scryfall_id = "353aaec9-79fb-4b83-b4f4-8c7dc2a6b1c1"
@@ -114835,6 +118058,11 @@ keywords = [
     "Haste",
     "Trample",
 ]
+
+[[token.source_card_refs]]
+card_name = "Sparkspitter"
+scryfall_oracle_id = "0fbec99f-0e49-4211-a06e-edd783cf47da"
+scryfall_id = "91431126-05b3-4c2e-aff7-41c2866265f6"
 
 [[token.source_card_refs]]
 card_name = "Sparkspitter"
@@ -115761,6 +118989,26 @@ supertypes = []
 colors = ["Black"]
 keywords = ["Flying"]
 
+[[token.source_card_refs]]
+card_name = "Bitterblossom"
+scryfall_oracle_id = "fb868840-09fa-49b1-85cb-b08ad065e972"
+scryfall_id = "07ed5249-ac56-4f56-a8ca-f1808460dac6"
+
+[[token.source_card_refs]]
+card_name = "Bitterblossom"
+scryfall_oracle_id = "fb868840-09fa-49b1-85cb-b08ad065e972"
+scryfall_id = "4c2fd7bd-6528-453b-b55d-a708967b14e8"
+
+[[token.source_card_refs]]
+card_name = "Bitterblossom"
+scryfall_oracle_id = "fb868840-09fa-49b1-85cb-b08ad065e972"
+scryfall_id = "bdf9661d-b581-4496-9004-f292d9ac03ef"
+
+[[token.source_card_refs]]
+card_name = "Bitterblossom"
+scryfall_oracle_id = "fb868840-09fa-49b1-85cb-b08ad065e972"
+scryfall_id = "4d6c0dc6-ab2e-4ab5-951a-1ddd6698e80e"
+
 [token.token_image_ref]
 scryfall_id = "096cbccf-cd00-49d6-9885-54ba68667c27"
 scryfall_oracle_id = "741b9f0d-8c0d-4865-b177-fb64b687ad11"
@@ -116221,6 +119469,8 @@ id = "89078c71-1e5f-5362-b049-a34bdf309172"
 category = "Creature"
 fidelity = "Full"
 source_card_names = [
+    "Edgar Markov's Coffin",
+    "Edgar, Charmed Groom",
     "Edgar, Charmed Groom // Edgar Markov's Coffin",
     "Glass-Cast Heart",
 ]
@@ -116248,6 +119498,18 @@ keywords = ["Lifelink"]
 card_name = "Glass-Cast Heart"
 scryfall_oracle_id = "3edd6272-20fa-4c3a-bf34-2f253cc8ac9e"
 scryfall_id = "f36a4054-903c-468a-877b-0ba43a403cc1"
+
+[[token.source_card_refs]]
+card_name = "Edgar, Charmed Groom // Edgar Markov's Coffin"
+face_name = "Edgar Markov's Coffin"
+scryfall_oracle_id = "96cb97ca-4ce0-4d33-86fb-4db4ce1956be"
+scryfall_id = "78f57a41-e9a6-4f71-92a0-46c4534c8fca"
+
+[[token.source_card_refs]]
+card_name = "Edgar, Charmed Groom // Edgar Markov's Coffin"
+face_name = "Edgar, Charmed Groom"
+scryfall_oracle_id = "96cb97ca-4ce0-4d33-86fb-4db4ce1956be"
+scryfall_id = "78f57a41-e9a6-4f71-92a0-46c4534c8fca"
 
 [token.token_image_ref]
 scryfall_id = "788a024d-4945-4ac0-b29c-31a327c3b5b5"
@@ -118593,6 +121855,11 @@ scryfall_oracle_id = "3b583358-d0d5-4f53-b06c-c6439156e684"
 scryfall_id = "d4ba75be-2428-45aa-bf02-75c379a5dfa2"
 
 [[token.source_card_refs]]
+card_name = "Chandra, Gremlin Wrangler"
+scryfall_oracle_id = "486757df-23c0-4b53-97c3-c38c4eb32a56"
+scryfall_id = "d7ee8f1a-76ca-48a5-b71c-bc787cf66a09"
+
+[[token.source_card_refs]]
 card_name = "Release the Gremlins"
 scryfall_oracle_id = "3b583358-d0d5-4f53-b06c-c6439156e684"
 scryfall_id = "a2f36565-2a11-48fd-8280-feaff5b8765a"
@@ -119988,6 +123255,11 @@ keywords = ["Flying"]
 [[token.source_card_refs]]
 card_name = "Griffin Guide"
 scryfall_oracle_id = "c5323a43-82de-4340-8578-b3ffcc66f8fa"
+scryfall_id = "e19a15d9-5899-4b84-9c00-345b19df53ae"
+
+[[token.source_card_refs]]
+card_name = "Griffin Guide"
+scryfall_oracle_id = "c5323a43-82de-4340-8578-b3ffcc66f8fa"
 scryfall_id = "344c8ece-80d7-4efc-badb-985fecb11761"
 
 [[token.source_card_refs]]
@@ -119999,6 +123271,11 @@ scryfall_id = "ba8e0599-082d-4252-a579-c773466347a2"
 card_name = "Griffin Aerie"
 scryfall_oracle_id = "7cab62dc-a256-4da8-a3ea-b3903ec37077"
 scryfall_id = "2a64a64f-55d2-41e2-aa33-31daba8344c8"
+
+[[token.source_card_refs]]
+card_name = "Griffin Aerie"
+scryfall_oracle_id = "7cab62dc-a256-4da8-a3ea-b3903ec37077"
+scryfall_id = "b0c1cd62-aa6e-4120-ba70-1f12c8efe389"
 
 [token.token_image_ref]
 scryfall_id = "f20992a9-7ea7-454d-aac6-ff6928eb80b5"
@@ -120699,6 +123976,21 @@ card_name = "Sek'Kuar, Deathkeeper"
 scryfall_oracle_id = "94426127-65c2-435e-ba92-423a3c102061"
 scryfall_id = "245d86df-388d-421d-b904-d563e81727ad"
 
+[[token.source_card_refs]]
+card_name = "Sek'Kuar, Deathkeeper"
+scryfall_oracle_id = "94426127-65c2-435e-ba92-423a3c102061"
+scryfall_id = "9257bb20-de32-460c-96cf-375acb6a0b1d"
+
+[[token.source_card_refs]]
+card_name = "Balduvian Dead"
+scryfall_oracle_id = "18d6b89a-3588-43d9-a247-4747a7d784fc"
+scryfall_id = "c9aee135-65f6-4abb-b0ca-ee5ceb958a24"
+
+[[token.source_card_refs]]
+card_name = "Balduvian Dead"
+scryfall_oracle_id = "18d6b89a-3588-43d9-a247-4747a7d784fc"
+scryfall_id = "fac1875a-feab-4213-aa15-69892b7df58b"
+
 [token.token_image_ref]
 scryfall_id = "07ab0fbc-293e-4917-9792-fdc9b512713d"
 scryfall_oracle_id = "3b2ccc79-67d6-437d-9696-fbd887c7d8b6"
@@ -121255,6 +124547,11 @@ scryfall_id = "372d0c0b-439c-413f-aac4-5174c75aadb0"
 [[token.source_card_refs]]
 card_name = "Big Score"
 scryfall_oracle_id = "a5cbd257-c836-493e-bb1a-76242619dea2"
+scryfall_id = "c7b698a1-dff1-413f-ba4f-0298c686999a"
+
+[[token.source_card_refs]]
+card_name = "Big Score"
+scryfall_oracle_id = "a5cbd257-c836-493e-bb1a-76242619dea2"
 scryfall_id = "8b2699d2-2057-4fbf-8e52-736fcfe2759d"
 
 [[token.source_card_refs]]
@@ -121684,15 +124981,35 @@ colors = ["White"]
 keywords = ["Vigilance"]
 
 [[token.source_card_refs]]
+card_name = "Valorous Steed"
+scryfall_oracle_id = "4b5f30a6-b0fb-4dcb-85d5-1db1bba73737"
+scryfall_id = "637c80b7-6cbb-4f3f-b279-55048b90ad1c"
+
+[[token.source_card_refs]]
 card_name = "Virtue of Loyalty // Ardenvale Fealty"
 face_name = "Virtue of Loyalty"
 scryfall_oracle_id = "f61f4307-4eec-476a-97e5-d4d3da2b54c3"
 scryfall_id = "ea7e7daf-7c06-4c74-8bcf-e42c1f611861"
 
 [[token.source_card_refs]]
+card_name = "Knightly Valor"
+scryfall_oracle_id = "9ba6cec6-97bf-4a83-9ffa-77e187d0945b"
+scryfall_id = "844b8b36-6c45-445c-92a3-f1058669d66a"
+
+[[token.source_card_refs]]
+card_name = "Selesnya Charm"
+scryfall_oracle_id = "a1a49639-bcc4-4522-8862-c9fb13d40880"
+scryfall_id = "f616ef56-51ed-47d2-910c-fa4e0bca0823"
+
+[[token.source_card_refs]]
 card_name = "Selesnya Charm"
 scryfall_oracle_id = "a1a49639-bcc4-4522-8862-c9fb13d40880"
 scryfall_id = "30284c06-4477-4dde-8b28-9646324303d5"
+
+[[token.source_card_refs]]
+card_name = "Knightly Valor"
+scryfall_oracle_id = "9ba6cec6-97bf-4a83-9ffa-77e187d0945b"
+scryfall_id = "39232813-d1d5-402f-a0c8-92acbf72ff51"
 
 [[token.source_card_refs]]
 card_name = "Lonesome Unicorn // Rider in Need"
@@ -121717,15 +125034,35 @@ scryfall_oracle_id = "9ba6cec6-97bf-4a83-9ffa-77e187d0945b"
 scryfall_id = "5ca1bf37-b372-400d-ba2d-3d456bcec393"
 
 [[token.source_card_refs]]
+card_name = "Gallant Cavalry"
+scryfall_oracle_id = "b500c460-2814-47a4-b307-17ca519f3565"
+scryfall_id = "38f370a9-1401-4018-bbd3-0a8737f9fbea"
+
+[[token.source_card_refs]]
 card_name = "Valorous Steed"
 scryfall_oracle_id = "4b5f30a6-b0fb-4dcb-85d5-1db1bba73737"
 scryfall_id = "19e8e7dd-4bbb-48a7-9427-f7557d670f74"
+
+[[token.source_card_refs]]
+card_name = "Knightly Valor"
+scryfall_oracle_id = "9ba6cec6-97bf-4a83-9ffa-77e187d0945b"
+scryfall_id = "c6f463b5-188f-4ecc-8cbf-0f200515bb09"
+
+[[token.source_card_refs]]
+card_name = "Basri's Lieutenant"
+scryfall_oracle_id = "57d0c688-6206-4c83-9fcb-27fd29e2a9ed"
+scryfall_id = "d38f37d7-4aa7-43bf-ad15-9a8a31d42594"
 
 [[token.source_card_refs]]
 card_name = "Lonesome Unicorn // Rider in Need"
 face_name = "Rider in Need"
 scryfall_oracle_id = "c8f6cc1f-b7e4-470d-8d48-ef848d7c1116"
 scryfall_id = "68fe8de1-8c3b-4e05-9d4a-67d979184980"
+
+[[token.source_card_refs]]
+card_name = "The Circle of Loyalty"
+scryfall_oracle_id = "fd1b4523-2399-4771-89bf-1d65f5d67056"
+scryfall_id = "29a37ed7-223e-4e19-b318-83cac54f6b16"
 
 [[token.source_card_refs]]
 card_name = "Virtue of Loyalty // Ardenvale Fealty"
@@ -122162,7 +125499,17 @@ keywords = ["Flying"]
 [[token.source_card_refs]]
 card_name = "Archon of Sun's Grace"
 scryfall_oracle_id = "48a99dce-0aa9-4aac-81df-cec5f94c639d"
+scryfall_id = "895da74d-26ce-4e0c-baef-6eabc40bf0de"
+
+[[token.source_card_refs]]
+card_name = "Archon of Sun's Grace"
+scryfall_oracle_id = "48a99dce-0aa9-4aac-81df-cec5f94c639d"
 scryfall_id = "0d3af89d-d22c-45e8-9fec-170ac9bb0a34"
+
+[[token.source_card_refs]]
+card_name = "Archon of Sun's Grace"
+scryfall_oracle_id = "48a99dce-0aa9-4aac-81df-cec5f94c639d"
+scryfall_id = "5c3f9a15-02ee-4d83-ab4c-6cec9071b841"
 
 [token.token_image_ref]
 scryfall_id = "f130171f-a3e2-4dac-806a-1f2c428ac9fc"
@@ -123028,6 +126375,11 @@ card_name = "Timeless Witness"
 scryfall_oracle_id = "a52a06aa-56fc-4845-bbcd-a54f16369b34"
 scryfall_id = "8b63ec86-670b-4acd-b14c-3d90acbde087"
 
+[[token.source_card_refs]]
+card_name = "Timeless Witness"
+scryfall_oracle_id = "a52a06aa-56fc-4845-bbcd-a54f16369b34"
+scryfall_id = "3483a95e-1b06-4973-a0f7-ff5b5f9c0e79"
+
 [token.token_image_ref]
 scryfall_id = "0902163b-9a92-4df3-afdd-396db24c7fd4"
 scryfall_oracle_id = "e292b492-1918-4c92-af43-3bfbe39dcea4"
@@ -123494,6 +126846,11 @@ scryfall_oracle_id = "e6f59807-eaf6-4889-8c89-2ac915afefff"
 scryfall_id = "fab7646a-61e8-446b-9dba-ac6e0db82f10"
 
 [[token.source_card_refs]]
+card_name = "Smothering Tithe"
+scryfall_oracle_id = "153376c9-dffd-458c-8ce3-a4c8269bc4e9"
+scryfall_id = "58178dd4-c61e-4017-b2e6-2d8308ded4fd"
+
+[[token.source_card_refs]]
 card_name = "Discerning Financier"
 scryfall_oracle_id = "734a5186-caa6-4811-b6d7-91b7b32fc403"
 scryfall_id = "584774b5-640f-45e0-810b-f5faf119645b"
@@ -123503,6 +126860,11 @@ card_name = "Decadent Dragon // Expensive Taste"
 face_name = "Decadent Dragon"
 scryfall_oracle_id = "5df44b8d-b337-49d8-8427-34253f52cb47"
 scryfall_id = "8a717d27-596d-4341-b592-4f9777f778e5"
+
+[[token.source_card_refs]]
+card_name = "Smothering Tithe"
+scryfall_oracle_id = "153376c9-dffd-458c-8ce3-a4c8269bc4e9"
+scryfall_id = "f6c69c2f-729b-49ed-909d-57190a728e11"
 
 [[token.source_card_refs]]
 card_name = "Redcap Thief"
@@ -123519,6 +126881,11 @@ scryfall_id = "315cbbf7-a2ad-4565-9877-1e903d7fd797"
 card_name = "Charming Scoundrel"
 scryfall_oracle_id = "9eec304d-ffcb-4287-b877-280ac1e4f496"
 scryfall_id = "c8090bcf-e17a-4110-a518-77ccd045b18f"
+
+[[token.source_card_refs]]
+card_name = "Smothering Tithe"
+scryfall_oracle_id = "153376c9-dffd-458c-8ce3-a4c8269bc4e9"
+scryfall_id = "a095e47e-8f02-45cf-a9d2-677fe171258d"
 
 [token.token_image_ref]
 scryfall_id = "73cbf189-a79b-4dca-8b29-33aef6306b5a"
@@ -125139,6 +128506,11 @@ scryfall_oracle_id = "b9176173-c4a1-45ae-8f34-bd6b31c141fe"
 scryfall_id = "90eaf94e-85a7-4958-aa58-8e2fe44db58d"
 
 [[token.source_card_refs]]
+card_name = "Oketra the True"
+scryfall_oracle_id = "646e68c8-cc42-4d6c-8363-a18b10a10eae"
+scryfall_id = "b3aa8c17-e37e-430e-a940-d016c4ab5852"
+
+[[token.source_card_refs]]
 card_name = "Supply Caravan"
 scryfall_oracle_id = "1abcfe8d-4beb-4910-b353-1227e1256329"
 scryfall_id = "d247bd88-9593-462c-8f9e-28e29c064c10"
@@ -125764,6 +129136,11 @@ subtypes = [
 supertypes = []
 colors = ["Red"]
 keywords = ["Prowess"]
+
+[[token.source_card_refs]]
+card_name = "Goblin Wizardry"
+scryfall_oracle_id = "f621dcaa-c500-4a17-a65a-60d9b5516a3b"
+scryfall_id = "04d250d6-7ab1-4b30-85a4-acb0b620629c"
 
 [[token.source_card_refs]]
 card_name = "Goblin Wizardry"
@@ -128262,6 +131639,21 @@ card_name = "Heroic Reinforcements"
 scryfall_oracle_id = "c442e8b0-a0a4-4839-8049-125b91b15c99"
 scryfall_id = "6a05e8d5-c2ad-489a-888d-22622886b620"
 
+[[token.source_card_refs]]
+card_name = "Raise the Alarm"
+scryfall_oracle_id = "5b2364d7-a811-4595-a1b4-224c70555ffa"
+scryfall_id = "81d3e5c5-6531-48e7-9dd6-2db519dd61b1"
+
+[[token.source_card_refs]]
+card_name = "Ancestral Blade"
+scryfall_oracle_id = "ab28a801-6ab1-4db2-8ae2-c24bb4c10ebb"
+scryfall_id = "7902956b-8d64-4320-89b0-6f369ce1f410"
+
+[[token.source_card_refs]]
+card_name = "Memorial to Glory"
+scryfall_oracle_id = "eb8ec34c-ae07-4a09-940f-ee965146a787"
+scryfall_id = "edad3735-0cf3-471d-9731-8118aa4dce68"
+
 [token.token_image_ref]
 scryfall_id = "d093322e-a717-4e2d-8199-fa560792bcf6"
 scryfall_oracle_id = "eac25f12-6459-438c-a09e-93e23d2cf80d"
@@ -128582,11 +131974,13 @@ source_card_names = [
     "Hero of Precinct One",
     "Increasing Devotion",
     "Inquisitive Puppet",
+    "Jerren, Corrupted Bishop",
     "Jerren, Corrupted Bishop // Ormendahl, the Corrupter",
     "Join the Dance",
     "Kharis & The Beholder",
     "Lovestruck Beast // Heart's Desire",
     "Oakhame Ranger // Bring Back",
+    "Ormendahl, the Corrupter",
     "Rally for the Throne",
     "Return from the Wilds",
     "Slaughter Specialist",
@@ -128596,7 +131990,9 @@ source_card_names = [
     "Visions of Glory",
     "Voice of the Provinces",
     "Watchful Giant",
+    "Wedding Announcement",
     "Wedding Announcement // Wedding Festivity",
+    "Wedding Festivity",
     "Welcome to Sweettooth",
     "Worthy Knight",
 ]
@@ -128622,9 +132018,72 @@ scryfall_oracle_id = "9a107e48-3d50-4941-95b1-10f2b29a4245"
 scryfall_id = "b000f605-177f-459d-a197-fcf54efec2fb"
 
 [[token.source_card_refs]]
+card_name = "Jerren, Corrupted Bishop // Ormendahl, the Corrupter"
+face_name = "Ormendahl, the Corrupter"
+scryfall_oracle_id = "20d0df30-013c-47c0-b70b-d628d427d30b"
+scryfall_id = "439d4cd6-afca-46d3-8850-898cb9212a26"
+
+[[token.source_card_refs]]
+card_name = "Adeline, Resplendent Cathar"
+scryfall_oracle_id = "38515f89-348b-4cf3-b7bd-1f6fe4ce2fba"
+scryfall_id = "0b9579d8-bc8f-4d74-bfc1-dcdd42568f79"
+
+[[token.source_card_refs]]
+card_name = "Stroke of Midnight"
+scryfall_oracle_id = "9a107e48-3d50-4941-95b1-10f2b29a4245"
+scryfall_id = "711135d0-7769-4154-873a-e2505f8795f0"
+
+[[token.source_card_refs]]
 card_name = "Voice of the Provinces"
 scryfall_oracle_id = "81b15ed1-7069-4f8b-96b9-f6d67298afef"
 scryfall_id = "c2599730-fc82-468b-bb5c-7e722dbabbe7"
+
+[[token.source_card_refs]]
+card_name = "Voice of the Provinces"
+scryfall_oracle_id = "81b15ed1-7069-4f8b-96b9-f6d67298afef"
+scryfall_id = "30a78066-c52e-48fd-bcf9-d0b60f00fddc"
+
+[[token.source_card_refs]]
+card_name = "Dawnhart Mentor"
+scryfall_oracle_id = "e12fb44a-524e-4603-a89c-fad8204fdb2b"
+scryfall_id = "d0c50047-013f-4a14-8cdd-08c6d5b89e8b"
+
+[[token.source_card_refs]]
+card_name = "Adeline, Resplendent Cathar"
+scryfall_oracle_id = "38515f89-348b-4cf3-b7bd-1f6fe4ce2fba"
+scryfall_id = "9c5743e9-7fae-483a-b591-496afdd905f2"
+
+[[token.source_card_refs]]
+card_name = "Cathar's Call"
+scryfall_oracle_id = "433e92d2-899a-4eed-98b9-80de5d25494b"
+scryfall_id = "8e9721c2-ca45-452b-9694-16cc8651a35b"
+
+[[token.source_card_refs]]
+card_name = "Kharis & The Beholder"
+scryfall_oracle_id = "329f84dd-889c-4d03-a0bb-d96712ebcad8"
+scryfall_id = "8dd4d771-366c-4d81-875d-7ba9f1f00320"
+
+[[token.source_card_refs]]
+card_name = "Clarion Cathars"
+scryfall_oracle_id = "193f9b12-ee34-40c2-9315-6794416a4f62"
+scryfall_id = "3937d712-e944-4540-bc38-812096977059"
+
+[[token.source_card_refs]]
+card_name = "Wedding Announcement // Wedding Festivity"
+face_name = "Wedding Festivity"
+scryfall_oracle_id = "259ac30c-cc05-4c04-9b23-71283f84b808"
+scryfall_id = "f56277ed-1c80-48c8-8fe0-e2e3a05e7caf"
+
+[[token.source_card_refs]]
+card_name = "Cemetery Protector"
+scryfall_oracle_id = "34c8fffd-1b23-4f40-ad29-1f0acb519e7e"
+scryfall_id = "efde8248-90ad-46ae-968d-9c6b252fa2a2"
+
+[[token.source_card_refs]]
+card_name = "Wedding Announcement // Wedding Festivity"
+face_name = "Wedding Announcement"
+scryfall_oracle_id = "259ac30c-cc05-4c04-9b23-71283f84b808"
+scryfall_id = "f56277ed-1c80-48c8-8fe0-e2e3a05e7caf"
 
 [[token.source_card_refs]]
 card_name = "Castle Ardenvale"
@@ -128632,9 +132091,30 @@ scryfall_oracle_id = "f8f4fc60-725d-46d8-8e8f-e68e00d20589"
 scryfall_id = "65e4de2e-47d2-4967-be31-9df0057a9c74"
 
 [[token.source_card_refs]]
+card_name = "Sunset Revelry"
+scryfall_oracle_id = "65779f3b-7fc5-4847-99d7-78f697d34c3d"
+scryfall_id = "b982565f-f2ca-453d-99f6-9560123f7448"
+
+[[token.source_card_refs]]
+card_name = "Join the Dance"
+scryfall_oracle_id = "d8fc015c-7e6d-441d-bbeb-98ca74b21314"
+scryfall_id = "d403fbce-132a-41d2-b3ed-82420d14ed55"
+
+[[token.source_card_refs]]
 card_name = "Join the Dance"
 scryfall_oracle_id = "d8fc015c-7e6d-441d-bbeb-98ca74b21314"
 scryfall_id = "e6dde9fc-def0-422f-94d0-e6d09101d543"
+
+[[token.source_card_refs]]
+card_name = "Slaughter Specialist"
+scryfall_oracle_id = "ab431f93-73bb-49d9-9321-a0712f096ed7"
+scryfall_id = "18386c30-b2c1-41b4-a3a6-90493d1c9c2d"
+
+[[token.source_card_refs]]
+card_name = "Jerren, Corrupted Bishop // Ormendahl, the Corrupter"
+face_name = "Jerren, Corrupted Bishop"
+scryfall_oracle_id = "20d0df30-013c-47c0-b70b-d628d427d30b"
+scryfall_id = "439d4cd6-afca-46d3-8850-898cb9212a26"
 
 [[token.source_card_refs]]
 card_name = "Adeline, Resplendent Cathar"
@@ -129645,6 +133125,11 @@ keywords = []
 card_name = "Labyrinth Guardian"
 scryfall_oracle_id = "867ee3e7-88df-4e4b-b199-f441a8460573"
 scryfall_id = "132c19f0-3b75-49a9-b3a9-501031fe3f50"
+
+[[token.source_card_refs]]
+card_name = "Labyrinth Guardian"
+scryfall_oracle_id = "867ee3e7-88df-4e4b-b199-f441a8460573"
+scryfall_id = "38013d49-a9cd-4398-bb6f-f985ec81301d"
 
 [[token.source_card_refs]]
 card_name = "Labyrinth Guardian"
@@ -131473,6 +134958,11 @@ card_name = "Rampaging Baloths"
 scryfall_oracle_id = "2d3e6549-6cc6-434f-a189-ba3b55e64c34"
 scryfall_id = "c25ee47b-d099-4788-9c2b-73d151bf56fb"
 
+[[token.source_card_refs]]
+card_name = "Somberwald Beastmaster"
+scryfall_oracle_id = "df35bf19-4cbf-4624-925d-ceca6bff596e"
+scryfall_id = "6488d613-59fa-4e26-a48c-eecab8754808"
+
 [token.token_image_ref]
 scryfall_id = "21bd6fb3-f60c-49cc-8854-6a20a1e1d9c7"
 scryfall_oracle_id = "695b14a0-920a-47bd-bd4a-7989862cdd0a"
@@ -131874,6 +135364,11 @@ scryfall_id = "b30fd369-68db-41f1-bb1e-eabfe4eb5356"
 card_name = "Dreadhorde Invasion"
 scryfall_oracle_id = "01deabbb-af6a-4998-99a7-35b7cfa9ef77"
 scryfall_id = "ccd2fc83-7fbe-45c4-a5f3-18a105ce6f09"
+
+[[token.source_card_refs]]
+card_name = "Lazotep Chancellor"
+scryfall_oracle_id = "c3e67b8f-1c91-4a2f-b924-35bbaff4bab9"
+scryfall_id = "2583c3c4-4238-4136-9020-37d46bff73d0"
 
 [[token.source_card_refs]]
 card_name = "Angrath, Captain of Chaos"
@@ -132619,7 +136114,11 @@ preset_id = "99859c93-5f3d-5dc3-ace1-f8c1802706f8"
 id = "99a2d3f7-bda1-5a31-8a8f-c11d0c7a2437"
 category = "Creature"
 fidelity = "Full"
-source_card_names = ["Research // Development"]
+source_card_names = [
+    "Development",
+    "Research",
+    "Research // Development",
+]
 set_code = "C20"
 set_name = "Commander 2020"
 collector_number = "10"
@@ -132635,6 +136134,18 @@ subtypes = ["Elemental"]
 supertypes = []
 colors = ["Red"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Research // Development"
+face_name = "Development"
+scryfall_oracle_id = "fa38394b-6ac4-460c-ae3a-54d50037715b"
+scryfall_id = "5d48ee48-aaeb-4907-b9dc-32f22e95ae4c"
+
+[[token.source_card_refs]]
+card_name = "Research // Development"
+face_name = "Research"
+scryfall_oracle_id = "fa38394b-6ac4-460c-ae3a-54d50037715b"
+scryfall_id = "5d48ee48-aaeb-4907-b9dc-32f22e95ae4c"
 
 [token.token_image_ref]
 scryfall_id = "9d952cde-4b40-4a05-833e-029da3554c6d"
@@ -133554,6 +137065,11 @@ scryfall_oracle_id = "2e18ee5b-cda3-428b-be91-939c410256ac"
 scryfall_id = "f082111b-9b1c-4a25-8c5d-d6ef77533a9b"
 
 [[token.source_card_refs]]
+card_name = "Conservatory"
+scryfall_oracle_id = "8f88b0bf-81bd-4223-9dad-d8c49ff4b87a"
+scryfall_id = "8bab22c5-4742-4f2e-bda1-26c72b09cd9c"
+
+[[token.source_card_refs]]
 card_name = "Morska, Undersea Sleuth"
 scryfall_oracle_id = "80ea3e65-946d-42c3-a26f-3d74e81d70b4"
 scryfall_id = "d6e8a859-92bf-452e-bcc2-3975bf1d6217"
@@ -133597,6 +137113,11 @@ scryfall_id = "e8578839-046f-4afd-a0e7-4737ded9e6eb"
 card_name = "Follow the Bodies"
 scryfall_oracle_id = "2d6a0d89-7ebd-420e-9892-be1506ab3714"
 scryfall_id = "387f3f54-d26c-4b2c-ab8b-8bdba0b11b1a"
+
+[[token.source_card_refs]]
+card_name = "Syndicate Heavy"
+scryfall_oracle_id = "01becf76-aa53-4fd5-94c1-665c64674219"
+scryfall_id = "251e36f1-1bfd-4c04-8c61-1c2bc18beb8a"
 
 [[token.source_card_refs]]
 card_name = "No Witnesses"
@@ -133645,6 +137166,11 @@ scryfall_oracle_id = "2d16d51b-47e0-4cdc-83dd-a805ba50bd83"
 scryfall_id = "aabfada0-3c1b-4237-b06c-573071ccd68d"
 
 [[token.source_card_refs]]
+card_name = "Secret Passage"
+scryfall_oracle_id = "c6a46fc2-fc8f-4dcd-bca7-682abfbf303d"
+scryfall_id = "6b35ede8-e882-46fd-9eda-9d6f64c73ea1"
+
+[[token.source_card_refs]]
 card_name = "Confirm Suspicions"
 scryfall_oracle_id = "a30d076b-c942-45e4-b943-3749ce955291"
 scryfall_id = "1d1463af-8f22-4771-af19-3799ffe706b8"
@@ -133679,6 +137205,11 @@ scryfall_id = "c1500cbf-5619-465e-a97b-75e676ce789b"
 card_name = "Erdwal Illuminator"
 scryfall_oracle_id = "5ff4ef34-acb9-46c3-8530-f4b093807066"
 scryfall_id = "5c39fa19-ca75-49f4-8e1e-8b59bc9b664a"
+
+[[token.source_card_refs]]
+card_name = "Dining Room"
+scryfall_oracle_id = "0880461e-8943-443b-90e7-ff84eef46550"
+scryfall_id = "1bf8dcb2-6fe7-4ab3-b290-fb427d116c74"
 
 [[token.source_card_refs]]
 card_name = "Teysa, Opulent Oligarch"
@@ -133741,6 +137272,11 @@ scryfall_oracle_id = "4ec0b64d-c793-47a6-9c26-9ad4d9e9c182"
 scryfall_id = "32a701da-47d6-4c85-a428-adeb4a20678d"
 
 [[token.source_card_refs]]
+card_name = "Ballroom"
+scryfall_oracle_id = "cb91e842-9f06-4863-a328-2cabe1bcfe27"
+scryfall_id = "6e982bf8-382f-4987-bc39-28e1ce290340"
+
+[[token.source_card_refs]]
 card_name = "Alquist Proft, Master Sleuth"
 scryfall_oracle_id = "dd79a994-7dad-49d4-8d8f-62dbedde4a38"
 scryfall_id = "e528424e-a3b1-4902-b42d-1ba9ac412e73"
@@ -133749,6 +137285,11 @@ scryfall_id = "e528424e-a3b1-4902-b42d-1ba9ac412e73"
 card_name = "Merchant of Truth"
 scryfall_oracle_id = "84275aab-f718-4896-b61c-63bf49fb483b"
 scryfall_id = "0f47e29e-54c5-4b1a-b9b9-d5e267a0203a"
+
+[[token.source_card_refs]]
+card_name = "Lavinia, Foil to Conspiracy"
+scryfall_oracle_id = "b5b26cea-9be3-46f7-9603-a6eee0dd107e"
+scryfall_id = "1f1b47ed-e935-44a4-b654-a32c0bf5dd19"
 
 [[token.source_card_refs]]
 card_name = "Novice Inspector"
@@ -133779,6 +137320,11 @@ scryfall_id = "7cbb17af-e17e-438a-ad72-0c942e6706b6"
 card_name = "Foreboding Steamboat"
 scryfall_oracle_id = "d97a0e41-9dd7-4466-afb7-3d8bd6cd0eed"
 scryfall_id = "dc8f50a0-d5a2-46c1-8f09-4c43f174dca7"
+
+[[token.source_card_refs]]
+card_name = "Lavinia, Foil to Conspiracy"
+scryfall_oracle_id = "b5b26cea-9be3-46f7-9603-a6eee0dd107e"
+scryfall_id = "d5435866-d48b-496a-ba07-438163b71ae8"
 
 [[token.source_card_refs]]
 card_name = "Torch the Witness"
@@ -133821,6 +137367,16 @@ scryfall_oracle_id = "dc4d5602-47cb-47c8-8a43-3b840e12b79c"
 scryfall_id = "21d6accd-167a-4b21-a488-44d54cdfa608"
 
 [[token.source_card_refs]]
+card_name = "Billiard Room"
+scryfall_oracle_id = "a4fc174e-7fa6-41a8-ae03-255f226840f9"
+scryfall_id = "dc2a3de1-01ac-4425-8534-e5019e01f2cd"
+
+[[token.source_card_refs]]
+card_name = "Lounge"
+scryfall_oracle_id = "98a22879-d0b2-441f-bcf6-a67b4552b73c"
+scryfall_id = "4b197079-488d-47c6-a494-8baf36c48667"
+
+[[token.source_card_refs]]
 card_name = "Sharp-Eyed Rookie"
 scryfall_oracle_id = "0642fb0d-73cb-4989-852c-3233fe36c3b4"
 scryfall_id = "be2b1b18-179d-48e1-ab8a-9374eb1ae429"
@@ -133851,9 +137407,19 @@ scryfall_oracle_id = "0232418d-1c52-4573-b488-c62345ca1c8d"
 scryfall_id = "08877e2c-79ac-4a4d-a7dd-60652c5eb5f6"
 
 [[token.source_card_refs]]
+card_name = "Resonance Technician"
+scryfall_oracle_id = "ec8a4b26-633a-4e88-aa8a-82e9704b3439"
+scryfall_id = "1e7c9ff3-9db9-41c0-9c8b-067e694973c5"
+
+[[token.source_card_refs]]
 card_name = "They Went This Way"
 scryfall_oracle_id = "47951720-9584-4ca3-a73d-3d259102b2f8"
 scryfall_id = "f4a31d4a-34bc-46b4-b20f-a5460191b35d"
+
+[[token.source_card_refs]]
+card_name = "Study"
+scryfall_oracle_id = "7ffadb3f-0b88-416f-b1a1-876383c22720"
+scryfall_id = "c694bc39-3eae-4b40-8f85-34785f9e75f1"
 
 [[token.source_card_refs]]
 card_name = "Kellan, Inquisitive Prodigy // Tail the Suspect"
@@ -133882,6 +137448,11 @@ scryfall_oracle_id = "b401179f-eded-4973-8182-df4627133886"
 scryfall_id = "6c134956-ba18-415e-b101-c1254415ea04"
 
 [[token.source_card_refs]]
+card_name = "Hall"
+scryfall_oracle_id = "949e455d-6a9e-491a-892f-826cc8be0fd9"
+scryfall_id = "ab3d0e50-630a-4ccc-aa79-1db912ea801e"
+
+[[token.source_card_refs]]
 card_name = "Chalk Outline"
 scryfall_oracle_id = "af335eb3-f60a-44b3-a1ed-1e165f3e3605"
 scryfall_id = "b3ff56c1-4153-4e15-9ac6-06d93fa2ae50"
@@ -133905,6 +137476,11 @@ scryfall_id = "9daf962d-f48d-4c93-98d1-ec32d3c758a1"
 card_name = "Deduce"
 scryfall_oracle_id = "eeae4161-9f35-45df-8b3c-c55e37f49cd1"
 scryfall_id = "5ad92dbd-828e-425f-8cab-819a04ea9020"
+
+[[token.source_card_refs]]
+card_name = "Kitchen"
+scryfall_oracle_id = "47f71408-5509-4651-9121-fd0867adae00"
+scryfall_id = "4388ae8f-a2c4-4e0d-a6a1-0204ff3f469b"
 
 [[token.source_card_refs]]
 card_name = "Flotsam // Jetsam"
@@ -133939,6 +137515,11 @@ scryfall_oracle_id = "24038629-7c12-45ef-8ec4-0d2bb3e2265c"
 scryfall_id = "c675428b-2dc4-408d-9632-81c1a700090f"
 
 [[token.source_card_refs]]
+card_name = "Library"
+scryfall_oracle_id = "33a7d29a-ebc0-4606-91b6-7381e2a16016"
+scryfall_id = "442cf173-8042-40fa-98d6-6ca93caa3e03"
+
+[[token.source_card_refs]]
 card_name = "Loxodon Eavesdropper"
 scryfall_oracle_id = "141a2757-8f20-4e10-9866-bb5d612ed62d"
 scryfall_id = "bbbf8c3a-6c74-42fd-bb8d-61e3f0a77848"
@@ -133969,6 +137550,11 @@ scryfall_oracle_id = "d4f5748f-bb0e-4c48-8802-45a7ad5a80a4"
 scryfall_id = "ba0870d4-b5b8-4fd7-a21b-417f832e0d7e"
 
 [[token.source_card_refs]]
+card_name = "Carnage Interpreter"
+scryfall_oracle_id = "4bc79fb3-81bb-42ed-9bbb-93f8cede3094"
+scryfall_id = "f6fb576e-a4a4-496b-b553-3f81cc651210"
+
+[[token.source_card_refs]]
 card_name = "Wojek Investigator"
 scryfall_oracle_id = "ab41243d-b178-4ebe-a7ac-bea37427be99"
 scryfall_id = "58eccc85-bdfe-48f4-a79e-76d9ef122815"
@@ -133993,6 +137579,11 @@ scryfall_id = "66660f7c-9e1c-4e88-856a-98fab1f1364d"
 card_name = "Homicide Investigator"
 scryfall_oracle_id = "dc4d5602-47cb-47c8-8a43-3b840e12b79c"
 scryfall_id = "b9106abf-f589-48a2-90f8-d606a7367377"
+
+[[token.source_card_refs]]
+card_name = "Lonis, Genetics Expert"
+scryfall_oracle_id = "52d8e492-b7b7-4ad4-8f1f-5c50993e55e0"
+scryfall_id = "59813845-48c9-4af2-8beb-91d58aac09ee"
 
 [[token.source_card_refs]]
 card_name = "Lazav, Wearer of Faces"
@@ -134237,6 +137828,11 @@ scryfall_oracle_id = "91b2520e-85b6-4e1f-88cf-a585feeb8e65"
 scryfall_id = "5524b712-c67d-4d2e-9344-9e85a6ce3227"
 
 [[token.source_card_refs]]
+card_name = "Krenko's Command"
+scryfall_oracle_id = "9cfe86ae-eebe-44aa-a956-4b3e9e621105"
+scryfall_id = "b07d96a1-87a0-45ff-ae6e-230deaf44dca"
+
+[[token.source_card_refs]]
 card_name = "A Killer Among Us"
 scryfall_oracle_id = "79d577a8-53c0-4220-bc0e-70764d72d5fd"
 scryfall_id = "2c1392c5-91a5-4e6e-803d-ed032e4d594b"
@@ -134368,6 +137964,11 @@ scryfall_id = "c77d9454-a78c-4063-ad66-46b2f5a030aa"
 card_name = "Kasmina, Enigmatic Mentor"
 scryfall_oracle_id = "df561b38-fe2a-4db9-a9d4-ec25b1c7572a"
 scryfall_id = "bf793e51-1e92-41ab-8516-dd78df5e1ca0"
+
+[[token.source_card_refs]]
+card_name = "Kasmina, Enigmatic Mentor"
+scryfall_oracle_id = "df561b38-fe2a-4db9-a9d4-ec25b1c7572a"
+scryfall_id = "ca2b53e2-aa6a-4cb2-899c-8e022e822ffc"
 
 [[token.source_card_refs]]
 card_name = "Kasmina, Enigmatic Mentor"
@@ -134809,9 +138410,44 @@ scryfall_oracle_id = "c1624d10-8838-4af8-aea1-a96c0fe6fd6b"
 scryfall_id = "a241317d-2277-467e-a8f9-aa71c944e244"
 
 [[token.source_card_refs]]
+card_name = "Dire Fleet Hoarder"
+scryfall_oracle_id = "7d48ad95-d428-4e2d-b697-56907c3ce579"
+scryfall_id = "9cd2e253-db7c-4c34-8cd5-8aca28752a60"
+
+[[token.source_card_refs]]
+card_name = "Grim Bounty"
+scryfall_oracle_id = "8060dc97-9868-4846-85f4-0ef70da2b021"
+scryfall_id = "eb485579-49c4-4834-9fba-a8ae2dde86e9"
+
+[[token.source_card_refs]]
+card_name = "Shambling Ghast"
+scryfall_oracle_id = "e5e6229a-3422-4afd-9a87-86daa2d31d3a"
+scryfall_id = "856e95de-792d-478a-91cf-fe0df549abdb"
+
+[[token.source_card_refs]]
+card_name = "Fake Your Own Death"
+scryfall_oracle_id = "ad01df89-29fe-44c7-a133-91425f8ff09c"
+scryfall_id = "271ac37f-305c-4918-8761-1779caa19f36"
+
+[[token.source_card_refs]]
 card_name = "Rapacious Dragon"
 scryfall_oracle_id = "0944ec2e-1dd9-459f-8f1d-667242cf52fe"
 scryfall_id = "5eaddac1-d8ca-4949-8140-c9193e3df921"
+
+[[token.source_card_refs]]
+card_name = "Prosperous Thief"
+scryfall_oracle_id = "6d03971a-8365-449a-8fbe-07b5b9bb42dc"
+scryfall_id = "5dea029b-ffc9-49d1-925c-b55a944d3439"
+
+[[token.source_card_refs]]
+card_name = "Pitiless Plunderer"
+scryfall_oracle_id = "a784481f-eccb-4112-bb38-04a659319660"
+scryfall_id = "1ac61e84-94d6-4ff7-a00f-29de93f09a38"
+
+[[token.source_card_refs]]
+card_name = "Undercity Scrounger"
+scryfall_oracle_id = "2750451f-348e-452f-88d0-bc921c46e8cc"
+scryfall_id = "ad8f033f-2626-44f0-b549-f0b2777731c3"
 
 [[token.source_card_refs]]
 card_name = "Involuntary Employment"
@@ -134829,9 +138465,39 @@ scryfall_oracle_id = "234a734b-ba28-4f1b-9d01-3c3e7d516590"
 scryfall_id = "a829747f-cf9b-4d81-ba66-9f0630ed4565"
 
 [[token.source_card_refs]]
+card_name = "Rev, Tithe Extractor"
+scryfall_oracle_id = "8345eb05-c04e-4c1d-9776-5ab7d91a7842"
+scryfall_id = "8bf88010-799d-4217-8e79-308bec7ad2ff"
+
+[[token.source_card_refs]]
+card_name = "Thieves' Tools"
+scryfall_oracle_id = "7fe361ef-a168-4847-92a2-21c1661aac06"
+scryfall_id = "7c3faae3-a117-4d59-bc19-c85ceffe6021"
+
+[[token.source_card_refs]]
 card_name = "Gleaming Barrier"
 scryfall_oracle_id = "1eb9e401-8975-447b-839d-f7cd23897465"
 scryfall_id = "1b49b009-e6f2-494a-9235-f5c25c2d70a9"
+
+[[token.source_card_refs]]
+card_name = "Ruthless Technomancer"
+scryfall_oracle_id = "4e58ad76-37c7-4531-b207-6890b39a2679"
+scryfall_id = "5a9832da-b790-47a7-b19a-360e5f90dc25"
+
+[[token.source_card_refs]]
+card_name = "Scion of Opulence"
+scryfall_oracle_id = "5818b31e-2e86-4230-937e-478e14534f91"
+scryfall_id = "d5af4995-f29f-4c4a-a2ed-a0e6ba94f334"
+
+[[token.source_card_refs]]
+card_name = "Tireless Provisioner"
+scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
+scryfall_id = "5dbc2162-238d-492b-b629-94f771230d92"
+
+[[token.source_card_refs]]
+card_name = "Seize the Spoils"
+scryfall_oracle_id = "58f83528-9110-4895-b5ea-51b90af30a8d"
+scryfall_id = "eecfce55-f288-40e6-887d-75bd0e065e28"
 
 [[token.source_card_refs]]
 card_name = "Brass's Bounty"
@@ -134839,9 +138505,29 @@ scryfall_oracle_id = "63b0538e-aa94-4e23-adf1-704cbf5bc3e5"
 scryfall_id = "65fe7127-b0ec-400f-97f1-6e17ab8e319d"
 
 [[token.source_card_refs]]
+card_name = "Contract Killing"
+scryfall_oracle_id = "a7a0e473-77c1-4a85-b6d7-b0dfdadb696f"
+scryfall_id = "b4e0debd-0157-4a7f-ac84-b322a821d88e"
+
+[[token.source_card_refs]]
+card_name = "Rapacious Dragon"
+scryfall_oracle_id = "0944ec2e-1dd9-459f-8f1d-667242cf52fe"
+scryfall_id = "5e4f1666-7df7-455d-85fc-03c117baa319"
+
+[[token.source_card_refs]]
+card_name = "Ruthless Knave"
+scryfall_oracle_id = "00225c40-27ff-410f-a591-5c788c6a2bd6"
+scryfall_id = "f679da19-5dac-4be6-983d-fee7e80cdb9c"
+
+[[token.source_card_refs]]
 card_name = "Seize the Spoils"
 scryfall_oracle_id = "58f83528-9110-4895-b5ea-51b90af30a8d"
 scryfall_id = "efcf7e75-5de2-45cc-9275-caccd73214fa"
+
+[[token.source_card_refs]]
+card_name = "Deadly Dispute"
+scryfall_oracle_id = "457af74a-02b3-4659-846d-63e482667f34"
+scryfall_id = "a788df2d-75e7-4a3b-a046-7e264e40cbfa"
 
 [[token.source_card_refs]]
 card_name = "An Offer You Can't Refuse"
@@ -135840,12 +139526,32 @@ scryfall_id = "a12cf50b-12f1-454a-b3cd-b3a30ee75585"
 [[token.source_card_refs]]
 card_name = "Wurmweaver Coil"
 scryfall_oracle_id = "83419229-c266-4022-8297-d1b05ec5ee20"
+scryfall_id = "661580bc-b5e5-48ce-b855-c177f1c61742"
+
+[[token.source_card_refs]]
+card_name = "Roar of the Wurm"
+scryfall_oracle_id = "b8b9e6fd-b3ed-4fbc-8753-74018fa33caa"
+scryfall_id = "3e282e0e-6462-40de-9abf-44385413fce9"
+
+[[token.source_card_refs]]
+card_name = "Wurmweaver Coil"
+scryfall_oracle_id = "83419229-c266-4022-8297-d1b05ec5ee20"
 scryfall_id = "37a71160-aa29-4662-8d7b-590771b42635"
 
 [[token.source_card_refs]]
 card_name = "Roar of the Wurm"
 scryfall_oracle_id = "b8b9e6fd-b3ed-4fbc-8753-74018fa33caa"
 scryfall_id = "0c315523-a023-42f3-9906-690d90eb99dd"
+
+[[token.source_card_refs]]
+card_name = "Crush of Wurms"
+scryfall_oracle_id = "6c12cd05-b673-453c-9f6b-f3aa022467c1"
+scryfall_id = "32a924b3-3bd6-43ad-acbd-1303dd670db4"
+
+[[token.source_card_refs]]
+card_name = "Roar of the Wurm"
+scryfall_oracle_id = "b8b9e6fd-b3ed-4fbc-8753-74018fa33caa"
+scryfall_id = "ddf54317-4c08-4a66-9fd2-9983384e2374"
 
 [[token.source_card_refs]]
 card_name = "Roar of the Wurm"
@@ -136390,6 +140096,11 @@ card_name = "Hare Apparent"
 scryfall_oracle_id = "3c1619bd-db5e-4df6-a196-0a9d62374f6d"
 scryfall_id = "9fc6f0e9-eb5f-4bc0-b3d7-756644b66d12"
 
+[[token.source_card_refs]]
+card_name = "Hop to It"
+scryfall_oracle_id = "e8a9350a-07c1-47ed-8c4f-88e4b3b17545"
+scryfall_id = "16fabbbf-e35b-468c-9aea-09aa6a388dee"
+
 [token.token_image_ref]
 scryfall_id = "63ae4f9c-ad6e-4d6a-89f1-653916bf5373"
 scryfall_oracle_id = "fee35fc4-a5b5-4c2c-8c6a-62dad166ea72"
@@ -136616,11 +140327,6 @@ scryfall_id = "7a832060-ecc6-406a-ab06-b371aa952e13"
 card_name = "Tippy-Toe, Terrific Partner"
 scryfall_oracle_id = "6a1bce89-0c11-4d8d-aacb-c0a5a5effffc"
 scryfall_id = "d3154e82-3497-47ad-99e5-369cb40ac869"
-
-[[token.source_card_refs]]
-card_name = "Tireless Provisioner"
-scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
-scryfall_id = "6d2e2e8d-8382-4d98-9e25-2dff1b1d0ff8"
 
 [[token.source_card_refs]]
 card_name = "Academy Manufactor"
@@ -137533,6 +141239,11 @@ card_name = "Chasm Skulker"
 scryfall_oracle_id = "69facbc7-3859-4716-b627-5199571fb3cf"
 scryfall_id = "92a08fad-56ad-4437-9bb8-6d016c1c714f"
 
+[[token.source_card_refs]]
+card_name = "Chasm Skulker"
+scryfall_oracle_id = "69facbc7-3859-4716-b627-5199571fb3cf"
+scryfall_id = "dd7619c0-bb4e-41ed-929b-7d6e0cc9fca0"
+
 [token.token_image_ref]
 scryfall_id = "660d8e43-13e1-464b-b251-c7c2d77732ca"
 scryfall_oracle_id = "dd85fcd6-9bfd-4deb-a56a-77c6bca8eb97"
@@ -138181,6 +141892,16 @@ subtypes = ["Beast"]
 supertypes = []
 colors = ["Green"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Primeval Bounty"
+scryfall_oracle_id = "f633c16d-d943-421c-ad18-af35db9ec9fc"
+scryfall_id = "f1623228-0935-4a8d-863c-249d613bd3ab"
+
+[[token.source_card_refs]]
+card_name = "Somberwald Beastmaster"
+scryfall_oracle_id = "df35bf19-4cbf-4624-925d-ceca6bff596e"
+scryfall_id = "6488d613-59fa-4e26-a48c-eecab8754808"
 
 [[token.source_card_refs]]
 card_name = "Primeval Bounty"
@@ -140802,6 +144523,11 @@ scryfall_oracle_id = "8e62d05a-6efd-4764-bca8-97895e0cb613"
 scryfall_id = "faac5cd1-ce93-4b98-97ad-8bdce2862b3b"
 
 [[token.source_card_refs]]
+card_name = "Assemble the Legion"
+scryfall_oracle_id = "6f81bef3-6ca0-4cf4-aa99-7b2813eeef04"
+scryfall_id = "a71c666d-a03b-4f2b-80ad-e1ecf0df1d10"
+
+[[token.source_card_refs]]
 card_name = "Sunhome Guildmage"
 scryfall_oracle_id = "f211d21f-7d78-4435-a592-a6896023af3b"
 scryfall_id = "d1d2de3e-5885-45df-8570-69d2d3e0e25c"
@@ -141561,6 +145287,11 @@ card_name = "Wrenn and Seven"
 scryfall_oracle_id = "63a509ea-cedc-40e9-b4e8-0ff4fc356485"
 scryfall_id = "302f0dc1-88ab-4961-b78c-fbe7980dca18"
 
+[[token.source_card_refs]]
+card_name = "Wrenn and Seven"
+scryfall_oracle_id = "63a509ea-cedc-40e9-b4e8-0ff4fc356485"
+scryfall_id = "365d2ecc-24ef-41fb-a1ee-055e99e1d94f"
+
 [token.token_image_ref]
 scryfall_id = "26981595-edf3-4f22-b2f0-fe0052408f8c"
 scryfall_oracle_id = "46e30c03-15cd-46ed-a122-c47cbca87368"
@@ -141725,7 +145456,17 @@ keywords = ["Trample"]
 [[token.source_card_refs]]
 card_name = "Voice of the Woods"
 scryfall_oracle_id = "12da8ba3-ca60-44c8-8627-1b4af2a2c4a3"
+scryfall_id = "1ebb4668-eebf-4b7e-ae29-75fff5963868"
+
+[[token.source_card_refs]]
+card_name = "Voice of the Woods"
+scryfall_oracle_id = "12da8ba3-ca60-44c8-8627-1b4af2a2c4a3"
 scryfall_id = "d7a6315c-aa6f-4be1-a002-d7824bfad622"
+
+[[token.source_card_refs]]
+card_name = "Voice of the Woods"
+scryfall_oracle_id = "12da8ba3-ca60-44c8-8627-1b4af2a2c4a3"
+scryfall_id = "30582551-8236-41d5-bedf-818f4af97d3f"
 
 [token.token_image_ref]
 scryfall_id = "7737cbbf-659e-4a8d-9918-50652d6c0863"
@@ -142056,9 +145797,19 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Sliver Hive"
+scryfall_oracle_id = "e7286688-ffbe-4d25-ad55-27990f005368"
+scryfall_id = "61d4a8e0-edbf-43b1-8047-8235f803c3aa"
+
+[[token.source_card_refs]]
 card_name = "Brood Sliver"
 scryfall_oracle_id = "6b1d178f-9713-4dcf-920b-ddf2c94cc427"
 scryfall_id = "c5bffc93-1162-49e5-a38b-8a7271915d0c"
+
+[[token.source_card_refs]]
+card_name = "Brood Sliver"
+scryfall_oracle_id = "6b1d178f-9713-4dcf-920b-ddf2c94cc427"
+scryfall_id = "33803c12-1d78-49fe-a3a3-7f47c60a96b6"
 
 [[token.source_card_refs]]
 card_name = "Sliver Hive"
@@ -142066,9 +145817,24 @@ scryfall_oracle_id = "e7286688-ffbe-4d25-ad55-27990f005368"
 scryfall_id = "04541650-6ee7-4825-984e-4794b306c274"
 
 [[token.source_card_refs]]
+card_name = "Hive Stirrings"
+scryfall_oracle_id = "c7dd0614-e11e-4b6b-a2cb-9904e457148f"
+scryfall_id = "93fa40de-1bf2-46ef-8cb8-7331386990d1"
+
+[[token.source_card_refs]]
 card_name = "Thrumming Hivepool"
 scryfall_oracle_id = "04ea21b3-084b-4746-9b49-99b6ef4f0885"
 scryfall_id = "85caf659-7b43-462e-a342-34703d46eb57"
+
+[[token.source_card_refs]]
+card_name = "Sliver Queen"
+scryfall_oracle_id = "b8376cca-ea96-478a-8e98-c4482031300a"
+scryfall_id = "235c0ece-aed0-4120-99cc-5d0e28fa70ab"
+
+[[token.source_card_refs]]
+card_name = "Sliver Queen"
+scryfall_oracle_id = "b8376cca-ea96-478a-8e98-c4482031300a"
+scryfall_id = "096cff82-28eb-4096-be1d-a02b9a56e682"
 
 [[token.source_card_refs]]
 card_name = "Thrumming Hivepool"
@@ -144435,6 +148201,11 @@ scryfall_oracle_id = "dfec65a0-6fb6-463d-aa62-e84a427db217"
 scryfall_id = "524a5d93-26ed-436d-a437-dc9460acce98"
 
 [[token.source_card_refs]]
+card_name = "Attended Healer"
+scryfall_oracle_id = "9442a18b-9093-4a10-ab61-6962f5af3bb6"
+scryfall_id = "1eae2fa8-032a-49d5-8e5f-de742cded9c2"
+
+[[token.source_card_refs]]
 card_name = "Arahbo, the First Fang"
 scryfall_oracle_id = "dfec65a0-6fb6-463d-aa62-e84a427db217"
 scryfall_id = "2507fddd-2dc0-45f0-ac47-1ddd8690be46"
@@ -144540,9 +148311,19 @@ colors = ["Blue"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
+card_name = "Moonblade Shinobi"
+scryfall_oracle_id = "046e25ee-c96d-4cff-93be-f7e3379d713c"
+scryfall_id = "ebfbb4fe-a415-44fa-9a5b-cd6c05251723"
+
+[[token.source_card_refs]]
 card_name = "Meloku the Clouded Mirror"
 scryfall_oracle_id = "3b96b8c3-b9c8-4712-a3b1-243a67cc013a"
 scryfall_id = "60b9db96-a6ab-454b-99a7-910ef77560d7"
+
+[[token.source_card_refs]]
+card_name = "Meloku the Clouded Mirror"
+scryfall_oracle_id = "3b96b8c3-b9c8-4712-a3b1-243a67cc013a"
+scryfall_id = "1caaa733-6d4c-4e18-a64e-f95851c7063b"
 
 [token.token_image_ref]
 scryfall_id = "7274e711-42fd-489e-809d-77d3bce24422"
@@ -145949,6 +149730,11 @@ card_name = "Witch's Mark"
 scryfall_oracle_id = "00807825-88e5-4b88-8527-a49f553a91be"
 scryfall_id = "7120f534-cc20-453a-8ddd-ebd6f64235e7"
 
+[[token.source_card_refs]]
+card_name = "Witch's Mark"
+scryfall_oracle_id = "00807825-88e5-4b88-8527-a49f553a91be"
+scryfall_id = "03c6aae5-f85a-4083-b880-71c0e141cc22"
+
 [token.token_image_ref]
 scryfall_id = "6929750f-cf08-4e3e-83b0-076e1f6fa8e0"
 scryfall_oracle_id = "0664dcc8-fa68-4802-936f-ecd2979ebf3c"
@@ -146140,6 +149926,7 @@ source_card_names = [
     "Auspicious Arrival",
     "Azula, On the Hunt",
     "Ballroom",
+    "Bearer of Overwhelming Truths",
     "Billiard Room",
     "Blink",
     "Briarbridge Patrol",
@@ -146157,9 +149944,12 @@ source_card_names = [
     "Conservatory",
     "Cunning Maneuver",
     "Curious Inquiry",
+    "Daring Sleuth",
     "Daring Sleuth // Bearer of Overwhelming Truths",
     "Declaration in Stone",
     "Deduce",
+    "Dennick, Pious Apparition",
+    "Dennick, Pious Apprentice",
     "Dennick, Pious Apprentice // Dennick, Pious Apparition",
     "Detective's Satchel",
     "Dining Room",
@@ -146312,14 +150102,258 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Press for Answers"
+scryfall_oracle_id = "4960c3a0-77ca-48d8-b565-6c5f1e6522cf"
+scryfall_id = "e7854c3f-8c89-4ac6-8cfe-3b5b3b651918"
+
+[[token.source_card_refs]]
+card_name = "Erdwal Illuminator"
+scryfall_oracle_id = "5ff4ef34-acb9-46c3-8530-f4b093807066"
+scryfall_id = "bba1f355-4aa0-421f-86fc-25de52f47d74"
+
+[[token.source_card_refs]]
+card_name = "Magnifying Glass"
+scryfall_oracle_id = "f2ce9e55-07c0-4f36-a59e-127693fc0f62"
+scryfall_id = "46881c84-d20f-4e9d-bd58-d11c349de83b"
+
+[[token.source_card_refs]]
+card_name = "Fleeting Memories"
+scryfall_oracle_id = "fbb0173d-7ec9-4f43-b457-f8de6703497e"
+scryfall_id = "14ee271d-f545-4fde-a859-f8a1bb92d512"
+
+[[token.source_card_refs]]
+card_name = "Tireless Tracker"
+scryfall_oracle_id = "e6555cca-e608-4c87-b835-9cd47fd1f543"
+scryfall_id = "e7fe81de-a81f-4226-9067-4d6598b82016"
+
+[[token.source_card_refs]]
+card_name = "Declaration in Stone"
+scryfall_oracle_id = "49554441-bb48-4829-b8d6-55e687a6c2e2"
+scryfall_id = "99822609-bba8-44da-8f86-54960b566522"
+
+[[token.source_card_refs]]
+card_name = "Deduce"
+scryfall_oracle_id = "eeae4161-9f35-45df-8b3c-c55e37f49cd1"
+scryfall_id = "a6813cd2-7151-459a-a2f1-52808584de53"
+
+[[token.source_card_refs]]
+card_name = "Briarbridge Tracker"
+scryfall_oracle_id = "8fe6e954-f19b-4d11-83d3-74c634d51bad"
+scryfall_id = "facfdada-406a-4b7f-8d59-7b740619394d"
+
+[[token.source_card_refs]]
+card_name = "Drownyard Explorers"
+scryfall_oracle_id = "c1ebbe89-8976-4ed7-a68a-8b08aac4616c"
+scryfall_id = "bb4e2569-7e5c-44d0-8d41-79d4a8e47d1d"
+
+[[token.source_card_refs]]
+card_name = "Erdwal Illuminator"
+scryfall_oracle_id = "5ff4ef34-acb9-46c3-8530-f4b093807066"
+scryfall_id = "d4fbfd62-0318-4f77-ab91-37e56233e493"
+
+[[token.source_card_refs]]
+card_name = "Ulvenwald Mysteries"
+scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
+scryfall_id = "749aafbf-9d17-4341-a137-dba1cc4d09da"
+
+[[token.source_card_refs]]
+card_name = "Briarbridge Tracker"
+scryfall_oracle_id = "8fe6e954-f19b-4d11-83d3-74c634d51bad"
+scryfall_id = "444abc67-ee3a-45ba-a4ce-95a22e139c64"
+
+[[token.source_card_refs]]
 card_name = "Agent 13, Sharon Carter"
 scryfall_oracle_id = "ddf7201a-6672-416d-be6b-202dafbeccab"
 scryfall_id = "107cb521-9806-47dc-92d8-b43112b63caa"
 
 [[token.source_card_refs]]
+card_name = "Fateful Absence"
+scryfall_oracle_id = "35bba442-1aec-4d33-b502-4c580d61644b"
+scryfall_id = "ea9e80c6-92b1-4c06-bf7e-b5e9f6c73418"
+
+[[token.source_card_refs]]
 card_name = "Thraben Inspector"
 scryfall_oracle_id = "caa02547-66e3-4e27-a2d3-5e94f3e7a069"
 scryfall_id = "ec18fa41-6948-4d94-8dcc-31fb63fb53ec"
+
+[[token.source_card_refs]]
+card_name = "Floodhound"
+scryfall_oracle_id = "6dd8ba09-f117-4514-9e09-f9f9f5fb5025"
+scryfall_id = "c0ca694c-f0ee-4994-92a2-be2a840c7e07"
+
+[[token.source_card_refs]]
+card_name = "Dennick, Pious Apprentice // Dennick, Pious Apparition"
+face_name = "Dennick, Pious Apparition"
+scryfall_oracle_id = "45802eb2-6848-416c-95e0-c1c1ea0620d0"
+scryfall_id = "4df8d711-09e3-43e5-b59e-ea6a92cae726"
+
+[[token.source_card_refs]]
+card_name = "Hard Evidence"
+scryfall_oracle_id = "0728b195-2dfe-4d73-91ae-e658a97b0b9a"
+scryfall_id = "204114ed-0d8e-460f-b7ce-9266536d4399"
+
+[[token.source_card_refs]]
+card_name = "Tireless Tracker"
+scryfall_oracle_id = "e6555cca-e608-4c87-b835-9cd47fd1f543"
+scryfall_id = "b3364018-aeba-4f58-8233-b0026c488dd0"
+
+[[token.source_card_refs]]
+card_name = "Foul Play"
+scryfall_oracle_id = "773c7a1e-0f59-4606-a2fc-c47bda760ecd"
+scryfall_id = "61639281-9a2d-4921-bed4-ce3ce9220b17"
+
+[[token.source_card_refs]]
+card_name = "Drownyard Explorers"
+scryfall_oracle_id = "c1ebbe89-8976-4ed7-a68a-8b08aac4616c"
+scryfall_id = "aa7a4792-0d24-47d7-a1df-818d97d40904"
+
+[[token.source_card_refs]]
+card_name = "Wavesifter"
+scryfall_oracle_id = "d1ec1e4e-faa6-4afc-9e00-a3327105c11b"
+scryfall_id = "c8d0613d-82eb-4400-9a24-902a9fd5ad80"
+
+[[token.source_card_refs]]
+card_name = "Floodhound"
+scryfall_oracle_id = "6dd8ba09-f117-4514-9e09-f9f9f5fb5025"
+scryfall_id = "50b2a8a0-93a3-4e83-8f14-efbce07d2d3a"
+
+[[token.source_card_refs]]
+card_name = "Jace's Scrutiny"
+scryfall_oracle_id = "8578c462-7b2d-4b69-ad10-a2eab44ac98d"
+scryfall_id = "4f6fa6db-c216-4973-96e7-4e10348e0aa8"
+
+[[token.source_card_refs]]
+card_name = "Tamiyo's Journal"
+scryfall_oracle_id = "20591a83-7138-4876-b088-035bd3788be3"
+scryfall_id = "b623e860-febb-4e30-9423-e8b1fadd5ee2"
+
+[[token.source_card_refs]]
+card_name = "Byway Courier"
+scryfall_oracle_id = "e186cc6f-8c11-4475-a704-0b4c3a9eade9"
+scryfall_id = "5b1c4e0f-734a-442a-b0b0-e26a2937c3f8"
+
+[[token.source_card_refs]]
+card_name = "Magnifying Glass"
+scryfall_oracle_id = "f2ce9e55-07c0-4f36-a59e-127693fc0f62"
+scryfall_id = "5db997a7-d54c-4821-9e9f-56292f9e7e5a"
+
+[[token.source_card_refs]]
+card_name = "Hold for Questioning"
+scryfall_oracle_id = "1095fcd9-8127-4345-9052-fccb350296d3"
+scryfall_id = "74004b11-53dc-475c-8d29-cf52403456cf"
+
+[[token.source_card_refs]]
+card_name = "Ongoing Investigation"
+scryfall_oracle_id = "68227832-2916-49b9-92bb-c09b8a0c13f5"
+scryfall_id = "c464b2f5-54e0-45a7-a58c-750f587ca339"
+
+[[token.source_card_refs]]
+card_name = "Foul Play"
+scryfall_oracle_id = "773c7a1e-0f59-4606-a2fc-c47bda760ecd"
+scryfall_id = "8e8fd73b-942a-44f1-85e3-bb599bccb05b"
+
+[[token.source_card_refs]]
+card_name = "Lonis, Cryptozoologist"
+scryfall_oracle_id = "0ee06ed0-717a-4bfa-b634-d00e013c1f16"
+scryfall_id = "e4b2e6f3-bba8-4ee5-b100-a5d89bd76253"
+
+[[token.source_card_refs]]
+card_name = "Dennick, Pious Apprentice // Dennick, Pious Apparition"
+face_name = "Dennick, Pious Apprentice"
+scryfall_oracle_id = "45802eb2-6848-416c-95e0-c1c1ea0620d0"
+scryfall_id = "4df8d711-09e3-43e5-b59e-ea6a92cae726"
+
+[[token.source_card_refs]]
+card_name = "Confirm Suspicions"
+scryfall_oracle_id = "a30d076b-c942-45e4-b943-3749ce955291"
+scryfall_id = "510df438-4ed3-4542-864e-0c23eacc4c30"
+
+[[token.source_card_refs]]
+card_name = "Daring Sleuth // Bearer of Overwhelming Truths"
+face_name = "Bearer of Overwhelming Truths"
+scryfall_oracle_id = "69ca69c7-403b-4b5d-be08-d9dce8ce410e"
+scryfall_id = "a7e2eed8-9a2d-4a6e-8bb2-53dc3022a4ac"
+
+[[token.source_card_refs]]
+card_name = "Funnel-Web Recluse"
+scryfall_oracle_id = "6148fcf5-466a-43aa-a0f3-d3d9fae4d883"
+scryfall_id = "bedd5fac-b7b1-46db-99af-41edc28663ef"
+
+[[token.source_card_refs]]
+card_name = "Tamiyo's Journal"
+scryfall_oracle_id = "20591a83-7138-4876-b088-035bd3788be3"
+scryfall_id = "de5c1782-e2bb-40f2-b3df-9b74a9166c73"
+
+[[token.source_card_refs]]
+card_name = "Weirding Wood"
+scryfall_oracle_id = "9ce5cc2f-e223-4c3b-adc1-c0109fd31762"
+scryfall_id = "65b73086-30f0-44c6-bf83-a0faeb91e885"
+
+[[token.source_card_refs]]
+card_name = "Secrets of the Key"
+scryfall_oracle_id = "55c7ce94-3cd3-42f3-9dd8-0c118fa626c8"
+scryfall_id = "c136e3ee-5134-480e-a322-69c9ed9b4677"
+
+[[token.source_card_refs]]
+card_name = "Jace's Scrutiny"
+scryfall_oracle_id = "8578c462-7b2d-4b69-ad10-a2eab44ac98d"
+scryfall_id = "a7e8e533-350b-4558-98d3-b7fcab3770f5"
+
+[[token.source_card_refs]]
+card_name = "Byway Courier"
+scryfall_oracle_id = "e186cc6f-8c11-4475-a704-0b4c3a9eade9"
+scryfall_id = "5d705a2b-9370-4f73-829c-823918f55c19"
+
+[[token.source_card_refs]]
+card_name = "Ulvenwald Mysteries"
+scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
+scryfall_id = "c6079979-8613-4613-a5bd-6b1fab382767"
+
+[[token.source_card_refs]]
+card_name = "Ulvenwald Mysteries"
+scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
+scryfall_id = "fd02c995-0a77-460c-9fa3-34f74b14b119"
+
+[[token.source_card_refs]]
+card_name = "Thraben Inspector"
+scryfall_oracle_id = "caa02547-66e3-4e27-a2d3-5e94f3e7a069"
+scryfall_id = "9b65852b-b748-4263-a5aa-7a44e891c582"
+
+[[token.source_card_refs]]
+card_name = "Daring Sleuth // Bearer of Overwhelming Truths"
+face_name = "Daring Sleuth"
+scryfall_oracle_id = "69ca69c7-403b-4b5d-be08-d9dce8ce410e"
+scryfall_id = "a7e2eed8-9a2d-4a6e-8bb2-53dc3022a4ac"
+
+[[token.source_card_refs]]
+card_name = "Thraben Inspector"
+scryfall_oracle_id = "caa02547-66e3-4e27-a2d3-5e94f3e7a069"
+scryfall_id = "6c727d20-51a0-443a-9d40-6efe7b91193a"
+
+[[token.source_card_refs]]
+card_name = "Confront the Unknown"
+scryfall_oracle_id = "221240c5-3c97-438c-b906-2508eacf190f"
+scryfall_id = "856c3be0-afe1-40c3-b84f-b50235246216"
+
+[[token.source_card_refs]]
+card_name = "Briarbridge Patrol"
+scryfall_oracle_id = "784f0ca3-efe1-4e22-aedd-57cba7996fa5"
+scryfall_id = "003b5fe1-4e9e-49ae-9af4-04eefb96398f"
+
+[[token.source_card_refs]]
+card_name = "Bygone Bishop"
+scryfall_oracle_id = "a47d9ea3-95fe-4774-8e72-30e7f56756f4"
+scryfall_id = "3fc53890-be06-42f0-9a78-eb0d62d0fffe"
+
+[[token.source_card_refs]]
+card_name = "Humble the Brute"
+scryfall_oracle_id = "bea6606c-ea9a-4199-a8cd-b35d7c47fd7b"
+scryfall_id = "65970840-0c4d-47b1-96d6-7d5c7a3411d9"
+
+[[token.source_card_refs]]
+card_name = "Tireless Tracker"
+scryfall_oracle_id = "e6555cca-e608-4c87-b835-9cd47fd1f543"
+scryfall_id = "5015b027-de1c-4e1e-8cf3-d946b8a3a4a3"
 
 [[token.source_card_refs]]
 card_name = "Panther Pounce"
@@ -146667,12 +150701,22 @@ keywords = ["Deathtouch"]
 [[token.source_card_refs]]
 card_name = "Ophiomancer"
 scryfall_oracle_id = "55eca80c-dcd8-4c2f-aa0f-fb0aec7b80f7"
+scryfall_id = "6c44fca9-3a41-41c3-aa74-f0f5a81e8b7d"
+
+[[token.source_card_refs]]
+card_name = "Ophiomancer"
+scryfall_oracle_id = "55eca80c-dcd8-4c2f-aa0f-fb0aec7b80f7"
 scryfall_id = "0ef8d3a2-5c6b-41e2-aa7d-81e4a5d04421"
 
 [[token.source_card_refs]]
 card_name = "Ophiomancer"
 scryfall_oracle_id = "55eca80c-dcd8-4c2f-aa0f-fb0aec7b80f7"
 scryfall_id = "baf793b6-9612-43f3-9f1b-2e53e81cb89f"
+
+[[token.source_card_refs]]
+card_name = "Aphelia, Viper Whisperer"
+scryfall_oracle_id = "191e003f-1a78-4d85-9c70-2ae132a5f9cc"
+scryfall_id = "1a0867be-a861-4fb4-b8ff-cb2966193755"
 
 [token.token_image_ref]
 scryfall_id = "62340bbb-cff0-48c1-8854-235340e80477"
@@ -148676,6 +152720,11 @@ scryfall_id = "cce2fce1-8172-43ed-937d-a543a474ef46"
 [[token.source_card_refs]]
 card_name = "Champion of Wits"
 scryfall_oracle_id = "3fd8ba0c-75ec-43ea-8706-f71e6cf1d236"
+scryfall_id = "b685b930-3201-4eb1-ac29-9c926651d118"
+
+[[token.source_card_refs]]
+card_name = "Champion of Wits"
+scryfall_oracle_id = "3fd8ba0c-75ec-43ea-8706-f71e6cf1d236"
 scryfall_id = "cf76d414-9424-4fd5-a1ff-2ff345ad6b0a"
 
 [[token.source_card_refs]]
@@ -150639,6 +154688,16 @@ scryfall_oracle_id = "936ae5dc-9838-47f3-ba1f-66523a7f5b76"
 scryfall_id = "31c99a7d-a70b-4599-9bd2-be7a5cac28ff"
 
 [[token.source_card_refs]]
+card_name = "Stolen by the Fae"
+scryfall_oracle_id = "5bafd0e0-8bf8-4e06-a54a-81cc6cc4bdb7"
+scryfall_id = "857d00b7-af88-483c-a209-6dde97d6e3c8"
+
+[[token.source_card_refs]]
+card_name = "Hunted Troll"
+scryfall_oracle_id = "1f789fcf-3df6-45a6-a732-9f43e33718d6"
+scryfall_id = "fd9d891e-ae8c-485a-b999-d1e08fffd164"
+
+[[token.source_card_refs]]
 card_name = "Alela, Artful Provocateur"
 scryfall_oracle_id = "936ae5dc-9838-47f3-ba1f-66523a7f5b76"
 scryfall_id = "80a94f62-2060-494b-924a-792b728dcf99"
@@ -150647,6 +154706,16 @@ scryfall_id = "80a94f62-2060-494b-924a-792b728dcf99"
 card_name = "Faebloom Trick"
 scryfall_oracle_id = "903d114b-1899-4e67-bee3-af0673850388"
 scryfall_id = "0c3bee8f-f5be-4404-a696-c902637799c3"
+
+[[token.source_card_refs]]
+card_name = "Faerie Formation"
+scryfall_oracle_id = "0366c2f6-6e78-4526-808c-fa7bace6006e"
+scryfall_id = "86682959-6720-44e0-8fe3-982f0b3e94ce"
+
+[[token.source_card_refs]]
+card_name = "Stolen by the Fae"
+scryfall_oracle_id = "5bafd0e0-8bf8-4e06-a54a-81cc6cc4bdb7"
+scryfall_id = "85d4af60-a143-42d1-a580-b4ba197ca1ea"
 
 [[token.source_card_refs]]
 card_name = "Alela, Artful Provocateur"
@@ -152628,9 +156697,34 @@ scryfall_oracle_id = "688e5e19-8f28-45c4-ace4-a38144f494f1"
 scryfall_id = "f824d5b6-259b-467b-93b5-e93db8b15359"
 
 [[token.source_card_refs]]
+card_name = "Scion Summoner"
+scryfall_oracle_id = "fa60f3a6-5834-4059-adea-dd17366b7885"
+scryfall_id = "e709bf1f-9bbb-4da7-a1ea-7deb94858b8c"
+
+[[token.source_card_refs]]
 card_name = "Eldrazi Skyspawner"
 scryfall_oracle_id = "b5661289-a03c-40fc-a1e4-f602adb56f81"
 scryfall_id = "1e1a05a1-8c66-4df9-8b57-f15b5d268973"
+
+[[token.source_card_refs]]
+card_name = "Blisterpod"
+scryfall_oracle_id = "2a62b226-d317-4212-9781-9c1d72056f11"
+scryfall_id = "8db1cc35-8901-4528-9100-38f12d89540c"
+
+[[token.source_card_refs]]
+card_name = "Brood Monitor"
+scryfall_oracle_id = "9a08bb4b-46df-4b99-8f86-670d07e900ba"
+scryfall_id = "0c6de7f2-fcc2-4a08-b49c-b50bb195a252"
+
+[[token.source_card_refs]]
+card_name = "Brood Monitor"
+scryfall_oracle_id = "9a08bb4b-46df-4b99-8f86-670d07e900ba"
+scryfall_id = "cf5a6be1-f706-4681-9f95-512381be123e"
+
+[[token.source_card_refs]]
+card_name = "Catacomb Sifter"
+scryfall_oracle_id = "4c2c5f3b-61f3-4772-9ade-f5be80719e9f"
+scryfall_id = "fcfb168b-86df-4e60-aee3-5e9976158edb"
 
 [[token.source_card_refs]]
 card_name = "Spawning Bed"
@@ -152658,6 +156752,21 @@ scryfall_oracle_id = "9a08bb4b-46df-4b99-8f86-670d07e900ba"
 scryfall_id = "cef68b13-74b6-4a8a-8f81-1427d18044a4"
 
 [[token.source_card_refs]]
+card_name = "Carrier Thrall"
+scryfall_oracle_id = "b3e0b8a6-5de4-4988-b042-2641b1ed3e32"
+scryfall_id = "755c5d2e-6f82-49e2-981c-d21567e2dbe6"
+
+[[token.source_card_refs]]
+card_name = "Warping Wail"
+scryfall_oracle_id = "c8b9fa02-0a0c-4a87-9a00-3c1c7e2f4bfd"
+scryfall_id = "f461d613-518f-41cf-b08f-0778d40d3cf7"
+
+[[token.source_card_refs]]
+card_name = "Spawning Bed"
+scryfall_oracle_id = "49e43de3-460b-4562-aef6-da43bd56debc"
+scryfall_id = "2c1059b9-99da-47ce-a013-84ad755fda11"
+
+[[token.source_card_refs]]
 card_name = "Vile Redeemer"
 scryfall_oracle_id = "a7a88bcc-eac2-4f74-804f-b49d16560184"
 scryfall_id = "7a08e28c-dee2-4ab8-bc72-1498a7dd3a40"
@@ -152673,8 +156782,10 @@ category = "Creature"
 fidelity = "Full"
 source_card_names = [
     "Cartouche of Solidarity",
+    "Finish",
     "Oketra the True",
     "Oketra's Monument",
+    "Start",
     "Start // Finish",
     "Steward of Solidarity",
     "Supply Caravan",
@@ -152697,6 +156808,27 @@ colors = ["White"]
 keywords = ["Vigilance"]
 
 [[token.source_card_refs]]
+card_name = "Start // Finish"
+face_name = "Finish"
+scryfall_oracle_id = "4ae2750e-3650-42df-a539-ea4cb72fa136"
+scryfall_id = "10cb9813-0c4b-40e7-a883-90737116a417"
+
+[[token.source_card_refs]]
+card_name = "Supply Caravan"
+scryfall_oracle_id = "1abcfe8d-4beb-4910-b353-1227e1256329"
+scryfall_id = "71899431-c397-4031-b01a-d8bd960bbe2d"
+
+[[token.source_card_refs]]
+card_name = "Cartouche of Solidarity"
+scryfall_oracle_id = "b9176173-c4a1-45ae-8f34-bd6b31c141fe"
+scryfall_id = "c0848afc-fc62-44d3-82be-5de86a12a630"
+
+[[token.source_card_refs]]
+card_name = "Oketra's Monument"
+scryfall_oracle_id = "0370afa0-07d3-4787-8a5b-10272cb3a486"
+scryfall_id = "f86bc112-4744-4310-a3a8-df5c6c9421b3"
+
+[[token.source_card_refs]]
 card_name = "Oketra's Monument"
 scryfall_oracle_id = "0370afa0-07d3-4787-8a5b-10272cb3a486"
 scryfall_id = "01bdc760-a5c9-45a9-9d83-dd3780f8ed6f"
@@ -152705,6 +156837,32 @@ scryfall_id = "01bdc760-a5c9-45a9-9d83-dd3780f8ed6f"
 card_name = "Cartouche of Solidarity"
 scryfall_oracle_id = "b9176173-c4a1-45ae-8f34-bd6b31c141fe"
 scryfall_id = "1ef605df-6dc5-4c1d-9cc3-14353ad15989"
+
+[[token.source_card_refs]]
+card_name = "Start // Finish"
+face_name = "Start"
+scryfall_oracle_id = "4ae2750e-3650-42df-a539-ea4cb72fa136"
+scryfall_id = "10cb9813-0c4b-40e7-a883-90737116a417"
+
+[[token.source_card_refs]]
+card_name = "Steward of Solidarity"
+scryfall_oracle_id = "dcaf3c6f-06e2-4762-82aa-625113e375a1"
+scryfall_id = "92f0245a-3784-4972-8322-7bd8a0e06f7f"
+
+[[token.source_card_refs]]
+card_name = "Oketra the True"
+scryfall_oracle_id = "646e68c8-cc42-4d6c-8363-a18b10a10eae"
+scryfall_id = "e6a94f2b-5b18-4e7e-b47f-185e6a8a40b3"
+
+[[token.source_card_refs]]
+card_name = "Steward of Solidarity"
+scryfall_oracle_id = "dcaf3c6f-06e2-4762-82aa-625113e375a1"
+scryfall_id = "6898c5d9-ac25-4ec8-94a8-6fb3df2700b3"
+
+[[token.source_card_refs]]
+card_name = "Cartouche of Solidarity"
+scryfall_oracle_id = "b9176173-c4a1-45ae-8f34-bd6b31c141fe"
+scryfall_id = "4d2bc626-7104-4995-bf29-6cba08cbaf9d"
 
 [token.token_image_ref]
 scryfall_id = "7728b4ea-4288-4699-b45f-21beb327d4ce"
@@ -152797,6 +156955,11 @@ scryfall_id = "90450177-4ed6-41e6-9917-70a0720bb84c"
 card_name = "Pentavus"
 scryfall_oracle_id = "1c0d4f28-2494-45b0-acb8-921fee602c01"
 scryfall_id = "a39ab7f7-c22f-4cf7-ae1f-d40b84996177"
+
+[[token.source_card_refs]]
+card_name = "Pentavus"
+scryfall_oracle_id = "1c0d4f28-2494-45b0-acb8-921fee602c01"
+scryfall_id = "32a11f0a-7547-4fda-a8ed-caf76ce98f10"
 
 [[token.source_card_refs]]
 card_name = "Pentavus"
@@ -152991,6 +157154,11 @@ subtypes = ["Spirit"]
 supertypes = []
 colors = ["White"]
 keywords = ["Flying"]
+
+[[token.source_card_refs]]
+card_name = "Oyobi, Who Split the Heavens"
+scryfall_oracle_id = "df5c1f34-94e4-4f89-b1af-943c430862d0"
+scryfall_id = "313bd276-2f69-447e-a2b1-240cf839614a"
 
 [[token.source_card_refs]]
 card_name = "Oyobi, Who Split the Heavens"
@@ -154481,6 +158649,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Stitcher's Apprentice"
 scryfall_oracle_id = "14bf3049-faa3-4c1f-a613-603e977a50a4"
+scryfall_id = "24e39028-a930-4751-91e9-0e91fa7f91ec"
+
+[[token.source_card_refs]]
+card_name = "Stitcher's Apprentice"
+scryfall_oracle_id = "14bf3049-faa3-4c1f-a613-603e977a50a4"
 scryfall_id = "717e34b9-161e-4b11-afb1-f41ee8027433"
 
 [token.token_image_ref]
@@ -155475,9 +159648,34 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Cavalier of Dawn"
+scryfall_oracle_id = "7c520355-1ab8-4d6d-9a29-0f63d6b60024"
+scryfall_id = "aea6ac4a-9e4a-4360-b87b-637a621aef1a"
+
+[[token.source_card_refs]]
+card_name = "Precursor Golem"
+scryfall_oracle_id = "668fc293-1b8f-4870-9784-4ac660925e30"
+scryfall_id = "d1b840bb-a772-40e3-97f0-92a27dc0fe2d"
+
+[[token.source_card_refs]]
+card_name = "Cavalier of Dawn"
+scryfall_oracle_id = "7c520355-1ab8-4d6d-9a29-0f63d6b60024"
+scryfall_id = "0d650ea3-2e80-4bcf-b800-7f2063d2acd9"
+
+[[token.source_card_refs]]
 card_name = "Precursor Golem"
 scryfall_oracle_id = "668fc293-1b8f-4870-9784-4ac660925e30"
 scryfall_id = "730c68d1-b218-43a6-831f-fe9f6b55c503"
+
+[[token.source_card_refs]]
+card_name = "Precursor Golem"
+scryfall_oracle_id = "668fc293-1b8f-4870-9784-4ac660925e30"
+scryfall_id = "13d8e349-e843-4460-92dc-5f4cbc9c1e92"
+
+[[token.source_card_refs]]
+card_name = "Precursor Golem"
+scryfall_oracle_id = "668fc293-1b8f-4870-9784-4ac660925e30"
+scryfall_id = "182c80d0-3ce2-42cd-8dd7-e28b10e2a9a1"
 
 [[token.source_card_refs]]
 card_name = "Golem Foundry"
@@ -157204,6 +161402,11 @@ card_name = "Firja's Retribution"
 scryfall_oracle_id = "fea32d4e-ceef-4954-a84d-e7e2509e4a13"
 scryfall_id = "e7d1bbe5-c63e-4a8d-b79a-0dcca221a726"
 
+[[token.source_card_refs]]
+card_name = "Valkyrie's Sword"
+scryfall_oracle_id = "236c4ff1-8c3f-4763-8df9-925021e65726"
+scryfall_id = "705c275e-bf42-4941-a1f6-c1dc3dcedc46"
+
 [token.token_image_ref]
 scryfall_id = "a2db6fe1-b6ec-43ca-933f-dbab4cd08064"
 scryfall_oracle_id = "8c5015a4-35ac-43ab-b5f7-20bd2e5fbe3c"
@@ -158394,6 +162597,11 @@ colors = [
     "Blue",
 ]
 keywords = ["Menace"]
+
+[[token.source_card_refs]]
+card_name = "Corpse Cobble"
+scryfall_oracle_id = "5b0b6c8f-472a-4ee2-8368-3b17a2df498d"
+scryfall_id = "5fac9235-9e9f-47ee-b8c2-9ebce780c930"
 
 [[token.source_card_refs]]
 card_name = "Corpse Cobble"
@@ -161262,6 +165470,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Pact of the Titan"
 scryfall_oracle_id = "cf4959bf-92ae-4c9b-b631-724ce100cbb8"
+scryfall_id = "8f332ef3-335a-494d-a90f-61a9e9834ccd"
+
+[[token.source_card_refs]]
+card_name = "Pact of the Titan"
+scryfall_oracle_id = "cf4959bf-92ae-4c9b-b631-724ce100cbb8"
 scryfall_id = "4612effe-8ca2-4c27-90d2-d9255acc80d9"
 
 [token.token_image_ref]
@@ -161757,6 +165970,11 @@ scryfall_id = "91eb9067-0bc7-4497-ba9c-c1ea41e5a379"
 card_name = "Contraband Livestock"
 scryfall_oracle_id = "fbafe993-8118-40cc-9cb7-ee3f62a2c888"
 scryfall_id = "d170361f-11f6-480e-8927-c63f00c7f331"
+
+[[token.source_card_refs]]
+card_name = "Stampede Surfer"
+scryfall_oracle_id = "22640b75-8db6-4264-a4aa-9174c159a228"
+scryfall_id = "7e782e90-d6e5-4a55-87a8-3bd6dce1b67a"
 
 [[token.source_card_refs]]
 card_name = "Curse of the Swine"
@@ -163722,6 +167940,11 @@ scryfall_id = "63e3de28-d6e9-4f27-a544-0434fb4b55bb"
 [[token.source_card_refs]]
 card_name = "Simulacrum Synthesizer"
 scryfall_oracle_id = "eb7a1f21-a66d-415b-8520-710b44890bb6"
+scryfall_id = "c201946b-0746-4f8b-bd7b-84dc0fa60395"
+
+[[token.source_card_refs]]
+card_name = "Simulacrum Synthesizer"
+scryfall_oracle_id = "eb7a1f21-a66d-415b-8520-710b44890bb6"
 scryfall_id = "28a11489-11c5-4018-aab8-c9d036638414"
 
 [[token.source_card_refs]]
@@ -163748,6 +167971,11 @@ scryfall_id = "c7658ec0-3207-4c7e-b31a-30a2a9249595"
 card_name = "Urza, Lord High Artificer"
 scryfall_oracle_id = "e87906d2-db1a-4e19-b910-adb4eb339945"
 scryfall_id = "f531402e-681f-4439-837c-4e184efd5a49"
+
+[[token.source_card_refs]]
+card_name = "Urza, Lord High Artificer"
+scryfall_oracle_id = "e87906d2-db1a-4e19-b910-adb4eb339945"
+scryfall_id = "98294441-b5a1-4b59-9325-80d0ff913ebd"
 
 [token.token_image_ref]
 scryfall_id = "3877d2d1-61f2-4295-b0fc-827965eaaefc"
@@ -164211,6 +168439,8 @@ source_card_names = [
     "Hobbling Zombie",
     "Jadar, Ghoulcaller of Nephalia",
     "No Way Out",
+    "Poppet Factory",
+    "Poppet Stitcher",
     "Poppet Stitcher // Poppet Factory",
     "Revenge of the Drowned",
     "Rotten Reunion",
@@ -164236,9 +168466,40 @@ colors = ["Black"]
 keywords = ["Decayed"]
 
 [[token.source_card_refs]]
+card_name = "Flip the Switch"
+scryfall_oracle_id = "a28eb946-c7f2-4c90-ab6c-b194e290e33d"
+scryfall_id = "78198be2-41e4-4e0b-ac21-9e2db577af01"
+
+[[token.source_card_refs]]
+card_name = "Falcon Abomination"
+scryfall_oracle_id = "21eea63f-72b2-4155-bfad-f9937a8f8614"
+scryfall_id = "40e5e0e9-bc54-4a23-b880-a1b5ec740a8c"
+
+[[token.source_card_refs]]
+card_name = "Poppet Stitcher // Poppet Factory"
+face_name = "Poppet Stitcher"
+scryfall_oracle_id = "bc2d0702-b140-4b78-8a8f-3a6d19073b59"
+scryfall_id = "f033f980-ddc5-4dea-a682-5a823be99aa5"
+
+[[token.source_card_refs]]
+card_name = "Rotten Reunion"
+scryfall_oracle_id = "1bde8eaa-9beb-4529-b540-5e0155c09713"
+scryfall_id = "b13cc06c-5f5e-4feb-8a44-a468d6e6c07d"
+
+[[token.source_card_refs]]
 card_name = "Wilhelt, the Rotcleaver"
 scryfall_oracle_id = "eada96a1-4964-4ad0-b0e3-2df08d6ae188"
 scryfall_id = "82471687-46fa-4ccf-a792-180db0a5dd22"
+
+[[token.source_card_refs]]
+card_name = "Diregraf Horde"
+scryfall_oracle_id = "d7947858-f11d-438c-8ad3-991afe950a11"
+scryfall_id = "4ac94b24-630d-4808-8603-e776f16bc7ca"
+
+[[token.source_card_refs]]
+card_name = "Tainted Adversary"
+scryfall_oracle_id = "8bed92cc-b3f8-4201-bcbc-44535ff1bd96"
+scryfall_id = "88e07d94-93fe-4827-b4e0-f73dc1962b9a"
 
 [[token.source_card_refs]]
 card_name = "Startle"
@@ -164256,9 +168517,50 @@ scryfall_oracle_id = "fb3defc0-c93a-4423-9ff9-c399f8a8ef1f"
 scryfall_id = "49d5d62b-72ed-446a-b280-ad04c38bdd0c"
 
 [[token.source_card_refs]]
+card_name = "Ghoulish Procession"
+scryfall_oracle_id = "39e20898-cf01-48dc-8972-7ac500c3fa79"
+scryfall_id = "e2c94193-85e2-4df6-a450-2d254a3b2ac0"
+
+[[token.source_card_refs]]
+card_name = "Hobbling Zombie"
+scryfall_oracle_id = "9d1c3ec1-00a4-4890-93a3-e3cf137ca7e4"
+scryfall_id = "83052fa8-bfb5-4d09-8235-a0e112ff3b4a"
+
+[[token.source_card_refs]]
+card_name = "Revenge of the Drowned"
+scryfall_oracle_id = "d5d869bc-8996-4d19-9e32-d1cfb968875c"
+scryfall_id = "401edb61-83f1-4a8d-ae91-58b62a9ced9c"
+
+[[token.source_card_refs]]
+card_name = "No Way Out"
+scryfall_oracle_id = "8cbbb1f4-4654-4865-a14c-0c94cd5d8b19"
+scryfall_id = "90cd492a-dbe6-49a5-92fd-ee2fa1b2f115"
+
+[[token.source_card_refs]]
+card_name = "Poppet Stitcher // Poppet Factory"
+face_name = "Poppet Factory"
+scryfall_oracle_id = "bc2d0702-b140-4b78-8a8f-3a6d19073b59"
+scryfall_id = "f033f980-ddc5-4dea-a682-5a823be99aa5"
+
+[[token.source_card_refs]]
 card_name = "Diregraf Horde"
 scryfall_oracle_id = "d7947858-f11d-438c-8ad3-991afe950a11"
 scryfall_id = "5f969e42-fd00-4bda-801a-7930d5ef67d5"
+
+[[token.source_card_refs]]
+card_name = "Ghoulcaller's Harvest"
+scryfall_oracle_id = "bbef4d8e-5861-4d50-9589-14b46c71e9af"
+scryfall_id = "1166c45b-292a-4441-8f73-266055de12c7"
+
+[[token.source_card_refs]]
+card_name = "Jadar, Ghoulcaller of Nephalia"
+scryfall_oracle_id = "fb3defc0-c93a-4423-9ff9-c399f8a8ef1f"
+scryfall_id = "92218f51-5b3f-4c4f-b472-7c03daaccc03"
+
+[[token.source_card_refs]]
+card_name = "Startle"
+scryfall_oracle_id = "7996222e-68c8-4a5c-9531-c60cdd88ae05"
+scryfall_id = "350b885a-5e09-45a2-b71e-c86d22f38758"
 
 [token.token_image_ref]
 scryfall_id = "b0d6fd21-48f0-4151-9671-762c25d95592"
@@ -164721,9 +169023,34 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Aether Chaser"
+scryfall_oracle_id = "8aab0b55-2779-43c7-a3ee-151b8e5c72f3"
+scryfall_id = "4139592c-6f0c-44ac-9de0-ebd639cd893d"
+
+[[token.source_card_refs]]
+card_name = "Glint-Sleeve Artisan"
+scryfall_oracle_id = "b5f35577-3d94-4835-bfca-3090cb0c63ff"
+scryfall_id = "e8a03ab1-29a2-4186-86da-09fa7ff469e6"
+
+[[token.source_card_refs]]
+card_name = "Marionette Master"
+scryfall_oracle_id = "dabbf796-3b88-499e-8839-06fa36fe01ac"
+scryfall_id = "09b3b0f5-5532-4367-9967-cd68ff869c7e"
+
+[[token.source_card_refs]]
 card_name = "Weaponcraft Enthusiast"
 scryfall_oracle_id = "7c27136a-bf9d-4f42-9c37-abe347fad1bb"
 scryfall_id = "4f096976-20a0-419b-9249-1cf0cccd2eb5"
+
+[[token.source_card_refs]]
+card_name = "Servo Schematic"
+scryfall_oracle_id = "6b8c6104-c537-4025-83e2-e89c8668f3ba"
+scryfall_id = "0acf747f-7ade-486c-b3b2-b48193a364fd"
+
+[[token.source_card_refs]]
+card_name = "Servo Exhibition"
+scryfall_oracle_id = "76a6ddc2-f894-4331-89a9-87ca16efd0c0"
+scryfall_id = "3727b70d-bee0-432d-863d-a319dd14a9fb"
 
 [[token.source_card_refs]]
 card_name = "Hidden Stockpile"
@@ -164736,9 +169063,29 @@ scryfall_oracle_id = "4b77479e-8d49-46f6-b774-d8caf151c15c"
 scryfall_id = "056b4bd0-1794-4319-9f72-8aad1298b8ca"
 
 [[token.source_card_refs]]
+card_name = "Cogworker's Puzzleknot"
+scryfall_oracle_id = "2065e9d0-c6e9-4270-898e-9822b532d467"
+scryfall_id = "4c0401df-6eb4-4eeb-b666-4384b5b739f4"
+
+[[token.source_card_refs]]
 card_name = "Saheeli, Sublime Artificer"
 scryfall_oracle_id = "ab655810-f67e-4576-9174-35b16f5e3235"
 scryfall_id = "5662d0a5-3222-4ab9-9e15-f06477730b75"
+
+[[token.source_card_refs]]
+card_name = "Hidden Stockpile"
+scryfall_oracle_id = "f5ded323-75c8-471e-a516-238b9d6b06d3"
+scryfall_id = "7a39586b-a31e-4a3d-8ff8-09897d307e06"
+
+[[token.source_card_refs]]
+card_name = "Aether Swooper"
+scryfall_oracle_id = "f7ed301a-dce7-49d0-a68a-d3a099201f65"
+scryfall_id = "d0a0595f-b98d-4593-a25f-3cfc5db14668"
+
+[[token.source_card_refs]]
+card_name = "Peema Outrider"
+scryfall_oracle_id = "7747e94c-35a7-4e3b-956b-339a16634502"
+scryfall_id = "ac1d4572-ce2e-4040-bd8e-e3d3a850ca05"
 
 [[token.source_card_refs]]
 card_name = "Saheeli, Sublime Artificer"
@@ -164746,9 +169093,54 @@ scryfall_oracle_id = "ab655810-f67e-4576-9174-35b16f5e3235"
 scryfall_id = "c8bbc692-8d2e-4487-bd19-1a5c78fd3d53"
 
 [[token.source_card_refs]]
+card_name = "Oviya Pashiri, Sage Lifecrafter"
+scryfall_oracle_id = "41e03224-bcdd-4127-a19a-fe66196339b9"
+scryfall_id = "e1c2b1b4-6439-4203-967d-c8a40a2e701e"
+
+[[token.source_card_refs]]
+card_name = "Visionary Augmenter"
+scryfall_oracle_id = "1782bfd7-7d8f-4ed2-9d45-ba9adb41e996"
+scryfall_id = "a77979b6-100a-40ed-ac40-6ed4941e4ca3"
+
+[[token.source_card_refs]]
+card_name = "Maulfist Squad"
+scryfall_oracle_id = "2a8ec988-b513-4e66-b7f5-b2196b4bbff2"
+scryfall_id = "da615e0c-09dd-439e-a874-993b0f2a3097"
+
+[[token.source_card_refs]]
+card_name = "Highspire Artisan"
+scryfall_oracle_id = "fc8c54c4-a436-43cc-888b-f4ba3e751c16"
+scryfall_id = "b335fda4-8611-41d9-b320-d96cd3ff01dc"
+
+[[token.source_card_refs]]
+card_name = "Propeller Pioneer"
+scryfall_oracle_id = "d17a9750-a89f-4ad1-9c15-7ccffc554ee5"
+scryfall_id = "0b916b0e-bb83-44b5-8fcc-88df4a4b3e77"
+
+[[token.source_card_refs]]
 card_name = "Glint-Sleeve Artisan"
 scryfall_oracle_id = "b5f35577-3d94-4835-bfca-3090cb0c63ff"
 scryfall_id = "bea3b945-ae35-4cf0-a5dd-b2398d192c2f"
+
+[[token.source_card_refs]]
+card_name = "Aether Poisoner"
+scryfall_oracle_id = "73757d44-7889-416b-94d2-e730e601ace3"
+scryfall_id = "9503d214-7268-4617-b1a8-51b6d520a029"
+
+[[token.source_card_refs]]
+card_name = "Master Trinketeer"
+scryfall_oracle_id = "aa57f607-c5eb-45a7-bfb1-adce0aef49c7"
+scryfall_id = "902e0fc2-cfec-4bc7-8b9a-d349e74e0b56"
+
+[[token.source_card_refs]]
+card_name = "Angel of Invention"
+scryfall_oracle_id = "28c7f2b6-ba67-4ccf-9e1b-99c89a9d1f72"
+scryfall_id = "d0bc9fc4-b343-431d-a756-0caa2c56c01a"
+
+[[token.source_card_refs]]
+card_name = "Countless Gears Renegade"
+scryfall_oracle_id = "9d1f9036-a466-46b6-ab7c-2de487876978"
+scryfall_id = "87eca36f-5d7c-46ed-bd13-914dad179743"
 
 [[token.source_card_refs]]
 card_name = "Angel of Invention"
@@ -164756,14 +169148,39 @@ scryfall_oracle_id = "28c7f2b6-ba67-4ccf-9e1b-99c89a9d1f72"
 scryfall_id = "98c42f02-6eda-4ef7-929f-b3a2ece9f650"
 
 [[token.source_card_refs]]
+card_name = "Aether Inspector"
+scryfall_oracle_id = "9373a176-a5e9-4fdc-906b-bc6aef657e5b"
+scryfall_id = "e0ae3458-4231-478f-9209-50ab70cf1eea"
+
+[[token.source_card_refs]]
+card_name = "Sram's Expertise"
+scryfall_oracle_id = "5cd17347-5558-46f9-b8bb-ae5deeb1f229"
+scryfall_id = "d4cad3d4-36e5-4df3-a7b3-09c73c86f3bc"
+
+[[token.source_card_refs]]
 card_name = "Servo Exhibition"
 scryfall_oracle_id = "76a6ddc2-f894-4331-89a9-87ca16efd0c0"
 scryfall_id = "256f0b63-ff50-4b4b-9598-d76c4aa9ee4e"
 
 [[token.source_card_refs]]
+card_name = "Sly Requisitioner"
+scryfall_oracle_id = "15ea4698-86b4-47c5-a9a7-60af16063a61"
+scryfall_id = "5f0fd407-8674-49fc-833a-783132cf7264"
+
+[[token.source_card_refs]]
 card_name = "Countless Gears Renegade"
 scryfall_oracle_id = "9d1f9036-a466-46b6-ab7c-2de487876978"
 scryfall_id = "5c7cebae-6ba2-4cf1-a442-2c7a4fbc58da"
+
+[[token.source_card_refs]]
+card_name = "Weaponcraft Enthusiast"
+scryfall_oracle_id = "7c27136a-bf9d-4f42-9c37-abe347fad1bb"
+scryfall_id = "c6323a7b-e640-4f68-92bb-ca01e575f730"
+
+[[token.source_card_refs]]
+card_name = "Animation Module"
+scryfall_oracle_id = "af42079b-a3c0-448c-9bb2-b915252e87a9"
+scryfall_id = "296ee786-b4f5-4e65-8e09-a0231aaed3b3"
 
 [[token.source_card_refs]]
 card_name = "Peema Outrider"
@@ -164921,6 +169338,11 @@ scryfall_oracle_id = "ce35f262-b93f-4409-8b33-26a7ed7abac8"
 scryfall_id = "41c42be7-84fe-4d9d-bf5c-e75e4d5635fa"
 
 [[token.source_card_refs]]
+card_name = "Paladin of the Bloodstained"
+scryfall_oracle_id = "f340018d-8b68-45d5-a72e-a922be68365d"
+scryfall_id = "ccd69b22-dc31-4af3-b0e2-ef75e1fe0e26"
+
+[[token.source_card_refs]]
 card_name = "Legion's Landing // Adanto, the First Fort"
 face_name = "Adanto, the First Fort"
 scryfall_oracle_id = "f7d8b91b-6541-4d3e-af51-7e000eac69c1"
@@ -165059,9 +169481,19 @@ colors = ["Red"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "General Kreat, the Boltbringer"
+scryfall_oracle_id = "da1c1c70-c2fa-4ba7-89fe-d9af3fb353b9"
+scryfall_id = "226fc101-abcc-4ed4-8c0b-3677dc8d8f0a"
+
+[[token.source_card_refs]]
 card_name = "Searslicer Goblin"
 scryfall_oracle_id = "86ec0b56-497f-481c-a03a-c4e64e8e7404"
 scryfall_id = "58deba9d-5c95-4633-a86c-2637a8bb7ce2"
+
+[[token.source_card_refs]]
+card_name = "Goblin Goliath"
+scryfall_oracle_id = "131069a6-8f30-4caf-8934-3588837b5f7f"
+scryfall_id = "86b29f57-010e-4b32-b49f-c5af989b8281"
 
 [[token.source_card_refs]]
 card_name = "Dragon Fodder"
@@ -165074,14 +169506,34 @@ scryfall_oracle_id = "68418069-f615-40ef-ae0d-764192acae00"
 scryfall_id = "824b2d73-2151-4e5e-9f05-8f63e2bdcaa9"
 
 [[token.source_card_refs]]
+card_name = "Goblin Surprise"
+scryfall_oracle_id = "79cd09e8-d738-47c0-9473-b6281bec6935"
+scryfall_id = "f092806d-b2de-44a8-85cd-0ab2b16e344e"
+
+[[token.source_card_refs]]
 card_name = "Searslicer Goblin"
 scryfall_oracle_id = "86ec0b56-497f-481c-a03a-c4e64e8e7404"
 scryfall_id = "0523f8d8-4324-4e1d-9a88-4fd871e93bb8"
 
 [[token.source_card_refs]]
+card_name = "Krenko's Command"
+scryfall_oracle_id = "9cfe86ae-eebe-44aa-a956-4b3e9e621105"
+scryfall_id = "699295ea-edf4-46f4-972e-82359c80bb2e"
+
+[[token.source_card_refs]]
+card_name = "Battle Cry Goblin"
+scryfall_oracle_id = "e74c4001-d958-4d2b-b57d-c3601f01580c"
+scryfall_id = "ba41ec1b-e631-4882-b897-df26e26ada04"
+
+[[token.source_card_refs]]
 card_name = "Goblin Negotiation"
 scryfall_oracle_id = "79824266-bffa-476c-bdd3-976e9d789a42"
 scryfall_id = "f2016585-e26c-4d13-b09f-af6383c192f7"
+
+[[token.source_card_refs]]
+card_name = "Goblin Rabblemaster"
+scryfall_oracle_id = "24661b81-6bee-4ad8-b3ab-53cb65005c51"
+scryfall_id = "9962cf82-a8ed-4984-adeb-b08b7c54751b"
 
 [[token.source_card_refs]]
 card_name = "Searslicer Goblin"
@@ -165097,6 +169549,16 @@ scryfall_id = "527dd5d4-5f72-40bb-8a9d-1f5ac3f81e2e"
 card_name = "Searslicer Goblin"
 scryfall_oracle_id = "86ec0b56-497f-481c-a03a-c4e64e8e7404"
 scryfall_id = "9e3059e4-b198-4eba-98e8-f0f9f83d1928"
+
+[[token.source_card_refs]]
+card_name = "Krenko, Tin Street Kingpin"
+scryfall_oracle_id = "e8065e1d-e937-4b56-8011-78f0d07328a0"
+scryfall_id = "0c7d8714-a0ef-4ae8-909b-60f3319c646c"
+
+[[token.source_card_refs]]
+card_name = "Beetleback Chief"
+scryfall_oracle_id = "f5c5f64c-6911-430c-a825-b32b96d39c7d"
+scryfall_id = "fe276be5-bc54-4fb7-82af-a2312c76f1d2"
 
 [token.token_image_ref]
 scryfall_id = "70f8a1de-cd4c-4afa-bf03-0245d375d42e"
@@ -165132,7 +169594,27 @@ scryfall_id = "698a050c-6828-4bb0-8dde-85b41e657034"
 [[token.source_card_refs]]
 card_name = "Sengir Autocrat"
 scryfall_oracle_id = "0561043a-3896-4bb1-8ff5-ee674ddfea2a"
+scryfall_id = "234a5401-bbe4-40ab-9204-12d944fbd2b1"
+
+[[token.source_card_refs]]
+card_name = "Sengir Autocrat"
+scryfall_oracle_id = "0561043a-3896-4bb1-8ff5-ee674ddfea2a"
+scryfall_id = "647b0f86-8ec1-4506-9a31-a8495232094e"
+
+[[token.source_card_refs]]
+card_name = "Sengir Autocrat"
+scryfall_oracle_id = "0561043a-3896-4bb1-8ff5-ee674ddfea2a"
 scryfall_id = "83fa8a17-ff86-465e-9092-0968081f4e28"
+
+[[token.source_card_refs]]
+card_name = "Sengir Autocrat"
+scryfall_oracle_id = "0561043a-3896-4bb1-8ff5-ee674ddfea2a"
+scryfall_id = "bac17237-778d-4551-9a92-8be546e233dc"
+
+[[token.source_card_refs]]
+card_name = "Sengir Autocrat"
+scryfall_oracle_id = "0561043a-3896-4bb1-8ff5-ee674ddfea2a"
+scryfall_id = "0d16e024-7865-43d0-8cd8-8933ef741d05"
 
 [token.token_image_ref]
 scryfall_id = "c98dbedd-b1f1-4a9c-af37-8ce2ae07a247"
@@ -168690,6 +173172,11 @@ card_name = "Hungry for More"
 scryfall_oracle_id = "3eaf1e6b-bf4c-4ea8-83ea-6827470fd802"
 scryfall_id = "ce09c0df-d022-4ebf-8f7f-8a913249e75f"
 
+[[token.source_card_refs]]
+card_name = "Hungry for More"
+scryfall_oracle_id = "3eaf1e6b-bf4c-4ea8-83ea-6827470fd802"
+scryfall_id = "e7e74cfe-d573-482c-87df-804551667aad"
+
 [token.token_image_ref]
 scryfall_id = "0f8fe08d-b469-4471-8a7d-cf75850ba312"
 scryfall_oracle_id = "e45c5c4e-2226-4c77-9480-8cc80a47e5a3"
@@ -168932,6 +173419,11 @@ scryfall_id = "1925dc45-4dee-4772-aa16-3b4ca54be6c7"
 card_name = "Grist, the Hunger Tide"
 scryfall_oracle_id = "0efb0d7e-dea0-4817-a243-15066e9ef333"
 scryfall_id = "a10b0238-fe30-4543-ae8a-ed834a0930b1"
+
+[[token.source_card_refs]]
+card_name = "Amzu, Swarm's Hunger"
+scryfall_oracle_id = "6777863c-e52c-4a7c-b8d2-a16b1438b3d2"
+scryfall_id = "634f6f70-347e-436f-abf9-4a573472e2c8"
 
 [[token.source_card_refs]]
 card_name = "Izoni, Thousand-Eyed"
@@ -169414,6 +173906,11 @@ colors = [
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Courier's Briefcase"
+scryfall_oracle_id = "00cd3bf9-0dd6-4ec0-a841-1839a71604ab"
+scryfall_id = "4960fa74-c0bf-4f1d-82a7-d5da5aa3e00a"
+
+[[token.source_card_refs]]
 card_name = "Master of Ceremonies"
 scryfall_oracle_id = "18ed0c8a-db8f-4247-87c4-544b833f01bd"
 scryfall_id = "ac736037-113f-4e4b-8b97-7b2300b0d276"
@@ -169458,9 +173955,24 @@ colors = ["Red"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Akroan Crusader"
+scryfall_oracle_id = "d981d85c-e97b-4fe7-b415-6e73a3e7e35c"
+scryfall_id = "45158565-dacd-4892-b51a-40da7d1da778"
+
+[[token.source_card_refs]]
+card_name = "Akroan Crusader"
+scryfall_oracle_id = "d981d85c-e97b-4fe7-b415-6e73a3e7e35c"
+scryfall_id = "b8569043-16b2-480f-b4d0-ba2fe6e19b46"
+
+[[token.source_card_refs]]
 card_name = "Frontline Heroism"
 scryfall_oracle_id = "4c340b82-22e1-445a-b236-82471b442031"
 scryfall_id = "7fb34149-5e09-47cb-bd1f-f2f9ee14dce3"
+
+[[token.source_card_refs]]
+card_name = "Frontline Heroism"
+scryfall_oracle_id = "4c340b82-22e1-445a-b236-82471b442031"
+scryfall_id = "e78eda51-255a-4421-9b6f-025a432e9df9"
 
 [token.token_image_ref]
 scryfall_id = "dfb0ae06-9a02-4cd6-bc1d-423662d7a1bd"
@@ -170513,6 +175025,11 @@ scryfall_oracle_id = "84e84532-498b-40ea-9510-46fb2403939b"
 scryfall_id = "4018dda4-c78b-4e8e-ab8b-391e16c4e0f7"
 
 [[token.source_card_refs]]
+card_name = "Tireless Provisioner"
+scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
+scryfall_id = "3cf04e55-b266-46cd-a79a-d87f5ceba469"
+
+[[token.source_card_refs]]
 card_name = "Sorin of House Markov // Sorin, Ravenous Neonate"
 face_name = "Sorin, Ravenous Neonate"
 scryfall_oracle_id = "84e84532-498b-40ea-9510-46fb2403939b"
@@ -171432,6 +175949,16 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Brindle Shoat"
 scryfall_oracle_id = "d385c2e1-a62e-43ad-80ef-a6178deac82c"
+scryfall_id = "318a41e3-1c5a-467e-9ffb-e6a5f817f8fe"
+
+[[token.source_card_refs]]
+card_name = "Brindle Shoat"
+scryfall_oracle_id = "d385c2e1-a62e-43ad-80ef-a6178deac82c"
+scryfall_id = "03eea9a2-3129-47f5-88cc-8295d0039cb7"
+
+[[token.source_card_refs]]
+card_name = "Brindle Shoat"
+scryfall_oracle_id = "d385c2e1-a62e-43ad-80ef-a6178deac82c"
 scryfall_id = "0a005933-e206-4b14-9a0f-755fae6c5a2a"
 
 [token.token_image_ref]
@@ -171523,9 +176050,19 @@ scryfall_oracle_id = "26ae37ab-91f8-4113-beb0-1154f9b62d28"
 scryfall_id = "7849b360-afad-4f50-b455-3d118f7bfcd0"
 
 [[token.source_card_refs]]
+card_name = "Varchild's War-Riders"
+scryfall_oracle_id = "258921f2-df26-4d8a-ad34-8f44d0158ae7"
+scryfall_id = "e879b457-dffa-4b3b-a3cd-717a60c1e586"
+
+[[token.source_card_refs]]
 card_name = "Varchild, Betrayer of Kjeldor"
 scryfall_oracle_id = "26ae37ab-91f8-4113-beb0-1154f9b62d28"
 scryfall_id = "2c67b70f-4090-4b1c-b4c9-804b6f90054b"
+
+[[token.source_card_refs]]
+card_name = "Varchild's War-Riders"
+scryfall_oracle_id = "258921f2-df26-4d8a-ad34-8f44d0158ae7"
+scryfall_id = "ee1d41da-aa72-434b-811f-95d4bae4ba5c"
 
 [token.token_image_ref]
 scryfall_id = "f4478979-19b6-4524-bbbd-519594c38f5a"
@@ -172473,6 +177010,11 @@ scryfall_oracle_id = "325b3469-531e-4ca2-bccb-bb95258c1b54"
 scryfall_id = "308fbcf8-0475-4c0b-a365-418588f84b5a"
 
 [[token.source_card_refs]]
+card_name = "Everythingamajig"
+scryfall_oracle_id = "7123b355-8606-4666-a8a8-9560cfea9e86"
+scryfall_id = "e9600f0b-c182-40fc-a0da-77f7758c94a9"
+
+[[token.source_card_refs]]
 card_name = "Trading Post"
 scryfall_oracle_id = "63788566-e25a-44bb-bb55-197e1b93b3e8"
 scryfall_id = "03499a72-e865-46ff-bcb2-75e53e4b600e"
@@ -172737,6 +177279,11 @@ subtypes = [
 supertypes = []
 colors = ["Blue"]
 keywords = ["Flying"]
+
+[[token.source_card_refs]]
+card_name = "Mu Yanling, Sky Dancer"
+scryfall_oracle_id = "1e825298-7c99-40cc-81c9-280cc7ed98d3"
+scryfall_id = "483f5d0c-26d1-467c-b5d8-96e8aa259a7e"
 
 [[token.source_card_refs]]
 card_name = "Mu Yanling, Sky Dancer"
@@ -173495,12 +178042,22 @@ keywords = ["Changeling"]
 [[token.source_card_refs]]
 card_name = "Irregular Cohort"
 scryfall_oracle_id = "c0636d16-671c-4e80-af8c-67d80d2cd979"
+scryfall_id = "1a578419-020e-4b54-be89-62eb186bfce4"
+
+[[token.source_card_refs]]
+card_name = "Irregular Cohort"
+scryfall_oracle_id = "c0636d16-671c-4e80-af8c-67d80d2cd979"
 scryfall_id = "b1ec325a-31bb-4df8-8b88-6d28c85907ce"
 
 [[token.source_card_refs]]
 card_name = "Irregular Cohort"
 scryfall_oracle_id = "c0636d16-671c-4e80-af8c-67d80d2cd979"
 scryfall_id = "61775227-34ad-469a-a4d4-ee8ce69dd10f"
+
+[[token.source_card_refs]]
+card_name = "Birthing Boughs"
+scryfall_oracle_id = "c6836d78-ca71-4413-aced-d4de19976221"
+scryfall_id = "3a3be8f6-8301-4389-876c-69fa42b7a9cc"
 
 [[token.source_card_refs]]
 card_name = "Birthing Boughs"
@@ -174711,6 +179268,11 @@ colors = ["Black"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
+card_name = "Tivash, Gloom Summoner"
+scryfall_oracle_id = "b5641fcf-135e-43e7-a547-344fac61e279"
+scryfall_id = "f930f102-ad69-4b70-ae0f-641f5c05f40c"
+
+[[token.source_card_refs]]
 card_name = "Reign of the Pit"
 scryfall_oracle_id = "3e1a6337-bb29-450f-bf29-ff71b357a983"
 scryfall_id = "098c7cd1-5f20-437d-9b81-f480f3f02833"
@@ -174718,7 +179280,17 @@ scryfall_id = "098c7cd1-5f20-437d-9b81-f480f3f02833"
 [[token.source_card_refs]]
 card_name = "Promise of Power"
 scryfall_oracle_id = "fde459b2-f45f-40d2-b328-58f65440f494"
+scryfall_id = "d96c3947-0eec-48a1-ba69-59734b4ac9da"
+
+[[token.source_card_refs]]
+card_name = "Promise of Power"
+scryfall_oracle_id = "fde459b2-f45f-40d2-b328-58f65440f494"
 scryfall_id = "ad5c6863-da34-4d5a-8782-ddaf3ccb498f"
+
+[[token.source_card_refs]]
+card_name = "Reign of the Pit"
+scryfall_oracle_id = "3e1a6337-bb29-450f-bf29-ff71b357a983"
+scryfall_id = "a74dd700-a326-4add-b563-01707f79df93"
 
 [token.token_image_ref]
 scryfall_id = "2c0e7faf-43cb-4a96-ac3c-9533f957ee28"
@@ -174895,6 +179467,11 @@ scryfall_oracle_id = "93c2b91d-7d4e-483c-a11f-4a525f881503"
 scryfall_id = "85e160f7-a641-4d39-8b47-7e27478d9e84"
 
 [[token.source_card_refs]]
+card_name = "Hexgold Hoverwings"
+scryfall_oracle_id = "63018d1c-f7fb-44c8-bcd2-292e74ab5b54"
+scryfall_id = "c8d4e0dd-a7fb-410b-9170-d8ebb161a9a5"
+
+[[token.source_card_refs]]
 card_name = "Barret, Avalanche Leader"
 scryfall_oracle_id = "83f776d9-f3b6-40c2-8008-1ace4d110825"
 scryfall_id = "2e37fd36-84f0-4869-bfae-da4b97c9725d"
@@ -174903,6 +179480,11 @@ scryfall_id = "2e37fd36-84f0-4869-bfae-da4b97c9725d"
 card_name = "Barret, Avalanche Leader"
 scryfall_oracle_id = "83f776d9-f3b6-40c2-8008-1ace4d110825"
 scryfall_id = "6ee716c6-a4be-4237-bdef-f812baffa6d5"
+
+[[token.source_card_refs]]
+card_name = "Mirran Bardiche"
+scryfall_oracle_id = "1fd04d9e-cf89-49ba-a932-5d278f65bf77"
+scryfall_id = "e8835209-c4ce-4c1b-8bd9-6a7d2c39f814"
 
 [token.token_image_ref]
 scryfall_id = "6afbbdad-aeed-428a-b840-c33f59a18d0b"
@@ -174996,6 +179578,11 @@ scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
 scryfall_id = "97fcf5a5-54e1-43f3-95e3-edc6215bf973"
 
 [[token.source_card_refs]]
+card_name = "Wall Crawl"
+scryfall_oracle_id = "4a09536e-dfc1-4b15-adc1-07ef866ebda0"
+scryfall_id = "c37e8b36-00bc-4fc0-89e1-dfd8a3188465"
+
+[[token.source_card_refs]]
 card_name = "Peter Parker // Amazing Spider-Man"
 face_name = "Amazing Spider-Man"
 scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
@@ -175005,7 +179592,18 @@ scryfall_id = "98912aae-4e42-4434-b979-9c85f09f8d6d"
 card_name = "Peter Parker // Amazing Spider-Man"
 face_name = "Peter Parker"
 scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
+scryfall_id = "2ec821c3-3e5c-4af8-a6ef-e2e77aa8668c"
+
+[[token.source_card_refs]]
+card_name = "Peter Parker // Amazing Spider-Man"
+face_name = "Peter Parker"
+scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
 scryfall_id = "3ce33422-5dba-4a42-8375-dd8ccc692a7b"
+
+[[token.source_card_refs]]
+card_name = "Origin of Spider-Man"
+scryfall_oracle_id = "7fbe9056-190f-40a1-bee9-59ebd6f981f5"
+scryfall_id = "1bb9f52a-8edc-4ca5-bc63-ac6f93874219"
 
 [[token.source_card_refs]]
 card_name = "Origin of Spider-Man"
@@ -175032,7 +179630,18 @@ scryfall_id = "1183262e-1f02-46b3-8cfa-fe30e0016c11"
 card_name = "Peter Parker // Amazing Spider-Man"
 face_name = "Amazing Spider-Man"
 scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
+scryfall_id = "2ec821c3-3e5c-4af8-a6ef-e2e77aa8668c"
+
+[[token.source_card_refs]]
+card_name = "Peter Parker // Amazing Spider-Man"
+face_name = "Amazing Spider-Man"
+scryfall_oracle_id = "f1b7488c-c675-42e9-818a-24a50347ec2c"
 scryfall_id = "97fcf5a5-54e1-43f3-95e3-edc6215bf973"
+
+[[token.source_card_refs]]
+card_name = "Spiders-Man, Heroic Horde"
+scryfall_oracle_id = "d21d7557-9702-46c1-8277-42a3442084c2"
+scryfall_id = "29f7f242-57fa-4714-84fa-3e65c7101985"
 
 [token.token_image_ref]
 scryfall_id = "4a40f6e1-3545-4503-af3e-f0acfb735e3a"
@@ -176465,6 +181074,11 @@ scryfall_oracle_id = "3d01c351-6dbd-4d63-9843-3aa1a3c039a6"
 scryfall_id = "f9d25b34-990d-416c-aef7-1b5a73f19dd4"
 
 [[token.source_card_refs]]
+card_name = "Deadly Dispute"
+scryfall_oracle_id = "457af74a-02b3-4659-846d-63e482667f34"
+scryfall_id = "a4e0b297-6d33-4e2b-b497-aa952dcf2141"
+
+[[token.source_card_refs]]
 card_name = "Zidane, Tantalus Thief"
 scryfall_oracle_id = "f267fb54-1881-464c-81af-9e03c3f3b41d"
 scryfall_id = "2eaffe7a-0e04-4c19-942b-695a0c350ef0"
@@ -176478,6 +181092,11 @@ scryfall_id = "af4481b1-43b0-43e6-a9ea-f4ec0a551e61"
 card_name = "Kain, Traitorous Dragoon"
 scryfall_oracle_id = "70fbb378-d905-47cf-8c54-cc166a7867b3"
 scryfall_id = "28eb294b-4cab-4c34-ae29-20aac9799471"
+
+[[token.source_card_refs]]
+card_name = "Ancient Copper Dragon"
+scryfall_oracle_id = "48daee9d-ddaf-410f-8c3a-12fa1064ab56"
+scryfall_id = "f6cbc754-8aed-4c32-857c-ea639943b5d2"
 
 [[token.source_card_refs]]
 card_name = "Magic Pot"
@@ -176504,6 +181123,11 @@ card_name = "Sidequest: Hunt the Mark // Yiazmat, Ultimate Mark"
 face_name = "Sidequest: Hunt the Mark"
 scryfall_oracle_id = "d74f9a18-8dab-4549-be3f-9697ff68d73c"
 scryfall_id = "de8067cc-3de3-43b2-8fcf-6dce6f4f7db1"
+
+[[token.source_card_refs]]
+card_name = "Ragavan, Nimble Pilferer"
+scryfall_oracle_id = "37108cd4-bbab-4ce3-9ed6-f60e8422e703"
+scryfall_id = "a71d1ec3-2d7a-4749-8936-8bf7a8b83d84"
 
 [[token.source_card_refs]]
 card_name = "Sidequest: Hunt the Mark // Yiazmat, Ultimate Mark"
@@ -176550,6 +181174,11 @@ scryfall_id = "545c98b3-dc78-4070-8dcb-f6a246abce09"
 card_name = "Undercity Dire Rat"
 scryfall_oracle_id = "f09811d0-c5da-4061-aaa7-835ccee3b05a"
 scryfall_id = "274788f4-fbf3-4a15-bdc0-f513a2fde30d"
+
+[[token.source_card_refs]]
+card_name = "Captain Lannery Storm"
+scryfall_oracle_id = "235bf0ba-658c-463f-b112-7478ba27bd7b"
+scryfall_id = "7c3aeedd-d41b-44c9-9b0a-e5952202f632"
 
 [[token.source_card_refs]]
 card_name = "Prompto Argentum"
@@ -177238,6 +181867,11 @@ keywords = []
 card_name = "Torens, Fist of the Angels"
 scryfall_oracle_id = "2cb96408-9195-4e41-ad9a-f8c74fbad083"
 scryfall_id = "f8566528-ba96-4425-8831-b5d6197da9ae"
+
+[[token.source_card_refs]]
+card_name = "Torens, Fist of the Angels"
+scryfall_oracle_id = "2cb96408-9195-4e41-ad9a-f8c74fbad083"
+scryfall_id = "e52fbb3a-f366-4c78-a617-3abbe08c4f47"
 
 [token.token_image_ref]
 scryfall_id = "e35e232f-e98b-49c7-a68c-d8e3339e90b5"
@@ -178349,6 +182983,16 @@ scryfall_id = "217201eb-3340-4aa2-8d38-5d9ff2997b39"
 [[token.source_card_refs]]
 card_name = "Seize the Storm"
 scryfall_oracle_id = "d3455e93-3a05-42db-945d-c4c85f4ac827"
+scryfall_id = "e3bd712f-e62e-46ff-bf3a-05a55573edea"
+
+[[token.source_card_refs]]
+card_name = "Seize the Storm"
+scryfall_oracle_id = "d3455e93-3a05-42db-945d-c4c85f4ac827"
+scryfall_id = "024b3bfd-3d2b-4f45-b015-2d94fe2f2bb3"
+
+[[token.source_card_refs]]
+card_name = "Seize the Storm"
+scryfall_oracle_id = "d3455e93-3a05-42db-945d-c4c85f4ac827"
 scryfall_id = "45ec2af6-8397-429f-900f-846a5056f8e0"
 
 [token.token_image_ref]
@@ -178430,9 +183074,26 @@ scryfall_oracle_id = "cb952c81-c7bb-4670-938d-296d35551986"
 scryfall_id = "e7fcfcba-6547-4617-a301-47e1d7523dae"
 
 [[token.source_card_refs]]
+card_name = "Seed Guardian"
+scryfall_oracle_id = "728045bf-0959-44ff-8de9-16ec35fd248f"
+scryfall_id = "e05367ee-9d50-4963-a317-81a2f663c35a"
+
+[[token.source_card_refs]]
 card_name = "Tumbleweed Rising"
 scryfall_oracle_id = "ef574346-1d98-447d-acb6-4d8d53c5f651"
 scryfall_id = "275d2d2a-ef85-48c9-919d-bc62cdad8a10"
+
+[[token.source_card_refs]]
+card_name = "Budoka Gardener // Dokai, Weaver of Life"
+face_name = "Dokai, Weaver of Life"
+scryfall_oracle_id = "cb952c81-c7bb-4670-938d-296d35551986"
+scryfall_id = "49999b95-5e62-414c-b975-4191b9c1ab39"
+
+[[token.source_card_refs]]
+card_name = "Budoka Gardener // Dokai, Weaver of Life"
+face_name = "Budoka Gardener"
+scryfall_oracle_id = "cb952c81-c7bb-4670-938d-296d35551986"
+scryfall_id = "49999b95-5e62-414c-b975-4191b9c1ab39"
 
 [[token.source_card_refs]]
 card_name = "Dance of the Tumbleweeds"
@@ -179222,6 +183883,11 @@ keywords = ["Flying"]
 [[token.source_card_refs]]
 card_name = "Ominous Roost"
 scryfall_oracle_id = "745fc118-ffab-45c6-b51a-7bef2f6931e8"
+scryfall_id = "cd643429-ba1f-4dec-a8a6-eb0a85597e60"
+
+[[token.source_card_refs]]
+card_name = "Ominous Roost"
+scryfall_oracle_id = "745fc118-ffab-45c6-b51a-7bef2f6931e8"
 scryfall_id = "daf2b49a-56f9-4093-960f-9ec7af8983b5"
 
 [token.token_image_ref]
@@ -179349,6 +184015,11 @@ scryfall_id = "4184638c-bfb8-424d-b106-ed7b3d80b668"
 card_name = "Hunted Dragon"
 scryfall_oracle_id = "39a4416f-9b40-432e-aeb6-cc7bf519b37a"
 scryfall_id = "f454ae09-6ad3-4ef5-b640-c09908ba3625"
+
+[[token.source_card_refs]]
+card_name = "Hunted Dragon"
+scryfall_oracle_id = "39a4416f-9b40-432e-aeb6-cc7bf519b37a"
+scryfall_id = "d2b9cc6e-47db-47d5-84c9-975e4b618261"
 
 [[token.source_card_refs]]
 card_name = "Hunted Dragon"
@@ -179560,6 +184231,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Tah-Crop Skirmisher"
 scryfall_oracle_id = "6fab0fa0-d082-414e-9bcf-edc0fc1f6211"
+scryfall_id = "2178f185-db23-41e8-b52b-a734f9d2344f"
+
+[[token.source_card_refs]]
+card_name = "Tah-Crop Skirmisher"
+scryfall_oracle_id = "6fab0fa0-d082-414e-9bcf-edc0fc1f6211"
 scryfall_id = "ab0429ec-0809-4e68-9790-8c21bde201a2"
 
 [token.token_image_ref]
@@ -179684,6 +184360,16 @@ scryfall_oracle_id = "0728b195-2dfe-4d73-91ae-e658a97b0b9a"
 scryfall_id = "501599d6-1072-4124-b05d-01f96de153f3"
 
 [[token.source_card_refs]]
+card_name = "Hard Evidence"
+scryfall_oracle_id = "0728b195-2dfe-4d73-91ae-e658a97b0b9a"
+scryfall_id = "204114ed-0d8e-460f-b7ce-9266536d4399"
+
+[[token.source_card_refs]]
+card_name = "Scuttletide"
+scryfall_oracle_id = "2be9c1e6-0226-497a-b548-21bf1cfbc286"
+scryfall_id = "d9b34ec1-8aa5-4cfd-b15e-1c479f82cfd0"
+
+[[token.source_card_refs]]
 card_name = "Scuttletide"
 scryfall_oracle_id = "2be9c1e6-0226-497a-b548-21bf1cfbc286"
 scryfall_id = "38e4ce27-aba2-4a3f-8de7-d442323d8be2"
@@ -179692,6 +184378,16 @@ scryfall_id = "38e4ce27-aba2-4a3f-8de7-d442323d8be2"
 card_name = "Specimen Collector"
 scryfall_oracle_id = "fdb51cc1-ce0e-4920-b123-1cdd570fc38b"
 scryfall_id = "bdfaed69-bc4c-4c73-abc3-00dce5e0177e"
+
+[[token.source_card_refs]]
+card_name = "Hard Evidence"
+scryfall_oracle_id = "0728b195-2dfe-4d73-91ae-e658a97b0b9a"
+scryfall_id = "c55901dc-3f5a-490d-8496-5b844530d410"
+
+[[token.source_card_refs]]
+card_name = "Specimen Collector"
+scryfall_oracle_id = "fdb51cc1-ce0e-4920-b123-1cdd570fc38b"
+scryfall_id = "a325b3f1-67f6-4b56-8572-94e9970a5acc"
 
 [token.token_image_ref]
 scryfall_id = "7ef7f37a-b7f5-45a1-8f2b-7097089ca2e5"
@@ -179754,7 +184450,17 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Thunderheads"
 scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
+scryfall_id = "56de9727-021e-4b37-b80b-08dcd898aec0"
+
+[[token.source_card_refs]]
+card_name = "Thunderheads"
+scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
 scryfall_id = "bf0a2851-946d-4f10-b43b-7444daa54ae1"
+
+[[token.source_card_refs]]
+card_name = "Thunderheads"
+scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
+scryfall_id = "381a7aaa-6cb8-47db-a381-6d1102e2338e"
 
 [[token.source_card_refs]]
 card_name = "Thunderheads"
@@ -180130,6 +184836,11 @@ scryfall_id = "067f24df-7018-45c8-bd67-1336b3672bb3"
 card_name = "Ominous Seas"
 scryfall_oracle_id = "58ea9b0a-1bef-4ccb-acb7-f03c8daf3df3"
 scryfall_id = "ce8965f2-756a-4461-a643-db024a11c2de"
+
+[[token.source_card_refs]]
+card_name = "Kiora, the Tide's Fury"
+scryfall_oracle_id = "6918a8b7-ced8-4f32-8780-69dfc8b9d11b"
+scryfall_id = "b42c67ad-847b-43af-b885-f55a8d859434"
 
 [token.token_image_ref]
 scryfall_id = "ca17c7b2-180a-4bd1-9ab2-152f8f656dba"
@@ -180763,6 +185474,11 @@ subtypes = ["Boar"]
 supertypes = []
 colors = ["Green"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Rural Recruit"
+scryfall_oracle_id = "fda06d9e-d17f-4bb6-916b-06116e47c8e8"
+scryfall_id = "428e7ae9-f299-4514-a225-ba8bbaa810f7"
 
 [[token.source_card_refs]]
 card_name = "Rural Recruit"
@@ -183868,6 +188584,16 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Endrek Sahr, Master Breeder"
 scryfall_oracle_id = "47a0079f-3544-45bc-a32a-bd93844c8c43"
+scryfall_id = "dac6faba-59f2-436f-addb-c53db2b0cc17"
+
+[[token.source_card_refs]]
+card_name = "Sarpadian Empires, Vol. VII"
+scryfall_oracle_id = "f71d55f5-f220-4cb0-9468-b8d339ab8535"
+scryfall_id = "b37a6cf7-f239-4bca-b4c3-a48932ef56b5"
+
+[[token.source_card_refs]]
+card_name = "Endrek Sahr, Master Breeder"
+scryfall_oracle_id = "47a0079f-3544-45bc-a32a-bd93844c8c43"
 scryfall_id = "22a14b34-c575-471b-b636-b25cb269196c"
 
 [[token.source_card_refs]]
@@ -185125,6 +189851,11 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Elmar, Ulvenwald Informant"
+scryfall_oracle_id = "5a35201d-e9b1-433a-bb70-3280ceedbcd6"
+scryfall_id = "95d197b3-fc56-43a2-981f-b5b905222b5c"
+
+[[token.source_card_refs]]
 card_name = "Havengul Laboratory // Havengul Mystery"
 face_name = "Havengul Laboratory"
 scryfall_oracle_id = "e71ac446-02a4-4468-8d29-f28b21617665"
@@ -185134,6 +189865,23 @@ scryfall_id = "83a86763-c3fe-4cff-8b65-22cb329d112c"
 card_name = "Wernog, Rider's Chaplain"
 scryfall_oracle_id = "6cd03270-54cc-43e1-9b86-70c76960c841"
 scryfall_id = "25a4af68-6e5e-4b44-9c1c-25ecdbd555b5"
+
+[[token.source_card_refs]]
+card_name = "Havengul Laboratory // Havengul Mystery"
+face_name = "Havengul Mystery"
+scryfall_oracle_id = "e71ac446-02a4-4468-8d29-f28b21617665"
+scryfall_id = "823b019e-10c0-4712-8167-d4f37a71e782"
+
+[[token.source_card_refs]]
+card_name = "Sophina, Spearsage Deserter"
+scryfall_oracle_id = "095dabda-4570-4764-8d62-4a29eb19d3e6"
+scryfall_id = "e0a64924-068e-483f-91a6-d450b67b3c75"
+
+[[token.source_card_refs]]
+card_name = "Havengul Laboratory // Havengul Mystery"
+face_name = "Havengul Laboratory"
+scryfall_oracle_id = "e71ac446-02a4-4468-8d29-f28b21617665"
+scryfall_id = "823b019e-10c0-4712-8167-d4f37a71e782"
 
 [[token.source_card_refs]]
 card_name = "Tireless Tracker"
@@ -185159,6 +189907,11 @@ scryfall_id = "c88eb33d-efba-4ad9-878f-f051079c9bce"
 card_name = "Elmar, Ulvenwald Informant"
 scryfall_oracle_id = "5a35201d-e9b1-433a-bb70-3280ceedbcd6"
 scryfall_id = "abb04ab1-2a74-432f-b3d3-d4f5b2534066"
+
+[[token.source_card_refs]]
+card_name = "Wernog, Rider's Chaplain"
+scryfall_oracle_id = "6cd03270-54cc-43e1-9b86-70c76960c841"
+scryfall_id = "39491011-bdf6-4e61-8534-fe26c1571f8f"
 
 [[token.source_card_refs]]
 card_name = "Tireless Tracker"
@@ -185255,12 +190008,22 @@ scryfall_id = "11ba43d1-e879-40e0-b49c-e009deb7e3aa"
 [[token.source_card_refs]]
 card_name = "Myr Sire"
 scryfall_oracle_id = "25794033-bd17-4056-b116-68d3acf52569"
+scryfall_id = "a3f2e2e5-5ed2-4040-92ba-ad1ac13f03f6"
+
+[[token.source_card_refs]]
+card_name = "Myr Sire"
+scryfall_oracle_id = "25794033-bd17-4056-b116-68d3acf52569"
 scryfall_id = "8e289d6c-1dcd-4431-9ed4-62b48eb207e1"
 
 [[token.source_card_refs]]
 card_name = "Parasitic Implant"
 scryfall_oracle_id = "4fc0f58c-5f7f-4a32-8f14-cae696672beb"
 scryfall_id = "e34f1bf3-9f3a-47f0-9761-8b2356328a39"
+
+[[token.source_card_refs]]
+card_name = "Parasitic Implant"
+scryfall_oracle_id = "4fc0f58c-5f7f-4a32-8f14-cae696672beb"
+scryfall_id = "43296ce8-f055-4778-a187-363a642001e4"
 
 [[token.source_card_refs]]
 card_name = "Myr Sire"
@@ -185991,9 +190754,12 @@ source_card_names = [
     "Arlinn Kord // Arlinn, Embraced by the Moon",
     "Arlinn, Embraced by the Moon",
     "Arlinn, Voice of the Pack",
+    "Arlinn, the Moon's Fury",
+    "Arlinn, the Pack's Hope",
     "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
     "Bestial Menace",
     "Bird",
+    "Child of the Pack",
     "Child of the Pack // Savage Packmate",
     "Cult of the Waxing Moon",
     "Elturgard Ranger",
@@ -186023,10 +190789,13 @@ source_card_names = [
     "Raised by Wolves",
     "Ranger Class",
     "Ravager of the Fells",
+    "Savage Packmate",
     "Silverfur Partisan",
     "Somberwald Beastmaster",
     "Sword of Body and Mind",
+    "Tovolar's Huntmaster",
     "Tovolar's Huntmaster // Tovolar's Packleader",
+    "Tovolar's Packleader",
     "Turntimber Ranger",
     "Varis, Silverymoon Ranger",
     "Wolf-Skull Shaman",
@@ -186054,16 +190823,66 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Nightpack Ambusher"
+scryfall_oracle_id = "4d67357c-5939-45c8-a656-aaf76728a5a6"
+scryfall_id = "4cd67241-6ff1-41bc-9bda-4a87fd4f6bdd"
+
+[[token.source_card_refs]]
 card_name = "Huntmaster of the Fells // Ravager of the Fells"
 face_name = "Ravager of the Fells"
 scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
 scryfall_id = "86da891f-08d0-459c-9d20-358032c6411a"
 
 [[token.source_card_refs]]
+card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
+face_name = "Garruk, the Veil-Cursed"
+scryfall_oracle_id = "7cec9021-6f25-4fd8-b40e-adf4ffd3a7b8"
+scryfall_id = "c340ad6b-aa09-4d12-a947-33b29b875158"
+
+[[token.source_card_refs]]
+card_name = "Arlinn Kord // Arlinn, Embraced by the Moon"
+face_name = "Arlinn, Embraced by the Moon"
+scryfall_oracle_id = "6bb7d0df-7a9f-4e17-8c31-7628c4b12356"
+scryfall_id = "49ed8050-1c98-47a0-82dd-ce08ee372387"
+
+[[token.source_card_refs]]
+card_name = "Child of the Pack // Savage Packmate"
+face_name = "Child of the Pack"
+scryfall_oracle_id = "a9c5b155-7c09-4100-9679-8fca2b5e9222"
+scryfall_id = "79fbd424-8668-4e36-8e2f-780362c9915e"
+
+[[token.source_card_refs]]
+card_name = "Sword of Body and Mind"
+scryfall_oracle_id = "fac42229-4f5f-4d04-85dd-5031d4e435aa"
+scryfall_id = "57c976cc-db75-4293-9ea4-a777d9ab426c"
+
+[[token.source_card_refs]]
+card_name = "Howling Moon"
+scryfall_oracle_id = "a814d4c7-2ec0-4278-8704-23b39dcead4e"
+scryfall_id = "37cad74a-df5c-467f-b8f6-7e8497d37d83"
+
+[[token.source_card_refs]]
+card_name = "Child of the Pack // Savage Packmate"
+face_name = "Savage Packmate"
+scryfall_oracle_id = "a9c5b155-7c09-4100-9679-8fca2b5e9222"
+scryfall_id = "79fbd424-8668-4e36-8e2f-780362c9915e"
+
+[[token.source_card_refs]]
 card_name = "Huntmaster of the Fells // Ravager of the Fells"
 face_name = "Huntmaster of the Fells"
 scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
 scryfall_id = "b3819a11-2f3e-4304-a1b0-6abf893c89c5"
+
+[[token.source_card_refs]]
+card_name = "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury"
+face_name = "Arlinn, the Moon's Fury"
+scryfall_oracle_id = "f227ce07-7e96-4a36-ab7c-9be6e777d649"
+scryfall_id = "5be8204f-8bb3-466c-a0c5-52b25bcdb7ba"
+
+[[token.source_card_refs]]
+card_name = "Somberwald Beastmaster"
+scryfall_oracle_id = "df35bf19-4cbf-4624-925d-ceca6bff596e"
+scryfall_id = "6488d613-59fa-4e26-a48c-eecab8754808"
 
 [[token.source_card_refs]]
 card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
@@ -186078,10 +190897,20 @@ scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
 scryfall_id = "b3819a11-2f3e-4304-a1b0-6abf893c89c5"
 
 [[token.source_card_refs]]
+card_name = "Feed the Pack"
+scryfall_oracle_id = "48981194-6465-4900-8cea-206f8ab5d00e"
+scryfall_id = "81df4f6c-fa65-43cd-bad1-4f255d75d1aa"
+
+[[token.source_card_refs]]
 card_name = "Arlinn Kord // Arlinn, Embraced by the Moon"
 face_name = "Arlinn Kord"
 scryfall_oracle_id = "6bb7d0df-7a9f-4e17-8c31-7628c4b12356"
 scryfall_id = "49825631-2498-41fe-a1df-f152ec05d1a8"
+
+[[token.source_card_refs]]
+card_name = "Bestial Menace"
+scryfall_oracle_id = "ef08d371-9d6c-4a2d-a444-d475fbf1b633"
+scryfall_id = "f0dd5077-7a1f-4a9c-8a86-9e87da909f0c"
 
 [[token.source_card_refs]]
 card_name = "Huntmaster of the Fells // Ravager of the Fells"
@@ -186096,10 +190925,48 @@ scryfall_oracle_id = "6e638587-30b3-4c4b-b463-fb415ea048f7"
 scryfall_id = "ef84540b-a132-4169-b3c0-b0edeb395c9b"
 
 [[token.source_card_refs]]
+card_name = "Garruk Relentless // Garruk, the Veil-Cursed"
+face_name = "Garruk Relentless"
+scryfall_oracle_id = "7cec9021-6f25-4fd8-b40e-adf4ffd3a7b8"
+scryfall_id = "c340ad6b-aa09-4d12-a947-33b29b875158"
+
+[[token.source_card_refs]]
+card_name = "Huntmaster of the Fells // Ravager of the Fells"
+face_name = "Huntmaster of the Fells"
+scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
+scryfall_id = "6c37fcdc-6187-4ed1-908a-74e2f9e188bf"
+
+[[token.source_card_refs]]
 card_name = "Arlinn Kord // Arlinn, Embraced by the Moon"
 face_name = "Arlinn Kord"
 scryfall_oracle_id = "6bb7d0df-7a9f-4e17-8c31-7628c4b12356"
 scryfall_id = "e72d7c11-2165-4c72-80f3-3c1a7b4b5572"
+
+[[token.source_card_refs]]
+card_name = "Mayor of Avabruck // Howlpack Alpha"
+face_name = "Mayor of Avabruck"
+scryfall_oracle_id = "6e638587-30b3-4c4b-b463-fb415ea048f7"
+scryfall_id = "af4bf1fc-19fe-4300-9842-9828178c419a"
+
+[[token.source_card_refs]]
+card_name = "Pack Guardian"
+scryfall_oracle_id = "61ad6bd2-c079-44e7-a1d9-8089f086ec69"
+scryfall_id = "8d1e8eb8-115e-41c4-bf49-7aa7ebd1c4e2"
+
+[[token.source_card_refs]]
+card_name = "Wolfkin Bond"
+scryfall_oracle_id = "49e22e88-d4d9-4781-81e3-bf77b76b132b"
+scryfall_id = "d8bb1b11-bf65-46a1-acb4-c7708a75e041"
+
+[[token.source_card_refs]]
+card_name = "Wolfwillow Haven"
+scryfall_oracle_id = "7579f57d-c76e-4703-a030-34fb7160cb23"
+scryfall_id = "7d135a17-2d93-41d9-be1d-80aa55f1050a"
+
+[[token.source_card_refs]]
+card_name = "Kessig Cagebreakers"
+scryfall_oracle_id = "d7407920-7596-497a-a135-b9343909a0cb"
+scryfall_id = "3d305e7c-81b2-460e-8f56-63cfbb018f15"
 
 [[token.source_card_refs]]
 card_name = "Mayor of Avabruck // Howlpack Alpha"
@@ -186126,9 +190993,70 @@ scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
 scryfall_id = "86da891f-08d0-459c-9d20-358032c6411a"
 
 [[token.source_card_refs]]
+card_name = "Ferocious Pup"
+scryfall_oracle_id = "a1112750-8d38-49e0-ab1c-77110b2bbc4d"
+scryfall_id = "eee53763-7344-4627-93c3-b4a5b26b1f16"
+
+[[token.source_card_refs]]
+card_name = "Huntmaster of the Fells // Ravager of the Fells"
+face_name = "Ravager of the Fells"
+scryfall_oracle_id = "582328cd-660d-47a4-bb23-e91e80b9a907"
+scryfall_id = "6c37fcdc-6187-4ed1-908a-74e2f9e188bf"
+
+[[token.source_card_refs]]
+card_name = "Arlinn, Voice of the Pack"
+scryfall_oracle_id = "a15b83df-91b7-49f0-9bec-5776a3dac8bd"
+scryfall_id = "98bee15d-6868-4dfc-9dd9-b437c5f3d6db"
+
+[[token.source_card_refs]]
+card_name = "Tovolar's Huntmaster // Tovolar's Packleader"
+face_name = "Tovolar's Packleader"
+scryfall_oracle_id = "18563bc9-6090-4629-b304-89a67d93f635"
+scryfall_id = "47f1be55-1a95-49e0-8943-4b8fa2f2f987"
+
+[[token.source_card_refs]]
 card_name = "Pack Guardian"
 scryfall_oracle_id = "61ad6bd2-c079-44e7-a1d9-8089f086ec69"
 scryfall_id = "7a40a06d-83ad-47d8-81ff-fbeafd92eafe"
+
+[[token.source_card_refs]]
+card_name = "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury"
+face_name = "Arlinn, the Pack's Hope"
+scryfall_oracle_id = "f227ce07-7e96-4a36-ab7c-9be6e777d649"
+scryfall_id = "5be8204f-8bb3-466c-a0c5-52b25bcdb7ba"
+
+[[token.source_card_refs]]
+card_name = "Tovolar's Huntmaster // Tovolar's Packleader"
+face_name = "Tovolar's Huntmaster"
+scryfall_oracle_id = "18563bc9-6090-4629-b304-89a67d93f635"
+scryfall_id = "47f1be55-1a95-49e0-8943-4b8fa2f2f987"
+
+[[token.source_card_refs]]
+card_name = "Master of the Wild Hunt"
+scryfall_oracle_id = "dd25cab9-15cc-40f5-9b68-8f345dd7e952"
+scryfall_id = "0cace1a3-34df-45d0-b653-b120b3617d40"
+
+[[token.source_card_refs]]
+card_name = "Wolfrider's Saddle"
+scryfall_oracle_id = "d0eeb863-6c1b-4e84-9199-e77f15724626"
+scryfall_id = "b66e1b92-194b-4efc-9bac-f15d7ee648a6"
+
+[[token.source_card_refs]]
+card_name = "Mayor of Avabruck // Howlpack Alpha"
+face_name = "Howlpack Alpha"
+scryfall_oracle_id = "6e638587-30b3-4c4b-b463-fb415ea048f7"
+scryfall_id = "af4bf1fc-19fe-4300-9842-9828178c419a"
+
+[[token.source_card_refs]]
+card_name = "Arlinn Kord // Arlinn, Embraced by the Moon"
+face_name = "Arlinn Kord"
+scryfall_oracle_id = "6bb7d0df-7a9f-4e17-8c31-7628c4b12356"
+scryfall_id = "49ed8050-1c98-47a0-82dd-ce08ee372387"
+
+[[token.source_card_refs]]
+card_name = "Predator's Howl"
+scryfall_oracle_id = "a1180796-6e26-4b45-9263-130620d702e5"
+scryfall_id = "f0976212-1e3f-4a31-ac56-15827fdbe28d"
 
 [[token.source_card_refs]]
 card_name = "Pack Guardian"
@@ -186146,6 +191074,11 @@ card_name = "Arlinn Kord // Arlinn, Embraced by the Moon"
 face_name = "Arlinn, Embraced by the Moon"
 scryfall_oracle_id = "6bb7d0df-7a9f-4e17-8c31-7628c4b12356"
 scryfall_id = "e72d7c11-2165-4c72-80f3-3c1a7b4b5572"
+
+[[token.source_card_refs]]
+card_name = "Wolfkin Bond"
+scryfall_oracle_id = "49e22e88-d4d9-4781-81e3-bf77b76b132b"
+scryfall_id = "40101dc6-4354-4f0a-aa90-946ed78d731e"
 
 [token.token_image_ref]
 scryfall_id = "89b89a55-3ea2-4186-b946-06831bc16169"
@@ -188016,7 +192949,17 @@ keywords = [
 [[token.source_card_refs]]
 card_name = "Thunderheads"
 scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
+scryfall_id = "56de9727-021e-4b37-b80b-08dcd898aec0"
+
+[[token.source_card_refs]]
+card_name = "Thunderheads"
+scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
 scryfall_id = "bf0a2851-946d-4f10-b43b-7444daa54ae1"
+
+[[token.source_card_refs]]
+card_name = "Thunderheads"
+scryfall_oracle_id = "9c5bc3a7-42fe-4f8f-b799-ece7dd98ea4d"
+scryfall_id = "381a7aaa-6cb8-47db-a381-6d1102e2338e"
 
 [[token.source_card_refs]]
 card_name = "Thunderheads"
@@ -188572,7 +193515,22 @@ scryfall_id = "6a03d849-67ef-47a8-babb-8a71c1f19d17"
 [[token.source_card_refs]]
 card_name = "Serra the Benevolent"
 scryfall_oracle_id = "8b0e2382-dd91-42e6-aba3-5e8a15418a49"
+scryfall_id = "fb89414e-ba6d-4d6f-957c-4f1946364331"
+
+[[token.source_card_refs]]
+card_name = "Serra the Benevolent"
+scryfall_oracle_id = "8b0e2382-dd91-42e6-aba3-5e8a15418a49"
 scryfall_id = "8e3c139e-fcd5-4a23-bcac-b887c6e198e5"
+
+[[token.source_card_refs]]
+card_name = "Finale of Glory"
+scryfall_oracle_id = "68273453-1059-4eab-8c27-5d96f998f3b1"
+scryfall_id = "1e71b0fb-2d36-4b81-bd5b-c3fd083e3e97"
+
+[[token.source_card_refs]]
+card_name = "Valkyrie Harbinger"
+scryfall_oracle_id = "18a5e71e-eb75-4ac7-bedd-2220aaa24f78"
+scryfall_id = "e9828a61-bc29-4a6d-8a41-e439dcb822db"
 
 [[token.source_card_refs]]
 card_name = "Valkyrie Harbinger"
@@ -188583,6 +193541,11 @@ scryfall_id = "edab83a9-35b5-4312-b8ee-1c042c02aa31"
 card_name = "Valkyrie Harbinger"
 scryfall_oracle_id = "18a5e71e-eb75-4ac7-bedd-2220aaa24f78"
 scryfall_id = "a79ecdf5-2167-4590-a964-e9d7eb32dfe6"
+
+[[token.source_card_refs]]
+card_name = "Valkyrie Harbinger"
+scryfall_oracle_id = "18a5e71e-eb75-4ac7-bedd-2220aaa24f78"
+scryfall_id = "e976523b-55cf-4cc0-b537-bb7c629004b4"
 
 [[token.source_card_refs]]
 card_name = "Parhelion II // Parhelion II"
@@ -188766,9 +193729,29 @@ scryfall_oracle_id = "0b768f8f-2213-45b9-bced-8fb1bbb441c3"
 scryfall_id = "1f20a82f-512e-47e7-9813-842cd5db1898"
 
 [[token.source_card_refs]]
+card_name = "Devils' Playground"
+scryfall_oracle_id = "ab9e2045-860a-40ab-bec1-0dffced003ef"
+scryfall_id = "336977de-7ece-40c1-8257-60bf0ffa32b4"
+
+[[token.source_card_refs]]
+card_name = "Make Mischief"
+scryfall_oracle_id = "5de50aa5-3b30-4d7d-9203-bc8fc0f8fb34"
+scryfall_id = "aeb6a7ca-b4ad-414b-9e1e-62dd87359451"
+
+[[token.source_card_refs]]
 card_name = "You Exist Only to Amuse"
 scryfall_oracle_id = "def8c0a9-ccf9-46e6-9027-6c841a0e146a"
 scryfall_id = "0fea7f06-f607-42a2-bb2f-50af43a0ff3a"
+
+[[token.source_card_refs]]
+card_name = "Dance with Devils"
+scryfall_oracle_id = "caeb508a-c1fd-45b5-a14e-e0ac7321c9a9"
+scryfall_id = "606f0b72-fc78-415c-9999-4ce362ed037d"
+
+[[token.source_card_refs]]
+card_name = "Zurzoth, Chaos Rider"
+scryfall_oracle_id = "a7da9ec5-f82f-4a6d-9737-06a1556e2dd6"
+scryfall_id = "3d94b4c3-7944-41b6-8c92-78fd6e50658d"
 
 [[token.source_card_refs]]
 card_name = "Spiked Corridor // Torture Pit"
@@ -188777,9 +193760,19 @@ scryfall_oracle_id = "e49b902f-a556-4dab-8928-93caf0a3f609"
 scryfall_id = "b90164a1-8b0a-4445-a0ad-43e4c3324925"
 
 [[token.source_card_refs]]
+card_name = "Dance with Devils"
+scryfall_oracle_id = "caeb508a-c1fd-45b5-a14e-e0ac7321c9a9"
+scryfall_id = "9189fafa-f30f-49a1-b07d-e432640d2bc5"
+
+[[token.source_card_refs]]
 card_name = "Tibalt, Rakish Instigator"
 scryfall_oracle_id = "0b768f8f-2213-45b9-bced-8fb1bbb441c3"
 scryfall_id = "7fcd6cc0-91b5-47ca-8f3d-c25cf26b81d7"
+
+[[token.source_card_refs]]
+card_name = "Burn Down the House"
+scryfall_oracle_id = "0ec54683-a65c-461d-862e-585b6499d6a5"
+scryfall_id = "4b73cbec-3c03-453f-903e-9a948cd40a8b"
 
 [[token.source_card_refs]]
 card_name = "Spiked Corridor // Torture Pit"
@@ -190831,6 +195824,11 @@ scryfall_oracle_id = "53fc09e1-1e5d-4f22-b623-2c5c770183ab"
 scryfall_id = "85050609-baf0-430a-ab33-83a6ea6d4741"
 
 [[token.source_card_refs]]
+card_name = "Monstrous Rage"
+scryfall_oracle_id = "646a2371-54c0-4492-ac2f-20f109d6108c"
+scryfall_id = "4b2e000b-a147-443b-9138-9ff2d16c0422"
+
+[[token.source_card_refs]]
 card_name = "Living Lectern"
 scryfall_oracle_id = "061e7fb2-2c04-4845-b60a-0e2512a2dec1"
 scryfall_id = "169afcaf-7ebf-4590-9e51-2a1a5eb3ac76"
@@ -190861,6 +195859,11 @@ scryfall_id = "79e4242c-a53a-4287-976b-8e545888a1fa"
 card_name = "Unassuming Sage"
 scryfall_oracle_id = "1cf4e16b-2273-41c7-9bcd-0cdc78e12198"
 scryfall_id = "a66fbaeb-1624-43b3-83e2-a37ce7588a5a"
+
+[[token.source_card_refs]]
+card_name = "Monstrous Rage"
+scryfall_oracle_id = "646a2371-54c0-4492-ac2f-20f109d6108c"
+scryfall_id = "9ebf25f9-844c-40c6-b0f0-d5c82ee04656"
 
 [[token.source_card_refs]]
 card_name = "Become Brutes"
@@ -191950,6 +196953,12 @@ scryfall_id = "4957bf8f-75ff-473e-9235-5441643a7c7b"
 card_name = "Incubation // Incongruity"
 face_name = "Incubation"
 scryfall_oracle_id = "363edb16-009f-4cc2-99e3-2b15db84e7af"
+scryfall_id = "2c1ace2e-b3eb-4e60-adfd-9f40b8cd4416"
+
+[[token.source_card_refs]]
+card_name = "Incubation // Incongruity"
+face_name = "Incubation"
+scryfall_oracle_id = "363edb16-009f-4cc2-99e3-2b15db84e7af"
 scryfall_id = "4957bf8f-75ff-473e-9235-5441643a7c7b"
 
 [[token.source_card_refs]]
@@ -191961,6 +196970,22 @@ scryfall_id = "917df0f5-af77-4e8a-af81-2f78a432b520"
 card_name = "Rapid Hybridization"
 scryfall_oracle_id = "06692cd9-ac2f-4a32-8fd1-043ba3c0fe71"
 scryfall_id = "ccda5bda-5afd-4548-bd48-12c780bfa68b"
+
+[[token.source_card_refs]]
+card_name = "Incubation // Incongruity"
+face_name = "Incongruity"
+scryfall_oracle_id = "363edb16-009f-4cc2-99e3-2b15db84e7af"
+scryfall_id = "2c1ace2e-b3eb-4e60-adfd-9f40b8cd4416"
+
+[[token.source_card_refs]]
+card_name = "Rapid Hybridization"
+scryfall_oracle_id = "06692cd9-ac2f-4a32-8fd1-043ba3c0fe71"
+scryfall_id = "49420431-0595-4525-b751-3d119fcaca22"
+
+[[token.source_card_refs]]
+card_name = "Rapid Hybridization"
+scryfall_oracle_id = "06692cd9-ac2f-4a32-8fd1-043ba3c0fe71"
+scryfall_id = "00f91207-c877-4911-8bb6-d8c5272b412d"
 
 [token.token_image_ref]
 scryfall_id = "42e98a20-325e-476f-8297-cbe8e09d85b2"
@@ -192899,6 +197924,11 @@ colors = ["Blue"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Crush of Tentacles"
+scryfall_oracle_id = "4ede153c-89cb-4121-bf23-a1d213d6f238"
+scryfall_id = "f8e07c79-8838-4df6-9554-661f535f0da0"
+
+[[token.source_card_refs]]
 card_name = "Octomancer"
 scryfall_oracle_id = "1cf7e5a0-cc8f-4bf7-9767-2f3bcae26339"
 scryfall_id = "f260197a-0297-4673-96de-dee915d79353"
@@ -193300,6 +198330,11 @@ scryfall_oracle_id = "58f12f0d-e2c1-48f9-9e27-d1de8db743cb"
 scryfall_id = "0f852937-381d-4445-99d3-2ecb8af6bb6a"
 
 [[token.source_card_refs]]
+card_name = "Orzhov Racketeers"
+scryfall_oracle_id = "4f6c9cee-5af7-4b00-a2a4-2770dab0a2dc"
+scryfall_id = "acb7c9c9-fad0-4394-9b4f-7ef3db765fea"
+
+[[token.source_card_refs]]
 card_name = "Teysa, Opulent Oligarch"
 scryfall_oracle_id = "d4f5748f-bb0e-4c48-8802-45a7ad5a80a4"
 scryfall_id = "9b5a13dd-c2fd-432e-bc49-cc62d94d62a0"
@@ -193315,6 +198350,11 @@ scryfall_oracle_id = "d4f5748f-bb0e-4c48-8802-45a7ad5a80a4"
 scryfall_id = "536f271e-5daa-4ffe-9dd4-0ccc48d6fb66"
 
 [[token.source_card_refs]]
+card_name = "Afterlife Insurance"
+scryfall_oracle_id = "05501e88-d4c3-4474-92a9-c02ab15b107b"
+scryfall_id = "2fa47810-ba83-4a6e-9940-7315ee7e44a5"
+
+[[token.source_card_refs]]
 card_name = "Teysa, Opulent Oligarch"
 scryfall_oracle_id = "d4f5748f-bb0e-4c48-8802-45a7ad5a80a4"
 scryfall_id = "ba0870d4-b5b8-4fd7-a21b-417f832e0d7e"
@@ -193325,9 +198365,19 @@ scryfall_oracle_id = "0a094c5f-cefb-4ba1-90c8-dd78ae8efe95"
 scryfall_id = "a2827593-4951-4ba7-b73e-c27de56f2606"
 
 [[token.source_card_refs]]
+card_name = "Syndicate Messenger"
+scryfall_oracle_id = "f5f4d78b-ed2b-471b-9ece-237fb55adc13"
+scryfall_id = "672b88fa-250b-4f8f-878e-ce3446c92ea9"
+
+[[token.source_card_refs]]
 card_name = "Teysa, Opulent Oligarch"
 scryfall_oracle_id = "d4f5748f-bb0e-4c48-8802-45a7ad5a80a4"
 scryfall_id = "4193a7bd-bba3-44f2-acf3-685847b8be27"
+
+[[token.source_card_refs]]
+card_name = "Seraph of the Scales"
+scryfall_oracle_id = "4a3acbf7-0699-4d7c-b4fa-aa15c7cde189"
+scryfall_id = "e1eb4816-2f33-4800-a9f0-11fec4ac4cd0"
 
 [token.token_image_ref]
 scryfall_id = "f4588570-bde4-4c2f-8469-81a3e15fb57b"
@@ -193667,6 +198717,11 @@ scryfall_oracle_id = "67f0cef6-8ef4-4c39-b306-2b580036894e"
 scryfall_id = "949ce545-4d5b-4329-a44e-5486fd3bebe6"
 
 [[token.source_card_refs]]
+card_name = "Awaken the Woods"
+scryfall_oracle_id = "3cc79d36-1a24-4395-8ad1-915a65db8a60"
+scryfall_id = "914e582c-978f-46fd-b06b-1ff2c20e5506"
+
+[[token.source_card_refs]]
 card_name = "Jyoti, Moag Ancient"
 scryfall_oracle_id = "67f0cef6-8ef4-4c39-b306-2b580036894e"
 scryfall_id = "f8a1f0ff-8680-41fb-bddb-e2ed071a166b"
@@ -193863,9 +198918,29 @@ scryfall_oracle_id = "7f2ba562-8d5e-4915-967e-54916c3c5876"
 scryfall_id = "a6e8433d-eb2a-43d1-b59b-7d70ff97c8e7"
 
 [[token.source_card_refs]]
+card_name = "Giant Opportunity"
+scryfall_oracle_id = "395aa62e-0786-4bd8-a88f-998e4700742e"
+scryfall_id = "6d284306-3365-45b4-8539-c2af7b3e16c4"
+
+[[token.source_card_refs]]
+card_name = "Fierce Witchstalker"
+scryfall_oracle_id = "ad69f48e-c387-4376-a04f-37d3992c7946"
+scryfall_id = "207788a7-c6aa-4aad-b2d1-f1b20355ae7b"
+
+[[token.source_card_refs]]
+card_name = "Hurska Sweet-Tooth"
+scryfall_oracle_id = "8d49b6a1-4ae2-4443-a6b3-9ef806cb6fc4"
+scryfall_id = "00841818-d46a-4865-a41c-daf627d10d1b"
+
+[[token.source_card_refs]]
 card_name = "Cat Collector"
 scryfall_oracle_id = "52f1b5a4-62ff-44de-80da-503d4e52d312"
 scryfall_id = "526fe356-bff1-4211-9e88-bf913ac76b1d"
+
+[[token.source_card_refs]]
+card_name = "Tough Cookie"
+scryfall_oracle_id = "8a1a5862-c027-4c15-99a7-1795d0da96da"
+scryfall_id = "09ffe48f-abfa-4110-805e-35671b42386d"
 
 [[token.source_card_refs]]
 card_name = "Midnight Snack"
@@ -193873,9 +198948,24 @@ scryfall_oracle_id = "3ddcaee9-a11e-477a-bd19-f5ee10512549"
 scryfall_id = "c9b7543f-2a45-4db6-b560-d15507a58c91"
 
 [[token.source_card_refs]]
+card_name = "Orchard Strider"
+scryfall_oracle_id = "c6906032-e08b-478f-bc71-cb1184f60bad"
+scryfall_id = "acdab158-3e36-42cd-9fda-e8282dbafeb2"
+
+[[token.source_card_refs]]
 card_name = "Bake into a Pie"
 scryfall_oracle_id = "1b9ec782-0ba1-41f1-bc39-d3302494ecb3"
 scryfall_id = "2ab0e660-86a3-4b92-82fa-77dcb5db947d"
+
+[[token.source_card_refs]]
+card_name = "Tireless Provisioner"
+scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
+scryfall_id = "5dbc2162-238d-492b-b629-94f771230d92"
+
+[[token.source_card_refs]]
+card_name = "Trail of Crumbs"
+scryfall_oracle_id = "185d6356-8f8d-4b32-8259-b4eb0a95866c"
+scryfall_id = "198be33b-d6d1-4c96-bdfa-4b4098079042"
 
 [token.token_image_ref]
 scryfall_id = "6f1077f8-9e2a-4155-a7f0-4604bc0f94e8"
@@ -193959,6 +199049,11 @@ scryfall_id = "ea1ab937-8647-4c83-99d5-6a40dffa4c9b"
 card_name = "Magma Opus"
 scryfall_oracle_id = "985f9dd7-e693-48ff-9dd6-a1a3cbaa236b"
 scryfall_id = "0fd4a0f7-ba03-4158-95cd-4effe798aec0"
+
+[[token.source_card_refs]]
+card_name = "Multiple Choice"
+scryfall_oracle_id = "b4d23acf-ff1f-4a6a-9ede-2667a99e9665"
+scryfall_id = "b71b23e7-4f4c-46bc-a512-4e2e6ff303cd"
 
 [[token.source_card_refs]]
 card_name = "Zaffai, Thunder Conductor"
@@ -194553,14 +199648,184 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Captain Lannery Storm"
+scryfall_oracle_id = "235bf0ba-658c-463f-b112-7478ba27bd7b"
+scryfall_id = "d33d910f-f378-4b55-9587-2101faefe0fa"
+
+[[token.source_card_refs]]
+card_name = "Rapacious Dragon"
+scryfall_oracle_id = "0944ec2e-1dd9-459f-8f1d-667242cf52fe"
+scryfall_id = "6d5d5f0b-7574-43d9-b9ab-b4d0fa419212"
+
+[[token.source_card_refs]]
+card_name = "Strike It Rich"
+scryfall_oracle_id = "c34c17c7-3827-49a2-be25-67f44fdfe150"
+scryfall_id = "d2e5d72a-5ef4-4578-8595-66eeef762c21"
+
+[[token.source_card_refs]]
+card_name = "Corsair Captain"
+scryfall_oracle_id = "a7ec13c6-7ade-433a-b5a2-047854eef486"
+scryfall_id = "a9b016d4-ddf6-47d6-b934-a0b979b60680"
+
+[[token.source_card_refs]]
+card_name = "Pitiless Plunderer"
+scryfall_oracle_id = "a784481f-eccb-4112-bb38-04a659319660"
+scryfall_id = "e8da4daa-1441-4d15-b9dc-7732343b38f1"
+
+[[token.source_card_refs]]
+card_name = "Brazen Freebooter"
+scryfall_oracle_id = "13e8d063-eece-4f38-83f6-02403130defa"
+scryfall_id = "60a1e6e9-5e5f-4431-9732-fd313df843df"
+
+[[token.source_card_refs]]
+card_name = "Unexpected Windfall"
+scryfall_oracle_id = "498c10c9-253d-4b15-b48c-1509381b17e8"
+scryfall_id = "b272df7e-f94c-4a57-a3dd-27d53525e726"
+
+[[token.source_card_refs]]
+card_name = "Gadrak, the Crown-Scourge"
+scryfall_oracle_id = "42d7ec93-0943-43e2-9b65-b7edc3349410"
+scryfall_id = "cbb13721-e6f7-439c-8993-a896de5d6892"
+
+[[token.source_card_refs]]
+card_name = "Old Rutstein"
+scryfall_oracle_id = "8f5ffb0b-0585-4a37-8048-eda53990d1dd"
+scryfall_id = "2bda3765-c56f-4b27-83f8-d01e16265328"
+
+[[token.source_card_refs]]
+card_name = "Trove of Temptation"
+scryfall_oracle_id = "f624c0f1-1c09-4b7a-b140-11329f27e3c7"
+scryfall_id = "faf67f7a-00da-422b-b517-fb55990a1999"
+
+[[token.source_card_refs]]
+card_name = "Tireless Provisioner"
+scryfall_oracle_id = "ab8d5f5c-1976-4f77-8ed2-8d28ee666741"
+scryfall_id = "5590a3a5-e0bd-451a-b98e-00a492487c46"
+
+[[token.source_card_refs]]
+card_name = "Emissary Green"
+scryfall_oracle_id = "c43e7fa5-ff93-42d9-af79-ee417a8e41a7"
+scryfall_id = "323e9430-b87c-4b02-9ade-c4c65343147b"
+
+[[token.source_card_refs]]
+card_name = "Malcolm, Keen-Eyed Navigator"
+scryfall_oracle_id = "a66f8b44-0163-4456-b152-4acefab896a4"
+scryfall_id = "cfcb3051-161f-42f8-bfec-db03b349ff00"
+
+[[token.source_card_refs]]
+card_name = "Goldvein Pick"
+scryfall_oracle_id = "c1624d10-8838-4af8-aea1-a96c0fe6fd6b"
+scryfall_id = "bd33b5fc-9901-493b-8d7f-5e98223fdcad"
+
+[[token.source_card_refs]]
+card_name = "Sailor of Means"
+scryfall_oracle_id = "c4efae03-99de-4439-925b-504602623bfd"
+scryfall_id = "10c1e6ad-1227-4049-89bf-69ace48c3076"
+
+[[token.source_card_refs]]
+card_name = "Prosperous Pirates"
+scryfall_oracle_id = "9dc6281b-08e0-4c66-9aef-abc7184ca36a"
+scryfall_id = "f6db054e-8303-44c7-8c96-d031a8c85b34"
+
+[[token.source_card_refs]]
+card_name = "Big Score"
+scryfall_oracle_id = "a5cbd257-c836-493e-bb1a-76242619dea2"
+scryfall_id = "5fbb7413-af44-4038-a56c-8cc3ca645a58"
+
+[[token.source_card_refs]]
+card_name = "Unexpected Windfall"
+scryfall_oracle_id = "498c10c9-253d-4b15-b48c-1509381b17e8"
+scryfall_id = "33ba9e5a-d078-4a47-b181-0ca7d1596919"
+
+[[token.source_card_refs]]
+card_name = "Improvised Weaponry"
+scryfall_oracle_id = "fa5dad0b-8e23-4b88-b383-849f7318e01f"
+scryfall_id = "828a5005-0b19-49a2-bc9a-5b32c719c74c"
+
+[[token.source_card_refs]]
+card_name = "Professional Face-Breaker"
+scryfall_oracle_id = "04152e7a-969c-4858-841b-0a569a9fc1bf"
+scryfall_id = "9c2561e6-c5b6-4c88-896e-67b33b8cf6bc"
+
+[[token.source_card_refs]]
+card_name = "Jewel-Eyed Cobra"
+scryfall_oracle_id = "bbfee53c-30a6-4ed0-beef-5c254be75fc5"
+scryfall_id = "56607174-63aa-415b-8511-1abe17689e78"
+
+[[token.source_card_refs]]
 card_name = "Pitiless Plunderer"
 scryfall_oracle_id = "a784481f-eccb-4112-bb38-04a659319660"
 scryfall_id = "6a4b4679-6ca9-49e1-a7ee-2b7a30e3e06c"
 
 [[token.source_card_refs]]
+card_name = "Iron Man, Titan of Innovation"
+scryfall_oracle_id = "67ab82de-1167-42f5-90bd-21c63edcc712"
+scryfall_id = "20d54b22-62e8-48ac-ba65-0bdbf42d6cad"
+
+[[token.source_card_refs]]
+card_name = "Vault Robber"
+scryfall_oracle_id = "68c90a32-d6ee-4595-8517-5f4cb0e4062d"
+scryfall_id = "e1f67518-b5ea-4b9b-96b5-e01de054b348"
+
+[[token.source_card_refs]]
+card_name = "Goldspan Dragon"
+scryfall_oracle_id = "716b3ea2-45b7-4a8f-af72-de7f4e510eff"
+scryfall_id = "0c67a683-4e1d-4a64-952d-a1c27a34ed1d"
+
+[[token.source_card_refs]]
+card_name = "Mastermind Plum"
+scryfall_oracle_id = "4605d8b3-b714-4717-8ff3-155fabfc1999"
+scryfall_id = "df81568b-c66a-49c6-bd48-7df98ea00117"
+
+[[token.source_card_refs]]
+card_name = "Burdened Aerialist"
+scryfall_oracle_id = "dd39cccb-095c-4ef4-8423-f4d328849295"
+scryfall_id = "d8cc9f89-4758-4236-ac08-638cbd8c107a"
+
+[[token.source_card_refs]]
 card_name = "Hullbreacher"
 scryfall_oracle_id = "2f533667-e29b-4bec-897a-e7a9eee08314"
 scryfall_id = "c2a0530f-7b72-4a33-8eec-bcd75d9c3045"
+
+[[token.source_card_refs]]
+card_name = "Covetous Elegy"
+scryfall_oracle_id = "dd69ef80-d30c-4b15-aec8-4154dc20cb25"
+scryfall_id = "f8f1f5e8-c1bf-405f-b8e3-655d5558e18d"
+
+[[token.source_card_refs]]
+card_name = "Shiny Impetus"
+scryfall_oracle_id = "aae76e5c-f5e0-4d18-b465-e6a829be908a"
+scryfall_id = "d91896ea-e0fd-4113-a3c6-a7811e16be46"
+
+[[token.source_card_refs]]
+card_name = "Gleaming Barrier"
+scryfall_oracle_id = "1eb9e401-8975-447b-839d-f7cd23897465"
+scryfall_id = "bf4ba8a3-77b0-4da8-9bdd-0950d0fe8401"
+
+[[token.source_card_refs]]
+card_name = "Halo Scarab"
+scryfall_oracle_id = "1201c146-54af-4668-a544-cde3ece23f2e"
+scryfall_id = "573857cf-2afe-455e-a0e3-b67a465d4f4e"
+
+[[token.source_card_refs]]
+card_name = "Deadly Dispute"
+scryfall_oracle_id = "457af74a-02b3-4659-846d-63e482667f34"
+scryfall_id = "e0f658ff-323e-4e32-beaa-1d5753b4f081"
+
+[[token.source_card_refs]]
+card_name = "Rapacious Dragon"
+scryfall_oracle_id = "0944ec2e-1dd9-459f-8f1d-667242cf52fe"
+scryfall_id = "495c0dbf-1671-40f9-809c-98ef6d588512"
+
+[[token.source_card_refs]]
+card_name = "Sudden Breakthrough"
+scryfall_oracle_id = "f5576cd4-6b21-4b29-902c-9c1fbdd7b2be"
+scryfall_id = "c78dd917-7748-41dd-b294-943302bdab34"
+
+[[token.source_card_refs]]
+card_name = "Deadly Dispute"
+scryfall_oracle_id = "457af74a-02b3-4659-846d-63e482667f34"
+scryfall_id = "1d3df7bd-b0ca-4f51-99e5-d259246196e8"
 
 [token.token_image_ref]
 scryfall_id = "c6e096bb-ad9e-4a8b-8b42-26852fa32c1d"
@@ -195998,6 +201263,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Gideon, Ally of Zendikar"
 scryfall_oracle_id = "51eae7ff-fed9-4afe-8053-7690379449dd"
+scryfall_id = "d5908dce-f02d-4cff-b793-0a97ee928823"
+
+[[token.source_card_refs]]
+card_name = "Gideon, Ally of Zendikar"
+scryfall_oracle_id = "51eae7ff-fed9-4afe-8053-7690379449dd"
 scryfall_id = "187e887c-c39d-4d25-a506-cdc95fc70316"
 
 [[token.source_card_refs]]
@@ -196583,6 +201853,16 @@ scryfall_id = "cf99efef-aec7-41e7-bde5-542421a03072"
 card_name = "Penumbra Wurm"
 scryfall_oracle_id = "abccb19f-098b-4453-b7bc-838ad5914ebe"
 scryfall_id = "de4ce98d-0a19-42c5-9ef9-32408da1d2a1"
+
+[[token.source_card_refs]]
+card_name = "Penumbra Wurm"
+scryfall_oracle_id = "abccb19f-098b-4453-b7bc-838ad5914ebe"
+scryfall_id = "ae3dffe7-ecaf-4cf0-a43e-8e2746282992"
+
+[[token.source_card_refs]]
+card_name = "Penumbra Wurm"
+scryfall_oracle_id = "abccb19f-098b-4453-b7bc-838ad5914ebe"
+scryfall_id = "a66be186-ccd3-4b51-b3fb-5a1116b189e4"
 
 [token.token_image_ref]
 scryfall_id = "31107acf-5969-42ff-a805-9152f439b7fa"
@@ -199409,9 +204689,19 @@ colors = ["White"]
 keywords = ["Lifelink"]
 
 [[token.source_card_refs]]
+card_name = "Regal Caracal"
+scryfall_oracle_id = "aa571676-b390-4b8a-baea-4c4cd60c01f6"
+scryfall_id = "c4b80710-0057-4b7e-aa50-4d4d67dfbae2"
+
+[[token.source_card_refs]]
 card_name = "Liberated Livestock"
 scryfall_oracle_id = "d080cb03-b3e5-42e8-b289-2ce2151b4cb8"
 scryfall_id = "890e8f0d-07c2-47bb-af99-944289c6ea56"
+
+[[token.source_card_refs]]
+card_name = "Pride Sovereign"
+scryfall_oracle_id = "a131c32d-2b4f-4ee4-aab2-ab05ab010978"
+scryfall_id = "4a8c3161-ccfd-456b-8453-5f77496892e4"
 
 [[token.source_card_refs]]
 card_name = "Basri, Tomorrow's Champion"
@@ -199424,6 +204714,11 @@ scryfall_oracle_id = "d8e1e9ba-708c-4f54-abc3-817004a2f2ac"
 scryfall_id = "991270fa-a391-4c2e-bd9a-19151386fb67"
 
 [[token.source_card_refs]]
+card_name = "Leonin Warleader"
+scryfall_oracle_id = "8b1351e6-165e-4ca3-96d5-4774b3176362"
+scryfall_id = "b24820fa-7cef-4396-920c-810dd06e3887"
+
+[[token.source_card_refs]]
 card_name = "Liberated Livestock"
 scryfall_oracle_id = "d080cb03-b3e5-42e8-b289-2ce2151b4cb8"
 scryfall_id = "f22f4c5a-fe42-4511-be96-78e0e807e704"
@@ -199432,6 +204727,11 @@ scryfall_id = "f22f4c5a-fe42-4511-be96-78e0e807e704"
 card_name = "Basri, Tomorrow's Champion"
 scryfall_oracle_id = "d8e1e9ba-708c-4f54-abc3-817004a2f2ac"
 scryfall_id = "440766a6-5820-4248-ad91-4d946235e136"
+
+[[token.source_card_refs]]
+card_name = "Regal Caracal"
+scryfall_oracle_id = "aa571676-b390-4b8a-baea-4c4cd60c01f6"
+scryfall_id = "8511fb74-dd0c-492d-87f6-7d27d39d101a"
 
 [token.token_image_ref]
 scryfall_id = "902fba98-92b7-461b-ac6e-29cb2c4e307f"
@@ -200017,6 +205317,11 @@ scryfall_oracle_id = "ea1eb902-a23c-44ff-9169-19baf71de238"
 scryfall_id = "0ea31d56-3530-41b4-8d31-c6ee16e87ae6"
 
 [[token.source_card_refs]]
+card_name = "Drake Haven"
+scryfall_oracle_id = "86d3def3-53fa-4cad-bb25-d3275af1e3f5"
+scryfall_id = "4cfe0645-79ec-4e94-a6eb-b38b920d2dab"
+
+[[token.source_card_refs]]
 card_name = "Drake Hatcher"
 scryfall_oracle_id = "4de0ccab-bb5d-4c7c-827e-36aa1d00b182"
 scryfall_id = "c4c31f0d-b77f-4cf9-8350-2dde15d427a7"
@@ -200035,6 +205340,21 @@ scryfall_id = "bcaf4196-6bf3-47fa-b5c7-0e77f45cf820"
 card_name = "Drake Hatcher"
 scryfall_oracle_id = "4de0ccab-bb5d-4c7c-827e-36aa1d00b182"
 scryfall_id = "b60cf418-b927-49b6-9613-41eae6296902"
+
+[[token.source_card_refs]]
+card_name = "Alandra, Sky Dreamer"
+scryfall_oracle_id = "97bb1589-2941-4a75-a5f6-916871e51e9e"
+scryfall_id = "61561585-f4fb-4e47-a65a-0c43a855ebcf"
+
+[[token.source_card_refs]]
+card_name = "Talrand's Invocation"
+scryfall_oracle_id = "43355ac4-bf8c-48f6-a322-fafbc9d132d1"
+scryfall_id = "4b153c2f-fc87-49bc-9d1e-d5e7e25b2142"
+
+[[token.source_card_refs]]
+card_name = "Talrand, Sky Summoner"
+scryfall_oracle_id = "ea1eb902-a23c-44ff-9169-19baf71de238"
+scryfall_id = "3d89c1a1-1896-4360-b123-52d82a6871d4"
 
 [[token.source_card_refs]]
 card_name = "Talrand, Sky Summoner"
@@ -200114,6 +205434,11 @@ scryfall_id = "34ec1216-1b8c-418f-bc25-c3f5ad4fda00"
 card_name = "Breya, Etherium Shaper"
 scryfall_oracle_id = "d460a9e2-5a7d-4562-880e-45174be19a9d"
 scryfall_id = "581591f0-b3c7-4fca-b4b9-1d1d098ca7fb"
+
+[[token.source_card_refs]]
+card_name = "Sharding Sphinx"
+scryfall_oracle_id = "9ebc0144-fc45-4de7-b3d8-ef8cf2e211ae"
+scryfall_id = "4df1ce35-1f1c-40ab-8e4d-cb087b4656d8"
 
 [token.token_image_ref]
 scryfall_id = "e0a7adb3-8e66-4e63-95f2-1a5f5827b676"
@@ -200249,6 +205574,11 @@ colors = ["Black"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Wakedancer"
+scryfall_oracle_id = "e850743e-e4c4-4a09-b797-d5f688b51451"
+scryfall_id = "9e20cdcc-1580-4495-9627-2f799b05e359"
+
+[[token.source_card_refs]]
 card_name = "Dread Summons"
 scryfall_oracle_id = "642fa01d-025e-44dd-8360-5325e5a28282"
 scryfall_id = "dfb5dd33-6e5b-4d78-92fa-678c9f01c606"
@@ -200259,6 +205589,26 @@ scryfall_oracle_id = "ea6ee33f-0cba-4e96-817f-dc89c9064ead"
 scryfall_id = "3d2c5345-eb55-4bca-9183-b4e1404405f8"
 
 [[token.source_card_refs]]
+card_name = "Boneclad Necromancer"
+scryfall_oracle_id = "6494e3c4-5489-44a5-94b6-4ee2d7830896"
+scryfall_id = "39f8e986-30a5-4184-a717-e30b0bc2a419"
+
+[[token.source_card_refs]]
+card_name = "Liliana, Death's Majesty"
+scryfall_oracle_id = "7fca595e-1902-40fd-a359-622caa612b6a"
+scryfall_id = "69264ed3-b31f-4b92-aec1-e46f91b2068d"
+
+[[token.source_card_refs]]
+card_name = "Army of the Damned"
+scryfall_oracle_id = "75d667ec-86f4-4850-a3b6-e7a9fc7053b0"
+scryfall_id = "b46b0818-cd87-41b4-85d2-c474b995d4c0"
+
+[[token.source_card_refs]]
+card_name = "Doomed Dissenter"
+scryfall_oracle_id = "11cb509d-21af-48f1-b355-135ebd3e4bd1"
+scryfall_id = "f6a99641-1796-4263-bbbb-b4bac0b07dd4"
+
+[[token.source_card_refs]]
 card_name = "Maalfeld Twins"
 scryfall_oracle_id = "dda4b515-49c0-43fe-9f6a-36defa326bb1"
 scryfall_id = "c166df8f-9508-427a-8ec7-bc8541b6ed88"
@@ -200267,6 +205617,11 @@ scryfall_id = "c166df8f-9508-427a-8ec7-bc8541b6ed88"
 card_name = "Liliana, Dreadhorde General"
 scryfall_oracle_id = "5e958212-6a5b-4288-8d31-f1572619d7dc"
 scryfall_id = "7a097413-b77c-45e8-a4ac-5b2dc1d34e16"
+
+[[token.source_card_refs]]
+card_name = "Moan of the Unhallowed"
+scryfall_oracle_id = "ce87e5ed-2562-4563-9a5b-bd53c04ec4a5"
+scryfall_id = "d95f7af9-cabf-47e0-9ca4-e276ff6605b9"
 
 [[token.source_card_refs]]
 card_name = "Liliana, Dreadhorde General"
@@ -200480,12 +205835,47 @@ keywords = ["Reach"]
 [[token.source_card_refs]]
 card_name = "Ishkanah, Grafwidow"
 scryfall_oracle_id = "6f4861f4-1b3b-4dbc-b55b-196075d0a693"
+scryfall_id = "045b6009-6215-4d2b-acce-5d90f2d4e391"
+
+[[token.source_card_refs]]
+card_name = "Ishkanah, Grafwidow"
+scryfall_oracle_id = "6f4861f4-1b3b-4dbc-b55b-196075d0a693"
 scryfall_id = "851c729f-1c98-4962-9cc9-84872133ac02"
+
+[[token.source_card_refs]]
+card_name = "Rotwidow Pack"
+scryfall_oracle_id = "27b5d9d8-cc19-46be-9862-405cf7ef5408"
+scryfall_id = "ce62fa4e-f76d-4ff2-aa6d-bcae4f725696"
+
+[[token.source_card_refs]]
+card_name = "Twin-Silk Spider"
+scryfall_oracle_id = "a2193302-402a-4cf0-8014-5facecad647b"
+scryfall_id = "9adcf067-b08c-4e36-afab-be41d7659c56"
+
+[[token.source_card_refs]]
+card_name = "Arasta of the Endless Web"
+scryfall_oracle_id = "695eea46-1535-48c5-bbb6-0b8379e77bfc"
+scryfall_id = "255544be-db0f-4dcc-8787-f05652cd2684"
+
+[[token.source_card_refs]]
+card_name = "Arasta of the Endless Web"
+scryfall_oracle_id = "695eea46-1535-48c5-bbb6-0b8379e77bfc"
+scryfall_id = "de819fd7-0823-42da-99bc-db87bb71acc8"
 
 [[token.source_card_refs]]
 card_name = "Spider Spawning"
 scryfall_oracle_id = "da113cc9-bb2b-4af4-9c43-32c165b87363"
 scryfall_id = "d798227e-b098-4eff-931c-0bef642ccc81"
+
+[[token.source_card_refs]]
+card_name = "Arachnogenesis"
+scryfall_oracle_id = "b655bee5-52d3-467e-b16c-cfc2edf2b1a1"
+scryfall_id = "922f0e2f-a211-4ac1-b7bb-4dc46a5802a3"
+
+[[token.source_card_refs]]
+card_name = "Arachnogenesis"
+scryfall_oracle_id = "b655bee5-52d3-467e-b16c-cfc2edf2b1a1"
+scryfall_id = "77e2f5ac-5c0d-4503-b8ab-fee00eaaa4a3"
 
 [[token.source_card_refs]]
 card_name = "Twin-Silk Spider"
@@ -200496,6 +205886,16 @@ scryfall_id = "68e9ba91-9bab-4b2f-a82d-05b333b8deed"
 card_name = "Arasta of the Endless Web"
 scryfall_oracle_id = "695eea46-1535-48c5-bbb6-0b8379e77bfc"
 scryfall_id = "95a87b4e-f0ea-457c-9517-4acf313c4ca6"
+
+[[token.source_card_refs]]
+card_name = "Spider Spawning"
+scryfall_oracle_id = "da113cc9-bb2b-4af4-9c43-32c165b87363"
+scryfall_id = "97858ce1-bfb3-4307-a0d5-b2139fa09b8b"
+
+[[token.source_card_refs]]
+card_name = "Brood Weaver"
+scryfall_oracle_id = "f0a7ef59-7897-4e84-a85e-1fcbe3dc9f6a"
+scryfall_id = "2ec08f5a-0dcc-426b-94d9-cf8877071d6a"
 
 [token.token_image_ref]
 scryfall_id = "a351094c-2315-4e95-89ed-16a1866f67cb"
@@ -202024,6 +207424,16 @@ colors = []
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Myr Matrix"
+scryfall_oracle_id = "46a07fdd-0ca3-4654-9caa-a88fae80c414"
+scryfall_id = "4a1af62e-d566-4f39-a467-244602c9240b"
+
+[[token.source_card_refs]]
+card_name = "Myr Incubator"
+scryfall_oracle_id = "d0a493af-551e-4475-af5d-ec4e080728cb"
+scryfall_id = "31b0f9ef-7404-4e05-b759-aaf1ebcfcb31"
+
+[[token.source_card_refs]]
 card_name = "Myr Battlesphere"
 scryfall_oracle_id = "c53ba31a-ba27-4e17-9a92-311acb1cab29"
 scryfall_id = "0db4cf09-8cf0-4aa7-8bfe-fe600352032d"
@@ -202042,6 +207452,11 @@ scryfall_id = "18957d46-01e9-4ef0-97ba-ddbe5b34ea10"
 card_name = "Mirrodin Besieged"
 scryfall_oracle_id = "674e2683-31c0-4fee-95fb-98b1201e41e7"
 scryfall_id = "edf98768-c7dd-434e-8883-19b47ad45790"
+
+[[token.source_card_refs]]
+card_name = "Genesis Chamber"
+scryfall_oracle_id = "150ab025-5cc3-4468-a724-bbba8838445d"
+scryfall_id = "f0a66ded-c697-4bab-8abf-464185f32a70"
 
 [token.token_image_ref]
 scryfall_id = "9d54ed64-573d-45cc-9d5c-94c5d0fc88ec"
@@ -202160,6 +207575,11 @@ keywords = ["Trample"]
 card_name = "Honored Hydra"
 scryfall_oracle_id = "db63d999-97a6-4a62-83bd-e0677e6f8956"
 scryfall_id = "21c33902-a06a-4321-bdf4-cea5494fda63"
+
+[[token.source_card_refs]]
+card_name = "Honored Hydra"
+scryfall_oracle_id = "db63d999-97a6-4a62-83bd-e0677e6f8956"
+scryfall_id = "c430a165-3bbf-4ee4-81f7-fe45bd7a201e"
 
 [token.token_image_ref]
 scryfall_id = "7365ffff-b171-4275-9fdb-e622f8456858"
@@ -203952,6 +209372,11 @@ card_name = "Reef Worm"
 scryfall_oracle_id = "e3ad5cbc-4245-4e1e-8204-509381fa0c1c"
 scryfall_id = "25576181-a5a4-4baf-a2b4-fbfe13fb9df6"
 
+[[token.source_card_refs]]
+card_name = "Kiora, the Crashing Wave"
+scryfall_oracle_id = "58cc2097-f4b4-4695-9076-78666050cdb6"
+scryfall_id = "6ace0bfa-254f-46e0-8a14-277f080e013c"
+
 [token.token_image_ref]
 scryfall_id = "9155825a-6449-4b36-aa14-4c227075ed51"
 scryfall_oracle_id = "cd0f813b-1f9f-484d-adab-bc8d16d2b867"
@@ -203984,7 +209409,22 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Pongify"
 scryfall_oracle_id = "05849bd6-8f38-4031-be2b-e2aa03beb8cc"
+scryfall_id = "cce74a84-4441-4f2e-89d8-df0b096790ed"
+
+[[token.source_card_refs]]
+card_name = "Side to Side"
+scryfall_oracle_id = "5201143e-3305-456a-813e-a51a5901ad81"
+scryfall_id = "a8512b3c-9a44-4c15-8217-0f13898846cd"
+
+[[token.source_card_refs]]
+card_name = "Pongify"
+scryfall_oracle_id = "05849bd6-8f38-4031-be2b-e2aa03beb8cc"
 scryfall_id = "cb504714-b034-4938-93ad-7cb2ae320829"
+
+[[token.source_card_refs]]
+card_name = "Pongify"
+scryfall_oracle_id = "05849bd6-8f38-4031-be2b-e2aa03beb8cc"
+scryfall_id = "5780936e-629d-4737-9005-651234f5426d"
 
 [token.token_image_ref]
 scryfall_id = "4b2ee605-3c7a-4769-978d-3199bdc7c504"
@@ -204509,6 +209949,11 @@ colors = ["Black"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
+card_name = "Belfry Spirit"
+scryfall_oracle_id = "c171065f-7947-4161-a481-1ea2d3ce8422"
+scryfall_id = "556e4e71-b149-49c8-8a22-83660bef57bb"
+
+[[token.source_card_refs]]
 card_name = "Skeletal Vampire"
 scryfall_oracle_id = "7ed8a69b-fba0-4d4d-98b2-311a92373669"
 scryfall_id = "7cb8d6b0-13c1-4b04-9a92-1b87f2b7c1ea"
@@ -204519,9 +209964,19 @@ scryfall_oracle_id = "c171065f-7947-4161-a481-1ea2d3ce8422"
 scryfall_id = "c1f5854d-63cf-419f-990c-6f473e181a68"
 
 [[token.source_card_refs]]
+card_name = "Skeletal Vampire"
+scryfall_oracle_id = "7ed8a69b-fba0-4d4d-98b2-311a92373669"
+scryfall_id = "69251d44-3038-4b64-ab78-fc87f0406ba2"
+
+[[token.source_card_refs]]
 card_name = "Lunar Convocation"
 scryfall_oracle_id = "cb68d1e4-36aa-4a00-b671-8959e7d526d4"
 scryfall_id = "4396e4c7-660d-4055-bc94-4ccea95223b7"
+
+[[token.source_card_refs]]
+card_name = "Bat Whisperer"
+scryfall_oracle_id = "f20f6da9-d678-486b-99f9-7121669fef81"
+scryfall_id = "a57d2348-a05c-4d40-bb3e-68ebf396cd62"
 
 [[token.source_card_refs]]
 card_name = "Lunar Convocation"
@@ -204538,8 +209993,10 @@ id = "ee98a86d-1691-56eb-ab6f-337e3ec7cd1b"
 category = "Creature"
 fidelity = "Full"
 source_card_names = [
+    "Assault",
     "Assault // Battery",
     "Autarch Mammoth",
+    "Battery",
     "Bestial Menace",
     "Call of the Herd",
     "Elephant Ambush",
@@ -204569,6 +210026,23 @@ colors = ["Green"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Elephant Ambush"
+scryfall_oracle_id = "09386931-59bd-481f-bccc-32e8a8abc0f9"
+scryfall_id = "b4abdf1c-a0a9-4e1d-b448-58742830f767"
+
+[[token.source_card_refs]]
+card_name = "Assault // Battery"
+face_name = "Assault"
+scryfall_oracle_id = "fcdeb83f-531c-4087-9254-7f19eb065f00"
+scryfall_id = "4a9f1e99-9de8-45cb-b035-4f920477e2e5"
+
+[[token.source_card_refs]]
+card_name = "Assault // Battery"
+face_name = "Assault"
+scryfall_oracle_id = "fcdeb83f-531c-4087-9254-7f19eb065f00"
+scryfall_id = "0ec6a889-c941-4898-a2f6-4d3863faf535"
+
+[[token.source_card_refs]]
 card_name = "Generous Gift"
 scryfall_oracle_id = "fae37e28-e137-4177-b973-fa8b4dd8f409"
 scryfall_id = "c3f9b454-97e9-4c77-b37a-e974221ae385"
@@ -204577,6 +210051,37 @@ scryfall_id = "c3f9b454-97e9-4c77-b37a-e974221ae385"
 card_name = "Trumpeting Herd"
 scryfall_oracle_id = "69501650-ed48-4ebf-9287-b0338c5bc5d5"
 scryfall_id = "a9b998c9-ff41-45b6-baf7-0fc456daf978"
+
+[[token.source_card_refs]]
+card_name = "Call of the Herd"
+scryfall_oracle_id = "ee243f81-f51c-4d9a-a396-f7cef84b46c1"
+scryfall_id = "ebff1b5d-b948-48fa-9fa7-690b13ab5d71"
+
+[[token.source_card_refs]]
+card_name = "Trumpeting Herd"
+scryfall_oracle_id = "69501650-ed48-4ebf-9287-b0338c5bc5d5"
+scryfall_id = "8f439a94-c3fa-4813-abbb-a39200a88bc7"
+
+[[token.source_card_refs]]
+card_name = "Bestial Menace"
+scryfall_oracle_id = "ef08d371-9d6c-4a2d-a444-d475fbf1b633"
+scryfall_id = "f0dd5077-7a1f-4a9c-8a86-9e87da909f0c"
+
+[[token.source_card_refs]]
+card_name = "Assault // Battery"
+face_name = "Battery"
+scryfall_oracle_id = "fcdeb83f-531c-4087-9254-7f19eb065f00"
+scryfall_id = "4a9f1e99-9de8-45cb-b035-4f920477e2e5"
+
+[[token.source_card_refs]]
+card_name = "Call of the Herd"
+scryfall_oracle_id = "ee243f81-f51c-4d9a-a396-f7cef84b46c1"
+scryfall_id = "429a88cc-53db-4c5e-a061-f0f49a38c675"
+
+[[token.source_card_refs]]
+card_name = "Elephant Guide"
+scryfall_oracle_id = "c138bd7f-8751-4e96-b54a-d5082e1a491f"
+scryfall_id = "7d3a7226-f574-430e-9b8f-4e531a21540f"
 
 [[token.source_card_refs]]
 card_name = "Elephant Guide"
@@ -204597,6 +210102,17 @@ scryfall_id = "4de50769-8cae-4eff-913b-0ebb6dde4f9c"
 card_name = "Terastodon"
 scryfall_oracle_id = "17975a20-2c13-4325-be1e-0bcda5063a2d"
 scryfall_id = "48783dc1-0976-4955-b7e3-afa311160d68"
+
+[[token.source_card_refs]]
+card_name = "Assault // Battery"
+face_name = "Battery"
+scryfall_oracle_id = "fcdeb83f-531c-4087-9254-7f19eb065f00"
+scryfall_id = "0ec6a889-c941-4898-a2f6-4d3863faf535"
+
+[[token.source_card_refs]]
+card_name = "Elephant Guide"
+scryfall_oracle_id = "c138bd7f-8751-4e96-b54a-d5082e1a491f"
+scryfall_id = "cc09ab3d-16ad-4d78-8d6c-5211104b41cf"
 
 [[token.source_card_refs]]
 card_name = "Generous Gift"
@@ -204627,6 +210143,11 @@ scryfall_id = "cd1383d8-fdc4-4830-a05b-a69ee15e3cd0"
 card_name = "Generous Gift"
 scryfall_oracle_id = "fae37e28-e137-4177-b973-fa8b4dd8f409"
 scryfall_id = "96d4e224-e630-4696-85ef-cf42f9d03ca5"
+
+[[token.source_card_refs]]
+card_name = "Generous Gift"
+scryfall_oracle_id = "fae37e28-e137-4177-b973-fa8b4dd8f409"
+scryfall_id = "47f44d5a-f3d6-4a9a-8bd3-b17a88565c51"
 
 [token.token_image_ref]
 scryfall_id = "e96f22c0-b9c8-418a-8224-e7d0b2841bd2"
@@ -204927,6 +210448,11 @@ keywords = []
 card_name = "Witch's Mark"
 scryfall_oracle_id = "00807825-88e5-4b88-8527-a49f553a91be"
 scryfall_id = "7120f534-cc20-453a-8ddd-ebd6f64235e7"
+
+[[token.source_card_refs]]
+card_name = "Witch's Mark"
+scryfall_oracle_id = "00807825-88e5-4b88-8527-a49f553a91be"
+scryfall_id = "03c6aae5-f85a-4083-b880-71c0e141cc22"
 
 [token.token_image_ref]
 scryfall_id = "6929750f-cf08-4e3e-83b0-076e1f6fa8e0"
@@ -205970,12 +211496,22 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "News Helicopter"
 scryfall_oracle_id = "192dd1e2-b6c2-432a-a1b4-e52ff39b3db2"
+scryfall_id = "cfe529d7-4418-4068-8f9d-6d74a74fd291"
+
+[[token.source_card_refs]]
+card_name = "News Helicopter"
+scryfall_oracle_id = "192dd1e2-b6c2-432a-a1b4-e52ff39b3db2"
 scryfall_id = "15717af0-30cd-4417-947a-c27cca06d93a"
 
 [[token.source_card_refs]]
 card_name = "Friendly Neighborhood"
 scryfall_oracle_id = "10fe402e-8d6f-4058-9f42-86f229055359"
 scryfall_id = "2e7c80af-4841-4e5f-a3c9-8448b63b3788"
+
+[[token.source_card_refs]]
+card_name = "Friendly Neighborhood"
+scryfall_oracle_id = "10fe402e-8d6f-4058-9f42-86f229055359"
+scryfall_id = "10e0dff7-8923-4e47-bf28-c6d0af78ce24"
 
 [[token.source_card_refs]]
 card_name = "Spider-Girl, Legacy Hero"
@@ -205993,9 +211529,19 @@ scryfall_oracle_id = "50477dc8-9a2a-41eb-984d-c9e1e78e08a2"
 scryfall_id = "f6ff59e4-c7b7-4fdc-a49e-2d7aab859474"
 
 [[token.source_card_refs]]
+card_name = "Spider-Girl, Legacy Hero"
+scryfall_oracle_id = "d459b3f5-a18c-4c17-a855-dc147f7c2161"
+scryfall_id = "ebc534ac-c33b-4059-9d11-82645f8fead1"
+
+[[token.source_card_refs]]
 card_name = "Friendly Neighborhood"
 scryfall_oracle_id = "10fe402e-8d6f-4058-9f42-86f229055359"
 scryfall_id = "17a18e2f-221f-4fc2-8dab-25bf12fb8756"
+
+[[token.source_card_refs]]
+card_name = "Silk, Web Weaver"
+scryfall_oracle_id = "50477dc8-9a2a-41eb-984d-c9e1e78e08a2"
+scryfall_id = "458cd7a1-7437-493b-b7b7-42ef489e77df"
 
 [token.token_image_ref]
 scryfall_id = "398fbcd8-fac7-4396-9c69-5c72695121a9"
@@ -206093,6 +211639,11 @@ keywords = ["Deathtouch"]
 card_name = "Hapatra, Vizier of Poisons"
 scryfall_oracle_id = "a8ddea1c-8d80-49c1-a5b4-630d5e51d66e"
 scryfall_id = "d19e17fc-ae3e-4533-ab94-70d5f2e1b8cd"
+
+[[token.source_card_refs]]
+card_name = "Hapatra, Vizier of Poisons"
+scryfall_oracle_id = "a8ddea1c-8d80-49c1-a5b4-630d5e51d66e"
+scryfall_id = "b43ba233-30c4-4b18-8489-4df76551aa73"
 
 [token.token_image_ref]
 scryfall_id = "9a9380a8-8f38-47cd-8648-20626c06b9b3"
@@ -206722,6 +212273,18 @@ card_name = "Dorothea, Vengeful Victim // Dorothea's Retribution"
 face_name = "Dorothea's Retribution"
 scryfall_oracle_id = "2cef4171-8151-4ee9-83a7-bcb5116451bf"
 scryfall_id = "ff66ee02-6b68-405e-a5c0-f59bb8020865"
+
+[[token.source_card_refs]]
+card_name = "Dorothea, Vengeful Victim // Dorothea's Retribution"
+face_name = "Dorothea's Retribution"
+scryfall_oracle_id = "2cef4171-8151-4ee9-83a7-bcb5116451bf"
+scryfall_id = "680ce9a3-b47a-4f79-8254-f0935266b467"
+
+[[token.source_card_refs]]
+card_name = "Dorothea, Vengeful Victim // Dorothea's Retribution"
+face_name = "Dorothea, Vengeful Victim"
+scryfall_oracle_id = "2cef4171-8151-4ee9-83a7-bcb5116451bf"
+scryfall_id = "680ce9a3-b47a-4f79-8254-f0935266b467"
 
 [[token.source_card_refs]]
 card_name = "Dorothea, Vengeful Victim // Dorothea's Retribution"
@@ -207899,6 +213462,16 @@ card_name = "Zendikar's Roil"
 scryfall_oracle_id = "a842cc2b-52eb-4dc5-86c6-6575c2ed913d"
 scryfall_id = "79298a0f-50ca-4bf5-b863-a60f07846970"
 
+[[token.source_card_refs]]
+card_name = "Zendikar's Roil"
+scryfall_oracle_id = "a842cc2b-52eb-4dc5-86c6-6575c2ed913d"
+scryfall_id = "3f0768ee-aa58-48ca-91e8-64332af5dcfe"
+
+[[token.source_card_refs]]
+card_name = "Zendikar's Roil"
+scryfall_oracle_id = "a842cc2b-52eb-4dc5-86c6-6575c2ed913d"
+scryfall_id = "180aa3d6-8475-4c98-a140-af736a9c135e"
+
 [token.token_image_ref]
 scryfall_id = "5dc134da-51b8-452d-b515-54def56fe0c7"
 scryfall_oracle_id = "e3c32eb9-508a-41d3-b85f-cb85ab2f2716"
@@ -208129,9 +213702,29 @@ scryfall_oracle_id = "792da586-a687-428c-a10e-75431249df5b"
 scryfall_id = "c08c7bf9-a2ed-45c6-8b48-15122d9d9e37"
 
 [[token.source_card_refs]]
+card_name = "Strength of Arms"
+scryfall_oracle_id = "40ff84c7-cd72-49a6-86ba-a8d23c819ee7"
+scryfall_id = "3e021db5-982b-457c-958f-951ba3be317d"
+
+[[token.source_card_refs]]
+card_name = "Bastion of Remembrance"
+scryfall_oracle_id = "c7f33cea-2ec8-4081-9208-a5b1d86721b3"
+scryfall_id = "0c9a8ae0-af8b-41e5-b841-314106e40eaf"
+
+[[token.source_card_refs]]
 card_name = "Omen of the Sun"
 scryfall_oracle_id = "08740dda-0629-4b6f-bbcc-c8088105b5e7"
 scryfall_id = "b3733812-32e5-407d-82f0-089983777e09"
+
+[[token.source_card_refs]]
+card_name = "Thraben Standard Bearer"
+scryfall_oracle_id = "679d5a1d-8da8-4142-924b-97b359f55309"
+scryfall_id = "0229a5ce-196b-494e-bc6f-a71daedf05cc"
+
+[[token.source_card_refs]]
+card_name = "Ulvenwald Mysteries"
+scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
+scryfall_id = "749aafbf-9d17-4341-a137-dba1cc4d09da"
 
 [[token.source_card_refs]]
 card_name = "Bastion of Remembrance"
@@ -208179,9 +213772,24 @@ scryfall_oracle_id = "8e953251-aa5c-4aa3-8e69-1ff1f609f3ff"
 scryfall_id = "3fa2050a-711f-4c6e-8b01-5353bd2a4234"
 
 [[token.source_card_refs]]
+card_name = "Ulvenwald Mysteries"
+scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
+scryfall_id = "c6079979-8613-4613-a5bd-6b1fab382767"
+
+[[token.source_card_refs]]
+card_name = "Ulvenwald Mysteries"
+scryfall_oracle_id = "6588ea9a-658f-40d9-a64b-3a418ab81183"
+scryfall_id = "fd02c995-0a77-460c-9fa3-34f74b14b119"
+
+[[token.source_card_refs]]
 card_name = "Bastion of Remembrance"
 scryfall_oracle_id = "c7f33cea-2ec8-4081-9208-a5b1d86721b3"
 scryfall_id = "7ad20d37-575d-490e-bf04-91323a35e89d"
+
+[[token.source_card_refs]]
+card_name = "Sigarda, Heron's Grace"
+scryfall_oracle_id = "79b56cf8-d573-40cf-b797-6b4eef2bed23"
+scryfall_id = "f1b34868-c8f0-4e55-beac-8068af672618"
 
 [token.token_image_ref]
 scryfall_id = "631c2c16-132d-4607-ab7e-207a6af188e5"
@@ -208378,6 +213986,17 @@ subtypes = ["Human"]
 supertypes = []
 colors = ["Red"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Stensia Uprising"
+scryfall_oracle_id = "a881bf6e-6247-4adb-9f9c-e4b928692573"
+scryfall_id = "2ea95b64-9c5f-4f0d-ab7e-e4412a3cdadf"
+
+[[token.source_card_refs]]
+card_name = "Hanweir Garrison // Hanweir, the Writhing Township"
+face_name = "Hanweir Garrison"
+scryfall_oracle_id = "7cb29569-48e1-4782-9906-fad155ebfafe"
+scryfall_id = "85822129-ee39-4239-ba88-807435170f94"
 
 [[token.source_card_refs]]
 card_name = "Hanweir Garrison // Hanweir, the Writhing Township"
@@ -209350,6 +214969,11 @@ card_name = "Garruk, Apex Predator"
 scryfall_oracle_id = "ef9a8bdc-3361-440d-89f6-0bf5ff7a09e8"
 scryfall_id = "07dd9bfc-b6d2-493d-b825-941556018dbd"
 
+[[token.source_card_refs]]
+card_name = "Garruk, Apex Predator"
+scryfall_oracle_id = "ef9a8bdc-3361-440d-89f6-0bf5ff7a09e8"
+scryfall_id = "3ebd3fd3-d629-4e14-876f-55342a3a97d2"
+
 [token.token_image_ref]
 scryfall_id = "b56fd392-17c2-43d5-a92d-3f91beb8adfb"
 scryfall_oracle_id = "3c27a325-4490-44e6-aa9a-b591697486c8"
@@ -209708,6 +215332,21 @@ card_name = "Oviya Pashiri, Sage Lifecrafter"
 scryfall_oracle_id = "41e03224-bcdd-4127-a19a-fe66196339b9"
 scryfall_id = "b7938b15-7585-43fb-897f-a57e820665b3"
 
+[[token.source_card_refs]]
+card_name = "Metallurgic Summonings"
+scryfall_oracle_id = "7d5149c6-0e7e-438c-a554-5235c85e2426"
+scryfall_id = "77dbf358-0f4f-4b7a-aede-a7fc13619f24"
+
+[[token.source_card_refs]]
+card_name = "Oviya Pashiri, Sage Lifecrafter"
+scryfall_oracle_id = "41e03224-bcdd-4127-a19a-fe66196339b9"
+scryfall_id = "e1c2b1b4-6439-4203-967d-c8a40a2e701e"
+
+[[token.source_card_refs]]
+card_name = "Gemini Engine"
+scryfall_oracle_id = "eab4241d-a0d8-4914-85a4-56bc4ff718f2"
+scryfall_id = "2e03e05b-011b-4695-950b-98dd7643b8a0"
+
 [token.token_image_ref]
 scryfall_id = "0f3954f9-776d-4a8d-a032-724c4eae0e13"
 scryfall_oracle_id = "63ff850d-df4a-4903-95cb-cc04dfacc3f1"
@@ -209738,6 +215377,11 @@ keywords = []
 card_name = "Trial of Strength"
 scryfall_oracle_id = "b272cb56-dcba-479e-9fba-5b31e616a95f"
 scryfall_id = "acadb754-4a3b-4633-b784-252c0e1ab650"
+
+[[token.source_card_refs]]
+card_name = "Trial of Strength"
+scryfall_oracle_id = "b272cb56-dcba-479e-9fba-5b31e616a95f"
+scryfall_id = "fb8484a4-3ee1-4104-b22a-8a2f1401fbdc"
 
 [token.token_image_ref]
 scryfall_id = "29b7ecd1-c70e-467c-a9ea-99c2668c3405"
@@ -209906,6 +215550,11 @@ subtypes = ["Human"]
 supertypes = []
 colors = ["White"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Apothecary White"
+scryfall_oracle_id = "7bf8bb41-6f46-492c-b6cf-5cfb29f973a4"
+scryfall_id = "4fedf84e-55ca-4334-a2c1-6e991112bb68"
 
 [[token.source_card_refs]]
 card_name = "Castle Ardenvale"
@@ -210821,6 +216470,11 @@ keywords = []
 [[token.source_card_refs]]
 card_name = "Rise of the Ants"
 scryfall_oracle_id = "d9d33dcd-3352-478e-afc4-40f2ff369c39"
+scryfall_id = "7fb63465-4fb4-429c-8ff5-f6527e0a0b16"
+
+[[token.source_card_refs]]
+card_name = "Rise of the Ants"
+scryfall_oracle_id = "d9d33dcd-3352-478e-afc4-40f2ff369c39"
 scryfall_id = "7b00ea7e-da6e-4ebd-b39a-eb4657a1f9a5"
 
 [[token.source_card_refs]]
@@ -211620,9 +217274,24 @@ colors = ["White"]
 keywords = []
 
 [[token.source_card_refs]]
+card_name = "Security Detail"
+scryfall_oracle_id = "2a26dee4-b4b6-489d-99e5-6dbd8d19419d"
+scryfall_id = "5b89d34b-1a67-4f5c-a731-54b56c5233ff"
+
+[[token.source_card_refs]]
 card_name = "Midnight Angel Armor"
 scryfall_oracle_id = "cdcfc66d-3d3a-4311-b864-937e7b624d61"
 scryfall_id = "a3881ae9-f6c4-4b35-b767-351a8cb4e7c4"
+
+[[token.source_card_refs]]
+card_name = "Elspeth, Sun's Champion"
+scryfall_oracle_id = "05e6b243-48a6-4a42-bc5f-413441de9c33"
+scryfall_id = "8f8bdb2a-d6be-4a9c-bfa8-de00ccf3ca06"
+
+[[token.source_card_refs]]
+card_name = "Even the Odds"
+scryfall_oracle_id = "6cd3605c-7885-4d32-8585-3b0b0f733702"
+scryfall_id = "f704cd76-dca8-4526-b03f-7e3753d8fbb5"
 
 [[token.source_card_refs]]
 card_name = "S.H.I.E.L.D. Deployment Drone"
@@ -211640,6 +217309,16 @@ scryfall_oracle_id = "d6f36172-d3ef-49e9-a55f-ce2983bb2439"
 scryfall_id = "e94da91d-6c76-4909-91e3-2f8d97398654"
 
 [[token.source_card_refs]]
+card_name = "Ironroot Warlord"
+scryfall_oracle_id = "abc49dc3-03b3-48a4-afe1-5fc435b65d0f"
+scryfall_id = "b78765aa-f952-47f5-b6fc-8aca93fc4104"
+
+[[token.source_card_refs]]
+card_name = "Decree of Justice"
+scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
+scryfall_id = "1d347ffc-5542-485c-8fc7-327c1c68b7aa"
+
+[[token.source_card_refs]]
 card_name = "Kimoyo Beads"
 scryfall_oracle_id = "c7bdbf7a-8054-4e91-bb32-84f47e98553c"
 scryfall_id = "e8f6d489-44d2-4613-a1bb-bd435577e16a"
@@ -211648,6 +217327,16 @@ scryfall_id = "e8f6d489-44d2-4613-a1bb-bd435577e16a"
 card_name = "Martial Coup"
 scryfall_oracle_id = "2b7c4dab-e432-4b34-b058-3cec5c0d72df"
 scryfall_id = "b6e7563a-a613-49f4-98a0-dd0f5c00f299"
+
+[[token.source_card_refs]]
+card_name = "Lena, Selfless Champion"
+scryfall_oracle_id = "a8a8407c-d0e3-4311-82ed-1ab1f75159d9"
+scryfall_id = "da1fb1a6-7f64-45a6-9fc0-a325b7600afa"
+
+[[token.source_card_refs]]
+card_name = "Evangel of Heliod"
+scryfall_oracle_id = "4fbe1c02-f5bf-47c7-80de-09a32d01e5db"
+scryfall_id = "403597f8-12c7-40be-bb06-4468f547b80c"
 
 [[token.source_card_refs]]
 card_name = "Decree of Justice"
@@ -211668,6 +217357,16 @@ scryfall_id = "9e308f77-206b-4c9d-bfba-f4c476ea574a"
 card_name = "Okoye, Dora Milaje Leader"
 scryfall_oracle_id = "6d397d26-7e52-47b2-9880-2c10e90cfba4"
 scryfall_id = "2c89acf5-20f0-4441-b96f-2c5cacd685fb"
+
+[[token.source_card_refs]]
+card_name = "Benalish Commander"
+scryfall_oracle_id = "3a1e85fe-7064-4df7-bc3b-24131cd15d06"
+scryfall_id = "44814da0-3bc8-423d-9b22-3fea123048fa"
+
+[[token.source_card_refs]]
+card_name = "Decree of Justice"
+scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
+scryfall_id = "5e8a7e5c-f252-4de8-94d7-e7327210bf26"
 
 [[token.source_card_refs]]
 card_name = "Secure Detention"
@@ -211700,9 +217399,29 @@ scryfall_oracle_id = "26e92eb8-7a23-4e7e-be83-244bb6078606"
 scryfall_id = "bfa75d51-307f-45da-8fac-81bb32830ee9"
 
 [[token.source_card_refs]]
+card_name = "Decree of Justice"
+scryfall_oracle_id = "67a98359-6f02-4556-ad47-c01b643686d6"
+scryfall_id = "c2cecbd0-87a7-45e5-bf10-e97b298803fd"
+
+[[token.source_card_refs]]
+card_name = "Mobilization"
+scryfall_oracle_id = "6b8119e9-a9a9-4349-be32-adcb84b8eb79"
+scryfall_id = "653cc07b-0f53-4b5b-9c5f-885b8b4a6e5f"
+
+[[token.source_card_refs]]
 card_name = "Wakandan Shield Guard"
 scryfall_oracle_id = "a9268e61-2697-46ff-b219-4f2be646cbe4"
 scryfall_id = "47eba4f9-8276-4367-8ff5-53a066e8c729"
+
+[[token.source_card_refs]]
+card_name = "Kjeldoran Outpost"
+scryfall_oracle_id = "8b370db5-dfb9-4ea0-9017-bae3e767b041"
+scryfall_id = "db90c357-26e3-4ab2-a280-0d8d74b95048"
+
+[[token.source_card_refs]]
+card_name = "Kjeldoran Outpost"
+scryfall_oracle_id = "8b370db5-dfb9-4ea0-9017-bae3e767b041"
+scryfall_id = "e0769fc7-50b5-4b49-8aff-af04536288fb"
 
 [[token.source_card_refs]]
 card_name = "Elspeth, Sun's Champion"
@@ -211710,9 +217429,24 @@ scryfall_oracle_id = "05e6b243-48a6-4a42-bc5f-413441de9c33"
 scryfall_id = "97f8d1ca-bc82-453a-b237-ef75ce027b8f"
 
 [[token.source_card_refs]]
+card_name = "Kjeldoran Outpost"
+scryfall_oracle_id = "8b370db5-dfb9-4ea0-9017-bae3e767b041"
+scryfall_id = "3aaf73be-ef08-43fb-af8c-7c2536f743e0"
+
+[[token.source_card_refs]]
+card_name = "Raise the Alarm"
+scryfall_oracle_id = "5b2364d7-a811-4595-a1b4-224c70555ffa"
+scryfall_id = "f552f9b6-0a60-44d8-985e-249617e04866"
+
+[[token.source_card_refs]]
 card_name = "Kimoyo Beads"
 scryfall_oracle_id = "c7bdbf7a-8054-4e91-bb32-84f47e98553c"
 scryfall_id = "1138096a-0d7c-461b-af83-3c90f681722d"
+
+[[token.source_card_refs]]
+card_name = "Murder Investigation"
+scryfall_oracle_id = "42ca56c5-a9c4-4a2c-ae05-bce47aa6e16c"
+scryfall_id = "612da129-c8dd-4f89-a505-548ad5c2f7e1"
 
 [[token.source_card_refs]]
 card_name = "Decree of Justice"
@@ -211733,6 +217467,21 @@ scryfall_id = "0cb5f2df-9a5c-4fdf-8bb3-24d4d670768b"
 card_name = "Martial Coup"
 scryfall_oracle_id = "2b7c4dab-e432-4b34-b058-3cec5c0d72df"
 scryfall_id = "a0660e74-6973-41d7-a20b-8d71fed1495a"
+
+[[token.source_card_refs]]
+card_name = "Darien, King of Kjeldor"
+scryfall_oracle_id = "d05336cb-6157-47e7-942f-43becd67a5bf"
+scryfall_id = "5ea571ae-b9bd-4bd2-9357-52915f0d2f15"
+
+[[token.source_card_refs]]
+card_name = "Stormfront Riders"
+scryfall_oracle_id = "9df318b9-16c6-42f1-9f81-6f73ca01e5c1"
+scryfall_id = "de5e892e-d321-436f-81a6-73975e65b45c"
+
+[[token.source_card_refs]]
+card_name = "Raise the Alarm"
+scryfall_oracle_id = "5b2364d7-a811-4595-a1b4-224c70555ffa"
+scryfall_id = "4be510c8-fc01-4374-ac04-7968d24480fe"
 
 [[token.source_card_refs]]
 card_name = "Darien, King of Kjeldor"
@@ -214338,6 +220087,11 @@ keywords = [
     "Indestructible",
 ]
 
+[[token.source_card_refs]]
+card_name = "Dark Depths"
+scryfall_oracle_id = "c9b82110-7dfd-4617-9399-9510be449043"
+scryfall_id = "92409c3a-fb1a-4205-9fe1-0f5affc7b21d"
+
 [token.token_image_ref]
 scryfall_id = "8f5c3863-c876-48a8-9bc8-be20cd61074c"
 scryfall_oracle_id = "48e9147e-59f7-4693-83d7-7f514be871bc"
@@ -215887,6 +221641,11 @@ scryfall_id = "3aecfe99-9c4b-4087-84ee-fb208fd22820"
 [[token.source_card_refs]]
 card_name = "Xenagos, the Reveler"
 scryfall_oracle_id = "942a318e-90eb-4f10-bb30-2e10f5cc922a"
+scryfall_id = "e7848a59-14f1-49ea-981e-8436acb70d85"
+
+[[token.source_card_refs]]
+card_name = "Xenagos, the Reveler"
+scryfall_oracle_id = "942a318e-90eb-4f10-bb30-2e10f5cc922a"
 scryfall_id = "edfd90ee-a142-4a80-b383-802bbee2cef1"
 
 [[token.source_card_refs]]
@@ -216336,6 +222095,11 @@ card_name = "B.O.B. (Bevy of Beebles)"
 scryfall_oracle_id = "c33af24f-3371-4af9-af33-940078d3cef2"
 scryfall_id = "7e41ecd9-8875-4765-a9a9-372f948b5ad7"
 
+[[token.source_card_refs]]
+card_name = "B.O.B. (Bevy of Beebles)"
+scryfall_oracle_id = "c33af24f-3371-4af9-af33-940078d3cef2"
+scryfall_id = "de1d5bfb-953f-4ce0-88ee-721e69254228"
+
 [token.token_image_ref]
 scryfall_id = "9bbfa4d4-106b-4fec-86ac-b81b71a8f432"
 scryfall_oracle_id = "2de03d67-1b55-4abc-9a64-4f59658b9e97"
@@ -216372,6 +222136,11 @@ colors = ["White"]
 keywords = ["Flying"]
 
 [[token.source_card_refs]]
+card_name = "Sacred Mesa"
+scryfall_oracle_id = "8776d14f-a5a2-4ef3-98d0-e1148e579e4d"
+scryfall_id = "6622f325-6bc3-49dc-ba8e-154e70772dd5"
+
+[[token.source_card_refs]]
 card_name = "Pegasus Stampede"
 scryfall_oracle_id = "16b4a48a-fec2-433c-948d-e0b16c961172"
 scryfall_id = "a5301a1b-5fa1-4311-a515-ff1b64c98945"
@@ -216380,6 +222149,11 @@ scryfall_id = "a5301a1b-5fa1-4311-a515-ff1b64c98945"
 card_name = "Storm Herd"
 scryfall_oracle_id = "30aa362b-7ab1-486e-9802-1171e0dc2416"
 scryfall_id = "62a3fc08-6d95-43da-8479-4289018c2d58"
+
+[[token.source_card_refs]]
+card_name = "Storm Herd"
+scryfall_oracle_id = "30aa362b-7ab1-486e-9802-1171e0dc2416"
+scryfall_id = "c8c86398-2cbc-4ad7-a231-6802e3b4d1c0"
 
 [[token.source_card_refs]]
 card_name = "Storm Herd"
@@ -216398,10 +222172,30 @@ scryfall_oracle_id = "e71863a7-0de1-4ab5-95e8-c39e6810d899"
 scryfall_id = "d32dcd09-8542-4135-8955-e29ee63e3589"
 
 [[token.source_card_refs]]
+card_name = "Pegasus Refuge"
+scryfall_oracle_id = "07462467-e4a3-409e-bcef-9cc92ca4c299"
+scryfall_id = "a2bce334-0ae6-4a7d-85db-99ee205ce546"
+
+[[token.source_card_refs]]
 card_name = "Pegasus Guardian // Rescue the Foal"
 face_name = "Rescue the Foal"
 scryfall_oracle_id = "e71863a7-0de1-4ab5-95e8-c39e6810d899"
 scryfall_id = "d32dcd09-8542-4135-8955-e29ee63e3589"
+
+[[token.source_card_refs]]
+card_name = "Sacred Mesa"
+scryfall_oracle_id = "8776d14f-a5a2-4ef3-98d0-e1148e579e4d"
+scryfall_id = "c76e4cc6-6e69-4787-9425-7a35e06c0b69"
+
+[[token.source_card_refs]]
+card_name = "Pegasus Stampede"
+scryfall_oracle_id = "16b4a48a-fec2-433c-948d-e0b16c961172"
+scryfall_id = "3b941576-8254-4d69-85ae-c748c7921ce5"
+
+[[token.source_card_refs]]
+card_name = "Pegasus Stampede"
+scryfall_oracle_id = "16b4a48a-fec2-433c-948d-e0b16c961172"
+scryfall_id = "7418d65f-1017-4f98-b039-db4228769454"
 
 [token.token_image_ref]
 scryfall_id = "ebd8f43d-7e54-46d4-9fe9-ac818a9fd91f"
@@ -217181,10 +222975,12 @@ id = "fb4ee9b2-1eb8-5465-9fcc-7c7089627d36"
 category = "Creature"
 fidelity = "Full"
 source_card_names = [
+    "Hanweir Militia Captain",
     "Hanweir Militia Captain // Westvale Cult Leader",
     "Ormendahl, Profane Prince",
     "Westvale Abbey",
     "Westvale Abbey // Ormendahl, Profane Prince",
+    "Westvale Cult Leader",
 ]
 set_code = "INR"
 set_name = "Innistrad Remastered"
@@ -217240,6 +223036,12 @@ scryfall_id = "d3182b40-a731-4957-9d6e-a1f69c3aeb5e"
 
 [[token.source_card_refs]]
 card_name = "Westvale Abbey // Ormendahl, Profane Prince"
+face_name = "Ormendahl, Profane Prince"
+scryfall_oracle_id = "04eeb9ad-5c59-411b-8809-db8349838588"
+scryfall_id = "20c2c22f-5115-4a66-bcad-e70619d43448"
+
+[[token.source_card_refs]]
+card_name = "Westvale Abbey // Ormendahl, Profane Prince"
 face_name = "Westvale Abbey"
 scryfall_oracle_id = "04eeb9ad-5c59-411b-8809-db8349838588"
 scryfall_id = "5fbc6091-a161-45b0-9932-543b569caaee"
@@ -217255,6 +223057,24 @@ card_name = "Westvale Abbey // Ormendahl, Profane Prince"
 face_name = "Ormendahl, Profane Prince"
 scryfall_oracle_id = "04eeb9ad-5c59-411b-8809-db8349838588"
 scryfall_id = "5fbc6091-a161-45b0-9932-543b569caaee"
+
+[[token.source_card_refs]]
+card_name = "Westvale Abbey // Ormendahl, Profane Prince"
+face_name = "Westvale Abbey"
+scryfall_oracle_id = "04eeb9ad-5c59-411b-8809-db8349838588"
+scryfall_id = "20c2c22f-5115-4a66-bcad-e70619d43448"
+
+[[token.source_card_refs]]
+card_name = "Hanweir Militia Captain // Westvale Cult Leader"
+face_name = "Hanweir Militia Captain"
+scryfall_oracle_id = "2d8eba16-cfca-4a38-bde0-6ee36c67231a"
+scryfall_id = "7e6b3fb3-897b-4665-b053-a29f25850b25"
+
+[[token.source_card_refs]]
+card_name = "Hanweir Militia Captain // Westvale Cult Leader"
+face_name = "Westvale Cult Leader"
+scryfall_oracle_id = "2d8eba16-cfca-4a38-bde0-6ee36c67231a"
+scryfall_id = "7e6b3fb3-897b-4665-b053-a29f25850b25"
 
 [token.token_image_ref]
 scryfall_id = "7081602e-84a3-45b0-87f6-f0f236a5264e"
@@ -218122,6 +223942,11 @@ subtypes = ["Skeleton"]
 supertypes = []
 colors = ["Black"]
 keywords = []
+
+[[token.source_card_refs]]
+card_name = "Drudge Spell"
+scryfall_oracle_id = "d63f4eeb-3fa5-4e65-8414-e3fd3c03c128"
+scryfall_id = "52b352de-e989-4ad5-963c-818092fc9f1a"
 
 [[token.source_card_refs]]
 card_name = "Skeletonize"
@@ -221682,9 +227507,159 @@ scryfall_oracle_id = "7c4e3a25-6b72-45ab-bcb0-9c4a67a4c7b1"
 scryfall_id = "833f4412-98eb-4ba5-8ae7-f3c973291db7"
 
 [[token.source_card_refs]]
+card_name = "Thopter Squadron"
+scryfall_oracle_id = "f1482ca4-610b-48fe-ac23-4526637bb72a"
+scryfall_id = "5fd13ac2-9642-4d59-a5c6-cc13c86991f0"
+
+[[token.source_card_refs]]
+card_name = "Ghirapur Gearcrafter"
+scryfall_oracle_id = "710dc9b1-7d32-4330-95a8-3e91a668202a"
+scryfall_id = "b9ec4def-3f9a-436e-aa7b-d1e03c7dbc6a"
+
+[[token.source_card_refs]]
+card_name = "Experimental Aviator"
+scryfall_oracle_id = "47f221a4-b51a-46b9-a4fc-46bc8ec7ddd3"
+scryfall_id = "9ddd283c-643a-449c-8cb6-178526d5476e"
+
+[[token.source_card_refs]]
+card_name = "Breya's Apprentice"
+scryfall_oracle_id = "8fb9ff2d-1e90-4a26-8397-bb981fda2f7b"
+scryfall_id = "7d4cc438-d93d-4fe9-8162-c7271c9d15b3"
+
+[[token.source_card_refs]]
+card_name = "Thopter Mechanic"
+scryfall_oracle_id = "a7e7be75-646d-4c99-8388-15bb422c8e25"
+scryfall_id = "282e630c-5d4a-469b-9b51-1127616dda34"
+
+[[token.source_card_refs]]
+card_name = "Pia Nalaar"
+scryfall_oracle_id = "715336f5-a708-488b-9f30-5702a9013af0"
+scryfall_id = "ba07c7db-9ec7-47c1-96a4-fa67492870f0"
+
+[[token.source_card_refs]]
+card_name = "Pia Nalaar, Consul of Revival"
+scryfall_oracle_id = "65d4ebdb-8757-4e5e-9411-d78597e20d57"
+scryfall_id = "413eedd5-ea42-4b6f-9282-3040e517d936"
+
+[[token.source_card_refs]]
+card_name = "Pia Nalaar, Consul of Revival"
+scryfall_oracle_id = "65d4ebdb-8757-4e5e-9411-d78597e20d57"
+scryfall_id = "613ed071-7672-44c4-bd19-66954ea0c83c"
+
+[[token.source_card_refs]]
+card_name = "Whirlermaker"
+scryfall_oracle_id = "bdf28770-0962-4317-822f-c187bc6706d1"
+scryfall_id = "48e02966-ff20-4e5e-b27d-adc6156c802d"
+
+[[token.source_card_refs]]
+card_name = "Launch Mishap"
+scryfall_oracle_id = "5d4ed768-0a37-4604-8121-43920ed9fb4a"
+scryfall_id = "abc561d3-9e52-41fd-8311-60cc9dfffdd1"
+
+[[token.source_card_refs]]
+card_name = "Thopter Squadron"
+scryfall_oracle_id = "f1482ca4-610b-48fe-ac23-4526637bb72a"
+scryfall_id = "25af067f-436c-4835-875a-3b2c2557104c"
+
+[[token.source_card_refs]]
+card_name = "Whirlermaker"
+scryfall_oracle_id = "bdf28770-0962-4317-822f-c187bc6706d1"
+scryfall_id = "f4acd88d-fc44-4ff8-81d7-5a8350fd6731"
+
+[[token.source_card_refs]]
+card_name = "Maverick Thopterist"
+scryfall_oracle_id = "71ba6f1b-2fa6-4d4c-8778-f0765b1a5d8e"
+scryfall_id = "8f5dc3c8-2a3c-42fc-9d88-55520af29f84"
+
+[[token.source_card_refs]]
+card_name = "Pia Nalaar, Consul of Revival"
+scryfall_oracle_id = "65d4ebdb-8757-4e5e-9411-d78597e20d57"
+scryfall_id = "0ae89461-4bce-4b49-b875-03afc2469fe7"
+
+[[token.source_card_refs]]
+card_name = "Pia and Kiran Nalaar"
+scryfall_oracle_id = "86084ed9-b8bb-4289-9579-6056194787bc"
+scryfall_id = "c8562d6b-25af-4d6b-9eb8-6ab08fa12dd1"
+
+[[token.source_card_refs]]
+card_name = "Pia Nalaar, Consul of Revival"
+scryfall_oracle_id = "65d4ebdb-8757-4e5e-9411-d78597e20d57"
+scryfall_id = "28216a47-709f-41fc-834c-7e4c99c806f7"
+
+[[token.source_card_refs]]
+card_name = "Sai, Master Thopterist"
+scryfall_oracle_id = "52241b9c-7a69-4176-9234-8bdab09d8e64"
+scryfall_id = "a1091e0e-a179-4241-8be0-ea92d86f4c08"
+
+[[token.source_card_refs]]
+card_name = "Thopter Spy Network"
+scryfall_oracle_id = "49be65fd-3755-410d-b0dc-2e5861ea2552"
+scryfall_id = "dc605d26-417f-4ef6-a3c4-8482ea05ee12"
+
+[[token.source_card_refs]]
+card_name = "Tezzeret, Artifice Master"
+scryfall_oracle_id = "e22824cf-07a1-4c83-b6c4-9d8fcff3892f"
+scryfall_id = "95b03fbb-10e9-4bf8-8fd3-e99e8c1cd84f"
+
+[[token.source_card_refs]]
 card_name = "Hangarback Walker"
 scryfall_oracle_id = "dde55256-5259-44e7-a267-fca45a7f0d04"
 scryfall_id = "cc387ccf-f746-4855-81e5-64f5a5e0fdda"
+
+[[token.source_card_refs]]
+card_name = "Etherium Spinner"
+scryfall_oracle_id = "b501128b-2797-401b-8aec-923050081cae"
+scryfall_id = "84130c94-f98c-4a66-9880-4b09fa663067"
+
+[[token.source_card_refs]]
+card_name = "Pia Nalaar, Consul of Revival"
+scryfall_oracle_id = "65d4ebdb-8757-4e5e-9411-d78597e20d57"
+scryfall_id = "7aafbdf8-b1cd-4dbb-863c-0d44494eec2b"
+
+[[token.source_card_refs]]
+card_name = "Barbed Spike"
+scryfall_oracle_id = "28b22709-3e69-4eb7-8a3d-b75b6e65f30e"
+scryfall_id = "227e37c6-1e5f-4b2b-b723-fcc6e8fa669d"
+
+[[token.source_card_refs]]
+card_name = "Thopter Squadron"
+scryfall_oracle_id = "f1482ca4-610b-48fe-ac23-4526637bb72a"
+scryfall_id = "d3ac2d30-7c9a-40b3-812e-e77e49229f48"
+
+[[token.source_card_refs]]
+card_name = "Whirlermaker"
+scryfall_oracle_id = "bdf28770-0962-4317-822f-c187bc6706d1"
+scryfall_id = "3624a056-2af8-4e55-8e19-f26c03701945"
+
+[[token.source_card_refs]]
+card_name = "Thopter Engineer"
+scryfall_oracle_id = "4ac53b34-20d2-4a53-bade-4f998fb6ae67"
+scryfall_id = "3ba40fc1-a92c-4676-90fa-66d0f7c0f9cf"
+
+[[token.source_card_refs]]
+card_name = "Hangarback Walker"
+scryfall_oracle_id = "dde55256-5259-44e7-a267-fca45a7f0d04"
+scryfall_id = "b46b2624-0396-4576-aedc-2b7980f76241"
+
+[[token.source_card_refs]]
+card_name = "Fairgrounds Patrol"
+scryfall_oracle_id = "8b0689b5-7c68-46b3-a72a-4f97ef1d0a15"
+scryfall_id = "21456767-bf7b-4813-b305-1bc3005f56b9"
+
+[[token.source_card_refs]]
+card_name = "Whirler Virtuoso"
+scryfall_oracle_id = "f82da236-e567-4221-a0bc-439a0c7e2b03"
+scryfall_id = "634c5d10-f71b-4673-b1d7-059f47717da9"
+
+[[token.source_card_refs]]
+card_name = "Whirler Rogue"
+scryfall_oracle_id = "7060f2c8-fca0-4b7a-bddf-37682f434596"
+scryfall_id = "c62a27a8-271c-4ac8-97a5-2efb192e3a15"
+
+[[token.source_card_refs]]
+card_name = "Aviation Pioneer"
+scryfall_oracle_id = "ad11ff81-acaa-4529-ba15-718dadbea259"
+scryfall_id = "4165233d-8651-4498-91b6-d3e5e6d613a5"
 
 [token.token_image_ref]
 scryfall_id = "b9d38c75-c69f-45cd-a745-03ac7513491b"
@@ -221746,6 +227721,11 @@ keywords = [
 card_name = "Sorin the Mirthless"
 scryfall_oracle_id = "fbffaf9f-40e7-4113-a037-533b733cebce"
 scryfall_id = "112394a6-7819-43b4-adad-f6900aff2936"
+
+[[token.source_card_refs]]
+card_name = "Sorin the Mirthless"
+scryfall_oracle_id = "fbffaf9f-40e7-4113-a037-533b733cebce"
+scryfall_id = "d1a38e25-297f-43e1-9455-73f00eb08cec"
 
 [[token.source_card_refs]]
 card_name = "Sorin the Mirthless"
@@ -223491,6 +229471,11 @@ card_name = "Triskelavus"
 scryfall_oracle_id = "e958f7bf-3011-4175-b467-ca225a9b7ad2"
 scryfall_id = "899eb19e-9932-4066-9de6-dfdbbab5e769"
 
+[[token.source_card_refs]]
+card_name = "Triskelavus"
+scryfall_oracle_id = "e958f7bf-3011-4175-b467-ca225a9b7ad2"
+scryfall_id = "978d11e7-cfb7-41bf-bb98-deb79549a074"
+
 [token.token_image_ref]
 scryfall_id = "b5ddb67c-82fb-42d6-a4c2-11cd38eb128d"
 scryfall_oracle_id = "80e72f55-b718-4442-93ee-f9175a739975"
@@ -224113,6 +230098,11 @@ card_name = "Sokenzan Smelter"
 scryfall_oracle_id = "dd645241-2992-4c4e-a6a8-c2215d2340ae"
 scryfall_id = "758724f9-93c9-4178-ae40-3fefc75a010e"
 
+[[token.source_card_refs]]
+card_name = "Sokenzan Smelter"
+scryfall_oracle_id = "dd645241-2992-4c4e-a6a8-c2215d2340ae"
+scryfall_id = "b4ec8275-80c0-4c1e-9432-a940a83756a0"
+
 [token.token_image_ref]
 scryfall_id = "cbafdfc0-380a-482b-b5f8-a7a00ecf8da6"
 scryfall_oracle_id = "74658c70-caa8-4172-8a65-055d327668f9"
@@ -224388,6 +230378,11 @@ keywords = []
 card_name = "Anointer Priest"
 scryfall_oracle_id = "4e0b9273-6614-41a8-9738-959349c0717b"
 scryfall_id = "46f810c2-310e-42f5-ab1f-d56396cf5124"
+
+[[token.source_card_refs]]
+card_name = "Anointer Priest"
+scryfall_oracle_id = "4e0b9273-6614-41a8-9738-959349c0717b"
+scryfall_id = "c1c4274b-4268-48af-bbf0-38349a317a99"
 
 [[token.source_card_refs]]
 card_name = "Anointer Priest"

--- a/crates/engine/src/analysis/ability_graph.rs
+++ b/crates/engine/src/analysis/ability_graph.rs
@@ -957,8 +957,7 @@ fn effect_projection(effect: &Effect) -> Projection {
         | Effect::GrantCastingPermission { .. }
         | Effect::ChooseFromZone { .. }
         | Effect::RememberCard { .. }
-        | Effect::ForEachCategoryExile { .. }
-        | Effect::ForEachCategoryPutCounter { .. }
+        | Effect::ForEachCategory { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }
         | Effect::EachPlayerCopyChosen { .. }

--- a/crates/engine/src/analysis/ability_graph.rs
+++ b/crates/engine/src/analysis/ability_graph.rs
@@ -958,6 +958,7 @@ fn effect_projection(effect: &Effect) -> Projection {
         | Effect::ChooseFromZone { .. }
         | Effect::RememberCard { .. }
         | Effect::ForEachCategoryExile { .. }
+        | Effect::ForEachCategoryPutCounter { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }
         | Effect::EachPlayerCopyChosen { .. }

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -3291,8 +3291,7 @@ fn legacy_effect(x: &Effect) -> bool {
         | Effect::RollToVisitAttractions
         | Effect::AssembleContraptionsFromRollDifference
         | Effect::ProcessRadCounters
-        | Effect::ForEachCategoryExile { .. }
-        | Effect::ForEachCategoryPutCounter { .. }
+        | Effect::ForEachCategory { .. }
         | Effect::GiftDelivery { .. }
         | Effect::SetDayNight { .. }
         | Effect::Conjure { .. }
@@ -5423,8 +5422,7 @@ fn rw_effect(
         | Effect::Harness
         | Effect::ChooseAndSacrificeRest { .. }
         | Effect::RememberCard { .. }
-        | Effect::ForEachCategoryExile { .. }
-        | Effect::ForEachCategoryPutCounter { .. }
+        | Effect::ForEachCategory { .. }
         | Effect::VentureInto { .. }
         | Effect::TakeTheInitiative
         | Effect::RollToVisitAttractions

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -3292,6 +3292,7 @@ fn legacy_effect(x: &Effect) -> bool {
         | Effect::AssembleContraptionsFromRollDifference
         | Effect::ProcessRadCounters
         | Effect::ForEachCategoryExile { .. }
+        | Effect::ForEachCategoryPutCounter { .. }
         | Effect::GiftDelivery { .. }
         | Effect::SetDayNight { .. }
         | Effect::Conjure { .. }
@@ -5423,6 +5424,7 @@ fn rw_effect(
         | Effect::ChooseAndSacrificeRest { .. }
         | Effect::RememberCard { .. }
         | Effect::ForEachCategoryExile { .. }
+        | Effect::ForEachCategoryPutCounter { .. }
         | Effect::VentureInto { .. }
         | Effect::TakeTheInitiative
         | Effect::RollToVisitAttractions

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -93,9 +93,10 @@
 
 use crate::types::ability::{
     AbilityCondition, ControllerRef, CountScope, Duration, EachDamageRecipient, Effect,
-    GuessSubject, ModalChoice, MultiTargetSpec, ObjectScope, PlayerFilter, PlayerScope,
-    QuantityExpr, QuantityRef, RepeatContinuation, ReplacementCondition, ResolvedAbility,
-    StaticCondition, TargetChoiceTiming, TargetFilter, TrackedAnaphorSource, TriggerCondition,
+    ForEachCategoryAction, GuessSubject, ModalChoice, MultiTargetSpec, ObjectScope, PlayerFilter,
+    PlayerScope, QuantityExpr, QuantityRef, RepeatContinuation, ReplacementCondition,
+    ResolvedAbility, StaticCondition, TargetChoiceTiming, TargetFilter, TrackedAnaphorSource,
+    TriggerCondition,
 };
 use crate::types::game_state::TargetSelectionConstraint;
 
@@ -1192,15 +1193,11 @@ fn scan_effect(x: &Effect) -> Axes {
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::ForEachCategoryExile {
-            category: _,
-            zone: _,
-            chooser: _,
-            up_to: _,
-        } => Axes::NONE,
-        Effect::ForEachCategoryPutCounter {
-            target, chooser: _, ..
+        Effect::ForEachCategory {
+            action: ForEachCategoryAction::PutCounter { target, .. },
+            ..
         } => scan_target_filter(target),
+        Effect::ForEachCategory { .. } => Axes::NONE,
         Effect::ChooseObjectsIntoTrackedSet {
             chooser,
             filter,
@@ -3630,8 +3627,7 @@ fn effect_resolution_choice_freedom(e: &Effect) -> ResolutionChoiceFreedom {
         | Effect::GrantCastingPermission { .. }
         | Effect::ChooseFromZone { .. }
         | Effect::RememberCard { .. }
-        | Effect::ForEachCategoryExile { .. }
-        | Effect::ForEachCategoryPutCounter { .. }
+        | Effect::ForEachCategory { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }
         | Effect::Exploit { .. }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1198,6 +1198,9 @@ fn scan_effect(x: &Effect) -> Axes {
             chooser: _,
             up_to: _,
         } => Axes::NONE,
+        Effect::ForEachCategoryPutCounter {
+            target, chooser: _, ..
+        } => scan_target_filter(target),
         Effect::ChooseObjectsIntoTrackedSet {
             chooser,
             filter,
@@ -3628,6 +3631,7 @@ fn effect_resolution_choice_freedom(e: &Effect) -> ResolutionChoiceFreedom {
         | Effect::ChooseFromZone { .. }
         | Effect::RememberCard { .. }
         | Effect::ForEachCategoryExile { .. }
+        | Effect::ForEachCategoryPutCounter { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }
         | Effect::Exploit { .. }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -20,13 +20,13 @@ use crate::types::ability::{
     AdditionalCost, AggregateFunction, AttackScope, AttackSubject, CardTypeSetSource, ChoiceType,
     Comparator, ContinuousModification, ControllerRef, CountScope, CounterSourceRider,
     DelayedTriggerCondition, DieRollModifier, DoublePTMode, Duration, EachDamageRecipient, Effect,
-    EffectOutcomeSignal, EffectScope, FilterProp, GameRestriction, LibraryPosition, ManaProduction,
-    ObjectProperty, ObjectScope, PerpetualModification, PlayerFilter, PlayerScope, PtStat, PtValue,
-    PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition,
-    ReplacementMode, SeatDirection, SharedQuality, SharedQualityRelation, SpeedDelta,
-    SpellCastingOption, SpellCastingOptionKind, SpellStackToGraveyardReplacement, StaticCondition,
-    StaticDefinition, TapStateChange, TargetFilter, TriggerDefinition, TypeFilter, TypedFilter,
-    ZoneRef,
+    EffectOutcomeSignal, EffectScope, FilterProp, ForEachCategoryAction, GameRestriction,
+    LibraryPosition, ManaProduction, ObjectProperty, ObjectScope, PerpetualModification,
+    PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
+    ReplacementCondition, ReplacementDefinition, ReplacementMode, SeatDirection, SharedQuality,
+    SharedQualityRelation, SpeedDelta, SpellCastingOption, SpellCastingOptionKind,
+    SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition, TapStateChange,
+    TargetFilter, TriggerDefinition, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::card::CardFace;
 use crate::types::card_type::CoreType;
@@ -3146,7 +3146,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         Effect::RememberCard { target } => {
             d.push(("target".into(), fmt_target(target)));
         }
-        Effect::ForEachCategoryExile { category, zone, .. } => {
+        Effect::ForEachCategory { category, action, .. } => {
             d.push((
                 "category".into(),
                 match category {
@@ -3154,23 +3154,19 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
                     crate::types::ability::IterationCategory::CardType => "card type".to_string(),
                 },
             ));
-            d.push(("zone".into(), fmt_zone(zone)));
-        }
-        Effect::ForEachCategoryPutCounter {
-            category,
-            target,
-            counter_type,
-            ..
-        } => {
-            d.push((
-                "category".into(),
-                match category {
-                    crate::types::ability::IterationCategory::Color => "color".to_string(),
-                    crate::types::ability::IterationCategory::CardType => "card type".to_string(),
-                },
-            ));
-            d.push(("target".into(), fmt_target(target)));
-            d.push(("counter_type".into(), counter_type.as_str().to_string()));
+            match action {
+                ForEachCategoryAction::ExileFromPool { zone, .. } => {
+                    d.push(("zone".into(), fmt_zone(zone)));
+                }
+                ForEachCategoryAction::PutCounter {
+                    target,
+                    counter_type,
+                    ..
+                } => {
+                    d.push(("target".into(), fmt_target(target)));
+                    d.push(("counter_type".into(), counter_type.as_str().to_string()));
+                }
+            }
         }
         Effect::ChooseObjectsIntoTrackedSet {
             chooser,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3156,6 +3156,22 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             ));
             d.push(("zone".into(), fmt_zone(zone)));
         }
+        Effect::ForEachCategoryPutCounter {
+            category,
+            target,
+            counter_type,
+            ..
+        } => {
+            d.push((
+                "category".into(),
+                match category {
+                    crate::types::ability::IterationCategory::Color => "color".to_string(),
+                    crate::types::ability::IterationCategory::CardType => "card type".to_string(),
+                },
+            ));
+            d.push(("target".into(), fmt_target(target)));
+            d.push(("counter_type".into(), counter_type.as_str().to_string()));
+        }
         Effect::ChooseObjectsIntoTrackedSet {
             chooser,
             filter,

--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -168,6 +168,39 @@ pub fn resolve_for_each_category(
     prompt_next_category_member(state, ability, &pool, member_filters, events)
 }
 
+/// CR 608.2c + CR 105.1 / CR 122.1: Resolve an `Effect::ForEachCategoryPutCounter`
+/// ("for each color/card type, put a counter on a permanent you control of that
+/// color/type"). Iterates the category's members in printed order, auto-applying
+/// when exactly one candidate exists and parking one `ChooseFromZoneChoice` per
+/// member when multiple candidates exist. Each countered object accumulates into
+/// a fresh chain tracked set for downstream "this way" references.
+pub fn resolve_for_each_category_put_counter(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let (category, target) = match &ability.effect {
+        Effect::ForEachCategoryPutCounter {
+            category, target, ..
+        } => (*category, target.clone()),
+        _ => {
+            return Err(EffectError::MissingParam(
+                "ForEachCategoryPutCounter".to_string(),
+            ))
+        }
+    };
+    let pool = resolve_put_counter_pool(state, ability, &target);
+    super::publish_fresh_tracked_set(state, Vec::new());
+    let member_filters = category
+        .member_filters()
+        .into_iter()
+        .map(|member| TargetFilter::And {
+            filters: vec![target.clone(), member],
+        })
+        .collect();
+    prompt_next_category_member(state, ability, &pool, member_filters, events)
+}
+
 /// CR 608.2c: Park the next category member's `ChooseFromZoneChoice` prompt for
 /// an `Effect::ForEachCategoryExile`. Members whose pool holds no matching card
 /// are skipped (CR 608.2c — nothing to exile of that color/type). When no member
@@ -181,16 +214,27 @@ fn prompt_next_category_member(
     mut remaining_member_filters: Vec<TargetFilter>,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (zone, chooser, up_to) = match &ability.effect {
+    let (zone, chooser, up_to, put_counter) = match &ability.effect {
         Effect::ForEachCategoryExile {
             zone,
             chooser,
             up_to,
             ..
-        } => (*zone, *chooser, *up_to),
+        } => (*zone, *chooser, *up_to, None),
+        Effect::ForEachCategoryPutCounter {
+            counter_type,
+            count,
+            chooser,
+            ..
+        } => (
+            Zone::Battlefield,
+            *chooser,
+            false,
+            Some((counter_type.clone(), count.clone())),
+        ),
         _ => {
             return Err(EffectError::MissingParam(
-                "ForEachCategoryExile".to_string(),
+                "ForEachCategoryIteration".to_string(),
             ))
         }
     };
@@ -200,6 +244,25 @@ fn prompt_next_category_member(
         let cards = filter_category_pool(state, ability, pool, zone, &member_filter);
         if cards.is_empty() {
             continue;
+        }
+
+        if let Some((counter_type, count)) = put_counter.as_ref() {
+            if cards.len() == 1 {
+                let object_id = cards[0];
+                let count_val =
+                    crate::game::quantity::resolve_quantity_with_targets(state, count, ability)
+                        .max(0) as u32;
+                crate::game::effects::counters::apply_counter_addition(
+                    state,
+                    ability.controller,
+                    object_id,
+                    counter_type.clone(),
+                    count_val,
+                    events,
+                );
+                publish_tracked_set_unique(state, &[object_id]);
+                continue;
+            }
         }
 
         // CR 608.2d: "you may exile" → 0..=1 of that member; `up_to` is true.
@@ -224,10 +287,13 @@ fn prompt_next_category_member(
     }
 
     // CR 608.2c: No member had an eligible card — emit the resolution event so
-    // the parked continuation ("put the rest into your graveyard"/"you may cast
-    // a spell from among them") still runs.
+    // the parked continuation still runs.
+    let kind = match &ability.effect {
+        Effect::ForEachCategoryPutCounter { .. } => EffectKind::PutCounter,
+        _ => EffectKind::ChooseFromZone,
+    };
     events.push(GameEvent::EffectResolved {
-        kind: EffectKind::ChooseFromZone,
+        kind,
         source_id: ability.source_id,
     });
     Ok(())
@@ -252,23 +318,69 @@ pub(crate) fn drain_pending_per_category_zone_choice(
         remaining_member_filters,
     } = pending;
 
-    // CR 608.2c: "you may EXILE a card of that color/type" — the per-member
-    // action is the exile itself, so the chosen card moves to Exile now, then
-    // EXTENDS the chain tracked set ("the cards exiled this way") for a
-    // downstream "from among them" / "the rest" clause. The chain set was
-    // rebound to a fresh EMPTY set at iteration start (`resolve_for_each_category`),
-    // so an all-decline iteration correctly leaves it empty — a continuation
-    // such as Portent's "if you exiled four or more cards this way" never sees
-    // the producer's revealed pool. An empty pick (the player declined this
-    // member) extends by nothing.
-    for &card_id in chosen {
-        crate::game::zones::move_to_zone(state, card_id, Zone::Exile, events);
-    }
-    if !chosen.is_empty() {
-        super::publish_tracked_set(state, chosen.to_vec());
+    match &ability.effect {
+        Effect::ForEachCategoryExile { .. } => {
+            for &card_id in chosen {
+                crate::game::zones::move_to_zone(state, card_id, Zone::Exile, events);
+            }
+            if !chosen.is_empty() {
+                super::publish_tracked_set(state, chosen.to_vec());
+            }
+        }
+        Effect::ForEachCategoryPutCounter {
+            counter_type,
+            count,
+            ..
+        } => {
+            let count_val =
+                crate::game::quantity::resolve_quantity_with_targets(state, count, &ability).max(0)
+                    as u32;
+            for &card_id in chosen {
+                crate::game::effects::counters::apply_counter_addition(
+                    state,
+                    ability.controller,
+                    card_id,
+                    counter_type.clone(),
+                    count_val,
+                    events,
+                );
+            }
+            if !chosen.is_empty() {
+                publish_tracked_set_unique(state, chosen);
+            }
+        }
+        _ => {}
     }
 
     let _ = prompt_next_category_member(state, &ability, &pool, remaining_member_filters, events);
+}
+
+fn publish_tracked_set_unique(state: &mut GameState, ids: &[ObjectId]) {
+    let unique: Vec<ObjectId> = ids
+        .iter()
+        .copied()
+        .filter(|id| {
+            state
+                .chain_tracked_set_id
+                .and_then(|set_id| state.tracked_object_sets.get(&set_id))
+                .is_none_or(|set| !set.contains(id))
+        })
+        .collect();
+    if !unique.is_empty() {
+        super::publish_tracked_set(state, unique);
+    }
+}
+
+fn resolve_put_counter_pool(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    target: &TargetFilter,
+) -> Vec<ObjectId> {
+    let filter_ctx = FilterContext::from_ability(ability);
+    crate::game::targeting::zone_object_ids(state, Zone::Battlefield)
+        .into_iter()
+        .filter(|id| matches_target_filter(state, *id, target, &filter_ctx))
+        .collect()
 }
 
 /// CR 608.2c: Snapshot the revealed/exiled pool for a `ForEachCategoryExile`

--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -3,8 +3,8 @@ use rand::seq::IndexedRandom; // rand 0.9: `choose_multiple` on `[T]` lives here
 use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::players;
 use crate::types::ability::{
-    ChooseFromZoneConstraint, Chooser, Effect, EffectError, EffectKind, ResolvedAbility,
-    TargetFilter, TargetRef, ZoneOwner,
+    ChooseFromZoneConstraint, Chooser, Effect, EffectError, EffectKind, ForEachCategoryAction,
+    ResolvedAbility, TargetFilter, TargetRef, ZoneOwner,
 };
 use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
@@ -127,78 +127,49 @@ pub fn resolve(
     Ok(())
 }
 
-/// CR 608.2c + CR 105.1 / CR 205.2a: Resolve an `Effect::ForEachCategoryExile`
-/// ("for each color/card type, you may exile a card of that color/type from
-/// among them"). Iterates the category's members in printed order, parking one
-/// `ChooseFromZoneChoice` per member whose candidate pool is the chain's tracked
-/// set (the revealed/exiled cards) restricted to cards matching that member.
-/// Each pick accumulates into a fresh chain tracked set so a downstream "from
-/// among them" / "put the rest …" clause reads exactly the exiled cards. This is
-/// the category-iteration sibling of `prompt_next_each_player`.
+/// CR 608.2c + CR 105.1 / CR 205.2a / CR 122.1: Resolve an
+/// `Effect::ForEachCategory` iteration ("for each color/card type, …"). Iterates
+/// the category's members in printed order; per-member body is either pool exile
+/// (Sanar) or battlefield counter placement (Call the Spirit Dragons).
 pub fn resolve_for_each_category(
     state: &mut GameState,
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let category = match &ability.effect {
-        Effect::ForEachCategoryExile { category, .. } => *category,
-        _ => {
-            return Err(EffectError::MissingParam(
-                "ForEachCategoryExile".to_string(),
-            ))
+    let (category, action) = match &ability.effect {
+        Effect::ForEachCategory {
+            category, action, ..
+        } => (*category, action),
+        _ => return Err(EffectError::MissingParam("ForEachCategory".to_string())),
+    };
+    let pool = match action {
+        ForEachCategoryAction::ExileFromPool { .. } => resolve_category_pool(state, ability),
+        ForEachCategoryAction::PutCounter { target, .. } => {
+            resolve_put_counter_pool(state, ability, target)
         }
     };
-    // CR 608.2c: Capture the revealed/exiled pool once; every member filters
-    // this snapshot (minus already-exiled cards), not the mutating chain set.
-    let pool = resolve_category_pool(state, ability);
-    // CR 603.7 + CR 608.2c: Rebind the chain tracked set to a FRESH, initially
-    // EMPTY "cards exiled this way" set BEFORE prompting any member. The captured
-    // `pool` snapshot (the revealed cards) drives member filtering; the chain set
-    // now exclusively accumulates the cards actually exiled across the members.
-    // Without this, a downstream "from among them" / "you may cast a spell from
-    // among the exiled cards" continuation would read whatever the chain set
-    // pointed at when the iteration started (the producer's revealed pool) on the
-    // all-decline path — so it would see cards that were never exiled this way
-    // (Portent of Calamity: "if you exiled four or more cards this way"). Because
-    // the chain set now starts as the exiled set, every later pick EXTENDS it
-    // (`accumulated = true`).
     super::publish_fresh_tracked_set(state, Vec::new());
-    // CR 105.1 / CR 205.2a: the ordered per-member candidate filters.
-    let member_filters = category.member_filters();
+    let member_filters = match action {
+        ForEachCategoryAction::PutCounter { target, .. } => category
+            .member_filters()
+            .into_iter()
+            .map(|member| TargetFilter::And {
+                filters: vec![target.clone(), member],
+            })
+            .collect(),
+        ForEachCategoryAction::ExileFromPool { .. } => category.member_filters(),
+    };
     prompt_next_category_member(state, ability, &pool, member_filters, events)
 }
 
-/// CR 608.2c + CR 105.1 / CR 122.1: Resolve an `Effect::ForEachCategoryPutCounter`
-/// ("for each color/card type, put a counter on a permanent you control of that
-/// color/type"). Iterates the category's members in printed order, auto-applying
-/// when exactly one candidate exists and parking one `ChooseFromZoneChoice` per
-/// member when multiple candidates exist. Each countered object accumulates into
-/// a fresh chain tracked set for downstream "this way" references.
+/// Deprecated alias kept for call-site clarity during migration — dispatches to
+/// [`resolve_for_each_category`].
 pub fn resolve_for_each_category_put_counter(
     state: &mut GameState,
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (category, target) = match &ability.effect {
-        Effect::ForEachCategoryPutCounter {
-            category, target, ..
-        } => (*category, target.clone()),
-        _ => {
-            return Err(EffectError::MissingParam(
-                "ForEachCategoryPutCounter".to_string(),
-            ))
-        }
-    };
-    let pool = resolve_put_counter_pool(state, ability, &target);
-    super::publish_fresh_tracked_set(state, Vec::new());
-    let member_filters = category
-        .member_filters()
-        .into_iter()
-        .map(|member| TargetFilter::And {
-            filters: vec![target.clone(), member],
-        })
-        .collect();
-    prompt_next_category_member(state, ability, &pool, member_filters, events)
+    resolve_for_each_category(state, ability, events)
 }
 
 /// CR 608.2c: Park the next category member's `ChooseFromZoneChoice` prompt for
@@ -215,16 +186,19 @@ fn prompt_next_category_member(
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
     let (zone, chooser, up_to, put_counter) = match &ability.effect {
-        Effect::ForEachCategoryExile {
-            zone,
+        Effect::ForEachCategory {
             chooser,
-            up_to,
+            action: ForEachCategoryAction::ExileFromPool { zone, up_to },
             ..
         } => (*zone, *chooser, *up_to, None),
-        Effect::ForEachCategoryPutCounter {
-            counter_type,
-            count,
+        Effect::ForEachCategory {
             chooser,
+            action:
+                ForEachCategoryAction::PutCounter {
+                    counter_type,
+                    count,
+                    ..
+                },
             ..
         } => (
             Zone::Battlefield,
@@ -289,7 +263,11 @@ fn prompt_next_category_member(
     // CR 608.2c: No member had an eligible card — emit the resolution event so
     // the parked continuation still runs.
     let kind = match &ability.effect {
-        Effect::ForEachCategoryPutCounter { .. } => EffectKind::PutCounter,
+        Effect::ForEachCategory {
+            action: ForEachCategoryAction::PutCounter { .. },
+            ..
+        } => EffectKind::PutCounter,
+        Effect::ForEachCategory { .. } => EffectKind::ChooseFromZone,
         _ => EffectKind::ChooseFromZone,
     };
     events.push(GameEvent::EffectResolved {
@@ -319,7 +297,10 @@ pub(crate) fn drain_pending_per_category_zone_choice(
     } = pending;
 
     match &ability.effect {
-        Effect::ForEachCategoryExile { .. } => {
+        Effect::ForEachCategory {
+            action: ForEachCategoryAction::ExileFromPool { .. },
+            ..
+        } => {
             for &card_id in chosen {
                 crate::game::zones::move_to_zone(state, card_id, Zone::Exile, events);
             }
@@ -327,9 +308,13 @@ pub(crate) fn drain_pending_per_category_zone_choice(
                 super::publish_tracked_set(state, chosen.to_vec());
             }
         }
-        Effect::ForEachCategoryPutCounter {
-            counter_type,
-            count,
+        Effect::ForEachCategory {
+            action:
+                ForEachCategoryAction::PutCounter {
+                    counter_type,
+                    count,
+                    ..
+                },
             ..
         } => {
             let count_val =
@@ -1979,11 +1964,13 @@ mod tests {
         state.chain_tracked_set_id = Some(set_id);
 
         let ability = ResolvedAbility::new(
-            Effect::ForEachCategoryExile {
+            Effect::ForEachCategory {
                 category: crate::types::ability::IterationCategory::Color,
-                zone: Zone::Library,
                 chooser: Chooser::Controller,
-                up_to: true,
+                action: ForEachCategoryAction::ExileFromPool {
+                    zone: Zone::Library,
+                    up_to: true,
+                },
             },
             vec![],
             ObjectId(100),
@@ -2039,11 +2026,13 @@ mod tests {
         state.chain_tracked_set_id = Some(set_id);
 
         let ability = ResolvedAbility::new(
-            Effect::ForEachCategoryExile {
+            Effect::ForEachCategory {
                 category: crate::types::ability::IterationCategory::Color,
-                zone: Zone::Library,
                 chooser: Chooser::Controller,
-                up_to: true,
+                action: ForEachCategoryAction::ExileFromPool {
+                    zone: Zone::Library,
+                    up_to: true,
+                },
             },
             vec![],
             ObjectId(100),
@@ -2120,11 +2109,13 @@ mod tests {
         state.chain_tracked_set_id = Some(set_id);
 
         let ability = ResolvedAbility::new(
-            Effect::ForEachCategoryExile {
+            Effect::ForEachCategory {
                 category: crate::types::ability::IterationCategory::Color,
-                zone: Zone::Library,
                 chooser: Chooser::Controller,
-                up_to: true,
+                action: ForEachCategoryAction::ExileFromPool {
+                    zone: Zone::Library,
+                    up_to: true,
+                },
             },
             vec![],
             ObjectId(100),
@@ -2210,11 +2201,13 @@ mod tests {
         let ability = ResolvedAbility {
             sub_ability: Some(Box::new(continuation)),
             ..ResolvedAbility::new(
-                Effect::ForEachCategoryExile {
+                Effect::ForEachCategory {
                     category: crate::types::ability::IterationCategory::Color,
-                    zone: Zone::Library,
                     chooser: Chooser::Controller,
-                    up_to: true,
+                    action: ForEachCategoryAction::ExileFromPool {
+                        zone: Zone::Library,
+                        up_to: true,
+                    },
                 },
                 vec![],
                 ObjectId(100),
@@ -2335,11 +2328,13 @@ mod tests {
             state.chain_tracked_set_id = Some(producer);
 
             let ability = ResolvedAbility::new(
-                Effect::ForEachCategoryExile {
+                Effect::ForEachCategory {
                     category: crate::types::ability::IterationCategory::CardType,
-                    zone: Zone::Library,
                     chooser: Chooser::Controller,
-                    up_to: true,
+                    action: ForEachCategoryAction::ExileFromPool {
+                        zone: Zone::Library,
+                        up_to: true,
+                    },
                 },
                 vec![],
                 ObjectId(100),
@@ -2444,11 +2439,13 @@ mod tests {
         state.pending_continuation = Some(PendingContinuation::new(Box::new(continuation)));
 
         let ability = ResolvedAbility::new(
-            Effect::ForEachCategoryExile {
+            Effect::ForEachCategory {
                 category: crate::types::ability::IterationCategory::Color,
-                zone: Zone::Library,
                 chooser: Chooser::Controller,
-                up_to: true,
+                action: ForEachCategoryAction::ExileFromPool {
+                    zone: Zone::Library,
+                    up_to: true,
+                },
             },
             vec![],
             ObjectId(100),
@@ -2550,11 +2547,13 @@ mod tests {
         state.chain_tracked_set_id = Some(set_id);
 
         let ability = ResolvedAbility::new(
-            Effect::ForEachCategoryExile {
+            Effect::ForEachCategory {
                 category: crate::types::ability::IterationCategory::CardType,
-                zone: Zone::Library,
                 chooser: Chooser::Controller,
-                up_to: true,
+                action: ForEachCategoryAction::ExileFromPool {
+                    zone: Zone::Library,
+                    up_to: true,
+                },
             },
             vec![],
             ObjectId(100),
@@ -2661,11 +2660,13 @@ mod tests {
         state.chain_tracked_set_id = Some(set_id);
 
         let ability = ResolvedAbility::new(
-            Effect::ForEachCategoryExile {
+            Effect::ForEachCategory {
                 category: crate::types::ability::IterationCategory::CardType,
-                zone: Zone::Library,
                 chooser: Chooser::Controller,
-                up_to: true,
+                action: ForEachCategoryAction::ExileFromPool {
+                    zone: Zone::Library,
+                    up_to: true,
+                },
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3354,11 +3354,8 @@ pub fn resolve_effect(
         Effect::GrantCastingPermission { .. } => grant_permission::resolve(state, ability, events),
         Effect::ChooseFromZone { .. } => choose_from_zone::resolve(state, ability, events),
         Effect::RememberCard { .. } => remember_card::resolve(state, ability, events),
-        Effect::ForEachCategoryExile { .. } => {
+        Effect::ForEachCategory { .. } => {
             choose_from_zone::resolve_for_each_category(state, ability, events)
-        }
-        Effect::ForEachCategoryPutCounter { .. } => {
-            choose_from_zone::resolve_for_each_category_put_counter(state, ability, events)
         }
         Effect::ChooseObjectsIntoTrackedSet { .. } => {
             choose_objects_into_tracked_set::resolve(state, ability, events)

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3357,6 +3357,9 @@ pub fn resolve_effect(
         Effect::ForEachCategoryExile { .. } => {
             choose_from_zone::resolve_for_each_category(state, ability, events)
         }
+        Effect::ForEachCategoryPutCounter { .. } => {
+            choose_from_zone::resolve_for_each_category_put_counter(state, ability, events)
+        }
         Effect::ChooseObjectsIntoTrackedSet { .. } => {
             choose_objects_into_tracked_set::resolve(state, ability, events)
         }

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -1160,8 +1160,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::GrantCastingPermission { .. }
         | Effect::ChooseFromZone { .. }
         | Effect::RememberCard { .. }
-        | Effect::ForEachCategoryExile { .. }
-        | Effect::ForEachCategoryPutCounter { .. }
+        | Effect::ForEachCategory { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }
         | Effect::EachPlayerCopyChosen { .. }

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -1161,6 +1161,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::ChooseFromZone { .. }
         | Effect::RememberCard { .. }
         | Effect::ForEachCategoryExile { .. }
+        | Effect::ForEachCategoryPutCounter { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }
         | Effect::EachPlayerCopyChosen { .. }

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -870,6 +870,7 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
         if let Ok((after_clause, condition)) =
             nom_cond::parse_you_control_or_returned_this_way_condition(rest)
                 .or_else(|_| nom_cond::parse_you_put_into_hand_this_way_condition(rest))
+                .or_else(|_| nom_cond::parse_you_put_counters_on_type_this_way_condition(rest))
                 .or_else(|_| nom_cond::parse_you_draw_this_way_condition(rest))
         {
             let body_lower = strip_reflexive_conditional_body_separator(after_clause);
@@ -6629,6 +6630,26 @@ mod tests {
         assert!(type_filters
             .iter()
             .any(|f| matches!(f, TypeFilter::Subtype(s) if s.eq_ignore_ascii_case("Town"))));
+    }
+
+    #[test]
+    fn s07_if_put_counters_on_type_this_way() {
+        // Call the Spirit Dragons: "if you put +1/+1 counters on five Dragons this way".
+        let (cond, body) = strip_if_you_do_conditional(
+            "if you put +1/+1 counters on five Dragons this way, you win the game",
+        );
+        assert_eq!(body, "you win the game");
+        assert!(
+            matches!(
+                cond,
+                Some(AbilityCondition::QuantityCheck {
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: 5 },
+                    ..
+                })
+            ),
+            "got {cond:?}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -5711,12 +5711,13 @@ fn try_parse_for_each_category_exile(tp: TextPair<'_>) -> Option<ParsedEffectCla
     }
 
     Some(ParsedEffectClause {
-        effect: Effect::ForEachCategoryExile {
+        effect: Effect::ForEachCategory {
             category,
-            // The pool cards were revealed from the top of the library.
-            zone: Zone::Library,
             chooser: crate::types::ability::Chooser::Controller,
-            up_to: true,
+            action: crate::types::ability::ForEachCategoryAction::ExileFromPool {
+                zone: Zone::Library,
+                up_to: true,
+            },
         },
         duration: None,
         sub_ability: None,
@@ -5781,12 +5782,14 @@ fn try_parse_for_each_category_put_counter(tp: TextPair<'_>) -> Option<ParsedEff
     }
 
     Some(ParsedEffectClause {
-        effect: Effect::ForEachCategoryPutCounter {
+        effect: Effect::ForEachCategory {
             category,
-            target,
-            counter_type,
-            count: QuantityExpr::Fixed { value: 1 },
             chooser: crate::types::ability::Chooser::Controller,
+            action: crate::types::ability::ForEachCategoryAction::PutCounter {
+                target,
+                counter_type,
+                count: QuantityExpr::Fixed { value: 1 },
+            },
         },
         duration: None,
         sub_ability: None,
@@ -5812,9 +5815,12 @@ mod for_each_category_put_counter_tests {
         let clause = try_parse_for_each_category_put_counter(tp).expect("combinator must match");
         assert!(matches!(
             clause.effect,
-            Effect::ForEachCategoryPutCounter {
+            Effect::ForEachCategory {
                 category: IterationCategory::Color,
-                counter_type: CounterType::Plus1Plus1,
+                action: crate::types::ability::ForEachCategoryAction::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    ..
+                },
                 ..
             }
         ));

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -5730,6 +5730,97 @@ fn try_parse_for_each_category_exile(tp: TextPair<'_>) -> Option<ParsedEffectCla
     })
 }
 
+/// CR 608.2c + CR 105.1 / CR 122.1: Parse the for-each-category put-counter
+/// clause — "for each color, put a +1/+1 counter on a Dragon you control of
+/// that color" (Call the Spirit Dragons). Composes the category axis and the
+/// "of that color/type" anaphoric target restriction rather than enumerating
+/// each sentence. Emits [`Effect::ForEachCategoryPutCounter`].
+fn try_parse_for_each_category_put_counter(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
+    type E<'a> = OracleError<'a>;
+    use crate::types::ability::IterationCategory;
+
+    let (rest, _) = tag::<_, _, E>("for each ").parse(tp.lower).ok()?;
+    let (rest, category) = alt((
+        value(
+            IterationCategory::Color,
+            (
+                opt(tag::<_, _, E>("of those ")),
+                tag("color"),
+                opt(tag::<_, _, E>("s")),
+            ),
+        ),
+        value(
+            IterationCategory::CardType,
+            (
+                opt(tag::<_, _, E>("of those ")),
+                tag("card type"),
+                opt(tag::<_, _, E>("s")),
+            ),
+        ),
+    ))
+    .parse(rest)
+    .ok()?;
+    let (rest, _) = tag::<_, _, E>(", put ").parse(rest).ok()?;
+    let (rest, _) = nom_primitives::parse_article.parse(rest).ok()?;
+    let (rest, counter_type) = nom_primitives::parse_counter_type_typed(rest).ok()?;
+    let (rest, _) = tag::<_, _, E>(" counter on ").parse(rest).ok()?;
+    let (target, rest) = parse_type_phrase(rest);
+    if matches!(target, TargetFilter::Any) {
+        return None;
+    }
+    let member_suffix = match category {
+        IterationCategory::Color => "of that color",
+        IterationCategory::CardType => "of that type",
+    };
+    let rest = rest.trim();
+    if !rest.starts_with(member_suffix) {
+        return None;
+    }
+    if !rest[member_suffix.len()..].trim().is_empty() {
+        return None;
+    }
+
+    Some(ParsedEffectClause {
+        effect: Effect::ForEachCategoryPutCounter {
+            category,
+            target,
+            counter_type,
+            count: QuantityExpr::Fixed { value: 1 },
+            chooser: crate::types::ability::Chooser::Controller,
+        },
+        duration: None,
+        sub_ability: None,
+        distribute: None,
+        multi_target: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
+}
+
+#[cfg(test)]
+mod for_each_category_put_counter_tests {
+    use super::*;
+    use crate::types::ability::IterationCategory;
+    use crate::types::counter::CounterType;
+
+    #[test]
+    fn combinator_matches_call_the_spirit_dragons_clause() {
+        let text = "for each color, put a +1/+1 counter on a Dragon you control of that color";
+        let lower = text.to_ascii_lowercase();
+        let tp = TextPair::new(text, &lower);
+        let clause = try_parse_for_each_category_put_counter(tp).expect("combinator must match");
+        assert!(matches!(
+            clause.effect,
+            Effect::ForEachCategoryPutCounter {
+                category: IterationCategory::Color,
+                counter_type: CounterType::Plus1Plus1,
+                ..
+            }
+        ));
+    }
+}
+
 fn unless_rider_defers_to_body_parser(text: &str) -> bool {
     let lower = text.to_lowercase();
     let Some((before_unless, _, after_unless)) =
@@ -7249,6 +7340,10 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     }
 
     if let Some(clause) = try_parse_for_each_category_exile(tp) {
+        return clause;
+    }
+
+    if let Some(clause) = try_parse_for_each_category_put_counter(tp) {
         return clause;
     }
 

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -23,9 +23,10 @@ use crate::types::ability::{
     AbilityCondition, AbilityDefinition, AbilityKind, CastingPermission, ChoiceType, Chooser,
     ContinuousModification, ControllerRef, CopyRetargetPermission, CounterSourceRider, DigSource,
     Duration, Effect, EffectScope, ExcessRecipient, FaceDownBody, FaceDownProfile, FilterProp,
-    LibraryPosition, MultiTargetSpec, ObjectScope, PermissionGrantee, PlayerFilter, PtValue,
-    QuantityExpr, QuantityRef, RevealUntilDisposition, SpellStackToGraveyardReplacement,
-    StaticDefinition, TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
+    ForEachCategoryAction, LibraryPosition, MultiTargetSpec, ObjectScope, PermissionGrantee,
+    PlayerFilter, PtValue, QuantityExpr, QuantityRef, RevealUntilDisposition,
+    SpellStackToGraveyardReplacement, StaticDefinition, TargetChoiceTiming, TargetFilter,
+    TypeFilter, TypedFilter,
 };
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
@@ -466,8 +467,12 @@ pub(super) fn patch_reveal_until_for_library_category_exile(def: &mut AbilityDef
                 rest_destination,
                 ..
             },
-            Effect::ForEachCategoryExile {
-                zone: Zone::Library,
+            Effect::ForEachCategory {
+                action:
+                    ForEachCategoryAction::ExileFromPool {
+                        zone: Zone::Library,
+                        ..
+                    },
                 ..
             },
         ) = (&mut *def.effect, &*sub.effect)
@@ -5570,8 +5575,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::GrantCastingPermission { .. }
         | Effect::ChooseFromZone { .. }
         | Effect::RememberCard { .. }
-        | Effect::ForEachCategoryExile { .. }
-        | Effect::ForEachCategoryPutCounter { .. }
+        | Effect::ForEachCategory { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }
         | Effect::EachPlayerCopyChosen { .. }

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -5571,6 +5571,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::ChooseFromZone { .. }
         | Effect::RememberCard { .. }
         | Effect::ForEachCategoryExile { .. }
+        | Effect::ForEachCategoryPutCounter { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }
         | Effect::EachPlayerCopyChosen { .. }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::parser::parse_oracle_text;
 use crate::types::ability::CardPlayMode::{Cast, Play};
 use crate::types::ability::CastFromZoneDriver::{DuringResolution, LingeringPermission};
-use crate::types::ability::{AttachmentKind, PerpetualModification};
+use crate::types::ability::{AttachmentKind, ForEachCategoryAction, PerpetualModification};
 use crate::types::card_type::CoreType;
 use crate::types::mana::{ManaCost, ManaCostShard};
 use crate::types::statics::CostModifyMode;
@@ -554,9 +554,9 @@ fn for_each_card_type_exile_from_among_them() {
     assert!(
         matches!(
             effect,
-            Effect::ForEachCategoryExile {
+            Effect::ForEachCategory {
                 category: IterationCategory::CardType,
-                up_to: true,
+                action: ForEachCategoryAction::ExileFromPool { up_to: true, .. },
                 ..
             }
         ),
@@ -579,9 +579,9 @@ fn for_each_color_exile_from_revealed_cards() {
             assert!(
                 matches!(
                     effect,
-                    Effect::ForEachCategoryExile {
+                    Effect::ForEachCategory {
                         category: IterationCategory::Color,
-                        up_to: true,
+                        action: ForEachCategoryAction::ExileFromPool { up_to: true, .. },
                         ..
                     }
                 ),
@@ -603,9 +603,12 @@ fn for_each_color_put_counter_on_typed_permanent_of_that_color() {
     assert!(
         matches!(
             effect,
-            Effect::ForEachCategoryPutCounter {
+            Effect::ForEachCategory {
                 category: IterationCategory::Color,
-                counter_type: CounterType::Plus1Plus1,
+                action: ForEachCategoryAction::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    ..
+                },
                 ..
             }
         ),
@@ -629,9 +632,12 @@ fn call_the_spirit_dragons_upkeep_parses_put_counter_and_win_rider() {
     assert!(
         matches!(
             &*def.effect,
-            Effect::ForEachCategoryPutCounter {
+            Effect::ForEachCategory {
                 category: IterationCategory::Color,
-                counter_type: CounterType::Plus1Plus1,
+                action: ForEachCategoryAction::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    ..
+                },
                 ..
             }
         ),
@@ -31546,14 +31552,17 @@ fn sanar_vivid_reveal_until_keeps_library_pile_for_per_color_exile() {
     assert!(
         matches!(
             exile.effect.as_ref(),
-            Effect::ForEachCategoryExile {
+            Effect::ForEachCategory {
                 category: IterationCategory::Color,
-                zone: Zone::Library,
-                up_to: true,
+                action: ForEachCategoryAction::ExileFromPool {
+                    zone: Zone::Library,
+                    up_to: true,
+                    ..
+                },
                 ..
             }
         ),
-        "expected ForEachCategoryExile, got {:?}",
+        "expected ForEachCategory(ExileFromPool), got {:?}",
         exile.effect
     );
 }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -590,7 +590,82 @@ fn for_each_color_exile_from_revealed_cards() {
         }
 }
 
-/// CR 608.2c: the for-each-category EXILE parser must NOT swallow the
+/// CR 105.1 + CR 122.1: "for each color, put a +1/+1 counter on a Dragon you
+/// control of that color" parses to `ForEachCategoryPutCounter` (Call the Spirit
+/// Dragons).
+#[test]
+fn for_each_color_put_counter_on_typed_permanent_of_that_color() {
+    use crate::types::ability::IterationCategory;
+    use crate::types::counter::CounterType;
+
+    let effect =
+        parse_effect("for each color, put a +1/+1 counter on a Dragon you control of that color");
+    assert!(
+        matches!(
+            effect,
+            Effect::ForEachCategoryPutCounter {
+                category: IterationCategory::Color,
+                counter_type: CounterType::Plus1Plus1,
+                ..
+            }
+        ),
+        "expected ForEachCategoryPutCounter(Color), got {effect:?}"
+    );
+}
+
+/// CR 608.2c + CR 104.2b: Call the Spirit Dragons upkeep chains per-color
+/// counter placement with a gated win rider.
+#[test]
+fn call_the_spirit_dragons_upkeep_parses_put_counter_and_win_rider() {
+    use crate::types::ability::{
+        AbilityCondition, Comparator, IterationCategory, QuantityExpr, QuantityRef,
+    };
+    use crate::types::counter::CounterType;
+    let def = parse_effect_chain(
+        "for each color, put a +1/+1 counter on a Dragon you control of that color. \
+         If you put +1/+1 counters on five Dragons this way, you win the game.",
+        AbilityKind::Spell,
+    );
+    assert!(
+        matches!(
+            &*def.effect,
+            Effect::ForEachCategoryPutCounter {
+                category: IterationCategory::Color,
+                counter_type: CounterType::Plus1Plus1,
+                ..
+            }
+        ),
+        "expected ForEachCategoryPutCounter, got {:?}",
+        def.effect
+    );
+    let win = def
+        .sub_ability
+        .as_ref()
+        .expect("win rider must chain after counter placement");
+    assert!(
+        matches!(win.effect.as_ref(), Effect::WinTheGame { .. }),
+        "expected WinTheGame sub_ability, got {:?}",
+        win.effect
+    );
+    let Some(AbilityCondition::QuantityCheck {
+        lhs,
+        comparator,
+        rhs,
+    }) = win.condition.as_ref()
+    else {
+        panic!("WinTheGame must be gated, got {:?}", win.condition);
+    };
+    assert_eq!(*comparator, Comparator::GE);
+    assert!(matches!(
+        lhs,
+        QuantityExpr::Ref {
+            qty: QuantityRef::FilteredTrackedSetSize { .. },
+        }
+    ));
+    assert!(matches!(rhs, QuantityExpr::Fixed { value: 5 }));
+}
+
+/// CR 608.2c: the for-each-category PUT-counter parser must NOT swallow the
 /// distinct-types PUT-to-hand form — "for each card type, you may put a card
 /// of that type from among the revealed cards into your hand" is a different
 /// instruction (put, not exile) and must still route to the distinct-types

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -1364,6 +1364,7 @@ fn stamp_effect_printed_slot(effect: &mut Effect, slot: usize, kind: PrintedItem
         Effect::ChooseFromZone { .. } => {}
         Effect::RememberCard { .. } => {}
         Effect::ForEachCategoryExile { .. } => {}
+        Effect::ForEachCategoryPutCounter { .. } => {}
         Effect::ChooseObjectsIntoTrackedSet { .. } => {}
         Effect::ChooseAndSacrificeRest { .. } => {}
         Effect::Exploit { .. } => {}

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -1363,8 +1363,7 @@ fn stamp_effect_printed_slot(effect: &mut Effect, slot: usize, kind: PrintedItem
         Effect::ProcessRadCounters => {}
         Effect::ChooseFromZone { .. } => {}
         Effect::RememberCard { .. } => {}
-        Effect::ForEachCategoryExile { .. } => {}
-        Effect::ForEachCategoryPutCounter { .. } => {}
+        Effect::ForEachCategory { .. } => {}
         Effect::ChooseObjectsIntoTrackedSet { .. } => {}
         Effect::ChooseAndSacrificeRest { .. } => {}
         Effect::Exploit { .. } => {}

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -8072,6 +8072,57 @@ pub fn parse_you_put_into_hand_this_way_condition(
     Ok((rest, AbilityCondition::ZoneChangedThisWay { filter }))
 }
 
+/// CR 608.2c + CR 122.1: Parse "you put [counter type] counters on [N] [type]
+/// this way" — active-voice reflexive gate for counter-placement producers
+/// (Call the Spirit Dragons: "If you put +1/+1 counters on five Dragons this
+/// way, you win the game"). Counts filtered tracked-set members matching the
+/// type phrase against the parsed threshold.
+pub fn parse_you_put_counters_on_type_this_way_condition(
+    input: &str,
+) -> OracleResult<'_, AbilityCondition> {
+    let (rest, _) = tag("you put ").parse(input)?;
+    let (rest, _) = opt(terminated(
+        super::primitives::parse_counter_type_typed,
+        alt((tag(" counters "), tag(" counter "))),
+    ))
+    .parse(rest)?;
+    let (rest, _) = tag("on ").parse(rest)?;
+    let (count_expr, rest) =
+        crate::parser::oracle_util::parse_count_expr(rest).ok_or_else(|| {
+            nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Fail))
+        })?;
+    let threshold = match count_expr {
+        QuantityExpr::Fixed { value } => value,
+        _ => {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Fail,
+            )))
+        }
+    };
+    let (filter, after_filter) = parse_type_phrase(rest);
+    if matches!(filter, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    let (rest, _) = tag("this way").parse(after_filter.trim())?;
+    Ok((
+        rest,
+        AbilityCondition::QuantityCheck {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::FilteredTrackedSetSize {
+                    filter: Box::new(filter),
+                    caused_by: None,
+                },
+            },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: threshold },
+        },
+    ))
+}
+
 /// CR 400.7 + CR 608.2c: Parse "returned [quantifier] [type] to your hand this
 /// way" — the passive/elided-subject bounce gate (Cache Grab's disjunct:
 /// "returned a Squirrel card to your hand this way"). Returns the matched type

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -11462,6 +11462,31 @@ pub enum Effect {
         #[serde(default = "default_true")]
         up_to: bool,
     },
+    /// CR 608.2c + CR 105.1 / CR 122.1: For each member of a fixed category
+    /// (the five colors, or CR 205.2a card types), put counters on one
+    /// battlefield permanent matching a base filter augmented with that member —
+    /// "for each color, put a +1/+1 counter on a Dragon you control of that
+    /// color" (Call the Spirit Dragons). Category-iteration sibling of
+    /// [`Effect::ForEachCategoryExile`]: scans the battlefield pool once, parks
+    /// one `ChooseFromZoneChoice` per member when multiple candidates exist,
+    /// auto-applies when exactly one candidate exists, and accumulates every
+    /// countered object into the chain tracked set for downstream "this way"
+    /// references.
+    ForEachCategoryPutCounter {
+        /// CR 105.1 / CR 205.2a: Which fixed category's members are iterated.
+        category: IterationCategory,
+        /// Base permanent filter before the per-member color/type restriction
+        /// ("a Dragon you control").
+        target: TargetFilter,
+        /// CR 122.1: Counter type placed on each chosen permanent.
+        counter_type: crate::types::counter::CounterType,
+        /// CR 122.1: Number of counters placed per member iteration.
+        count: QuantityExpr,
+        /// CR 700.2: Who makes each per-member choice when multiple candidates
+        /// exist. Controller by default.
+        #[serde(default)]
+        chooser: Chooser,
+    },
     /// CR 603.7e: An affected-player-chosen battlefield permanent set, written
     /// into the chain's tracked object set so downstream effects ("pay {N} for
     /// each ... chosen this way", "untap those creatures") reference the exact
@@ -13563,6 +13588,7 @@ impl Effect {
             | Effect::ReturnAsAura { .. }
             | Effect::ChooseFromZone { .. }
             | Effect::ForEachCategoryExile { .. }
+            | Effect::ForEachCategoryPutCounter { .. }
             | Effect::ChooseAndSacrificeRest { .. }
             | Effect::EachPlayerCopyChosen { .. }
             | Effect::GainEnergy { .. }
@@ -13917,6 +13943,7 @@ impl Effect {
             | Effect::ChooseFromZone { .. }
             | Effect::RememberCard { .. }
             | Effect::ForEachCategoryExile { .. }
+            | Effect::ForEachCategoryPutCounter { .. }
             | Effect::ChooseObjectsIntoTrackedSet { .. }
             | Effect::ChooseOneOf { .. }
             // CR 122.1: parent count is forwarded verbatim into the per-kind
@@ -14169,6 +14196,7 @@ impl Effect {
             | Effect::ChooseFromZone { .. }
             | Effect::RememberCard { .. }
             | Effect::ForEachCategoryExile { .. }
+            | Effect::ForEachCategoryPutCounter { .. }
             | Effect::ChooseObjectsIntoTrackedSet { .. }
             | Effect::ChooseOneOf { .. }
             // CR 122.1: parent count is forwarded verbatim into the per-kind
@@ -14414,6 +14442,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::ChooseFromZone { .. } => "ChooseFromZone",
         Effect::RememberCard { .. } => "RememberCard",
         Effect::ForEachCategoryExile { .. } => "ForEachCategoryExile",
+        Effect::ForEachCategoryPutCounter { .. } => "ForEachCategoryPutCounter",
         Effect::ChooseObjectsIntoTrackedSet { .. } => "ChooseObjectsIntoTrackedSet",
         Effect::ChooseAndSacrificeRest { .. } => "ChooseAndSacrificeRest",
         Effect::EachPlayerCopyChosen { .. } => "EachPlayerCopyChosen",
@@ -14925,6 +14954,7 @@ impl From<&Effect> for EffectKind {
             // The per-member iteration parks `ChooseFromZoneChoice` prompts and
             // emits `ChooseFromZone` resolution events; it shares the kind.
             Effect::ForEachCategoryExile { .. } => EffectKind::ChooseFromZone,
+            Effect::ForEachCategoryPutCounter { .. } => EffectKind::PutCounter,
             Effect::ChooseObjectsIntoTrackedSet { .. } => EffectKind::ChooseObjectsIntoTrackedSet,
             Effect::ChooseCounterKind { .. } => EffectKind::ChooseCounterKind,
             Effect::PutChosenCounter { .. } => EffectKind::PutChosenCounter,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -175,6 +175,37 @@ impl IterationCategory {
     }
 }
 
+/// CR 608.2c: Per-member terminal action during [`Effect::ForEachCategory`]
+/// iteration. The category axis (`IterationCategory`) is shared; only the
+/// per-member body differs (exile from tracked pool vs put counter on permanent).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ForEachCategoryAction {
+    /// CR 608.2c + CR 105.1 / CR 205.2a: Exile one card of the bound member from
+    /// the chain tracked pool — "for each color, you may exile a card of that
+    /// color from among the revealed cards" (Sanar).
+    ExileFromPool {
+        /// The zone the pool cards live in (where each chosen card is exiled from).
+        zone: Zone,
+        /// CR 608.2d: When true (the "you may exile" idiom), each member's pick
+        /// is a resolution-time optional choice (0..=1 per member).
+        #[serde(default = "default_true")]
+        up_to: bool,
+    },
+    /// CR 608.2c + CR 105.1 / CR 122.1: Put counters on one battlefield permanent
+    /// matching a base filter augmented with the bound member — "for each color,
+    /// put a +1/+1 counter on a Dragon you control of that color" (Call the Spirit
+    /// Dragons).
+    PutCounter {
+        /// Base permanent filter before the per-member color/type restriction.
+        target: TargetFilter,
+        /// CR 122.1: Counter type placed on each chosen permanent.
+        counter_type: crate::types::counter::CounterType,
+        /// CR 122.1: Number of counters placed per member iteration.
+        count: QuantityExpr,
+    },
+}
+
 /// CR 101.4: Who selects permanents in a multi-player category choice effect
 /// (e.g., Cataclysm, Tragic Arrogance). Determines whether each player independently
 /// chooses which of their permanents to keep, or the spell's controller decides for everyone.
@@ -11427,65 +11458,21 @@ pub enum Effect {
     RememberCard {
         target: TargetFilter,
     },
-    /// CR 608.2c + CR 105.1 / CR 205.2a: For each member of a fixed category
-    /// (the five colors, or the CR 205.2a card types that can appear in a
-    /// library — nine: artifact, battle, creature, enchantment, instant,
-    /// kindred, land, planeswalker, sorcery), optionally choose one
-    /// card of *that* member from a card pool and exile it — "for each color,
-    /// you may exile a card of that color from among the revealed cards"
-    /// (Sanar), "for each card type, you may exile a card of that type from
-    /// among them" (Portent of Calamity).
-    ///
-    /// This is the category-iteration sibling of
-    /// `ChooseFromZone { zone_owner: EachPlayer }`: it parks one
-    /// `ChooseFromZoneChoice` prompt per category member, augmenting the pool
-    /// candidate filter with the bound member's color/type, and accumulates
-    /// every pick into the resolution chain's tracked object set so a
-    /// downstream "you may cast a spell from among them" / "put the rest into
-    /// your graveyard" reads exactly the cards chosen across all members. The
-    /// pool source is the same as `ChooseFromZone`'s tracked-set resolution
-    /// (the most recent revealed/exiled set). Optionality lives in `up_to`
-    /// (each member's pick is "you may", i.e. 0..=1).
-    ForEachCategoryExile {
+    /// CR 608.2c + CR 105.1: For each member of a fixed category (the five colors,
+    /// or CR 205.2a card types), perform a per-member action referencing the
+    /// bound member ("that color/type"). Iterates members in printed order,
+    /// parking one `ChooseFromZoneChoice` per member when multiple candidates
+    /// exist, and accumulates every pick into the chain tracked set for
+    /// downstream "this way" / "among them" references.
+    ForEachCategory {
         /// CR 105.1 / CR 205.2a: Which fixed category's members are iterated.
         category: IterationCategory,
-        /// The zone the pool cards live in (where each chosen card is exiled
-        /// from — typically `Library` for revealed-from-top pools).
-        zone: Zone,
-        /// CR 700.2: Who makes each per-member choice. Controller by default.
-        #[serde(default)]
-        chooser: Chooser,
-        /// CR 608.2d: When true (the "you may exile" idiom), each member's pick
-        /// is a resolution-time optional choice — the player announces the choice
-        /// while applying the effect, selecting 0 or 1 card of that member (a
-        /// 0..=1 optional pick per member).
-        #[serde(default = "default_true")]
-        up_to: bool,
-    },
-    /// CR 608.2c + CR 105.1 / CR 122.1: For each member of a fixed category
-    /// (the five colors, or CR 205.2a card types), put counters on one
-    /// battlefield permanent matching a base filter augmented with that member —
-    /// "for each color, put a +1/+1 counter on a Dragon you control of that
-    /// color" (Call the Spirit Dragons). Category-iteration sibling of
-    /// [`Effect::ForEachCategoryExile`]: scans the battlefield pool once, parks
-    /// one `ChooseFromZoneChoice` per member when multiple candidates exist,
-    /// auto-applies when exactly one candidate exists, and accumulates every
-    /// countered object into the chain tracked set for downstream "this way"
-    /// references.
-    ForEachCategoryPutCounter {
-        /// CR 105.1 / CR 205.2a: Which fixed category's members are iterated.
-        category: IterationCategory,
-        /// Base permanent filter before the per-member color/type restriction
-        /// ("a Dragon you control").
-        target: TargetFilter,
-        /// CR 122.1: Counter type placed on each chosen permanent.
-        counter_type: crate::types::counter::CounterType,
-        /// CR 122.1: Number of counters placed per member iteration.
-        count: QuantityExpr,
         /// CR 700.2: Who makes each per-member choice when multiple candidates
         /// exist. Controller by default.
         #[serde(default)]
         chooser: Chooser,
+        /// Per-member terminal action (exile from pool or put counter).
+        action: ForEachCategoryAction,
     },
     /// CR 603.7e: An affected-player-chosen battlefield permanent set, written
     /// into the chain's tracked object set so downstream effects ("pay {N} for
@@ -12319,8 +12306,8 @@ fn is_one(n: &u32) -> bool {
     *n == 1
 }
 
-/// `serde` default for the `up_to` flag of `Effect::ForEachCategoryExile` — the
-/// "you may exile" idiom makes each per-member pick optional (0..=1).
+/// `serde` default for the `up_to` flag of `ForEachCategoryAction::ExileFromPool` —
+/// the "you may exile" idiom makes each per-member pick optional (0..=1).
 fn default_true() -> bool {
     true
 }
@@ -13587,8 +13574,7 @@ impl Effect {
             // `WaitingFor::ReturnAsAuraTarget`. No stack-push target slot.
             | Effect::ReturnAsAura { .. }
             | Effect::ChooseFromZone { .. }
-            | Effect::ForEachCategoryExile { .. }
-            | Effect::ForEachCategoryPutCounter { .. }
+            | Effect::ForEachCategory { .. }
             | Effect::ChooseAndSacrificeRest { .. }
             | Effect::EachPlayerCopyChosen { .. }
             | Effect::GainEnergy { .. }
@@ -13942,8 +13928,7 @@ impl Effect {
             | Effect::ChooseDamageSource { .. }
             | Effect::ChooseFromZone { .. }
             | Effect::RememberCard { .. }
-            | Effect::ForEachCategoryExile { .. }
-            | Effect::ForEachCategoryPutCounter { .. }
+            | Effect::ForEachCategory { .. }
             | Effect::ChooseObjectsIntoTrackedSet { .. }
             | Effect::ChooseOneOf { .. }
             // CR 122.1: parent count is forwarded verbatim into the per-kind
@@ -14195,8 +14180,7 @@ impl Effect {
             | Effect::ChooseDamageSource { .. }
             | Effect::ChooseFromZone { .. }
             | Effect::RememberCard { .. }
-            | Effect::ForEachCategoryExile { .. }
-            | Effect::ForEachCategoryPutCounter { .. }
+            | Effect::ForEachCategory { .. }
             | Effect::ChooseObjectsIntoTrackedSet { .. }
             | Effect::ChooseOneOf { .. }
             // CR 122.1: parent count is forwarded verbatim into the per-kind
@@ -14441,8 +14425,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::GrantCastingPermission { .. } => "GrantCastingPermission",
         Effect::ChooseFromZone { .. } => "ChooseFromZone",
         Effect::RememberCard { .. } => "RememberCard",
-        Effect::ForEachCategoryExile { .. } => "ForEachCategoryExile",
-        Effect::ForEachCategoryPutCounter { .. } => "ForEachCategoryPutCounter",
+        Effect::ForEachCategory { .. } => "ForEachCategory",
         Effect::ChooseObjectsIntoTrackedSet { .. } => "ChooseObjectsIntoTrackedSet",
         Effect::ChooseAndSacrificeRest { .. } => "ChooseAndSacrificeRest",
         Effect::EachPlayerCopyChosen { .. } => "EachPlayerCopyChosen",
@@ -14953,8 +14936,11 @@ impl From<&Effect> for EffectKind {
             Effect::RememberCard { .. } => EffectKind::RememberCard,
             // The per-member iteration parks `ChooseFromZoneChoice` prompts and
             // emits `ChooseFromZone` resolution events; it shares the kind.
-            Effect::ForEachCategoryExile { .. } => EffectKind::ChooseFromZone,
-            Effect::ForEachCategoryPutCounter { .. } => EffectKind::PutCounter,
+            Effect::ForEachCategory {
+                action: ForEachCategoryAction::PutCounter { .. },
+                ..
+            } => EffectKind::PutCounter,
+            Effect::ForEachCategory { .. } => EffectKind::ChooseFromZone,
             Effect::ChooseObjectsIntoTrackedSet { .. } => EffectKind::ChooseObjectsIntoTrackedSet,
             Effect::ChooseCounterKind { .. } => EffectKind::ChooseCounterKind,
             Effect::PutChosenCounter { .. } => EffectKind::PutChosenCounter,

--- a/crates/engine/tests/integration/issue_4253_sanar_vivid.rs
+++ b/crates/engine/tests/integration/issue_4253_sanar_vivid.rs
@@ -11,8 +11,9 @@ use engine::game::effects::resolve_ability_chain;
 use engine::game::scenario::{GameScenario, P0};
 use engine::parser::oracle_effect::parse_effect_chain;
 use engine::types::ability::{
-    AbilityKind, Chooser, ControllerRef, Effect, IterationCategory, QuantityExpr, QuantityRef,
-    ResolvedAbility, RevealUntilDisposition, TargetFilter, TypeFilter, TypedFilter,
+    AbilityKind, Chooser, ControllerRef, Effect, ForEachCategoryAction, IterationCategory,
+    QuantityExpr, QuantityRef, ResolvedAbility, RevealUntilDisposition, TargetFilter, TypeFilter,
+    TypedFilter,
 };
 use engine::types::card_type::CoreType;
 use engine::types::game_state::WaitingFor;
@@ -57,11 +58,13 @@ fn sanar_vivid_chain(source: ObjectId) -> ResolvedAbility {
         P0,
     );
     ability.sub_ability = Some(Box::new(ResolvedAbility::new(
-        Effect::ForEachCategoryExile {
+        Effect::ForEachCategory {
             category: IterationCategory::Color,
-            zone: Zone::Library,
             chooser: Chooser::Controller,
-            up_to: true,
+            action: ForEachCategoryAction::ExileFromPool {
+                zone: Zone::Library,
+                up_to: true,
+            },
         },
         vec![],
         source,
@@ -93,14 +96,17 @@ fn sanar_vivid_parses_library_reveal_then_per_color_exile() {
     assert!(
         matches!(
             exile.effect.as_ref(),
-            Effect::ForEachCategoryExile {
+            Effect::ForEachCategory {
                 category: IterationCategory::Color,
-                zone: Zone::Library,
-                up_to: true,
+                action: ForEachCategoryAction::ExileFromPool {
+                    zone: Zone::Library,
+                    up_to: true,
+                    ..
+                },
                 ..
             }
         ),
-        "expected ForEachCategoryExile, got {:?}",
+        "expected ForEachCategory(ExileFromPool), got {:?}",
         exile.effect
     );
 }

--- a/crates/engine/tests/integration/issue_5274_call_the_spirit_dragons.rs
+++ b/crates/engine/tests/integration/issue_5274_call_the_spirit_dragons.rs
@@ -12,7 +12,7 @@ use engine::game::ability_utils::build_resolved_from_def;
 use engine::game::effects::resolve_ability_chain;
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::parser::oracle_effect::parse_effect_chain;
-use engine::types::ability::{AbilityKind, Effect, IterationCategory};
+use engine::types::ability::{AbilityKind, Effect, ForEachCategoryAction, IterationCategory};
 use engine::types::counter::CounterType;
 use engine::types::game_state::WaitingFor;
 use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
@@ -75,12 +75,16 @@ fn call_the_spirit_dragons_upkeep_puts_counters_on_five_dragons_and_wins() {
     assert!(
         matches!(
             &*def.effect,
-            Effect::ForEachCategoryPutCounter {
+            Effect::ForEachCategory {
                 category: IterationCategory::Color,
+                action: ForEachCategoryAction::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    ..
+                },
                 ..
             }
         ),
-        "expected ForEachCategoryPutCounter, got {:?}",
+        "expected ForEachCategory(PutCounter), got {:?}",
         def.effect
     );
 

--- a/crates/engine/tests/integration/issue_5274_call_the_spirit_dragons.rs
+++ b/crates/engine/tests/integration/issue_5274_call_the_spirit_dragons.rs
@@ -1,0 +1,126 @@
+//! Regression for GitHub issue #5274 — Call the Spirit Dragons upkeep counter
+//! placement and win rider.
+//!
+//! Oracle: "At the beginning of your upkeep, for each color, put a +1/+1
+//! counter on a Dragon you control of that color. If you put +1/+1 counters on
+//! five Dragons this way, you win the game."
+//!
+//! CR 105.1: iterates each color; CR 122.1: places +1/+1 counters; CR 608.2c:
+//! tracked-set "this way" gate for the five-Dragon win (CR 104.2b).
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, Effect, IterationCategory};
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+
+const UPKEEP_ORACLE: &str =
+    "for each color, put a +1/+1 counter on a Dragon you control of that color. \
+If you put +1/+1 counters on five Dragons this way, you win the game.";
+
+fn one_color_cost(color: ManaColor) -> ManaCost {
+    let shard = match color {
+        ManaColor::White => ManaCostShard::White,
+        ManaColor::Blue => ManaCostShard::Blue,
+        ManaColor::Black => ManaCostShard::Black,
+        ManaColor::Red => ManaCostShard::Red,
+        ManaColor::Green => ManaCostShard::Green,
+    };
+    ManaCost::Cost {
+        generic: 0,
+        shards: vec![shard],
+    }
+}
+
+fn add_mono_color_dragon(
+    scenario: &mut GameScenario,
+    name: &str,
+    color: ManaColor,
+) -> engine::types::identifiers::ObjectId {
+    let mut b = scenario.add_creature(P0, name, 4, 4);
+    b.with_subtypes(vec!["Dragon"]);
+    b.with_mana_cost(one_color_cost(color));
+    b.id()
+}
+
+#[test]
+fn call_the_spirit_dragons_upkeep_puts_counters_on_five_dragons_and_wins() {
+    let mut scenario = GameScenario::new_n_player(2, 5274);
+    scenario.at_phase(Phase::Upkeep);
+    scenario.with_life(P0, 20);
+    scenario.with_life(P1, 20);
+
+    let source = scenario
+        .add_creature(P0, "Call the Spirit Dragons", 0, 0)
+        .id();
+
+    for (i, color) in [
+        ManaColor::White,
+        ManaColor::Blue,
+        ManaColor::Black,
+        ManaColor::Red,
+        ManaColor::Green,
+    ]
+    .iter()
+    .enumerate()
+    {
+        add_mono_color_dragon(&mut scenario, &format!("Dragon {i}"), *color);
+    }
+
+    let def = parse_effect_chain(UPKEEP_ORACLE, AbilityKind::Spell);
+    assert!(
+        matches!(
+            &*def.effect,
+            Effect::ForEachCategoryPutCounter {
+                category: IterationCategory::Color,
+                ..
+            }
+        ),
+        "expected ForEachCategoryPutCounter, got {:?}",
+        def.effect
+    );
+
+    let mut runner = scenario.build();
+    let ability = build_resolved_from_def(&def, source, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0).unwrap();
+
+    let state = runner.state();
+    for obj in state.objects.values() {
+        if obj
+            .card_types
+            .subtypes
+            .iter()
+            .any(|s| s.eq_ignore_ascii_case("Dragon"))
+        {
+            assert_eq!(
+                obj.counters.get(&CounterType::Plus1Plus1).copied(),
+                Some(1),
+                "{} should have one +1/+1 counter",
+                obj.name
+            );
+        }
+    }
+
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::GameOver { winner: Some(w) } if w == P0
+        ),
+        "five Dragons countered this way must win for P0, got {:?}",
+        state.waiting_for
+    );
+    assert!(
+        state
+            .players
+            .iter()
+            .find(|p| p.id == P1)
+            .map(|p| p.is_eliminated)
+            .unwrap(),
+        "opponent must be eliminated after win"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -439,6 +439,7 @@ mod issue_4999_treasure_cruise_delve_tokens;
 mod issue_5145_violent_eruption_choose_target_distribution;
 mod issue_5159_attacks_alone_investigate;
 mod issue_5268_invincible_iron_man;
+mod issue_5274_call_the_spirit_dragons;
 mod issue_5279_grave_sifter;
 mod issue_5282_nissa_ultimate_emblem_search;
 mod issue_5283_hall_of_bandit_lord;

--- a/crates/phase-ai/src/policies/effect_classify.rs
+++ b/crates/phase-ai/src/policies/effect_classify.rs
@@ -288,7 +288,7 @@ pub(crate) fn effect_polarity(effect: &Effect) -> EffectPolarity {
         | Effect::FlipCoinUntilLose { .. }
         | Effect::Forage
         | Effect::ForceAttack { .. }
-        | Effect::ForEachCategoryExile { .. }
+        | Effect::ForEachCategory { .. }
         | Effect::FreeCastFromZones { .. }
         | Effect::GainActivatedAbilitiesOfTarget { .. }
         | Effect::GainControlAll { .. }

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -509,7 +509,7 @@ fn redundancy_delta(
         | Effect::ReverseTurnOrder
         | Effect::GrantCastingPermission { .. }
         | Effect::ChooseFromZone { .. }
-        | Effect::ForEachCategoryExile { .. }
+        | Effect::ForEachCategory { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }
         | Effect::EachPlayerCopyChosen { .. }


### PR DESCRIPTION
Closes #5274

## Summary

- Parse `for each color, put a +1/+1 counter on a Dragon you control of that color` as `Effect::ForEachCategoryPutCounter` (Call the Spirit Dragons upkeep).
- Resolve per-color counter placement on the battlefield with tracked-set accumulation for the `this way` win gate.
- Parse `If you put +1/+1 counters on five Dragons this way, you win the game` as a gated `WinTheGame` sub-ability (`FilteredTrackedSetSize >= 5`).

## Test plan

- [x] `for_each_color_put_counter_on_typed_permanent_of_that_color` — upkeep clause → `ForEachCategoryPutCounter`
- [x] `call_the_spirit_dragons_upkeep_parses_put_counter_and_win_rider` — chained `WinTheGame` gated by `FilteredTrackedSetSize >= 5`
- [x] `s07_if_put_counters_on_type_this_way` — reflexive `if you put … this way` gate strips correctly
- [x] `call_the_spirit_dragons_upkeep_puts_counters_on_five_dragons_and_wins` — integration: five WUBRG Dragons, P0 wins

## Verification

```bash
cargo fmt --all
cargo test -p engine --lib call_the_spirit
cargo test -p engine --lib for_each_color_put
cargo test -p engine --lib s07_if_put_counters
cargo test -p engine issue_5274 -- --nocapture
```
