### PR TITLE
docs(parser): correct systemically miscited CR 609.3 annotations

### DIFF
--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -114,7 +114,8 @@ pub(crate) struct ClauseContext {
     /// CR 608.2d: Implicit per-player iteration from an opponent-may prefix
     /// (`each opponent may`, `target opponent may`, `defending player may`, …).
     pub(crate) may_implicit_player_scope: Option<PlayerFilter>,
-    /// CR 609.3: `for each [qty], ` prefix or trailing `twice` / `N times`.
+    /// CR 608.2c: `for each [qty], ` prefix or trailing `twice` / `N times` — the
+    /// controller follows the instruction as written, once per counted iteration.
     pub(crate) repeat_for: Option<QuantityExpr>,
     /// CR 109.5: `each opponent` / `each player` subject-prefix iteration scope.
     pub(crate) player_scope: Option<PlayerFilter>,
@@ -215,7 +216,8 @@ fn peel_inner(text: String, mut ctx: ClauseContext) -> (String, ClauseContext) {
         }
     }
 
-    // Repeat-for: "for each [qty], " leading prefix (CR 107.1 / CR 609.3).
+    // Repeat-for: "for each [qty], " leading prefix (CR 608.2c: the instruction is
+    // followed as written, once per counted iteration).
     if ctx.repeat_for.is_none() {
         let (qty, rest) = peel_for_each_prefix(&text);
         if qty.is_some() {
@@ -260,7 +262,8 @@ enum YouMayBlocklist {
     ChunkLoop,
 }
 
-/// CR 107.1 + CR 609.3: Peel a leading `for each [qty], ` repeat prefix.
+/// CR 608.2c: Peel a leading `for each [qty], ` repeat prefix — the controller
+/// follows the instruction as written, once per counted iteration.
 /// Delegates to the existing `strip_for_each_prefix` building block.
 pub(crate) fn peel_for_each_prefix(text: &str) -> (Option<QuantityExpr>, String) {
     super::oracle_effect::lower::strip_for_each_prefix(text)

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -364,12 +364,15 @@ const STATIC_CONTAINS_PATTERNS: &[&str] = &[
     // The "of ..." infix between "abilities" and "can't be activated" blocks the contiguous
     // scan above; recognize the dispatched prefix separately so parse_static_line is reached.
     "activated abilities of ",
-    // CR 701.23 + CR 609.3: Ashiok-class search prohibition.
+    // CR 701.23 + CR 101.2: Ashiok-class search prohibition — a "can't search"
+    // effect takes precedence over any effect directing a search.
     "can't cause their controller to search their library",
-    // CR 603.2 + CR 609.3: The Master, Multiplied-class sacrifice/exile prohibition.
+    // CR 603.2 + CR 101.2: The Master, Multiplied-class sacrifice/exile prohibition —
+    // the "can't" effect takes precedence over the triggered ability directing it.
     "triggered abilities ",
     "can't cause you to sacrifice or exile",
-    // CR 701.23 + CR 609.3: Mindlock Orb-class search prohibition.
+    // CR 701.23 + CR 101.2: Mindlock Orb-class search prohibition — the "can't"
+    // effect takes precedence over any effect directing a search.
     "can't search libraries",
     "cannot search libraries",
     "may not search libraries",

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -4049,9 +4049,11 @@ fn counter_threshold_to_condition(
     }
 }
 
-/// CR 609.3: Compose a `QuantityExpr::Difference` from a two-operand quantity
+/// CR 608.2c: Compose a `QuantityExpr::Difference` from a two-operand quantity
 /// comparison condition — the unsigned magnitude gap between the operands, as
 /// referenced by "a number of times equal to the difference" repeat suffixes.
+/// "The difference" is an anaphoric back-reference to the operands the earlier
+/// condition text established (read the whole text, apply the rules of English).
 ///
 /// Class-general: any `AbilityCondition::QuantityCheck` yields the difference
 /// of its operands. Both `lhs` and `rhs` are already `QuantityExpr`, so they
@@ -7417,8 +7419,8 @@ mod tests {
 
     #[test]
     fn difference_expr_composes_unsigned_gap_from_quantity_check() {
-        // CR 609.3: a two-operand comparison yields the difference of its
-        // operands — class-general over any QuantityCheck.
+        // CR 608.2c: "the difference" back-references the two operands the earlier
+        // condition established — class-general over any QuantityCheck.
         let cond = AbilityCondition::QuantityCheck {
             lhs: QuantityExpr::Ref {
                 qty: QuantityRef::TrackedSetSize,

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1312,10 +1312,10 @@ pub(super) fn parse_one_or_more_sacrifice(
     Some((count, target, min_count))
 }
 
-/// CR 701.21a + CR 609.3: "sacrifice all <filter>" carries a mandatory
-/// count equal to the eligible object pool. This lets the sacrifice resolver's
-/// existing mandatory-all fast path perform every legal sacrifice without a
-/// one-card special case.
+/// CR 701.21a: "sacrifice all <filter>" carries a mandatory count equal to the
+/// eligible object pool (`QuantityRef::ObjectCount` over the parsed filter).
+/// This lets the sacrifice resolver's existing mandatory-all fast path perform
+/// every legal sacrifice without a one-card special case.
 pub(super) fn parse_all_sacrifice<'a>(
     text: &'a str,
     ctx: &mut ParseContext,
@@ -4708,7 +4708,7 @@ pub(super) fn lower_choose_ast(ast: ChooseImperativeAst) -> Effect {
             // control gain that ability" clause can read the typed
             // `ChosenAttribute::Keyword` via
             // `ContinuousModification::AddChosenKeyword` at layer evaluation.
-            // CR 609.3 + CR 608.2d: a `DistinctFromSourceHistory` number choice
+            // CR 608.2d: a `DistinctFromSourceHistory` number choice
             // ("...that hasn't been chosen") must persist each committed value on
             // the source so successive resolutions exclude prior picks — an
             // already-chosen number is an illegal option (CR 608.2d). The same

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -3257,7 +3257,7 @@ mod tests {
         );
     }
 
-    /// CR 106.1 + CR 609.3 + CR 122.1: Coalition Relic — "add one mana of any
+    /// CR 106.1 + CR 608.2c + CR 122.1: Coalition Relic — "add one mana of any
     /// color for each charge counter removed this way". This is the AnyOneColor
     /// equivalent of the fixed-color "Add {R} for each X" pattern. Class also
     /// includes the Storage Counter cycle (Saprazzan Cove, Dwarven Hold, etc.).

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13110,7 +13110,7 @@ fn try_parse_proliferate_target(text: &str) -> Option<Effect> {
 ///   - `repeat_for: DistinctCounterKindsAmong { filter: ParentTarget }` — one
 ///     iteration per distinct counter kind already on the chosen permanent. The
 ///     `repeat_for` loop resolves the kind set against the inherited target and
-///     rebinds each tagged branch to the iterated kind (CR 609.3 + CR 608.2c).
+///     rebinds each tagged branch to the iterated kind (CR 608.2c).
 ///   - `Effect::ChooseOneOf { chooser: Controller, branches: [PutCounter,
 ///     RemoveCounter] }` — both branches act on `ParentTarget` (the same chosen
 ///     permanent) and are tagged `RebindToIteratedKind`, so each iteration's
@@ -20571,9 +20571,11 @@ fn parse_guess_proposition(body: &str) -> Option<GuessSubject> {
     })
 }
 
-/// CR 609.3: detect a trailing "...that hasn't been chosen" distinctness clause
-/// on a "choose a number" prompt. Returns `DistinctFromSourceHistory` when the
-/// committed value must differ from prior commits on the source, else
+/// CR 608.2d: detect a trailing "...that hasn't been chosen" distinctness clause
+/// on a "choose a number" prompt — a player can't choose an option that's illegal
+/// or impossible, and an already-chosen number is such an option. Returns
+/// `DistinctFromSourceHistory` when the committed value must differ from prior
+/// commits on the source, else
 /// `Repeatable`. `tail` is the text following the parsed number.
 fn parse_number_distinctness(tail: &str) -> NumberDistinctness {
     let tail = tail.trim_start();
@@ -20653,7 +20655,8 @@ pub(crate) fn try_parse_named_choice(lower: &str) -> Option<ChoiceType> {
         let and = parts.next();
         // Split the leading max digits from any trailing distinctness clause
         // ("...5 that hasn't been chosen") with a nom digit combinator so the
-        // clause is detected (CR 609.3), not silently dropped.
+        // clause is detected (CR 608.2d: a player can't choose an illegal or
+        // impossible option), not silently dropped.
         let max_token = parts.next().unwrap_or("");
         let (max, tail) = match nom::character::complete::digit1::<_, ()>(max_token) {
             Ok((rest_after, digits)) => (digits.parse::<u8>().unwrap_or(20), rest_after),
@@ -22330,7 +22333,7 @@ fn quantity_expr_references_controller_life_gained(expr: &QuantityExpr) -> bool 
     }
 }
 
-/// CR 609.3 + CR 119.3: "distribute up to that many ..." on end-step life-gain
+/// CR 608.2c + CR 119.3: "distribute up to that many ..." on end-step life-gain
 /// triggers anaphorizes "that many" to life gained this turn, not
 /// `EventContextAmount` (which has no scalar on a phase trigger).
 pub(crate) fn rewrite_gained_life_that_many_distribution_refs(def: &mut AbilityDefinition) {
@@ -26068,7 +26071,7 @@ pub(crate) fn parse_effect_chain_ir(
 
         let (text_no_temporal, delayed_condition) = strip_temporal_suffix(&text);
         let (text_no_qty, mut multi_target) = strip_any_number_quantifier(text_no_temporal);
-        // CR 121.1 + CR 609.3: "draw cards equal to the difference" — anaphoric draw
+        // CR 121.1 + CR 608.2c: "draw cards equal to the difference" — anaphoric draw
         // count. When a leading QuantityCheck condition establishes two operands (e.g.
         // "if you have fewer than seven cards in hand"), "the difference" draws the
         // unsigned gap between them. Resolved here, in scope of both operands, to
@@ -26088,7 +26091,7 @@ pub(crate) fn parse_effect_chain_ir(
                 None
             }
         });
-        // CR 119.3 + CR 609.3: "they lose life equal to the difference" — when a
+        // CR 119.3 + CR 608.2c: "they lose life equal to the difference" — when a
         // leading QuantityCheck condition bounds life lost (Lolth emblem: "if that
         // player lost less than 8 life this turn"), the loss amount is the unsigned
         // gap between the threshold and life lost this turn.

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -9080,7 +9080,7 @@ fn tidus_combat_damage_trigger_draws_then_proliferates() {
 
 #[test]
 fn expand_the_sphere_difference_repeat_threads_onto_proliferate_sub() {
-    // CR 609.3: "If you put fewer than two lands onto the battlefield this
+    // CR 608.2c: "If you put fewer than two lands onto the battlefield this
     // way, proliferate a number of times equal to the difference." — the
     // leading comparison condition AND the difference-repeat count must
     // both thread onto the Proliferate sub-ability.
@@ -11170,7 +11170,7 @@ fn assassins_trophy_its_controller_may_search_chain() {
     );
 }
 
-/// CR 608.2c + CR 117.3a + CR 701.23a + CR 609.3 + CR 603.7: Winds of
+/// CR 608.2c + CR 117.3a + CR 701.23a + CR 603.7: Winds of
 /// Abandon — iterated subject-anchored search. The structure mirrors
 /// Assassin's Trophy but the search step carries `repeat_for:
 /// TrackedSetSize` so each exiled creature's controller searches their own
@@ -40858,7 +40858,7 @@ fn that_creatures_controller_faces_villainous_choice_uses_parent_controller_choo
     }
 }
 
-/// CR 120.1 + CR 202.3 + CR 609.3 (cluster 32, Class C — Ensnared by the
+/// CR 120.1 + CR 202.3 + CR 608.2c (cluster 32, Class C — Ensnared by the
 /// Mara): the branch-1 damage amount "the total mana value of those exiled
 /// cards" is an aggregate over the most recent chain tracked set — the cards
 /// the branch-head `ExileTop` published. It parses to

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -712,7 +712,8 @@ fn parse_token_description_with_context(
         }
     }
 
-    // CR 609.3: "for each [thing] this way" -- count from preceding zone moves.
+    // CR 608.2c: "for each [thing] this way" -- the "this way" anaphor counts from
+    // the preceding zone moves in the same effect.
     // Matches "for each card put into a graveyard this way", "for each creature
     // exiled this way", etc.
     {
@@ -737,7 +738,7 @@ fn parse_token_description_with_context(
                     .ok()
                     .filter(|(rest, _)| rest.is_empty())
                     .map(|(_, qty)| QuantityExpr::Ref { qty })
-                    // CR 609.3 + CR 205.2a: a TYPE-restricted "for each <type> card
+                    // CR 608.2c + CR 205.2a: a TYPE-restricted "for each <type> card
                     // <verb> this way" (Dread Summons: "for each creature card put
                     // into a graveyard this way") counts only the matching cards
                     // moved this way — `FilteredTrackedSetSize` — not every card

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -8134,7 +8134,7 @@ pub fn parse_you_control_or_returned_this_way_condition(
     ))
 }
 
-/// CR 121 + CR 608.2c + CR 609.3: Parse "you draw [one or more] card[s] this
+/// CR 121 + CR 608.2c: Parse "you draw [one or more] card[s] this
 /// way" — the active-voice draw-count gate (Transcendent Archaic: "you may draw
 /// X cards … If you draw one or more cards this way, discard two cards"). Reads
 /// the amount moved by the immediately preceding draw effect in the sub-ability

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -3211,7 +3211,8 @@ pub(crate) fn parse_for_each_clause_ref_with_context<'a>(
     parse_for_each_clause_ref_with_they_controller(input, they_controller)
 }
 
-/// CR 608.2c + CR 609.3: Read the Runes — "for each card[s] drawn this way".
+/// CR 608.2c: Read the Runes — "for each card[s] drawn this way". The "this way"
+/// anaphor reads the count the preceding draw in the same effect established.
 fn parse_for_each_card_drawn_this_way(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, _) = alt((tag("card drawn this way"), tag("cards drawn this way"))).parse(input)?;
     Ok((rest, QuantityRef::EventContextAmount))
@@ -4938,9 +4939,10 @@ mod tests {
         }
     }
 
-    /// CR 609.3 + CR 208.1: "the total power of the cards exiled this way"
-    /// reads the most recent chain tracked set (Stitcher Geralf), not the
-    /// linked-exile craft pool.
+    /// CR 608.2c + CR 208.1: the "this way" anaphor in "the total power of the
+    /// cards exiled this way" reads the most recent chain tracked set (Stitcher
+    /// Geralf) — the set the earlier text published — not the linked-exile craft
+    /// pool.
     #[test]
     fn parse_total_power_of_cards_exiled_this_way_is_tracked_set_aggregate() {
         use crate::types::ability::TrackedAnaphorSource;

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -314,7 +314,7 @@ pub(crate) fn parse_quantity_ref_with_context(
     ))
     .parse(trimmed)
     {
-        // CR 608.2c + CR 609.3 + CR 107.3e: "the total <property> of those exiled
+        // CR 608.2c + CR 107.3e: "the total <property> of those exiled
         // cards" is an aggregate over the most recent chain tracked set, not over live
         // battlefield objects — the anaphor "those exiled cards" refers to the set
         // the preceding effect published (e.g. Ensnared by the Mara's `ExileTop`).
@@ -4842,7 +4842,7 @@ mod tests {
 
     #[test]
     fn cda_quantity_total_mana_value_of_those_exiled_cards_is_tracked_set_aggregate() {
-        // CR 609.3 + CR 202.3: the plural anaphor "those exiled cards" aggregates
+        // CR 608.2c + CR 202.3: the plural anaphor "those exiled cards" aggregates
         // over the most recent chain tracked set (the set the preceding effect
         // published), NOT over live battlefield/exile objects via a type filter.
         // Drives Ensnared by the Mara's "deals damage equal to the total mana
@@ -5963,8 +5963,9 @@ mod tests {
         );
     }
 
-    /// CR 604.3 + CR 609.3: Wernog's full repeat count "one plus the number of
-    /// opponents who investigated this way" composes the "N plus" Offset arm
+    /// CR 604.3 + CR 608.2c: Wernog's full repeat count "one plus the number of
+    /// opponents who investigated this way" — the "this way" anaphor reads back to
+    /// the same effect — composes the "N plus" Offset arm
     /// over the inner player-action count. Before the inner resolved, the whole
     /// phrase collapsed to an opaque `Variable`.
     #[test]
@@ -6886,7 +6887,7 @@ mod tests {
         }
     }
 
-    /// CR 608.2c + CR 609.3: Read the Runes — "for each card drawn this way"
+    /// CR 608.2c: Read the Runes — "for each card drawn this way"
     /// binds repeat count to the parent draw via `EventContextAmount`.
     #[test]
     fn card_drawn_this_way_uses_event_context_amount() {

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2302,8 +2302,9 @@ pub(crate) fn parse_static_line_inner(
     }
 
     // --- "Spells and abilities <scope> can't cause their controller to search their library" ---
-    // CR 701.23 + CR 609.3: Ashiok, Dream Render's first static. Subject-scoped
-    // prohibition where `cause` identifies whose spells/abilities are muzzled.
+    // CR 701.23 + CR 101.2: Ashiok, Dream Render's first static. Subject-scoped
+    // prohibition — the "can't" effect takes precedence over any effect directing
+    // a search — where `cause` identifies whose spells/abilities are muzzled.
     if let Some(def) = parse_cant_search_library(&tp, &text) {
         return Some(def);
     }
@@ -2318,9 +2319,10 @@ pub(crate) fn parse_static_line_inner(
     }
 
     // --- "Triggered abilities <scope> can't cause you to sacrifice or exile <affected>" ---
-    // CR 603.2 + CR 609.3: The Master, Multiplied class. Subject-scoped prohibition
-    // where `cause` identifies whose triggered abilities are muzzled and `affected`
-    // identifies the protected objects.
+    // CR 603.2 + CR 101.2: The Master, Multiplied class. Subject-scoped prohibition
+    // — the "can't" effect takes precedence over the triggered ability directing the
+    // action — where `cause` identifies whose triggered abilities are muzzled and
+    // `affected` identifies the protected objects.
     if let Some(def) = parse_cant_cause_sacrifice_or_exile(&tp, &text) {
         return Some(def);
     }

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -417,7 +417,8 @@ pub(crate) fn parse_filter_scoped_cant_be_activated(
     )
 }
 
-/// CR 701.23 + CR 609.3: Parse CantSearchLibrary statics.
+/// CR 701.23 + CR 101.2: Parse CantSearchLibrary statics — a "can't search"
+/// continuous effect takes precedence over any effect directing a search.
 ///
 /// Supported Oracle classes:
 /// - "Spells and abilities <scope> can't cause their controller to search their
@@ -535,8 +536,9 @@ pub(crate) fn parse_restrict_search_to_top(
     )
 }
 
-/// CR 603.2 + CR 609.3: Parse "Triggered abilities <scope> can't cause you to
-/// sacrifice or exile <affected>." statics (The Master, Multiplied class).
+/// CR 603.2 + CR 101.2: Parse "Triggered abilities <scope> can't cause you to
+/// sacrifice or exile <affected>." statics (The Master, Multiplied class). The
+/// "can't" effect takes precedence over the triggered ability directing the action.
 ///
 /// Supported Oracle class:
 /// - "Triggered abilities you control can't cause you to sacrifice or exile

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -10691,7 +10691,8 @@ fn static_legend_rule_commanders_you_control() {
 
 #[test]
 fn static_cant_cause_sacrifice_or_exile_creature_tokens() {
-    // CR 603.2 + CR 609.3: The Master, Multiplied.
+    // CR 603.2 + CR 101.2: The Master, Multiplied — the "can't" effect takes
+    // precedence over the triggered ability directing the sacrifice/exile.
     let def = parse_static_line(
         "Triggered abilities you control can't cause you to sacrifice or exile creature tokens you control.",
     )
@@ -22529,11 +22530,11 @@ fn cant_be_activated_sorcerous_spyglass_chosen_name_with_mana_exemption() {
     }
 }
 
-// --- CR 701.23 + CR 609.3: CantSearchLibrary (Ashiok class) ---
+// --- CR 701.23 + CR 101.2: CantSearchLibrary ("can't" beats "can"; Ashiok class) ---
 
 #[test]
 fn cant_search_library_ashiok() {
-    // CR 701.23 + CR 609.3: Ashiok, Dream Render — "Spells and abilities your
+    // CR 701.23 + CR 101.2: Ashiok, Dream Render — "Spells and abilities your
     // opponents control can't cause their controller to search their library."
     let def = parse_static_line(
             "Spells and abilities your opponents control can't cause their controller to search their library.",
@@ -22564,7 +22565,8 @@ fn cant_search_library_controller_variant() {
 
 #[test]
 fn cant_search_library_mindlock_orb_players() {
-    // CR 701.23 + CR 609.3: Mindlock Orb — blanket all-players search prohibition.
+    // CR 701.23 + CR 101.2: Mindlock Orb — blanket all-players search prohibition;
+    // the "can't" effect takes precedence over any effect directing a search.
     let def = parse_static_line("Players can't search libraries.")
         .expect("Mindlock Orb Oracle text should parse");
     assert_eq!(
@@ -22590,7 +22592,8 @@ fn cant_search_library_each_player_may_not_variant() {
 
 #[test]
 fn cant_search_library_opponents_form() {
-    // CR 701.23 + CR 609.3: opponent-scoped direct search prohibition.
+    // CR 701.23 + CR 101.2: opponent-scoped direct search prohibition — the "can't"
+    // effect takes precedence over any effect directing a search.
     let def = parse_static_line("Your opponents can't search libraries.")
         .expect("opponent-scoped direct search prohibition should parse");
     assert_eq!(

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -11003,7 +11003,8 @@ fn investigate_twice_uses_repeat_for() {
         "first effect should be Investigate, got {:?}",
         def.effect,
     );
-    // CR 609.3: "twice" → repeat_for = Fixed(2), resolver handles repetition.
+    // CR 608.2c: "twice" → repeat_for = Fixed(2); the instruction is followed as
+    // written, once per iteration, and the resolver handles the repetition.
     assert_eq!(def.repeat_for, Some(QuantityExpr::Fixed { value: 2 }));
     assert!(def.sub_ability.is_none());
 }
@@ -11164,7 +11165,8 @@ fn investigate_three_times_uses_repeat_for() {
     use crate::parser::oracle_effect::parse_effect_chain;
     let def = parse_effect_chain("investigate three times", AbilityKind::Spell);
     assert!(matches!(*def.effect, Effect::Investigate));
-    // CR 609.3: "three times" → repeat_for = Fixed(3), not cloned sub_ability chain.
+    // CR 608.2c: "three times" → repeat_for = Fixed(3) — the instruction is followed
+    // as written, once per iteration — not a cloned sub_ability chain.
     assert_eq!(
         def.repeat_for,
         Some(QuantityExpr::Fixed { value: 3 }),

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -4591,7 +4591,8 @@ fn parse_ezio_damage_trigger_full_structure() {
     // Outer execute is the "you may pay {WUBRG}" cost.
     let execute = def.execute.as_ref().expect("execute must be Some");
 
-    // (c) Optional flag — the "you may" prefix on the cost (CR 609.3).
+    // (c) Optional flag — the "you may" prefix on the cost (CR 603.5: a triggered
+    // ability's "may" effect is optional; the choice is made when it resolves).
     assert!(
         execute.optional,
         "execute.optional must be true (the 'you may pay' wording)",
@@ -4712,7 +4713,8 @@ fn parse_ezio_damage_trigger_verbatim_oracle_text() {
 
     let execute = def.execute.as_ref().expect("execute must be Some");
 
-    // (b) Optional flag — the "you may pay" wording (CR 609.3).
+    // (b) Optional flag — the "you may pay" wording (CR 603.5: a triggered
+    // ability's "may" effect is optional; the choice is made when it resolves).
     assert!(
         execute.optional,
         "execute.optional must be true (the 'you may pay' wording)",

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -456,9 +456,10 @@ pub fn parse_count_expr(text: &str) -> Option<(QuantityExpr, &str)> {
         }
     }
 
-    // CR 609.3: "that many" / "that much" — chained-effect amount referring
-    // to the previous effect's count. Resolves to `EventContextAmount` (which
-    // falls back to `state.last_effect_count` for chained sub-ability
+    // CR 608.2c: "that many" / "that much" — an anaphoric back-reference to the
+    // previous effect's count (read the whole text and apply the rules of
+    // English). Resolves to `EventContextAmount` (which falls back to
+    // `state.last_effect_count` for chained sub-ability
     // continuations). Composes with the "twice"/"three times" multipliers
     // above so "twice that many cards" parses as Multiply{2, EventContextAmount}.
     if let Some(((), rest)) = super::oracle_nom::bridge::nom_on_lower(text, &lower, |i| {

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -3445,7 +3445,8 @@ pub(crate) fn check_cascade_diff(
     }
 
     if snap.repeat_for.is_some() && def.repeat_for.is_none() {
-        // CR 609.3: "for each X" / "twice" repeat counts are sometimes
+        // CR 608.2c: "for each X" / "twice" repeat counts (the instruction is
+        // followed as written, once per iteration) are sometimes
         // pushed onto a sub_ability instead of the def itself for
         // TargetOnly wrappers (line ~6411). Walk the sub_ability chain
         // before declaring loss.


### PR DESCRIPTION
## The defect

**CR 609.3** is *"If an effect attempts to do something impossible, it does only as much as possible."* That is all it says.

**56 sites** under `crates/engine/src/parser/` cited it. Only the **9 that reference it negatively** (*"…not the CR 609.3 'do as much as possible' rule"*) were accurate. The other 44 described three unrelated things.

Per CLAUDE.md: *"A wrong CR number is worse than no CR number — it creates false confidence that code was verified against the wrong rule."* `grep -r "CR 609"` currently returns a majority of false positives, so the annotation index is unusable for its stated purpose.

## Each replacement was derived from the code, then grep-verified in `docs/MagicCompRules.txt`

| Cluster | Correct rule |
|---|---|
| "can't search libraries" / "can't cause you to sacrifice or exile" prohibition statics (Ashiok, Mindlock Orb, The Master Multiplied) | **CR 101.2** — the "can't" effect takes precedence |
| "you may pay …" optionality on triggered abilities (Ezio) | **CR 603.5** — a triggered ability's "may" is optional; the choice is made on resolution |
| Repeat counts / anaphora — "for each X", "twice", "N times", "that many", "this way", "those exiled cards", "the difference" | **CR 608.2c** — follow the instructions as written; read the whole text and apply the rules of English |
| "choose a number that hasn't been chosen" distinctness | **CR 608.2d** — a player can't choose an illegal or impossible option |
| "sacrifice all \<filter\>" | **citation removed.** The count is just the size of the eligible pool (`QuantityRef::ObjectCount`); no impossibility is involved, and CR 701.21a (sacrifice) already carried the rule. |

## A note on the proposed fix, which was wrong

The tracking issue proposed **CR 107.1** for the repeat-count cluster. **CR 107.1 is "The only numbers the Magic game uses are integers"** and does not apply. The CR has no rule defining "for each" or repeat counts, so those sites now cite the instruction-following rule (**CR 608.2c**) that makes the count load-bearing.

Applying the proposed mapping would have replaced one unverified citation with another — the exact defect being fixed.

## Scope

Comment-only; every changed line is a `//` or `///` line. No behavior change.

Three sites in `oracle_ir/effect_chain.rs` and `oracle_effect/sequence.rs` are **deliberately excluded** — those files are being rewritten by the in-flight U6 refactor, and are corrected there to avoid conflicting with that stack.