### PR TITLE
refactor(parser): remove orphaned DocEmitter::card_data_keyword and stale dead_code allows (U8)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3079,7 +3079,6 @@ fn parse_strive_cost_body(effect_text: &str) -> Option<ManaCost> {
 ///
 /// This replaces the former category-ordered `parsed_abilities_to_doc_ir` on
 /// every non-Class path. `whole_document` spans survive only in the Class shim.
-#[allow(dead_code)] // wired by the dispatch-loop/preprocessor cutover in this unit.
 struct DocEmitter<'a> {
     builder: OracleDocBuilder,
     lines: &'a [&'a str],
@@ -3102,7 +3101,6 @@ struct DocEmitter<'a> {
     last_static: Option<StaticDefinition>,
 }
 
-#[allow(dead_code)] // wired by the dispatch-loop/preprocessor cutover in this unit.
 impl<'a> DocEmitter<'a> {
     fn new(lines: &'a [&'a str]) -> Self {
         let mut line_start = Vec::with_capacity(lines.len());
@@ -3245,21 +3243,6 @@ impl<'a> DocEmitter<'a> {
     }
     fn modal_at(&mut self, line: usize, m: ModalChoice) {
         self.emit_at(line, OracleNodeIr::Modal(m));
-    }
-
-    /// A card-data (MTGJSON) keyword that has NO printed source line: a zero-width
-    /// Exact span anchored at `(0, 0, 0)`-bytes, ordinal drawn from the SAME
-    /// `next_ordinal_for_line(0)` authority so multiple card-data keywords keep
-    /// their emission order. `whole_document` is deliberately NOT used — it must
-    /// remain a reliable Class-shim-only marker. The empty fragment is honest: a
-    /// zero-width span covers no text.
-    fn card_data_keyword(&mut self, kw: Keyword) {
-        let ordinal = self.builder.next_ordinal_for_line(0);
-        let span = OracleSourceSpan::exact(0, 0, 0, 0, ordinal);
-        let slot = self.builder.begin_item(span, Some(""));
-        self.builder
-            .emit(slot, OracleNodeIr::Keyword(kw))
-            .expect("distinct ordinals keep zero-width card-data keyword keys distinct");
     }
 
     /// Remove and return the most recently emitted spell item — the typed


### PR DESCRIPTION
Two pieces of scaffolding left behind by the Milestone-1 parser refactor.

- **`DocEmitter::card_data_keyword`** — zero callers. The card-data (MTGJSON) keyword path never routed through `DocEmitter`.
- **Two `#[allow(dead_code)]` on `DocEmitter`** — they claimed the struct would be *"wired by the dispatch-loop/preprocessor cutover in this unit."* That cutover landed. `DocEmitter` is live, and the attributes were left behind suppressing warnings for code that is now used.

The two are linked: removing the orphan is what makes the allows unnecessary. With `card_data_keyword` gone, every remaining `DocEmitter` item has a caller.

## Note on the burden of proof

These look like one task but need **opposite** evidence, which is why they're proven separately:

- `card_data_keyword` is removable **iff it has zero callers** → proof is finding nothing.
- An `#[allow(dead_code)]` is removable **iff the item it covers DOES have callers** → proof is finding something. Strip the attribute off something genuinely unused and you don't clean up, you convert a suppressed warning into a `-D warnings` build failure.

Callers were re-checked across `#[cfg(test)]` blocks, the other crates (`engine-wasm`, `phase-ai`, `phase-server`, `mtgish-import`), and feature-gated code — because an incomplete search is exactly how "dead code" that isn't dead gets deleted.

## Context

From a wider audit of Milestone-1 scaffolding: of 11 items catalogued, **only these 2 are removable.** The other 9 have live callers or belong to later units (Plan 02 owns `check_swallowed_clauses`; U7 owns the `patch_*` passes; U6-C5/C6 own `lower.rs`'s widened visibility). Useful to know before U8 is scoped as a deletion pass — it mostly isn't one.