### PR TITLE
fix(release): break the stuck-tag deadlock in the nightly release guard

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -170,46 +170,20 @@ jobs:
 
           echo "skip_creation=true" >> "$GITHUB_OUTPUT"
 
-          TAG_SHA=$(git rev-list -n 1 "$TAG")
-          RUNS=$(gh api --method GET "repos/$GITHUB_REPOSITORY/actions/workflows/release.yml/runs" \
-            -f per_page=50)
-          MATCH=$(jq -r --arg sha "$TAG_SHA" '
-            [
-              .workflow_runs[]
-              | select(.head_sha == $sha)
-              | {status, conclusion, html_url, created_at}
-            ]
-            | sort_by(.created_at)
-            | reverse
-            | .[0] // empty
-            | @base64
-          ' <<< "$RUNS")
-
-          if [ -z "$MATCH" ]; then
-            echo "No Release workflow run exists for $TAG; dispatching recovery in the follow-up job."
-            echo "dispatch_recovery=true" >> "$GITHUB_OUTPUT"
+          # The published GitHub Release is the authoritative signal, not a release-run
+          # conclusion. The version step above already derives next_minor from the highest
+          # published release, so keying recovery off that same fact keeps the two
+          # consistent. Matching on run conclusions instead let them disagree: a tag whose
+          # release run died before the publish gate (e.g. a build-server timeout) left the
+          # version step forever recomputing that same version while this guard hard-failed
+          # on the stale run — a deadlock no nightly could clear.
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG is already published; nothing to recover."
             exit 0
           fi
 
-          run_field() {
-            echo "$MATCH" | base64 -d | jq -r "$1"
-          }
-
-          STATUS=$(run_field '.status')
-          CONCLUSION=$(run_field '.conclusion')
-          URL=$(run_field '.html_url')
-
-          if [ "$STATUS" != "completed" ]; then
-            echo "Release workflow for $TAG is already $STATUS: $URL"
-            exit 0
-          fi
-          if [ "$CONCLUSION" = "success" ]; then
-            echo "Release workflow for $TAG already succeeded: $URL"
-            exit 0
-          fi
-
-          echo "::error::Release workflow for $TAG completed with $CONCLUSION. Rerun it here: $URL"
-          exit 1
+          echo "Tag $TAG exists but its release is not published; dispatching recovery."
+          echo "dispatch_recovery=true" >> "$GITHUB_OUTPUT"
 
       - name: Stop after existing tag handling
         if: ${{ steps.release-run.outputs.skip_creation == 'true' }}
@@ -422,4 +396,9 @@ jobs:
           TAG: ${{ needs.cut-nightly-release.outputs.release_tag }}
         run: |
           set -euo pipefail
-          gh workflow run release.yml --ref "$TAG" -f tag="$TAG"
+          # Dispatch from main, not from the tag: --ref selects which release.yml is
+          # EXECUTED, and the tag's copy is frozen at whatever was broken when it was cut,
+          # so a CI fix landed on main could never reach a stuck tag. `-f tag=` still pins
+          # the SOURCE that gets built to the tag's SHA (see release.yml resolve-release-ref),
+          # so this changes the CI config only, never the released code.
+          gh workflow run release.yml --ref main -f tag="$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ on:
 permissions:
   contents: write
 
+# Serialize per release tag, so a tag-push and a recovery dispatch for the same tag can
+# never build and publish it concurrently. Both triggers resolve to the same group: a push
+# has no `tag` input and carries the tag in ref_name; a dispatch passes it explicitly.
+# Never cancel-in-progress — a half-cancelled release is what leaves a tag stuck.
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   resolve-release-ref:
     name: Resolve Release Ref


### PR DESCRIPTION
A tag whose Release run died before the publish gate (v0.21.0: Build Server
(windows) hit the old 35-minute timeout and was cancelled) deadlocked the
nightly permanently. Two independent defects compounded:

1. Signal mismatch. The version step derives next_minor from the highest
   PUBLISHED GitHub Release, but the existing-tag guard keyed off release-RUN
   conclusions. When those disagree the nightly jams: version computation keeps
   recomputing 0.21.0 (no published release), the tag already exists, and the
   guard hard-exits on the stale cancelled run. Nothing in the nightly could
   ever clear that. Key the guard off the published release instead -- the same
   fact the version step already uses -- so the two cannot disagree, and a tag
   with no published release self-heals into a recovery dispatch.

2. Recovery could never carry a fix. dispatch-recovery ran
   `gh workflow run release.yml --ref "$TAG"`, which EXECUTES the release.yml
   frozen in the tag's tree -- i.e. the same broken workflow that just failed
   (35m timeout). A CI fix landed on main could not reach a stuck tag. Dispatch
   from main instead; `-f tag=` still pins the built SOURCE to the tag SHA via
   resolve-release-ref, so this changes CI config only, never released code.

Dropping the guard's "already in progress" branch (it matched runs by
head_sha == TAG_SHA, which a main-ref dispatch no longer satisfies) means a
tag-push and a recovery dispatch could in principle overlap, so release.yml
gains a per-tag concurrency group. cancel-in-progress is false: a half-cancelled
release is precisely what leaves a tag stuck.
