### PR TITLE
fix(scripts): close the freshness gate's remaining false-green and worktree holes

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,20 @@ enabled = config.parse().get('enable', [])
 # restarts the watching resources mid-build.
 TMP_IGNORE = ['**/*.tmp.*']
 
-ENGINE_SRC = ['crates/engine/src/']
+# Must stay a SUPERSET of what `scripts/engine-source-hash.sh` hashes as the engine cache
+# key (src + data + build.rs + Cargo.toml). `data/` is `include_str!`d into the binary and
+# `build.rs`/`Cargo.toml` change what gets compiled, so a change to any of them changes the
+# engine -- but a resource only rebuilds on its `deps`, and `tilt-wait.sh` derives build
+# freshness from those same `deps`. So anything hashed-but-unwatched is doubly invisible:
+# Tilt does not rebuild, AND the freshness scan does not look there, so `tilt-wait.sh
+# card-data` answers "fresh + ok" for a change that was never compiled. Under-specifying
+# `deps` here silently re-opens the false green that tilt-wait.sh exists to close.
+ENGINE_SRC = [
+    'crates/engine/src/',
+    'crates/engine/data/',
+    'crates/engine/build.rs',
+    'crates/engine/Cargo.toml',
+]
 ENGINE_TESTS = ['crates/engine/tests/']
 AI_SRC = ['crates/phase-ai/src/']
 AI_TESTS = ['crates/phase-ai/tests/']

--- a/scripts/tilt-wait.sh
+++ b/scripts/tilt-wait.sh
@@ -7,7 +7,14 @@
 #   0    all resources are fresh and reached updateStatus=ok with no in-flight build
 #   1    a resource is fresh and reached updateStatus=error with no in-flight build
 #   2    usage error
+#   3    cannot answer the question (Tilt not reachable, or Tilt watches a different
+#        checkout than this one). NOT a build failure -- never report it as one.
 #   124  --timeout elapsed before all resources settled
+#
+# 1 vs 3 is load-bearing: 1 means "your code is broken", 3 means "I could not find out".
+# Collapsing them is how a wrong-checkout or a stopped Tilt gets misread as a compile error,
+# which teaches callers to distrust the script -- and a distrusted freshness gate gets
+# bypassed, which restores the very false green this script exists to prevent.
 #
 # A resource must be both TERMINAL and FRESH before its status is believed.
 #
@@ -155,16 +162,48 @@ freshness() {
     ((${#prune[@]})) && prune+=(-o)
     prune+=(-path "$p")
   done < <(jq -r '.spec.ignores[]? | select((.patterns // []) | length == 0) | .basePath' <<< "$fw")
+
+  # Translate Tilt's ignore globs to `find` predicates -- but ONLY the shapes we can
+  # translate faithfully, and bail out loudly on the rest.
+  #
+  # `-name "${p##*/}"` is faithful for a basename glob matched at any depth (`**/*.tmp.*`
+  # -> `-name '*.tmp.*'`). It is NOT faithful for a directory glob: `target/**` reduces to
+  # `-name '**'`, which fnmatches EVERY file, prunes the entire watch root, and makes the
+  # scan report `fresh` unconditionally -- silently restoring the false green this whole
+  # script exists to prevent. One `ignore=` line in the Tiltfile could disarm it with no
+  # visible symptom, so an untranslatable pattern must fail CLOSED, not guess.
+  local base
   while IFS= read -r p; do
     [[ -z "$p" ]] && continue
+    base="${p##*/}"
+    # Reject a basename that is empty or only `*`s -- `target/**` reduces to `**`, and
+    # `-name '**'` fnmatches every file, pruning the whole tree.
+    if [[ -z "$base" || "$base" =~ ^\*+$ ]]; then
+      echo "tilt-wait: $r has ignore pattern '$p' that cannot be translated to a find" >&2
+      echo "tilt-wait: predicate without risking a match-everything prune; refusing to guess." >&2
+      echo unverifiable
+      return
+    fi
     ((${#prune[@]})) && prune+=(-o)
-    prune+=(-name "${p##*/}")
+    prune+=(-name "$base")
   done < <(jq -r '.spec.ignores[]? | .patterns[]?' <<< "$fw")
 
+  # A `find` failure must NOT read as "nothing changed". The old `|| true` swallowed the
+  # status into an empty string, which is indistinguishable from a clean scan -- it failed
+  # OPEN, toward green, in the one script whose whole job is to not lie green. Fail closed.
+  #
+  # `|| rc=$?` (not a bare assignment) is required: `set -e` is on, so an unguarded failing
+  # command substitution would abort the script before any status check could run.
+  local rc=0
   if ((${#prune[@]})); then
-    newer=$(find "${paths[@]}" \( "${prune[@]}" \) -prune -o -type f -newer "$start_ref" -print -quit 2>/dev/null || true)
+    newer=$(find "${paths[@]}" \( "${prune[@]}" \) -prune -o -type f -newer "$start_ref" -print -quit 2>/dev/null) || rc=$?
   else
-    newer=$(find "${paths[@]}" -type f -newer "$start_ref" -print -quit 2>/dev/null || true)
+    newer=$(find "${paths[@]}" -type f -newer "$start_ref" -print -quit 2>/dev/null) || rc=$?
+  fi
+  if ((rc != 0)); then
+    echo "tilt-wait: $r mtime scan failed (find rc=$rc); cannot establish freshness" >&2
+    echo unverifiable
+    return
   fi
 
   if [[ -n "$newer" ]]; then
@@ -181,7 +220,7 @@ while true; do
   for r in "${resources[@]}"; do
     if ! json=$(tilt get uiresource "$r" -o json 2>/dev/null); then
       echo "tilt-wait: failed to read resource '$r' (is Tilt running?)" >&2
-      exit 1
+      exit 3
     fi
     st=$(jq -r '.status.updateStatus // "unknown"' <<< "$json")
     current=$(jq -r '.status.currentBuild.spanID // "none"' <<< "$json")
@@ -198,7 +237,7 @@ while true; do
 
     case "$fresh" in
       foreign)
-        exit 1
+        exit 3
         ;;
       stale|never-built)
         # Any ok/error here describes code from before the change (or no code at all).


### PR DESCRIPTION
Follow-up to #5589, from an isolated review of it. Three ways the freshness gate
could still lie, and one way it could be made to lie in future.

1. `foreign` and "Tilt unreachable" both exited 1 -- the code the script's own
   table documents as "a resource is fresh and reached updateStatus=error", i.e.
   "your code is broken". `repo_root` derives from the script's own location, so
   running a worktree's copy of the script yields the worktree root while Tilt
   watches the main checkout -> foreign -> exit 1. Every skill in this repo
   (ship-commits, engine-implementer, the PR-review flows) runs in a worktree,
   and docs/AI-CONTRIBUTOR.md tells contributors to call this script directly.
   They would all read "wrong checkout" as "compile error".

   Split them out as exit 3, "cannot answer the question". 1 vs 3 is
   load-bearing: 1 means "your code is broken", 3 means "I could not find out".
   Collapsing them teaches callers to distrust the gate -- and a distrusted gate
   gets bypassed, which restores the false green the gate exists to prevent.

2. A surviving false green. `card-data`'s cache key (engine-source-hash.sh)
   hashes src + data + build.rs + Cargo.toml, but ENGINE_SRC watched only src/.
   Anything hashed-but-unwatched is doubly invisible: Tilt does not rebuild, AND
   the freshness scan does not look there -- so editing crates/engine/data (e.g.
   known-tokens.toml, which is include_str!'d) left `tilt-wait.sh card-data`
   answering "fresh + ok" for a change that was never compiled. Widen ENGINE_SRC
   to a superset of the hash inputs, which repairs the rebuild and the freshness
   oracle in one edit.

3. The ignore-glob translation could disarm the whole mechanism. Tilt patterns
   are reduced to their last path component for `find -name`, which is faithful
   for `**/*.tmp.*` (today's only pattern) but not for a directory glob:
   `target/**` reduces to `-name '**'`, which fnmatches every file, prunes the
   entire watch root, and reports `fresh` unconditionally. Verified: a `find`
   with `-name '**' -prune` returns nothing where the plain scan sees the change.
   One future `ignore=` line could silently re-open the false green engine-wide.
   Refuse to guess -- an untranslatable pattern now reports `unverifiable`.

4. `find` failures were swallowed by `|| true` into an empty result, which is
   indistinguishable from a clean scan: the mtime check failed OPEN, toward
   green, in the one script whose whole job is to not lie green. Fail closed.
   (`|| rc=$?` is required rather than a bare assignment -- `set -e` is on, so an
   unguarded failing command substitution aborts before any status check runs.)

Verified against live Tilt, each fix watched to go red before green:
  - settled resource, main checkout: reaches freshness=fresh -> exit 0 (the
    happy path still works, and is non-vacuous -- it reaches the changed code)
  - foreign condition, new script: exit 3; OLD script, same input: exit 1
  - `-name '**'` prune demonstrably hides a real change; the new guard rejects
    `**`/`*`/empty while still allowing `*.tmp.*` and normal globs
  - card-data watchedPaths now match engine-source-hash.sh's inputs exactly
