### PR TITLE
docs(parser): correct miscited CR 608.2e -> 608.2c in the U6 files

### DIFF
--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -1681,7 +1681,7 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
         }
     }
 
-    // CR 702.33d + CR 608.2e: Resolve "create [N] of those tokens [instead]"
+    // CR 702.33d + CR 608.2c: Resolve "create [N] of those tokens [instead]"
     // anaphoric subs — the sub-ability parses as `Unimplemented` because the
     // noun "those tokens" refers back to the previous clause's token-creation
     // effect. Rewrite those subs by cloning the previous effect with an

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1896,7 +1896,7 @@ fn sub_targets_moved_card(sub: &AbilityDefinition) -> bool {
     false
 }
 
-/// CR 702.33d + CR 608.2e: Resolve "create [N] of those tokens [instead]"
+/// CR 702.33d + CR 608.2c: Resolve "create [N] of those tokens [instead]"
 /// anaphoric clauses. The clause refers back to the previous def's token
 /// creation effect (either `Token` or `CopyTokenOf`) and reproduces it with
 /// a new count. We walk `defs` looking for an `Unimplemented` clause whose

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -57,7 +57,7 @@ pub(crate) struct EffectChainIr {
 /// `sub_link` is the sole residue, so it is the sole shell field.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub(crate) struct AbilityShellIr {
-    /// CR 608.2e: how the lowered root attaches to its parent — a resolution step
+    /// CR 608.2c: how the lowered root attaches to its parent — a resolution step
     /// of the parent's instruction, or an independent following instruction that
     /// resolves even when an optional parent is declined.
     ///
@@ -304,7 +304,7 @@ pub(crate) enum ReplaceMeaningKind {
     /// CR 614.1a + CR 608.2c: multi-clause base + "instead" override via Cow-swap;
     /// tail clauses stashed in the override's `else_ability`.
     Instead(Box<AbilityDefinition>),
-    /// CR 608.2e: build this clause's def from `parsed` + condition, attach as the
+    /// CR 608.2c: build this clause's def from `parsed` + condition, attach as the
     /// prior def's `sub_ability` (keyword-instead override).
     KeywordOverride,
 }


### PR DESCRIPTION
CR 608.2e is APNAP ordering for multi-step actions involving multiple
players. These four sites describe later text modifying the meaning of
earlier text ('create [N] of those tokens instead'; how a lowered root
attaches to its parent) — that is CR 608.2c.

Held back from #5581 deliberately so the engine-wide sweep would not
conflict with the in-flight U6 stack; corrected here instead.

Comment-only.
