### PR TITLE
fix(engine): parse Land Equilibrium's chained control-gated sacrifice replacement

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -3992,6 +3992,31 @@ pub(crate) fn controller_controls_source_gate(
 
 /// Evaluate a replacement condition against the current game state.
 /// Returns `true` if the replacement should apply, `false` if it should be skipped.
+/// CR 608.2c + CR 109.5: Quantity-resolution context for a replacement condition.
+/// `scoped_player` binds `ControllerRef::ScopedPlayer` to the entering/affected
+/// object's controller — the SPECIFIC player the replacement is evaluated against
+/// (Land Equilibrium's "an opponent who controls at least as many lands as you
+/// do") — while `ControllerRef::You` stays on the printed ability's controller.
+/// `entering` is left `None` so this is byte-identical to the prior
+/// `resolve_quantity` call for every existing `OnlyIfQuantity`/`UnlessQuantity`
+/// card (none of which populate `scoped_player`); only `ScopedPlayer`-flavored
+/// filters observe the new binding.
+fn replacement_condition_quantity_ctx(
+    state: &GameState,
+    source_id: ObjectId,
+    affected_object_id: Option<ObjectId>,
+) -> crate::game::quantity::QuantityContext {
+    let scoped_player = affected_object_id
+        .and_then(|id| state.objects.get(&id))
+        .map(replacement_source_player);
+    crate::game::quantity::QuantityContext {
+        entering: None,
+        source: source_id,
+        recipient: None,
+        scoped_player,
+    }
+}
+
 fn evaluate_replacement_condition(
     condition: &ReplacementCondition,
     controller: PlayerId,
@@ -4131,10 +4156,13 @@ fn evaluate_replacement_condition(
             if !turn_ok {
                 return true; // Turn requirement not met → replacement applies
             }
+            // CR 608.2c: resolve with the scoped-player context so `ScopedPlayer`
+            // filters bind to the entering/affected object's controller.
+            let ctx = replacement_condition_quantity_ctx(state, source_id, affected_object_id);
             let lhs_val =
-                crate::game::quantity::resolve_quantity(state, lhs, controller, source_id);
+                crate::game::quantity::resolve_quantity_with_ctx(state, lhs, controller, ctx);
             let rhs_val =
-                crate::game::quantity::resolve_quantity(state, rhs, controller, source_id);
+                crate::game::quantity::resolve_quantity_with_ctx(state, rhs, controller, ctx);
             !comparator.evaluate(lhs_val, rhs_val)
         }
         ReplacementCondition::OnlyIfQuantity {
@@ -4173,10 +4201,14 @@ fn evaluate_replacement_condition(
             if !turn_ok {
                 return false;
             }
+            // CR 608.2c: resolve with the scoped-player context so `ScopedPlayer`
+            // filters bind to the entering/affected object's controller (Land
+            // Equilibrium's LHS "an opponent who controls at least as many lands").
+            let ctx = replacement_condition_quantity_ctx(state, source_id, affected_object_id);
             let lhs_val =
-                crate::game::quantity::resolve_quantity(state, lhs, controller, source_id);
+                crate::game::quantity::resolve_quantity_with_ctx(state, lhs, controller, ctx);
             let rhs_val =
-                crate::game::quantity::resolve_quantity(state, rhs, controller, source_id);
+                crate::game::quantity::resolve_quantity_with_ctx(state, rhs, controller, ctx);
             comparator.evaluate(lhs_val, rhs_val)
         }
         ReplacementCondition::HasMaxSpeed => super::speed::has_max_speed(state, controller),
@@ -6348,10 +6380,28 @@ fn apply_single_replacement(
                     // CR 615.5 + CR 609.7: only the Prevented arm populates
                     // `post_replacement_event_source`; clear here so a prior
                     // prevention's source can't leak into a non-prevention stash.
+                    //
+                    // CR 614.13 + CR 608.2c: stash the AFFECTED object of the
+                    // (possibly modified) event as the continuation source, so a
+                    // scoped-player execute (Land Equilibrium's "that player …
+                    // sacrifices a land": `ControllerRef::You` bound via the entering
+                    // land's resulting controller) keys off the entering object, not
+                    // the replacement's own source. For a self-scoped replacement
+                    // (`valid_card: SelfRef`, the Devour family) these coincide.
+                    //
+                    // NOTE: for battlefield-ENTRY drains this is defensive alignment
+                    // rather than the sole binding — the land-play epilogue
+                    // (`engine.rs`) and the general zone-change drain
+                    // (`engine_replacement.rs`, "For ZoneChange events the post-effect
+                    // resolves against the zone-changing object") both clear
+                    // `post_replacement_source` and re-pass the entering object at
+                    // drain time. The stashed source is observable only on the
+                    // `TokenEntry` drain path, which does not clear it. See the
+                    // implementation report's Part 3 finding.
                     stash_post_replacement_continuation(
                         state,
                         post,
-                        rid.source,
+                        new_event.affected_object_id().unwrap_or(rid.source),
                         replacement_applied.clone(),
                         None,
                         None,

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -7708,6 +7708,30 @@ fn player_count_comparison_filters(type_text: &str) -> Option<(TargetFilter, Tar
     Some((type_filter, you_filter))
 }
 
+/// CR 614.1a: "an opponent who controls at least as many <filter> as you do" —
+/// the applicability condition of an "instead" replacement effect (Land
+/// Equilibrium). The relative clause ("who controls …") binds to the SPECIFIC
+/// entering/acting opponent — the player who would put the permanent onto the
+/// battlefield — not to an existential aggregate over all opponents. Returns the
+/// bare `(type_filter, you_filter)` pair (via the comparator-agnostic
+/// `player_count_comparison_filters` helper) so the replacement-condition builder
+/// can compose it directly into `ReplacementCondition::OnlyIfQuantity` with the
+/// scoped-player controller stamped on `type_filter`. This deliberately does NOT
+/// build `StaticCondition::QuantityComparison` / `PlayerFilter::ControlsCount`
+/// (the shape used by `parse_opponent_controls_more_than_you`): that shape is an
+/// existential "an opponent controls more <filter> than you" aggregate check and
+/// would be WRONG here — it does not bind the count to the specific entering
+/// player the replacement is evaluated against.
+pub(crate) fn parse_opponent_who_controls_at_least_as_many(
+    input: &str,
+) -> OracleResult<'_, (TargetFilter, TargetFilter)> {
+    let (rest, _) = tag("an opponent who controls at least as many ").parse(input)?;
+    let (rest, type_text) = take_until::<_, _, OracleError<'_>>(" as you do").parse(rest)?;
+    let (rest, _) = tag(" as you do").parse(rest)?;
+    let pair = player_count_comparison_filters(type_text).ok_or_else(|| oracle_err(type_text))?;
+    Ok((rest, pair))
+}
+
 /// CR 118.12a: Parse "[player] pays {cost}" → UnlessPay { cost }.
 ///
 /// Handles "you pay {N}", "their controller pays {N}", "its controller pays {N}".

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -17,7 +17,10 @@ use super::oracle_effect::{
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::replacement::ReplacementIr;
 use super::oracle_nom::bridge::{nom_on_lower, split_once_on_lower};
-use super::oracle_nom::condition::{parse_attached_subject_target_filter, parse_inner_condition};
+use super::oracle_nom::condition::{
+    parse_attached_subject_target_filter, parse_inner_condition,
+    parse_opponent_who_controls_at_least_as_many,
+};
 use super::oracle_nom::duration::parse_duration;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_nom::quantity as nom_quantity;
@@ -740,6 +743,18 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
     // --- Damage redirection: "all damage that would be dealt to [target] is dealt to ~ instead" ---
     // CR 614.1a: Replacement effects that redirect damage to a different recipient.
     if let Some(def) = parse_damage_redirection_replacement(&norm_lower, &text) {
+        return Some(def);
+    }
+
+    // --- "If an opponent who controls at least as many <filter> as you do would
+    //     put a land onto the battlefield, that player instead puts that land onto
+    //     the battlefield then sacrifices a land of their choice." (Land
+    //     Equilibrium) ---
+    // CR 614.1a: an "instead" replacement whose applicability is gated by a
+    // quantity comparison bound to the SPECIFIC entering opponent. Checked before
+    // the generic event-substitution / mana handlers so the chained "then
+    // sacrifices" rider is not dropped (misparse backlog category #4).
+    if let Some(def) = parse_opponent_put_land_sacrifice_replacement(&norm_lower, &text) {
         return Some(def);
     }
 
@@ -9105,6 +9120,130 @@ fn parse_event_substitution_replacement(
     }
 
     None
+}
+
+/// CR 614.1a: Land Equilibrium — "If an opponent who controls at least as many
+/// lands as you do would put a land onto the battlefield, that player instead
+/// puts that land onto the battlefield then sacrifices a land of their choice."
+///
+/// A `Moved`/Battlefield replacement whose applicability is gated by an
+/// `OnlyIfQuantity` comparison bound to the SPECIFIC entering opponent (via
+/// `ControllerRef::ScopedPlayer` on the LHS filter — threaded from the entering
+/// land's controller through `evaluate_replacement_condition`). The chained "then
+/// sacrifices a land of their choice" rider becomes the mandatory `execute`
+/// ability (misparse-backlog root-cause category #4: conjoined second clause).
+fn parse_opponent_put_land_sacrifice_replacement(
+    norm_lower: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
+    // Combinator-only dispatch: strip "if ", extract the opponent-comparison
+    // subject via the shared condition combinator, then match the replaced event
+    // and its sacrifice rider as two composed `tag`s (no string dispatch).
+    let (rest, _) = tag::<_, _, OracleError<'_>>("if ").parse(norm_lower).ok()?;
+    let (rest, (type_filter, you_filter)) =
+        parse_opponent_who_controls_at_least_as_many(rest).ok()?;
+    // The replaced event: the specific opponent putting a permanent of the SAME
+    // type the applicability gate counts onto the battlefield. Rather than hardcode
+    // "a land" (which silently diverges from the already-parsed gate type), match
+    // the structural frame and re-derive the entering permanent's filter from the
+    // event noun via the shared `parse_type_phrase` combinator, then require it to
+    // equal the gate's `type_filter`. This keeps the condition, the replaced event,
+    // and the sacrifice rider bound to one type — so the same construction with a
+    // different permanent noun stays internally consistent instead of half generic.
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" would put a ")
+        .parse(rest)
+        .ok()?;
+    let (rest, event_noun) = take_until::<_, _, OracleError<'_>>(" onto the battlefield")
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" onto the battlefield")
+        .parse(rest)
+        .ok()?;
+    let (event_filter, event_rem) = parse_type_phrase(event_noun.trim());
+    if !event_rem.trim().is_empty() || event_filter != type_filter {
+        return None;
+    }
+    // Preserve the parsed gate type for the sacrifice rider before the applicability
+    // gate's LHS below consumes `type_filter`.
+    let sacrifice_type_filter = type_filter.clone();
+    // The chained rider: "that player instead puts that land onto the battlefield
+    // then sacrifices a land of their choice." This is the clause a naive "instead"
+    // handler drops.
+    let (rest, _) = tag::<_, _, OracleError<'_>>(
+        ", that player instead puts that land onto the battlefield then sacrifices a land of their choice",
+    )
+    .parse(rest)
+    .ok()?;
+    let (rest, _) = opt(char::<_, OracleError<'_>>('.')).parse(rest).ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    // CR 614.1a: applicability gate. LHS counts lands the SPECIFIC entering
+    // opponent controls (`ScopedPlayer` — resolved from the entering land's
+    // controller at condition-evaluation time, before the land enters); RHS counts
+    // lands "you" (Land Equilibrium's controller) control. GE ⇒ "at least as many."
+    let condition = ReplacementCondition::OnlyIfQuantity {
+        lhs: QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount {
+                filter: inject_controller(type_filter, ControllerRef::ScopedPlayer),
+            },
+        },
+        comparator: Comparator::GE,
+        rhs: QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { filter: you_filter },
+        },
+        active_player_req: None,
+    };
+
+    // CR 701.21a: "sacrifices a land of their choice." `ControllerRef::You`
+    // resolves to the entering land's resulting controller because the
+    // post-replacement continuation is stashed with the ENTERING object as its
+    // source (see `apply_single_replacement`), NOT `ControllerRef::ParentTargetController`
+    // (which has no target context here and would never resolve).
+    //
+    // KNOWN, ACCEPTED SCOPE LIMITATION (CR 614.13 / Gatherer ruling): Land
+    // Equilibrium's official ruling states "it doesn't matter under whose control
+    // the land enters … If the opponent would put the land onto the battlefield
+    // under someone else's control (as a result of Yavimaya Dryad's ability, for
+    // example), that opponent will still have to sacrifice a land." This
+    // implementation binds the sacrificer to the entering land's RESULTING
+    // controller, not the player who performed the "put" action. These are the
+    // same player in the overwhelming majority of cases and diverge only in
+    // control-redirect scenarios (Yavimaya Dryad's "enters under target player's
+    // control"), which are not currently reachable for lands in this engine
+    // (Yavimaya Dryad does not implement `enters_under` today — a separate
+    // pre-existing gap, out of scope for this change).
+    let sacrifice_ability = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Sacrifice {
+            // CR 701.21a: the sacrificed permanent is the SAME type the gate counts,
+            // derived from the parsed `type_filter` (not a hardcoded land), so a card
+            // of this class with a different permanent noun stays consistent. For
+            // Land Equilibrium this is byte-identical to `TypedFilter::land()`.
+            target: inject_controller(sacrifice_type_filter, ControllerRef::You),
+            count: QuantityExpr::Fixed { value: 1 },
+            min_count: 0,
+        },
+    );
+
+    Some(
+        ReplacementDefinition::new(ReplacementEvent::Moved)
+            .valid_card(TargetFilter::Typed(
+                TypedFilter::land().controller(ControllerRef::Opponent),
+            ))
+            // CR 614.1c: battlefield-ENTRY-scoped — gate on the destination so the
+            // replacement matches an opponent's land ENTERING, not any departure.
+            .destination_zone(Zone::Battlefield)
+            .condition(condition)
+            .execute(sacrifice_ability)
+            // `valid_player` intentionally omitted: `evaluate_replacement_condition`
+            // consults `valid_player` only for LifeGain/Draw/Scry/Mill/Proliferate/
+            // CoinFlip/AddCounter events, NOT ZoneChange/Moved — it would be silently
+            // inert here. Opponent-scoping for this event is done entirely via
+            // `valid_card`'s `controller = Opponent`.
+            .description(original_text.to_string()),
+    )
 }
 
 /// CR 106.3 + CR 614.1a: Parse mana replacement effects.

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -6039,6 +6039,73 @@ fn library_of_leng_parses_hand_size_static_and_discard_replacement() {
     ));
 }
 
+/// Land Equilibrium: the chained "then sacrifices a land of their choice" clause
+/// must be represented, not dropped as a `SwallowedClause` (misparse-backlog
+/// category #4). Asserts the parser now yields a single `Moved` replacement gated
+/// by an `OnlyIfQuantity { comparator: GE }` land-count comparison whose execute
+/// is the forced `Sacrifice`. Revert-discriminating: before Part 1/Part 2 the
+/// card produced `replacements: []` plus a `SwallowedClause/Replacement_Instead`
+/// warning.
+#[test]
+fn land_equilibrium_parses_chained_sacrifice_replacement() {
+    use crate::types::ability::{
+        Comparator, ControllerRef, Effect, ReplacementCondition, TargetFilter, TypedFilter,
+    };
+    use crate::types::replacements::ReplacementEvent;
+
+    let text = "If an opponent who controls at least as many lands as you do would put a land onto the battlefield, that player instead puts that land onto the battlefield then sacrifices a land of their choice.";
+    let r = parse(text, "Land Equilibrium", &[], &["Enchantment"], &[]);
+
+    // The conjoined second clause must NOT be swallowed.
+    assert!(
+        !r.parse_warnings.iter().any(|w| matches!(
+            w,
+            OracleDiagnostic::SwallowedClause { detector, .. } if detector == "Replacement_Instead"
+        )),
+        "Land Equilibrium must no longer emit a Replacement_Instead SwallowedClause; got {:?}",
+        r.parse_warnings
+    );
+
+    assert_eq!(
+        r.replacements.len(),
+        1,
+        "one replacement, got {:?}",
+        r.replacements
+    );
+    let repl = &r.replacements[0];
+    assert_eq!(repl.event, ReplacementEvent::Moved);
+    // Gate: the entering opponent controls >= as many lands as the caster.
+    assert!(
+        matches!(
+            &repl.condition,
+            Some(ReplacementCondition::OnlyIfQuantity {
+                comparator: Comparator::GE,
+                ..
+            })
+        ),
+        "condition must be an OnlyIfQuantity GE land-count gate; got {:?}",
+        repl.condition
+    );
+    // The dropped rider is now the mandatory forced sacrifice.
+    let execute = repl
+        .execute
+        .as_ref()
+        .expect("replacement execute (the sacrifice rider)");
+    // The sacrifice target is now derived from the parsed gate type rather than a
+    // hardcoded `TypedFilter::land()`. For Land Equilibrium's own Oracle text the
+    // derivation must be byte-identical to the previous hardcoded filter — a land
+    // controlled by the entering player (ControllerRef::You), with no extra
+    // properties leaked from the type-phrase parse.
+    let Effect::Sacrifice { target, .. } = &*execute.effect else {
+        panic!("execute must be a Sacrifice; got {:?}", execute.effect);
+    };
+    assert_eq!(
+        *target,
+        TargetFilter::Typed(TypedFilter::land().controller(ControllerRef::You)),
+        "sacrifice target must be byte-identical to a You-controlled land filter"
+    );
+}
+
 #[test]
 fn block_restriction_routes_to_static_parser() {
     let r = parse(

--- a/crates/engine/tests/integration/land_equilibrium_forced_sacrifice.rs
+++ b/crates/engine/tests/integration/land_equilibrium_forced_sacrifice.rs
@@ -1,0 +1,550 @@
+//! Runtime pipeline regression for Land Equilibrium (misparse-backlog category
+//! #4 — conjoined/chained second-effect clause dropped).
+//!
+//! Land Equilibrium (Legends): "If an opponent who controls at least as many
+//! lands as you do would put a land onto the battlefield, that player instead
+//! puts that land onto the battlefield then sacrifices a land of their choice."
+//!
+//! These tests drive the REAL replacement pipeline: they parse the card's exact
+//! Oracle text through `engine::parser::parse_oracle_text` (so Part 1's new
+//! `parse_opponent_who_controls_at_least_as_many` combinator and Part 2's
+//! dispatch branch are exercised), attach the resulting `ReplacementDefinition`
+//! to a Land Equilibrium enchantment on P0's battlefield, and then have an
+//! opponent PLAY A LAND through `GameAction::PlayLand`. The forced sacrifice is
+//! observed as a real `WaitingFor::EffectZoneChoice` for the ENTERING opponent,
+//! gated by the scoped-player land-count comparison (Part 4 — `ScopedPlayer`
+//! resolves against the entering land's controller).
+//!
+//! NOTE on Part 3: the sacrifice binds to the ENTERING opponent (not the caster)
+//! because the land-drop epilogue and the general zone-change drain both rebind
+//! the post-replacement continuation to the entering object at drain time. That
+//! binding is PRE-EXISTING; Part 3's stash-source change is defensive alignment
+//! and is NOT observable on the land-drop path (all of these tests pass with
+//! Part 3 reverted). Part 4's `scoped_player` threading, by contrast, IS uniquely
+//! discriminating here — see the per-test notes.
+//!
+//! Discriminating signals:
+//!   * (a) positive / (c) boundary: the sacrifice `EffectZoneChoice.player` is the
+//!     ENTERING OPPONENT and its eligible pool is that opponent's lands only.
+//!   * (b) negative / (d) three-player ungated: NO `EffectZoneChoice` — reverting
+//!     Part 4's `scoped_player` threading makes the condition compare the caster's
+//!     land count against itself (`ScopedPlayer` falls back to the source
+//!     controller ⇒ always equal ⇒ GE true), wrongly forcing a sacrifice here.
+
+use engine::game::effects::change_zone;
+use engine::game::engine::apply_as_current;
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, ControllerRef, Effect, QuantityExpr, QuantityRef,
+    ReplacementDefinition, ResolvedAbility, TargetFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::replacements::ReplacementEvent;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+const P2: PlayerId = PlayerId(2);
+
+/// Verbatim Oracle text (matches `card-data.json`'s `"land equilibrium"` entry).
+const LAND_EQUILIBRIUM_TEXT: &str = "If an opponent who controls at least as many lands as you do would put a land onto the battlefield, that player instead puts that land onto the battlefield then sacrifices a land of their choice.";
+
+/// Parse Land Equilibrium's real Oracle text and return its single replacement.
+/// Exercises the new parser combinator + dispatch branch end-to-end.
+fn land_equilibrium_replacement() -> ReplacementDefinition {
+    let parsed =
+        engine::parser::parse_oracle_text(LAND_EQUILIBRIUM_TEXT, "Land Equilibrium", &[], &[], &[]);
+    assert_eq!(
+        parsed.replacements.len(),
+        1,
+        "Land Equilibrium must parse to exactly one replacement; got {:?}",
+        parsed.replacements
+    );
+    assert!(
+        !parsed
+            .parse_warnings
+            .iter()
+            .any(|w| format!("{w:?}").contains("SwallowedClause")),
+        "Land Equilibrium must no longer emit a SwallowedClause warning; got {:?}",
+        parsed.parse_warnings
+    );
+    parsed.replacements.into_iter().next().unwrap()
+}
+
+/// Create a Land permanent named `name` on the battlefield controlled by `owner`.
+fn add_battlefield_land(state: &mut GameState, owner: PlayerId, name: &str) -> ObjectId {
+    let card_id = CardId(state.next_object_id);
+    let id = create_object(state, card_id, owner, name.to_string(), Zone::Battlefield);
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Land);
+    obj.base_card_types = obj.card_types.clone();
+    obj.entered_battlefield_turn = Some(state.turn_number.saturating_sub(1));
+    obj.summoning_sick = false;
+    id
+}
+
+/// Create the Land Equilibrium enchantment on P0's battlefield carrying the
+/// real parsed replacement.
+fn add_land_equilibrium(state: &mut GameState) -> ObjectId {
+    let card_id = CardId(state.next_object_id);
+    let id = create_object(
+        state,
+        card_id,
+        P0,
+        "Land Equilibrium".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Enchantment);
+    obj.base_card_types = obj.card_types.clone();
+    obj.entered_battlefield_turn = Some(state.turn_number.saturating_sub(1));
+    obj.summoning_sick = false;
+    obj.replacement_definitions = vec![land_equilibrium_replacement()].into();
+    id
+}
+
+/// Put a Land card named `name` into `player`'s hand. Returns its object id.
+fn add_land_to_hand(state: &mut GameState, player: PlayerId, name: &str) -> ObjectId {
+    let card_id = CardId(state.next_object_id);
+    let id = create_object(state, card_id, player, name.to_string(), Zone::Hand);
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Land);
+    obj.base_card_types = obj.card_types.clone();
+    id
+}
+
+/// Make `player` the active player with priority in their pre-combat main phase.
+fn give_turn(runner: &mut GameRunner, player: PlayerId) {
+    let state = runner.state_mut();
+    state.phase = Phase::PreCombatMain;
+    state.active_player = player;
+    state.priority_player = player;
+    state.waiting_for = WaitingFor::Priority { player };
+}
+
+/// Play the land `land_id` from `actor`'s hand.
+fn play_land(runner: &mut GameRunner, land_id: ObjectId) {
+    let card_id = runner.state().objects[&land_id].card_id;
+    runner
+        .act(GameAction::PlayLand {
+            object_id: land_id,
+            card_id,
+        })
+        .expect("actor should be able to play a land");
+}
+
+fn lands_in_graveyard(state: &GameState, player: PlayerId) -> Vec<ObjectId> {
+    state.players[player.0 as usize]
+        .graveyard
+        .iter()
+        .copied()
+        .filter(|id| {
+            state
+                .objects
+                .get(id)
+                .is_some_and(|o| o.card_types.core_types.contains(&CoreType::Land))
+        })
+        .collect()
+}
+
+/// (a) Positive: an opponent controlling MORE lands than the caster plays a land
+/// — the land enters AND that opponent is forced to sacrifice a land of THEIR
+/// choice (not the caster's).
+#[test]
+fn opponent_with_more_lands_is_forced_to_sacrifice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut runner = scenario.build();
+
+    let eq_id = add_land_equilibrium(runner.state_mut());
+    // Caster (P0) controls 1 land; opponent (P1) controls 2 → GE holds.
+    let p0_land = add_battlefield_land(runner.state_mut(), P0, "Plains");
+    let p1_land_a = add_battlefield_land(runner.state_mut(), P1, "Forest");
+    let p1_land_b = add_battlefield_land(runner.state_mut(), P1, "Island");
+    let hand_land = add_land_to_hand(runner.state_mut(), P1, "Mountain");
+
+    give_turn(&mut runner, P1);
+    play_land(&mut runner, hand_land);
+
+    // The land entered the battlefield.
+    assert_eq!(
+        runner.state().objects[&hand_land].zone,
+        Zone::Battlefield,
+        "the played land must still enter the battlefield (it is put on, THEN a sacrifice follows)"
+    );
+
+    // The forced sacrifice must prompt the ENTERING OPPONENT (P1), not the caster.
+    let WaitingFor::EffectZoneChoice {
+        player,
+        cards,
+        count,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "expected the opponent's forced-sacrifice EffectZoneChoice, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(
+        *player, P1,
+        "Land Equilibrium forces the ENTERING opponent (P1) to sacrifice, NOT the caster (P0)"
+    );
+    assert_eq!(*count, 1, "exactly one land must be sacrificed");
+    // Eligible pool is P1's lands only (including the just-entered one); never P0's.
+    for c in cards {
+        assert_eq!(
+            runner.state().objects[c].controller,
+            P1,
+            "the sacrifice pool must contain only the entering opponent's lands; {c:?} is not P1's"
+        );
+    }
+    assert!(
+        !cards.contains(&p0_land),
+        "the caster's land ({p0_land:?}) must NEVER be a sacrifice candidate; pool={cards:?}"
+    );
+    assert!(
+        cards.contains(&p1_land_a) && cards.contains(&p1_land_b) && cards.contains(&hand_land),
+        "P1's three lands must all be eligible; pool={cards:?}"
+    );
+
+    // P1 sacrifices Forest.
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![p1_land_a],
+        })
+        .expect("opponent sacrifices a land");
+
+    assert_eq!(
+        runner.state().objects[&p1_land_a].zone,
+        Zone::Graveyard,
+        "the opponent's chosen land is sacrificed to the graveyard"
+    );
+    assert_eq!(
+        runner.state().objects[&p0_land].zone,
+        Zone::Battlefield,
+        "the CASTER's land is untouched — only the opponent sacrifices"
+    );
+    assert!(
+        lands_in_graveyard(runner.state(), P0).is_empty(),
+        "no caster land may end up in the caster's graveyard"
+    );
+    // Sanity reach-guard: the replacement really fired (the enchantment exists and
+    // the entering land is present), so the negative assertions above are not vacuous.
+    assert!(runner.state().objects.contains_key(&eq_id));
+}
+
+/// (b) Negative: an opponent controlling FEWER lands than the caster plays a land
+/// — it enters normally with NO forced sacrifice.
+#[test]
+fn opponent_with_fewer_lands_plays_land_normally() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut runner = scenario.build();
+
+    add_land_equilibrium(runner.state_mut());
+    // Caster (P0) controls 3 lands; opponent (P1) controls 1 → GE fails.
+    add_battlefield_land(runner.state_mut(), P0, "Plains");
+    add_battlefield_land(runner.state_mut(), P0, "Island");
+    add_battlefield_land(runner.state_mut(), P0, "Swamp");
+    add_battlefield_land(runner.state_mut(), P1, "Forest");
+    let hand_land = add_land_to_hand(runner.state_mut(), P1, "Mountain");
+
+    give_turn(&mut runner, P1);
+    play_land(&mut runner, hand_land);
+
+    // Reach-guard: the land actually entered (input got past the replacement gate).
+    assert_eq!(
+        runner.state().objects[&hand_land].zone,
+        Zone::Battlefield,
+        "the land must enter normally"
+    );
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::EffectZoneChoice { .. }
+        ),
+        "no forced sacrifice may occur when the opponent controls fewer lands; got {:?}",
+        runner.state().waiting_for
+    );
+    assert!(
+        lands_in_graveyard(runner.state(), P1).is_empty(),
+        "the opponent must not have sacrificed any land"
+    );
+}
+
+/// (c) Boundary: the opponent's land count EXACTLY equals the caster's (GE, not
+/// GT) — the sacrifice still triggers.
+#[test]
+fn equal_land_counts_still_force_sacrifice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut runner = scenario.build();
+
+    add_land_equilibrium(runner.state_mut());
+    // Both control 2 lands at the moment the land would enter → 2 >= 2 holds.
+    add_battlefield_land(runner.state_mut(), P0, "Plains");
+    add_battlefield_land(runner.state_mut(), P0, "Island");
+    let p1_land_a = add_battlefield_land(runner.state_mut(), P1, "Forest");
+    let p1_land_b = add_battlefield_land(runner.state_mut(), P1, "Mountain");
+    let hand_land = add_land_to_hand(runner.state_mut(), P1, "Swamp");
+
+    give_turn(&mut runner, P1);
+    play_land(&mut runner, hand_land);
+
+    let WaitingFor::EffectZoneChoice { player, cards, .. } = &runner.state().waiting_for else {
+        panic!(
+            "equal land counts (GE boundary) must still force a sacrifice, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(
+        *player, P1,
+        "the entering opponent sacrifices at the GE boundary"
+    );
+    assert!(
+        cards.contains(&p1_land_a) && cards.contains(&p1_land_b) && cards.contains(&hand_land),
+        "all of the opponent's lands are eligible; pool={cards:?}"
+    );
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![p1_land_b],
+        })
+        .expect("opponent sacrifices at the boundary");
+    assert_eq!(runner.state().objects[&p1_land_b].zone, Zone::Graveyard);
+}
+
+/// (d) Three-player hostile fixture: the gate binds to the SPECIFIC entering
+/// player, not an aggregate across all opponents. P1 (>= caster) is gated; P2
+/// (< caster) is NOT — even though P1, another opponent, controls many lands.
+#[test]
+fn three_player_gate_binds_to_specific_entering_player() {
+    // --- Sub-case 1: P1 (many lands) plays → forced sacrifice. ---
+    {
+        let mut scenario = GameScenario::new_n_player(3, 7);
+        scenario.at_phase(Phase::PreCombatMain);
+        let mut runner = scenario.build();
+
+        add_land_equilibrium(runner.state_mut());
+        // Caster P0: 2 lands. P1: 3 lands (gated). P2: 1 land (ungated).
+        add_battlefield_land(runner.state_mut(), P0, "Plains");
+        add_battlefield_land(runner.state_mut(), P0, "Island");
+        add_battlefield_land(runner.state_mut(), P1, "Forest");
+        add_battlefield_land(runner.state_mut(), P1, "Mountain");
+        add_battlefield_land(runner.state_mut(), P1, "Swamp");
+        add_battlefield_land(runner.state_mut(), P2, "Plains");
+        let p1_hand = add_land_to_hand(runner.state_mut(), P1, "Wastes");
+
+        give_turn(&mut runner, P1);
+        play_land(&mut runner, p1_hand);
+
+        let WaitingFor::EffectZoneChoice { player, .. } = &runner.state().waiting_for else {
+            panic!(
+                "P1 (>= caster lands) must be forced to sacrifice, got {:?}",
+                runner.state().waiting_for
+            );
+        };
+        assert_eq!(*player, P1, "the gated opponent P1 sacrifices");
+    }
+
+    // --- Sub-case 2: P2 (few lands) plays → NO sacrifice, even though P1 has
+    //     many lands. An existential/aggregate check would wrongly fire here. ---
+    {
+        let mut scenario = GameScenario::new_n_player(3, 7);
+        scenario.at_phase(Phase::PreCombatMain);
+        let mut runner = scenario.build();
+
+        add_land_equilibrium(runner.state_mut());
+        add_battlefield_land(runner.state_mut(), P0, "Plains");
+        add_battlefield_land(runner.state_mut(), P0, "Island");
+        add_battlefield_land(runner.state_mut(), P1, "Forest");
+        add_battlefield_land(runner.state_mut(), P1, "Mountain");
+        add_battlefield_land(runner.state_mut(), P1, "Swamp");
+        let p2_land = add_battlefield_land(runner.state_mut(), P2, "Plains");
+        let p2_hand = add_land_to_hand(runner.state_mut(), P2, "Wastes");
+
+        give_turn(&mut runner, P2);
+        play_land(&mut runner, p2_hand);
+
+        // Reach-guard: P2's land entered (past the gate).
+        assert_eq!(
+            runner.state().objects[&p2_hand].zone,
+            Zone::Battlefield,
+            "P2's land enters"
+        );
+        assert!(
+            !matches!(
+                runner.state().waiting_for,
+                WaitingFor::EffectZoneChoice { .. }
+            ),
+            "P2 controls FEWER lands than the caster, so it must NOT be forced to \
+             sacrifice — the gate binds to the entering player, not an aggregate over \
+             opponents; got {:?}",
+            runner.state().waiting_for
+        );
+        assert!(
+            lands_in_graveyard(runner.state(), P2).is_empty(),
+            "ungated P2 must not sacrifice"
+        );
+        // Reach-guard: P2's pre-existing land is untouched.
+        assert_eq!(runner.state().objects[&p2_land].zone, Zone::Battlefield);
+    }
+}
+
+/// (e) Regression: the Part 3 continuation-source change is a no-op for the
+/// Devour family (all `valid_card: SelfRef`, so `rid.source ==
+/// affected_object_id`). A Devour-1 creature entering the battlefield must still
+/// stash and resolve its post-replacement continuation — sacrifice a creature,
+/// then receive one +1/+1 counter (EventContextAmount = 1 creature devoured) —
+/// unaffected by the entering-object source rebinding.
+#[test]
+fn devour_post_replacement_continuation_still_resolves() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = P0;
+    state.priority_player = P0;
+
+    // The devourer's only legal victim (a pre-existing creature on the battlefield).
+    let victim = {
+        let id = create_object(
+            &mut state,
+            CardId(10),
+            P0,
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        id
+    };
+
+    // A Devour-1 creature waiting in Exile, mirroring `synthesize_devour`:
+    // Sacrifice(any number of your creatures) → sub_ability PutCounter(EventContextAmount).
+    let devourer = {
+        let id = create_object(
+            &mut state,
+            CardId(20),
+            P0,
+            "Devourer".to_string(),
+            Zone::Exile,
+        );
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        let put_counters = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                },
+                target: TargetFilter::SelfRef,
+            },
+        );
+        let sacrifice = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Sacrifice {
+                target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+                count: QuantityExpr::up_to(QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::creature().controller(ControllerRef::You),
+                        ),
+                    },
+                }),
+                min_count: 0,
+            },
+        )
+        .sub_ability(put_counters);
+        let repl = ReplacementDefinition {
+            event: ReplacementEvent::Moved,
+            execute: Some(Box::new(sacrifice)),
+            valid_card: Some(TargetFilter::SelfRef),
+            ..ReplacementDefinition::new(ReplacementEvent::Moved)
+        };
+        state.objects.get_mut(&id).unwrap().replacement_definitions = vec![repl].into();
+        id
+    };
+
+    let change_zone = ResolvedAbility::new(
+        Effect::ChangeZone {
+            origin: Some(Zone::Exile),
+            destination: Zone::Battlefield,
+            target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: engine::types::zones::EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        },
+        vec![],
+        ObjectId(100),
+        P0,
+    );
+
+    let mut events = Vec::new();
+    change_zone::resolve(&mut state, &change_zone, &mut events).unwrap();
+
+    // The as-enters sacrifice continuation surfaced its prompt (still stashed +
+    // drained after the Part 3 change). Its pool excludes the entering devourer.
+    let WaitingFor::EffectZoneChoice { player, cards, .. } = &state.waiting_for else {
+        panic!(
+            "Devour's post-replacement sacrifice continuation must still surface, got {:?}",
+            state.waiting_for
+        );
+    };
+    assert_eq!(
+        *player, P0,
+        "the devourer's controller makes the devour choice"
+    );
+    assert!(
+        cards.contains(&victim) && !cards.contains(&devourer),
+        "pool is the controller's creatures excluding the entering devourer; pool={cards:?}"
+    );
+
+    // Devour the pre-existing creature.
+    apply_as_current(
+        &mut state,
+        GameAction::SelectCards {
+            cards: vec![victim],
+        },
+    )
+    .expect("devour the victim");
+
+    assert_eq!(
+        state.objects[&victim].zone,
+        Zone::Graveyard,
+        "the devoured creature is sacrificed"
+    );
+    // The chained PutCounter continuation ran: devour-1 of one creature = one +1/+1.
+    assert_eq!(
+        state.objects[&devourer]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied(),
+        Some(1),
+        "the devourer must receive exactly one +1/+1 counter from its post-replacement \
+         continuation — proving Part 3 did not break the SelfRef stash/resolve path"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -512,6 +512,7 @@ mod kodama_anti_recursion_intervening_if;
 mod krark_clan_ironworks_castability;
 mod krark_thumb_coin_flip;
 mod kutzils_flanker_mode_one_counter;
+mod land_equilibrium_forced_sacrifice;
 mod lathiel_end_step_counters_repro;
 mod leeching_sliver;
 mod leyline_taps_for_mana_repro;


### PR DESCRIPTION
## Summary

Land Equilibrium ({2}{U}{U}, Enchantment, *Legends*): "If an opponent who controls at least as many lands as you do would put a land onto the battlefield, that player instead puts that land onto the battlefield then sacrifices a land of their choice."

Previously parsed with zero coverage — the chained "then sacrifices" clause was swallowed (`SwallowedClause`/`Replacement_Instead` parse warning, `replacements: []`).

- Adds a nom combinator for the "an opponent who controls at least as many `<X>` as you do" subject-relative clause (CR 614.1a), reusing the existing comparator-agnostic `player_count_comparison_filters` helper rather than the existential-aggregate shape used by "an opponent controls more lands than you."
- Wires this into a new `ReplacementDefinition` that gates on the **entering opponent's own** land count — not an aggregate check across all opponents — via a new `ScopedPlayer`-aware `QuantityContext` threaded through `OnlyIfQuantity`/`UnlessQuantity` condition evaluation (`game/replacement.rs`). Verified this is additive: none of the 27 existing cards using these condition variants reference `ScopedPlayer` today.
- Generalizes the sacrifice-execute and event-tag derivation from the same parsed type filter rather than hardcoding "land" in three places, so the whole replacement (condition + event-tag + execute) stays internally consistent if a sibling card with a different permanent noun is ever found; a mismatch fails safely (`None`, falls through to the next dispatch branch) rather than misparsing.
- Fixes a latent continuation-source bug in `stash_post_replacement_continuation`: the stashed source used `rid.source` (the replacement's bearer) instead of the entering object. This is a no-op for every existing card reaching this code path (all 21 Devour-family cards have `valid_card: SelfRef`, so bearer == entering object by construction — verified via a whole-database query), but is required for Land Equilibrium's `TokenEntry` drain path (an opponent creating a land token under Land Equilibrium), since it's the first external (non-self-referential) replacement to reach this code.

## Test plan
- [x] New parser unit test: Land Equilibrium's real Oracle text produces exactly one `Moved` replacement with `OnlyIfQuantity{GE}` and a `Sacrifice` execute (no `SwallowedClause`), asserting exact target-filter equality.
- [x] New integration test suite (`land_equilibrium_forced_sacrifice.rs`, 5 scenarios), driving the real `GameRunner`/`PlayLand` pipeline:
  - Opponent with **more** lands than caster is forced to sacrifice (land still enters first).
  - Opponent with **fewer** lands plays normally, no sacrifice.
  - **Equal** counts still trigger (GE boundary).
  - **3-player** fixture proves the gate binds to the specific entering opponent, not an aggregate check (one gated opponent, one not, despite the caster's own count being fixed).
  - An existing Devour-family card's post-replacement continuation is unaffected by the stash-source change (regression guard).
- [x] `cargo clippy -p engine --tests -- -D warnings` clean
- [x] `cargo fmt --all`
- [x] Parser combinator gate (`./scripts/check-parser-combinators.sh`) clean
- [x] All CR citations (614.1a, 614.1c, 614.13, 608.2c, 109.5, 701.21a) verified against the Comprehensive Rules text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbgwGxbU9NHN9kou9isp8K