### PR TITLE
fix(parser): keep granted-ability description case when stripping turn conditions

### DIFF
--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -307,9 +307,14 @@ pub(crate) fn parse_subject_continuous_static(text: &str) -> Option<StaticDefini
         return parse_continuous_gets_has(predicate, affected, text);
     }
 
-    // CR 604.1: Strip suffix turn conditions from predicate —
-    // "has first strike during your turn" → "has first strike" + DuringYourTurn
-    let (effective_predicate, suffix_condition) = strip_suffix_turn_condition(&pred_lower);
+    // CR 604.1: Strip suffix turn conditions from the ORIGINAL-case predicate
+    // (not `pred_lower`) — "has first strike during your turn" → "has first
+    // strike" + DuringYourTurn. The condition phrase is lowercase in the original
+    // too, so `strip_suffix_turn_condition` still matches, and the retained
+    // predicate keeps its printed case: a granted ability's serialized,
+    // user-visible `description` must read "{T}: Add {G}.", not "{t}: add {g}."
+    // (issue #5599, Brightcap Badger).
+    let (effective_predicate, suffix_condition) = strip_suffix_turn_condition(predicate);
 
     let modifications = parse_continuous_modifications(&effective_predicate);
     if !modifications.is_empty() {

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1929,12 +1929,12 @@ pub(crate) fn parse_static_line_inner(
         {
             let after = &tp.original[pos + verb_len..];
             let predicate = format!("{}{}", verb_prefix, after);
-            let predicate_lower = predicate.to_lowercase();
 
-            // CR 604.1: Strip suffix turn conditions —
-            // "has first strike during your turn" → condition + "has first strike"
-            let (effective_predicate, suffix_condition) =
-                strip_suffix_turn_condition(&predicate_lower);
+            // CR 604.1: Strip suffix turn conditions from the ORIGINAL-case
+            // predicate so a granted ability's serialized `description` keeps its
+            // printed case (issue #5599) — "has first strike during your turn" →
+            // condition + "has first strike".
+            let (effective_predicate, suffix_condition) = strip_suffix_turn_condition(&predicate);
 
             if let Some(mut def) =
                 parse_continuous_gets_has(&effective_predicate, TargetFilter::SelfRef, tp.original)

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -9762,6 +9762,30 @@ fn tokens_you_control_grant_spans_all_token_permanents() {
     );
 }
 
+// Issue #5599: a granted ability's `description` is a serialized, user-visible
+// field. The compound-subject anthem path stripped its trailing turn condition
+// on the LOWERCASED predicate and emitted the lowercase buffer, so Brightcap
+// Badger's "{T}: Add {G}." rendered as "{t}: add {g}.". The description must keep
+// its printed case.
+#[test]
+fn compound_subject_granted_ability_description_keeps_original_case() {
+    let def =
+        parse_static_line("Each Fungus and Saproling you control has \"{T}: Add {G}.\"").unwrap();
+    let ContinuousModification::GrantAbility { definition } = def
+        .modifications
+        .iter()
+        .find(|m| matches!(m, ContinuousModification::GrantAbility { .. }))
+        .expect("compound-subject anthem must grant the quoted ability")
+    else {
+        unreachable!()
+    };
+    assert_eq!(
+        definition.description.as_deref(),
+        Some("{T}: Add {G}."),
+        "granted-ability description must keep printed case, not the lowercased parse buffer"
+    );
+}
+
 // CR 702.95 + CR 613.1f: A soulbond pair grants a QUOTED activated/triggered
 // ability to both paired creatures — "As long as ~ is paired with another
 // creature, each of those creatures has "<ability>."". The granted ability's own


### PR DESCRIPTION
Closes #5599

CR 604.1

## Bug

A granted ability's `description` is a **serialized, user-visible** field (`AbilityDefinition.description` → `card-data.json`, rendered in the client). Two compound-subject / self static paths passed the **lowercased** predicate to `strip_suffix_turn_condition` and then fed the lowercase result to `parse_continuous_modifications` / `parse_continuous_gets_has`, so the granted ability's description leaked the lowercase parse buffer:

- **Brightcap Badger** — `Each Fungus and Saproling you control has "{T}: Add {G}."` rendered its grant as **`{t}: add {g}.`** instead of `{T}: Add {G}.`.

Per the issue, the lowercase-mana-symbol leak spans ~40 cards across the pool; the compound-subject anthem path is the reproducing route.

## Fix

Pass the **original-case** predicate to `strip_suffix_turn_condition` in both leaking callers:

- `parse_subject_continuous_static` (`anthem.rs`)
- the self-static verb-scan path (`dispatch.rs`) — the now-redundant `predicate_lower` is removed.

The trailing condition phrase (`during your turn` / `during turns other than yours`) is lowercase in the original text too, so the suffix still matches and the correct `StaticCondition` is still recovered (regression-tested) — the retained predicate simply keeps its printed case. The third caller (`grammar.rs`, Hunter's Blowgun `. Otherwise` path) already passed original-case text and is unchanged; this brings the two leaking callers in line with it and with the sibling handlers, which build predicates from `.original`.

## Tests

- `compound_subject_granted_ability_description_keeps_original_case` — Brightcap Badger's compound-subject grant → `description == "{T}: Add {G}."`.
- Verified live that a trailing turn condition still strips to `DuringYourTurn` (the suffix match is case-insensitive to the mixed-case predicate because the phrase itself is lowercase), and single-subject anthems are unchanged.
- Full `parser::oracle_static::tests` (1050 passed, 0 failed).

## CR verification

- **CR 604.1** — a granted ability functions independently; its printed text (the `description`) must render faithfully — verified in `docs/MagicCompRules.txt`.

## AI-contributor notes

- **Rules-correct / user-facing:** the granted activated ability now displays its printed case; no gameplay change, only the serialized description surface.
- **Class fix:** both compound-subject and self static grant paths keep case, matching the already-correct grammar path.
- **Verified:** live-parsed Brightcap Badger + a turn-condition predicate before/after; `cargo fmt`, CI-exact `clippy -p engine --all-targets --features proptest -D warnings`, and the full oracle_static module are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
