### PR TITLE
feat(parser): conjure into the top N cards of a library at random

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -9142,6 +9142,29 @@ fn parse_conjure_zone(lower: &str) -> Option<(Zone, &str)> {
         // Digital-only Alchemy conjures can also land in exile (e.g. a random card
         // conjured from a spellbook into exile with a play-permission rider).
         value(Zone::Exile, tag(" into exile")),
+        // Digital-only Alchemy conjures can slot a card into a random position among the
+        // top N cards of a library (e.g. "into the top five cards of your library at
+        // random"). The engine models conjure destinations at Zone granularity, so — like
+        // the plain "into your library" arm above, and matching the established
+        // "Some(Zone::Library) covers top-of-library variants" convention — these collapse
+        // to Zone::Library. `parse_number` consumes the count word; "your" and "each
+        // player's" libraries both map here.
+        value(
+            Zone::Library,
+            preceded(
+                tag::<_, _, OracleError<'_>>(" into the top "),
+                preceded(
+                    nom_primitives::parse_number,
+                    preceded(
+                        tag(" cards of "),
+                        alt((
+                            tag("your library at random"),
+                            tag("each player's library at random"),
+                        )),
+                    ),
+                ),
+            ),
+        ),
     ))
     .parse(lower)
     .ok()

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -32879,6 +32879,69 @@ fn conjure_named_into_exile() {
 }
 
 #[test]
+fn conjure_named_into_top_n_library_at_random() {
+    // "into the top N cards of your library at random" is a positional library slot; the
+    // engine models conjure destinations at Zone granularity, so it maps to Library (like
+    // the plain "into your library" wording).
+    let e = parse_effect(
+        "conjure a card named Sanguine Bond into the top fifteen cards of your library at random",
+    );
+    match e {
+        Effect::Conjure {
+            destination, cards, ..
+        } => {
+            assert_eq!(destination, Zone::Library);
+            assert_eq!(cards.len(), 1);
+        }
+        other => panic!("expected Conjure, got: {other:?}"),
+    }
+}
+
+#[test]
+fn conjure_named_into_top_n_each_players_library_at_random() {
+    // "each player's library" (a shared-library slot) also maps to the Library zone.
+    let e = parse_effect(
+        "conjure three cards named Sunscorched Desert into the top ten cards of each player's library at random",
+    );
+    match e {
+        Effect::Conjure { destination, .. } => assert_eq!(destination, Zone::Library),
+        other => panic!("expected Conjure, got: {other:?}"),
+    }
+}
+
+#[test]
+fn conjure_random_from_spellbook_into_top_n_library_at_random() {
+    // The top-N-library destination composes with the random draft-from-spellbook wording,
+    // which parses to DraftFromSpellbook (random) rather than Conjure.
+    let e = parse_effect(
+        "conjure a random card from the Slivers Spellbook into the top five cards of your library at random",
+    );
+    match e {
+        Effect::DraftFromSpellbook {
+            destination,
+            random,
+            ..
+        } => {
+            assert_eq!(destination, Zone::Library);
+            assert!(random);
+        }
+        other => panic!("expected DraftFromSpellbook, got: {other:?}"),
+    }
+}
+
+#[test]
+fn conjure_duplicate_into_top_n_library_at_random() {
+    // The top-N-library destination composes with the "conjure a duplicate of <ref>" wording.
+    let e = parse_effect(
+        "conjure a duplicate of that card into the top five cards of your library at random",
+    );
+    match e {
+        Effect::Conjure { destination, .. } => assert_eq!(destination, Zone::Library),
+        other => panic!("expected Conjure, got: {other:?}"),
+    }
+}
+
+#[test]
 fn conjure_random_from_spellbook_into_exile() {
     // The exile destination composes with the random draft-from-spellbook wording.
     let e = parse_effect("conjure a random card from ~'s spellbook into exile");


### PR DESCRIPTION
## What

Adds a `parse_conjure_zone` destination arm for the digital-only Alchemy wording
**"into the top N cards of {your | each player's} library at random"**, mapping it to
`Zone::Library`.

The engine models conjure destinations at `Zone` granularity, so the positional
"top N … at random" library slot collapses to `Zone::Library` — consistent with the
existing plain `" into your library"` / `" into their library"` arms (which already
collapse the owner distinction) and the documented *"`Some(Zone::Library)` covers
top-of-library variants"* convention. `parse_number` consumes the count word
(five/six/eight/ten/fifteen/…), and both "your" and "each player's" libraries map here.

## Why

`parse_conjure_zone` is shared by all three conjure entry points — `try_parse_conjure`
(named card), `try_parse_conjure_duplicate`, and `try_parse_conjure_from_spellbook` — so
this single arm lets previously-unparsed conjures resolve their destination instead of
failing the whole clause. The arm is appended after the existing alternatives, so it only
catches text that matched none of them (strictly additive — no previously-parsing card
changes).

Wordings that now parse include those on Sanguine Soothsayer, Mine Security, and Jessie
Zane (named), Sheoldred's Assimilator (duplicate), Sliver Weftwinder (from-spellbook,
random), and Sandcloud Harbinger's each-player's-library variant.

## Tests

Four unit tests, one per routing path (named / each-player's / duplicate /
from-spellbook-random):

- `cargo test -p engine --lib` → 16184 passed, 0 failed
- `cargo clippy -p engine --all-targets -- -D warnings` → clean
- rebased on latest `main`

Model: Claude Opus 4.8
