### PR TITLE
fix(parser): enforce the arena mirror on every clause path, and make the assert O(n) (U6-0b)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -410,12 +410,20 @@ impl Arena {
                 .all(|id| matches!(self.node(*id).status, NodeStatus::Live)),
             "arena/defs divergence: a non-Live node is in `order`"
         );
-        debug_assert!(
-            self.nodes.iter().enumerate().all(|(i, n)| {
-                let live_by_status = matches!(n.status, NodeStatus::Live);
-                let live_by_order = self.order.contains(&NodeId(i as u32));
-                live_by_status == live_by_order
-            }),
+        // Live-by-status and live-by-`order` are the same SET. With the assert above
+        // ("everything in `order` is Live") this count is equivalent to a membership
+        // scan, and O(n) rather than the O(nodes x order) `contains`-in-a-loop it
+        // replaces — this assert is LIVE in the full-pool export, where
+        // `[profile.tool] inherits = "dev"` keeps `debug_assert` on.
+        //
+        // It is also strictly STRONGER: a duplicate id in `order` inflates the length
+        // and fails the count, where a `contains` scan would have waved it through.
+        debug_assert_eq!(
+            self.nodes
+                .iter()
+                .filter(|n| matches!(n.status, NodeStatus::Live))
+                .count(),
+            self.order.len(),
             "arena/defs divergence: Live status and `order` membership disagree"
         );
 
@@ -921,6 +929,19 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
     // `Comma`/`Then`/no boundary makes it a within-clause `ContinuationStep`.
     let mut prev_boundary: Option<ClauseBoundary> = None;
     for clause_ir in &ir.clauses {
+        // "The arena mirrors `defs`" is load-bearing for every binding below, and it
+        // is asserted HERE, at the one point every clause path must pass through.
+        //
+        // `settle` runs at the end of the normal and special paths, but the five
+        // rider `continue`s below skip it. Those are safe today only because their
+        // helpers fold into a PRIOR def without changing `defs.len()` — a fact
+        // nothing enforced. Asserting at the top of the loop enforces it for every
+        // path, including any rider added later: a clause that mutates `defs` without
+        // telling the arena is caught on the NEXT clause rather than silently
+        // self-healed by `sync_len` (which would push a fresh node carrying the wrong
+        // provenance and hand it to role membership).
+        env.arena.assert_mirrors(&defs);
+
         // CR 608.2c: Handle absorbed clauses and special (rider) clauses that
         // modify previous defs rather than emitting new sibling defs. Each path
         // evaluates to `true`; the boundary advance below then runs uniformly so


### PR DESCRIPTION
F5 — `settle` runs at the end of the normal and special paths, but the five rider
`continue`s skip it. They are safe today only because their helpers fold into a PRIOR
def without changing `defs.len()` — a fact nothing enforced, on a codepath where the
failure mode is silent: `sync_len` SELF-HEALS a length drift by pushing a fresh node
carrying the wrong provenance, and hands it to role membership.

Adding `settle` to those five sites would not enforce anything — a sixth rider would
still forget. Assert the mirror at the TOP of the clause loop instead: the one point
every path must pass through. A clause that mutates `defs` without telling the arena
is now caught on the next clause, for every path present and future.

Not a hypothetical guard: the assert is live in the full-pool export and confirms
empirically, across ~35k faces, that the five rider paths really do leave the arena
in sync. That was previously an assumption.

F6 — `assert_mirrors`'s status/order-agreement check was O(nodes x order) via
`order.contains()` inside `nodes.iter()`, and it is LIVE in the full-pool export
(`[profile.tool] inherits = "dev"`). Counting Live nodes is O(n) and, together with
the "everything in `order` is Live" assert above it, equivalent — and strictly
STRONGER: a duplicate id in `order` inflates the length and fails the count, where a
`contains` scan would have waved it through.

F4 (Phase 2 mutates `defs` with no `observe`/`settle`) is deliberately NOT fixed here
— see the report. `env` is provably dead after Phase 1 (zero `env.` reads), so there
is no consumer, and therefore nothing that could falsify a Phase-2 arena model. Wiring
one now would re-ship the exact defect commit (0) exists to remove: a model asserted
by construction and verified by nothing. It belongs to commit (e), whose fold rewrite
is the consumer that can prove it.

Evidence: full-pool export byte-identical to base a61e7fdd91 — sha256
5eded903cd5fd5d534b3d581d57d089d7c14f30d5bc35b5c0a17335d4953be28, 98,187,284 B, exit 0,
no assert fired. 16,178 lib tests pass; clippy -D warnings clean.
