### PR TITLE
docs(engine): cite CR 608.2c/d/e for resolution-time choices miscited as CR 700.2 (#5598)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -1178,7 +1178,7 @@ pub fn candidate_actions_broad_with_probe(
                 })
                 .collect()
         }
-        // CR 700.2: Choose card(s) from a tracked set (exiled/revealed cards).
+        // CR 608.2d: Choose card(s) from a tracked set (exiled/revealed cards).
         WaitingFor::ChooseFromZoneChoice {
             player,
             cards,

--- a/crates/engine/src/game/effects/choose_card.rs
+++ b/crates/engine/src/game/effects/choose_card.rs
@@ -2,7 +2,7 @@ use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 
-/// CR 700.2: Choose — player makes a choice from available options.
+/// CR 608.2d: Choose — player makes a choice from available options.
 pub fn resolve(
     state: &mut GameState,
     ability: &ResolvedAbility,

--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -13,7 +13,7 @@ use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 
-/// CR 700.2: Choose card(s) from a tracked set — player selects from exiled/revealed cards.
+/// CR 608.2d: Choose card(s) from a tracked set — player selects from exiled/revealed cards.
 /// The available cards come from the most recent tracked set recorded by the parent effect
 /// (e.g., ChangeZone to exile). The `chooser` field determines whether the controller or
 /// an opponent makes the selection.
@@ -76,7 +76,8 @@ pub fn resolve(
         filter.as_ref(),
     )?;
 
-    // CR 700.2: If there are no objects to choose from, skip the choice.
+    // CR 608.2d: If there are no objects to choose from, skip the choice
+    // (a player can't choose an option that's illegal or impossible).
     if cards.is_empty() || count == 0 {
         state.last_choose_from_zone_found_nothing = true;
         events.push(GameEvent::EffectResolved {
@@ -88,7 +89,7 @@ pub fn resolve(
 
     let clamped_count = count.min(cards.len());
 
-    // CR 700.2: Determine who makes the choice.
+    // CR 608.2d: Determine who makes the choice.
     let choosing_player = resolve_chooser(state, ability, chooser);
 
     // CR 608.2: An ability's resolution is a single ongoing process. This
@@ -843,7 +844,7 @@ fn object_ids_in_player_zone(state: &GameState, player: PlayerId, zone: Zone) ->
     }
 }
 
-/// CR 700.2: Resolve the `Chooser` enum to an actual `PlayerId`.
+/// CR 608.2c-e: Resolve the `Chooser` enum to an actual `PlayerId`.
 /// For `Opponent`, first checks ability targets for a pre-targeted opponent player
 /// (handles "target opponent chooses"), then falls back to the first opponent in APNAP order.
 fn resolve_chooser(state: &GameState, ability: &ResolvedAbility, chooser: Chooser) -> PlayerId {

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3766,7 +3766,7 @@ fn try_parse_choose_owned_by_voter(
 fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
     type E<'a> = OracleError<'a>;
 
-    // CR 608.2c + CR 700.2: A standalone "Choose one." / "Choose one card."
+    // CR 608.2c + CR 608.2d: A standalone "Choose one." / "Choose one card."
     // clause (empty tail) in a resolution chain is the impulse-exile reduction
     // idiom — a preceding clause exiled one or more cards and a following clause
     // grants permission to play one of them ("Exile the top three cards of your
@@ -4740,7 +4740,7 @@ pub(super) fn lower_choose_ast(ast: ChooseImperativeAst) -> Effect {
             choice_optional,
             reveal: true,
         },
-        // CR 700.2: Anaphoric "choose N of them/those" → select from the tracked set
+        // CR 608.2d: Anaphoric "choose N of them/those" → select from the tracked set
         // populated by the preceding effect (RevealTop, RevealHand, ExileTop, etc.).
         ChooseImperativeAst::FromTrackedSet {
             count,
@@ -9136,7 +9136,7 @@ pub(super) fn parse_imperative_family_ast(
                     .map(|ast| ImperativeFamilyAst::Structured(ImperativeAst::HandReveal(ast)))
             }),
 
-        // Choose (CR 700.2)
+        // Choose (CR 608.2d)
         "choose" | "secretly" => parse_choose_discard_rest_of_hand(text, lower)
             .map(|ast| ImperativeFamilyAst::Structured(ImperativeAst::Targeted(ast)))
             .or_else(|| {

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3416,7 +3416,7 @@ pub(super) fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, St
         return (None, text.to_string());
     }
 
-    // CR 700.2 + CR 701.21a + CR 608.2c: "for each player, you choose …" (Tragic
+    // CR 608.2c + CR 608.2d + CR 701.21a: "for each player, you choose …" (Tragic
     // Arrogance → CategoryChooserScope::ControllerForAll) and "for each player,
     // choose … in that player's graveyard/zone" (Breach the Multiverse →
     // ChooseFromZone { zone_owner: EachPlayer }) have DEDICATED dispatchers that

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -4155,7 +4155,7 @@ fn parse_unless_player_have_deal_damage_cost(after_unless: &str) -> Option<Abili
     })
 }
 
-/// CR 700.2 + CR 608.2d: "[DEFAULT] unless that player [A] or [B]" —
+/// CR 608.2d: "[DEFAULT] unless that player [A] or [B]" —
 /// three-branch forced choice. The scoped player picks an avoidance option or
 /// accepts the default consequence. Called before `try_parse_choose_one_of_inline`
 /// to prevent the 2-branch splitter from misreading the left half.
@@ -4893,7 +4893,7 @@ fn retarget_put_counter_to_parent(effect: &mut Effect) {
     }
 }
 
-/// CR 700.2 + CR 608.2d: Detect inline binary-choice imperatives of the form
+/// CR 608.2d: Detect inline binary-choice imperatives of the form
 /// "A or B" where both A and B parse independently as supported effects.
 /// Emits `Effect::ChooseOneOf { branches: [A, B] }` so the second branch is
 /// preserved in card data rather than silently dropped by the single-verb
@@ -7274,12 +7274,12 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return clause;
     }
 
-    // CR 700.2 + CR 118.12a: "[DEFAULT] unless a player has ~ deal N to them".
+    // CR 608.2d + CR 118.12a: "[DEFAULT] unless a player has ~ deal N to them".
     if let Some(clause) = try_parse_unless_player_have_deal_damage(tp, ctx) {
         return clause;
     }
 
-    // CR 700.2 + CR 608.2d: Three-branch "[DEFAULT] unless that player A or B"
+    // CR 608.2d: Three-branch "[DEFAULT] unless that player A or B"
     // forced choice — checked BEFORE the two-branch splitter so the more-specific
     // "unless that player" pattern is matched before the left half is misread as
     // just the default consequence (losing the avoidance alternative).
@@ -7314,7 +7314,7 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return clause;
     }
 
-    // CR 700.2 + CR 608.2d: Inline binary-choice imperative — "discard a card
+    // CR 608.2d: Inline binary-choice imperative — "discard a card
     // or sacrifice a land" (Highway Robbery) and analogous "A or B" patterns
     // that are not bulleted `Choose one —` modals. The split happens BEFORE
     // any single-verb dispatch so the second branch isn't silently dropped

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -6336,7 +6336,7 @@ pub(super) fn parse_followup_continuation_ast(
                 parse_put_chosen_cards_at_library_position(&lower)
                     .map(|position| ContinuationAst::PutChosenCardsAtLibraryPosition { position })
             }),
-        // CR 700.2: "Choose/You choose/An opponent chooses/Target opponent chooses one/two/N
+        // CR 608.2d: "Choose/You choose/An opponent chooses/Target opponent chooses one/two/N
         // of them/those" after ChangeZone, ExileTop, RevealTop, or RevealHand →
         // ChooseFromZone building block
         Effect::ChangeZone { .. }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -35385,7 +35385,7 @@ fn kindred_dominance_excludes_chosen_creature_type() {
 }
 
 // ------------------------------------------------------------------
-// CR 700.2 + CR 608.2d: ChooseOneOf inline binary-choice regression.
+// CR 608.2d: ChooseOneOf inline binary-choice regression.
 // ------------------------------------------------------------------
 
 /// Highway Robbery's spell text "You may discard a card or sacrifice a

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -35,13 +35,15 @@ use crate::types::events::{ClashResult, PlayerActionKind};
 // Supporting types
 // ---------------------------------------------------------------------------
 
-/// CR 700.2: Who makes a choice during an effect's resolution.
+/// CR 608.2c-e: Who makes a choice during an effect's resolution (controller by
+/// default per CR 608.2c; opponent/APNAP ordering per CR 608.2e). Not CR 700.2 —
+/// that defines *modal* choices (picking a bulleted mode), a distinct concept.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Chooser {
     /// The controller of the spell/ability makes the choice.
     #[default]
     Controller,
-    /// An opponent of the controller makes the choice (CR 700.2).
+    /// An opponent of the controller makes the choice (CR 608.2e).
     /// In 2-player, the single opponent. In multiplayer, controller chooses which opponent.
     Opponent,
 }
@@ -5806,7 +5808,7 @@ pub enum AttackScope {
 #[serde(tag = "type")]
 pub enum PlayerFilter {
     /// The controller of the effect or quantity.
-    /// CR 700.2a: the default chooser for any modal/effect player reference.
+    /// CR 608.2c: the controller is the default player for any effect/quantity reference.
     #[default]
     Controller,
     /// All opponents of the controller.
@@ -11417,7 +11419,7 @@ pub enum Effect {
     /// Building block for impulse draw, cascade, hideaway, and similar exile-then-select patterns.
     /// The selection is from the tracked set of the parent effect's result, falling back to
     /// direct zone contents for wordings like "choose a card in your hand."
-    /// CR 700.2: The `chooser` field determines who makes the selection.
+    /// CR 608.2d: The `chooser` field determines who makes the selection.
     ChooseFromZone {
         /// How many cards to choose.
         #[serde(default = "default_one")]
@@ -11479,7 +11481,7 @@ pub enum Effect {
     ForEachCategory {
         /// CR 105.1 / CR 205.2a: Which fixed category's members are iterated.
         category: IterationCategory,
-        /// CR 700.2: Who makes each per-member choice when multiple candidates
+        /// CR 608.2d: Who makes each per-member choice when multiple candidates
         /// exist. Controller by default.
         #[serde(default)]
         chooser: Chooser,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3718,7 +3718,7 @@ pub enum WaitingFor {
         up_to: bool,
         destination: Zone,
     },
-    /// CR 700.2: Player selects card(s) from a tracked set (e.g., exiled cards).
+    /// CR 608.2d: Player selects card(s) from a tracked set (e.g., exiled cards).
     /// Chosen/unchosen cards flow into sub-abilities via pending_continuation,
     /// unlike DigChoice which moves to fixed zones.
     ChooseFromZoneChoice {

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -2371,7 +2371,7 @@ pub(crate) fn deterministic_choice(
         }
     }
 
-    // CR 700.2: ChooseFromZoneChoice — select cards from a tracked set.
+    // CR 608.2d: ChooseFromZoneChoice — select cards from a tracked set.
     if let WaitingFor::ChooseFromZoneChoice {
         cards,
         count,


### PR DESCRIPTION
Closes #5598.

`CR 700.2` defines a *modal* spell (choosing a bulleted mode). It was systemically miscited across the engine for **resolution-time choices of objects and choosers** — choosing cards from a tracked set, resolving the `Chooser` enum, and inline "A or B" forced choices. Those are governed by CR 608.2:

- **CR 608.2c** — the controller is the default actor ("follows its instructions in the order written").
- **CR 608.2d** — general resolution-time choice ("the player announces these while applying the effect").
- **CR 608.2e** — multi-player / APNAP choice ordering (`Chooser::Opponent`).

## What changed

24 annotation sites rewritten across:
- `types/ability.rs` — `Chooser` enum + its `Opponent` variant, `ChooseFromZone`/`ForEachCategory` `chooser` fields, `PlayerFilter::Controller` default.
- `game/effects/choose_from_zone.rs`, `game/effects/choose_card.rs` — card-selection resolution + `resolve_chooser`.
- `types/game_state.rs` — `ChooseFromZoneChoice`; `ai_support/candidates.rs`, `phase-ai/src/search.rs` — AI candidate/deterministic-choice sites.
- `parser/oracle_effect/{mod,imperative,sequence,lower,tests}.rs` — inline binary-choice / anaphoric "choose N of them" object-pick parsers (dropped the redundant-and-wrong `CR 700.2` companion, keeping the already-correct `CR 608.2d`).

## Deliberately left as CR 700.2 (genuinely modal)

Mode selection, pawprint points-budgets, reflexive modal caps — and, notably, `game_state.rs` `modal_modes_chosen_this_turn` / `modal_modes_chosen_this_game`. The issue's table listed those as miscited, but they are **mode-indexed** (`HashSet<(ObjectId, mode_index)>`), so CR 700.2 is correct there and switching them to 608.2 would introduce a fresh miscitation. This is the one divergence from the issue's starting-point table.

## Verification

- `cargo fmt --all` clean.
- Every new CR number re-verified against `docs/MagicCompRules.txt`.
- Comment/annotation-only; doc-/line-comment syntax preserved; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)