### PR TITLE
fix: Block NinjutsuFamily marker from ActivateAbility without paying mana (#5338)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -14529,6 +14529,11 @@ pub fn can_activate_ability_now_with_restriction_gates(
     ) {
         return false;
     }
+    // CR 702.49: Ninjutsu-family marker abilities are not normal activated
+    // abilities — they must route through `GameAction::ActivateNinjutsu`.
+    if super::keywords::is_ninjutsu_family_marker_ability(&ability_def) {
+        return false;
+    }
 
     // CR 702.61a + CR 702.61b: While a spell with split second is on the stack,
     // players can't activate abilities that aren't mana abilities.
@@ -14848,6 +14853,14 @@ pub fn handle_activate_ability(
         ability_def.activator_filter.as_ref(),
     ) {
         return Err(EngineError::NotYourPriority);
+    }
+    // CR 702.49: Ninjutsu-family marker abilities must not use the generic
+    // activated-ability stack path — mana is only paid in `activate_ninjutsu`.
+    if super::keywords::is_ninjutsu_family_marker_ability(&ability_def) {
+        return Err(EngineError::InvalidAction(
+            "Ninjutsu-family abilities must be activated via ActivateNinjutsu (CR 702.49)"
+                .to_string(),
+        ));
     }
     // CR 602.1: Check activation zone — default to battlefield.
     let required_zone = ability_def.activation_zone.unwrap_or(Zone::Battlefield);

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -623,22 +623,9 @@ impl AbilityCost {
             AbilityCost::Waterbend { cost } => {
                 super::casting::can_pay_cost_after_auto_tap(state, player, source, cost)
             }
-            // CR 702.49: Ninjutsu-family marker costs are only paid on the dedicated
-            // `ActivateNinjutsu` path; if this shape is ever consulted, both the
-            // returnable attacker and mana legs must be satisfied (CR 601.2b-g).
-            AbilityCost::NinjutsuFamily { variant, mana_cost } => {
+            AbilityCost::NinjutsuFamily { variant, .. } => {
                 !super::keywords::returnable_creatures_for_variant(state, player, variant)
                     .is_empty()
-                    && super::casting::can_pay_ability_mana_cost_after_auto_tap(
-                        state,
-                        player,
-                        source,
-                        &super::keywords::effective_ninjutsu_mana_cost(
-                            state,
-                            player,
-                            mana_cost.clone(),
-                        ),
-                    )
             }
             // CR 118.3: Effect-as-cost is conservatively treated as payable.
             // Runtime resolution determines actual outcome.

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -623,11 +623,22 @@ impl AbilityCost {
             AbilityCost::Waterbend { cost } => {
                 super::casting::can_pay_cost_after_auto_tap(state, player, source, cost)
             }
-            // CR 702.49: Ninjutsu requires at least one returnable creature for
-            // the variant. Mana affordability is deferred to payment (per CR 601.2g).
-            AbilityCost::NinjutsuFamily { variant, .. } => {
+            // CR 702.49: Ninjutsu-family marker costs are only paid on the dedicated
+            // `ActivateNinjutsu` path; if this shape is ever consulted, both the
+            // returnable attacker and mana legs must be satisfied (CR 601.2b-g).
+            AbilityCost::NinjutsuFamily { variant, mana_cost } => {
                 !super::keywords::returnable_creatures_for_variant(state, player, variant)
                     .is_empty()
+                    && super::casting::can_pay_ability_mana_cost_after_auto_tap(
+                        state,
+                        player,
+                        source,
+                        &super::keywords::effective_ninjutsu_mana_cost(
+                            state,
+                            player,
+                            mana_cost.clone(),
+                        ),
+                    )
             }
             // CR 118.3: Effect-as-cost is conservatively treated as payable.
             // Runtime resolution determines actual outcome.

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -623,6 +623,8 @@ impl AbilityCost {
             AbilityCost::Waterbend { cost } => {
                 super::casting::can_pay_cost_after_auto_tap(state, player, source, cost)
             }
+            // CR 702.49: Ninjutsu requires at least one returnable creature for
+            // the variant. Mana affordability is deferred to payment (per CR 601.2g).
             AbilityCost::NinjutsuFamily { variant, .. } => {
                 !super::keywords::returnable_creatures_for_variant(state, player, variant)
                     .is_empty()

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -5,7 +5,9 @@ use crate::game::combat::AttackTarget;
 use crate::game::game_object::GameObject;
 use crate::game::zone_pipeline::{self, ZoneMoveRequest};
 use crate::parser::oracle_util::parse_subtype;
-use crate::types::ability::{AbilityCost, CastVariantPaid, NinjutsuVariant};
+use crate::types::ability::{
+    AbilityCost, AbilityDefinition, CastVariantPaid, Effect, NinjutsuVariant, RuntimeHandler,
+};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::identifiers::{CardId, ObjectId};
@@ -647,6 +649,34 @@ pub fn returnable_creatures_for_variant(
                 .collect()
         }
     }
+}
+
+/// CR 702.49: Marker activated ability synthesized from a Ninjutsu-family keyword.
+/// Real activation must use `GameAction::ActivateNinjutsu` — the marker's
+/// `AbilityCost::NinjutsuFamily` arm is a no-op in `pay_ability_cost`, so routing
+/// through `GameAction::ActivateAbility` would stack the ability without paying mana.
+pub fn is_ninjutsu_family_marker_ability(ability: &AbilityDefinition) -> bool {
+    if matches!(
+        ability.effect.as_ref(),
+        Effect::RuntimeHandled {
+            handler: RuntimeHandler::NinjutsuFamily
+        }
+    ) {
+        return true;
+    }
+    ability
+        .cost
+        .as_ref()
+        .is_some_and(|cost| matches!(cost, AbilityCost::NinjutsuFamily { .. }))
+}
+
+/// CR 601.2f: Effective ninjutsu-family mana cost after static reductions.
+pub(crate) fn effective_ninjutsu_mana_cost(
+    state: &GameState,
+    player: PlayerId,
+    mana_cost: ManaCost,
+) -> ManaCost {
+    apply_ability_cost_reduction(state, player, "ninjutsu", mana_cost)
 }
 
 /// CR 702.49a-c: Resolve Ninjutsu-family activation.
@@ -2572,5 +2602,27 @@ mod tests {
             None,
             "Flashback (compound-cost kind) must be refused by the single authority",
         );
+    }
+
+    /// CR 702.49: synthesized marker must be classified so it cannot stack via
+    /// `ActivateAbility` without paying mana (issue #5338).
+    #[test]
+    fn ninjutsu_family_marker_ability_is_detected() {
+        use crate::types::ability::{AbilityDefinition, AbilityKind, Effect, RuntimeHandler};
+
+        let marker = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::RuntimeHandled {
+                handler: RuntimeHandler::NinjutsuFamily,
+            },
+        )
+        .cost(AbilityCost::NinjutsuFamily {
+            variant: NinjutsuVariant::Ninjutsu,
+            mana_cost: ManaCost::Cost {
+                shards: vec![crate::types::mana::ManaCostShard::Blue],
+                generic: 0,
+            },
+        });
+        assert!(is_ninjutsu_family_marker_ability(&marker));
     }
 }

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -670,15 +670,6 @@ pub fn is_ninjutsu_family_marker_ability(ability: &AbilityDefinition) -> bool {
         .is_some_and(|cost| matches!(cost, AbilityCost::NinjutsuFamily { .. }))
 }
 
-/// CR 601.2f: Effective ninjutsu-family mana cost after static reductions.
-pub(crate) fn effective_ninjutsu_mana_cost(
-    state: &GameState,
-    player: PlayerId,
-    mana_cost: ManaCost,
-) -> ManaCost {
-    apply_ability_cost_reduction(state, player, "ninjutsu", mana_cost)
-}
-
 /// CR 702.49a-c: Resolve Ninjutsu-family activation.
 ///
 /// Validates the activation, returns the specified creature to its owner's hand,
@@ -2624,5 +2615,9 @@ mod tests {
             },
         });
         assert!(is_ninjutsu_family_marker_ability(&marker));
+
+        let ordinary = AbilityDefinition::new(AbilityKind::Activated, Effect::Proliferate)
+            .cost(AbilityCost::Tap);
+        assert!(!is_ninjutsu_family_marker_ability(&ordinary));
     }
 }

--- a/crates/engine/tests/integration/issue_5338_moon_circuit_hacker_ninjutsu_mana.rs
+++ b/crates/engine/tests/integration/issue_5338_moon_circuit_hacker_ninjutsu_mana.rs
@@ -1,5 +1,7 @@
-//! Issue #5338 — Moon-Circuit Hacker ninjutsu must pay {U}; marker abilities must
-//! not route through `ActivateAbility` (which stacks without paying mana).
+//! Issue #5338 — Synthesized ninjutsu marker abilities on the battlefield must
+//! not route through `GameAction::ActivateAbility` (CR 702.49a: ninjutsu functions
+//! only from hand). The marker's `NinjutsuFamily` cost is a no-op in
+//! `pay_ability_cost`, so the generic activation path would stack without paying mana.
 
 use std::sync::Arc;
 
@@ -10,20 +12,12 @@ use engine::types::ability::{
 use engine::types::actions::GameAction;
 use engine::types::game_state::WaitingFor;
 use engine::types::keywords::Keyword;
-use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::mana::{ManaCost, ManaCostShard};
 use engine::types::phase::Phase;
 
 use super::rules::AttackTarget;
 
-fn moon_circuit_ninjutsu_cost() -> ManaCost {
-    ManaCost::Cost {
-        shards: vec![ManaCostShard::Blue],
-        generic: 0,
-    }
-}
-
 fn moon_circuit_ninjutsu_marker_ability() -> AbilityDefinition {
-    let cost = moon_circuit_ninjutsu_cost();
     AbilityDefinition::new(
         AbilityKind::Activated,
         Effect::RuntimeHandled {
@@ -32,19 +26,23 @@ fn moon_circuit_ninjutsu_marker_ability() -> AbilityDefinition {
     )
     .cost(AbilityCost::NinjutsuFamily {
         variant: NinjutsuVariant::Ninjutsu,
-        mana_cost: cost,
+        mana_cost: ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue],
+            generic: 0,
+        },
     })
 }
 
-fn wire_moon_circuit_hacker(obj: &mut engine::game::game_object::GameObject, with_marker: bool) {
-    let cost = moon_circuit_ninjutsu_cost();
-    obj.keywords.push(Keyword::Ninjutsu(cost.clone()));
+fn wire_moon_circuit_hacker_battlefield_marker(obj: &mut engine::game::game_object::GameObject) {
+    let cost = ManaCost::Cost {
+        shards: vec![ManaCostShard::Blue],
+        generic: 0,
+    };
+    obj.keywords.push(Keyword::Ninjutsu(cost));
     obj.base_keywords = obj.keywords.clone();
-    if with_marker {
-        let marker = moon_circuit_ninjutsu_marker_ability();
-        obj.abilities = Arc::new(vec![marker.clone()]);
-        obj.base_abilities = Arc::new(vec![marker]);
-    }
+    let marker = moon_circuit_ninjutsu_marker_ability();
+    obj.abilities = Arc::new(vec![marker.clone()]);
+    obj.base_abilities = Arc::new(vec![marker]);
 }
 
 fn advance_to_declare_blockers_priority(
@@ -72,94 +70,6 @@ fn advance_to_declare_blockers_priority(
 }
 
 #[test]
-fn moon_circuit_hacker_hand_ninjutsu_not_offered_without_mana() {
-    let mut scenario = GameScenario::new();
-    scenario.at_phase(Phase::PreCombatMain);
-
-    let attacker = scenario.add_creature(P0, "Attacker", 1, 1).id();
-    let hand_hacker = scenario
-        .add_creature_to_hand(P0, "Moon-Circuit Hacker", 1, 3)
-        .id();
-
-    let mut runner = scenario.build();
-    wire_moon_circuit_hacker(
-        runner.state_mut().objects.get_mut(&hand_hacker).unwrap(),
-        false,
-    );
-    advance_to_declare_blockers_priority(&mut runner, attacker);
-
-    runner.state_mut().players[P0.0 as usize].mana_pool.clear();
-
-    let actions = engine::ai_support::legal_actions(runner.state());
-    assert!(
-        !actions.iter().any(|a| matches!(
-            a,
-            GameAction::ActivateNinjutsu {
-                ninjutsu_object_id,
-                creature_to_return,
-            } if *ninjutsu_object_id == hand_hacker && *creature_to_return == attacker
-        )),
-        "ActivateNinjutsu must not be offered with no mana and no tappable sources"
-    );
-
-    let result = runner.act(GameAction::ActivateNinjutsu {
-        ninjutsu_object_id: hand_hacker,
-        creature_to_return: attacker,
-    });
-    assert!(
-        result.is_err(),
-        "forced ActivateNinjutsu must fail without mana"
-    );
-}
-
-#[test]
-fn moon_circuit_hacker_hand_ninjutsu_deducts_blue_mana() {
-    let mut scenario = GameScenario::new();
-    scenario.at_phase(Phase::PreCombatMain);
-
-    let attacker = scenario.add_creature(P0, "Attacker", 1, 1).id();
-    let hand_hacker = scenario
-        .add_creature_to_hand(P0, "Moon-Circuit Hacker", 1, 3)
-        .id();
-
-    let mut runner = scenario.build();
-    wire_moon_circuit_hacker(
-        runner.state_mut().objects.get_mut(&hand_hacker).unwrap(),
-        false,
-    );
-    advance_to_declare_blockers_priority(&mut runner, attacker);
-
-    runner.state_mut().players[P0.0 as usize].mana_pool.clear();
-    runner.state_mut().players[P0.0 as usize]
-        .mana_pool
-        .add(ManaUnit::new(
-            ManaType::Blue,
-            hand_hacker,
-            false,
-            Vec::new(),
-        ));
-
-    let mana_before = runner.state().players[P0.0 as usize].mana_pool.total();
-    runner
-        .act(GameAction::ActivateNinjutsu {
-            ninjutsu_object_id: hand_hacker,
-            creature_to_return: attacker,
-        })
-        .expect("ActivateNinjutsu with {U} in pool should succeed");
-
-    assert_eq!(
-        runner.state().players[P0.0 as usize].mana_pool.total(),
-        mana_before - 1,
-        "ninjutsu must deduct exactly one blue mana"
-    );
-    assert_eq!(
-        runner.state().objects[&hand_hacker].zone,
-        engine::types::zones::Zone::Battlefield,
-        "Moon-Circuit Hacker must enter from hand after ninjutsu"
-    );
-}
-
-#[test]
 fn battlefield_ninjutsu_marker_not_offered_as_activate_ability_without_mana() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
@@ -168,13 +78,12 @@ fn battlefield_ninjutsu_marker_not_offered_as_activate_ability_without_mana() {
     let battlefield_hacker = scenario.add_creature(P0, "Moon-Circuit Hacker", 1, 3).id();
 
     let mut runner = scenario.build();
-    wire_moon_circuit_hacker(
+    wire_moon_circuit_hacker_battlefield_marker(
         runner
             .state_mut()
             .objects
             .get_mut(&battlefield_hacker)
             .unwrap(),
-        true,
     );
     advance_to_declare_blockers_priority(&mut runner, attacker);
 

--- a/crates/engine/tests/integration/issue_5338_moon_circuit_hacker_ninjutsu_mana.rs
+++ b/crates/engine/tests/integration/issue_5338_moon_circuit_hacker_ninjutsu_mana.rs
@@ -1,0 +1,213 @@
+//! Issue #5338 — Moon-Circuit Hacker ninjutsu must pay {U}; marker abilities must
+//! not route through `ActivateAbility` (which stacks without paying mana).
+
+use std::sync::Arc;
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, Effect, NinjutsuVariant, RuntimeHandler,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+use super::rules::AttackTarget;
+
+fn moon_circuit_ninjutsu_cost() -> ManaCost {
+    ManaCost::Cost {
+        shards: vec![ManaCostShard::Blue],
+        generic: 0,
+    }
+}
+
+fn moon_circuit_ninjutsu_marker_ability() -> AbilityDefinition {
+    let cost = moon_circuit_ninjutsu_cost();
+    AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::RuntimeHandled {
+            handler: RuntimeHandler::NinjutsuFamily,
+        },
+    )
+    .cost(AbilityCost::NinjutsuFamily {
+        variant: NinjutsuVariant::Ninjutsu,
+        mana_cost: cost,
+    })
+}
+
+fn wire_moon_circuit_hacker(obj: &mut engine::game::game_object::GameObject, with_marker: bool) {
+    let cost = moon_circuit_ninjutsu_cost();
+    obj.keywords.push(Keyword::Ninjutsu(cost.clone()));
+    obj.base_keywords = obj.keywords.clone();
+    if with_marker {
+        let marker = moon_circuit_ninjutsu_marker_ability();
+        obj.abilities = Arc::new(vec![marker.clone()]);
+        obj.base_abilities = Arc::new(vec![marker]);
+    }
+}
+
+fn advance_to_declare_blockers_priority(
+    runner: &mut engine::game::scenario::GameRunner,
+    attacker: engine::types::identifiers::ObjectId,
+) {
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P1))])
+        .expect("declare attackers");
+    if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+        runner.pass_both_players();
+    }
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::DeclareBlockers { .. }
+    ) {
+        runner
+            .act(GameAction::DeclareBlockers {
+                assignments: vec![],
+            })
+            .expect("declare no blockers");
+    }
+    assert_eq!(runner.state().phase, Phase::DeclareBlockers);
+}
+
+#[test]
+fn moon_circuit_hacker_hand_ninjutsu_not_offered_without_mana() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let attacker = scenario.add_creature(P0, "Attacker", 1, 1).id();
+    let hand_hacker = scenario
+        .add_creature_to_hand(P0, "Moon-Circuit Hacker", 1, 3)
+        .id();
+
+    let mut runner = scenario.build();
+    wire_moon_circuit_hacker(
+        runner.state_mut().objects.get_mut(&hand_hacker).unwrap(),
+        false,
+    );
+    advance_to_declare_blockers_priority(&mut runner, attacker);
+
+    runner.state_mut().players[P0.0 as usize].mana_pool.clear();
+
+    let actions = engine::ai_support::legal_actions(runner.state());
+    assert!(
+        !actions.iter().any(|a| matches!(
+            a,
+            GameAction::ActivateNinjutsu {
+                ninjutsu_object_id,
+                creature_to_return,
+            } if *ninjutsu_object_id == hand_hacker && *creature_to_return == attacker
+        )),
+        "ActivateNinjutsu must not be offered with no mana and no tappable sources"
+    );
+
+    let result = runner.act(GameAction::ActivateNinjutsu {
+        ninjutsu_object_id: hand_hacker,
+        creature_to_return: attacker,
+    });
+    assert!(
+        result.is_err(),
+        "forced ActivateNinjutsu must fail without mana"
+    );
+}
+
+#[test]
+fn moon_circuit_hacker_hand_ninjutsu_deducts_blue_mana() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let attacker = scenario.add_creature(P0, "Attacker", 1, 1).id();
+    let hand_hacker = scenario
+        .add_creature_to_hand(P0, "Moon-Circuit Hacker", 1, 3)
+        .id();
+
+    let mut runner = scenario.build();
+    wire_moon_circuit_hacker(
+        runner.state_mut().objects.get_mut(&hand_hacker).unwrap(),
+        false,
+    );
+    advance_to_declare_blockers_priority(&mut runner, attacker);
+
+    runner.state_mut().players[P0.0 as usize].mana_pool.clear();
+    runner.state_mut().players[P0.0 as usize]
+        .mana_pool
+        .add(ManaUnit::new(
+            ManaType::Blue,
+            hand_hacker,
+            false,
+            Vec::new(),
+        ));
+
+    let mana_before = runner.state().players[P0.0 as usize].mana_pool.total();
+    runner
+        .act(GameAction::ActivateNinjutsu {
+            ninjutsu_object_id: hand_hacker,
+            creature_to_return: attacker,
+        })
+        .expect("ActivateNinjutsu with {U} in pool should succeed");
+
+    assert_eq!(
+        runner.state().players[P0.0 as usize].mana_pool.total(),
+        mana_before - 1,
+        "ninjutsu must deduct exactly one blue mana"
+    );
+    assert_eq!(
+        runner.state().objects[&hand_hacker].zone,
+        engine::types::zones::Zone::Battlefield,
+        "Moon-Circuit Hacker must enter from hand after ninjutsu"
+    );
+}
+
+#[test]
+fn battlefield_ninjutsu_marker_not_offered_as_activate_ability_without_mana() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let attacker = scenario.add_creature(P0, "Attacker", 1, 1).id();
+    let battlefield_hacker = scenario.add_creature(P0, "Moon-Circuit Hacker", 1, 3).id();
+
+    let mut runner = scenario.build();
+    wire_moon_circuit_hacker(
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&battlefield_hacker)
+            .unwrap(),
+        true,
+    );
+    advance_to_declare_blockers_priority(&mut runner, attacker);
+
+    runner.state_mut().players[P0.0 as usize].mana_pool.clear();
+
+    let actions = engine::ai_support::legal_actions(runner.state());
+    assert!(
+        !actions.iter().any(|a| matches!(
+            a,
+            GameAction::ActivateAbility {
+                source_id,
+                ability_index: 0,
+            } if *source_id == battlefield_hacker
+        )),
+        "synthesized NinjutsuFamily marker must not be offered via ActivateAbility"
+    );
+    assert!(
+        !engine::game::casting::can_activate_ability_now(runner.state(), P0, battlefield_hacker, 0),
+        "can_activate_ability_now must reject the ninjutsu marker ability"
+    );
+
+    let stack_before = runner.state().stack.len();
+    let result = runner.act(GameAction::ActivateAbility {
+        source_id: battlefield_hacker,
+        ability_index: 0,
+    });
+    assert!(
+        result.is_err(),
+        "ActivateAbility on ninjutsu marker must be rejected at runtime"
+    );
+    assert_eq!(
+        runner.state().stack.len(),
+        stack_before,
+        "ninjutsu marker must not be put on the stack without paying mana"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -460,6 +460,7 @@ mod issue_5332_gandalf_trigger_doubling;
 mod issue_5334_furious_rise_may_play;
 mod issue_5335_stonehoof_mass_attack;
 mod issue_5336_kodama_mana_value_filter;
+mod issue_5338_moon_circuit_hacker_ninjutsu_mana;
 mod issue_5339_armory_automaton;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;


### PR DESCRIPTION
Closes #5338

## Summary

Moon-Circuit Hacker (and every ninjutsu card) synthesizes a marker activated ability with `AbilityCost::NinjutsuFamily`. That cost is intentionally a no-op in `pay_ability_cost` because real ninjutsu must use `GameAction::ActivateNinjutsu`, which pays mana in `activate_ninjutsu`.

The bug: once a ninja is on the battlefield, the generic `ActivateAbility` path could still offer and stack that marker during declare blockers. `NinjutsuFamily` affordability skipped mana (only checked for a returnable attacker), so the ability reached the stack without spending `{U}` — matching the Discord report of "ninjutsu activations on the stack without spending mana."

This PR:

1. Adds `is_ninjutsu_family_marker_ability` — single classifier for synthesized ninjutsu marker abilities.
2. Rejects marker abilities in `can_activate_ability_now` and `handle_activate_ability` (must use `ActivateNinjutsu`).
3. Tightens `AbilityCost::NinjutsuFamily` payability to require mana affordability (defense in depth).
4. Adds Moon-Circuit Hacker regression tests (hand path pays `{U}`; battlefield marker cannot stack).

The dedicated `ActivateNinjutsu` path was already correct; this closes the stray `ActivateAbility` leak.

## Files changed

- `crates/engine/src/game/keywords.rs` — marker classifier + `effective_ninjutsu_mana_cost` helper
- `crates/engine/src/game/casting.rs` — legality + runtime rejection gates
- `crates/engine/src/game/cost_payability.rs` — `NinjutsuFamily` mana affordability
- `crates/engine/tests/integration/issue_5338_moon_circuit_hacker_ninjutsu_mana.rs` — regression tests
- `crates/engine/tests/integration/main.rs` — mod registration

## Test plan

- [x] `battlefield_ninjutsu_marker_not_offered_as_activate_ability_without_mana` (integration)
- [x] `ninjutsu_family_marker_ability_is_detected` (unit, `game/keywords.rs`)

<sub>Maintainer edit: the two `moon_circuit_hacker_hand_ninjutsu_*` tests were removed along with the unreachable payability leg they covered, so this list now reflects the tests that actually exist at the current head.</sub>

## Verification

```bash
cargo fmt --all
cargo test -p engine issue_5338 -- --nocapture
cargo test -p engine --lib 'game::keywords::tests::ninjutsu_family_marker' -- --nocapture
```

- [x] `cargo fmt --all`
- [x] `cargo test -p engine issue_5338 -- --nocapture`
- [x] `cargo test -p engine --lib 'game::keywords::tests::ninjutsu_family_marker' -- --nocapture`
- [ ] `tilt logs test-engine` (when Tilt is up)


