### PR TITLE
ship/u7 dead pass deletions

### DIFF
--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -28,8 +28,7 @@ use super::lower::{
     apply_where_x_to_latest_def, attach_any_color_mana_rider_to_previous_play_from_exile,
     attach_cast_cost_raise_to_previous_play_from_exile,
     attach_graveyard_redirect_rider_to_prior_cast_from_zone,
-    attach_land_enters_tapped_to_previous_play_from_exile,
-    attach_until_next_same_source_exile_to_previous_play_from_exile, cast_cost_raise_rider,
+    attach_land_enters_tapped_to_previous_play_from_exile, cast_cost_raise_rider,
     consolidate_die_and_coin_defs, definition_targets_self_source,
     effect_publishes_revealed_subject, extract_bounded_target_multi_target,
     extract_exact_target_multi_target, extract_optional_target_multi_target,
@@ -38,7 +37,7 @@ use super::lower::{
     fold_token_it_has_grants_into_token_statics, gate_other_revealed_card_on_multiplayer_reveal,
     gate_reflexive_rider_on_declined_optional_target, is_land_enters_tapped_rider,
     is_linked_exile_cast_bottom_cleanup, is_spend_mana_as_any_color_rider, is_stable_branch_amount,
-    is_until_next_same_source_exile_rider, nest_whenever_this_turn_token_cleanup_delayed_trigger,
+    nest_whenever_this_turn_token_cleanup_delayed_trigger,
     normalize_linked_exile_cast_bottom_cleanup,
     parse_controlled_by_different_players_target_constraint,
     parse_same_zone_owner_target_constraint, parse_total_mana_value_target_constraint,
@@ -1491,12 +1490,6 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
         }
         if is_land_enters_tapped_rider(clause_ir)
             && attach_land_enters_tapped_to_previous_play_from_exile(&mut defs)
-        {
-            prev_boundary = clause_ir.boundary;
-            continue;
-        }
-        if is_until_next_same_source_exile_rider(clause_ir)
-            && attach_until_next_same_source_exile_to_previous_play_from_exile(&mut defs)
         {
             prev_boundary = clause_ir.boundary;
             continue;

--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -46,11 +46,10 @@ use super::lower::{
     patch_self_ref_head_tap_anaphor, resolve_populated_token_anaphors,
     resolve_populated_unsuspect_anaphors, resolve_those_tokens_anaphors,
     rewire_cross_sentence_token_counter_attach, rewire_result_anchored_subchain,
-    rewire_token_attach_sibling, rewrite_counter_instead_target_from_antecedent,
-    rewrite_else_event_context_to_stable, rewrite_else_parent_target_to_self_ref,
-    rewrite_player_anaphor_targets_in_definition, rewrite_those_tokens_from_antecedent,
-    rewrite_two_target_counter_chain, target_choice_timing_for_clause,
-    thread_chosen_damage_source_into_oneshot_effects,
+    rewrite_counter_instead_target_from_antecedent, rewrite_else_event_context_to_stable,
+    rewrite_else_parent_target_to_self_ref, rewrite_player_anaphor_targets_in_definition,
+    rewrite_those_tokens_from_antecedent, rewrite_two_target_counter_chain,
+    target_choice_timing_for_clause, thread_chosen_damage_source_into_oneshot_effects,
 };
 use super::sequence::apply_clause_continuation;
 use super::{
@@ -2118,7 +2117,6 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
     // forward_result branch), so `Attach::resolve` operates on the correct
     // attaching object.
     rewire_cross_sentence_token_counter_attach(&mut result);
-    rewire_token_attach_sibling(&mut result);
     fold_token_it_has_grants_into_token_statics(&mut result);
     fold_copy_spell_gains_haste_and_quoted_grant(&mut result);
     nest_whenever_this_turn_token_cleanup_delayed_trigger(&mut result);

--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -45,11 +45,11 @@ use super::lower::{
     patch_choose_from_zone_counter_continuation_target, patch_population_head_tap_anaphor,
     patch_self_ref_head_tap_anaphor, resolve_populated_token_anaphors,
     resolve_populated_unsuspect_anaphors, resolve_those_tokens_anaphors,
-    rewire_cross_sentence_token_counter_attach, rewire_result_anchored_subchain,
-    rewrite_counter_instead_target_from_antecedent, rewrite_else_event_context_to_stable,
-    rewrite_else_parent_target_to_self_ref, rewrite_player_anaphor_targets_in_definition,
-    rewrite_those_tokens_from_antecedent, rewrite_two_target_counter_chain,
-    target_choice_timing_for_clause, thread_chosen_damage_source_into_oneshot_effects,
+    rewire_result_anchored_subchain, rewrite_counter_instead_target_from_antecedent,
+    rewrite_else_event_context_to_stable, rewrite_else_parent_target_to_self_ref,
+    rewrite_player_anaphor_targets_in_definition, rewrite_those_tokens_from_antecedent,
+    rewrite_two_target_counter_chain, target_choice_timing_for_clause,
+    thread_chosen_damage_source_into_oneshot_effects,
 };
 use super::sequence::apply_clause_continuation;
 use super::{
@@ -2093,6 +2093,9 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
     inject_chosen_color_choice_grant(&mut result, false);
     rewrite_that_type_mana_instead(&mut result);
 
+    fold_token_it_has_grants_into_token_statics(&mut result);
+    fold_copy_spell_gains_haste_and_quoted_grant(&mut result);
+    nest_whenever_this_turn_token_cleanup_delayed_trigger(&mut result);
     // CR 303.4f + CR 301.5b + CR 603.7d: Wire `forward_result: true` on a
     // parent zone-change to Battlefield when the chained sub-ability is an
     // `Attach` gated by `ZoneChangedThisWay`. Without this, the runtime
@@ -2116,10 +2119,6 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
     // card's id as the sub-ability's `source_id` (see `effects/mod.rs`
     // forward_result branch), so `Attach::resolve` operates on the correct
     // attaching object.
-    rewire_cross_sentence_token_counter_attach(&mut result);
-    fold_token_it_has_grants_into_token_statics(&mut result);
-    fold_copy_spell_gains_haste_and_quoted_grant(&mut result);
-    nest_whenever_this_turn_token_cleanup_delayed_trigger(&mut result);
     rewire_result_anchored_subchain(&mut result);
     fold_enters_this_way_counter_rider(&mut result);
     wire_optional_cast_decline_fallback(&mut result);

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -31,10 +31,10 @@ use crate::types::ability::{
     AttackSubject, CastingPermission, Comparator, ConjureSource, ContinuousModification,
     ControllerRef, DamageSource, DelayedTriggerCondition, Duration, Effect, EffectScope,
     FilterProp, GameRestriction, LibraryPosition, ManaSpendPermission, MultiTargetSpec,
-    ObjectScope, PlayPermissionInvalidation, PlayerFilter, PreventionAmount, PreventionScope,
-    PtValue, QuantityExpr, QuantityRef, RestrictionPlayerScope, RoundingMode,
-    SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition, SubAbilityLink,
-    TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
+    ObjectScope, PlayerFilter, PreventionAmount, PreventionScope, PtValue, QuantityExpr,
+    QuantityRef, RestrictionPlayerScope, RoundingMode, SpellStackToGraveyardReplacement,
+    StaticCondition, StaticDefinition, SubAbilityLink, TargetChoiceTiming, TargetFilter,
+    TypeFilter, TypedFilter,
 };
 use crate::types::counter::CounterType;
 use crate::types::game_state::{DistributionUnit, TargetSelectionConstraint};
@@ -1056,20 +1056,6 @@ fn parse_until_next_same_source_exile_invalidation(input: &str) -> OracleResult<
     Ok((input, ()))
 }
 
-pub(super) fn is_until_next_same_source_exile_rider(clause: &ClauseIr) -> bool {
-    let lower = clause
-        .source
-        .fragment()
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    nom_on_lower(
-        clause.source.fragment().unwrap_or_default().trim(),
-        lower.trim(),
-        |i| all_consuming(parse_until_next_same_source_exile_invalidation).parse(i),
-    )
-    .is_some()
-}
-
 /// Walk the previous def and its `sub_ability` chain for a `PlayFromExile`
 /// permission. The grant produced by the compound "exile … and may play that
 /// card" chain (Lightstall Inquisitor) lands as a sibling def during the lower
@@ -1124,22 +1110,6 @@ pub(super) fn attach_land_enters_tapped_to_previous_play_from_exile(
         return false;
     };
     *land_enter_tapped = EtbTapState::Tapped;
-    true
-}
-
-pub(super) fn attach_until_next_same_source_exile_to_previous_play_from_exile(
-    defs: &mut [AbilityDefinition],
-) -> bool {
-    let Some(CastingPermission::PlayFromExile {
-        duration,
-        invalidation,
-        ..
-    }) = find_prev_play_from_exile_permission_mut(defs)
-    else {
-        return false;
-    };
-    *duration = Duration::Permanent;
-    *invalidation = Some(PlayPermissionInvalidation::UntilNextGrantFromSameSource);
     true
 }
 

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2244,52 +2244,6 @@ fn rewrite_populated_anaphor_in_def(def: &mut AbilityDefinition) {
     }
 }
 
-/// CR 608.2c + CR 122.6 + CR 614.1c: Fractal Harness class — sentence
-/// splitting lowers token creation and a sibling `PutCounter` targeting
-/// `SelfRef` (the ETB source). Preserve `Token -> PutCounter -> Attach` as
-/// separate instructions; rebind anaphoric targets to `LastCreated`.
-pub(super) fn rewire_cross_sentence_token_counter_attach(def: &mut AbilityDefinition) {
-    if !matches!(&*def.effect, Effect::Token { .. }) {
-        return;
-    }
-    let Some(put_box) = def.sub_ability.take() else {
-        return;
-    };
-    let mut put_sub = *put_box;
-    if put_sub.sub_link != SubAbilityLink::SequentialSibling {
-        def.sub_ability = Some(Box::new(put_sub));
-        return;
-    }
-    let Effect::PutCounter { target, .. } = put_sub.effect.as_ref() else {
-        def.sub_ability = Some(Box::new(put_sub));
-        return;
-    };
-    if !matches!(target, TargetFilter::SelfRef | TargetFilter::ParentTarget) {
-        def.sub_ability = Some(Box::new(put_sub));
-        return;
-    }
-    let attach_sub = match put_sub.sub_ability.take() {
-        Some(sub) if matches!(&*sub.effect, Effect::Attach { .. }) => sub,
-        other => {
-            put_sub.sub_ability = other;
-            def.sub_ability = Some(Box::new(put_sub));
-            return;
-        }
-    };
-
-    if let Effect::PutCounter { target, .. } = &mut *put_sub.effect {
-        *target = TargetFilter::LastCreated;
-    }
-    put_sub.sub_link = SubAbilityLink::ContinuationStep;
-
-    let mut attach_sub = *attach_sub;
-    attach_sub.sub_link = SubAbilityLink::ContinuationStep;
-    rewrite_parent_target_to_last_created(&mut attach_sub.effect);
-
-    put_sub.sub_ability = Some(Box::new(attach_sub));
-    def.sub_ability = Some(Box::new(put_sub));
-}
-
 /// CR 111.3 + CR 702.6a: Intrinsic token statics (Equipment tokens with Equip,
 /// Urza's Saga Construct-style explicit permanent grants) belong on the token's
 /// own `static_abilities`. Transient resolution-time grants — keyword pumps and

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2290,42 +2290,6 @@ pub(super) fn rewire_cross_sentence_token_counter_attach(def: &mut AbilityDefini
     def.sub_ability = Some(Box::new(put_sub));
 }
 
-/// CR 608.2c + CR 301.5b: Token creation followed by a sibling `Attach`
-/// ("create a Kor Soldier token. You may attach an Equipment you control to
-/// it") — the bare-"it" host anaphor must target `LastCreated`, not the
-/// source object or parent trigger subject (the token-creating effect has no
-/// parent target slot).
-pub(super) fn rewire_token_attach_sibling(def: &mut AbilityDefinition) {
-    // Walk the whole sub-ability chain: the token + bare-Attach pair is not
-    // always at the root. Field-Tested Frying Pan ("create a Food token, then
-    // create a 1/1 white Halfling creature token and attach this Equipment to
-    // it") nests the Attach under the *second* token, so a root-only check would
-    // miss it and leave "it" bound to ParentTarget/TriggeringSource (which has no
-    // referent here) instead of the just-created token.
-    let mut node: Option<&mut AbilityDefinition> = Some(def);
-    while let Some(current) = node {
-        if matches!(&*current.effect, Effect::Token { .. }) {
-            if let Some(sub) = current.sub_ability.as_mut() {
-                // Token → PutCounter → Attach is owned by
-                // `rewire_cross_sentence_token_counter_attach`.
-                if !matches!(&*sub.effect, Effect::PutCounter { .. }) {
-                    if let Effect::Attach { target, .. } = sub.effect.as_mut() {
-                        if matches!(
-                            target,
-                            TargetFilter::SelfRef
-                                | TargetFilter::ParentTarget
-                                | TargetFilter::TriggeringSource
-                        ) {
-                            *target = TargetFilter::LastCreated;
-                        }
-                    }
-                }
-            }
-        }
-        node = current.sub_ability.as_deref_mut();
-    }
-}
-
 /// CR 111.3 + CR 702.6a: Intrinsic token statics (Equipment tokens with Equip,
 /// Urza's Saga Construct-style explicit permanent grants) belong on the token's
 /// own `static_abilities`. Transient resolution-time grants — keyword pumps and

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -7531,8 +7531,7 @@ mod tests {
         // Field-Tested Frying Pan (#835): "create a 1/1 white Halfling creature
         // token and attach this Equipment to it" — "attach " is an imperative game
         // action, so the conjunct must peel into its own clause and lower to a
-        // Token -> Attach sibling (rewire_token_attach_sibling rebinds onto
-        // LastCreated). Without the split the attach is silently dropped.
+        // Token -> Attach sibling. Without the split the attach is silently dropped.
         let chunks = clause_texts(
             "create a 1/1 white Halfling creature token and attach this Equipment to it",
         );

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -433,16 +433,10 @@ pub(super) fn parse_choice_partition_destination(
     .parse(input)
 }
 
-fn append_definition_to_sub_chain(ability: &mut AbilityDefinition, mut next: AbilityDefinition) {
+fn append_definition_to_sub_chain(ability: &mut AbilityDefinition, next: AbilityDefinition) {
     let mut cursor = ability;
     loop {
         if cursor.sub_ability.is_none() {
-            if cursor.optional
-                && super::lower::is_linked_exile_cast_bottom_cleanup(&cursor.effect, &next.effect)
-            {
-                super::lower::normalize_linked_exile_cast_bottom_cleanup(&mut next.effect);
-                cursor.else_ability = Some(Box::new(next.clone()));
-            }
             cursor.sub_ability = Some(Box::new(next));
             break;
         }


### PR DESCRIPTION
- **refactor(parser): delete dead shape-repair pass rewire_token_attach_sibling (U7)**
- **refactor(parser): delete dead shape-repair pass rewire_cross_sentence_token_counter_attach (U7)**
- **refactor(parser): delete dead until-next-same-source-exile rider pass + guard (U7)**
- **refactor(parser): excise dead linked-exile-cast inline block from append_definition_to_sub_chain (U7)**
