### PR TITLE
fix(client): atomic engine snapshots + revision-gated commit authority to fix P2P split-epoch softlock

### DIFF
--- a/client/src/adapter/__tests__/contract-fixtures.test.ts
+++ b/client/src/adapter/__tests__/contract-fixtures.test.ts
@@ -120,10 +120,15 @@ describe("shared adapter contract fixtures", () => {
 
     ws.dispatchSynthetic("message", JSON.stringify(stateUpdateFixture));
 
+    // The engine pair now travels as one seq-stamped `EngineSnapshot`, so the
+    // state is asserted through `snapshot.state` rather than a sibling field.
     expect(listener).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "stateChanged",
-        state: stateUpdateFixture.data.state,
+        snapshot: expect.objectContaining({
+          state: expect.objectContaining(stateUpdateFixture.data.state),
+          seq: expect.any(Number),
+        }),
         events: stateUpdateFixture.data.events,
       }),
     );

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -12,7 +12,7 @@ import type Peer from "peerjs";
 import type { DataConnection } from "peerjs";
 
 import { P2PGuestAdapter, P2PHostAdapter, playerSlotsFromSeatView } from "../p2p-adapter";
-import type { FormatConfig, GameEvent, GameLogEntry, GameState } from "../types";
+import type { FormatConfig, GameAction, GameEvent, GameLogEntry, GameState } from "../types";
 import { FakeDataConnection } from "../../network/__tests__/fakeDataConnection";
 import { WIRE_PROTOCOL_VERSION } from "../../network/protocol";
 
@@ -43,13 +43,30 @@ vi.mock("../../network/protocol", async (orig) => {
 // ── Mock the WasmAdapter so we don't need an actual WASM build ─────────────
 // `vi.hoisted` lets us share these refs with the hoisted vi.mock factory.
 const mocks = vi.hoisted(() => {
+  const getState = vi.fn(async () => ({ players: [], objects: {} }));
+  const getLegalActions = vi.fn(async () => ({
+    actions: [],
+    autoPassRecommended: false,
+  }));
+  // Local monotonic stamp — the hoisted factory runs before imports, so it
+  // can't call the adapter module's `nextSnapshotSeq`. Only ordering matters
+  // to these assertions, and `seq` is never compared across clients.
+  let seq = 0;
   return {
     initialize: vi.fn(async () => undefined),
     submitAction: vi.fn(async (_action: unknown) => ({ events: [] })),
-    getState: vi.fn(async () => ({ players: [], objects: {} })),
-    getLegalActions: vi.fn(async () => ({
-      actions: [],
-      autoPassRecommended: false,
+    getState,
+    getLegalActions,
+    /**
+     * Reads through the SAME `getState`/`getLegalActions` mocks the tests
+     * script with `mockResolvedValueOnce`, so a host AI-loop iteration consumes
+     * exactly the two `getState` values it always did (loop-top read + the
+     * post-submit pair read) and every scripted sequence still lines up.
+     */
+    getSnapshot: vi.fn(async () => ({
+      state: await getState(),
+      legalResult: await getLegalActions(),
+      seq: ++seq,
     })),
     getLegalActionsForViewer: vi.fn(async (_pid: number) => ({
       actions: [],
@@ -193,6 +210,7 @@ vi.mock("../wasm-adapter", () => ({
       submitAction: mocks.submitAction,
       getState: mocks.getState,
       getLegalActions: mocks.getLegalActions,
+      getSnapshot: mocks.getSnapshot,
       getLegalActionsForViewer: mocks.getLegalActionsForViewer,
       getFilteredState: mocks.getFilteredState,
       getViewerSnapshot: mocks.getViewerSnapshot,
@@ -1190,13 +1208,68 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
       autoPassRecommended: false,
     });
 
+    // The engine pair now travels as one seq-stamped `EngineSnapshot`.
     expect(emitted).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "stateChanged",
-        state: unsolicitedState,
+        snapshot: expect.objectContaining({
+          state: unsolicitedState,
+          seq: expect.any(Number),
+        }),
         events: unsolicitedEvents,
         logEntries: unsolicitedLogs,
       }),
     );
+  });
+
+  it("guest snapshots stay coherent and strictly ordered across successive state updates", async () => {
+    const { peer } = createFakePeer();
+    const conn = new FakeDataConnection();
+    const adapter = new P2PGuestAdapter(
+      { player: { main_deck: [], sideboard: [] } },
+      peer as unknown as Peer,
+      "host-peer",
+      conn as unknown as DataConnection,
+    );
+    await adapter.initialize();
+
+    /** One inbound host update carrying a state and the legal actions derived from it. */
+    const pushUpdate = (label: string, actions: GameAction[]) =>
+      conn.simulateData({
+        type: "state_update",
+        state: remoteState(label),
+        events: [],
+        legalActions: actions,
+        autoPassRecommended: false,
+      });
+
+    const passPriority = [{ type: "PassPriority" }] as unknown as GameAction[];
+    const decideOptional = [
+      { type: "DecideOptionalEffect", data: { accept: true } },
+    ] as unknown as GameAction[];
+
+    await pushUpdate("first", passPriority);
+    const first = await adapter.getSnapshot();
+
+    // Coherence: the pair in a snapshot is the pair that arrived together.
+    expect((first.state as unknown as { label: string }).label).toBe("first");
+    expect(first.legalResult.actions).toEqual(passPriority);
+
+    // And the un-paired reads are served from that SAME cached snapshot, so they
+    // cannot straddle two updates the way two independent fields could.
+    expect(await adapter.getState()).toBe(first.state);
+    expect(await adapter.getLegalActions()).toBe(first.legalResult);
+
+    await pushUpdate("second", decideOptional);
+    const second = await adapter.getSnapshot();
+
+    // The second update replaces BOTH halves together — never one without the
+    // other. A `state:"second"` paired with the first update's `PassPriority`
+    // actions is precisely the mixed pair that softlocked the host.
+    expect((second.state as unknown as { label: string }).label).toBe("second");
+    expect(second.legalResult.actions).toEqual(decideOptional);
+
+    // Strictly increasing stamps let the store's gate order these commits.
+    expect(second.seq).toBeGreaterThan(first.seq);
   });
 });

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -146,10 +146,14 @@ describe("WebSocketAdapter", () => {
         }),
       );
 
+      // The engine pair now travels as one seq-stamped `EngineSnapshot`.
       expect(listener).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "stateChanged",
-          state: mockState,
+          snapshot: expect.objectContaining({
+            state: expect.objectContaining(mockState),
+            seq: expect.any(Number),
+          }),
           events: mockEvents,
           logEntries: mockLogEntries,
         }),

--- a/client/src/adapter/engine-worker-client.ts
+++ b/client/src/adapter/engine-worker-client.ts
@@ -232,6 +232,19 @@ export class EngineWorkerClient {
     );
   }
 
+  /**
+   * Atomic state + legal-actions read. The worker services this as one
+   * synchronous block, so the pair can never straddle an engine advance.
+   * Same timeout class as `getState`. The caller (`WasmAdapter.getSnapshot`)
+   * stamps the `seq` on arrival.
+   */
+  async getSnapshot(): Promise<{ state: GameState; legalResult: LegalActionsResult }> {
+    return this.request<{ state: GameState; legalResult: LegalActionsResult }>(
+      { type: "getSnapshot" },
+      ENGINE_REQUEST_TIMEOUT_MS,
+    );
+  }
+
   async getLegalActionsForViewer(viewerId: number): Promise<LegalActionsResult> {
     return this.request<LegalActionsResult>(
       { type: "getLegalActionsForViewer", viewerId },

--- a/client/src/adapter/engine-worker.ts
+++ b/client/src/adapter/engine-worker.ts
@@ -60,6 +60,7 @@ type EngineRequest =
   | { type: "getState"; id: number }
   | { type: "getFilteredState"; id: number; viewerId: number }
   | { type: "getLegalActions"; id: number }
+  | { type: "getSnapshot"; id: number }
   | { type: "getLegalActionsForViewer"; id: number; viewerId: number }
   | { type: "getViewerSnapshot"; id: number; viewerId: number }
   | { type: "getAiAction"; id: number; difficulty: string; playerId: number }
@@ -286,6 +287,25 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
           break;
         }
         result(msg.id, r);
+        break;
+      }
+
+      case "getSnapshot": {
+        // Atomicity guarantee: these two reads form ONE synchronous block with
+        // no yield point between them, and the only engine mutation
+        // (`submit_action`) is itself a single synchronous call. This handler
+        // is `async` and handlers CAN interleave at await points (e.g.
+        // submitAction's Debug/CreateCard card-DB fetch), so the absence of an
+        // `await` between the two calls below is exactly what makes the pair
+        // atomic: a snapshot can never observe a half-applied action, nor
+        // straddle two engine versions.
+        const state = get_game_state();
+        const legalResult = get_legal_actions_js();
+        if (state === null || legalResult === null) {
+          error(msg.id, "NOT_INITIALIZED: get_game_state/get_legal_actions_js returned null");
+          break;
+        }
+        result(msg.id, { state, legalResult });
         break;
       }
 

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -3,6 +3,7 @@ import type { DataConnection } from "peerjs";
 
 import type {
   EngineAdapter,
+  EngineSnapshot,
   FormatConfig,
   GameAction,
   GameEvent,
@@ -16,7 +17,7 @@ import type {
 } from "./types";
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 
-import { AdapterError, AdapterErrorCode } from "./types";
+import { AdapterError, AdapterErrorCode, EMPTY_LEGAL_ACTIONS, nextSnapshotSeq } from "./types";
 import { WasmAdapter } from "./wasm-adapter";
 import { createPeerSession, type PeerSession } from "../network/peer";
 import type { P2PMessage } from "../network/protocol";
@@ -61,10 +62,15 @@ export type P2PAdapterEvent =
    */
   | { type: "hostingFailed"; reason: "room_still_claimed"; message: string }
   | {
+      /**
+       * The engine pair travels as ONE `EngineSnapshot` rather than separate
+       * `state`/`legalResult` fields: the two halves plus their ordering stamp
+       * stay inseparable by construction, so no consumer can pair a state from
+       * one engine version with legal actions from another.
+       */
       type: "stateChanged";
-      state: GameState;
+      snapshot: EngineSnapshot;
       events: GameEvent[];
-      legalResult: LegalActionsResult;
       logEntries?: GameLogEntry[];
     }
   // 3-4p multiplayer additions:
@@ -730,13 +736,10 @@ export class P2PHostAdapter implements EngineAdapter {
       }
       const result = await this.wasm.submitAction(action, actor);
       await this.broadcastStateUpdate(result.events, result.log_entries);
-      const nextState = await this.wasm.getState();
-      const legalResult = await this.wasm.getLegalActions();
       this.emit({
         type: "stateChanged",
-        state: nextState,
+        snapshot: await this.wasm.getSnapshot(),
         events: result.events,
-        legalResult,
         logEntries: result.log_entries,
       });
     }
@@ -1110,6 +1113,15 @@ export class P2PHostAdapter implements EngineAdapter {
     return this.wasm.getLegalActions();
   }
 
+  /** The host owns the engine — delegate to the inner WASM adapter, which
+   *  stamps the seq when the worker response arrives. (The broadcast path
+   *  `getViewerSnapshot` deliberately does NOT consume the counter: guests
+   *  stamp arrival order on their own ordered channel, and `seq` is never
+   *  compared across clients.) */
+  async getSnapshot(): Promise<EngineSnapshot> {
+    return this.wasm.getSnapshot();
+  }
+
   getAiAction(_difficulty: string, _playerId: number): GameAction | null {
     return null;
   }
@@ -1263,13 +1275,10 @@ export class P2PHostAdapter implements EngineAdapter {
           // and the game stalls (same pattern as concedePlayer/host submit).
           await this.runAiLoop();
           // Emit local stateChanged so host UI updates for opponent actions.
-          const state = await this.wasm.getState();
-          const legalResult = await this.wasm.getLegalActions();
           this.emit({
             type: "stateChanged",
-            state,
+            snapshot: await this.wasm.getSnapshot(),
             events: result.events,
-            legalResult,
             logEntries: result.log_entries,
           });
         } catch (err) {
@@ -1462,13 +1471,10 @@ export class P2PHostAdapter implements EngineAdapter {
       const result = await this.wasm.submitAction(concedeAction, pid);
       await this.broadcastStateUpdate(result.events, result.log_entries);
       await this.runAiLoop();
-      const state = await this.wasm.getState();
-      const legalResult = await this.wasm.getLegalActions();
       this.emit({
         type: "stateChanged",
-        state,
+        snapshot: await this.wasm.getSnapshot(),
         events: result.events,
-        legalResult,
         logEntries: result.log_entries,
       });
       this.emit(
@@ -1590,11 +1596,15 @@ export class P2PHostAdapter implements EngineAdapter {
  * applies host-broadcasted state updates locally.
  */
 export class P2PGuestAdapter implements EngineAdapter {
-  private gameState: GameState | null = null;
-  private legalActions: LegalActionsResult = {
-    actions: [],
-    autoPassRecommended: false,
-  };
+  /**
+   * The single cached engine pair, rebuilt (and re-stamped) once per inbound
+   * state-bearing message — `game_setup`, `reconnect_ack`, `state_update`.
+   * `getState`/`getLegalActions` both read from THIS object, so they can no
+   * longer straddle two updates the way two independently-cached fields could.
+   * The host's ordered DataChannel delivers updates in engine order, so
+   * stamping on arrival reproduces that order exactly.
+   */
+  private snapshot: EngineSnapshot | null = null;
   private listeners: P2PAdapterEventListener[] = [];
   private pendingResolve: ((result: SubmitResult) => void) | null = null;
   private pendingReject: ((error: Error) => void) | null = null;
@@ -1720,14 +1730,28 @@ export class P2PGuestAdapter implements EngineAdapter {
   }
 
   async getState(): Promise<GameState> {
-    if (!this.gameState) {
+    if (!this.snapshot) {
       throw new AdapterError("P2P_ERROR", "No game state available", false);
     }
-    return this.gameState;
+    return this.snapshot.state;
   }
 
   async getLegalActions(): Promise<LegalActionsResult> {
-    return this.legalActions;
+    return this.snapshot?.legalResult ?? EMPTY_LEGAL_ACTIONS;
+  }
+
+  async getSnapshot(): Promise<EngineSnapshot> {
+    if (!this.snapshot) {
+      throw new AdapterError("P2P_ERROR", "No game state available", false);
+    }
+    return this.snapshot;
+  }
+
+  /** Rebuild the cached pair from an inbound state-bearing message, stamping
+   *  it with a fresh globally-monotonic seq at arrival. */
+  private cacheSnapshot(state: GameState, legalResult: LegalActionsResult): EngineSnapshot {
+    this.snapshot = { state, legalResult, seq: nextSnapshotSeq() };
+    return this.snapshot;
   }
 
   getAiAction(_difficulty: string, _playerId: number): GameAction | null {
@@ -1765,8 +1789,7 @@ export class P2PGuestAdapter implements EngineAdapter {
     } catch {
       /* best-effort */
     }
-    this.gameState = null;
-    this.legalActions = { actions: [], autoPassRecommended: false };
+    this.snapshot = null;
     this.pendingResolve = null;
     this.pendingReject = null;
     this.listeners = [];
@@ -1800,8 +1823,7 @@ export class P2PGuestAdapter implements EngineAdapter {
           playerToken: msg.playerToken,
           playerId: msg.assignedPlayerId,
         });
-        this.gameState = msg.state;
-        this.legalActions = legalActionsFromWire(msg);
+        this.cacheSnapshot(msg.state, legalActionsFromWire(msg));
         this.emit({ type: "playerIdentity", playerId: msg.assignedPlayerId, playerNames: msg.playerNames });
         this.settleGameSetup({ events: msg.events });
         break;
@@ -1814,14 +1836,12 @@ export class P2PGuestAdapter implements EngineAdapter {
             playerId: msg.assignedPlayerId,
           });
         }
-        this.gameState = msg.state;
-        this.legalActions = legalActionsFromWire(msg);
+        const reconnectSnapshot = this.cacheSnapshot(msg.state, legalActionsFromWire(msg));
         this.emit({ type: "playerIdentity", playerId: msg.assignedPlayerId, playerNames: msg.playerNames });
         this.emit({
           type: "stateChanged",
-          state: msg.state,
+          snapshot: reconnectSnapshot,
           events: [],
-          legalResult: this.legalActions,
         });
         // Resolve `initializeGame()` for the reconnect path too. Reconnecting
         // guests never receive `game_setup`; without this they would hang.
@@ -1857,8 +1877,7 @@ export class P2PGuestAdapter implements EngineAdapter {
         break;
       }
       case "state_update": {
-        this.gameState = msg.state;
-        this.legalActions = legalActionsFromWire(msg);
+        const updateSnapshot = this.cacheSnapshot(msg.state, legalActionsFromWire(msg));
         if (this.pendingResolve) {
           this.pendingResolve({ events: msg.events, log_entries: msg.logEntries });
           this.pendingResolve = null;
@@ -1866,9 +1885,8 @@ export class P2PGuestAdapter implements EngineAdapter {
         } else {
           this.emit({
             type: "stateChanged",
-            state: msg.state,
+            snapshot: updateSnapshot,
             events: msg.events,
-            legalResult: this.legalActions,
             logEntries: msg.logEntries,
           });
         }

--- a/client/src/adapter/replay-adapter.ts
+++ b/client/src/adapter/replay-adapter.ts
@@ -1,6 +1,7 @@
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 import type {
   EngineAdapter,
+  EngineSnapshot,
   GameAction,
   GameState,
   LegalActionsResult,
@@ -83,6 +84,14 @@ export class ReplayAdapter implements EngineAdapter {
 
   async getLegalActions(): Promise<LegalActionsResult> {
     return { actions: [], autoPassRecommended: false, spellCosts: {}, legalActionsByObject: {} };
+  }
+
+  /** Same "no single current state" contract as `getState` — the Replay Viewer
+   *  drives the store via `seek()`, never through the snapshot commit path. */
+  getSnapshot(): Promise<EngineSnapshot> {
+    return Promise.reject(
+      new Error("ReplayAdapter has no single current state — call seek(index) instead"),
+    );
   }
 
   getAiAction(): Promise<GameAction | null> {

--- a/client/src/adapter/server-draft-adapter.ts
+++ b/client/src/adapter/server-draft-adapter.ts
@@ -1,5 +1,6 @@
 import type {
   EngineAdapter,
+  EngineSnapshot,
   GameAction,
   GameEvent,
   GameLogEntry,
@@ -9,7 +10,7 @@ import type {
   PlayerId,
   SubmitResult,
 } from "./types";
-import { AdapterError, AdapterErrorCode } from "./types";
+import { AdapterError, AdapterErrorCode, EMPTY_LEGAL_ACTIONS, nextSnapshotSeq } from "./types";
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 import {
   HandshakeError,
@@ -92,9 +93,13 @@ export class ServerDraftAdapter implements EngineAdapter {
   private draftView: DraftPlayerView | null = null;
 
   // ── Game-phase state ───────────────────────────────────────────────
-  private gameState: GameState | null = null;
+  /**
+   * The single cached engine pair, rebuilt (and re-stamped) once per inbound
+   * state-bearing message — same pattern as the P2P guest / ws adapters, so
+   * `getState`/`getLegalActions` can never straddle two updates.
+   */
+  private snapshot: EngineSnapshot | null = null;
   private _playerId: PlayerId | null = null;
-  private _legalActions: LegalActionsResult = { actions: [], autoPassRecommended: false };
   private activeMatchId: string | null = null;
   private _gameCode: string | null = null;
 
@@ -188,10 +193,10 @@ export class ServerDraftAdapter implements EngineAdapter {
   }
 
   async getState(): Promise<GameState> {
-    if (!this.gameState) {
+    if (!this.snapshot) {
       throw new AdapterError("WS_ERROR", "No game state available", false);
     }
-    return this.gameState;
+    return this.snapshot.state;
   }
 
   getAiAction(): GameAction | null {
@@ -199,7 +204,21 @@ export class ServerDraftAdapter implements EngineAdapter {
   }
 
   async getLegalActions(): Promise<LegalActionsResult> {
-    return this._legalActions;
+    return this.snapshot?.legalResult ?? EMPTY_LEGAL_ACTIONS;
+  }
+
+  async getSnapshot(): Promise<EngineSnapshot> {
+    if (!this.snapshot) {
+      throw new AdapterError("WS_ERROR", "No game state available", false);
+    }
+    return this.snapshot;
+  }
+
+  /** Rebuild the cached pair from an inbound state-bearing message, stamping
+   *  it with a fresh globally-monotonic seq at arrival. */
+  private cacheSnapshot(state: GameState, legalResult: LegalActionsResult): EngineSnapshot {
+    this.snapshot = { state, legalResult, seq: nextSnapshotSeq() };
+    return this.snapshot;
   }
 
   restoreState(): void {
@@ -561,19 +580,21 @@ export class ServerDraftAdapter implements EngineAdapter {
           legal_actions_by_object?: Record<string, GameAction[]>;
           derived?: GameState["derived"];
         };
-        this.gameState = { ...data.state, derived: data.derived ?? data.state.derived };
+        const startedSnapshot = this.cacheSnapshot(
+          { ...data.state, derived: data.derived ?? data.state.derived },
+          {
+            actions: data.legal_actions ?? [],
+            autoPassRecommended: data.auto_pass_recommended ?? false,
+            spellCosts: data.spell_costs,
+            legalActionsByObject: data.legal_actions_by_object,
+          },
+        );
         this._playerId = data.your_player;
-        this._legalActions = {
-          actions: data.legal_actions ?? [],
-          autoPassRecommended: data.auto_pass_recommended ?? false,
-          spellCosts: data.spell_costs,
-          legalActionsByObject: data.legal_actions_by_object,
-        };
         this.emit({
           type: "gameStateUpdated",
-          state: this.gameState,
+          state: startedSnapshot.state,
           events: [],
-          legalResult: this._legalActions,
+          legalResult: startedSnapshot.legalResult,
         });
         break;
       }
@@ -589,13 +610,15 @@ export class ServerDraftAdapter implements EngineAdapter {
           log_entries?: GameLogEntry[];
           derived?: GameState["derived"];
         };
-        this.gameState = { ...data.state, derived: data.derived ?? data.state.derived };
-        this._legalActions = {
-          actions: data.legal_actions ?? [],
-          autoPassRecommended: data.auto_pass_recommended ?? false,
-          spellCosts: data.spell_costs,
-          legalActionsByObject: data.legal_actions_by_object,
-        };
+        const updateSnapshot = this.cacheSnapshot(
+          { ...data.state, derived: data.derived ?? data.state.derived },
+          {
+            actions: data.legal_actions ?? [],
+            autoPassRecommended: data.auto_pass_recommended ?? false,
+            spellCosts: data.spell_costs,
+            legalActionsByObject: data.legal_actions_by_object,
+          },
+        );
         if (this.pendingResolve) {
           this.emit({ type: "actionPendingChanged", pending: false });
           this.pendingResolve({ events: data.events, log_entries: data.log_entries });
@@ -604,9 +627,9 @@ export class ServerDraftAdapter implements EngineAdapter {
         } else {
           this.emit({
             type: "gameStateUpdated",
-            state: this.gameState,
+            state: updateSnapshot.state,
             events: data.events,
-            legalResult: this._legalActions,
+            legalResult: updateSnapshot.legalResult,
             logEntries: data.log_entries,
           });
         }
@@ -633,7 +656,7 @@ export class ServerDraftAdapter implements EngineAdapter {
         this.phase = "between_rounds";
         this.activeMatchId = null;
         this._gameCode = null;
-        this.gameState = null;
+        this.snapshot = null;
         this.emit({ type: "actionPendingChanged", pending: false });
         this.emit({
           type: "gameOver",
@@ -757,7 +780,7 @@ export class ServerDraftAdapter implements EngineAdapter {
       this.ws.close();
       this.ws = null;
     }
-    this.gameState = null;
+    this.snapshot = null;
     this._playerId = null;
     this._gameCode = null;
     this.draftCode = null;

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2721,6 +2721,60 @@ export interface BatchResolveResult {
 }
 
 /**
+ * A `GameState` and the `LegalActionsResult` derived from that exact engine
+ * version, captured with no interleaving window between them.
+ *
+ * The two halves MUST be produced together (one worker round-trip, or one
+ * inbound wire message) and travel together thereafter. Fetching them as two
+ * separate adapter calls lets an engine advance land between them, producing a
+ * pair like `waiting_for = Priority` + `[DecideOptionalEffect]` legal actions —
+ * the UI then renders affordances the engine rejects, and the game softlocks.
+ */
+export interface EngineSnapshot {
+  state: GameState;
+  legalResult: LegalActionsResult;
+  /**
+   * Globally monotonic ordering stamp. Larger = derived from a newer engine
+   * version. Compared only within one store (never across clients); the store's
+   * commit authority drops pairs stamped older than the last one it committed.
+   */
+  seq: number;
+}
+
+/**
+ * Monotonic counter behind `EngineSnapshot.seq`, shared by EVERY adapter
+ * instance in the tab.
+ *
+ * Module-global (not per-adapter) on purpose: adapters are recreated per match
+ * (a Bo3 draft builds a fresh `P2PHostAdapter`/`P2PGuestAdapter`/`WasmAdapter`
+ * per game), while `dispatch.ts`'s queue and in-flight animation are module-level
+ * and outlive an adapter teardown. With per-adapter counters restarting at 1, a
+ * leftover game-1 commit could carry a *higher* stamp than game-2's fresh reads
+ * and latch the store's gate above every subsequent commit — a permanent
+ * softlock. One global counter stamps a leftover game-1 commit *below* anything
+ * fetched after the new match installs, so the gate drops it, which is exactly
+ * the desired behavior. No epoch or reset machinery is needed.
+ */
+let snapshotSeq = 0;
+
+/** Consume the next globally monotonic snapshot stamp. */
+export function nextSnapshotSeq(): number {
+  snapshotSeq += 1;
+  return snapshotSeq;
+}
+
+/**
+ * Legal actions for a transport adapter with no cached engine snapshot yet —
+ * before the first state-bearing message arrives, and after dispose. Shared by
+ * every snapshot-caching adapter (P2P guest, ws, server-draft) so the empty
+ * shape is defined once.
+ */
+export const EMPTY_LEGAL_ACTIONS: LegalActionsResult = {
+  actions: [],
+  autoPassRecommended: false,
+};
+
+/**
  * Engine-built game-scoped AI card-DB subset descriptor (the `build_ai_card_subset`
  * WASM export, serialized as a tagged union). `full` means the game's card
  * universe is not statically bounded (today: Momir) and AI workers must load the
@@ -2749,6 +2803,15 @@ export interface EngineAdapter {
   submitAction(action: GameAction, actor: PlayerId): Promise<SubmitResult>;
   getState(): Promise<GameState>;
   getLegalActions(): Promise<LegalActionsResult>;
+  /**
+   * Fetch the state and its legal actions as one atomic, seq-stamped pair.
+   *
+   * This is the ONLY correct way to read the engine pair for a store commit —
+   * `getState()` followed by `getLegalActions()` can straddle an engine advance
+   * and yield a mismatched pair. Those two methods remain for callers that
+   * genuinely need one half in isolation.
+   */
+  getSnapshot(): Promise<EngineSnapshot>;
   getAiAction(difficulty: string, playerId: number, waitingForType?: WaitingFor["type"]): Promise<GameAction | null> | GameAction | null;
   resolveAll?(
     requester: number,

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -1,6 +1,7 @@
 import type {
   BatchResolveResult,
   EngineAdapter,
+  EngineSnapshot,
   FormatConfig,
   GameAction,
   GameState,
@@ -11,7 +12,7 @@ import type {
   ViewerSnapshot,
   WaitingFor,
 } from "./types";
-import { AdapterError, AdapterErrorCode, isStaleActionMessage, isStateLostMessage } from "./types";
+import { AdapterError, AdapterErrorCode, isStaleActionMessage, isStateLostMessage, nextSnapshotSeq } from "./types";
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 import { isBracketEstimate } from "../types/bracketEstimate";
 import { EngineWorkerClient } from "./engine-worker-client";
@@ -295,6 +296,32 @@ export class WasmAdapter implements EngineAdapter {
     try {
       if (this.engine) return await this.engine.getLegalActionsForViewer(viewerId);
       return await this.fallback!.getLegalActionsForViewer(viewerId);
+    } catch (err) {
+      throw await classifyEngineErrorAsync(err, this.takePanic);
+    }
+  }
+
+  /**
+   * Atomic state + legal-actions pair, stamped when the response ARRIVES.
+   *
+   * Worker responses post in worker-processing order and awaiting callers
+   * resume in resolution order, so stamping here reproduces engine order even
+   * with concurrent callers. The `state` half gets the same
+   * `unwrapClientGameState` envelope flatten `getState` applies — without it a
+   * raw `{ state, derived }` envelope would reach the store and silently break
+   * every `derived` consumer.
+   */
+  async getSnapshot(): Promise<EngineSnapshot> {
+    this.assertInitialized();
+    try {
+      const raw = this.engine
+        ? await this.engine.getSnapshot()
+        : await this.fallback!.getSnapshot();
+      return {
+        state: unwrapClientGameState(raw.state),
+        legalResult: raw.legalResult,
+        seq: nextSnapshotSeq(),
+      };
     } catch (err) {
       throw await classifyEngineErrorAsync(err, this.takePanic);
     }
@@ -637,6 +664,7 @@ interface MainThreadFallback {
   getState(): Promise<GameState>;
   getFilteredState(viewerId: number): Promise<GameState>;
   getLegalActions(): Promise<LegalActionsResult>;
+  getSnapshot(): Promise<{ state: GameState; legalResult: LegalActionsResult }>;
   getLegalActionsForViewer(viewerId: number): Promise<LegalActionsResult>;
   getViewerSnapshot(viewerId: number): Promise<ViewerSnapshot>;
   getAiAction(difficulty: string, playerId: number, waitingForType?: WaitingFor["type"]): Promise<GameAction | null>;
@@ -708,6 +736,20 @@ async function createMainThreadFallback(): Promise<MainThreadFallback> {
         const r = wasm.get_legal_actions_js();
         if (r === null) throw new Error("NOT_INITIALIZED: get_legal_actions_js returned null");
         return r as LegalActionsResult;
+      }),
+
+    // Same atomicity guarantee as the worker's `getSnapshot` case: both WASM
+    // exports are synchronous and run back-to-back inside ONE `enqueue`
+    // callback, so no other queued operation (notably `submit_action`) can
+    // interleave between them.
+    getSnapshot: () =>
+      enqueue(() => {
+        const s = wasm.get_game_state();
+        const r = wasm.get_legal_actions_js();
+        if (s === null || r === null) {
+          throw new Error("NOT_INITIALIZED: get_game_state/get_legal_actions_js returned null");
+        }
+        return { state: s as GameState, legalResult: r as LegalActionsResult };
       }),
 
     getLegalActionsForViewer: (viewerId: number) =>

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -1,5 +1,6 @@
 import type {
   EngineAdapter,
+  EngineSnapshot,
   GameAction,
   GameEvent,
   GameLogEntry,
@@ -9,7 +10,7 @@ import type {
   PlayerId,
   SubmitResult,
 } from "./types";
-import { AdapterError, AdapterErrorCode } from "./types";
+import { AdapterError, AdapterErrorCode, EMPTY_LEGAL_ACTIONS, nextSnapshotSeq } from "./types";
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 import {
   HandshakeError,
@@ -90,7 +91,9 @@ export type WsAdapterEvent =
   | { type: "reconnecting"; attempt: number; maxAttempts: number }
   | { type: "reconnected" }
   | { type: "reconnectFailed" }
-  | { type: "stateChanged"; state: GameState; events: GameEvent[]; legalResult: LegalActionsResult; logEntries?: GameLogEntry[] }
+  /** The engine pair travels as one `EngineSnapshot` — see the P2P adapter's
+   *  `stateChanged` for why the halves must stay inseparable. */
+  | { type: "stateChanged"; snapshot: EngineSnapshot; events: GameEvent[]; logEntries?: GameLogEntry[] }
   | { type: "emoteReceived"; fromPlayer: PlayerId; emote: string }
   | { type: "conceded"; player: PlayerId }
   | { type: "timerUpdate"; player: PlayerId; remainingSeconds: number }
@@ -116,9 +119,14 @@ function playerNamesFromWire(names: string[]): Record<number, string> {
  */
 export class WebSocketAdapter implements EngineAdapter {
   private ws: WebSocket | null = null;
-  private gameState: GameState | null = null;
+  /**
+   * The single cached engine pair, rebuilt (and re-stamped) once per inbound
+   * state-bearing message. `getState`/`getLegalActions` both read from THIS
+   * object, so they can no longer straddle two updates. The WebSocket delivers
+   * server messages in order, so stamping on arrival reproduces engine order.
+   */
+  private snapshot: EngineSnapshot | null = null;
   private _playerId: PlayerId | null = null;
-  private _legalActions: LegalActionsResult = { actions: [], autoPassRecommended: false };
   private playerToken: string | null = null;
   private _gameCode: string | null = null;
   private pendingResolve: ((result: SubmitResult) => void) | null = null;
@@ -334,7 +342,7 @@ export class WebSocketAdapter implements EngineAdapter {
         );
         this.initResolve = null;
         this.initReject = null;
-      } else if (this.gameState !== null || this.playerToken !== null) {
+      } else if (this.snapshot !== null || this.playerToken !== null) {
         this.attemptReconnect();
       }
     };
@@ -377,10 +385,10 @@ export class WebSocketAdapter implements EngineAdapter {
   }
 
   async getState(): Promise<GameState> {
-    if (!this.gameState) {
+    if (!this.snapshot) {
       throw new AdapterError("WS_ERROR", "No game state available", false);
     }
-    return this.gameState;
+    return this.snapshot.state;
   }
 
   getAiAction(_difficulty: string, _playerId: number): GameAction | null {
@@ -388,7 +396,21 @@ export class WebSocketAdapter implements EngineAdapter {
   }
 
   async getLegalActions(): Promise<LegalActionsResult> {
-    return this._legalActions;
+    return this.snapshot?.legalResult ?? EMPTY_LEGAL_ACTIONS;
+  }
+
+  async getSnapshot(): Promise<EngineSnapshot> {
+    if (!this.snapshot) {
+      throw new AdapterError("WS_ERROR", "No game state available", false);
+    }
+    return this.snapshot;
+  }
+
+  /** Rebuild the cached pair from an inbound state-bearing message, stamping
+   *  it with a fresh globally-monotonic seq at arrival. */
+  private cacheSnapshot(state: GameState, legalResult: LegalActionsResult): EngineSnapshot {
+    this.snapshot = { state, legalResult, seq: nextSnapshotSeq() };
+    return this.snapshot;
   }
 
   restoreState(_state: GameState): void {
@@ -457,7 +479,7 @@ export class WebSocketAdapter implements EngineAdapter {
       this.ws.close();
       this.ws = null;
     }
-    this.gameState = null;
+    this.snapshot = null;
     this._playerId = null;
     this.playerToken = null;
     this._gameCode = null;
@@ -629,14 +651,16 @@ export class WebSocketAdapter implements EngineAdapter {
             opponentName: data.opponent_name,
           });
         }
-        this.gameState = { ...data.state, derived: data.derived ?? data.state.derived };
+        const startedSnapshot = this.cacheSnapshot(
+          { ...data.state, derived: data.derived ?? data.state.derived },
+          {
+            actions: data.legal_actions ?? [],
+            autoPassRecommended: data.auto_pass_recommended ?? false,
+            spellCosts: data.spell_costs,
+            legalActionsByObject: data.legal_actions_by_object,
+          },
+        );
         this._playerId = data.your_player;
-        this._legalActions = {
-          actions: data.legal_actions ?? [],
-          autoPassRecommended: data.auto_pass_recommended ?? false,
-          spellCosts: data.spell_costs,
-          legalActionsByObject: data.legal_actions_by_object,
-        };
         // Joiners receive their player_token here (hosts get it via GameCreated).
         // Set _gameCode from joinGameCode if not already set (host sets it via GameCreated).
         if (!this._gameCode && this.joinGameCode) {
@@ -666,8 +690,10 @@ export class WebSocketAdapter implements EngineAdapter {
           this.initReject = null;
         } else {
           // Reconnect path — no initResolve pending, so emit state change
-          // so GameProvider's event listener populates the store.
-          this.emit({ type: "stateChanged", state: data.state, events: [], legalResult: this._legalActions });
+          // so GameProvider's event listener populates the store. Emits the
+          // cached snapshot, which carries the derived-attached state (this
+          // emit previously sent the raw `data.state`, dropping `derived`).
+          this.emit({ type: "stateChanged", snapshot: startedSnapshot, events: [] });
         }
         break;
       }
@@ -678,13 +704,15 @@ export class WebSocketAdapter implements EngineAdapter {
         // components (e.g. CommanderDamage) can read them via gameState.derived
         // without a separate subscription path. See
         // crates/engine/src/game/derived_views.rs.
-        this.gameState = { ...data.state, derived: data.derived ?? data.state.derived };
-        this._legalActions = {
-          actions: data.legal_actions ?? [],
-          autoPassRecommended: data.auto_pass_recommended ?? false,
-          spellCosts: data.spell_costs,
-          legalActionsByObject: data.legal_actions_by_object,
-        };
+        const updateSnapshot = this.cacheSnapshot(
+          { ...data.state, derived: data.derived ?? data.state.derived },
+          {
+            actions: data.legal_actions ?? [],
+            autoPassRecommended: data.auto_pass_recommended ?? false,
+            spellCosts: data.spell_costs,
+            legalActionsByObject: data.legal_actions_by_object,
+          },
+        );
         if (this.pendingResolve) {
           this.emit({ type: "actionPendingChanged", pending: false });
           this.pendingResolve({ events: data.events, log_entries: data.log_entries });
@@ -693,9 +721,8 @@ export class WebSocketAdapter implements EngineAdapter {
         } else {
           this.emit({
             type: "stateChanged",
-            state: data.state,
+            snapshot: updateSnapshot,
             events: data.events,
-            legalResult: this._legalActions,
             logEntries: data.log_entries,
           });
         }

--- a/client/src/game/__tests__/dispatchRemoteUpdate.test.ts
+++ b/client/src/game/__tests__/dispatchRemoteUpdate.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import type { GameLogEntry, GameState, LegalActionsResult } from "../../adapter/types";
+import type { EngineSnapshot, GameLogEntry, GameState, LegalActionsResult } from "../../adapter/types";
+import { nextSnapshotSeq } from "../../adapter/types";
 import { useGameStore } from "../../stores/gameStore";
 import { processRemoteUpdate } from "../dispatch";
 
@@ -36,6 +37,14 @@ function noLegalActions(): LegalActionsResult {
   };
 }
 
+function prioritySnapshot(): EngineSnapshot {
+  return {
+    state: priorityState(),
+    legalResult: noLegalActions(),
+    seq: nextSnapshotSeq(),
+  };
+}
+
 describe("processRemoteUpdate", () => {
   beforeEach(() => {
     useGameStore.getState().reset();
@@ -50,7 +59,7 @@ describe("processRemoteUpdate", () => {
       segments: [{ type: "Text", value: "AI guesses Nonland" }],
     };
 
-    await processRemoteUpdate(priorityState(), [], noLegalActions(), [aiGuessLog]);
+    await processRemoteUpdate(prioritySnapshot(), [], [aiGuessLog]);
 
     expect(useGameStore.getState().logHistory).toEqual([
       {

--- a/client/src/game/__tests__/dispatchResolveAll.test.ts
+++ b/client/src/game/__tests__/dispatchResolveAll.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { BatchResolveResult, GameState } from "../../adapter/types";
+import type { BatchResolveResult, EngineSnapshot, GameState } from "../../adapter/types";
+import { nextSnapshotSeq } from "../../adapter/types";
 import { useGameStore } from "../../stores/gameStore";
 import { usePreferencesStore } from "../../stores/preferencesStore";
 import { buildGameState, buildPriorityWaitingFor, buildStackEntry } from "../../test/factories/gameStateFactory";
@@ -18,6 +19,20 @@ function stateWithStack(len: number): GameState {
 
 function chunk(itemsResolved: number, total: number): BatchResolveResult {
   return { events: [], waitingFor: priorityWf, logEntries: [], itemsResolved, total };
+}
+
+/**
+ * A `getSnapshot` stub that reads through the test's own `getState` script and
+ * pairs it with empty legal actions. The drain now reads ONE atomic pair per
+ * chunk (not getState + getLegalActions), so this keeps each test's per-chunk
+ * `getState` sequencing intact while matching the real adapter contract.
+ */
+function snapshotVia(getState: () => Promise<GameState>) {
+  return vi.fn(async (): Promise<EngineSnapshot> => ({
+    state: await getState(),
+    legalResult: { actions: [], autoPassRecommended: false },
+    seq: nextSnapshotSeq(),
+  }));
 }
 
 describe("dispatchResolveAll progress", () => {
@@ -72,6 +87,7 @@ describe("dispatchResolveAll progress", () => {
         resolveAll,
         getState,
         getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
+        getSnapshot: snapshotVia(getState),
       } as never,
     });
 
@@ -105,11 +121,13 @@ describe("dispatchResolveAll progress", () => {
       return chunk(0, 19192);
     });
 
+    const getState = vi.fn().mockResolvedValue(stateWithStack(0));
     useGameStore.setState({
       adapter: {
         resolveAll,
-        getState: vi.fn().mockResolvedValue(stateWithStack(0)),
+        getState,
         getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
+        getSnapshot: snapshotVia(getState),
       } as never,
     });
 
@@ -125,13 +143,15 @@ describe("dispatchResolveAll progress", () => {
       .fn<(action: unknown, actor: number) => Promise<{ events: never[] }>>()
       .mockResolvedValue({ events: [] });
 
+    const getState = vi.fn().mockResolvedValue(stateWithStack(2));
     useGameStore.setState({
       gameState: stateWithStack(3),
       adapter: {
         resolveAll,
         submitAction,
-        getState: vi.fn().mockResolvedValue(stateWithStack(2)),
+        getState,
         getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
+        getSnapshot: snapshotVia(getState),
       } as never,
     });
 
@@ -152,12 +172,14 @@ describe("dispatchResolveAll progress", () => {
       .fn<(action: unknown, actor: number) => Promise<{ events: never[] }>>()
       .mockResolvedValue({ events: [] });
 
+    const getState = vi.fn().mockResolvedValue(stateWithStack(2));
     useGameStore.setState({
       gameState: stateWithStack(3),
       adapter: {
         submitAction,
-        getState: vi.fn().mockResolvedValue(stateWithStack(2)),
+        getState,
         getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
+        getSnapshot: snapshotVia(getState),
       } as never,
     });
 

--- a/client/src/game/__tests__/dispatchSplitEpochSoftlock.test.ts
+++ b/client/src/game/__tests__/dispatchSplitEpochSoftlock.test.ts
@@ -1,0 +1,259 @@
+/**
+ * P2P host softlock — split-epoch commit regression.
+ *
+ * Observed (saved game-state ZIP): the host store held
+ * `gameState.waiting_for = Priority{player:0}` while `legalActions` was
+ * `[DecideOptionalEffect, DecideOptionalEffect]`. The engine was actually at
+ * `OptionalEffectChoice`. The UI, driven by the stale `waitingFor`, rendered
+ * Resolve / Resolve All — actions the engine rejected — while the Yes/No
+ * optional-effect modal never mounted. The game locked permanently.
+ *
+ * Root cause: `processAction` fetched the state BEFORE the animation window and
+ * the legal actions AFTER it, so any engine advance during that window produced
+ * a pair read at two different engine versions. On the host that advance is real
+ * and common: `P2PHostAdapter.runAiLoop` / `handleGuestMessage` drive the shared
+ * engine outside the dispatch mutex.
+ *
+ * This test drives the REAL `dispatchAction` pipeline against an adapter whose
+ * engine advances Priority → OptionalEffectChoice *during* the animation window,
+ * and asserts the store never lands on the mixed pair.
+ *
+ * Discrimination: these assertions were confirmed RED against the pre-fix
+ * `processAction` (state fetched at step 3b, legal actions re-fetched at step 8,
+ * committed as one pair) — `storeHoldsMixedPair()` returned true and the stale
+ * pair clobbered the newer commit. The third test below is a standing control:
+ * it replays that old pairing directly and asserts it DOES produce the softlock
+ * shape, so `storeHoldsMixedPair()` is proven non-vacuous without needing to
+ * re-break the source.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  EngineAdapter,
+  EngineSnapshot,
+  GameAction,
+  GameState,
+  LegalActionsResult,
+  SubmitResult,
+} from "../../adapter/types";
+import { nextSnapshotSeq } from "../../adapter/types";
+import { useGameStore } from "../../stores/gameStore";
+import { usePreferencesStore } from "../../stores/preferencesStore";
+import {
+  buildGameState,
+  buildLegalActionsResult,
+  buildPriorityWaitingFor,
+} from "../../test/factories/gameStateFactory";
+import { dispatchAction } from "../dispatch";
+
+const PRIORITY = buildPriorityWaitingFor({ data: { player: 0 } });
+
+const OPTIONAL_EFFECT_CHOICE = {
+  type: "OptionalEffectChoice",
+  data: {
+    player: 0,
+    source_id: 100,
+    description: "Ob Nixilis, the Fallen — you may have target player lose 3 life.",
+  },
+} as unknown as GameState["waiting_for"];
+
+const PRIORITY_ACTIONS = [{ type: "PassPriority" }] as unknown as GameAction[];
+const OPTIONAL_EFFECT_ACTIONS = [
+  { type: "DecideOptionalEffect", data: { accept: true } },
+  { type: "DecideOptionalEffect", data: { accept: false } },
+] as unknown as GameAction[];
+
+const PRIORITY_STATE = buildGameState({ waiting_for: PRIORITY, turn_number: 3 });
+const OPTIONAL_STATE = buildGameState({ waiting_for: OPTIONAL_EFFECT_CHOICE, turn_number: 3 });
+
+const PRIORITY_LEGAL = buildLegalActionsResult({ actions: PRIORITY_ACTIONS });
+const OPTIONAL_LEGAL = buildLegalActionsResult({ actions: OPTIONAL_EFFECT_ACTIONS });
+
+/**
+ * An engine that advances Priority → OptionalEffectChoice once, on a schedule the
+ * test controls (`advance()`), modelling the host's out-of-band AI-loop /
+ * guest-action advance landing during the animation window.
+ */
+function fakeEngine() {
+  let advanced = false;
+  return {
+    advance: () => {
+      advanced = true;
+    },
+    state: (): GameState => (advanced ? OPTIONAL_STATE : PRIORITY_STATE),
+    legal: (): LegalActionsResult => (advanced ? OPTIONAL_LEGAL : PRIORITY_LEGAL),
+  };
+}
+
+/** True when the store holds the exact softlock shape from the bug report. */
+function storeHoldsMixedPair(): boolean {
+  const { waitingFor, legalActions } = useGameStore.getState();
+  return (
+    waitingFor?.type === "Priority" &&
+    legalActions.some((a) => a.type === "DecideOptionalEffect")
+  );
+}
+
+function seedStore(adapter: EngineAdapter): void {
+  useGameStore.setState({
+    gameId: null,
+    gameMode: "ai",
+    adapter,
+    gameState: PRIORITY_STATE,
+    waitingFor: PRIORITY,
+    legalActions: PRIORITY_ACTIONS,
+    events: [],
+    eventHistory: [],
+    logHistory: [],
+    nextLogSeq: 0,
+    stateHistory: [],
+    turnCheckpoints: [],
+    lastCommittedSeq: 0,
+  });
+}
+
+const baseAdapter = (): Pick<
+  EngineAdapter,
+  "initialize" | "initializeGame" | "restoreState" | "getAiAction" | "estimateBracket" | "dispose"
+> => ({
+  initialize: vi.fn().mockResolvedValue(undefined),
+  initializeGame: vi.fn().mockResolvedValue({ events: [] } as SubmitResult),
+  restoreState: vi.fn(),
+  getAiAction: vi.fn().mockReturnValue(null),
+  estimateBracket: vi.fn().mockResolvedValue(null),
+  dispose: vi.fn(),
+});
+
+describe("P2P host softlock — engine advance during the animation window", () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+    // A non-zero multiplier keeps a real animation window open, which is the
+    // window the engine advance lands in. `normalizeEvents` produces a step for
+    // the LifeChanged event below, so the pipeline genuinely awaits a timer.
+    usePreferencesStore.setState({ animationSpeedMultiplier: 1 });
+    vi.useFakeTimers();
+  });
+
+  it("never commits state and legal actions read at different engine versions", async () => {
+    const engine = fakeEngine();
+
+    const adapter: EngineAdapter = {
+      ...baseAdapter(),
+      submitAction: vi.fn(async (): Promise<SubmitResult> => ({
+        events: [{ type: "LifeChanged", data: { player_id: 1, amount: -3 } }],
+        log_entries: [],
+      })),
+      getState: vi.fn(async () => engine.state()),
+      getLegalActions: vi.fn(async () => engine.legal()),
+      // The atomic read: BOTH halves come from the engine version live at the
+      // moment of the call. This is the contract the fix depends on.
+      getSnapshot: vi.fn(async (): Promise<EngineSnapshot> => ({
+        state: engine.state(),
+        legalResult: engine.legal(),
+        seq: nextSnapshotSeq(),
+      })),
+    };
+    seedStore(adapter);
+
+    const dispatched = dispatchAction({ type: "PassPriority" } as GameAction, 0);
+
+    // Let submitAction + the snapshot read settle, then advance the engine out of
+    // band — exactly what `runAiLoop` does to the shared engine mid-animation.
+    await vi.advanceTimersByTimeAsync(0);
+    engine.advance();
+
+    // Drain the animation window and the rest of the pipeline.
+    await vi.runAllTimersAsync();
+    await dispatched;
+
+    // THE assertion: the store must never hold Priority + DecideOptionalEffect.
+    expect(storeHoldsMixedPair()).toBe(false);
+
+    // And the pair it does hold must be internally consistent — both halves from
+    // the same engine version.
+    const { waitingFor, legalActions, gameState } = useGameStore.getState();
+    expect(waitingFor).toEqual(gameState?.waiting_for);
+    if (waitingFor?.type === "OptionalEffectChoice") {
+      expect(legalActions).toEqual(OPTIONAL_EFFECT_ACTIONS);
+    } else {
+      expect(legalActions).toEqual(PRIORITY_ACTIONS);
+    }
+  });
+
+  it("drops the in-flight pair when a newer commit lands mid-animation, instead of clobbering it", async () => {
+    // The other direction of the same bug: a concurrent `gameStore.dispatch`
+    // (PassButton, choice modals, mana UI — ~30 components bypass the animation
+    // queue) commits the NEWER pair while `processAction` is still animating. The
+    // in-flight older pair must not overwrite it on arrival.
+    const engine = fakeEngine();
+
+    const adapter: EngineAdapter = {
+      ...baseAdapter(),
+      submitAction: vi.fn(async (): Promise<SubmitResult> => ({
+        events: [{ type: "LifeChanged", data: { player_id: 1, amount: -3 } }],
+        log_entries: [],
+      })),
+      getState: vi.fn(async () => engine.state()),
+      getLegalActions: vi.fn(async () => engine.legal()),
+      getSnapshot: vi.fn(async (): Promise<EngineSnapshot> => ({
+        state: engine.state(),
+        legalResult: engine.legal(),
+        seq: nextSnapshotSeq(),
+      })),
+    };
+    seedStore(adapter);
+
+    const dispatched = dispatchAction({ type: "PassPriority" } as GameAction, 0);
+    // `processAction` has now captured its (pre-advance) snapshot.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Engine advances, and a newer commit lands while the animation is still
+    // playing — a strictly newer seq than the in-flight one.
+    engine.advance();
+    const newer = await adapter.getSnapshot();
+    useGameStore.getState().commitEngineSnapshot(newer);
+    expect(useGameStore.getState().waitingFor).toEqual(OPTIONAL_EFFECT_CHOICE);
+
+    await vi.runAllTimersAsync();
+    await dispatched;
+
+    // The older in-flight pair was dropped by the revision gate: the store still
+    // shows the newer engine version, coherently paired.
+    expect(useGameStore.getState().waitingFor).toEqual(OPTIONAL_EFFECT_CHOICE);
+    expect(useGameStore.getState().legalActions).toEqual(OPTIONAL_EFFECT_ACTIONS);
+    expect(storeHoldsMixedPair()).toBe(false);
+  });
+
+  it("red-before-green control: the OLD split-fetch pairing produces exactly the softlock shape", async () => {
+    // This test does NOT exercise the fix — it pins the bug, so the assertion in
+    // the tests above is provably non-vacuous. It reproduces the pre-fix flow
+    // literally: state read BEFORE the animation window, legal actions read
+    // AFTER it, then committed as one pair (the old `useGameStore.setState`).
+    const engine = fakeEngine();
+
+    // Step 3b of the old flow: state fetched pre-animation (engine still Priority).
+    const staleState = engine.state();
+
+    // …the engine advances during the animation window…
+    engine.advance();
+
+    // Step 8 of the old flow: legal actions fetched post-animation (now Optional).
+    const freshLegal = engine.legal();
+
+    // The old code committed this cross-epoch pair verbatim.
+    useGameStore.setState({
+      gameState: staleState,
+      waitingFor: staleState.waiting_for,
+      legalActions: freshLegal.actions,
+    });
+
+    // That is precisely the reported softlock: waitingFor says Priority (so the
+    // UI renders Resolve/Resolve All) while the engine wants DecideOptionalEffect.
+    expect(storeHoldsMixedPair()).toBe(true);
+    expect(useGameStore.getState().waitingFor?.type).toBe("Priority");
+    expect(useGameStore.getState().legalActions.map((a) => a.type)).toEqual([
+      "DecideOptionalEffect",
+      "DecideOptionalEffect",
+    ]);
+  });
+});

--- a/client/src/game/__tests__/dispatchTimeout.test.ts
+++ b/client/src/game/__tests__/dispatchTimeout.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EngineAdapter, GameAction, SubmitResult } from "../../adapter/types";
-import { AdapterError, AdapterErrorCode } from "../../adapter/types";
+import { AdapterError, AdapterErrorCode, nextSnapshotSeq } from "../../adapter/types";
 import { useAppNotificationStore } from "../../stores/appToastStore";
 import { useGameStore } from "../../stores/gameStore";
 import { buildEngineAdapterMock } from "../../test/factories/engineAdapterFactory";
@@ -119,15 +119,18 @@ describe("dispatchAction recovery on ENGINE_UNRESPONSIVE", () => {
     const submitAction = vi
       .fn<EngineAdapter["submitAction"]>()
       .mockResolvedValue({ events: [], log_entries: [] } as unknown as SubmitResult);
-    const getState = vi
-      .fn<EngineAdapter["getState"]>()
-      .mockResolvedValue(emptyState);
-    const getLegalActions = vi
-      .fn<EngineAdapter["getLegalActions"]>()
-      .mockResolvedValue(buildLegalActionsResult());
+    // `processAction` reads the engine pair through `getSnapshot` only — the
+    // old getState + post-animation getLegalActions pair is gone.
+    const getSnapshot = vi
+      .fn<EngineAdapter["getSnapshot"]>()
+      .mockImplementation(async () => ({
+        state: emptyState,
+        legalResult: buildLegalActionsResult(),
+        seq: nextSnapshotSeq(),
+      }));
 
     useGameStore.setState({
-      adapter: buildEngineAdapterMock(emptyState, { submitAction, getState, getLegalActions }),
+      adapter: buildEngineAdapterMock(emptyState, { submitAction, getSnapshot }),
       gameState: emptyState,
       gameMode: "ai",
     });
@@ -138,6 +141,9 @@ describe("dispatchAction recovery on ENGINE_UNRESPONSIVE", () => {
 
     // The healthy path must never surface the engine-lost recovery prompt.
     expect(notifyEngineLost).not.toHaveBeenCalled();
+    // Exactly one engine pair read per dispatch — the split-epoch second fetch
+    // is gone, so a regression that reintroduces it shows up here.
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
   });
 
   it("drops a queued local action when the waiting prompt changes before it runs", async () => {
@@ -163,17 +169,18 @@ describe("dispatchAction recovery on ENGINE_UNRESPONSIVE", () => {
           }),
       )
       .mockResolvedValue({ events: [], log_entries: [] } as unknown as SubmitResult);
-    const getState = vi
-      .fn<EngineAdapter["getState"]>()
-      .mockResolvedValue(nextState);
-    const getLegalActions = vi
-      .fn<EngineAdapter["getLegalActions"]>()
-      .mockResolvedValue(buildLegalActionsResult({
-        actions: [{ type: "SelectCards", data: { cards: [] } }],
+    const getSnapshot = vi
+      .fn<EngineAdapter["getSnapshot"]>()
+      .mockImplementation(async () => ({
+        state: nextState,
+        legalResult: buildLegalActionsResult({
+          actions: [{ type: "SelectCards", data: { cards: [] } }],
+        }),
+        seq: nextSnapshotSeq(),
       }));
 
     useGameStore.setState({
-      adapter: buildEngineAdapterMock(initialState, { submitAction, getState, getLegalActions }),
+      adapter: buildEngineAdapterMock(initialState, { submitAction, getSnapshot }),
       gameState: initialState,
       waitingFor: firstWaitingFor,
       gameMode: "ai",

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -1,4 +1,4 @@
-import type { BatchResolveResult, GameAction, GameEvent, GameLogEntry, GameState, LegalActionsResult, WaitingFor } from "../adapter/types";
+import type { BatchResolveResult, EngineSnapshot, GameAction, GameEvent, GameLogEntry, GameState, WaitingFor } from "../adapter/types";
 import { AdapterError, AdapterErrorCode } from "../adapter/types";
 import { attemptStateRehydrate, isEnginePanic, notifyEngineLost, routePanic } from "./engineRecovery";
 import { normalizeEvents } from "../animation/eventNormalizer";
@@ -12,7 +12,7 @@ import { flashInGameRolls } from "./diceContest";
 import i18n from "../i18n";
 import { useAnimationStore } from "../stores/animationStore";
 import { useAppNotificationStore } from "../stores/appToastStore";
-import { isMultiplayerMode, useGameStore, legalResultState, saveGame, saveCheckpoints } from "../stores/gameStore";
+import { isMultiplayerMode, useGameStore, saveGame, saveCheckpoints } from "../stores/gameStore";
 import { getOpponentDisplayName } from "../stores/multiplayerStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
 import { useUiStore } from "../stores/uiStore";
@@ -61,10 +61,9 @@ interface PendingLocalAction {
 
 interface PendingRemoteUpdate {
   kind: "remote";
-  state: GameState;
+  snapshot: EngineSnapshot;
   events: GameEvent[];
   logEntries?: GameLogEntry[];
-  legalResult: LegalActionsResult;
   resolve: () => void;
   reject: (err: unknown) => void;
 }
@@ -276,42 +275,53 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
   }
   const events: GameEvent[] = result.events;
 
-  // 3b. Fetch new state eagerly and persist before animations so a mid-animation
-  //     page reload (e.g. PWA service-worker update) doesn't lose the latest state.
+  // 3b. Fetch the state AND its legal actions as ONE atomic snapshot, and persist
+  //     before animations so a mid-animation page reload (e.g. PWA service-worker
+  //     update) doesn't lose the latest state.
+  //
+  // This single fetch is the fix for the observed softlock. The old flow read
+  // `getState()` here and `getLegalActions()` again *after* the animation window
+  // (step 8), pairing values from two different engine versions: any advance
+  // during the animation produced e.g. `waiting_for = Priority` alongside
+  // `DecideOptionalEffect` legal actions, so the UI rendered Resolve/Resolve All
+  // while the engine waited on an optional-effect choice whose modal never
+  // appeared. The pair is now captured together and committed together.
+  //
   // Recover from STATE_LOST here too — a worker restart could happen between
-  // submitAction and getState. Critically: if recovery fails, do NOT call
+  // submitAction and this fetch. Critically: if recovery fails, do NOT call
   // saveGame — earlier revisions silently wrote a default empty GameState to
   // IDB on null, corrupting the checkpoint we now rely on for Layer 3 reload.
-  let newState: GameState;
+  let snapshotResult: EngineSnapshot;
   try {
-    newState = await adapter.getState();
+    snapshotResult = await adapter.getSnapshot();
   } catch (err) {
     if (isEnginePanic(err)) {
-      await routePanic("getState-panic", err.panic);
+      await routePanic("getSnapshot-panic", err.panic);
       throw err;
     }
     if (isEngineUnresponsive(err)) {
-      notifyEngineLost("getState-timeout");
+      notifyEngineLost("getSnapshot-timeout");
       throw err;
     }
     if (!isStateLost(err)) throw err;
-    debugLog("processAction: STATE_LOST on getState; attempting rehydrate", "warn");
+    debugLog("processAction: STATE_LOST on getSnapshot; attempting rehydrate", "warn");
     const recovered = await attemptStateRehydrate();
     if (!recovered) {
-      notifyEngineLost("getState");
+      notifyEngineLost("getSnapshot");
       throw err;
     }
     try {
-      newState = await adapter.getState();
+      snapshotResult = await adapter.getSnapshot();
     } catch (retryErr) {
       if (isEnginePanic(retryErr)) {
-        notifyEngineLost("getState-retry-panic", retryErr.panic);
+        notifyEngineLost("getSnapshot-retry-panic", retryErr.panic);
       } else {
-        notifyEngineLost("getState-retry");
+        notifyEngineLost("getSnapshot-retry");
       }
       throw retryErr;
     }
   }
+  const newState = snapshotResult.state;
   const { gameId } = useGameStore.getState();
   if (gameId) saveGame(gameId, newState);
 
@@ -392,61 +402,25 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
     }
   }
 
-  // 8. Update game state (deferred after animations — state already fetched in step 3b).
-  // Engine state could have been lost during the animation window; rehydrate
-  // once if needed so the UI doesn't render empty legal actions.
-  let legalResult;
-  try {
-    legalResult = await adapter.getLegalActions();
-  } catch (err) {
-    if (isEnginePanic(err)) {
-      notifyEngineLost("getLegalActions-panic", err.panic);
-      throw err;
-    }
-    if (isEngineUnresponsive(err)) {
-      notifyEngineLost("getLegalActions-timeout");
-      throw err;
-    }
-    if (!isStateLost(err)) throw err;
-    const recovered = await attemptStateRehydrate();
-    if (!recovered) {
-      notifyEngineLost("getLegalActions");
-      throw err;
-    }
-    try {
-      legalResult = await adapter.getLegalActions();
-    } catch (retryErr) {
-      if (isEnginePanic(retryErr)) {
-        notifyEngineLost("getLegalActions-retry-panic", retryErr.panic);
-      } else {
-        notifyEngineLost("getLegalActions-retry");
-      }
-      throw retryErr;
-    }
-  }
-
-  useGameStore.setState((prev) => {
-    const newHistory = shouldSaveHistory
-      ? [...prev.stateHistory, gameState].slice(-MAX_UNDO_HISTORY)
-      : prev.stateHistory;
-
-    // Assign monotonic sequence numbers to new log entries
-    let seq = prev.nextLogSeq;
-    const newLogEntries = (result.log_entries ?? []).map((entry) => ({
-      ...entry,
-      seq: seq++,
-    }));
-
-    return {
-      gameState: newState,
-      events,
-      eventHistory: [...prev.eventHistory, ...events].slice(-1000),
-      logHistory: [...prev.logHistory, ...newLogEntries].slice(-2000),
-      nextLogSeq: seq,
-      waitingFor: newState.waiting_for,
-      ...legalResultState(legalResult),
-      stateHistory: newHistory,
-    };
+  // 8. Commit the snapshot captured in step 3b — the pair, together.
+  //
+  // There is deliberately NO second engine fetch here. Re-reading legal actions
+  // after the animation window is what created the mixed-epoch pair in the first
+  // place. Recovery for a state lost *during* the animation window is now lazy:
+  // the next engine call classifies and recovers, exactly as it already does for
+  // every other window between calls.
+  //
+  // The commit is revision-gated, so if a newer commit landed mid-animation
+  // (a `gameStore.dispatch` from a modal, a remote update, an AI-loop advance),
+  // THIS older pair is dropped rather than clobbering it.
+  const store = useGameStore.getState();
+  const stateHistory = shouldSaveHistory
+    ? [...store.stateHistory, gameState].slice(-MAX_UNDO_HISTORY)
+    : undefined;
+  store.commitEngineSnapshot(snapshotResult, {
+    events,
+    logEntries: result.log_entries ?? [],
+    stateHistory,
   });
 
   // Play victory/defeat stinger on GameOver
@@ -480,7 +454,7 @@ async function processQueue(): Promise<void> {
           inFlightLocalAction = null;
         }
       } else {
-        await processRemoteUpdateInner(next.state, next.events, next.legalResult, next.logEntries);
+        await processRemoteUpdateInner(next.snapshot, next.events, next.logEntries);
       }
       next.resolve();
     } catch (err) {
@@ -605,14 +579,14 @@ export async function dispatchAction(
  * Inner implementation for remote state updates — runs the animation pipeline.
  */
 async function processRemoteUpdateInner(
-  state: GameState,
+  snapshot: EngineSnapshot,
   events: GameEvent[],
-  legalResult: LegalActionsResult,
   logEntries: GameLogEntry[] = [],
 ): Promise<void> {
-  // 1. Capture snapshot before updating state (for position lookups during animation)
-  const snapshot = useAnimationStore.getState().captureSnapshot();
-  currentSnapshot = snapshot;
+  const state = snapshot.state;
+
+  // 1. Capture positions before updating state (for lookups during animation)
+  currentSnapshot = useAnimationStore.getState().captureSnapshot();
 
   // 2. Flash turn banner
   const turnEvent = events.find((e) => e.type === "TurnStarted");
@@ -654,24 +628,10 @@ async function processRemoteUpdateInner(
     }
   }
 
-  // 5. Update game state after animations complete
-  useGameStore.setState((prev) => {
-    let seq = prev.nextLogSeq;
-    const newLogEntries = logEntries.map((entry) => ({
-      ...entry,
-      seq: seq++,
-    }));
-
-    return {
-      gameState: state,
-      events,
-      eventHistory: [...prev.eventHistory, ...events].slice(-1000),
-      logHistory: [...prev.logHistory, ...newLogEntries].slice(-2000),
-      nextLogSeq: seq,
-      waitingFor: state.waiting_for,
-      ...legalResultState(legalResult),
-    };
-  });
+  // 5. Commit the pair after animations complete — revision-gated, so a remote
+  //    update that was superseded while its animation played is dropped rather
+  //    than clobbering the newer state.
+  useGameStore.getState().commitEngineSnapshot(snapshot, { events, logEntries });
 
   // 6. Play victory/defeat stinger on GameOver
   const gameOverEvent = events.find((e) => e.type === "GameOver");
@@ -692,20 +652,19 @@ async function processRemoteUpdateInner(
  * local actions and vice versa — no overlapping animations.
  */
 export async function processRemoteUpdate(
-  state: GameState,
+  snapshot: EngineSnapshot,
   events: GameEvent[],
-  legalResult: LegalActionsResult,
   logEntries?: GameLogEntry[],
 ): Promise<void> {
   if (isAnimating) {
     return new Promise<void>((resolve, reject) => {
-      pendingQueue.push({ kind: "remote", state, events, logEntries, legalResult, resolve, reject });
+      pendingQueue.push({ kind: "remote", snapshot, events, logEntries, resolve, reject });
     });
   }
 
   isAnimating = true;
   try {
-    await processRemoteUpdateInner(state, events, legalResult, logEntries);
+    await processRemoteUpdateInner(snapshot, events, logEntries);
   } finally {
     if (pendingQueue.length > 0) {
       processQueue().catch(() => { isAnimating = false; });
@@ -732,24 +691,23 @@ export async function restoreGameState(
     return err instanceof Error ? err.message : "Failed to restore state";
   }
 
-  const restoredState = await adapter.getState();
-  const legalResult = await adapter.getLegalActions();
+  // Post-restore fetch — newest-by-construction, so it always passes the gate.
+  const snapshot = await adapter.getSnapshot();
   const preservedCheckpoints = options.preserveCheckpoints
     ? useGameStore.getState().turnCheckpoints
     : [];
-  useGameStore.setState({
-    gameState: restoredState,
-    waitingFor: restoredState.waiting_for,
-    ...legalResultState(legalResult),
-    events: [],
-    eventHistory: [],
-    logHistory: [],
-    nextLogSeq: 0,
-    stateHistory: [],
-    turnCheckpoints: preservedCheckpoints,
+  useGameStore.getState().commitEngineSnapshot(snapshot, {
+    extraState: {
+      events: [],
+      eventHistory: [],
+      logHistory: [],
+      nextLogSeq: 0,
+      stateHistory: [],
+      turnCheckpoints: preservedCheckpoints,
+    },
   });
   if (gameId) {
-    await saveGame(gameId, restoredState);
+    await saveGame(gameId, snapshot.state);
     await saveCheckpoints(gameId, preservedCheckpoints);
   }
 
@@ -760,7 +718,7 @@ const BATCH_CHUNK_SIZE = 5;
 // Under "Instant" stack pressure (a multi-hundred/thousand identical-trigger
 // storm, e.g. Scute Swarm) the 5-at-a-time animated countdown is wasted. Keep
 // large storms in engine-owned fast-forward batches so partial stacks collapse
-// before the frontend pays the per-chunk `getState` + `getLegalActions` cost.
+// before the frontend pays the per-chunk `getSnapshot` cost.
 // The value is intentionally large: the worker boundary already keeps the main
 // thread responsive, while this still lets the overlay update during truly
 // pathological stacks.
@@ -837,20 +795,21 @@ export async function dispatchResolveAll(
         });
       }
 
-      const newState = await adapter.getState();
-      const legalResult = await adapter.getLegalActions();
+      // One atomic pair per chunk, committed through the single authority. The
+      // store's `waitingFor` therefore comes from the snapshot's own state, not
+      // from `batchResult.waitingFor` — the pair must stay self-consistent.
+      // Equivalent or fresher: only `WasmAdapter` implements `resolveAll`, and
+      // worker FIFO guarantees this snapshot reflects at least the chunk's end
+      // state.
+      const snapshot = await adapter.getSnapshot();
+      useGameStore.getState().commitEngineSnapshot(snapshot);
 
-      useGameStore.setState({
-        gameState: newState,
-        waitingFor: batchResult.waitingFor,
-        ...legalResultState(legalResult),
-      });
-
+      // Anything other than Priority ends the drain — GameOver included, since
+      // the drain only continues while this seat keeps receiving priority.
       const done =
         batchResult.itemsResolved === 0 ||
-        newState.stack.length === 0 ||
-        batchResult.waitingFor.type === "GameOver" ||
-        batchResult.waitingFor.type !== "Priority";
+        snapshot.state.stack.length === 0 ||
+        snapshot.state.waiting_for.type !== "Priority";
       if (done) break;
 
       if (instant) {

--- a/client/src/game/sessionCleanup.ts
+++ b/client/src/game/sessionCleanup.ts
@@ -6,6 +6,13 @@ import { useUiStore } from "../stores/uiStore.ts";
  * adapter. Used on game-session boundaries (concede, provider unmount/remount)
  * so deferred store resets or async `initGame` cannot leave `ManaPayment` /
  * `pendingAbilityChoice` bleed into the next session (issue #2369).
+ *
+ * Documented exemption from the `commitEngineSnapshot` single-writer invariant:
+ * this is a session-boundary CLEAR, not a live-game commit. It writes the prompt
+ * + legal-action fields without advancing `lastCommittedSeq`, so a commit already
+ * in flight can re-populate the prompts it just cleared. That race pre-dates this
+ * mechanism and is neither worsened nor fixed by it — the clear has no snapshot to
+ * gate on, and gating it would require inventing an epoch it doesn't have.
  */
 export function clearPromptOverlayState(): void {
   useGameStore.setState({

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -802,7 +802,10 @@ function GamePageContent({
   const objects = useGameStore((s) => s.gameState?.objects);
   const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
   const turnNumber = useGameStore((s) => s.gameState?.turn_number);
-  const engineWaitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  // Store `waitingFor`, not `gameState.waiting_for`: this is paired below with
+  // the store-slice `legalActionsByObject`, and only the store's own field is
+  // committed atomically with the legal actions.
+  const engineWaitingFor = useGameStore((s) => s.waitingFor);
   const deckPools = useGameStore((s) => s.gameState?.deck_pools);
   const stackLength = useGameStore((s) => s.gameState?.stack.length ?? 0);
   const isSandboxGame = useGameStore(
@@ -2876,11 +2879,19 @@ function AbilityChoiceModal() {
   );
 }
 
+// ── Prompt modals ───────────────────────────────────────────────────────
+//
+// Every modal below reads the store's `waitingFor` — the SAME authority its
+// outer mount gate uses, and the one `commitEngineSnapshot` writes atomically
+// with the legal actions. Do NOT reach for `gameState.waiting_for` here: that
+// re-opens the split-authority gap where the outer gate opens a modal while the
+// inner component sees a different prompt and renders nothing.
+
 function SpellbookDraftModal() {
   const { t } = useTranslation("game");
   const canActForWaitingState = useCanActForWaitingState();
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
   const source = useGameStore((s) =>
     waitingFor?.type === "SpellbookDraft"
       ? s.gameState?.objects[waitingFor.data.source_id]
@@ -2912,7 +2923,7 @@ function SpellbookDraftModal() {
 
 function OptionalCostModal() {
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
 
   if (waitingFor?.type !== "OptionalCostChoice") return null;
 
@@ -2924,7 +2935,7 @@ function OptionalCostModal() {
 function DefilerPaymentModal() {
   const { t } = useTranslation("game");
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
 
   if (waitingFor?.type !== "DefilerPayment") return null;
 
@@ -2950,7 +2961,7 @@ function DefilerPaymentModal() {
 
 function OptionalEffectModal() {
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
   const objects = useGameStore((s) => s.gameState?.objects);
 
   if (waitingFor?.type !== "OptionalEffectChoice" && waitingFor?.type !== "OpponentMayChoice") return null;
@@ -2962,7 +2973,7 @@ function OptionalEffectModal() {
 
 function TopOrBottomModal() {
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
   const objects = useGameStore((s) => s.gameState?.objects);
 
   if (waitingFor?.type !== "TopOrBottomChoice" && waitingFor?.type !== "ClashCardPlacement") return null;
@@ -2974,7 +2985,7 @@ function TopOrBottomModal() {
 
 function MutateMergeModal() {
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
   const objects = useGameStore((s) => s.gameState?.objects);
 
   if (waitingFor?.type !== "MutateMergeChoice") return null;
@@ -2984,7 +2995,7 @@ function MutateMergeModal() {
 
 function CipherEncodeModal() {
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
   const objects = useGameStore((s) => s.gameState?.objects);
 
   if (waitingFor?.type !== "CipherEncodeChoice") return null;
@@ -2997,7 +3008,7 @@ function CipherEncodeModal() {
 function UntapChoiceModal() {
   const { t } = useTranslation("game");
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
   const objects = useGameStore((s) => s.gameState?.objects);
 
   if (waitingFor?.type !== "UntapChoice") return null;
@@ -3041,7 +3052,7 @@ function UntapChoiceModal() {
 function ExertChoiceModal() {
   const { t } = useTranslation("game");
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
   const objects = useGameStore((s) => s.gameState?.objects);
 
   if (waitingFor?.type !== "ExertChoice") return null;
@@ -3084,7 +3095,7 @@ function ExertChoiceModal() {
 function EnlistChoiceModal() {
   const { t } = useTranslation("game");
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
   const objects = useGameStore((s) => s.gameState?.objects);
 
   if (waitingFor?.type !== "EnlistChoice") return null;
@@ -3181,7 +3192,7 @@ function formatUnlessCost(
 function UnlessPaymentPanel() {
   const { t } = useTranslation("game");
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
 
   if (waitingFor?.type !== "UnlessPayment") return null;
 
@@ -3240,7 +3251,7 @@ function UnlessPaymentPanel() {
 function UnlessPaymentChooseCostModal() {
   const { t } = useTranslation("game");
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
 
   if (waitingFor?.type !== "UnlessPaymentChooseCost") return null;
 
@@ -3285,7 +3296,7 @@ function UnlessPaymentChooseCostModal() {
 function ActivationCostOneOfChoiceModal() {
   const { t } = useTranslation("game");
   const dispatch = useGameDispatch();
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
 
   if (waitingFor?.type !== "ActivationCostOneOfChoice") return null;
 

--- a/client/src/pages/__tests__/greenwardenDoubledTrigger.test.ts
+++ b/client/src/pages/__tests__/greenwardenDoubledTrigger.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   EngineAdapter,
+  EngineSnapshot,
   GameAction,
   GameEvent,
   GameState,
@@ -10,6 +11,7 @@ import type {
   SubmitResult,
   WaitingFor,
 } from "../../adapter/types";
+import { nextSnapshotSeq } from "../../adapter/types";
 import { dispatchAction } from "../../game/dispatch";
 import { useGameStore } from "../../stores/gameStore";
 import { usePreferencesStore } from "../../stores/preferencesStore";
@@ -93,6 +95,11 @@ function makeAdapter(
     getLegalActions: vi.fn(async (): Promise<LegalActionsResult> => ({
       actions: [],
       autoPassRecommended: false,
+    })),
+    getSnapshot: vi.fn(async (): Promise<EngineSnapshot> => ({
+      state: baseState(nextWaitingFor),
+      legalResult: { actions: [], autoPassRecommended: false },
+      seq: nextSnapshotSeq(),
     })),
     restoreState: vi.fn(),
     getAiAction: vi.fn().mockReturnValue(null),

--- a/client/src/pages/__tests__/optionalEffectChoiceTransition.test.tsx
+++ b/client/src/pages/__tests__/optionalEffectChoiceTransition.test.tsx
@@ -32,12 +32,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   EngineAdapter,
+  EngineSnapshot,
   GameAction,
   GameState,
   LegalActionsResult,
   SubmitResult,
   WaitingFor,
 } from "../../adapter/types";
+import { nextSnapshotSeq } from "../../adapter/types";
 import { OptionalEffectModalContent } from "../../components/modal/OptionalEffectModal.tsx";
 import { DialogHost } from "../../components/modal/DialogHost.tsx";
 import { dispatchAction } from "../../game/dispatch.ts";
@@ -132,6 +134,11 @@ function scriptedAdapter(): {
     ),
     getState: vi.fn(async () => sequence[step]),
     getLegalActions: vi.fn(async () => EMPTY_LEGAL),
+    getSnapshot: vi.fn(async (): Promise<EngineSnapshot> => ({
+      state: sequence[step],
+      legalResult: EMPTY_LEGAL,
+      seq: nextSnapshotSeq(),
+    })),
     restoreState: vi.fn(),
     getAiAction: vi.fn().mockReturnValue(null),
     estimateBracket: vi.fn().mockResolvedValue(null),

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -669,7 +669,7 @@ export function GameProvider({
             }
           }
           if (event.type === "stateChanged") {
-            processRemoteUpdate(event.state, event.events, event.legalResult, event.logEntries);
+            processRemoteUpdate(event.snapshot, event.events, event.logEntries);
           }
           if (event.type === "guestConnected") {
             notifyOpponentJoined(tRef.current);
@@ -1017,11 +1017,12 @@ export function GameProvider({
             if (needAdapter) {
               useGameStore.setState({ adapter: wsAdapter });
             }
-            processRemoteUpdate(event.state, event.events, event.legalResult, event.logEntries);
+            processRemoteUpdate(event.snapshot, event.events, event.logEntries);
             useMultiplayerStore.getState().setConnectionStatus("connected");
+            const wsState = event.snapshot.state;
             if (
-              event.state.match_phase === "Completed"
-              || (!event.state.match_phase && event.state.waiting_for.type === "GameOver")
+              wsState.match_phase === "Completed"
+              || (!wsState.match_phase && wsState.waiting_for.type === "GameOver")
             ) {
               clearActiveGame();
             }

--- a/client/src/stores/__tests__/gameStore.test.ts
+++ b/client/src/stores/__tests__/gameStore.test.ts
@@ -1,7 +1,7 @@
 import { act } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import type { GameEvent } from "../../adapter/types";
+import type { GameEvent, GameState } from "../../adapter/types";
 import { buildEngineAdapterMock } from "../../test/factories/engineAdapterFactory";
 import {
   buildGameState,
@@ -125,6 +125,14 @@ describe("gameStore", () => {
     const state1 = buildGameState({ turn_number: 1 });
     const state2 = buildGameState({ turn_number: 2 });
     const adapter = buildEngineAdapterMock(state1);
+    // Model a real engine: `restoreState` actually rewinds it, so the read that
+    // follows returns the restored state. `undo` commits the snapshot's own
+    // post-restore state (post-restore, the engine is the source of truth and
+    // both halves of the pair must come from it), so a mock whose reads ignored
+    // `restoreState` would be lying about the engine.
+    adapter.restoreState.mockImplementation((restored: GameState) => {
+      adapter.getState.mockResolvedValue(restored);
+    });
 
     await act(() => useGameStore.getState().initGame("test-id", adapter));
     adapter.getState.mockResolvedValue(state2);

--- a/client/src/stores/__tests__/gameStoreCommitGate.test.ts
+++ b/client/src/stores/__tests__/gameStoreCommitGate.test.ts
@@ -1,0 +1,180 @@
+/**
+ * `commitEngineSnapshot` is the single writer of the live-game engine pair
+ * (`gameState`, `waitingFor`, and the `legalResultState(...)` fields). These
+ * tests pin its two load-bearing properties:
+ *
+ *  1. **Revision gate** — a pair derived from an OLDER engine version never
+ *     clobbers a newer one already committed. This is what makes a mid-animation
+ *     commit safe: whichever pair is newer wins, regardless of arrival order.
+ *  2. **History is not gated** — events, log entries, and undo checkpoints are
+ *     ordered by arrival, not by engine epoch, so they apply even when the pair
+ *     they arrived with is dropped.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { EngineSnapshot, GameEvent, GameLogEntry, GameState } from "../../adapter/types";
+import { nextSnapshotSeq } from "../../adapter/types";
+import {
+  buildGameState,
+  buildLegalActionsResult,
+  buildPriorityWaitingFor,
+} from "../../test/factories/gameStateFactory";
+import { useGameStore } from "../gameStore";
+
+const PRIORITY = buildPriorityWaitingFor({ data: { player: 0 } });
+
+const OPTIONAL_EFFECT_CHOICE = {
+  type: "OptionalEffectChoice",
+  data: { player: 0, source_id: 100, description: "you may have target player lose 3 life." },
+} as unknown as GameState["waiting_for"];
+
+/** A coherent pair: the state and the legal actions the engine derived from it. */
+function snapshotOf(
+  waitingFor: GameState["waiting_for"],
+  actions: { type: string }[],
+  seq: number = nextSnapshotSeq(),
+): EngineSnapshot {
+  return {
+    state: buildGameState({ waiting_for: waitingFor }),
+    legalResult: buildLegalActionsResult({ actions: actions as never }),
+    seq,
+  };
+}
+
+function logEntry(text: string): GameLogEntry {
+  return {
+    seq: 0,
+    turn: 1,
+    phase: "PreCombatMain",
+    category: "Debug",
+    segments: [{ type: "Text", value: text }],
+  } as GameLogEntry;
+}
+
+describe("gameStore commitEngineSnapshot — revision gate", () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+  });
+
+  it("commits a fresh pair and records its seq", () => {
+    const snapshot = snapshotOf(PRIORITY, [{ type: "PassPriority" }]);
+
+    const accepted = useGameStore.getState().commitEngineSnapshot(snapshot);
+
+    const store = useGameStore.getState();
+    expect(accepted).toBe(true);
+    expect(store.gameState).toEqual(snapshot.state);
+    expect(store.waitingFor).toEqual(PRIORITY);
+    expect(store.legalActions).toEqual(snapshot.legalResult.actions);
+    expect(store.lastCommittedSeq).toBe(snapshot.seq);
+  });
+
+  it("drops a stale pair rather than letting it clobber a newer one", () => {
+    // The exact softlock shape: the NEWER engine version is at
+    // OptionalEffectChoice; an older in-flight commit still holds Priority.
+    const newer = snapshotOf(OPTIONAL_EFFECT_CHOICE, [
+      { type: "DecideOptionalEffect" },
+    ]);
+    const stale = snapshotOf(PRIORITY, [{ type: "PassPriority" }], newer.seq - 1);
+
+    useGameStore.getState().commitEngineSnapshot(newer);
+    const accepted = useGameStore.getState().commitEngineSnapshot(stale);
+
+    const store = useGameStore.getState();
+    expect(accepted).toBe(false);
+    // Every pair field still reflects the NEWER snapshot, not the stale one.
+    expect(store.waitingFor).toEqual(OPTIONAL_EFFECT_CHOICE);
+    expect(store.legalActions).toEqual(newer.legalResult.actions);
+    expect(store.gameState).toEqual(newer.state);
+    expect(store.lastCommittedSeq).toBe(newer.seq);
+  });
+
+  it("accepts an equal seq (idempotent re-commit of one cached wire snapshot)", () => {
+    // A guest/ws snapshot can be committed twice — once by the remote-update
+    // path, once by a local read of the same cached object. The pairs are
+    // byte-identical, so `>=` must let both through rather than wedging the gate.
+    const snapshot = snapshotOf(PRIORITY, [{ type: "PassPriority" }]);
+
+    expect(useGameStore.getState().commitEngineSnapshot(snapshot)).toBe(true);
+    expect(useGameStore.getState().commitEngineSnapshot(snapshot)).toBe(true);
+
+    expect(useGameStore.getState().waitingFor).toEqual(PRIORITY);
+    expect(useGameStore.getState().lastCommittedSeq).toBe(snapshot.seq);
+  });
+
+  it("drops a leftover cross-match commit (Bo3 game-2 case)", () => {
+    // Game 1's dispatch queue captured a snapshot, then the match ended and a new
+    // adapter was built for game 2. Because the seq counter is module-GLOBAL (not
+    // per-adapter), game 2's fresh post-init fetch outranks the leftover — so the
+    // late game-1 commit is dropped instead of latching the gate above game 2 and
+    // softlocking it permanently.
+    const leftoverGame1 = snapshotOf(PRIORITY, [{ type: "PassPriority" }]);
+    const game2Install = snapshotOf(OPTIONAL_EFFECT_CHOICE, [
+      { type: "DecideOptionalEffect" },
+    ]);
+    expect(game2Install.seq).toBeGreaterThan(leftoverGame1.seq);
+
+    useGameStore.getState().commitEngineSnapshot(game2Install);
+    const accepted = useGameStore.getState().commitEngineSnapshot(leftoverGame1);
+
+    expect(accepted).toBe(false);
+    expect(useGameStore.getState().gameState).toEqual(game2Install.state);
+    expect(useGameStore.getState().waitingFor).toEqual(OPTIONAL_EFFECT_CHOICE);
+  });
+
+  it("applies events, log entries, and undo checkpoints even when the pair is dropped", () => {
+    const newer = snapshotOf(OPTIONAL_EFFECT_CHOICE, [{ type: "DecideOptionalEffect" }]);
+    useGameStore.getState().commitEngineSnapshot(newer);
+
+    const stale = snapshotOf(PRIORITY, [{ type: "PassPriority" }], newer.seq - 1);
+    const events: GameEvent[] = [{ type: "PriorityPassed", data: { player_id: 0 } }];
+    const checkpoint = buildGameState({ turn_number: 7 });
+
+    const accepted = useGameStore.getState().commitEngineSnapshot(stale, {
+      events,
+      logEntries: [logEntry("stale-but-real")],
+      stateHistory: [checkpoint],
+    });
+
+    const store = useGameStore.getState();
+    expect(accepted).toBe(false);
+    // History is ordered by ARRIVAL, not engine epoch — it lands regardless.
+    expect(store.events).toEqual(events);
+    expect(store.eventHistory).toEqual(events);
+    expect(store.logHistory).toEqual([{ ...logEntry("stale-but-real"), seq: 0 }]);
+    expect(store.nextLogSeq).toBe(1);
+    // A checkpoint is a PRE-action state — valid whichever pair wins. Dropping it
+    // would silently lose an undo step.
+    expect(store.stateHistory).toEqual([checkpoint]);
+    // …but the pair itself is still the newer one.
+    expect(store.waitingFor).toEqual(OPTIONAL_EFFECT_CHOICE);
+  });
+
+  it("applies extraState only on an accepted commit, after the base commit", () => {
+    const first = snapshotOf(PRIORITY, [{ type: "PassPriority" }]);
+    useGameStore.getState().commitEngineSnapshot(first, {
+      events: [{ type: "PriorityPassed", data: { player_id: 0 } }],
+    });
+
+    // An init/restore-shaped commit: newest-by-construction, and its extraState
+    // resets the histories atomically with its pair.
+    const reinit = snapshotOf(OPTIONAL_EFFECT_CHOICE, [{ type: "DecideOptionalEffect" }]);
+    useGameStore.getState().commitEngineSnapshot(reinit, {
+      extraState: { gameId: "game-2", events: [], eventHistory: [], logHistory: [], nextLogSeq: 0 },
+    });
+
+    const store = useGameStore.getState();
+    expect(store.gameId).toBe("game-2");
+    expect(store.eventHistory).toEqual([]);
+    expect(store.waitingFor).toEqual(OPTIONAL_EFFECT_CHOICE);
+  });
+
+  it("reset returns the gate counter to zero", () => {
+    useGameStore.getState().commitEngineSnapshot(snapshotOf(PRIORITY, []));
+    expect(useGameStore.getState().lastCommittedSeq).toBeGreaterThan(0);
+
+    useGameStore.getState().reset();
+
+    expect(useGameStore.getState().lastCommittedSeq).toBe(0);
+  });
+});

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import type {
   EngineAdapter,
+  EngineSnapshot,
   FormatConfig,
   GameAction,
   GameEvent,
@@ -135,7 +136,31 @@ interface GameStoreState {
    * p2p). Consumed by telemetry `game_end` to classify `winner_kind`.
    */
   aiSeatIds: PlayerId[];
+  /**
+   * `EngineSnapshot.seq` of the most recently committed engine pair — the gate
+   * `commitEngineSnapshot` uses to drop commits derived from an older engine
+   * version than one already applied. Transient (never persisted); returns to 0
+   * with the rest of `initialState` on `reset`.
+   */
+  lastCommittedSeq: number;
 }
+
+/**
+ * Fields written exclusively by `commitEngineSnapshot` from the snapshot's own
+ * contents. `extraState` structurally EXCLUDES them: were they writable there,
+ * a caller could smuggle an ungated pair field past the revision gate and
+ * reintroduce exactly the mixed-epoch commit this authority exists to prevent.
+ * `lastCommittedSeq` (the gate counter itself) is excluded for the same reason.
+ */
+type CommitExtraState = Partial<Omit<GameStoreState,
+  | "gameState"
+  | "waitingFor"
+  | "legalActions"
+  | "autoPassRecommended"
+  | "spellCosts"
+  | "legalActionsByObject"
+  | "stuckDiagnostic"
+  | "lastCommittedSeq">>;
 
 interface GameStoreActions {
   initGame: (
@@ -160,9 +185,52 @@ interface GameStoreActions {
   undo: () => Promise<void>;
   reset: () => void;
   setAdapter: (adapter: EngineAdapter) => void;
-  setGameState: (state: GameState) => void;
-  setWaitingFor: (waitingFor: WaitingFor | null) => void;
-  setLegalActions: (actions: GameAction[]) => void;
+  /**
+   * THE single writer of the live-game engine pair (`gameState`, `waitingFor`,
+   * and every `legalResultState(...)` field). Every live-game commit — local
+   * dispatch, remote update, batch resolve, init, resume, undo, restore —
+   * routes through here.
+   *
+   * Revision gate: the pair is applied iff `snapshot.seq >= lastCommittedSeq`,
+   * so a commit derived from an OLDER engine version can never clobber a newer
+   * one already applied. (Equal seq arises only from two reads of the same
+   * cached wire snapshot, whose pairs are byte-identical, so `>=` is idempotent
+   * and lets a remote update and a local read of that snapshot coexist.)
+   * Returns false when the pair was dropped as stale.
+   *
+   * Events, log entries, and undo checkpoints are applied ALWAYS, even for a
+   * dropped pair: history is ordered by arrival, not by engine epoch, and a
+   * checkpoint is a pre-action state that stays valid whichever pair wins.
+   *
+   * Known residue (documented, not fixed here): because history applies
+   * unconditionally, a leftover cross-match commit can append game-1 entries
+   * into game-2's histories after its pair is correctly dropped. Strictly less
+   * wrong than the pre-fix behavior, where the whole stale pair clobbered.
+   *
+   * Documented exemptions from this authority (all write outside a live game,
+   * or are immediately superseded by a newest-by-construction commit):
+   * `replayStore` timeline scrubbing, the GameOver-only `waitingFor` writes in
+   * `GamePage`, `sessionCleanup`'s session-boundary prompt clear, and the
+   * teardown clears in `GameProvider`/`disposeMatchAdapter`.
+   */
+  commitEngineSnapshot: (
+    snapshot: EngineSnapshot,
+    opts?: {
+      /** Replaces `events`; appended to `eventHistory`. Applied even when the pair is dropped. */
+      events?: GameEvent[];
+      /** Seq-stamped and appended to `logHistory`. Applied even when the pair is dropped. */
+      logEntries?: GameLogEntry[];
+      /** Undo checkpoints. Applied even when the pair is dropped. */
+      stateHistory?: GameState[];
+      /**
+       * Site-specific fields applied in the SAME `set()` — but only when the
+       * pair commit is accepted, and after the base commit + history handling,
+       * so init/resume/restore sites can atomically reset or seed history
+       * fields alongside their pair.
+       */
+      extraState?: CommitExtraState;
+    },
+  ) => boolean;
   setGameMode: (mode: GameMode) => void;
   setLobbyProgress: (progress: { joined: number; total: number } | null) => void;
   setResolutionProgress: (progress: { resolved: number; total: number } | null) => void;
@@ -195,11 +263,58 @@ const initialState: GameStoreState = {
   isResolvingAll: false,
   startingContest: null,
   aiSeatIds: [],
+  lastCommittedSeq: 0,
 };
 
 export const useGameStore = create<GameStore>()(
   subscribeWithSelector((set, get) => ({
     ...initialState,
+
+    commitEngineSnapshot: (snapshot, opts) => {
+      // Decide the gate BEFORE `set`, so the updater stays a pure reducer.
+      // Safe: `get()` → `set()` runs synchronously with no `await` between, so
+      // no other commit can land in the window.
+      const accepted = snapshot.seq >= get().lastCommittedSeq;
+
+      set((prev) => {
+        // Seq-stamp incoming log entries against the CURRENT counter.
+        let nextLogSeq = prev.nextLogSeq;
+        const stampedLogEntries = (opts?.logEntries ?? []).map((entry) => ({
+          ...entry,
+          seq: nextLogSeq++,
+        }));
+
+        return {
+          // 1. The engine pair — gated.
+          ...(accepted
+            ? {
+                gameState: snapshot.state,
+                waitingFor: snapshot.state.waiting_for,
+                ...legalResultState(snapshot.legalResult),
+                lastCommittedSeq: snapshot.seq,
+              }
+            : {}),
+          // 2. History — ordered by arrival, so applied unconditionally.
+          ...(opts?.events
+            ? {
+                events: opts.events,
+                eventHistory: [...prev.eventHistory, ...opts.events].slice(-1000),
+              }
+            : {}),
+          ...(opts?.logEntries
+            ? {
+                logHistory: [...prev.logHistory, ...stampedLogEntries].slice(-2000),
+                nextLogSeq,
+              }
+            : {}),
+          ...(opts?.stateHistory ? { stateHistory: opts.stateHistory } : {}),
+          // 3. Site-specific fields last, so an init/resume/restore reset wins
+          //    over the history append above.
+          ...(accepted ? opts?.extraState : undefined),
+        };
+      });
+      return accepted;
+    },
 
     initGame: async (gameId, adapter, deckData, formatConfig, playerCount, matchConfig, firstPlayer) => {
       // Clear the display-only stack-pacing tracker so a fast-churning end to a
@@ -208,8 +323,11 @@ export const useGameStore = create<GameStore>()(
       resetStackThroughput();
       await adapter.initialize();
       const initResult = await adapter.initializeGame(deckData, formatConfig, playerCount, matchConfig, firstPlayer);
-      const state = await adapter.getState();
-      const legalResult = await adapter.getLegalActions();
+      // Fetched AFTER the engine is initialized, so this snapshot is
+      // newest-by-construction under the global counter — it always passes the
+      // gate, and it drops any leftover in-flight commit from a prior match.
+      const snapshot = await adapter.getSnapshot();
+      const state = snapshot.state;
       const initLogEntries = (initResult.log_entries ?? []).map((entry, i) => ({
         ...entry,
         seq: i,
@@ -230,19 +348,18 @@ export const useGameStore = create<GameStore>()(
             startingPlayer: state.current_starting_player ?? state.active_player,
           }
         : null;
-      set({
-        gameId,
-        adapter,
-        gameState: state,
-        waitingFor: state.waiting_for,
-        ...legalResultState(legalResult),
-        events: [],
-        eventHistory: [],
-        logHistory: initLogEntries,
-        nextLogSeq: initLogEntries.length,
-        stateHistory: [],
-        turnCheckpoints: [],
-        startingContest,
+      get().commitEngineSnapshot(snapshot, {
+        extraState: {
+          gameId,
+          adapter,
+          events: [],
+          eventHistory: [],
+          logHistory: initLogEntries,
+          nextLogSeq: initLogEntries.length,
+          stateHistory: [],
+          turnCheckpoints: [],
+          startingContest,
+        },
       });
       saveGame(gameId, state);
     },
@@ -253,21 +370,20 @@ export const useGameStore = create<GameStore>()(
       resetStackThroughput();
       await adapter.initialize();
       await adapter.restoreState(savedState);
-      const state = await adapter.getState();
-      const legalResult = await adapter.getLegalActions();
+      // Post-restore fetch — newest-by-construction, so it always passes the gate.
+      const snapshot = await adapter.getSnapshot();
       const savedCheckpoints = await loadCheckpoints(gameId);
-      set({
-        gameId,
-        adapter,
-        gameState: state,
-        waitingFor: state.waiting_for,
-        ...legalResultState(legalResult),
-        events: [],
-        eventHistory: [],
-        logHistory: [],
-        nextLogSeq: 0,
-        stateHistory: [],
-        turnCheckpoints: savedCheckpoints,
+      get().commitEngineSnapshot(snapshot, {
+        extraState: {
+          gameId,
+          adapter,
+          events: [],
+          eventHistory: [],
+          logHistory: [],
+          nextLogSeq: 0,
+          stateHistory: [],
+          turnCheckpoints: savedCheckpoints,
+        },
       });
     },
 
@@ -280,20 +396,20 @@ export const useGameStore = create<GameStore>()(
       // is to pull the state out and seed the store. No stateHistory
       // (multiplayer = no undo); no checkpoints (P2P never saved them).
       await adapter.initialize();
-      const state = await adapter.getState();
-      const legalResult = await adapter.getLegalActions();
-      set({
-        gameId,
-        adapter,
-        gameState: state,
-        waitingFor: state.waiting_for,
-        ...legalResultState(legalResult),
-        events: [],
-        eventHistory: [],
-        logHistory: [],
-        nextLogSeq: 0,
-        stateHistory: [],
-        turnCheckpoints: [],
+      // Fetched after that `initialize()` (which is what restored the engine, per
+      // the note above), so the snapshot is newest-by-construction.
+      const snapshot = await adapter.getSnapshot();
+      get().commitEngineSnapshot(snapshot, {
+        extraState: {
+          gameId,
+          adapter,
+          events: [],
+          eventHistory: [],
+          logHistory: [],
+          nextLogSeq: 0,
+          stateHistory: [],
+          turnCheckpoints: [],
+        },
       });
     },
 
@@ -321,34 +437,21 @@ export const useGameStore = create<GameStore>()(
       // The engine rejects the action if this doesn't match the authorized
       // submitter — never trust the UI to route actions to the right seat.
       const result = await adapter.submitAction(submittedAction, getPlayerId());
-      const newState = await adapter.getState();
-      const legalResult = await adapter.getLegalActions();
+      // ONE atomic pair — a separate getState()/getLegalActions() pair could
+      // straddle an engine advance and commit a mismatched state/actions pair.
+      const snapshot = await adapter.getSnapshot();
 
-      set((prev) => {
-        const newHistory = shouldSaveHistory
-          ? [...prev.stateHistory, gameState].slice(-MAX_UNDO_HISTORY)
-          : prev.stateHistory;
-
-        // Assign monotonic sequence numbers to new log entries
-        let seq = prev.nextLogSeq;
-        const newLogEntries = (result.log_entries ?? []).map((entry) => ({
-          ...entry,
-          seq: seq++,
-        }));
-
-        return {
-          gameState: newState,
-          events: result.events,
-          eventHistory: [...prev.eventHistory, ...result.events].slice(-1000),
-          logHistory: [...prev.logHistory, ...newLogEntries].slice(-2000),
-          nextLogSeq: seq,
-          waitingFor: newState.waiting_for,
-          ...legalResultState(legalResult),
-          stateHistory: newHistory,
-        };
+      // Read-then-commit with no `await` between, so no other commit interleaves.
+      const stateHistory = shouldSaveHistory
+        ? [...get().stateHistory, gameState].slice(-MAX_UNDO_HISTORY)
+        : undefined;
+      get().commitEngineSnapshot(snapshot, {
+        events: result.events,
+        logEntries: result.log_entries ?? [],
+        stateHistory,
       });
 
-      if (gameId) saveGame(gameId, newState);
+      if (gameId) saveGame(gameId, snapshot.state);
 
       return result.events;
     },
@@ -362,14 +465,16 @@ export const useGameStore = create<GameStore>()(
 
       // Sync WASM engine state with the restored client state
       await adapter.restoreState(previous);
-      const legalResult = await adapter.getLegalActions();
+      // Commit the snapshot's OWN state, not `previous`: post-restore the engine
+      // is the source of truth, and taking both halves from one snapshot is what
+      // keeps the pair coherent. Newest-by-construction, so it passes the gate.
+      const snapshot = await adapter.getSnapshot();
 
-      set({
-        gameState: previous,
-        waitingFor: previous.waiting_for,
-        ...legalResultState(legalResult),
-        events: [],
-        stateHistory: stateHistory.slice(0, -1),
+      get().commitEngineSnapshot(snapshot, {
+        extraState: {
+          events: [],
+          stateHistory: stateHistory.slice(0, -1),
+        },
       });
     },
 
@@ -383,18 +488,6 @@ export const useGameStore = create<GameStore>()(
 
     setAdapter: (adapter) => {
       set({ adapter });
-    },
-
-    setGameState: (state) => {
-      set({ gameState: state });
-    },
-
-    setWaitingFor: (waitingFor) => {
-      set({ waitingFor });
-    },
-
-    setLegalActions: (actions) => {
-      set({ legalActions: actions });
     },
 
     setGameMode: (mode) => {

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -26,7 +26,7 @@ import type { DraftMatchLaunch, DraftPauseReason } from "../network/draftProtoco
 import type { AISeatBinding } from "../game/controllers/aiController";
 import { createGameLoopController, type GameLoopController } from "../game/controllers/gameLoopController";
 import { processRemoteUpdate } from "../game/dispatch";
-import { legalResultState, useGameStore } from "./gameStore";
+import { useGameStore } from "./gameStore";
 import {
   DraftPodHostAdapter,
   type DraftPodHostConfig,
@@ -285,27 +285,29 @@ async function installMatchRuntime(
   initResult: SubmitResult,
   controllerMode: "ai" | "online",
 ): Promise<void> {
-  const state = await adapter.getState();
-  const legalResult = await adapter.getLegalActions();
+  // Fetched after this match's engine is up, so the snapshot is
+  // newest-by-construction under the global seq counter: it always passes the
+  // commit gate, and it inherently drops any commit still in flight from the
+  // previous game of a Bo3 (whose stamps are strictly lower).
+  const snapshot = await adapter.getSnapshot();
   const initLogEntries: GameLogEntry[] = (initResult.log_entries ?? []).map((entry, i) => ({
     ...entry,
     seq: i,
   }));
 
-  useGameStore.setState({
-    gameId,
-    gameMode: "draft-match",
-    adapter,
-    gameState: state,
-    waitingFor: state.waiting_for,
-    ...legalResultState(legalResult),
-    events: [] as GameEvent[],
-    eventHistory: [] as GameEvent[],
-    logHistory: initLogEntries,
-    nextLogSeq: initLogEntries.length,
-    stateHistory: [],
-    turnCheckpoints: [],
-    lobbyProgress: null,
+  useGameStore.getState().commitEngineSnapshot(snapshot, {
+    extraState: {
+      gameId,
+      gameMode: "draft-match",
+      adapter,
+      events: [] as GameEvent[],
+      eventHistory: [] as GameEvent[],
+      logHistory: initLogEntries,
+      nextLogSeq: initLogEntries.length,
+      stateHistory: [],
+      turnCheckpoints: [],
+      lobbyProgress: null,
+    },
   });
 
   disposeMatchController();
@@ -396,7 +398,14 @@ function activePhaseForDraftViewStatus(status: DraftPlayerView["status"]): Activ
   }
 }
 
-/** Dispose the active match adapter (P2PHostAdapter or P2PGuestAdapter). */
+/**
+ * Dispose the active match adapter (P2PHostAdapter or P2PGuestAdapter).
+ *
+ * Documented exemption from the `commitEngineSnapshot` single-writer invariant:
+ * this is a teardown clear, not a live-game commit. It has no snapshot to gate
+ * on, and any subsequent live commit arrives newest-by-construction (a fresh
+ * post-init fetch), so it cannot be resurrected by a stale pair.
+ */
 function disposeMatchAdapter(set: SetFn): void {
   const state = useMultiplayerDraftStore.getState();
   disposeMatchController();
@@ -642,10 +651,10 @@ export const useMultiplayerDraftStore = create<
             resolveRoomFull();
           }
           if (event.type === "stateChanged") {
-            void processRemoteUpdate(event.state, event.events, event.legalResult, event.logEntries);
+            void processRemoteUpdate(event.snapshot, event.events, event.logEntries);
           }
           if (event.type === "stateChanged") {
-            const wf = event.state?.waiting_for;
+            const wf = event.snapshot.state?.waiting_for;
             if (!wf) return;
 
             if (wf.type === "GameOver") {
@@ -715,10 +724,10 @@ export const useMultiplayerDraftStore = create<
 
         matchAdapter.onEvent((event) => {
           if (event.type === "stateChanged") {
-            void processRemoteUpdate(event.state, event.events, event.legalResult, event.logEntries);
+            void processRemoteUpdate(event.snapshot, event.events, event.logEntries);
           }
           if (event.type === "stateChanged") {
-            const wf = event.state?.waiting_for;
+            const wf = event.snapshot.state?.waiting_for;
             if (!wf) return;
 
             if (wf.type === "GameOver") {

--- a/client/src/test/factories/engineAdapterFactory.ts
+++ b/client/src/test/factories/engineAdapterFactory.ts
@@ -1,23 +1,48 @@
 import { vi } from "vitest";
 
-import type { EngineAdapter } from "../../adapter/types.ts";
+import type { EngineAdapter, EngineSnapshot } from "../../adapter/types.ts";
+import { nextSnapshotSeq } from "../../adapter/types.ts";
 import { buildGameState, buildLegalActionsResult } from "./gameStateFactory.ts";
 
 export const buildEngineAdapterMock = (
   state = buildGameState(),
   overrides: Partial<EngineAdapter> = {},
 ) => {
+  // Holder for the FINAL (post-override) adapter, so the default `getSnapshot`
+  // below can delegate to whatever `getState` / `getLegalActions` the caller
+  // ended up with. A holder (rather than a direct self-reference) keeps TS out
+  // of circular inference.
+  const ref: { current?: EngineAdapter } = {};
+
   const adapter = {
     initialize: vi.fn().mockResolvedValue(undefined),
     initializeGame: vi.fn().mockResolvedValue({ events: [] }),
     submitAction: vi.fn().mockResolvedValue({ events: [] }),
     getState: vi.fn().mockResolvedValue(state),
     getLegalActions: vi.fn().mockResolvedValue(buildLegalActionsResult()),
+    /**
+     * Default `getSnapshot` composes the adapter's OWN `getState` +
+     * `getLegalActions` at call time, so a test that scripts either of those
+     * (via `overrides`, or by reassigning them afterwards) gets a snapshot
+     * consistent with its script for free — the same pair, read together.
+     *
+     * The seq comes from the real global counter, so a snapshot taken later in a
+     * test always outranks one taken earlier and the store's revision gate
+     * behaves exactly as it does in production. A test that needs a *stale*
+     * snapshot overrides `getSnapshot` and supplies its own lower seq.
+     */
+    getSnapshot: vi.fn(async (): Promise<EngineSnapshot> => ({
+      state: await ref.current!.getState(),
+      legalResult: await ref.current!.getLegalActions(),
+      seq: nextSnapshotSeq(),
+    })),
     restoreState: vi.fn(),
     getAiAction: vi.fn().mockReturnValue(null),
     dispose: vi.fn(),
     estimateBracket: vi.fn().mockResolvedValue(null),
   } satisfies EngineAdapter;
 
-  return Object.assign(adapter, overrides);
+  const merged = Object.assign(adapter, overrides);
+  ref.current = merged;
+  return merged;
 };


### PR DESCRIPTION
A P2P host could permanently softlock with the store holding a gameState
fetched before the animation window paired with legalActions fetched after
it (waiting_for: Priority + DecideOptionalEffect actions), so the UI showed
Resolve/Resolve All while the engine rejected those actions and the
optional-effect modal never appeared.

- Add EngineSnapshot {state, legalResult, seq} with a required
  getSnapshot() on EngineAdapter; the worker reads state + legal actions
  in one yield-free synchronous block, guests/ws cache one snapshot per
  inbound message, and seq comes from one module-global monotonic counter.
- Add commitEngineSnapshot to gameStore as the single revision-gated
  writer of the pair fields (accept iff seq >= lastCommittedSeq; events,
  logs, and undo checkpoints still apply in arrival order); delete the
  dead bypass setters; type extraState to structurally exclude the pair.
- processAction commits the one snapshot it fetched (second post-animation
  getLegalActions fetch removed); P2PHostAdapter internal advance paths
  (AI loop, guest actions, concede) use atomic snapshots; stateChanged
  events carry the snapshot object end to end.
- Unify waitingFor authority across 14 GamePage modal/effect sites that
  re-read gameState.waiting_for behind outer gates on store waitingFor.
- Incidentally fix the ws GameStarted reconnect emit sending raw state
  without the derived-data attach.
- Regression tests: commit-gate semantics, the observed softlock shape
  (demonstrated red against the pre-fix pairing), guest snapshot coherence.
