### PR TITLE
fix(parser): bind cross-resolution "the exiled card" to ExiledBySource (Hideaway LTB)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6040,7 +6040,7 @@ pub(super) fn parse_put_ast(
         }
     }
 
-    if let Some((effect, choice_count)) = super::try_parse_put_zone_change_parts(lower, text) {
+    if let Some((effect, choice_count)) = super::try_parse_put_zone_change_parts(lower, text, ctx) {
         return match effect {
             Effect::ChangeZoneAll {
                 origin,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -27514,12 +27514,13 @@ fn tracked_anaphor_cause(before_lower: &str, is_dig_anaphor: bool) -> Option<Opt
 
 #[cfg(test)]
 fn try_parse_put_zone_change(lower: &str, text: &str) -> Option<Effect> {
-    try_parse_put_zone_change_parts(lower, text).map(|(effect, _)| effect)
+    try_parse_put_zone_change_parts(lower, text, &ParseContext::default()).map(|(effect, _)| effect)
 }
 
 fn try_parse_put_zone_change_parts(
     lower: &str,
     text: &str,
+    ctx: &ParseContext,
 ) -> Option<(Effect, Option<MultiTargetSpec>)> {
     let tp = TextPair::new(text, lower);
     let (_, after_put_tp) = tp.split_at(4);
@@ -27641,6 +27642,27 @@ fn try_parse_put_zone_change_parts(
                     caused_by,
                 },
                 None => target,
+            };
+            // CR 406.6 + CR 607.1/607.2a (#5577): a singular "the exiled card"
+            // anaphor in a `ChangeZoneAll` "put" clause whose exile was made in a
+            // SEPARATE, earlier resolution must bind durably to `ExiledBySource`,
+            // not the chain-local `TrackedSet(0)` sentinel — the THIRD emission
+            // site (after the Copy verb and `try_parse_cast_effect`) of the #5571
+            // cross-resolution rebinding. Watcher for Tomorrow's Hideaway LTB
+            // ("put the exiled card into its owner's hand") references the card
+            // exiled by its ETB, so the LTB chain has no exile producer and the
+            // `TrackedSet(0)` sentinel is empty at resolution. A SAME-chain exile
+            // keeps `TrackedSet(0)` (the helper returns `same_chain_binding`); a
+            // "this way" tracked anaphor keeps its `TrackedSetFiltered` path
+            // (guarded by `!is_tracked_anaphor`); an exile-cost zone context is
+            // excluded exactly as the cast-path caller does.
+            let target = if !is_tracked_anaphor
+                && ctx.current_ability_exile_cost_zone.is_none()
+                && target_text.trim().eq_ignore_ascii_case("the exiled card")
+            {
+                resolve_singular_exiled_card_target(ctx.chain_has_prior_exile_producer, target)
+            } else {
+                target
             };
             // CR 608.2c: A tracked-set anaphor ("<filter> revealed/milled/…
             // this way", "from among them") already names the exact objects;

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -8707,6 +8707,74 @@ fn return_leading_their_hand_all_exiled_with_source() {
     ));
 }
 
+/// CR 406.6 + CR 607.1/607.2a (#5577): Watcher for Tomorrow's Hideaway
+/// leaves-the-battlefield trigger — "put the exiled card into its owner's hand"
+/// — references the card THIS source exiled in a SEPARATE, earlier resolution
+/// (its ETB Hideaway). The LTB chain has no exile producer, so the singular "the
+/// exiled card" anaphor in the `ChangeZoneAll` "put" clause must bind durably to
+/// `ExiledBySource` (resolved at runtime via `exile_links`), not the chain-local
+/// `TrackedSet(0)` sentinel that is empty at LTB time. Third emission site of the
+/// #5571 cross-resolution fix (after the Copy verb and `try_parse_cast_effect`).
+#[test]
+fn hideaway_ltb_put_exiled_card_binds_exiled_by_source() {
+    let parsed = parse_oracle_text(
+        "Hideaway 4 (When this creature enters, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\n\
+         This creature enters tapped.\n\
+         When this creature leaves the battlefield, put the exiled card into its owner's hand.",
+        "Watcher for Tomorrow",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Wizard".to_string()],
+    );
+    let ltb = parsed
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_deref())
+        .expect("Watcher must have an LTB execute chain");
+    assert!(
+        matches!(
+            &*ltb.effect,
+            Effect::ChangeZoneAll {
+                origin: Some(Zone::Exile),
+                destination: Zone::Hand,
+                target: TargetFilter::ExiledBySource,
+                ..
+            }
+        ),
+        "cross-resolution LTB 'put the exiled card' must bind ExiledBySource, got {:?}",
+        ltb.effect
+    );
+}
+
+/// Regression guard for the #5577 fix: a SAME-chain exile-then-put keeps the
+/// chain-local `TrackedSet(0)` binding (the helper returns `same_chain_binding`
+/// when `chain_has_prior_exile_producer` is set), so it must NOT flip to
+/// `ExiledBySource`.
+#[test]
+fn same_chain_put_exiled_card_keeps_tracked_set() {
+    let def = parse_effect_chain(
+        "Exile the top card of your library. Put the exiled card into your hand.",
+        AbilityKind::Spell,
+    );
+    // Walk the chain to the ChangeZoneAll "put" node.
+    fn find_put(def: &AbilityDefinition) -> Option<&TargetFilter> {
+        if let Effect::ChangeZoneAll {
+            destination: Zone::Hand,
+            target,
+            ..
+        } = &*def.effect
+        {
+            return Some(target);
+        }
+        def.sub_ability.as_deref().and_then(find_put)
+    }
+    let target = find_put(&def).expect("expected a ChangeZoneAll into hand");
+    assert!(
+        matches!(target, TargetFilter::TrackedSet { .. }),
+        "same-chain 'put the exiled card' must keep TrackedSet(0), got {target:?}"
+    );
+}
+
 #[test]
 fn effect_draw() {
     let e = parse_effect("Draw two cards");


### PR DESCRIPTION
Fixes #5577.

## Problem

Watcher for Tomorrow's Hideaway leaves-the-battlefield trigger reads:

> When this creature leaves the battlefield, put the exiled card into its owner's hand.

The exile is made during Hideaway's ETB resolution; the LTB "put the exiled card" clause resolves in a **separate, later** resolution. The parser was binding the singular "the exiled card" anaphor to the chain-local `TrackedSet(0)` sentinel, which only survives *within one resolution* (CR 608.2). By the time the LTB resolves, that ephemeral set is empty (or clobbered by unrelated activity), so the hidden card was never returned to hand.

Per CR 406.6 + CR 607.1/607.2a, a cross-resolution "the exiled card" reference must bind durably to the card **this permanent** exiled — i.e. `TargetFilter::ExiledBySource`, resolved at runtime through the `exile_links` table.

## Fix (parser-only)

In `try_parse_put_zone_change_parts` (oracle_effect/mod.rs), a singular `"the exiled card"` target in a `ChangeZoneAll` "put" clause is now re-bound to `ExiledBySource` **only when** the exile was *not* produced in the same chain (`chain_has_prior_exile_producer == false`) — the existing same-chain case still keeps `TrackedSet`, and the anaphor/exile-cost cases are excluded. This reuses the read-only `resolve_singular_exiled_card_target` helper (oracle_target.rs), threading `ParseContext` down the one call path that lacked it.

No enum, runtime, or converter change is needed: the runtime already honors `ExiledBySource` — `linked_exile_cards_for_source` (filter.rs:1937) matches the source's exile links and `extract_zones(ExiledBySource)` yields `Zone::Exile` (ability.rs). This is the **same** ExiledBySource → zone-move path already exercised end-to-end by the existing `issue_3246_windbrisk_heights_hideaway_exiled_by_source` runtime test.

## Verification

- **`hideaway_ltb_put_exiled_card_binds_exiled_by_source`** — parses the full Watcher for Tomorrow card, locates the LTB trigger, asserts `Effect::ChangeZoneAll { origin: Some(Zone::Exile), destination: Zone::Hand, target: TargetFilter::ExiledBySource, .. }`. Fails (binds `TrackedSet`) if the fix is reverted.
- **`same_chain_put_exiled_card_keeps_tracked_set`** — parses `"Exile the top card of your library. Put the exiled card into your hand."` and asserts the same-chain clause still binds `TargetFilter::TrackedSet { .. }` — guards against over-reaching into the intra-resolution case.
- Full parser lib suite: **7968 passed / 0 failed**. Parser-combinator gate + clippy clean.

Coverage note: this is a parser **emission** change on a narrow cross-resolution anaphor; it does not alter same-resolution parses (guarded by the second test).
