### PR TITLE
fix(parser): Rayami — per-keyword conditional keyword grant from exiled blood-countered cards (Fixes #5257)

### DIFF
--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1173,6 +1173,82 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
     defs
 }
 
+/// CR 611.3a + CR 702 (#5257 Rayami, First of the Fallen): "As long as an exiled
+/// <type> card [with a <counter> counter on it] has <K0>, ~ has <K0>. The same is
+/// true for <K1>, …, and <Kn>." Each listed keyword is an INDEPENDENT conditional
+/// grant — the source has keyword K as long as an exiled matching card that HAS K
+/// is present — so this emits one Continuous SelfRef static per keyword, gated on
+/// `IsPresent { filter + WithKeyword(K) }`. The shared runtime already evaluates
+/// this: `IsPresent` scans every object and `WithKeyword` reads the exiled card's
+/// keywords. Modeling it as one static with a shared condition (the prior fallback
+/// left the condition `Unrecognized`) made every keyword apply unconditionally.
+fn parse_keyword_grant_from_exiled_object_static(text: &str) -> Option<Vec<StaticDefinition>> {
+    // "As long as a[n] exiled " → the object phrase (original case for parse_type_phrase).
+    let lower = text.to_lowercase();
+    let (_, obj) = nom_on_lower(text, &lower, |i| {
+        let (i, _) = tag::<_, _, OracleError<'_>>("as long as ").parse(i)?;
+        let (i, _) = alt((tag("an "), tag("a "))).parse(i)?;
+        let (i, _) = tag("exiled ").parse(i)?;
+        Ok((i, ()))
+    })?;
+
+    // The object type phrase; the remainder begins at " has <keyword>".
+    let (base_filter, remainder) = parse_type_phrase(obj);
+    let TargetFilter::Typed(mut typed) = base_filter else {
+        return None;
+    };
+    // CR 400.1: "exiled" scopes the presence check to the exile zone.
+    typed
+        .properties
+        .push(FilterProp::InZone { zone: Zone::Exile });
+    let base = TargetFilter::Typed(typed);
+
+    // remainder (lowercased for keyword matching): "has <K0>, ~ has <K0>. The same
+    // is true for <list>." The condition keyword and the granted keyword must match.
+    let rem = remainder.trim_start().to_lowercase();
+    let (i, _) = tag::<_, _, OracleError<'_>>("has ")
+        .parse(rem.as_str())
+        .ok()?;
+    let (i, k0_name) = crate::parser::oracle_nom::primitives::parse_keyword_name(i).ok()?;
+    let (i, _) = tag::<_, _, OracleError<'_>>(", ").parse(i).ok()?;
+    let (i, _) = alt((tag::<_, _, OracleError<'_>>("~ has "), tag("it has ")))
+        .parse(i)
+        .ok()?;
+    let (tail, k0b_name) = crate::parser::oracle_nom::primitives::parse_keyword_name(i).ok()?;
+    if k0_name != k0b_name {
+        return None;
+    }
+    let k0: Keyword = k0_name.parse().ok()?;
+
+    // tail: ". the same is true for <list>." (or "." / "" for a single keyword).
+    let tail = tail.trim_start_matches('.').trim_start();
+    let mut keywords = vec![k0];
+    if !tail.is_empty() {
+        keywords.extend(
+            super::super::oracle_effect::sequence::try_parse_same_is_true_continuation(tail)?,
+        );
+    }
+
+    let defs = keywords
+        .into_iter()
+        .map(|ki| {
+            let TargetFilter::Typed(mut tf) = base.clone() else {
+                unreachable!("base is Typed")
+            };
+            tf.properties
+                .push(FilterProp::WithKeyword { value: ki.clone() });
+            StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::AddKeyword { keyword: ki }])
+                .condition(StaticCondition::IsPresent {
+                    filter: Some(TargetFilter::Typed(tf)),
+                })
+                .description(text.to_string())
+        })
+        .collect();
+    Some(defs)
+}
+
 fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
     let stripped = strip_reminder_text(text);
     let lower = stripped.to_lowercase();
@@ -1209,6 +1285,16 @@ fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
     // there are 2+ segments and EVERY segment yields at least one static, which
     // restricts the path to genuine sibling-static lines and leaves trailing
     // non-static prose to the single-sentence fallback below.
+    // CR 611.3a + CR 702 (#5257 Rayami): "As long as an exiled <type> card
+    // [with a <counter> counter on it] has <K0>, ~ has <K0>. The same is true
+    // for <K1>, …" — one independent conditional keyword grant per listed
+    // keyword. Must precede generic multi-sentence splitting, which would strand
+    // the shared condition on the first keyword only (the observed bug: the grant
+    // applies unconditionally to every keyword).
+    if let Some(defs) = parse_keyword_grant_from_exiled_object_static(&stripped) {
+        return defs;
+    }
+
     if let Some(defs) = parse_multi_sentence_statics(&stripped) {
         return defs;
     }

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1201,7 +1201,7 @@ fn parse_keyword_grant_from_exiled_object_static(text: &str) -> Option<Vec<Stati
     typed
         .properties
         .push(FilterProp::InZone { zone: Zone::Exile });
-    let base = TargetFilter::Typed(typed);
+    let base = typed;
 
     // remainder (lowercased for keyword matching): "has <K0>, ~ has <K0>. The same
     // is true for <list>." The condition keyword and the granted keyword must match.
@@ -1232,9 +1232,7 @@ fn parse_keyword_grant_from_exiled_object_static(text: &str) -> Option<Vec<Stati
     let defs = keywords
         .into_iter()
         .map(|ki| {
-            let TargetFilter::Typed(mut tf) = base.clone() else {
-                unreachable!("base is Typed")
-            };
+            let mut tf = base.clone();
             tf.properties
                 .push(FilterProp::WithKeyword { value: ki.clone() });
             StaticDefinition::continuous()

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -28098,3 +28098,157 @@ fn combat_relation_subject_static_binds_source_anchored_filter() {
         );
     }
 }
+
+/// #5257 Rayami, First of the Fallen — parser shape. "As long as an exiled
+/// creature card with a blood counter on it has flying, Rayami has flying. The
+/// same is true for first strike, ..., and vigilance." Each listed keyword is an
+/// INDEPENDENT conditional grant, so the line must yield one continuous
+/// `SelfRef` static per keyword, each gated on `IsPresent { <exiled creature +
+/// blood counter + WithKeyword(K)> }` with modification `AddKeyword(K)`.
+///
+/// Discriminator: on `main` this yields a SINGLE static whose condition falls
+/// back to `StaticCondition::Unrecognized`, so all 13 keywords apply
+/// unconditionally — the reported bug (Rayami always has every keyword).
+#[test]
+fn rayami_exiled_keyword_grant_splits_into_conditional_per_keyword_statics() {
+    // `~` is the normalized self-reference the pipeline substitutes for the card
+    // name before static-line dispatch.
+    let line = "As long as an exiled creature card with a blood counter on it has flying, ~ has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.";
+    let statics = super::shared::parse_static_line_multi(line);
+
+    assert_eq!(
+        statics.len(),
+        13,
+        "expected one conditional grant per listed keyword, got {statics:?}"
+    );
+
+    for s in &statics {
+        let Some(ContinuousModification::AddKeyword { keyword }) = s.modifications.first() else {
+            panic!(
+                "each static grants exactly one keyword, got {:?}",
+                s.modifications
+            );
+        };
+        assert_eq!(
+            s.affected,
+            Some(TargetFilter::SelfRef),
+            "the grant is on the source itself"
+        );
+        let Some(StaticCondition::IsPresent {
+            filter: Some(TargetFilter::Typed(tf)),
+        }) = &s.condition
+        else {
+            panic!(
+                "expected an independently-evaluated IsPresent(Typed) condition, got {:?}",
+                s.condition
+            );
+        };
+        assert!(
+            tf.type_filters.contains(&TypeFilter::Creature),
+            "presence check requires an exiled creature card, got {:?}",
+            tf.type_filters
+        );
+        assert!(
+            tf.properties.contains(&FilterProp::InZone {
+                zone: crate::types::zones::Zone::Exile
+            }),
+            "presence check is scoped to the exile zone, got {:?}",
+            tf.properties
+        );
+        assert!(
+            tf.properties.contains(&FilterProp::WithKeyword {
+                value: keyword.clone()
+            }),
+            "each keyword K is granted only while an exiled card that HAS K is present, got {:?}",
+            tf.properties
+        );
+    }
+
+    let granted: Vec<Keyword> = statics
+        .iter()
+        .filter_map(|s| match s.modifications.first() {
+            Some(ContinuousModification::AddKeyword { keyword }) => Some(keyword.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        granted.contains(&Keyword::Flying),
+        "grants flying: {granted:?}"
+    );
+    assert!(
+        granted.contains(&Keyword::Vigilance),
+        "grants vigilance: {granted:?}"
+    );
+    assert!(
+        granted.contains(&Keyword::Deathtouch),
+        "grants deathtouch: {granted:?}"
+    );
+}
+
+/// #5257 Rayami runtime discriminator: the keyword grant is CONDITIONAL and
+/// re-evaluated (CR 611.3a). With no matching exiled card, Rayami must NOT have
+/// flying; once an exiled creature card with a blood counter that itself has
+/// flying is present, Rayami gains flying — and only that keyword.
+///
+/// Discriminator: on `main` the condition is `Unrecognized`, so Rayami has
+/// flying (and every other listed keyword) unconditionally and the negative
+/// assertion flips.
+#[test]
+fn rayami_flying_grant_is_conditional_on_matching_exiled_card() {
+    use crate::game::scenario::{GameScenario, P0};
+    use crate::game::zones::create_object;
+    use crate::types::actions::GameAction;
+    use crate::types::card_type::CoreType;
+    use crate::types::counter::CounterType;
+    use crate::types::identifiers::CardId;
+    use crate::types::zones::Zone;
+
+    const RAYAMI: &str = "As long as an exiled creature card with a blood counter on it has flying, Rayami has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.";
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let rayami_id = scenario
+        .add_creature_from_oracle(P0, "Rayami, First of the Fallen", 4, 4, RAYAMI)
+        .id();
+    let mut runner = scenario.build();
+    // Force layer evaluation (SBAs run, continuous effects recomputed).
+    runner.act(GameAction::PassPriority).ok();
+
+    assert!(
+        !runner.state().objects[&rayami_id].has_keyword(&Keyword::Flying),
+        "Rayami must not have flying with no matching exiled card present"
+    );
+
+    // Positive reach-guard: an exiled creature card with a blood counter that has
+    // flying. Rayami now gains flying — proving the grant path actually fires, so
+    // the negative above is a genuine conditional rather than flying being
+    // unreachable. (Seed the object directly, then re-run the continuous-effect
+    // engine — a raw state edit bypasses the normal change tracking.)
+    {
+        let state = runner.state_mut();
+        let exiled = create_object(
+            state,
+            CardId(900),
+            P0,
+            "Exiled Bat".to_string(),
+            Zone::Exile,
+        );
+        let obj = state.objects.get_mut(&exiled).expect("exiled card exists");
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_card_types = obj.card_types.clone();
+        obj.keywords.push(Keyword::Flying);
+        *obj.counters
+            .entry(CounterType::Generic("blood".to_string()))
+            .or_insert(0) += 1;
+    }
+    crate::game::layers::evaluate_layers(runner.state_mut());
+
+    assert!(
+        runner.state().objects[&rayami_id].has_keyword(&Keyword::Flying),
+        "Rayami must gain flying while an exiled flying creature card with a blood counter is present"
+    );
+    assert!(
+        !runner.state().objects[&rayami_id].has_keyword(&Keyword::Vigilance),
+        "Rayami must not gain vigilance — no exiled card has vigilance"
+    );
+}


### PR DESCRIPTION
## Summary

**Rayami, First of the Fallen** (#5257):

> As long as an exiled creature card with a blood counter on it has flying, Rayami has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.

This parsed to a **single** `Continuous` static whose condition fell back to `StaticCondition::Unrecognized { text: "an exiled creature card with a blood counter on it has flying" }`. Because the condition was unrecognized, **all 13 keywords applied unconditionally** — Rayami always had flying/deathtouch/indestructible/etc. regardless of whether any matching exiled card was actually present. (CR 611.3a: a conditional continuous effect applies only while its condition holds.)

## Fix

Parse this class into **one independent `Continuous` `SelfRef` static per listed keyword**, each gated on:

```
StaticCondition::IsPresent {
    filter: Typed(<object filter> + InZone(Exile) + WithKeyword(K))
}
```

with modification `AddKeyword(K)`. Each keyword `K` is now granted **only while an exiled card that itself has `K` is present** — the correct semantics.

This reuses the existing `IsPresent` / `FilterProp::WithKeyword` runtime (`layers.rs` scans every object; `WithKeyword` reads the exiled card's keywords) — **no new engine variant**. Pure parser change, one file.

## Verification

Parsed via the oracle pipeline — Rayami now yields **13 statics**, one per keyword, each with:
- `condition: IsPresent { Typed(Creature + Counters(blood ≥ 1) + InZone(Exile) + WithKeyword(K)) }`
- `modifications: [AddKeyword(K)]`, `affected: SelfRef`

The parse hook is guarded by a line-leading `as long as an exiled …` + matching condition/grant keyword, so it is inert for every other card (e.g. Wretched Bonemass, which phrases "as long as" mid-sentence, is untouched).

Fixes #5257