### PR TITLE
refactor(parser): bind the last 3 undisclosed positional scans by role (U20)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -57,12 +57,13 @@ use super::{
     attach_repeat_process_keywords, attach_same_is_true_keywords,
     bind_anaphoric_damage_subject_keep_recipient, collapse_ephemeral_color_choice_mana,
     contains_explicit_tracked_set_pronoun, contains_implicit_tracked_set_pronoun,
-    def_is_dig_or_mill, def_is_generic_effect_head, def_is_keyword_counter_placement,
-    fold_cast_copy_of_card_defs, has_explicit_player_target, inject_chosen_color_choice_grant,
-    mark_uses_tracked_set, parse_spell_graveyard_replacement_rider,
-    publishes_tracked_set_from_resolution, retarget_counter_additional_cost_to_target,
-    rewrite_parent_targets_to_tracked_set, rewrite_rounding_mode, rewrite_that_type_mana_instead,
-    stamp_delayed_returns, try_fold_token_repeat_into_count, wire_optional_cast_decline_fallback,
+    def_is_damage_dealer, def_is_dig_look, def_is_dig_or_mill, def_is_generic_effect_head,
+    def_is_keyword_counter_placement, fold_cast_copy_of_card_defs, has_explicit_player_target,
+    inject_chosen_color_choice_grant, mark_uses_tracked_set,
+    parse_spell_graveyard_replacement_rider, publishes_tracked_set_from_resolution,
+    retarget_counter_additional_cost_to_target, rewrite_parent_targets_to_tracked_set,
+    rewrite_rounding_mode, rewrite_that_type_mana_instead, stamp_delayed_returns,
+    try_fold_token_repeat_into_count, wire_optional_cast_decline_fallback,
 };
 
 // ===========================================================================
@@ -142,7 +143,7 @@ struct NodeRef {
 //    `mem::take()` — the ops that invalidate any index-keyed reference (the
 //    reason U6-B1's registries had to be recomputed after every mutation).
 //  * A node that leaves top-level `defs` is not deleted. It is `Absorbed { into }`
-//    — nested under a known parent — or honestly `Dropped`. Design §2.2: a node
+//    — nested under a known parent. Design §2.2: a node
 //    can migrate OUT of the node-set (nested by a handler, or wrapped into an
 //    `Effect` payload), and a registry that later binds to such a node would
 //    mutate a def that is no longer in the output. That must be a typed state,
@@ -196,7 +197,6 @@ struct ArenaNode {
 /// because the asserts only ever compare witnesses of defs that are still ALIVE —
 /// a node in `order` (its def is in `defs`) or an `Absorbed` node (its def was
 /// MOVED into a parent's `sub_ability`/`else_ability`, so its `Box` is not freed).
-/// A `Dropped` node's witness is never compared against anything.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct DefWitness(usize);
 
@@ -603,6 +603,31 @@ pub(super) enum AntecedentRole {
     /// the sibling template a "Repeat this process for <keywords>" continuation
     /// clones (Kathril, Aspect Warper).
     KeywordCounterPlacement,
+    /// A `DealDamage` — the antecedent an "excess damage" rider redirects from
+    /// (CR 120.4a). The rider need not be adjacent to the damage clause, which is
+    /// why this is a role and not `LastEmitted`.
+    ///
+    /// Membership is the EFFECT VARIANT ALONE. It deliberately does NOT require
+    /// `excess.is_none()`: the scan this replaces stopped at the nearest
+    /// `DealDamage` unconditionally and then overwrote `excess`. Narrowing the role
+    /// to "has no excess yet" would make an already-written def a NON-candidate and
+    /// resume the walk to an earlier `DealDamage` the old code never reached. The
+    /// overwrite is the mutator's business; the role names where the walk STOPS.
+    DamageDealer,
+    /// A `Dig` — the "look at the top N" anchor that BOTH private-look riders bind
+    /// back to: `ExileLookedAtCard` (the Gonti impulse idiom, CR 608.2c) rewrites it
+    /// into an `ExileTop`, and `ExileOneOfThemFaceDown` (Hideaway, CR 702.75a)
+    /// patches it into the choose-one-and-exile shape. One role, because the two
+    /// scans it replaces had BYTE-IDENTICAL predicates — they are the same
+    /// antecedent, named twice.
+    ///
+    /// Membership is the EFFECT VARIANT ALONE — NOT `reveal: false`. The private-look
+    /// requirement (CR 701.20e) is a filter the RECOGNIZERS already applied upstream
+    /// when they decided to emit these continuations at all; importing it here would
+    /// make a revealed `Dig` a non-candidate and walk PAST it to an earlier one the
+    /// old scans never reached. Same trap, mirrored, as narrowing `GenericEffectHead`
+    /// to "has a static".
+    DigLook,
 }
 
 /// Membership predicates for the roles whose candidacy is **live** — recomputed
@@ -631,6 +656,19 @@ fn live_role_predicate(role: AntecedentRole) -> Option<fn(&AbilityDefinition) ->
         // something else without any length change. Cached, this role would go on
         // naming a def that is no longer a `Dig`/`Mill`. Live, it is EXACTLY the scan.
         AntecedentRole::DigOrMill => Some(def_is_dig_or_mill),
+        // LIVE, for the same reason as `DigOrMill` — and it is the SAME rewrite that
+        // forces it: `ExileLookedAtCard` does `*previous.effect = Effect::ExileTop`,
+        // turning a `Dig` into a non-`Dig` with NO length change, so `observe` never
+        // fires and a cached registry would go on naming it. `ExileOneOfThemFaceDown`
+        // nests a `sub_ability` in place — also length-preserving. Live, the role is
+        // EXACTLY the scan it replaces.
+        AntecedentRole::DigLook => Some(def_is_dig_look),
+        // LIVE. `ExcessDamageToController` writes a FIELD (`*excess = Some(..)`) — the
+        // most length-preserving mutation there is. A cached registry is refreshed only
+        // where `defs.len()` changes, so it could not see this at all; that it happens
+        // to stay correct for THIS role today is luck, not design. Cached membership is
+        // stale by construction here, so it is not offered.
+        AntecedentRole::DamageDealer => Some(def_is_damage_dealer),
         AntecedentRole::Conditional
         | AntecedentRole::OptionalHead
         | AntecedentRole::DigOrRevealUntil
@@ -905,7 +943,9 @@ impl AssemblyEnv {
                     // NEW role cannot be added without choosing a side.
                     AntecedentRole::GenericEffectHead
                     | AntecedentRole::KeywordCounterPlacement
-                    | AntecedentRole::DigOrMill => None,
+                    | AntecedentRole::DigOrMill
+                    | AntecedentRole::DigLook
+                    | AntecedentRole::DamageDealer => None,
                 },
             },
         };
@@ -2316,8 +2356,16 @@ mod arena_tests {
         // absorb the (wrong) one, which is what the old `settle` did by inferring a
         // parent. `settle` then has nothing to object to, and the identity assert is
         // left to catch the divergence on its own.
+        //
+        // The parent is `id_at(1)`, NOT `id_at(0)`, so this test does not depend on the
+        // ORDER of the asserts. The stray node is the tail one, whose def is the one
+        // that shifted into `defs[1]`; naming `id_at(1)` as its parent therefore makes
+        // the absorbed-parenthood assert (b) genuinely TRUE (`live_root_index` lands on
+        // `defs[1]`, which IS that def), leaving assert (a) — identity — as the only
+        // false one. Absorbing into `id_at(0)` would ALSO trip (b), and (a) would only
+        // be the observed failure because it happens to run first.
         let stray = arena.detached[0];
-        let parent = arena.id_at(0).expect("defs[0] is live");
+        let parent = arena.id_at(1).expect("defs[1] is live");
         arena.absorb(stray, parent);
         arena.settle();
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -20266,6 +20266,30 @@ pub(super) fn def_is_dig_or_mill(def: &AbilityDefinition) -> bool {
     matches!(&*def.effect, Effect::Dig { .. } | Effect::Mill { .. })
 }
 
+/// Membership mirror for `AntecedentRole::DamageDealer` — the `DealDamage` an
+/// "excess damage" rider redirects from (CR 120.4a).
+///
+/// The effect variant alone, mirroring where the scan it replaced STOPPED. It does
+/// NOT require `excess.is_none()`: the scan bound the nearest `DealDamage`
+/// unconditionally and then overwrote the field. Folding "not yet written" in here
+/// would resume the walk past an already-written def and bind an earlier one the old
+/// code never reached — the overwrite is the MUTATION's business, not the selector's.
+pub(super) fn def_is_damage_dealer(def: &AbilityDefinition) -> bool {
+    matches!(&*def.effect, Effect::DealDamage { .. })
+}
+
+/// Membership mirror for `AntecedentRole::DigLook` — the `Dig` anchor that both
+/// private-look riders bind back to (`ExileLookedAtCard`, `ExileOneOfThemFaceDown`).
+/// ONE predicate because the two scans it replaces were byte-identical.
+///
+/// The effect variant alone, NOT `reveal: false`. The private-look condition
+/// (CR 701.20e) is the RECOGNIZERS' filter — already applied upstream, when they
+/// decided to emit these continuations. Importing it into the selector would skip a
+/// revealed `Dig` and walk back to an earlier one the old scans never reached.
+pub(super) fn def_is_dig_look(def: &AbilityDefinition) -> bool {
+    matches!(&*def.effect, Effect::Dig { .. })
+}
+
 /// CR 608.2c: Apply a "Repeat this process for <keyword list>" continuation
 /// (Kathril, Aspect Warper). Walks `defs` from the back for the most recent
 /// conditional keyword-counter placement (`PutCounter { counter_type:

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3573,16 +3573,30 @@ pub(super) fn apply_clause_continuation(
             }
         }
         ContinuationAst::ExcessDamageToController => {
-            // CR 120.4a + CR 608.2c: walk backward to the nearest DealDamage and
-            // attach the excess-redirect rider. The clause may not be adjacent to
-            // the DealDamage effect, mirroring the CantRegenerate walk above.
-            if let Some(def) = defs
-                .iter_mut()
-                .rev()
-                .find(|d| matches!(&*d.effect, Effect::DealDamage { .. }))
-            {
-                if let Effect::DealDamage { excess, .. } = &mut *def.effect {
-                    *excess = Some(ExcessRecipient::TargetController);
+            // CR 120.4a + CR 608.2c: bind the nearest DealDamage and attach the
+            // excess-redirect rider. The clause may not be adjacent to the DealDamage
+            // effect, mirroring the CantRegenerate walk above — so this is a role, not
+            // `LastEmitted`.
+            //
+            // `DamageDealer` is a LIVE predicate (`def_is_damage_dealer`), so
+            // `LastWithRole` resolves to `(0..defs.len()).rev().find(|i|
+            // is_damage_dealer(&defs[i]))` — the scan this replaces, over the same
+            // `defs` at the same moment.
+            let bound = env.resolve(
+                defs,
+                super::assembly::AntecedentSelector::LastWithRole(
+                    super::assembly::AntecedentRole::DamageDealer,
+                ),
+                None,
+                super::assembly::OnMiss::Ignore,
+            );
+            if let Some(bound_index) = bound {
+                let def = &mut defs[bound_index];
+                match &mut *def.effect {
+                    Effect::DealDamage { excess, .. } => {
+                        *excess = Some(ExcessRecipient::TargetController);
+                    }
+                    _ => unreachable!(),
                 }
             }
         }
@@ -4353,14 +4367,22 @@ pub(super) fn apply_clause_continuation(
             count,
             face_down,
         } => {
-            let Some(previous) = defs
-                .iter_mut()
-                .rev()
-                .find(|d| matches!(&*d.effect, Effect::Dig { .. }))
-            else {
+            // `DigLook` is a LIVE predicate (`def_is_dig_look`) — it MUST be, and this
+            // is the site that forces it: the rewrite below replaces the bound def's
+            // effect IN PLACE, turning a `Dig` into an `ExileTop` with no change to
+            // `defs.len()`. `observe`/`refresh` only run where the length changes, so a
+            // cached registry would go on naming a def that is no longer a `Dig`.
+            let Some(bound_index) = env.resolve(
+                defs,
+                super::assembly::AntecedentSelector::LastWithRole(
+                    super::assembly::AntecedentRole::DigLook,
+                ),
+                None,
+                super::assembly::OnMiss::Ignore,
+            ) else {
                 return;
             };
-            *previous.effect = Effect::ExileTop {
+            *defs[bound_index].effect = Effect::ExileTop {
                 player,
                 count,
                 face_down,
@@ -4378,23 +4400,33 @@ pub(super) fn apply_clause_continuation(
         // a keep_count:0 pure-peek and a sibling `ChangeZone { ParentTarget }`
         // exiled the trigger source itself (#1146).
         ContinuationAst::ExileOneOfThemFaceDown => {
-            let Some(previous) = defs
-                .iter_mut()
-                .rev()
-                .find(|d| matches!(&*d.effect, Effect::Dig { .. }))
-            else {
+            // Same `DigLook` antecedent as `ExileLookedAtCard` above — the two scans
+            // this replaces had byte-identical predicates, so they name ONE role, not
+            // two. LIVE, not cached: `append_conceal_sub_ability` nests a `sub_ability`
+            // in place, which preserves `defs.len()` and so is invisible to `refresh`.
+            let Some(bound_index) = env.resolve(
+                defs,
+                super::assembly::AntecedentSelector::LastWithRole(
+                    super::assembly::AntecedentRole::DigLook,
+                ),
+                None,
+                super::assembly::OnMiss::Ignore,
+            ) else {
                 return;
             };
-            if let Effect::Dig {
-                keep_count,
-                up_to,
-                destination,
-                ..
-            } = &mut *previous.effect
-            {
-                *keep_count = Some(1);
-                *up_to = false;
-                *destination = Some(Zone::Exile);
+            let previous = &mut defs[bound_index];
+            match &mut *previous.effect {
+                Effect::Dig {
+                    keep_count,
+                    up_to,
+                    destination,
+                    ..
+                } => {
+                    *keep_count = Some(1);
+                    *up_to = false;
+                    *destination = Some(Zone::Exile);
+                }
+                _ => unreachable!(),
             }
             // CR 608.2c: chain the conceal continuation onto the Dig. The
             // `DigChoice` resolution binds the chosen (exiled) card onto this


### PR DESCRIPTION
The three remaining `.iter_mut().rev().find(..)` walk-backs in
`apply_clause_continuation` chose their antecedent by scanning `defs`
backward in place — an undisclosed positional coupling of exactly the kind
U6 exists to delete. Each now names its antecedent through the assembler's
single binding authority (`AssemblyEnv::resolve`).

Two new roles, both LIVE (`live_role_predicate`), never cached:

* `DamageDealer` — the `DealDamage` an excess-damage rider redirects from
  (CR 120.4a). Membership is the effect variant ALONE: the scan bound the
  nearest `DealDamage` unconditionally and then overwrote `excess`, so
  folding `excess.is_none()` into the role would resume the walk past an
  already-written def and bind an earlier one the old code never reached.

* `DigLook` — the private-look `Dig` that BOTH `ExileLookedAtCard`
  (CR 608.2c) and `ExileOneOfThemFaceDown` (Hideaway, CR 702.75a) bind back
  to. ONE role, because the two scans it replaces had byte-identical
  predicates: they are the same antecedent, named twice. Membership is
  `Effect::Dig` ALONE, NOT `reveal: false` — the private-look condition
  (CR 701.20e) is the RECOGNIZERS' filter, already applied upstream when
  they decided to emit these continuations at all. Importing it into the
  selector would walk PAST a revealed `Dig` to an earlier one the old scans
  never reached — the mirror image of narrowing `GenericEffectHead` to "has
  a static".

Both roles are LIVE for the reason #19 converted `DigOrMill` cached->live:
`refresh` only runs where `defs.len()` changes, and all three of these
mutations are length-preserving (a `*previous.effect = ExileTop` variant
rewrite, an `*excess = Some(..)` field write, and a `sub_ability` nested in
place). A cached registry for them would be stale by construction.

Neither role reuses `DigOrRevealUntil`/`DigOrMill` (strict supersets) nor
collapses to `LastEmitted`: both are output-identical today only because
every hit is at depth 0, which is a property of the current card pool, not
of the grammar.

Ride-along (U6-0e review follow-ups):
* Delete the two STALE `NodeStatus::Dropped` mentions (the `Absorbed`-or-
  `Dropped` doc phrase, and `DefWitness`'s ABA carve-out sentence — the ABA
  argument is now unconditional, since every witness refers to a live
  allocation). The six remaining mentions are KEPT: they record WHY the
  variant is gone, which is what stops a future third state.
* `tail_pop_mirroring_a_mid_vector_removal_is_caught` absorbed its stray
  into `id_at(0)`, a false parenthood claim that assert (b) would also have
  caught — the test only observed assert (a) because (a) runs first. Absorb
  into `id_at(1)` instead, which is a TRUE parenthood claim, so identity is
  the only false assert and the test no longer depends on assert order.
