### PR TITLE
fix(parser): thread ChosenDamageSource through Desperate Gambit's flattened-head choose-source chain

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -4451,6 +4451,38 @@ fn build_ability_item(def: &AbilityDefinition) -> ParsedItem {
         children.push(build_ability_item(mode_ability));
     }
 
+    // CR 705.2 (#5601): coin-flip branch effects are embedded `AbilityDefinition`s
+    // (not `sub_ability` links), so — like the sub-ability / else / modal chains
+    // above — recurse into them here. Without this the win/lose branch parse
+    // signatures are swallowed by the bare `("win"/"lose", "yes")` presence
+    // markers in `effect_details`, making a real parser change inside a branch
+    // (e.g. Desperate Gambit's lose-branch `damage_source_filter` flipping
+    // `SelfRef` → `ChosenDamageSource`) invisible to the coverage parse-diff.
+    // Same swallowed-structure class as #5492/#5495/#5501.
+    match &*def.effect {
+        Effect::FlipCoin {
+            win_effect,
+            lose_effect,
+            ..
+        }
+        | Effect::FlipCoins {
+            win_effect,
+            lose_effect,
+            ..
+        } => {
+            if let Some(win) = win_effect {
+                children.push(build_ability_item(win));
+            }
+            if let Some(lose) = lose_effect {
+                children.push(build_ability_item(lose));
+            }
+        }
+        Effect::FlipCoinUntilLose { win_effect } => {
+            children.push(build_ability_item(win_effect));
+        }
+        _ => {}
+    }
+
     ParsedItem {
         category: ParseCategory::Ability,
         label,
@@ -10495,6 +10527,48 @@ mod tests {
                 .iter()
                 .any(|k| k == "damage_source_filter"),
             "an absent damage_source_filter must not appear",
+        );
+    }
+
+    /// #5601 (same swallowed-structure class as #5492/#5495/#5501): a parser
+    /// change INSIDE a coin-flip branch — e.g. Desperate Gambit's lose-branch
+    /// `damage_source_filter` flipping `SelfRef` → `ChosenDamageSource` — must be
+    /// visible to the coverage parse-diff. The FlipCoin branch effects are
+    /// embedded `AbilityDefinition`s (not `sub_ability` links), so
+    /// `build_ability_item` must recurse into `win_effect`/`lose_effect` rather
+    /// than emit only the bare `("lose", "yes")` presence marker — otherwise the
+    /// change is swallowed and the sticky reports a false "No card-parse changes".
+    #[test]
+    fn flip_coin_branch_effects_are_exposed_in_parse_details() {
+        use crate::types::ability::{AbilityDefinition, AbilityKind};
+
+        let lose = Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PreventDamage {
+                amount: PreventionAmount::All,
+                amount_dynamic: None,
+                target: TargetFilter::Any,
+                scope: PreventionScope::AllDamage,
+                damage_source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
+                prevention_duration: None,
+            },
+        ));
+        let def = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::FlipCoin {
+                win_effect: None,
+                lose_effect: Some(lose),
+                flipper: TargetFilter::Controller,
+            },
+        );
+        let item = build_ability_item(&def);
+        assert!(
+            item.children
+                .iter()
+                .any(|c| c.details.iter().any(|(k, _)| k == "damage_source_filter")),
+            "FlipCoin lose-branch damage_source_filter must be exposed as a child \
+             parse detail; got children {:#?}",
+            item.children
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -16697,51 +16697,120 @@ mod tests {
         }
     }
 
-    /// CR 609.7a + CR 705: Desperate Gambit's lose branch bare "it" must thread
-    /// `ChosenDamageSource` when the chain opens with `ChooseDamageSource`.
-    #[test]
-    fn desperate_gambit_lose_branch_threads_chosen_damage_source() {
-        use crate::parser::oracle_effect::parse_effect_chain;
-
-        fn find_flip_coin(def: &AbilityDefinition) -> Option<&Effect> {
-            if matches!(&*def.effect, Effect::FlipCoin { .. }) {
-                return Some(&def.effect);
-            }
-            def.sub_ability
-                .as_deref()
-                .and_then(find_flip_coin)
-                .or_else(|| def.else_ability.as_deref().and_then(find_flip_coin))
+    /// Depth-first search for the first effect matching `pred`, descending
+    /// through `sub_ability`, `else_ability`, AND `FlipCoin` win/lose branches
+    /// (each branch is a boxed `AbilityDefinition`). Needed because the shipped
+    /// Desperate Gambit text produces TWO sibling `FlipCoin` nodes — one per
+    /// "If you win / If you lose" sentence — each with only one populated branch.
+    #[cfg(test)]
+    fn find_effect_in_def<'a>(
+        def: &'a AbilityDefinition,
+        pred: &dyn Fn(&Effect) -> bool,
+    ) -> Option<&'a Effect> {
+        if pred(&def.effect) {
+            return Some(&def.effect);
         }
-
-        let text = "Choose a source you control. Flip a coin. If you win the flip, \
-            the next time that source would deal damage this turn, it deals double that damage instead. \
-            If you lose the flip, the next time it would deal damage this turn, prevent that damage.";
-        let def = parse_effect_chain(text, AbilityKind::Spell);
-        let flip = find_flip_coin(&def).expect("expected FlipCoin in chain");
-        let Effect::FlipCoin {
+        if let Effect::FlipCoin {
             win_effect,
             lose_effect,
             ..
-        } = flip
-        else {
-            unreachable!();
-        };
-        let win = win_effect.as_ref().expect("win branch");
-        let lose = lose_effect.as_ref().expect("lose branch");
-        assert!(matches!(
-            &*win.effect,
-            Effect::CreateDamageReplacement {
-                source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
-                ..
+        } = &*def.effect
+        {
+            for branch in [win_effect, lose_effect] {
+                if let Some(found) = branch
+                    .as_deref()
+                    .and_then(|b| find_effect_in_def(b, pred))
+                {
+                    return Some(found);
+                }
             }
-        ));
-        assert!(matches!(
-            &*lose.effect,
-            Effect::PreventDamage {
-                damage_source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
-                ..
-            }
-        ));
+        }
+        def.sub_ability
+            .as_deref()
+            .and_then(|s| find_effect_in_def(s, pred))
+            .or_else(|| {
+                def.else_ability
+                    .as_deref()
+                    .and_then(|e| find_effect_in_def(e, pred))
+            })
+    }
+
+    /// CR 609.7a + CR 608.2c + CR 615.1 (#5601): Desperate Gambit's win and lose
+    /// branches share one anaphor — "a source you control" — so both the win
+    /// branch's damage-doubling replacement and the lose branch's prevention must
+    /// bind `ChosenDamageSource`, never `SelfRef` (the Instant on the stack, which
+    /// deals no damage, so the prevention would shield nothing).
+    ///
+    /// This uses the VERBATIM shipped oracle text ("Choose a source you control
+    /// AND flip a coin" — one sentence). That form lowers the head choice to a
+    /// bare target selection rather than `Effect::ChooseDamageSource`, so the
+    /// repair pass's original `ChooseDamageSource`-keyed gate no longer fired and
+    /// the lose branch silently reverted to `SelfRef` (the pass mutated
+    /// 0/35,396 pool-wide). Reverting the flattened-head gate signal flips the
+    /// lose-branch assertion below back to `SelfRef` — this test can fail if the
+    /// fix is removed (AI-CONTRIBUTOR.md §5(i)).
+    #[test]
+    fn desperate_gambit_shipped_text_threads_chosen_damage_source_both_branches() {
+        use crate::parser::oracle_effect::parse_effect_chain;
+
+        let text = "Choose a source you control and flip a coin. If you win the flip, \
+            the next time that source would deal damage this turn, it deals double that damage instead. \
+            If you lose the flip, the next time it would deal damage this turn, prevent that damage.";
+        let def = parse_effect_chain(text, AbilityKind::Spell);
+
+        let win = find_effect_in_def(&def, &|e| {
+            matches!(e, Effect::CreateDamageReplacement { .. })
+        })
+        .expect("win branch must emit a CreateDamageReplacement");
+        assert!(
+            matches!(
+                win,
+                Effect::CreateDamageReplacement {
+                    source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
+                    ..
+                }
+            ),
+            "win branch must bind ChosenDamageSource, got {win:?}"
+        );
+
+        let lose = find_effect_in_def(&def, &|e| matches!(e, Effect::PreventDamage { .. }))
+            .expect("lose branch must emit a PreventDamage");
+        assert!(
+            matches!(
+                lose,
+                Effect::PreventDamage {
+                    damage_source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
+                    ..
+                }
+            ),
+            "lose branch prevention must thread ChosenDamageSource (not SelfRef), got {lose:?}"
+        );
+    }
+
+    /// CR 615.1 no-regression guard for #5601: a prevention whose damage source
+    /// is the source itself ("this creature", Mercenaries) has NO chosen-source
+    /// context, so the #5601 gate must NOT fire — `SelfRef` must be preserved.
+    /// Mercenaries is the only other card in the pool with a `SelfRef`
+    /// damage-source prevention filter, so this pins the gate's blast radius.
+    #[test]
+    fn mercenaries_selfref_prevention_is_not_rewritten() {
+        use crate::parser::oracle_effect::parse_effect_chain;
+
+        let text =
+            "The next time this creature would deal damage to you this turn, prevent that damage.";
+        let def = parse_effect_chain(text, AbilityKind::Spell);
+        let prevent = find_effect_in_def(&def, &|e| matches!(e, Effect::PreventDamage { .. }))
+            .expect("must emit a PreventDamage");
+        assert!(
+            matches!(
+                prevent,
+                Effect::PreventDamage {
+                    damage_source_filter: Some(TargetFilter::SelfRef),
+                    ..
+                }
+            ),
+            "no chosen-source context: SelfRef must be preserved, got {prevent:?}"
+        );
     }
 
     /// CR 115.1c + CR 608.2c regression: "target X and put a counter on it"

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -16717,10 +16717,7 @@ mod tests {
         } = &*def.effect
         {
             for branch in [win_effect, lose_effect] {
-                if let Some(found) = branch
-                    .as_deref()
-                    .and_then(|b| find_effect_in_def(b, pred))
-                {
+                if let Some(found) = branch.as_deref().and_then(|b| find_effect_in_def(b, pred)) {
                     return Some(found);
                 }
             }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -16746,19 +16746,28 @@ mod tests {
     /// 0/35,396 pool-wide). Reverting the flattened-head gate signal flips the
     /// lose-branch assertion below back to `SelfRef` — this test can fail if the
     /// fix is removed (AI-CONTRIBUTOR.md §5(i)).
+    ///
+    /// It drives the FULL card pipeline via `parse_oracle_text` — the exact entry
+    /// `database::synthesis` uses to generate `card-data.json` — NOT the
+    /// standalone `parse_effect_chain`, so it exercises the path the shipped card
+    /// actually takes and cannot go green while the card is broken.
     #[test]
     fn desperate_gambit_shipped_text_threads_chosen_damage_source_both_branches() {
-        use crate::parser::oracle_effect::parse_effect_chain;
+        use crate::parser::oracle::parse_oracle_text;
 
         let text = "Choose a source you control and flip a coin. If you win the flip, \
             the next time that source would deal damage this turn, it deals double that damage instead. \
             If you lose the flip, the next time it would deal damage this turn, prevent that damage.";
-        let def = parse_effect_chain(text, AbilityKind::Spell);
+        let parsed =
+            parse_oracle_text(text, "Desperate Gambit", &[], &["Instant".to_string()], &[]);
 
-        let win = find_effect_in_def(&def, &|e| {
-            matches!(e, Effect::CreateDamageReplacement { .. })
-        })
-        .expect("win branch must emit a CreateDamageReplacement");
+        let win = parsed
+            .abilities
+            .iter()
+            .find_map(|d| {
+                find_effect_in_def(d, &|e| matches!(e, Effect::CreateDamageReplacement { .. }))
+            })
+            .expect("win branch must emit a CreateDamageReplacement");
         assert!(
             matches!(
                 win,
@@ -16770,7 +16779,10 @@ mod tests {
             "win branch must bind ChosenDamageSource, got {win:?}"
         );
 
-        let lose = find_effect_in_def(&def, &|e| matches!(e, Effect::PreventDamage { .. }))
+        let lose = parsed
+            .abilities
+            .iter()
+            .find_map(|d| find_effect_in_def(d, &|e| matches!(e, Effect::PreventDamage { .. })))
             .expect("lose branch must emit a PreventDamage");
         assert!(
             matches!(
@@ -16791,12 +16803,22 @@ mod tests {
     /// damage-source prevention filter, so this pins the gate's blast radius.
     #[test]
     fn mercenaries_selfref_prevention_is_not_rewritten() {
-        use crate::parser::oracle_effect::parse_effect_chain;
+        use crate::parser::oracle::parse_oracle_text;
 
-        let text =
-            "The next time this creature would deal damage to you this turn, prevent that damage.";
-        let def = parse_effect_chain(text, AbilityKind::Spell);
-        let prevent = find_effect_in_def(&def, &|e| matches!(e, Effect::PreventDamage { .. }))
+        // Full card pipeline, activated ability form (Mercenaries' real card).
+        let text = "{3}: The next time this creature would deal damage to you this turn, \
+            prevent that damage. Any player may activate this ability.";
+        let parsed = parse_oracle_text(
+            text,
+            "Mercenaries",
+            &[],
+            &["Creature".to_string()],
+            &["Human".to_string(), "Mercenary".to_string()],
+        );
+        let prevent = parsed
+            .abilities
+            .iter()
+            .find_map(|d| find_effect_in_def(d, &|e| matches!(e, Effect::PreventDamage { .. })))
             .expect("must emit a PreventDamage");
         assert!(
             matches!(

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2451,6 +2451,59 @@ fn definition_contains_choose_damage_source(def: &AbilityDefinition) -> bool {
             .is_some_and(definition_contains_choose_damage_source)
 }
 
+/// CR 609.7a + CR 608.2c (#5601): A resolution chain that chose a damage source
+/// but whose head `Effect::ChooseDamageSource` was flattened away during
+/// lowering still leaves a bound `ChosenDamageSource` anaphor in whichever
+/// branch spelled the source out. Desperate Gambit ("Choose a source you
+/// control and flip a coin. … the next time *that source* would deal damage …,
+/// it deals double … . … the next time *it* would deal damage …, prevent that
+/// damage.") lowers the head choice to a bare target selection, so the win
+/// branch's `CreateDamageReplacement { source_filter: ChosenDamageSource }` is
+/// the only surviving marker of the chosen-source context. That surviving
+/// binding is the signal that a *sibling* bare-"it" prevention/replacement in
+/// the SAME chain co-refers with the chosen source (the two "it"s share one
+/// antecedent, CR 608.2c) and must be threaded too. Detecting it lets the
+/// existing `SelfRef` → `ChosenDamageSource` rewrite fire even though the head
+/// no longer matches [`definition_contains_choose_damage_source`].
+fn definition_contains_chosen_damage_source_binding(def: &AbilityDefinition) -> bool {
+    fn effect_binds_chosen(effect: &Effect) -> bool {
+        match effect {
+            Effect::CreateDamageReplacement { source_filter, .. } => {
+                matches!(source_filter, Some(TargetFilter::ChosenDamageSource { .. }))
+            }
+            Effect::PreventDamage {
+                damage_source_filter,
+                ..
+            } => matches!(
+                damage_source_filter,
+                Some(TargetFilter::ChosenDamageSource { .. })
+            ),
+            Effect::FlipCoin {
+                win_effect,
+                lose_effect,
+                ..
+            } => {
+                win_effect
+                    .as_deref()
+                    .is_some_and(definition_contains_chosen_damage_source_binding)
+                    || lose_effect
+                        .as_deref()
+                        .is_some_and(definition_contains_chosen_damage_source_binding)
+            }
+            _ => false,
+        }
+    }
+    effect_binds_chosen(&def.effect)
+        || def
+            .sub_ability
+            .as_deref()
+            .is_some_and(definition_contains_chosen_damage_source_binding)
+        || def
+            .else_ability
+            .as_deref()
+            .is_some_and(definition_contains_chosen_damage_source_binding)
+}
+
 /// CR 609.7a + CR 608.2c: When a resolution chain begins with
 /// `ChooseDamageSource`, bare "it" in a coin-flip one-shot prevention branch
 /// co-refers with the chosen source — rewrite `SelfRef` to `ChosenDamageSource`.
@@ -2494,7 +2547,14 @@ fn rewrite_oneshot_selfref_to_chosen_in_def(def: &mut AbilityDefinition) {
 }
 
 pub(super) fn thread_chosen_damage_source_into_oneshot_effects(defs: &mut [AbilityDefinition]) {
-    if !defs.iter().any(definition_contains_choose_damage_source) {
+    // CR 609.7a (#5601): fire when either the head `ChooseDamageSource` survives
+    // OR a `ChosenDamageSource` anaphor was already bound in a branch (the head
+    // was flattened during lowering, Desperate Gambit) — both prove the chain
+    // chose a damage source, so a sibling bare-"it" `SelfRef` must be threaded.
+    if !defs.iter().any(|def| {
+        definition_contains_choose_damage_source(def)
+            || definition_contains_chosen_damage_source_binding(def)
+    }) {
         return;
     }
     for def in defs.iter_mut() {


### PR DESCRIPTION
Fixes #5601.

## Problem

Desperate Gambit's win and lose branches share one anaphor — "a source you control" — but the parser bound them two different ways:

```
WIN  branch: CreateDamageReplacement { source_filter: ChosenDamageSource }  ✅
LOSE branch: PreventDamage { damage_source_filter: SelfRef }                ❌
```

Bound to `SelfRef`, the lose-branch prevention shields against damage from the *Instant on the stack* (which deals none), so losing the flip prevents nothing (CR 615.1). Both "it"s co-refer with the chosen source (CR 608.2c + CR 609.7a), so both must bind `ChosenDamageSource`.

## Root cause — the repair pass gate drifted

`thread_chosen_damage_source_into_oneshot_effects` (lower.rs) exists precisely to thread `SelfRef` → `ChosenDamageSource` across the flip branches, and its rewrite logic is intact. But its **gate** keyed solely on the head `Effect::ChooseDamageSource`:

```rust
if !defs.iter().any(definition_contains_choose_damage_source) { return; }
```

The shipped oracle text spells the choice as **"Choose a source you control *and* flip a coin"** — one sentence, which lowers the head choice to a bare target selection, so no `ChooseDamageSource` node survives. The gate never fired → the pass mutated **0 / 35,396** pool-wide (as the issue measured), and the lose branch stayed `SelfRef`.

Why fix at the repair pass rather than at construction: the two branches are *sibling* definitions, so the lose branch's bare "it" cannot see the chosen-source antecedent when it is lowered — which is exactly why a post-hoc threading pass exists. Restoring its gate is the intended seam.

## Fix

Add a second gate signal, `definition_contains_chosen_damage_source_binding`: the chain chose a damage source if a `ChosenDamageSource` anaphor is *already bound* in any branch (the win branch's "that source"), even when the head `ChooseDamageSource` was flattened away. The existing (unchanged) rewrite recursion then threads the sibling lose-branch `SelfRef` → `ChosenDamageSource`.

## Blast radius — exactly one card

- Pool-wide, only **2** cards carry a `SelfRef` damage-source filter: Desperate Gambit and Mercenaries.
- Mercenaries ("the next time **this creature** would deal damage … prevent that damage") has **no** `ChosenDamageSource` in its chain, so the new gate does not fire — its `SelfRef` is correctly preserved (`this creature` = the source itself).
- Intersection {`ChosenDamageSource` present} ∩ {`SelfRef` damage-source filter} = **{Desperate Gambit}**.

## Tests

- `desperate_gambit_shipped_text_threads_chosen_damage_source_both_branches` — parses the **verbatim shipped** oracle text (the "…and flip a coin" form that flattens the head, i.e. the actual bug — the previous test used a sanitized two-sentence form that never hit it) and asserts *both* branches bind `ChosenDamageSource`. Fails (lose branch reverts to `SelfRef`) if the gate signal is removed.
- `mercenaries_selfref_prevention_is_not_rewritten` — pins the gate's blast radius: no chosen-source context ⇒ `SelfRef` preserved.
- Full parser lib suite green; parser-combinator gate + clippy clean.
