### PR TITLE
refactor(parser): retire the Class whole-document shim (U8, removal gate 5)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3077,8 +3077,10 @@ fn parse_strive_cost_body(effect_text: &str) -> Option<ManaCost> {
 /// surface, so the source-order guarantee is a property of this one type rather
 /// than of 90 hand-written call sites.
 ///
-/// This replaces the former category-ordered `parsed_abilities_to_doc_ir` on
-/// every non-Class path. `whole_document` spans survive only in the Class shim.
+/// This is the single emission authority for EVERY path — the dispatch loop and
+/// every preprocessor, Class included. The category-ordered
+/// `parsed_abilities_to_doc_ir` façade it replaced is gone, and with it the last
+/// producer of whole-document spans.
 struct DocEmitter<'a> {
     builder: OracleDocBuilder,
     lines: &'a [&'a str],
@@ -3377,14 +3379,26 @@ pub(crate) fn parse_oracle_ir(
     let mut strive_cost_line: Option<usize> = None;
     let mut modal_line: Option<usize> = None;
 
-    // CR 716: Class cards use the whole-document shim (unit 6 unifies the path).
-    // HOISTED above the saga/attraction/level/spacecraft pre-loop blocks so the
-    // shim can never drop a pre-emitted builder item — the emitter is provably
-    // empty at this early return.
+    // CR 716: Class cards are a preprocessor like any other — they emit through
+    // `DocEmitter` at their printed source line. HOISTED above the
+    // saga/attraction/level/spacecraft pre-loop blocks so the early return can
+    // never drop a pre-emitted builder item: the emitter is provably empty here.
+    //
+    // `parse_class_oracle_text` returns items already in printed source order, so
+    // no sort is needed — the builder keys them by span anyway. Emission is via the
+    // `emit_at` primitive rather than the typed `*_at` helpers because this branch
+    // returns immediately: the `last_trigger`/`last_static` mirrors those helpers
+    // maintain exist solely for the dispatch loop's mid-loop readers, and no
+    // dispatch loop runs on a Class card.
     if subtypes.iter().any(|s| s == "Class") {
-        let class_result =
-            parse_class_oracle_text(&lines, card_name, mtgjson_keyword_names, result);
-        let doc = parsed_abilities_to_doc_ir(class_result, oracle_text, card_name, &mut ctx);
+        for (line, node) in parse_class_oracle_text(&lines, card_name, mtgjson_keyword_names) {
+            emitter.emit_at(line, node);
+        }
+        // `oracle_text` (the ORIGINAL, un-normalized text), not `oracle_text_owned`
+        // — matching the main path's `finish` below. `OracleDocIr.source_text` is
+        // the swallow audit's input, so normalizing it here would change which
+        // clauses the audit sees.
+        let doc = emitter.finish(oracle_text, card_name, std::mem::take(&mut ctx.diagnostics));
         return finalize_document_relations(doc, types);
     }
 
@@ -5536,8 +5550,7 @@ pub(crate) fn parse_oracle_ir(
 
     // Emit the four order-agnostic SINGLETONS (held on `result` for mid-loop
     // read-back/merge/dedup) as Exact items at their captured source line, then
-    // finish — producing items already in Oracle source order. `whole_document`
-    // survives only in the Class shim, which returned earlier.
+    // finish — producing items already in Oracle source order.
     if let Some(modal) = result.modal {
         emitter.modal_at(modal_line.unwrap_or(0), modal);
     }
@@ -5675,82 +5688,6 @@ fn parse_activated_ability_definition(
     extract_cost_reduction_from_chain(&mut def);
     extract_mana_spend_trigger_from_chain(&mut def);
     (def, effect_text)
-}
-
-/// Convert a `ParsedAbilities` into an `OracleDocIr` using `PreLowered*` variants.
-///
-/// UNIT-3B DEBT — this is the document façade, and it is still category-ordered.
-/// It runs *after* lowering and therefore has no access to the line cursor, so it
-/// cannot recover an exact source position for any item. Every item is emitted
-/// with `OracleSourceSpan::whole_document` (a true containing span, not a minimal
-/// one) and a distinct `ordinal_within_span` that reproduces today's category
-/// emission order exactly. Lowered output is therefore byte-identical.
-///
-/// Unit 3b moves emission into `parse_oracle_ir`'s dispatch loop, where the exact
-/// line/byte range is in hand; this function is deleted there (removal gate 5).
-///
-/// Routing through `OracleDocBuilder` now — rather than pushing a bare `Vec` — is
-/// what makes item identity, the CR 707.9a printed-slot counters, and the span
-/// invariants have a single authority before that move.
-fn parsed_abilities_to_doc_ir(
-    result: ParsedAbilities,
-    oracle_text: &str,
-    card_name: &str,
-    ctx: &mut ParseContext,
-) -> OracleDocIr {
-    let mut builder = OracleDocBuilder::new();
-    let mut ordinal: u32 = 0;
-
-    // One helper, so the ordinal can never be advanced without emitting, and an
-    // emission can never reuse an ordinal. Both are builder-rejected anyway; this
-    // makes the pairing structural.
-    let mut emit = |builder: &mut OracleDocBuilder, node: OracleNodeIr| {
-        let span = OracleSourceSpan::whole_document(oracle_text, ordinal);
-        ordinal += 1;
-        // `None`: a whole-document span cannot honestly name a fragment — the only
-        // text it covers is the entire card. Unit 3b supplies `Some(line)` with an
-        // `Exact` span. `emit` rejects any other combination.
-        let slot = builder.begin_item(span, None);
-        builder
-            .emit(slot, node)
-            .expect("whole-document spans carry distinct ordinals, so emit cannot reject");
-    };
-
-    for def in result.abilities {
-        emit(&mut builder, OracleNodeIr::PreLoweredSpell(def));
-    }
-    for def in result.triggers {
-        emit(&mut builder, OracleNodeIr::PreLoweredTrigger(def));
-    }
-    for def in result.statics {
-        emit(&mut builder, OracleNodeIr::PreLoweredStatic(def));
-    }
-    for def in result.replacements {
-        emit(&mut builder, OracleNodeIr::PreLoweredReplacement(def));
-    }
-    for kw in result.extracted_keywords {
-        emit(&mut builder, OracleNodeIr::Keyword(kw));
-    }
-    if let Some(modal) = result.modal {
-        emit(&mut builder, OracleNodeIr::Modal(modal));
-    }
-    if let Some(cost) = result.additional_cost {
-        emit(&mut builder, OracleNodeIr::AdditionalCost(cost));
-    }
-    for restriction in result.casting_restrictions {
-        emit(&mut builder, OracleNodeIr::CastingRestriction(restriction));
-    }
-    for option in result.casting_options {
-        emit(&mut builder, OracleNodeIr::CastingOption(option));
-    }
-    if let Some(condition) = result.solve_condition {
-        emit(&mut builder, OracleNodeIr::SolveCondition(condition));
-    }
-    if let Some(cost) = result.strive_cost {
-        emit(&mut builder, OracleNodeIr::StriveCost(cost));
-    }
-
-    builder.finish(oracle_text, card_name, std::mem::take(&mut ctx.diagnostics))
 }
 
 /// Parse Oracle text into structured ability definitions.

--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -1,4 +1,4 @@
-use super::oracle_ir::doc::PrintedTriggerIndex;
+use super::oracle_ir::doc::{OracleNodeIr, PrintedTriggerIndex};
 use crate::parser::oracle_nom::error::OracleError;
 use nom::bytes::complete::tag;
 use nom::Parser;
@@ -11,7 +11,7 @@ use crate::types::ability::{
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 
-use super::oracle::{has_unimplemented, make_unimplemented, ParsedAbilities};
+use super::oracle::{has_unimplemented, make_unimplemented};
 use super::oracle_classifier::{
     is_effect_sentence_candidate, is_granted_static_line, is_replacement_pattern, is_static_pattern,
 };
@@ -56,15 +56,19 @@ pub(crate) fn parse_class_oracle_text(
     lines: &[&str],
     card_name: &str,
     mtgjson_keyword_names: &[String],
-    mut result: ParsedAbilities,
-) -> ParsedAbilities {
-    // Split lines into level sections: (level, lines)
-    // Level 1 section has level=1, subsequent sections have level=2, 3, etc.
+) -> Vec<(usize, OracleNodeIr)> {
+    // Split lines into level sections. Level 1 has level=1; each "{cost}: Level N"
+    // line opens a new section. Every retained line keeps the index of the printed
+    // source line it came from, so each item this function produces can be emitted
+    // at its true position (`DocEmitter::emit_at`) instead of at a whole-document
+    // span. Reminder-text stripping and trimming rewrite the line's TEXT but never
+    // its INDEX, so the index stays a faithful pointer into `lines`.
     struct LevelSection {
         level: u8,
-        /// For levels > 1: cost text and the level line description.
-        level_up: Option<(String, String)>,
-        lines: Vec<String>,
+        /// For levels > 1: the level line's source index, its cost text, and the
+        /// level line description.
+        level_up: Option<(usize, String, String)>,
+        lines: Vec<(usize, String)>,
     }
 
     let mut sections: Vec<LevelSection> = vec![LevelSection {
@@ -73,7 +77,7 @@ pub(crate) fn parse_class_oracle_text(
         lines: Vec::new(),
     }];
 
-    for &raw_line in lines {
+    for (index, &raw_line) in lines.iter().enumerate() {
         let trimmed = raw_line.trim();
         if trimmed.is_empty() {
             continue;
@@ -86,21 +90,25 @@ pub(crate) fn parse_class_oracle_text(
         if let Some((level, cost_text)) = parse_class_level_line(&stripped) {
             sections.push(LevelSection {
                 level,
-                level_up: Some((cost_text, stripped.to_string())),
+                level_up: Some((index, cost_text, stripped.to_string())),
                 lines: Vec::new(),
             });
         } else {
             // Add line to the current (last) section
             if let Some(section) = sections.last_mut() {
-                section.lines.push(stripped);
+                section.lines.push((index, stripped));
             }
         }
     }
 
+    // Items in printed source order: sections run in source order, and within a
+    // section the "{cost}: Level N" line precedes the lines it gates.
+    let mut items: Vec<(usize, OracleNodeIr)> = Vec::new();
+
     // Process each level section
     for section in &sections {
         // Generate the "{cost}: Level N" activated ability
-        if let Some((cost_text, description)) = &section.level_up {
+        if let Some((level_line, cost_text, description)) = &section.level_up {
             let cost = parse_oracle_cost(cost_text);
             let mut def = AbilityDefinition::new(
                 AbilityKind::Activated,
@@ -118,25 +126,30 @@ pub(crate) fn parse_class_oracle_text(
                 .push(ActivationRestriction::ClassLevelIs {
                     level: section.level - 1,
                 });
-            result.abilities.push(def);
+            items.push((*level_line, OracleNodeIr::PreLoweredSpell(def)));
         }
 
         // Parse ability lines for this level section
-        for line in &section.lines {
+        for (line_index, line) in &section.lines {
+            let line_index = *line_index;
             let lower = line.to_lowercase();
             let static_line = normalize_self_refs_for_static(line, card_name);
 
             // Check for "When this Class becomes level N" trigger pattern
             if is_class_level_trigger(&lower, card_name) {
                 if let Some(trigger) = parse_class_level_trigger(line, card_name, section.level) {
-                    result.triggers.push(trigger);
+                    items.push((line_index, OracleNodeIr::PreLoweredTrigger(trigger)));
                     continue;
                 }
             }
 
             // Keyword-only lines
             if let Some(extracted) = extract_keyword_line(line, mtgjson_keyword_names) {
-                result.extracted_keywords.extend(extracted);
+                items.extend(
+                    extracted
+                        .into_iter()
+                        .map(|kw| (line_index, OracleNodeIr::Keyword(kw))),
+                );
                 continue;
             }
 
@@ -165,7 +178,11 @@ pub(crate) fn parse_class_oracle_text(
                         });
                     }
                 }
-                result.triggers.extend(triggers);
+                items.extend(
+                    triggers
+                        .into_iter()
+                        .map(|t| (line_index, OracleNodeIr::PreLoweredTrigger(t))),
+                );
                 continue;
             }
 
@@ -175,7 +192,7 @@ pub(crate) fn parse_class_oracle_text(
                     if section.level > 1 {
                         static_def = wrap_static_with_class_level(static_def, section.level);
                     }
-                    result.statics.push(static_def);
+                    items.push((line_index, OracleNodeIr::PreLoweredStatic(static_def)));
                     continue;
                 }
             }
@@ -186,7 +203,7 @@ pub(crate) fn parse_class_oracle_text(
                     if section.level > 1 {
                         static_def = wrap_static_with_class_level(static_def, section.level);
                     }
-                    result.statics.push(static_def);
+                    items.push((line_index, OracleNodeIr::PreLoweredStatic(static_def)));
                     continue;
                 }
             }
@@ -203,7 +220,7 @@ pub(crate) fn parse_class_oracle_text(
                     if section.level > 1 {
                         rep_def = wrap_replacement_with_class_level(rep_def, section.level);
                     }
-                    result.replacements.push(rep_def);
+                    items.push((line_index, OracleNodeIr::PreLoweredReplacement(rep_def)));
                     continue;
                 }
             }
@@ -231,7 +248,11 @@ pub(crate) fn parse_class_oracle_text(
                             });
                         }
                     }
-                    result.triggers.extend(triggers);
+                    items.extend(
+                        triggers
+                            .into_iter()
+                            .map(|t| (line_index, OracleNodeIr::PreLoweredTrigger(t))),
+                    );
                     continue;
                 }
                 if is_static_pattern(&effect_lower) {
@@ -240,7 +261,7 @@ pub(crate) fn parse_class_oracle_text(
                         if section.level > 1 {
                             static_def = wrap_static_with_class_level(static_def, section.level);
                         }
-                        result.statics.push(static_def);
+                        items.push((line_index, OracleNodeIr::PreLoweredStatic(static_def)));
                         continue;
                     }
                 }
@@ -250,17 +271,20 @@ pub(crate) fn parse_class_oracle_text(
             if is_effect_sentence_candidate(&lower) {
                 let def = parse_effect_chain(line, AbilityKind::Spell);
                 if !has_unimplemented(&def) {
-                    result.abilities.push(def);
+                    items.push((line_index, OracleNodeIr::PreLoweredSpell(def)));
                     continue;
                 }
             }
 
             // Fallback: unimplemented
-            result.abilities.push(make_unimplemented(line));
+            items.push((
+                line_index,
+                OracleNodeIr::PreLoweredSpell(make_unimplemented(line)),
+            ));
         }
     }
 
-    result
+    items
 }
 
 /// Check if a line matches "when ~ becomes level N" pattern.

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -8,13 +8,11 @@
 //! for item identity, ordering, and span invariants. Nothing constructs an
 //! `OracleItemIr` directly.
 //!
-//! **Unit-3a status.** The builder orders items by `(first_line, ordinal)` and is
-//! ready to receive exact spans, but its only current producer is
-//! `parsed_abilities_to_doc_ir`, which runs after lowering and can supply only a
-//! whole-document containing span (see `OracleSourceSpan::whole_document`). So
-//! today's item order still reproduces the category order of `ParsedAbilities`.
-//! Unit 3b moves emission into the dispatch loop, at which point items become
-//! genuinely source-ordered with exact spans and this note is deleted.
+//! The builder orders items by `(first_line, ordinal)`, and every producer —
+//! the dispatch loop and every preprocessor, Class included — emits through
+//! `DocEmitter` at the item's printed source line. Items are therefore genuinely
+//! source-ordered, and every span is `SpanPrecision::Exact` or the honest
+//! chain-local `SpanPrecision::ChainRelative`.
 
 // NOTE ON `dead_code`: suppression in this module is **per item**, never
 // module-wide. A module-wide `#![allow(dead_code)]` also silences code not yet
@@ -64,26 +62,19 @@ pub(crate) struct OracleUnitId {
 /// How precisely a span locates its unit.
 ///
 /// A span is always *true* — it always contains its unit — but it is not always
-/// *minimal*. A consumer that renders a position (Plan 02's per-unit
-/// diagnostics) must be able to tell the difference, because `first_line == 0`
-/// on a whole-document span is not the claim "this unit is on line 0"; it is the
-/// claim "we do not yet know which line". Rendering the former as the latter is
-/// a precise-looking wrong answer, which is worse than an admittedly coarse one.
+/// *card-absolute*. A consumer that renders a position (Plan 02's per-unit
+/// diagnostics) must be able to tell the difference: printing a chain-local byte
+/// offset as a card position is a precise-looking wrong answer, which is worse
+/// than an admittedly coarse one.
 ///
 /// Typed rather than a `bool` per CLAUDE.md: a future `LineOnly` precision (line
 /// known, byte range not) is an enum value, not a second flag.
-// No `Ord`: `Exact < WholeDocument` would be a meaningless magnitude claim on a
+// No `Ord`: `Exact < ChainRelative` would be a meaningless magnitude claim on a
 // qualifier this enum's own docs call orthogonal to containment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
 pub(crate) enum SpanPrecision {
     /// The span is the unit's exact byte/line extent. Safe to render.
     Exact,
-    /// The span is the whole Oracle document: a true containing range whose
-    /// bounds carry no per-unit information. A renderer must NOT print
-    /// `first_line`/`start_byte` as this unit's position.
-    ///
-    /// UNIT-3B DEBT — emitted only by `OracleSourceSpan::whole_document`.
-    WholeDocument,
     /// The span's byte range is exact **within the effect chain** it was parsed
     /// from, but NOT card-absolute: it is an offset into a single
     /// `parse_effect_chain_ir` invocation's text, not into the whole Oracle
@@ -97,7 +88,7 @@ pub(crate) enum SpanPrecision {
     /// `SpanPrecision::Exact` by adding the chain's base offset — or, if
     /// preprocessing was not offset-linear, by re-locating the fragment in the
     /// card text. A renderer must NOT print `first_line`/`start_byte` as a
-    /// card-absolute position, exactly as for `WholeDocument`.
+    /// card-absolute position.
     ///
     /// U5 DEBT — upgrades to `Exact` when the allocator is threaded.
     ChainRelative,
@@ -127,35 +118,6 @@ pub(crate) struct OracleSourceSpan {
 }
 
 impl OracleSourceSpan {
-    /// The whole Oracle document, distinguished only by `ordinal_within_span`.
-    ///
-    /// UNIT-3B DEBT, and deliberately coarse rather than fabricated. Items are
-    /// currently emitted by `parsed_abilities_to_doc_ir`, which runs *after*
-    /// lowering and never sees the line cursor, so no exact position is
-    /// recoverable there. Recovering one by searching `source_text` for a
-    /// lowered definition's `description` would be precisely the lowered-shape
-    /// scan this plan exists to delete.
-    ///
-    /// This span is *true* — the document does contain the item — merely not
-    /// minimal. Unit 3b moves emission into the dispatch loop, where the exact
-    /// line/byte range is in hand, and this constructor disappears.
-    ///
-    /// Invariants still hold: `is_contained_by` is satisfied by construction,
-    /// and `conflicts_with` cannot fire because ordinals are distinct.
-    ///
-    /// Carries `SpanPrecision::WholeDocument` so a consumer cannot mistake
-    /// `first_line == 0` for "this unit is on line 0".
-    pub(crate) fn whole_document(source_text: &str, ordinal_within_span: u32) -> Self {
-        Self {
-            first_line: 0,
-            last_line: source_text.lines().count().saturating_sub(1),
-            start_byte: 0,
-            end_byte: source_text.len(),
-            precision: SpanPrecision::WholeDocument,
-            ordinal_within_span,
-        }
-    }
-
     /// An exactly-located span. The constructor unit 3b uses once emission moves
     /// into the dispatch loop and the real line/byte range is in hand.
     #[allow(dead_code)] // production caller lands in unit 3b.
@@ -215,13 +177,15 @@ impl OracleSourceSpan {
 
     /// True when this precision tier is allowed to carry a verbatim `fragment`.
     ///
-    /// Both `Exact` (card-absolute) and `ChainRelative` (chain-local honest)
-    /// address a concrete byte range and therefore have a real verbatim
-    /// fragment; only `WholeDocument`, whose sole honest "fragment" would be the
-    /// entire card, must not. This is the single authority the fail-closed
-    /// `check_fragment_precision` guard consults — widened (not loosened) from
-    /// `is_exact` so the ChainRelative tier can carry its fragment without
-    /// reopening the whole-document-fragment hole `SpanPrecision` closed.
+    /// Both live tiers — `Exact` (card-absolute) and `ChainRelative` (chain-local
+    /// but honest) — address a concrete byte range and therefore have a real
+    /// verbatim fragment, so this is currently true for every span. That is not a
+    /// tautology to be collapsed into `true`: it is the single authority the
+    /// fail-closed `check_fragment_precision` guard consults, and because the
+    /// match is exhaustive, a future non-locating tier (the `LineOnly` this
+    /// enum's docs anticipate) cannot be added without deciding here whether it
+    /// may carry a fragment. The retired `WholeDocument` tier was the `false`
+    /// case: its sole honest "fragment" would have been the entire card.
     pub(crate) fn carries_fragment(&self) -> bool {
         matches!(
             self.precision,
@@ -251,14 +215,14 @@ impl OracleSourceSpan {
 pub(crate) struct OracleUnitSource {
     id: OracleUnitId,
     span: OracleSourceSpan,
-    /// The verbatim Oracle text this unit covers — **only** when `span.precision`
-    /// is `Exact`.
+    /// The verbatim Oracle text this unit covers — present exactly when
+    /// `span.precision.carries_fragment()`, which today is every tier.
     ///
-    /// `None` under `WholeDocument`, because the only "fragment" such a span could
-    /// honestly report is the entire card. Handing a diagnostic renderer the whole
-    /// card as "the offending clause" is a precise-looking wrong answer, exactly
-    /// what `SpanPrecision` exists to prevent — guarding the span while leaving the
-    /// fragment lying would move the lie, not remove it.
+    /// A tier that cannot locate the unit must NOT report a fragment: handing a
+    /// diagnostic renderer the whole card as "the offending clause" is a
+    /// precise-looking wrong answer, exactly what `SpanPrecision` exists to
+    /// prevent — guarding the span while leaving the fragment lying would move
+    /// the lie, not remove it. (This was the retired `WholeDocument` tier's case.)
     ///
     /// `emit` rejects any unit whose fragment presence disagrees with its precision.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -728,19 +692,19 @@ impl OracleDocBuilder {
     /// The printed slot the next emitted ability will occupy (CR 707.9a). Read
     /// before emission. This — not `Vec::len()` — is the authority in unit 3b.
     ///
-    /// **UNIT-3B PRECONDITION, do not lose this.** An ability's *real* printed slot
-    /// is its source rank among spells: `lower_oracle_ir` fills `result.abilities`
-    /// by iterating `ir.items`, which is key-ordered by source position. This
-    /// counter instead reports the *emission* rank. The two agree only while `emit`
-    /// is called in nondecreasing `first_line` order — which unit 3a satisfies by
-    /// accident (every span is `WholeDocument`, so the key degenerates to the
-    /// emission ordinal) and which unit 3b's dispatch-loop emission must either
-    /// guarantee or replace.
+    /// **PRECONDITION, do not lose this.** An ability's *real* printed slot is its
+    /// source rank among spells: `lower_oracle_ir` fills `result.abilities` by
+    /// iterating `ir.items`, which is key-ordered by source position. This counter
+    /// instead reports the *emission* rank. The two agree only while `emit` is
+    /// called in nondecreasing `first_line` order, which no producer is required
+    /// to guarantee — a preprocessor may legitimately emit a later line before the
+    /// dispatch loop reaches an earlier one.
     ///
-    /// So unit 3b must do one of: (a) assert `emit` is called in nondecreasing
-    /// `first_line` order, or (b) derive both counters at `finish()` from the
-    /// source-ordered item vector rather than at `emit()`. Option (b) is the honest
-    /// one; (a) merely re-states today's accident as a rule.
+    /// That is why the live CR 707.9a authority is NOT this counter but the
+    /// per-category stamping walk in `finish()`, which derives each slot from the
+    /// source-ordered item map after all emission is done. These accessors remain
+    /// only as the read-before-emission form; anything that needs a *true* printed
+    /// slot must go through `finish()`.
     #[allow(dead_code)] // becomes the sole index authority in unit 3b.
     pub(crate) fn ability_index(&self) -> PrintedAbilityIndex {
         PrintedAbilityIndex(self.spells_emitted.len())
@@ -917,18 +881,18 @@ impl OracleDocBuilder {
     ) -> OracleDocIr {
         // CR 707.9a: resolve every "…except it has this ability" printed slot now.
         //
-        // The load-bearing invariant is PER-CATEGORY COUNTING, not source order:
-        // `parsed_abilities_to_doc_ir` still emits items in CATEGORY order today
-        // (all abilities, then all triggers, …) — see its own note — so
-        // `values_mut()` does NOT yet visit in printed source order. The walk is
-        // correct regardless because it counts each category SEPARATELY
-        // (`trigger_slot` among triggers, `ability_slot` among abilities), which
-        // reproduces exactly the position the parse-time `from_category_vector_len`
-        // computed. Each `RetainPrinted{Trigger,Ability}FromSource` is a
+        // The load-bearing invariant is PER-CATEGORY COUNTING, not source order.
+        // `values_mut()` visits in source order now that every producer emits at a
+        // real line, but the walk never depended on that: it counts each category
+        // SEPARATELY (`trigger_slot` among triggers, `ability_slot` among
+        // abilities), which is exactly the position `lower_oracle_ir` will give the
+        // definition when it re-buckets items into the per-category vectors of
+        // `ParsedAbilities`. That is why retiring the category-ordered Class façade
+        // — the last producer that visited out of source order — left every stamped
+        // slot unchanged. Each `RetainPrinted{Trigger,Ability}FromSource` is a
         // self-reference to its enclosing item (CR 603.1 / CR 602.1), stamped with
         // that item's per-category slot, replacing the `placeholder()` (= 0) the
-        // dispatch loop baked in. This per-category counting stays correct when a
-        // later commit makes item ordering truly source-based.
+        // dispatch loop baked in.
         //
         // Match is EXHAUSTIVE over `OracleNodeIr` (no `_`), mirroring `emit`'s
         // printed-slot match above: a future node variant — or the currently
@@ -1585,19 +1549,13 @@ mod tests {
             "an out-of-range child must be REJECTED pre-emit, got {bad:?}"
         );
 
-        // Fragment/precision coupling is enforced on children too. This span IS
-        // contained (0..10 of a 10-byte document), so only the precision mismatch
-        // can reject it — the assertion cannot pass for the wrong reason.
-        let mism = alloc.allocate_with_span(
-            OracleSourceSpan::whole_document("abcdefghij", 3),
-            Some("abc"),
-        );
-        assert!(
-            matches!(mism, Err(DocBuilderError::FragmentPrecisionMismatch { .. })),
-            "a WholeDocument child carrying a fragment must be rejected, got {mism:?}"
-        );
-
-        // ...and the converse: an Exact span with no fragment is equally rejected.
+        // Fragment/precision coupling is enforced on children too. Only ONE
+        // direction of that coupling is still REPRESENTABLE: every live tier
+        // (`Exact`, `ChainRelative`) returns `carries_fragment() == true`, so
+        // "a span that must not carry a fragment, carrying one" — the retired
+        // `WholeDocument` case — can no longer be constructed. The guard is not
+        // weaker for it; the case moved from a runtime rejection to a type-level
+        // impossibility. The surviving direction still discriminates:
         let missing = alloc.allocate_with_span(span(0, 2, 6, 4), None);
         assert!(
             matches!(
@@ -1893,32 +1851,36 @@ mod tests {
         assert_eq!(b3.ability_index().get(), 0);
     }
 
-    /// A whole-document span must be self-describing: `first_line == 0` is "we
-    /// don't know the line", not "line 0". `SpanPrecision` carries that.
+    /// A span that is NOT card-absolute must say so. `ChainRelative` carries a
+    /// truthful byte range — but one measured inside a single effect chain, not
+    /// into the card — so a position renderer must be able to refuse to print it
+    /// as a card position. This is the discriminating case that keeps `is_exact`
+    /// from being tautologically true now that `WholeDocument` is retired.
     #[test]
-    fn span_precision_distinguishes_coarse_from_exact() {
-        let coarse = OracleSourceSpan::whole_document("Flying\n{T}: Add {G}.", 0);
-        assert_eq!(coarse.precision, SpanPrecision::WholeDocument);
+    fn span_precision_distinguishes_chain_relative_from_exact() {
+        let chain_local = OracleSourceSpan::chain_relative(0, 0, 0, 6, 0);
+        assert_eq!(chain_local.precision, SpanPrecision::ChainRelative);
         assert!(
-            !coarse.is_exact(),
-            "a renderer must be able to refuse to print line 0 for this span"
+            !chain_local.is_exact(),
+            "a renderer must be able to refuse to print a chain-local offset as a card position"
         );
 
         let exact = OracleSourceSpan::exact(1, 1, 7, 20, 0);
         assert_eq!(exact.precision, SpanPrecision::Exact);
         assert!(exact.is_exact());
 
-        // Both are true containing spans; precision is orthogonal to containment.
-        assert!(exact.is_contained_by(&coarse));
+        // Both tiers locate a real byte range, so both carry their fragment.
+        assert!(chain_local.carries_fragment() && exact.carries_fragment());
     }
 
-    /// The 3a document span is coarse but true: it contains the item, and
-    /// distinct ordinals keep co-located siblings from tripping the overlap rule.
+    /// Two items may legitimately share one printed line — `Kicker {2}{G}` emits a
+    /// `Keyword` and an `AdditionalCost` from the same bytes. Distinct ordinals are
+    /// what keep those co-located siblings from tripping the overlap rule; the rule
+    /// itself must still fire when the ordinal is NOT distinct.
     #[test]
-    fn whole_document_span_contains_items_and_never_conflicts() {
-        let text = "Flying\n{T}: Add {G}.";
-        let first = OracleSourceSpan::whole_document(text, 0);
-        let second = OracleSourceSpan::whole_document(text, 1);
+    fn colocated_siblings_conflict_only_on_a_shared_ordinal() {
+        let first = OracleSourceSpan::exact(0, 0, 0, 6, 0);
+        let second = OracleSourceSpan::exact(0, 0, 0, 6, 1);
         assert!(first.is_contained_by(&second) && second.is_contained_by(&first));
         assert!(
             !first.conflicts_with(&second),
@@ -1928,7 +1890,5 @@ mod tests {
             first.conflicts_with(&first.clone()),
             "same ordinal + overlapping bytes must still conflict (rule is live)"
         );
-        assert_eq!(first.last_line, 1);
-        assert_eq!(first.end_byte, text.len());
     }
 }


### PR DESCRIPTION
`parsed_abilities_to_doc_ir` was the last category-ordered document façade and
the sole producer of `SpanPrecision::WholeDocument`. It was not dead code: its
one caller was the live Class-card branch, so this is a conversion, not a
deletion. Class now emits through `DocEmitter` at its printed source line, like
every other preprocessor (Saga, Attraction, Leveler, Spacecraft) since U4.

- `parse_class_oracle_text` returns `Vec<(usize, OracleNodeIr)>` — each item
  tagged with the source line it was printed on — instead of pushing into a
  category-bucketed `ParsedAbilities`. `LevelSection` now carries the line index
  of every retained line; reminder-stripping rewrites a line's TEXT but never
  its INDEX, so the index stays a faithful pointer into `lines`. The `result`
  in-param is dropped: it was always empty at the Class branch.
- The four-item cascade this unblocks: the shim, `OracleSourceSpan::whole_document`,
  `SpanPrecision::WholeDocument`, and the WholeDocument arms of the renderer
  caveats. The caveats themselves STAY: they are shared with the live
  `SpanPrecision::ChainRelative` tier (U5 debt), whose spans are equally not
  card-absolute. `carries_fragment()` / `check_fragment_precision()` remain the
  fail-closed authority — the guard is bidirectional, so it still rejects an
  Exact span with no fragment.

Why the output is unchanged: `lower_oracle_ir` re-buckets document items BY
CATEGORY into `ParsedAbilities`, so cross-category interleaving never reaches
card-data.json; `parse_class_oracle_text` already pushed into each bucket in
source order; and CR 707.9a printed slots are stamped in `finish()` by
PER-CATEGORY counting, which never depended on visit order.

Evidence (full-pool export, data/card-data.json, 35,396 faces):
  base   950c667b1d  sha ab448fc64cb965907455257bcd98de68f58c58272bd7cb515703dae306740854
  after  this commit sha ab448fc64cb965907455257bcd98de68f58c58272bd7cb515703dae306740854  (byte-identical)
Non-vacuity: the shim reached exactly 38 Class faces, so a full-pool green is
vacuous on the other 35,358. Forced probe — invert the Class span sort key —
diverges on exactly 38 faces, all 38 of them Class, zero collateral. The green
was watched go red before it was accepted.
(A first probe that reversed EMISSION order came back identical, which is
correct and not a defect: `OracleDocBuilder` keys items by `(first_line,
ordinal)` and re-sorts, so emission order is genuinely irrelevant — see
`builder_returns_items_in_source_order_regardless_of_emission_order`. That is
also why the retired category-order emission and source-order emission agree.)

Two doc.rs precision tests are re-pointed at the surviving tiers rather than
deleted, so they keep discriminating: `is_exact` would be tautologically true
without a non-card-absolute case, so the coarse side is now `ChainRelative`;
the co-located-sibling test now uses two Exact spans on one line (`Kicker
{2}{G}`), the real live case. The "must not carry a fragment" direction of the
fragment/precision guard is now unrepresentable — it moved from a runtime
rejection to a type-level impossibility.

cargo check --all-targets: 0 errors, 0 warnings. 7,973 parser tests pass.
scripts/check-parser-combinators.sh: PASS.
