### PR TITLE
feat(engine): register CantBeBlockedUnlessAllBlock in static registry

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -8739,6 +8739,10 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
                 effective_lower.contains("can't be blocked")
             }
             StaticMode::CantBeBlockedBy { .. } => effective_lower.contains("can't be blocked"),
+            // CR 509.1b: CantBeBlockedUnlessAllBlock — "can't be blocked" anchor
+            // (Tromokratis). The "unless all creatures" clause is validated by
+            // parser tests.
+            StaticMode::CantBeBlockedUnlessAllBlock => effective_lower.contains("can't be blocked"),
             // CR 502.3: Smoke / Damping Field / Winter Orb max-untap cap. Anchor
             // on the verb phrase; the type filter half is the reused TargetFilter
             // and is validated by parser tests.
@@ -13154,6 +13158,31 @@ mod tests {
         assert!(
             gaps.is_empty(),
             "Data-carrying combat statics should be fully supported, but got gaps: {:?}",
+            gaps
+        );
+    }
+
+    /// CR 509.1b: CantBeBlockedUnlessAllBlock is a nullary registry-keyed
+    /// static enforced by combat.rs declare-blockers validation (Tromokratis).
+    #[test]
+    fn cant_be_blocked_unless_all_block_has_no_coverage_gap() {
+        let mut face = make_face();
+        face.oracle_text = Some(
+            "Tromokratis can't be blocked unless all creatures defending player controls block it."
+                .to_string(),
+        );
+        face.static_abilities.push(
+            StaticDefinition::new(StaticMode::CantBeBlockedUnlessAllBlock)
+                .affected(TargetFilter::SelfRef)
+                .description(
+                    "Tromokratis can't be blocked unless all creatures defending player controls block it.".to_string(),
+                ),
+        );
+
+        let gaps = card_face_gaps(&face);
+        assert!(
+            gaps.is_empty(),
+            "CantBeBlockedUnlessAllBlock should be fully supported, but got gaps: {:?}",
             gaps
         );
     }

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -127,6 +127,10 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
 
     // CR 509.1b: CantBeBlocked — creature cannot be blocked.
     registry.insert(StaticMode::CantBeBlocked, handle_cant_be_blocked);
+    // CR 509.1b: CantBeBlockedUnlessAllBlock — creature can't be blocked unless
+    // all creatures defending player controls block it (Tromokratis). Runtime
+    // enforcement is in combat.rs declare-blockers validation.
+    registry.insert(StaticMode::CantBeBlockedUnlessAllBlock, handle_rule_mod);
     // CR 702.16: Protection prevents targeting, blocking, damage, and attachment.
     registry.insert(StaticMode::Protection, handle_protection);
 


### PR DESCRIPTION
## Summary

Closes the last remaining coverage gap for **Tromokratis** by registering `StaticMode::CantBeBlockedUnlessAllBlock` in the static-abilities registry and wiring the coverage classifier to recognise it as a supported variant.

## Card

**Tromokratis** — {5}{U}{U} Legendary Creature — Kraken (8/8 )

> Tromokratis has hexproof unless it's attacking or blocking.
> Tromokratis can't be blocked unless all creatures defending player controls block it.
> Whenever Tromokratis becomes blocked, tap all creatures defending player controls.

## What already existed

| Component | Status | Location |
|-----------|--------|----------|
| Parser | ✅ implemented | `oracle_static/evasion.rs:1769` — `parse_block_unless_all_block_nom` |
| Combat enforcement | ✅ implemented | `combat.rs:1574–1655` — declare-blockers validation |
| Integration tests | ✅ registered | `tromokratis.rs` (6 tests) in `main.rs:906` |

## What this PR adds

| File | Change |
|------|--------|
| `static_abilities.rs` | Register `CantBeBlockedUnlessAllBlock` in `build_static_registry()` as a `handle_rule_mod` entry (nullary marker, same pattern as Goaded/CantCrew) |
| `coverage.rs` | Add text-anchor arm: `StaticMode::CantBeBlockedUnlessAllBlock => effective_lower.contains("can't be blocked")` |
| `coverage.rs` | Add regression test `cant_be_blocked_unless_all_block_has_no_coverage_gap()` asserting zero gaps for a face carrying this static with the Tromokratis oracle text |

## Design rationale

`CantBeBlockedUnlessAllBlock` is a nullary (no payload) `StaticMode` variant. Its runtime semantics are entirely handled by `combat.rs` declare-blockers validation — the registry entry only needs to be `handle_rule_mod` (the no-op handler that marks the variant as "known and supported" for the layer system). This mirrors the pattern used for `Goaded`, `CantCrew`, `MustAttack`, and other passive combat-restriction markers.

The coverage classifier uses the `"can't be blocked"` text anchor (same as `CantBeBlocked`, `CantBeBlockedExceptBy`, `CantBeBlockedBy`) since all four share the same oracle-text prefix. The "unless all creatures" clause specificity is validated by the parser unit tests.

## Testing

- **Unit test**: `cant_be_blocked_unless_all_block_has_no_coverage_gap` — constructs a synthetic face with the Tromokratis oracle text and asserts `card_face_gaps()` returns empty
- **Integration tests** (pre-existing, already green): 6 tests in `tromokratis.rs` exercising the full combat path

## Checklist

- [x] `cargo check --lib -p engine` — zero errors/warnings
- [x] `rustfmt --check` — clean
- [x] `scripts/check-parser-combinators.sh` — Gate A PASS
- [x] No `unwrap()` / `expect()` in non-test code
- [x] No `todo!()` / `unimplemented!()` in non-test code
- [x] CR reference in commit message

CR: 509.1b
