### PR TITLE
refactor(parser): re-home swallow-audit diagnostics into OracleDocIr (ISSUES #17)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -2629,7 +2629,13 @@ fn parse_flash_cleanup_sacrifice_casting_option(
 /// `ParsedAbilities` stays category-grouped because it is the runtime-facing
 /// type; only *within*-category order and explicit cross-item relations are
 /// semantic after lowering.
-pub(crate) fn lower_oracle_ir(ir: &OracleDocIr) -> ParsedAbilities {
+///
+/// Takes `ir` by `&mut` so the swallow audit — whose input is the assembled
+/// result, and which therefore cannot run before the fold — can still emit into
+/// `OracleDocIr.diagnostics`. That keeps the doc IR the single warning channel
+/// (`OracleDocIr.diagnostics` → `ParsedAbilities.parse_warnings`) rather than
+/// letting the audit direct-append to `parse_warnings` behind the doc's back.
+pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
     let mut result = ParsedAbilities {
         abilities: Vec::new(),
         triggers: Vec::new(),
@@ -2712,7 +2718,6 @@ pub(crate) fn lower_oracle_ir(ir: &OracleDocIr) -> ParsedAbilities {
             }
         }
     }
-    result.parse_warnings = ir.diagnostics.clone();
 
     // ---- Cross-item document relation application (CR 607.2d) -----------------
     // `ir.relations` were recovered at parse time by pairing producer/consumer
@@ -2742,14 +2747,14 @@ pub(crate) fn lower_oracle_ir(ir: &OracleDocIr) -> ParsedAbilities {
 
     // Architectural rule: the parser must never silently discard Oracle text. Run
     // the swallow audit against the parsed result so any unrepresented clause
-    // surfaces as a parse_warning. Post-relocation the audit runs after `finish()`
-    // has sealed `OracleDocIr.diagnostics`, so its warnings DIRECT-APPEND to
-    // `result.parse_warnings` (card-data parity holds — both routes end in
-    // `parse_warnings`, same order: loop diagnostics then swallow diagnostics).
-    // `OracleDocIr.diagnostics` no longer carries swallow warnings until Plan 02
-    // re-homes the audit — see ISSUES.md #17. Source text is the original
-    // (un-normalized) `ir.source_text`, matching today's swallow input.
-    let mut swallow_diags = Vec::new();
+    // surfaces as a parse_warning. The audit's INPUT is the assembled `result`, so
+    // it cannot run before the fold; its OUTPUT nonetheless belongs in the doc's
+    // one warning channel, so it emits into `ir.diagnostics` (the reason this
+    // function borrows `ir` mutably). `parse_warnings` is then assigned ONCE, from
+    // that channel, at the end — no direct-append behind the doc's back.
+    // Source text is the original (un-normalized) `ir.source_text`, matching
+    // today's swallow input.
+    //
     // Draft-time "draft matters" lines (CR 905) are intentionally consumed as
     // no-ops; their "you may"/"if you do"/"as long as" markers would otherwise be
     // reported as swallowed clauses. Strip them before the audit; constructed-play
@@ -2766,8 +2771,7 @@ pub(crate) fn lower_oracle_ir(ir: &OracleDocIr) -> ParsedAbilities {
     } else {
         &ir.source_text
     };
-    super::swallow_check::check_swallowed_clauses(swallow_input, &result, &mut swallow_diags);
-    result.parse_warnings.extend(swallow_diags);
+    super::swallow_check::check_swallowed_clauses(swallow_input, &result, &mut ir.diagnostics);
     // ---------------------------------------------------------------------------
 
     // CR 607.1 + CR 610.3: Two-trigger exile-return synthesis (Journey to
@@ -2778,6 +2782,13 @@ pub(crate) fn lower_oracle_ir(ir: &OracleDocIr) -> ParsedAbilities {
     // former `synthesize`/`bind` passes ran (the audit reads `result` first).
     apply_etb_exile_ltb_return(&mut result, &ir.relations, &trigger_ids);
     apply_active_player_punisher(&mut result, &ir.relations, &ability_ids);
+
+    // The doc IR's diagnostics channel is the single source of parse warnings.
+    // Assigned once, here, so it carries BOTH the parse-time diagnostics sealed by
+    // `finish()` and the swallow-audit diagnostics emitted above, in that order.
+    // None of the relation passes touch `parse_warnings`, so this placement is
+    // equivalent to assigning before them.
+    result.parse_warnings = ir.diagnostics.clone();
     result
 }
 
@@ -5729,14 +5740,14 @@ pub fn parse_oracle_text(
     types: &[String],
     subtypes: &[String],
 ) -> ParsedAbilities {
-    let ir = parse_oracle_ir(
+    let mut ir = parse_oracle_ir(
         oracle_text,
         card_name,
         mtgjson_keyword_names,
         types,
         subtypes,
     );
-    let mut parsed = lower_oracle_ir(&ir);
+    let mut parsed = lower_oracle_ir(&mut ir);
     scrub_granting_placeholder_descriptions(&mut parsed);
     parsed
 }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -5,6 +5,7 @@
 //! both layers so structural drift and assembly bugs are independently caught.
 
 use crate::parser::oracle::{lower_oracle_ir, parse_oracle_ir, ParsedAbilities};
+use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::doc::OracleDocIr;
 
 /// Parse Oracle text through both IR and lowering layers.
@@ -27,9 +28,58 @@ fn parse_two_layer_with_keywords(
     let keywords: Vec<String> = keywords.iter().map(|s| s.to_string()).collect();
     let types: Vec<String> = types.iter().map(|s| s.to_string()).collect();
     let subtypes: Vec<String> = subtypes.iter().map(|s| s.to_string()).collect();
-    let ir = parse_oracle_ir(oracle_text, card_name, &keywords, &types, &subtypes);
-    let lowered = lower_oracle_ir(&ir);
+    let mut ir = parse_oracle_ir(oracle_text, card_name, &keywords, &types, &subtypes);
+    let lowered = lower_oracle_ir(&mut ir);
     (ir, lowered)
+}
+
+/// ISSUES #17: the swallow audit's findings must live in the doc IR's diagnostics
+/// channel, not be direct-appended to `ParsedAbilities::parse_warnings` behind the
+/// doc's back.
+///
+/// The audit's *input* is the assembled result, so it necessarily runs after the
+/// fold — but that is a reason to hand it the doc channel as its sink, not a reason
+/// to give it a private one. `OracleDocIr.diagnostics` is the single warning
+/// channel; `parse_warnings` is a copy of it.
+///
+/// Fixture is pool-verified, not synthetic: Intermediate Chirography's Oracle text
+/// is verbatim MTGJSON, and it carries a live `Duration_ThisTurn` swallowed-clause
+/// warning in shipped `card-data.json` (M1 defect ledger → issue #5638) — the
+/// "this turn" in its level-3 trigger is not represented in the parse. A synthetic
+/// fixture could go vacuously green if the detector stopped firing; this one cannot
+/// without that separately-tracked defect being fixed.
+#[test]
+fn swallow_diagnostics_are_homed_in_the_doc_ir_channel() {
+    let (ir, lowered) = parse_two_layer(
+        "(Gain the next level as a sorcery to add its ability.)\n\
+         When this Class enters, create a 2/1 white and black Inkling creature token with flying.\n\
+         {1}{B}: Level 2\n\
+         Whenever you lose life for the first time each turn, put a +1/+1 counter on target creature you control.\n\
+         {2}{B}: Level 3\n\
+         At the beginning of each end step, if a modified creature died under your control this turn, create a 2/1 white and black Inkling creature token with flying. (Equipment, Auras you control, and counters are modifications.)",
+        "Intermediate Chirography",
+        &["Enchantment"],
+        &["Class"],
+    );
+
+    // (a) The re-homing itself. Before this change the audit wrote to a private vec
+    //     that was appended straight onto `parse_warnings`, so the doc channel never
+    //     saw a swallowed clause and this assertion was unsatisfiable.
+    assert!(
+        ir.diagnostics
+            .iter()
+            .any(|d| matches!(d, OracleDiagnostic::SwallowedClause { .. })),
+        "swallow audit must emit into OracleDocIr.diagnostics; got {:?}",
+        ir.diagnostics
+    );
+
+    // (b) One channel, one order. `parse_warnings` is assigned FROM the doc channel,
+    //     so any future direct-append to `parse_warnings` re-opens the bypass and
+    //     fails here.
+    assert_eq!(
+        lowered.parse_warnings, ir.diagnostics,
+        "parse_warnings must be a copy of OracleDocIr.diagnostics, not a separate sink"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The swallow audit's input is the assembled `ParsedAbilities`, so it cannot run
before the fold — but that is a reason to hand it the doc's diagnostics channel
as its sink, not a reason to give it a private one. Since the reconcile-seam
relocation it direct-appended to `result.parse_warnings` after `finish()` had
sealed `OracleDocIr.diagnostics`, so the doc IR — the parser's single warning
channel — never carried a swallowed clause.

`lower_oracle_ir` now takes `&mut OracleDocIr`, the audit emits into
`ir.diagnostics`, and `parse_warnings` is assigned once, from that channel, at
the end. Plan 02 builds a unit-keyed audit on top of this channel and forbids a
parallel warning path; this makes that invariant true rather than aspirational.

Byte-identical by construction: the vector is built in the same order (parse-time
diagnostics, then swallow diagnostics), the audit's sink is push-only (no
detector reads it), and none of the six post-fold relation passes touch
`parse_warnings`. Verified on the full pool — 35,396 faces, export sha
b18035f9bb5699766657cb15058293998d67d7ea9ebfa656a9d0a731a129adb3, identical to
the pristine origin/main baseline (98,198,576 B).

The regression test is pinned to a pool-verified card: Intermediate Chirography
carries a live Duration_ThisTurn swallowed clause in shipped card-data (#5638).
It was watched go red against the restored bypass ("got []"), so it cannot pass
vacuously.
