### PR TITLE
docs(ci): name both event-decode shapes so the comment cannot drift from the regex

### DIFF
--- a/scripts/draw_replacement_census.py
+++ b/scripts/draw_replacement_census.py
@@ -65,19 +65,24 @@ CARD_DATA = REPO_ROOT / "data" / "card-data.json"
 # This is where `.draw_scope(..)` has to be threaded.
 CONSTRUCTOR = re.compile(r"ReplacementDefinition::new\(\s*ReplacementEvent::Draw(Cards)?\b")
 
-# A definition decoded from text: a match arm YIELDING `ReplacementEvent::Draw`
-# (the Forge importer, `FromStr`). These mint Draw definitions without ever
-# calling the constructor above, so a constructor-only census misses them.
+# A definition decoded from text: a match arm YIELDING `ReplacementEvent::Draw`.
+# These mint Draw definitions without ever calling the constructor above, so a
+# constructor-only census misses them. Both shapes in the tree are matched, and
+# both are named here so this comment cannot drift away from the regex below:
+#
+#     => ReplacementEvent::Draw           types/replacements.rs::from_str
+#     => Ok(ReplacementEvent::Draw)       database/forge/replacement.rs
+#                                         (Result-returning, hence the Ok wrap)
 #
 # Keyed on the arm's RESULT, not on its `"Draw"` string literal, because the
 # shared scanner strips string literals before matching (brace counting must not
 # see a `{` inside a string). A pattern spelled `"Draw"\s*=>` would match nothing
-# and the census would silently report zero decode sites.
+# and the census would silently report zero decode sites while passing green.
 #
-# Direction matters: `=> ReplacementEvent::Draw` PRODUCES the event, while
-# `ReplacementEvent::Draw =>` merely matches on it (e.g. coverage.rs's
+# Direction matters: an arrow BEFORE the variant produces the event; an arrow
+# AFTER it merely matches on the event (e.g. coverage.rs's
 # `ReplacementEvent::Draw | ReplacementEvent::DrawCards => {`). Only the former
-# is a producer.
+# is a producer, so the `=>` must lead.
 EVENT_DECODE = re.compile(r"=>\s*(?:Ok\()?\s*ReplacementEvent::Draw(Cards)?\b")
 
 FAMILIES = (("constructor", CONSTRUCTOR), ("event-decode", EVENT_DECODE))


### PR DESCRIPTION
The EVENT_DECODE comment spelled the pattern as `=> ReplacementEvent::Draw` and
omitted the `(?:Ok\()?` branch. The regex has always matched both shapes and the
frozen baseline has always contained both sites — but a reader going by the prose
would reasonably conclude the Forge importer's `=> Ok(ReplacementEvent::Draw)`
could not match, and therefore that the census was blind to a producer.

A review did exactly that and nearly held the ship on it. The code was right; the
description of the code was the defect. An instrument whose stated behaviour does
not match its actual behaviour will be misread, and a census that is misread is a
census that gets "fixed" into something wrong.

Name both shapes and the file each one lives in, next to the pattern they
describe. No behaviour change: the baseline is byte-identical.
