### PR TITLE
feat(parser): dynamic P/T pump scaling by source intensity (Minthara/Teysa/Quickbeast)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2137,7 +2137,7 @@ fn parse_scoped_zone_ref(input: &str) -> OracleResult<'_, (ZoneRef, CountScope)>
 /// templating used "its" exclusively, so admitting the gendered forms here
 /// keeps the whole "his/her/their <characteristic>" class on one path rather
 /// than special-casing one card.
-fn parse_self_possessive(input: &str) -> OracleResult<'_, ()> {
+pub(crate) fn parse_self_possessive(input: &str) -> OracleResult<'_, ()> {
     value(
         (),
         alt((

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -1140,7 +1140,9 @@ pub(crate) fn parse_dynamic_pt_in_text(
     // Run whose effect text has no binding clause — the X is bound to the
     // cost, not to a derived quantity.
     let quantity = match where_x_expression {
-        Some(wx) => parse_cda_quantity(wx).or_else(|| parse_event_context_quantity(wx))?,
+        Some(wx) => parse_cda_quantity(wx)
+            .or_else(|| parse_event_context_quantity(wx))
+            .or_else(|| parse_source_intensity_where_x(wx))?,
         None => QuantityExpr::Ref {
             qty: QuantityRef::CostXPaid,
         },
@@ -1182,6 +1184,30 @@ pub(crate) fn parse_dynamic_pt_in_text(
     }
 
     Some(mods)
+}
+
+/// Digital-only Alchemy (Arena): "where X is <source>'s intensity" — a dynamic
+/// P/T pump that scales by the STATIC's own source object's intensity (Minthara
+/// of the Absolute, Teysa of the Ghost Council, Quickbeast Amulet). The
+/// self-possessive axis reuses [`nom_quantity::parse_self_possessive`]
+/// (its / ~'s / this creature's / …) rather than enumerating verbatim strings;
+/// `normalize_card_name_refs` funnels every card-name and permanent-type
+/// self-reference to `~` upstream, so `~'s intensity` is the form the static
+/// parser actually receives. `QuantityRef::Intensity { scope: Source }` is fully
+/// evaluated at runtime by `game::quantity`, so this is a grammar-only seam that
+/// reuses existing modeling.
+fn parse_source_intensity_where_x(wx: &str) -> Option<QuantityExpr> {
+    nom_parse_lower(wx.trim().trim_end_matches('.').trim(), |i| {
+        value(
+            QuantityExpr::Ref {
+                qty: QuantityRef::Intensity {
+                    scope: ObjectScope::Source,
+                },
+            },
+            terminated(nom_quantity::parse_self_possessive, tag(" intensity")),
+        )
+        .parse(i)
+    })
 }
 
 pub(crate) fn parse_base_pt_mod(text: &str) -> Option<(i32, i32)> {

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -24,11 +24,12 @@ mod prelude {
     };
     pub(super) use super::super::oracle_ir::context::ParseContext;
     pub(super) use super::super::oracle_ir::static_ir::StaticIr;
-    pub(super) use super::super::oracle_nom::bridge::nom_on_lower;
+    pub(super) use super::super::oracle_nom::bridge::{nom_on_lower, nom_parse_lower};
     pub(super) use super::super::oracle_nom::condition as nom_condition;
     pub(super) use super::super::oracle_nom::error::OracleResult;
     pub(super) use super::super::oracle_nom::filter as nom_filter;
     pub(super) use super::super::oracle_nom::primitives as nom_primitives;
+    pub(super) use super::super::oracle_nom::quantity as nom_quantity;
     pub(super) use super::super::oracle_nom::target as nom_target;
     pub(super) use super::super::oracle_quantity::{
         parse_cda_quantity, parse_event_context_quantity, parse_for_each_clause, parse_quantity_ref,

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -28252,3 +28252,64 @@ fn rayami_flying_grant_is_conditional_on_matching_exiled_card() {
         "Rayami must not gain vigilance — no exiled card has vigilance"
     );
 }
+
+/// Digital-only Alchemy: a dynamic P/T pump that scales by the source's own
+/// intensity — Minthara of the Absolute / Teysa of the Ghost Council ("get
+/// +X/+0, where X is ~'s intensity") and Quickbeast Amulet ("gets +X/+X, where
+/// X is this Equipment's intensity"). X binds to `QuantityRef::Intensity {
+/// scope: Source }`, which `game::quantity` evaluates at runtime.
+#[test]
+fn dynamic_pt_pump_scales_by_source_intensity() {
+    let intensity = QuantityExpr::Ref {
+        qty: QuantityRef::Intensity {
+            scope: ObjectScope::Source,
+        },
+    };
+
+    // +X/+0: power scales by intensity, toughness untouched.
+    let s = super::shared::parse_static_line_multi(
+        "Creatures you control get +X/+0, where X is ~'s intensity.",
+    );
+    assert_eq!(s.len(), 1, "Minthara: {s:?}");
+    assert!(
+        s[0].modifications
+            .contains(&ContinuousModification::AddDynamicPower {
+                value: intensity.clone()
+            }),
+        "expected power to scale by source intensity, got {:?}",
+        s[0].modifications
+    );
+    assert!(
+        !s[0]
+            .modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::AddDynamicToughness { .. })),
+        "+X/+0 must not pump toughness, got {:?}",
+        s[0].modifications
+    );
+
+    // +X/+X: both axes scale by intensity (Quickbeast Amulet). The card's
+    // printed "this Equipment's intensity" is rewritten to "~'s intensity" by
+    // `normalize_card_name_refs` before the static parser runs (see
+    // `normalize_card_name_refs`), so the AST test feeds the `~` form.
+    let s = super::shared::parse_static_line_multi(
+        "Equipped creature gets +X/+X, where X is ~'s intensity.",
+    );
+    assert_eq!(s.len(), 1, "Quickbeast Amulet: {s:?}");
+    assert!(
+        s[0].modifications
+            .contains(&ContinuousModification::AddDynamicPower {
+                value: intensity.clone()
+            }),
+        "expected power axis, got {:?}",
+        s[0].modifications
+    );
+    assert!(
+        s[0].modifications
+            .contains(&ContinuousModification::AddDynamicToughness {
+                value: intensity.clone()
+            }),
+        "expected toughness axis, got {:?}",
+        s[0].modifications
+    );
+}


### PR DESCRIPTION
## Summary

Parse the dropped intensity-scaling P/T pump — `get/gets +X/+0` or `+X/+X, where X is <source>'s intensity` — for **Minthara of the Absolute**, **Teysa of the Ghost Council**, and **Quickbeast Amulet**. Grammar-only: `QuantityRef::Intensity { scope: Source }` is already runtime-evaluated; the parser simply had no producer for it on the P/T-pump axis (it was parse-side dead).

## Implementation method

Hand-authored (not via `/engine-implementer`). Per review on this PR, the parse is a single combinator — `terminated(nom_quantity::parse_self_possessive, tag(\" intensity\"))` inside `nom_parse_lower` — wired into the existing `where X` quantity chain in `parse_dynamic_pt_in_text`. No new vocabulary; it reuses the existing self-possessive axis, so it also covers `its` / `this card's` / the gendered forms for free.

## CR references

None — Intensity is digital-only Alchemy with no Comprehensive Rules entry; the doc comment states that rather than inventing a CR number.

## Files changed

- `parser/oracle_static/anthem.rs` — `parse_source_intensity_where_x` + `.or_else` into the `where X` chain.
- `parser/oracle_nom/quantity.rs` — `parse_self_possessive` made `pub(crate)`.
- `parser/oracle_static/mod.rs` — prelude: add `nom_parse_lower` + `nom_quantity` alias.
- `parser/oracle_static/tests.rs` — `dynamic_pt_pump_scales_by_source_intensity` (typed AST; both fixtures use the normalized `~'s intensity` form the card actually produces post-`normalize_card_name_refs`).

## Verification (local, committed head `d1d0bfc0b1b15010095d058df69ef7846d15daba`)

- `cargo test -p engine --lib dynamic_pt_pump_scales_by_source_intensity` — ok (1 passed)
- `cargo test -p engine --lib parser::oracle_static` — ok (**1112 passed, 0 failed**)
- `cargo fmt -p engine -- --check` — clean
- `cargo clippy -p engine --lib` (`-D warnings`) — clean
- `scripts/check-parser-combinators.sh <base>` — pass (now a combinator, not verbatim `matches!`)
- `scripts/check-engine-authorities.sh <base>` — pass

Transparency: I did **not** run `scripts/ai-gate.sh` (Gate A) this session — it does a fresh `--release` build in a separate target dir and the local disk was ~100% full. I'm not fabricating a Gate A PASS line. CI's full suite (parser gate + both test shards) is green on this head.

## Anchored on

- `crates/engine/src/parser/oracle_nom/quantity.rs:2140` — `parse_self_possessive`, the self-possessive axis this reuses.
- `crates/engine/src/parser/oracle_static/anthem.rs` — the existing `where X` quantity chain (`parse_cda_quantity` / `parse_event_context_quantity`) this arm extends.

## Claimed parse impact

- **Minthara of the Absolute** — `+X/+0` pump now scales by source intensity
- **Teysa of the Ghost Council** — `+X/+0` pump now scales by source intensity
- **Quickbeast Amulet** — `+X/+X` pump now scales by source intensity (both axes)