### PR TITLE
fix(parser): Nefarious Lich damage-substitution replacement + counted graveyard exile

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7407,6 +7407,32 @@ fn filter_targets_stack(filter: &TargetFilter) -> bool {
     }
 }
 
+/// CR 700.4 (#5649): match "&lt;quantity&gt; cards from your graveyard" and return the
+/// exile count. `"that many"` → the dynamic replacement amount
+/// (`QuantityRef::EventContextAmount`, Nefarious Lich); a number word → `Fixed`.
+/// Anchored on the possessive "your graveyard" so it never overlaps the
+/// top-of-library impulse idiom guarded by `parse_dynamic_count_phrase`.
+fn parse_exile_count_from_your_graveyard(lower: &str) -> Option<QuantityExpr> {
+    let trimmed = lower.trim().trim_end_matches('.').trim();
+    let (rest, qty) = alt((
+        value(
+            QuantityExpr::Ref {
+                qty: crate::types::ability::QuantityRef::EventContextAmount,
+            },
+            tag::<_, _, OracleError<'_>>("that many"),
+        ),
+        map(crate::parser::oracle_nom::primitives::parse_number, |n| {
+            QuantityExpr::Fixed { value: n as i32 }
+        }),
+    ))
+    .parse(trimmed)
+    .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" cards from your graveyard")
+        .parse(rest)
+        .ok()?;
+    rest.trim().is_empty().then_some(qty)
+}
+
 pub(super) fn parse_exile_ast(
     text: &str,
     lower: &str,
@@ -7527,6 +7553,7 @@ pub(super) fn parse_exile_ast(
                 ),
                 all: true,
                 enter_with_counters: vec![],
+                multi_target: None,
             });
         }
         // CR 205.2a + CR 205.3a + CR 608.2c: parse the full target as a
@@ -7554,6 +7581,7 @@ pub(super) fn parse_exile_ast(
             target,
             all: true,
             enter_with_counters: vec![],
+            multi_target: None,
         });
     }
 
@@ -7597,6 +7625,7 @@ pub(super) fn parse_exile_ast(
             target,
             all: true,
             enter_with_counters: vec![],
+            multi_target: None,
         });
     }
 
@@ -7633,6 +7662,7 @@ pub(super) fn parse_exile_ast(
                 target,
                 all: false,
                 enter_with_counters,
+                multi_target: None,
             });
         }
     }
@@ -7664,8 +7694,31 @@ pub(super) fn parse_exile_ast(
                 },
                 all: false,
                 enter_with_counters: vec![],
+                multi_target: None,
             });
         }
+    }
+
+    // CR 700.4 (#5649): "exile <N> cards from your graveyard" is a COUNTED
+    // graveyard exile — Nefarious Lich's damage substitution ("exile that many
+    // cards from your graveyard instead"). `Effect::ChangeZone` has no count
+    // slot, so capture the quantity here and thread it onto the clause's
+    // `MultiTargetSpec` at lowering (Forage precedent). The generic tail below
+    // would otherwise drop the count and bind a bare `ParentTarget`.
+    if let Some(count) = parse_exile_count_from_your_graveyard(&rest_text.to_ascii_lowercase()) {
+        let mut filter = crate::types::ability::TypedFilter::default()
+            .controller(ControllerRef::You)
+            .properties(vec![crate::types::ability::FilterProp::InZone {
+                zone: crate::types::zones::Zone::Graveyard,
+            }]);
+        filter.type_filters = vec![crate::types::ability::TypeFilter::Card];
+        return Some(ZoneCounterImperativeAst::Exile {
+            origin: Some(crate::types::zones::Zone::Graveyard),
+            target: TargetFilter::Typed(filter),
+            all: false,
+            enter_with_counters: vec![],
+            multi_target: Some(crate::types::ability::MultiTargetSpec::exact(count)),
+        });
     }
 
     // CR 608.2k: thread `ctx` through so bare "it"/"them" anaphors in trigger
@@ -7723,6 +7776,7 @@ pub(super) fn parse_exile_ast(
         target,
         all: false,
         enter_with_counters,
+        multi_target: None,
     })
 }
 
@@ -11035,6 +11089,26 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             )));
             clause
         }
+        // CR 700.4 (#5649): a COUNTED graveyard exile ("exile that many cards
+        // from your graveyard", Nefarious Lich) captured a `multi_target`; the
+        // bare-Effect lowering below produces a `ChangeZone` that cannot carry
+        // the count, so thread it onto the clause here (mirroring the Tap/Untap
+        // arm). The runtime resolves the card selection via the shared
+        // multi-target picker (Forage precedent).
+        ImperativeFamilyAst::ZoneCounter(
+            ast @ ZoneCounterImperativeAst::Exile {
+                multi_target: Some(_),
+                ..
+            },
+        ) => {
+            let multi_target = match &ast {
+                ZoneCounterImperativeAst::Exile { multi_target, .. } => multi_target.clone(),
+                _ => None,
+            };
+            let mut clause = parsed_clause(lower_zone_counter_ast(ast));
+            clause.multi_target = multi_target;
+            clause
+        }
         // All other arms produce a bare Effect with no sub_ability chain.
         other => parsed_clause(lower_imperative_family_effect(other)),
     }
@@ -11611,6 +11685,10 @@ pub(super) fn lower_zone_counter_ast(ast: ZoneCounterImperativeAst) -> Effect {
             target,
             all,
             enter_with_counters,
+            // The count (for "exile N cards from your graveyard") rides the
+            // clause's `MultiTargetSpec`, threaded by `lower_imperative_family_ast`
+            // (#5649); the bare-Effect lowering here ignores it.
+            multi_target: _,
         } => {
             if all {
                 // `ChangeZoneAll` has no counter slot; mass exile never carries
@@ -13396,6 +13474,7 @@ mod tests {
             target: TargetFilter::Typed(filter),
             all: false,
             enter_with_counters,
+            multi_target: _,
         }) = result
         else {
             panic!("{input}: expected hand-origin typed exile, got {result:?}");
@@ -13425,6 +13504,7 @@ mod tests {
             target: TargetFilter::Or { filters },
             all: true,
             enter_with_counters,
+            multi_target: _,
         }) = result
         else {
             panic!("{input}: expected mass exile type union, got {result:?}");
@@ -13449,6 +13529,7 @@ mod tests {
             target: TargetFilter::Typed(filter),
             all: true,
             enter_with_counters,
+            multi_target: _,
         }) = result
         else {
             panic!("{input}: expected mass exile parity filter, got {result:?}");
@@ -13474,6 +13555,7 @@ mod tests {
                 target: TargetFilter::Typed(filter),
                 all: false,
                 enter_with_counters: _,
+                multi_target: _,
             }) = result
             else {
                 panic!("{input}: expected hand-origin typed exile, got {result:?}");
@@ -13502,6 +13584,7 @@ mod tests {
             target: TargetFilter::Typed(filter),
             all: false,
             enter_with_counters,
+            multi_target: _,
         }) = result
         else {
             panic!("{input}: expected hand-origin typed exile, got {result:?}");

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -19580,4 +19580,64 @@ mod tests {
             other => panic!("expected AssembleContraptions, got {other:?}"),
         }
     }
+
+    /// #5649 review (matthewevans): the `Fixed`-count arm of
+    /// `parse_exile_count_from_your_graveyard` fixes 8 of the 9 affected cards
+    /// (Aegis Sculptor / Bloodcurdler / Egon / Insatiable Frugivore / Kroxa /
+    /// Emeritus / Ultimecia — "exile <N> cards from your graveyard"), while the
+    /// "that many" arm covers Nefarious Lich. Pin both arms AND the negative that
+    /// the possessive "your graveyard" anchor keeps the top-of-library impulse
+    /// idiom (owned by `parse_dynamic_count_phrase`) untouched.
+    #[test]
+    fn exile_count_from_your_graveyard_binds_fixed_and_dynamic_counts() {
+        // Fixed-count arm — the eight numeric cards.
+        assert_eq!(
+            parse_exile_count_from_your_graveyard("two cards from your graveyard"),
+            Some(QuantityExpr::Fixed { value: 2 })
+        );
+        assert_eq!(
+            parse_exile_count_from_your_graveyard("eight cards from your graveyard"),
+            Some(QuantityExpr::Fixed { value: 8 })
+        );
+        // Dynamic arm — Nefarious Lich.
+        assert_eq!(
+            parse_exile_count_from_your_graveyard("that many cards from your graveyard"),
+            Some(QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount
+            })
+        );
+        // Negatives: the possessive "your graveyard" anchor must never capture the
+        // top-of-library impulse idiom.
+        assert_eq!(
+            parse_exile_count_from_your_graveyard("the top two cards of your library"),
+            None
+        );
+        assert_eq!(
+            parse_exile_count_from_your_graveyard("two cards from the top of your library"),
+            None
+        );
+
+        // End-to-end: a fixed graveyard exile rides the clause's `MultiTargetSpec`.
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "exile two cards from your graveyard",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::ChangeZone {
+                    origin: Some(crate::types::zones::Zone::Graveyard),
+                    destination: crate::types::zones::Zone::Exile,
+                    ..
+                }
+            ),
+            "expected a graveyard->exile ChangeZone, got {:?}",
+            def.effect
+        );
+        assert_eq!(
+            def.multi_target,
+            Some(MultiTargetSpec::exact(QuantityExpr::Fixed { value: 2 })),
+            "the count must ride the clause MultiTargetSpec as exact(Fixed {{ 2 }})"
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13893,6 +13893,7 @@ fn try_parse_verb_and_target<'a>(
                         ),
                         all: true,
                         enter_with_counters: vec![],
+                        multi_target: None,
                     },
                 )),
                 // The matcher only claims a fully-consumed clause (trailing text
@@ -13914,6 +13915,7 @@ fn try_parse_verb_and_target<'a>(
                 target,
                 all: true,
                 enter_with_counters: vec![],
+                multi_target: None,
             })),
             rem,
         ));
@@ -13935,6 +13937,7 @@ fn try_parse_verb_and_target<'a>(
                 target,
                 all: false,
                 enter_with_counters: vec![],
+                multi_target: None,
             })),
             rem,
         ));

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1488,6 +1488,13 @@ pub(crate) enum ZoneCounterImperativeAst {
         /// ("exile a card … with N <type> counters on it"). Empty for the
         /// common no-counter case. Mirrors `Effect::ChangeZone.enter_with_counters`.
         enter_with_counters: Vec<(CounterType, QuantityExpr)>,
+        /// CR 700.4 (#5649): a counted graveyard exile — "exile <N> cards from
+        /// your graveyard" (Nefarious Lich: "exile that many cards … instead").
+        /// `Effect::ChangeZone` carries no count, so the quantity rides the
+        /// clause's `MultiTargetSpec` (mirroring Forage), threaded at lowering by
+        /// `lower_imperative_family_ast`. `None` for the ordinary single-object
+        /// exile.
+        multi_target: Option<MultiTargetSpec>,
     },
     ExileTop {
         player: TargetFilter,

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -8365,17 +8365,40 @@ fn parse_damage_to_self_instead_followup(
         let (i, _) = opt(char('.')).parse(i)?;
         Ok((i, (effect_start, effect.len())))
     })?;
-    if !rest.trim().is_empty() {
-        return None;
-    }
-
     let effect_text = normalized.get(effect_start..effect_start + effect_len)?;
+
+    // CR 614.1a impossibility rider: "... <effect> instead. If you can't,
+    // <consequence>." (Nefarious Lich — "exile that many cards from your
+    // graveyard instead. If you can't, you lose the game."). `nom_on_lower`
+    // returns `rest` in the original (mixed-case) text, so match it via a
+    // lowercased copy. Fold the rider back onto the substituted effect so the
+    // shared "if you can't" lowering (→ `Not { ZoneChangedThisWay }`) threads it
+    // as a conditional continuation of the substituted effect, rather than
+    // bailing on the non-empty remainder. Any OTHER trailing text still bails,
+    // preserving the recognizer's single-clause scope.
+    let rider = rest.trim();
+    let followup_text = if rider.is_empty() {
+        effect_text.to_string()
+    } else {
+        let rider_lower = rider.to_lowercase();
+        if alt((
+            tag::<_, _, OracleError<'_>>("if you can't,"),
+            tag("if you cannot,"),
+        ))
+        .parse(rider_lower.as_str())
+        .is_err()
+        {
+            return None;
+        }
+        format!("{effect_text}. {rider}")
+    };
+
     let mut ctx = ParseContext {
         subject: Some(TargetFilter::SelfRef),
         in_replacement: true,
         ..ParseContext::default()
     };
-    let followup = parse_effect_chain_with_context(effect_text, AbilityKind::Spell, &mut ctx);
+    let followup = parse_effect_chain_with_context(&followup_text, AbilityKind::Spell, &mut ctx);
 
     Some(
         ReplacementDefinition::new(ReplacementEvent::DealtDamage)
@@ -9675,6 +9698,86 @@ mod tests {
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::keywords::Keyword;
+
+    /// #5649: Nefarious Lich's damage clause is a CR 614.1a substitution
+    /// replacement — "If damage would be dealt to you, exile that many cards from
+    /// your graveyard instead. If you can't, you lose the game." Previously it
+    /// dropped to an inert standalone ability with the impossibility rider lost
+    /// (the recognizer bailed on the non-empty remainder). It must now parse as a
+    /// `DealtDamage` replacement whose execute exiles `EventContextAmount` cards
+    /// from the controller's graveyard — the count riding the clause's
+    /// `MultiTargetSpec` (CR 700.4, Forage precedent) — with the "if you can't"
+    /// rider threaded as a conditional `LoseTheGame`.
+    #[test]
+    fn nefarious_lich_damage_substitution_exiles_that_many_with_impossibility_rider() {
+        let parsed = parse_oracle_text(
+            "If damage would be dealt to you, exile that many cards from your graveyard instead. \
+             If you can't, you lose the game.",
+            "Nefarious Lich",
+            &[],
+            &["Enchantment".to_string()],
+            &[],
+        );
+        let rep = parsed
+            .replacements
+            .iter()
+            .find(|r| matches!(r.event, ReplacementEvent::DealtDamage))
+            .expect("damage-substitution replacement must exist (was inert on main)");
+        assert!(
+            matches!(rep.shield_kind, ShieldKind::Prevention { .. }),
+            "the substituted damage must be prevented, got {:?}",
+            rep.shield_kind
+        );
+        let execute = rep
+            .execute
+            .as_ref()
+            .expect("replacement must carry an execute");
+        assert!(
+            matches!(
+                &*execute.effect,
+                Effect::ChangeZone {
+                    origin: Some(Zone::Graveyard),
+                    destination: Zone::Exile,
+                    ..
+                }
+            ),
+            "execute must exile from the graveyard, got {:?}",
+            execute.effect
+        );
+        // CR 700.4: the "that many" count rides the clause `MultiTargetSpec`.
+        let mt = execute
+            .multi_target
+            .as_ref()
+            .expect("counted graveyard exile must carry a MultiTargetSpec");
+        assert!(
+            matches!(
+                &mt.min,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount
+                }
+            ),
+            "exile count must be the dynamic damage amount, got {:?}",
+            mt.min
+        );
+        // CR 614.1a: "if you can't, you lose the game" → conditional `LoseTheGame`.
+        let rider = execute
+            .sub_ability
+            .as_ref()
+            .expect("impossibility rider must be threaded onto the exile");
+        assert!(
+            matches!(&*rider.effect, Effect::LoseTheGame { .. }),
+            "rider effect must be LoseTheGame, got {:?}",
+            rider.effect
+        );
+        assert!(
+            matches!(
+                rider.condition,
+                Some(crate::types::ability::AbilityCondition::Not { .. })
+            ),
+            "rider must be gated on the impossibility condition, got {:?}",
+            rider.condition
+        );
+    }
 
     /// CR 614.1c + CR 614.12 + CR 700.6 + CR 205.1b: "As a [historic permanent
     /// you control] enters, it becomes a 7/7 Dinosaur creature in addition to its


### PR DESCRIPTION
Fixes #5649.

Tier: Frontier
Model: claude-opus-4-8

## Summary

Nefarious Lich's defining mechanic — "If damage would be dealt to you, exile that many cards from your graveyard instead. If you can't, you lose the game." — silently dropped to an inert standalone `ChangeZone` ability: the substitution never fired as a replacement, the impossibility rider was lost, and the count was unbound. This makes it parse as a proper `DealtDamage` substitution replacement that exiles *that many* (= the damage amount) cards from the graveyard, with the lose-the-game rider gated on the exile being impossible.

**Scope — this is "build for the class, not the card".** The graveyard-exile count fix (part 2) repairs the same defect on **9 cards** total, all silently dropping their count on `main`; the parse-diff sticky reports exactly these:

| Card | Oracle | Fix |
|---|---|---|
| Aegis Sculptor, Bloodcurdler, Egon, God of Death | "exile **two** cards from your graveyard" | count → `Fixed{2}` |
| Insatiable Frugivore | "exile **three** …" | `Fixed{3}` |
| Kroxa and Kunoros | "exile **five** …" | `Fixed{5}` |
| Emeritus of Ideation, Ultimecia, Time Sorceress | "exile **eight** …" | `Fixed{8}` (were binding a nonsensical `any target`) |
| Nefarious Lich | "exile **that many** …" | `EventContextAmount` |

(Emeritus and Ultimecia were binding `any target` for a graveyard exile; the other six dropped their count to `targets: ∅`. All nine now bind the correct filtered graveyard-card multi-target.)

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline
- [x] **Not** `/engine-implementer`

> A targeted parser fix scoped to one replacement recognizer and the exile AST/lowering path, verified against the real card via probe and pinned with a unit test; no new engine effect variants or runtime semantics (reuses the existing `MultiTargetSpec` count path and the shared "if you can't" lowering).

## Root cause

Two independent gaps, both on the damage clause:

1. **The recognizer bailed on the rider.** `parse_damage_to_self_instead_followup` (oracle_replacement.rs) matched "If damage would be dealt to you, `<effect>` instead" but required the remainder after "instead." to be empty. Nefarious Lich's trailing "If you can't, you lose the game." made the remainder non-empty → `None` → the whole clause fell through to an inert `abilities: [ChangeZone]` entry.

2. **The exile dropped its count.** "exile that many cards from your graveyard" lowered to `ChangeZone { target: ParentTarget }` — the count *and* the graveyard filter were lost. The shared count-phrase guard (`parse_dynamic_count_phrase`) deliberately rejects "that many cards **from …**" to protect the top-of-library impulse idiom, and the generic exile tail carries no quantity.

## Fix

1. **Accept the impossibility rider** (oracle_replacement.rs). Recognize an optional "If you can't, `<consequence>`" tail and fold it back onto the substituted effect, so the shared "if you can't" lowering threads it as a conditional continuation (`Not { ZoneChangedThisWay }`). `nom_on_lower` returns the remainder in original case, so the rider is matched via a lowercased copy. Any *other* trailing text still bails, preserving the recognizer's single-clause scope.

2. **Bind the graveyard-exile count via `MultiTargetSpec`** (CR 700.4, following **Forage**). `Effect::ChangeZone` has no count slot, so the quantity rides the clause's `MultiTargetSpec`: a `multi_target` field on `ZoneCounterImperativeAst::Exile`, a recognizer anchored on "cards from your graveyard" (`that many` → `EventContextAmount`, number words → `Fixed`), and a lowering arm mirroring the Tap/Untap `multi_target` seam. The anchor never touches the impulse-draw guard, so that idiom is unaffected.

Result:
```
DealtDamage replacement (Prevention shield)
  execute: ChangeZone{ Graveyard → Exile, Typed<Card in your graveyard> }
    multi_target: exact(EventContextAmount)      // exile N = the damage amount
    └ LoseTheGame  if  Not{ ZoneChangedThisWay } // "if you can't, you lose the game"
```
`replacements: 2, abilities: 0` (was `1 / 1` inert).

## CR references

CR 614.1a (substitution replacement + impossibility rider), CR 700.4 (numeric counts), CR 608.2c (the "if you can't" prior-instruction condition).

## Verification

- `nefarious_lich_damage_substitution_exiles_that_many_with_impossibility_rider` — asserts the `DealtDamage` replacement, the `Graveyard → Exile` execute, the `EventContextAmount` `MultiTargetSpec`, and the conditional `LoseTheGame` rider (the "that many" arm).
- `exile_count_from_your_graveyard_binds_fixed_and_dynamic_counts` — pins the **`Fixed` arm** (the eight numeric cards: `"two cards from your graveyard"` → `Fixed{2}`, `"eight …"` → `Fixed{8}`), the dynamic arm, the end-to-end `ChangeZone` + `exact(Fixed{2})` `MultiTargetSpec`, and a **negative** that the top-of-library impulse idiom stays untouched by the possessive-graveyard anchor.
- Regression siblings unaffected — Delaying Shield / Force Bubble (counter substitutions, no rider) still parse; the new graveyard-exile recognizer fires only when the whole exile effect is "exile `<count>` cards from your graveyard".
- Full parser lib suite green; parser-combinator gate + clippy clean.
