### PR TITLE
fix(parser): self-scoped damage shields prevent only damage dealt TO the source (Fixes #5652)

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -16360,8 +16360,9 @@ mod tests {
             "UnlessYourTurn shield should match on opponent's turn"
         );
     }
-    /// #5652 (CR 614.1a): a self-scoped damage shield must fire only for damage
-    /// dealt TO its own object, never for damage the object DEALS. Swans of Bryn
+    /// #5652 (CR 615.1): a prevention effect is a "shield around whatever it's
+    /// affecting" — a self-scoped shield must fire only for damage dealt TO its
+    /// own object, never for damage the object DEALS. Swans of Bryn
     /// Argoll blocks: the attacker's damage to Swans is prevented (draw rider
     /// fires), but Swans' combat damage to the attacker must LAND. Before the
     /// parser fix Swans' shield had `valid_card: None`, so it also prevented the

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -16360,4 +16360,58 @@ mod tests {
             "UnlessYourTurn shield should match on opponent's turn"
         );
     }
+    /// #5652 (CR 614.1a): a self-scoped damage shield must fire only for damage
+    /// dealt TO its own object, never for damage the object DEALS. Swans of Bryn
+    /// Argoll blocks: the attacker's damage to Swans is prevented (draw rider
+    /// fires), but Swans' combat damage to the attacker must LAND. Before the
+    /// parser fix Swans' shield had `valid_card: None`, so it also prevented the
+    /// damage Swans dealt — the attacker took 0.
+    #[test]
+    fn swans_self_shield_does_not_prevent_damage_it_deals() {
+        use crate::game::combat::AttackTarget;
+        use crate::game::scenario::{GameScenario, P0, P1};
+        use crate::types::game_state::WaitingFor;
+        use crate::types::phase::Phase;
+
+        const SWANS: &str = "Flying\nIf a source would deal damage to ~, prevent that damage. The source's controller draws cards equal to the damage prevented this way.";
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        // P0 attacks with a 2/4 (survives 2 damage so we can read marked damage).
+        let attacker = scenario.add_creature(P0, "Grizzly", 2, 4).id();
+        // The prevented-damage rider makes the damage source's controller draw;
+        // the source of the prevented damage is P0's attacker, so seed P0's
+        // library to avoid a draw-from-empty loss confounding the combat step.
+        scenario.with_library_top(P0, &["Forest", "Forest", "Forest"]);
+        // P1 blocks with Swans (2/2). Flying does not stop a flyer from blocking.
+        let swans = scenario
+            .add_creature_from_oracle(P1, "Swans of Bryn Argoll", 2, 2, SWANS)
+            .id();
+
+        let mut runner = scenario.build();
+        runner.advance_to_combat();
+        runner
+            .declare_attackers(&[(attacker, AttackTarget::Player(P1))])
+            .expect("declare attackers");
+        if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+            runner.pass_both_players();
+        }
+        runner
+            .declare_blockers(&[(swans, attacker)])
+            .expect("declare blockers");
+        let _ = runner.combat_damage();
+
+        // Discriminator: Swans deals 2 to the attacker and it MUST land.
+        assert_eq!(
+            runner.state().objects[&attacker].damage_marked,
+            2,
+            "Swans' own combat damage must not be prevented by its self-shield"
+        );
+        // Reach-guard: the attacker's 2 damage TO Swans is still prevented.
+        assert_eq!(
+            runner.state().objects[&swans].damage_marked,
+            0,
+            "damage dealt TO Swans must still be prevented"
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -8355,15 +8355,20 @@ fn parse_damage_to_self_instead_followup(
     original_text: &str,
 ) -> Option<ReplacementDefinition> {
     let total_len = norm_lower.len();
-    let ((effect_start, effect_len), rest) = nom_on_lower(normalized, norm_lower, |i| {
+    let ((effect_start, effect_len, is_self), rest) = nom_on_lower(normalized, norm_lower, |i| {
         let (i, _) = tag("if damage would be dealt to ").parse(i)?;
-        let (i, _) = alt((tag("~"), tag("you"))).parse(i)?;
+        // CR 614.1a + CR 615.1a: "~" is the source's own object (a self-scoped
+        // shield); "you" is the controller (a player-scoped shield). They must
+        // not resolve identically — a self shield that leaves the recipient
+        // scope unset wrongly replaces damage the source DEALS, not just damage
+        // dealt TO it (#5652).
+        let (i, is_self) = alt((value(true, tag("~")), value(false, tag("you")))).parse(i)?;
         let (i, _) = tag(", ").parse(i)?;
         let effect_start = total_len - i.len();
         let (i, effect) = take_until::<_, _, OracleError<'_>>(" instead").parse(i)?;
         let (i, _) = tag(" instead").parse(i)?;
         let (i, _) = opt(char('.')).parse(i)?;
-        Ok((i, (effect_start, effect.len())))
+        Ok((i, (effect_start, effect.len(), is_self)))
     })?;
     let effect_text = normalized.get(effect_start..effect_start + effect_len)?;
 
@@ -8400,12 +8405,20 @@ fn parse_damage_to_self_instead_followup(
     };
     let followup = parse_effect_chain_with_context(&followup_text, AbilityKind::Spell, &mut ctx);
 
-    Some(
-        ReplacementDefinition::new(ReplacementEvent::DealtDamage)
-            .prevention_shield(PreventionAmount::All)
-            .execute(followup)
-            .description(original_text.to_string()),
-    )
+    let mut def = ReplacementDefinition::new(ReplacementEvent::DealtDamage)
+        .prevention_shield(PreventionAmount::All)
+        .execute(followup)
+        .description(original_text.to_string());
+    if is_self {
+        // CR 614.1a + CR 615.1a: scope the shield to damage dealt TO the source's
+        // own object. The runtime applies `valid_card` against the damage
+        // recipient (`ProposedEvent::Damage::affected_object_id`), so `SelfRef`
+        // fires only when the source itself is the recipient — not when it deals
+        // damage. Without this, Phytohydra/Lichenthrope-class shields also
+        // replace the source's own combat damage (#5652).
+        def = def.valid_card(TargetFilter::SelfRef);
+    }
+    Some(def)
 }
 
 fn parse_damage_to_player_instead_followup(
@@ -8639,6 +8652,14 @@ fn parse_damage_prevention_replacement(
     // class of bug.
     let valid_card_filter: Option<TargetFilter> = if nom_primitives::scan_contains(working_lower, "dealt to ~")
             || nom_primitives::scan_contains(working_lower, "dealt to and dealt by ~")
+            // CR 614.1a: Active-voice self-recipient form — "If a source would
+            // deal damage to ~, prevent that damage ..." (Swans of Bryn Argoll —
+            // #5652). The passive "dealt to ~" scan above misses it because the
+            // recipient trails the verb; `~` is still the source card, so the
+            // shield is self-scoped. Without `SelfRef` `valid_card` stays None
+            // and the shield also prevents damage the source DEALS (Swans
+            // prevented its own combat damage and drew off it).
+            || nom_primitives::scan_contains(working_lower, "deal damage to ~")
             // CR 615.1a: Subject-first self-recipient form — "If ~ would be dealt
             // damage, prevent that damage ..." (Unbreathing Horde — issue #2888).
             // `~` is the source card, so the shield is self-scoped; without
@@ -18828,6 +18849,69 @@ mod snapshot_tests {
             )
             .is_none(),
             "external-subject entry must not match the self controller-override arm"
+        );
+    }
+    /// #5652 (CR 614.1a): a self-scoped damage shield ("If [a source would deal]
+    /// damage to ~, <prevent / X instead>") must scope to damage dealt TO the
+    /// source's own object via `valid_card: SelfRef`. Without it the shield
+    /// leaves the recipient scope unset and also replaces damage the source
+    /// DEALS. Covers the passive "instead" form (Phytohydra) and the active-voice
+    /// prevention form (Swans of Bryn Argoll); the player-scoped "to you" form
+    /// (Nefarious Lich) must NOT be flipped to `SelfRef`.
+    #[test]
+    fn self_scoped_damage_shields_bind_valid_card_selfref() {
+        fn valid_card_of(name: &str, kw: &[&str], text: &str) -> Option<TargetFilter> {
+            let kw: Vec<String> = kw.iter().map(|s| s.to_string()).collect();
+            let parsed = crate::parser::oracle::parse_oracle_text(
+                text,
+                name,
+                &kw,
+                &["Creature".to_string()],
+                &[],
+            );
+            assert_eq!(
+                parsed.replacements.len(),
+                1,
+                "{name}: expected exactly one replacement, got {:?}",
+                parsed.replacements
+            );
+            parsed.replacements[0].valid_card.clone()
+        }
+
+        // Active-voice prevention self-shield (Swans) — previously valid_card: None.
+        assert_eq!(
+            valid_card_of(
+                "Swans of Bryn Argoll",
+                &["Flying"],
+                "Flying\nIf a source would deal damage to ~, prevent that damage. \
+                 The source's controller draws cards equal to the damage prevented this way.",
+            ),
+            Some(TargetFilter::SelfRef),
+            "Swans must scope its prevention shield to damage dealt TO itself"
+        );
+
+        // Passive "X instead" self-shield (Phytohydra) — previously valid_card: None.
+        assert_eq!(
+            valid_card_of(
+                "Phytohydra",
+                &[],
+                "If damage would be dealt to ~, put that many +1/+1 counters on it instead.",
+            ),
+            Some(TargetFilter::SelfRef),
+            "Phytohydra must scope its replacement to damage dealt TO itself"
+        );
+
+        // Player-scoped "to you" shield (Nefarious Lich) must stay unscoped by
+        // `valid_card` — it is a player recipient, not the source's object.
+        assert_eq!(
+            valid_card_of(
+                "Nefarious Lich probe",
+                &[],
+                "If damage would be dealt to you, exile that many cards from your \
+                 graveyard instead. If you can't, you lose the game.",
+            ),
+            None,
+            "the 'to you' player shield must not be flipped to SelfRef"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -8355,21 +8355,27 @@ fn parse_damage_to_self_instead_followup(
     original_text: &str,
 ) -> Option<ReplacementDefinition> {
     let total_len = norm_lower.len();
-    let ((effect_start, effect_len, is_self), rest) = nom_on_lower(normalized, norm_lower, |i| {
-        let (i, _) = tag("if damage would be dealt to ").parse(i)?;
-        // CR 614.1a + CR 615.1a: "~" is the source's own object (a self-scoped
-        // shield); "you" is the controller (a player-scoped shield). They must
-        // not resolve identically — a self shield that leaves the recipient
-        // scope unset wrongly replaces damage the source DEALS, not just damage
-        // dealt TO it (#5652).
-        let (i, is_self) = alt((value(true, tag("~")), value(false, tag("you")))).parse(i)?;
-        let (i, _) = tag(", ").parse(i)?;
-        let effect_start = total_len - i.len();
-        let (i, effect) = take_until::<_, _, OracleError<'_>>(" instead").parse(i)?;
-        let (i, _) = tag(" instead").parse(i)?;
-        let (i, _) = opt(char('.')).parse(i)?;
-        Ok((i, (effect_start, effect.len(), is_self)))
-    })?;
+    let ((effect_start, effect_len, recipient_scope), rest) =
+        nom_on_lower(normalized, norm_lower, |i| {
+            let (i, _) = tag("if damage would be dealt to ").parse(i)?;
+            // CR 614.1: a replacement effect is a "shield" around whatever it's
+            // affecting. "~" is the source's own object (self-scoped → scope to
+            // `SelfRef`); "you" is the controller (a player-scoped shield, not an
+            // object filter → no `valid_card`). They must not resolve identically:
+            // a self shield left with no recipient scope wrongly replaces damage
+            // the source DEALS, not just damage dealt TO it (#5652).
+            let (i, recipient_scope) = alt((
+                value(Some(TargetFilter::SelfRef), tag("~")),
+                value(Option::<TargetFilter>::None, tag("you")),
+            ))
+            .parse(i)?;
+            let (i, _) = tag(", ").parse(i)?;
+            let effect_start = total_len - i.len();
+            let (i, effect) = take_until::<_, _, OracleError<'_>>(" instead").parse(i)?;
+            let (i, _) = tag(" instead").parse(i)?;
+            let (i, _) = opt(char('.')).parse(i)?;
+            Ok((i, (effect_start, effect.len(), recipient_scope)))
+        })?;
     let effect_text = normalized.get(effect_start..effect_start + effect_len)?;
 
     // CR 614.1a impossibility rider: "... <effect> instead. If you can't,
@@ -8409,14 +8415,15 @@ fn parse_damage_to_self_instead_followup(
         .prevention_shield(PreventionAmount::All)
         .execute(followup)
         .description(original_text.to_string());
-    if is_self {
-        // CR 614.1a + CR 615.1a: scope the shield to damage dealt TO the source's
-        // own object. The runtime applies `valid_card` against the damage
-        // recipient (`ProposedEvent::Damage::affected_object_id`), so `SelfRef`
-        // fires only when the source itself is the recipient — not when it deals
-        // damage. Without this, Phytohydra/Lichenthrope-class shields also
-        // replace the source's own combat damage (#5652).
-        def = def.valid_card(TargetFilter::SelfRef);
+    if let Some(scope) = recipient_scope {
+        // CR 614.1: scope the replacement to damage dealt TO the source's own
+        // object (the "shield around whatever it's affecting"). The runtime
+        // applies `valid_card` against the damage recipient
+        // (`ProposedEvent::Damage::affected_object_id`), so `SelfRef` fires only
+        // when the source itself is the recipient — not when it deals damage.
+        // Without this, Phytohydra/Lichenthrope-class shields also replace the
+        // source's own combat damage (#5652).
+        def = def.valid_card(scope);
     }
     Some(def)
 }
@@ -8652,12 +8659,13 @@ fn parse_damage_prevention_replacement(
     // class of bug.
     let valid_card_filter: Option<TargetFilter> = if nom_primitives::scan_contains(working_lower, "dealt to ~")
             || nom_primitives::scan_contains(working_lower, "dealt to and dealt by ~")
-            // CR 614.1a: Active-voice self-recipient form — "If a source would
+            // CR 615.1: Active-voice self-recipient form — "If a source would
             // deal damage to ~, prevent that damage ..." (Swans of Bryn Argoll —
-            // #5652). The passive "dealt to ~" scan above misses it because the
-            // recipient trails the verb; `~` is still the source card, so the
-            // shield is self-scoped. Without `SelfRef` `valid_card` stays None
-            // and the shield also prevents damage the source DEALS (Swans
+            // #5652). A prevention effect is a "shield around whatever it's
+            // affecting"; here that is `~`, the source card. The passive "dealt
+            // to ~" scan above misses the active-voice phrasing because the
+            // recipient trails the verb. Without `SelfRef` `valid_card` stays
+            // None and the shield also prevents damage the source DEALS (Swans
             // prevented its own combat damage and drew off it).
             || nom_primitives::scan_contains(working_lower, "deal damage to ~")
             // CR 615.1a: Subject-first self-recipient form — "If ~ would be dealt
@@ -18851,9 +18859,10 @@ mod snapshot_tests {
             "external-subject entry must not match the self controller-override arm"
         );
     }
-    /// #5652 (CR 614.1a): a self-scoped damage shield ("If [a source would deal]
-    /// damage to ~, <prevent / X instead>") must scope to damage dealt TO the
-    /// source's own object via `valid_card: SelfRef`. Without it the shield
+    /// #5652 (CR 614.1 / CR 615.1): a self-scoped damage shield ("If [a source
+    /// would deal] damage to ~, <prevent / X instead>") is a "shield around
+    /// whatever it's affecting" — it must scope to damage dealt TO the source's
+    /// own object via `valid_card: SelfRef`. Without it the shield
     /// leaves the recipient scope unset and also replaces damage the source
     /// DEALS. Covers the passive "instead" form (Phytohydra) and the active-voice
     /// prevention form (Swans of Bryn Argoll); the player-scoped "to you" form

--- a/crates/engine/tests/integration/draw_from_general_post_replacement.rs
+++ b/crates/engine/tests/integration/draw_from_general_post_replacement.rs
@@ -112,23 +112,14 @@ fn advance_to_declare_blockers(runner: &mut GameRunner) {
 /// by `apply_pending_post_replacement_effect`, which runs `Effect::Draw` as a
 /// general (non-draw-owned) post-replacement continuation.
 ///
-/// # This test pins a KNOWN BUG (issue #5652). Read before "fixing" it.
+/// # Self-scope (issue #5652, FIXED).
 ///
 /// Swans' Oracle text scopes its shield to damage dealt **to this creature**.
-/// `DamageTargetFilter` has no variant that can express that (`CreatureOnly`,
-/// `Player`, `PlayerOrPermanentsControlledBy` — none mean "the host object"), so
-/// the parser leaves `damage_target_filter: None`, and `replacement.rs`'s
-/// `if let Some(ref tf) = repl_def.damage_target_filter` then applies **no target
-/// restriction at all**. The shield therefore also fires on the damage Swans
-/// *deals*: the blocker takes 0 damage and P0 draws 4.
-///
-/// Correct behaviour is `hand_drawn(P0) == 0` and `blocker.damage_marked == 4`.
-/// The assertions below deliberately encode the CURRENT (wrong) values, because
-/// Plan 03's job is to rewrite the draw-delivery seam **without changing
-/// observable behaviour** — a pin that encoded the fix would fail for the entire
-/// rewrite and tell us nothing. When the scoping bug is fixed, this test SHOULD
-/// go red; flip the two marked assertions then, and delete this section. The
-/// fix lands under issue #5652.
+/// The parser now sets `valid_card: SelfRef` for self-scoped damage shields,
+/// which `replacement.rs` applies against `ProposedEvent::Damage`'s recipient
+/// (`affected_object_id`), so the shield fires only for damage dealt TO Swans —
+/// not for the damage Swans *deals*. The blocker takes Swans' full 4 and P0
+/// draws nothing (see the two assertions at the end of this test).
 ///
 /// What the test pins that is genuinely correct, and that the rewrite must keep:
 ///   * **who draws** — P1, the *source's* controller, for the damage dealt to
@@ -209,27 +200,21 @@ fn swans_prevented_damage_draws_that_many_for_the_sources_controller() {
         "Swans (4/3) survives — the 3 damage was prevented, not merely sub-lethal"
     );
 
-    // ── BUG-PIN — issue #5652 (see the "KNOWN BUG" section on this test) ──────
-    // Swans' shield has `damage_target_filter: None`, so it is not scoped to
-    // damage dealt TO Swans. It also intercepts the 4 damage Swans DEALS to the
-    // blocker: the blocker takes none, and the rider draws for that damage's
-    // source's controller — P0.
-    //
-    // CORRECT: hand_drawn(P0) == 0 and blocker damage_marked == 4.
-    // These two assertions encode today's wrong values on purpose, so the Plan 03
-    // rewrite cannot change them silently. Fixing the scoping SHOULD break them.
+    // ── #5652 FIXED: the shield is now scoped to damage dealt TO Swans
+    //    (`valid_card: SelfRef`), so it no longer intercepts the 4 damage Swans
+    //    DEALS to the blocker. The blocker takes the full 4, and no draw fires
+    //    for Swans' own damage — P0 draws nothing. ─────────────────────────────
     assert_eq!(
         outcome.hand_drawn(P0),
-        4,
-        "BUG-PIN (#5652): P0 draws 4 because Swans' unscoped shield also prevents \
-         the damage Swans deals. Correct value is 0 — Swans is not the source's \
-         controller for any damage dealt TO it. Fixing #5652 flips this to 0."
+        0,
+        "P0 must draw 0: Swans' self-scoped shield only prevents damage dealt TO \
+         Swans, so no prevention rider fires for the damage Swans deals (#5652)"
     );
     assert_eq!(
         runner.state().objects[&blocker].damage_marked,
-        0,
-        "BUG-PIN (#5652): the blocker takes 0 of Swans' 4 damage because the \
-         unscoped shield prevented it. Correct value is 4. Fixing #5652 flips this."
+        4,
+        "the blocker takes Swans' full 4 combat damage — the self-scoped shield \
+         no longer prevents damage Swans deals (#5652)"
     );
 }
 


### PR DESCRIPTION
## Summary

A damage-replacement shield whose antecedent is **self-scoped** — "If [a source would deal] damage to **~**, *prevent* / *…instead*" — parsed with **no recipient scope** (`valid_card: None`, `damage_target_filter: None`). Per CR 614.1a a `None` recipient scope applies **no restriction**, so at runtime the shield also replaced damage the source itself **deals**:

- **Swans of Bryn Argoll** — its combat damage to a blocker was prevented (blocker took 0) and it drew off its own damage.
- **Phytohydra / Lichenthrope** — grew / shrank on damage they *dealt*.

## Fix — reuse `valid_card: SelfRef`, no new variant

The engine already expresses "damage dealt to this object" as `valid_card: Some(TargetFilter::SelfRef)` — applied against `ProposedEvent::Damage`'s recipient via `affected_object_id()` (`replacement.rs`). So the correct scope already exists; the two self-scoped parser seams simply weren't setting it (per the `add-engine-variant` gate, an existing mechanism beats a new `DamageTargetFilter` sibling):

1. `parse_damage_to_self_instead_followup` — the `~` (self) and `you` (player) branches resolved identically. Thread which matched and set `valid_card: SelfRef` for the **self** case only → Phytohydra, Lichenthrope. The `to you` player shield (Nefarious Lich) is deliberately left untouched.
2. `parse_damage_prevention_replacement` — its self-scope scan matched passive `dealt to ~` but not the active-voice `deal damage to ~` form → Swans. Add that form.

## Blast radius

Narrowly `~`-anchored, so genuinely-unrestricted replacements ("to a permanent or player" / "any target") are unaffected, and passive Phantom/en-Kor self-shields (already `SelfRef` via the existing scan) are unchanged. Verified controls: the `to you` shield stays `None`; Phantom Nishoba stays `SelfRef`. This is a **32-card class** (Swans, the Phantom/en-Kor/Hydra family, Phytohydra, Lichenthrope, …); the previously-broken members are the `instead`-followup and active-voice-prevention forms.

## Tests

- **Parser**: self forms bind `valid_card: SelfRef`; the `to you` form stays `None`.
- **Runtime** (combat): Swans blocks — the attacker's damage to Swans is still prevented, but **Swans' combat damage to the attacker now lands** (`damage_marked == 2`; on `main` it was `0`).
- Full engine lib suite green: **16232 passed, 0 failed** (incl. the existing self-scoped `damage_target_filter` guard tests — untouched, since this sets `valid_card`).

Fixes #5652