### PR TITLE
fix(parser): split "... and flip a coin" so choose-source + flip parse (#5601)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -16697,51 +16697,103 @@ mod tests {
         }
     }
 
-    /// CR 609.7a + CR 705: Desperate Gambit's lose branch bare "it" must thread
-    /// `ChosenDamageSource` when the chain opens with `ChooseDamageSource`.
+    /// CR 705.1 + CR 609.7a + CR 608.2c: Desperate Gambit's real Oracle wording
+    /// joins the "choose a source" step to "flip a coin" with a bare " and "
+    /// ("Choose a source you control and flip a coin."). The clause splitter must
+    /// treat "flip a coin" as an independent instruction so the head parses as
+    /// `ChooseDamageSource` (not `TargetOnly { Any }`), the flip becomes a single
+    /// consolidated `FlipCoin`, and both coin-flip branches bind the chosen
+    /// source — the win branch via "that source" and the lose branch via the
+    /// `thread_chosen_damage_source_into_oneshot_effects` anaphor repair (issue
+    /// #5601). The pre-fix parse dropped the choose step, split the flip into two
+    /// `FlipCoin`s, and left the lose branch pointed at `SelfRef`.
     #[test]
     fn desperate_gambit_lose_branch_threads_chosen_damage_source() {
         use crate::parser::oracle_effect::parse_effect_chain;
 
-        fn find_flip_coin(def: &AbilityDefinition) -> Option<&Effect> {
-            if matches!(&*def.effect, Effect::FlipCoin { .. }) {
-                return Some(&def.effect);
+        fn collect_effects<'a>(def: &'a AbilityDefinition, out: &mut Vec<&'a Effect>) {
+            out.push(&def.effect);
+            if let Effect::FlipCoin {
+                win_effect,
+                lose_effect,
+                ..
+            } = &*def.effect
+            {
+                if let Some(win) = win_effect.as_deref() {
+                    collect_effects(win, out);
+                }
+                if let Some(lose) = lose_effect.as_deref() {
+                    collect_effects(lose, out);
+                }
             }
-            def.sub_ability
-                .as_deref()
-                .and_then(find_flip_coin)
-                .or_else(|| def.else_ability.as_deref().and_then(find_flip_coin))
+            if let Some(sub) = def.sub_ability.as_deref() {
+                collect_effects(sub, out);
+            }
+            if let Some(else_def) = def.else_ability.as_deref() {
+                collect_effects(else_def, out);
+            }
         }
 
-        let text = "Choose a source you control. Flip a coin. If you win the flip, \
+        // Real Scryfall Oracle text: single sentence joining choose + flip with
+        // " and ", verified against the printed card.
+        let text = "Choose a source you control and flip a coin. If you win the flip, \
             the next time that source would deal damage this turn, it deals double that damage instead. \
             If you lose the flip, the next time it would deal damage this turn, prevent that damage.";
         let def = parse_effect_chain(text, AbilityKind::Spell);
-        let flip = find_flip_coin(&def).expect("expected FlipCoin in chain");
+
+        let mut effects = Vec::new();
+        collect_effects(&def, &mut effects);
+
+        // The "choose a source you control" step must survive as a real
+        // ChooseDamageSource — without it, ChosenDamageSource has nothing to bind
+        // to at resolution and both branches are inert.
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::ChooseDamageSource { .. })),
+            "expected a ChooseDamageSource effect in the chain, got {effects:#?}"
+        );
+
+        // CR 705.1: exactly one coin flip — not two.
+        let flips: Vec<&Effect> = effects
+            .iter()
+            .copied()
+            .filter(|e| matches!(e, Effect::FlipCoin { .. }))
+            .collect();
+        assert_eq!(flips.len(), 1, "expected a single FlipCoin, got {flips:#?}");
+
         let Effect::FlipCoin {
             win_effect,
             lose_effect,
             ..
-        } = flip
+        } = flips[0]
         else {
             unreachable!();
         };
         let win = win_effect.as_ref().expect("win branch");
         let lose = lose_effect.as_ref().expect("lose branch");
-        assert!(matches!(
-            &*win.effect,
-            Effect::CreateDamageReplacement {
-                source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
-                ..
-            }
-        ));
-        assert!(matches!(
-            &*lose.effect,
-            Effect::PreventDamage {
-                damage_source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
-                ..
-            }
-        ));
+        assert!(
+            matches!(
+                &*win.effect,
+                Effect::CreateDamageReplacement {
+                    source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
+                    ..
+                }
+            ),
+            "win branch: {:#?}",
+            win.effect
+        );
+        assert!(
+            matches!(
+                &*lose.effect,
+                Effect::PreventDamage {
+                    damage_source_filter: Some(TargetFilter::ChosenDamageSource { filter: None }),
+                    ..
+                }
+            ),
+            "lose branch: {:#?}",
+            lose.effect
+        );
     }
 
     /// CR 115.1c + CR 608.2c regression: "target X and put a counter on it"

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2392,6 +2392,30 @@ fn starts_up_to_target_combat_clause_lower(s: &str) -> OracleResult<'_, ()> {
     Ok((rest, ()))
 }
 
+/// CR 705.1 + CR 710.4: "flip <count> coin[s]" clause start — the COIN sense of
+/// "flip" only. Used by `starts_bare_and_clause_lower` to peel a coin-flip
+/// conjunct joined by a bare " and " into its own clause (Desperate Gambit:
+/// "Choose a source you control and flip a coin" — issue #5601). Without the
+/// split the "choose a source" head is rejected by the damage-source candidate
+/// parser (trailing "and flip a coin") and the clause collapses to a generic
+/// `TargetOnly { Any }`, dropping both the `ChooseDamageSource` step and the
+/// coin-flip anchor; splitting restores "choose a source you control" →
+/// `ChooseDamageSource` and "flip a coin" → `FlipCoin`.
+///
+/// The "coin"/"coins" noun is REQUIRED, mirroring the `FlipCoin`/`FlipCoins`
+/// leaf parser (`try_parse_flip_n_coins`). That noun is what distinguishes the
+/// CR 705.1 coin flip from the CR 710.4 permanent-flip mechanic ("flip
+/// <permanent>", the Kamigawa double-faced flip cards), which carries no coin
+/// noun and routes to a different effect — so this arm never bisects a
+/// permanent-flip conjunct. `parse_count_expr` accepts the printed count forms
+/// ("a", "two", "X", "that many"), keeping the split general across the class.
+fn starts_flip_coin_clause_lower(s: &str) -> OracleResult<'_, ()> {
+    let (rest, _) = tag("flip ").parse(s)?;
+    let (_, after_count) = crate::parser::oracle_util::parse_count_expr(rest)
+        .ok_or_else(|| nom::Err::Error(OracleError::new(rest, nom::error::ErrorKind::Alt)))?;
+    value((), alt((tag("coins"), tag("coin")))).parse(after_count)
+}
+
 /// Inner implementation operating on pre-lowercased input.
 fn starts_bare_and_clause_lower(s: &str) -> bool {
     // CR 613.1b + CR 110.2: "<player-subject> gains control of …" control-handoff
@@ -2433,6 +2457,13 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     .or(value((), tag("cast ")))
     .or(value((), tag("cloak ")))
     .or(value((), tag("convert ")))
+    // CR 705.1 + CR 608.2c: "flip <count> coin[s]" is an imperative game action,
+    // so a leading clause joined to it by a bare " and " is an independent
+    // instruction (Desperate Gambit: "Choose a source you control and flip a
+    // coin"). Delegated to `starts_flip_coin_clause_lower` (trailing `.or()` arm
+    // mirroring `starts_target_continuous_clause_lower`) so it requires the
+    // "coin"/"coins" noun and never bisects the CR 710.4 permanent-flip mechanic.
+    .or(value((), starts_flip_coin_clause_lower))
     // CR 701.34a + CR 608.2c: "draw a card and proliferate" is two
     // independent instructions. `proliferate` is intransitive, so it has no
     // trailing space; keep it in the bare-and splitter instead of letting the
@@ -7543,6 +7574,30 @@ mod tests {
                 "attach this Equipment to it"
             ]
         );
+    }
+
+    #[test]
+    fn bare_and_splits_choose_source_and_flip_a_coin() {
+        // CR 705.1 + CR 608.2c (issue #5601): Desperate Gambit — "Choose a source
+        // you control and flip a coin" is two independent instructions. "flip " is
+        // an imperative game action, so the conjunct must peel into its own clause;
+        // without the split the choose head is rejected (trailing "and flip a
+        // coin") and collapses to TargetOnly { Any }, dropping both the
+        // ChooseDamageSource step and the coin-flip anchor.
+        let chunks = clause_texts("Choose a source you control and flip a coin");
+        assert_eq!(chunks, vec!["Choose a source you control", "flip a coin"]);
+    }
+
+    #[test]
+    fn bare_and_keeps_permanent_flip_conjunct() {
+        // CR 710.4 (issue #5601 review): the permanent-flip mechanic ("flip
+        // <permanent>", the Kamigawa double-faced flip cards) is NOT a coin flip
+        // and carries no "coin" noun, so " and flip <cardname>" must NOT split at
+        // the flip conjunct. `starts_flip_coin_clause_lower` requires the coin
+        // noun precisely so this boundary is preserved; a broad `tag("flip ")`
+        // would wrongly bisect the conjunct here.
+        let chunks = clause_texts("remove all of them and flip ~");
+        assert_eq!(chunks, vec!["remove all of them and flip ~"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #5601. Desperate Gambit's real Oracle text joins the choose-source step to the coin flip with a bare `" and "`:

> **Choose a source you control and flip a coin.** If you win the flip, the next time that source would deal damage this turn, it deals double that damage instead. If you lose the flip, the next time it would deal damage this turn, prevent that damage.

The clause splitter's `starts_bare_and_clause_lower` allow-list had no `flip` clause-starter arm, so the whole leading sentence stayed **one** clause. The damage-source candidate parser then rejected the trailing `"and flip a coin"` and the clause collapsed to `TargetOnly { Any }` — with three downstream failures:

1. **`ChooseDamageSource` was dropped**, so `ChosenDamageSource` had nothing to bind at resolution (the *win* branch was broken at runtime too, not just the lose branch).
2. **The coin-flip anchor was swallowed**, so the win/lose conditionals became **two separate `FlipCoin`s** (CR 705.1 — one flip).
3. The lose branch's bare `"it"` stayed `SelfRef`, because `thread_chosen_damage_source_into_oneshot_effects`'s gate never matched (no `ChooseDamageSource` def in the chain — this is why the issue observed the repair pass firing 0/35,396).

## Fix

Add a `flip <count> coin[s]` bare-and clause starter (**CR 705.1**) via `starts_flip_coin_clause_lower`. It **requires the `"coin"`/`"coins"` noun**, mirroring the `FlipCoin`/`FlipCoins` leaf parser (`try_parse_flip_n_coins`), so it never bisects the **CR 710.4** permanent-flip mechanic (`"flip <permanent>"`, the Kamigawa double-faced flip cards). `parse_count_expr` accepts the printed count forms (`a`/`two`/`X`/`that many`), keeping the split general across the whole coin-flip class rather than special-casing one card.

The split restores `"choose a source you control"` → `ChooseDamageSource` and `"flip a coin"` → a single `FlipCoin`, which lets the existing anaphor-repair pass bind the lose branch to `ChosenDamageSource`.

## Tests

- `bare_and_splits_choose_source_and_flip_a_coin` — building-block: the clause splits into two chunks.
- `bare_and_keeps_permanent_flip_conjunct` — negative: `"... and flip ~"` (permanent flip) does **not** split.
- `desperate_gambit_lose_branch_threads_chosen_damage_source` — rewritten to the real single-sentence wording; asserts `ChooseDamageSource` presence, exactly one `FlipCoin`, and both branches bound to `ChosenDamageSource`.

## Verification

`cargo fmt --check` ✅ · `cargo clippy -p engine --lib --tests -D warnings` ✅ · parser-combinator gate ✅ · 354 targeted + coin-flip/sequence/swallow_check regression tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
