### PR TITLE
fix(parser): guard bounded counter distribution choices

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1,7 +1,9 @@
+use std::ops::Range;
+
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till1, take_until};
 use nom::character::complete::{multispace0, multispace1, satisfy};
-use nom::combinator::{all_consuming, eof, map, not, opt, peek, rest, value, verify};
+use nom::combinator::{all_consuming, eof, map, not, opt, peek, recognize, rest, value, verify};
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
@@ -9,7 +11,7 @@ use super::super::oracle_nom::bridge::{nom_on_lower, nom_parse_lower, split_once
 use super::super::oracle_nom::duration::{
     parse_duration, parse_for_as_long_as_condition, parse_until_source_exiles_another_card_body,
 };
-use super::super::oracle_nom::error::{OracleError, OracleResult};
+use super::super::oracle_nom::error::{oracle_err, OracleError, OracleResult};
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
 use super::super::oracle_quantity::{
@@ -4709,17 +4711,12 @@ pub(crate) fn extract_bounded_target_multi_target(text: &str) -> Option<MultiTar
         else {
             continue;
         };
-        for (prefix, min, max) in [
-            ("one or two ", 1usize, 2usize),
-            ("one, two, or three ", 1, 3),
-        ] {
-            if let Ok((after_prefix, _)) = tag::<_, _, OracleError<'_>>(prefix).parse(after_verb) {
-                if tag::<_, _, OracleError<'_>>("target ")
-                    .parse(after_prefix)
-                    .is_ok()
-                {
-                    return Some(MultiTargetSpec::fixed(min, max));
-                }
+        for &(prefix, min, max) in BOUNDED_TARGET_PREFIX_PHRASES {
+            if tag::<_, _, OracleError<'_>>(prefix)
+                .parse(after_verb)
+                .is_ok()
+            {
+                return Some(MultiTargetSpec::fixed(min, max));
             }
         }
     }
@@ -4964,6 +4961,11 @@ pub(super) const BOUNDED_TARGET_PHRASES: &[(&str, usize, usize)] = &[
     ("one, two, or three targets", 1, 3),
 ];
 
+pub(super) const BOUNDED_TARGET_PREFIX_PHRASES: &[(&str, usize, usize)] = &[
+    ("one or two target ", 1, 2),
+    ("one, two, or three target ", 1, 3),
+];
+
 /// CR 115.1d + CR 601.2c: Strip exact target-count prefix before a targeted
 /// phrase. "two target creatures" and "X target creatures" both set the exact
 /// number of targets, unlike "up to X target creatures".
@@ -5006,7 +5008,7 @@ fn parse_exact_target_count_expr(input: &str) -> OracleResult<'_, QuantityExpr> 
 fn strip_bounded_targets_placeholder(text: &str) -> Option<(&str, MultiTargetSpec)> {
     let lower = text.to_ascii_lowercase();
     for &(phrase, min, max) in BOUNDED_TARGET_PHRASES {
-        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(phrase).parse(lower.as_str()) {
+        if let Ok((rest, _)) = parse_bounded_target_placeholder(phrase, lower.as_str()) {
             let consumed = lower.len() - rest.len();
             return Some((
                 text[consumed..].trim_start(),
@@ -5022,10 +5024,7 @@ fn strip_bounded_targets_placeholder(text: &str) -> Option<(&str, MultiTargetSpe
 /// players").
 fn strip_bounded_target_prefix(text: &str) -> Option<(&str, MultiTargetSpec)> {
     let lower = text.to_ascii_lowercase();
-    for (prefix, min, max) in [
-        ("one or two target ", 1usize, 2usize),
-        ("one, two, or three target ", 1, 3),
-    ] {
+    for &(prefix, min, max) in BOUNDED_TARGET_PREFIX_PHRASES {
         if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(prefix).parse(lower.as_str()) {
             let consumed = lower.len() - rest.len();
             return Some((
@@ -5035,6 +5034,70 @@ fn strip_bounded_target_prefix(text: &str) -> Option<(&str, MultiTargetSpec)> {
         }
     }
     None
+}
+
+fn is_bounded_cardinality_boundary(c: char) -> bool {
+    c.is_whitespace() || matches!(c, ',' | '.' | ';' | ':' | '"' | '/' | '-' | ')' | '(')
+}
+
+fn parse_bounded_target_placeholder<'a>(
+    phrase: &'static str,
+    input: &'a str,
+) -> OracleResult<'a, &'a str> {
+    terminated(
+        tag::<_, _, OracleError<'a>>(phrase),
+        peek(alt((
+            recognize(eof),
+            recognize(satisfy(is_bounded_cardinality_boundary)),
+        ))),
+    )
+    .parse(input)
+}
+
+fn parse_bounded_target_cardinality_phrase(input: &str) -> OracleResult<'_, ()> {
+    for &(phrase, _, _) in BOUNDED_TARGET_PHRASES {
+        if let Ok((rest, _)) = parse_bounded_target_placeholder(phrase, input) {
+            return Ok((rest, ()));
+        }
+    }
+    for &(prefix, _, _) in BOUNDED_TARGET_PREFIX_PHRASES {
+        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(prefix).parse(input) {
+            return Ok((rest, ()));
+        }
+    }
+    Err(oracle_err(input))
+}
+
+pub(super) fn selected_separator_inside_bounded_target_cardinality(
+    lower: &str,
+    separator: Range<usize>,
+) -> bool {
+    if separator.is_empty() || separator.end > lower.len() {
+        return false;
+    }
+
+    let mut cursor = lower;
+    let mut base_offset = 0;
+    while let Some((before, _, rest)) =
+        nom_primitives::scan_preceded(cursor, parse_bounded_target_cardinality_phrase)
+    {
+        let matched_start = base_offset + before.len();
+        let matched_end = lower.len() - rest.len();
+        if matched_start <= separator.start && separator.end <= matched_end {
+            return true;
+        }
+        if rest.is_empty() {
+            break;
+        }
+        let next_offset = lower.len() - rest.len();
+        if next_offset <= base_offset {
+            break;
+        }
+        base_offset = next_offset;
+        cursor = rest;
+    }
+
+    false
 }
 
 fn strip_distribute_among_target_quantifier<'a>(
@@ -8971,6 +9034,38 @@ mod tests {
             spec,
             MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 5 })
         );
+    }
+
+    #[test]
+    fn bounded_target_cardinality_separator_span_detection() {
+        assert!(super::selected_separator_inside_bounded_target_cardinality(
+            "one or two target creatures",
+            3..7,
+        ));
+        assert!(super::selected_separator_inside_bounded_target_cardinality(
+            "one, two, or three target creatures",
+            8..13,
+        ));
+        assert!(super::selected_separator_inside_bounded_target_cardinality(
+            "one or two targets",
+            3..7,
+        ));
+        assert!(super::selected_separator_inside_bounded_target_cardinality(
+            "one, two, or three targets.",
+            8..13,
+        ));
+        assert!(!super::selected_separator_inside_bounded_target_cardinality(
+            "tap one or two target creatures, or draw a card",
+            31..36,
+        ));
+        assert!(!super::selected_separator_inside_bounded_target_cardinality(
+            "one or two targetsmiths",
+            3..7,
+        ));
+        assert!(!super::selected_separator_inside_bounded_target_cardinality(
+            "target creature or player",
+            15..19,
+        ));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -45,7 +45,8 @@ use lower::{
     extract_switch_pt_multi_target, is_token_creating_effect, parse_damage_player_scope,
     parse_for_each_opponent_target_fanout_clause, rebind_clause_recipients_with,
     rebind_decline_body_recipient, rebind_subject_only_body_recipient,
-    scan_until_next_same_source_exile_invalidation, split_difference_repeat_suffix,
+    scan_until_next_same_source_exile_invalidation, selected_separator_inside_bounded_target_cardinality,
+    split_difference_repeat_suffix,
     strip_any_number_quantifier, strip_each_player_subject, strip_each_scope_who_cant_subject,
     strip_each_scope_who_does_subject, strip_each_scope_who_doesnt_subject,
     strip_for_each_opponent_who_doesnt, strip_for_each_prefix, strip_for_each_repeat_suffix,
@@ -4971,8 +4972,24 @@ fn try_parse_choose_one_of_inline(
     {
         return None;
     }
-    let (before_lower, after_lower) =
-        split_around(tp.lower, ", or ").or_else(|| split_around(tp.lower, " or "))?;
+    let (before_lower, after_lower) = {
+        let mut search_start = 0;
+        loop {
+            let search = &tp.lower[search_start..];
+            let (candidate_before, candidate_after, separator) = split_around(search, ", or ")
+                .map(|(before, after)| (before, after, ", or "))
+                .or_else(|| {
+                    split_around(search, " or ").map(|(before, after)| (before, after, " or "))
+                })?;
+            let separator_start = search_start + candidate_before.len();
+            let separator_range = separator_start..separator_start + separator.len();
+            if selected_separator_inside_bounded_target_cardinality(tp.lower, separator_range.clone()) {
+                search_start = separator_range.end;
+                continue;
+            }
+            break (&tp.lower[..separator_start], candidate_after);
+        }
+    };
 
     // CR 205.2 + CR 112.1: A bare " or " between two card-type words is a TYPE
     // disjunction ("an instant or sorcery spell", "an artifact or creature

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -35310,6 +35310,143 @@ fn choose_one_of_detects_highway_robbery_pattern() {
 }
 
 #[test]
+fn choose_one_of_ignores_bounded_counter_distribution_cardinality() {
+    let ability = parse_effect_chain(
+        "Distribute three +1/+1 counters among one, two, or three target creatures you control.",
+        AbilityKind::Spell,
+    );
+    assert!(
+        !matches!(&*ability.effect, Effect::ChooseOneOf { .. }),
+        "bounded target cardinality must not split into ChooseOneOf"
+    );
+    assert!(
+        !matches!(&*ability.effect, Effect::Unimplemented { .. }),
+        "bounded counter distribution must parse, got {:?}",
+        ability.effect
+    );
+    match &*ability.effect {
+        Effect::PutCounter {
+            counter_type,
+            count,
+            target: TargetFilter::Typed(_),
+        } => {
+            assert_eq!(*counter_type, CounterType::Plus1Plus1);
+            assert_eq!(*count, QuantityExpr::Fixed { value: 3 });
+        }
+        other => panic!("expected distributed PutCounter, got {other:?}"),
+    }
+    assert_eq!(
+        ability.distribute,
+        Some(DistributionUnit::Counters("P1P1".to_string()))
+    );
+    assert_eq!(ability.multi_target, Some(MultiTargetSpec::fixed(1, 3)));
+}
+
+#[test]
+fn ajani_mentor_of_heroes_counter_distribution_survives_full_parse() {
+    let parsed = parse_oracle_text(
+        "+1: Distribute three +1/+1 counters among one, two, or three target creatures you control.\n\
++1: Look at the top four cards of your library. You may reveal an Aura, creature, or planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\n\
+−8: You gain 100 life.",
+        "Ajani, Mentor of Heroes",
+        &[],
+        &["Planeswalker".to_string()],
+        &["Ajani".to_string()],
+    );
+    let mut matching_ability = None;
+    for ability in &parsed.abilities {
+        if matches!(
+            &*ability.effect,
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 3 },
+                ..
+            }
+        ) {
+            matching_ability = Some(ability);
+            break;
+        }
+    }
+    let ability = matching_ability
+        .expect("Ajani's first loyalty ability should parse as counter distribution");
+    assert!(
+        !matches!(&*ability.effect, Effect::ChooseOneOf { .. }),
+        "Ajani's counter distribution must not be a ChooseOneOf"
+    );
+    assert_eq!(
+        ability.distribute,
+        Some(DistributionUnit::Counters("P1P1".to_string()))
+    );
+    assert_eq!(ability.multi_target, Some(MultiTargetSpec::fixed(1, 3)));
+}
+
+#[test]
+fn choose_one_of_preserves_external_choice_after_bounded_target_branch() {
+    for (text, expected_multi_target) in [
+        (
+            "tap one or two target creatures, or draw a card",
+            MultiTargetSpec::fixed(1, 2),
+        ),
+        (
+            "tap one, two, or three target creatures, or draw a card",
+            MultiTargetSpec::fixed(1, 3),
+        ),
+    ] {
+        let ability = parse_effect_chain(text, AbilityKind::Spell);
+        match &*ability.effect {
+            Effect::ChooseOneOf { branches, .. } => {
+                assert_eq!(branches.len(), 2);
+                assert!(
+                    !matches!(&*branches[0].effect, Effect::Unimplemented { .. }),
+                    "first branch must parse for {text}"
+                );
+                assert!(
+                    !matches!(&*branches[1].effect, Effect::Unimplemented { .. }),
+                    "second branch must parse for {text}"
+                );
+                assert!(
+                    matches!(&*branches[0].effect, Effect::SetTapState { .. }),
+                    "first branch should tap bounded targets for {text}, got {:?}",
+                    branches[0].effect
+                );
+                assert_eq!(branches[0].multi_target, Some(expected_multi_target));
+                assert!(
+                    matches!(&*branches[1].effect, Effect::Draw { .. }),
+                    "second branch should draw for {text}, got {:?}",
+                    branches[1].effect
+                );
+            }
+            other => panic!("expected external ChooseOneOf for {text}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn choose_one_of_skips_internal_bounded_target_or_to_external_separator() {
+    let ability = parse_effect_chain(
+        "tap one or two target creatures or draw a card",
+        AbilityKind::Spell,
+    );
+    match &*ability.effect {
+        Effect::ChooseOneOf { branches, .. } => {
+            assert_eq!(branches.len(), 2);
+            assert!(
+                matches!(&*branches[0].effect, Effect::SetTapState { .. }),
+                "first branch should tap bounded targets, got {:?}",
+                branches[0].effect
+            );
+            assert_eq!(branches[0].multi_target, Some(MultiTargetSpec::fixed(1, 2)));
+            assert!(
+                matches!(&*branches[1].effect, Effect::Draw { .. }),
+                "second branch should draw, got {:?}",
+                branches[1].effect
+            );
+        }
+        other => panic!("expected external ChooseOneOf after bounded target, got {other:?}"),
+    }
+}
+
+#[test]
 fn choose_one_of_detects_shared_create_token_verb() {
     let ability = parse_effect_chain(
         "Create a Food token or a Treasure token.",


### PR DESCRIPTION
## Summary
- Fixes #5613 for bounded counter distribution parsing.
- Implements the selected card: Ajani, Mentor of Heroes.
- Keeps `one, two, or three target ...` cardinality text from being misclassified as an inline `ChooseOneOf` separator.
- Preserves real external binary choices after bounded target branches by skipping only separators inside bounded-cardinality phrases and continuing the separator scan.

## Card / Oracle
Selected card: Ajani, Mentor of Heroes

Scryfall Oracle verified:
```text
+1: Distribute three +1/+1 counters among one, two, or three target creatures you control.
+1: Look at the top four cards of your library. You may reveal an Aura, creature, or planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in any order.
-8: You gain 100 life.
```

## Review Notes
- Followed the non-developer track because no Rust toolchain is available on this machine.
- Checked open PRs/issues for an existing Ajani / #5613 / bounded counter-distribution implementation; no duplicate or claimed PR found.
- Plan review completed with a clean final pass.
- Implementation review initially found two issues around external choice scanning and test coverage; both were fixed.
- Final implementation review: Maintainer-Simulation Gate PASS, no blocking findings.

## Validation
- `C:\Program Files\Git\bin\bash.exe scripts/check-parser-combinators.sh`
- `git diff --check`
- Added focused parser regression tests for Ajani and bounded-target choice separator behavior.

## Not Run
- `cargo fmt --all`: `cargo` is not available on PATH.
- Rust unit tests / card-data generation / coverage: Rust toolchain and generated card-data artifacts are unavailable in this environment.