### PR TITLE
fix(engine): support Ram Through excess rider

### DIFF
--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -652,7 +652,9 @@ pub(crate) fn apply_damage_after_replacement(
         && matches!(
             (ctx.excess_recipient, &t),
             (
-                Some(ExcessRecipient::TargetController),
+                Some(ExcessRecipient::TargetController {
+                    source_keyword: None
+                }),
                 TargetRef::Object(_)
             )
         ) {
@@ -778,8 +780,12 @@ pub(crate) fn apply_damage_after_replacement(
     // the snapshot / PendingReplacement). `redirected` records that the excess and
     // this leg's lifelink were handed off, so the creature leg gains nothing here.
     let mut redirected = false;
-    if let (Some(ExcessRecipient::TargetController), TargetRef::Object(obj_id)) =
-        (ctx.excess_recipient, t)
+    if let (
+        Some(ExcessRecipient::TargetController {
+            source_keyword: None,
+        }),
+        TargetRef::Object(obj_id),
+    ) = (ctx.excess_recipient, t)
     {
         if redirect_excess > 0 {
             if let Some(controller) = state.objects.get(obj_id).map(|o| o.controller) {
@@ -1070,11 +1076,17 @@ fn active_excess_recipient(
     excess: Option<ExcessRecipient>,
 ) -> Option<ExcessRecipient> {
     match excess {
-        Some(ExcessRecipient::TargetController) => Some(ExcessRecipient::TargetController),
-        Some(ExcessRecipient::TargetControllerIfSourceHasKeyword { keyword })
-            if keywords::object_has_effective_keyword_kind(state, ctx.source_id, keyword) =>
-        {
-            Some(ExcessRecipient::TargetController)
+        Some(ExcessRecipient::TargetController {
+            source_keyword: None,
+        }) => Some(ExcessRecipient::TargetController {
+            source_keyword: None,
+        }),
+        Some(ExcessRecipient::TargetController {
+            source_keyword: Some(keyword),
+        }) if keywords::object_has_effective_keyword_kind(state, ctx.source_id, keyword) => {
+            Some(ExcessRecipient::TargetController {
+                source_keyword: None,
+            })
         }
         _ => None,
     }
@@ -4982,8 +4994,8 @@ mod tests {
                     amount: QuantityExpr::Fixed { value: 5 },
                     target: TargetFilter::Any,
                     damage_source: Some(DamageSource::Target),
-                    excess: Some(ExcessRecipient::TargetControllerIfSourceHasKeyword {
-                        keyword: crate::types::keywords::KeywordKind::Trample,
+                    excess: Some(ExcessRecipient::TargetController {
+                        source_keyword: Some(crate::types::keywords::KeywordKind::Trample),
                     }),
                 },
                 vec![TargetRef::Object(source_id), TargetRef::Object(target_id)],
@@ -5009,7 +5021,10 @@ mod tests {
         );
 
         let (no_trample_state, no_trample_events, no_trample_target) = run(false);
-        assert_eq!(no_trample_state.objects[&no_trample_target].damage_marked, 5);
+        assert_eq!(
+            no_trample_state.objects[&no_trample_target].damage_marked,
+            5
+        );
         assert_eq!(no_trample_state.players[1].life, 20);
         assert_eq!(
             no_trample_events

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -1061,6 +1061,25 @@ fn stash_remaining_each_source_damage(
     append_to_pending_continuation(state, Some(Box::new(head)));
 }
 
+/// CR 120.4a + CR 608.2c + CR 702: Resolve an excess-redirect rider against
+/// the actual damage source. Unconditional riders apply directly; keyword-gated
+/// riders apply only while the source has the named effective keyword.
+fn active_excess_recipient(
+    state: &GameState,
+    ctx: &DamageContext,
+    excess: Option<ExcessRecipient>,
+) -> Option<ExcessRecipient> {
+    match excess {
+        Some(ExcessRecipient::TargetController) => Some(ExcessRecipient::TargetController),
+        Some(ExcessRecipient::TargetControllerIfSourceHasKeyword { keyword })
+            if keywords::object_has_effective_keyword_kind(state, ctx.source_id, keyword) =>
+        {
+            Some(ExcessRecipient::TargetController)
+        }
+        _ => None,
+    }
+}
+
 /// CR 120.1: Deal N damage — reduces life for players, marks damage on creatures.
 /// Reads amount from `Effect::DealDamage { amount }`.
 pub fn resolve(
@@ -1126,11 +1145,12 @@ pub fn resolve(
         }
     };
 
-    // CR 120.4a: attach the excess-redirect rider parsed onto this DealDamage so
-    // `apply_damage_after_replacement` can redirect excess to the target's
-    // controller. Inert for combat damage (that path builds its own contexts).
+    // CR 120.4a + CR 608.2c: attach the active excess-redirect rider parsed onto
+    // this DealDamage so `apply_damage_after_replacement` can redirect excess to
+    // the target's controller. Keyword-gated riders read the resolved damage
+    // source (for DamageSource::Target, the first object target), not the spell.
     if let Effect::DealDamage { excess, .. } = &ability.effect {
-        ctx.excess_recipient = *excess;
+        ctx.excess_recipient = active_excess_recipient(state, &ctx, *excess);
     }
 
     // CR 120.1 + CR 608.2c: Resolve effective damage targets.
@@ -4923,6 +4943,82 @@ mod tests {
         } else {
             panic!("expected DamageDealt event");
         }
+    }
+
+    /// CR 120.4a + CR 608.2c + CR 702: A source-keyword-gated excess rider
+    /// redirects only when the resolved damage source target has the keyword.
+    #[test]
+    fn source_keyword_gated_excess_redirect_requires_source_keyword() {
+        fn run(source_has_trample: bool) -> (GameState, Vec<GameEvent>, ObjectId) {
+            let mut state = GameState::new_two_player(42);
+            let source_id = create_object(
+                &mut state,
+                CardId(10),
+                PlayerId(0),
+                "Source Creature".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&source_id).unwrap();
+                obj.card_types.core_types.push(CoreType::Creature);
+                if source_has_trample {
+                    obj.keywords.push(crate::types::keywords::Keyword::Trample);
+                }
+            }
+            let target_id = create_object(
+                &mut state,
+                CardId(20),
+                PlayerId(1),
+                "Target Creature".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&target_id).unwrap();
+                obj.card_types.core_types.push(CoreType::Creature);
+                obj.toughness = Some(2);
+            }
+            let ability = ResolvedAbility::new(
+                Effect::DealDamage {
+                    amount: QuantityExpr::Fixed { value: 5 },
+                    target: TargetFilter::Any,
+                    damage_source: Some(DamageSource::Target),
+                    excess: Some(ExcessRecipient::TargetControllerIfSourceHasKeyword {
+                        keyword: crate::types::keywords::KeywordKind::Trample,
+                    }),
+                },
+                vec![TargetRef::Object(source_id), TargetRef::Object(target_id)],
+                ObjectId(100),
+                PlayerId(0),
+            );
+            let mut events = Vec::new();
+
+            resolve(&mut state, &ability, &mut events).unwrap();
+            (state, events, target_id)
+        }
+
+        let (trample_state, trample_events, trample_target) = run(true);
+        assert_eq!(trample_state.objects[&trample_target].damage_marked, 2);
+        assert_eq!(trample_state.players[1].life, 17);
+        assert_eq!(
+            trample_events
+                .iter()
+                .filter(|event| matches!(event, GameEvent::DamageDealt { .. }))
+                .count(),
+            2,
+            "lethal creature leg plus redirected controller leg"
+        );
+
+        let (no_trample_state, no_trample_events, no_trample_target) = run(false);
+        assert_eq!(no_trample_state.objects[&no_trample_target].damage_marked, 5);
+        assert_eq!(no_trample_state.players[1].life, 20);
+        assert_eq!(
+            no_trample_events
+                .iter()
+                .filter(|event| matches!(event, GameEvent::DamageDealt { .. }))
+                .count(),
+            1,
+            "without trample the excess stays on the creature event"
+        );
     }
 
     /// CR 120.10 + CR 120.6: the Torch the Witness / Orbital Plunge class —

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -20285,8 +20285,29 @@ pub(super) fn def_is_dig_or_mill(def: &AbilityDefinition) -> bool {
 /// unconditionally and then overwrote the field. Folding "not yet written" in here
 /// would resume the walk past an already-written def and bind an earlier one the old
 /// code never reached — the overwrite is the MUTATION's business, not the selector's.
+///
+/// Unwraps a `TargetOnly` head the same way `intrinsic_continuation_effect`
+/// does: "Target creature you control deals damage..." (Ram Through-class)
+/// lowers to a `TargetOnly` clause with `DealDamage` as its own `sub_ability`
+/// (assembly.rs's `is_target_only` handling), so the damage-dealer role must
+/// look past the head to find it.
 pub(super) fn def_is_damage_dealer(def: &AbilityDefinition) -> bool {
-    matches!(&*def.effect, Effect::DealDamage { .. })
+    matches!(
+        intrinsic_continuation_effect(def),
+        Effect::DealDamage { .. }
+    )
+}
+
+/// Mutable counterpart to `def_is_damage_dealer` — the effect to patch when a
+/// rider binds to the `DamageDealer` role, unwrapping the same `TargetOnly`
+/// head.
+pub(super) fn damage_dealer_effect_mut(def: &mut AbilityDefinition) -> &mut Effect {
+    if matches!(*def.effect, Effect::TargetOnly { .. }) {
+        if let Some(sub_ability) = def.sub_ability.as_deref_mut() {
+            return &mut sub_ability.effect;
+        }
+    }
+    &mut def.effect
 }
 
 /// Membership mirror for `AntecedentRole::DigLook` — the `Dig` anchor that both
@@ -27075,6 +27096,22 @@ pub(crate) fn parse_effect_chain_ir(
                 None
             }
         });
+        // CR 608.2c: A clause's own `parsed.effect` is only its HEAD — a clause
+        // like "Target creature you control deals damage ... to target creature
+        // you don't control" lowers to a `TargetOnly` head with `DealDamage` as
+        // its own internal `sub_ability`. In the old flat-`defs` model,
+        // `defs.last()` after such a clause would be the DealDamage entry (the
+        // last one pushed), not the TargetOnly head — so lookback must walk to
+        // the deepest effect in the clause's own chain, mirroring
+        // `sequence::deepest_effect`, or a later followup rider (e.g. an
+        // excess-damage redirect) targeting the DealDamage never matches and
+        // silently falls back to `Effect::Unimplemented`.
+        fn deepest_clause_effect(clause: &ClauseIr) -> Effect {
+            match clause.parsed.sub_ability.as_deref() {
+                Some(sub) => sequence::deepest_effect(sub).clone(),
+                None => clause.parsed.effect.clone(),
+            }
+        }
         // "Effective effect" of a non-absorbed clause — what `defs.last()` would
         // be after intrinsic/followup continuation application. Shared by the
         // nearest-clause lookback and the CR 608.2c deeper-clause lookback.
@@ -27111,11 +27148,14 @@ pub(crate) fn parse_effect_chain_ir(
                         }
                     }
                     // Simple patch-in-place continuations leave the previous
-                    // effect type as the effective lookback target.
-                    _ => previous.parsed.effect.clone(),
+                    // effect type as the effective lookback target — but that
+                    // clause may itself carry its own internal sub_ability
+                    // chain (see below), so route through the same deepest-effect
+                    // walk rather than the bare head effect.
+                    _ => deepest_clause_effect(previous),
                 }
             } else {
-                previous.parsed.effect.clone()
+                deepest_clause_effect(previous)
             }
         };
         // Non-absorbed clauses, nearest-first — the lookback search space.

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -640,7 +640,7 @@ fn target_filter_uses_chosen_card_predicate(filter: &TargetFilter) -> bool {
     }
 }
 
-fn deepest_effect(ability: &AbilityDefinition) -> &Effect {
+pub(super) fn deepest_effect(ability: &AbilityDefinition) -> &Effect {
     let mut cursor = ability;
     while let Some(sub) = cursor.sub_ability.as_deref() {
         cursor = sub;
@@ -3610,13 +3610,15 @@ pub(super) fn apply_clause_continuation(
             );
             if let Some(bound_index) = bound {
                 let def = &mut defs[bound_index];
-                match &mut *def.effect {
+                // CR 608.2c: `def` itself may be the `TargetOnly` head of a
+                // Ram Through-class "Target creature you control deals
+                // damage..." clause, with `DealDamage` nested as its
+                // `sub_ability` — unwrap the same way `def_is_damage_dealer`
+                // detected membership.
+                match super::damage_dealer_effect_mut(def) {
                     Effect::DealDamage { excess, .. } => {
-                        *excess = Some(match source_keyword_condition {
-                            Some(keyword) => ExcessRecipient::TargetControllerIfSourceHasKeyword {
-                                keyword,
-                            },
-                            None => ExcessRecipient::TargetController,
+                        *excess = Some(ExcessRecipient::TargetController {
+                            source_keyword: source_keyword_condition,
                         });
                     }
                     _ => unreachable!(),
@@ -5862,9 +5864,7 @@ pub(crate) fn is_moved_object_put_onto_battlefield_counters_clause(sentence: &st
 /// with an optional source-keyword condition such as Ram Through's "If the
 /// creature you control has trample" prefix. The body remains the same
 /// CR 120.4a redirect; only the source-keyword gate is optional.
-fn parse_excess_damage_to_controller_rider(
-    input: &str,
-) -> OracleResult<'_, Option<KeywordKind>> {
+fn parse_excess_damage_to_controller_rider(input: &str) -> OracleResult<'_, Option<KeywordKind>> {
     /// CR 608.2c + CR 702: Parse the source-referential keyword gate.
     fn parse_source_keyword_condition(input: &str) -> OracleResult<'_, KeywordKind> {
         // This is not parse_inner_condition: Ram Through's definite phrase
@@ -5881,10 +5881,8 @@ fn parse_excess_damage_to_controller_rider(
     }
 
     let (input, source_keyword_condition) = opt(parse_source_keyword_condition).parse(input)?;
-    let (input, _) = tag(
-        "excess damage is dealt to that creature's controller instead",
-    )
-    .parse(input)?;
+    let (input, _) =
+        tag("excess damage is dealt to that creature's controller instead").parse(input)?;
     let (input, _) = opt(tag(".")).parse(input)?;
     let (input, _) = eof(input)?;
     Ok((input, source_keyword_condition))
@@ -9254,7 +9252,9 @@ mod tests {
         };
         assert_eq!(
             *excess,
-            Some(ExcessRecipient::TargetController),
+            Some(ExcessRecipient::TargetController {
+                source_keyword: None
+            }),
             "the rider must walk back to the DealDamage at index 0 — `LastEmitted` \
              would have bound the intervening def at index 1"
         );

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -30,7 +30,7 @@ use crate::types::ability::{
 };
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
-use crate::types::keywords::Keyword;
+use crate::types::keywords::{Keyword, KeywordKind};
 use crate::types::mana::ManaCost;
 use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
@@ -3588,7 +3588,9 @@ pub(super) fn apply_clause_continuation(
                 }
             }
         }
-        ContinuationAst::ExcessDamageToController => {
+        ContinuationAst::ExcessDamageToController {
+            source_keyword_condition,
+        } => {
             // CR 120.4a + CR 608.2c: bind the nearest DealDamage and attach the
             // excess-redirect rider. The clause may not be adjacent to the DealDamage
             // effect, mirroring the CantRegenerate walk above — so this is a role, not
@@ -3610,7 +3612,12 @@ pub(super) fn apply_clause_continuation(
                 let def = &mut defs[bound_index];
                 match &mut *def.effect {
                     Effect::DealDamage { excess, .. } => {
-                        *excess = Some(ExcessRecipient::TargetController);
+                        *excess = Some(match source_keyword_condition {
+                            Some(keyword) => ExcessRecipient::TargetControllerIfSourceHasKeyword {
+                                keyword,
+                            },
+                            None => ExcessRecipient::TargetController,
+                        });
                     }
                     _ => unreachable!(),
                 }
@@ -4578,7 +4585,7 @@ pub(super) fn continuation_absorbs_current(
         ContinuationAst::CantRegenerate => true,
         // CR 120.4a: recognition was gated on a preceding DealDamage, so the
         // rider is always absorbed into that effect (never a standalone effect).
-        ContinuationAst::ExcessDamageToController => true,
+        ContinuationAst::ExcessDamageToController { .. } => true,
         ContinuationAst::PutRest { .. } => true,
         ContinuationAst::ChooseFromExile { .. } => true,
         ContinuationAst::SearchRevealResult => true,
@@ -5851,6 +5858,38 @@ pub(crate) fn is_moved_object_put_onto_battlefield_counters_clause(sentence: &st
     nom_primitives::scan_contains(body, "counter")
 }
 
+/// CR 120.4a + CR 608.2c + CR 702: Parse an excess-damage redirect rider,
+/// with an optional source-keyword condition such as Ram Through's "If the
+/// creature you control has trample" prefix. The body remains the same
+/// CR 120.4a redirect; only the source-keyword gate is optional.
+fn parse_excess_damage_to_controller_rider(
+    input: &str,
+) -> OracleResult<'_, Option<KeywordKind>> {
+    /// CR 608.2c + CR 702: Parse the source-referential keyword gate.
+    fn parse_source_keyword_condition(input: &str) -> OracleResult<'_, KeywordKind> {
+        // This is not parse_inner_condition: Ram Through's definite phrase
+        // refers to the damage source target selected by the preceding sentence,
+        // not to any matching creature on the battlefield.
+        let (input, _) = tag("if ").parse(input)?;
+        let (input, _) = tag("the creature you control has ").parse(input)?;
+        let (input, keyword_name) = parse_keyword_name(input)?;
+        let keyword: Keyword = keyword_name
+            .parse()
+            .map_err(|_| nom::Err::Error(OracleError::new(input, nom::error::ErrorKind::Fail)))?;
+        let (input, _) = tag(", ").parse(input)?;
+        Ok((input, keyword.kind()))
+    }
+
+    let (input, source_keyword_condition) = opt(parse_source_keyword_condition).parse(input)?;
+    let (input, _) = tag(
+        "excess damage is dealt to that creature's controller instead",
+    )
+    .parse(input)?;
+    let (input, _) = opt(tag(".")).parse(input)?;
+    let (input, _) = eof(input)?;
+    Ok((input, source_keyword_condition))
+}
+
 pub(super) fn parse_followup_continuation_ast(
     text: &str,
     previous_effect: &Effect,
@@ -6349,21 +6388,16 @@ pub(super) fn parse_followup_continuation_ast(
         {
             Some(ContinuationAst::CantRegenerate)
         }
-        // CR 120.4a: "Excess damage is dealt to that creature's controller
-        // instead." — trailing rider on a `DealDamage` (Flame Spill, Gandalf's
-        // Sanction, Ravenous Tyrannosaurus). The two negative guards defer the
-        // conditional / trample-gated form (Ram Through: "If the creature you
-        // control has trample, excess ...") to `Effect::Unimplemented` — that
-        // form requires a controlled-source trample check we do not model here.
-        Effect::DealDamage { .. }
-            if nom_primitives::scan_contains(&lower, "excess damage")
-                && nom_primitives::scan_contains(&lower, "that creature's controller")
-                && nom_primitives::scan_contains(&lower, "instead")
-                && !nom_primitives::scan_contains(&lower, "has trample")
-                && !nom_primitives::scan_contains(&lower, "if ") =>
-        {
-            Some(ContinuationAst::ExcessDamageToController)
-        }
+        // CR 120.4a + CR 608.2c + CR 702: excess-damage redirect rider on a
+        // `DealDamage` (Flame Spill, Gandalf's Sanction, Ravenous Tyrannosaurus),
+        // optionally source-keyword-gated (Ram Through's "If the creature you
+        // control has trample" prefix). The combinator owns the full rider shape
+        // so unrelated "if" clauses or partial excess-damage fragments fail closed.
+        Effect::DealDamage { .. } => parse_excess_damage_to_controller_rider(&lower)
+            .ok()
+            .map(|(_, source_keyword_condition)| ContinuationAst::ExcessDamageToController {
+                source_keyword_condition,
+            }),
         Effect::ChooseFromZone { .. } if parse_put_rest_on_bottom_line(&lower).is_ok() => {
             Some(ContinuationAst::PutChoiceRemainderOnBottom)
         }
@@ -9208,7 +9242,9 @@ mod tests {
         let env = env_for(&defs);
         apply_clause_continuation(
             &mut defs,
-            ContinuationAst::ExcessDamageToController,
+            ContinuationAst::ExcessDamageToController {
+                source_keyword_condition: None,
+            },
             AbilityKind::Spell,
             &env,
         );

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -2,7 +2,9 @@ use super::*;
 use crate::parser::parse_oracle_text;
 use crate::types::ability::CardPlayMode::{Cast, Play};
 use crate::types::ability::CastFromZoneDriver::{DuringResolution, LingeringPermission};
-use crate::types::ability::{AttachmentKind, ForEachCategoryAction, PerpetualModification};
+use crate::types::ability::{
+    AttachmentKind, ExcessRecipient, ForEachCategoryAction, PerpetualModification,
+};
 use crate::types::card_type::CoreType;
 use crate::types::mana::{ManaCost, ManaCostShard};
 use crate::types::statics::CostModifyMode;
@@ -921,25 +923,31 @@ fn ram_through_trample_gated_excess_rider_patches_damage() {
         AbilityKind::Spell,
     );
 
+    // The head is `TargetOnly` (selecting "target creature you control" as the
+    // damage source); `DealDamage` is that clause's own `sub_ability`.
+    let damage_def = def
+        .sub_ability
+        .as_deref()
+        .expect("expected a DealDamage sub_ability under the TargetOnly source selection");
     let Effect::DealDamage {
         damage_source,
         excess,
         ..
-    } = &*def.effect
+    } = &*damage_def.effect
     else {
-        panic!("expected DealDamage, got {:?}", def.effect);
+        panic!("expected DealDamage, got {:?}", damage_def.effect);
     };
     assert_eq!(*damage_source, Some(DamageSource::Target));
     assert_eq!(
         *excess,
-        Some(ExcessRecipient::TargetControllerIfSourceHasKeyword {
-            keyword: crate::types::keywords::KeywordKind::Trample,
+        Some(ExcessRecipient::TargetController {
+            source_keyword: Some(crate::types::keywords::KeywordKind::Trample),
         })
     );
     assert!(
-        def.sub_ability.is_none(),
+        damage_def.sub_ability.is_none(),
         "conditional excess rider must be absorbed, got {:?}",
-        def.sub_ability
+        damage_def.sub_ability
     );
 }
 
@@ -955,7 +963,12 @@ fn unconditional_excess_rider_still_patches_damage() {
     let Effect::DealDamage { excess, .. } = &*def.effect else {
         panic!("expected DealDamage, got {:?}", def.effect);
     };
-    assert_eq!(*excess, Some(ExcessRecipient::TargetController));
+    assert_eq!(
+        *excess,
+        Some(ExcessRecipient::TargetController {
+            source_keyword: None
+        })
+    );
 }
 
 /// CR 120.4a + CR 608.2c: Partial or misspelled conditional riders must fail
@@ -967,13 +980,58 @@ fn partial_conditional_excess_rider_does_not_patch_damage() {
         AbilityKind::Spell,
     );
 
-    let Effect::DealDamage { excess, .. } = &*def.effect else {
-        panic!("expected DealDamage head, got {:?}", def.effect);
+    let damage_def = def
+        .sub_ability
+        .as_deref()
+        .expect("expected a DealDamage sub_ability under the TargetOnly source selection");
+    let Effect::DealDamage { excess, .. } = &*damage_def.effect else {
+        panic!("expected DealDamage head, got {:?}", damage_def.effect);
     };
     assert_eq!(*excess, None);
     assert!(
-        def.sub_ability.is_some(),
+        damage_def.sub_ability.is_some(),
         "invalid rider should remain visible as an unparsed follow-up"
+    );
+}
+
+/// CR 120.4a + CR 608.2c + CR 702: Ram Through's real, complete Oracle text
+/// (verified against Scryfall) through the actual card pipeline
+/// (`parse_oracle_text`, not the fragment-only `parse_effect_chain`). Proves
+/// the `Unimplemented("excess", ...)` node reported by issue #5632 no longer
+/// survives when the card is parsed the way `card-data.json` parses it.
+#[test]
+fn ram_through_real_oracle_text_has_no_unimplemented_excess() {
+    let parsed = parse_oracle_text(
+        "Target creature you control deals damage equal to its power to target \
+         creature you don't control. If the creature you control has trample, \
+         excess damage is dealt to that creature's controller instead.",
+        "Ram Through",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    let ability = parsed.abilities.first().expect("expected a spell ability");
+    assert!(
+        !ability_chain_has_unimplemented(ability),
+        "Ram Through must have no residual Unimplemented node, got {ability:#?}"
+    );
+
+    fn find_deal_damage(ability: &AbilityDefinition) -> Option<&AbilityDefinition> {
+        if matches!(*ability.effect, Effect::DealDamage { .. }) {
+            return Some(ability);
+        }
+        ability.sub_ability.as_deref().and_then(find_deal_damage)
+    }
+    let deal_damage = find_deal_damage(ability).expect("expected a DealDamage node in the chain");
+    let Effect::DealDamage { excess, .. } = &*deal_damage.effect else {
+        unreachable!()
+    };
+    assert_eq!(
+        *excess,
+        Some(ExcessRecipient::TargetController {
+            source_keyword: Some(crate::types::keywords::KeywordKind::Trample),
+        }),
+        "excess rider must be attached to the DealDamage node via the real pipeline"
     );
 }
 

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -911,6 +911,72 @@ fn multi_source_each_power_damage_back_reference_shape() {
     );
 }
 
+/// CR 120.4a + CR 608.2c + CR 702: Ram Through's conditional excess-damage
+/// rider patches the preceding target-source damage effect without making the
+/// damage instruction itself conditional.
+#[test]
+fn ram_through_trample_gated_excess_rider_patches_damage() {
+    let def = parse_effect_chain(
+        "Target creature you control deals damage equal to its power to target creature you don't control. If the creature you control has trample, excess damage is dealt to that creature's controller instead.",
+        AbilityKind::Spell,
+    );
+
+    let Effect::DealDamage {
+        damage_source,
+        excess,
+        ..
+    } = &*def.effect
+    else {
+        panic!("expected DealDamage, got {:?}", def.effect);
+    };
+    assert_eq!(*damage_source, Some(DamageSource::Target));
+    assert_eq!(
+        *excess,
+        Some(ExcessRecipient::TargetControllerIfSourceHasKeyword {
+            keyword: crate::types::keywords::KeywordKind::Trample,
+        })
+    );
+    assert!(
+        def.sub_ability.is_none(),
+        "conditional excess rider must be absorbed, got {:?}",
+        def.sub_ability
+    );
+}
+
+/// CR 120.4a: Existing unconditional excess-damage riders still patch to the
+/// plain target-controller redirect.
+#[test]
+fn unconditional_excess_rider_still_patches_damage() {
+    let def = parse_effect_chain(
+        "~ deals 4 damage to target creature. Excess damage is dealt to that creature's controller instead.",
+        AbilityKind::Spell,
+    );
+
+    let Effect::DealDamage { excess, .. } = &*def.effect else {
+        panic!("expected DealDamage, got {:?}", def.effect);
+    };
+    assert_eq!(*excess, Some(ExcessRecipient::TargetController));
+}
+
+/// CR 120.4a + CR 608.2c: Partial or misspelled conditional riders must fail
+/// closed instead of broadly matching on loose excess-damage words.
+#[test]
+fn partial_conditional_excess_rider_does_not_patch_damage() {
+    let def = parse_effect_chain(
+        "Target creature you control deals damage equal to its power to target creature you don't control. If the creature you control has tramplers, excess damage is dealt to that creature's controller instead.",
+        AbilityKind::Spell,
+    );
+
+    let Effect::DealDamage { excess, .. } = &*def.effect else {
+        panic!("expected DealDamage head, got {:?}", def.effect);
+    };
+    assert_eq!(*excess, None);
+    assert!(
+        def.sub_ability.is_some(),
+        "invalid rider should remain visible as an unparsed follow-up"
+    );
+}
+
 // CR 120.1 + CR 115.1d: "Up to two target creatures you control each deal
 // damage equal to their power to target creature" (Band Together) parses to
 // `EachDealsDamageEqualToPower` with a you-control creature source filter and

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -276,12 +276,13 @@ pub(crate) enum ContinuationAst {
     /// CR 701.19c: "It can't be regenerated" / "They can't be regenerated" — sets
     /// `cant_regenerate: true` on the preceding Destroy/DestroyAll effect.
     CantRegenerate,
-    /// CR 120.4a: "Excess damage is dealt to that creature's controller instead."
-    /// — sets `excess = Some(ExcessRecipient::TargetController)` on the preceding
-    /// `Effect::DealDamage` (Flame Spill, Gandalf's Sanction, Ravenous
-    /// Tyrannosaurus). The conditional / trample-gated form (Ram Through) is NOT
-    /// recognized and lowers to `Effect::Unimplemented` instead.
-    ExcessDamageToController,
+    /// CR 120.4a + CR 608.2c + CR 702: "Excess damage is dealt to that
+    /// creature's controller instead" patches the preceding `DealDamage`; an
+    /// optional source-keyword gate covers Ram Through's "If the creature you
+    /// control has trample" prefix without making the damage itself conditional.
+    ExcessDamageToController {
+        source_keyword_condition: Option<crate::types::keywords::KeywordKind>,
+    },
     /// "Choose one/N of them" / "An opponent chooses one/N of those cards" after a ChangeZone
     /// to exile → ChooseFromZone { count, zone: Exile, chooser }.
     ChooseFromExile {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8763,13 +8763,14 @@ pub enum EachDamageRecipient {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ExcessRecipient {
-    /// CR 120.4a: excess is dealt to the damaged permanent's controller.
-    TargetController,
-    /// CR 120.4a + CR 608.2c + CR 702: excess is dealt to the damaged
-    /// permanent's controller only if the resolved damage source has the named
-    /// keyword. Covers Ram Through's "If the creature you control has trample"
-    /// gate without making the whole damage instruction conditional.
-    TargetControllerIfSourceHasKeyword { keyword: KeywordKind },
+    /// CR 120.4a: excess is dealt to the damaged permanent's controller,
+    /// optionally gated on the resolved damage source having the named
+    /// keyword (CR 608.2c + CR 702; Ram Through's "If the creature you
+    /// control has trample" prefix). `None` redirects unconditionally.
+    TargetController {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source_keyword: Option<KeywordKind>,
+    },
 }
 
 /// CR 120.3: Source characteristics captured before applying an already-replaced

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8765,6 +8765,11 @@ pub enum EachDamageRecipient {
 pub enum ExcessRecipient {
     /// CR 120.4a: excess is dealt to the damaged permanent's controller.
     TargetController,
+    /// CR 120.4a + CR 608.2c + CR 702: excess is dealt to the damaged
+    /// permanent's controller only if the resolved damage source has the named
+    /// keyword. Covers Ram Through's "If the creature you control has trample"
+    /// gate without making the whole damage instruction conditional.
+    TargetControllerIfSourceHasKeyword { keyword: KeywordKind },
 }
 
 /// CR 120.3: Source characteristics captured before applying an already-replaced

--- a/crates/engine/tests/integration/flame_spill_excess_damage.rs
+++ b/crates/engine/tests/integration/flame_spill_excess_damage.rs
@@ -549,3 +549,74 @@ fn t9_snapshot_carries_excess_recipient_across_resume() {
         "the deferred lifelink bonus must survive the snapshot round-trip"
     );
 }
+
+/// Build a scenario, add a `source_power`-power source creature controlled by
+/// P0 (with trample if requested) and a `victim_toughness`-toughness victim
+/// creature controlled by P1, cast a free Ram Through targeting
+/// `[source, victim]` (matching "target creature you control ... target
+/// creature you don't control" order), and return the outcome plus both ids.
+fn cast_ram_through_at(
+    source_has_trample: bool,
+    source_power: i32,
+    victim_toughness: i32,
+) -> (CastOutcome, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let source = {
+        let mut c = scenario.add_creature(P0, "Rammer", source_power, source_power);
+        if source_has_trample {
+            c.with_keyword(Keyword::Trample);
+        }
+        c.id()
+    };
+    let victim = scenario
+        .add_creature(P1, "Victim", 2, victim_toughness)
+        .id();
+
+    let spell = {
+        let mut b = scenario.add_spell_to_hand_from_oracle(P0, "Ram Through", false, RAM_THROUGH);
+        b.with_mana_cost(ManaCost::generic(0));
+        b.id()
+    };
+
+    let mut runner = scenario.build();
+    let outcome = runner
+        .cast(spell)
+        .target_objects(&[source, victim])
+        .resolve();
+    (outcome, source, victim)
+}
+
+/// T13 — cast-pipeline proof (trample): Ram Through's parsed `TargetOnly →
+/// DealDamage` chain, real cast target ordering, and source resolution must
+/// compose so the trample gate redirects excess. A power-5 trampling source
+/// hits a toughness-2 victim: the victim takes only the lethal 2, and the
+/// excess 3 redirects to the victim's controller (P1). Revert-fails if the
+/// `TargetOnly`-unwrap fix (or the trample gate itself) regresses: the
+/// redirect silently vanishes and `foe_life_delta` reads 0.
+#[test]
+fn t13_ram_through_trample_redirects_excess_through_real_cast() {
+    let (outcome, _source, victim) = cast_ram_through_at(true, 5, 2);
+    outcome.assert_life_delta(P1, -3);
+    assert_eq!(
+        outcome.state().objects[&victim].damage_marked,
+        2,
+        "the victim must take only the lethal 2, not the full 5 — the rest redirects"
+    );
+}
+
+/// T14 — cast-pipeline proof (no trample), the paired negative: the same
+/// power-5 source WITHOUT trample deals its full damage directly to the
+/// victim with no redirect — the gate must not fire, and the victim (not its
+/// controller) absorbs all 5.
+#[test]
+fn t14_ram_through_no_trample_deals_full_damage_no_redirect() {
+    let (outcome, _source, victim) = cast_ram_through_at(false, 5, 2);
+    outcome.assert_life_delta(P1, 0);
+    assert_eq!(
+        outcome.state().objects[&victim].damage_marked,
+        5,
+        "without trample the victim must take the full 5 with no redirect"
+    );
+}

--- a/crates/engine/tests/integration/flame_spill_excess_damage.rs
+++ b/crates/engine/tests/integration/flame_spill_excess_damage.rs
@@ -6,7 +6,9 @@
 //! `cast(..).resolve()` + `CastOutcome` deltas) and would fail if the excess
 //! redirect were removed (T1) or bound to the wrong player (T2). Class members:
 //! Flame Spill, Gandalf's Sanction, Ravenous Tyrannosaurus. Ram Through's
-//! trample-conditional form is deferred to `Effect::Unimplemented` (T8).
+//! trample-conditional form redirects only while its damage source has
+//! trample (`ExcessRecipient::TargetController { source_keyword: Some(Trample) }`,
+//! T8; issue #5632).
 
 use engine::game::scenario::{CastOutcome, GameScenario, P0, P1};
 use engine::parser::parse_oracle_text;
@@ -18,7 +20,7 @@ use engine::types::ability::{
 use engine::types::actions::GameAction;
 use engine::types::game_state::{CastPaymentMode, WaitingFor};
 use engine::types::identifiers::ObjectId;
-use engine::types::keywords::Keyword;
+use engine::types::keywords::{Keyword, KeywordKind};
 use engine::types::mana::ManaCost;
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
@@ -28,10 +30,10 @@ use engine::types::zones::Zone;
 const FLAME_SPILL: &str = "Flame Spill deals 4 damage to target creature. \
 Excess damage is dealt to that creature's controller instead.";
 
-// Ram Through: the excess redirect is gated on a controlled-source trample check
-// we do not model, so the whole conditional rider must be deferred (honest red),
-// NOT absorbed unconditionally (which would be rules-wrong for a non-trample
-// source).
+// Ram Through: the excess redirect is gated on the damage source (the
+// creature you control) having trample — absorbed onto `DealDamage` as a
+// source-keyword-gated rider, not an unconditional one (CR 120.4a + CR
+// 608.2c + CR 702).
 const RAM_THROUGH: &str = "Target creature you control deals damage equal to its power \
 to target creature you don't control. If the creature you control has trample, excess \
 damage is dealt to that creature's controller instead.";
@@ -447,11 +449,12 @@ fn parse_effects(oracle: &str, name: &str) -> Vec<Effect> {
     refs.into_iter().cloned().collect()
 }
 
-/// T8 — SHAPE: Flame Spill absorbs the rider onto its `DealDamage` with zero
-/// residual `Unimplemented` (fully supported); Ram Through's conditional form is
-/// NOT absorbed and stays `Unimplemented` (honest red), proving the guard.
+/// T8 — SHAPE: Flame Spill absorbs the rider onto its `DealDamage` as an
+/// unconditional redirect; Ram Through absorbs the rider onto its `DealDamage`
+/// as a trample-gated redirect. Both have zero residual `Unimplemented`
+/// (issue #5632).
 #[test]
-fn t8_shape_flame_spill_absorbs_ram_through_defers() {
+fn t8_shape_flame_spill_and_ram_through_absorb_excess_rider() {
     let fs = parse_effects(FLAME_SPILL, "Flame Spill");
     let fs_damage: Vec<&Effect> = fs
         .iter()
@@ -466,7 +469,9 @@ fn t8_shape_flame_spill_absorbs_ram_through_defers() {
         matches!(
             fs_damage[0],
             Effect::DealDamage {
-                excess: Some(ExcessRecipient::TargetController),
+                excess: Some(ExcessRecipient::TargetController {
+                    source_keyword: None
+                }),
                 ..
             }
         ),
@@ -477,33 +482,33 @@ fn t8_shape_flame_spill_absorbs_ram_through_defers() {
         "Flame Spill must have no Unimplemented residue (fully supported): {fs:?}"
     );
 
-    // Ram Through: the trample-conditional rider must NOT be absorbed onto the
-    // DealDamage (the `!has trample` / `!if ` guards defer it).
+    // Ram Through: the trample-conditional rider must be absorbed onto the
+    // DealDamage as a source-keyword-gated redirect, not an unconditional one.
     let rt = parse_effects(RAM_THROUGH, "Ram Through");
+    let rt_damage: Vec<&Effect> = rt
+        .iter()
+        .filter(|e| matches!(e, Effect::DealDamage { .. }))
+        .collect();
+    assert_eq!(
+        rt_damage.len(),
+        1,
+        "Ram Through should parse to exactly one DealDamage effect: {rt:?}"
+    );
     assert!(
-        rt.iter().all(|e| !matches!(
-            e,
+        matches!(
+            rt_damage[0],
             Effect::DealDamage {
-                excess: Some(_),
+                excess: Some(ExcessRecipient::TargetController {
+                    source_keyword: Some(KeywordKind::Trample)
+                }),
                 ..
             }
-        )),
-        "Ram Through's CONDITIONAL excess must not be absorbed unconditionally: {rt:?}"
-    );
-    // Coverage-honesty: the deferred conditional rider must leave an Unimplemented
-    // marker somewhere in the parse (not be silently dropped). Checked on the full
-    // parse Debug so it is robust to whether the residue lands as an effect, a
-    // sub-ability, or a swallowed-clause warning.
-    let rt_parsed = parse_oracle_text(
-        RAM_THROUGH,
-        "Ram Through",
-        &[],
-        &["Sorcery".to_string()],
-        &[],
+        ),
+        "Ram Through's excess must be trample-gated on the DealDamage, got: {rt:?}"
     );
     assert!(
-        format!("{rt_parsed:?}").contains("Unimplemented"),
-        "Ram Through's deferred excess rider must remain honestly Unimplemented"
+        !rt.iter().any(|e| matches!(e, Effect::Unimplemented { .. })),
+        "Ram Through must have no Unimplemented residue (fully supported): {rt:?}"
     );
 }
 
@@ -525,14 +530,18 @@ fn t9_snapshot_carries_excess_recipient_across_resume() {
         has_wither: false,
         has_infect: false,
         combat_damage_poison: 0,
-        excess_recipient: Some(ExcessRecipient::TargetController),
+        excess_recipient: Some(ExcessRecipient::TargetController {
+            source_keyword: None,
+        }),
         lifelink_bonus: 3,
     };
     let json = serde_json::to_string(&snap).expect("snapshot serializes");
     let back: DamageContextSnapshot = serde_json::from_str(&json).expect("snapshot deserializes");
     assert_eq!(
         back.excess_recipient,
-        Some(ExcessRecipient::TargetController),
+        Some(ExcessRecipient::TargetController {
+            source_keyword: None
+        }),
         "the excess-redirect rider must survive the snapshot round-trip"
     );
     assert_eq!(


### PR DESCRIPTION
## Summary

- Parse Ram Through's conditional excess-damage rider into the existing DealDamage excess path.
- Add a source-keyword-gated excess recipient.
- Resolve the condition against the actual damage source target.
- Add focused parser and runtime regression coverage.

Fixes #5632