### PR TITLE
ship/p03s2 draw delivery

### DIFF
--- a/crates/engine/src/database/forge/replacement.rs
+++ b/crates/engine/src/database/forge/replacement.rs
@@ -1,4 +1,4 @@
-use crate::types::ability::ReplacementDefinition;
+use crate::types::ability::{DrawReplacementScope, ReplacementDefinition};
 use crate::types::replacements::ReplacementEvent;
 
 use super::filter::translate_filter;
@@ -25,6 +25,14 @@ pub(crate) fn translate_replacement(
     let event = translate_replacement_event(event_str)?;
 
     let mut def = ReplacementDefinition::new(event);
+    // CR 121.2 + CR 121.6b: a Forge `R:` line carries no grammatical antecedent to
+    // read the draw scope from — its `Event$ Draw` is always a per-draw
+    // substitution, never a CR 121.2a instruction-count modifier (Forge encodes
+    // those as a separate DrawnCards event). Declared explicitly rather than left
+    // to default, so `validate_draw_scope` cannot pass on an unset scope.
+    if matches!(def.event, ReplacementEvent::Draw) {
+        def.draw_scope = Some(DrawReplacementScope::IndividualDraw);
+    }
 
     // ReplaceWith$ → execute (resolve SVar)
     if let Some(replace_name) = params.get("ReplaceWith") {

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -2959,7 +2959,10 @@ pub fn synthesize_dredge(face: &mut CardFace) {
     );
     mill.sub_ability = Some(Box::new(return_to_hand));
 
-    let mut replacement = ReplacementDefinition::new(ReplacementEvent::Draw);
+    // CR 702.52a + CR 121.6b: Dredge replaces a single individual card draw
+    // ("if you would draw a card, you may instead mill N"), not the instruction count.
+    let mut replacement = ReplacementDefinition::new(ReplacementEvent::Draw)
+        .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw);
     replacement.mode = crate::types::ability::ReplacementMode::Optional { decline: None };
     replacement.description = Some(
         "CR 702.52a: Dredge — instead of drawing, you may mill N cards and return this \

--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -1113,9 +1113,14 @@ fn fire_combat_prevention_riders(
             continue;
         };
         state.last_effect_count = Some(total_prevented);
-        state.post_replacement_applied.clear();
-        state.post_replacement_continuation =
-            Some(crate::types::ability::PostReplacementContinuation::Resolved(runtime));
+        // Policy is `Replace`: this path has always overwritten a resident
+        // continuation rather than deferring to it. The rider inherits no applied
+        // set (it is the batch's own aggregate follow-up) — the fresh drain says
+        // that by construction, where the old code had to remember to clear a
+        // parallel field.
+        state.install_ready_continuation(
+            crate::types::ability::PostReplacementContinuation::Resolved(runtime),
+        );
         let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
             state, None, None, None, events,
         );

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -11205,9 +11205,10 @@ mod tests {
     #[test]
     fn card_face_with_replacement_decline_unimplemented_is_detected() {
         let mut face = make_face();
-        face.replacements
-            .push(ReplacementDefinition::new(ReplacementEvent::Draw).mode(
-                ReplacementMode::Optional {
+        face.replacements.push(
+            ReplacementDefinition::new(ReplacementEvent::Draw)
+                .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw)
+                .mode(ReplacementMode::Optional {
                     decline: Some(Box::new(AbilityDefinition::new(
                         AbilityKind::Spell,
                         Effect::Unimplemented {
@@ -11215,8 +11216,8 @@ mod tests {
                             description: None,
                         },
                     ))),
-                },
-            ));
+                }),
+        );
 
         assert!(card_face_has_unimplemented_parts(&face));
     }

--- a/crates/engine/src/game/effects/connive.rs
+++ b/crates/engine/src/game/effects/connive.rs
@@ -1443,7 +1443,8 @@ mod tests {
         // leading draw PARKS. No execute => no continuation-slot competition.
         let install_count_modifier = |state: &mut GameState, modification: QuantityModification| {
             let host = make_battlefield_creature(state, PlayerId(0));
-            let mut repl = ReplacementDefinition::new(ReplacementEvent::Draw);
+            let mut repl = ReplacementDefinition::new(ReplacementEvent::Draw)
+                .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw);
             repl.quantity_modification = Some(modification);
             // Retire after the leading draw so the connive's own later draw is
             // not re-parked by these helpers.
@@ -1648,7 +1649,8 @@ mod tests {
         // deterministic).
         let install_draw_prevent = |state: &mut GameState| -> ObjectId {
             let host = make_battlefield_creature(state, PlayerId(0));
-            let mut repl = ReplacementDefinition::new(ReplacementEvent::Draw);
+            let mut repl = ReplacementDefinition::new(ReplacementEvent::Draw)
+                .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw);
             repl.quantity_modification = Some(QuantityModification::Prevent);
             repl.consume_on_apply = true;
             state

--- a/crates/engine/src/game/effects/create_draw_replacement.rs
+++ b/crates/engine/src/game/effects/create_draw_replacement.rs
@@ -53,7 +53,10 @@ pub fn resolve(
 
     // CR 614.1a + CR 113.7a: anchor the installing controller at resolution
     // time so the shield outlives the source permanent's zone/controller.
-    let mut shield = ReplacementDefinition::new(ReplacementEvent::Draw);
+    // CR 121.6b: a runtime shield substitutes ONE individual card draw ("the next
+    // time you would draw a card this turn, ... instead"), not the instruction count.
+    let mut shield = ReplacementDefinition::new(ReplacementEvent::Draw)
+        .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw);
     shield.runtime_execute = Some(Box::new(substitute));
     shield.consume_on_apply = true; // CR 614.6: one-shot ("the next time").
     shield.expiry = Some(RestrictionExpiry::EndOfTurn); // CR 514.2: "this turn".

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -392,7 +392,7 @@ pub(crate) fn apply_damage_to_target(
             // prevention riders fire once post-batch in `combat_damage.rs`
             // against the aggregate prevented amount. Firing inline here would
             // re-fire the rider once per attacker against a fragmented count.
-            if !is_combat && state.post_replacement_continuation.is_some() {
+            if !is_combat && state.has_post_replacement_drain() {
                 // CR 615.5 + CR 609.7: leave `post_replacement_event_source`
                 // populated for the call so `TargetFilter::PostReplacementSourceController`
                 // can resolve against the prevented event's damage source. Clear
@@ -1372,7 +1372,7 @@ fn resolve_each_target_power_damage(
             ReplacementResult::Prevented => {
                 // CR 615.5: A prevention rider (e.g. "for each 1 damage prevented
                 // this way") resolves immediately afterward for non-combat damage.
-                if state.post_replacement_continuation.is_some() {
+                if state.has_post_replacement_drain() {
                     let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
                         state, None, None, None, events,
                     );
@@ -2331,7 +2331,7 @@ pub fn resolve_each_source_deals_damage(
                 // CR 615.5: fire any prevention rider (e.g. Phyrexian Hydra
                 // "-1/-1 counter for each 1 damage prevented") inline so it
                 // resolves "immediately afterward" as the rule requires.
-                if state.post_replacement_continuation.is_some() {
+                if state.has_post_replacement_drain() {
                     let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
                         state, None, None, None, events,
                     );

--- a/crates/engine/src/game/effects/draw.rs
+++ b/crates/engine/src/game/effects/draw.rs
@@ -660,17 +660,22 @@ mod tests {
             Zone::Battlefield,
         );
         let teferi_obj = state.objects.get_mut(&teferi).unwrap();
-        teferi_obj.replacement_definitions = vec![ReplacementDefinition::new(
-            ReplacementEvent::Draw,
-        )
-        .execute(AbilityDefinition::new(
-            AbilityKind::Spell,
-            Effect::Draw {
-                count: QuantityExpr::Fixed { value: 2 },
-                target: TargetFilter::Controller,
-            },
-        ))]
-        .into();
+        // CR 121.6b: Teferi's antecedent is SINGULAR — "if you would draw a card …
+        // draw two cards instead" — so it replaces one individual draw, and is
+        // `IndividualDraw` despite being a doubler colloquially. This matches what
+        // the real card carries in the corpus; a hand-built fixture that disagreed
+        // with its own card would be testing a shape that does not exist.
+        teferi_obj.replacement_definitions =
+            vec![ReplacementDefinition::new(ReplacementEvent::Draw)
+                .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::Draw {
+                        count: QuantityExpr::Fixed { value: 2 },
+                        target: TargetFilter::Controller,
+                    },
+                ))]
+            .into();
 
         for card_id in 2..=4 {
             create_object(

--- a/crates/engine/src/game/effects/draw.rs
+++ b/crates/engine/src/game/effects/draw.rs
@@ -284,7 +284,7 @@ pub(crate) fn draw_through_replacement(
     match &result {
         ReplacementResult::Execute(event) => {
             apply_executed(state, event.clone(), events);
-            if state.post_replacement_continuation.is_some() {
+            if state.has_post_replacement_drain() {
                 let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
                     state, None, None, None, events,
                 );

--- a/crates/engine/src/game/effects/draw.rs
+++ b/crates/engine/src/game/effects/draw.rs
@@ -135,10 +135,11 @@ pub fn resolve(
         _ => (1, ability.controller),
     };
 
-    // CR 121.6b: Route through `resume_multi_draw` so a multi-card draw
-    // (num_cards > 1) offers replacement independently to each unit instead
-    // of the whole count being replaced or drawn as one atomic batch.
-    match resume_multi_draw(state, drawing_player, num_cards, 0, events) {
+    // CR 121.2: Route through the draw-sequence stack so a multi-card draw
+    // (num_cards > 1) performs that many individual card draws, each offered
+    // replacement independently, instead of the whole count being replaced or
+    // drawn as one atomic batch.
+    match start_draw_sequence(state, drawing_player, num_cards, events) {
         ReplacementResult::Execute(_) | ReplacementResult::Prevented => {}
         ReplacementResult::NeedsChoice(_) => return Ok(()),
     }
@@ -151,65 +152,97 @@ pub fn resolve(
     Ok(())
 }
 
-/// CR 121.6b: Resolve `remaining` independent draw events for `player`, one at
-/// a time, offering each its own replacement choice — "if an effect replaces a
-/// draw within a sequence of card draws, the replacement effect is completed
-/// before resuming the sequence." Called both by `resolve`'s first pass
-/// (`remaining` = the full requested count, `accumulated` = 0) and by
-/// `handle_replacement_choice`'s resume path (`remaining`/`accumulated` =
-/// whatever `PendingMultiDraw` recorded when the previous unit parked).
+/// CR 121.2: Begin one draw instruction — "if a player is instructed to draw
+/// multiple cards, that player performs that many individual card draws."
 ///
-/// CR 609.3: `accumulated` is the running total of cards ACTUALLY delivered
-/// across every completed unit of this instruction (0 for a unit whose draw
-/// was replaced by something else, e.g. Dredge; the post-replacement count for
-/// a unit doubled by a count-modifier like Teferi's Ageless Insight). Committed
-/// to `state.last_effect_count` exactly once, when `remaining` reaches 0, so a
-/// chained "discard that many" sub-ability sees the true total across the
-/// WHOLE original multi-draw, not just the last unit processed.
-///
-/// Returns `NeedsChoice` and stashes `state.pending_multi_draw` if a unit
-/// pauses with units still left; otherwise returns the terminal
-/// `Execute`/`Prevented`-equivalent result with `state.last_effect_count`
-/// already committed. The `Execute(ProposedEvent::Draw{count: 0, ..})` used as
-/// the completion sentinel reuses the engine's existing zero-count draw shape
-/// (already produced today by `Effect::Draw{count: 0}` via
-/// `resolve_quantity_with_targets(...).max(0)`), not a new event shape.
-pub(crate) fn resume_multi_draw(
+/// Pushes a [`DrawSequenceFrame`] and immediately drives it. The frame is the
+/// durable record of the instruction: it survives a pause (a per-unit replacement
+/// choice) so the remaining individual draws resume against exactly this
+/// instruction and not some other draw that started in the meantime.
+pub(crate) fn start_draw_sequence(
     state: &mut GameState,
     player: crate::types::player::PlayerId,
-    remaining: u32,
-    accumulated: u32,
+    count: u32,
     events: &mut Vec<GameEvent>,
 ) -> replacement::ReplacementResult {
-    let mut total = accumulated;
-    let mut left = remaining;
-    while left > 0 {
-        // This unit is now in flight — decrement BEFORE attempting so a park
-        // mid-attempt stores the count of units AFTER this one, not including
-        // it (the paused unit resumes via the accepted/declined choice itself,
-        // not via a fresh loop iteration).
-        left -= 1;
+    let frame_id = state.draw_sequences.push(player, count);
+    resume_draw_sequence(state, frame_id, events)
+}
+
+/// CR 121.6b: The single post-pause driver for a draw instruction — "if an effect
+/// replaces a draw within a sequence of card draws, the replacement effect is
+/// completed before resuming the sequence."
+///
+/// Drives `frame_id`'s remaining individual draws to completion. On a pause the
+/// frame stays on the stack with its cursor already advanced past the in-flight
+/// unit, so the resume that follows the player's choice picks up exactly where it
+/// left off; the paused unit is settled by the choice itself, not replayed here.
+///
+/// CR 608.2c: on completion the frame's running total is committed to
+/// `state.last_effect_count` exactly once — the value a later "that many" clause
+/// on the same card reads ("Draw two cards, then discard that many"), which must
+/// be the true total across the WHOLE instruction rather than the last unit's
+/// count. A unit whose draw was replaced by something else (Dredge) contributes
+/// 0; one doubled by a count modifier (Teferi's Ageless Insight) contributes its
+/// post-replacement count.
+///
+/// The terminal `Execute(ProposedEvent::Draw { count: 0, .. })` is a completion
+/// sentinel, reusing the engine's existing zero-count draw shape (already produced
+/// by `Effect::Draw { count: 0 }`), not a new event shape.
+///
+/// `frame_id` must be the active frame. It cannot be an outer frame with a nested
+/// instruction still above it (CR 616.1g) — that resume must wait for the inner
+/// instruction to complete.
+pub(crate) fn resume_draw_sequence(
+    state: &mut GameState,
+    frame_id: crate::types::game_state::DrawSequenceFrameId,
+    events: &mut Vec<GameEvent>,
+) -> replacement::ReplacementResult {
+    loop {
+        // Take the next owed unit off the cursor BEFORE attempting it, so a park
+        // mid-attempt leaves the frame recording the units AFTER this one. The
+        // in-flight unit is settled by the replacement choice that parked it.
+        let Some(frame) = state.draw_sequences.active_if(frame_id) else {
+            debug_assert!(
+                false,
+                "resume_draw_sequence({frame_id:?}) is not the active draw frame — a nested \
+                 instruction is still above it, or the frame was already popped"
+            );
+            return ReplacementResult::Prevented;
+        };
+        if frame.remaining == 0 {
+            break;
+        }
+        frame.remaining -= 1;
+        let player = frame.player;
+
         let mut unit_drawn: u32 = 0;
         let result = draw_through_replacement(state, player, 1, events, |state, event, events| {
             unit_drawn = apply_draw_after_replacement(state, event, events);
         });
         match result {
             ReplacementResult::Execute(_) | ReplacementResult::Prevented => {
-                total += unit_drawn;
+                // The unit's delivery may itself have pushed and popped a nested
+                // instruction, so re-address this frame by ID rather than assuming
+                // it is still whatever `active_mut()` returns.
+                if let Some(frame) = state.draw_sequences.active_if(frame_id) {
+                    frame.accumulated += unit_drawn;
+                }
             }
+            // The frame stays parked on the stack; the choice resumes it.
             ReplacementResult::NeedsChoice(waiting_player) => {
-                state.pending_multi_draw = Some(crate::types::game_state::PendingMultiDraw {
-                    player,
-                    remaining: left,
-                    accumulated: total,
-                });
                 return ReplacementResult::NeedsChoice(waiting_player);
             }
         }
     }
-    state.last_effect_count = Some(total as i32);
+
+    let Some(frame) = state.draw_sequences.pop(frame_id) else {
+        debug_assert!(false, "draw frame {frame_id:?} vanished before completion");
+        return ReplacementResult::Prevented;
+    };
+    state.last_effect_count = Some(frame.accumulated as i32);
     ReplacementResult::Execute(ProposedEvent::Draw {
-        player_id: player,
+        player_id: frame.player,
         count: 0,
         applied: HashSet::new(),
     })
@@ -272,15 +305,16 @@ pub(crate) fn draw_through_replacement(
 /// `handle_replacement_choice` when a player accepts a draw-replacement choice.
 /// Caller is responsible for emitting `EffectResolved`.
 ///
-/// Returns the number of cards actually delivered by this call. CR 609.3: this
-/// function does NOT write `state.last_effect_count` itself — `resume_multi_draw`
-/// accumulates the returned counts across every unit of the original
-/// multi-card draw and commits the TRUE total once, when the whole instruction
-/// completes, so a chained "discard that many" sees the real total rather than
-/// just the last unit's count. Callers outside `resume_multi_draw` that invoke
-/// this directly for a single, non-multi-draw event (the two unit tests below,
-/// `scry.rs`'s delegation arm, `handle_replacement_choice`'s non-multi-draw
-/// resume path) may ignore the return value — Rust does not require consuming it.
+/// Returns the number of cards actually delivered by this call. CR 608.2c: this
+/// function does NOT write `state.last_effect_count` itself — the draw sequence
+/// accumulates the returned counts across every unit of the instruction into its
+/// [`DrawSequenceFrame`] and commits the TRUE total once, when the whole
+/// instruction completes, so a chained "discard that many" reads the real total
+/// rather than just the last unit's count ("later text on the card may modify the
+/// meaning of earlier text"). Callers outside the sequence driver that invoke this
+/// directly for a single, non-sequenced event (the two unit tests below,
+/// `scry.rs`'s delegation arm, `handle_replacement_choice`'s resume path) may
+/// ignore the return value — Rust does not require consuming it.
 pub fn apply_draw_after_replacement(
     state: &mut GameState,
     event: ProposedEvent,

--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -175,7 +175,7 @@ pub fn apply_life_gain(
 /// (CR 615.5 fallback path), which the applier stamps with the prevented
 /// amount before returning.
 fn drain_substitution_continuation(state: &mut GameState, events: &mut Vec<GameEvent>) {
-    if state.post_replacement_continuation.is_some() {
+    if state.has_post_replacement_drain() {
         let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
             state, None, None, None, events,
         );
@@ -1565,7 +1565,7 @@ mod tests {
         );
         // The post-replacement continuation must be drained.
         assert!(
-            state.post_replacement_continuation.is_none(),
+            !state.has_post_replacement_drain(),
             "post_replacement_continuation must be drained after life-gain replacement"
         );
     }
@@ -1633,10 +1633,10 @@ mod tests {
         // change as a phantom GainLife — same defect class as Jace
         // empty-library win.
         assert!(
-            state.post_replacement_continuation.is_none(),
+            !state.has_post_replacement_drain(),
             "GainLife→GainLife amount-substitution must not leak a post-replacement \
              continuation; found {:?}",
-            state.post_replacement_continuation
+            state.post_replacement_continuation()
         );
     }
 

--- a/crates/engine/src/game/effects/planeswalk.rs
+++ b/crates/engine/src/game/effects/planeswalk.rs
@@ -44,7 +44,7 @@ pub fn resolve(
             // fires in this same resolution step (mirrors
             // `draw_through_replacement`'s Execute-arm drain; `replace_event`
             // does not drain — the caller must). No planeswalk occurs.
-            if state.post_replacement_continuation.is_some() {
+            if state.has_post_replacement_drain() {
                 let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
                     state, None, None, None, events,
                 );

--- a/crates/engine/src/game/effects/prevent_damage.rs
+++ b/crates/engine/src/game/effects/prevent_damage.rs
@@ -1135,8 +1135,9 @@ mod tests {
             .clone()
             .unwrap();
         state.last_effect_count = Some(prevented);
-        state.post_replacement_continuation =
-            Some(crate::types::ability::PostReplacementContinuation::Resolved(runtime));
+        state.install_ready_continuation(
+            crate::types::ability::PostReplacementContinuation::Resolved(runtime),
+        );
         let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
             &mut state,
             None,

--- a/crates/engine/src/game/effects/scry.rs
+++ b/crates/engine/src/game/effects/scry.rs
@@ -48,7 +48,7 @@ pub fn resolve(
             // `effects::draw::draw_through_replacement` — scry's own propose
             // event variant means we can't use that helper directly, but the
             // CR-mandated drain is identical.
-            if state.post_replacement_continuation.is_some() {
+            if state.has_post_replacement_drain() {
                 let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
                     state, None, None, None, events,
                 );

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -561,7 +561,7 @@ pub(crate) fn apply_copy_token_after_replacement_with_created_ids(
             };
             match crate::game::replacement::replace_event(state, proposed, events) {
                 crate::game::replacement::ReplacementResult::Execute(event) => {
-                    if state.post_replacement_continuation.is_some() {
+                    if state.has_post_replacement_drain() {
                         if let Some(waiting_for) =
                             crate::game::engine_replacement::apply_pending_post_replacement_effect(
                                 state,

--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -1086,8 +1086,8 @@ mod tests {
         };
         // Coupled continuation slots the resume drain would clear on a normal answer.
         state.replacement_may_cost_paused = true;
-        state.post_replacement_continuation = Some(PostReplacementContinuation::Resolved(
-            Box::new(ResolvedAbility::new(
+        state.install_ready_continuation(PostReplacementContinuation::Resolved(Box::new(
+            ResolvedAbility::new(
                 Effect::Unimplemented {
                     name: "psrc".into(),
                     description: None,
@@ -1095,11 +1095,23 @@ mod tests {
                 vec![],
                 o,
                 PlayerId(2),
-            )),
-        ));
-        state.post_replacement_source = Some(o);
-        state.post_replacement_event_source = Some(o);
-        state.post_replacement_event_target = Some(TargetRef::Object(o));
+            ),
+        )));
+        state
+            .post_replacement_drains
+            .resident_mut()
+            .expect("a drain must be resident")
+            .source = Some(o);
+        state
+            .post_replacement_drains
+            .resident_mut()
+            .expect("a drain must be resident")
+            .event_source = Some(o);
+        state
+            .post_replacement_drains
+            .resident_mut()
+            .expect("a drain must be resident")
+            .event_target = Some(TargetRef::Object(o));
         // Issue #4886 (review #6): a live Jinnie Fay-class token-choice applied
         // seed, owned by this same abandoned continuation, must be abandoned
         // alongside its siblings — this field was added after the teardown
@@ -1147,10 +1159,10 @@ mod tests {
         );
         // Every coupled continuation slot the resume drain owns is torn down.
         assert!(!state.replacement_may_cost_paused);
-        assert!(state.post_replacement_continuation.is_none());
-        assert!(state.post_replacement_source.is_none());
-        assert!(state.post_replacement_event_source.is_none());
-        assert!(state.post_replacement_event_target.is_none());
+        assert!(!state.has_post_replacement_drain());
+        assert!(state.post_replacement_source().is_none());
+        assert!(state.post_replacement_event_source().is_none());
+        assert!(state.post_replacement_event_target().is_none());
         assert!(
             state.post_replacement_token_choice_applied.is_none(),
             "abandoning the parked chooser's continuation must also clear the token-choice \

--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -1112,14 +1112,10 @@ mod tests {
             count: 1,
             applied: HashSet::new(),
         });
-        // CR 121.6b: a paused multi-card draw owned by the LEAVING chooser
-        // (P2) — single-player-scoped, must clear alongside its siblings via
+        // CR 121.2: a paused draw instruction owned by the LEAVING chooser (P2) —
+        // single-player-scoped, must clear alongside its siblings via
         // `abandon_post_replacement_continuation` (replacement.rs).
-        state.pending_multi_draw = Some(crate::types::game_state::PendingMultiDraw {
-            player: PlayerId(2),
-            remaining: 1,
-            accumulated: 0,
-        });
+        state.draw_sequences.push(PlayerId(2), 1);
         // Coupled spell-resolution ctx owned by the LEAVING chooser (P2) — must clear.
         state.pending_spell_resolution = Some(PendingSpellResolution {
             object_id: o,
@@ -1162,8 +1158,8 @@ mod tests {
         );
         assert!(state.pending_connive_reentry.is_none());
         assert!(
-            state.pending_multi_draw.is_none(),
-            "CR 121.6b: the leaving chooser's paused multi-card draw must be \
+            state.draw_sequences.is_empty(),
+            "CR 121.2: the leaving chooser's paused draw instruction must be \
              cleared via abandon_post_replacement_continuation, not stranded"
         );
         assert!(
@@ -1214,13 +1210,14 @@ mod tests {
             additional_cost_payments: vec![],
             convoked_creatures: vec![],
         });
-        // CR 121.6b: a paused multi-card draw owned by the LIVING chooser (P0)
+        // CR 121.2: a paused draw instruction owned by the LIVING chooser (P0)
         // must survive a different player's departure — no over-clear.
-        state.pending_multi_draw = Some(crate::types::game_state::PendingMultiDraw {
-            player: PlayerId(0),
-            remaining: 2,
-            accumulated: 1,
-        });
+        let living_frame = state.draw_sequences.push(PlayerId(0), 2);
+        state
+            .draw_sequences
+            .active_if(living_frame)
+            .expect("the frame just pushed is active")
+            .accumulated = 1;
 
         let mut events = Vec::new();
         eliminate_players_simultaneously(&mut state, &[PlayerId(1)], &mut events);
@@ -1235,14 +1232,15 @@ mod tests {
             state.pending_spell_resolution.is_some(),
             "an opponent leaving must not tear down the living player's spell-resolution ctx"
         );
+        let survivor = state
+            .draw_sequences
+            .active()
+            .expect("an opponent leaving must not clear the living chooser's paused instruction");
         assert_eq!(
-            state.pending_multi_draw,
-            Some(crate::types::game_state::PendingMultiDraw {
-                player: PlayerId(0),
-                remaining: 2,
-                accumulated: 1,
-            }),
-            "an opponent leaving must not clear the living chooser's paused multi-card draw"
+            (survivor.player, survivor.remaining, survivor.accumulated),
+            (PlayerId(0), 2, 1),
+            "the living chooser's paused draw instruction must survive intact — owed units and \
+             already-delivered count both preserved"
         );
         assert!(
             matches!(

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5913,8 +5913,8 @@ fn handle_play_land(
             // execute ability is non-modifier work (Choose, etc.). Without this,
             // the choice prompt would fire at a random later resolution point with
             // the wrong controller context.
-            if state.post_replacement_continuation.is_some() {
-                state.post_replacement_source = None;
+            if state.has_post_replacement_drain() {
+                state.clear_post_replacement_source();
                 if let Some(next_waiting_for) =
                     engine_replacement::apply_pending_post_replacement_effect(
                         state,

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -119,8 +119,7 @@ pub fn apply_debug_action(
             // continuations (Jace WinTheGame, Abundance reveal-until) still
             // drain in the same step.
             let event_start = events.len();
-            let result =
-                super::effects::draw::resume_multi_draw(state, player_id, count, 0, events);
+            let result = super::effects::draw::start_draw_sequence(state, player_id, count, events);
             // CR 603.2: Mirror the normal draw pipeline — `PassPriority` /
             // `run_post_action_pipeline` scans CardDrawn events after the draw
             // step's turn-based action. Debug draw previously returned without

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -2070,6 +2070,7 @@ mod tests {
         );
         shield_obj.replacement_definitions.push(
             ReplacementDefinition::new(ReplacementEvent::Draw)
+                .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw)
                 .mode(ReplacementMode::Optional { decline: None })
                 .description("Draw Shield".to_string()),
         );

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -23,7 +23,7 @@ use super::ability_utils::build_resolved_from_def_with_targets;
 use super::effects;
 use super::effects::deal_damage::{apply_damage_after_replacement, DamageContext};
 use super::effects::destroy::apply_destroy_after_replacement;
-use super::effects::draw::{apply_draw_after_replacement, resume_multi_draw};
+use super::effects::draw::apply_draw_after_replacement;
 use super::effects::life::{
     apply_life_gain_after_replacement, apply_life_loss_after_replacement,
     drain_pending_life_total_assignment,
@@ -388,19 +388,17 @@ pub(super) fn handle_replacement_choice(
                 // drain below runs the chain (Choose → RevealUntil).
                 draw @ ProposedEvent::Draw { player_id, .. } => {
                     let drawn_count = apply_draw_after_replacement(state, draw, events);
-                    // CR 121.6b + CR 609.3: this Draw arm resolves the ONE unit
-                    // that was paused (the choice just answered) — it does NOT
-                    // go through `resume_multi_draw`'s own closure, so its
-                    // actually-drawn count is never folded into the running
-                    // total unless done here explicitly. Fold it into the
-                    // stashed `PendingMultiDraw.accumulated` (if this player has
-                    // one in flight) BEFORE the drain below reads it, so the
-                    // eventual `state.last_effect_count` commit includes every
-                    // unit of the original instruction — not just the units
-                    // `resume_multi_draw` itself executed without pausing.
-                    if let Some(pending) = state.pending_multi_draw.as_mut() {
-                        if pending.player == player_id {
-                            pending.accumulated += drawn_count;
+                    // CR 121.6b + CR 608.2c: this Draw arm settles the ONE unit
+                    // that was paused (the choice just answered) — it does not go
+                    // through the sequence driver's own delivery closure, so its
+                    // actually-drawn count is folded into the active instruction's
+                    // frame here, BEFORE the drain below resumes that frame. Without
+                    // this the eventual `last_effect_count` commit would omit every
+                    // unit that paused, and a chained "discard that many" would read
+                    // short.
+                    if let Some(frame) = state.draw_sequences.active_mut() {
+                        if frame.player == player_id {
+                            frame.accumulated += drawn_count;
                         }
                     }
                     // CR 805.4b: if this resumed draw IS the front of the
@@ -695,30 +693,22 @@ pub(super) fn handle_replacement_choice(
                 }
             }
 
-            // CR 121.6b: a multi-card draw (`Effect::Draw{count: N}`, N > 1)
-            // paused mid-sequence because a per-unit replacement (Dredge,
-            // Notion Thief, Hullbreacher, a count-doubling static, etc.) needed
-            // this choice. The just-resolved unit was applied above (Draw arm);
-            // drain the remaining units via `resume_multi_draw`, which
-            // internally re-parks `pending_multi_draw` and sets
-            // `state.waiting_for` (via `draw_through_replacement`) if the next
-            // unit surfaces its own choice — an arbitrary number of sequential
-            // re-pauses compose correctly since each drain call re-reads
-            // whatever the previous one stashed.
-            if matches!(waiting_for, WaitingFor::Priority { .. })
-                && state.pending_multi_draw.is_some()
-            {
-                if let Some(pending) = state.pending_multi_draw.take() {
-                    let _ = resume_multi_draw(
-                        state,
-                        pending.player,
-                        pending.remaining,
-                        pending.accumulated,
-                        events,
-                    );
-                }
-                if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                    waiting_for = state.waiting_for.clone();
+            // CR 121.6b: a draw instruction (`Effect::Draw{count: N}`) paused
+            // mid-sequence because a per-unit replacement (Dredge, Notion Thief,
+            // Hullbreacher, a count-doubling static, etc.) needed this choice. The
+            // just-resolved unit was settled above (Draw arm); resume the frame to
+            // drive its remaining units. `resume_draw_sequence` leaves the frame
+            // parked and sets `state.waiting_for` (via `draw_through_replacement`)
+            // if the next unit surfaces its own choice, so an arbitrary number of
+            // sequential re-pauses compose — each resume re-addresses the same
+            // frame by ID.
+            if matches!(waiting_for, WaitingFor::Priority { .. }) {
+                if let Some(frame_id) = state.draw_sequences.active().map(|f| f.frame_id) {
+                    let _ =
+                        crate::game::effects::draw::resume_draw_sequence(state, frame_id, events);
+                    if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+                        waiting_for = state.waiting_for.clone();
+                    }
                 }
             }
 

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -249,7 +249,7 @@ pub(super) fn handle_replacement_choice(
                     zone_change_object_id = Some(object_id);
                 }
                 event @ ProposedEvent::TokenEntry { entry_ref, .. } => {
-                    if state.post_replacement_continuation.is_some() {
+                    if state.has_post_replacement_drain() {
                         if let Some(waiting_for) = apply_pending_post_replacement_effect(
                             state,
                             Some(entry_ref),
@@ -649,7 +649,7 @@ pub(super) fn handle_replacement_choice(
                 replacement_ctx = Some(ctx);
             }
 
-            if state.post_replacement_continuation.is_some() {
+            if state.has_post_replacement_drain() {
                 // CR 614.12a + CR 614.1c: For ZoneChange events the post-effect
                 // resolves against the zone-changing object, not the replacement
                 // source — drop the source slot so it doesn't leak into an
@@ -662,7 +662,7 @@ pub(super) fn handle_replacement_choice(
                 // Abundance's controller, not `ObjectId(0)` / active_player.
                 let is_zone_change = zone_change_object_id.is_some();
                 if is_zone_change {
-                    state.post_replacement_source = None;
+                    state.clear_post_replacement_source();
                 }
                 if let Some(next_waiting_for) = apply_pending_post_replacement_effect(
                     state,
@@ -1575,8 +1575,6 @@ pub(crate) fn apply_pending_post_replacement_effect(
     event: Option<ReplacementEvent>,
     events: &mut Vec<GameEvent>,
 ) -> Option<WaitingFor> {
-    let source = state.post_replacement_source.take().or(object_id);
-    let replacement_applied = std::mem::take(&mut state.post_replacement_applied);
     // CR 614.12a (approximation): sacrifice prompt fires after ZoneChange completes,
     // matching Siege/Tribute precedent. A strict reading of 614.12a says the choice
     // is made *before* the permanent enters, but the engine's pipeline applies the
@@ -1584,10 +1582,26 @@ pub(crate) fn apply_pending_post_replacement_effect(
     // observable behavior is equivalent for as-enters sacrifice/counter mechanics
     // (Devour, Siege protector, Tribute) where the choice doesn't gate entry.
     //
-    // CR 614.12a + CR 615.5: Single dispatch on the unified continuation slot.
-    // `Resolved` carries captured targets (prevention follow-ups); `Template`
-    // is an AST that resolves against `source` for ETB / Optional accept.
-    let waiting_for = match state.post_replacement_continuation.take() {
+    // CR 614.12a + CR 615.5: Resident-top dispatch. `begin_dispatch` takes the
+    // continuation and marks the drain `Dispatching` WITHOUT removing it, so:
+    //   * a nested `has_post_replacement_drain()` taken while the effect runs sees
+    //     no ready work and cannot re-drain this one (the old slot was likewise
+    //     empty at this point — the continuation had been moved out of it), and
+    //   * the effect can still read this drain's event context (CR 615.5), which is
+    //     how `PostReplacementSourceController` resolves "the source's controller
+    //     draws cards" for Swans of Bryn Argoll.
+    // The drain is popped after the dispatch returns.
+    //
+    // `Resolved` carries captured targets (prevention follow-ups); `Template` is an
+    // AST that resolves against `source` for ETB / Optional accept.
+    let source = state.post_replacement_source().or(object_id);
+    let replacement_applied = state
+        .post_replacement_drains
+        .resident_mut()
+        .map(|drain| std::mem::take(&mut drain.applied))
+        .unwrap_or_default();
+
+    let waiting_for = match state.post_replacement_drains.begin_dispatch() {
         Some(PostReplacementContinuation::Resolved(resolved)) => {
             apply_post_replacement_resolved_effect(state, &resolved, replacement_applied, events)
         }
@@ -1602,6 +1616,10 @@ pub(crate) fn apply_pending_post_replacement_effect(
         ),
         None => None,
     };
+    // The dispatch is over: retire the drain, taking its event context with it.
+    // This replaces the hand-clearing of `post_replacement_event_source` /
+    // `_event_target` that used to sit below.
+    state.post_replacement_drains.finish_dispatch();
     // NOTE: the inherited token-choice applied seed is intentionally NOT cleared
     // here. This drain runs for EVERY replacement continuation — including a
     // nested one that pauses inside an outer token-choice ChooseOneOf (issue
@@ -1611,8 +1629,6 @@ pub(crate) fn apply_pending_post_replacement_effect(
     // seed is owned and cleared by the originating ChooseOneOf's completion
     // (effects/choose_one_of.rs), which is the only frame that can correctly
     // detect "the token-choice continuation has fully drained."
-    state.post_replacement_event_source = None;
-    state.post_replacement_event_target = None;
     // CR 614.12a + CR 707.9: When the post-effect pauses on `CopyTargetChoice`,
     // the entering object's battlefield-entry `ZoneChanged` event is already
     // in `events` (emitted by the prior `move_to_zone`). `BecomeCopy` and its
@@ -3634,12 +3650,16 @@ mod tests {
                 count: QuantityExpr::Fixed { value: 1 },
             },
         );
-        state.post_replacement_continuation = Some(
+        state.install_ready_continuation(
             crate::types::ability::PostReplacementContinuation::Template(Box::new(
                 draw_continuation,
             )),
         );
-        state.post_replacement_source = Some(jinnie_source);
+        state
+            .post_replacement_drains
+            .resident_mut()
+            .expect("a drain must be resident")
+            .source = Some(jinnie_source);
 
         let mut events = Vec::new();
         let waiting_for = apply_pending_post_replacement_effect(
@@ -4280,8 +4300,7 @@ mod tests {
                 target: None,
             },
         );
-        state.post_replacement_continuation =
-            Some(PostReplacementContinuation::Template(Box::new(template)));
+        state.install_ready_continuation(PostReplacementContinuation::Template(Box::new(template)));
 
         let mut events = Vec::new();
         let waiting = apply_pending_post_replacement_effect(
@@ -4294,7 +4313,7 @@ mod tests {
 
         // Resolved cleanly — no follow-up WaitingFor and slot drained.
         assert!(waiting.is_none(), "Template path resolved without prompt");
-        assert!(state.post_replacement_continuation.is_none());
+        assert!(!state.has_post_replacement_drain());
         // Source's controller (P0) lost 2 life.
         assert_eq!(state.players[0].life, initial_life - 2);
     }
@@ -4337,8 +4356,7 @@ mod tests {
                 destination: Zone::Graveyard,
             },
         );
-        state.post_replacement_continuation =
-            Some(PostReplacementContinuation::Template(Box::new(template)));
+        state.install_ready_continuation(PostReplacementContinuation::Template(Box::new(template)));
 
         let mut events = Vec::new();
         let waiting = apply_pending_post_replacement_effect(
@@ -4383,8 +4401,7 @@ mod tests {
             source,
             PlayerId(1),
         );
-        state.post_replacement_continuation =
-            Some(PostReplacementContinuation::Resolved(Box::new(resolved)));
+        state.install_ready_continuation(PostReplacementContinuation::Resolved(Box::new(resolved)));
 
         let mut events = Vec::new();
         let waiting = apply_pending_post_replacement_effect(
@@ -4396,7 +4413,7 @@ mod tests {
         );
 
         assert!(waiting.is_none(), "Resolved path resolved without prompt");
-        assert!(state.post_replacement_continuation.is_none());
+        assert!(!state.has_post_replacement_drain());
         // Resolved ability's own controller (P1) lost 3 life.
         assert_eq!(state.players[1].life, initial_life - 3);
     }
@@ -4418,11 +4435,11 @@ mod tests {
         );
         // Simulate legacy deserialization: only the legacy slot is populated.
         state.legacy_post_replacement_effect = Some(Box::new(template.clone()));
-        assert!(state.post_replacement_continuation.is_none());
+        assert!(!state.has_post_replacement_drain());
 
         state.migrate_post_replacement_continuation();
 
-        match state.post_replacement_continuation {
+        match state.post_replacement_continuation() {
             Some(PostReplacementContinuation::Template(ref def)) => {
                 assert_eq!(**def, template);
             }
@@ -4569,7 +4586,7 @@ mod tests {
 
         state.migrate_post_replacement_continuation();
 
-        match state.post_replacement_continuation {
+        match state.post_replacement_continuation() {
             Some(PostReplacementContinuation::Resolved(ref boxed)) => {
                 assert_eq!(**boxed, resolved);
             }
@@ -4593,9 +4610,9 @@ mod tests {
                 target: None,
             },
         );
-        state.post_replacement_continuation = Some(PostReplacementContinuation::Template(
-            Box::new(new_template.clone()),
-        ));
+        state.install_ready_continuation(PostReplacementContinuation::Template(Box::new(
+            new_template.clone(),
+        )));
         // Legacy slots also populated (corrupted/hybrid input).
         state.legacy_post_replacement_effect = Some(Box::new(AbilityDefinition::new(
             AbilityKind::Spell,
@@ -4608,7 +4625,7 @@ mod tests {
 
         state.migrate_post_replacement_continuation();
 
-        match state.post_replacement_continuation {
+        match state.post_replacement_continuation() {
             Some(PostReplacementContinuation::Template(ref def)) => {
                 assert_eq!(**def, new_template);
             }
@@ -4923,7 +4940,7 @@ mod tests {
         // continuation (the ChooseOneOf execute).
         crate::game::zones::move_to_zone(&mut state, object_id, to, &mut events);
         assert!(
-            state.post_replacement_continuation.is_some(),
+            state.has_post_replacement_drain(),
             "ChooseOneOf execute must stash a post-replacement continuation"
         );
         let waiting = apply_pending_post_replacement_effect(

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -1582,7 +1582,7 @@ pub(crate) fn apply_pending_post_replacement_effect(
     // observable behavior is equivalent for as-enters sacrifice/counter mechanics
     // (Devour, Siege protector, Tribute) where the choice doesn't gate entry.
     //
-    // CR 614.12a + CR 615.5: Resident-top dispatch. `begin_dispatch` takes the
+    // CR 615.5 + CR 616.1g: Resident-top dispatch. `begin_dispatch` takes the
     // continuation and marks the drain `Dispatching` WITHOUT removing it, so:
     //   * a nested `has_post_replacement_drain()` taken while the effect runs sees
     //     no ready work and cannot re-drain this one (the old slot was likewise

--- a/crates/engine/src/game/planechase_tests.rs
+++ b/crates/engine/src/game/planechase_tests.rs
@@ -1187,7 +1187,7 @@ fn fixed_point_replaces_planar_die_planeswalk_with_chaos() {
     );
     // The continuation slot is drained (no leftover post-replacement effect).
     assert!(
-        state.post_replacement_continuation.is_none(),
+        !state.has_post_replacement_drain(),
         "the post-replacement continuation must be drained exactly once"
     );
 

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -21,6 +21,9 @@ pub fn finalize_rules_state(state: &mut GameState) {
     // post-replacement-continuation slot fold. Idempotent on already-migrated
     // states; cheap on every other invocation.
     state.migrate_post_replacement_continuation();
+    // CR 121.2: Backward-compat for the single-slot `pending_multi_draw` →
+    // `draw_sequences` stack conversion. Idempotent on already-migrated states.
+    state.migrate_pending_multi_draw();
     normalize_legacy_attach_waiting_for(state);
     sync_priority_player_from_waiting_for(state);
     flush_layers(state);

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -6888,6 +6888,21 @@ fn replacement_definition_for_id(
                 .map(|entry| &entry.object)
         })
         .and_then(|obj| obj.replacement_definitions.get(rid.index))
+    // CR 121.2: a `debug_assert!(def.validate_draw_scope().is_ok())` belongs here —
+    // this is the single point where the engine resolves a definition it is about to
+    // consult, so it is the one place a producer that forgot `.draw_scope(...)` can be
+    // caught. It is deliberately NOT wired, and the reason is a finding rather than an
+    // oversight: the committed fixture `crates/engine/tests/fixtures/integration_cards.json`
+    // predates the field and carries 7 Draw replacements with no scope (Abundance, Blood
+    // Scrivener, Jace Wielder of Mysteries, Laboratory Maniac, Living Conundrum, Quantum
+    // Riddler, Teferi's Ageless Insight). Wiring the assert fails all 7 until that fixture
+    // is regenerated — a separate, deliberate act, since a regen sweeps in whatever else
+    // has changed in the card pool.
+    //
+    // Production is unaffected: `card-data.json` is regenerated from the parser by CI and
+    // all 6 producers set the scope. The release-build authority is
+    // `draw_replacement_census.py`, which cross-checks every declared scope against an
+    // independently derived one across the full 51-card corpus.
 }
 
 fn pipeline_loop(
@@ -9744,8 +9759,9 @@ mod tests {
 
     #[test]
     fn draw_replacement_uses_event_context_amount_with_offset() {
-        let repl =
-            ReplacementDefinition::new(ReplacementEvent::Draw).execute(AbilityDefinition::new(
+        let repl = ReplacementDefinition::new(ReplacementEvent::Draw)
+            .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw)
+            .execute(AbilityDefinition::new(
                 crate::types::ability::AbilityKind::Spell,
                 Effect::Draw {
                     count: QuantityExpr::Offset {
@@ -9934,7 +9950,8 @@ mod tests {
             },
         );
         mill.sub_ability = Some(Box::new(return_to_hand));
-        let mut repl = ReplacementDefinition::new(ReplacementEvent::Draw);
+        let mut repl = ReplacementDefinition::new(ReplacementEvent::Draw)
+            .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw);
         repl.mode = ReplacementMode::Optional { decline: None };
         repl.execute = Some(Box::new(mill));
         repl
@@ -10356,6 +10373,7 @@ mod tests {
     #[test]
     fn draw_replacement_does_not_apply_when_quantity_gate_is_false() {
         let repl = ReplacementDefinition::new(ReplacementEvent::Draw)
+            .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw)
             .condition(ReplacementCondition::OnlyIfQuantity {
                 lhs: QuantityExpr::Ref {
                     qty: crate::types::ability::QuantityRef::HandSize {
@@ -10399,8 +10417,9 @@ mod tests {
 
     #[test]
     fn draw_replacement_does_not_apply_to_zero_card_draws() {
-        let repl =
-            ReplacementDefinition::new(ReplacementEvent::Draw).execute(AbilityDefinition::new(
+        let repl = ReplacementDefinition::new(ReplacementEvent::Draw)
+            .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw)
+            .execute(AbilityDefinition::new(
                 crate::types::ability::AbilityKind::Spell,
                 Effect::Draw {
                     count: QuantityExpr::Offset {
@@ -13218,6 +13237,7 @@ mod tests {
     #[test]
     fn only_if_quantity_is_filtered_for_opponent_draws() {
         let repl = ReplacementDefinition::new(ReplacementEvent::Draw)
+            .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw)
             .condition(ReplacementCondition::OnlyIfQuantity {
                 lhs: QuantityExpr::Ref {
                     qty: crate::types::ability::QuantityRef::HandSize {
@@ -14351,9 +14371,11 @@ mod tests {
         use crate::types::ability::PtValue;
 
         let doubler = ReplacementDefinition::new(ReplacementEvent::Draw)
+            .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw)
             .quantity_modification(QuantityModification::DOUBLE);
-        let draw_to_token =
-            ReplacementDefinition::new(ReplacementEvent::Draw).execute(AbilityDefinition::new(
+        let draw_to_token = ReplacementDefinition::new(ReplacementEvent::Draw)
+            .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw)
+            .execute(AbilityDefinition::new(
                 AbilityKind::Spell,
                 Effect::Token {
                     name: "Beast".to_string(),

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -340,13 +340,15 @@ pub(crate) fn abandon_post_replacement_continuation(state: &mut GameState) {
     // abandoned alongside the applied seed it rides with.
     state.post_replacement_token_substitution_count = None;
     state.pending_connive_reentry = None;
-    // CR 121.6b + CR 800.4a: `PendingMultiDraw` is single-player-scoped (it
-    // tracks only the departing player's own in-flight multi-card draw), so
-    // it is safe to null outright here — unlike the deliberately-preserved
-    // multi-player queue fields nearby in `elimination.rs`
-    // (`pending_team_draw_step` etc.), which need the interrupted APNAP queue
-    // resumed for the remaining players rather than field-nulling.
-    state.pending_multi_draw = None;
+    // CR 121.2 + CR 800.4a: draw frames are single-player-scoped (each tracks one
+    // player's own in-flight instruction), so the whole stack is abandoned outright
+    // here — unlike the deliberately-preserved multi-player queue fields nearby in
+    // `elimination.rs` (`pending_team_draw_step` etc.), which need the interrupted
+    // APNAP queue resumed for the remaining players rather than field-nulling.
+    //
+    // The frame-ID allocator deliberately does NOT rewind: a `DrawSequenceFrameId`
+    // captured before the abandonment must never alias a frame allocated after it.
+    state.draw_sequences.abandon_all();
 }
 
 pub type ReplacementMatcher = fn(&ProposedEvent, ObjectId, &GameState) -> bool;
@@ -10040,30 +10042,30 @@ mod tests {
     /// the single dredge outcome, matching "drew no cards" from the report).
     #[test]
     fn multi_draw_dredges_one_of_two_units_other_draws_normally() {
-        use crate::game::effects::draw::resume_multi_draw;
+        use crate::game::effects::draw::start_draw_sequence;
         use crate::types::actions::GameAction;
 
         let mut state = dredge_state(10);
         let mut events = Vec::new();
 
-        let result = resume_multi_draw(&mut state, PlayerId(0), 2, 0, &mut events);
+        let result = start_draw_sequence(&mut state, PlayerId(0), 2, &mut events);
         let ReplacementResult::NeedsChoice(chooser) = result else {
             panic!("expected the first unit's dredge offer to pause, got {result:?}");
         };
         assert_eq!(chooser, PlayerId(0));
+        let parked = state
+            .draw_sequences
+            .active()
+            .expect("the paused instruction must stay on the draw-sequence stack");
         assert_eq!(
-            state.pending_multi_draw,
-            Some(crate::types::game_state::PendingMultiDraw {
-                player: PlayerId(0),
-                remaining: 1,
-                accumulated: 0,
-            }),
-            "one unit must remain queued after the first unit parks"
+            (parked.player, parked.remaining, parked.accumulated),
+            (PlayerId(0), 1, 0),
+            "one unit must remain owed after the first unit parks, with nothing yet delivered"
         );
 
         // Accept the dredge offer for unit 1 through the real production path —
-        // `handle_replacement_choice` applies the accepted event AND drains
-        // `pending_multi_draw` for the remaining unit.
+        // `handle_replacement_choice` settles the accepted event AND resumes the
+        // parked frame for the remaining unit.
         state.priority_player = chooser;
         crate::game::engine::apply_as_current(
             &mut state,
@@ -10072,9 +10074,9 @@ mod tests {
         .expect("resume the dredge choice");
 
         assert!(
-            state.pending_multi_draw.is_none(),
-            "the multi-draw must fully complete once both units resolve, got {:?}",
-            state.pending_multi_draw
+            state.draw_sequences.is_empty(),
+            "the instruction must fully complete once both units resolve, got {:?}",
+            state.draw_sequences
         );
         assert!(
             state.players[0].hand.contains(&ObjectId(10)),
@@ -10104,13 +10106,13 @@ mod tests {
     /// — the hostile sibling of the accept case above.
     #[test]
     fn multi_draw_decline_dredge_unit_one_still_draws_unit_two_normally() {
-        use crate::game::effects::draw::resume_multi_draw;
+        use crate::game::effects::draw::start_draw_sequence;
         use crate::types::actions::GameAction;
 
         let mut state = dredge_state(10);
         let mut events = Vec::new();
 
-        let result = resume_multi_draw(&mut state, PlayerId(0), 2, 0, &mut events);
+        let result = start_draw_sequence(&mut state, PlayerId(0), 2, &mut events);
         let ReplacementResult::NeedsChoice(chooser) = result else {
             panic!("expected the first unit's dredge offer to pause, got {result:?}");
         };

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -266,7 +266,8 @@ pub enum ApplyResult {
     Prevented,
 }
 
-/// CR 614.12a: Install a mandatory post-effect's continuation.
+/// CR 614.6: Install a mandatory post-effect's continuation — the replacement's own
+/// actions, which run as part of the modified event that occurs instead.
 ///
 /// Policy is [`ResidentDrainPolicy::KeepResident`], preserving this function's
 /// long-standing behaviour: when a continuation is already resident, the incoming
@@ -7288,7 +7289,8 @@ fn continue_replacement_impl(
                 state.post_replacement_token_substitution_count = Some(*count as i32);
             }
         }
-        // CR 614.12a: install (or clear) the optional branch's continuation.
+        // CR 614.6: install (or clear) the optional branch's continuation — the
+        // replacement's own actions for the branch that was taken.
         //
         // Policy is `Replace`: unlike `stash_post_replacement_continuation`, this
         // path has always OVERWRITTEN a resident continuation rather than

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -18,7 +18,8 @@ use super::filter::{
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    GameState, PendingReplacement, ReplacementCandidateSummary, ReplacementIndexEntry, WaitingFor,
+    DrainStatus, GameState, PendingReplacement, PostReplacementDrain, ReplacementCandidateSummary,
+    ReplacementIndexEntry, ResidentDrainPolicy, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{StepEndManaAction, UnitDisposition};
@@ -265,6 +266,13 @@ pub enum ApplyResult {
     Prevented,
 }
 
+/// CR 614.12a: Install a mandatory post-effect's continuation.
+///
+/// Policy is [`ResidentDrainPolicy::KeepResident`], preserving this function's
+/// long-standing behaviour: when a continuation is already resident, the incoming
+/// one is **discarded**. That is lossy — CR 616.1g contemplates a replacement
+/// applying to an event contained within another — but it is what the engine does
+/// today, and changing it is a separate, characterized commit.
 fn stash_post_replacement_continuation(
     state: &mut GameState,
     continuation: PostReplacementContinuation,
@@ -273,14 +281,16 @@ fn stash_post_replacement_continuation(
     event_source: Option<ObjectId>,
     event_target: Option<TargetRef>,
 ) {
-    if state.post_replacement_continuation.is_some() {
-        return;
-    }
-    state.post_replacement_continuation = Some(continuation);
-    state.post_replacement_source = Some(source);
-    state.post_replacement_applied = applied;
-    state.post_replacement_event_source = event_source;
-    state.post_replacement_event_target = event_target;
+    state.post_replacement_drains.install(
+        PostReplacementDrain {
+            status: DrainStatus::Ready(continuation),
+            source: Some(source),
+            applied,
+            event_source,
+            event_target,
+        },
+        ResidentDrainPolicy::KeepResident,
+    );
 }
 
 fn ability_tree_creates_tokens(def: &AbilityDefinition) -> bool {
@@ -331,10 +341,10 @@ fn is_copy_token_substitution(def: &AbilityDefinition) -> bool {
 /// (player elimination mid-resolution, `elimination.rs`) precisely because it
 /// was hand-listed there instead of routed through one function.
 pub(crate) fn abandon_post_replacement_continuation(state: &mut GameState) {
-    state.post_replacement_continuation = None;
-    state.post_replacement_source = None;
-    state.post_replacement_event_source = None;
-    state.post_replacement_event_target = None;
+    // The drain owns its source / applied / event-source / event-target, so one
+    // call abandons all four. This is precisely the hand-listing hazard the doc
+    // above describes: those four could no longer be stranded individually.
+    state.post_replacement_drains.abandon_all();
     state.post_replacement_token_choice_applied = None;
     // CR 614.1a: the Moonlit-scoped "that many" copy count is single-authority
     // abandoned alongside the applied seed it rides with.
@@ -7063,7 +7073,7 @@ pub(crate) fn replace_combat_damage_batch(
         // partial prevention (`Modified` → `Execute`) — so a depletion-shield
         // rider fires "immediately afterward" and never leaks past the batch.
         if !matches!(result, ReplacementResult::NeedsChoice(_))
-            && state.post_replacement_continuation.is_some()
+            && state.has_post_replacement_drain()
         {
             let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
                 state, None, None, None, events,
@@ -7235,17 +7245,6 @@ fn continue_replacement_impl(
         // `draw_applier`) can see the continuation slot and suppress the
         // original event when its replacement is a non-modifier chain
         // (CR 614.6: the draw never happens when fully replaced).
-        if post_effect.is_some() {
-            state.post_replacement_source = Some(rid.source);
-            state.post_replacement_applied = proposed.applied_set().clone();
-            // CR 615.5 + CR 609.7: Optional/decline post-effects don't carry
-            // prevention-event-source semantics — clear so a prior prevention
-            // can't leak into a non-prevention stash.
-            state.post_replacement_event_source = None;
-            state.post_replacement_event_target = None;
-        } else {
-            state.post_replacement_applied.clear();
-        }
         // CR 614.12a + CR 616.1: Seed the inherited replacement-applied set ONLY
         // when this replacement originates a token-choice continuation (Jinnie
         // Fay-class `CreateToken -> ChooseOneOf(Token, Token)`). The seed is
@@ -7274,8 +7273,35 @@ fn continue_replacement_impl(
                 state.post_replacement_token_substitution_count = Some(*count as i32);
             }
         }
-        state.post_replacement_continuation =
-            post_effect.map(PostReplacementContinuation::Template);
+        // CR 614.12a: install (or clear) the optional branch's continuation.
+        //
+        // Policy is `Replace`: unlike `stash_post_replacement_continuation`, this
+        // path has always OVERWRITTEN a resident continuation rather than
+        // discarding the incoming one. The two policies genuinely disagree; both
+        // are preserved exactly here, and naming them is the point.
+        //
+        // CR 615.5 + CR 609.7: an optional/decline post-effect carries no
+        // prevention-event-source semantics, so `event_source`/`event_target` are
+        // empty — a prior prevention must not leak into a non-prevention drain.
+        // The drain owns those fields, so replacing it clears them by construction.
+        match post_effect {
+            Some(def) => {
+                state.post_replacement_drains.install(
+                    PostReplacementDrain {
+                        status: DrainStatus::Ready(PostReplacementContinuation::Template(def)),
+                        source: Some(rid.source),
+                        applied: proposed.applied_set().clone(),
+                        event_source: None,
+                        event_target: None,
+                    },
+                    ResidentDrainPolicy::Replace,
+                );
+            }
+            // No post-effect: this branch produces no continuation, so any resident
+            // one (and the `applied` set that rode with it) is dropped — exactly
+            // what `continuation = None` + `applied.clear()` did before.
+            None => state.post_replacement_drains.abandon_all(),
+        }
 
         match apply_single_replacement_and_dirty(state, proposed, rid, branch, registry, events) {
             Ok(new_event) => proposed = new_event,
@@ -7449,7 +7475,7 @@ mod tests {
             "chosen-dependent counters must not fold pre-choice"
         );
         assert!(
-            state.post_replacement_continuation.is_some(),
+            state.has_post_replacement_drain(),
             "Choose + chosen-dependent PutCounter must stash post-replacement work"
         );
     }
@@ -7493,7 +7519,7 @@ mod tests {
         assert!(enter_tapped.resolve(false));
         assert_eq!(enter_with_counters, vec![(CounterType::Stun, 1)]);
         assert!(
-            state.post_replacement_continuation.is_none(),
+            !state.has_post_replacement_drain(),
             "pure ETB modifier chains must not be replayed after the event"
         );
     }
@@ -9338,7 +9364,7 @@ mod tests {
             "Gate land should enter the battlefield tapped"
         );
         assert!(
-            state.post_replacement_continuation.is_some(),
+            state.has_post_replacement_drain(),
             "the as-enters color Choose should be stashed as a post-replacement continuation"
         );
     }
@@ -9673,10 +9699,10 @@ mod tests {
         // continuation. A leaked Template here is the same defect class as
         // the Jace empty-library win bug.
         assert!(
-            state.post_replacement_continuation.is_none(),
+            !state.has_post_replacement_drain(),
             "GainLife→GainLife amount-substitution must not leak a post-replacement \
              continuation; found {:?}",
-            state.post_replacement_continuation
+            state.post_replacement_continuation()
         );
     }
 
@@ -14183,7 +14209,7 @@ mod tests {
         };
 
         assert!(
-            state.post_replacement_continuation.is_none(),
+            !state.has_post_replacement_drain(),
             "token substitution must not stash a post-replacement continuation"
         );
 
@@ -14276,7 +14302,7 @@ mod tests {
         };
         assert_eq!(count, 0, "accepted substitution suppresses original batch");
         assert!(
-            state.post_replacement_continuation.is_some(),
+            state.has_post_replacement_drain(),
             "accepted substitution must park the branch choice as a continuation"
         );
 

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -10095,7 +10095,7 @@ mod tests {
         assert_eq!(
             state.last_effect_count,
             Some(1),
-            "CR 609.3: the TRUE total actually drawn across the whole 2-unit \
+            "CR 608.2c: the TRUE total actually drawn across the whole 2-unit \
              instruction is 1 (unit 1 dredged for 0, unit 2 drew 1 normally) — \
              not 2 (the naive per-unit count) and not 0 (the last unit's count \
              if last_effect_count were wrongly overwritten per-unit)"
@@ -10158,10 +10158,10 @@ mod tests {
         assert_eq!(
             state.last_effect_count,
             Some(2),
-            "CR 609.3: both units drew normally (unit 1's declined draw, folded \
-             into the resumed multi-draw's total, PLUS unit 2's declined draw) \
+            "CR 608.2c: both units drew normally (unit 1's declined draw, folded \
+             into the resumed instruction's frame, PLUS unit 2's declined draw) \
              — the total must be 2, not 1 (which would mean unit 1's own draw \
-             was silently dropped from the accumulator)"
+             was silently dropped from the frame's accumulator)"
         );
     }
 

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1058,8 +1058,8 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                     // Sets `state.waiting_for` to the resulting prompt, if any — the
                     // caller's post-stack resolution checks waiting_for before returning
                     // priority. Without this drain the choice would be silently dropped.
-                    if state.post_replacement_continuation.is_some() {
-                        state.post_replacement_source = None;
+                    if state.has_post_replacement_drain() {
+                        state.clear_post_replacement_source();
                         let _ = super::engine_replacement::apply_pending_post_replacement_effect(
                             state,
                             Some(entry.id),

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -1162,11 +1162,11 @@ pub(crate) fn resolve_event_context_target_for_event_or_state(
         // resolution. Returns `None` if invoked outside the post-replacement
         // window — caller should never reach this filter from elsewhere.
         TargetFilter::PostReplacementSourceController => {
-            let source_obj_id = state.post_replacement_event_source?;
+            let source_obj_id = state.post_replacement_event_source()?;
             let controller = state.objects.get(&source_obj_id)?.controller;
             Some(TargetRef::Player(controller))
         }
-        TargetFilter::PostReplacementDamageTarget => state.post_replacement_event_target.clone(),
+        TargetFilter::PostReplacementDamageTarget => state.post_replacement_event_target().cloned(),
         // CR 108.3 + CR 400.3 + CR 615.5: Owner of the prevented event's damage
         // recipient ("that creature's owner shuffles it into their library").
         // Mirrors `PostReplacementSourceController`'s player-projection but reads
@@ -1174,7 +1174,7 @@ pub(crate) fn resolve_event_context_target_for_event_or_state(
         // slot / controller (CR 109.4). Routed here to the recipient's owner's
         // library by CR 400.3.
         TargetFilter::PostReplacementDamageTargetOwner => {
-            match &state.post_replacement_event_target {
+            match state.post_replacement_event_target() {
                 Some(TargetRef::Object(id)) => {
                     state.objects.get(id).map(|o| TargetRef::Player(o.owner))
                 }
@@ -2314,7 +2314,9 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{Comparator, ContinuousModification, Duration, QuantityExpr};
     use crate::types::card_type::CoreType;
-    use crate::types::game_state::CastingVariant;
+    use crate::types::game_state::{
+        CastingVariant, DrainStatus, PostReplacementDrain, ResidentDrainPolicy,
+    };
     use crate::types::identifiers::CardId;
     use crate::types::keywords::{HexproofFilter, ProtectionTarget};
     use crate::types::mana::ManaColor;
@@ -2389,7 +2391,19 @@ mod tests {
         let (mut state, c0, _c1) = setup_with_creatures();
         // c0 is controlled by P0 — pretend it's the prevented damage source
         // and the prevention shield (e.g. Swans) is controlled by P1.
-        state.post_replacement_event_source = Some(c0);
+        // `Dispatching`, not `Ready`: production reads this filter from inside a
+        // running continuation, whose own work has already been taken out of the
+        // drain but whose prevented-event context is still readable (CR 615.5).
+        state.post_replacement_drains.install(
+            PostReplacementDrain {
+                status: DrainStatus::Dispatching,
+                source: None,
+                applied: HashSet::new(),
+                event_source: Some(c0),
+                event_target: None,
+            },
+            ResidentDrainPolicy::Replace,
+        );
         let result = resolve_event_context_target(
             &state,
             &TargetFilter::PostReplacementSourceController,
@@ -2404,7 +2418,7 @@ mod tests {
         // Outside that window the slot is `None` and the filter should return
         // `None`, letting callers fall back to controller / target_player.
         let (state, _c0, _c1) = setup_with_creatures();
-        assert!(state.post_replacement_event_source.is_none());
+        assert!(state.post_replacement_event_source().is_none());
         let result = resolve_event_context_target(
             &state,
             &TargetFilter::PostReplacementSourceController,
@@ -2425,7 +2439,17 @@ mod tests {
         // would return P0 and fail this assertion.
         let (mut state, _c0, c1) = setup_with_creatures();
         state.objects.get_mut(&c1).unwrap().controller = PlayerId(0);
-        state.post_replacement_event_target = Some(TargetRef::Object(c1));
+        // `Dispatching` for the same reason as the sibling test above.
+        state.post_replacement_drains.install(
+            PostReplacementDrain {
+                status: DrainStatus::Dispatching,
+                source: None,
+                applied: HashSet::new(),
+                event_target: Some(TargetRef::Object(c1)),
+                event_source: None,
+            },
+            ResidentDrainPolicy::Replace,
+        );
         let result = resolve_event_context_target(
             &state,
             &TargetFilter::PostReplacementDamageTargetOwner,
@@ -2438,7 +2462,7 @@ mod tests {
     fn post_replacement_damage_target_owner_returns_none_when_slot_empty() {
         // Defensive: only resolves inside the post-replacement window.
         let (state, _c0, _c1) = setup_with_creatures();
-        assert!(state.post_replacement_event_target.is_none());
+        assert!(state.post_replacement_event_target().is_none());
         let result = resolve_event_context_target(
             &state,
             &TargetFilter::PostReplacementDamageTargetOwner,

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -4988,7 +4988,7 @@ fn can_drain_deferred_triggers(state: &GameState, allow_spell_on_stack: bool) ->
     if state.pending_repeat_iteration.is_some() {
         return false;
     }
-    if state.post_replacement_continuation.is_some() {
+    if state.has_post_replacement_drain() {
         return false;
     }
     if state.pending_change_zone_iteration.is_some() {

--- a/crates/engine/src/game/triggers_devour_runtime_tests.rs
+++ b/crates/engine/src/game/triggers_devour_runtime_tests.rs
@@ -145,11 +145,11 @@ fn drive_devour_etb_to_sacrifice_choice(
     move_to_zone(&mut state, object_id, to, &mut events);
 
     assert!(
-        state.post_replacement_continuation.is_some(),
+        state.has_post_replacement_drain(),
         "Devour's non-modifier execute (Effect::Sacrifice) must be \
              stashed as a post-replacement continuation by the pipeline"
     );
-    state.post_replacement_source = None;
+    state.clear_post_replacement_source();
     let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
         &mut state,
         Some(obj_id),

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -1288,7 +1288,7 @@ pub(crate) fn apply_zone_delivery_tail(
     // only after `apply_pending_spell_resolution` (Phase-B divergence
     // reconciliation — the tail is parameterized instead of copied).
     if matches!(drain, PostReplacementDrainOwner::DeliveryTail)
-        && state.post_replacement_continuation.is_some()
+        && state.has_post_replacement_drain()
     {
         // CR 603.6d + CR 614.12a: For an "as-enters" (battlefield-entry) Moved
         // post-effect, the effect resolves against the zone-changing object (the
@@ -1307,7 +1307,7 @@ pub(crate) fn apply_zone_delivery_tail(
         // must keep the host source slot — its post-effect belongs to the host,
         // not the moved card.
         if to == Zone::Battlefield {
-            state.post_replacement_source = None;
+            state.clear_post_replacement_source();
         }
         let waiting_for = crate::game::engine_replacement::apply_pending_post_replacement_effect(
             state,

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -34,11 +34,12 @@ use super::oracle_util::{
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, CastVariantPaid, ChoiceType, CombatDamageScope,
     Comparator, ContinuousModification, ControllerRef, CopyManaValueLimit, DamageModification,
-    DamageRedirectTarget, DamageTargetFilter, DamageTargetPlayerScope, Duration, Effect,
-    EffectScope, FilterProp, LibraryPosition, ManaModification, ManaReplacementScope, PlayerFilter,
-    PreventionAmount, QuantityExpr, QuantityModification, QuantityRef, ReplacementCondition,
-    ReplacementDefinition, ReplacementMode, ReplacementPlayerScope, StaticCondition,
-    StaticDefinition, TapStateChange, TargetFilter, TypeFilter, TypedFilter,
+    DamageRedirectTarget, DamageTargetFilter, DamageTargetPlayerScope, DrawReplacementScope,
+    Duration, Effect, EffectScope, FilterProp, LibraryPosition, ManaModification,
+    ManaReplacementScope, PlayerFilter, PreventionAmount, QuantityExpr, QuantityModification,
+    QuantityRef, ReplacementCondition, ReplacementDefinition, ReplacementMode,
+    ReplacementPlayerScope, StaticCondition, StaticDefinition, TapStateChange, TargetFilter,
+    TypeFilter, TypedFilter,
 };
 use crate::types::card_type::Supertype;
 use crate::types::counter::{CounterMatch, CounterType};
@@ -406,21 +407,29 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
     // CR 614.1a: Widened from "you would draw" to handle opponent/player
     // scope (Notion Thief, Hullbreacher, Chains of Mephistopheles) mirroring
     // the gain-life widening below.
-    let mentions_draw = nom_primitives::scan_at_word_boundaries(&lower, |i| {
-        value(
-            (),
-            alt((
+    // CR 121.2 + CR 121.2a: the antecedent's grammatical number IS the draw scope,
+    // so capture which alternative matched instead of discarding it. A singular
+    // "would draw a card" hooks one individual draw; a count-form "would draw one
+    // or more cards" hooks the instruction, which CR 121.2a modifies "before
+    // considering any of the individual card draws".
+    let draw_scope = nom_primitives::scan_at_word_boundaries(&lower, |i| {
+        alt((
+            value(
+                DrawReplacementScope::IndividualDraw,
                 tag::<_, _, OracleError<'_>>("would draw a card"),
+            ),
+            value(
+                DrawReplacementScope::InstructionCount,
                 tag("would draw one or more cards"),
-            )),
-        )
+            ),
+        ))
         .parse(i)
-    })
-    .is_some();
-    if mentions_draw {
+    });
+    if let Some(draw_scope) = draw_scope {
         let effect_text = extract_replacement_effect(&normalized);
-        let mut def =
-            ReplacementDefinition::new(ReplacementEvent::Draw).description(text.to_string());
+        let mut def = ReplacementDefinition::new(ReplacementEvent::Draw)
+            .draw_scope(draw_scope)
+            .description(text.to_string());
         // CR 614.6 + CR 121.6: "skip that draw instead" fully suppresses the
         // draw (Living Conundrum: "If you would draw a card while your library
         // has no cards in it, skip that draw instead"). The body lowers to a
@@ -6985,6 +6994,10 @@ fn parse_conditional_draw_replacement(text: &str, lower: &str) -> Option<Replace
 
     Some(
         ReplacementDefinition::new(ReplacementEvent::Draw)
+            // CR 121.2a: this branch is the count-form antecedent ("if you would draw
+            // one or more cards, you draw that many cards plus one instead" — Quantum
+            // Riddler). It modifies the INSTRUCTION before any individual draw happens.
+            .draw_scope(DrawReplacementScope::InstructionCount)
             .condition(ReplacementCondition::OnlyIfQuantity {
                 lhs,
                 comparator,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -18479,7 +18479,8 @@ pub enum CombatDamageScope {
 /// event's business, and is a separate type.
 ///
 /// Required exactly when `ReplacementDefinition::event` is `Draw`, and forbidden
-/// otherwise; see `ReplacementDefinition::validate_draw_scope`.
+/// otherwise; checkable by `ReplacementDefinition::validate_draw_scope`, and enforced
+/// across the full corpus by `scripts/draw_replacement_census.py`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DrawReplacementScope {
     /// Modifies the draw *instruction*'s count before any individual draw happens
@@ -18600,8 +18601,10 @@ pub struct ReplacementDefinition {
     /// [`DrawReplacementScope`].
     ///
     /// `Some` exactly when `event` is `Draw`, `None` otherwise; declared at
-    /// construction and never inferred later. Checked by
-    /// [`ReplacementDefinition::validate_draw_scope`].
+    /// construction and never inferred later. Checkable by
+    /// [`ReplacementDefinition::validate_draw_scope`]; the enforcing authority is the
+    /// corpus census gate (`scripts/draw_replacement_census.py`), which cross-checks
+    /// every declared scope against an independently derived one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub draw_scope: Option<DrawReplacementScope>,
     /// Shield type for one-shot replacement effects that expire at cleanup.
@@ -18750,17 +18753,28 @@ impl ReplacementDefinition {
     /// match time; a non-`Draw` definition with a scope is a category error. Both
     /// are construction bugs, so this returns the offending definition's problem
     /// rather than silently defaulting.
+    /// `DrawCards` is treated as a draw event here, not as a non-draw one. It is a
+    /// dead registry alias (zero producers, zero corpus rows) slated for removal,
+    /// but while it exists it names a draw, and `draw_replacement_census.py` scans
+    /// `event in ("Draw", "DrawCards")`. Having the validator forbid a scope on a
+    /// variant the census demands one for would be a contradiction between the two
+    /// authorities, so they agree: both treat it as a draw.
     pub fn validate_draw_scope(&self) -> Result<(), String> {
-        match (&self.event, &self.draw_scope) {
-            (ReplacementEvent::Draw, None) => Err(format!(
-                "ReplacementEvent::Draw definition has no draw_scope (CR 121.2: a \
-                 definition must declare whether it modifies the instruction's count \
-                 or replaces one individual draw). description={:?}",
-                self.description
+        let is_draw_event = matches!(
+            self.event,
+            ReplacementEvent::Draw | ReplacementEvent::DrawCards
+        );
+        match (is_draw_event, &self.draw_scope) {
+            (true, None) => Err(format!(
+                "{:?} definition has no draw_scope (CR 121.2: a definition must declare \
+                 whether it modifies the instruction's count or replaces one individual \
+                 draw). description={:?}",
+                self.event, self.description
             )),
-            (event, Some(scope)) if !matches!(event, ReplacementEvent::Draw) => Err(format!(
-                "non-Draw replacement ({event:?}) carries draw_scope {scope:?} — \
-                 draw_scope is meaningless outside CR 121.2"
+            (false, Some(scope)) => Err(format!(
+                "non-Draw replacement ({:?}) carries draw_scope {scope:?} — draw_scope is \
+                 meaningless outside CR 121.2",
+                self.event
             )),
             _ => Ok(()),
         }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -18463,6 +18463,35 @@ pub enum CombatDamageScope {
     NoncombatOnly,
 }
 
+/// CR 121.2 + CR 616.1g: Which stage of a draw a `ReplacementEvent::Draw`
+/// definition applies at.
+///
+/// CR 121.2 makes "draw N cards" two distinct things: the *instruction*, and the N
+/// *individual card draws* it performs. CR 121.2a says an instruction "can be
+/// modified by replacement effects that refer to the number of cards drawn. This
+/// modification occurs before considering any of the individual card draws. See
+/// rule 616.1g." A definition watches exactly one of those, and conflating them is
+/// the CR 121.2a divergence this axis exists to close.
+///
+/// This is a restriction on the *definition* — a sibling of `combat_scope`,
+/// `destination_zone` and `damage_target_filter`, evaluated in the same matcher —
+/// not a property of the event. Which stage an event is currently at is the
+/// event's business, and is a separate type.
+///
+/// Required exactly when `ReplacementDefinition::event` is `Draw`, and forbidden
+/// otherwise; see `ReplacementDefinition::validate_draw_scope`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DrawReplacementScope {
+    /// Modifies the draw *instruction*'s count before any individual draw happens
+    /// (CR 121.2a). Quantum Riddler — "if you would draw one or more cards, you
+    /// draw that many cards plus one instead" — is the only card in the pool that
+    /// does this.
+    InstructionCount,
+    /// Replaces or prevents a single individual card draw (CR 121.6b). Dredge,
+    /// Notion Thief, Hullbreacher, and the runtime "you can't draw" shields.
+    IndividualDraw,
+}
+
 /// CR 614.1a: Which player(s) a replacement effect applies to, scoped relative
 /// to the replacement source player. For permanents/spells this is the source's
 /// controller; for cards outside the battlefield/stack, CR 109.4 + CR 108.4a
@@ -18566,6 +18595,15 @@ pub struct ReplacementDefinition {
     /// None = all damage.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub combat_scope: Option<CombatDamageScope>,
+    /// CR 121.2 + CR 616.1g: which stage of a draw this definition watches — the
+    /// instruction's count, or one individual card draw. See
+    /// [`DrawReplacementScope`].
+    ///
+    /// `Some` exactly when `event` is `Draw`, `None` otherwise; declared at
+    /// construction and never inferred later. Checked by
+    /// [`ReplacementDefinition::validate_draw_scope`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub draw_scope: Option<DrawReplacementScope>,
     /// Shield type for one-shot replacement effects that expire at cleanup.
     #[serde(default, skip_serializing_if = "ShieldKind::is_none")]
     pub shield_kind: ShieldKind,
@@ -18695,11 +18733,48 @@ impl ReplacementDefinition {
         }
     }
 
+    /// CR 121.2 + CR 616.1g: declare which draw stage this definition watches.
+    ///
+    /// Chainable, so a `Draw` producer reads `ReplacementDefinition::new(Draw)
+    /// .draw_scope(IndividualDraw)`. The scope is declared at construction and
+    /// never inferred later — inferring it from the `execute` shape is exactly the
+    /// CR 121.2a conflation this axis exists to prevent.
+    pub fn draw_scope(mut self, scope: DrawReplacementScope) -> Self {
+        self.draw_scope = Some(scope);
+        self
+    }
+
+    /// CR 121.2: `draw_scope` is `Some` exactly when `event` is `Draw`.
+    ///
+    /// A `Draw` definition with no scope would have to have one guessed for it at
+    /// match time; a non-`Draw` definition with a scope is a category error. Both
+    /// are construction bugs, so this returns the offending definition's problem
+    /// rather than silently defaulting.
+    pub fn validate_draw_scope(&self) -> Result<(), String> {
+        match (&self.event, &self.draw_scope) {
+            (ReplacementEvent::Draw, None) => Err(format!(
+                "ReplacementEvent::Draw definition has no draw_scope (CR 121.2: a \
+                 definition must declare whether it modifies the instruction's count \
+                 or replaces one individual draw). description={:?}",
+                self.description
+            )),
+            (event, Some(scope)) if !matches!(event, ReplacementEvent::Draw) => Err(format!(
+                "non-Draw replacement ({event:?}) carries draw_scope {scope:?} — \
+                 draw_scope is meaningless outside CR 121.2"
+            )),
+            _ => Ok(()),
+        }
+    }
+
     /// Create a new replacement definition with only the required event field.
     /// All optional fields default to `None`/`Mandatory`.
+    ///
+    /// A `Draw` event REQUIRES a follow-up `.draw_scope(...)` (CR 121.2); see
+    /// [`Self::validate_draw_scope`].
     pub fn new(event: ReplacementEvent) -> Self {
         Self {
             event,
+            draw_scope: None,
             execute: None,
             runtime_execute: None,
             mode: ReplacementMode::Mandatory,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6694,24 +6694,26 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_connive_reentry: Option<PendingConniveReentry>,
 
-    /// CR 121.6b: "If an effect replaces a draw within a sequence of card
-    /// draws, the replacement effect is completed before resuming the
-    /// sequence." Tracks an in-progress multi-card draw (`Effect::Draw{count:
-    /// N}`, N > 1) paused mid-way by a per-unit replacement choice (Dredge,
-    /// Notion Thief, Hullbreacher, etc.) so the remaining units resolve
-    /// independently instead of the whole count being replaced or drawn as
-    /// one atomic batch. `accumulated` (CR 609.3) is the running total of
-    /// cards ACTUALLY delivered across every already-completed unit of this
-    /// instruction — committed to `state.last_effect_count` exactly once,
-    /// when the full original count is exhausted, so chained "discard that
-    /// many" sub-abilities see the true total, not just the last unit's
-    /// count. Drained only by `engine_replacement::handle_replacement_choice`
-    /// (the `Draw` arm) and `replacement::abandon_post_replacement_continuation`
-    /// (player departure, CR 800.4a) — single-player-scoped, safe to null
-    /// outright on departure unlike the deliberately-preserved multi-player
-    /// queue fields (`pending_team_draw_step` etc.) nearby in `elimination.rs`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pending_multi_draw: Option<PendingMultiDraw>,
+    /// CR 121.2 + CR 121.6b + CR 616.1g: draw instructions in flight, innermost
+    /// last. See [`DrawSequenceStack`]. Every pause and resume of a multi-card
+    /// draw addresses a frame here by [`DrawSequenceFrameId`]; the single resume
+    /// authority is `effects::draw::resume_draw_sequence`.
+    ///
+    /// Replaced the single `pending_multi_draw` slot, which could not represent a
+    /// nested instruction (CR 616.1g) — a substituted inner draw overwrote the
+    /// outer frame and its remaining units were silently lost.
+    #[serde(default, skip_serializing_if = "DrawSequenceStack::is_empty")]
+    pub draw_sequences: DrawSequenceStack,
+
+    /// Legacy save shape for the single in-flight multi-card draw, superseded by
+    /// [`Self::draw_sequences`]. JSON only; migrated into the stack by
+    /// [`Self::migrate_pending_multi_draw`]. Never written.
+    #[serde(
+        default,
+        rename = "pending_multi_draw",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub legacy_pending_multi_draw: Option<PendingMultiDraw>,
 
     /// CR 701.12c + CR 616.1: Tail of a life-total assignment that paused on a
     /// gain/loss replacement choice. Drained by `handle_replacement_choice` after
@@ -8406,15 +8408,169 @@ pub struct PendingConniveReentry {
     pub applied: HashSet<AppliedReplacementKey>,
 }
 
-/// CR 121.6b + CR 609.3: See the doc comment on `GameState::pending_multi_draw`.
+/// Legacy pre-`DrawSequenceStack` save shape: the single in-flight multi-card
+/// draw. Deserialize-only — [`GameState::migrate_pending_multi_draw`] converts it
+/// into a one-frame [`DrawSequenceStack`]. No production writer remains.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingMultiDraw {
     pub player: PlayerId,
-    /// Units of the original multi-card draw not yet attempted.
     pub remaining: u32,
-    /// Running total of cards actually delivered across every already-completed
-    /// unit — committed to `state.last_effect_count` once `remaining` reaches 0.
     pub accumulated: u32,
+}
+
+/// Identifies one draw-instruction frame within [`DrawSequenceStack`].
+///
+/// Frames are addressed by ID, never by position: a resume that arrives after a
+/// pause must prove it is resuming the frame it parked, not merely "whatever is
+/// on top now". Between the park and the resume a nested instruction (CR 616.1g)
+/// may have been pushed and popped above it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct DrawSequenceFrameId(pub u64);
+
+/// CR 121.2: "Cards may only be drawn one at a time. If a player is instructed to
+/// draw multiple cards, that player performs that many individual card draws."
+///
+/// One frame is one *draw instruction* in flight — the unit of a `Draw N`, not of
+/// a single card. It survives a pause (a per-unit replacement choice: Dredge,
+/// Notion Thief, Hullbreacher, a Miracle reveal) so the remaining individual
+/// draws resume against exactly this instruction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DrawSequenceFrame {
+    pub frame_id: DrawSequenceFrameId,
+    pub player: PlayerId,
+    /// CR 121.6b: individual draws of this instruction not yet attempted. "If an
+    /// effect replaces a draw within a sequence of card draws, the replacement
+    /// effect is completed before resuming the sequence."
+    pub remaining: u32,
+    /// CR 608.2c: running total of cards ACTUALLY delivered across every
+    /// completed unit of this instruction. This is the value a later "that many"
+    /// clause on the same card reads ("Draw two cards, then discard that many") —
+    /// "later text on the card may modify the meaning of earlier text". Committed
+    /// to `state.last_effect_count` exactly once, when the instruction completes,
+    /// so the chained clause sees the true total across the WHOLE instruction and
+    /// not just the last unit. A unit whose draw was replaced by something else
+    /// (Dredge) contributes 0; a unit doubled by a count modifier contributes its
+    /// post-replacement count.
+    pub accumulated: u32,
+}
+
+/// CR 121.2 + CR 616.1g: the stack of draw instructions in flight.
+///
+/// A stack rather than a single slot because a replacement applied to one
+/// instruction's individual draw may itself perform a draw (CR 616.1g: "one
+/// replacement or prevention effect may apply to an event, and another may apply
+/// to an event contained within the first event"). The inner instruction must run
+/// to completion and then resume the outer one.
+///
+/// The predecessor of this type was a single `Option<PendingMultiDraw>` slot,
+/// which could not represent that nesting: a substituted inner draw overwrote the
+/// outer instruction's frame and its remaining units were silently lost.
+///
+/// Invariants, enforced by [`DrawSequenceStack::validate`]:
+///   * every `frame_id` is distinct and `< next_frame_id`;
+///   * `next_frame_id` never rewinds, so a stale [`DrawSequenceFrameId`] from an
+///     abandoned frame can never alias a live one.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DrawSequenceStack {
+    frames: Vec<DrawSequenceFrame>,
+    next_frame_id: u64,
+}
+
+impl DrawSequenceStack {
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    /// The instruction currently being executed — the innermost one.
+    pub fn active(&self) -> Option<&DrawSequenceFrame> {
+        self.frames.last()
+    }
+
+    pub fn active_mut(&mut self) -> Option<&mut DrawSequenceFrame> {
+        self.frames.last_mut()
+    }
+
+    /// The active frame, but only if it is the one the caller parked.
+    ///
+    /// CR 616.1g: a resume must address its own instruction. If a nested
+    /// instruction is still above this one, the outer frame is not resumable yet
+    /// and this returns `None` rather than letting the outer resume run against
+    /// the inner frame's cursor.
+    pub fn active_if(&mut self, frame_id: DrawSequenceFrameId) -> Option<&mut DrawSequenceFrame> {
+        self.frames
+            .last_mut()
+            .filter(|frame| frame.frame_id == frame_id)
+    }
+
+    /// Push a new instruction and return its ID. Monotonic: the allocator never
+    /// rewinds, so an ID from a popped frame is never reissued.
+    pub fn push(&mut self, player: PlayerId, count: u32) -> DrawSequenceFrameId {
+        let frame_id = DrawSequenceFrameId(self.next_frame_id);
+        self.next_frame_id += 1;
+        self.frames.push(DrawSequenceFrame {
+            frame_id,
+            player,
+            remaining: count,
+            accumulated: 0,
+        });
+        frame_id
+    }
+
+    /// Pop the active instruction, which must be `frame_id`.
+    pub fn pop(&mut self, frame_id: DrawSequenceFrameId) -> Option<DrawSequenceFrame> {
+        if self.frames.last()?.frame_id != frame_id {
+            return None;
+        }
+        self.frames.pop()
+    }
+
+    /// CR 800.4a: abandon every in-flight instruction (player departure).
+    ///
+    /// The allocator deliberately does NOT rewind: a [`DrawSequenceFrameId`]
+    /// captured before the abandonment must never alias a frame allocated after
+    /// it, or a stale resume would drive the wrong instruction.
+    pub fn abandon_all(&mut self) {
+        self.frames.clear();
+    }
+
+    /// CR 104.4b: loop-equality projection — compares game *position*, not history.
+    ///
+    /// Two states that differ only in how many draw frames the game has allocated
+    /// over its lifetime are the same position, so the monotonic `next_frame_id`
+    /// allocator and the per-frame `frame_id` (both pure identity) are excluded.
+    /// What remains is exactly what the predecessor `Option<PendingMultiDraw>`
+    /// compared: who is drawing, how many units are owed, how many have landed.
+    ///
+    /// This must NOT be the derived `PartialEq`. Comparing the allocator would
+    /// mean two identical positions never compare equal, and CR 104.4b loop
+    /// detection would silently stop firing — a failure invisible to every draw
+    /// test, surfacing only as "the engine no longer draws a mandatory loop".
+    /// `GameState`'s hand-curated `PartialEq` already excludes the other
+    /// identity-bearing state (`transient_continuous_effects`,
+    /// `resolution_source_relatch`) for the same reason.
+    pub(crate) fn loop_equal(&self, other: &Self) -> bool {
+        self.frames.len() == other.frames.len()
+            && self.frames.iter().zip(&other.frames).all(|(a, b)| {
+                a.player == b.player && a.remaining == b.remaining && a.accumulated == b.accumulated
+            })
+    }
+
+    /// Returns `Err` describing the first broken invariant, if any.
+    pub fn validate(&self) -> Result<(), String> {
+        let mut seen = std::collections::HashSet::new();
+        for frame in &self.frames {
+            if frame.frame_id.0 >= self.next_frame_id {
+                return Err(format!(
+                    "draw frame {:?} is at or above the allocator {} — a stale ID can alias a live frame",
+                    frame.frame_id, self.next_frame_id
+                ));
+            }
+            if !seen.insert(frame.frame_id) {
+                return Err(format!("duplicate draw frame id {:?}", frame.frame_id));
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -8893,7 +9049,8 @@ impl GameState {
             post_replacement_token_choice_applied: None,
             post_replacement_token_substitution_count: None,
             pending_connive_reentry: None,
-            pending_multi_draw: None,
+            draw_sequences: DrawSequenceStack::default(),
+            legacy_pending_multi_draw: None,
             pending_life_total_assignment: None,
             pending_spell_resolution: None,
             pending_mutate_merge: None,
@@ -9387,6 +9544,31 @@ impl GameState {
         }
     }
 
+    /// CR 121.2: Migrate the legacy single-slot `pending_multi_draw` save shape
+    /// into [`Self::draw_sequences`] as a one-frame stack. Idempotent — a no-op
+    /// once the legacy slot is empty (the steady state after one post-load hop).
+    /// Called from `finalize_public_state` alongside
+    /// [`Self::migrate_post_replacement_continuation`], so every deserialize
+    /// boundary (engine-wasm restore, multiplayer host resume, gamePersistence
+    /// rehydration) migrates without per-callsite plumbing.
+    ///
+    /// A legacy save can only ever have recorded ONE in-flight instruction, so it
+    /// converts to exactly one frame. Nesting (CR 616.1g) that the old shape could
+    /// not record is not invented here.
+    pub fn migrate_pending_multi_draw(&mut self) {
+        let Some(legacy) = self.legacy_pending_multi_draw.take() else {
+            return;
+        };
+        // A canonical stack already present wins: the legacy slot is stale.
+        if !self.draw_sequences.is_empty() {
+            return;
+        }
+        let frame_id = self.draw_sequences.push(legacy.player, legacy.remaining);
+        if let Some(frame) = self.draw_sequences.active_if(frame_id) {
+            frame.accumulated = legacy.accumulated;
+        }
+    }
+
     /// CR 104.4b: a cheap pre-filter fingerprint of loop-mutable state. It need
     /// NOT be complete — a confirmation pass (`loop_states_equal`) deep-compares
     /// before any draw, so a fingerprint collision can never cause a wrongful
@@ -9614,7 +9796,10 @@ impl PartialEq for GameState {
             && self.priority_pass_count == other.priority_pass_count
             && self.pending_replacement == other.pending_replacement
             && self.pending_connive_reentry == other.pending_connive_reentry
-            && self.pending_multi_draw == other.pending_multi_draw
+            // CR 104.4b: position, not history — see `DrawSequenceStack::loop_equal`.
+            // Comparing the stack structurally would fold the monotonic frame-ID
+            // allocator into loop equality and silently disable loop detection.
+            && self.draw_sequences.loop_equal(&other.draw_sequences)
             && self.pending_life_total_assignment == other.pending_life_total_assignment
             && self.pending_spell_resolution == other.pending_spell_resolution
             && self.deferred_entry_events == other.deferred_entry_events

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6602,54 +6602,36 @@ pub struct GameState {
     /// `post_replacement_resolved_effect` fields were merged here. Old saved
     /// JSON migrates via `migrate_post_replacement_continuation`, called from
     /// `finalize_public_state`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub post_replacement_continuation: Option<crate::types::ability::PostReplacementContinuation>,
+    #[serde(default, skip_serializing_if = "PostReplacementDrainStack::is_empty")]
+    pub post_replacement_drains: PostReplacementDrainStack,
+
     /// Pre-2026-05-09 audit M4 compat: legacy template slot. Read from old
-    /// JSON only; migrated into `post_replacement_continuation` by
+    /// JSON only; migrated into `post_replacement_drains` by
     /// `migrate_post_replacement_continuation`. Never written to.
     #[serde(default, skip_serializing, rename = "post_replacement_effect")]
     pub(crate) legacy_post_replacement_effect:
         Option<Box<crate::types::ability::AbilityDefinition>>,
     /// Pre-2026-05-09 audit M4 compat: legacy resolved slot. Read from old
-    /// JSON only; migrated into `post_replacement_continuation` by
+    /// JSON only; migrated into `post_replacement_drains` by
     /// `migrate_post_replacement_continuation`. Never written to.
     #[serde(default, skip_serializing, rename = "post_replacement_resolved_effect")]
     pub(crate) legacy_post_replacement_resolved_effect:
         Option<Box<crate::types::ability::ResolvedAbility>>,
 
-    /// CR 615.5: Source object of the replacement that stashed
-    /// `post_replacement_continuation`. Used by prevention follow-ups (e.g.
-    /// Phyrexian Hydra) so the post-effect's `SelfRef`-targeted PutCounter
-    /// resolves against the shield's own object rather than the damaged target.
-    /// Set alongside `post_replacement_continuation` and consumed at the same
-    /// time.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub post_replacement_source: Option<crate::types::identifiers::ObjectId>,
-
-    /// CR 614.5 + CR 616.1f: replacement identities already applied to the
-    /// event that produced a deferred post-replacement continuation.
-    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
-    pub post_replacement_applied: HashSet<AppliedReplacementKey>,
-
-    /// CR 615.5 + CR 609.7: Source object of the *prevented event itself*
-    /// (e.g. the damage dealer in a damage-prevention replacement) — distinct
-    /// from `post_replacement_source` (which is the replacement's own source,
-    /// e.g. Swans of Bryn Argoll). Used by `TargetFilter::PostReplacementSourceController`
-    /// to resolve "the source's controller draws cards" / "deals damage to the
-    /// source's controller" follow-ups. Architectural twin of `last_effect_count`
-    /// (the quantity-side post-replacement fallback at `replacement.rs:317`):
-    /// both stash event context that lives outside the trigger window. Set
-    /// only at the prevention applier's `Prevented` arm; cleared at every
-    /// other set-site of `post_replacement_source` and at every consume-site.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub post_replacement_event_source: Option<crate::types::identifiers::ObjectId>,
-
-    /// CR 615.5: Target of the prevented event itself. Used by
-    /// `TargetFilter::PostReplacementDamageTarget` for follow-ups like
-    /// "that player exiles that many cards" after damage to a player is
-    /// prevented and replaced.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub post_replacement_event_target: Option<crate::types::ability::TargetRef>,
+    /// Legacy flat save shape for the drain's companion values, superseded by the
+    /// fields inside [`PostReplacementDrain`]. Read from old JSON only; folded
+    /// into the resident drain by `migrate_post_replacement_continuation`.
+    #[serde(default, skip_serializing, rename = "post_replacement_continuation")]
+    pub(crate) legacy_post_replacement_continuation:
+        Option<crate::types::ability::PostReplacementContinuation>,
+    #[serde(default, skip_serializing, rename = "post_replacement_source")]
+    pub(crate) legacy_post_replacement_source: Option<crate::types::identifiers::ObjectId>,
+    #[serde(default, skip_serializing, rename = "post_replacement_applied")]
+    pub(crate) legacy_post_replacement_applied: HashSet<AppliedReplacementKey>,
+    #[serde(default, skip_serializing, rename = "post_replacement_event_source")]
+    pub(crate) legacy_post_replacement_event_source: Option<crate::types::identifiers::ObjectId>,
+    #[serde(default, skip_serializing, rename = "post_replacement_event_target")]
+    pub(crate) legacy_post_replacement_event_target: Option<crate::types::ability::TargetRef>,
 
     /// CR 614.6 + CR 616.1: When an optional CreateToken replacement defers a
     /// `ChooseOneOf` post-effect (Jinnie Fay class), the chosen branch's token
@@ -8408,6 +8390,210 @@ pub struct PendingConniveReentry {
     pub applied: HashSet<AppliedReplacementKey>,
 }
 
+/// CR 614.12a + CR 615.5: a post-replacement continuation and every value that is
+/// consumed with it — one record, installed and drained as a unit.
+///
+/// These five values used to be five parallel `GameState` fields. They were
+/// written by three different install paths, none of which set all five, and the
+/// teardown had to remember to null each one by hand. `elimination.rs` still
+/// carries the scar of that design: *"this field was added after the teardown
+/// block below was written and was missed until this regression."* Bundling them
+/// makes "a continuation is pending" one fact instead of an invariant maintained
+/// by hand across ~40 sites.
+/// CR 614.12a: where a drain is in its lifecycle.
+///
+/// The continuation and the drain do not die together, and that is load-bearing.
+/// A drain's *event context* (CR 615.5 — the prevented event's source and target)
+/// must stay readable while its continuation runs: that is how
+/// `TargetFilter::PostReplacementSourceController` resolves "the source's
+/// controller draws cards" (Swans of Bryn Argoll). But the continuation itself
+/// must already be gone, so a nested "is a continuation pending?" check taken
+/// during the dispatch sees none and does not re-drain it.
+///
+/// The old single slot expressed this by taking the continuation early and
+/// clearing the event fields late — an interleaving that no type enforced and
+/// every caller had to respect. Here it is a state transition:
+/// `Ready(work)` → `Dispatching` → popped.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum DrainStatus {
+    /// Not yet run. `Template` is an AST resolved against `source`; `Resolved`
+    /// carries targets captured at shield-install time.
+    Ready(crate::types::ability::PostReplacementContinuation),
+    /// Taken and running. The drain stays resident so the running effect can still
+    /// read its event context (CR 615.5).
+    Dispatching,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PostReplacementDrain {
+    /// CR 614.12a: the work to run, and whether it has been taken yet.
+    pub status: DrainStatus,
+
+    /// CR 615.5: the replacement's own source (Swans of Bryn Argoll), so a
+    /// `SelfRef`-targeted post-effect resolves against the shield rather than the
+    /// damaged object.
+    ///
+    /// `Option` *inside* the drain, not a parallel field: several paths
+    /// deliberately clear the source while the continuation stays resident
+    /// (CR 614.12a — a zone change's caller epilogue drains with the
+    /// spell-resolution ctx and no source).
+    pub source: Option<crate::types::identifiers::ObjectId>,
+
+    /// CR 614.5 + CR 616.1f: replacement identities already applied to the event
+    /// that produced this continuation, so a def cannot fire twice on it.
+    pub applied: HashSet<AppliedReplacementKey>,
+
+    /// CR 615.5 + CR 609.7: source of the *prevented event itself* (the damage
+    /// dealer), distinct from `source` (the shield). Resolves
+    /// `TargetFilter::PostReplacementSourceController` — "the source's controller
+    /// draws cards".
+    pub event_source: Option<crate::types::identifiers::ObjectId>,
+
+    /// CR 615.5: target of the prevented event itself, for
+    /// `TargetFilter::PostReplacementDamageTarget`.
+    pub event_target: Option<crate::types::ability::TargetRef>,
+}
+
+/// CR 616.1g: what an install does when a continuation is already resident.
+///
+/// This is an explicit parameter because the three production install paths
+/// genuinely disagree today, and a refactor that silently picked one would change
+/// behaviour:
+///
+///   * [`Self::KeepResident`] — `apply_single_replacement`'s stash: the *incoming*
+///     continuation is discarded.
+///   * [`Self::Replace`] — the optional accept/decline path and the combat
+///     prevention riders: the *resident* continuation is overwritten.
+///
+/// Both are lossy, in opposite directions. Neither can be right in general —
+/// CR 616.1g explicitly contemplates one replacement applying to an event
+/// contained within another, so a resident continuation and an incoming one are
+/// both real work and a single slot can hold only one.
+///
+/// Naming them is the point: today the policy is an accident of where the
+/// assignment happens to sit. Once the stack can hold both (nesting), this enum
+/// goes away.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResidentDrainPolicy {
+    KeepResident,
+    Replace,
+}
+
+/// CR 614.12a + CR 616.1g: the post-replacement continuations awaiting a drain.
+///
+/// Depth is currently capped at one by [`ResidentDrainPolicy`] — this type
+/// reproduces the old single-slot behaviour exactly. It is a stack so that
+/// nesting can be turned on as an isolated, reviewable change rather than as a
+/// side effect of the bundling.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PostReplacementDrainStack {
+    drains: Vec<PostReplacementDrain>,
+}
+
+impl PostReplacementDrain {
+    /// A ready drain carrying only a continuation — no source, no inherited applied
+    /// set, no prevented-event context. The shape the combat prevention riders and
+    /// most test setups want.
+    pub fn ready(continuation: crate::types::ability::PostReplacementContinuation) -> Self {
+        Self {
+            status: DrainStatus::Ready(continuation),
+            source: None,
+            applied: HashSet::new(),
+            event_source: None,
+            event_target: None,
+        }
+    }
+
+    /// The continuation, if it has not been taken for dispatch yet.
+    pub fn ready_continuation(
+        &self,
+    ) -> Option<&crate::types::ability::PostReplacementContinuation> {
+        match &self.status {
+            DrainStatus::Ready(continuation) => Some(continuation),
+            DrainStatus::Dispatching => None,
+        }
+    }
+}
+
+impl PostReplacementDrainStack {
+    pub fn is_empty(&self) -> bool {
+        self.drains.is_empty()
+    }
+
+    /// CR 614.12a: is there a continuation that has not run yet?
+    ///
+    /// A `Dispatching` drain does NOT count: its continuation is already running,
+    /// and a nested check taken during that dispatch must not try to re-drain it.
+    /// This is exactly what `post_replacement_continuation.is_some()` meant, since
+    /// the old code took the continuation out of the slot before dispatching.
+    pub fn has_ready(&self) -> bool {
+        self.drains
+            .iter()
+            .any(|drain| matches!(drain.status, DrainStatus::Ready(_)))
+    }
+
+    /// The innermost drain, whatever its status. Event-context reads (CR 615.5)
+    /// go through here, because they must still resolve while it is `Dispatching`.
+    pub fn resident(&self) -> Option<&PostReplacementDrain> {
+        self.drains.last()
+    }
+
+    pub fn resident_mut(&mut self) -> Option<&mut PostReplacementDrain> {
+        self.drains.last_mut()
+    }
+
+    /// Install `drain`, resolving a collision with any resident one per `policy`.
+    ///
+    /// Returns `false` when the incoming drain was discarded (`KeepResident` onto
+    /// an occupied stack), so a caller can distinguish "installed" from "silently
+    /// dropped" — something the old `stash_post_replacement_continuation` could not.
+    pub fn install(&mut self, drain: PostReplacementDrain, policy: ResidentDrainPolicy) -> bool {
+        match policy {
+            ResidentDrainPolicy::KeepResident if !self.drains.is_empty() => false,
+            ResidentDrainPolicy::KeepResident => {
+                self.drains.push(drain);
+                true
+            }
+            ResidentDrainPolicy::Replace => {
+                self.drains.pop();
+                self.drains.push(drain);
+                true
+            }
+        }
+    }
+
+    /// CR 614.12a: take the resident continuation and mark the drain `Dispatching`,
+    /// leaving it resident so the running effect can still read its event context.
+    ///
+    /// Returns `None` if there is no resident drain, or its continuation was
+    /// already taken.
+    pub fn begin_dispatch(&mut self) -> Option<crate::types::ability::PostReplacementContinuation> {
+        let drain = self.drains.last_mut()?;
+        match std::mem::replace(&mut drain.status, DrainStatus::Dispatching) {
+            DrainStatus::Ready(continuation) => Some(continuation),
+            // Already dispatching: put the status back and report no work. Restoring
+            // it matters — `Dispatching` is not idempotent state to overwrite.
+            DrainStatus::Dispatching => {
+                drain.status = DrainStatus::Dispatching;
+                None
+            }
+        }
+    }
+
+    /// Pop the drain whose continuation has finished dispatching.
+    pub fn finish_dispatch(&mut self) -> Option<PostReplacementDrain> {
+        if matches!(self.drains.last()?.status, DrainStatus::Dispatching) {
+            return self.drains.pop();
+        }
+        None
+    }
+
+    /// CR 800.4a: abandon every pending continuation (player departure).
+    pub fn abandon_all(&mut self) {
+        self.drains.clear();
+    }
+}
+
 /// Legacy pre-`DrawSequenceStack` save shape: the single in-flight multi-card
 /// draw. Deserialize-only — [`GameState::migrate_pending_multi_draw`] converts it
 /// into a one-frame [`DrawSequenceStack`]. No production writer remains.
@@ -9039,13 +9225,14 @@ impl GameState {
             liminal_entries: HashMap::new(),
             pending_liminal_entry_resume: None,
             replacement_may_cost_paused: false,
-            post_replacement_continuation: None,
+            post_replacement_drains: PostReplacementDrainStack::default(),
             legacy_post_replacement_effect: None,
             legacy_post_replacement_resolved_effect: None,
-            post_replacement_source: None,
-            post_replacement_applied: HashSet::new(),
-            post_replacement_event_source: None,
-            post_replacement_event_target: None,
+            legacy_post_replacement_continuation: None,
+            legacy_post_replacement_source: None,
+            legacy_post_replacement_applied: HashSet::new(),
+            legacy_post_replacement_event_source: None,
+            legacy_post_replacement_event_target: None,
             post_replacement_token_choice_applied: None,
             post_replacement_token_substitution_count: None,
             pending_connive_reentry: None,
@@ -9528,20 +9715,130 @@ impl GameState {
     /// plumbing. The Resolved arm wins when both legacy slots are
     /// (impossibly) populated, mirroring the pre-fold dispatcher precedence
     /// at `engine_replacement.rs::apply_pending_post_replacement_effect`.
+    /// CR 614.12a: is a post-replacement continuation waiting to drain?
+    ///
+    /// The scattered `post_replacement_continuation.is_some()` checks this replaces
+    /// were asking exactly this: is there work that has NOT been taken yet. A drain
+    /// that is mid-dispatch does not count — the old slot was already empty at that
+    /// point, because the continuation had been moved out of it before dispatching.
+    pub fn has_post_replacement_drain(&self) -> bool {
+        self.post_replacement_drains.has_ready()
+    }
+
+    /// CR 614.12a: install a ready continuation carrying no source, no inherited
+    /// applied set and no prevented-event context.
+    ///
+    /// Policy is `Replace` — the shape the combat prevention riders use, which have
+    /// always overwritten a resident continuation rather than deferring to it.
+    pub fn install_ready_continuation(
+        &mut self,
+        continuation: crate::types::ability::PostReplacementContinuation,
+    ) {
+        self.post_replacement_drains.install(
+            PostReplacementDrain::ready(continuation),
+            ResidentDrainPolicy::Replace,
+        );
+    }
+
+    /// CR 614.12a: the resident drain's continuation, if it has not been taken for
+    /// dispatch yet.
+    pub fn post_replacement_continuation(
+        &self,
+    ) -> Option<&crate::types::ability::PostReplacementContinuation> {
+        self.post_replacement_drains
+            .resident()
+            .and_then(|drain| drain.ready_continuation())
+    }
+
+    /// CR 615.5: the resident drain's replacement source (the shield's own object).
+    pub fn post_replacement_source(&self) -> Option<crate::types::identifiers::ObjectId> {
+        self.post_replacement_drains
+            .resident()
+            .and_then(|drain| drain.source)
+    }
+
+    /// CR 615.5 + CR 609.7: the resident drain's *prevented-event* source — the
+    /// damage dealer, not the shield.
+    pub fn post_replacement_event_source(&self) -> Option<crate::types::identifiers::ObjectId> {
+        self.post_replacement_drains
+            .resident()
+            .and_then(|drain| drain.event_source)
+    }
+
+    /// CR 615.5: the resident drain's prevented-event target.
+    pub fn post_replacement_event_target(&self) -> Option<&crate::types::ability::TargetRef> {
+        self.post_replacement_drains
+            .resident()
+            .and_then(|drain| drain.event_target.as_ref())
+    }
+
+    /// CR 614.12a: clear the resident drain's replacement source while leaving the
+    /// continuation itself resident.
+    ///
+    /// A real thing several callers need, not a convenience: a zone change's
+    /// caller epilogue drains with the spell-resolution ctx and must not resolve
+    /// `SelfRef` against the replacement's source.
+    pub fn clear_post_replacement_source(&mut self) {
+        if let Some(drain) = self.post_replacement_drains.resident_mut() {
+            drain.source = None;
+        }
+    }
+
     pub fn migrate_post_replacement_continuation(&mut self) {
-        if self.post_replacement_continuation.is_some() {
+        // The canonical stack wins outright: every legacy slot is stale.
+        if !self.post_replacement_drains.is_empty() {
             self.legacy_post_replacement_effect = None;
             self.legacy_post_replacement_resolved_effect = None;
+            self.legacy_post_replacement_continuation = None;
+            self.legacy_post_replacement_source = None;
+            self.legacy_post_replacement_applied.clear();
+            self.legacy_post_replacement_event_source = None;
+            self.legacy_post_replacement_event_target = None;
             return;
         }
-        if let Some(resolved) = self.legacy_post_replacement_resolved_effect.take() {
-            self.post_replacement_continuation =
-                Some(crate::types::ability::PostReplacementContinuation::Resolved(resolved));
-            self.legacy_post_replacement_effect = None;
-        } else if let Some(template) = self.legacy_post_replacement_effect.take() {
-            self.post_replacement_continuation =
-                Some(crate::types::ability::PostReplacementContinuation::Template(template));
-        }
+
+        // The continuation itself comes from whichever generation of the save
+        // recorded it. The Resolved arm wins when both pre-fold slots are
+        // (impossibly) populated, mirroring the pre-fold dispatcher precedence.
+        let continuation = self
+            .legacy_post_replacement_continuation
+            .take()
+            .or_else(|| {
+                self.legacy_post_replacement_resolved_effect
+                    .take()
+                    .map(crate::types::ability::PostReplacementContinuation::Resolved)
+            })
+            .or_else(|| {
+                self.legacy_post_replacement_effect
+                    .take()
+                    .map(crate::types::ability::PostReplacementContinuation::Template)
+            });
+        self.legacy_post_replacement_effect = None;
+        self.legacy_post_replacement_resolved_effect = None;
+
+        let Some(continuation) = continuation else {
+            // No continuation means the companion values are orphans; drop them
+            // rather than leaving them to bleed into an unrelated later drain.
+            self.legacy_post_replacement_source = None;
+            self.legacy_post_replacement_applied.clear();
+            self.legacy_post_replacement_event_source = None;
+            self.legacy_post_replacement_event_target = None;
+            return;
+        };
+
+        self.post_replacement_drains.install(
+            PostReplacementDrain {
+                // A legacy save recorded a continuation that had not run, so it
+                // deserializes as `Ready`. A save can never have captured one
+                // mid-dispatch: the old slot was emptied before dispatching.
+                status: DrainStatus::Ready(continuation),
+                source: self.legacy_post_replacement_source.take(),
+                applied: std::mem::take(&mut self.legacy_post_replacement_applied),
+                event_source: self.legacy_post_replacement_event_source.take(),
+                event_target: self.legacy_post_replacement_event_target.take(),
+            },
+            ResidentDrainPolicy::Replace,
+        );
     }
 
     /// CR 121.2: Migrate the legacy single-slot `pending_multi_draw` save shape
@@ -11757,12 +12054,12 @@ mod tests {
         let serialized = serde_json::to_string(&snapshot).unwrap();
         let mut state: GameState = serde_json::from_str(&serialized).unwrap();
         // Pre-migration: legacy slot populated, unified slot empty.
-        assert!(state.post_replacement_continuation.is_none());
+        assert!(!state.has_post_replacement_drain());
         assert!(state.legacy_post_replacement_effect.is_some());
 
         state.migrate_post_replacement_continuation();
 
-        match state.post_replacement_continuation {
+        match state.post_replacement_continuation() {
             Some(PostReplacementContinuation::Template(ref def)) => {
                 assert_eq!(**def, template);
             }
@@ -11795,12 +12092,12 @@ mod tests {
 
         let serialized = serde_json::to_string(&snapshot).unwrap();
         let mut state: GameState = serde_json::from_str(&serialized).unwrap();
-        assert!(state.post_replacement_continuation.is_none());
+        assert!(!state.has_post_replacement_drain());
         assert!(state.legacy_post_replacement_resolved_effect.is_some());
 
         state.migrate_post_replacement_continuation();
 
-        match state.post_replacement_continuation {
+        match state.post_replacement_continuation() {
             Some(PostReplacementContinuation::Resolved(ref boxed)) => {
                 assert_eq!(**boxed, resolved);
             }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -8441,6 +8441,23 @@ pub struct PostReplacementDrain {
 
     /// CR 614.5 + CR 616.1f: replacement identities already applied to the event
     /// that produced this continuation, so a def cannot fire twice on it.
+    ///
+    /// This lives INSIDE the drain rather than beside it, and that is a deliberate
+    /// call backed by a census of the field's every use before the bundling
+    /// (`git grep post_replacement_applied d1f7d05ea8`, 7 sites):
+    ///
+    ///   * exactly ONE read — `apply_pending_post_replacement_effect`'s
+    ///     `std::mem::take`, which IS the drain;
+    ///   * both writes sit with a continuation install (`stash_*`, and the optional
+    ///     accept/decline branch);
+    ///   * both clears pair with one too — `combat_damage.rs`'s clear is the line
+    ///     immediately before the continuation it is zeroing the set *for*, and the
+    ///     optional branch's clear pairs with that branch installing no continuation.
+    ///
+    /// So the set never lives without a drain and is never read except at drain
+    /// time. It is co-owned, not merely co-located. (The reading that it has an
+    /// independent lifecycle comes from looking at the *instant* of the
+    /// `combat_damage` clear rather than its *purpose*; that reading is wrong.)
     pub applied: HashSet<AppliedReplacementKey>,
 
     /// CR 615.5 + CR 609.7: source of the *prevented event itself* (the damage
@@ -8465,14 +8482,42 @@ pub struct PostReplacementDrain {
 ///   * [`Self::Replace`] — the optional accept/decline path and the combat
 ///     prevention riders: the *resident* continuation is overwritten.
 ///
-/// Both are lossy, in opposite directions. Neither can be right in general —
-/// CR 616.1g explicitly contemplates one replacement applying to an event
-/// contained within another, so a resident continuation and an incoming one are
-/// both real work and a single slot can hold only one.
-///
 /// Naming them is the point: today the policy is an accident of where the
-/// assignment happens to sit. Once the stack can hold both (nesting), this enum
-/// goes away.
+/// assignment happens to sit.
+///
+/// # `KeepResident` is currently correct BY ACCIDENT. Read this before "fixing" it.
+///
+/// Discarding the incoming continuation looks like a plain bug, and dropping it in
+/// favour of a real stack looks like the obvious fix. **It is not.** Instrumenting
+/// every collision across the full suite finds exactly two live occupants, and in
+/// both the discarded continuation is *byte-identical to the resident one*:
+///
+///   * Wolverine, Fierce Fighter — `RemoveAllDamage { target: SelfRef }`, stashed
+///     once per damage instance in a combat batch;
+///   * Krark's Thumb — `FlipCoins { count: Multiply { 2, EventContextAmount } }`.
+///
+/// So the discard is *accidentally de-duplicating*: the same replacement's
+/// continuation is stashed twice and the second is dropped, so the effect runs
+/// once — which is right. **Letting the stack nest naively runs both: Wolverine
+/// heals twice, Krark's Thumb doubles twice.** No pin covers that.
+///
+/// The slot is conflating two different rules:
+///
+///   * CR 614.5 — a replacement "gets only one opportunity to affect an event or
+///     any modified events that may replace that event": the SAME definition
+///     arriving twice must be suppressed.
+///   * CR 616.1g — "one replacement or prevention effect may apply to an event, and
+///     another may apply to an event contained within the first event": a DIFFERENT
+///     definition on a contained event must nest.
+///
+/// A blind "is the slot occupied?" test satisfies the first by accident (for
+/// today's occupants) while destroying the second (which has no occupant today).
+///
+/// The fix therefore gates on the **identity of the replacement**, not the
+/// **occupancy of the slot**: suppress when the incoming `ReplacementId` is already
+/// in the event's `applied` set (CR 614.5), nest otherwise (CR 616.1g). Those two
+/// cards are the regression tests — Wolverine must heal once, Krark must double
+/// once. Tracked in GitHub issue #5676.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResidentDrainPolicy {
     KeepResident,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -8390,7 +8390,7 @@ pub struct PendingConniveReentry {
     pub applied: HashSet<AppliedReplacementKey>,
 }
 
-/// CR 614.12a + CR 615.5: a post-replacement continuation and every value that is
+/// CR 614.6 + CR 615.5: a post-replacement continuation and every value that is
 /// consumed with it — one record, installed and drained as a unit.
 ///
 /// These five values used to be five parallel `GameState` fields. They were
@@ -8400,7 +8400,7 @@ pub struct PendingConniveReentry {
 /// block below was written and was missed until this regression."* Bundling them
 /// makes "a continuation is pending" one fact instead of an invariant maintained
 /// by hand across ~40 sites.
-/// CR 614.12a: where a drain is in its lifecycle.
+/// CR 615.5: where a drain is in its lifecycle.
 ///
 /// The continuation and the drain do not die together, and that is load-bearing.
 /// A drain's *event context* (CR 615.5 — the prevented event's source and target)
@@ -8426,7 +8426,7 @@ pub enum DrainStatus {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PostReplacementDrain {
-    /// CR 614.12a: the work to run, and whether it has been taken yet.
+    /// The work to run, and whether it has been taken yet.
     pub status: DrainStatus,
 
     /// CR 615.5: the replacement's own source (Swans of Bryn Argoll), so a
@@ -8435,7 +8435,7 @@ pub struct PostReplacementDrain {
     ///
     /// `Option` *inside* the drain, not a parallel field: several paths
     /// deliberately clear the source while the continuation stays resident
-    /// (CR 614.12a — a zone change's caller epilogue drains with the
+    /// (a zone change's caller epilogue drains with the
     /// spell-resolution ctx and no source).
     pub source: Option<crate::types::identifiers::ObjectId>,
 
@@ -8524,7 +8524,7 @@ pub enum ResidentDrainPolicy {
     Replace,
 }
 
-/// CR 614.12a + CR 616.1g: the post-replacement continuations awaiting a drain.
+/// CR 616.1g: the post-replacement continuations awaiting a drain.
 ///
 /// Depth is currently capped at one by [`ResidentDrainPolicy`] — this type
 /// reproduces the old single-slot behaviour exactly. It is a stack so that
@@ -8565,7 +8565,7 @@ impl PostReplacementDrainStack {
         self.drains.is_empty()
     }
 
-    /// CR 614.12a: is there a continuation that has not run yet?
+    /// Is there a continuation that has not run yet?
     ///
     /// A `Dispatching` drain does NOT count: its continuation is already running,
     /// and a nested check taken during that dispatch must not try to re-drain it.
@@ -8589,12 +8589,27 @@ impl PostReplacementDrainStack {
 
     /// Install `drain`, resolving a collision with any resident one per `policy`.
     ///
-    /// Returns `false` when the incoming drain was discarded (`KeepResident` onto
-    /// an occupied stack), so a caller can distinguish "installed" from "silently
-    /// dropped" — something the old `stash_post_replacement_continuation` could not.
+    /// Returns `false` when the incoming drain was discarded (`KeepResident` while
+    /// another continuation is still *pending*), so a caller can distinguish
+    /// "installed" from "silently dropped" — something the old
+    /// `stash_post_replacement_continuation` could not.
+    ///
+    /// `KeepResident` collides on [`Self::has_ready`], **not** on
+    /// `!drains.is_empty()`, and the difference is a real bug rather than a
+    /// nicety. A drain stays resident while it *dispatches* (its event context must
+    /// remain readable — CR 615.5), but its continuation has already been taken, so
+    /// it is no longer pending work. The predecessor slot expressed this by moving
+    /// the continuation out before dispatching: the slot then read empty, and a
+    /// re-entrant stash landed.
+    ///
+    /// CR 616.1g: that re-entrant stash is real. A running continuation draws, the
+    /// draw is replaced, and the replacement carries a mandatory post-effect (Jace,
+    /// Wielder of Mysteries' win; Abundance's reveal-until). Colliding on mere
+    /// residency drops it, and `draw_through_replacement` — which gates its drain on
+    /// `has_post_replacement_drain()`, i.e. on `has_ready()` — then never runs it.
     pub fn install(&mut self, drain: PostReplacementDrain, policy: ResidentDrainPolicy) -> bool {
         match policy {
-            ResidentDrainPolicy::KeepResident if !self.drains.is_empty() => false,
+            ResidentDrainPolicy::KeepResident if self.has_ready() => false,
             ResidentDrainPolicy::KeepResident => {
                 self.drains.push(drain);
                 true
@@ -8607,7 +8622,7 @@ impl PostReplacementDrainStack {
         }
     }
 
-    /// CR 614.12a: take the resident continuation and mark the drain `Dispatching`,
+    /// CR 615.5: take the resident continuation and mark the drain `Dispatching`,
     /// leaving it resident so the running effect can still read its event context.
     ///
     /// Returns `None` if there is no resident drain, or its continuation was
@@ -8616,12 +8631,9 @@ impl PostReplacementDrainStack {
         let drain = self.drains.last_mut()?;
         match std::mem::replace(&mut drain.status, DrainStatus::Dispatching) {
             DrainStatus::Ready(continuation) => Some(continuation),
-            // Already dispatching: put the status back and report no work. Restoring
-            // it matters — `Dispatching` is not idempotent state to overwrite.
-            DrainStatus::Dispatching => {
-                drain.status = DrainStatus::Dispatching;
-                None
-            }
+            // Already dispatching: report no work. The `mem::replace` above has
+            // already written `Dispatching` back, so there is nothing to restore.
+            DrainStatus::Dispatching => None,
         }
     }
 
@@ -8744,6 +8756,11 @@ impl DrawSequenceStack {
             remaining: count,
             accumulated: 0,
         });
+        debug_assert!(
+            self.validate().is_ok(),
+            "draw-sequence stack invariant broken after push: {:?}",
+            self.validate()
+        );
         frame_id
     }
 
@@ -9760,7 +9777,7 @@ impl GameState {
     /// plumbing. The Resolved arm wins when both legacy slots are
     /// (impossibly) populated, mirroring the pre-fold dispatcher precedence
     /// at `engine_replacement.rs::apply_pending_post_replacement_effect`.
-    /// CR 614.12a: is a post-replacement continuation waiting to drain?
+    /// Is a post-replacement continuation waiting to drain?
     ///
     /// The scattered `post_replacement_continuation.is_some()` checks this replaces
     /// were asking exactly this: is there work that has NOT been taken yet. A drain
@@ -9770,7 +9787,7 @@ impl GameState {
         self.post_replacement_drains.has_ready()
     }
 
-    /// CR 614.12a: install a ready continuation carrying no source, no inherited
+    /// Install a ready continuation carrying no source, no inherited
     /// applied set and no prevented-event context.
     ///
     /// Policy is `Replace` — the shape the combat prevention riders use, which have
@@ -9785,7 +9802,7 @@ impl GameState {
         );
     }
 
-    /// CR 614.12a: the resident drain's continuation, if it has not been taken for
+    /// The resident drain's continuation, if it has not been taken for
     /// dispatch yet.
     pub fn post_replacement_continuation(
         &self,
@@ -9817,7 +9834,7 @@ impl GameState {
             .and_then(|drain| drain.event_target.as_ref())
     }
 
-    /// CR 614.12a: clear the resident drain's replacement source while leaving the
+    /// Clear the resident drain's replacement source while leaving the
     /// continuation itself resident.
     ///
     /// A real thing several callers need, not a convenience: a zone change's
@@ -10349,6 +10366,97 @@ impl Eq for GameState {}
 /// serialized `WaitingFor::SeparatePiles*` states).
 fn default_pile_source_battlefield() -> PileSource {
     PileSource::Battlefield
+}
+
+#[cfg(test)]
+mod drain_stack_reentrancy_tests {
+    use super::*;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, Effect, PostReplacementContinuation,
+    };
+
+    fn ready_drain(name: &str) -> PostReplacementDrain {
+        PostReplacementDrain::ready(PostReplacementContinuation::Template(Box::new(
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::unimplemented(name, "drain-reentrancy fixture"),
+            ),
+        )))
+    }
+
+    /// CR 616.1g: a continuation that is RUNNING must not block a new one from
+    /// being installed.
+    ///
+    /// A drain stays resident while it dispatches (its event context must remain
+    /// readable — CR 615.5). But its continuation has already been taken, so it is
+    /// no longer *pending work*. If the running continuation causes a fresh
+    /// replacement to stash a post-effect — a continuation draws, that draw is
+    /// replaced, and the replacement carries a mandatory post-effect (Jace Wielder
+    /// of Mysteries' win, Abundance's reveal-until) — that post-effect MUST install.
+    ///
+    /// The predecessor slot got this right for the wrong reason: it moved the
+    /// continuation out of the slot before dispatching, so the slot read empty and
+    /// the re-entrant stash landed. Guarding the stack on "is a drain resident?"
+    /// instead of "is a drain READY?" silently drops it, and the nested post-effect
+    /// never runs — `draw_through_replacement` gates its drain on
+    /// `has_post_replacement_drain()`, which reports only Ready drains.
+    ///
+    /// The correct predicate is the one `has_ready` already documents.
+    #[test]
+    fn keep_resident_does_not_drop_a_stash_arriving_while_the_outer_drain_dispatches() {
+        let mut stack = PostReplacementDrainStack::default();
+
+        // Outer replacement stashes its continuation, then begins running it.
+        assert!(stack.install(ready_drain("outer"), ResidentDrainPolicy::KeepResident));
+        let taken = stack.begin_dispatch();
+        assert!(
+            taken.is_some(),
+            "the outer continuation is handed out to run"
+        );
+
+        // The outer drain is still resident (its CR 615.5 event context must stay
+        // readable) but it is no longer pending work.
+        assert!(!stack.is_empty(), "the dispatching drain stays resident");
+        assert!(
+            !stack.has_ready(),
+            "a Dispatching drain is not pending work — this is what the old slot's \
+             emptiness stood for"
+        );
+
+        // The running continuation now causes a fresh replacement to stash a
+        // mandatory post-effect. It MUST install; dropping it strands the post-effect.
+        let installed = stack.install(ready_drain("nested"), ResidentDrainPolicy::KeepResident);
+        assert!(
+            installed,
+            "a stash arriving while the outer continuation is DISPATCHING must install, \
+             not be dropped: the old code took the continuation out of the slot before \
+             dispatching, so the slot read empty and this landed. Guarding on \
+             `!drains.is_empty()` instead of `has_ready()` silently strands every nested \
+             mandatory post-effect (Jace win, Abundance reveal-until)."
+        );
+        assert!(
+            stack.has_ready(),
+            "the nested post-effect must be visible as pending work — \
+             draw_through_replacement gates its drain on exactly this predicate"
+        );
+    }
+
+    /// The dedup that `KeepResident` performs BY ACCIDENT is on a READY resident,
+    /// and must survive the fix above. (Wolverine / Krark's Thumb — see the
+    /// `ResidentDrainPolicy` docs and issue #5676.)
+    #[test]
+    fn keep_resident_still_drops_a_stash_arriving_while_a_ready_drain_is_pending() {
+        let mut stack = PostReplacementDrainStack::default();
+        assert!(stack.install(ready_drain("first"), ResidentDrainPolicy::KeepResident));
+        let dropped = !stack.install(ready_drain("second"), ResidentDrainPolicy::KeepResident);
+        assert!(
+            dropped,
+            "a stash arriving while a READY continuation is still pending is still \
+             discarded — that is the pre-existing accidental CR 614.5 dedup the \
+             Wolverine and Krark witnesses depend on. Task #39 replaces it with an \
+             identity gate; this fix must not prejudge that."
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/tests/integration/boon_reflection_gain_life_drain.rs
+++ b/crates/engine/tests/integration/boon_reflection_gain_life_drain.rs
@@ -11,7 +11,7 @@
 //!      modifiers and returned the GainLife AST.
 //!   3. `apply_life_gain` Execute arm did NOT drain — only the Prevented arm
 //!      called `drain_substitution_continuation`.
-//!   4. The Template sat in `state.post_replacement_continuation` and drained
+//!   4. The Template sat in `state.post_replacement_continuation()` and drained
 //!      on the next zone-change / land-play as a phantom GainLife on the
 //!      wrong player. Same defect class as the Jace WinTheGame leak.
 //!
@@ -74,10 +74,10 @@ fn boon_reflection_doubles_gain_and_does_not_leak_continuation() {
     // The load-bearing assertion: a leaked Template here is the latent
     // GainLife class's analogue of the Jace empty-library win bug.
     assert!(
-        runner.state().post_replacement_continuation.is_none(),
+        runner.state().post_replacement_continuation().is_none(),
         "GainLife → GainLife amount-substitution must not leak a \
          post-replacement continuation; found {:?}",
-        runner.state().post_replacement_continuation
+        runner.state().post_replacement_continuation()
     );
 }
 
@@ -110,9 +110,9 @@ fn boon_reflection_two_sequential_gains_do_not_compound_or_leak() {
             .expect("first life gain must resolve");
     assert_eq!(first, 4, "first gain doubles to 4");
     assert!(
-        runner.state().post_replacement_continuation.is_none(),
+        runner.state().post_replacement_continuation().is_none(),
         "first gain must not leak a continuation; found {:?}",
-        runner.state().post_replacement_continuation
+        runner.state().post_replacement_continuation()
     );
 
     let second =
@@ -120,9 +120,9 @@ fn boon_reflection_two_sequential_gains_do_not_compound_or_leak() {
             .expect("second life gain must resolve");
     assert_eq!(second, 10, "second gain doubles to 10");
     assert!(
-        runner.state().post_replacement_continuation.is_none(),
+        runner.state().post_replacement_continuation().is_none(),
         "second gain must not leak a continuation; found {:?}",
-        runner.state().post_replacement_continuation
+        runner.state().post_replacement_continuation()
     );
 
     assert_eq!(

--- a/crates/engine/tests/integration/draw_from_general_post_replacement.rs
+++ b/crates/engine/tests/integration/draw_from_general_post_replacement.rs
@@ -458,3 +458,97 @@ fn new_way_forward_combat(db: &CardDatabase, shield: Shield) -> CombatDeltas {
         p1_library_delta: library_len(runner.state(), P1) as i64 - p1_library_before as i64,
     }
 }
+
+/// END-TO-END regression witness for the `install(KeepResident)` guard.
+///
+/// This is the full path the unit tests in `drain_stack_reentrancy_tests` model at
+/// the API level, driven through real cards and the real pipeline:
+///
+/// ```text
+/// combat damage -> Swans prevention -> apply_pending_post_replacement_effect
+///   -> begin_dispatch            (Swans' drain is now resident + DISPATCHING)
+///   -> Swans' continuation DRAWS for the damage source's controller (P1)
+///     -> draw_through_replacement -> replace_event
+///       -> Jace, Wielder of Mysteries matches (P1's library is empty)
+///         -> apply_single_replacement stashes its MANDATORY post-effect (WinTheGame)
+///           -> install(KeepResident)   <-- the seam under test
+/// ```
+///
+/// The stash arrives while Swans' drain is resident but **already dispatching**.
+/// Guarding the install on `!drains.is_empty()` drops it, `draw_through_replacement`
+/// (which gates its drain on `has_ready()`) then never runs it, and **P1 never wins**.
+/// The predecessor slot installed it, because the continuation had been moved out of
+/// the slot before dispatching and the slot read empty.
+///
+/// Jace's replacement is `mode: Mandatory` with `execute: WinTheGame` — verified from
+/// the card data, not recalled. It is exactly the "nested mandatory post-effect" class
+/// the fix exists for.
+///
+/// CR 616.1g + CR 615.5 + CR 104.2a.
+#[test]
+fn nested_mandatory_post_effect_runs_when_a_dispatching_continuation_draws() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0 draws normally; only P1's library is empty, so only P1's draw is replaced.
+    scenario.with_library_top(P0, &["Card A", "Card B", "Card C", "Card D", "Card E"]);
+
+    let swans = scenario
+        .add_creature_from_oracle(P0, "Swans of Bryn Argoll", 4, 3, SWANS_TEXT)
+        .id();
+
+    // P1 blocks with a reach creature (Swans has flying). Its damage to Swans is
+    // prevented, and Swans' CR 615.5 rider draws that many for the SOURCE's
+    // controller — P1.
+    let blocker = scenario
+        .add_creature_from_oracle(P1, "Canopy Sentinel", 3, 5, "Reach")
+        .id();
+
+    // P1's library is EMPTY and P1 controls Jace, so P1's very first drawn card is
+    // replaced by "you win the game instead".
+    scenario.add_real_card(P1, "Jace, Wielder of Mysteries", Zone::Battlefield, db);
+
+    let mut runner = scenario.build();
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(swans, AttackTarget::Player(P1))])
+        .expect("P0 attacks with Swans");
+    advance_to_declare_blockers(&mut runner);
+    runner
+        .declare_blockers(&[(blocker, swans)])
+        .expect("P1 blocks Swans with the 3/5 reach creature");
+
+    assert!(
+        runner.state().players[1].library.is_empty(),
+        "precondition: P1's library must be empty, or Jace's replacement never matches \
+         and this test proves nothing"
+    );
+
+    runner.combat_damage();
+    runner.advance_until_stack_empty();
+
+    // The nested mandatory post-effect ran: P1 won.
+    //
+    // Before the `has_ready()` fix this assertion failed — the stash arrived while
+    // Swans' drain was Dispatching, `install(KeepResident)` dropped it on
+    // `!drains.is_empty()`, and WinTheGame never executed.
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::GameOver {
+                winner: Some(PlayerId(1)),
+                ..
+            }
+        ),
+        "P1 must win: Swans' prevention rider draws for P1, P1's library is empty, and \
+         Jace, Wielder of Mysteries replaces that draw with a MANDATORY WinTheGame. \
+         Dropping the re-entrant stash strands that post-effect and P1 never wins — \
+         exactly the regression the has_ready() guard fixes. got {:?}",
+        runner.state().waiting_for
+    );
+}

--- a/crates/engine/tests/integration/jace_wielder_empty_library_win.rs
+++ b/crates/engine/tests/integration/jace_wielder_empty_library_win.rs
@@ -87,10 +87,10 @@ fn jace_draw_from_nonempty_library_does_not_win_and_does_not_leak() {
     // post-replacement continuation. A leaked `WinTheGame` continuation is what
     // drained against the wrong player on a later turn in the bug report.
     assert!(
-        runner.state().post_replacement_continuation.is_none(),
+        runner.state().post_replacement_continuation().is_none(),
         "a non-empty draw must NOT leak a stashed post-replacement continuation; \
          found {:?}",
-        runner.state().post_replacement_continuation
+        runner.state().post_replacement_continuation()
     );
 }
 
@@ -137,9 +137,9 @@ fn jace_draw_from_empty_library_wins() {
     // CR 704.3: the continuation must drain in the same resolution step — no
     // leak into the next priority pass.
     assert!(
-        runner.state().post_replacement_continuation.is_none(),
+        runner.state().post_replacement_continuation().is_none(),
         "post_replacement_continuation must drain in the same step; found {:?}",
-        runner.state().post_replacement_continuation
+        runner.state().post_replacement_continuation()
     );
 }
 
@@ -186,9 +186,9 @@ fn laboratory_maniac_draw_from_empty_library_wins() {
         "the replaced draw never happens (CR 614.6); empty-library flag must stay false"
     );
     assert!(
-        runner.state().post_replacement_continuation.is_none(),
+        runner.state().post_replacement_continuation().is_none(),
         "post_replacement_continuation must drain in the same step; found {:?}",
-        runner.state().post_replacement_continuation
+        runner.state().post_replacement_continuation()
     );
 }
 
@@ -242,8 +242,8 @@ fn jace_natural_draw_step_from_empty_library_wins() {
         "the replaced draw never happens (CR 614.6); empty-library flag must stay false"
     );
     assert!(
-        runner.state().post_replacement_continuation.is_none(),
+        runner.state().post_replacement_continuation().is_none(),
         "post_replacement_continuation must drain in the same step; found {:?}",
-        runner.state().post_replacement_continuation
+        runner.state().post_replacement_continuation()
     );
 }

--- a/crates/engine/tests/integration/swans_prevention_followup.rs
+++ b/crates/engine/tests/integration/swans_prevention_followup.rs
@@ -18,10 +18,14 @@
 //! CR 121.1: A player draws a card by putting the top card of their library
 //!           into their hand.
 
+use std::collections::HashSet;
+
 use engine::game::effects;
 use engine::game::zones::create_object;
 use engine::types::ability::{Effect, QuantityExpr, QuantityRef, ResolvedAbility, TargetFilter};
-use engine::types::game_state::GameState;
+use engine::types::game_state::{
+    DrainStatus, GameState, PostReplacementDrain, ResidentDrainPolicy,
+};
 use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::player::PlayerId;
 use engine::types::zones::Zone;
@@ -52,11 +56,26 @@ fn swans_followup_draws_for_damage_sources_controller() {
         Zone::Battlefield,
     );
 
-    // Simulate the prevention applier's `Prevented` arm having stamped state:
+    // Simulate the state the prevention applier's `Prevented` arm leaves behind at
+    // the moment the follow-up runs:
     // - `last_effect_count` carries the prevented amount (1 damage)
-    // - `post_replacement_event_source` carries the damage source's id
+    // - the drain carries the damage source's id as its prevented-event source
+    //
+    // The drain is `Dispatching`, not `Ready`: production reaches this point with
+    // the continuation already taken (it is the thing currently running) but its
+    // event context still readable, which is exactly what
+    // `PostReplacementSourceController` reads below.
     state.last_effect_count = Some(1);
-    state.post_replacement_event_source = Some(damage_source);
+    state.post_replacement_drains.install(
+        PostReplacementDrain {
+            status: DrainStatus::Dispatching,
+            source: None,
+            applied: HashSet::new(),
+            event_source: Some(damage_source),
+            event_target: None,
+        },
+        ResidentDrainPolicy::Replace,
+    );
 
     let p1_hand_before = state.players[1].hand.len();
     let p0_hand_before = state.players[0].hand.len();

--- a/crates/mtgish-import/src/convert/replacement.rs
+++ b/crates/mtgish-import/src/convert/replacement.rs
@@ -7,8 +7,8 @@
 
 use engine::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, ChoiceType, ContinuousModification, ControllerRef,
-    DamageModification, DamageTargetFilter, DamageTargetPlayerScope, Effect, EffectScope,
-    FilterProp, ManaReplacementScope, QuantityExpr, QuantityModification, QuantityRef,
+    DamageModification, DamageTargetFilter, DamageTargetPlayerScope, DrawReplacementScope, Effect,
+    EffectScope, FilterProp, ManaReplacementScope, QuantityExpr, QuantityModification, QuantityRef,
     ReplacementCondition, ReplacementDefinition, ReplacementMode, RestrictionExpiry,
     TapStateChange, TargetFilter, TypedFilter,
 };
@@ -73,6 +73,7 @@ pub fn convert_as_enters(
         out.push(ReplacementDefinition {
             expiry: None,
             event: ReplacementEvent::ChangeZone,
+            draw_scope: None,
             execute: Some(Box::new(exec)),
             runtime_execute: None,
             mode,
@@ -155,6 +156,7 @@ pub fn convert_replace_would_enter(
         out.push(ReplacementDefinition {
             expiry: None,
             event: ReplacementEvent::ChangeZone,
+            draw_scope: None,
             execute: Some(Box::new(exec)),
             runtime_execute: None,
             mode,
@@ -220,6 +222,7 @@ pub fn convert_replace_would_deal_damage(
         out.push(ReplacementDefinition {
             expiry: None,
             event: ReplacementEvent::DamageDone,
+            draw_scope: None,
             execute: None,
             runtime_execute: None,
             mode: Default::default(),
@@ -596,6 +599,19 @@ pub fn convert_replace_would_draw(
         out.push(ReplacementDefinition {
             expiry: None,
             event: ReplacementEvent::Draw,
+            // CR 121.2 + CR 121.2a: the scope follows the Forge event variant and is
+            // NOT one constant. A count-form antecedent ("would draw one or more /
+            // two or more cards") is the instruction-level hook CR 121.2a modifies
+            // "before considering any of the individual card draws"; a singular
+            // antecedent ("would draw a card", the draw step, a cycling draw) is one
+            // individual draw. Same rule the Oracle parser applies.
+            draw_scope: Some(match event {
+                ReplacableEventWouldDraw::APlayerWouldDrawOneOrMoreCards(_)
+                | ReplacableEventWouldDraw::APlayerWouldDrawTwoOrMoreCards(_) => {
+                    DrawReplacementScope::InstructionCount
+                }
+                _ => DrawReplacementScope::IndividualDraw,
+            }),
             execute: Some(Box::new(exec)),
             runtime_execute: None,
             mode: Default::default(),
@@ -721,6 +737,7 @@ pub fn convert_replace_would_put_into_graveyard(
         out.push(ReplacementDefinition {
             expiry: None,
             event: ReplacementEvent::Moved,
+            draw_scope: None,
             execute: Some(Box::new(exec)),
             runtime_execute: None,
             mode: Default::default(),
@@ -971,6 +988,7 @@ pub fn convert_as_put_into_graveyard_from_anywhere(
         out.push(ReplacementDefinition {
             expiry: None,
             event: ReplacementEvent::Moved,
+            draw_scope: None,
             execute: Some(Box::new(exec)),
             runtime_execute: None,
             mode: Default::default(),
@@ -1061,6 +1079,7 @@ pub fn convert_replace_would_put_counters(
         out.push(ReplacementDefinition {
             expiry: None,
             event: ReplacementEvent::AddCounter,
+            draw_scope: None,
             execute: None,
             runtime_execute: None,
             mode: Default::default(),
@@ -1245,6 +1264,7 @@ pub fn convert_replace_would_gain_life(
         out.push(ReplacementDefinition {
             expiry: None,
             event: ReplacementEvent::GainLife,
+            draw_scope: None,
             execute: None,
             runtime_execute: None,
             mode: Default::default(),
@@ -1363,6 +1383,7 @@ fn try_build_may_cost_pair(
     Ok(Some(ReplacementDefinition {
         expiry: None,
         event: ReplacementEvent::ChangeZone,
+        draw_scope: None,
         execute: execute.map(Box::new),
         runtime_execute: None,
         mode: ReplacementMode::MayCost {

--- a/scripts/draw_replacement_census.py
+++ b/scripts/draw_replacement_census.py
@@ -304,6 +304,32 @@ def corpus_rows(export: dict) -> list[tuple[str, ...]]:
             nested_draw = any(
                 d.get("type") == "Draw" and "count" in d for d in walk(execute)
             )
+
+            # The scope column stopped being an aspiration the day the engine
+            # started emitting `draw_scope`. Two INDEPENDENT derivations must now
+            # agree: what the producer declared at construction (`emitted`), and
+            # what this script derives from the definition's shape (`required`).
+            #
+            # Checking only that the field is present would be vacuous — a producer
+            # that defaulted every Draw to IndividualDraw would sail through. The
+            # cross-check is what makes a wrong scope a build failure, and it is the
+            # whole reason the scope is declared rather than inferred at match time.
+            required = classify_scope(card, repl)
+            emitted = repl.get("draw_scope")
+            if emitted is None:
+                raise ClassificationError(
+                    f"{card}: Draw replacement has no `draw_scope` (CR 121.2 requires "
+                    f"every Draw definition to declare its scope at construction; "
+                    f"expected {required!r}). A producer is not setting it."
+                )
+            if emitted != required:
+                raise ClassificationError(
+                    f"{card}: producer declared draw_scope={emitted!r} but the "
+                    f"definition's shape requires {required!r} (CR 121.2a). Either the "
+                    f"producer is wrong, or this card is a shape the classifier has "
+                    f"not been taught."
+                )
+
             rows.append(
                 (
                     card,
@@ -312,7 +338,7 @@ def corpus_rows(export: dict) -> list[tuple[str, ...]]:
                     str(qm or "none"),
                     effect.get("type", "none") if execute else "none",
                     "nested-draw" if nested_draw else "-",
-                    classify_scope(card, repl),
+                    required,
                 )
             )
     return sorted(rows)


### PR DESCRIPTION
- **refactor(engine): make draw delivery a frame-addressed sequence (Plan 03 / 2b)**
- **docs(engine): cite CR 608.2c, not CR 609.3, for the multi-draw running total**
- **refactor(engine): own the post-replacement continuation in a drain stack (Plan 03 / 2c-1)**
- **feat(engine): declare a DrawReplacementScope on every Draw replacement (Plan 03 / 2a)**
- **docs(engine): record why `applied` is drain-owned, and that KeepResident is right by accident**
- **fix(engine): install() must collide on has_ready(), not on residency (Plan 03 review)**
- **test(engine): end-to-end witness for the has_ready() install guard**
- **docs(engine): re-cite the last net-new CR 614.12a tags on continuation plumbing**
