### PR TITLE
fix(parser): keep dynamic "for each" scaling when a trailing type-addition follows

### DIFF
--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1546,9 +1546,23 @@ pub(crate) fn is_text_based_cost_prefix(lower_prefix: &str) -> bool {
 /// no boundary is present. Mirrors the keyword recognition in
 /// `extract_keyword_clause` but in the inverse direction (returns the
 /// pre-boundary span instead of the post-boundary one).
+/// Peel a trailing grant conjunct off a dynamic "for each <count>" clause so the
+/// count itself parses cleanly. Strips a trailing keyword grant (" and has
+/// flying") and — CR 205.1b — a trailing type-addition (" and is an Avatar in
+/// addition to its other types"). The peeled clause is recovered separately by
+/// the caller (`extract_keyword_clause` / `parse_additive_type_clause_modifications`
+/// over the full description); without this the count parse fails on the tail and
+/// the whole dynamic pump collapses to a fixed +N/+M (Avatar Destiny, Machinist's
+/// Arsenal). The type-addition arm is guarded on the "in addition to" marker so a
+/// genuine "<count> and is <...>" count phrase is never mis-truncated.
 pub(crate) fn strip_trailing_keyword_clause(clause: &str) -> &str {
     for needle in [" and gains ", " and gain ", " and has ", " and have "] {
         if let Some(pos) = clause.find(needle) {
+            return &clause[..pos];
+        }
+    }
+    if let Some(pos) = clause.find(" and is ") {
+        if clause[pos..].contains("in addition to") {
             return &clause[..pos];
         }
     }

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1561,10 +1561,22 @@ pub(crate) fn strip_trailing_keyword_clause(clause: &str) -> &str {
             return &clause[..pos];
         }
     }
-    if let Some(pos) = clause.find(" and is ") {
-        if clause[pos..].contains("in addition to") {
-            return &clause[..pos];
-        }
+    // CR 205.1b: peel a trailing type-addition (" and is an Avatar in addition
+    // to its other types"), guarded on the "in addition to " tail so a genuine
+    // "<count> and is <...>" count phrase is never mis-truncated. Mirrors the
+    // type-addition grammar in `type_change.rs`: scan word boundaries for the
+    // "and is " verb boundary whose remainder reaches " in addition to ", and
+    // return the span preceding it. `clause` is already lowercase (caller passes
+    // `after_for_each.lower`), so tags match directly.
+    if let Some((before, _)) = nom_primitives::scan_split_at_phrase(clause, |i| {
+        (
+            tag::<_, _, OracleError<'_>>("and is "),
+            take_until::<_, _, OracleError<'_>>(" in addition to "),
+            tag::<_, _, OracleError<'_>>(" in addition to "),
+        )
+            .parse(i)
+    }) {
+        return before.trim_end();
     }
     clause
 }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -82,6 +82,37 @@ fn dynamic_for_each_pump_trailing_keyword_unchanged() {
     );
 }
 
+// CR 205.1b + CR 613.4c: when a "for each X" dynamic pump carries a trailing "and
+// is a <Subtype> in addition to its other types", the type-addition tail used to
+// break the count parse and collapse the whole pump to a FIXED +N/+M (Avatar
+// Destiny, Machinist's Arsenal). The count must still scale dynamically, and the
+// trailing subtype must still be added.
+#[test]
+fn dynamic_for_each_pump_with_trailing_type_keeps_dynamic_scaling() {
+    let defs = parse_static_line_multi(
+        "Enchanted creature gets +1/+1 for each creature card in your graveyard and is an Avatar in addition to its other types.",
+    );
+    assert_eq!(defs.len(), 1);
+    let mods = &defs[0].modifications;
+    assert!(
+        mods.iter()
+            .any(|m| matches!(m, ContinuousModification::AddDynamicPower { .. })),
+        "pump must stay DYNAMIC, not collapse to fixed +N/+M: {mods:?}"
+    );
+    assert!(
+        !mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::AddPower { .. })),
+        "must not emit a fixed AddPower: {mods:?}"
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddSubtype {
+            subtype: "Avatar".to_string()
+        }),
+        "trailing 'is an Avatar' dropped: {mods:?}"
+    );
+}
+
 /// CR 207.2c: an ability word is italic flavor with no rules meaning. A leading
 /// ability-word label on a subject-anchored static must be stripped so the static
 /// still parses; a leading label that is NOT a recognized ability word must be

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -87,6 +87,10 @@ fn dynamic_for_each_pump_trailing_keyword_unchanged() {
 // break the count parse and collapse the whole pump to a FIXED +N/+M (Avatar
 // Destiny, Machinist's Arsenal). The count must still scale dynamically, and the
 // trailing subtype must still be added.
+//
+// Avatar Destiny (Aura), exact Oracle text: the count is a graveyard
+// `ZoneCardCount` (creature cards in your graveyard), asserted by zone,
+// card_types, and scope — not merely "some dynamic pump".
 #[test]
 fn dynamic_for_each_pump_with_trailing_type_keeps_dynamic_scaling() {
     let defs = parse_static_line_multi(
@@ -94,22 +98,123 @@ fn dynamic_for_each_pump_with_trailing_type_keeps_dynamic_scaling() {
     );
     assert_eq!(defs.len(), 1);
     let mods = &defs[0].modifications;
+    // No fixed pump may survive — the whole point is the count stays dynamic.
     assert!(
-        mods.iter()
-            .any(|m| matches!(m, ContinuousModification::AddDynamicPower { .. })),
-        "pump must stay DYNAMIC, not collapse to fixed +N/+M: {mods:?}"
+        !mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddPower { .. } | ContinuousModification::AddToughness { .. }
+        )),
+        "must not emit a fixed AddPower/AddToughness: {mods:?}"
     );
-    assert!(
-        !mods
-            .iter()
-            .any(|m| matches!(m, ContinuousModification::AddPower { .. })),
-        "must not emit a fixed AddPower: {mods:?}"
+    let expected_qty = QuantityExpr::Ref {
+        qty: QuantityRef::ZoneCardCount {
+            zone: ZoneRef::Graveyard,
+            card_types: vec![TypeFilter::Creature],
+            scope: CountScope::Controller,
+            filter: None,
+        },
+    };
+    let power = mods
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::AddDynamicPower { value } => Some(value),
+            _ => None,
+        })
+        .expect("dynamic power pump must be present");
+    assert_eq!(
+        *power, expected_qty,
+        "power must scale by graveyard creatures"
     );
+    let toughness = mods
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::AddDynamicToughness { value } => Some(value),
+            _ => None,
+        })
+        .expect("dynamic toughness pump must be present");
+    assert_eq!(*toughness, expected_qty, "toughness must scale identically");
     assert!(
         mods.contains(&ContinuousModification::AddSubtype {
             subtype: "Avatar".to_string()
         }),
         "trailing 'is an Avatar' dropped: {mods:?}"
+    );
+}
+
+// CR 205.1b + CR 613.4c: the Equipment sibling of the above — Machinist's Arsenal,
+// exact Oracle text. Here the count is an `ObjectCount` over artifacts you
+// control (asserted by filter type and controller scope), and the trailing type
+// is Artificer. Proves the fix covers BOTH quantity classes the parse-diff
+// measured, not just Avatar's graveyard count.
+#[test]
+fn dynamic_for_each_pump_with_trailing_type_machinists_arsenal() {
+    let defs = parse_static_line_multi(
+        "Equipped creature gets +2/+2 for each artifact you control and is an Artificer in addition to its other types.",
+    );
+    assert_eq!(defs.len(), 1);
+    let mods = &defs[0].modifications;
+    assert!(
+        !mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddPower { .. } | ContinuousModification::AddToughness { .. }
+        )),
+        "must not emit a fixed AddPower/AddToughness: {mods:?}"
+    );
+    let power = mods
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::AddDynamicPower { value } => Some(value),
+            _ => None,
+        })
+        .expect("dynamic power pump must be present");
+    // Extract the ObjectCount count from either bare or "+N per" (Multiply-wrapped)
+    // dynamic pumps so the artifact filter + controller scope are asserted directly.
+    fn object_count_filter(value: &QuantityExpr) -> &TargetFilter {
+        let inner = match value {
+            // "+2/+2 for each" scales at 2 per artifact → Multiply(2, ObjectCount).
+            QuantityExpr::Multiply { factor, inner } => {
+                assert_eq!(*factor, 2, "must scale at +2 per artifact");
+                inner.as_ref()
+            }
+            other => other,
+        };
+        let QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { filter },
+        } = inner
+        else {
+            panic!("count must be an ObjectCount, got {inner:?}");
+        };
+        filter
+    }
+    let power_filter = object_count_filter(power);
+    let TargetFilter::Typed(tf) = power_filter else {
+        panic!("ObjectCount filter must be a Typed artifact filter, got {power_filter:?}");
+    };
+    assert_eq!(tf.type_filters, vec![TypeFilter::Artifact]);
+    assert_eq!(
+        tf.controller,
+        Some(ControllerRef::You),
+        "must count artifacts YOU control, got {:?}",
+        tf.controller
+    );
+    // Toughness scales by the identical count.
+    let toughness = mods
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::AddDynamicToughness { value } => Some(value),
+            _ => None,
+        })
+        .expect("dynamic toughness pump must be present");
+    assert_eq!(
+        object_count_filter(toughness),
+        power_filter,
+        "toughness must scale by the same artifact count as power"
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddSubtype {
+            subtype: "Artificer".to_string()
+        }),
+        "trailing 'is an Artificer' dropped: {mods:?}"
     );
 }
 


### PR DESCRIPTION
CR 205.1b + CR 613.4c

## Bug

A dynamic "gets +N/+M **for each** X **and is a `<Subtype>` in addition to its other types**" pump collapsed to a **fixed** +N/+M. The trailing type-addition tail stayed on the count clause and broke `parse_for_each_clause_expr`, so the whole pump fell through to the fixed-pump path — the wrong power/toughness:

- **Avatar Destiny** — "Enchanted creature gets +1/+1 for each creature card in your graveyard and is an Avatar in addition to its other types."
- **Machinist's Arsenal** — "Equipped creature gets +2/+2 for each artifact you control and is an Artificer in addition to its other types."

Both emitted `AddPower`/`AddToughness` (fixed) instead of `AddDynamicPower`/`AddDynamicToughness`. (Verified: the same counts parse dynamically when the trailing clause is absent.)

## Fix

`strip_trailing_keyword_clause` — which already peels a trailing keyword grant (" and has flying") off the for-each count so the count parses — now also peels a trailing " and is `<...>` in addition to its other types" type-addition, **guarded on the "in addition to" marker** so a genuine "`<count>` and is `<...>`" count phrase is never truncated. The count then parses dynamically, and the trailing subtype is recovered by the existing `parse_additive_type_clause_modifications` pass (added in #5621).

This completes the for-each trailing-conjunct handling: #5621 recovered the trailing subtype/quoted-ability when the count already parsed (counter-based, Reaper's Scythe); this recovers the **dynamic scaling itself** when the tail was breaking the count (object-count, Avatar Destiny / Machinist's Arsenal).

## Why it's the right seam / minimal blast radius

- One authority: `strip_trailing_keyword_clause` is the shared for-each count-clause stripper (both for-each paths in anthem.rs use it), so both inherit the fix.
- The `" and is "` arm is gated on the type-addition marker; counter-based pumps (Reaper's Scythe) and keyword-only pumps (Claws of Valakut) are unchanged — regression-tested.

## Tests

- `dynamic_for_each_pump_with_trailing_type_keeps_dynamic_scaling` — Avatar Destiny → `AddDynamicPower` (NOT fixed `AddPower`) + `AddSubtype("Avatar")`.
- Full `parser::oracle_static::tests` (1060 passed, 0 failed), including the #5621 counter/keyword regression tests.

## CR verification

- **CR 205.1b** — "in addition to its other types" type-addition; **CR 613.4c** — layer-7c dynamic P/T (both verified in `docs/MagicCompRules.txt`).

## AI-contributor notes

- **Rules-correct:** the equipped/enchanted creature's power/toughness now scales with the count, not a fixed value.
- **Verified:** live-parsed Avatar Destiny / Machinist's Arsenal (dynamic recovered) and Reaper's Scythe / Claws of Valakut (unchanged) before/after; `cargo fmt`, CI-exact `clippy -p engine --all-targets --features proptest -D warnings`, and the full oracle_static module are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
