### PR TITLE
feat(engine): gate continuous statics on the top card of the library

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -1936,6 +1936,7 @@ fn legacy_static_condition(x: &StaticCondition) -> bool {
         | StaticCondition::OpponentPoisonAtLeast { .. }
         | StaticCondition::SpellCastWithVariantThisTurn { .. }
         | StaticCondition::SourceMatchesFilter { .. }
+        | StaticCondition::TopOfLibraryMatches { .. }
         | StaticCondition::UnlessPay { .. }
         | StaticCondition::SourceAttackingAlone
         | StaticCondition::SourceIsAttacking
@@ -6024,6 +6025,13 @@ fn rw_static_condition(x: &StaticCondition) -> RwProfile {
             reads_player_of(StateKind::JournalCast)
         }
         StaticCondition::SourceMatchesFilter { filter: _ } => reads_src_of(StateKind::ObjectPt),
+        // CR 401/402: reads the controller's library top card (contents + order).
+        // A draw/scry/surveil/mill/shuffle writes `HandLibrary`, so marking this
+        // gate as reading `HandLibrary` invalidates it whenever the library top
+        // can change — the correct dependency for a top-of-library static.
+        StaticCondition::TopOfLibraryMatches { filter: _ } => {
+            reads_player_of(StateKind::HandLibrary)
+        }
         StaticCondition::And { conditions } | StaticCondition::Or { conditions } => {
             let mut p = RwProfile::empty();
             for c in conditions {

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -3015,6 +3015,11 @@ fn scan_static_condition(x: &StaticCondition) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
+        StaticCondition::TopOfLibraryMatches { filter } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
         StaticCondition::RecipientMatchesFilter { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -4036,6 +4036,9 @@ fn fmt_static_condition(cond: &StaticCondition) -> String {
         SC::SourceIsHarnessed => "source is harnessed".into(),
         SC::SourceAttachedToCreature => "source is attached to a creature".into(),
         SC::SourceMatchesFilter { filter } => format!("source is {}", fmt_target(filter)),
+        SC::TopOfLibraryMatches { filter } => {
+            format!("top card of library is {}", fmt_target(filter))
+        }
         SC::RecipientMatchesFilter { filter } => format!("recipient is {}", fmt_target(filter)),
         SC::RecipientAttackingOwnerTarget { .. } => {
             "recipient is attacking its owner's target".into()
@@ -7448,6 +7451,9 @@ fn static_condition_feature(cond: &StaticCondition) -> (&'static str, FeatureSup
         StaticCondition::SourceAttachedToCreature => ("SourceAttachedToCreature", Handled),
         // SourceMatchesFilter resolved by layers::evaluate_condition (layers.rs:1104)
         StaticCondition::SourceMatchesFilter { .. } => ("SourceMatchesFilter", Handled),
+        // CR 401.1 + CR 401.5: top-of-library gate, resolved by
+        // layers::evaluate_condition_with_context against the controller's library top.
+        StaticCondition::TopOfLibraryMatches { .. } => ("TopOfLibraryMatches", Handled),
         StaticCondition::SourceIsPaired => ("SourceIsPaired", Handled),
         // CR 113.6b: evaluated by `layers::evaluate_condition` — checks source
         // object's zone against the specified zone. Runtime-handled.

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -151,10 +151,15 @@ pub(crate) fn resolve_search_continuation_attach_host(
 /// CR 701.24a: Shuffle a player's library using the game's seeded RNG.
 /// Reusable helper for auto-shuffle after zone moves to Library.
 pub fn shuffle_library(state: &mut GameState, player: PlayerId, events: &mut Vec<GameEvent>) {
-    let GameState { players, rng, .. } = state;
-    if let Some(p) = players.iter_mut().find(|p| p.id == player) {
-        crate::util::im_ext::shuffle_vector(&mut p.library, rng);
+    {
+        let GameState { players, rng, .. } = state;
+        if let Some(p) = players.iter_mut().find(|p| p.id == player) {
+            crate::util::im_ext::shuffle_vector(&mut p.library, rng);
+        }
     }
+    // CR 401.5 + CR 611.3a: shuffling changes the library's top card, so a
+    // `TopOfLibraryMatches` static must be re-evaluated (self-gated on liveness).
+    crate::game::layers::mark_layers_full_if_top_of_library_static_live(state);
     // CR 701.24a: Emit player-action event so trigger matchers can filter
     // by the identity of the shuffling player.
     events.push(GameEvent::PlayerPerformedAction {

--- a/crates/engine/src/game/effects/shuffle.rs
+++ b/crates/engine/src/game/effects/shuffle.rs
@@ -76,6 +76,14 @@ pub fn resolve(
         crate::util::im_ext::shuffle_vector(&mut player.library, rng);
     }
 
+    // CR 401.5 + CR 611.3a: shuffling reorders the library, changing its top
+    // card, so a continuous static gated on the top (`TopOfLibraryMatches`) must
+    // be re-evaluated. Only when the shuffle actually happened and such a static
+    // is live (the helper self-gates).
+    if !suppressed {
+        crate::game::layers::mark_layers_full_if_top_of_library_static_live(state);
+    }
+
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::Shuffle,
         source_id: ability.source_id,

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -584,6 +584,10 @@ pub(super) fn handle_resolution_choice(
             for &card_id in &bottom_cards {
                 player_state.library.push_back(card_id);
             }
+            // CR 401.5 + CR 611.3a: Scry reorders the library top directly (not
+            // through the zone-move seam), so a continuous `TopOfLibraryMatches`
+            // static must be re-evaluated — self-gated so it's a no-op otherwise.
+            crate::game::layers::mark_layers_full_if_top_of_library_static_live(state);
             ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
         }
         (
@@ -1906,6 +1910,10 @@ pub(super) fn handle_resolution_choice(
                         None => Some(Zone::Graveyard),
                     }
                 };
+                // CR 401.5 + CR 611.3a: Dig kept cards on top by editing the
+                // library directly, so a `TopOfLibraryMatches` static must be
+                // re-evaluated (self-gated on liveness).
+                crate::game::layers::mark_layers_full_if_top_of_library_static_live(state);
                 if let Some(zone) = move_unkept_to {
                     // CR 614.6 + CR 603.10a: route the unkept pile through the
                     // zone-change pipeline so a per-card `Moved` graveyard→exile
@@ -5065,6 +5073,10 @@ fn surveil_keep_on_top(
     for (index, &card_id) in top_cards.iter().enumerate() {
         player_state.library.insert(index, card_id);
     }
+    // CR 401.5 + CR 611.3a: Surveil keeps cards on top by editing the library
+    // directly (this shared helper backs every Surveil caller), so a
+    // `TopOfLibraryMatches` static must be re-evaluated — self-gated on liveness.
+    crate::game::layers::mark_layers_full_if_top_of_library_static_live(state);
 }
 
 fn resume_with_error_propagation(
@@ -5093,6 +5105,162 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::identifiers::CardId;
     use crate::types::player::PlayerId;
+
+    /// CR 401.5 + CR 611.3a production-path harness: a battlefield permanent whose
+    /// continuous static grants itself Flying as long as the top card of player
+    /// 0's library is black (Vampire Nocturnus). Library starts black-on-top over
+    /// white. Returns (state, permanent, black, white).
+    fn top_gated_flying_library_scenario() -> (GameState, ObjectId, ObjectId, ObjectId) {
+        use crate::types::ability::{
+            ContinuousModification, FilterProp, StaticCondition, StaticDefinition, TargetFilter,
+            TypedFilter,
+        };
+        use crate::types::card_type::CoreType;
+        use crate::types::keywords::Keyword;
+        use crate::types::mana::ManaColor;
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new_two_player(42);
+        let vampire = create_object(
+            &mut state,
+            CardId(10),
+            PlayerId(0),
+            "Vampire Nocturnus".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let def = StaticDefinition::new(StaticMode::Continuous)
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::AddKeyword {
+                    keyword: Keyword::Flying,
+                }])
+                .condition(StaticCondition::TopOfLibraryMatches {
+                    filter: TargetFilter::Typed(TypedFilter::default().properties(vec![
+                        FilterProp::HasColor {
+                            color: ManaColor::Black,
+                        },
+                    ])),
+                });
+            let obj = state.objects.get_mut(&vampire).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.static_definitions.push(def);
+        }
+        let black = create_object(
+            &mut state,
+            CardId(11),
+            PlayerId(0),
+            "Black Card".to_string(),
+            Zone::Library,
+        );
+        let white = create_object(
+            &mut state,
+            CardId(12),
+            PlayerId(0),
+            "White Card".to_string(),
+            Zone::Library,
+        );
+        state.objects.get_mut(&black).unwrap().color = vec![ManaColor::Black];
+        state.objects.get_mut(&white).unwrap().color = vec![ManaColor::White];
+        {
+            let p0 = state
+                .players
+                .iter_mut()
+                .find(|p| p.id == PlayerId(0))
+                .unwrap();
+            p0.library.retain(|&id| id != black && id != white);
+            p0.library.push_back(white);
+            p0.library.push_front(black); // CR 401.1: front() == top.
+        }
+        (state, vampire, black, white)
+    }
+
+    fn has_flying(state: &GameState, id: ObjectId) -> bool {
+        use crate::types::keywords::Keyword;
+        state
+            .objects
+            .get(&id)
+            .unwrap()
+            .has_keyword(&Keyword::Flying)
+    }
+
+    // CR 401.5 + CR 611.3a: Scry reorders the library top by editing the library
+    // directly (outside the zone-move seam); the top-gated static must recompute.
+    #[test]
+    fn scry_reorders_top_and_reevaluates_top_gated_static() {
+        let (mut state, vampire, black, white) = top_gated_flying_library_scenario();
+        crate::game::layers::flush_layers(&mut state);
+        assert!(has_flying(&state, vampire), "black top → Flying granted");
+
+        // Scry 2: keep white on top, black to the bottom.
+        let mut events = vec![];
+        handle_resolution_choice(
+            &mut state,
+            WaitingFor::ScryChoice {
+                player: PlayerId(0),
+                cards: vec![black, white],
+            },
+            GameAction::SelectCards { cards: vec![white] },
+            &mut events,
+        )
+        .expect("scry resolves");
+        crate::game::layers::flush_layers(&mut state);
+        assert!(
+            !has_flying(&state, vampire),
+            "white scryed to top → Flying must be recomputed away"
+        );
+    }
+
+    // CR 401.5 + CR 611.3a: the shared Surveil keep-on-top helper reorders the
+    // library top directly; the top-gated static must recompute.
+    #[test]
+    fn surveil_keep_on_top_reevaluates_top_gated_static() {
+        let (mut state, vampire, _black, white) = top_gated_flying_library_scenario();
+        crate::game::layers::flush_layers(&mut state);
+        assert!(has_flying(&state, vampire), "black top → Flying granted");
+
+        surveil_keep_on_top(&mut state, PlayerId(0), &[white]);
+        crate::game::layers::flush_layers(&mut state);
+        assert!(
+            !has_flying(&state, vampire),
+            "surveil kept white on top → Flying must be recomputed away"
+        );
+    }
+
+    // CR 401.5 + CR 611.3a: a Dig that keeps a card on top of the library edits the
+    // library directly (kept_destination == Library); the static must recompute.
+    #[test]
+    fn dig_kept_to_library_top_reevaluates_top_gated_static() {
+        let (mut state, vampire, black, white) = top_gated_flying_library_scenario();
+        crate::game::layers::flush_layers(&mut state);
+        assert!(has_flying(&state, vampire), "black top → Flying granted");
+
+        // Dig looks at [black, white]; keep white on top, rest to bottom.
+        let mut events = vec![];
+        handle_resolution_choice(
+            &mut state,
+            WaitingFor::DigChoice {
+                player: PlayerId(0),
+                library_owner: PlayerId(0),
+                cards: vec![black, white],
+                keep_count: 1,
+                up_to: false,
+                selectable_cards: vec![black, white],
+                kept_destination: Some(Zone::Library),
+                rest_destination: Some(Zone::Library),
+                source_id: None,
+                enter_tapped: false,
+            },
+            GameAction::SelectCards { cards: vec![white] },
+            &mut events,
+        )
+        .expect("dig resolves");
+        crate::game::layers::flush_layers(&mut state);
+        assert!(
+            !has_flying(&state, vampire),
+            "dig kept white on top → Flying must be recomputed away"
+        );
+    }
 
     #[test]
     fn land_nonland_guess_logs_without_persisting_a_source_label() {

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -880,6 +880,9 @@ fn static_condition_uses_object_population(condition: &StaticCondition) -> bool 
         | StaticCondition::SourceIsHarnessed
         | StaticCondition::SourceAttachedToCreature
         | StaticCondition::SourceMatchesFilter { .. }
+        // CR 401.1: reads the controller's LIBRARY top card, never battlefield
+        // population — a battlefield entry cannot change the library top.
+        | StaticCondition::TopOfLibraryMatches { .. }
         | StaticCondition::RecipientMatchesFilter { .. }
         | StaticCondition::SourceIsPaired
         | StaticCondition::SourceInZone { .. }
@@ -1009,6 +1012,9 @@ fn entered_object_perturbs_static_condition(
         | StaticCondition::SourceIsHarnessed
         | StaticCondition::SourceAttachedToCreature
         | StaticCondition::SourceMatchesFilter { .. }
+        // CR 401.1: reads the controller's LIBRARY top card, never battlefield
+        // population — a battlefield entry cannot change the library top.
+        | StaticCondition::TopOfLibraryMatches { .. }
         | StaticCondition::RecipientMatchesFilter { .. }
         | StaticCondition::SourceIsPaired
         | StaticCondition::SourceInZone { .. }
@@ -1334,6 +1340,25 @@ fn evaluate_condition_with_context(
             filter,
             &FilterContext::from_source(state, source_id),
         ),
+        // CR 401.1 + CR 401.5: True when the top card of the source controller's
+        // library (`library[0]`) matches `filter`. Resolves the specific top-card
+        // object and matches its printed characteristics — the filter is a plain
+        // color/type/subtype `TargetFilter` with no zone constraint, so a card in
+        // the (hidden) library zone matches on characteristics alone. Empty
+        // library → no top card → false.
+        StaticCondition::TopOfLibraryMatches { filter } => state
+            .players
+            .iter()
+            .find(|p| p.id == controller)
+            .and_then(|p| p.library.front())
+            .is_some_and(|&top_id| {
+                matches_target_filter(
+                    state,
+                    top_id,
+                    filter,
+                    &FilterContext::from_source(state, source_id),
+                )
+            }),
         StaticCondition::SourceIsPaired => state
             .objects
             .get(&source_id)
@@ -12125,6 +12150,110 @@ mod tests {
             &StaticCondition::SourceMatchesFilter { filter },
             PlayerId(0),
             creature,
+        ));
+    }
+
+    // CR 401.1 + CR 401.5: `TopOfLibraryMatches` gates a continuous static on the
+    // top card of the CONTROLLER's library matching a characteristic filter
+    // (Vampire Nocturnus "is black", Mul Daya Channelers "is a creature card").
+    // The library is hidden and off-battlefield, so the filter matches on the top
+    // card's printed characteristics alone (`library[0]` = the top). Discriminating:
+    // a non-matching top card, a different player's library, and an empty library
+    // all report false; only the matching controller's top card is true.
+    #[test]
+    fn top_of_library_matches_reads_controller_library_top() {
+        let mut state = setup();
+        // Source permanent controlled by player 0. Its identity is irrelevant —
+        // the gate reads player 0's LIBRARY, not the source's characteristics.
+        let source = make_creature(&mut state, "Vampire Nocturnus", 3, 3, PlayerId(0));
+
+        // Top card of player 0's library: a black creature card.
+        let top = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Top Card".to_string(),
+            Zone::Library,
+        );
+        {
+            let obj = state.objects.get_mut(&top).unwrap();
+            obj.card_types.core_types = vec![CoreType::Creature];
+            obj.color = vec![ManaColor::Black];
+        }
+        {
+            let p0 = state
+                .players
+                .iter_mut()
+                .find(|p| p.id == PlayerId(0))
+                .unwrap();
+            p0.library.retain(|&id| id != top);
+            p0.library.push_front(top); // CR 401.1: front() == library[0] == top.
+        }
+
+        let black = StaticCondition::TopOfLibraryMatches {
+            filter: TargetFilter::Typed(TypedFilter::default().properties(vec![
+                FilterProp::HasColor {
+                    color: ManaColor::Black,
+                },
+            ])),
+        };
+        let creature = StaticCondition::TopOfLibraryMatches {
+            filter: TargetFilter::Typed(TypedFilter::creature()),
+        };
+
+        // Black creature on top → both the color and the type gate hold.
+        assert!(evaluate_condition_for_test(
+            &state,
+            &black,
+            PlayerId(0),
+            source
+        ));
+        assert!(evaluate_condition_for_test(
+            &state,
+            &creature,
+            PlayerId(0),
+            source
+        ));
+
+        // Recolor the top card white → the black gate no longer holds; the
+        // creature gate still does (discriminates the filter, not mere presence).
+        state.objects.get_mut(&top).unwrap().color = vec![ManaColor::White];
+        assert!(!evaluate_condition_for_test(
+            &state,
+            &black,
+            PlayerId(0),
+            source
+        ));
+        assert!(evaluate_condition_for_test(
+            &state,
+            &creature,
+            PlayerId(0),
+            source
+        ));
+
+        // The gate is controller-scoped: player 1 has an empty library, so the
+        // same creature gate evaluated for player 1 is false.
+        assert!(!evaluate_condition_for_test(
+            &state,
+            &creature,
+            PlayerId(1),
+            source
+        ));
+
+        // Empty player 0's library → no top card → false.
+        {
+            let p0 = state
+                .players
+                .iter_mut()
+                .find(|p| p.id == PlayerId(0))
+                .unwrap();
+            p0.library.clear();
+        }
+        assert!(!evaluate_condition_for_test(
+            &state,
+            &creature,
+            PlayerId(0),
+            source
         ));
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2275,6 +2275,54 @@ pub(crate) fn any_active_static_reads_zone_membership(state: &GameState, zone: Z
     found
 }
 
+/// True when `condition` (recursively through the And/Or/Not combinators) reads
+/// the top card of a library — `StaticCondition::TopOfLibraryMatches`.
+fn static_condition_reads_top_of_library(condition: &StaticCondition) -> bool {
+    match condition {
+        StaticCondition::TopOfLibraryMatches { .. } => true,
+        StaticCondition::Not { condition } => static_condition_reads_top_of_library(condition),
+        StaticCondition::And { conditions } | StaticCondition::Or { conditions } => {
+            conditions.iter().any(static_condition_reads_top_of_library)
+        }
+        _ => false,
+    }
+}
+
+/// CR 401.5 + CR 611.3a: True when any active continuous static is gated on the
+/// top card of a library (`TopOfLibraryMatches`, Vampire Nocturnus). The
+/// continuous effect isn't locked in (CR 611.3a), so a library-top change must
+/// re-evaluate it — but only when such a static is live, so routine library
+/// churn (draws, mills, shuffles with no top-gated static) stays cheap. Mirrors
+/// `any_active_static_reads_zone_membership`.
+pub(crate) fn any_active_static_reads_top_of_library(state: &GameState) -> bool {
+    let mut found = false;
+    for_each_static_effect_source(state, |_state, obj| {
+        if found {
+            return;
+        }
+        if obj.static_definitions.iter_all().any(|def| {
+            def.mode == StaticMode::Continuous
+                && def
+                    .condition
+                    .as_ref()
+                    .is_some_and(static_condition_reads_top_of_library)
+        }) {
+            found = true;
+        }
+    });
+    found
+}
+
+/// CR 401.5 + CR 611.3a: Force a full layer recompute after a library-top-changing
+/// event (shuffle, mill, put-on-top, draw), but only when a `TopOfLibraryMatches`
+/// static is actually live. Single authority called by every top-changing library
+/// move and shuffle helper so a stale layer cache can't survive the change.
+pub(crate) fn mark_layers_full_if_top_of_library_static_live(state: &mut GameState) {
+    if any_active_static_reads_top_of_library(state) {
+        mark_layers_full(state);
+    }
+}
+
 /// Mark the layer system as requiring a FULL battlefield re-evaluation. The
 /// conservative escalation used by every mutation other than a battlefield entry.
 pub fn mark_layers_full(state: &mut GameState) {
@@ -12255,6 +12303,155 @@ mod tests {
             PlayerId(0),
             source
         ));
+    }
+
+    /// CR 401.5 + CR 611.3a production-path harness: a battlefield permanent whose
+    /// continuous static grants itself Flying as long as the top card of its
+    /// controller's library is black (the Vampire Nocturnus shape). The library
+    /// starts black-on-top (`black`) over `white`. Returns
+    /// (state, permanent, black, white).
+    fn top_gated_flying_scenario() -> (GameState, ObjectId, ObjectId, ObjectId) {
+        let mut state = setup();
+        let permanent = make_creature(&mut state, "Vampire Nocturnus", 2, 2, PlayerId(0));
+        {
+            let def = StaticDefinition::new(StaticMode::Continuous)
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::AddKeyword {
+                    keyword: Keyword::Flying,
+                }])
+                .condition(StaticCondition::TopOfLibraryMatches {
+                    filter: TargetFilter::Typed(TypedFilter::default().properties(vec![
+                        FilterProp::HasColor {
+                            color: ManaColor::Black,
+                        },
+                    ])),
+                });
+            state
+                .objects
+                .get_mut(&permanent)
+                .unwrap()
+                .static_definitions
+                .push(def);
+        }
+        let black = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Black Card".to_string(),
+            Zone::Library,
+        );
+        let white = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "White Card".to_string(),
+            Zone::Library,
+        );
+        state.objects.get_mut(&black).unwrap().color = vec![ManaColor::Black];
+        state.objects.get_mut(&white).unwrap().color = vec![ManaColor::White];
+        {
+            let p0 = state
+                .players
+                .iter_mut()
+                .find(|p| p.id == PlayerId(0))
+                .unwrap();
+            p0.library.retain(|&id| id != black && id != white);
+            p0.library.push_back(white); // beneath
+            p0.library.push_front(black); // CR 401.1: front() == top.
+        }
+        (state, permanent, black, white)
+    }
+
+    fn has_flying(state: &GameState, id: ObjectId) -> bool {
+        state
+            .objects
+            .get(&id)
+            .unwrap()
+            .has_keyword(&Keyword::Flying)
+    }
+
+    // CR 401.5 + CR 611.3a: a `Library → Graveyard` mill of the black top card
+    // must re-evaluate the top-gated static through the real `move_to_zone` path,
+    // not leave the granted Flying stale.
+    #[test]
+    fn top_of_library_static_reevaluated_after_mill_to_graveyard() {
+        let (mut state, vampire, black, _white) = top_gated_flying_scenario();
+        flush_layers(&mut state);
+        assert!(has_flying(&state, vampire), "black top → Flying granted");
+
+        let mut events = vec![];
+        crate::game::zones::move_to_zone(&mut state, black, Zone::Graveyard, &mut events);
+        flush_layers(&mut state);
+        assert!(
+            !has_flying(&state, vampire),
+            "after milling the black top away, the white top must strip Flying"
+        );
+    }
+
+    // CR 401.5 + CR 611.3a: placing a white card on top via `move_to_library_at_index`
+    // (the put-on-top path that bypasses `move_to_zone`) must recompute the static.
+    #[test]
+    fn top_of_library_static_reevaluated_after_put_on_top() {
+        let (mut state, vampire, _black, _white) = top_gated_flying_scenario();
+        flush_layers(&mut state);
+        assert!(has_flying(&state, vampire), "black top → Flying granted");
+
+        let white_top = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "New White".to_string(),
+            Zone::Hand,
+        );
+        state.objects.get_mut(&white_top).unwrap().color = vec![ManaColor::White];
+        let mut events = vec![];
+        crate::game::zones::move_to_library_at_index(&mut state, white_top, Some(0), &mut events);
+        flush_layers(&mut state);
+        assert!(
+            !has_flying(&state, vampire),
+            "a white card put on top must strip Flying"
+        );
+    }
+
+    // CR 401.5 + CR 611.3a: a real shuffle reorders the library, so the static is
+    // no longer locked in. The shuffle must invalidate layers, and after a flush
+    // the granted Flying must match whatever card is actually on top now.
+    #[test]
+    fn top_of_library_static_reevaluated_after_shuffle() {
+        let (mut state, vampire, _black, _white) = top_gated_flying_scenario();
+        flush_layers(&mut state);
+        assert!(has_flying(&state, vampire), "black top → Flying granted");
+
+        let mut events = vec![];
+        crate::game::effects::change_zone::shuffle_library(&mut state, PlayerId(0), &mut events);
+        // The shuffle alone must force a recompute — a stale clean cache would
+        // otherwise survive the reorder.
+        assert!(
+            matches!(state.layers_dirty, LayersDirty::Full),
+            "shuffle must invalidate layers while a top-gated static is live"
+        );
+        flush_layers(&mut state);
+
+        let top_is_black = state
+            .players
+            .iter()
+            .find(|p| p.id == PlayerId(0))
+            .unwrap()
+            .library
+            .front()
+            .is_some_and(|&id| {
+                state
+                    .objects
+                    .get(&id)
+                    .unwrap()
+                    .color
+                    .contains(&ManaColor::Black)
+            });
+        assert_eq!(
+            has_flying(&state, vampire),
+            top_is_black,
+            "after shuffle + flush, Flying must match the recomputed top card, not the stale one"
+        );
     }
 
     // --- CR 305.7: SetBasicLandType tests ---

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -570,6 +570,7 @@ pub(crate) fn static_condition_uses_unspent_mana(condition: &StaticCondition) ->
         | StaticCondition::SourceIsHarnessed
         | StaticCondition::SourceAttachedToCreature
         | StaticCondition::SourceMatchesFilter { .. }
+        | StaticCondition::TopOfLibraryMatches { .. }
         | StaticCondition::RecipientMatchesFilter { .. }
         | StaticCondition::RecipientAttackingOwnerTarget { .. }
         | StaticCondition::SourceIsPaired

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -846,6 +846,17 @@ pub fn move_to_zone(
         crate::game::layers::mark_layers_full(state);
     }
 
+    // CR 401.5 + CR 611.3a: A move into or out of a library can change that
+    // library's top card, flipping a continuous static gated on it (Vampire
+    // Nocturnus: "as long as the top card of your library is black, ..."). The
+    // hand/battlefield and graveyard marks above don't cover library moves (a
+    // draw off the top, a mill into the graveyard, a put-on-top), so re-evaluate
+    // — self-gated so routine library churn stays cheap when no such static is
+    // live.
+    if to == Zone::Library || from == Zone::Library {
+        crate::game::layers::mark_layers_full_if_top_of_library_static_live(state);
+    }
+
     // CR 702.145c + CR 702.145f: Daybound/Nightbound permanents entering under
     // the opposite day/night designation transform immediately. Runs after
     // battlefield-entry bookkeeping but before the ZoneChanged event is emitted
@@ -1181,6 +1192,11 @@ pub fn move_to_library_at_index(
         to: Zone::Library,
         record: Box::new(zone_change_record),
     });
+
+    // CR 401.5 + CR 611.3a: placing a card at library index 0 changes the top
+    // card, so a `TopOfLibraryMatches` static must be re-evaluated. This path
+    // bypasses `move_to_zone`, so it invalidates directly (self-gated).
+    crate::game::layers::mark_layers_full_if_top_of_library_static_live(state);
 }
 
 /// Remove an ObjectId from the appropriate zone collection (CR 400.1).

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -4396,6 +4396,10 @@ pub(crate) fn static_condition_to_ability_condition(
         // an effect-resolution gate — no `AbilityCondition` equivalent.
         | StaticCondition::IsTapped { .. }
         | StaticCondition::CastingAsVariant { .. }
+        // CR 401.1 + CR 401.5: the top-of-library gate is a continuous-static-only
+        // predicate (Layer 6 / duration `ForAsLongAs`); no effect-resolution
+        // (`AbilityCondition`) equivalent — lowering returns `None`.
+        | StaticCondition::TopOfLibraryMatches { .. }
         | StaticCondition::None => None,
     }
 }

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -106,6 +106,10 @@ fn parse_state_presence_conditions(input: &str) -> OracleResult<'_, StaticCondit
         parse_event_object_pt_vs_source_comparison,
         parse_attached_object_is_filter_condition,
         parse_recipient_is_filter_condition,
+        // CR 401.1 + CR 401.5: "the top card of your library is [predicate]" — a
+        // distinctive "the top card of your library is " prefix, so ordering
+        // relative to the other filter conditions is not sensitive.
+        parse_top_of_library_condition,
         parse_source_state_conditions,
         parse_player_state_conditions,
         parse_you_have_conditions,
@@ -1406,6 +1410,45 @@ fn attached_filter_condition(filter: TargetFilter) -> StaticCondition {
 /// the `" or "` separator for the next iteration.
 fn parse_bare_predicate_disjunction(input: &str) -> OracleResult<'_, Vec<TargetFilter>> {
     nom::multi::separated_list1(tag(" or "), parse_bare_predicate_tail).parse(input)
+}
+
+/// CR 401.1 + CR 401.5: "the top card of your library is [predicate]" — a
+/// continuous-static gate reading the top card of the controller's library
+/// (Vampire Nocturnus "is black", Mul Daya Channelers "is a creature card",
+/// Conspicuous Snoop "is a Goblin card", Skill Borrower "is an artifact or
+/// creature card", Oura "is a Faerie or instant card"). The predicate reuses
+/// `parse_bare_predicate_disjunction`, so the informational " card" suffix,
+/// bare colors, and N-way "a X or Y" disjunction are folded exactly as in the
+/// recipient/attached filter paths — no bespoke type parsing. A single filter
+/// emits `TopOfLibraryMatches`; a disjunction wraps them in the existing `Or`
+/// combinator (matching `parse_recipient_is_filter_condition`'s shape). The
+/// controller-scoped "your library" reading needs no player field on the
+/// variant. A terminal-boundary guard (end / "," / ";" / ".") rejects partial
+/// matches so a longer combinator can own an unrelated trailing phrase.
+fn parse_top_of_library_condition(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = tag("the top card of your library is ").parse(input)?;
+    let (rest, filters) = parse_bare_predicate_disjunction(rest)?;
+    if !(rest.is_empty()
+        || alt((tag::<_, _, OracleError<'_>>(","), tag(";"), tag(".")))
+            .parse(rest)
+            .is_ok())
+    {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    // Fold any disjunction into a single gate over an `Or` *filter* (the runtime
+    // `matches_target_filter` handles `TargetFilter::Or`). The common "X or Y
+    // card" form is already one `Or` filter (parse_type_phrase folds it); an
+    // article-delimited "a X or a Y" would yield multiple filters, which we wrap
+    // here so the result is always one `TopOfLibraryMatches`.
+    let filter = if filters.len() > 1 {
+        TargetFilter::Or { filters }
+    } else {
+        filters.into_iter().next().expect("non-empty")
+    };
+    Ok((rest, StaticCondition::TopOfLibraryMatches { filter }))
 }
 
 /// CR 611.3a: "it's a Zombie" / "it isn't white" / "it's a Zombie or a Skeleton" —
@@ -16642,6 +16685,95 @@ mod tests {
             assert!(rest.is_empty(), "{text}: leftover {rest:?}");
             assert_eq!(c, expected, "{text}");
         }
+    }
+
+    /// CR 401.1 + CR 401.5: Vampire Nocturnus's "the top card of your library is
+    /// black" parses to a top-of-library color gate. Full-shape assert on the
+    /// `HasColor` filter (bare color, no article, no " card" suffix).
+    #[test]
+    fn parse_inner_condition_top_of_library_is_black() {
+        let (rest, c) = parse_inner_condition("the top card of your library is black").unwrap();
+        assert!(rest.is_empty(), "leftover: {rest:?}");
+        assert_eq!(
+            c,
+            StaticCondition::TopOfLibraryMatches {
+                filter: TargetFilter::Typed(TypedFilter::default().properties(vec![
+                    FilterProp::HasColor {
+                        color: ManaColor::Black
+                    }
+                ])),
+            }
+        );
+    }
+
+    /// CR 401.1: Mul Daya Channelers's "the top card of your library is a creature
+    /// card" / "... a land card" parse to top-of-library core-type gates. The
+    /// informational " card" suffix is folded by `parse_type_phrase` (the same
+    /// helper the graveyard-presence gate uses), so the filter is exactly the bare
+    /// core-type filter — asserted against `parse_type_phrase`'s own output.
+    #[test]
+    fn parse_inner_condition_top_of_library_is_type_card() {
+        for (text, phrase) in [
+            (
+                "the top card of your library is a creature card",
+                "creature card",
+            ),
+            ("the top card of your library is a land card", "land card"),
+        ] {
+            let (rest, c) = parse_inner_condition(text).unwrap_or_else(|e| panic!("{text}: {e:?}"));
+            assert!(rest.is_empty(), "{text}: leftover {rest:?}");
+            let (expected_filter, _) = parse_type_phrase(phrase);
+            assert_eq!(
+                c,
+                StaticCondition::TopOfLibraryMatches {
+                    filter: expected_filter
+                },
+                "{text}"
+            );
+        }
+    }
+
+    /// CR 401.1: Conspicuous Snoop's "the top card of your library is a Goblin
+    /// card" parses to a top-of-library subtype gate (the subtype-word path of
+    /// `parse_type_phrase`). The condition parser runs on lowercased text.
+    #[test]
+    fn parse_inner_condition_top_of_library_is_subtype_card() {
+        let (rest, c) =
+            parse_inner_condition("the top card of your library is a goblin card").unwrap();
+        assert!(rest.is_empty(), "leftover: {rest:?}");
+        let (expected_filter, _) = parse_type_phrase("goblin card");
+        assert_eq!(
+            c,
+            StaticCondition::TopOfLibraryMatches {
+                filter: expected_filter
+            }
+        );
+    }
+
+    /// CR 401.1: Skill Borrower's "the top card of your library is an
+    /// artifact or creature card" folds the "X or Y card" disjunction into a
+    /// single top-of-library gate over an `Or` *filter* — `parse_type_phrase`
+    /// consumes the whole compound (no per-disjunct article), so
+    /// `parse_bare_predicate_disjunction` yields one filter and the runtime
+    /// `matches_target_filter` disjunction handles the two card types. The `Or`
+    /// filter is asserted against `parse_type_phrase`'s own compound output.
+    #[test]
+    fn parse_inner_condition_top_of_library_is_disjunction() {
+        let (rest, c) =
+            parse_inner_condition("the top card of your library is an artifact or creature card")
+                .unwrap();
+        assert!(rest.is_empty(), "leftover: {rest:?}");
+        let (expected_filter, _) = parse_type_phrase("artifact or creature card");
+        assert!(
+            matches!(&expected_filter, TargetFilter::Or { filters } if filters.len() == 2),
+            "sanity: expected an Or filter, got {expected_filter:?}"
+        );
+        assert_eq!(
+            c,
+            StaticCondition::TopOfLibraryMatches {
+                filter: expected_filter
+            }
+        );
     }
 
     /// CR 119.3 + CR 109.4: Thought-Stalker Warlock's "they lost life this turn"

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -6995,6 +6995,66 @@ fn static_as_long_as_unrecognized_condition() {
     ));
 }
 
+/// CR 401.1 + CR 401.5: Mul Daya Channelers — a leading "As long as the top card
+/// of your library is a creature card" gate on a self-anthem. The gate assembles
+/// onto the continuous static's `condition` through the same leading-"as long
+/// as" split as the `you control six or more lands` analogue, proving the
+/// `TopOfLibraryMatches` recognizer is reached end-to-end from a real, verbatim
+/// card line — not only from `parse_inner_condition`. Full-shape: the type gate
+/// AND the +3/+3 anthem body both survive lowering.
+#[test]
+fn static_top_of_library_creature_gate_mul_daya_channelers() {
+    let def = parse_static_line(
+        "As long as the top card of your library is a creature card, this creature gets +3/+3.",
+    )
+    .unwrap();
+
+    assert_eq!(def.mode, StaticMode::Continuous);
+    let (creature_filter, _) = crate::parser::oracle_target::parse_type_phrase("creature card");
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::TopOfLibraryMatches {
+            filter: creature_filter
+        })
+    );
+    assert!(def
+        .modifications
+        .iter()
+        .any(|m| m == &ContinuousModification::AddPower { value: 3 }));
+    assert!(def
+        .modifications
+        .iter()
+        .any(|m| m == &ContinuousModification::AddToughness { value: 3 }));
+}
+
+/// CR 401.1 + CR 401.5: Vampire Nocturnus — the marquee "top card of your library
+/// is black" card. Verifies the color gate attaches end-to-end from the verbatim
+/// line; the anthem body (compound subject, "+2/+1 and have flying") is exercised
+/// only enough to confirm the gate rides on top of a lowered body, not instead.
+#[test]
+fn static_top_of_library_black_gate_vampire_nocturnus() {
+    let def = parse_static_line(
+        "As long as the top card of your library is black, this creature and other Vampire creatures you control get +2/+1 and have flying.",
+    )
+    .unwrap();
+
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::TopOfLibraryMatches {
+            filter: TargetFilter::Typed(TypedFilter::default().properties(vec![
+                FilterProp::HasColor {
+                    color: crate::types::mana::ManaColor::Black,
+                }
+            ])),
+        })
+    );
+    assert!(
+        !def.modifications.is_empty(),
+        "anthem body should still lower"
+    );
+}
+
 #[test]
 fn static_enchanted_or_equipped_stays_unrecognized() {
     // Novice Knight: "As long as this creature is enchanted or equipped, ~ has

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3891,6 +3891,10 @@ pub(crate) fn static_condition_to_trigger_condition(
         // intervening-if (`TriggerCondition`) equivalent.
         | StaticCondition::AdditionalCostPaid
         | StaticCondition::CastingAsVariant { .. }
+        // CR 401.1 + CR 401.5: the top-of-library gate is a continuous-static-only
+        // predicate; no intervening-if (`TriggerCondition`) equivalent — lowering
+        // returns `None`.
+        | StaticCondition::TopOfLibraryMatches { .. }
         | StaticCondition::None => None,
 
         // CR 309.7: Dungeon completion bridges directly.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6836,6 +6836,26 @@ pub enum StaticCondition {
     SourceMatchesFilter {
         filter: TargetFilter,
     },
+    /// CR 401.1 + CR 401.5: True when the top card of the source controller's
+    /// library matches `filter`. A library is a single face-down ordered pile
+    /// (CR 401.1/401.2); its top card is `library[0]` in the engine convention.
+    /// CR 401.5 governs the "play with the top card of your library revealed"
+    /// statics that gate on it. Controller-scoped ("your library") — evaluated
+    /// against the source controller's library, so no player field is needed for
+    /// the current class (add a `ControllerRef` axis if an opponent-library form
+    /// ever appears). `filter` is a plain characteristic `TargetFilter` (color,
+    /// core type, or subtype — or an `Or` of them) with no zone/controller
+    /// constraint: the runtime resolves the specific top-card object and matches
+    /// its printed characteristics directly. Empty library → false (no top card).
+    ///
+    /// Covers the whole class: Vampire Nocturnus ("is black"), Mul Daya
+    /// Channelers ("is a creature card" / "is a land card"), Conspicuous Snoop
+    /// ("is a Goblin card"), Crown of Convergence and Chittering Illuminator
+    /// ("is a creature card"), Skill Borrower ("is an artifact or creature
+    /// card"), and Oura, the Imitator ("is a Faerie or instant card").
+    TopOfLibraryMatches {
+        filter: TargetFilter,
+    },
     /// CR 611.3a: the recipient (effective subject) of the continuous effect matches
     /// `filter`; re-evaluated per affected object each layer cycle (mirrors
     /// `RecipientHasCounters`, the recipient analog of `HasCounters`). CR 611.3a: "A


### PR DESCRIPTION
## Summary

Adds engine support for the **top-of-library static condition** — a new `StaticCondition::TopOfLibraryMatches { filter }` that gates a continuous static on the top card of the source controller's library (`library[0]`, CR 401.1) matching a characteristic `TargetFilter`. Covers the whole "As long as the top card of your library is `X`" class: **Vampire Nocturnus** (black), **Mul Daya Channelers** (creature/land card), **Conspicuous Snoop** (Goblin card), **Crown of Convergence** and **Chittering Illuminator** (creature card), **Skill Borrower** (artifact or creature card), and **Oura, the Imitator** (Faerie or instant card).

## Files changed

- `crates/engine/src/types/ability.rs`
- `crates/engine/src/parser/oracle_nom/condition.rs`
- `crates/engine/src/game/layers.rs`
- `crates/engine/src/game/ability_rw.rs`
- `crates/engine/src/game/ability_scan.rs`
- `crates/engine/src/game/coverage.rs`
- `crates/engine/src/game/quantity.rs`
- `crates/engine/src/parser/oracle_effect/conditions.rs`
- `crates/engine/src/parser/oracle_trigger.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`

## CR references

- CR 401.1 — a library is a single ordered pile; its top card is `library[0]`.
- CR 401.5 — "play with the top card of your library revealed" statics gate on the top card, re-read live when the top changes.

## Note on variant choice (not a sibling to parameterize)

`TopOfLibraryMatches` sits alongside the existing filter-scoped conditions `IsPresent`, `SourceMatchesFilter`, `RecipientMatchesFilter`, and `DefendingPlayerControls` — the engine already models each object-scope as its own variant rather than one parameterized `MatchesFilter { scope }`. This one is a distinct *resolution context*, not a leaf parameterization of `SourceMatchesFilter`: it resolves a **library-position card** (CR 401 zone access, `library[0]`) rather than a battlefield object (`source_id` / `recipient_id`), so it cannot ride an object-scope axis. It reuses the runtime match (`matches_target_filter`) and the parser vocabulary (`parse_bare_predicate_disjunction`) rather than re-implementing them.

## Implementation method (required)

Method: not-applicable — authored directly against the `oracle-parser` skill and the `add-engine-variant` discipline (existence + parameterization + categorical-boundary checks). Pure AST + runtime change; no card-data regeneration required.

## Track

Developer

## LLM

Model: claude-opus-4-8
Thinking: high

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Verification below is for the current committed head (`031d5f641`).
- [x] Final review below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

Results on head `031d5f641`:

- `cargo test -p engine top_of_library` — **ok. 39 passed; 0 failed** (4 parser + 1 runtime + 2 end-to-end new tests; 32 pre-existing top-of-library tests unaffected).
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` — **Finished, 0 warnings**.
- `cargo fmt --all` — clean.

## Anchored on

- `crates/engine/src/parser/oracle_nom/condition.rs` (`parse_recipient_is_filter_condition`) — the analogous "`it` is a `<filter>`" condition that composes the same `parse_bare_predicate_disjunction` seam (bare colors, informational " card" suffix, "X or Y" disjunction).
- `crates/engine/src/game/layers.rs` (`SourceMatchesFilter` arm in `evaluate_condition_with_context`) — the analogous "object matches a `TargetFilter`" runtime using `matches_target_filter` + `FilterContext::from_source`.

## Final review

Self-review against the review-impl lenses on head `031d5f641`. Verified: `.front()` on the library `im::Vector` is `library[0]` (the top, per the engine convention in `game/zones.rs`); a zoneless `TargetFilter::Typed` matches a library card on printed characteristics (no implicit battlefield requirement in `filter_inner_for_object`); the `ability_rw` profile reads `StateKind::HandLibrary`, which draw/scry/mill/shuffle write, so the gate re-evaluates when the top changes; the two population classifiers correctly place the variant in the `false` group (a battlefield entry never changes the library); and the ability/trigger bridges return `None` (a top-of-library gate has no effect-resolution or intervening-if equivalent). The passing runtime test discriminates on filter, player scope, and empty library. One fix applied pre-commit: a disjunction-fold comment mis-cited CR 608.2c (which governs instruction ordering, not filter disjunction) — citation removed.

## Claimed parse impact

- Vampire Nocturnus — verified end-to-end (`As long as the top card of your library is black, ...` → `TopOfLibraryMatches { HasColor(Black) }` plus the anthem body).
- Mul Daya Channelers — verified end-to-end (`... is a creature card, this creature gets +3/+3.`).

The condition building block recognizes the whole "top card of your library is `X`" family; the CI `coverage-parse-diff` sticky enumerates the full set of affected cards for the current head.

## Validation Failures

None.

## CI Failures

None.
