### PR TITLE
ship/u2c typed evidence

### DIFF
--- a/crates/engine/src/parser/mod.rs
+++ b/crates/engine/src/parser/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod oracle_trigger;
 pub mod oracle_util;
 pub(crate) mod oracle_vote;
 pub(crate) mod swallow_check;
+pub(crate) mod swallow_evidence;
 #[cfg(test)]
 #[allow(dead_code)] // shared parser test assertions; ad-hoc call sites converted incrementally
 pub(crate) mod test_support;

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -30,10 +30,10 @@ use super::swallow_evidence::UnitEvidence;
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, ActivationRestriction, CastingPermission, Comparator,
     ContinuousModification, CopyRetargetPermission, DelayedTriggerCondition, Duration, Effect,
-    FilterProp, ModalSelectionConstraint, OpponentMayScope, ParsedCondition, PlayerFilter,
-    QuantityExpr, QuantityRef, ReplacementCondition, ReplacementMode, RestrictionExpiry,
-    StaticCondition, StaticDefinition, TargetFilter, TriggerCondition, TriggerConstraint,
-    TriggerDefinition, UnlessPayScaling,
+    FilterProp, ManaProduction, ModalSelectionConstraint, OpponentMayScope, ParsedCondition,
+    PlayerFilter, QuantityExpr, QuantityRef, ReplacementCondition, ReplacementMode,
+    RestrictionExpiry, StaticCondition, StaticDefinition, TargetFilter, TriggerCondition,
+    TriggerConstraint, TriggerDefinition, UnlessPayScaling,
 };
 use crate::types::game_state::RetargetScope;
 use crate::types::keywords::Keyword;
@@ -2047,8 +2047,19 @@ fn detect_dynamic_qty(
     // That exclusion is load-bearing: `QuantityExpr`'s hand-written `Deserialize` also
     // accepts a BARE INTEGER as `Fixed` (the legacy on-disk form), so a predicate that
     // forgot to exclude it would be satisfied by any number anywhere on the card.
-    if evidence.any::<QuantityRef>(|_| true)
-        || evidence.any::<QuantityExpr>(|q| !matches!(q, QuantityExpr::Fixed { .. }))
+    //
+    // KEY-ANCHORED (`any_quantity_ref` / `any_quantity_expr`, see `QUANTITY_KEYS`). These
+    // were once unanchored, on the reasoning that an internally-tagged enum carries its own
+    // discriminator. It does not: an internally-tagged UNIT variant matches on `type` alone
+    // and serde drops unknown fields, and 10 of `QuantityRef`'s variant names are shared
+    // with other tagged enums. Unanchored, this probe read Boing!'s
+    // `AbilityCondition::PreviousEffectAmount` (a CONDITION, under key `condition`) and
+    // Siren's Call's `FilterProp::AttackedThisTurn` (a TARGET FILTER, under key
+    // `properties[].prop`) as dynamic quantities, and suppressed both cards' real warnings.
+    // Boing! lowers "scry a number of cards equal to the result" to `Scry { count: Fixed(1) }`
+    // — the quantity IS dropped, and the warning it silenced was a true positive.
+    if evidence.any_quantity_ref(|_| true)
+        || evidence.any_quantity_expr(|q| !matches!(q, QuantityExpr::Fixed { .. }))
     {
         return;
     }
@@ -2067,6 +2078,31 @@ fn detect_dynamic_qty(
                 | Effect::EachPlayerCopyChosen { .. }
                 | Effect::ChooseDrawnThisTurnPayOrTopdeck { .. }
         )
+    }) {
+        return;
+    }
+    // CR 106.1: a mana ability whose AMOUNT is read from game state carries its quantity in
+    // the `ManaProduction` variant itself — `Effect::Mana.produced` is typed `ManaProduction`,
+    // NOT `QuantityRef`, so the key-anchored quantity probes above cannot see it.
+    //
+    //   Bloom Tender / Faeburrow Elder / Sunbird Effigy / Tarnation Vista —
+    //   "For each color among permanents you control, add one mana of that color."
+    //
+    // This leg exists BECAUSE the probes above are anchored. Unanchored, they "saw" this
+    // carrier only by ACCIDENT: `DistinctColorsAmongPermanents` is also a `QuantityRef`
+    // variant name, so the `ManaProduction` node deserialized as a `QuantityRef` by cross-enum
+    // collision. Right answer, wrong reason — and the same collision suppressed Boing! and
+    // Siren's Call. Anchoring removed the accident; this restores the fact, typed.
+    //
+    // ONE variant, and that is a MEASURED bound, not a guess: over the full 35,396-face pool,
+    // `DistinctColorsAmongPermanents` is the only `ManaProduction` on a face where the marker
+    // fires and no other dynamic carrier exists. Every other variant that appears on a warning
+    // face (Colorless, AnyOneColor, Fixed, ChosenColor, AnyInCommandersColorIdentity,
+    // TriggerEventManaType) warns on main too — widening this `matches!` would SUPPRESS true
+    // positives, which is the silent direction. A future state-derived variant that is missing
+    // here over-reports instead: conservative-RED, and the full-pool delta shows it.
+    if evidence.any_at::<ManaProduction>(&["produced"], |p| {
+        matches!(p, ManaProduction::DistinctColorsAmongPermanents { .. })
     }) {
         return;
     }
@@ -2948,7 +2984,7 @@ fn detect_condition_if(
     // allow-noncombinator: swallow detector marker scan on classified text
     if (stripped.contains("lost life this way") || stripped.contains("gained life this way"))
         && stripped.contains("that many") // allow-noncombinator: swallow detector marker scan on classified text
-        && evidence.any::<QuantityRef>(|q| matches!(q, QuantityRef::EventContextAmount { .. }))
+        && evidence.any_quantity_ref(|q| matches!(q, QuantityRef::EventContextAmount { .. }))
     {
         return;
     }
@@ -3663,7 +3699,13 @@ fn detect_duration_this_turn(
     //     ROT DIRECTION (declared): a NEW `*ThisTurn` variant added later is not caught
     //     here until this list is regenerated. That failure is conservative-RED — the
     //     audit over-reports a swallow — never a silent false green.
-    if evidence.any::<QuantityRef>(|x| {
+    // KEY-ANCHORED: four of the variants below — `AttackedThisTurn`, `EnteredThisTurn`,
+    // `BattlefieldEntriesThisTurn`, `CounterAddedThisTurn` — are ALSO variant names of
+    // `FilterProp` / `TriggerCondition` / `ParsedCondition`. Unanchored, a target filter
+    // saying "creatures that attacked this turn" would deserialize as
+    // `QuantityRef::AttackedThisTurn` and silently discharge a "this turn" duration
+    // expectation. See `QUANTITY_KEYS`.
+    if evidence.any_quantity_ref(|x| {
         matches!(
             x,
             QuantityRef::LifeLostThisTurn { .. }

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -3904,9 +3904,9 @@ fn detect_duration_this_turn(
     // (l) CR 614.6: a `DamageDone` replacement event scopes to a single resolution; the
     //     "this turn" is implicit in the spell-level replacement lifetime.
     //     `ReplacementEvent` is EXTERNALLY tagged, so it is key-anchored.
-    if evidence.any_at::<ReplacementEvent>(&["event"], |e| {
-        matches!(e, ReplacementEvent::DamageDone)
-    }) {
+    if evidence
+        .any_at::<ReplacementEvent>(&["event"], |e| matches!(e, ReplacementEvent::DamageDone))
+    {
         return;
     }
     // (m) CR 601.2 + CR 604.1: per-turn limit statics ARE the enforcement window; the

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -181,6 +181,7 @@ pub(crate) fn check_swallowed_clauses(
         let evidence = UnitEvidence::of(&scoped);
 
         let mut found = Vec::new();
+        detect_replacement(&cleaned, fragment, &scoped, &evidence, &mut found);
         detect_replacement_instead(&cleaned, fragment, &scoped, &mut found);
         detect_activate_only_during(&cleaned, fragment, &scoped, &mut found);
         detect_activate_limit(&cleaned, fragment, &scoped, &mut found);
@@ -199,6 +200,154 @@ pub(crate) fn check_swallowed_clauses(
         stamp_line(&mut found, unit.first_line);
         diagnostics.append(&mut found);
     }
+}
+
+/// CR 603.2: true when this line's "enters with" is the TRIGGER's event filter
+/// ("Whenever a creature you control enters with a counter on it, ...") rather than a
+/// CR 614.1c replacement. A trigger's condition clause runs up to the comma that closes
+/// it, so an "enters with" ahead of that comma on a `when`/`whenever` line describes
+/// which entries FIRE the ability — it does not replace the entry event.
+fn enters_with_is_trigger_filter(line: &str) -> bool {
+    let l = line.trim_start();
+    // allow-noncombinator: swallow detector marker scan on classified text
+    if !(l.starts_with("whenever ") || l.starts_with("when ")) {
+        return false;
+    }
+    // allow-noncombinator: swallow detector marker scan on classified text
+    // allow-noncombinator: swallow detector marker scan on classified text
+    l.split(',')
+        .next()
+        .is_some_and(|cond| cond.contains("enters with")) // allow-noncombinator: swallow detector marker scan on classified text
+}
+
+// ── Detector N: Replacement (CR 614) ────────────────────────────────────
+
+/// CR 614: an event-modifying effect exists. This is the CR 614 replacement
+/// grammar that does **not** use the word "instead" — `Replacement_Instead`
+/// (CR 614.1a) already owns that one, and the two are deliberately separate
+/// labels so per-detector regression attribution survives.
+///
+/// The two grammars this owns, both verified against the Comprehensive Rules:
+///
+///   CR 614.1b  "Effects that use the word 'skip' are replacement effects."
+///              Carriers: `StaticMode::SkipStep`, `Effect::SkipNextTurn`,
+///              `Effect::SkipNextStep`.
+///   CR 614.1c  "Effects that read '[This permanent] enters with . . . ,'
+///              'As [this permanent] enters . . . ,' or '[This permanent]
+///              enters as . . .' are replacement effects."
+///              Carrier: a `ReplacementDefinition`, or one of the non-`replacements`
+///              carriers the shared helpers below already know about.
+///
+/// CR 614.1d ("[This permanent] enters . . ." / "[Objects] enter . . .") is
+/// deliberately NOT claimed here. Its marker would be the bare word "enters",
+/// which every ETB *trigger* on every creature in the pool also matches — the
+/// expectation would fire on the whole pool and the label would carry no
+/// information. It needs a grammar that distinguishes the replacement reading
+/// from the trigger reading, which is recognizer-bring-up work, not audit work.
+/// Stated rather than silently omitted.
+///
+/// Evidence reuses the SAME carrier helpers as `detect_replacement_instead`:
+/// a replacement is a replacement however its text spelled it, so the two
+/// detectors must not drift apart on what counts as one.
+fn detect_replacement(
+    cleaned: &str,
+    original: &str,
+    parsed: &ParsedAbilities,
+    evidence: &UnitEvidence,
+    diagnostics: &mut Vec<OracleDiagnostic>,
+) {
+    // CR 614.1b: "skip" — scoped to the verb form, so "skipped" / a card NAMED
+    // "Skip" cannot raise the expectation.
+    // allow-noncombinator: swallow detector marker scan on classified text
+    let has_skip = cleaned.contains("skip your ") // allow-noncombinator: swallow detector marker scan on classified text
+        || cleaned.contains("skip their ") // allow-noncombinator: swallow detector marker scan on classified text
+        || cleaned.contains("skip the next ") // allow-noncombinator: swallow detector marker scan on classified text
+        || cleaned.contains("skips their ") // allow-noncombinator: swallow detector marker scan on classified text
+        || cleaned.contains("skips his or her "); // allow-noncombinator: swallow detector marker scan on classified text
+
+    // CR 614.1c: the three explicit enters-replacement templates. "as ~ enters" is
+    // matched per LINE (a line whose first word is "as" and which mentions entering),
+    // because the unit text carries the card's REAL name, not the normalized `~` —
+    // `AuditUnit::text` is sliced from raw `source_text` precisely so the detectors'
+    // marker phrases and the emitted `description` stay raw-text concepts.
+    // CR 614.1c vs CR 603.2: "Whenever a creature you control enters WITH a counter on
+    // it, ..." (Murderous Redcap Avatar) reads "enters with" as a TRIGGER EVENT FILTER —
+    // it describes which entries fire the trigger, and replaces no event. Only the
+    // REPLACEMENT reading raises a CR 614 expectation, so the trigger reading is excluded
+    // per line: when the phrase sits inside the trigger's condition clause (ahead of the
+    // comma that closes it) on a line that opens with "when"/"whenever", it is a filter.
+    let has_enters_with = cleaned
+        .lines()
+        // allow-noncombinator: swallow detector marker scan on classified text
+        .filter(|line| line.contains("enters with "))
+        .any(|line| !enters_with_is_trigger_filter(line)); // allow-noncombinator: swallow detector marker scan on classified text
+                                                           // allow-noncombinator: swallow detector marker scan on classified text
+    let has_enters_as = cleaned.contains(" enters as "); // allow-noncombinator: swallow detector marker scan on classified text
+    let has_as_enters = cleaned.lines().any(|line| {
+        let l = line.trim_start();
+        // allow-noncombinator: swallow detector marker scan on classified text
+        l.starts_with("as ") && l.contains(" enters")
+    });
+
+    if !(has_skip || has_enters_with || has_enters_as || has_as_enters) {
+        return;
+    }
+
+    // CR 614: the replacement is represented if this unit produced a
+    // `ReplacementDefinition`, or any of the carriers that hold a replacement
+    // OUTSIDE the `replacements` collection (rider replacements registered at
+    // resolution, effect-chain `*Instead` conditions, replacement-bearing statics).
+    if !parsed.replacements.is_empty()
+        || any_ability_has_target_replacement(parsed)
+        || any_ability_has_replacement_carrier(parsed)
+    {
+        return;
+    }
+    // CR 614.1b carriers: a skip is modelled as a step-skipping static or a
+    // skip-next-turn/step effect rather than a `ReplacementDefinition`.
+    if evidence.any_static_mode(|m| matches!(m, StaticMode::SkipStep { .. }))
+        || evidence.any::<Effect>(|e| {
+            matches!(e, Effect::SkipNextTurn { .. } | Effect::SkipNextStep { .. })
+        })
+    {
+        return;
+    }
+    // CR 614.1c carriers: an "enters with ..." replacement is frequently modelled as a
+    // STATIC or a continuous modification rather than a `ReplacementDefinition` — the
+    // effect is continuous and applies to a CLASS of objects, so it lives in the layer
+    // system. Thunderous Velocipede ("Each other Vehicle and creature you control enters
+    // with an additional +1/+1 counter ...") is the motivating case: it lowers to
+    // `StaticMode::EntersWithAdditionalCounters` and carries no ReplacementDefinition at
+    // all. Completeness grep over the type definitions:
+    //
+    //   $ rg '^    \w*Enter\w*\s*[,{(]' crates/engine/src/types/
+    //     StaticMode::EntersWithAdditionalCounters   StaticMode::CantEnterBattlefieldFrom
+    //     ContinuousModification::AddCounterOnEnter  Effect::AddPendingEntersModifications
+    if evidence.any_static_mode(|m| {
+        matches!(
+            m,
+            StaticMode::EntersWithAdditionalCounters { .. } | StaticMode::CantEnterBattlefieldFrom
+        )
+    }) || evidence.any::<ContinuousModification>(|m| {
+        matches!(m, ContinuousModification::AddCounterOnEnter { .. })
+    }) || evidence.any::<Effect>(|e| matches!(e, Effect::AddPendingEntersModifications { .. }))
+    {
+        return;
+    }
+    // CR 614.1c + CR 614.12: the per-object enters-modifier slots — an "as it enters"
+    // gate the parser folded onto the moving object rather than into a standalone
+    // replacement definition.
+    if evidence.has_slot("enters_modified_if")
+        || evidence.has_slot("conditional_enter_with_counters")
+        || evidence.has_slot("enter_with_counters")
+    {
+        return;
+    }
+    diagnostics.push(OracleDiagnostic::SwallowedClause {
+        detector: OracleSemanticFeature::Replacement.detector_label().into(),
+        description: truncate(original, 140).into(),
+        line_index: 0,
+    });
 }
 
 // ── Detector A: Replacement_Instead ─────────────────────────────────────

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -26,14 +26,20 @@ use super::oracle_effect::player_lookback_relative_clause_owns_suffix;
 use super::oracle_ir::diagnostic::{CascadeSlot, OracleDiagnostic};
 use super::oracle_ir::doc::OracleItemIr;
 use super::oracle_ir::feature::{audit_units, scope_to_unit, ItemIdTracks, OracleSemanticFeature};
+use super::swallow_evidence::UnitEvidence;
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, ActivationRestriction, Comparator, ContinuousModification,
-    CopyRetargetPermission, Duration, Effect, FilterProp, ModalSelectionConstraint,
-    OpponentMayScope, PlayerFilter, QuantityExpr, ReplacementMode, StaticDefinition, TargetFilter,
-    TriggerDefinition,
+    AbilityCondition, AbilityDefinition, ActivationRestriction, CastingPermission, Comparator,
+    ContinuousModification, CopyRetargetPermission, DelayedTriggerCondition, Duration, Effect,
+    FilterProp, ModalSelectionConstraint, OpponentMayScope, ParsedCondition, PlayerFilter,
+    QuantityExpr, QuantityRef, ReplacementCondition, ReplacementMode, RestrictionExpiry,
+    StaticCondition, StaticDefinition, TargetFilter, TriggerCondition, TriggerConstraint,
+    TriggerDefinition, UnlessPayScaling,
 };
 use crate::types::game_state::RetargetScope;
 use crate::types::keywords::Keyword;
+use crate::types::mana::{ManaCost, ManaExpiry};
+use crate::types::replacements::ReplacementEvent;
+use crate::types::statics::ActivationExemption;
 use crate::types::statics::StaticMode;
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
@@ -167,27 +173,28 @@ pub(crate) fn check_swallowed_clauses(
         let lower_owned = fragment.to_ascii_lowercase();
         let cleaned = strip_parens(&lower_owned);
 
-        // JSON haystack for detectors that still introspect AST shape via serialized
-        // field presence, now scoped to this item's definitions. Serialization can
-        // fail on pathological data; on failure those detectors skip rather than
-        // panic. (Deleted in the next commit, in favour of typed predicates.)
-        let ast_json = serde_json::to_string(&scoped).unwrap_or_default();
+        // Typed evidence probe over this item's definitions: the tree the detectors
+        // interrogate for "is a carrier for semantic S present?". Replaces the
+        // serialized-AST substring haystack — see `swallow_evidence` for why a string
+        // marker is unsound (it can name a type that does not exist, or silently match
+        // a LONGER type's name and discharge an unrelated rule's fact).
+        let evidence = UnitEvidence::of(&scoped);
 
         let mut found = Vec::new();
         detect_replacement_instead(&cleaned, fragment, &scoped, &mut found);
         detect_activate_only_during(&cleaned, fragment, &scoped, &mut found);
         detect_activate_limit(&cleaned, fragment, &scoped, &mut found);
-        detect_duration_until_eot(&cleaned, fragment, &scoped, &mut found);
+        detect_duration_until_eot(&cleaned, fragment, &scoped, &evidence, &mut found);
         detect_optional_you_may(&cleaned, fragment, &scoped, &mut found);
-        detect_dynamic_qty(&cleaned, fragment, &ast_json, &mut found);
-        detect_condition_if(&cleaned, fragment, &ast_json, &scoped, &mut found);
-        detect_condition_unless(&cleaned, fragment, &ast_json, &mut found);
-        detect_condition_as_long_as(&cleaned, fragment, &ast_json, &scoped, &mut found);
-        detect_duration_this_turn(&cleaned, fragment, &ast_json, &mut found);
-        detect_duration_next_turn(&cleaned, fragment, &scoped, &mut found);
-        detect_optional_may_have(&cleaned, fragment, &ast_json, &mut found);
+        detect_dynamic_qty(&cleaned, fragment, &evidence, &mut found);
+        detect_condition_if(&cleaned, fragment, &evidence, &scoped, &mut found);
+        detect_condition_unless(&cleaned, fragment, &evidence, &mut found);
+        detect_condition_as_long_as(&cleaned, fragment, &evidence, &scoped, &mut found);
+        detect_duration_this_turn(&cleaned, fragment, &evidence, &mut found);
+        detect_duration_next_turn(&cleaned, fragment, &evidence, &mut found);
+        detect_optional_may_have(&cleaned, fragment, &evidence, &mut found);
         detect_apnap(&cleaned, fragment, &scoped, &mut found);
-        detect_modal_dynamic_max_dropped(&cleaned, fragment, &ast_json, &mut found);
+        detect_modal_dynamic_max_dropped(&cleaned, fragment, &evidence, &mut found);
 
         stamp_line(&mut found, unit.first_line);
         diagnostics.append(&mut found);
@@ -315,43 +322,56 @@ fn detect_duration_until_eot(
     cleaned: &str,
     original: &str,
     parsed: &ParsedAbilities,
+    evidence: &UnitEvidence,
     diagnostics: &mut Vec<OracleDiagnostic>,
 ) {
     // allow-noncombinator: swallow detector marker scan on classified text
     if !cleaned.contains("until end of turn") {
         return;
     }
-    // CR 611.2a: the evidence is an END-OF-TURN duration, not "some duration". The two
-    // things this replaces were both vacuous: `any_ability_has_duration` accepted a
-    // duration of ANY kind (a `Permanent` grant discharged an "until end of turn"
-    // expectation), and its `static_has_duration` leg returned `true` for any static at
-    // all. The `json_has_any` fallback beside them existed only because the structured
-    // walk could not reach into `Effect::Token`; `effect_has_duration` now reaches every
-    // container, so the string channel is not needed here.
-    if unit_has_duration(parsed, &duration_is_end_of_turn) {
+    // CR 611.2a: the evidence must be an END-OF-TURN duration, not "some duration" — a
+    // `Permanent` grant must not discharge an "until end of turn" expectation. The typed
+    // probe is the SINGLE evidence channel for `Duration`-typed carriers. Its reach is
+    // serde-derived, so it structurally cannot miss one: it sees carriers that a
+    // hand-enumerated walk missed, e.g. a duration nested in
+    // `Effect::Token.static_abilities -> GrantTrigger -> trigger.execute`, or
+    // `ManaSpellGrant::AddKeywordUntilEndOfTurn.duration` (a `Box<Duration>`; `Box` is
+    // transparent to serde).
+    //
+    // Key-anchored (`any_duration`) because `Duration` is externally tagged: its unit
+    // variants serialize as BARE STRINGS, so an unanchored probe would accept any string
+    // anywhere that happened to equal a variant name. The anchor also fixes a blind spot
+    // the substring marker had: `Effect::PreventDamage` stores its duration in
+    // `prevention_duration`, and `"prevention_duration":"UntilEndOfTurn"` does NOT contain
+    // the substring `"duration":"UntilEndOfTurn"` — so every damage-prevention shield's
+    // end-of-turn duration was invisible to the old marker.
+    if evidence.any_duration(|d| matches!(d, Duration::UntilEndOfTurn | Duration::UntilEndOfCombat))
+    {
         return;
     }
-    // CR 106.4: "that mana doesn't empty until end of turn" — the duration is carried by
-    // `Effect::Mana.expiry` (`ManaExpiry`), which is not typed `Duration`.
+    // The two carriers below sit OUTSIDE the typed probe's reach BY CONSTRUCTION, not by
+    // omission: the probe is keyed on values of type `Duration`, and each of these expresses
+    // an end-of-turn scope WITHOUT one. No widening of `any_duration` can subsume them, so
+    // they remain typed legs beside it rather than being folded into it.
+
+    // CR 106.4: a player's mana pool empties at the end of each step and phase; "that mana
+    // doesn't empty until end of turn" overrides that. The scope is carried by
+    // `Effect::Mana.expiry`, typed `ManaExpiry` — a DIFFERENT TYPE than `Duration`.
     if unit_has_end_of_turn_mana_expiry(parsed) {
         return;
     }
     // CR 614.6 + CR 514.2: a one-shot DAMAGE replacement created by a resolving spell
     // ("Until end of turn, all damage that would be dealt to you ... is dealt to that
-    // creature instead" — Heroic Sacrifice) has NO `duration` field to carry the scope:
-    // `ReplacementDefinition` has none. Its "until end of turn" lifetime is structural —
-    // the shield is created on resolution and expires at cleanup. So the event type IS
-    // the duration, and the clause is represented.
-    //
-    // This leg was lost when `any_ability_has_duration` was deleted, and the full-pool
-    // delta caught it as a false-positive cluster (blind fury, heroic sacrifice). Restored
-    // here as a TYPED exemption on the event, rather than as a blanket "has a replacement".
-    if parsed.replacements.iter().any(|replacement| {
-        matches!(
-            replacement.event,
-            crate::types::replacements::ReplacementEvent::DamageDone
-        )
-    }) {
+    // creature instead" — Heroic Sacrifice) has NO duration field at all —
+    // `ReplacementDefinition` does not have one. Its "until end of turn" lifetime is
+    // structural: the modified event replaces the original (CR 614.6) and the shield ends at
+    // cleanup (CR 514.2). The event type IS the duration, so the clause is represented.
+    // Typed exemption on the EVENT, not a blanket "this unit has a replacement".
+    if parsed
+        .replacements
+        .iter()
+        .any(|replacement| matches!(replacement.event, ReplacementEvent::DamageDone))
+    {
         return;
     }
     diagnostics.push(OracleDiagnostic::SwallowedClause {
@@ -1593,284 +1613,44 @@ fn modal_has_conditional_max(modal: &crate::types::ability::ModalChoice) -> bool
     })
 }
 
-// `def_tree_has_duration`, `any_ability_has_duration` and `static_has_duration` used to
-// live here. All three are DELETED, and the third is why:
+// ── Duration evidence: one typed channel, plus two non-`Duration` carriers ───────────────
+//
+// Three vacuous helpers used to live here — `def_tree_has_duration`, `any_ability_has_duration`
+// and `static_has_duration`. All are DELETED. The third is why:
 //
 //     fn static_has_duration(s: &StaticDefinition) -> bool { let _ = s; true }
 //
-// It returned `true` for ANY static ability whatsoever — a keyword grant, an anthem, a
-// cost modifier — so `any_ability_has_duration` (its only caller, and the sole evidence
-// gate on `detect_duration_until_eot`) was discharged by the mere EXISTENCE of a static.
+// It returned `true` for ANY static ability whatsoever — a keyword grant, an anthem, a cost
+// modifier — so `any_ability_has_duration` (its only caller, and the sole evidence gate on
+// `detect_duration_until_eot`) was discharged by the mere EXISTENCE of a static.
 // `StaticDefinition` has no `Duration` field at all; a static's duration lives on the
-// `Effect::GenericEffect` that wraps it. So the stub was not a conservative approximation
-// of a duration — it was unrelated to one.
+// `Effect::GenericEffect` that wraps it. The stub was not a conservative approximation of a
+// duration — it was unrelated to one. `any_ability_has_duration` compounded it by accepting a
+// duration of ANY KIND: a `Permanent` grant satisfied an "until end of turn" expectation.
+// Evidence must be the fact the expectation asked about (CR 611.2a).
 //
-// `any_ability_has_duration` compounded it by accepting a duration of ANY KIND: a
-// `Permanent` grant satisfied an "until end of turn" expectation. Evidence must be the
-// fact the expectation asked about (CR 611.2a), which is what `unit_has_duration(parsed,
-// &duration_is_end_of_turn)` now demands.
-
-// ── Typed duration evidence (CR 611.2a) ─────────────────────────────────
+// A hand-written typed walk replaced them, and was in turn replaced by the serde probe in
+// `swallow_evidence`. The reason is worth keeping, because it is the argument for the probe:
+// a hand-enumerated carrier list is a CLAIM ABOUT A POPULATION, and that claim was falsified
+// twice in review — first by `ManaSpellGrant::AddKeywordUntilEndOfTurn.duration` (a
+// `Box<Duration>`, fully qualified, in `mana.rs`), then by durations nested under
+// `Effect::Token.static_abilities -> GrantTrigger -> trigger.execute`. Each miss surfaced as a
+// false-positive warning cluster. `UnitEvidence::any_duration` derives its reach from serde
+// instead of from a human, so it structurally cannot miss a `Duration`-typed carrier.
 //
-// `Duration` is a BOUNDED fact: its parse-time carriers are a small closed set, so it is
-// hand-typed here rather than probed. THE CARRIER LIST IS THE WHOLE CORRECTNESS ARGUMENT,
-// so it is spelled out and its derivation is reproducible:
+// THE PROBE'S REACH IS A TYPE, NOT A CONCEPT. It finds values of type `Duration`. Two carriers
+// express an end-of-turn scope WITHOUT being a `Duration`, so they are outside it BY
+// CONSTRUCTION and keep the typed legs below — no widening of `any_duration` can subsume them:
 //
-//     rg ':\s*[^,/]*\bDuration\b' crates/engine/src/types/{ability,statics,triggers,replacements,mana}.rs
-//
-// THE GREP ABOVE IS THE SECOND ONE. The first was `:\s*(Option<)?(Box<)?Duration\b` over
-// ability/statics/triggers/replacements only, and it MISSED `ManaSpellGrant` — boxed, fully
-// qualified, and in `mana.rs`. The full-pool delta caught the omission as a false-positive
-// cluster (Generator Servant / Carnelian Orb / Arena of Glory). A carrier list is a claim
-// about a population; state the population, and measure the claim.
-//
-// POPULATION: 10 parse-time carriers (below). Excluded, and why:
-//   - `AbilityDefinition` L15728 — the serde *repr* of the same `duration` field, not a
-//     second carrier.
-//   - `ResolvedAbility` L19445 — a RUNTIME type. It never appears in `ParsedAbilities`.
-// `StaticDefinition` carries NO `Duration` field at all: a static's duration lives on the
-// `Effect::GenericEffect` that wraps it, which is why `static_has_duration`'s blanket
-// `true` was vacuous (see `unit_has_duration`).
-//
-// The nine parse-time carriers:
-//   1. `AbilityDefinition.duration`
-//   2. `Effect::BecomeCopy.duration`
-//   3. `Effect::GainActivatedAbilitiesOfTarget.duration`
-//   4. `Effect::GenericEffect.duration`
-//   5. `Effect::CastFromZone.duration`
-//   6. `Effect::ForceAttack.duration`            (non-optional)
-//   7. `Effect::PreventDamage.prevention_duration`
-//   8. `CastingPermission::ExileWithAltCost.duration`
-//   9. `CastingPermission::PlayFromExile.duration` (non-optional)
-//  10. `ManaSpellGrant::AddKeywordUntilEndOfTurn.duration` — reached via `Effect::Mana.grants`
-//      (CR 609.4b). The one the first grep missed.
-//
-// Plus one duration-EQUIVALENT that is not typed `Duration`: `Effect::Mana.expiry`
-// (`ManaExpiry`, CR 106.4 — "this mana doesn't empty until end of turn"). It is mapped
-// onto the same kinds so a mana-persistence card is not reported as a swallowed duration.
-//
-// DECLARED REACH GAP: the `_ => {}` arm below means a FUTURE `Effect` variant carrying a
-// `Duration` is invisible until it is added here. That is why the grep above is pinned in
-// the commit message: the completeness claim is only as good as the population behind it.
+//   1. `Effect::Mana.expiry` (`ManaExpiry`, CR 106.4) — "that mana doesn't empty until end of
+//      turn". A different TYPE.
+//   2. `ReplacementEvent::DamageDone` (CR 614.6 + CR 514.2) — a one-shot damage shield has no
+//      duration FIELD at all; its lifetime is structural. Handled inline in the detector.
 
-/// The kinds of duration a detector can ask for. Each detector asks for ITS OWN kind —
-/// the defect being fixed is that `detect_duration_until_eot` used to accept ANY duration
-/// (via `any_ability_has_duration`), so a `Permanent` duration discharged an "until end of
-/// turn" expectation. Evidence must be the fact the expectation asked about.
-fn duration_is_end_of_turn(duration: &Duration) -> bool {
-    // CR 611.2a + CR 514.2: "until end of turn" / "until end of combat" both expire at a
-    // cleanup within THIS turn, and the Oracle marker " until end of turn" is the surface
-    // form of both in the printings this detector scans.
-    matches!(
-        duration,
-        Duration::UntilEndOfTurn | Duration::UntilEndOfCombat
-    )
-}
-
-/// CR 611.2a: "until your next turn" / "until that player's next turn".
-fn duration_is_next_turn(duration: &Duration) -> bool {
-    matches!(
-        duration,
-        Duration::UntilNextTurnOf { .. } | Duration::UntilEndOfNextTurnOf { .. }
-    )
-}
-
-fn mana_expiry_is_end_of_turn(expiry: &crate::types::mana::ManaExpiry) -> bool {
-    // CR 106.4: mana normally empties at each step/phase end; an expiry overrides that.
-    matches!(
-        expiry,
-        crate::types::mana::ManaExpiry::EndOfTurn | crate::types::mana::ManaExpiry::EndOfCombat
-    )
-}
-
-/// Does any `Duration` reachable from this effect satisfy `pred`?
-///
-/// Both halves matter: the seven Effect-level CARRIERS above, and the CONTAINERS that nest
-/// further definitions. The container half is why the JSON marker existed at all — the old
-/// `def_tree_has_duration` walked only `sub`/`else`/`mode`, so an "until end of turn"
-/// nested in `Effect::Token.static_abilities -> GrantTrigger -> trigger.execute` was
-/// invisible to it and only the serialized-string scan could see it.
-fn effect_has_duration(effect: &Effect, pred: &dyn Fn(&Duration) -> bool) -> bool {
-    match effect {
-        // ---- carriers ----
-        Effect::BecomeCopy { duration, .. }
-        | Effect::GainActivatedAbilitiesOfTarget { duration, .. }
-        | Effect::CastFromZone { duration, .. } => duration.as_ref().is_some_and(pred),
-        Effect::ForceAttack { duration, .. } => pred(duration),
-        Effect::PreventDamage {
-            prevention_duration,
-            ..
-        } => prevention_duration.as_ref().is_some_and(pred),
-        Effect::GenericEffect {
-            duration,
-            static_abilities,
-            ..
-        } => {
-            duration.as_ref().is_some_and(pred)
-                || static_abilities
-                    .iter()
-                    .any(|s| static_has_duration_matching(s, pred))
-        }
-        Effect::GrantCastingPermission { permission, .. } => {
-            casting_permission_has_duration(permission, pred)
-        }
-        // CR 609.4b + CR 611.2a: "If that mana is spent on a creature spell, it gains haste
-        // until end of turn" (Generator Servant, Carnelian Orb of Dragonkind, Arena of
-        // Glory). The duration rides on the conditional mana grant, not on the def.
-        //
-        // This carrier was MISSED by my first completeness grep (`:\s*(Option<)?Duration\b`)
-        // because its type is `Box<crate::types::ability::Duration>` — boxed AND fully
-        // qualified. The full-pool delta caught it as a false-positive cluster, which is the
-        // whole argument for measuring: a carrier list is a CLAIM ABOUT A POPULATION and is
-        // only ever as good as the grep behind it. Corrected grep, pinned:
-        //   rg ':\s*[^,/]*\bDuration\b' crates/engine/src/types/{ability,statics,triggers,replacements,mana}.rs
-        Effect::Mana { grants, .. } => grants.iter().any(|grant| match grant {
-            crate::types::mana::ManaSpellGrant::AddKeywordUntilEndOfTurn { duration, .. } => {
-                pred(duration)
-            }
-            _ => false,
-        }),
-        // ---- containers: nested definitions the duration may live inside ----
-        Effect::Token {
-            static_abilities, ..
-        } => static_abilities
-            .iter()
-            .any(|s| static_has_duration_matching(s, pred)),
-        Effect::CreateEmblem { statics, triggers } => {
-            statics
-                .iter()
-                .any(|s| static_has_duration_matching(s, pred))
-                || triggers.iter().any(|t| {
-                    t.execute
-                        .as_deref()
-                        .is_some_and(|d| def_has_duration(d, pred))
-                })
-        }
-        Effect::ChooseOneOf { branches, .. } => branches.iter().any(|b| def_has_duration(b, pred)),
-        Effect::CreateDelayedTrigger { effect, .. } => def_has_duration(effect, pred),
-        Effect::Vote {
-            per_choice_effect, ..
-        } => per_choice_effect.iter().any(|d| def_has_duration(d, pred)),
-        Effect::SeparateIntoPiles {
-            chosen_pile_effect,
-            unchosen_pile_effect,
-            ..
-        } => {
-            def_has_duration(chosen_pile_effect, pred)
-                || unchosen_pile_effect
-                    .as_deref()
-                    .is_some_and(|d| def_has_duration(d, pred))
-        }
-        Effect::RevealFromHand { on_decline, .. } => on_decline
-            .as_deref()
-            .is_some_and(|d| def_has_duration(d, pred)),
-        Effect::FlipCoin {
-            win_effect,
-            lose_effect,
-            ..
-        }
-        | Effect::FlipCoins {
-            win_effect,
-            lose_effect,
-            ..
-        } => {
-            win_effect
-                .as_deref()
-                .is_some_and(|d| def_has_duration(d, pred))
-                || lose_effect
-                    .as_deref()
-                    .is_some_and(|d| def_has_duration(d, pred))
-        }
-        Effect::FlipCoinUntilLose { win_effect, .. } => def_has_duration(win_effect, pred),
-        Effect::AddTargetReplacement { replacement, .. } => replacement
-            .execute
-            .as_deref()
-            .is_some_and(|d| def_has_duration(d, pred)),
-        // DECLARED REACH GAP — see the module note above. A new Duration-carrying variant
-        // must be added to the carrier list; the grep is the census that finds it.
-        _ => false,
-    }
-}
-
-fn casting_permission_has_duration(
-    permission: &crate::types::ability::CastingPermission,
-    pred: &dyn Fn(&Duration) -> bool,
-) -> bool {
-    match permission {
-        crate::types::ability::CastingPermission::ExileWithAltCost { duration, .. } => {
-            duration.as_ref().is_some_and(pred)
-        }
-        crate::types::ability::CastingPermission::PlayFromExile { duration, .. } => pred(duration),
-        _ => false,
-    }
-}
-
-fn static_has_duration_matching(
-    static_def: &StaticDefinition,
-    pred: &dyn Fn(&Duration) -> bool,
-) -> bool {
-    // CR 613.1f: a granted ability/trigger/static can itself carry the duration.
-    static_def.modifications.iter().any(|m| match m {
-        ContinuousModification::GrantTrigger { trigger } => trigger
-            .execute
-            .as_deref()
-            .is_some_and(|d| def_has_duration(d, pred)),
-        ContinuousModification::GrantAbility { definition } => def_has_duration(definition, pred),
-        ContinuousModification::GrantStaticAbility { definition } => {
-            static_has_duration_matching(definition, pred)
-        }
-        _ => false,
-    })
-}
-
-fn def_has_duration(def: &AbilityDefinition, pred: &dyn Fn(&Duration) -> bool) -> bool {
-    if def.duration.as_ref().is_some_and(pred) {
-        return true;
-    }
-    if effect_has_duration(&def.effect, pred) {
-        return true;
-    }
-    if def
-        .sub_ability
-        .as_deref()
-        .is_some_and(|d| def_has_duration(d, pred))
-    {
-        return true;
-    }
-    if def
-        .else_ability
-        .as_deref()
-        .is_some_and(|d| def_has_duration(d, pred))
-    {
-        return true;
-    }
-    def.mode_abilities.iter().any(|d| def_has_duration(d, pred))
-}
-
-/// Does THIS UNIT's parse carry a duration of the kind the detector asked for?
-///
-/// Note what is deliberately absent: `parsed.statics.iter().any(static_has_duration)`, whose
-/// callee is a stub returning `true` unconditionally. Under it, ANY static ability at all —
-/// a keyword grant, a cost modifier, an anthem — discharged a duration expectation. That is
-/// the APNAP defect a third time: evidence satisfied by a fact the expectation never asked
-/// about. Statics reach durations only through their granted definitions, which
-/// `static_has_duration_matching` walks properly.
-fn unit_has_duration(parsed: &ParsedAbilities, pred: &dyn Fn(&Duration) -> bool) -> bool {
-    parsed.abilities.iter().any(|d| def_has_duration(d, pred))
-        || parsed.triggers.iter().any(|t| {
-            t.execute
-                .as_deref()
-                .is_some_and(|d| def_has_duration(d, pred))
-        })
-        || parsed.replacements.iter().any(|r| {
-            r.execute
-                .as_deref()
-                .is_some_and(|d| def_has_duration(d, pred))
-        })
-        || parsed
-            .statics
-            .iter()
-            .any(|s| static_has_duration_matching(s, pred))
+fn mana_expiry_is_end_of_turn(expiry: &ManaExpiry) -> bool {
+    // CR 106.4: a player's mana pool empties at the end of each step and phase; an expiry
+    // overrides that, which is what makes it duration-equivalent for this detector.
+    matches!(expiry, ManaExpiry::EndOfTurn | ManaExpiry::EndOfCombat)
 }
 
 /// CR 106.4: `Effect::Mana.expiry` is a duration-equivalent that is not typed `Duration`.
@@ -2060,20 +1840,14 @@ fn any_ability_has_apnap_ordering(parsed: &ParsedAbilities) -> bool {
 // Their sole caller was `any_text_field_contains(parsed, "instead")` in
 // `detect_replacement_instead`, now `any_ability_has_replacement_carrier`.
 
-// ── JSON-haystack detectors ─────────────────────────────────────────────
+// ── Typed-evidence detectors ────────────────────────────────────────────
 //
-// These detectors operate by checking the serialized AST for representation
-// markers. They share a single `ast_json` haystack pre-computed once per
-// card. JSON-string scanning is less precise than struct walking but
-// dramatically simpler for detectors that touch many AST shapes (e.g.,
-// dynamic-quantity is carried by `QuantityExpr` which lives inside dozens
-// of effect variants).
-
-/// Word-bounded contains check on the JSON haystack. Looks for any of the
-/// given representation markers; returns true if at least one is present.
-fn json_has_any(ast_json: &str, markers: &[&str]) -> bool {
-    markers.iter().any(|m| ast_json.contains(m))
-}
+// These detectors answer tree-global existence questions ("is a dynamic quantity
+// carried ANYWHERE under this unit's definitions?") against the typed probe in
+// `swallow_evidence`. They previously scanned the serialized AST for substring
+// markers; see that module's header for why a string marker cannot be trusted —
+// it can name a type that does not exist, or match a LONGER type's name and
+// discharge an unrelated rule's fact.
 
 // ── Detector F: DynamicQty ──────────────────────────────────────────────
 
@@ -2087,7 +1861,7 @@ fn json_has_any(ast_json: &str, markers: &[&str]) -> bool {
 fn detect_dynamic_qty(
     cleaned: &str,
     original: &str,
-    ast_json: &str,
+    evidence: &UnitEvidence,
     diagnostics: &mut Vec<OracleDiagnostic>,
 ) {
     // CR 605.1g: "Activate ... twice each turn" is a fixed-count activation
@@ -2108,124 +1882,118 @@ fn detect_dynamic_qty(
     if !has_marker {
         return;
     }
-    // Any of these AST markers is sufficient evidence the dynamic clause
-    // was captured somewhere. The list mirrors the QuantityExpr / QuantityRef
-    // variant names plus the few specialty refs that don't tag-serialize as
-    // `"Variable"`/`"Multiply"`/etc.
-    let dynamic_markers: &[&str] = &[
-        "\"type\":\"Ref\"",
-        // CR 120.1: "each deal damage equal to their power" — the per-source
-        // power is an implicit dynamic quantity carried by the effect variant
-        // itself (no separate QuantityExpr field), so the variant name is the
-        // coverage marker. Band Together / Allies at Last class.
-        "EachDealsDamageEqualToPower",
-        "\"type\":\"Multiply\"",
-        "\"type\":\"DivideRounded\"",
-        "\"type\":\"Offset\"",
-        "\"type\":\"Sum\"",
-        "\"Variable\"",
-        "EventContext",
-        "CountersOn",
-        "NumberOf",
-        "ForEach",
-        "TrackedSetSize",
-        "LifeLost",
-        "LifeGained",
-        "Devotion",
-        "ManaValue",
-        // CR 601.2f / CR 117.7: spell- and ability-cost reductions whose
-        // {N} amount is multiplied by a dynamic count of objects, zone
-        // contents, mana value, etc. The carrier is the `dynamic_count`
-        // field on `StaticMode::ModifyCost` (Reduce / Raise modes),
-        // populated with `ObjectCount` / `ZoneCardCount` / `Devotion` /
-        // `ManaValue` typed quantity refs.
-        "\"dynamic_count\":{",
-        "ObjectCount",
-        "ZoneCardCount",
-        // Bloom Tender / Faeburrow Elder class: "For each color among
-        // permanents you control, add one mana of that color" is captured as
-        // a dynamic mana-production carrier, not a QuantityExpr count.
-        "DistinctColorsAmongPermanents",
-        // CR 122.1: Bribe Taker class — "for each kind of counter on
-        // permanents you control" is captured as a `DistinctCounterKindsAmong`
-        // iteration-source QuantityRef driving `repeat_for`, not a swallowed
-        // count.
-        "DistinctCounterKindsAmong",
-        // CR 701.34a + CR 122.1: Skyship Plunderer / Maulfist Revolutionary —
-        // "for each kind of counter on target permanent or player, give that
-        // permanent or player another counter of that kind" is captured whole by
-        // `Effect::ProliferateTarget`. The counter-kind iteration is intrinsic to
-        // the proliferate operation, not a swallowed `QuantityExpr` count.
-        "\"type\":\"ProliferateTarget\"",
-        // CR 207.2c + CR 601.2f: Strive — "this spell costs {N} more for each target
-        // beyond the first" is captured on the top-level `Card` as
-        // `strive_cost: Some(ManaCost)`, not inside an ability tree.
-        "\"striveCost\":{",
-        // CR 702.139 / CR 702.41: Affinity / Improvise / Convoke style
-        // built-in cost mods — captured as `keywords` entries with cost
-        // payload, not as in-AST quantity expressions.
-        "\"Affinity\":",
-        // CR 702.34 / CR 702.144 / CR 702.83: Flashback / Scavenge /
-        // Replicate "cost equal to its mana cost" — encoded as a dynamic
-        // mana-cost reference rather than a fixed cost.
-        "SelfManaCost",
-        "SelfManaValue",
-        "TargetManaCost",
-        // CR 702.170a: "The plot cost is equal to its mana cost" — the plot cost
-        // is intrinsic to the `TopOfLibraryHasPlot` static (computed at synthesis
-        // from the live top card's mana_cost), not a stored `QuantityExpr`. The
-        // static's presence in the AST is the coverage marker, mirroring the
-        // `SelfManaCost` precedent for Flashback/Scavenge "cost equal to its mana
-        // cost" (Fblthp, Lost on the Range).
-        "TopOfLibraryHasPlot",
-        // CR 702.143d: "Its foretell cost is equal to its mana cost reduced by
-        // {N}" — the derived cost is intrinsic to the granted keyword and is
-        // computed per recipient by `CostDerivation` (no stored `QuantityExpr`),
-        // so the `AddKeywordWithDerivedCost` continuous-modification variant is
-        // itself the coverage marker. Mirrors the `SelfManaCost` /
-        // `TopOfLibraryHasPlot` "cost equal to its mana cost" precedents.
-        // Singing Towers of Darillium class.
-        "AddKeywordWithDerivedCost",
-        // CR 702.20a: "assigns combat damage equal to its toughness
-        // rather than its power" — Brontodon class. Encoded as a typed
-        // continuous-modification variant, not a quantity expression.
-        "AssignDamageFromToughness",
-        "AssignDamageAsThoughUnblocked",
-        // CR 508.1h + CR 509.1d: Ghostly Prison / Propaganda combat-tax
-        // phrasing uses "for each creature" but is encoded as a typed
-        // scaling mode on `StaticCondition::UnlessPay`, not as a
-        // `QuantityExpr` carrier.
-        "PerAffectedCreature",
-        // CR 614.1d: "twice that many" / "thrice that many" replacement
-        // multipliers (Doubling Season, Parallel Lives, Anointed
-        // Procession, Branching Evolution, Hardened Scales class) are
-        // encoded as `quantity_modification: { type: Double }` on the
-        // ReplacementDefinition, not as a QuantityExpr in the effect.
-        "\"quantity_modification\":{",
-        // CR 115.10 + CR 608.2c: Non-targeting "for each [object], create a
-        // token that's a copy of it" effects carry the iterated source set as
-        // `CopyTokenOf::source_filter`, not as `repeat_for` or a QuantityExpr.
-        "\"source_filter\":{",
-        // Sylvan Library class: "For each of those cards, pay N life or put
-        // the card on top" is captured as a dedicated per-card choice effect.
-        "ChooseDrawnThisTurnPayOrTopdeck",
-        // CR 608.2c + CR 701.38: "For each player who chose <choice>" vote
-        // bodies are captured by `PlayerFilter::VotedFor`, which resolves
-        // against the vote ballot ledger rather than a QuantityExpr.
-        "VotedFor",
-        // CR 122.1 + CR 208.1: "puts a number of +1/+1 counters ... equal to the
-        // power of the second creature they chose" (Human—Time Lord Meta-Crisis)
-        // is captured whole by `Effect::EachPlayerCopyChosen`'s `scale` clause
-        // (`scale_property` read live at placement), not a stored `QuantityExpr`.
-        // The variant name is the coverage marker, mirroring
-        // `EachDealsDamageEqualToPower`.
-        "EachPlayerCopyChosen",
-    ];
-    if json_has_any(ast_json, dynamic_markers) {
+    // ── Typed dynamic-quantity carriers ─────────────────────────────────
+    //
+    // CR 107.1a + CR 107.3 + CR 119.1. The engine has exactly ONE dynamic-quantity
+    // vocabulary: `QuantityRef` (a value read from game state), wrapped in
+    // `QuantityExpr`. Nearly every marker in the deleted list — `"type":"Ref"`,
+    // CountersOn, NumberOf, ForEach, TrackedSetSize, Devotion, ObjectCount,
+    // ZoneCardCount, EventContext*, DistinctColorsAmongPermanents,
+    // DistinctCounterKindsAmong, SelfManaValue, `"dynamic_count":{` — was a
+    // `QuantityRef` variant name. The whole family collapses into one typed predicate
+    // whose reach the compiler maintains: a new `QuantityRef` variant, or a new
+    // `Effect` field that carries one, is covered on the day it is added.
+    //
+    // `QuantityExpr::Fixed` is a CONSTANT, not a dynamic quantity, and is excluded.
+    // That exclusion is load-bearing: `QuantityExpr`'s hand-written `Deserialize` also
+    // accepts a BARE INTEGER as `Fixed` (the legacy on-disk form), so a predicate that
+    // forgot to exclude it would be satisfied by any number anywhere on the card.
+    if evidence.any::<QuantityRef>(|_| true)
+        || evidence.any::<QuantityExpr>(|q| !matches!(q, QuantityExpr::Fixed { .. }))
+    {
+        return;
+    }
+    // Carriers that express a dynamic amount WITHOUT a `QuantityExpr` field — the
+    // quantity is intrinsic to the variant, so the variant itself is the evidence.
+    //   CR 120.1   EachDealsDamageEqualToPower — "each deals damage equal to its power"
+    //              (Band Together / Allies at Last).
+    //   CR 701.34a ProliferateTarget — counter-kind iteration is intrinsic to proliferate.
+    //   CR 122.1   EachPlayerCopyChosen — `scale_property` is read live at placement.
+    //   Sylvan Library  ChooseDrawnThisTurnPayOrTopdeck — per-card choice effect.
+    if evidence.any::<Effect>(|e| {
+        matches!(
+            e,
+            Effect::EachDealsDamageEqualToPower { .. }
+                | Effect::ProliferateTarget { .. }
+                | Effect::EachPlayerCopyChosen { .. }
+                | Effect::ChooseDrawnThisTurnPayOrTopdeck { .. }
+        )
+    }) {
+        return;
+    }
+    //   CR 702.143d AddKeywordWithDerivedCost — foretell cost "equal to its mana cost
+    //              reduced by {N}", computed per recipient by `CostDerivation`.
+    //   CR 702.20a  AssignDamageFromToughness / AssignDamageAsThoughUnblocked —
+    //              Brontodon class; a typed modification, not a quantity expression.
+    if evidence.any::<ContinuousModification>(|m| {
+        matches!(
+            m,
+            ContinuousModification::AddKeywordWithDerivedCost { .. }
+                | ContinuousModification::AssignDamageFromToughness
+                | ContinuousModification::AssignDamageAsThoughUnblocked
+        )
+    }) {
+        return;
+    }
+    //   CR 702.170a TopOfLibraryHasPlot — "plot cost equal to its mana cost" is computed
+    //              at synthesis from the live top card, not stored.
+    if evidence.any_static_mode(|m| matches!(m, StaticMode::TopOfLibraryHasPlot)) {
+        return;
+    }
+    //   CR 702.34 / 702.144 / 702.83 / 702.143d  A cost derived from the card's OWN mana
+    //              cost rather than a fixed amount: Flashback / Scavenge / Replicate
+    //              ("equal to its mana cost") and Foretell ("equal to its mana cost
+    //              reduced by {N}", Singing Towers of Darillium). `ManaCost` has exactly
+    //              three self-referential variants and all three are dynamic; `Cost` and
+    //              `NoCost` are fixed and are excluded.
+    //
+    //              `SelfManaCostReduced` is here because the OLD marker list did not
+    //              actually name it: it carried `AddKeywordWithDerivedCost` (a
+    //              `ContinuousModification` variant this card never produces — the parser
+    //              emits `AddKeyword` + `ManaCost::SelfManaCostReduced`) and got away with
+    //              it only because its OTHER marker, `SelfManaCost`, is a SUBSTRING of
+    //              `SelfManaCostReduced`. The typed probe cannot lean on that accident, so
+    //              the real carrier has to be named.
+    if evidence.any::<ManaCost>(|c| {
+        matches!(
+            c,
+            ManaCost::SelfManaCost | ManaCost::SelfManaValue | ManaCost::SelfManaCostReduced { .. }
+        )
+    }) {
+        return;
+    }
+    //   CR 508.1h + CR 509.1d  Ghostly Prison / Propaganda phrase their combat tax with
+    //              "for each creature", but it is a typed scaling mode on
+    //              `StaticCondition::UnlessPay`, not a `QuantityExpr`.
+    if evidence.any::<UnlessPayScaling>(|s| matches!(s, UnlessPayScaling::PerAffectedCreature)) {
+        return;
+    }
+    //   CR 608.2c + CR 701.38  "For each player who chose <choice>" vote bodies resolve
+    //              against the ballot ledger via `PlayerFilter::VotedFor`.
+    if evidence.any::<PlayerFilter>(|p| matches!(p, PlayerFilter::VotedFor { .. })) {
+        return;
+    }
+    //   CR 702.139 / 702.41  Affinity-style built-in cost mods carry their scaling in the
+    //              keyword payload. `Keyword` is EXTERNALLY tagged, so it is key-anchored
+    //              (array elements inherit their field's key).
+    if evidence.any_at::<Keyword>(&["extracted_keywords", "keywords"], |k| {
+        matches!(k, Keyword::Affinity { .. })
+    }) {
+        return;
+    }
+    // Slot-shaped carriers: the fact IS "the parser filled this slot", and the slot's
+    // value carries no further discrimination this detector needs.
+    //   CR 207.2c + CR 601.2f  strive_cost — "{N} more for each target beyond the first"
+    //   CR 614.1d              quantity_modification — "twice that many" (Doubling Season)
+    //   CR 115.10 + CR 608.2c  source_filter — "for each X, create a token copy of it"
+    if evidence.has_slot("striveCost")
+        || evidence.has_slot("quantity_modification")
+        || evidence.has_slot("source_filter")
+    {
         return;
     }
     if cleaned_has_only_counter_multiplier_dynamic(cleaned)
-        && json_has_any(ast_json, &["\"type\":\"MultiplyCounter\""])
+        && evidence.any::<Effect>(|e| matches!(e, Effect::MultiplyCounter { .. }))
     {
         return;
     }
@@ -2236,9 +2004,7 @@ fn detect_dynamic_qty(
     // `repeat_for` is a structural field, not a value-typed `"type":"Ref"` node.
     // When "twice" is the SOLE dynamic marker and the AST carries a `repeat_for`,
     // the quantity IS represented; the warning is a false positive.
-    if cleaned_twice_is_only_dynamic_marker(cleaned)
-        && json_has_any(ast_json, &["\"repeat_for\":{"])
-    {
+    if cleaned_twice_is_only_dynamic_marker(cleaned) && evidence.has_slot("repeat_for") {
         return;
     }
     // CR 608.2e + CR 109.5: "For each opponent who doesn't, <body>" is a
@@ -2251,14 +2017,21 @@ fn detect_dynamic_qty(
     // would suppress the warning even when the decline body failed to parse.
     // The `Not` gate is what proves the decline-consequence clause is
     // represented (issue #491 follow-up).
-    if cleaned_for_each_is_only_decline_iteration(cleaned) && json_has_any(ast_json, &["\"Not\""]) {
+    // The `Not` wrapper is what proves the decline-consequence clause is represented; a
+    // bare `IfYouDo` sits on EVERY Braids-class AST whether or not the decline body
+    // attached. Both condition enums carry a `Not` (they share 17 variant names) and
+    // either satisfies this fact, so the probe deliberately accepts both.
+    if cleaned_for_each_is_only_decline_iteration(cleaned)
+        && (evidence.any::<AbilityCondition>(|c| matches!(c, AbilityCondition::Not { .. }))
+            || evidence.any::<StaticCondition>(|c| matches!(c, StaticCondition::Not { .. })))
+    {
         return;
     }
     // CR 101.4 + CR 701.21a: Tragic Arrogance-style "For each player, you choose
     // ..." is a turn-order choice procedure, not a numeric quantity. Its carrier
     // is the dedicated ChooseAndSacrificeRest effect rather than a QuantityExpr.
     if cleaned.contains("for each player, you choose ") // allow-noncombinator: swallow detector marker scan on classified text
-        && json_has_any(ast_json, &["ChooseAndSacrificeRest"])
+        && evidence.any::<Effect>(|e| matches!(e, Effect::ChooseAndSacrificeRest { .. }))
     {
         return;
     }
@@ -2270,7 +2043,8 @@ fn detect_dynamic_qty(
     // represented by the `Vote` structure, not a `QuantityExpr` carrier. When
     // the AST is a Vote and every dynamic marker is tally phrasing, nothing was
     // swallowed.
-    if cleaned_dynamic_is_only_vote_tally(cleaned) && json_has_any(ast_json, &["\"type\":\"Vote\""])
+    if cleaned_dynamic_is_only_vote_tally(cleaned)
+        && evidence.any::<Effect>(|e| matches!(e, Effect::Vote { .. }))
     {
         return;
     }
@@ -2287,7 +2061,9 @@ fn detect_dynamic_qty(
                 // allow-noncombinator: swallow detector marker scan on classified text
                 .match_indices("for each ")
                 .all(|(idx, _)| cleaned[idx + "for each ".len()..].starts_with('{'));
-        if all_for_each_are_mana_subst && json_has_any(ast_json, &["PayLifeAsColoredMana"]) {
+        if all_for_each_are_mana_subst
+            && evidence.any_static_mode(|m| matches!(m, StaticMode::PayLifeAsColoredMana { .. }))
+        {
             return;
         }
     }
@@ -2338,7 +2114,7 @@ fn detect_dynamic_qty(
 fn detect_modal_dynamic_max_dropped(
     cleaned: &str,
     original: &str,
-    ast_json: &str,
+    evidence: &UnitEvidence,
     diagnostics: &mut Vec<OracleDiagnostic>,
 ) {
     // (1) Oracle carries a dynamic modal header (the "choose " lead is intrinsic
@@ -2349,11 +2125,11 @@ fn detect_modal_dynamic_max_dropped(
         return;
     }
     // (2) A modal node was parsed (excludes non-modal selection clauses).
-    if !json_has_any(ast_json, &["\"modal\":{"]) {
+    if !evidence.has_slot("modal") {
         return;
     }
     // (3) ...but it carries no dynamic cap — the "up to X / that many" was lost.
-    if json_has_any(ast_json, &["\"dynamic_max_choices\":{"]) {
+    if evidence.has_slot("dynamic_max_choices") {
         return;
     }
     diagnostics.push(OracleDiagnostic::SwallowedClause {
@@ -2659,9 +2435,8 @@ fn dig_if_you_do_is_only_if_marker(stripped: &str) -> bool {
 /// clause is located and dropped via the shared `is_moved_object_enters_modifier_clause`
 /// combinator, and suppression fires ONLY when no OTHER bare " if " remains — so
 /// a compound card carrying the gate AND a separate dropped " if " still flags.
-fn enters_modified_if_is_only_if_marker(stripped: &str, ast_json: &str) -> bool {
-    // allow-noncombinator: structural AST-shape JSON probe (mirrors source_rider / countered_spell_zone)
-    if !ast_json.contains("\"enters_modified_if\":") {
+fn enters_modified_if_is_only_if_marker(stripped: &str, evidence: &UnitEvidence) -> bool {
+    if !evidence.has_slot("enters_modified_if") {
         return false;
     }
     // Text-scoped: drop the represented moved-object enters-modifier clause(s)
@@ -2855,9 +2630,11 @@ fn strip_represented_replacement_instead_sentences(
 /// combinator and dropped sentence-by-sentence, and suppression fires ONLY when no
 /// OTHER bare " if " survives, so a compound card carrying the gate AND a separate
 /// unrelated " if " still flags.
-fn conditional_enter_counters_if_is_only_if_marker(stripped: &str, ast_json: &str) -> bool {
-    // allow-noncombinator: structural AST-shape JSON probe (mirrors enters_modified_if)
-    if !ast_json.contains("\"conditional_enter_with_counters\":") {
+fn conditional_enter_counters_if_is_only_if_marker(
+    stripped: &str,
+    evidence: &UnitEvidence,
+) -> bool {
+    if !evidence.has_slot("conditional_enter_with_counters") {
         return false;
     }
     let residual: String = stripped
@@ -2883,7 +2660,7 @@ fn conditional_enter_counters_if_is_only_if_marker(stripped: &str, ast_json: &st
 fn detect_condition_if(
     cleaned: &str,
     original: &str,
-    ast_json: &str,
+    evidence: &UnitEvidence,
     parsed: &ParsedAbilities,
     diagnostics: &mut Vec<OracleDiagnostic>,
 ) {
@@ -2972,13 +2749,13 @@ fn detect_condition_if(
     // The leading moved-object type condition is represented by the typed
     // `enters_modified_if` gate on the absorbed ChangeZone. Text-scoped: only
     // suppresses when that enters-modifier clause is the card's only bare " if ".
-    if enters_modified_if_is_only_if_marker(&stripped, ast_json) {
+    if enters_modified_if_is_only_if_marker(&stripped, evidence) {
         return;
     }
     // CR 122.1 + CR 614.1c + CR 608.2c: "If you put a[n] <type> onto the
     // battlefield this way, put [N] +1/+1 counters on it" (Oviya) is represented
     // by `Effect::ChangeZone.conditional_enter_with_counters`.
-    if conditional_enter_counters_if_is_only_if_marker(&stripped, ast_json) {
+    if conditional_enter_counters_if_is_only_if_marker(&stripped, evidence) {
         return;
     }
     // CR 615.5: "If damage is prevented this way, [effect]" is not an
@@ -3000,8 +2777,7 @@ fn detect_condition_if(
     // a separate `condition` field) aren't suppressed.
     if stripped.contains("if damage would be dealt to") // allow-noncombinator: swallow detector marker scan on classified text
         && stripped.contains("prevent that damage") // allow-noncombinator: swallow detector marker scan on classified text
-        && ast_json.contains("\"type\":\"PreventDamage\"")
-    // allow-noncombinator: structural AST-shape JSON probe
+        && evidence.any::<Effect>(|e| matches!(e, Effect::PreventDamage { .. }))
     {
         return;
     }
@@ -3023,8 +2799,7 @@ fn detect_condition_if(
     // allow-noncombinator: swallow detector marker scan on classified text
     if (stripped.contains("lost life this way") || stripped.contains("gained life this way"))
         && stripped.contains("that many") // allow-noncombinator: swallow detector marker scan on classified text
-        && ast_json.contains("EventContextAmount")
-    // allow-noncombinator: structural AST-shape JSON probe
+        && evidence.any::<QuantityRef>(|q| matches!(q, QuantityRef::EventContextAmount { .. }))
     {
         return;
     }
@@ -3055,95 +2830,110 @@ fn detect_condition_if(
     if !has_marker {
         return;
     }
-    let cond_markers: &[&str] = &[
-        "\"condition\":{",
-        "\"constraint\":{",
-        "\"unless_filter\":{",
-        "\"unless_pay\":{",
-        "\"if_clause\"",
-        "\"intervening_if\"",
-        "Conditional",
-        "QuantityCheck",
-        "ConditionMet",
-        // "if you do" pattern produces sub_ability chains; this is a
-        // representation marker.
-        "IfYouDo",
-        "ConditionalEffect",
-        // CR 614.1a: AddTargetReplacement encodes the "if [target] would die"
-        // gate via the carried ReplacementDefinition's event/destination_zone.
-        "AddTargetReplacement",
-        // CR 614.1a + CR 901.9c: CreatePlaneswalkReplacement encodes the "if a
-        // player would planeswalk as a result of rolling the planar die,
-        // [effect] instead" gate (Fixed Point in Time). Its presence IS the
-        // conditional-replacement representation — the leading "if" is a marker,
-        // not a swallowed condition.
-        "\"type\":\"CreatePlaneswalkReplacement\"",
-        // CR 508.1d / CR 509.1c / CR 506.6: must-attack and must-block "if able"
-        // riders are encoded as static-mode constraints or as
-        // `ForceBlock`/`ForceAttack` effects, not conditional gates.
-        "\"mode\":\"MustAttack\"",
-        "\"mode\":\"MustBlock\"",
-        // `MustBeBlocked` is data-carrying (`MustBeBlocked { by: Option<_> }`).
-        // The `by` field has no `skip_serializing_if`, so serde emits the object
-        // form `{"MustBeBlocked":{"by":...}}` for BOTH shapes: `{"by":null}` for
-        // the bare "must be blocked if able" rider (`by: None`) and
-        // `{"by":{...}}` for typed riders (Ace's Baseball Bat, Slayer's Cleaver).
-        // Match the quoted variant key `"MustBeBlocked"`, which is common to both
-        // serializations, so both suppress the "if able" Condition_If marker.
-        "\"MustBeBlocked\"",
-        "\"type\":\"ForceBlock\"",
-        "\"type\":\"ForceAttack\"",
-        // CR 305.9: "as ~ enters, you may pay X. If you don't, it enters
-        // tapped." — encoded as ReplacementMode::Optional with a `decline`
-        // branch that performs the alternative, OR (for cards like Ancient
-        // Amphitheater) as an effect with an `on_decline` branch.
-        "\"mode\":{\"type\":\"Optional\"",
-        "\"on_decline\":{",
-        // CR 701.20a + CR 608.2c: RevealUntil's kept_optional_to encodes the
-        // "you may put that card onto the battlefield. If you don't, ..."
-        // decline branch — the "if" is the optional-destination gate.
-        "\"kept_optional_to\":",
-        // CR 117.3a: TopOfLibraryCastPermission with `alt_cost` IS the "if
-        // you cast a spell this way, pay X" gate (Bolas's Citadel etc.).
-        "TopOfLibraryCastPermission",
-        // CR 113.6 + CR 601.2a: Evelyn's "you may play a card from exile … if
-        // it was exiled by an ability you controlled" — the "if" provenance
-        // clause is represented structurally by the
-        // LinkedCollectionCounterPlayPermission live-source marker static plus
-        // the per-card `PlayFromExile { exiled_by_ability_controller }` grant
-        // the ETB trigger attaches (set in grant_permission.rs, enforced in
-        // casting.rs / layers.rs), not a swallowed condition.
-        "LinkedCollectionCounterPlayPermission",
-        // CR 614.1a: GraveyardCastPermission with this flag carries the "if
-        // a spell cast this way would be put into your graveyard, exile it
-        // instead" replacement rider.
-        "graveyard_destination_replacement",
-        // CR 705: FlipCoin / FlipCoins / RollDie variants encode the
-        // "if you win the flip" / "if you lose" / die-result branches as
-        // structured win_effect/lose_effect/results sub-trees. Their
-        // presence IS the conditional gate (Aleatory, Chaotic Strike,
-        // Boompile, Bottle of Suleiman, etc.).
-        "\"win_effect\":{",
-        "\"lose_effect\":{",
-        "\"type\":\"FlipCoin\"",
-        "\"type\":\"FlipCoins\"",
-        "\"type\":\"RollDie\"",
-        "DefilerCostReduction",
-        // CR 701.6 + CR 608.2c: Effect::Counter.source_rider encodes the
-        // "If a permanent's ability is countered this way, [destroy that
-        // permanent | that permanent loses all abilities]" follow-up. Its
-        // presence (serialized as the `source_rider` field key with
-        // skip_serializing_if = is_none) IS the conditional gate (Teferi's
-        // Response, Green Slime, Tishana's Tidebinder).
-        "\"source_rider\":",
-        // CR 701.6a: Effect::Counter.countered_spell_zone encodes the
-        // "if that spell is countered this way, put it [on top of / on
-        // the bottom of its owner's library | into its owner's hand]"
-        // destination override. Its presence IS the conditional gate
-        // (Memory Lapse, Lapse of Certainty, Remand, Spell Crumple).
-        "\"countered_spell_zone\":",
-    ];
-    if json_has_any(ast_json, cond_markers) {
+    // ── Typed condition-representation carriers ─────────────────────────
+    //
+    // THREE markers from the deleted list are GONE, not translated, because they name
+    // no type in the engine and so could never have matched what they claimed:
+    //
+    //   `ConditionMet`      — there is NO `ConditionMet` variant anywhere. Its only
+    //                         matches were the SUBSTRING inside
+    //                         `TriggerCondition::SolveConditionMet`, a CR 719 Case
+    //                         solve-condition. So on every card carrying a Case, this
+    //                         `Condition_If` expectation was silently discharged by an
+    //                         unrelated rule's fact (15/15 pool hits). This is the
+    //                         collision the typed cutover exists to kill: it fails
+    //                         CLOSED, suppressing true positives.
+    //   `ConditionalEffect` — names no type; 0 pool hits; dead on arrival.
+    //   `IfYouDo`           — names no type either; the token occurs only inside doc
+    //                         comments. "If you do" chains are represented as
+    //                         sub_ability linkage, which the slot probes below cover.
+    //
+    // A condition slot being POPULATED is the fact here — which of the three condition
+    // enums fills it is not something this detector needs to distinguish, so the slot
+    // probes below are deliberately type-agnostic.
+    if evidence.has_slot("condition")
+        || evidence.has_slot("constraint")
+        || evidence.has_slot("unless_filter")
+        || evidence.has_slot("unless_pay")
+        || evidence.has_slot("if_clause")
+        || evidence.has_slot("intervening_if")
+    {
+        return;
+    }
+    // CR 700.2a / CR 601.2b: a conditional modal cap is a casting-time choice gate.
+    if evidence.any::<ModalSelectionConstraint>(|m| {
+        matches!(m, ModalSelectionConstraint::ConditionalMaxChoices { .. })
+    }) {
+        return;
+    }
+    // CR 603.4: an explicit quantity comparison IS the conditional gate.
+    if evidence.any::<AbilityCondition>(|c| matches!(c, AbilityCondition::QuantityCheck { .. })) {
+        return;
+    }
+    // CR 614.1a: replacement riders whose carried event/destination IS the "if X would Y"
+    // gate — AddTargetReplacement ("if [target] would die"), CreatePlaneswalkReplacement
+    // (CR 901.9c). CR 705: coin-flip / die-roll branches encode "if you win the flip" and
+    // the result table as structured win_effect / lose_effect / results sub-trees, so the
+    // effect IS the gate. CR 508.1d / CR 509.1c: "if able" attack/block requirements.
+    if evidence.any::<Effect>(|e| {
+        matches!(
+            e,
+            Effect::AddTargetReplacement { .. }
+                | Effect::CreatePlaneswalkReplacement { .. }
+                | Effect::FlipCoin { .. }
+                | Effect::FlipCoins { .. }
+                | Effect::RollDie { .. }
+                | Effect::ForceBlock { .. }
+                | Effect::ForceAttack { .. }
+        )
+    }) {
+        return;
+    }
+    // CR 508.1d / CR 509.1c / CR 506.6: must-attack / must-block / must-be-blocked "if
+    // able" riders are static-mode constraints, not conditional gates.
+    // CR 117.3a: TopOfLibraryCastPermission with `alt_cost` IS the "if you cast a spell
+    // this way, pay X" gate (Bolas's Citadel).
+    // CR 113.6 + CR 601.2a: Evelyn's "... if it was exiled by an ability you controlled"
+    // provenance clause is represented by the LinkedCollectionCounterPlayPermission
+    // live-source marker static.
+    if evidence.any_static_mode(|m| {
+        matches!(
+            m,
+            StaticMode::MustAttack
+                | StaticMode::MustBlock
+                | StaticMode::MustBeBlocked { .. }
+                | StaticMode::TopOfLibraryCastPermission { .. }
+                | StaticMode::LinkedCollectionCounterPlayPermission
+                | StaticMode::DefilerCostReduction { .. }
+        )
+    }) {
+        return;
+    }
+    // CR 305.9: "as ~ enters, you may pay X. If you don't, it enters tapped." — the
+    // decline branch IS the "if you don't" gate. `ReplacementMode` is internally tagged
+    // but shares the key `mode` with the externally tagged `StaticMode`; the two cannot
+    // be confused (object-with-tag vs bare string), and anchoring keeps the probe honest.
+    if evidence
+        .any_at::<ReplacementMode>(&["mode"], |m| matches!(m, ReplacementMode::Optional { .. }))
+    {
+        return;
+    }
+    // Slot-shaped gates: the parser filled a branch slot, and its presence IS the
+    // conditional representation.
+    //   CR 305.9   on_decline                        — "if you don't" alternative
+    //   CR 701.20a kept_optional_to                  — RevealUntil decline branch
+    //   CR 614.1a  graveyard_destination_replacement — "exile it instead" rider
+    //   CR 705     win_effect / lose_effect          — flip branches
+    //   CR 701.6   source_rider                      — "if countered this way, ..."
+    //   CR 701.6a  countered_spell_zone              — countered-spell destination
+    if evidence.has_slot("on_decline")
+        || evidence.has_slot("kept_optional_to")
+        || evidence.has_slot("graveyard_destination_replacement")
+        || evidence.has_slot("win_effect")
+        || evidence.has_slot("lose_effect")
+        || evidence.has_slot("source_rider")
+        || evidence.has_slot("countered_spell_zone")
+    {
         return;
     }
     diagnostics.push(OracleDiagnostic::SwallowedClause {
@@ -3306,30 +3096,77 @@ fn target_filter_has_cmc(filter: &TargetFilter, comparator: Comparator, threshol
 fn detect_condition_unless(
     cleaned: &str,
     original: &str,
-    ast_json: &str,
+    evidence: &UnitEvidence,
     diagnostics: &mut Vec<OracleDiagnostic>,
 ) {
     // allow-noncombinator: swallow detector marker scan on classified text
     if !cleaned.contains(" unless ") {
         return;
     }
-    let markers: &[&str] = &[
-        "\"unless_filter\":{",
-        "\"unless_pay\":{",
-        "\"unless_condition\":{",
-        "\"condition\":{",
-        "Unless",
-        // CR 605.1a: `CantBeActivated { exemption: ManaAbilities }` is the
-        // structural encoding of "can't be activated unless they're mana abilities."
-        "\"exemption\":\"ManaAbilities\"",
-        // CR 118.12 (post-2026-05-09 fold): "Counter target spell unless its
-        // controller pays X" is now captured as
-        // `AbilityDefinition.unless_pay` rather than
-        // `Effect::Counter.unless_payment`. The `"unless_pay":{` marker
-        // above subsumes both the trigger-level and counter-level encodings
-        // — the `unless_payment` marker has been retired.
-    ];
-    if json_has_any(ast_json, markers) {
+    // CR 118.12 + CR 603.5: the "unless" payment/condition slot. `unless_pay` subsumes
+    // both the trigger-level and the (retired) `Effect::Counter.unless_payment` encoding.
+    if evidence.has_slot("unless_filter")
+        || evidence.has_slot("unless_pay")
+        || evidence.has_slot("unless_condition")
+        || evidence.has_slot("condition")
+    {
+        return;
+    }
+    // CR 605.1a: an activation `exemption` IS the "unless they're mana abilities" clause.
+    // THREE `StaticMode` variants carry that field — pinning only `CantBeActivated` (as a
+    // first cut of this cutover did) makes Suppression Field ("Activated abilities cost
+    // {2} more to activate unless they're mana abilities", which lowers to
+    // `ReduceAbilityCost`) report a swallow it fully represents. Completeness grep:
+    //
+    //   $ rg -A8 '^    [A-Z]\w* \{' types/statics.rs | rg -B8 'exemption:'
+    //     StaticMode::CantBeActivated
+    //     StaticMode::ReduceAbilityCost
+    //     StaticMode::CantActivateDuring
+    if evidence.any_static_mode(|m| {
+        matches!(
+            m,
+            StaticMode::CantBeActivated {
+                exemption: ActivationExemption::ManaAbilities,
+                ..
+            } | StaticMode::ReduceAbilityCost {
+                exemption: ActivationExemption::ManaAbilities,
+                ..
+            } | StaticMode::CantActivateDuring {
+                exemption: ActivationExemption::ManaAbilities,
+                ..
+            }
+        )
+    }) {
+        return;
+    }
+    // CR 509.1c: "can't be blocked unless all creatures defending player controls block
+    // it" (Tromokratis) folds its whole `unless` clause into one typed static mode — the
+    // condition slot stays empty because the mode IS the condition. The deleted marker
+    // list caught this only through the bare substring `Unless`, which matched the tail
+    // of the variant name by accident.
+    if evidence.any_static_mode(|m| matches!(m, StaticMode::CantBeBlockedUnlessAllBlock)) {
+        return;
+    }
+    // CR 118.12 + CR 614.1a: replacement-effect `unless` gates. The complete closed set
+    // (grep: `rg '^    Unless\w*' types/replacements.rs`) — each is an "unless <clause>"
+    // guard folded into the replacement's condition.
+    if evidence.any::<ReplacementCondition>(|c| {
+        matches!(
+            c,
+            ReplacementCondition::UnlessControlsSubtype { .. }
+                | ReplacementCondition::UnlessControlsOtherLeq { .. }
+                | ReplacementCondition::UnlessControlsMatching { .. }
+                | ReplacementCondition::UnlessControlsCountMatching { .. }
+                | ReplacementCondition::UnlessPlayerLifeAtMost { .. }
+                | ReplacementCondition::UnlessMultipleOpponents
+                | ReplacementCondition::UnlessYourTurn
+                | ReplacementCondition::UnlessQuantity { .. }
+        )
+    }) {
+        return;
+    }
+    // CR 118.12: `StaticCondition::UnlessPay` — the payment gate itself.
+    if evidence.any::<StaticCondition>(|c| matches!(c, StaticCondition::UnlessPay { .. })) {
         return;
     }
     // CR 508.1f + CR 701.26a: "... can't become tapped unless [they're/it's]
@@ -3342,7 +3179,9 @@ fn detect_condition_unless(
     // tap restriction lowered to a `CantTap` static (Ood Sphere's Red-Eye).
     let declared_as_attacker_exemption = cleaned.contains("declared as an attacker") // allow-noncombinator: swallow detector marker scan on classified text
         || cleaned.contains("declared as attackers"); // allow-noncombinator: swallow detector marker scan on classified text
-    if declared_as_attacker_exemption && json_has_any(ast_json, &["\"CantTap\""]) {
+    if declared_as_attacker_exemption
+        && evidence.any_static_mode(|m| matches!(m, StaticMode::CantTap))
+    {
         return;
     }
     diagnostics.push(OracleDiagnostic::SwallowedClause {
@@ -3361,7 +3200,7 @@ fn detect_condition_unless(
 fn detect_condition_as_long_as(
     cleaned: &str,
     original: &str,
-    ast_json: &str,
+    evidence: &UnitEvidence,
     parsed: &ParsedAbilities,
     diagnostics: &mut Vec<OracleDiagnostic>,
 ) {
@@ -3383,24 +3222,29 @@ fn detect_condition_as_long_as(
     .iter()
     .any(|phrase| cleaned.contains(phrase));
     if exile_duration_clause_recognized
-        && json_has_any(ast_json, &["\"type\":\"PlayFromExile\""])
-        && json_has_any(ast_json, &["\"duration\":\"Permanent\""])
+        && evidence
+            .any::<CastingPermission>(|c| matches!(c, CastingPermission::PlayFromExile { .. }))
+        && evidence.any_duration(|d| matches!(d, Duration::Permanent))
     {
         return;
     }
-    let markers: &[&str] = &[
-        "\"condition\":{",
-        "\"AsLongAs\"",
-        "AsLongAs",
-        "ConditionalStatic",
-        // CR 611.3a: A `Duration::UntilHostLeavesPlay` IS the "as long as
-        // you control this creature" / "as long as ~ remains on the
-        // battlefield" gate (Aegis Angel, Hostage Taker, Gonti, etc.).
-        // The duration's lifetime equates to a perpetual conditional
-        // static on the host's controllership.
-        "UntilHostLeavesPlay",
-    ];
-    if json_has_any(ast_json, markers) {
+    // CR 611.3. `AsLongAs` and `ConditionalStatic` are GONE, not translated: neither
+    // names a type. `AsLongAs` matched only as a SUBSTRING of `Duration::ForAsLongAs`,
+    // and `ConditionalStatic` matched nothing at all (0 pool hits).
+    //
+    // The real carriers: a populated condition slot, or a duration that IS the gate —
+    // `ForAsLongAs` (CR 611.2b, an explicit conditional duration) and `UntilHostLeavesPlay`
+    // (CR 611.3a, "as long as you control this creature" — the duration's lifetime IS the
+    // controllership condition; Aegis Angel, Hostage Taker).
+    if evidence.has_slot("condition") {
+        return;
+    }
+    if evidence.any_duration(|d| {
+        matches!(
+            d,
+            Duration::ForAsLongAs { .. } | Duration::UntilHostLeavesPlay
+        )
+    }) {
         return;
     }
     if any_static_has_per_object_as_long_as_gate(parsed) {
@@ -3500,7 +3344,7 @@ fn target_filter_has_per_object_condition_property(filter: &TargetFilter) -> boo
 fn detect_duration_this_turn(
     cleaned: &str,
     original: &str,
-    ast_json: &str,
+    evidence: &UnitEvidence,
     diagnostics: &mut Vec<OracleDiagnostic>,
 ) {
     // allow-noncombinator: swallow detector marker scan on classified text
@@ -3551,7 +3395,9 @@ fn detect_duration_this_turn(
         .sum();
     if total_this_turn > 0
         && total_this_turn == activate_only_this_turn
-        && json_has_any(ast_json, &["RequiresCondition"])
+        && evidence.any::<ActivationRestriction>(|r| {
+            matches!(r, ActivationRestriction::RequiresCondition { .. })
+        })
     {
         return;
     }
@@ -3632,137 +3478,257 @@ fn detect_duration_this_turn(
     if total_this_turn == 1 && player_lookback_relative_clause_owns_suffix(cleaned) {
         return;
     }
-    let markers: &[&str] = &[
-        "\"duration\":\"",
-        "UntilEndOfTurn",
-        "ThisTurn",
-        "EndOfTurn",
-        "EndOfCombat",
-        // CR 514.2: AddTargetReplacement carries `expiry: Some(RestrictionExpiry::EndOfTurn)`,
-        // which IS the EOT duration encoded structurally on the
-        // ReplacementDefinition rather than via `def.duration`.
-        "\"expiry\":{\"type\":\"EndOfTurn\"}",
-        // CR 614.6: `DamageDone` replacement events scope to a single
-        // resolution (one-shot prevention/redirection); the "this turn"
-        // wording is implicit in the spell-level replacement lifetime,
-        // not a separate `duration` slot.
-        "\"event\":\"DamageDone\"",
-        // CR 615.1: `PreventDamage` creates the prevention shield described
-        // by "prevent [damage] this turn"; the lifetime is inherent to the
-        // one-shot prevention effect.
-        "PreventDamage",
-        // CR 614.9 + CR 615.1: `CreateDamageReplacement` is the typed prevention
-        // /redirection shield for "the next [N] damage that would be dealt to ~
-        // this turn is [prevented/dealt to <recipient>] instead" (the en-Kor
-        // cycle, General's Regalia). Like `PreventDamage` and the `DamageDone`
-        // replacement event above, the shield's "this turn" lifetime is inherent
-        // to the one-shot effect (it expires at cleanup, CR 514.2), not a
-        // separate `duration` slot.
-        "CreateDamageReplacement",
-        // CR 614.11 + CR 514.2: `CreateDrawReplacement` is the one-shot draw
-        // replacement for "the next time you would draw a card this turn,
-        // [effect] instead" (Words of Worship/Wilding). Its "this turn" lifetime
-        // is inherent to the one-shot effect (expires at cleanup), not a
-        // separate `duration` slot — same as `CreateDamageReplacement` above.
-        "CreateDrawReplacement",
-        "AddTargetReplacement",
-        // CR 603.7c: A `CreateDelayedTrigger` with `WhenNextEvent` condition
-        // IS the "next [event] this turn" delayed-trigger scope (Chandra,
-        // the Firebrand's [-2], Doublecast-class copy-on-next-cast). The
-        // "this turn" scope is implicit in the delayed-trigger semantics —
-        // delayed triggers created by spells expire at end of turn per CR.
-        "CreateDelayedTrigger",
-        "WhenNextEvent",
-        // CR 514.2 + CR 601.2f: `ReduceNextSpellCost` is a one-shot cost
-        // reduction consumed by the next-cast spell — its "this turn"
-        // scope is structural, not a `duration` slot.
-        "ReduceNextSpellCost",
-        // CR 509.1c: `ForceBlock` is the typed representation for
-        // "blocks this turn if able" / "must be blocked this turn if able".
-        // The one-turn combat requirement is inherent to the effect.
-        "ForceBlock",
-        // CR 601.2 / CR 400.7: cast/play permissions that say "this turn"
-        // are represented by `CastFromZone`; choosing not to cast is not a
-        // separate duration field on the ability.
-        "CastFromZone",
-        // Case solve conditions and other turn-history gates represent
-        // "this turn" as a condition/quantity over prior events, not as a
-        // forward-looking effect duration.
-        "SolveConditionMet",
-        "YouCastSpellThisTurn",
-        "YouCastSpellCountAtLeast",
-        "YouCastNoncreatureSpellThisTurn",
-        "YouGainedLifeThisTurn",
-        "YouDiscardedCardThisTurn",
-        "YouSacrificedArtifactThisTurn",
-        "CreatureDiedThisTurn",
-        "YouHadCreatureEnterThisTurn",
-        "YouHadAngelOrBerserkerEnterThisTurn",
-        "YouHadArtifactEnterThisTurn",
-        "BattlefieldEntriesThisTurn",
-        "EnteredThisTurn",
-        "CardsLeftYourGraveyardThisTurnAtLeast",
-        "SourceEnteredThisTurn",
-        "OpponentSearchedLibraryThisTurn",
-        "OpponentGainedLife",
-        "CastSpellThisTurn",
-        "SpellsCastThisTurn",
-        // CR 305.2a + CR 603.4: "played a land this turn" / "played a land or cast a
-        // spell this turn from anywhere other than your hand" — the land-play count
-        // IS the "this turn" scope; `LandsPlayedThisTurn` in the AST means the clause
-        // was captured by the intervening-if condition parser, not swallowed.
-        "LandsPlayedThisTurn",
-        "DamageDealtThisTurn",
-        "AttackedThisTurn",
-        "CounterAddedThisTurn",
-        "NthSpellThisTurn",
-        "NthDrawThisTurn",
-        "CardsDrawnThisTurn",
-        "BattlefieldEntriesThisTurn",
-        "PlayerActionsThisTurn",
-        // CR 603.4: "if you've done all four this turn" — the distinct-bend-count
-        // intervening-if condition consumes the "this turn" scope (Avatar Aang).
-        "BendTypesThisTurn",
-        "OpponentLostLife",
-        "OpponentDealtDamage",
-        // CR 611.3: a condition slot serialized as the typed `Unrecognized`
-        // marker means the parser routed the "as long as ... this turn" clause
-        // INTO a condition slot (and explicitly recorded that it could not
-        // parse it). "this turn" there is unambiguously consumed by a
-        // condition, not an effect duration. This is a specific node proving a
-        // *condition slot was populated* — same precision class as the
-        // `CreatureDiedThisTurn` / `AttackedThisTurn` markers — so it is not
-        // subject to the container over-breadth concern. The card itself
-        // remains visibly unsupported (`Unrecognized` is an explicit failure
-        // node + coverage `supported=false`), so no gap is hidden.
-        "\"condition\":{\"type\":\"Unrecognized\"",
-        // CR 601.2 + CR 601.3a + CR 604.1: `PerTurnCastLimit` / `PerTurnDrawLimit`
-        // static modes are themselves the per-turn enforcement window — the
-        // "this turn" / "each turn" scope is intrinsic to the variant and not
-        // a separate `duration` slot (CR 604.1 anchors the static; CR 601.2 +
-        // CR 601.3a authorize the casting prohibition itself). Cards like
-        // Ethersworn Canonist phrase the subject as "...who has cast a
-        // [type] spell this turn..."; that "this turn" is consumed by the
-        // per-turn limit, not swallowed.
-        //
-        // Markers use the serde-default external-tag JSON shape
-        // `"<Variant>":{` so they only match when the typed variant is the
-        // current node — matching the precision class of the
-        // `"condition":{"type":"Unrecognized"` marker above and ruling out
-        // false positives where the literal token "PerTurnCastLimit" appears
-        // in unrelated positions (e.g. a description string).
-        "\"PerTurnCastLimit\":{",
-        "\"PerTurnDrawLimit\":{",
-        // CR 604.1 + CR 601.2a + CR 113.6b: `ExileCastPermission` is a static
-        // ability (CR 604.1) that is itself the per-turn permission window
-        // (`frequency: OncePerTurn` slot reset at turn cleanup, plus the per-turn
-        // rolling `cards_exiled_with_source_this_turn` pool keyed by source). The
-        // "this turn" / "once each turn" wording is intrinsic to the variant — not
-        // a separate `duration` slot. Mirrors PerTurnCastLimit / PerTurnDrawLimit
-        // above.
-        "\"ExileCastPermission\":{",
-    ];
-    if json_has_any(ast_json, markers) {
+    // ── Typed "this turn" carriers ──────────────────────────────────────
+    //
+    // The deleted list leaned on three UNANCHORED substrings — `"ThisTurn"`,
+    // `"EndOfTurn"`, `"EndOfCombat"` — which silently matched ANY variant name
+    // CONTAINING them, across every enum in the tree. That is why the list "worked":
+    // ~25 turn-history variants were caught by accident rather than by name. Each is now
+    // an explicit arm the compiler checks.
+    //
+    // (a) CR 611.2a + CR 514.2: a real duration carrier of ANY kind — the "this turn"
+    //     landed on a duration slot, which is exactly what this detector asks about.
+    if evidence.any_duration(|_| true) {
+        return;
+    }
+    // (b)–(h) CR 700.4 + CR 700.5 + CR 603.4: TURN-HISTORY references. "this turn" here
+    //     is a suffix on a count/condition read from the turn's history, not a
+    //     forward-looking duration on an effect.
+    //
+    //     These arms are the COMPLETE closed set of `*ThisTurn` variants, generated from
+    //     the type definitions rather than hand-picked:
+    //
+    //       $ rg '^    (\w*ThisTurn\w*)\s*[,{(]' crates/engine/src/types/
+    //         QuantityRef       20      TriggerCondition   8
+    //         ParsedCondition   18      FilterProp         7
+    //         AbilityCondition   3      StaticCondition    2
+    //         TriggerConstraint  2
+    //
+    //     The deleted substring marker `"ThisTurn"` caught all 60 of these BY ACCIDENT —
+    //     it matched any variant name containing the token, in any enum. Hand-picking a
+    //     subset (as a first cut of this cutover did) silently reintroduces a
+    //     false-positive wave: `QuantityRef::LifeGainedThisTurn` was missed, and Follow
+    //     the Lumarets ("If you gained life this turn, ... instead") immediately reported
+    //     a swallowed duration it does in fact represent. Generating the set closes that.
+    //
+    //     ROT DIRECTION (declared): a NEW `*ThisTurn` variant added later is not caught
+    //     here until this list is regenerated. That failure is conservative-RED — the
+    //     audit over-reports a swallow — never a silent false green.
+    if evidence.any::<QuantityRef>(|x| {
+        matches!(
+            x,
+            QuantityRef::LifeLostThisTurn { .. }
+                | QuantityRef::SpellsCastThisTurn { .. }
+                | QuantityRef::EnteredThisTurn { .. }
+                | QuantityRef::SacrificedThisTurn { .. }
+                | QuantityRef::CrimesCommittedThisTurn
+                | QuantityRef::BendTypesThisTurn
+                | QuantityRef::LifeGainedThisTurn { .. }
+                | QuantityRef::CardsDrawnThisTurn { .. }
+                | QuantityRef::BattlefieldEntriesThisTurn { .. }
+                | QuantityRef::LandsPlayedThisTurn { .. }
+                | QuantityRef::ZoneChangeCountThisTurn { .. }
+                | QuantityRef::ZoneChangeAggregateThisTurn { .. }
+                | QuantityRef::DamageDealtThisTurn { .. }
+                | QuantityRef::AttackedThisTurn { .. }
+                | QuantityRef::DescendedThisTurn
+                | QuantityRef::LoyaltyAbilitiesActivatedThisTurn { .. }
+                | QuantityRef::CounterAddedThisTurn { .. }
+                | QuantityRef::CardsDiscardedThisTurn { .. }
+                | QuantityRef::TokensCreatedThisTurn { .. }
+                | QuantityRef::PlayerActionsThisTurn { .. }
+        )
+    }) {
+        return;
+    }
+    if evidence.any::<ParsedCondition>(|x| {
+        matches!(
+            x,
+            ParsedCondition::SourceEnteredThisTurn
+                | ParsedCondition::SourceAttackedThisTurn
+                | ParsedCondition::OpponentSearchedLibraryThisTurn
+                | ParsedCondition::YouAttackedThisTurn
+                | ParsedCondition::YouAttackedSourceControllerThisTurn
+                | ParsedCondition::YouPlayedLandThisTurn
+                | ParsedCondition::YouCastSpellThisTurn { .. }
+                | ParsedCondition::YouCastNoncreatureSpellThisTurn
+                | ParsedCondition::YouGainedLifeThisTurn
+                | ParsedCondition::YouCreatedTokenThisTurn
+                | ParsedCondition::YouDiscardedCardThisTurn
+                | ParsedCondition::YouSacrificedArtifactThisTurn
+                | ParsedCondition::CreatureDiedThisTurn
+                | ParsedCondition::YouHadCreatureEnterThisTurn
+                | ParsedCondition::YouHadAngelOrBerserkerEnterThisTurn
+                | ParsedCondition::YouHadArtifactEnterThisTurn
+                | ParsedCondition::BattlefieldEntriesThisTurn { .. }
+                | ParsedCondition::CardsLeftYourGraveyardThisTurnAtLeast { .. }
+        )
+    }) {
+        return;
+    }
+    if evidence.any::<StaticCondition>(|x| {
+        matches!(
+            x,
+            StaticCondition::SpellCastWithVariantThisTurn { .. }
+                | StaticCondition::SourceEnteredThisTurn
+        )
+    }) {
+        return;
+    }
+    if evidence.any::<AbilityCondition>(|x| {
+        matches!(
+            x,
+            AbilityCondition::SourceEnteredThisTurn
+                | AbilityCondition::SpellCastWithVariantThisTurn { .. }
+                | AbilityCondition::NthResolutionThisTurn { .. }
+        )
+    }) {
+        return;
+    }
+    if evidence.any::<TriggerCondition>(|x| {
+        matches!(
+            x,
+            TriggerCondition::SourceEnteredThisTurn
+                | TriggerCondition::DealtDamageBySourceThisTurn
+                | TriggerCondition::DealtDamageThisTurnBySource { .. }
+                | TriggerCondition::FirstTimeObjectTappedThisTurn
+                | TriggerCondition::AttackedThisTurn
+                | TriggerCondition::CastSpellThisTurn { .. }
+                | TriggerCondition::SpellCastWithVariantThisTurn { .. }
+                | TriggerCondition::CounterAddedThisTurn
+        )
+    }) {
+        return;
+    }
+    if evidence.any::<TriggerConstraint>(|x| {
+        matches!(
+            x,
+            TriggerConstraint::NthSpellThisTurn { .. } | TriggerConstraint::NthDrawThisTurn { .. }
+        )
+    }) {
+        return;
+    }
+    if evidence.any::<FilterProp>(|x| {
+        matches!(
+            x,
+            FilterProp::WasDealtDamageThisTurn
+                | FilterProp::EnteredThisTurn
+                | FilterProp::ZoneChangedThisTurn { .. }
+                | FilterProp::AttackedThisTurn { .. }
+                | FilterProp::BlockedThisTurn
+                | FilterProp::AttackedOrBlockedThisTurn
+                | FilterProp::CountersPutOnThisTurn { .. }
+        )
+    }) {
+        return;
+    }
+    // CR 700.2 + CR 603.4: "choose one that hasn't been chosen this turn" (the Alliance
+    //     cycle: Gala Greeters, Monument to Endurance, The Fantastic Four) folds its turn
+    //     scope into a typed modal-selection constraint. `ModalSelectionConstraint` is a
+    //     separate enum from the seven above, so the generated `*ThisTurn` sweep does not
+    //     reach it and it must be named. Missing it produced 6 false-positive swallows.
+    if evidence.any::<ModalSelectionConstraint>(|c| {
+        matches!(c, ModalSelectionConstraint::NoRepeatThisTurn)
+    }) {
+        return;
+    }
+    // (h2) Turn-history carriers whose names do NOT end in `ThisTurn`, so the generated
+    //     set above cannot reach them. They must be named explicitly — and the fact that
+    //     they must is itself the point: a NAME-SHAPED rule ("contains ThisTurn") is not
+    //     the same as a SEMANTIC one ("is turn-scoped"), and only the compiler-checked
+    //     enumeration keeps the two from drifting apart.
+    //       CR 603.4  ParsedCondition::YouCastSpellCountAtLeast — "only if you've cast
+    //                 another spell this turn" (Illusory Angel); the turn scope is
+    //                 implicit in the per-turn cast counter.
+    //       CR 719.2  TriggerCondition::SolveConditionMet — a Case solve condition.
+    //       CR 119.3  PlayerFilter per-turn player-history filters.
+    if evidence
+        .any::<ParsedCondition>(|c| matches!(c, ParsedCondition::YouCastSpellCountAtLeast { .. }))
+    {
+        return;
+    }
+    if evidence.any::<TriggerCondition>(|c| matches!(c, TriggerCondition::SolveConditionMet)) {
+        return;
+    }
+    if evidence.any::<PlayerFilter>(|p| {
+        matches!(
+            p,
+            PlayerFilter::OpponentGainedLife
+                | PlayerFilter::OpponentLostLife
+                | PlayerFilter::OpponentDealtDamage { .. }
+        )
+    }) {
+        return;
+    }
+    // A condition slot holding the typed `Unrecognized` node means the parser ROUTED the
+    // clause into a condition slot and explicitly recorded that it could not parse it —
+    // the "this turn" is consumed by a condition, and the card stays visibly unsupported
+    // (CR 611.3).
+    if evidence.any_at::<StaticCondition>(&["condition"], |c| {
+        matches!(c, StaticCondition::Unrecognized { .. })
+    }) {
+        return;
+    }
+    // (i) One-shot effects whose "this turn" lifetime is INTRINSIC (they expire at
+    //     cleanup, CR 514.2) rather than stored in a `duration` slot:
+    //       CR 615.1   PreventDamage / CreateDamageReplacement — prevention shields
+    //       CR 614.11  CreateDrawReplacement — "next time you would draw ... instead"
+    //       CR 614.1a  AddTargetReplacement
+    //       CR 603.7c  CreateDelayedTrigger — delayed triggers from spells expire at EOT
+    //       CR 601.2f  ReduceNextSpellCost — consumed by the next cast
+    //       CR 509.1c  ForceBlock — a one-turn combat requirement
+    //       CR 601.2   CastFromZone — a cast permission, not a duration
+    if evidence.any::<Effect>(|e| {
+        matches!(
+            e,
+            Effect::PreventDamage { .. }
+                | Effect::CreateDamageReplacement { .. }
+                | Effect::CreateDrawReplacement { .. }
+                | Effect::AddTargetReplacement { .. }
+                | Effect::CreateDelayedTrigger { .. }
+                | Effect::ReduceNextSpellCost { .. }
+                | Effect::ForceBlock { .. }
+                | Effect::CastFromZone { .. }
+        )
+    }) {
+        return;
+    }
+    // (j) CR 603.7c: a `WhenNextEvent` delayed-trigger condition IS the "next [event] this
+    //     turn" scope (Chandra, the Firebrand -2; Doublecast).
+    if evidence.any::<DelayedTriggerCondition>(|c| {
+        matches!(c, DelayedTriggerCondition::WhenNextEvent { .. })
+    }) {
+        return;
+    }
+    // (k) CR 514.2: `AddTargetReplacement` carries `expiry: EndOfTurn` — the EOT scope
+    //     encoded structurally on the ReplacementDefinition rather than via `duration`.
+    if evidence.any_at::<RestrictionExpiry>(&["expiry"], |e| {
+        matches!(
+            e,
+            RestrictionExpiry::EndOfTurn | RestrictionExpiry::EndOfCombat
+        )
+    }) {
+        return;
+    }
+    // (l) CR 614.6: a `DamageDone` replacement event scopes to a single resolution; the
+    //     "this turn" is implicit in the spell-level replacement lifetime.
+    //     `ReplacementEvent` is EXTERNALLY tagged, so it is key-anchored.
+    if evidence.any_at::<ReplacementEvent>(&["event"], |e| {
+        matches!(e, ReplacementEvent::DamageDone { .. })
+    }) {
+        return;
+    }
+    // (m) CR 601.2 + CR 604.1: per-turn limit statics ARE the enforcement window; the
+    //     "this turn" / "once each turn" wording is intrinsic to the variant (Ethersworn
+    //     Canonist), not a separate duration slot.
+    if evidence.any_static_mode(|m| {
+        matches!(
+            m,
+            StaticMode::PerTurnCastLimit { .. }
+                | StaticMode::PerTurnDrawLimit { .. }
+                | StaticMode::ExileCastPermission { .. }
+        )
+    }) {
         return;
     }
     diagnostics.push(OracleDiagnostic::SwallowedClause {
@@ -3780,7 +3746,7 @@ fn detect_duration_this_turn(
 fn detect_duration_next_turn(
     cleaned: &str,
     original: &str,
-    parsed: &ParsedAbilities,
+    evidence: &UnitEvidence,
     diagnostics: &mut Vec<OracleDiagnostic>,
 ) {
     // allow-noncombinator: swallow detector marker scan on classified text
@@ -3790,19 +3756,28 @@ fn detect_duration_next_turn(
     {
         return;
     }
-    // CR 611.2a: the two typed next-turn durations. The markers this replaces were
-    // `["YourNextTurn", "NextTurn", "UntilYourNextTurn"]` — bare substrings, and the
-    // `NextTurn` one is a MEASURED SUBSTRING COLLISION, not a hypothetical. Counting
-    // `[A-Za-z]*NextTurn[A-Za-z]*` over the full 35,396-face export:
+    // CR 611.2a + CR 514.2. The three markers this replaces were, respectively: DEAD
+    // (`YourNextTurn` names no type), DEAD (`UntilYourNextTurn` names no type), and a
+    // SUBSTRING ACCIDENT (`NextTurn` matched only because it is a substring of
+    // `Duration::UntilNextTurnOf` / `UntilEndOfNextTurnOf`). This detector's entire
+    // evidence therefore rested on one accidental substring hit — and that same substring
+    // made the expectation dischargeable by `Effect::SkipNextTurn` / `Effect::ControlNextTurn`,
+    // which are facts about extra/skipped turns, not about how long a continuous effect
+    // lasts. Counting `[A-Za-z]*NextTurn[A-Za-z]*` over the full 35,396-face export:
     //
     //     UntilNextTurnOf 216 | UntilEndOfNextTurnOf 182   <- real durations
     //     SkipNextTurn     10 | ControlNextTurn        8   <- NOT durations
     //
-    // So an "until your next turn" expectation was dischargeable by `Effect::SkipNextTurn`
-    // or `Effect::ControlNextTurn` — a fact about extra/skipped turns, not about how long
-    // a continuous effect lasts. Same defect as APNAP's `player_scope`, arriving by
-    // substring. A typed match cannot make that mistake.
-    if unit_has_duration(parsed, &duration_is_next_turn) {
+    // A typed, key-anchored match cannot make that mistake. These are the two real carriers,
+    // keyed off the `PlayerScope`-parameterized variants:
+    //   UntilNextTurnOf      — expires at the BEGINNING of that player's next turn
+    //   UntilEndOfNextTurnOf — persists THROUGH that turn (Light Up the Stage class)
+    if evidence.any_duration(|d| {
+        matches!(
+            d,
+            Duration::UntilNextTurnOf { .. } | Duration::UntilEndOfNextTurnOf { .. }
+        )
+    }) {
         return;
     }
     diagnostics.push(OracleDiagnostic::SwallowedClause {
@@ -3822,7 +3797,7 @@ fn detect_duration_next_turn(
 fn detect_optional_may_have(
     cleaned: &str,
     original: &str,
-    ast_json: &str,
+    evidence: &UnitEvidence,
     diagnostics: &mut Vec<OracleDiagnostic>,
 ) {
     let has_marker = cleaned.contains("may have ") || cleaned.contains("you may have "); // allow-noncombinator: swallow detector marker scan on classified text
@@ -3832,22 +3807,26 @@ fn detect_optional_may_have(
     // The "have causative" parser produces effects that recursively contain
     // optional sub-abilities. Conservative check: if the AST contains any
     // optional flag OR explicit causative marker, treat as captured.
-    let markers: &[&str] = &[
-        "\"optional\":true",
-        "Causative",
-        "HaveCausative",
-        "HaveItVerb",
-        // CR 614.1a: "you may have this creature enter as a copy ..." — the
-        // optional choice is captured on the replacement's `mode` field
-        // (ReplacementMode::Optional), not via `def.optional`.
-        "\"mode\":{\"type\":\"Optional\"",
-        // CR 702.20a: "you may have this creature assign its combat damage
-        // as though it weren't blocked" — captured as a continuous
-        // modification on a static, with the optionality implicit in the
-        // modification's per-combat-step player decision.
-        "AssignDamageAsThoughUnblocked",
-    ];
-    if json_has_any(ast_json, markers) {
+    // CR 603.5. THREE of this detector's six markers were DEAD — `Causative`,
+    // `HaveCausative` and `HaveItVerb` name no type in the engine (0 pool hits each), so
+    // half its evidence list could never have matched anything. Its real evidence is only
+    // the three carriers below.
+    if evidence.any::<AbilityDefinition>(|d| d.optional) {
+        return;
+    }
+    // CR 614.1a: "you may have this creature enter as a copy ..." — the optional choice
+    // lives on the replacement's mode, not on `def.optional`.
+    if evidence
+        .any_at::<ReplacementMode>(&["mode"], |m| matches!(m, ReplacementMode::Optional { .. }))
+    {
+        return;
+    }
+    // CR 702.20a: "you may have this creature assign its combat damage as though it
+    // weren't blocked" — a continuous modification whose optionality is the per-combat
+    // player decision.
+    if evidence.any::<ContinuousModification>(|m| {
+        matches!(m, ContinuousModification::AssignDamageAsThoughUnblocked)
+    }) {
         return;
     }
     diagnostics.push(OracleDiagnostic::SwallowedClause {
@@ -4040,6 +4019,8 @@ fn effect_name(effect: &Effect) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use crate::parser::swallow_evidence::UnitEvidence;
+
     use super::{
         any_ability_has_unimplemented, def_tree_has_optional, def_tree_has_unimplemented,
         trigger_tree_has_optional,
@@ -4103,13 +4084,14 @@ mod tests {
     /// (or gate (1)/(2)/(3)) drops the diagnostic and fails this assertion.
     #[test]
     fn modal_dynamic_max_dropped_fires_on_modal_without_dynamic_cap() {
-        let ast_json =
-            r#"{"abilities":[{"modal":{"min_choices":1,"max_choices":1,"mode_count":3}}]}"#;
+        let evidence = UnitEvidence::from_json_for_test(
+            r#"{"abilities":[{"modal":{"min_choices":1,"max_choices":1,"mode_count":3}}]}"#,
+        );
         let mut diags = Vec::new();
         super::detect_modal_dynamic_max_dropped(
             "when you do, choose up to that many",
             "When you do, choose up to that many.",
-            ast_json,
+            &evidence,
             &mut diags,
         );
         assert!(
@@ -4127,12 +4109,14 @@ mod tests {
     /// detector keys on the AST cap, not the phrase. Revert gate (3) → fires.
     #[test]
     fn modal_dynamic_max_dropped_silent_when_dynamic_cap_present() {
-        let ast_json = r#"{"abilities":[{"modal":{"min_choices":0,"max_choices":3,"mode_count":3,"dynamic_max_choices":{"type":"Ref","qty":"CostXPaid"}}}]}"#;
+        let evidence = UnitEvidence::from_json_for_test(
+            r#"{"abilities":[{"modal":{"min_choices":0,"max_choices":3,"mode_count":3,"dynamic_max_choices":{"type":"Ref","qty":"CostXPaid"}}}]}"#,
+        );
         let mut diags = Vec::new();
         super::detect_modal_dynamic_max_dropped(
             "choose up to x",
             "Choose up to X —",
-            ast_json,
+            &evidence,
             &mut diags,
         );
         assert!(
@@ -4147,12 +4131,14 @@ mod tests {
     /// Heroic Feast / Temporal Firestorm.
     #[test]
     fn modal_dynamic_max_dropped_silent_without_modal_node() {
-        let ast_json = r#"{"abilities":[{"effect":{"type":"PutCounter","count":{"type":"Ref","qty":"CostXPaid"}}}]}"#;
+        let evidence = UnitEvidence::from_json_for_test(
+            r#"{"abilities":[{"effect":{"type":"PutCounter","count":{"type":"Ref","qty":"CostXPaid"}}}]}"#,
+        );
         let mut diags = Vec::new();
         super::detect_modal_dynamic_max_dropped(
             "choose up to that many target creatures you control",
             "Choose up to that many target creatures you control.",
-            ast_json,
+            &evidence,
             &mut diags,
         );
         assert!(
@@ -5831,7 +5817,8 @@ mod tests {
     /// if the marker is implemented whole-AST instead of text-scoped.
     #[test]
     fn enters_modified_if_exemption_is_text_scoped() {
-        let ast = "{\"enters_modified_if\":{\"type\":\"Typed\"}}";
+        let ast = &UnitEvidence::from_json_for_test(r#"{"enters_modified_if":{"type":"Typed"}}"#);
+        let no_gate = &UnitEvidence::from_json_for_test("{}");
         // The represented enters-modifier clause is the card's only " if " -> suppress.
         assert!(super::enters_modified_if_is_only_if_marker(
             "you may put a creature card from your hand onto the battlefield. if that card \
@@ -5848,7 +5835,7 @@ mod tests {
         // No AST gate (clause not structurally represented) -> do NOT suppress.
         assert!(!super::enters_modified_if_is_only_if_marker(
             "if that card is an enchantment card, it enters tapped and attacking.",
-            "{}",
+            no_gate,
         ));
     }
 
@@ -7723,7 +7710,8 @@ mod detect_condition_if_replacement_exemption_tests {
 
         let cleaned = text.to_ascii_lowercase();
         let mut diagnostics = Vec::new();
-        detect_condition_if(&cleaned, &text, "{}", &parsed, &mut diagnostics);
+        let evidence = UnitEvidence::from_json_for_test("{}");
+        detect_condition_if(&cleaned, &text, &evidence, &parsed, &mut diagnostics);
 
         assert!(
             has_condition_if_swallow(&diagnostics),
@@ -7747,7 +7735,8 @@ mod detect_condition_if_replacement_exemption_tests {
 
         let cleaned = sentence.to_ascii_lowercase();
         let mut diagnostics = Vec::new();
-        detect_condition_if(&cleaned, sentence, "{}", &parsed, &mut diagnostics);
+        let evidence = UnitEvidence::from_json_for_test("{}");
+        detect_condition_if(&cleaned, sentence, &evidence, &parsed, &mut diagnostics);
 
         assert!(
             has_condition_if_swallow(&diagnostics),

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -2984,7 +2984,7 @@ fn detect_condition_if(
     // allow-noncombinator: swallow detector marker scan on classified text
     if (stripped.contains("lost life this way") || stripped.contains("gained life this way"))
         && stripped.contains("that many") // allow-noncombinator: swallow detector marker scan on classified text
-        && evidence.any_quantity_ref(|q| matches!(q, QuantityRef::EventContextAmount { .. }))
+        && evidence.any_quantity_ref(|q| matches!(q, QuantityRef::EventContextAmount))
     {
         return;
     }
@@ -3905,7 +3905,7 @@ fn detect_duration_this_turn(
     //     "this turn" is implicit in the spell-level replacement lifetime.
     //     `ReplacementEvent` is EXTERNALLY tagged, so it is key-anchored.
     if evidence.any_at::<ReplacementEvent>(&["event"], |e| {
-        matches!(e, ReplacementEvent::DamageDone { .. })
+        matches!(e, ReplacementEvent::DamageDone)
     }) {
         return;
     }

--- a/crates/engine/src/parser/swallow_evidence.rs
+++ b/crates/engine/src/parser/swallow_evidence.rs
@@ -1,0 +1,456 @@
+//! Typed evidence probe over one audit unit's lowered definitions.
+//!
+//! The swallow audit asks, per source unit: *does this unit's Oracle text raise a
+//! semantic expectation that this unit's parse does not represent?* This module owns
+//! the **evidence half** of that question — "is a carrier for semantic S present in
+//! the parse?" — and answers it with a **typed** `match`, not a substring scan.
+//!
+//! # Why this exists: a string marker is not checked by anything
+//!
+//! The audit previously answered every tree-global evidence question by scanning the
+//! serialized AST text for representation markers — a raw substring search for, say,
+//! the marker `ConditionMet`. Nothing checks a string. A marker naming a type that does not exist compiles,
+//! runs, and silently never matches; a marker that is a *substring of a longer type
+//! name* compiles, runs, and silently matches the **wrong rule's fact**. Both were
+//! present, and the second is the dangerous one — it fails CLOSED, suppressing true
+//! positives:
+//!
+//! | marker (as written) | what it actually matched | pool hits |
+//! |---|---|---|
+//! | `ConditionMet` | `TriggerCondition::SolveConditionMet` — a CR 719 Case **solve** condition | 15/15 |
+//! | `AsLongAs` | `Duration::ForAsLongAs` | — |
+//! | `ManaValue` | `CastPermissionConstraint::ManaValue` (a cast gate, not a quantity) | — |
+//! | `Causative`, `HaveCausative`, `HaveItVerb`, `ConditionalEffect`, `ConditionalStatic` | nothing — they name no type in the engine | 0 |
+//!
+//! There is no `ConditionMet` variant anywhere in the engine. So a `Condition_If`
+//! expectation ("is this card's `if` represented?") was being discharged by the
+//! presence of an unrelated rule's fact, on every card carrying a Case. The compiler
+//! could not object, because to the compiler it was a string.
+//!
+//! Typed evidence removes the channel: `matches!(c, AbilityCondition::QuantityCheck { .. })`
+//! either names a real variant or does not compile.
+//!
+//! # How total reach is achieved without hand-enumerating the type closure
+//!
+//! The facts these detectors need are **tree-global existence** facts ("is there a
+//! dynamic quantity *anywhere* under this unit's definitions?"). Their typed carriers
+//! span a 187-type forward closure (187 types transitively reach `QuantityExpr`;
+//! `Effect` alone has 224 variants), so a hand-written total walk would be thousands
+//! of arms — every one of which is a silent reach gap if forgotten, and a missed
+//! carrier is a **false positive wave**, not a compile error.
+//!
+//! Instead the probe walks the `serde_json::Value` the definitions already serialize
+//! to and attempts `T::deserialize` on each node. Reach is therefore **serde-derived**
+//! — the compiler maintains it — while the predicate stays typed Rust. Adding a new
+//! `Effect` variant that carries a `QuantityExpr` extends the probe's reach for free.
+//!
+//! # Soundness: what a node deserializing as `T` does and does NOT prove
+//!
+//! Ruling (B) was accepted on the premise that "a false deserialize is structurally
+//! impossible". That is **not literally true**, and the module is built to the weaker,
+//! accurate statement. Two distinct hazards:
+//!
+//! **(1) Externally tagged enums.** `Duration` and `StaticMode` are NOT `#[serde(tag =
+//! "type")]`. Their unit variants serialize as **bare strings** (`"UntilEndOfTurn"`,
+//! `"Permanent"`). An unanchored `any::<Duration>` would therefore match *any string
+//! anywhere* that happens to equal a variant name — and `"Permanent"` is a common
+//! string in this tree (card kinds, filters). These two types MUST be probed with
+//! [`UnitEvidence::any_at`], which anchors on the JSON key the carrier field actually
+//! uses. See [`DURATION_KEYS`] / [`STATIC_MODE_KEYS`].
+//!
+//! **(2) Shared variant names between internally tagged enums.** Computed over the
+//! probed set, the colliding pairs are:
+//!
+//! ```text
+//! Effect                 ∩ AbilityCondition = {CastFromZone}
+//! Effect                 ∩ StaticMode       = {RevealHand}
+//! QuantityExpr           ∩ QuantityRef      = {Power}
+//! QuantityRef            ∩ AbilityCondition = {PreviousEffectAmount}
+//! AbilityCondition       ∩ StaticCondition  = {And, Not, Or, SourceMatchesFilter, IsMonarch, …17}
+//! StaticCondition        ∩ ActivationRestriction = {DuringYourTurn, SourceIsHarnessed}
+//! ContinuousModification ∩ StaticMode       = {AssignNoCombatDamage}
+//! ```
+//!
+//! A node bearing a shared name can deserialize as *either* enum. This is only a
+//! defect if a predicate's ANSWER differs across the collision. Every predicate in
+//! `swallow_check.rs` is written to be insensitive to the list above:
+//!   * no predicate matches `CastFromZone`, `RevealHand`, `PreviousEffectAmount`,
+//!     `AssignNoCombatDamage`, `DuringYourTurn` or `SourceIsHarnessed`;
+//!   * `QuantityExpr::Power` and `QuantityRef::Power` are BOTH dynamic quantities, so
+//!     the collision cannot change a `DynamicQty` answer;
+//!   * the `AbilityCondition`/`StaticCondition` 17-way overlap is asked only as
+//!     "*a* condition slot is populated", a question whose answer is the same for both.
+//!
+//! The collision that motivated this module — `ConditionMet` vs `SolveConditionMet` —
+//! is NOT in that table, because the names differ. That is precisely the property a
+//! type has and a substring does not.
+//!
+//! # The `description` channel (cond-1)
+//!
+//! `description` fields carry raw Oracle prose. Deserializing prose as a semantic
+//! carrier is the same defect one layer down, so [`UnitEvidence`] **never descends
+//! into a `description` value**. The walk is the single choke point, so no probe —
+//! present or future — can read prose as evidence.
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::parser::oracle::ParsedAbilities;
+
+/// The JSON key whose value is raw Oracle prose, never semantic evidence.
+const DESCRIPTION_KEY: &str = "description";
+
+/// Every JSON key at which a `Duration`-typed field is serialized.
+///
+/// `Duration` is externally tagged, so its unit variants are bare strings and it MUST
+/// be probed key-anchored (see module docs, hazard 1). Completeness is a grep over the
+/// type definitions, not a guess — the carrier set is closed:
+///
+/// ```text
+/// $ rg ': (Option<)?Duration[,>]' crates/engine/src/types/
+///   AbilityDefinition.duration                        <- the definition's own slot
+///   Effect::BecomeCopy.duration                       ┐
+///   Effect::GainActivatedAbilitiesOfTarget.duration   │
+///   Effect::GenericEffect.duration                    ├ the 6 Effect carriers
+///   Effect::ForceAttack.duration                      │
+///   Effect::CastFromZone.duration                     │
+///   Effect::PreventDamage.prevention_duration         ┘ <- NOT named `duration`
+///   CastingPermission::ExileWithAltCost.duration      ┐ CastingPermission
+///   CastingPermission::PlayFromExile.duration         ┘
+/// ```
+///
+/// `Effect::PreventDamage.prevention_duration` is why this is a key SET rather than the
+/// single key `"duration"` — and it is a fact the old substring marker got wrong in the
+/// other direction: `"prevention_duration":"UntilEndOfTurn"` does NOT contain the
+/// substring `"duration":"UntilEndOfTurn"` (the character before `duration` is `_`, not
+/// `"`), so the marker was blind to every damage-prevention shield's duration.
+const DURATION_KEYS: &[&str] = &["duration", "prevention_duration"];
+
+/// Every JSON key at which a `StaticMode`-typed field is serialized. Externally tagged,
+/// same anchoring requirement as [`DURATION_KEYS`].
+///
+/// ```text
+/// $ rg ': (Option<)?StaticMode[,>]' crates/engine/src/types/
+///   StaticDefinition.mode
+///   ContinuousModification::GrantStatic.mode
+/// ```
+///
+/// The key `"mode"` also carries `ReplacementMode` (on `ReplacementDefinition`), which is
+/// internally tagged. The two cannot be confused: a `ReplacementMode` value is the object
+/// `{"type":"Optional",…}` and fails `StaticMode::deserialize`, while a `StaticMode` unit
+/// variant is the bare string `"CantTap"` and fails `ReplacementMode::deserialize`.
+const STATIC_MODE_KEYS: &[&str] = &["mode"];
+
+/// One audit unit's lowered definitions, as a walkable tree with the prose removed.
+///
+/// Built once per unit and shared by every detector — the same one-serialization-per-unit
+/// cost the `ast_json` haystack it replaces already paid.
+pub(super) struct UnitEvidence {
+    root: Value,
+}
+
+impl UnitEvidence {
+    /// Serialize this unit's scoped definitions into a probe tree.
+    ///
+    /// Serialization of a definition tree cannot fail in practice (no maps with
+    /// non-string keys, no non-finite floats), and a failure here must not take the
+    /// parse down — an empty tree yields NO evidence, so every expectation this unit
+    /// raises is reported as swallowed. That is the conservative-red direction: the
+    /// audit over-reports rather than silently going green.
+    pub(super) fn of(scoped: &ParsedAbilities) -> Self {
+        Self {
+            root: serde_json::to_value(scoped).unwrap_or(Value::Null),
+        }
+    }
+
+    /// Visit nodes depth-first, short-circuiting on the first `true`.
+    ///
+    /// `key` is the object key the node is stored under (`None` at the root). Array
+    /// elements inherit their array's key, so a `Vec<Duration>` field would still be
+    /// anchored by its field name.
+    ///
+    /// **The `description` skip lives here and only here.** Prose is not evidence; the
+    /// walk is the choke point that makes that true for every probe built on it.
+    fn visit(
+        node: &Value,
+        key: Option<&str>,
+        f: &mut impl FnMut(&Value, Option<&str>) -> bool,
+    ) -> bool {
+        if f(node, key) {
+            return true;
+        }
+        match node {
+            Value::Object(map) => map
+                .iter()
+                .filter(|(k, _)| k.as_str() != DESCRIPTION_KEY)
+                .any(|(k, v)| Self::visit(v, Some(k), f)),
+            Value::Array(items) => items.iter().any(|v| Self::visit(v, key, f)),
+            _ => false,
+        }
+    }
+
+    /// Does any node in the tree deserialize as `T` and satisfy `pred`?
+    ///
+    /// For **internally tagged** types only (`#[serde(tag = "type")]`): `Effect`,
+    /// `QuantityExpr`, `QuantityRef`, `AbilityCondition`, `StaticCondition`,
+    /// `ContinuousModification`, `ReplacementMode`, `ActivationRestriction`. The tag must
+    /// name a real variant of `T` and the variant's fields must typecheck, which is what
+    /// makes the match discriminating.
+    ///
+    /// Do NOT use for `Duration` or `StaticMode` — see [`Self::any_at`].
+    pub(super) fn any<T: DeserializeOwned>(&self, pred: impl Fn(&T) -> bool) -> bool {
+        Self::visit(&self.root, None, &mut |node, _| {
+            T::deserialize(node.clone()).is_ok_and(|value| pred(&value))
+        })
+    }
+
+    /// Does any node stored at one of `keys` deserialize as `T` and satisfy `pred`?
+    ///
+    /// Key anchoring is **mandatory** for externally tagged enums, whose unit variants are
+    /// bare strings that would otherwise match unrelated prose-free strings elsewhere in
+    /// the tree (`Duration::Permanent` vs. any `"Permanent"` string). Anchoring restores
+    /// the discrimination the tag would have provided.
+    pub(super) fn any_at<T: DeserializeOwned>(
+        &self,
+        keys: &[&str],
+        pred: impl Fn(&T) -> bool,
+    ) -> bool {
+        Self::visit(&self.root, None, &mut |node, key| {
+            key.is_some_and(|k| keys.contains(&k))
+                && T::deserialize(node.clone()).is_ok_and(|value| pred(&value))
+        })
+    }
+
+    /// Is an optional slot named `key` populated anywhere?
+    ///
+    /// For facts that are purely about **slot presence** — the parser filled in an
+    /// `Option` field — where the slot's *value* carries no further discrimination the
+    /// detector needs (`modal`, `dynamic_max_choices`, `repeat_for`, `source_rider`, …).
+    /// Every such field is `skip_serializing_if = "Option::is_none"`, so key presence IS
+    /// population; the `!is_null` guard covers any field that is not.
+    ///
+    /// This is a structural JSON-key test, not a substring scan: it cannot match inside a
+    /// string, cannot match a longer key that contains it, and never sees prose. What it
+    /// does not get is a compiler check on the key spelling — so prefer [`Self::any`] /
+    /// [`Self::any_at`] whenever the fact has a typed carrier, and use this only when the
+    /// fact genuinely IS "the slot is filled".
+    pub(super) fn has_slot(&self, key: &str) -> bool {
+        Self::visit(&self.root, None, &mut |node, _| match node {
+            Value::Object(map) => map.get(key).is_some_and(|v| !v.is_null()),
+            _ => false,
+        })
+    }
+
+    /// Build a probe straight from a JSON fixture.
+    ///
+    /// Test-only, and deliberately so: production evidence must come from a real
+    /// `ParsedAbilities` via [`Self::of`]. This exists for the handful of detector unit
+    /// tests that pin a gate against a minimal hand-written AST shape.
+    #[cfg(test)]
+    pub(super) fn from_json_for_test(json: &str) -> Self {
+        Self {
+            root: serde_json::from_str(json).expect("test fixture must be valid JSON"),
+        }
+    }
+
+    /// Does any `Duration` carrier satisfy `pred`? Key-anchored per [`DURATION_KEYS`].
+    pub(super) fn any_duration(
+        &self,
+        pred: impl Fn(&crate::types::ability::Duration) -> bool,
+    ) -> bool {
+        self.any_at(DURATION_KEYS, pred)
+    }
+
+    /// Does any `StaticMode` carrier satisfy `pred`? Key-anchored per [`STATIC_MODE_KEYS`].
+    pub(super) fn any_static_mode(
+        &self,
+        pred: impl Fn(&crate::types::statics::StaticMode) -> bool,
+    ) -> bool {
+        self.any_at(STATIC_MODE_KEYS, pred)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, Duration, Effect, PlayerScope, QuantityExpr, QuantityRef,
+        TargetFilter,
+    };
+
+    fn parsed_with(def: AbilityDefinition) -> ParsedAbilities {
+        ParsedAbilities {
+            abilities: vec![def],
+            triggers: Vec::new(),
+            statics: Vec::new(),
+            replacements: Vec::new(),
+            extracted_keywords: Vec::new(),
+            modal: None,
+            additional_cost: None,
+            casting_restrictions: Vec::new(),
+            casting_options: Vec::new(),
+            solve_condition: None,
+            strive_cost: None,
+            parse_warnings: Vec::new(),
+        }
+    }
+
+    /// A def whose *prose* names a duration, but which carries NO duration carrier.
+    fn prose_only_duration() -> ParsedAbilities {
+        parsed_with(AbilityDefinition::new(
+            AbilityKind::Spell,
+            // `Effect::Unimplemented`'s fragment/description channel is raw Oracle text.
+            Effect::unimplemented("x", "target creature gets +1/+1 until end of turn"),
+        ))
+    }
+
+    /// COND-1, DIRECTION 1 — the skip is APPLIED.
+    ///
+    /// This test is the reason the skip is not vacuous. `Duration` is externally tagged,
+    /// so `Duration::UntilEndOfTurn` serializes as the bare string `"UntilEndOfTurn"` —
+    /// which means a *description string* containing exactly that text would deserialize
+    /// as a `Duration` and be accepted as evidence. Delete the `description` filter in
+    /// `visit` and this assertion goes RED while direction 2 below stays green: an
+    /// unapplied skip is invisible to the positive test alone, which is why BOTH are
+    /// mandatory.
+    #[test]
+    fn description_prose_is_never_evidence() {
+        let mut parsed = prose_only_duration();
+        // Plant the exact serialized form of `Duration::UntilEndOfTurn` inside prose.
+        parsed.abilities[0].description = Some("UntilEndOfTurn".to_string());
+        let evidence = UnitEvidence::of(&parsed);
+
+        assert!(
+            !evidence.any::<Duration>(|_| true),
+            "a Duration variant name planted in a `description` string must NOT be read \
+             as a Duration carrier — the walk must not descend into prose"
+        );
+    }
+
+    /// COND-1, DIRECTION 2 — the walk still SEES real carriers.
+    ///
+    /// Without this, "skip everything" would pass direction 1 trivially.
+    #[test]
+    fn a_real_duration_node_is_evidence() {
+        let def = AbilityDefinition::new(AbilityKind::Spell, Effect::unimplemented("x", "y"))
+            .duration(Duration::UntilEndOfTurn);
+        let evidence = UnitEvidence::of(&parsed_with(def));
+
+        assert!(
+            evidence.any_duration(|d| matches!(d, Duration::UntilEndOfTurn)),
+            "a real `AbilityDefinition.duration` carrier must be visible to the probe"
+        );
+    }
+
+    /// HAZARD 1 — why `Duration` must be key-anchored.
+    ///
+    /// `Duration::Permanent` serializes as the bare string `"Permanent"`, and that string
+    /// occurs all over a definition tree in positions that are not durations at all. An
+    /// unanchored `any::<Duration>` therefore over-reads; `any_duration` (key-anchored)
+    /// does not. This pins the anchoring as load-bearing rather than decorative.
+    #[test]
+    fn duration_probe_is_key_anchored_not_string_matched() {
+        // A `Token` effect naming the "Permanent" *type*, with no duration anywhere.
+        let parsed = parsed_with(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::unimplemented("x", "y"),
+        ));
+        let mut root = serde_json::to_value(&parsed).unwrap();
+        // Splice a non-duration field whose value is the bare string a unit variant uses.
+        root["abilities"][0]["kind_label"] = Value::String("Permanent".into());
+        let evidence = UnitEvidence { root };
+
+        assert!(
+            evidence.any::<Duration>(|d| matches!(d, Duration::Permanent)),
+            "unanchored: the bare string IS accepted — this is the hazard being guarded"
+        );
+        assert!(
+            !evidence.any_duration(|d| matches!(d, Duration::Permanent)),
+            "key-anchored: a `Permanent` string outside a duration slot is NOT a duration"
+        );
+    }
+
+    /// The typed probe reaches a carrier nested arbitrarily deep — the property that
+    /// replaces hand-enumerating the 187-type closure.
+    #[test]
+    fn typed_probe_reaches_nested_carriers() {
+        let def = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                target: TargetFilter::Controller,
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize {
+                        player: PlayerScope::Controller,
+                    },
+                },
+            },
+        );
+        let evidence = UnitEvidence::of(&parsed_with(def));
+
+        assert!(
+            evidence.any::<QuantityRef>(|_| true),
+            "a QuantityRef nested inside Effect::DrawCards.count must be reachable"
+        );
+        assert!(
+            evidence.any::<QuantityExpr>(|q| !matches!(q, QuantityExpr::Fixed { .. })),
+            "the wrapping QuantityExpr::Ref is a dynamic carrier"
+        );
+    }
+
+    /// A `Fixed` quantity is NOT dynamic evidence. Guards the `QuantityExpr` custom
+    /// `Deserialize`, which also accepts a **bare integer** as `Fixed` — so every integer
+    /// in the tree deserializes as a `QuantityExpr`. A `DynamicQty` predicate that forgot
+    /// to exclude `Fixed` would be satisfied by literally any number on the card.
+    #[test]
+    fn fixed_quantities_are_not_dynamic_evidence() {
+        let def = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                target: TargetFilter::Controller,
+                count: QuantityExpr::Fixed { value: 2 },
+            },
+        );
+        let evidence = UnitEvidence::of(&parsed_with(def));
+
+        assert!(
+            !evidence.any::<QuantityRef>(|_| true),
+            "a Fixed count carries no QuantityRef"
+        );
+        assert!(
+            !evidence.any::<QuantityExpr>(|q| !matches!(q, QuantityExpr::Fixed { .. })),
+            "Fixed is a constant, not a dynamic quantity — and a bare integer must not \
+             be mistaken for one"
+        );
+    }
+
+    /// `has_slot` is a structural key test: it must not match a longer key that merely
+    /// CONTAINS it, which is exactly the failure mode of the substring channel.
+    #[test]
+    fn has_slot_does_not_match_a_containing_key() {
+        let parsed = prose_only_duration();
+        let mut root = serde_json::to_value(&parsed).unwrap();
+        root["abilities"][0]["prevention_duration"] = Value::String("UntilEndOfTurn".into());
+        let evidence = UnitEvidence { root };
+
+        assert!(evidence.has_slot("prevention_duration"));
+        assert!(
+            !evidence.has_slot("duration"),
+            "`duration` must not be found inside the longer key `prevention_duration` — \
+             the substring marker `\"duration\":\"…\"` had this bug in reverse"
+        );
+    }
+
+    /// The `PlayerScope`-parameterized duration variants are objects, not bare strings,
+    /// and must still be reachable through the key anchor.
+    #[test]
+    fn data_carrying_duration_variants_are_reachable() {
+        let def = AbilityDefinition::new(AbilityKind::Spell, Effect::unimplemented("x", "y"))
+            .duration(Duration::UntilNextTurnOf {
+                player: PlayerScope::Controller,
+            });
+        let evidence = UnitEvidence::of(&parsed_with(def));
+
+        assert!(evidence.any_duration(|d| matches!(d, Duration::UntilNextTurnOf { .. })));
+        assert!(!evidence.any_duration(|d| matches!(d, Duration::UntilEndOfTurn)));
+    }
+}

--- a/crates/engine/src/parser/swallow_evidence.rs
+++ b/crates/engine/src/parser/swallow_evidence.rs
@@ -58,31 +58,100 @@
 //! [`UnitEvidence::any_at`], which anchors on the JSON key the carrier field actually
 //! uses. See [`DURATION_KEYS`] / [`STATIC_MODE_KEYS`].
 //!
-//! **(2) Shared variant names between internally tagged enums.** Computed over the
-//! probed set, the colliding pairs are:
+//! **(2) Shared variant names between internally tagged enums.** An internally tagged
+//! enum is often assumed to be self-identifying, so that anchoring is needed only for the
+//! externally tagged types in hazard (1). **That assumption is false**, for two compounding
+//! reasons:
+//!
+//!   * an internally-tagged **unit** variant matches on the `type` field ALONE, and serde
+//!     **ignores unknown fields** by default — so a node carrying extra fields still
+//!     deserializes cleanly, with those fields silently dropped;
+//!   * a tag only discriminates if the variant NAME is unique across every tagged enum in
+//!     the tree. It is not.
+//!
+//! For `QuantityRef` alone — 84 variants, against the 91 `#[serde(tag = "type")]` enums in
+//! `types/` — 10 names are shared:
 //!
 //! ```text
-//! Effect                 ∩ AbilityCondition = {CastFromZone}
-//! Effect                 ∩ StaticMode       = {RevealHand}
-//! QuantityExpr           ∩ QuantityRef      = {Power}
-//! QuantityRef            ∩ AbilityCondition = {PreviousEffectAmount}
-//! AbilityCondition       ∩ StaticCondition  = {And, Not, Or, SourceMatchesFilter, IsMonarch, …17}
-//! StaticCondition        ∩ ActivationRestriction = {DuringYourTurn, SourceIsHarnessed}
-//! ContinuousModification ∩ StaticMode       = {AssignNoCombatDamage}
+//! QuantityRef ∩ AbilityCondition         = {PreviousEffectAmount}
+//! QuantityRef ∩ FilterProp               = {AttackedThisTurn, EnteredThisTurn}
+//! QuantityRef ∩ TriggerCondition         = {AttackedThisTurn, CounterAddedThisTurn}
+//! QuantityRef ∩ ParsedCondition          = {BattlefieldEntriesThisTurn}
+//! QuantityRef ∩ ChooseFromZoneConstraint = {DistinctCardTypes}
+//! QuantityRef ∩ ManaCost                 = {SelfManaValue}
+//! QuantityRef ∩ ManaProduction           = {DistinctColorsAmongPermanents}
+//! QuantityRef ∩ SolveCondition           = {ObjectCount}
+//! QuantityRef ∩ QuantityExpr             = {Power}
 //! ```
 //!
-//! A node bearing a shared name can deserialize as *either* enum. This is only a
-//! defect if a predicate's ANSWER differs across the collision. Every predicate in
-//! `swallow_check.rs` is written to be insensitive to the list above:
-//!   * no predicate matches `CastFromZone`, `RevealHand`, `PreviousEffectAmount`,
-//!     `AssignNoCombatDamage`, `DuringYourTurn` or `SourceIsHarnessed`;
-//!   * `QuantityExpr::Power` and `QuantityRef::Power` are BOTH dynamic quantities, so
-//!     the collision cannot change a `DynamicQty` answer;
-//!   * the `AbilityCondition`/`StaticCondition` 17-way overlap is asked only as
-//!     "*a* condition slot is populated", a question whose answer is the same for both.
+//! and elsewhere in the probed set:
+//!
+//! ```text
+//! Effect                 ∩ AbilityCondition      = {CastFromZone}
+//! Effect                 ∩ StaticMode            = {RevealHand}
+//! AbilityCondition       ∩ StaticCondition       = {And, Not, Or, SourceMatchesFilter, …17}
+//! StaticCondition        ∩ ActivationRestriction = {DuringYourTurn, SourceIsHarnessed}
+//! ContinuousModification ∩ StaticMode            = {AssignNoCombatDamage}
+//! ```
+//!
+//! A node bearing a shared name can deserialize as *either* enum. That is only a defect if
+//! a predicate's ANSWER differs across the collision — so the safety argument has to be made
+//! per predicate, and it is:
+//!   * `QuantityExpr::Power` and `QuantityRef::Power` are BOTH dynamic quantities, so that
+//!     collision cannot change a `DynamicQty` answer;
+//!   * the `AbilityCondition`/`StaticCondition` 17-way overlap is asked only as "*a*
+//!     condition slot is populated", a question whose answer is the same for both;
+//!   * no predicate matches `CastFromZone`, `RevealHand`, `AssignNoCombatDamage`,
+//!     `DuringYourTurn` or `SourceIsHarnessed`.
+//!
+//! **This argument was once made for the quantity probes too, and it was WRONG.** The
+//! `PreviousEffectAmount` collision above was known and listed, under the claim "no predicate
+//! matches it". But `detect_dynamic_qty` probed `any::<QuantityRef>(|_| true)` — and `|_| true`
+//! is the ONE predicate that cannot be insensitive to a collision, because it matches every
+//! variant by construction. The consequence was measured over the full 35,396-face pool:
+//! Boing!'s `AbilityCondition::PreviousEffectAmount` (under key `condition`) and Siren's Call's
+//! `FilterProp::AttackedThisTurn` (under key `properties[].prop`, a TARGET FILTER) were both
+//! read as dynamic quantities, silently suppressing two true swallowed-clause warnings. The
+//! `FilterProp` collision was not even in the old table — the table had been computed against
+//! too small a set of enums.
+//!
+//! So the rule is now structural rather than argued: **`QuantityRef` and `QuantityExpr` are
+//! probed KEY-ANCHORED** ([`QUANTITY_KEYS`]), exactly like the externally tagged types. A value
+//! reached through a quantity key IS a quantity by construction, so no collision is reachable.
+//! Prefer anchoring to a per-predicate soundness argument wherever a key set exists: the
+//! argument has to be re-derived every time a predicate or an enum changes, and nothing checks
+//! it. **Anchoring fails LOUD** (a missing key over-reports, and the full-pool delta shows it);
+//! **an unanchored probe fails QUIET** (it under-reports, and nothing shows it).
+//!
+//! RESIDUAL RISK — MEASURED, NOT ASSUMED, AND IT IS NOT ZERO. 15 other types are still probed
+//! unanchored in `swallow_check.rs`. The tempting claim is that they are safe because each
+//! matches a *specific* variant rather than `|_| true`. That claim was tested against the
+//! collision map above and it is FALSE: **13 unanchored predicates match a variant name that
+//! is shared with another tagged enum**, and 8 of those are UNIT variants — no required
+//! fields, so the deserialize succeeds on the tag alone, which is the widest possible surface:
+//!
+//! ```text
+//! any::<ManaCost>         SelfManaValue               (unit)   also: QuantityRef
+//! any::<TriggerCondition> AttackedThisTurn            (unit)   also: FilterProp, QuantityRef
+//! any::<TriggerCondition> CounterAddedThisTurn        (unit)   also: QuantityRef
+//! any::<TriggerCondition> SourceEnteredThisTurn       (unit)   also: Static/Ability/ParsedCondition
+//! any::<FilterProp>       EnteredThisTurn             (unit)   also: QuantityRef
+//! any::<FilterProp>       AttackedThisTurn            (struct) also: QuantityRef, TriggerCondition
+//! any::<StaticCondition>  SourceEnteredThisTurn       (unit)   also: Ability/Parsed/TriggerCondition
+//! any::<AbilityCondition> SourceEnteredThisTurn       (unit)   also: Static/Parsed/TriggerCondition
+//! any::<Effect>           CastFromZone                (struct) also: Ability/ReplacementCondition
+//! …and 4 more (SpellCastWithVariantThisTurn ×3, DealtDamageThisTurnBySource)
+//! ```
+//!
+//! A collision is only a DEFECT where the two readings give different answers, and that has
+//! not been adjudicated per site — so these are UNPROVEN, not proven-safe. They are NOT
+//! touched here: each needs its own variant-level ruling and its own full-pool delta, because
+//! anchoring one blind can *remove* evidence that was accidentally load-bearing (that is not
+//! hypothetical — anchoring the quantity probes did exactly that to `ManaProduction`, and the
+//! fact had to be restored as a typed leg). Tracked as its own unit. Do not "tidy" them.
 //!
 //! The collision that motivated this module — `ConditionMet` vs `SolveConditionMet` —
-//! is NOT in that table, because the names differ. That is precisely the property a
+//! is NOT in any table above, because the names differ. That is precisely the property a
 //! type has and a substring does not.
 //!
 //! # The `description` channel (cond-1)

--- a/crates/engine/src/parser/swallow_evidence.rs
+++ b/crates/engine/src/parser/swallow_evidence.rs
@@ -229,15 +229,17 @@ const STATIC_MODE_KEYS: &[&str] = &["mode"];
 ///     in the tree. It is not. 10 of `QuantityRef`'s 84 variant names are shared with
 ///     another internally-tagged enum reachable from a parsed unit:
 ///
-///       QuantityRef ∩ AbilityCondition         PreviousEffectAmount
-///       QuantityRef ∩ FilterProp               AttackedThisTurn, EnteredThisTurn
-///       QuantityRef ∩ TriggerCondition         AttackedThisTurn, CounterAddedThisTurn
-///       QuantityRef ∩ ParsedCondition          BattlefieldEntriesThisTurn
-///       QuantityRef ∩ ChooseFromZoneConstraint DistinctCardTypes
-///       QuantityRef ∩ ManaCost                 SelfManaValue
-///       QuantityRef ∩ ManaProduction           DistinctColorsAmongPermanents
-///       QuantityRef ∩ SolveCondition           ObjectCount
-///       QuantityRef ∩ QuantityExpr             Power
+///     ```text
+///     QuantityRef ∩ AbilityCondition         PreviousEffectAmount
+///     QuantityRef ∩ FilterProp               AttackedThisTurn, EnteredThisTurn
+///     QuantityRef ∩ TriggerCondition         AttackedThisTurn, CounterAddedThisTurn
+///     QuantityRef ∩ ParsedCondition          BattlefieldEntriesThisTurn
+///     QuantityRef ∩ ChooseFromZoneConstraint DistinctCardTypes
+///     QuantityRef ∩ ManaCost                 SelfManaValue
+///     QuantityRef ∩ ManaProduction           DistinctColorsAmongPermanents
+///     QuantityRef ∩ SolveCondition           ObjectCount
+///     QuantityRef ∩ QuantityExpr             Power
+///     ```
 ///
 /// Both failures were MEASURED, not hypothesized. Unanchored, `detect_dynamic_qty` accepted
 /// Boing!'s `AbilityCondition::PreviousEffectAmount` (under key `condition`) and Siren's

--- a/crates/engine/src/parser/swallow_evidence.rs
+++ b/crates/engine/src/parser/swallow_evidence.rs
@@ -345,7 +345,7 @@ impl UnitEvidence {
     /// Do NOT use for `Duration` or `StaticMode` — see [`Self::any_at`].
     pub(super) fn any<T: DeserializeOwned>(&self, pred: impl Fn(&T) -> bool) -> bool {
         Self::visit(&self.root, None, &mut |node, _| {
-            T::deserialize(node.clone()).is_ok_and(|value| pred(&value))
+            T::deserialize(node).is_ok_and(|value| pred(&value))
         })
     }
 
@@ -362,7 +362,7 @@ impl UnitEvidence {
     ) -> bool {
         Self::visit(&self.root, None, &mut |node, key| {
             key.is_some_and(|k| keys.contains(&k))
-                && T::deserialize(node.clone()).is_ok_and(|value| pred(&value))
+                && T::deserialize(node).is_ok_and(|value| pred(&value))
         })
     }
 

--- a/crates/engine/src/parser/swallow_evidence.rs
+++ b/crates/engine/src/parser/swallow_evidence.rs
@@ -141,6 +141,80 @@ const DURATION_KEYS: &[&str] = &["duration", "prevention_duration"];
 /// variant is the bare string `"CantTap"` and fails `ReplacementMode::deserialize`.
 const STATIC_MODE_KEYS: &[&str] = &["mode"];
 
+/// Every JSON key at which a `QuantityExpr`- or `QuantityRef`-typed field is serialized.
+///
+/// ```text
+/// $ rg '(\w+): (Option<)?(Box<)?(Vec<)?(QuantityExpr|QuantityRef)\b' crates/engine/src/types/
+/// ```
+///
+/// Anchoring these is **mandatory**, and for a different reason than [`DURATION_KEYS`].
+/// `QuantityRef` is INTERNALLY tagged, so the naive argument is that its tag makes it
+/// self-identifying and anchoring is unnecessary. That argument is false twice over:
+///
+///  1. An internally-tagged **unit** variant matches on the `type` field ALONE, and serde
+///     ignores unknown fields by default. So `AbilityCondition::PreviousEffectAmount`,
+///     serialized as `{"type":"PreviousEffectAmount","comparator":"LE","rhs":…}`,
+///     deserializes CLEANLY as `QuantityRef::PreviousEffectAmount` — the extra fields are
+///     silently dropped.
+///  2. A tag is only discriminating if the variant NAME is unique across every tagged enum
+///     in the tree. It is not. 10 of `QuantityRef`'s 84 variant names are shared with
+///     another internally-tagged enum reachable from a parsed unit:
+///
+///       QuantityRef ∩ AbilityCondition         PreviousEffectAmount
+///       QuantityRef ∩ FilterProp               AttackedThisTurn, EnteredThisTurn
+///       QuantityRef ∩ TriggerCondition         AttackedThisTurn, CounterAddedThisTurn
+///       QuantityRef ∩ ParsedCondition          BattlefieldEntriesThisTurn
+///       QuantityRef ∩ ChooseFromZoneConstraint DistinctCardTypes
+///       QuantityRef ∩ ManaCost                 SelfManaValue
+///       QuantityRef ∩ ManaProduction           DistinctColorsAmongPermanents
+///       QuantityRef ∩ SolveCondition           ObjectCount
+///       QuantityRef ∩ QuantityExpr             Power
+///
+/// Both failures were MEASURED, not hypothesized. Unanchored, `detect_dynamic_qty` accepted
+/// Boing!'s `AbilityCondition::PreviousEffectAmount` (under key `condition`) and Siren's
+/// Call's `FilterProp::AttackedThisTurn` (under key `properties[].prop`) as proof of a
+/// dynamic quantity, and SUPPRESSED both cards' real swallowed-clause warnings — Boing!
+/// lowers "scry a number of cards equal to the result" to `Scry { count: Fixed(1) }`, so the
+/// dynamic quantity is genuinely dropped and the warning is a true positive.
+///
+/// Note the shape of the fix: a value reached through one of these keys IS a quantity by
+/// construction, so no collision is possible there. The failure directions are asymmetric —
+/// a key MISSING from this list makes a detector over-report (conservative-RED, visible in
+/// the full-pool delta), whereas an unanchored probe under-reports SILENTLY. Anchoring fails
+/// loud; not anchoring fails quiet.
+const QUANTITY_KEYS: &[&str] = &[
+    "amount",
+    "amount_dynamic",
+    "attr",
+    "back",
+    "count",
+    "depth",
+    "dynamic_count",
+    "dynamic_max_choices",
+    "exponent",
+    "expr",
+    "exprs",
+    "inner",
+    "keep_count_expr",
+    "left",
+    "lhs",
+    "life_payment",
+    "mana_value_limit",
+    "max",
+    "max_ticket_cost",
+    "min",
+    "mv_bound",
+    "qty",
+    "quantity",
+    "repeat_for",
+    "rhs",
+    "right",
+    "scale",
+    "threshold",
+    "total_power_cap",
+    "value",
+];
+
 /// One audit unit's lowered definitions, as a walkable tree with the prose removed.
 ///
 /// Built once per unit and shared by every detector — the same one-serialization-per-unit
@@ -261,6 +335,29 @@ impl UnitEvidence {
         self.any_at(DURATION_KEYS, pred)
     }
 
+    /// Does any `QuantityRef` carrier satisfy `pred`? Key-anchored per [`QUANTITY_KEYS`].
+    ///
+    /// Never probe `QuantityRef` unanchored: its tag is not discriminating, because 10 of its
+    /// variant names are shared with other internally-tagged enums. See [`QUANTITY_KEYS`].
+    pub(super) fn any_quantity_ref(
+        &self,
+        pred: impl Fn(&crate::types::ability::QuantityRef) -> bool,
+    ) -> bool {
+        self.any_at(QUANTITY_KEYS, pred)
+    }
+
+    /// Does any `QuantityExpr` carrier satisfy `pred`? Key-anchored per [`QUANTITY_KEYS`].
+    ///
+    /// Anchoring matters doubly here: `QuantityExpr`'s hand-written `Deserialize` also accepts
+    /// a BARE INTEGER as `Fixed` (the legacy on-disk form), so an unanchored probe would parse
+    /// any number anywhere on the card as a quantity.
+    pub(super) fn any_quantity_expr(
+        &self,
+        pred: impl Fn(&crate::types::ability::QuantityExpr) -> bool,
+    ) -> bool {
+        self.any_at(QUANTITY_KEYS, pred)
+    }
+
     /// Does any `StaticMode` carrier satisfy `pred`? Key-anchored per [`STATIC_MODE_KEYS`].
     pub(super) fn any_static_mode(
         &self,
@@ -367,6 +464,46 @@ mod tests {
         assert!(
             !evidence.any_duration(|d| matches!(d, Duration::Permanent)),
             "key-anchored: a `Permanent` string outside a duration slot is NOT a duration"
+        );
+    }
+
+    /// An INTERNALLY tagged enum still needs key-anchoring, because a tag only discriminates
+    /// if the variant NAME is unique across every tagged enum in the tree — and it is not.
+    ///
+    /// This is the Boing! defect, reduced to the building block. `AbilityCondition` and
+    /// `QuantityRef` both have a `PreviousEffectAmount` variant; the condition's node carries
+    /// extra fields, which serde silently DROPS when it deserializes the node as the unit
+    /// variant `QuantityRef::PreviousEffectAmount`. Unanchored, a *condition* was therefore
+    /// read as proof the unit carries a *dynamic quantity*, suppressing a real swallow.
+    #[test]
+    fn quantity_probe_is_key_anchored_not_tag_matched() {
+        // The verbatim shape the parser lowers Boing!'s "if the result is 3 or less" to:
+        // an AbilityCondition, sitting under the key `condition`.
+        let evidence = UnitEvidence::from_json_for_test(
+            r#"{"abilities":[{"condition":{"type":"PreviousEffectAmount","comparator":"LE","rhs":{"type":"Fixed","value":3}}}]}"#,
+        );
+
+        assert!(
+            evidence.any::<QuantityRef>(|_| true),
+            "unanchored: the AbilityCondition IS accepted as a QuantityRef — the hazard"
+        );
+        assert!(
+            !evidence.any_quantity_ref(|_| true),
+            "key-anchored: a condition under `condition` is NOT a dynamic quantity"
+        );
+    }
+
+    /// The anchored probe still sees a genuine quantity — the fix must not blind the detector.
+    /// This is Collective Restraint's Domain count, which legitimately dissolves its warning.
+    #[test]
+    fn a_quantity_under_a_quantity_key_is_still_evidence() {
+        let evidence = UnitEvidence::from_json_for_test(
+            r#"{"statics":[{"condition":{"scaling":{"data":{"quantity":{"type":"BasicLandTypeCount","controller":"You"}}}}}]}"#,
+        );
+
+        assert!(
+            evidence.any_quantity_ref(|q| matches!(q, QuantityRef::BasicLandTypeCount { .. })),
+            "a real QuantityRef under the `quantity` key must still be evidence"
         );
     }
 


### PR DESCRIPTION
- **fix(parser): swallow audit — typed-evidence probe, delete the substring marker channel**
- **feat(parser): swallow audit — emit the CR 614 Replacement expectation**
- **fix(parser): swallow audit — key-anchor the dynamic-quantity probes (CR 106.1)**
