### PR TITLE
feat(parser): parameterize superlative-property aggregate direction (least/lowest/smallest → Min)

### DIFF
--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -4647,15 +4647,26 @@ fn parse_superlative_property_suffix(
     ctx: &mut ParseContext,
 ) -> Option<(FilterProp, usize)> {
     let trimmed = text.trim_start();
-    // "with the <greatest|highest> <property> among " — greatest/highest are
-    // synonyms (both AggregateFunction::Max), property is the second axis.
-    // Factor the 2×3 cross product into two alts (PATTERNS.md §8b).
+    // "with the <superlative> <property> among " — the superlative head selects
+    // the aggregate direction and the property is the second axis. Factor the
+    // 2×3 cross product into two alts (PATTERNS.md §8b).
+    // CR 208.1 (power and toughness) + CR 202.3 (mana value): greatest/highest =
+    // Max, least/lowest/smallest = Min. Both directions feed the same generic
+    // superlative_property_filter_prop, so the runtime (values.min()/max() in
+    // game/quantity.rs) and the Sacrifice/Destroy/return resolvers select the
+    // constrained object unchanged.
     let (rest, (function, property)) = (
         tag::<_, _, OracleError<'_>>("with the "),
-        value(
-            AggregateFunction::Max,
-            alt((tag("greatest "), tag("highest "))),
-        ),
+        alt((
+            value(
+                AggregateFunction::Max,
+                alt((tag("greatest "), tag("highest "))),
+            ),
+            value(
+                AggregateFunction::Min,
+                alt((tag("least "), tag("lowest "), tag("smallest "))),
+            ),
+        )),
         alt((
             value(ObjectProperty::Power, tag("power")),
             value(ObjectProperty::Toughness, tag("toughness")),
@@ -7625,6 +7636,89 @@ mod tests {
             TargetFilter::And { filters } => filters.iter().find_map(typed_leg),
             _ => None,
         }
+    }
+
+    /// Extract the `AggregateFunction` a superlative-property suffix encodes,
+    /// regardless of whether it landed as a `PtComparison` (power/toughness) or a
+    /// `Cmc` (mana value) filter prop.
+    fn superlative_aggregate_function(text: &str) -> AggregateFunction {
+        let mut ctx = ParseContext::default();
+        let (prop, _consumed) = parse_superlative_property_suffix(text, &mut ctx)
+            .unwrap_or_else(|| panic!("superlative suffix should parse: {text}"));
+        let value = match prop {
+            FilterProp::PtComparison { value, .. } | FilterProp::Cmc { value, .. } => value,
+            other => panic!("expected PtComparison/Cmc, got {other:?}"),
+        };
+        match value {
+            QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate { function, .. },
+            } => function,
+            other => panic!("expected Aggregate quantity, got {other:?}"),
+        }
+    }
+
+    /// CR 208.1 + CR 202.3: the superlative head maps each direction word to an
+    /// `AggregateFunction` — least/lowest/smallest = Min (new), greatest/highest =
+    /// Max (regression). Tests the parameterized `alt` at the building-block level
+    /// across its full input range, not one card.
+    #[test]
+    fn superlative_direction_maps_word_to_aggregate_function() {
+        for word in ["least", "lowest", "smallest"] {
+            let text = format!("with the {word} power among creatures you control");
+            assert_eq!(
+                superlative_aggregate_function(&text),
+                AggregateFunction::Min,
+                "{word} should map to Min"
+            );
+        }
+        for word in ["greatest", "highest"] {
+            let text = format!("with the {word} power among creatures you control");
+            assert_eq!(
+                superlative_aggregate_function(&text),
+                AggregateFunction::Max,
+                "{word} should map to Max"
+            );
+        }
+    }
+
+    /// CR 208.1 + CR 701.21: "with the least toughness among creatures you control"
+    /// (The Dining Car's upkeep sacrifice) → a Min-aggregate toughness
+    /// `PtComparison` over "creatures you control", tie-inclusive (`EQ`).
+    #[test]
+    fn superlative_least_toughness_suffix_emits_min_aggregate_pt_comparison() {
+        let text = "with the least toughness among creatures you control";
+        let mut ctx = ParseContext::default();
+        let (prop, consumed) =
+            parse_power_suffix(text, &mut ctx).expect("least-toughness suffix should parse");
+        assert_eq!(consumed, text.len(), "the whole suffix must be consumed");
+        let FilterProp::PtComparison {
+            stat,
+            comparator,
+            value,
+            ..
+        } = prop
+        else {
+            panic!("expected PtComparison, got {prop:?}");
+        };
+        assert_eq!(stat, PtStat::Toughness);
+        assert_eq!(comparator, Comparator::EQ);
+        let QuantityExpr::Ref {
+            qty:
+                QuantityRef::Aggregate {
+                    function,
+                    property,
+                    filter,
+                },
+        } = value
+        else {
+            panic!("expected Aggregate quantity, got {value:?}");
+        };
+        assert_eq!(function, AggregateFunction::Min);
+        assert_eq!(property, ObjectProperty::Toughness);
+        // The eligible set is "creatures you control".
+        let tf = typed_leg(&filter).expect("aggregate filter should be a typed creature filter");
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+        assert!(tf.type_filters.contains(&TypeFilter::Creature));
     }
 
     /// CR 122.1 + CR 702.62b (Clockspinning): "target permanent or suspended


### PR DESCRIPTION
## Summary

Parameterizes the superlative-property suffix combinator in `parse_superlative_property_suffix` so the **aggregate direction is a single `alt`**: `greatest`/`highest`/`most` → `AggregateFunction::Max` (existing), and `least`/`lowest`/`smallest` → `AggregateFunction::Min` (new). Both directions feed the same generic `superlative_property_filter_prop`, so this closes the **entire `least`/`lowest`/`smallest` superlative-selection class** — over power, toughness, and mana value — across every card that uses the "with the &lt;superlative&gt; &lt;property&gt; among &lt;set&gt;" shape.

**No new engine variant.** The runtime already ships `AggregateFunction::Min` (used by `values.min()` in `game/quantity.rs`); previously only the `Max` head was reachable from the parser, so `Min` selection was a pure parser gap. The Sacrifice/Destroy/return resolvers consume the resulting `PtComparison`/`Cmc` filter prop unchanged.

Concretely, **The Dining Car**'s upkeep clause "sacrifice a creature with the least toughness among creatures you control" now parses to a `Sacrifice` whose target carries a tie-inclusive (`Comparator::EQ`) `PtComparison` on toughness bound to `Aggregate { function: Min, property: Toughness, filter: creatures you control }` — i.e. it selects the least-toughness creature, as the Oracle text specifies.

This was **split out of #5651 at matt's request** ("GAP A is clean; if you split GAP A out, I'd take it as-is"). GAP B from that branch never touched `oracle_target.rs` and is not included here — this PR is superlative-direction-only.

Tier: Standard

## Files changed
- `crates/engine/src/parser/oracle_target.rs`

## CR references
- `CR 208.1` — power and toughness (superlative selection over power/toughness)
- `CR 202.3` — mana value (superlative selection over mana value)
- `CR 701.21` — Sacrifice (The Dining Car's upkeep least-toughness sacrifice)

## Implementation method (required)
Method: not-applicable — single-combinator parameterization split verbatim out of the already-reviewed #5651 branch (matt approved GAP A as-is); reuses an existing runtime `AggregateFunction` with no new engine variant.

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh <merge-base>` — Gate A PASS (see below)
- `cargo clippy -p engine -p phase-ai -p engine-wasm --all-targets -- -D warnings` — clean (exit 0, no warnings)
- `cargo test -p engine -p phase-ai` — all pass; new tests `superlative_direction_maps_word_to_aggregate_function` and `superlative_least_toughness_suffix_emits_min_aggregate_pt_comparison` green
- `cargo run --profile tool --features cli --bin oracle-gen -- data --filter "the dining car|goblin ringleader"` — The Dining Car upkeep clause emits `Sacrifice` + `Aggregate { function: Min, property: Toughness, filter: creatures you control }`, `Comparator::EQ`; 0 Unimplemented/Unknown on the fixed clause; Goblin Ringleader fully clean; no regression

## Gate A
Gate A PASS head=de39411921ca8a62a5daddec8274100bffced85a base=302fab2fee76251c4ed835dfd8bc20fd3e02ee8a

## Anchored on
- `crates/engine/src/parser/oracle_target.rs:4658` — the pre-existing `value(AggregateFunction::Max, alt((tag("greatest "), tag("highest "))))` head this change lifts into an `alt` of two `value(function, alt(...))` branches (PATTERNS.md §8b cross-product factoring)
- `crates/engine/src/parser/oracle_target.rs:4670` — the sibling property `alt` (`Power`/`Toughness`/`ManaValue`) that already parameterizes the second axis of this combinator, the pattern the direction axis now mirrors

## Claimed parse impact
- The Dining Car (upkeep least-toughness sacrifice clause)
- Class-level: every "with the least/lowest/smallest &lt;power|toughness|mana value&gt; among &lt;set&gt;" card

## Validation Failures
None.

## CI Failures
None.
