### PR TITLE
Add Alchemist's Gift (pump + modal keyword-choice grant)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -3138,7 +3138,7 @@ fn try_split_pump_compound(
     let remainder = remainder_tp.original.trim();
 
     // Parse the pump clause first to check whether it carries its own duration.
-    let (power, toughness, duration) =
+    let (power, toughness, mut duration) =
         super::lower::parse_pump_clause_with_context(pump_part, ctx)?;
 
     // Guard: when the pump part has NO duration (e.g., "get +2/+2 and gain flying
@@ -3170,7 +3170,10 @@ fn try_split_pump_compound(
     // the general effect-chain parse.
     let sub_ability = if remainder.is_empty() {
         None
-    } else if let Some(choice) = build_keyword_choice_sub_ability(application, remainder) {
+    } else if let Some((choice, choice_duration)) =
+        build_keyword_choice_sub_ability(application, remainder)
+    {
+        duration = duration.or(choice_duration);
         Some(Box::new(choice))
     } else {
         Some(Box::new(super::parse_effect_chain(
@@ -3200,7 +3203,7 @@ fn try_split_pump_compound(
 fn build_keyword_choice_sub_ability(
     application: &SubjectApplication,
     remainder: &str,
-) -> Option<AbilityDefinition> {
+) -> Option<(AbilityDefinition, Option<Duration>)> {
     // The split remainder keeps its conjugated verb ("gains ..."):
     // `deconjugate_verb` in `build_continuous_clause` only normalizes the
     // compound's leading verb ("gets"), so the second clause arrives as
@@ -3209,16 +3212,20 @@ fn build_keyword_choice_sub_ability(
     let normalized = deconjugate_verb(remainder);
     let (first, second, duration) = parse_keyword_choice_grant(&normalized)?;
     let affected = static_affected_for_application(application);
+    let choice_duration = duration.clone();
     let branches = vec![
         keyword_choice_branch(first, affected.clone(), None, duration.clone()),
         keyword_choice_branch(second, affected, None, duration),
     ];
-    Some(AbilityDefinition::new(
-        AbilityKind::Spell,
-        Effect::ChooseOneOf {
-            chooser: PlayerFilter::Controller,
-            branches,
-        },
+    Some((
+        AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChooseOneOf {
+                chooser: PlayerFilter::Controller,
+                branches,
+            },
+        ),
+        choice_duration,
     ))
 }
 

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -3157,9 +3157,21 @@ fn try_split_pump_compound(
 
     let effect = build_pump_effect(application, power, toughness);
 
-    // Parse the remainder as an independent effect chain (sub_ability).
+    // CR 608.2d: a pump compounded with a modal keyword grant --
+    // "gets +1/+1 and gains your choice of deathtouch or lifelink" (Alchemist's
+    // Gift) -- has a grant half that is a two-branch player choice, so it cannot
+    // collapse into a single `ContinuousModification` the way a fixed "and gains
+    // trample" does (which the guard above routes to `build_continuous_clause`'s
+    // coalescing path). Route the choice through the same
+    // `parse_keyword_choice_grant` / `keyword_choice_branch` builders the
+    // standalone modal grant uses (`build_keyword_choice_clause`), riding the
+    // pump as a `ChooseOneOf` sub_ability keyed to the pumped creature
+    // (`ParentTarget`). Non-modal remainders ("you gain 1 life") fall back to
+    // the general effect-chain parse.
     let sub_ability = if remainder.is_empty() {
         None
+    } else if let Some(choice) = build_keyword_choice_sub_ability(application, remainder) {
+        Some(Box::new(choice))
     } else {
         Some(Box::new(super::parse_effect_chain(
             remainder,
@@ -3176,6 +3188,38 @@ fn try_split_pump_compound(
         optional: false,
         unless_pay: None,
     })
+}
+
+/// CR 608.2d: build the modal keyword-grant half of a pump
+/// compound ("gets +1/+1 AND gains your choice of X or Y") as a `ChooseOneOf`
+/// sub_ability. Reuses the same `parse_keyword_choice_grant` /
+/// `keyword_choice_branch` builders as the standalone `build_keyword_choice_clause`,
+/// keyed to the pumped creature via `static_affected_for_application`
+/// (`ParentTarget` for a targeted application). Returns `None` for a non-modal
+/// remainder so the caller falls back to the general effect-chain parse.
+fn build_keyword_choice_sub_ability(
+    application: &SubjectApplication,
+    remainder: &str,
+) -> Option<AbilityDefinition> {
+    // The split remainder keeps its conjugated verb ("gains ..."):
+    // `deconjugate_verb` in `build_continuous_clause` only normalizes the
+    // compound's leading verb ("gets"), so the second clause arrives as
+    // "gains your choice of ...". `parse_keyword_choice_grant` anchors on the
+    // bare "gain ..." form, so deconjugate the remainder here first.
+    let normalized = deconjugate_verb(remainder);
+    let (first, second, duration) = parse_keyword_choice_grant(&normalized)?;
+    let affected = static_affected_for_application(application);
+    let branches = vec![
+        keyword_choice_branch(first, affected.clone(), None, duration.clone()),
+        keyword_choice_branch(second, affected, None, duration),
+    ];
+    Some(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::ChooseOneOf {
+            chooser: PlayerFilter::Controller,
+            branches,
+        },
+    ))
 }
 
 fn parse_keyword_choice_grant(predicate: &str) -> Option<(Keyword, Keyword, Option<Duration>)> {

--- a/crates/engine/tests/integration/alchemists_gift_pump_modal_keyword_choice.rs
+++ b/crates/engine/tests/integration/alchemists_gift_pump_modal_keyword_choice.rs
@@ -133,6 +133,11 @@ fn alchemists_gift_grants_the_chosen_keyword_to_the_pumped_creature() {
 
     // End-to-end: the pumped creature gains ONLY the chosen keyword.
     let obj = &runner.state().objects[&target];
+    assert_eq!(
+        (obj.power, obj.toughness),
+        (Some(3), Some(3)),
+        "the pump half must remain a +1/+1 effect until end of turn"
+    );
     assert!(
         obj.has_keyword(&Keyword::Deathtouch),
         "the chosen keyword (deathtouch) must be granted to the pumped creature"

--- a/crates/engine/tests/integration/alchemists_gift_pump_modal_keyword_choice.rs
+++ b/crates/engine/tests/integration/alchemists_gift_pump_modal_keyword_choice.rs
@@ -1,0 +1,144 @@
+//! Alchemist's Gift -- a pump compounded with a modal keyword grant.
+//!
+//! Oracle:
+//!   Target creature gets +1/+1 and gains your choice of deathtouch or lifelink
+//!   until end of turn.
+//!
+//! Surface parser near-miss (coverage gap). `try_split_pump_compound` peels the
+//! pump half ("gets +1/+1") off the trailing grant. A fixed "and gains trample"
+//! collapses into a single `ContinuousModification` (Mortal's Resolve), but a
+//! two-branch "your choice of X or Y" cannot -- so the remainder was handed to
+//! the general effect-chain parser, which does not recognize the modal grant,
+//! leaving an `Unimplemented` sub_ability. The standalone targeted modal grant
+//! (Orcish Medicine) and the self pump+modal (Argivian Avenger) both parse;
+//! only the *targeted pump + modal* did not. The fix routes the remainder
+//! through the same `parse_keyword_choice_grant` / `keyword_choice_branch`
+//! builders the standalone modal grant uses, riding the pump as a `ChooseOneOf`
+//! sub_ability keyed to the pumped creature (`ParentTarget`).
+//!
+//! This drives the REAL cast -> resolve -> `ChooseOneOfBranch` pipeline and
+//! FAILS on `main`: the grant parses to `Unimplemented`, so no branch surfaces
+//! and no keyword is granted.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+
+const ALCHEMISTS_GIFT_ORACLE: &str = "Target creature gets +1/+1 and gains your \
+     choice of deathtouch or lifelink until end of turn.";
+
+/// Drive the engine forward until it pauses on the modal branch choice or a
+/// terminal state, passing priority and declaring nothing so resolution runs.
+fn advance_to_choice(runner: &mut GameRunner) {
+    for _ in 0..60 {
+        match &runner.state().waiting_for {
+            WaitingFor::ChooseOneOfBranch { .. } => return,
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    return;
+                }
+            }
+            WaitingFor::DeclareAttackers { .. } => {
+                if runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                if runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            _ => return,
+        }
+    }
+}
+
+/// Casting Alchemist's Gift at a vanilla creature must pump it +1/+1 AND offer a
+/// two-branch "your choice of deathtouch or lifelink" grant; resolving the
+/// chosen branch grants ONLY that keyword to the pumped creature.
+#[test]
+fn alchemists_gift_grants_the_chosen_keyword_to_the_pumped_creature() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    // Non-empty libraries so an unfixed run does not deck out before the
+    // ChooseOneOfBranch assertion has a chance to observe the missing branch.
+    for pid in [P0, P1] {
+        scenario.with_library_top(pid, &["Lib A", "Lib B", "Lib C", "Lib D"]);
+    }
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Alchemist Gift", true, ALCHEMISTS_GIFT_ORACLE)
+        .id();
+    // A vanilla 2/2: any deathtouch/lifelink it has after resolution can only
+    // have come from the modal grant.
+    let target = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+
+    let mut runner = scenario.build();
+
+    assert!(
+        !runner.state().objects[&target].has_keyword(&Keyword::Deathtouch),
+        "precondition: the vanilla creature has no deathtouch"
+    );
+    assert!(
+        !runner.state().objects[&target].has_keyword(&Keyword::Lifelink),
+        "precondition: the vanilla creature has no lifelink"
+    );
+
+    runner.cast(spell).target_object(target).commit();
+    advance_to_choice(&mut runner);
+
+    // The modal grant must surface as a two-branch choice made by the spell's
+    // controller. On `main` the grant parsed to `Unimplemented`, so no branch
+    // ever appeared here.
+    let deathtouch_index = match &runner.state().waiting_for {
+        WaitingFor::ChooseOneOfBranch {
+            player, branches, ..
+        } => {
+            assert_eq!(*player, P0, "the spell's controller (P0) makes the choice");
+            assert_eq!(
+                branches.len(),
+                2,
+                "deathtouch-or-lifelink is a two-branch choice"
+            );
+            branches
+                .iter()
+                .position(|b| {
+                    b.description
+                        .as_deref()
+                        .is_some_and(|d| d.to_lowercase().contains("deathtouch"))
+                })
+                .expect("a gain-Deathtouch branch must exist")
+        }
+        other => panic!("expected a ChooseOneOfBranch for the modal keyword grant, got {other:?}"),
+    };
+
+    runner
+        .act(GameAction::ChooseBranch {
+            index: deathtouch_index,
+        })
+        .expect("resolving the deathtouch branch must succeed");
+
+    // End-to-end: the pumped creature gains ONLY the chosen keyword.
+    let obj = &runner.state().objects[&target];
+    assert!(
+        obj.has_keyword(&Keyword::Deathtouch),
+        "the chosen keyword (deathtouch) must be granted to the pumped creature"
+    );
+    assert!(
+        !obj.has_keyword(&Keyword::Lifelink),
+        "the unchosen keyword (lifelink) must NOT be granted"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -4,6 +4,7 @@ mod ad_nauseam_repeat;
 mod adapter_contract_fixtures;
 mod advanced_reconstruction_regression;
 mod ajani_nacatl_pariah_transform;
+mod alchemists_gift_pump_modal_keyword_choice;
 mod ambuscade_one_sided_fight_anaphoric;
 mod amphin_mutineer_regression;
 mod ancient_brass_dragon_roll_d20;


### PR DESCRIPTION
## Summary

Route the modal keyword-grant half of a pump compound to the existing `ChooseOneOf` builders. "Target creature gets +1/+1 and gains your choice of deathtouch or lifelink until end of turn" (Alchemist's Gift) left the grant `Unimplemented`: `try_split_pump_compound` peels the pump off and hands the trailing "gains your choice of X or Y" to the general effect-chain parser, and a two-branch choice cannot collapse into a single `ContinuousModification` the way a fixed "and gains trample" does (Mortal's Resolve).

The split remainder now routes through the same `parse_keyword_choice_grant` / `keyword_choice_branch` builders the standalone modal grant uses (`build_keyword_choice_clause`), riding the pump as a `ChooseOneOf` sub_ability keyed to the pumped creature (`ParentTarget`). No new effect variant and no runtime path. The standalone targeted modal grant (Orcish Medicine) and the self pump+modal (Argivian Avenger) both already parse; only the targeted pump + modal did not.

## Files changed

- `crates/engine/src/parser/oracle_effect/subject.rs` — new `build_keyword_choice_sub_ability` helper, wired into `try_split_pump_compound` ahead of the general effect-chain fallback (returns `None` for non-modal remainders so those fall back unchanged).
- `crates/engine/tests/integration/alchemists_gift_pump_modal_keyword_choice.rs` — discriminating integration test driving the real cast -> resolve -> ChooseOneOfBranch pipeline.
- `crates/engine/tests/integration/main.rs` — register the new test module.

## Rules

CR 608.2d — the two-branch modal keyword grant is a player choice made on resolution, so it cannot coalesce into a single continuous modification.

## Method: /engine-implementer

Track: Developer
LLM: Model claude-opus-4-8, Thinking high

## Verification

- [x] `cargo fmt --all --check` clean
- [x] Gate A (parser-combinators) PASS
- [x] `cargo test -p engine --test integration -- alchemists_gift` PASS (1 passed, 0 failed)
- [x] Rebased clean on `origin/main`; trailer-free single commit; 3 files

Gate A PASS head=f73debbde1e863452378c888ac03a58bf9c52325 base=b6d5ca3e2aff6fd5f6db036a721a8f4ee5d4cd8c

Anchored on (subject.rs:3294 build_keyword_choice_clause + subject.rs:3225 parse_keyword_choice_grant)

Final review-impl PASS head=f73debbde1e863452378c888ac03a58bf9c52325

Claimed parse impact: Alchemist's Gift
Validation Failures: None
CI Failures: None
