### PR TITLE
fix(parser): thread the counter rider into the 'exile one of them face down' fusion

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21607,7 +21607,10 @@ fn chain_clause_is_exile_producer(effect: &Effect) -> bool {
 fn continuation_is_exile_producer(continuation: Option<&ContinuationAst>) -> bool {
     matches!(
         continuation,
-        Some(ContinuationAst::ExileOneOfThemFaceDown { .. } | ContinuationAst::ExileLookedAtCard { .. })
+        Some(
+            ContinuationAst::ExileOneOfThemFaceDown { .. }
+                | ContinuationAst::ExileLookedAtCard { .. }
+        )
     )
 }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21607,7 +21607,7 @@ fn chain_clause_is_exile_producer(effect: &Effect) -> bool {
 fn continuation_is_exile_producer(continuation: Option<&ContinuationAst>) -> bool {
     matches!(
         continuation,
-        Some(ContinuationAst::ExileOneOfThemFaceDown | ContinuationAst::ExileLookedAtCard { .. })
+        Some(ContinuationAst::ExileOneOfThemFaceDown { .. } | ContinuationAst::ExileLookedAtCard { .. })
     )
 }
 

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -834,17 +834,41 @@ fn parse_exile_looked_at_card(lower: &str) -> Option<bool> {
 /// selects exactly one of the N looked-at cards. The "face down" suffix is the
 /// CR 406.3 hidden-information marker required by this class; pure-peek Digs
 /// (Delver of Secrets — no exile clause) never reach this recognizer.
-fn parse_exile_one_of_them_face_down(lower: &str) -> bool {
+///
+/// CR 122.1: An optional counter rider ("... face down with a hatching counter
+/// on it", The Dragon-Kami Reborn) may follow "face down". `Some(entries)`
+/// signals a match (empty `entries` = the bare Gonti form; non-empty = the
+/// counters the fusion threads onto the chosen exiled card). Delegates the
+/// rider to the shared `parse_counter_suffix_body_combinator`, so every
+/// `<count> <type> counter(s) on it` shape (a/two/X, +1/+1, keyword, named)
+/// is covered by the one building block — not just "a hatching counter".
+fn parse_exile_one_of_them_face_down(lower: &str) -> Option<Vec<(CounterType, QuantityExpr)>> {
     let trimmed = lower.trim().trim_end_matches('.').trim_end();
-    (
+    let (rest, _) = (
         tag::<_, _, OracleError<'_>>("exile "),
         alt((tag("one of them"), tag("one of those cards"))),
         multispace1,
         tag("face down"),
-        eof,
     )
         .parse(trimmed)
-        .is_ok()
+        .ok()?;
+    // CR 122.1: optional "with <count> <type> counter(s) on it" rider. Either
+    // the bare form (nothing after "face down") or exactly one counter clause.
+    match preceded(
+        tag::<_, _, OracleError<'_>>(" with "),
+        crate::parser::oracle_effect::parse_counter_suffix_body_combinator,
+    )
+    .parse(rest)
+    {
+        Ok((after, entry)) => {
+            eof::<_, OracleError<'_>>(after).ok()?;
+            Some(vec![entry])
+        }
+        Err(_) => {
+            eof::<_, OracleError<'_>>(rest).ok()?;
+            Some(Vec::new())
+        }
+    }
 }
 
 pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
@@ -4424,7 +4448,9 @@ pub(super) fn apply_clause_continuation(
         // binds to the dug card). Without this fusion the Dig short-circuited as
         // a keep_count:0 pure-peek and a sibling `ChangeZone { ParentTarget }`
         // exiled the trigger source itself (#1146).
-        ContinuationAst::ExileOneOfThemFaceDown => {
+        ContinuationAst::ExileOneOfThemFaceDown {
+            enter_with_counters,
+        } => {
             // Same `DigLook` antecedent as `ExileLookedAtCard` above — the two scans
             // this replaces had byte-identical predicates, so they name ONE role, not
             // two. LIVE, not cached: `append_conceal_sub_ability` nests a `sub_ability`
@@ -4458,6 +4484,12 @@ pub(super) fn apply_clause_continuation(
             // sub-ability's `ParentTarget`; `HideawayConceal` then flips it face
             // down (CR 406.3) and links it to the source (CR 607.2a / CR 702.75a).
             append_conceal_sub_ability(previous);
+            // CR 122.1: a "... face down with a <type> counter on it" rider (The
+            // Dragon-Kami Reborn) places the counters on the CHOSEN dug card.
+            // Append after the conceal so each `PutCounter { ParentTarget }`
+            // inherits the same bound target (the chosen exiled card) — without
+            // this the counters rode a discarded sibling `ChangeZone`.
+            append_counter_riders_sub_abilities(previous, enter_with_counters);
         }
         ContinuationAst::ChooseAndSacrificeRestFilter { sacrifice_filter } => {
             let Some(filter) = sacrifice_filter else {
@@ -4498,6 +4530,44 @@ fn append_conceal_sub_ability(dig: &mut AbilityDefinition) {
             .expect("sub_ability checked above");
     }
     cursor.sub_ability = Some(conceal);
+}
+
+/// CR 122.1 + CR 702.75a: Append the exile-rider's counters onto the fused
+/// Hideaway exile. Each `PutCounter { target: ParentTarget }` link inherits the
+/// continuation chain's bound target (the chosen dug card the `DigChoice` flow
+/// routed to exile), so the whole chain places counters on the ONE card the
+/// player selected — mirroring `lower_put_counter_list`'s `ParentTarget` chain.
+/// Appended at the deepest sub (after the conceal) so it runs once the chosen
+/// card is exiled face down. No-op for the bare Gonti form (empty `entries`).
+fn append_counter_riders_sub_abilities(
+    dig: &mut AbilityDefinition,
+    entries: Vec<(CounterType, QuantityExpr)>,
+) {
+    // Build the counter chain right-to-left so each link owns its successor.
+    let mut chain: Option<Box<AbilityDefinition>> = None;
+    for (counter_type, count) in entries.into_iter().rev() {
+        let mut def = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PutCounter {
+                counter_type,
+                count,
+                target: TargetFilter::ParentTarget,
+            },
+        );
+        def.sub_ability = chain;
+        chain = Some(Box::new(def));
+    }
+    let Some(chain) = chain else {
+        return;
+    };
+    let mut cursor = dig;
+    while cursor.sub_ability.is_some() {
+        cursor = cursor
+            .sub_ability
+            .as_mut()
+            .expect("sub_ability checked above");
+    }
+    cursor.sub_ability = Some(chain);
 }
 
 fn apply_search_destination_to_ability_chain(
@@ -4612,7 +4682,7 @@ pub(super) fn continuation_absorbs_current(
         // Recognition was already gated on a preceding `Dig`; the "exile one of
         // them face down" clause patches that Dig (keep_count:1 / Exile) and
         // pushes the conceal sub-ability — it emits no sibling def.
-        ContinuationAst::ExileOneOfThemFaceDown => true,
+        ContinuationAst::ExileOneOfThemFaceDown { .. } => true,
         ContinuationAst::ChooseAndSacrificeRestFilter { .. } => true,
     }
 }
@@ -6050,8 +6120,16 @@ pub(super) fn parse_followup_continuation_ast(
         // face down and linked to the source — NOT a sibling
         // `ChangeZone { ParentTarget }`, which exiled the trigger source itself.
         // `reveal: false` scopes this to the private look form.
-        Effect::Dig { reveal: false, .. } if parse_exile_one_of_them_face_down(&lower) => {
-            Some(ContinuationAst::ExileOneOfThemFaceDown)
+        Effect::Dig { reveal: false, .. }
+            if parse_exile_one_of_them_face_down(&lower).is_some() =>
+        {
+            // CR 122.1: carry any "... face down with a <type> counter on it"
+            // rider so the fusion places the counters on the CHOSEN dug card.
+            let enter_with_counters =
+                parse_exile_one_of_them_face_down(&lower).unwrap_or_default();
+            Some(ContinuationAst::ExileOneOfThemFaceDown {
+                enter_with_counters,
+            })
         }
         // CR 201.2 + CR 608.2c: "[You may] put one of those cards onto the
         // battlefield if it has the same name as a permanent" after Dig —
@@ -9276,7 +9354,9 @@ mod tests {
         let env = env_for(&defs);
         apply_clause_continuation(
             &mut defs,
-            ContinuationAst::ExileOneOfThemFaceDown,
+            ContinuationAst::ExileOneOfThemFaceDown {
+                enter_with_counters: Vec::new(),
+            },
             AbilityKind::Spell,
             &env,
         );
@@ -9307,6 +9387,69 @@ mod tests {
             "the intervening def must be left untouched, got {:?}",
             defs[1].effect
         );
+    }
+
+    /// #5631 (The Dragon-Kami Reborn): the "... face down with a hatching
+    /// counter on it" rider threads its counters into the fused exile as a
+    /// `PutCounter { ParentTarget }` chained AFTER the conceal, so the CHOSEN
+    /// dug card (not the trigger source) receives the counter.
+    #[test]
+    fn exile_one_of_them_face_down_counter_rider_appends_put_counter_after_conceal() {
+        let mut defs = vec![AbilityDefinition::new(AbilityKind::Spell, make_dig_effect())];
+        let env = env_for(&defs);
+        let hatching = crate::types::counter::parse_counter_type("hatching");
+        apply_clause_continuation(
+            &mut defs,
+            ContinuationAst::ExileOneOfThemFaceDown {
+                enter_with_counters: vec![(hatching.clone(), QuantityExpr::Fixed { value: 1 })],
+            },
+            AbilityKind::Spell,
+            &env,
+        );
+
+        // The Dig is patched into the choose-one exile shape.
+        let Effect::Dig {
+            keep_count,
+            destination,
+            ..
+        } = &*defs[0].effect
+        else {
+            panic!("expected patched Dig, got {:?}", defs[0].effect);
+        };
+        assert_eq!(*keep_count, Some(1));
+        assert_eq!(*destination, Some(Zone::Exile));
+
+        // Chain shape: Dig -> HideawayConceal(ParentTarget) -> PutCounter(ParentTarget).
+        let conceal = defs[0]
+            .sub_ability
+            .as_ref()
+            .expect("conceal sub-ability must be chained onto the Dig");
+        assert!(
+            matches!(&*conceal.effect, Effect::HideawayConceal { .. }),
+            "first sub must be the conceal, got {:?}",
+            conceal.effect
+        );
+        let put_counter = conceal
+            .sub_ability
+            .as_ref()
+            .expect("the counter rider must append a PutCounter after the conceal");
+        match &*put_counter.effect {
+            Effect::PutCounter {
+                counter_type,
+                count,
+                target,
+            } => {
+                assert_eq!(*counter_type, hatching);
+                assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+                assert_eq!(
+                    *target,
+                    TargetFilter::ParentTarget,
+                    "the counter must land on the chosen dug card (ParentTarget), \
+                     inherited through the continuation chain"
+                );
+            }
+            other => panic!("expected PutCounter after conceal, got {other:?}"),
+        }
     }
 
     /// CR 406.3 + CR 701.20e: the Gonti impulse rewrite binds the same `Dig`.
@@ -11716,7 +11859,9 @@ mod tests {
         );
         assert_eq!(
             result,
-            Some(ContinuationAst::ExileOneOfThemFaceDown),
+            Some(ContinuationAst::ExileOneOfThemFaceDown {
+                enter_with_counters: Vec::new(),
+            }),
             "the Gonti-class exile-the-dug-card clause must be recognized"
         );
     }
@@ -11731,7 +11876,44 @@ mod tests {
             &dig,
             &mut ParseContext::default(),
         );
-        assert_eq!(result, Some(ContinuationAst::ExileOneOfThemFaceDown));
+        assert_eq!(
+            result,
+            Some(ContinuationAst::ExileOneOfThemFaceDown {
+                enter_with_counters: Vec::new(),
+            })
+        );
+    }
+
+    /// #5631 (The Dragon-Kami Reborn): a CR 122.1 counter rider between "face
+    /// down" and the clause end is accepted, and its counter is captured so the
+    /// fusion can place it on the CHOSEN dug card. Before this, the counter
+    /// rider made the recognizer decline and the clause silently exiled the
+    /// trigger source itself (the #1146 shape).
+    #[test]
+    fn exile_one_of_them_face_down_with_counter_rider_captures_counters() {
+        let entries = parse_exile_one_of_them_face_down(
+            "exile one of them face down with a hatching counter on it",
+        )
+        .expect("the counter-rider form must still be recognized");
+        assert_eq!(
+            entries,
+            vec![(
+                crate::types::counter::parse_counter_type("hatching"),
+                QuantityExpr::Fixed { value: 1 }
+            )],
+            "the hatching-counter rider must be captured for the fusion to thread"
+        );
+    }
+
+    /// The bare Gonti form recognizes with NO counters — a match with an empty
+    /// rider list, distinct from a decline.
+    #[test]
+    fn exile_one_of_them_face_down_bare_form_has_no_counters() {
+        assert_eq!(
+            parse_exile_one_of_them_face_down("exile one of them face down"),
+            Some(Vec::new()),
+            "the bare form is a match with no counter rider"
+        );
     }
 
     /// #1146 scope guard: the recognizer requires the "face down" CR 406.3
@@ -11740,7 +11922,7 @@ mod tests {
     #[test]
     fn exile_one_of_them_without_face_down_is_not_gonti_continuation() {
         assert!(
-            !parse_exile_one_of_them_face_down("exile one of them"),
+            parse_exile_one_of_them_face_down("exile one of them").is_none(),
             "without the 'face down' marker this is not the Gonti look-and-exile class"
         );
     }
@@ -11757,9 +11939,11 @@ mod tests {
             &dig,
             &mut ParseContext::default(),
         );
-        assert_ne!(
-            result,
-            Some(ContinuationAst::ExileOneOfThemFaceDown),
+        assert!(
+            !matches!(
+                result,
+                Some(ContinuationAst::ExileOneOfThemFaceDown { .. })
+            ),
             "a pure-peek 'you may reveal it' must not be fused into the Gonti exile continuation"
         );
     }

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -9395,7 +9395,10 @@ mod tests {
     /// dug card (not the trigger source) receives the counter.
     #[test]
     fn exile_one_of_them_face_down_counter_rider_appends_put_counter_after_conceal() {
-        let mut defs = vec![AbilityDefinition::new(AbilityKind::Spell, make_dig_effect())];
+        let mut defs = vec![AbilityDefinition::new(
+            AbilityKind::Spell,
+            make_dig_effect(),
+        )];
         let env = env_for(&defs);
         let hatching = crate::types::counter::parse_counter_type("hatching");
         apply_clause_continuation(
@@ -11940,10 +11943,7 @@ mod tests {
             &mut ParseContext::default(),
         );
         assert!(
-            !matches!(
-                result,
-                Some(ContinuationAst::ExileOneOfThemFaceDown { .. })
-            ),
+            !matches!(result, Some(ContinuationAst::ExileOneOfThemFaceDown { .. })),
             "a pure-peek 'you may reveal it' must not be fused into the Gonti exile continuation"
         );
     }

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -449,7 +449,17 @@ pub(crate) enum ContinuationAst {
     /// flow, then chains a `HideawayConceal` sub-ability to turn the chosen card
     /// face down and link it to the source. Gated on the exile-the-dug-card
     /// continuation, so genuine pure-peek Digs (Delver of Secrets) are untouched.
-    ExileOneOfThemFaceDown,
+    ExileOneOfThemFaceDown {
+        /// CR 122.1: A "... face down with <count> <type> counter(s) on it"
+        /// rider (The Dragon-Kami Reborn: "Exile one of them face down with a
+        /// hatching counter on it"). Threaded into the fused exile as a
+        /// `PutCounter { target: ParentTarget }` sub-ability chain appended
+        /// after the conceal, so the player-selected dug card — NOT the trigger
+        /// source — receives the counters. Empty for the bare "exile one of
+        /// them face down" form (Gonti, Lord of Luxury).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        enter_with_counters: Vec<(CounterType, QuantityExpr)>,
+    },
     /// CR 608.2c + CR 701.21a: absorbs the explicit/bare sacrifice-rest clause
     /// following a choose-and-sacrifice-rest effect, optionally narrowing the
     /// final sacrifice sweep ("all other nonland permanents they control").

--- a/crates/engine/tests/integration/issue_5631_dragon_kami_reborn_hatching_counter.rs
+++ b/crates/engine/tests/integration/issue_5631_dragon_kami_reborn_hatching_counter.rs
@@ -1,0 +1,248 @@
+//! Runtime resolution regression for **issue #5631** (The Dragon-Kami Reborn).
+//!
+//! Chapters I–II read: *"You gain 2 life. Look at the top three cards of your
+//! library. **Exile one of them face down with a hatching counter on it**, then
+//! put the rest on the bottom of your library in any order."*
+//!
+//! Root cause (pre-fix): `parse_exile_one_of_them_face_down` required
+//! end-of-clause immediately after `"face down"`, so the CR 122.1 counter rider
+//! (`"with a hatching counter on it"`) made the recognizer decline. With the
+//! recognizer declining, the Hideaway-style fusion never fired: the `Dig`
+//! short-circuited as a `keep_count: 0` pure-peek and a sibling
+//! `ChangeZone { ParentTarget }` exiled the **trigger source itself** (the Saga,
+//! with a hatching counter) instead of one of the three looked-at cards.
+//!
+//! Fix (parser): the recognizer accepts the optional counter rider and threads
+//! it into the fused exile as `Dig(keep_count:1, Exile) ->
+//! HideawayConceal(ParentTarget) -> PutCounter(hatching, ParentTarget)`. The
+//! `DigChoice` resolution binds the CHOSEN dug card onto the continuation
+//! chain's `ParentTarget`, so the hatching counter lands on the one card the
+//! player selected.
+//!
+//! The existing PR coverage only inspects the parsed AST shape. This test drives
+//! the real resolution path: it resolves the chapter effect, answers the
+//! `DigChoice`, and asserts (a) the player-selected card is exiled face down
+//! with exactly one hatching counter, and (b) the Saga stays on the battlefield
+//! with NO hatching counter. Both assertions flip when the fusion or the
+//! counter-target binding is reverted (the counter would ride the source Saga).
+//!
+//! CR 122.1: counters are placed on the object the instruction specifies.
+//! CR 406.3 / CR 708.2: a card exiled face down has no characteristics.
+//! CR 608.2c: a `ParentTarget` sub-ability inherits the parent link's target.
+//! CR 702.75a: Hideaway is the structural analog this lowering mirrors.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::counter::{parse_counter_type, CounterType};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::CardId;
+use engine::types::zones::Zone;
+
+/// Chapters I–II of The Dragon-Kami Reborn, verbatim minus the "I, II —"
+/// chapter prefix (the parser receives the effect text, not the chapter label).
+const CHAPTER_I_II: &str = "You gain 2 life. Look at the top three cards of your library. \
+Exile one of them face down with a hatching counter on it, then put the rest on the bottom of your library in any order.";
+
+/// The fused-exile clause in isolation (no leading "You gain 2 life."), so the
+/// Dig sits at the chain root for the AST shape guard.
+const FUSED_CLAUSE: &str = "Look at the top three cards of your library. \
+Exile one of them face down with a hatching counter on it, then put the rest on the bottom of your library in any order.";
+
+#[test]
+fn hatching_counter_lands_on_chosen_exiled_card_not_the_saga() {
+    let hatching = parse_counter_type("hatching");
+    assert_eq!(
+        hatching,
+        CounterType::Generic("hatching".to_string()),
+        "sanity: the rider counter is a generic hatching counter"
+    );
+
+    // POSITIVE REACH-GUARD (foot-gun #6): prove the clause parses to the fused
+    // choose-one exile with the hatching counter chained onto the chosen card.
+    // Without this the "Saga has no counter" assertion below could pass
+    // vacuously (e.g. if the effect stopped parsing to a Dig at all). Walk the
+    // parsed chain's sub_ability spine, capturing the fused shape.
+    let fused = parse_effect_chain(FUSED_CLAUSE, AbilityKind::Spell);
+    let mut dig_keep_count: Option<u32> = None;
+    let mut dig_destination: Option<Zone> = None;
+    let mut saw_conceal = false;
+    let mut counter_rider: Option<(CounterType, QuantityExpr, TargetFilter)> = None;
+    let mut cursor: Option<&AbilityDefinition> = Some(&fused);
+    while let Some(node) = cursor {
+        match &*node.effect {
+            Effect::Dig {
+                keep_count,
+                destination,
+                ..
+            } => {
+                dig_keep_count = *keep_count;
+                dig_destination = *destination;
+            }
+            Effect::HideawayConceal { .. } => saw_conceal = true,
+            Effect::PutCounter {
+                counter_type,
+                count,
+                target,
+            } => {
+                counter_rider = Some((counter_type.clone(), count.clone(), target.clone()));
+            }
+            _ => {}
+        }
+        cursor = node.sub_ability.as_deref();
+    }
+
+    assert_eq!(
+        dig_keep_count,
+        Some(1),
+        "the fusion must patch the peek Dig to keep exactly one card"
+    );
+    assert_eq!(
+        dig_destination,
+        Some(Zone::Exile),
+        "the chosen card is routed to exile by the Dig itself"
+    );
+    assert!(
+        saw_conceal,
+        "a HideawayConceal must be chained onto the Dig (CR 702.75a)"
+    );
+    let (rider_type, rider_count, rider_target) =
+        counter_rider.expect("the counter rider must append a PutCounter");
+    assert_eq!(rider_type, hatching, "the rider counter is hatching");
+    assert_eq!(rider_count, QuantityExpr::Fixed { value: 1 });
+    assert_eq!(
+        rider_target,
+        TargetFilter::ParentTarget,
+        "the counter must land on the chosen dug card (ParentTarget), not the source"
+    );
+
+    // Build the game: stack the library so the top three are the looked-at cards
+    // and a fourth, deeper card must NOT be seen (proves the dig is bounded to
+    // three). `add_card_to_library_top` inserts at the top, so add the deepest
+    // card first.
+    let mut scenario = GameScenario::new();
+    let lib_deep = scenario.add_card_to_library_top(P0, "Lib Deep Card");
+    let lib3 = scenario.add_card_to_library_top(P0, "Lib Card 3");
+    let lib2 = scenario.add_card_to_library_top(P0, "Lib Card 2");
+    let lib1 = scenario.add_card_to_library_top(P0, "Lib Card 1");
+
+    let mut runner = scenario.build();
+
+    // The Dragon-Kami Reborn as an Enchantment Saga on the battlefield. Its
+    // chapter ability's source is this permanent — it must stay put and must not
+    // catch the hatching counter.
+    let saga = {
+        let state = runner.state_mut();
+        let card_id = CardId(state.next_object_id);
+        let id = zones::create_object(
+            state,
+            card_id,
+            P0,
+            "The Dragon-Kami Reborn".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.card_types.subtypes.push("Saga".to_string());
+        obj.base_card_types = obj.card_types.clone();
+        obj.summoning_sick = false;
+        id
+    };
+
+    let life_before = runner.state().players[0].life;
+
+    // Resolve the FULL chapter effect (source = the Saga). GainLife runs, then
+    // the Dig pauses at a DigChoice; its conceal + counter continuation is
+    // stashed. Using the whole chapter text keeps this faithful to the card.
+    let def = parse_effect_chain(CHAPTER_I_II, AbilityKind::Spell);
+    let resolved = build_resolved_from_def(&def, saga, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("chapter I/II resolution must reach the DigChoice");
+
+    // POSITIVE REACH-GUARD: the "gain 2 life" clause ran before the Dig paused,
+    // proving the chain actually executed rather than short-circuiting.
+    assert_eq!(
+        runner.state().players[0].life,
+        life_before + 2,
+        "the chapter must gain 2 life before looking at the library"
+    );
+
+    // The Dig surfaced a choice over exactly the top three cards (CR 701.20e) —
+    // the deeper card was not looked at.
+    let looked_at = match runner.state().waiting_for.clone() {
+        WaitingFor::DigChoice { cards, .. } => cards,
+        other => panic!("expected a DigChoice from the fused exile, got {other:?}"),
+    };
+    assert_eq!(looked_at.len(), 3, "the chapter looks at three cards");
+    assert_eq!(looked_at, vec![lib1, lib2, lib3]);
+    assert!(
+        !looked_at.contains(&lib_deep),
+        "the deeper (4th) card must not be looked at"
+    );
+
+    // Player picks the first looked-at card to exile.
+    let chosen = looked_at[0];
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![chosen],
+        })
+        .expect("SelectCards (dig keep) accepted");
+
+    let state = runner.state();
+    let chosen_obj = &state.objects[&chosen];
+    let saga_obj = &state.objects[&saga];
+
+    // DISCRIMINATOR, part 1: the player-selected card is exiled face down with
+    // exactly one hatching counter (CR 122.1 + CR 406.3).
+    assert_eq!(
+        chosen_obj.zone,
+        Zone::Exile,
+        "the chosen dug card must be exiled"
+    );
+    assert!(
+        chosen_obj.face_down,
+        "the exiled dug card must be face down (CR 406.3)"
+    );
+    assert_eq!(
+        chosen_obj.counters.get(&hatching).copied().unwrap_or(0),
+        1,
+        "the chosen exiled card must carry exactly one hatching counter (CR 122.1)"
+    );
+
+    // DISCRIMINATOR, part 2 — the regression direction: the Saga stays on the
+    // battlefield and does NOT catch the hatching counter. Pre-fix the discarded
+    // sibling `ChangeZone { ParentTarget }` / `PutCounter { ParentTarget }` rode
+    // the trigger source, so the counter (and the exile) landed on the Saga.
+    assert_eq!(
+        saga_obj.zone,
+        Zone::Battlefield,
+        "the Saga must remain on the battlefield — the dug card is exiled, not the Saga"
+    );
+    assert!(
+        !saga_obj.face_down,
+        "the Saga must not be turned face down (CR 406.3)"
+    );
+    assert_eq!(
+        saga_obj.counters.get(&hatching).copied().unwrap_or(0),
+        0,
+        "the hatching counter must NOT ride the Saga (the #5631 regression)"
+    );
+
+    // The other two looked-at cards are not exiled (they go to the bottom of the
+    // library) and carry no hatching counter.
+    for &id in &[lib2, lib3] {
+        let obj = &state.objects[&id];
+        assert_ne!(obj.zone, Zone::Exile, "only the chosen card is exiled");
+        assert_eq!(
+            obj.counters.get(&hatching).copied().unwrap_or(0),
+            0,
+            "an unchosen looked-at card must not receive the counter"
+        );
+    }
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -468,6 +468,7 @@ mod issue_5339_armory_automaton;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;
+mod issue_5631_dragon_kami_reborn_hatching_counter;
 mod issue_564_wishclaw_talisman_control;
 mod issue_565_birthing_ritual_end_step_trigger;
 mod issue_566_ragavan_dash_cast;


### PR DESCRIPTION
Closes #5631

## Summary

The Dragon-Kami Reborn's chapters I–II read: *"…Look at the top three cards of
your library. **Exile one of them face down with a hatching counter on it**,
then put the rest on the bottom of your library in any order."*

Coverage reported this card as **supported** (zero `Unimplemented` nodes), but it
resolved wrong — a **silent misparse** of the #1146 class. The
`parse_exile_one_of_them_face_down` recognizer required end-of-clause immediately
after `"face down"`, so the CR 122.1 counter rider (`"with a hatching counter on
it"`) made it **decline**. With the recognizer declining, the Hideaway-style
fusion never fired: the `Dig` short-circuited as a `keep_count: 0` pure-peek and a
sibling `ChangeZone { ParentTarget }` exiled the **trigger source itself** (the
Saga, with a hatching counter) instead of one of the three looked-at cards.

Per the issue, this is a **recognizer extension, not new engine work**: the fix
lets the recognizer accept an optional counter rider between `"face down"` and the
clause end, captures those counters, and threads them onto the **chosen** dug card
in the fused exile.

## Changes

- **Recognizer** (`oracle_effect/sequence.rs`, `parse_exile_one_of_them_face_down`)
  — now returns `Option<Vec<(CounterType, QuantityExpr)>>` instead of `bool`.
  `Some(entries)` signals a match (empty = the bare Gonti form; non-empty = the
  rider's counters). The optional rider is parsed by delegating to the shared
  `parse_counter_suffix_body_combinator`, so the **whole class** of
  `"with <count> <type> counter(s) on it"` shapes (a/two/X, `+1/+1`, keyword,
  named) is covered — not just `"a hatching counter"`.
- **Continuation** (`oracle_ir/ast.rs`) — `ContinuationAst::ExileOneOfThemFaceDown`
  gains a `enter_with_counters: Vec<(CounterType, QuantityExpr)>` field
  (`#[serde(default, skip_serializing_if = "Vec::is_empty")]` keeps the bare-form
  serialization byte-stable).
- **Fusion** (`oracle_effect/sequence.rs`, `apply_clause_continuation`) — after the
  existing `append_conceal_sub_ability`, a new `append_counter_riders_sub_abilities`
  appends a `PutCounter { target: ParentTarget }` chain at the deepest sub. Because
  the `DigChoice` resolution binds the chosen (exiled) card onto the continuation
  chain's targets and `ParentTarget` sub-abilities inherit the parent's target
  (mirroring `lower_put_counter_list`), the counters land on the **one card the
  player selected**, not the Saga.
- Exhaustive `ContinuationAst` match/`matches!` sites (`produces_sibling_def`,
  the `dig_continuation_*` helper in `oracle_effect/mod.rs`) updated to the new
  struct-variant shape (no wildcard fallbacks).

## Why this is the right shape

`enter_with_counters` was already parsed correctly onto the (buggy, discarded)
sibling `ChangeZone`; the only defect was that the recognizer's `eof` gate
rejected the rider so the fusion never ran. `Dig` carries no counter field and
`HideawayConceal` carries only a target, so the rider is applied with the existing
`PutCounter` building block chained onto the same `ParentTarget` the conceal
already uses — no new engine variant or field, and `apply_counter_addition`
already places counters on objects regardless of zone (exile included).

## Affected cards

`"exile one of them face down"` matches 5 cards in the full-pool sweep; 4 already
fired the recognizer correctly, and The Dragon-Kami Reborn was the sole decline.
The generalized rider combinator also future-proofs any later choose-one exile
that attaches a counter.

## Tests

- Recognizer: `exile_one_of_them_face_down_with_counter_rider_captures_counters`
  (the hatching rider is captured), `exile_one_of_them_face_down_bare_form_has_no_counters`
  (bare form is a match with an empty rider), plus the updated
  `exile_one_of_them_without_face_down_is_not_gonti_continuation` /
  `delver_pure_peek_is_not_gonti_continuation` scope guards.
- Fusion: `exile_one_of_them_face_down_counter_rider_appends_put_counter_after_conceal`
  — asserts the fused chain is `Dig(keep_count:1, Exile) -> HideawayConceal(ParentTarget)
  -> PutCounter(hatching, ParentTarget)`.

## Test plan

- [ ] `cargo fmt --all`
- [ ] `clippy` / `test-engine` green (Tilt)
- [ ] `card-data` regenerates cleanly (The Dragon-Kami Reborn now parses to the
      choose-one exile + conceal + hatching-counter shape, not a source self-exile)
