### PR TITLE
fix(parser): route 'that player investigates' Clue to the target's controller (#5254)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -6556,11 +6556,18 @@ fn resolve_chain_body(
             controller,
         );
         let matching_players: Vec<PlayerId> = match scope {
-            PlayerFilter::AllExcept { .. } => {
-                // CR 608.2c + CR 109.4 + CR 608.2h: the `AllExcept` anchor may be an
-                // ability-target reference (ParentObjectTargetController), which the
-                // generic `matches_player_scope` predicate cannot resolve (it carries
-                // no `ResolvedAbility`). Route through the ability-aware
+            PlayerFilter::AllExcept { .. }
+            | PlayerFilter::ParentObjectTargetController
+            | PlayerFilter::ParentObjectTargetOwner => {
+                // CR 608.2c + CR 109.4 + CR 608.2h: these anchors are all
+                // ability-target references — the `AllExcept` exclude anchor and the
+                // direct `ParentObjectTargetController` / `ParentObjectTargetOwner`
+                // scopes (e.g. Declaration in Stone's "That player investigates",
+                // where "that player" = the controller of the exiled target). The
+                // generic `matches_player_scope` predicate cannot resolve them (it
+                // carries no `ResolvedAbility`, so `parent_target_controller`'s
+                // last-known-information lookup over `ability.targets` is
+                // unavailable). Route through the ability-aware
                 // `speed_effects::players_for_filter`, then re-impose APNAP order by
                 // intersecting against the apnap sequence.
                 let set =

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17657,6 +17657,21 @@ fn lower_subject_predicate_ast(
             if let Some(wrapped) = wrap_target_subject_damage(clause.clone(), &subject) {
                 return wrapped;
             }
+            // CR 608.2c + CR 109.4 + CR 701.16a: `Effect::Investigate` is a
+            // fieldless unit variant with no player slot for `inject_subject_target`
+            // to stamp the subject onto, so an explicit non-caster subject ("That
+            // player investigates" — Declaration in Stone, where "that player" is
+            // the controller of the exiled target) would be silently dropped and
+            // the Clue handed to the caster. Record the subject as a pending
+            // `player_scope` (consumed by the effect-chain loop) so resolution fans
+            // the Investigate out to the anchored player instead. Only lifts an
+            // explicit parent-target player anaphor; a bare "investigate" leaves
+            // `affected == SelfRef`/`Controller` and is untouched (caster default).
+            if matches!(clause.effect, Effect::Investigate) {
+                if let Some(scope) = player_scope_from_parent_target_subject(&subject.affected) {
+                    ctx.pending_player_scope = Some(scope);
+                }
+            }
             inject_subject_target(&mut clause.effect, &subject);
             sync_subject_into_nested_shuffle_sub(&mut clause, &subject);
             // CR 109.4 + CR 608.2c (issue #534): When the subject phrase
@@ -17848,6 +17863,22 @@ fn extract_player_anchor_in_chain(clause: &ParsedEffectClause) -> Option<TargetF
 /// keeps its default.
 fn player_filter_from_anchor_for_chooser(anchor: &TargetFilter) -> Option<PlayerFilter> {
     match anchor {
+        TargetFilter::ParentTargetOwner => Some(PlayerFilter::ParentObjectTargetOwner),
+        _ => None,
+    }
+}
+
+/// CR 109.4 + CR 608.2h: Map a subject-phrase player anaphor that resolved to
+/// the controller/owner of the spell's target ("its controller" / "that
+/// player" → `ParentTargetController`/`ParentTargetOwner`) to the matching
+/// `PlayerFilter` player-scope axis. Used when the predicate effect has no
+/// player field to carry the subject (`Effect::Investigate`), so the subject is
+/// lifted to `AbilityDefinition.player_scope` instead. Returns `None` for any
+/// non-parent-target subject (caster default, chosen player, target player),
+/// which belong on the effect's own field or a different scope path.
+fn player_scope_from_parent_target_subject(affected: &TargetFilter) -> Option<PlayerFilter> {
+    match affected {
+        TargetFilter::ParentTargetController => Some(PlayerFilter::ParentObjectTargetController),
         TargetFilter::ParentTargetOwner => Some(PlayerFilter::ParentObjectTargetOwner),
         _ => None,
     }
@@ -26782,6 +26813,19 @@ pub(crate) fn parse_effect_chain_ir(
         // the resolver iterates all players and `Controller` reads the
         // rebound per-player controller.
         lift_each_player_exile_top_scope(&mut clause.effect, &mut player_scope);
+        // CR 608.2c + CR 109.4: Fold a pending player-scope lifted from a
+        // fieldless subject-predicate (`Effect::Investigate` — "That player
+        // investigates", Declaration in Stone) into this chunk's `player_scope`.
+        // `lower_subject_predicate_ast` stamps `ctx.pending_player_scope` because
+        // the effect has no player field for the subject; here it becomes the
+        // chunk's `AbilityDefinition.player_scope`. Take() so it is consumed
+        // within this chunk and cannot leak to a later one; a pre-existing scope
+        // (e.g. a leading "each opponent") wins.
+        if let Some(scope) = ctx.pending_player_scope.take() {
+            if player_scope.is_none() {
+                player_scope = Some(scope);
+            }
+        }
         // CR 109.5: Rebind recipient-bearing nodes inside a decline body so the
         // body's "you"/"that player" anaphors resolve relative to the surrounding
         // per-player iteration. The two walkers are parallel inverses:

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17671,6 +17671,15 @@ fn lower_subject_predicate_ast(
                 if let Some(scope) = player_scope_from_parent_target_subject(&subject.affected) {
                     ctx.pending_player_scope = Some(scope);
                 }
+                // CR 701.16a + CR 608.2c + CR 400.7: "investigate FOR EACH nontoken
+                // creature exiled this way" — the fieldless Investigate carries no
+                // count slot, so lift the "for each <filter> … this way" suffix to a
+                // pending `repeat_for` (the effect-chain loop stamps it on this
+                // clause's def). The resolver loops the Investigate N times over the
+                // merged exile tracked set, one Clue per nontoken creature exiled.
+                if let Some(qty) = repeat_for_each_this_way_suffix(&pred_lower) {
+                    ctx.pending_repeat_for = Some(qty);
+                }
             }
             inject_subject_target(&mut clause.effect, &subject);
             sync_subject_into_nested_shuffle_sub(&mut clause, &subject);
@@ -17880,6 +17889,36 @@ fn player_scope_from_parent_target_subject(affected: &TargetFilter) -> Option<Pl
     match affected {
         TargetFilter::ParentTargetController => Some(PlayerFilter::ParentObjectTargetController),
         TargetFilter::ParentTargetOwner => Some(PlayerFilter::ParentObjectTargetOwner),
+        _ => None,
+    }
+}
+
+/// CR 701.16a + CR 400.7: Parse a "for each <filter> <cause> this way" SUFFIX
+/// (lowercased predicate text) into a `repeat_for` count for a count-less effect
+/// like `Effect::Investigate`. Routes the tail through the shared
+/// `parse_for_each_clause` (the parser the "for each …, <effect>" prefix path
+/// already uses) and accepts ONLY a cause-filtered tracked-set count
+/// (`FilteredTrackedSetSize { caused_by: Some(_) }`, e.g. "nontoken creature
+/// exiled this way") — an unfiltered or non-"this way" suffix returns `None` so
+/// the caller leaves the effect untouched. The chain-tracked exile set the count
+/// reads is published by the preceding `ChangeZone`/`ChangeZoneAll` exiles.
+fn repeat_for_each_this_way_suffix(pred_lower: &str) -> Option<QuantityExpr> {
+    // Combinator split at the " for each " delimiter (PATTERNS.md Pattern 6): the
+    // tail is the count clause.
+    let (after_base, _) = take_until::<_, _, OracleError<'_>>(" for each ")
+        .parse(pred_lower)
+        .ok()?;
+    let (tail, _) = tag::<_, _, OracleError<'_>>(" for each ")
+        .parse(after_base)
+        .ok()?;
+    // allow-noncombinator: trailing-sentence-period cleanup on the pre-split tail, not parse dispatch
+    let clause = tail.trim_end().trim_end_matches('.').trim_end();
+    match parse_for_each_clause(clause) {
+        Some(
+            qty @ QuantityRef::FilteredTrackedSetSize {
+                caused_by: Some(_), ..
+            },
+        ) => Some(QuantityExpr::Ref { qty }),
         _ => None,
     }
 }
@@ -26826,6 +26865,11 @@ pub(crate) fn parse_effect_chain_ir(
                 player_scope = Some(scope);
             }
         }
+        // CR 701.16a + CR 608.2c: Fold a pending `repeat_for` lifted from a
+        // count-less "investigate for each … this way" (Declaration in Stone) into
+        // this chunk's repeat count (→ `AbilityDefinition.repeat_for`). take() so
+        // it is consumed within this chunk; a pre-existing repeat_for wins.
+        let repeat_for = repeat_for.or_else(|| ctx.pending_repeat_for.take());
         // CR 109.5: Rebind recipient-bearing nodes inside a decline body so the
         // body's "you"/"that player" anaphors resolve relative to the surrounding
         // per-player iteration. The two walkers are parallel inverses:

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -45636,3 +45636,70 @@ fn instead_override_never_absorbs_the_preceding_sentence() {
         "Draw a card. If you control three or more artifacts, draw two cards instead.",
     );
 }
+
+/// CR 109.4 + CR 608.2h + CR 701.16a: an "its controller / that player
+/// investigates" subject-predicate (whose fieldless `Effect::Investigate` gives
+/// `inject_subject_target` nowhere to stamp the subject) lifts the dropped
+/// player anaphor to the Investigate sub-ability's `player_scope`, so the Clue
+/// goes to the target's controller — not the caster. Covers the whole class
+/// (Declaration in Stone + Fateful Absence) plus a caster-default negative.
+#[test]
+fn investigate_subject_lifts_parent_target_controller_to_player_scope() {
+    fn find_investigate_scope(def: &AbilityDefinition) -> Option<Option<PlayerFilter>> {
+        let mut node = Some(def);
+        while let Some(d) = node {
+            if matches!(&*d.effect, Effect::Investigate) {
+                return Some(d.player_scope.clone());
+            }
+            node = d.sub_ability.as_deref();
+        }
+        None
+    }
+
+    // Declaration in Stone: "That player investigates for each nontoken creature
+    // exiled this way" — "that player" = the exiled creature's controller.
+    let dis = parse_oracle_text(
+        "Exile target creature and all other creatures its controller controls with the same \
+         name as that creature. That player investigates for each nontoken creature exiled this way.",
+        "Declaration in Stone",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+    assert_eq!(
+        find_investigate_scope(&dis.abilities[0]),
+        Some(Some(PlayerFilter::ParentObjectTargetController)),
+        "Declaration in Stone's Investigate must fan out to the exiled creature's controller"
+    );
+
+    // Fateful Absence: "Destroy target creature or planeswalker. Its controller
+    // investigates." — same class, singular non-token target.
+    let fateful = parse_oracle_text(
+        "Destroy target creature or planeswalker. Its controller investigates.",
+        "Fateful Absence",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    assert_eq!(
+        find_investigate_scope(&fateful.abilities[0]),
+        Some(Some(PlayerFilter::ParentObjectTargetController)),
+        "Fateful Absence's \"its controller investigates\" must fan out to the destroyed \
+         permanent's controller"
+    );
+
+    // Negative: a bare "investigate" with no player subject stays the caster
+    // default (no player_scope) — the lift must not over-apply.
+    let press = parse_oracle_text(
+        "Tap target creature. Investigate.",
+        "Press for Answers",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    assert_eq!(
+        find_investigate_scope(&press.abilities[0]),
+        Some(None),
+        "a bare \"investigate\" must keep the caster default (no player_scope)"
+    );
+}

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -45638,18 +45638,21 @@ fn instead_override_never_absorbs_the_preceding_sentence() {
 }
 
 /// CR 109.4 + CR 608.2h + CR 701.16a: an "its controller / that player
-/// investigates" subject-predicate (whose fieldless `Effect::Investigate` gives
-/// `inject_subject_target` nowhere to stamp the subject) lifts the dropped
-/// player anaphor to the Investigate sub-ability's `player_scope`, so the Clue
-/// goes to the target's controller — not the caster. Covers the whole class
-/// (Declaration in Stone + Fateful Absence) plus a caster-default negative.
+/// investigates [for each … this way]" subject-predicate (whose fieldless
+/// `Effect::Investigate` gives `inject_subject_target` nowhere to stamp the
+/// subject and no slot for the count) lifts BOTH the dropped player anaphor to
+/// the Investigate sub-ability's `player_scope` (so the Clue goes to the
+/// target's controller, not the caster) AND the "for each … exiled this way"
+/// suffix to `repeat_for` (so N creatures exiled → N Clues). Covers the class
+/// (Declaration in Stone with count + Fateful Absence single-target) plus a
+/// caster-default negative.
 #[test]
 fn investigate_subject_lifts_parent_target_controller_to_player_scope() {
-    fn find_investigate_scope(def: &AbilityDefinition) -> Option<Option<PlayerFilter>> {
+    fn find_investigate(def: &AbilityDefinition) -> Option<&AbilityDefinition> {
         let mut node = Some(def);
         while let Some(d) = node {
             if matches!(&*d.effect, Effect::Investigate) {
-                return Some(d.player_scope.clone());
+                return Some(d);
             }
             node = d.sub_ability.as_deref();
         }
@@ -45657,7 +45660,8 @@ fn investigate_subject_lifts_parent_target_controller_to_player_scope() {
     }
 
     // Declaration in Stone: "That player investigates for each nontoken creature
-    // exiled this way" — "that player" = the exiled creature's controller.
+    // exiled this way" — "that player" = the exiled creature's controller, and
+    // the Investigate repeats once per nontoken creature exiled this way.
     let dis = parse_oracle_text(
         "Exile target creature and all other creatures its controller controls with the same \
          name as that creature. That player investigates for each nontoken creature exiled this way.",
@@ -45666,14 +45670,28 @@ fn investigate_subject_lifts_parent_target_controller_to_player_scope() {
         &["Sorcery".to_string()],
         &[],
     );
+    let dis_inv = find_investigate(&dis.abilities[0]).expect("Declaration has an Investigate");
     assert_eq!(
-        find_investigate_scope(&dis.abilities[0]),
-        Some(Some(PlayerFilter::ParentObjectTargetController)),
+        dis_inv.player_scope,
+        Some(PlayerFilter::ParentObjectTargetController),
         "Declaration in Stone's Investigate must fan out to the exiled creature's controller"
+    );
+    assert!(
+        matches!(
+            dis_inv.repeat_for.as_ref(),
+            Some(QuantityExpr::Ref {
+                qty: QuantityRef::FilteredTrackedSetSize {
+                    caused_by: Some(ThisWayCause::Exiled),
+                    ..
+                }
+            })
+        ),
+        "Declaration's Investigate must repeat once per nontoken creature exiled this way, got {:?}",
+        dis_inv.repeat_for
     );
 
     // Fateful Absence: "Destroy target creature or planeswalker. Its controller
-    // investigates." — same class, singular non-token target.
+    // investigates." — same recipient class, singular target, NO count suffix.
     let fateful = parse_oracle_text(
         "Destroy target creature or planeswalker. Its controller investigates.",
         "Fateful Absence",
@@ -45681,15 +45699,21 @@ fn investigate_subject_lifts_parent_target_controller_to_player_scope() {
         &["Instant".to_string()],
         &[],
     );
+    let fa_inv =
+        find_investigate(&fateful.abilities[0]).expect("Fateful Absence has an Investigate");
     assert_eq!(
-        find_investigate_scope(&fateful.abilities[0]),
-        Some(Some(PlayerFilter::ParentObjectTargetController)),
+        fa_inv.player_scope,
+        Some(PlayerFilter::ParentObjectTargetController),
         "Fateful Absence's \"its controller investigates\" must fan out to the destroyed \
          permanent's controller"
     );
+    assert_eq!(
+        fa_inv.repeat_for, None,
+        "Fateful Absence has no \"for each\" suffix — a single Clue, no repeat"
+    );
 
-    // Negative: a bare "investigate" with no player subject stays the caster
-    // default (no player_scope) — the lift must not over-apply.
+    // Negative: a bare "investigate" with no player subject and no count stays the
+    // caster default — neither lift may over-apply.
     let press = parse_oracle_text(
         "Tap target creature. Investigate.",
         "Press for Answers",
@@ -45697,9 +45721,13 @@ fn investigate_subject_lifts_parent_target_controller_to_player_scope() {
         &["Instant".to_string()],
         &[],
     );
+    let press_inv = find_investigate(&press.abilities[0]).expect("Press has an Investigate");
     assert_eq!(
-        find_investigate_scope(&press.abilities[0]),
-        Some(None),
+        press_inv.player_scope, None,
         "a bare \"investigate\" must keep the caster default (no player_scope)"
+    );
+    assert_eq!(
+        press_inv.repeat_for, None,
+        "a bare \"investigate\" must not gain a repeat count"
     );
 }

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -5,7 +5,8 @@
 
 use super::diagnostic::OracleDiagnostic;
 use crate::types::ability::{
-    ControllerRef, PlayerFilter, PtValue, QuantityRef, TargetFilter, TargetSelectionMode,
+    ControllerRef, PlayerFilter, PtValue, QuantityExpr, QuantityRef, TargetFilter,
+    TargetSelectionMode,
 };
 use crate::types::zones::Zone;
 
@@ -64,6 +65,17 @@ pub(crate) struct ParseContext {
     /// fans the effect out to the anchored player rather than the caster. Set and
     /// consumed within a single chunk parse; never serialized.
     pub pending_player_scope: Option<PlayerFilter>,
+    /// CR 608.2c + CR 701.16a: Transient per-chunk `repeat_for` lifted from a
+    /// fieldless-effect subject-predicate that carries a "for each <filter> …
+    /// this way" SUFFIX count (Declaration in Stone's "investigate for each
+    /// nontoken creature exiled this way"). `Effect::Investigate` has no count
+    /// slot and the suffix `for each` handler is CopySpell-only, so the count is
+    /// otherwise dropped. `lower_subject_predicate_ast` records it here; the
+    /// effect-chain loop folds it into the chunk's `repeat_for` (→
+    /// `AbilityDefinition.repeat_for`), composing with `player_scope` via the
+    /// resolver's outermost-repeat driver. Set and consumed within a single
+    /// chunk parse; never serialized.
+    pub pending_repeat_for: Option<QuantityExpr>,
     /// CR 608.2c + CR 109.4: Count of `Effect::Choose { choice_type: Player }`
     /// clauses emitted so far in the current effect chain. Each "choose a
     /// player" / "choose a [second|third] player" clause increments this; the

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -5,7 +5,7 @@
 
 use super::diagnostic::OracleDiagnostic;
 use crate::types::ability::{
-    ControllerRef, PtValue, QuantityRef, TargetFilter, TargetSelectionMode,
+    ControllerRef, PlayerFilter, PtValue, QuantityRef, TargetFilter, TargetSelectionMode,
 };
 use crate::types::zones::Zone;
 
@@ -54,6 +54,16 @@ pub(crate) struct ParseContext {
     /// CR 109.4 + CR 115.1: Relative-player scope for "that player controls"
     /// resolution inside trigger effects. Replaces thread-local oracle_target_scope.
     pub relative_player_scope: Option<ControllerRef>,
+    /// CR 608.2c + CR 109.4: Transient per-chunk `player_scope` lifted from a
+    /// subject-predicate whose EFFECT carries no player field to stamp the
+    /// subject onto (the fieldless `Effect::Investigate` — Declaration in Stone's
+    /// "That player investigates"). `inject_subject_target` drops such a subject
+    /// silently, so `lower_subject_predicate_ast` records it here instead; the
+    /// effect-chain loop folds it into the chunk's `player_scope` local (→
+    /// `ClauseIr.player_scope` → `AbilityDefinition.player_scope`) so resolution
+    /// fans the effect out to the anchored player rather than the caster. Set and
+    /// consumed within a single chunk parse; never serialized.
+    pub pending_player_scope: Option<PlayerFilter>,
     /// CR 608.2c + CR 109.4: Count of `Effect::Choose { choice_type: Player }`
     /// clauses emitted so far in the current effect chain. Each "choose a
     /// player" / "choose a [second|third] player" clause increments this; the

--- a/crates/engine/tests/integration/issue_5254_declaration_in_stone_clue_owner.rs
+++ b/crates/engine/tests/integration/issue_5254_declaration_in_stone_clue_owner.rs
@@ -1,0 +1,83 @@
+//! Issue #5254 — Declaration in Stone: "That player investigates for each
+//! nontoken creature exiled this way" handed the Clue to the CASTER instead of
+//! to "that player" (the controller of the exiled creature).
+//!
+//! The second sentence's subject ("That player" → the exiled creature's
+//! controller, CR 109.4 / CR 608.2h) lowered to a bare `Effect::Investigate`,
+//! whose fieldless unit shape gave `inject_subject_target` nowhere to stamp the
+//! subject — so it was dropped and the resolver defaulted the Clue to
+//! `ability.controller` (the spell's caster). Lifting the dropped subject to the
+//! Investigate sub-ability's `player_scope` fans the effect out to the anchored
+//! player, so the OPPONENT (whose creature was exiled) gets the Clue.
+//!
+//! https://github.com/phase-rs/phase/issues/5254
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const DECLARATION_IN_STONE: &str = "Exile target creature and all other creatures its \
+controller controls with the same name as that creature. That player investigates for each \
+nontoken creature exiled this way.";
+
+/// Battlefield Clue tokens (CR 111.10f) controlled by `player`.
+fn clues_controlled(state: &GameState, player: PlayerId) -> usize {
+    state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .filter(|o| o.controller == player && o.card_types.subtypes.iter().any(|s| s == "Clue"))
+        .count()
+}
+
+#[test]
+fn declaration_in_stone_gives_clue_to_exiled_creatures_controller_not_caster() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // The OPPONENT (P1) controls the creature that gets exiled. Its controller —
+    // the opponent — is "that player" who investigates.
+    let victim = scenario.add_creature(P1, "Grizzly Bear", 2, 2).id();
+
+    let dis = scenario
+        .add_spell_to_hand(P0, "Declaration in Stone", false)
+        .from_oracle_text(DECLARATION_IN_STONE)
+        // Free cast — the scoring/routing under test is orthogonal to the mana cost.
+        .with_mana_cost(ManaCost::Cost {
+            generic: 0,
+            shards: vec![],
+        })
+        .id();
+
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(dis).target_objects(&[victim]).resolve();
+
+    // The exile → investigate chain resolves cleanly back to priority.
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "Declaration in Stone must resolve cleanly, got {:?}",
+        outcome.final_waiting_for()
+    );
+
+    // The creature was exiled (it left the battlefield).
+    assert!(
+        !runner.state().battlefield.contains(&victim),
+        "the targeted creature must be exiled"
+    );
+
+    // THE FIX: the Clue goes to P1 (the exiled creature's controller — "that
+    // player"), NOT P0 (the caster). On `main` this is inverted: P0 gets the Clue.
+    assert_eq!(
+        clues_controlled(runner.state(), P1),
+        1,
+        "the exiled creature's controller (the opponent) must receive the Clue"
+    );
+    assert_eq!(
+        clues_controlled(runner.state(), P0),
+        0,
+        "the caster must NOT receive the Clue"
+    );
+}

--- a/crates/engine/tests/integration/issue_5254_declaration_in_stone_clue_owner.rs
+++ b/crates/engine/tests/integration/issue_5254_declaration_in_stone_clue_owner.rs
@@ -81,3 +81,56 @@ fn declaration_in_stone_gives_clue_to_exiled_creatures_controller_not_caster() {
         "the caster must NOT receive the Clue"
     );
 }
+
+#[test]
+fn declaration_in_stone_investigates_once_per_nontoken_creature_exiled() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // The opponent (P1) controls TWO same-name nontoken creatures. Declaration in
+    // Stone exiles the target AND all other same-name creatures its controller
+    // controls — so BOTH are exiled — and "investigates for each nontoken creature
+    // exiled this way" must create TWO Clues, both to P1. On `main` (and on the
+    // recipient-only fix) the count is dropped and only ONE Clue is made.
+    let victim = scenario.add_creature(P1, "Grizzly Bear", 2, 2).id();
+    let twin = scenario.add_creature(P1, "Grizzly Bear", 2, 2).id();
+
+    let dis = scenario
+        .add_spell_to_hand(P0, "Declaration in Stone", false)
+        .from_oracle_text(DECLARATION_IN_STONE)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 0,
+            shards: vec![],
+        })
+        .id();
+
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(dis).target_objects(&[victim]).resolve();
+
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "Declaration in Stone must resolve cleanly, got {:?}",
+        outcome.final_waiting_for()
+    );
+
+    // Both same-name creatures were exiled.
+    assert!(
+        !runner.state().battlefield.contains(&victim)
+            && !runner.state().battlefield.contains(&twin),
+        "both same-name creatures must be exiled"
+    );
+
+    // THE COUNT FIX: two nontoken creatures exiled this way → TWO Clues, both to
+    // the opponent (the exiled creatures' controller); zero to the caster.
+    assert_eq!(
+        clues_controlled(runner.state(), P1),
+        2,
+        "one Clue per nontoken creature exiled this way (two exiled → two Clues), all to the opponent"
+    );
+    assert_eq!(
+        clues_controlled(runner.state(), P0),
+        0,
+        "the caster must NOT receive any Clue"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -450,6 +450,7 @@ mod issue_5145_violent_eruption_choose_target_distribution;
 mod issue_5159_attacks_alone_investigate;
 mod issue_5247_kinetic_ooze_conditional_multi_target;
 mod issue_5252_additional_sacrifice_after_mana_abilities;
+mod issue_5254_declaration_in_stone_clue_owner;
 mod issue_5268_invincible_iron_man;
 mod issue_5274_call_the_spirit_dragons;
 mod issue_5279_grave_sifter;


### PR DESCRIPTION
Tier: Frontier
Model: claude-opus-4-8

Fixes #5254

## Summary

Declaration in Stone's second sentence — *"That player investigates for each nontoken creature exiled this way"* — was mis-executed on two axes: the Clue went to the **caster** instead of *that player* (the controller of the exiled creature, CR 109.4 / CR 608.2h), and the **count** was dropped so exactly one Clue was made regardless of how many creatures were exiled. Both are now fixed: the exiled creatures' controller gets **one Clue per nontoken creature exiled this way**.

Root cause for both: the predicate lowers to the **fieldless** unit variant `Effect::Investigate`, which has neither a player slot for `inject_subject_target` to stamp the subject onto nor a count slot for the `for each … this way` suffix — so both were silently dropped.

The recipient fix is also a class fix — it corrects **Fateful Absence** (*"Its controller investigates"*, single target, no count). A bare *"investigate"* with no player subject and no count (Press for Answers, Hold for Questioning) stays caster-default, single Clue.

## Implementation method

Two symmetric lifts off the fieldless `Effect::Investigate`, both stamped in `lower_subject_predicate_ast` and folded into the chunk's `AbilityDefinition` in the effect-chain loop (no enum churn):

1. **Recipient → `player_scope`.** A transient `ParseContext.pending_player_scope` records the parent-target player anaphor (`ParentTargetController`/`Owner` → `PlayerFilter::ParentObjectTargetController`/`Owner`).
2. **Count → `repeat_for`.** A transient `ParseContext.pending_repeat_for` records the `for each <filter> <cause> this way` suffix, parsed by the shared `parse_for_each_clause` (the parser the `for each …, <effect>` prefix path already uses), accepting **only** `FilteredTrackedSetSize { caused_by: Some(_) }`. Scoped to `Effect::Investigate`, so count-bearing `for each … this way` effects (gain life / draw / counters) are untouched.
3. **Engine driver arm** (`game/effects/mod.rs`) — `ParentObjectTargetController` / `Owner` route through the ability-aware `speed_effects::players_for_filter` (mirroring the existing `AllExcept` arm), then re-impose APNAP. Previously these hit the generic `matches_player_scope` arm and produced an empty fan-out.

Runtime composes with **no engine change to the count**: the `ChangeZone → ChangeZoneAll` chain publishes one **merged** exile tracked set, and `repeat_for` drives **outside** `player_scope` (the Torment of Hailfire shape), so N nontoken creatures exiled ⇒ N Clues to the exiled creatures' controller.

## CR references

- **CR 109.4 / CR 608.2h** — "that player" / "its controller" = the controller of the object targeted earlier in the instruction, resolved via last-known information after it leaves the battlefield.
- **CR 701.16a** — investigate = create a Clue token for the acting player.
- **CR 400.7 / CR 608.2c** — the `… this way` count reads the merged tracked set of objects the chain's exiles moved.

## Verification

- **Recipient regression** (`declaration_in_stone_gives_clue_to_exiled_creatures_controller_not_caster`): opponent's creature exiled → the Clue is controlled by the opponent, **0** to the caster (inverted on `main`).
- **Count regression** (`declaration_in_stone_investigates_once_per_nontoken_creature_exiled`): opponent controls **two** same-name nontoken creatures; casting exiles both and asserts **2** Clues to the opponent, **0** to the caster. Fails on both `main` and a recipient-only fix (count = 1).
- **Parser building-block test**: pins `player_scope = ParentObjectTargetController` **and** `repeat_for = FilteredTrackedSetSize{Exiled}` for Declaration; `player_scope` set but `repeat_for: None` for Fateful Absence; both `None` for a bare `investigate` negative.
- Parser lib suite: **7984 passed, 0 failed**. `cargo fmt --check` clean; parser-combinator gate passes.
