### PR TITLE
ship/census spanscan

### DIFF
--- a/scripts/zone_authority_census.py
+++ b/scripts/zone_authority_census.py
@@ -126,7 +126,43 @@ STRING_LIT = re.compile(r'(?:b|c)?"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'')
 # the only thing that closes one -- and the only thing we have to carry.
 RAW_OPEN = re.compile(r'(?:b|c)?r(#*)"')
 
-IDENT_CHAR = re.compile(r"[A-Za-z0-9_]")
+# Where a comment or a literal could START. Everything between two candidates is
+# ordinary code and is appended in ONE slice.
+#
+# This exists for throughput, and it is load-bearing: the scanner sweeps ~7MB of
+# Rust per census run, and a character-at-a-time loop that fires a regex per
+# character does that at ~0.2 MB/s -- minutes per gate. Only these positions can
+# open something:
+#
+#     /   a line or block comment            "  '   a string or char literal
+#     b c r   a literal prefix, but ONLY when a `"` follows (through any `#`s),
+#             which is what the lookahead checks -- otherwise every identifier
+#             starting with b/c/r would be a false stop
+#
+# Over-inclusion here is free (the branch logic below rejects a false candidate
+# and moves on). Under-inclusion is a BUG: a missed candidate is a literal
+# scanned as code. Every construct the branches can consume starts at one of
+# these characters.
+#
+# EVERY alternative starts with a character from one small set, deliberately:
+# that lets the regex engine prefilter on the first character and skip runs of
+# ordinary code at C speed. Do NOT add a lookbehind here to enforce the token
+# boundary -- it defeats the prefilter and drags the scan back to per-character
+# lookaround. `_at_token_boundary` already enforces it, in Python, at the few
+# positions that survive this far.
+# The `r?` in the lookahead is load-bearing: it lets the candidate fire on the
+# FIRST letter of a two-letter prefix (`br#"`, `cr"`). Without it the scan stops
+# on the `r` instead, where the boundary check correctly rejects it -- and the
+# literal is then mis-lexed as an ordinary string. The test suite catches this.
+CANDIDATE = re.compile(r"""[/"']|[bcr](?=r?#*")""")
+
+IDENT_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+
+# Bound up front: these are called once per candidate across every line of the
+# tree, and re-resolving the attribute each time is measurable at that volume.
+_find_candidate = CANDIDATE.search
+_match_raw_open = RAW_OPEN.match
+_match_string_lit = STRING_LIT.match
 
 
 class ScanState(NamedTuple):
@@ -150,7 +186,7 @@ class CensusError(Exception):
 def _at_token_boundary(line: str, i: int) -> bool:
     """True if `i` starts a token. `r`/`b`/`c` mean "literal prefix" only at a
     token boundary; elsewhere they are the tail of an identifier."""
-    return i == 0 or not IDENT_CHAR.match(line[i - 1])
+    return i == 0 or line[i - 1] not in IDENT_CHARS
 
 
 def _consume_raw(line: str, i: int, hashes: int) -> tuple[int, bool]:
@@ -183,12 +219,21 @@ def strip_noncode(line: str, state: ScanState) -> tuple[str, ScanState]:
     hit: it starts a comment that eats the file, or a skip region that eats the
     production code after it.
     """
+    # Fast path. 4 lines in 5 hold no comment and no literal, and for those the
+    # scanner has nothing to do -- so it should ALLOCATE nothing: no char list,
+    # no join, no fresh ScanState. Doing the work anyway is most of what made the
+    # per-character version too slow to run on the tree it was written to sweep.
+    if state.block_depth == 0 and state.raw_hashes is None and _find_candidate(line) is None:
+        return line, state
+
     out: list[str] = []
     i = 0
+    n = len(line)
     block_depth = state.block_depth
     raw_hashes = state.raw_hashes
+    append = out.append
 
-    while i < len(line):
+    while i < n:
         if raw_hashes is not None:
             i, closed = _consume_raw(line, i, raw_hashes)
             if closed:
@@ -211,32 +256,50 @@ def strip_noncode(line: str, state: ScanState) -> tuple[str, ScanState]:
                 i = closed_at + 2
             continue
 
-        if line.startswith("//", i):
+        # Skip straight to the next position that could open a comment or a
+        # literal, taking everything before it as code in one slice.
+        m = _find_candidate(line, i)
+        if m is None:
+            append(line[i:])
             break
-        if line.startswith("/*", i):
-            block_depth += 1
-            i += 2
+        start = m.start()
+        if start > i:
+            append(line[i:start])
+            i = start
+
+        ch = line[i]
+        if ch == "/":
+            nxt = line[i + 1 : i + 2]
+            if nxt == "/":
+                break
+            if nxt == "*":
+                block_depth += 1
+                i += 2
+                continue
+            append("/")  # division, not a comment
+            i += 1
             continue
 
         # A literal may open here. The `r`/`b`/`c` prefixes only mean "literal"
         # at a token boundary -- mid-identifier they are ordinary letters. A bare
         # quote needs no boundary: it always opens one.
-        boundary = _at_token_boundary(line, i)
+        boundary = i == 0 or line[i - 1] not in IDENT_CHARS
         if boundary:
-            m = RAW_OPEN.match(line, i)
+            m = _match_raw_open(line, i)
             if m:
                 hashes = len(m.group(1))
                 i, closed = _consume_raw(line, m.end(), hashes)
                 if not closed:
                     raw_hashes = hashes
                 continue
-        if boundary or line[i] in "\"'":
-            m = STRING_LIT.match(line, i)
+        if boundary or ch == '"' or ch == "'":
+            m = _match_string_lit(line, i)
             if m:
                 i = m.end()
                 continue
 
-        out.append(line[i])
+        # A false candidate: an `r`/`b`/`c` that opens nothing.
+        append(ch)
         i += 1
 
     return "".join(out), ScanState(block_depth, raw_hashes)

--- a/scripts/zone_authority_census.py
+++ b/scripts/zone_authority_census.py
@@ -43,6 +43,7 @@ import argparse
 import re
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BASELINE = REPO_ROOT / "scripts" / "zone-authority-baseline.txt"
@@ -115,7 +116,30 @@ def is_cfg_test_attr(line: str) -> bool:
     return bool(BARE_TEST.search(pred)) and "not(" not in pred
 
 
-STRING_LIT = re.compile(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'')
+# A non-raw literal: `"..."` (with a `b`/`c` prefix, which is part of the token),
+# or a char literal. The char alternative earns its place: `'"'` must be consumed
+# whole, or the leaked `"` opens a phantom string that swallows the line.
+STRING_LIT = re.compile(r'(?:b|c)?"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'')
+
+# A raw-string opener: `r"`, `r#"`, `r##"`, and the byte/C-string forms `br#"` /
+# `cr#"`. Rust raw strings do NOT nest and honour NO escapes, so the `#` count is
+# the only thing that closes one -- and the only thing we have to carry.
+RAW_OPEN = re.compile(r'(?:b|c)?r(#*)"')
+
+IDENT_CHAR = re.compile(r"[A-Za-z0-9_]")
+
+
+class ScanState(NamedTuple):
+    """Lexer state carried BETWEEN lines.
+
+    Both constructs that can span a line boundary need a count, not a flag:
+    block comments nest (`/* /* */ */`) and a raw string is closed only by its
+    own `#` count. The two are mutually exclusive -- a raw string opened inside a
+    block comment is comment text, and a `/*` inside a raw string is data.
+    """
+
+    block_depth: int = 0
+    raw_hashes: int | None = None  # `#` count of the raw string we are inside
 
 
 class CensusError(Exception):
@@ -123,38 +147,99 @@ class CensusError(Exception):
     that silently mis-scopes is worse than no census."""
 
 
-def strip_noncode(line: str, in_block: bool) -> tuple[str, bool]:
-    """Return (code, still_in_block_comment).
+def _at_token_boundary(line: str, i: int) -> bool:
+    """True if `i` starts a token. `r`/`b`/`c` mean "literal prefix" only at a
+    token boundary; elsewhere they are the tail of an identifier."""
+    return i == 0 or not IDENT_CHAR.match(line[i - 1])
+
+
+def _consume_raw(line: str, i: int, hashes: int) -> tuple[int, bool]:
+    """Consume raw-string body from `i`. Returns (next_index, closed_on_this_line).
+
+    The terminator is `"` followed by exactly the opening `#` count, so a bare `"`
+    -- or a `"` with too few `#` -- is content. Nothing else terminates a raw
+    string: not a backslash, not a newline.
+    """
+    close = '"' + "#" * hashes
+    end = line.find(close, i)
+    if end == -1:
+        return len(line), False
+    return end + len(close), True
+
+
+def strip_noncode(line: str, state: ScanState) -> tuple[str, ScanState]:
+    """Return (code, state_for_the_next_line).
 
     Strings and comments are removed before ANY brace counting or pattern
     matching. Brace counting in particular must not see a stray `{` inside a
-    string literal: inside a skipped `#[cfg(test)]` mod that would extend the
-    skip past the mod's closing brace and silently swallow the production code
-    that follows.
+    literal: inside a skipped `#[cfg(test)]` mod that would extend the skip past
+    the mod's closing brace and silently swallow the production code that
+    follows.
+
+    Raw strings are the reason this is a state machine rather than a regex. Their
+    contents are arbitrary bytes -- `//`, `/*`, `{`, `"`, and `#[cfg(test)]` all
+    appear inside them as DATA (see any `format!(r#"{{...}}"#)` JSON fixture) --
+    and they run across lines. A scanner that mishandles one does not just miss a
+    hit: it starts a comment that eats the file, or a skip region that eats the
+    production code after it.
     """
-    out = []
+    out: list[str] = []
     i = 0
+    block_depth = state.block_depth
+    raw_hashes = state.raw_hashes
+
     while i < len(line):
-        if in_block:
-            end = line.find("*/", i)
-            if end == -1:
-                return "".join(out), True
-            i = end + 2
-            in_block = False
+        if raw_hashes is not None:
+            i, closed = _consume_raw(line, i, raw_hashes)
+            if closed:
+                raw_hashes = None
             continue
+
+        if block_depth:
+            # Rust block comments nest: `/* a /* b */ still a comment */`. Closing
+            # at the first `*/` leaves the comment's tail behind as "code", and a
+            # stray brace in that tail desyncs exactly like a raw string does.
+            opened_at = line.find("/*", i)
+            closed_at = line.find("*/", i)
+            if opened_at == -1 and closed_at == -1:
+                break
+            if opened_at != -1 and (closed_at == -1 or opened_at < closed_at):
+                block_depth += 1
+                i = opened_at + 2
+            else:
+                block_depth -= 1
+                i = closed_at + 2
+            continue
+
         if line.startswith("//", i):
             break
         if line.startswith("/*", i):
-            in_block = True
+            block_depth += 1
             i += 2
             continue
-        m = STRING_LIT.match(line, i)
-        if m:
-            i = m.end()
-            continue
+
+        # A literal may open here. The `r`/`b`/`c` prefixes only mean "literal"
+        # at a token boundary -- mid-identifier they are ordinary letters. A bare
+        # quote needs no boundary: it always opens one.
+        boundary = _at_token_boundary(line, i)
+        if boundary:
+            m = RAW_OPEN.match(line, i)
+            if m:
+                hashes = len(m.group(1))
+                i, closed = _consume_raw(line, m.end(), hashes)
+                if not closed:
+                    raw_hashes = hashes
+                continue
+        if boundary or line[i] in "\"'":
+            m = STRING_LIT.match(line, i)
+            if m:
+                i = m.end()
+                continue
+
         out.append(line[i])
         i += 1
-    return "".join(out), in_block
+
+    return "".join(out), ScanState(block_depth, raw_hashes)
 
 
 def annotation_reason(line: str) -> str | None:
@@ -190,27 +275,35 @@ def iter_production_lines(rel: str, lines: list[str]):
     silent in both directions (test code scanned as production, production
     skipped as test).
 
-    NOTE for callers: `code` has string literals REMOVED, because brace counting
-    must not see a `{` inside a string. A pattern that needs a literal (e.g.
-    matching `"Draw" => ReplacementEvent::Draw`) will never fire against `code`.
-    Rewrite the pattern to key on the code around the literal, or match `raw`
-    and accept that comments are then in scope.
+    NOTE for callers: `code` has string literals REMOVED (raw strings included),
+    because brace counting must not see a `{` inside a literal. A pattern that
+    needs a literal (e.g. matching `"Draw" => ReplacementEvent::Draw`) will never
+    fire against `code`. Rewrite the pattern to key on the code around the
+    literal, or match `raw` and accept that comments are then in scope.
     """
     current_fn = "<module>"
     skip_until_depth: int | None = None
     depth = 0
     pending_cfg_test = False
-    in_block = False
+    state = ScanState()
 
     for i, raw in enumerate(lines):
-        code, in_block = strip_noncode(raw, in_block)
+        code, state = strip_noncode(raw, state)
 
         # Track an inline `#[cfg(test)] mod foo { .. }` body and skip it whole.
         # A naive "first #[cfg(test)] wins" is wrong: engine.rs has 10 and
         # synthesis.rs has 75, nearly all `#[cfg(test)] mod foo;` *declarations*
         # of outlined files, which are excluded by name instead.
+        #
+        # Keyed on `code`, never `raw`, so a `#[cfg(test)]` QUOTED inside a raw
+        # string is text and cannot arm the skip. Belt-and-braces: the `code.strip()`
+        # clear below already saves this today, because a raw-string terminator
+        # always leaves at least a `;` behind. That is a coincidence of the
+        # terminator's punctuation, not a property anyone declared -- and a
+        # structural decision taken on unstripped text is exactly the bug this
+        # function exists to prevent.
         if skip_until_depth is None:
-            if is_cfg_test_attr(raw):
+            if is_cfg_test_attr(code):
                 pending_cfg_test = True
             elif pending_cfg_test:
                 if INLINE_TEST_MOD.match(code):

--- a/scripts/zone_authority_census_tests.py
+++ b/scripts/zone_authority_census_tests.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Tests for the census scanner seam (`iter_production_lines` / `strip_noncode`).
+
+The scanner is shared: the zone-authority census AND the Draw-replacement census
+classify hits against the `code` it yields, and both rely on it to skip
+`#[cfg(test)]` bodies. A scanner that loses track of the source structure does
+not merely miss a hit -- it mis-scopes, and a mis-scope is silent in BOTH
+directions (test code scanned as production, production skipped as test). So the
+seam is tested at the seam, not through either census's classifier.
+
+Everything here drives `iter_production_lines`, because that is what the censuses
+consume and it is the level at which the failure modes are observable:
+
+    code            what a pattern is matched against  -> a leak here is a FALSE HIT
+    yielded lines   what counts as production          -> a leak here is a MIS-SCOPE
+    CensusError     the loud failure                   -> better than a silent lie
+
+Run:  python3 scripts/zone_authority_census_tests.py
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from zone_authority_census import CensusError, iter_production_lines
+
+
+def scan(src: str) -> list[tuple[int, str, str, str]]:
+    """Every production line of `src`, as the censuses see it."""
+    return list(iter_production_lines("t.rs", src.splitlines()))
+
+
+def code_of(src: str) -> str:
+    """The scanned code of `src`, one line per source line, comments/strings gone.
+
+    Non-production (skipped `#[cfg(test)]`) lines are absent -- that is the
+    point: what is not here cannot be classified.
+    """
+    return "\n".join(code for _i, _raw, code, _fn in scan(src))
+
+
+class RawStringTests(unittest.TestCase):
+    """Rust raw strings: `r"..."`, `r#"..."#` at any `#` depth, and the `b`/`c`
+    prefixed forms. Their contents are DATA and must never reach a classifier or
+    the brace counter."""
+
+    def test_plain_raw_string_content_is_not_code(self) -> None:
+        code = code_of('let s = r"add_to_zone(x)"; let y = 1;')
+        self.assertNotIn("add_to_zone", code)
+        self.assertIn("let y = 1;", code)
+
+    def test_hashed_raw_string_content_is_not_code(self) -> None:
+        # The `#` delimiters are DELIMITERS -- they are not code either.
+        code = code_of('let s = r#"add_to_zone(x)"#; let y = 1;')
+        self.assertNotIn("add_to_zone", code)
+        self.assertNotIn("#", code)
+        self.assertIn("let y = 1;", code)
+
+    def test_arbitrary_hash_depth(self) -> None:
+        # Only a quote followed by the SAME number of `#` closes the literal, so
+        # `"##` and a bare `"` inside `r###"..."###` are content, not the end.
+        code = code_of('let s = r###"a"## b" c"###; let y = 1;')
+        self.assertEqual(code, "let s = ; let y = 1;")
+
+    def test_byte_and_c_string_raw_forms(self) -> None:
+        for lit in ('br"x{"', 'br#"x{"#', 'cr"x{"', 'cr#"x{"#', 'br##"x{"##'):
+            with self.subTest(lit=lit):
+                code = code_of(f"let s = {lit}; let y = 1;")
+                self.assertEqual(code, "let s = ; let y = 1;")
+
+    def test_non_raw_byte_and_c_strings_still_stripped(self) -> None:
+        for lit in ('b"x{"', 'c"x{"', '"x{"'):
+            with self.subTest(lit=lit):
+                code = code_of(f"let s = {lit}; let y = 1;")
+                self.assertEqual(code, "let s = ; let y = 1;")
+
+    def test_raw_string_prefix_must_start_at_a_token_boundary(self) -> None:
+        # An identifier ending in `r`/`b`/`c` is not a raw-string prefix. `for` is
+        # not `f` + `or`, and `r` here is the tail of a name, not a literal.
+        code = code_of('let bar = 1; let s = "x"; let cr = 2;')
+        self.assertIn("let bar = 1;", code)
+        self.assertIn("let cr = 2;", code)
+
+    # ---- failure shape (a): comment markers inside a raw string ----
+
+    def test_raw_string_comment_markers_do_not_start_a_comment(self) -> None:
+        # `//` inside a raw string is DATA. If it opens a line comment, the rest
+        # of the line is eaten.
+        #
+        # The embedded `"` is load-bearing: it is the whole REASON to reach for
+        # `r#"..."#`, and it is what breaks a scanner that treats the raw
+        # string's inner quotes as an ordinary string literal. Without it the
+        # inner `"..."` pairs up by luck and the bug hides.
+        code = code_of('let s = r#"a" // b"#; add_to_zone(z);')
+        self.assertNotIn("//", code)
+        self.assertIn("add_to_zone(z);", code)
+
+    def test_raw_string_block_comment_open_does_not_eat_the_file(self) -> None:
+        # Same shape with `/*`, which does not stop at the end of the line: it
+        # runs to the next `*/` ANYWHERE, i.e. it can eat the rest of the file.
+        src = 'let s = r#"a" /* b"#;\nadd_to_zone(a);\nlet z = 2;\n'
+        code = code_of(src)
+        self.assertIn("add_to_zone(a);", code)
+        self.assertIn("let z = 2;", code)
+
+    # ---- failure shape (b): the multi-line remainder ----
+
+    def test_multiline_raw_string_remainder_survives(self) -> None:
+        # The historical bite: the remainder after a multi-line raw string was
+        # dropped, so the production code that followed was never scanned.
+        src = 'let s = r#"\nadd_to_zone(inside);\n"#;\nadd_to_zone(after);\n'
+        code = code_of(src)
+        self.assertNotIn("inside", code)
+        self.assertIn("add_to_zone(after);", code)
+
+    def test_multiline_raw_string_braces_do_not_desync(self) -> None:
+        # crates/draft-wasm/src/suggest.rs:437 in miniature: a brace-bearing
+        # multi-line raw string inside a `#[cfg(test)]` mod. Unbalanced braces
+        # leaking out of it desync brace tracking and the mod's closing brace
+        # arrives "early" -> CensusError, or worse, a swallowed production tail.
+        src = (
+            "fn prod_before() { add_to_zone(a); }\n"
+            "#[cfg(test)]\n"
+            "mod tests {\n"
+            "    fn fixture() -> String {\n"
+            '        format!(r#"{{ "name": "{n}", "t": {{ "x": [] }}"#)\n'
+            "    }\n"
+            "}\n"
+            "fn prod_after() { add_to_zone(b); }\n"
+        )
+        code = code_of(src)  # must not raise CensusError
+        self.assertIn("add_to_zone(a);", code)
+        self.assertIn("add_to_zone(b);", code)
+        self.assertNotIn("name", code)
+
+    # ---- failure shape (c): a fake region marker inside a raw string ----
+
+    def test_raw_string_cannot_toggle_the_cfg_test_region(self) -> None:
+        # A raw string that QUOTES `#[cfg(test)] mod ... {` must not start a skip
+        # region. If it does, the production code after it silently disappears --
+        # the census reports zero hits and calls that a pass.
+        src = (
+            "fn prod_before() { add_to_zone(a); }\n"
+            "const DOC: &str = r#\"\n"
+            "#[cfg(test)]\n"
+            "mod fake {\n"
+            '"#;\n'
+            "fn prod_after() { add_to_zone(b); }\n"
+        )
+        code = code_of(src)
+        self.assertIn("add_to_zone(a);", code)
+        self.assertIn("add_to_zone(b);", code)
+
+    def test_quoted_cfg_test_does_not_arm_the_next_real_mod(self) -> None:
+        # A GUARD, not a regression witness: this passes both before and after
+        # the raw-string branch, and it is recorded as green-both-ways rather
+        # than dressed up as a catch.
+        #
+        # It pins the belt to the braces. The region marker is read off `code`,
+        # so a quoted `#[cfg(test)]` cannot arm a skip. Today the BRACES alone
+        # would also save it -- `pending_cfg_test` is cleared by any line with
+        # non-empty code, and a raw-string terminator always leaves at least a
+        # `;` behind. That is a coincidence of the terminator's punctuation, not
+        # a property anyone declared, so the marker keys on `code` too.
+        src = (
+            'const DOC: &str = r#"#[cfg(test)]"#;\n'
+            "mod real_production {\n"
+            "    fn f() { add_to_zone(a); }\n"
+            "}\n"
+        )
+        self.assertIn("add_to_zone(a);", code_of(src))
+
+
+class PreservedBehaviourTests(unittest.TestCase):
+    """The scanner's existing contracts. The raw-string branch must not cost any
+    of them."""
+
+    def test_line_comment_is_stripped(self) -> None:
+        self.assertEqual(code_of("let x = 1; // add_to_zone(a)"), "let x = 1; ")
+
+    def test_block_comment_is_stripped_across_lines(self) -> None:
+        code = code_of("let a = 1; /* add_to_zone(x)\nstill add_to_zone(y) */ let b = 2;")
+        self.assertNotIn("add_to_zone", code)
+        self.assertIn("let b = 2;", code)
+
+    def test_nested_block_comment_is_stripped_to_its_true_end(self) -> None:
+        # Rust block comments NEST. Closing at the first `*/` leaves the tail of
+        # the comment behind as "code" -- and a stray brace in that tail desyncs
+        # brace tracking exactly like a raw string does.
+        code = code_of("/* a /* b */ add_to_zone(x) */ let y = 1;")
+        self.assertNotIn("add_to_zone", code)
+        self.assertIn("let y = 1;", code)
+
+    def test_normal_string_content_is_not_code(self) -> None:
+        code = code_of('let s = "add_to_zone(x) {"; let y = 1;')
+        self.assertNotIn("add_to_zone", code)
+        self.assertIn("let y = 1;", code)
+
+    def test_escaped_quote_in_string(self) -> None:
+        code = code_of('let s = "a\\"add_to_zone(x)"; let y = 1;')
+        self.assertNotIn("add_to_zone", code)
+        self.assertIn("let y = 1;", code)
+
+    def test_double_quote_char_literal(self) -> None:
+        # `'"'` must be consumed whole: a leaked `"` opens a phantom string that
+        # swallows the rest of the line.
+        code = code_of("""let c = '"'; add_to_zone(a);""")
+        self.assertIn("add_to_zone(a);", code)
+
+    def test_inline_cfg_test_mod_is_skipped(self) -> None:
+        src = (
+            "fn prod() { add_to_zone(a); }\n"
+            "#[cfg(test)]\n"
+            "mod tests {\n"
+            "    fn t() { add_to_zone(b); }\n"
+            "}\n"
+            "fn prod2() { add_to_zone(c); }\n"
+        )
+        code = code_of(src)
+        self.assertIn("add_to_zone(a);", code)
+        self.assertNotIn("add_to_zone(b);", code)
+        self.assertIn("add_to_zone(c);", code)
+
+    def test_compound_cfg_test_predicate_is_skipped(self) -> None:
+        src = (
+            '#[cfg(all(test, target_arch = "wasm32"))]\n'
+            "mod tests {\n"
+            "    fn t() { add_to_zone(b); }\n"
+            "}\n"
+            "fn prod() { add_to_zone(c); }\n"
+        )
+        code = code_of(src)
+        self.assertNotIn("add_to_zone(b);", code)
+        self.assertIn("add_to_zone(c);", code)
+
+    def test_cfg_not_test_is_production(self) -> None:
+        src = "#[cfg(not(test))]\nmod prod_only {\n    fn f() { add_to_zone(a); }\n}\n"
+        self.assertIn("add_to_zone(a);", code_of(src))
+
+    def test_feature_test_support_is_production(self) -> None:
+        src = '#[cfg(feature = "test-support")]\nmod s {\n    fn f() { add_to_zone(a); }\n}\n'
+        self.assertIn("add_to_zone(a);", code_of(src))
+
+    def test_enclosing_fn_is_tracked(self) -> None:
+        src = "fn alpha() {\n    add_to_zone(a);\n}\nfn beta() {\n    add_to_zone(b);\n}\n"
+        fns = {code.strip(): fn for _i, _raw, code, fn in scan(src)}
+        self.assertEqual(fns["add_to_zone(a);"], "alpha")
+        self.assertEqual(fns["add_to_zone(b);"], "beta")
+
+    def test_desync_still_raises(self) -> None:
+        # The loud failure must stay loud: a census that silently mis-scopes is
+        # worse than no census. The surplus `}` has to land INSIDE the skip
+        # region -- that is the only place the guard is armed.
+        src = "#[cfg(test)]\nmod tests {\n    fn t() { } } }\n"
+        with self.assertRaises(CensusError):
+            code_of(src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
- **fix(scripts): teach the census scanner Rust raw strings**
- **perf(scripts): scan the census seam span-wise, not character-wise**
