### PR TITLE
ship/census lifetimes

### DIFF
--- a/scripts/check-engine-authorities.sh
+++ b/scripts/check-engine-authorities.sh
@@ -136,6 +136,15 @@ snapshots), annotate the line with:
 EOF
 fi
 
+# (B0) The census scanner's own seam suite. Gates (B) and (C) both stand on
+# `strip_noncode` in zone_authority_census.py; a lexer regression there would
+# not fail those gates — it would silently mis-scope them (a swallowed hit
+# reads as migration progress). So the suite that pins the lexer runs here,
+# ahead of the gates it protects.
+if ! python3 "$(dirname "$0")/zone_authority_census_tests.py"; then
+    FAIL=1
+fi
+
 # (B) Raw zone mutation — full-tree ratchet against the frozen baseline.
 if ! python3 "$(dirname "$0")/zone_authority_census.py" --check; then
     FAIL=1
@@ -149,14 +158,12 @@ fi
 # card-data and therefore runs in the card-data CI job, not this one.
 #
 # SCOPE: three crates — engine, engine-wasm, mtgish-import — of a 13-crate
-# workspace. NOT full-tree, and previously mislabelled as such. It is not
-# full-tree because the shared scanner cannot yet read the whole workspace:
-# `strip_noncode` has no branch for Rust RAW strings (`r#"..."#`), so braces
-# inside one are counted, and a genuinely workspace-wide scan dies with
-# `CensusError: crates/draft-wasm/src/suggest.rs:437: brace tracking desynced`.
-# That is the scanner failing loudly rather than mis-scoping, which is correct —
-# but it means "full-tree" is an aspiration, not a description. Teaching
-# `strip_noncode` about raw strings would unlock it.
+# workspace. NOT full-tree, and previously mislabelled as such. The historical
+# blocker (no raw-string branch in `strip_noncode`, which made a workspace-wide
+# scan die on crates/draft-wasm/src/suggest.rs:437) was fixed in #5704; the
+# scope has simply not been widened yet. Widening it changes this gate's frozen
+# producer population, so it is its own unit with its own baseline review — not
+# a drive-by.
 if ! python3 "$(dirname "$0")/draw_replacement_census.py" --producers --check; then
     FAIL=1
 fi

--- a/scripts/zone_authority_census.py
+++ b/scripts/zone_authority_census.py
@@ -119,7 +119,27 @@ def is_cfg_test_attr(line: str) -> bool:
 # A non-raw literal: `"..."` (with a `b`/`c` prefix, which is part of the token),
 # or a char literal. The char alternative earns its place: `'"'` must be consumed
 # whole, or the leaked `"` opens a phantom string that swallows the line.
-STRING_LIT = re.compile(r'(?:b|c)?"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'')
+#
+# The char alternative is EXACTLY ONE char (or one escape) followed by the closing
+# quote, and that precision is the whole point: in Rust a `'` also opens a LIFETIME
+# (`&'a str`, `Foo<'_>`) and a loop LABEL (`'outer: loop`), neither of which is ever
+# closed by a second `'`. A permissive `'(?:\\.|[^'\\])*'` cannot tell them apart --
+# it runs from a lifetime tick to whatever quote comes next and eats the code in
+# between, braces included:
+#
+#     char::<_, OracleError<'_>>('{'),   ->   char::<_, OracleError<{'),
+#
+# which does not merely lose a hit: it LEAKS a `{` into the code stream and desyncs
+# brace tracking for the rest of the file -- the raw-string failure mode again.
+# Rust's own rule is the one encoded here: `'x'`, `'\n'`, `'\x41'`, `'\u{1F600}'` are
+# literals; a `'` that does not close after one char is a lifetime, and the scanner
+# emits its tick as ordinary code. (The byte form `b'x'` needs no prefix alternative:
+# CANDIDATE only stops on a `b` that a `"` follows, so a byte-char literal is always
+# entered at its quote and its `b` is scanned as the ordinary code it lexes like.)
+STRING_LIT = re.compile(
+    r'(?:b|c)?"(?:\\.|[^"\\])*"'
+    r"|'(?:\\(?:x[0-9a-fA-F]{2}|u\{[0-9a-fA-F_]{1,6}\}|.)|[^'\\])'"
+)
 
 # A raw-string opener: `r"`, `r#"`, `r##"`, and the byte/C-string forms `br#"` /
 # `cr#"`. Rust raw strings do NOT nest and honour NO escapes, so the `#` count is
@@ -281,8 +301,11 @@ def strip_noncode(line: str, state: ScanState) -> tuple[str, ScanState]:
             continue
 
         # A literal may open here. The `r`/`b`/`c` prefixes only mean "literal"
-        # at a token boundary -- mid-identifier they are ordinary letters. A bare
-        # quote needs no boundary: it always opens one.
+        # at a token boundary -- mid-identifier they are ordinary letters. A `"`
+        # needs no boundary: it always opens a string. A `'` is the one candidate
+        # that is genuinely ambiguous, and STRING_LIT is what resolves it: it opens
+        # a char literal only if a single char (or escape) then a closing quote
+        # follows -- otherwise it is a lifetime or a loop label and falls through.
         boundary = i == 0 or line[i - 1] not in IDENT_CHARS
         if boundary:
             m = _match_raw_open(line, i)
@@ -298,7 +321,9 @@ def strip_noncode(line: str, state: ScanState) -> tuple[str, ScanState]:
                 i = m.end()
                 continue
 
-        # A false candidate: an `r`/`b`/`c` that opens nothing.
+        # A false candidate: an `r`/`b`/`c` that opens nothing, or a `'` that opens
+        # a lifetime rather than a literal. Either way it is ordinary code: emit the
+        # one character and let the next slice pick up the rest of the token.
         append(ch)
         i += 1
 

--- a/scripts/zone_authority_census_tests.py
+++ b/scripts/zone_authority_census_tests.py
@@ -171,6 +171,85 @@ class RawStringTests(unittest.TestCase):
         self.assertIn("add_to_zone(a);", code_of(src))
 
 
+class LifetimeTests(unittest.TestCase):
+    """A `'` opens a char literal ONLY when a single char (or escape) closes it.
+    Everywhere else in Rust it opens a LIFETIME (`&'a str`, `Foo<'_>`) or a loop
+    LABEL (`'outer:`), which no second `'` ever closes.
+
+    Read as a permissive `'...'` literal, a lifetime tick runs to whatever quote
+    comes next and eats the code in between -- the same ceiling as raw strings, and
+    with the same two failure modes: a swallowed HIT, and a leaked BRACE that
+    desyncs the scanner for the rest of the file.
+    """
+
+    def test_lifetime_does_not_swallow_the_hit_after_it(self) -> None:
+        # The census-visible loss. An ODD number of ticks is what bites: the lifetime
+        # tick pairs with the OPENING quote of a later char literal, and everything
+        # between them -- here a `container`-family hit AND the fn's `{` -- is eaten
+        # as literal content:
+        #
+        #     fn drain(&'a mut self) { self.hand.push_back(c); assert!(c != 'x'); }
+        #       ->  fn drain(&x'); }
+        #
+        # The census does not report a mis-scan; it reports one fewer hit, which
+        # reads exactly like migration progress.
+        code = code_of("    fn drain(&'a mut self) { self.hand.push_back(c); assert!(c != 'x'); }")
+        self.assertIn(".hand.push_back(c);", code)
+        self.assertEqual(code.count("{"), 1)
+
+    def test_lifetime_does_not_eat_a_brace(self) -> None:
+        # `struct S<'a> { x: &'a str }` -- the `{` lives BETWEEN the two ticks, so a
+        # permissive char literal eats it and the line closes a brace it never opened.
+        code = code_of("struct S<'a> { x: &'a str }")
+        self.assertEqual(code.count("{"), 1)
+        self.assertEqual(code.count("}"), 1)
+
+    def test_lifetime_before_a_brace_char_literal_does_not_leak_the_brace(self) -> None:
+        # The witness, verbatim from crates/engine/src/parser/oracle_replacement.rs:
+        # the lifetime tick in `<'_>` pairs with the OPENING quote of the `'{'` char
+        # literal, so the `{` is left behind as code. This is the strictly worse
+        # direction: not a missed hit but an INVENTED brace, and brace depth then
+        # drifts for every line that follows.
+        code = code_of("char::<_, OracleError<'_>>('{'),")
+        self.assertNotIn("{", code)
+
+    def test_lifetime_does_not_desync_a_cfg_test_skip_region(self) -> None:
+        # The mis-scope, end to end. A lifetime + a `'}'` char literal inside a
+        # `#[cfg(test)]` body leaves the eaten line closing braces it never opened;
+        # brace tracking walks out through the mod's floor and the scanner either
+        # raises CensusError or swallows the production code that follows.
+        src = (
+            "fn prod_before() { add_to_zone(a); }\n"
+            "#[cfg(test)]\n"
+            "mod tests {\n"
+            "    fn t(c: &'a char) -> bool { *c == '}' }\n"
+            "}\n"
+            "fn prod_after() { add_to_zone(b); }\n"
+        )
+        code = code_of(src)  # must not raise CensusError
+        self.assertIn("add_to_zone(a);", code)
+        self.assertIn("add_to_zone(b);", code)
+
+    def test_loop_label_is_not_a_char_literal(self) -> None:
+        # `'outer:` is the same shape as a lifetime and fails the same way: the label
+        # tick pairs with the char literal's quote and the loop's `{` goes with it.
+        code = code_of("'outer: loop { if c == 'x' { add_to_zone(a); } }")
+        self.assertIn("add_to_zone(a);", code)
+        self.assertEqual(code.count("{"), code.count("}"))
+
+    # ---- the char literals themselves must still be consumed whole ----
+
+    def test_char_literal_escapes_are_still_stripped(self) -> None:
+        # Each is ONE char once escapes are honoured, so each must be consumed whole.
+        # `'\''` is the sharp one: its escaped quote must not be read as the closer.
+        for lit in ("'x'", "'{'", "'}'", "'\\n'", "'\\''", "'\\\\'", "'\\x41'", "'\\u{1F600}'", "b'x'"):
+            with self.subTest(lit=lit):
+                code = code_of(f"let c = {lit}; add_to_zone(a);")
+                self.assertNotIn("{", code)
+                self.assertNotIn("}", code)
+                self.assertIn("add_to_zone(a);", code)
+
+
 class PreservedBehaviourTests(unittest.TestCase):
     """The scanner's existing contracts. The raw-string branch must not cost any
     of them."""


### PR DESCRIPTION
- **fix(census): lex a Rust lifetime as a lifetime, not as a char literal**
- **ci(census): gate the census scanner's own seam suite, and un-stale the draw-census scope note**
