### PR TITLE
fix(parser): bind "where X is …" P/T or fail honestly (CR 107.3c)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -7052,8 +7052,12 @@ pub(crate) fn parse_pump_clause_with_context(
         Ok::<_, nom::Err<OracleError<'_>>>((rest, pt))
     })(lower.as_str())
     .ok()?;
-    let power = apply_where_x_expression(power, where_x_expression.as_deref());
-    let toughness = apply_where_x_expression(toughness, where_x_expression.as_deref());
+    // CR 107.3c: if the clause defines X but we cannot represent the definition,
+    // this pump clause does not lower — fail the parse rather than fabricate a
+    // dead placeholder. The line then falls through to the gap path and is
+    // reported honestly instead of resolving as a silent +0/+0 no-op.
+    let power = apply_where_x_expression(power, where_x_expression.as_deref())?;
+    let toughness = apply_where_x_expression(toughness, where_x_expression.as_deref())?;
 
     // CR 613.4c: Compose with "for each" quantity to produce dynamic PtValue.
     let (power, toughness) = if let Some(quantity) = for_each_qty {
@@ -7238,24 +7242,35 @@ pub(super) fn strip_leading_sequence_connector(text: &str) -> &str {
     }
 }
 
-fn apply_where_x_expression(value: PtValue, where_x_expression: Option<&str>) -> PtValue {
+/// CR 107.3c: A "where X is …" clause DEFINES the value of X in the ability's
+/// text — the controller does not choose it. Bind the X placeholder to the typed
+/// quantity the clause names.
+///
+/// Returns `None` when the clause defines X but the parser cannot represent that
+/// definition. That is a PARSE FAILURE and callers MUST surface it through
+/// `Effect::unimplemented`; they must never fabricate a substitute value.
+///
+/// This function previously fell back to `PtValue::Variable("<raw oracle text>")`.
+/// That fallback was a silent lie: `resolve_variable_pt` (game/effects/pump.rs)
+/// dispatches only `X`/`-X` and returns `None` for any other content, so
+/// `pt_modifications` pushed NO `ContinuousModification` at all and the pump
+/// resolved as a +0/+0 no-op — while the raw text still rendered as a supported
+/// dynamic quantity in the coverage report. The node was well-typed and
+/// completely dead. Honest failure is the only correct answer here.
+fn apply_where_x_expression(value: PtValue, where_x_expression: Option<&str>) -> Option<PtValue> {
     match (value, where_x_expression) {
         (PtValue::Variable(alias), Some(expression)) if alias.eq_ignore_ascii_case("X") => {
-            parse_where_x_quantity_expression(expression)
-                .map(PtValue::Quantity)
-                .unwrap_or_else(|| PtValue::Variable(expression.to_string()))
+            parse_where_x_quantity_expression(expression).map(PtValue::Quantity)
         }
         (PtValue::Variable(alias), Some(expression)) if alias.eq_ignore_ascii_case("-X") => {
-            parse_where_x_quantity_expression(expression)
-                .map(|inner| {
-                    PtValue::Quantity(QuantityExpr::Multiply {
-                        factor: -1,
-                        inner: Box::new(inner),
-                    })
+            parse_where_x_quantity_expression(expression).map(|inner| {
+                PtValue::Quantity(QuantityExpr::Multiply {
+                    factor: -1,
+                    inner: Box::new(inner),
                 })
-                .unwrap_or_else(|| PtValue::Variable(format!("-({expression})")))
+            })
         }
-        (value, _) => value,
+        (value, _) => Some(value),
     }
 }
 
@@ -7339,6 +7354,9 @@ pub(crate) fn parse_where_x_quantity_expression(where_x_expression: &str) -> Opt
     if let Some(expr) = parse_where_x_kicker_count(expression) {
         return Some(expr);
     }
+    if let Some(expr) = parse_where_x_exiled_card_power(expression_lower.as_str()) {
+        return Some(expr);
+    }
     let lower = expression.to_ascii_lowercase();
     if tag::<_, _, OracleError<'_>>("the number of times ")
         .parse(lower.as_str())
@@ -7405,6 +7423,26 @@ pub(crate) fn parse_where_x_quantity_expression(where_x_expression: &str) -> Opt
     // `None` for the bare die-result phrase (see `cda_quantity_returns_none_for_the_result`),
     // so this fallback is what binds Ancient Bronze Dragon's "where X is the result".
     crate::parser::oracle_quantity::parse_event_context_quantity(where_x_expression)
+}
+
+/// CR 107.3c + CR 608.2h: "where X is the power of the exiled card" DEFINES X as
+/// the power of the card exiled by this ability's source — Bishop of Binding
+/// ("Whenever this creature attacks, target Vampire gets +X/+X until end of
+/// turn, where X is the power of the exiled card") and Redemptor Dreadnought.
+/// CR 608.2h: the exiled card is read via last known information, which is what
+/// `QuantityRef::ExiledCardPower` resolves against (game/quantity.rs).
+///
+/// `index: 0` is the first (and, for this class, only) card the source exiled.
+fn parse_where_x_exiled_card_power(expression_lower: &str) -> Option<QuantityExpr> {
+    all_consuming(value(
+        QuantityExpr::Ref {
+            qty: QuantityRef::ExiledCardPower { index: 0 },
+        },
+        tag::<_, _, OracleError<'_>>("the power of the exiled card"),
+    ))
+    .parse(expression_lower)
+    .ok()
+    .map(|(_, expr)| expr)
 }
 
 /// CR 608.2c + CR 202.3: Match EXACTLY `that card's mana value` (or its
@@ -7646,6 +7684,10 @@ pub(super) fn apply_where_x_effect_expression(
     effect: &mut Effect,
     where_x_expression: Option<&str>,
 ) {
+    // CR 107.3c: set when the clause DEFINES X but the definition is not
+    // representable. Recorded here and converted to a gap node after the match
+    // (the arms hold a mutable borrow of `effect`'s fields).
+    let mut unbound_where_x: Option<String> = None;
     match effect {
         Effect::DealDamage { amount, .. }
         | Effect::DamageAll { amount, .. }
@@ -7672,8 +7714,16 @@ pub(super) fn apply_where_x_effect_expression(
             ..
         } => {
             *count = apply_where_x_quantity_expression(count.clone(), where_x_expression);
-            *power = apply_where_x_expression(power.clone(), where_x_expression);
-            *toughness = apply_where_x_expression(toughness.clone(), where_x_expression);
+            match (
+                apply_where_x_expression(power.clone(), where_x_expression),
+                apply_where_x_expression(toughness.clone(), where_x_expression),
+            ) {
+                (Some(bound_power), Some(bound_toughness)) => {
+                    *power = bound_power;
+                    *toughness = bound_toughness;
+                }
+                _ => unbound_where_x = where_x_expression.map(str::to_string),
+            }
         }
         // CR 107.3i + CR 109.4 + CR 109.5: "search/seek for up to X …, where X
         // is …" binds the search count (Oreskos Explorer). Eldritch Evolution
@@ -7718,8 +7768,16 @@ pub(super) fn apply_where_x_effect_expression(
         | Effect::PumpAll {
             power, toughness, ..
         } => {
-            *power = apply_where_x_expression(power.clone(), where_x_expression);
-            *toughness = apply_where_x_expression(toughness.clone(), where_x_expression);
+            match (
+                apply_where_x_expression(power.clone(), where_x_expression),
+                apply_where_x_expression(toughness.clone(), where_x_expression),
+            ) {
+                (Some(bound_power), Some(bound_toughness)) => {
+                    *power = bound_power;
+                    *toughness = bound_toughness;
+                }
+                _ => unbound_where_x = where_x_expression.map(str::to_string),
+            }
         }
         Effect::PreventDamage {
             amount,
@@ -7800,6 +7858,12 @@ pub(super) fn apply_where_x_effect_expression(
             }
         }
         _ => {}
+    }
+    // CR 107.3c: the clause defines X, but we cannot represent that definition.
+    // Report the gap instead of keeping a P/T placeholder that resolves to no
+    // modification at all (a silent +0/+0 no-op that still reads as supported).
+    if let Some(expression) = unbound_where_x {
+        *effect = Effect::unimplemented("where_x_binding", format!("where X is {expression}"));
     }
 }
 

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -28915,6 +28915,40 @@ fn craterhoof_where_x_binds_dynamic_pump_to_object_count() {
     }
 }
 
+/// CR 107.3c: "where X is …" DEFINES X in the ability's text — the controller
+/// does not choose it, and the parser must bind it to a typed quantity. Bishop
+/// of Binding ("target Vampire gets +X/+X until end of turn, where X is the
+/// power of the exiled card") and Redemptor Dreadnought share this binding.
+///
+/// Regression pin: the binding previously degraded to the lossy
+/// `PtValue::Variable("<raw oracle text>")` fallback, which `resolve_variable_pt`
+/// (game/effects/pump.rs) resolves to `None` — so the pump silently applied
+/// NOTHING. `QuantityRef::ExiledCardPower` is the typed home for this quantity.
+#[test]
+fn where_x_power_of_the_exiled_card_binds_exiled_card_power() {
+    let def = parse_effect_chain(
+        "target Vampire gets +X/+X until end of turn, where X is the power of the exiled card",
+        AbilityKind::Spell,
+    );
+    let Effect::Pump {
+        power, toughness, ..
+    } = &*def.effect
+    else {
+        panic!("expected Pump, got {:?}", def.effect);
+    };
+    let expected = QuantityExpr::Ref {
+        qty: QuantityRef::ExiledCardPower { index: 0 },
+    };
+    for (stat, value) in [("power", power), ("toughness", toughness)] {
+        assert_eq!(
+            value,
+            &PtValue::Quantity(expected.clone()),
+            "X must bind to ExiledCardPower in {stat}; an unbound PtValue::Variable \
+             resolves to no modification at all (silent no-op), got {value:?}"
+        );
+    }
+}
+
 #[test]
 fn duration_preserved_with_for_each_suffix() {
     // Goblin Piledriver pattern: "gets +2/+0 until end of turn for each other attacking Goblin"

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -662,31 +662,34 @@ fn parse_token_description_with_context(
         // to `QuantityRef::Variable("X")` so the upstream `PayCost { Mana { X } }`
         // loop's accumulated total flows through. Falls back to the CDA path
         // (and then the raw variable name) for phrases neither layer recognizes.
-        let resolve_count = || {
-            super::parse_where_x_quantity_expression(&where_expression)
-                .or_else(|| crate::parser::oracle_quantity::parse_cda_quantity(&where_expression))
-        };
-        if matches!(&count, QuantityExpr::Ref { qty: QuantityRef::Variable { ref name } } if name == "X")
-        {
-            count = resolve_count().unwrap_or_else(|| QuantityExpr::Ref {
-                qty: QuantityRef::Variable {
-                    name: where_expression.clone(),
-                },
-            });
-        }
-        if matches!(&power, Some(PtValue::Variable(alias)) if alias == "X") {
-            power = Some(
-                resolve_count()
-                    .map(PtValue::Quantity)
-                    .unwrap_or_else(|| PtValue::Variable(where_expression.clone())),
-            );
-        }
-        if matches!(&toughness, Some(PtValue::Variable(alias)) if alias == "X") {
-            toughness = Some(
-                resolve_count()
-                    .map(PtValue::Quantity)
-                    .unwrap_or_else(|| PtValue::Variable(where_expression)),
-            );
+        let binds_x = matches!(&count, QuantityExpr::Ref { qty: QuantityRef::Variable { ref name } } if name == "X")
+            || matches!(&power, Some(PtValue::Variable(alias)) if alias == "X")
+            || matches!(&toughness, Some(PtValue::Variable(alias)) if alias == "X");
+        if binds_x {
+            // CR 107.3c: the clause DEFINES X. If the definition is not
+            // representable, this token clause does not lower — fail the parse
+            // instead of fabricating a raw-text placeholder.
+            //
+            // The fabricated forms (`PtValue::Variable("<oracle text>")` and
+            // `QuantityRef::Variable { name: "<oracle text>" }`) are well-typed
+            // but DEAD: nothing resolves a non-`X` variable name, so the token
+            // entered as a 0/0 (or with a count of 0) while the raw text still
+            // rendered as a supported dynamic quantity in the coverage report —
+            // a fabricated green. Honest failure is the only correct answer.
+            let bound =
+                super::parse_where_x_quantity_expression(&where_expression).or_else(|| {
+                    crate::parser::oracle_quantity::parse_cda_quantity(&where_expression)
+                })?;
+            if matches!(&count, QuantityExpr::Ref { qty: QuantityRef::Variable { ref name } } if name == "X")
+            {
+                count = bound.clone();
+            }
+            if matches!(&power, Some(PtValue::Variable(alias)) if alias == "X") {
+                power = Some(PtValue::Quantity(bound.clone()));
+            }
+            if matches!(&toughness, Some(PtValue::Variable(alias)) if alias == "X") {
+                toughness = Some(PtValue::Quantity(bound));
+            }
         }
     }
     bind_bare_token_x_pt_to_cost_x(&mut power);
@@ -759,18 +762,14 @@ fn parse_token_description_with_context(
 
     if power.is_none() || toughness.is_none() {
         if let Some(pt_expression) = extract_token_pt_expression(suffix) {
-            let parsed = crate::parser::oracle_quantity::parse_cda_quantity(&pt_expression);
-            power = Some(
-                parsed
-                    .clone()
-                    .map(PtValue::Quantity)
-                    .unwrap_or_else(|| PtValue::Variable(pt_expression.clone())),
-            );
-            toughness = Some(
-                parsed
-                    .map(PtValue::Quantity)
-                    .unwrap_or_else(|| PtValue::Variable(pt_expression)),
-            );
+            // CR 107.3c + CR 208.2: a token whose P/T is defined by an
+            // expression ("an X/X token, where X is …") must bind that
+            // expression to a typed quantity. If it is not representable the
+            // token clause does not lower — a raw-text `PtValue::Variable` is a
+            // dead node that silently produces a 0/0 token.
+            let parsed = crate::parser::oracle_quantity::parse_cda_quantity(&pt_expression)?;
+            power = Some(PtValue::Quantity(parsed.clone()));
+            toughness = Some(PtValue::Quantity(parsed));
         }
     }
 

--- a/crates/engine/tests/integration/bishop_of_binding_where_x_exiled_card_power.rs
+++ b/crates/engine/tests/integration/bishop_of_binding_where_x_exiled_card_power.rs
@@ -1,0 +1,142 @@
+//! CR 107.3c — "where X is the power of the exiled card" must actually pump.
+//!
+//! Bishop of Binding (RIX), Oracle text (read from the card export, not memory):
+//!   "When this creature enters, exile target creature an opponent controls
+//!    until this creature leaves the battlefield.
+//!    Whenever this creature attacks, target Vampire gets +X/+X until end of
+//!    turn, where X is the power of the exiled card."
+//!
+//! THE BUG this discriminates (harvest task #48):
+//! `apply_where_x_expression` used to fall back to
+//! `PtValue::Variable("<raw oracle text>")` whenever the where-X expression was
+//! not representable — here, `Variable("the power of the exiled card")`. That
+//! node is well-typed but completely DEAD: `resolve_variable_pt`
+//! (game/effects/pump.rs) dispatches only `X` / `-X` and returns `None` for any
+//! other content, so `pt_modifications` pushed NO `ContinuousModification` at
+//! all. The Vampire silently got +0/+0 — while the raw text still rendered as a
+//! supported dynamic quantity in the coverage report (a fabricated green).
+//!
+//! The fix binds the clause to `QuantityRef::ExiledCardPower { index: 0 }`
+//! (CR 607.2a — the card exiled by this source), which `game/quantity.rs`
+//! resolves against `cards_exiled_with_source_this_turn`.
+//!
+//! This is a RUNTIME test, not an AST-shape test: it drives declare-attackers →
+//! the `Attacks` trigger → target selection → stack resolution → the layer
+//! system, and reads the EFFECTIVE (post-layer) power/toughness off the pumped
+//! Vampire. If the where-X binding is dropped, the pump contributes nothing and
+//! the Vampire stays 2/2 — which is exactly what this asserts against.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+use super::rules::AttackTarget;
+
+/// Bishop of Binding's printed Oracle text.
+const BISHOP_OF_BINDING: &str = "When this creature enters, exile target creature an opponent \
+controls until this creature leaves the battlefield.\n\
+Whenever this creature attacks, target Vampire gets +X/+X until end of turn, where X is the power \
+of the exiled card.";
+
+/// CR 107.3c + CR 607.2a: X is DEFINED by the ability's text as the power of the
+/// card exiled with Bishop of Binding. With a 4/4 exiled, the targeted Vampire
+/// must become an effective 2/2 + 4/4 = 6/6.
+#[test]
+fn bishop_of_binding_pumps_target_vampire_by_exiled_card_power() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let bishop = scenario
+        .add_creature_from_oracle(P0, "Bishop of Binding", 2, 2, BISHOP_OF_BINDING)
+        .id();
+
+    // The pump recipient: a Vampire P0 controls (the trigger targets "target
+    // Vampire"). Base 2/2 so the +X/+X delta is unambiguous.
+    let vampire = {
+        let mut builder = scenario.add_creature(P0, "Vampire Ally", 2, 2);
+        builder.with_subtypes(vec!["Vampire"]);
+        builder.id()
+    };
+
+    // The card whose power DEFINES X: a 4/4. Created on P1's battlefield, then
+    // moved to exile and linked to Bishop below — the state Bishop's own ETB
+    // ("exile target creature an opponent controls until this leaves") would
+    // have established. Seeding it directly keeps this test focused on the
+    // where-X binding rather than re-testing the exile machinery.
+    let exiled = scenario.add_creature(P1, "Exiled Brute", 4, 4).id();
+
+    // Idle defender so the DeclareBlockers prompt appears (it declares no blocks).
+    scenario.add_creature(P1, "Idle Bystander", 1, 1);
+
+    let mut runner = scenario.build();
+
+    // CR 607.2a: link the exiled card to its exiling source. `ExiledCardPower`
+    // resolves against `cards_exiled_with_source_this_turn`.
+    {
+        let state = runner.state_mut();
+        state.battlefield.retain(|&id| id != exiled);
+        state.exile.push_back(exiled);
+        state
+            .cards_exiled_with_source_this_turn
+            .insert(bishop, vec![exiled]);
+    }
+
+    // CR 508.1: declare Bishop as an attacker — this fires the `Attacks` trigger.
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(bishop, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("DeclareAttackers should succeed");
+
+    // Drive the trigger to resolution. The Vampire is the ONLY legal target for
+    // "target Vampire" (Bishop itself is not given the subtype here), so the
+    // engine may auto-select it rather than raising a TriggerTargetSelection
+    // prompt — handle both paths.
+    for _ in 0..24 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::TriggerTargetSelection { .. } => {
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(TargetRef::Object(vampire)),
+                    })
+                    .expect("choose the Vampire as the pump target");
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("empty DeclareBlockers should succeed");
+            }
+            WaitingFor::Priority { .. } => {
+                runner.advance_until_stack_empty();
+                break;
+            }
+            other => panic!("unexpected prompt while resolving the attack trigger: {other:?}"),
+        }
+    }
+
+    // THE DISCRIMINATOR. Pre-fix this read (2, 2): the dropped where-X binding
+    // left a dead `PtValue::Variable("the power of the exiled card")`, which
+    // `resolve_variable_pt` maps to `None`, so no modification was ever pushed.
+    let pumped = &runner.state().objects[&vampire];
+    assert_eq!(
+        (pumped.power, pumped.toughness),
+        (Some(6), Some(6)),
+        "CR 107.3c: X is DEFINED as the exiled card's power (4), so the targeted \
+         Vampire must be 2/2 + 4/4 = 6/6. A 2/2 here means the where-X binding was \
+         dropped and the pump silently resolved as a +0/+0 no-op."
+    );
+
+    // Bishop itself is not the target — it must be untouched (scope check).
+    let attacker = &runner.state().objects[&bishop];
+    assert_eq!(
+        (attacker.power, attacker.toughness),
+        (Some(2), Some(2)),
+        "the pump targets the Vampire only — Bishop must not be pumped"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -27,6 +27,7 @@ mod banding_combat;
 mod batched_trigger_subject_count;
 mod belbe_thornbow_life_loss;
 mod betor_lifelink_counters_repro;
+mod bishop_of_binding_where_x_exiled_card_power;
 mod blessed_orator_other_anthem;
 mod bolas_citadel_regression;
 mod boneyard_parley_pile_separation;


### PR DESCRIPTION
A "where X is <expr>" clause DEFINES the value of X in an ability's text
(CR 107.3c) — the controller does not choose it. When the parser could not
represent that definition it fabricated a well-typed placeholder holding the
raw Oracle text and carried on. Every such node is DEAD at runtime while still
rendering as a supported dynamic quantity in the coverage report:

  PtValue::Variable(raw)  pump P/T  -> resolve_variable_pt (game/effects/pump.rs)
                                       matches only X/-X, returns None
                                       -> NO ContinuousModification pushed (+0/+0)
  PtValue::Variable(raw)  token P/T -> resolve_pt_value (game/effects/token.rs)
                                       -> 0  -> a 0/0 token
  QuantityRef::Variable{name: raw}  -> game/quantity.rs, non-"X" arm
                                       -> unwrap_or(0) -> zero tokens created

Bishop of Binding's Vampire got +0/+0. Call the Coppercoats made no Soldiers.
Hazezon Tamar made no Sand Warriors. All reported as supported.

This removes the fabrication at every site (oracle_effect/lower.rs and
oracle_effect/token.rs). An unrepresentable where-X definition is now a parse
failure, surfaced through Effect::unimplemented / the token path's existing
`return None` idiom, so the gap is visible instead of silently wrong.

Also binds the one expression class whose typed home and runtime resolver both
already existed: "the power of the exiled card" ->
QuantityRef::ExiledCardPower{index:0} (CR 607.2a), resolved in game/quantity.rs.
Bishop of Binding and Redemptor Dreadnought now pump correctly.

Full-pool measured on 35,396 faces (base 302fab2fee), gains and reds listed
separately, never netted:
  P/T class (43 faces):  2 bound green, 28 honest-red (were lying-green),
                         13 unsupportable-red (un-set/custom), 0 still-broken.
  Count channel:         13 further token faces converted to honest gaps.
  Invariant: zero raw-text PtValue::Variable nodes survive pool-wide.
  Collateral: no face outside the defect set regressed.

A sibling class remains and is NOT addressed here: the same fabrication idiom in
the quantity channel (QuantityRef::Variable{name: "<raw text>"}) still affects
94 faces / 75 distinct expressions. Tracked separately.

Tests: parser witness (Bishop of Binding binds ExiledCardPower; watched fail
first) and a runtime witness driving declare-attackers -> Attacks trigger ->
stack -> layers, asserting the targeted Vampire resolves to 6/6 rather than 2/2.
