### PR TITLE
refactor(parser): bind copy-retarget by role, not position

### DIFF
--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -50,7 +50,7 @@ use super::lower::{
     rewrite_two_target_counter_chain, target_choice_timing_for_clause,
     thread_chosen_damage_source_into_oneshot_effects,
 };
-use super::sequence::apply_clause_continuation;
+use super::sequence::{apply_clause_continuation, def_bears_retargetable_copy};
 use super::{
     append_to_deepest_sub_ability, apply_player_scope_rewrites,
     attach_alt_cost_to_prior_cast_from_zone, attach_mana_retention_to_prior_mana,
@@ -628,6 +628,33 @@ pub(super) enum AntecedentRole {
     /// old scans never reached. Same trap, mirrored, as narrowing `GenericEffectHead`
     /// to "has a static".
     DigLook,
+    /// A def whose effect TREE bears a `CopySpell` — the antecedent a "you may choose
+    /// new targets for the copy/copies" sentence binds back to (CR 707.10c). A clause
+    /// that resolves between the copy and the sentence may sit in between (Narset's
+    /// Reversal's bounce, Spinerock Tyrant's wither rider), which is why this is a
+    /// role and not `LastEmitted`.
+    ///
+    /// The FIRST TREE-RECURSIVE role. Every role above is a property of a def's own
+    /// top-level effect (`DamageDealer` already peeks one level, through a `TargetOnly`
+    /// head); this one is a property of the def's whole effect SUBTREE, because the
+    /// `CopySpell` it names can be nested arbitrarily deep — under a
+    /// `CreateDelayedTrigger` wrapper (Galvanic Iteration) or down the `sub_ability`
+    /// chain (the Chain cycle nests the optional copy under the parent discard).
+    ///
+    /// This does NOT breach the "no recursive inspection of the output" rule. That rule
+    /// forbids a handler from walking the output GRAPH — sideways across `defs`, or
+    /// through parent/sibling links — to discover WHICH node is its antecedent. Here the
+    /// search across `defs` is exactly the declared `LastWithRole` walk, and membership
+    /// of each candidate is a property of that candidate ALONE, computed from its own
+    /// subtree. Node-local, just deeper than one level.
+    ///
+    /// Membership mirrors the mutator's descent EXACTLY — see
+    /// `sequence::def_bears_retargetable_copy`. Widening it (e.g. descending
+    /// `else_ability`, which the mutator does not) would bind a def the mutator cannot
+    /// patch, and because the walk STOPS at the bound node the retarget would be
+    /// silently dropped instead of reaching the real copy further back. Same trap as
+    /// narrowing `GenericEffectHead`, in the opposite direction.
+    CopySpellBearer,
 }
 
 /// Membership predicates for the roles whose candidacy is **live** — recomputed
@@ -669,6 +696,14 @@ fn live_role_predicate(role: AntecedentRole) -> Option<fn(&AbilityDefinition) ->
         // to stay correct for THIS role today is luck, not design. Cached membership is
         // stale by construction here, so it is not offered.
         AntecedentRole::DamageDealer => Some(def_is_damage_dealer),
+        // LIVE — and this role could not be cached even in principle. Its membership is
+        // a property of a def's whole effect SUBTREE, and the assembler moves effects
+        // INTO subtrees without touching `defs.len()`: nesting a `sub_ability` in place
+        // can make a def that was NOT a copy-bearer into one (the Chain cycle hangs the
+        // optional `CopySpell` under the parent discard). `observe` only refreshes where
+        // the length changes, so a registry would miss that node's birth entirely — not
+        // merely go stale on a rewrite, but never see it. Live, the role IS the scan.
+        AntecedentRole::CopySpellBearer => Some(def_bears_retargetable_copy),
         AntecedentRole::Conditional
         | AntecedentRole::OptionalHead
         | AntecedentRole::DigOrRevealUntil
@@ -945,7 +980,8 @@ impl AssemblyEnv {
                     | AntecedentRole::KeywordCounterPlacement
                     | AntecedentRole::DigOrMill
                     | AntecedentRole::DigLook
-                    | AntecedentRole::DamageDealer => None,
+                    | AntecedentRole::DamageDealer
+                    | AntecedentRole::CopySpellBearer => None,
                 },
             },
         };

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3340,6 +3340,42 @@ fn set_copy_retarget_in_ability(
     patched_here || patched_sub
 }
 
+/// Membership mirror for `AntecedentRole::CopySpellBearer` (CR 707.10c) — does this
+/// def's effect TREE bear a `CopySpell` that `set_copy_retarget_in_ability` can reach?
+///
+/// A STRUCTURAL MIRROR of that mutator's descent, and it lives beside it so the two
+/// cannot drift apart: the def's own effect, through a `CreateDelayedTrigger` wrapper's
+/// inner ability, and down the `sub_ability` chain. It deliberately does NOT descend
+/// `else_ability` — the mutator does not either. A predicate WIDER than its mutator is
+/// the dangerous direction here: `LastWithRole` stops the walk at the node it binds, so
+/// claiming membership for a def the mutator cannot patch would swallow the retarget
+/// instead of reaching the real copy further back.
+///
+/// Independent of the mutator's `all` flag BY CONSTRUCTION, so one predicate mirrors
+/// both the singular ("the copy") and plural ("the copies") clause: `all` decides how
+/// MANY copies get patched, never WHETHER one is found. Every return path of
+/// `set_copy_retarget_in_ability` reduces to "a reachable `CopySpell` exists" — the
+/// `!all` early return is taken only when `patched_here` is already true.
+///
+/// Membership therefore holds exactly when the mutator would return true, which is why
+/// the binding site can `debug_assert!` the mutation lands.
+pub(super) fn def_bears_retargetable_copy(def: &AbilityDefinition) -> bool {
+    effect_bears_retargetable_copy(&def.effect)
+        || def
+            .sub_ability
+            .as_deref()
+            .is_some_and(def_bears_retargetable_copy)
+}
+
+/// The effect half of `def_bears_retargetable_copy` — mirrors `set_copy_retarget`.
+fn effect_bears_retargetable_copy(effect: &Effect) -> bool {
+    match effect {
+        Effect::CopySpell { .. } => true,
+        Effect::CreateDelayedTrigger { effect: inner, .. } => def_bears_retargetable_copy(inner),
+        _ => false,
+    }
+}
+
 pub(super) fn apply_clause_continuation(
     defs: &mut Vec<AbilityDefinition>,
     continuation: ContinuationAst,
@@ -3505,32 +3541,46 @@ pub(super) fn apply_clause_continuation(
             }
         }
         ContinuationAst::CopyMayRetarget { all_copies } => {
-            // CR 707.10c: patch the nearest preceding CopySpell — descending
-            // through a CreateDelayedTrigger wrapper ("When you next cast ...,
-            // copy that spell" — Galvanic Iteration) and through the sub-ability
-            // chain ("That player may copy this spell ..." — the Chain cycle,
-            // where the optional CopySpell is nested under the parent discard).
-            // The copy is usually the last def, but a clause that resolves
-            // between the copy and the retarget sentence (Narset's Reversal's
-            // bounce, Increasing Vengeance's conditional "copy that spell twice",
-            // Spinerock Tyrant's "those spells gain wither" rider) can sit in
-            // between — so walk the defs backward to the first ability whose
-            // effect-tree contains a CopySpell. Recognition already confirmed a
-            // preceding copy exists (parse_followup_continuation_ast), so this
-            // binds it; if somehow none is found, the loop is a no-op.
+            // CR 707.10c: bind the most recent copy-bearing ability and grant its
+            // CopySpell(s) the retarget permission. The copy is usually the last def,
+            // but a clause that resolves between the copy and the retarget sentence can
+            // sit in between (Narset's Reversal's bounce, Spinerock Tyrant's "those
+            // spells gain wither" rider) — so this is a ROLE, not `LastEmitted`.
             //
-            // `all_copies` (the plural "the copies" clause) patches every copy in
-            // that copy-bearing ability — Increasing Vengeance's primary copy and
-            // its nested conditional "copy that spell twice" copy both live in one
-            // ability — while the singular clause keeps nearest-only binding.
-            for previous in defs.iter_mut().rev() {
-                if set_copy_retarget_in_ability(
-                    previous,
+            // `CopySpellBearer` is a LIVE predicate (`def_bears_retargetable_copy`), so
+            // `LastWithRole` resolves to `(0..defs.len()).rev().find(|i|
+            // bears_copy(&defs[i]))` — the backward scan this replaces, over the same
+            // `defs` at the same moment, with the SAME tree descent (own effect →
+            // CreateDelayedTrigger wrapper → sub-ability chain). Recognition already
+            // confirmed a preceding copy exists (parse_followup_continuation_ast); if
+            // somehow none does, `OnMiss::Ignore` keeps it a silent no-op, as before.
+            //
+            // `all_copies` (the plural "the copies" clause) patches every copy in that
+            // copy-bearing ability — Increasing Vengeance's primary copy and its nested
+            // conditional "copy that spell twice" copy both live in one ability — while
+            // the singular clause keeps nearest-only binding. The flag steers the
+            // MUTATION only; it is not part of the role (see the predicate's doc).
+            let bound = env.resolve(
+                defs,
+                super::assembly::AntecedentSelector::LastWithRole(
+                    super::assembly::AntecedentRole::CopySpellBearer,
+                ),
+                None,
+                super::assembly::OnMiss::Ignore,
+            );
+            if let Some(bound_index) = bound {
+                // `CopySpellBearer` membership is the structural mirror of this
+                // mutator's own success condition (`def_bears_retargetable_copy`), so a
+                // bound node ALWAYS patches — the role and the mutator cannot disagree.
+                let patched = set_copy_retarget_in_ability(
+                    &mut defs[bound_index],
                     &CopyRetargetPermission::MayChooseNewTargets,
                     all_copies,
-                ) {
-                    break;
-                }
+                );
+                debug_assert!(
+                    patched,
+                    "CopySpellBearer membership must imply the mutator patches"
+                );
             }
         }
         ContinuationAst::SuspectLastCreated => {


### PR DESCRIPTION
`set_copy_retarget`'s antecedent was the last free-standing Class A positional
walk-back in the assembler: a raw `defs.iter_mut().rev()` loop that re-derived
"the copy this sentence refers to" by scanning backward. Convert it to a declared
arena binding — `LastWithRole(AntecedentRole::CopySpellBearer)` + `OnMiss::Ignore`
— which closes Class A (0 free-standing scans remain).

The site resisted the U6-C5 pattern because its membership test is TREE-RECURSIVE
and FUSED with its mutation: `set_copy_retarget_in_ability` descends a def's effect
tree and returns whether it found AND patched a `CopySpell`. No find/patch split was
needed. The fused function's return value is independent of its `all` flag by
construction — `all` decides how MANY copies get patched, never WHETHER one is found
(the `!all` early return is taken only when `patched_here` is already true), and a
`false` return implies zero writes (the sole write site returns `true` immediately).
So the loop is exactly "find the last def whose tree bears a reachable CopySpell,
then patch it", which is `LastWithRole` + the existing mutator.

`CopySpellBearer` is the first role whose membership is a property of a def's whole
effect SUBTREE rather than its top-level effect (`DamageDealer` already peeks one
level, through a `TargetOnly` head). This does not breach the no-recursive-inspection
rule: that rule forbids a handler from walking the output GRAPH sideways to discover
WHICH node is its antecedent; here the walk across `defs` is the declared
`LastWithRole` walk, and each candidate's membership is computed from that candidate
alone. `def_bears_retargetable_copy` mirrors the mutator's descent EXACTLY (own effect
→ `CreateDelayedTrigger` inner → `sub_ability` chain) and deliberately does NOT descend
`else_ability`, which the mutator does not either. A WIDER predicate is the dangerous
direction: `LastWithRole` stops at the node it binds, so claiming membership for a def
the mutator cannot patch would swallow the retarget instead of reaching the real copy
further back. Membership therefore holds exactly when the mutator succeeds, which the
call site now `debug_assert!`s.

LIVE predicate, never cached: `observe` refreshes only where `defs.len()` changes, and
the assembler nests `sub_ability`s in place — a length-preserving move that can make a
def a copy-bearer without any length change (the Chain cycle hangs the optional
`CopySpell` under the parent discard). A registry would not merely go stale; it would
never see that node's birth.

Full-pool evidence (35,396 faces, base sha 2eeb18ff…, 98,260,147 B):
- Unforced output BYTE-IDENTICAL to base, from the shipping (probe-free) binary.
  Coverage identical: 31,985/34,625 fully implemented, 2,640 unimplemented — 0 lost.
- Causally identical, not merely equal-by-coincidence. Six-run diagonal over one
  dual-impl probe binary (probe(old) reproduces pristine base byte-for-byte; sentinel
  verified applied, 211 fires/run):
    forced MISS     → old 183 faces move, new 183 — SAME SET
    forced COLLAPSE → old 2 faces move,   new 2   — SAME SET (the 2 walk-back witnesses)
- The walk-back's causal set is exactly {Narset's Reversal, Spinerock Tyrant},
  re-derived from the OUTPUT (task #22 found them via a depth histogram).
- Red-first: forcing the role binding wrong makes both witness regression tests fail
  with `got [KeepOriginalTargets]`; honest binding is green.

Supersedes the "208/208 zero-miss" figure, which was an artifact of counter placement
(it counted loop ENTRIES, not defs tried). Measured from output: 238 faces carry
`MayChooseNewTargets`, of which 183 come from THIS binding and 55 are set at
construction by the `imperative.rs` path. A reachability counter cannot tell those apart.
