### PR TITLE
fix(parser): plural copy-retarget must reach EVERY copy-bearing def (CR 707.10c)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -535,6 +535,33 @@ pub(super) enum AntecedentSelector {
     /// The most recent node registered under a role, walking back past any
     /// candidate that fails the guard.
     LastWithRole(AntecedentRole),
+    /// **EVERY node registered under a role** — the one FAN-OUT binding in the
+    /// assembler. Bound with [`AssemblyEnv::resolve_all`]; [`AssemblyEnv::resolve`]
+    /// rejects it, because a point binding cannot express it.
+    ///
+    /// Grammatical class, not a card: a PLURAL quantifier ("you may choose new
+    /// targets for the copIES") scopes over the SELECTOR, not merely over the
+    /// mutation the selected node undergoes. When the things it quantifies over land
+    /// in SIBLING defs — Banish into Fable's two conditional copies, Ulalek's
+    /// spells-then-abilities pair — a `LastWithRole` binding reaches only the last of
+    /// them and every earlier one silently keeps its original targets (CR 707.10c).
+    ///
+    /// Membership is the SAME predicate/registry split as `LastWithRole` (see
+    /// `live_role_predicate`) — this selector changes only how many candidates are
+    /// taken, never which nodes qualify. That is deliberate: a fan-out whose
+    /// membership drifted from the point selector's would be a second, undeclared
+    /// role.
+    ///
+    /// Note the SWALLOW trap that haunts `LastWithRole` does NOT apply here, and the
+    /// direction is worth stating: `LastWithRole` STOPS the walk at the node it binds,
+    /// so an over-generous role hides a real antecedent further back. A fan-out never
+    /// stops, so an extra member cannot hide an earlier one. The exposure is the
+    /// MIRROR risk — patching a node that should have been left alone — which is why
+    /// the plural clause must only be bound to defs emitted BEFORE it. That holds by
+    /// construction: continuations are applied in SOURCE ORDER as clauses stream, so
+    /// `defs` at binding time contains exactly the copies already stated (a later
+    /// mode's copy — Choreographed Sparks' retarget-less mode 2 — does not exist yet).
+    AllWithRole(AntecedentRole),
     /// A node pushed by a continuation rather than a clause body — it has NO
     /// `ClauseId` (audit §2), so it can only be named by role + provenance.
     ContinuationProduct(ContinuationRole),
@@ -912,40 +939,131 @@ impl AssemblyEnv {
         guard: Option<BindGuard>,
         on_miss: OnMiss,
     ) -> Option<usize> {
-        let passes = |index: usize| -> bool {
-            match guard {
-                None => true,
-                Some(BindGuard::NoSubAbility) => defs[index].sub_ability.is_none(),
-                Some(BindGuard::EffectShape(EffectClass::PermanentCreator)) => matches!(
-                    &*defs[index].effect,
-                    Effect::CopyTokenOf { .. } | Effect::Token { .. } | Effect::ChangeZone { .. }
-                ),
-                Some(BindGuard::EffectShape(EffectClass::DrawnThisTurnChoice)) => matches!(
-                    &*defs[index].effect,
-                    Effect::ChooseDrawnThisTurnPayOrTopdeck { .. }
-                ),
-                Some(BindGuard::DigLookbackTransparentCost) => {
-                    let d = &defs[index];
-                    d.optional
-                        && super::sequence::clause_is_dig_lookback_transparent(&d.effect)
-                        && matches!(
-                            &*d.effect,
-                            Effect::Sacrifice { .. } | Effect::PayCost { .. }
-                        )
-                }
+        debug_assert!(
+            !matches!(selector, AntecedentSelector::AllWithRole(_)),
+            "`AllWithRole` is a FAN-OUT selector — bind it with `resolve_all`. Taking one \
+             node from it would silently drop every other member, which is the exact \
+             CR 707.10c defect the selector exists to fix."
+        );
+        let hit = self.point_hit(defs, selector, guard);
+        match hit {
+            Some(i) => Some(i),
+            None => match on_miss {
+                OnMiss::Ignore => None,
+            },
+        }
+    }
+
+    /// The FAN-OUT counterpart of [`Self::resolve`] — every bound node's CURRENT
+    /// index in `defs`, in emission order. Empty on a miss.
+    ///
+    /// Only [`AntecedentSelector::AllWithRole`] can bind more than one node; every
+    /// other selector is a point binding and yields 0 or 1 index here, with exactly
+    /// the semantics it has in `resolve` (including `Between`'s forward-first walk).
+    /// Both entry points therefore share ONE guard evaluator and ONE membership
+    /// authority, so a fan-out can never disagree with the point binding about which
+    /// nodes qualify.
+    pub(super) fn resolve_all(
+        &self,
+        defs: &[AbilityDefinition],
+        selector: AntecedentSelector,
+        guard: Option<BindGuard>,
+        on_miss: OnMiss,
+    ) -> Vec<usize> {
+        let hits: Vec<usize> = match selector {
+            AntecedentSelector::AllWithRole(role) => self.role_members(defs, role, guard),
+            point => self.point_hit(defs, point, guard).into_iter().collect(),
+        };
+        if hits.is_empty() {
+            return match on_miss {
+                OnMiss::Ignore => Vec::new(),
+            };
+        }
+        hits
+    }
+
+    /// Does the node at `index` satisfy the binding guard? Guards are evaluated
+    /// against the bound node ALONE — never by walking the output tree.
+    fn guard_passes(
+        &self,
+        defs: &[AbilityDefinition],
+        index: usize,
+        guard: Option<BindGuard>,
+    ) -> bool {
+        match guard {
+            None => true,
+            Some(BindGuard::NoSubAbility) => defs[index].sub_ability.is_none(),
+            Some(BindGuard::EffectShape(EffectClass::PermanentCreator)) => matches!(
+                &*defs[index].effect,
+                Effect::CopyTokenOf { .. } | Effect::Token { .. } | Effect::ChangeZone { .. }
+            ),
+            Some(BindGuard::EffectShape(EffectClass::DrawnThisTurnChoice)) => matches!(
+                &*defs[index].effect,
+                Effect::ChooseDrawnThisTurnPayOrTopdeck { .. }
+            ),
+            Some(BindGuard::DigLookbackTransparentCost) => {
+                let d = &defs[index];
+                d.optional
+                    && super::sequence::clause_is_dig_lookback_transparent(&d.effect)
+                    && matches!(
+                        &*d.effect,
+                        Effect::Sacrifice { .. } | Effect::PayCost { .. }
+                    )
             }
+        }
+    }
+
+    /// EVERY index carrying `role` whose guard also holds, in emission order.
+    ///
+    /// The single membership authority. `role_members(..).last()` is by construction
+    /// what `LastWithRole` binds, so the point selector and the fan-out cannot drift:
+    /// the live-predicate / cached-registry split below is the one in
+    /// `live_role_predicate`, not a copy of it.
+    fn role_members(
+        &self,
+        defs: &[AbilityDefinition],
+        role: AntecedentRole,
+        guard: Option<BindGuard>,
+    ) -> Vec<usize> {
+        let members: Vec<usize> = match live_role_predicate(role) {
+            Some(is_member) => (0..defs.len()).filter(|i| is_member(&defs[*i])).collect(),
+            None => match role {
+                AntecedentRole::Conditional => self.conditional_nodes.clone(),
+                AntecedentRole::OptionalHead => self.optional_head_nodes.clone(),
+                AntecedentRole::DigOrRevealUntil => self.dig_or_reveal_until_nodes.clone(),
+                AntecedentRole::DestroyLike => self.destroy_like_nodes.clone(),
+                AntecedentRole::FaceDownProfileHolder => self.face_down_profile_nodes.clone(),
+                // `live_role_predicate` returned `Some` for these, so this arm is
+                // unreachable — but it is spelled out rather than wildcarded so a
+                // NEW role cannot be added without choosing a side.
+                AntecedentRole::GenericEffectHead
+                | AntecedentRole::KeywordCounterPlacement
+                | AntecedentRole::DigOrMill
+                | AntecedentRole::DigLook
+                | AntecedentRole::DamageDealer
+                | AntecedentRole::CopySpellBearer => Vec::new(),
+            },
         };
-        // The most recent index (in `defs` order) whose membership AND guard hold.
-        let last_live = |is_member: fn(&AbilityDefinition) -> bool| -> Option<usize> {
-            (0..defs.len())
-                .rev()
-                .find(|i| is_member(&defs[*i]) && passes(*i))
-        };
+        members
+            .into_iter()
+            .filter(|i| self.guard_passes(defs, *i, guard))
+            .collect()
+    }
+
+    /// The single node a POINT selector binds, or `None`. Shared by `resolve` and
+    /// `resolve_all`; `AllWithRole` is not a point selector and never reaches here.
+    fn point_hit(
+        &self,
+        defs: &[AbilityDefinition],
+        selector: AntecedentSelector,
+        guard: Option<BindGuard>,
+    ) -> Option<usize> {
+        let passes = |index: usize| -> bool { self.guard_passes(defs, index, guard) };
         // The most recent candidate from a `refresh`-maintained emission-ordered list.
         let last_cached =
             |list: &[usize]| -> Option<usize> { list.iter().rev().copied().find(|i| passes(*i)) };
 
-        let hit: Option<usize> = match selector {
+        match selector {
             AntecedentSelector::LastEmitted => defs.len().checked_sub(1).filter(|i| passes(*i)),
             AntecedentSelector::FirstEmitted => {
                 (!defs.is_empty()).then_some(0).filter(|i| passes(*i))
@@ -959,38 +1077,14 @@ impl AssemblyEnv {
                 let anchor_pos = self.arena.order.iter().position(|id| *id == anchor);
                 anchor_pos.and_then(|a| ((a + 1)..defs.len()).find(|i| passes(*i)))
             }
-            // Roles split by HOW membership is determined — live predicate over
-            // `defs` (U6-C5) vs. emission-ordered registry (U6-C2/C3). The split and
-            // its rationale live in `live_role_predicate`.
-            AntecedentSelector::LastWithRole(role) => match live_role_predicate(role) {
-                Some(is_member) => last_live(is_member),
-                None => match role {
-                    AntecedentRole::Conditional => last_cached(&self.conditional_nodes),
-                    AntecedentRole::OptionalHead => last_cached(&self.optional_head_nodes),
-                    AntecedentRole::DigOrRevealUntil => {
-                        last_cached(&self.dig_or_reveal_until_nodes)
-                    }
-                    AntecedentRole::DestroyLike => last_cached(&self.destroy_like_nodes),
-                    AntecedentRole::FaceDownProfileHolder => {
-                        last_cached(&self.face_down_profile_nodes)
-                    }
-                    // `live_role_predicate` returned `Some` for these, so this arm is
-                    // unreachable — but it is spelled out rather than wildcarded so a
-                    // NEW role cannot be added without choosing a side.
-                    AntecedentRole::GenericEffectHead
-                    | AntecedentRole::KeywordCounterPlacement
-                    | AntecedentRole::DigOrMill
-                    | AntecedentRole::DigLook
-                    | AntecedentRole::DamageDealer
-                    | AntecedentRole::CopySpellBearer => None,
-                },
-            },
-        };
-        match hit {
-            Some(i) => Some(i),
-            None => match on_miss {
-                OnMiss::Ignore => None,
-            },
+            // "The most recent node with the role" IS the last member of the same
+            // membership set the fan-out enumerates — one authority, two arities.
+            AntecedentSelector::LastWithRole(role) => {
+                self.role_members(defs, role, guard).last().copied()
+            }
+            // Unreachable: `resolve` debug_asserts it away and `resolve_all` handles
+            // it before calling here. Spelled out so the match stays exhaustive.
+            AntecedentSelector::AllWithRole(_) => None,
         }
     }
 }

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3589,34 +3589,47 @@ pub(super) fn apply_clause_continuation(
             }
         }
         ContinuationAst::CopyMayRetarget { all_copies } => {
-            // CR 707.10c: bind the most recent copy-bearing ability and grant its
+            // CR 707.10c: bind the copy-bearing ability/abilities and grant their
             // CopySpell(s) the retarget permission. The copy is usually the last def,
             // but a clause that resolves between the copy and the retarget sentence can
             // sit in between (Narset's Reversal's bounce, Spinerock Tyrant's "those
             // spells gain wither" rider) — so this is a ROLE, not `LastEmitted`.
             //
-            // `CopySpellBearer` is a LIVE predicate (`def_bears_retargetable_copy`), so
-            // `LastWithRole` resolves to `(0..defs.len()).rev().find(|i|
-            // bears_copy(&defs[i]))` — the backward scan this replaces, over the same
-            // `defs` at the same moment, with the SAME tree descent (own effect →
-            // CreateDelayedTrigger wrapper → sub-ability chain). Recognition already
-            // confirmed a preceding copy exists (parse_followup_continuation_ast); if
-            // somehow none does, `OnMiss::Ignore` keeps it a silent no-op, as before.
+            // `all_copies` — the PLURAL "you may choose new targets for the copIES" —
+            // scopes over BOTH axes, and they are independent:
             //
-            // `all_copies` (the plural "the copies" clause) patches every copy in that
-            // copy-bearing ability — Increasing Vengeance's primary copy and its nested
-            // conditional "copy that spell twice" copy both live in one ability — while
-            // the singular clause keeps nearest-only binding. The flag steers the
-            // MUTATION only; it is not part of the role (see the predicate's doc).
-            let bound = env.resolve(
-                defs,
-                super::assembly::AntecedentSelector::LastWithRole(
-                    super::assembly::AntecedentRole::CopySpellBearer,
-                ),
-                None,
-                super::assembly::OnMiss::Ignore,
-            );
-            if let Some(bound_index) = bound {
+            //   SELECTOR (which defs):   plural ⇒ `AllWithRole`, because a card can make
+            //     its copies in SIBLING defs. Banish into Fable copies once if you
+            //     control an artifact and again if you control an enchantment; Ulalek
+            //     copies all spells, THEN all other abilities. A point binding reaches
+            //     only the last of those and every earlier copy silently keeps its
+            //     original targets — the CR 707.10c defect this arm exists to fix.
+            //   MUTATION (which copies inside one def): plural ⇒ `all = true`, so the
+            //     descent does not stop at the nearest copy. Increasing Vengeance's
+            //     primary copy and its nested conditional "copy that spell twice" copy
+            //     live in ONE def's sub-ability chain, and both must be patched.
+            //
+            // The singular clause ("the copy") keeps the nearest-only point binding on
+            // both axes. Binding only defs already emitted is what makes the fan-out
+            // safe: continuations apply in SOURCE ORDER, so a copy stated AFTER this
+            // sentence (Choreographed Sparks' retarget-less second mode) is not in
+            // `defs` yet and cannot be over-patched.
+            //
+            // `CopySpellBearer` is a LIVE predicate (`def_bears_retargetable_copy`) that
+            // mirrors the mutator's descent exactly (own effect → CreateDelayedTrigger
+            // wrapper → sub-ability chain), so every bound node patches. Recognition
+            // already confirmed a preceding copy exists
+            // (parse_followup_continuation_ast); if somehow none does, `OnMiss::Ignore`
+            // keeps it a silent no-op, as before.
+            let role = super::assembly::AntecedentRole::CopySpellBearer;
+            let selector = if all_copies {
+                super::assembly::AntecedentSelector::AllWithRole(role)
+            } else {
+                super::assembly::AntecedentSelector::LastWithRole(role)
+            };
+            for bound_index in
+                env.resolve_all(defs, selector, None, super::assembly::OnMiss::Ignore)
+            {
                 // `CopySpellBearer` membership is the structural mirror of this
                 // mutator's own success condition (`def_bears_retargetable_copy`), so a
                 // bound node ALWAYS patches — the role and the mutator cannot disagree.

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -10440,6 +10440,163 @@ fn effect_copy_retarget_with_no_preceding_copy_stays_orphaned() {
     );
 }
 
+// ── CR 707.10c: the PLURAL clause scopes over the SELECTOR, not just the
+// mutation ────────────────────────────────────────────────────────────────────
+//
+// `Increasing Vengeance` (above) pins the case where both copies live in ONE
+// def's sub-ability chain. The four tests below pin the case the point binding
+// could not reach: a card whose copies land in SIBLING defs. Before
+// `AllWithRole`, a `LastWithRole` binding patched only the LAST copy-bearing def
+// and every earlier copy silently kept its original targets — measured on the
+// full pool as `[KeepOriginalTargets, MayChooseNewTargets]` on each of these
+// four faces.
+
+/// CR 707.10c: Banish into Fable — TWO conditional copies emitted as SIBLING
+/// defs ("copy it if you control an artifact, THEN copy it if you control an
+/// enchantment"). The plural "the copies" must reach both, not just the second.
+#[test]
+fn effect_copy_retarget_plural_reaches_sibling_defs_banish_into_fable() {
+    let (retargets, orphaned) = copy_retarget_scan_card(
+        "When you cast this spell from your hand, copy it if you control an artifact, \
+         then copy it if you control an enchantment. You may choose new targets for the copies.\n\
+         Return target nonland permanent to its owner's hand. You create a 2/2 white Knight \
+         creature token with vigilance.",
+        "Banish into Fable",
+        &["Instant"],
+        &[],
+    );
+    assert_eq!(orphaned, 0, "orphaned_copy_retarget must not survive");
+    assert_eq!(
+        retargets.len(),
+        2,
+        "both conditional copies must be present, got {retargets:?}"
+    );
+    assert!(
+        retargets
+            .iter()
+            .all(|r| *r == CopyRetargetPermission::MayChooseNewTargets),
+        "the plural clause must retarget EVERY sibling copy, not just the last, \
+         got {retargets:?}"
+    );
+}
+
+/// CR 707.10c: Ulalek, Fused Atrocity — copies all spells, THEN all other
+/// activated and triggered abilities: two sibling copy defs under one trigger.
+#[test]
+fn effect_copy_retarget_plural_reaches_sibling_defs_ulalek() {
+    let (retargets, orphaned) = copy_retarget_scan_card(
+        "Devoid (This card has no color.)\n\
+         Whenever you cast an Eldrazi spell, you may pay {C}{C}. If you do, copy all spells \
+         you control, then copy all other activated and triggered abilities you control. \
+         You may choose new targets for the copies. (Mana abilities can't be copied.)",
+        "Ulalek, Fused Atrocity",
+        &["Creature"],
+        &["Eldrazi"],
+    );
+    assert_eq!(orphaned, 0, "orphaned_copy_retarget must not survive");
+    assert!(
+        retargets.len() >= 2,
+        "both the spell-copy and the ability-copy must be present, got {retargets:?}"
+    );
+    assert!(
+        retargets
+            .iter()
+            .all(|r| *r == CopyRetargetPermission::MayChooseNewTargets),
+        "the plural clause must retarget EVERY sibling copy, got {retargets:?}"
+    );
+}
+
+/// CR 707.10c: Sea Gate Stormcaller — the delayed-trigger copy and the
+/// conditional "copy that spell twice instead" land in sibling defs (unlike
+/// Increasing Vengeance, whose second copy nests as a sub-ability), so the
+/// plural clause must fan out across defs to reach the first one.
+#[test]
+fn effect_copy_retarget_plural_reaches_sibling_defs_sea_gate_stormcaller() {
+    let (retargets, orphaned) = copy_retarget_scan_card(
+        "Kicker {4}{U}\n\
+         When this creature enters, copy the next instant or sorcery spell with mana value 2 \
+         or less you cast this turn when you cast it. If this creature was kicked, copy that \
+         spell twice instead. You may choose new targets for the copies.",
+        "Sea Gate Stormcaller",
+        &["Creature"],
+        &["Human", "Wizard"],
+    );
+    assert_eq!(orphaned, 0, "orphaned_copy_retarget must not survive");
+    assert!(
+        retargets.len() >= 2,
+        "both the base copy and the kicked 'twice instead' copy must be present, \
+         got {retargets:?}"
+    );
+    assert!(
+        retargets
+            .iter()
+            .all(|r| *r == CopyRetargetPermission::MayChooseNewTargets),
+        "the plural clause must retarget EVERY sibling copy, got {retargets:?}"
+    );
+}
+
+/// CR 707.10c: Tomb of Horrors Adventurer — same sibling-def shape as Sea Gate
+/// Stormcaller ("copy it. If you've completed a dungeon, copy that spell twice
+/// instead. You may choose new targets for the copies.").
+#[test]
+fn effect_copy_retarget_plural_reaches_sibling_defs_tomb_of_horrors_adventurer() {
+    let (retargets, orphaned) = copy_retarget_scan_card(
+        "When this creature enters, you take the initiative.\n\
+         Whenever you cast your second spell each turn, copy it. If you've completed a dungeon, \
+         copy that spell twice instead. You may choose new targets for the copies. \
+         (A copy of a permanent spell becomes a token.)",
+        "Tomb of Horrors Adventurer",
+        &["Creature"],
+        &["Elf", "Monk"],
+    );
+    assert_eq!(orphaned, 0, "orphaned_copy_retarget must not survive");
+    assert!(
+        retargets.len() >= 2,
+        "both the base copy and the dungeon 'twice instead' copy must be present, \
+         got {retargets:?}"
+    );
+    assert!(
+        retargets
+            .iter()
+            .all(|r| *r == CopyRetargetPermission::MayChooseNewTargets),
+        "the plural clause must retarget EVERY sibling copy, got {retargets:?}"
+    );
+}
+
+/// CR 707.10c: OVER-PATCH GUARD — the mirror risk a fan-out selector introduces.
+///
+/// Choreographed Sparks' mode 1 carries a retarget sentence; mode 2 ("Copy target
+/// creature spell you control. The copy gains haste ...") deliberately does NOT.
+/// A retarget clause may only reach copies STATED BEFORE it, which holds because
+/// continuations are applied in source order — so mode 2's copy must survive with
+/// `KeepOriginalTargets`. If a future change makes the fan-out reach forward (or
+/// widens `CopySpellBearer` membership), this test goes red instead of silently
+/// granting a retarget the card never printed.
+#[test]
+fn effect_copy_retarget_singular_does_not_leak_to_later_mode_choreographed_sparks() {
+    let (retargets, orphaned) = copy_retarget_scan_card(
+        "This spell can't be copied.\n\
+         Choose one or both —\n\
+         • Copy target instant or sorcery spell you control. You may choose new targets for \
+         the copy.\n\
+         • Copy target creature spell you control. The copy gains haste and \"At the beginning \
+         of the end step, sacrifice this token.\"",
+        "Choreographed Sparks",
+        &["Instant"],
+        &[],
+    );
+    assert_eq!(orphaned, 0, "orphaned_copy_retarget must not survive");
+    assert!(
+        retargets.contains(&CopyRetargetPermission::KeepOriginalTargets),
+        "mode 2 prints no retarget sentence and must keep its original targets, \
+         got {retargets:?}"
+    );
+    assert!(
+        retargets.contains(&CopyRetargetPermission::MayChooseNewTargets),
+        "mode 1 prints a retarget sentence and must carry it, got {retargets:?}"
+    );
+}
+
 /// CR 603.7 (issue #1191): Tzaangor Shaman — "copy the next instant or
 /// sorcery spell you cast this turn when you cast it" must install a
 /// one-shot delayed trigger, not a combat-damage CopySpell.


### PR DESCRIPTION
CR 707.10c: "Some effects copy a spell or ability and state that its controller
may choose new targets for the copy." A card that makes SEVERAL copies and then
says "You may choose new targets for the copIES" grants that permission to every
copy it made. We granted it to only one.

`ContinuationAst::CopyMayRetarget { all_copies }` bound its antecedent with
`LastWithRole(CopySpellBearer)` — a POINT selector — and then let `all_copies`
widen `set_copy_retarget_in_ability`'s descent WITHIN that single def. The flag
therefore widened the MUTATION but not the SELECTOR, while the plural quantifier
scopes over both. When a card's copies land in SIBLING defs rather than nested
under one def's sub-ability chain, every copy but the last silently kept its
original targets.

Add `AntecedentSelector::AllWithRole` — the assembler's first FAN-OUT binding —
and select it when the clause is plural. Membership is unchanged: `role_members`
is now the single authority that BOTH arities read, so `LastWithRole` is
literally `role_members(..).last()` and a fan-out cannot drift from the point
binding about which nodes qualify. `resolve()` debug_asserts it was not handed a
fan-out, because taking one node from one would silently drop the rest — the
exact defect this fixes.

The role predicate `def_bears_retargetable_copy` is untouched, so it still
mirrors the mutator's descent exactly. Note the swallow trap that haunts
`LastWithRole` (an over-generous role STOPS the walk at the wrong node, hiding
the real antecedent) does not apply to a fan-out, which never stops. The mirror
risk — patching a copy that should have been left alone — is prevented by
construction: continuations are applied in SOURCE ORDER, so `defs` at binding
time holds exactly the copies already STATED, and a copy printed after the
sentence (Choreographed Sparks' retarget-less second mode) is not yet there.

Full-pool measured, base 9d7baeecf5 (35,396 faces, dual export, per-face delta):
exactly 4 faces change, all KeepOriginalTargets -> MayChooseNewTargets on the
first copy; ZERO regressions; ZERO faces outside the set touched.

  banish into fable            [Keep, May] -> [May, May]
  sea gate stormcaller         [Keep, May] -> [May, May]
  tomb of horrors adventurer   [Keep, May] -> [May, May]
  ulalek, fused atrocity       [Keep, May] -> [May, May]

The class is closed at 4: the multiset [Keep, May] occurs exactly 4 times across
all 35,396 faces. Negative controls hold — Increasing Vengeance stays [May, May]
(its second copy is a sub-ability, already reached), Lithoform Engine keeps the
Keep on its third ability, and Choreographed Sparks keeps the Keep on its
retarget-less second mode (pinned by a new over-patch guard test).
