### PR TITLE
chore(gate): widen draw-producers census from 3 crates to the full workspace

### DIFF
--- a/scripts/check-engine-authorities.sh
+++ b/scripts/check-engine-authorities.sh
@@ -157,13 +157,24 @@ fi
 # producers is frozen here. The corpus half of this census needs the generated
 # card-data and therefore runs in the card-data CI job, not this one.
 #
-# SCOPE: three crates — engine, engine-wasm, mtgish-import — of a 13-crate
-# workspace. NOT full-tree, and previously mislabelled as such. The historical
-# blocker (no raw-string branch in `strip_noncode`, which made a workspace-wide
-# scan die on crates/draft-wasm/src/suggest.rs:437) was fixed in #5704; the
-# scope has simply not been widened yet. Widening it changes this gate's frozen
-# producer population, so it is its own unit with its own baseline review — not
-# a drive-by.
+# SCOPE: the whole cargo workspace — every `crates/*/src`, 13 crates today,
+# globbed rather than enumerated so crate #14 is in scope the day it lands. This
+# was 3 hand-named crates until the raw-string branch in `strip_noncode` (#5704)
+# lifted the scanner ceiling a workspace-wide scan used to hit (`CensusError:
+# crates/draft-wasm/src/suggest.rs:437: brace tracking desynced`).
+#
+# Widening surfaced ZERO new producers: `ReplacementEvent::Draw` occurs in exactly
+# two crates (engine, mtgish-import). The other ten are not producer-free merely by
+# assumption — phase-ai builds `ReplacementDefinition`s with the same constructor
+# and struct-literal idioms this census matches, just never with `Draw`. So the
+# frozen population is unchanged at 7 rows, and now covers the surface it always
+# claimed to.
+#
+# Outside the workspace, and NOT scanned: `client/src-tauri` and
+# `lobby-worker/broker-wasm` (Cargo `exclude`; 4 `.rs` files, zero mentions of
+# `ReplacementEvent`). `client/src-tauri` also grows a gitignored `target/` on any
+# local Tauri build, which an rglob would descend into — making the scanned
+# population depend on whether a developer had run one.
 if ! python3 "$(dirname "$0")/draw_replacement_census.py" --producers --check; then
     FAIL=1
 fi

--- a/scripts/draw-replacement-producers.txt
+++ b/scripts/draw-replacement-producers.txt
@@ -24,11 +24,18 @@
 # family=struct-literal  `ReplacementDefinition { .. event: ReplacementEvent::Draw .. }`
 #                        (mtgish-import). Same: no constructor call.
 #
-# SCOPE, stated exactly rather than implied: this scans the engine crates AND
-# crates/mtgish-import/src. It does NOT scan any other crate. The first cut of
-# this gate scanned the engine only, and froze 6 producers while a 7th was live in
-# mtgish-import -- the count was right about the population it looked at and wrong
-# about the question it claimed to answer.
+# SCOPE, stated exactly rather than implied: this scans the whole cargo workspace
+# -- every `crates/*/src` (13 crates today), globbed rather than enumerated so a
+# new crate is in scope the day it is created. It does NOT scan the two Rust trees
+# Cargo excludes from the workspace (`client/src-tauri`, `lobby-worker/broker-wasm`,
+# 4 `.rs` files); neither mentions `ReplacementEvent` at all.
+#
+# Earlier cuts scanned less and said so imprecisely. v1 scanned the engine only and
+# froze 6 producers while a 7th was live in mtgish-import. v2 hand-added
+# mtgish-import, reaching 3 of 13 crates -- not by choice but because the shared
+# scanner could not read raw strings and died on crates/draft-wasm. Both counts were
+# right about the population they looked at and wrong about the question they
+# claimed to answer.
 #
 # COVERAGE BOUNDARY, stated so this is not mistaken for "every possible source":
 # a `ReplacementDefinition` also comes back to life via its plain serde derive

--- a/scripts/draw_replacement_census.py
+++ b/scripts/draw_replacement_census.py
@@ -48,7 +48,6 @@ from pathlib import Path
 # free to drift, and their disagreements would be silent in both directions.
 from zone_authority_census import (
     REPO_ROOT,
-    SCOPES as ENGINE_SCOPES,
     TEST_SUPPORT_FILES,
     iter_production_lines,
 )
@@ -58,14 +57,37 @@ CORPUS_BASELINE = REPO_ROOT / "scripts" / "draw-replacement-corpus.tsv"
 CARD_DATA = REPO_ROOT / "data" / "card-data.json"
 
 # The zone census scans the engine, because only the engine mutates zones. A Draw
-# REPLACEMENT DEFINITION, though, can be minted by anything that builds one and
-# hands it to the engine — and `crates/mtgish-import` does exactly that. Scanning
-# it is a READ; nothing here modifies it.
+# REPLACEMENT DEFINITION, though, can be minted by ANY crate that builds one and
+# hands it to the engine, so the population here is the whole workspace: every
+# `crates/*/src`. Scanning is a READ; nothing here modifies any crate.
 #
-# Omitting it is how the first cut of this gate froze 6 producers while a 7th was
-# live: a census is only as honest as the population it admits, and "the engine"
-# was the wrong population for this question.
-SCOPES = ENGINE_SCOPES + ("crates/mtgish-import/src",)
+# History, because the scope of this census has been wrong twice and each time the
+# count was right about the population it looked at and wrong about the question it
+# claimed to answer:
+#   - v1 scanned the engine only, and froze 6 producers while a 7th was live in
+#     mtgish-import.
+#   - v2 added mtgish-import by hand: 3 named crates of a 13-crate workspace. Full
+#     workspace was the intent, but `strip_noncode` had no branch for Rust RAW
+#     strings, so a workspace-wide scan died on `crates/draft-wasm/src/suggest.rs`.
+#     The 3-crate list was a workaround for a scanner ceiling, frozen as if it were
+#     a decision.
+#   - v3 (here): the raw-string ceiling is fixed, so the scope is the workspace.
+#
+# GLOBBED, not enumerated. A hand-written 13-tuple is a list that goes stale the
+# moment crate #14 is added -- which is precisely how v1 and v2 went wrong. The
+# glob cannot go stale, and because the producer baseline is an EXACT-MATCH gate, a
+# Draw producer minted in a brand-new crate fails the build on the day it lands.
+#
+# BOUNDARY, named rather than implied: this is the cargo workspace (`members =
+# ["crates/*"]`). Two Rust trees are excluded from that workspace by Cargo itself
+# -- `client/src-tauri` and `lobby-worker/broker-wasm`, 4 `.rs` files between them
+# -- and they are NOT scanned. Neither mentions `ReplacementEvent` or
+# `ReplacementDefinition` at all (grep-verified), so the omission costs no
+# producer today. They stay out because they are not workspace members and because
+# `client/src-tauri` grows a gitignored `target/` on any local Tauri build, which
+# an `rglob("*.rs")` would happily descend into -- making the scanned population
+# depend on whether a developer had run a Tauri build.
+SCOPES = tuple(sorted(str(p.relative_to(REPO_ROOT)) for p in (REPO_ROOT / "crates").glob("*/src")))
 
 # ---------------------------------------------------------------------------
 # (A) Producer surface
@@ -186,11 +208,18 @@ PRODUCERS_HEADER = """\
 # family=struct-literal  `ReplacementDefinition { .. event: ReplacementEvent::Draw .. }`
 #                        (mtgish-import). Same: no constructor call.
 #
-# SCOPE, stated exactly rather than implied: this scans the engine crates AND
-# crates/mtgish-import/src. It does NOT scan any other crate. The first cut of
-# this gate scanned the engine only, and froze 6 producers while a 7th was live in
-# mtgish-import -- the count was right about the population it looked at and wrong
-# about the question it claimed to answer.
+# SCOPE, stated exactly rather than implied: this scans the whole cargo workspace
+# -- every `crates/*/src` (13 crates today), globbed rather than enumerated so a
+# new crate is in scope the day it is created. It does NOT scan the two Rust trees
+# Cargo excludes from the workspace (`client/src-tauri`, `lobby-worker/broker-wasm`,
+# 4 `.rs` files); neither mentions `ReplacementEvent` at all.
+#
+# Earlier cuts scanned less and said so imprecisely. v1 scanned the engine only and
+# froze 6 producers while a 7th was live in mtgish-import. v2 hand-added
+# mtgish-import, reaching 3 of 13 crates -- not by choice but because the shared
+# scanner could not read raw strings and died on crates/draft-wasm. Both counts were
+# right about the population they looked at and wrong about the question they
+# claimed to answer.
 #
 # COVERAGE BOUNDARY, stated so this is not mistaken for "every possible source":
 # a `ReplacementDefinition` also comes back to life via its plain serde derive


### PR DESCRIPTION
Gate (C) in check-engine-authorities.sh froze the `ReplacementEvent::Draw`
producer surface by scanning 3 named crates (engine, engine-wasm,
mtgish-import) of a 13-crate workspace. That list was never a decision — it
was a workaround for a scanner ceiling: `strip_noncode` had no branch for Rust
raw strings, so a workspace-wide scan died on
`crates/draft-wasm/src/suggest.rs:437: brace tracking desynced`. #5704 taught
the scanner raw strings, so the scope can now be what it always claimed to be.

SCOPES is now globbed (`crates/*/src`), not enumerated. A hand-written tuple is
a list that goes stale the moment crate #14 lands — which is exactly how this
census went wrong twice before (v1 froze 6 producers while a 7th was live in
mtgish-import). The glob cannot go stale, and because the producer baseline is
an exact-match gate, a Draw producer minted in a brand-new crate fails the
build on the day it arrives.

Population: 3 -> 13 crates, 469 -> 701 .rs files scanned (+232).
Producers: 7 rows -> 7 rows. ZERO new producers. `ReplacementEvent::Draw`
occurs in exactly two crates (engine, mtgish-import), so no producer was
missing a CR 121.2 scope decision and no row's scope moved. The baseline diff
is header prose only.

The zero is not vacuous. phase-ai builds `ReplacementDefinition`s with the very
same constructor and struct-literal idioms this census matches (AddCounter,
Moved, ChangeZone) — just never with `Draw`. And a synthetic `Draw` producer
planted in phase-ai turns the widened gate RED (`ADDED
crates/phase-ai/src/cast_facts.rs scratch_t59_synthetic_draw_producer
constructor 1`) while the OLD 3-crate scope reports `PASS (7 rows)` — the
widening is what catches it.

Boundary, named rather than implied: the two Rust trees Cargo excludes from the
workspace (`client/src-tauri`, `lobby-worker/broker-wasm`; 4 .rs files) are not
scanned. Neither mentions `ReplacementEvent`. `client/src-tauri` also grows a
gitignored `target/` on any local Tauri build, which an rglob would descend
into — making the scanned population depend on whether a developer had run one.

CR 121.2 (grep-verified, docs/MagicCompRules.txt:1144): cards may only be drawn
one at a time. CR 121.2a (:1146): an instruction to draw multiple cards can be
modified by replacement effects that refer to the number of cards drawn.
