### PR TITLE
fix(census): carry backslash-continued non-raw strings across lines in strip_noncode

### DIFF
--- a/scripts/zone_authority_census.py
+++ b/scripts/zone_authority_census.py
@@ -141,6 +141,14 @@ STRING_LIT = re.compile(
     r"|'(?:\\(?:x[0-9a-fA-F]{2}|u\{[0-9a-fA-F_]{1,6}\}|.)|[^'\\])'"
 )
 
+# The BODY of a non-raw string, from just past its opening quote through its
+# closing quote. Escapes are honoured -- `\"` is content, `\\` is a spent backslash
+# -- and a line that ends in a backslash matches NOTHING here, which is precisely
+# the Rust rule: a `\` immediately before the newline escapes it and the literal
+# RUNS ON to the next line (Reference, STRING_CONTINUE). So a non-match is not a
+# syntax error to guess around; it is the signal to carry the string.
+STRING_BODY = re.compile(r'(?:\\.|[^"\\])*"')
+
 # A raw-string opener: `r"`, `r#"`, `r##"`, and the byte/C-string forms `br#"` /
 # `cr#"`. Rust raw strings do NOT nest and honour NO escapes, so the `#` count is
 # the only thing that closes one -- and the only thing we have to carry.
@@ -183,19 +191,26 @@ IDENT_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012
 _find_candidate = CANDIDATE.search
 _match_raw_open = RAW_OPEN.match
 _match_string_lit = STRING_LIT.match
+_match_string_body = STRING_BODY.match
 
 
 class ScanState(NamedTuple):
     """Lexer state carried BETWEEN lines.
 
-    Both constructs that can span a line boundary need a count, not a flag:
-    block comments nest (`/* /* */ */`) and a raw string is closed only by its
-    own `#` count. The two are mutually exclusive -- a raw string opened inside a
-    block comment is comment text, and a `/*` inside a raw string is data.
+    THREE constructs span a line boundary, and each needs its own carrier:
+
+        block comments   nest, so they need a DEPTH (`/* /* */ */`)
+        raw strings      close only on their own `#` count, so they need that COUNT
+        non-raw strings  continue on a trailing `\\`, which is all-or-nothing: a FLAG
+
+    They are mutually exclusive by construction. A raw string opened inside a block
+    comment is comment text; a `/*` inside either kind of string is data; a `\\` is
+    inert inside a raw string, which honours no escapes at all.
     """
 
     block_depth: int = 0
     raw_hashes: int | None = None  # `#` count of the raw string we are inside
+    in_string: bool = False  # inside a non-raw string continued from the line above
 
 
 class CensusError(Exception):
@@ -223,6 +238,21 @@ def _consume_raw(line: str, i: int, hashes: int) -> tuple[int, bool]:
     return end + len(close), True
 
 
+def _consume_string(line: str, i: int) -> tuple[int, bool]:
+    """Consume non-raw string body from `i` (just past the opening `"`).
+
+    Returns (next_index, closed_on_this_line). A non-raw string is closed by the
+    first unescaped `"`; if there is none, the line ends in a `\\` that escapes the
+    newline and the literal continues onto the next line -- Rust's STRING_CONTINUE,
+    and the ONLY way a non-raw string spans a line break (an unescaped newline
+    inside one is a compile error, so there is no third case to guess at).
+    """
+    m = _match_string_body(line, i)
+    if m is None:
+        return len(line), False
+    return m.end(), True
+
+
 def strip_noncode(line: str, state: ScanState) -> tuple[str, ScanState]:
     """Return (code, state_for_the_next_line).
 
@@ -232,18 +262,26 @@ def strip_noncode(line: str, state: ScanState) -> tuple[str, ScanState]:
     the mod's closing brace and silently swallow the production code that
     follows.
 
-    Raw strings are the reason this is a state machine rather than a regex. Their
-    contents are arbitrary bytes -- `//`, `/*`, `{`, `"`, and `#[cfg(test)]` all
-    appear inside them as DATA (see any `format!(r#"{{...}}"#)` JSON fixture) --
-    and they run across lines. A scanner that mishandles one does not just miss a
-    hit: it starts a comment that eats the file, or a skip region that eats the
+    Multi-line literals are the reason this is a state machine rather than a regex.
+    A raw string's contents are arbitrary bytes -- `//`, `/*`, `{`, `"`, and
+    `#[cfg(test)]` all appear inside them as DATA (see any `format!(r#"{{...}}"#)`
+    JSON fixture) -- and an ORDINARY string carries the same data across the same
+    line break whenever it ends in a `\\` (Rust's STRING_CONTINUE), which is how
+    every wrapped `assert!` message in the tree is written. A scanner that
+    mishandles either does not just miss a hit: it starts a comment that eats the
+    file, leaks a brace into the counter, or opens a skip region that eats the
     production code after it.
     """
     # Fast path. 4 lines in 5 hold no comment and no literal, and for those the
     # scanner has nothing to do -- so it should ALLOCATE nothing: no char list,
     # no join, no fresh ScanState. Doing the work anyway is most of what made the
     # per-character version too slow to run on the tree it was written to sweep.
-    if state.block_depth == 0 and state.raw_hashes is None and _find_candidate(line) is None:
+    if (
+        state.block_depth == 0
+        and state.raw_hashes is None
+        and not state.in_string
+        and _find_candidate(line) is None
+    ):
         return line, state
 
     out: list[str] = []
@@ -251,6 +289,7 @@ def strip_noncode(line: str, state: ScanState) -> tuple[str, ScanState]:
     n = len(line)
     block_depth = state.block_depth
     raw_hashes = state.raw_hashes
+    in_string = state.in_string
     append = out.append
 
     while i < n:
@@ -258,6 +297,14 @@ def strip_noncode(line: str, state: ScanState) -> tuple[str, ScanState]:
             i, closed = _consume_raw(line, i, raw_hashes)
             if closed:
                 raw_hashes = None
+            continue
+
+        if in_string:
+            # A continued non-raw string. Its body is data exactly like a raw
+            # string's -- and unlike a raw string's, it honours escapes, so the
+            # closing quote is the first UNESCAPED one.
+            i, closed = _consume_string(line, i)
+            in_string = not closed
             continue
 
         if block_depth:
@@ -321,13 +368,32 @@ def strip_noncode(line: str, state: ScanState) -> tuple[str, ScanState]:
                 i = m.end()
                 continue
 
+            # No closing quote on this line. For a `"` -- with or without its `b`/`c`
+            # prefix -- that is not a syntax error and not a false candidate: Rust
+            # closes a non-raw string with an unescaped quote or CONTINUES it past a
+            # trailing `\`, and nothing else is legal. So the literal is open, and it
+            # is open ACROSS the line boundary. Carry it, and the body it holds --
+            # braces, `//`, `add_to_zone(` and all -- is data on every line it spans.
+            # (A `'` that reaches here is a lifetime or a loop label, which no second
+            # quote closes; it opens nothing and falls through to the code stream.)
+            if ch == '"':
+                quote = i + 1
+            elif ch in ("b", "c") and line[i + 1 : i + 2] == '"':
+                quote = i + 2
+            else:
+                quote = None
+            if quote is not None:
+                i, closed = _consume_string(line, quote)
+                in_string = not closed
+                continue
+
         # A false candidate: an `r`/`b`/`c` that opens nothing, or a `'` that opens
         # a lifetime rather than a literal. Either way it is ordinary code: emit the
         # one character and let the next slice pick up the rest of the token.
         append(ch)
         i += 1
 
-    return "".join(out), ScanState(block_depth, raw_hashes)
+    return "".join(out), ScanState(block_depth, raw_hashes, in_string)
 
 
 def annotation_reason(line: str) -> str | None:

--- a/scripts/zone_authority_census_tests.py
+++ b/scripts/zone_authority_census_tests.py
@@ -298,6 +298,146 @@ class LifetimeTests(unittest.TestCase):
                 self.assertIn("add_to_zone(a);", code)
 
 
+class LineContinuationTests(unittest.TestCase):
+    r"""A non-raw string RUNS ON when the line ends in a backslash.
+
+    Rust's STRING_CONTINUE (Reference, "String literals"): a `\` immediately before
+    the newline escapes it, dropping the newline and the next line's leading
+    whitespace, and the literal continues. It is the ONLY way a non-raw string spans
+    a line break -- an unescaped newline inside `"..."` is a compile error -- and it
+    is how every wrapped assertion message in the tree is written:
+
+        assert!(x, "combined MV 5 must satisfy the threshold; the front-only \
+                    MV (1) would wrongly omit Assault // Battery");
+
+    A scanner that stops at the end of the line reads that continuation body as
+    CODE, which is the raw-string ceiling (#5704) and the lifetime ceiling (#5705)
+    for a third time -- and it fails in all three of their directions at once: the
+    `//` above opens a phantom comment, a `{` in a message LEAKS into the brace
+    counter, and an `add_to_zone(` inside a message is a FALSE HIT.
+    """
+
+    def test_continuation_body_is_not_code(self) -> None:
+        # The census-visible loss, in both directions on one line: the body carries
+        # a pattern (a FALSE HIT if scanned) and the tail after the close is real
+        # code (a MISSED HIT if the scanner never gets back out of the literal).
+        src = 'let s = "add_to_zone(inside) \\\n         tail"; add_to_zone(after);\n'
+        code = code_of(src)
+        self.assertNotIn("inside", code)
+        self.assertIn("add_to_zone(after);", code)
+
+    def test_continuation_brace_does_not_leak(self) -> None:
+        # The strictly worse direction: an INVENTED brace. A `{` inside the message
+        # is data; counted, it opens a scope the file never closes and brace depth
+        # drifts for every line that follows.
+        src = 'let s = "a { b \\\n         c"; let y = 1;\n'
+        code = code_of(src)
+        self.assertEqual(code.count("{"), 0)
+        self.assertEqual(code.count("}"), 0)
+        self.assertIn("let y = 1;", code)
+
+    def test_continuation_comment_markers_do_not_start_a_comment(self) -> None:
+        # `//` inside the continuation is DATA -- and it is not hypothetical: the
+        # tree's own message text says `Assault // Battery`. Read as a comment, it
+        # eats the rest of the line, including the string's own terminator, and the
+        # scanner never learns the literal closed.
+        src = 'let s = "x \\\n         a // b"; add_to_zone(after);\n'
+        code = code_of(src)
+        self.assertNotIn("//", code)
+        self.assertIn("add_to_zone(after);", code)
+
+    def test_continuation_block_comment_open_does_not_eat_the_file(self) -> None:
+        # `/*` does not stop at the end of the line: it runs to the next `*/`
+        # ANYWHERE, so a mis-scanned one eats the production code after it.
+        src = 'let s = "x \\\n         a /* b"; add_to_zone(a);\nlet z = 2;\n'
+        code = code_of(src)
+        self.assertIn("add_to_zone(a);", code)
+        self.assertIn("let z = 2;", code)
+
+    def test_multiline_continuation_across_three_lines(self) -> None:
+        # The literal is closed only by its own quote, however many continuations
+        # it takes to get there. Every intermediate line is body, not code.
+        src = 'let s = "a \\\n         b add_to_zone(mid) \\\n         c"; add_to_zone(after);\n'
+        code = code_of(src)
+        self.assertNotIn("mid", code)
+        self.assertIn("add_to_zone(after);", code)
+
+    def test_continuation_cannot_toggle_the_cfg_test_region(self) -> None:
+        # The mis-scope, end to end. A continued message that QUOTES a region marker
+        # must not arm a skip: if it does, the production code after it silently
+        # disappears and the census reports zero hits and calls that a pass.
+        src = (
+            "fn prod_before() { add_to_zone(a); }\n"
+            'const DOC: &str = "x \\\n'
+            "#[cfg(test)] \\\n"
+            "mod fake { \\\n"
+            '";\n'
+            "fn prod_after() { add_to_zone(b); }\n"
+        )
+        code = code_of(src)
+        self.assertIn("add_to_zone(a);", code)
+        self.assertIn("add_to_zone(b);", code)
+
+    def test_continuation_inside_a_cfg_test_body_does_not_desync(self) -> None:
+        # Where the tree actually keeps these: a wrapped `assert!` message inside a
+        # `#[cfg(test)]` mod. An unbalanced brace leaking out of the message walks
+        # brace tracking out through the mod's floor -- CensusError, or worse, a
+        # swallowed production tail.
+        src = (
+            "fn prod_before() { add_to_zone(a); }\n"
+            "#[cfg(test)]\n"
+            "mod tests {\n"
+            "    fn t() {\n"
+            '        assert!(x, "the {} form } } } is wrong \\\n'
+            '                    and so is this");\n'
+            "    }\n"
+            "}\n"
+            "fn prod_after() { add_to_zone(b); }\n"
+        )
+        code = code_of(src)  # must not raise CensusError
+        self.assertIn("add_to_zone(a);", code)
+        self.assertIn("add_to_zone(b);", code)
+
+    def test_byte_and_c_string_continuations(self) -> None:
+        # The prefixed non-raw forms continue exactly like a bare `"` string: the
+        # prefix is part of the token, not a separate thing the scanner may skip.
+        for prefix in ("", "b", "c"):
+            with self.subTest(prefix=prefix):
+                src = f'let s = {prefix}"a {{ add_to_zone(inside) \\\n         b"; add_to_zone(after);\n'
+                code = code_of(src)
+                self.assertNotIn("inside", code)
+                self.assertEqual(code.count("{"), 0)
+                self.assertIn("add_to_zone(after);", code)
+
+    # ---- the minimal pair: an ESCAPED backslash does not continue anything ----
+
+    def test_escaped_backslash_before_the_closing_quote_closes_the_string(self) -> None:
+        # `"a\\"` is a string holding ONE backslash, and it CLOSES. Only a backslash
+        # that escapes the NEWLINE continues; a backslash that escapes another
+        # backslash is spent. Read the wrong way, the string stays open, swallows the
+        # next line, and the miss propagates for as long as the file has quotes.
+        src = 'let s = "a\\\\"; add_to_zone(after);\nlet y = 1;\n'
+        code = code_of(src)
+        self.assertIn("add_to_zone(after);", code)
+        self.assertIn("let y = 1;", code)
+
+    def test_trailing_backslash_outside_a_string_continues_nothing(self) -> None:
+        # A `\` at the end of a line of ordinary code (Rust has no line-continuation
+        # outside literals; this shape shows up in doc/macro text) must not put the
+        # scanner into a string it never entered.
+        src = "let x = 1; \\\nadd_to_zone(after);\n"
+        self.assertIn("add_to_zone(after);", code_of(src))
+
+    def test_raw_string_is_not_continued_by_a_backslash(self) -> None:
+        # Raw strings honour NO escapes (CR-free Rust grammar): a trailing `\` inside
+        # one is content, and the very next `"` closes the literal regardless. The
+        # continuation branch must not reach into the raw branch and hold it open.
+        src = 'let s = r"a \\"; add_to_zone(after);\nlet y = 1;\n'
+        code = code_of(src)
+        self.assertIn("add_to_zone(after);", code)
+        self.assertIn("let y = 1;", code)
+
+
 class PreservedBehaviourTests(unittest.TestCase):
     """The scanner's existing contracts. The raw-string branch must not cost any
     of them."""


### PR DESCRIPTION
The census lexer closed a non-raw string only if its quote closed on the same
line. Rust's STRING_CONTINUE says otherwise: a `\` immediately before the newline
escapes it and the literal RUNS ON -- which is how every wrapped `assert!` message
in the tree is written. Scanned as code, the continuation body was the raw-string
ceiling (#5704) and the lifetime ceiling (#5705) a third time, and it failed in
all three of their directions at once: a `//` in the body opened a phantom comment
(`Assault // Battery` is real message text in this tree), a `{` LEAKED into the
brace counter, and an `add_to_zone(` in a message was a FALSE HIT.

Population, measured (instrument: an independent Rust lexer over the census
scopes, 434 scanned files / 919,557 lines): 1,114 continued-string lines in the
files the census scans, 872 more in the name-excluded ones. On production lines
the old lexer emitted 204 string-body lines as code and leaked 160 braces out of
them. The leak was live-by-luck: they balanced, so no skip region moved -- an
unbalanced one desyncs brace tracking and either raises CensusError or silently
swallows the production code after it.

ScanState now carries the third multi-line construct alongside block-comment depth
and raw-string `#` count. The three are mutually exclusive by construction: a `\`
is inert inside a raw string (no escapes at all), and either string inside a block
comment is comment text.

Old-vs-new whole-scope sweep: 204 code-text divergences, ALL of them string body
that is no longer scanned as code; 0 lines added to or removed from the production
stream; 0 hit-set changes; 0 CensusError either way. Both baselines (zone,
draw-replacement) byte-identical, `--write` idempotent, all three gates in
check-engine-authorities.sh green. Throughput 18.8 MB/s CPU (best-of-5,
process_time, 5 largest engine/src files), up from 17.9: a continuation line now
short-circuits instead of being scanned character by character.

Tests: 11 red-first cases in the seam suite (8 failures + 1 CensusError against
the old lexer) covering false hit, leaked brace, phantom line comment, phantom
block comment, 3-line continuation, cfg(test) region toggle and desync, the b/c
prefixed forms, and the minimal pairs an escaped backslash and a raw string make.
