### PR TITLE
fix(parser): bind a copy-retarget grant printed under an "if you do" gate (CR 707.10c)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3294,9 +3294,28 @@ fn recognize_counter_spell_zone_redirect(lower: &str) -> Option<SpellStackToGrav
 /// (Increasing Vengeance's "You may choose new targets for the copies" — every
 /// copy the spell makes is retargetable), `false` for the singular "the copy" /
 /// "that copy" forms (Fork/Twincast; the Chain cycle).
+///
+/// The leading `opt(parse_affirmative_reflexive_connector)` axis accepts the form
+/// where the grant is printed as the CONSEQUENT of a reflexive gate rather than as
+/// its own sentence — Spider-Verse's "you may copy it. IF YOU DO, you may choose new
+/// targets for the copy." (compare Spinerock Tyrant, which prints the same grant as a
+/// standalone sentence). Without it the clause reached the continuation recognizer
+/// still wearing its "if you do, " prefix, failed `all_consuming`, and fell through
+/// to an honest `orphaned_copy_retarget` residual — the copy was modeled, but its
+/// controller could never retarget it.
+///
+/// Folding the gate away is sound precisely BECAUSE it is affirmative and the copy it
+/// rides is itself optional: "if you do" means "if you made the copy", and a retarget
+/// permission on a copy that was never made is unreachable. So the gate carries no
+/// information the `CopySpell`'s own optionality does not already carry, and CR 707.10c
+/// is satisfied without a separate condition node. This reasoning does NOT extend to
+/// the NEGATED connectors, which is exactly why the affirmative half is its own
+/// combinator (see `oracle_nom::condition`) rather than the whole set with the
+/// condition thrown away.
 pub(super) fn parse_copy_retarget_clause(input: &str) -> OracleResult<'_, bool> {
     map(
         (
+            opt(crate::parser::oracle_nom::condition::parse_affirmative_reflexive_connector),
             opt(alt((tag(", and "), tag("and ")))),
             opt(tag("you ")),
             tag("may choose "),
@@ -3308,7 +3327,7 @@ pub(super) fn parse_copy_retarget_clause(input: &str) -> OracleResult<'_, bool> 
             )),
             opt(alt((tag("."), tag(",")))),
         ),
-        |(_, _, _, _, _, all_copies, _)| all_copies,
+        |(_, _, _, _, _, _, all_copies, _)| all_copies,
     )
     .parse(input)
 }
@@ -8687,6 +8706,34 @@ mod tests {
         assert!(!recognize_copy_retarget_clause("copy that spell"));
         assert!(!recognize_copy_retarget_clause(
             "may choose a new target for the creature"
+        ));
+
+        // CR 707.10c + CR 603.12: the grant printed as the CONSEQUENT of an
+        // AFFIRMATIVE reflexive gate rather than as its own sentence (Spider-Verse's
+        // "you may copy it. If you do, you may choose new targets for the copy.").
+        // The gate is redundant on an already-optional copy — no copy, nothing to
+        // retarget — so it folds into the same continuation.
+        assert!(recognize_copy_retarget_clause(
+            "if you do, you may choose new targets for the copy."
+        ));
+        assert!(recognize_copy_retarget_clause(
+            "when you do, you may choose new targets for the copies"
+        ));
+        assert_eq!(
+            copy_retarget_clause_all_copies("if you do, you may choose new targets for the copies"),
+            Some(true),
+            "the gate must not disturb the plurality axis"
+        );
+
+        // A NEGATED reflexive gate must NOT be folded away. "if you don't" gates a
+        // branch that runs precisely when the antecedent did NOT happen, so swallowing
+        // it into an unconditional retarget permission would invert the clause. Only
+        // the affirmative half of the connector set is accepted.
+        assert!(!recognize_copy_retarget_clause(
+            "if you don't, you may choose new targets for the copy"
+        ));
+        assert!(!recognize_copy_retarget_clause(
+            "if they don't, you may choose new targets for the copy"
         ));
     }
 

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -10418,6 +10418,41 @@ fn effect_copy_retarget_binds_across_wither_rider_spinerock_tyrant() {
     );
 }
 
+/// CR 707.10c + CR 603.12: Spider-Verse — the retarget grant is printed as the
+/// CONSEQUENT of a reflexive gate ("you may copy it. IF YOU DO, you may choose new
+/// targets for the copy.") rather than as its own sentence. It must still bind to
+/// the copy.
+///
+/// This is the class boundary against Spinerock Tyrant (tested above), which prints
+/// the identical grant as a standalone sentence and always worked. Before the fix the
+/// gated form reached the continuation recognizer still wearing its "if you do, "
+/// prefix, failed to match, and fell through to an honest `orphaned_copy_retarget` —
+/// so the copy existed but could never be retargeted.
+///
+/// Folding the gate away is sound because it is AFFIRMATIVE and the copy is already
+/// optional: "if you do" means "if you made the copy", and a retarget permission on a
+/// copy that was never made is unreachable.
+#[test]
+fn effect_copy_retarget_binds_through_if_you_do_gate_spider_verse() {
+    let (retargets, orphaned) = copy_retarget_scan_card(
+        "The \"legend rule\" doesn't apply to Spiders you control.\n\
+         Whenever you cast a spell from anywhere other than your hand, you may copy it. \
+         If you do, you may choose new targets for the copy. If the copy is a permanent \
+         spell, it gains haste. Do this only once each turn.",
+        "Spider-Verse",
+        &["Enchantment"],
+        &[],
+    );
+    assert_eq!(
+        orphaned, 0,
+        "the gated retarget clause must bind, not survive as an orphaned residual"
+    );
+    assert!(
+        retargets.contains(&CopyRetargetPermission::MayChooseNewTargets),
+        "the copy must carry MayChooseNewTargets (CR 707.10c), got {retargets:?}"
+    );
+}
+
 /// CR 707.10c: COVERAGE HONESTY — a "you may choose new targets for the copy"
 /// sentence with NO preceding `CopySpell` anywhere in the chain must stay an
 /// honest `orphaned_copy_retarget` residual, never a silently-wrong retarget.

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -8583,12 +8583,20 @@ pub fn parse_you_draw_this_way_condition(input: &str) -> OracleResult<'_, Abilit
     ))
 }
 
-/// CR 603.12 + CR 608.2c: Recognize a leading reflexive-conditional connector
-/// and return the corresponding AbilityCondition with the connector consumed.
-/// Single authority for this set; consumed by both
-/// `oracle_effect::conditions::strip_if_you_do_conditional` and the
-/// `oracle_effect::sequence` chunk-splitter sticky-detection so they never drift.
-pub(crate) fn parse_reflexive_conditional_connector(
+/// CR 603.12: the AFFIRMATIVE half of the reflexive-conditional connector set —
+/// "the preceding optional effect WAS performed" ("if you do, ", "when you do, ",
+/// "if they do, ", …).
+///
+/// Split out from [`parse_reflexive_conditional_connector`] because the two halves
+/// are NOT interchangeable to a consumer that wants to fold the gate away. A gate
+/// that is redundant in the affirmative — a permission attached to an effect that
+/// only exists when the antecedent happened, e.g. CR 707.10c's "If you do, you may
+/// choose new targets for the copy" riding an already-optional `CopySpell` — is the
+/// exact OPPOSITE of redundant in the negative ("if they don't, …" gates a branch
+/// that runs precisely when the antecedent did NOT happen). A consumer must
+/// therefore be able to ask for the affirmative set ALONE; matching the whole set
+/// and discarding the condition would silently invert a negated clause.
+pub(crate) fn parse_affirmative_reflexive_connector(
     input: &str,
 ) -> OracleResult<'_, AbilityCondition> {
     alt((
@@ -8606,6 +8614,19 @@ pub(crate) fn parse_reflexive_conditional_connector(
             AbilityCondition::effect_performed(),
             tag("if the player does, "),
         ),
+        value(AbilityCondition::effect_performed(), tag("if you do, ")),
+    ))
+    .parse(input)
+}
+
+/// CR 603.12: the NEGATED half — "the preceding optional effect was NOT performed".
+///
+/// Kept disjoint from the affirmative half by construction, not by luck: each tag
+/// here ends in `n't, `, so no affirmative tag (which requires `, ` immediately
+/// after the verb) can prefix-match one of these. Splitting the original single
+/// `alt` into two therefore preserves its behavior exactly.
+fn parse_negated_reflexive_connector(input: &str) -> OracleResult<'_, AbilityCondition> {
+    alt((
         value(
             AbilityCondition::Not {
                 condition: Box::new(AbilityCondition::effect_performed()),
@@ -8624,7 +8645,25 @@ pub(crate) fn parse_reflexive_conditional_connector(
             },
             tag("if they don't, "),
         ),
-        value(AbilityCondition::effect_performed(), tag("if you do, ")),
+    ))
+    .parse(input)
+}
+
+/// CR 603.12 + CR 608.2c: Recognize a leading reflexive-conditional connector
+/// and return the corresponding AbilityCondition with the connector consumed.
+/// Single authority for this set; consumed by both
+/// `oracle_effect::conditions::strip_if_you_do_conditional` and the
+/// `oracle_effect::sequence` chunk-splitter sticky-detection so they never drift.
+///
+/// Composed from the affirmative + negated halves so a consumer that needs only one
+/// polarity (CR 707.10c copy-retarget) shares this exact tag set rather than
+/// re-spelling it.
+pub(crate) fn parse_reflexive_conditional_connector(
+    input: &str,
+) -> OracleResult<'_, AbilityCondition> {
+    alt((
+        parse_affirmative_reflexive_connector,
+        parse_negated_reflexive_connector,
     ))
     .parse(input)
 }


### PR DESCRIPTION
Spider-Verse prints its retarget grant as the CONSEQUENT of a reflexive gate —
"you may copy it. IF YOU DO, you may choose new targets for the copy." — rather
than as its own sentence. The copy was modeled, but its controller could never
retarget it: CR 707.10c silently unhonored.

The asymmetry that caused it: the followup-continuation recognizer sees the chunk
BEFORE the condition machinery runs, so it was handed "if you do, you may choose
new targets for the copy" and `recognize_copy_retarget_clause` (an
`all_consuming` grammar with no gate axis) rejected it. The clause then fell
through to the normal path, where `strip_if_you_do_conditional` DID peel the
prefix — so by the time it reached the effect parser the text was bare, the same
recognizer now matched, and it lowered to an honest `orphaned_copy_retarget`
residual. One recognizer, two different inputs, depending on which side of the
condition strip it ran on.

Give `parse_copy_retarget_clause` an optional leading affirmative-reflexive-gate
axis. Compare Spinerock Tyrant, which prints the identical grant as a standalone
sentence and always bound correctly — the two are the same clause wearing
different grammar, so this is one more axis on an existing combinator, not a new
parser.

Folding the gate away is sound BECAUSE it is affirmative and the copy it rides is
itself optional: "if you do" means "if you made the copy", and a retarget
permission on a copy that was never made is unreachable. The gate carries no
information the `CopySpell`'s own optionality does not already carry.

That reasoning does NOT extend to the negated connectors ("if they don't, …"
gates a branch that runs precisely when the antecedent did NOT happen), so
matching the whole connector set and discarding the condition would silently
invert those clauses. `parse_reflexive_conditional_connector` is therefore split
into its affirmative and negated halves, and the retarget clause consumes only
the affirmative one. The two halves are disjoint by construction, not by luck —
every negated tag ends in `n't, ` and every affirmative tag requires `, `
immediately after the verb — so splitting the original single `alt` preserves its
behavior exactly.

Measured full-pool, dual export (35,396 faces). Because this change touches a
combinator shared with `strip_if_you_do_conditional` and the chunk-splitter, the
copy-retarget ledger alone would be blind to collateral on other channels, so the
invariant is checked by diffing every face's ENTIRE tree:

  faces with ANY structural change, on ANY channel: 1
    spider-verse  retargets=[Keep] orphans=1  ->  retargets=[May] orphans=0

Zero regressions. Zero faces outside the set touched. The connector split is
behavior-preserving for all 35,395 other faces.
