### PR TITLE
fix(gate): lex the cross-product detector's alt blocks as CODE, not raw text (#76)

### DIFF
--- a/scripts/check-parser-combinators.sh
+++ b/scripts/check-parser-combinators.sh
@@ -58,6 +58,39 @@ if [ -n "${GIT_INDEX_FILE:-}" ] || [ "$BASE" = "$(git rev-parse HEAD 2>/dev/null
     DIFF_MODE="--cached"
 fi
 
+# ---------------------------------------------------------------------------
+# DO NOT "harden" families (A), (B), (E), (F) by filtering them through the
+# census lexer (scripts/zone_authority_census.py `strip_noncode`). It looks like
+# the obvious single-authority move. It would BLIND this gate. (#76)
+#
+# Those families match ON the string literal itself:
+#
+#     .contains("        "lit" =>        == "long sentence"        name: "..."
+#
+# `strip_noncode` returns a code stream with literals REMOVED, so the very quote
+# each pattern keys on is gone: every one of them would silently stop matching
+# real violations, and the gate would pass string-matching parser code forever
+# while reporting green. (Measured during #76: routing these through stripped
+# code misread 194 REAL match arms as non-matches.)
+#
+# What they are exposed to is the mirror-image, and it is BENIGN: a forbidden
+# pattern written inside a COMMENT or a literal is a FALSE HIT. That is loud (it
+# blocks a commit, the author sees exactly why) and it already has an escape
+# hatch (`// allow-noncombinator:`). #76 measured 10 such lines in the whole
+# parser scope, all of them doc comments describing the forbidden pattern.
+# A false MISS from this class is structurally impossible here: these greps read
+# raw text, so literal-awareness could only ever REMOVE matches, never add them.
+#
+# If the false hits ever become a real cost, the fix is NOT strip_noncode: it is
+# a POSITION mask (which character offsets are code vs comment vs literal), and
+# these greps would filter candidates by match offset. Two APIs, one grammar.
+#
+# Family (D) is the opposite case and DOES delegate: it needs paren counting on
+# CODE (see scripts/lib/detect-cross-product-alts.py), where a `)` inside
+# `take_until(")")` is data. It reads structure from the code stream and arms
+# from the raw text.
+# ---------------------------------------------------------------------------
+
 # (A) String-method dispatch. The "..." suffix on `.contains` / `.starts_with`
 # / `.ends_with` / `.find` / `.rfind` / `.split` / `.trim_*_matches` matches
 # only string-literal arguments — `.contains(&item)` (Vec/slice op),
@@ -142,6 +175,23 @@ files=$(git diff $DIFF_MODE --name-only "$BASE" -- "$SCOPE" \
 if [ -z "$files" ]; then
     printf 'Gate A PASS head=%s base=%s\n' "$HEAD_SHA" "$BASE_SHA"
     exit 0
+fi
+
+# (D0) Family (D)'s own seam suite, ahead of the scan it protects — the same
+# shape as section (B0) of check-engine-authorities.sh, and for the same reason.
+# The cross-product detector finds an `alt` block's end by COUNTING PARENS, which
+# is a lex; a regression there does not fail this gate, it silently mis-scopes it
+# in both directions (a phantom block from an `alt((` in a comment BLOCKS a good
+# commit; a stray `))` in a comment truncates a real block so a cross product
+# SHIPS). Neither shows up as a failure here, so the suite that pins the lexing
+# runs first. It costs ~5ms and only when parser files actually changed.
+if command -v python3 >/dev/null 2>&1 && [ -f "$SCRIPT_DIR/lib/detect_cross_product_alts_tests.py" ]; then
+    if ! python3 "$SCRIPT_DIR/lib/detect_cross_product_alts_tests.py" >/dev/null 2>&1; then
+        echo "ERROR: the cross-product detector's own test suite is RED." >&2
+        echo "       Family (D) cannot be trusted until it passes:" >&2
+        echo "           python3 scripts/lib/detect_cross_product_alts_tests.py" >&2
+        exit 1
+    fi
 fi
 
 while IFS= read -r file; do

--- a/scripts/lib/detect-cross-product-alts.py
+++ b/scripts/lib/detect-cross-product-alts.py
@@ -24,6 +24,11 @@ Exit code is always 0; the caller decides pass/fail from whether output is empty
 
 import re
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from zone_authority_census import ScanState, strip_noncode  # noqa: E402
 
 # Conservative thresholds (see check-parser-combinators.sh family D). A genuine
 # cross product has many arms that are nearly identical — long shared prefix AND
@@ -62,20 +67,52 @@ def common_suffix(strings):
     return common_prefix([s[::-1] for s in strings])[::-1]
 
 
+def code_stream(lines):
+    """`lines` with comments and string/char literals removed.
+
+    Delegated to the census lexer (scripts/zone_authority_census.py), which is the
+    single authority for CODE-STREAM lexing in this repo. It already knows raw
+    strings (#5704), char-vs-lifetime ticks (#5705) and backslash-continued
+    strings (#5715) — three bugs this detector would otherwise have had to
+    rediscover one at a time, each of them a literal scanned as code.
+    """
+    out = []
+    state = ScanState()
+    for line in lines:
+        code, state = strip_noncode(line.rstrip("\n"), state)
+        out.append(code)
+    return out
+
+
 def alt_blocks(lines):
     """Yield (start_idx, end_idx, [tag_literals]) for each `alt((...))`, 0-based
-    inclusive line indices. Nested alts are yielded independently."""
+    inclusive line indices. Nested alts are yielded independently.
+
+    TWO views of the source, and the split is the whole design (#76):
+
+        STRUCTURE (does an `alt((` open here? where do its parens balance?)
+            read off the CODE STREAM. A `)` inside `take_until(")")` is data, and
+            counted as code it closes the block early — the arms below are never
+            collected and a real cross product ships unflagged, past the gate
+            built to stop it. An `alt((` inside a COMMENT is likewise not an alt.
+
+        CONTENT (which literals are the arms?)
+            read off the RAW text. The arms ARE string literals: a detector that
+            looked for them in the stripped stream would find none, ever, and
+            flag nothing — blind, not hardened. This is exactly why the gate's
+            sibling families (A/B/E/F, in check-parser-combinators.sh) must NOT
+            be routed through strip_noncode: they match ON the literal.
+    """
+    codes = code_stream(lines)
     n = len(lines)
-    for idx, line in enumerate(lines):
-        if not ALT_OPEN_RE.search(line):
+    for idx, code in enumerate(codes):
+        if not ALT_OPEN_RE.search(code):
             continue
         depth = 0
         started = False
-        buf = []
         end = idx
         for j in range(idx, min(idx + 60, n)):
-            buf.append(lines[j])
-            for ch in lines[j]:
+            for ch in codes[j]:
                 if ch == '(':
                     depth += 1
                     started = True
@@ -84,24 +121,19 @@ def alt_blocks(lines):
             end = j
             if started and depth <= 0:
                 break
-        tags = TAG_RE.findall('\n'.join(buf))
+        tags = TAG_RE.findall(''.join(lines[idx:end + 1]))
         yield idx, end, tags
 
 
-def main():
-    if len(sys.argv) != 2:
-        sys.stderr.write("usage: detect-cross-product-alts.py <file> (diff on stdin)\n")
-        return 0
-    path = sys.argv[1]
-    added = added_lines_from_diff(sys.stdin.read())
-    if not added:
-        return 0
-    try:
-        with open(path, encoding="utf-8") as f:
-            lines = f.readlines()
-    except OSError:
-        return 0
+def flagged_blocks(lines, added, path):
+    """Report lines for every flagged cross-product block. Pure: no I/O.
 
+    Split out from `main` so the gate's DECISION is testable at the seam it is
+    enforced on. The witnesses that matter are flag decisions ("does this block
+    the commit?"), not block coordinates, and a test that can only reach the
+    latter cannot pin the former.
+    """
+    out = []
     for start, end, tags in alt_blocks(lines):
         uniq = []
         for t in tags:
@@ -121,14 +153,38 @@ def main():
         if not added.intersection(block_range):
             continue
         # Escape hatch: allow-noncombinator anywhere in the block or directly above.
+        # Read off the RAW lines, deliberately: the annotation IS a comment, so a
+        # scan that consulted stripped code here would strip the escape hatch away
+        # and re-flag every annotated block. Structure comes from the code stream;
+        # anything whose content is the point (annotations, tag literals) is read
+        # from the raw text. See #76.
         window = lines[max(0, start - 1): end + 1]
         if any("allow-noncombinator" in w for w in window):
             continue
-        print(f"  {path}:{start + 1}  ({len(uniq)} arms, shared prefix {cp!r} + suffix {cs!r})")
+        out.append(f"  {path}:{start + 1}  ({len(uniq)} arms, shared prefix {cp!r} + suffix {cs!r})")
         for t in uniq[:6]:
-            print(f'    tag("{t}")')
+            out.append(f'    tag("{t}")')
         if len(uniq) > 6:
-            print(f"    ... +{len(uniq) - 6} more")
+            out.append(f"    ... +{len(uniq) - 6} more")
+    return out
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: detect-cross-product-alts.py <file> (diff on stdin)\n")
+        return 0
+    path = sys.argv[1]
+    added = added_lines_from_diff(sys.stdin.read())
+    if not added:
+        return 0
+    try:
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError:
+        return 0
+
+    for report in flagged_blocks(lines, added, path):
+        print(report)
 
     return 0
 

--- a/scripts/lib/detect_cross_product_alts_tests.py
+++ b/scripts/lib/detect_cross_product_alts_tests.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Tests for family (D) of the parser-combinator gate (detect-cross-product-alts.py).
+
+The detector finds the END of an `alt((...))` block by counting parentheses. That
+count is a LEX, and a lex that reads literals and comments as code is the ceiling
+class that has now bitten this repo's other scanner three times (raw strings
+#5704, lifetimes #5705, backslash-continued strings #5715). Here it has teeth in
+BOTH directions, because the gate it feeds is diff-based and commit-blocking:
+
+    a comment that OPENS a phantom block   -> FALSE HIT   -> blocks a good commit
+    a comment that TRUNCATES a real block  -> FALSE MISS  -> a real cross-product
+                                                             alt lands on main, i.e.
+                                                             string-matching parsing
+                                                             ships past the gate
+                                                             built to stop it
+
+So the tests drive `flagged_blocks` — the DECISION — not the block coordinates.
+A test that can only see coordinates cannot pin what the gate actually does.
+
+Run:  python3 scripts/lib/detect_cross_product_alts_tests.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "detect_cross_product_alts", Path(__file__).with_name("detect-cross-product-alts.py")
+)
+xp = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(xp)
+
+
+def flags(src: str) -> list[str]:
+    """Every flag the gate would raise on `src`, with the whole file treated as
+    added (the gate only reports blocks a diff touches; here everything is new)."""
+    lines = src.splitlines(keepends=True)
+    added = set(range(1, len(lines) + 1))
+    return xp.flagged_blocks(lines, added, "t.rs")
+
+
+# A genuine 4-arm cross product: same prefix, same suffix, one varying interior
+# word. This is the shape the gate exists to catch (PATTERNS.md 8b).
+CROSS_PRODUCT_ARMS = (
+    '        tag("in addition to its other types"),\n'
+    '        tag("in addition to their other types"),\n'
+    '        tag("in addition to his other types"),\n'
+    '        tag("in addition to her other types"),\n'
+)
+
+
+class CommentLexingTests(unittest.TestCase):
+    """A comment is not code. The paren counter must not read one."""
+
+    def test_comment_mentioning_alt_does_not_open_a_phantom_block(self) -> None:
+        # FALSE HIT. A comment that merely QUOTES `alt((` — e.g. explaining the
+        # factoring that was already done — opens a block in a raw-text scan. The
+        # block then swallows the ordinary `tag(...)` bindings below it, which
+        # share a prefix and suffix because they are the same grammar axis, and
+        # the gate blocks a commit over an `alt` that does not exist.
+        src = (
+            "// Historical note: this used to be a flat `alt((\n"
+            "// ... which we since factored. Do not reintroduce.\n"
+            "fn parse_axis(i: &str) -> IResult<&str, ()> {\n"
+            '    let a = tag("in addition to its other types");\n'
+            '    let b = tag("in addition to their other types");\n'
+            '    let c = tag("in addition to his other types");\n'
+            '    let d = tag("in addition to her other types");\n'
+            "    Ok((i, ()))\n"
+            "}\n"
+        )
+        self.assertEqual(flags(src), [])
+
+    def test_stray_parens_in_a_comment_do_not_truncate_a_real_block(self) -> None:
+        # FALSE MISS — the direction that matters. `alt((` gives the counter two
+        # units of depth headroom, so ONE stray paren is survivable; two are not.
+        # A comment inside the block carrying `))` closes it early, the arms below
+        # are never collected, and a real cross product ships unflagged.
+        src = (
+            "fn f(i: &str) -> IResult<&str, ()> {\n"
+            "    alt((\n"
+            '        // handles the ")" and "))" cases))\n'
+            f"{CROSS_PRODUCT_ARMS}"
+            "    ))\n"
+            "    .parse(i)\n"
+            "}\n"
+        )
+        self.assertEqual(len(flags(src)), 5)  # 1 header + 4 arm lines
+        self.assertIn("4 arms", flags(src)[0])
+
+    def test_block_comment_inside_an_alt_does_not_desync(self) -> None:
+        # The same failure with `/* */`, which does not stop at the end of a line.
+        src = (
+            "fn f(i: &str) -> IResult<&str, ()> {\n"
+            "    alt((\n"
+            "        /* the )) shape\n"
+            "           spans lines )) */\n"
+            f"{CROSS_PRODUCT_ARMS}"
+            "    ))\n"
+            "    .parse(i)\n"
+            "}\n"
+        )
+        self.assertIn("4 arms", flags(src)[0])
+
+
+class LiteralLexingTests(unittest.TestCase):
+    """A string literal is not code either. Its parens are data."""
+
+    def test_paren_inside_a_tag_literal_does_not_end_the_block(self) -> None:
+        # `take_until(")")` is real parser code (oracle.rs and static_helpers.rs
+        # both carry one). The `)` inside the literal is DATA; counted, it eats
+        # the block's depth and can close it before the arms are read.
+        src = (
+            "fn f(i: &str) -> IResult<&str, ()> {\n"
+            "    alt((\n"
+            '        preceded(take_until("))"), tag("in addition to its other types")),\n'
+            '        tag("in addition to their other types"),\n'
+            '        tag("in addition to his other types"),\n'
+            '        tag("in addition to her other types"),\n'
+            "    ))\n"
+            "    .parse(i)\n"
+            "}\n"
+        )
+        self.assertIn("4 arms", flags(src)[0])
+
+    def test_raw_string_parens_are_data(self) -> None:
+        # A raw string honours no escapes and can hold anything, parens included.
+        src = (
+            "fn f(i: &str) -> IResult<&str, ()> {\n"
+            "    alt((\n"
+            '        preceded(tag(r#"))"#), tag("in addition to its other types")),\n'
+            '        tag("in addition to their other types"),\n'
+            '        tag("in addition to his other types"),\n'
+            '        tag("in addition to her other types"),\n'
+            "    ))\n"
+            "    .parse(i)\n"
+            "}\n"
+        )
+        self.assertIn("4 arms", flags(src)[0])
+
+
+class PreservedBehaviourTests(unittest.TestCase):
+    """What the gate already does correctly, and must keep doing. The lexer
+    delegation must not cost any of it."""
+
+    def test_real_cross_product_is_flagged(self) -> None:
+        src = (
+            "fn f(i: &str) -> IResult<&str, ()> {\n"
+            "    alt((\n"
+            f"{CROSS_PRODUCT_ARMS}"
+            "    ))\n"
+            "    .parse(i)\n"
+            "}\n"
+        )
+        out = flags(src)
+        self.assertIn("4 arms", out[0])
+        self.assertIn("in addition to ", out[0])
+
+    def test_distinct_word_dispatch_is_not_flagged(self) -> None:
+        # destroy/exile/sacrifice share neither prefix nor suffix: a legitimate
+        # alt, and never the gate's business.
+        src = (
+            "fn f(i: &str) -> IResult<&str, ()> {\n"
+            "    alt((\n"
+            '        tag("destroy"),\n'
+            '        tag("exile"),\n'
+            '        tag("sacrifice"),\n'
+            '        tag("counter"),\n'
+            "    ))\n"
+            "    .parse(i)\n"
+            "}\n"
+        )
+        self.assertEqual(flags(src), [])
+
+    def test_allow_noncombinator_annotation_still_exempts(self) -> None:
+        # The escape hatch lives in a COMMENT. Structure is read off the code
+        # stream, but the annotation's CONTENT is the point — so it is read off the
+        # RAW line. A scan that consulted stripped code here would strip the hatch
+        # away and re-flag every annotated block in the tree.
+        src = (
+            "fn f(i: &str) -> IResult<&str, ()> {\n"
+            "    // allow-noncombinator: the axes are genuinely independent here\n"
+            "    alt((\n"
+            f"{CROSS_PRODUCT_ARMS}"
+            "    ))\n"
+            "    .parse(i)\n"
+            "}\n"
+        )
+        self.assertEqual(flags(src), [])
+
+    def test_tag_literals_are_read_from_raw_text_not_stripped_code(self) -> None:
+        # The other half of the two-API split, pinned: the block's STRUCTURE comes
+        # from the code stream, but the arms ARE string literals. A detector that
+        # collected its tags from stripped code would find zero arms and flag
+        # nothing, ever — blind, not hardened. (#76)
+        src = (
+            "fn f(i: &str) -> IResult<&str, ()> {\n"
+            "    alt((\n"
+            f"{CROSS_PRODUCT_ARMS}"
+            "    ))\n"
+            "    .parse(i)\n"
+            "}\n"
+        )
+        self.assertIn('tag("in addition to its other types")', "\n".join(flags(src)))
+
+    def test_untouched_blocks_are_frozen(self) -> None:
+        # The gate only reports blocks a diff TOUCHES. A pre-existing offender that
+        # no added line intersects stays frozen in amber.
+        src = (
+            "fn f(i: &str) -> IResult<&str, ()> {\n"
+            "    alt((\n"
+            f"{CROSS_PRODUCT_ARMS}"
+            "    ))\n"
+            "}\n"
+        )
+        lines = src.splitlines(keepends=True)
+        self.assertEqual(xp.flagged_blocks(lines, set(), "t.rs"), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Family (D) of the parser-combinator gate finds an `alt((...))` block's end by
counting parentheses over RAW text. That count is a lex, and a lex that reads
literals and comments as code is the ceiling class that has now bitten this
repo's census scanner three times (raw strings #5704, lifetimes #5705,
backslash-continued strings #5715). Here it has teeth in BOTH directions,
because the gate it feeds is commit-blocking:

  FALSE HIT   an `alt((` written inside a COMMENT opens a phantom block, which
              swallows the ordinary tag() bindings below it and blocks a good
              commit over an `alt` that does not exist.
  FALSE MISS  a comment carrying `))` exhausts the counter's depth headroom and
              truncates a REAL block: the arms are never collected and a genuine
              cross-product alt ships past the gate built to stop it. This is
              string-matching parsing landing on main with a green gate.

Both are witnessed and committed as tests. In-tree today the bug is live-by-luck:
9 of 2,853 alt blocks in crates/engine/src/parser have their end line computed
wrong (all of them phantom blocks opened by an `alt((` inside a comment), but
zero FLAG DECISIONS change. Equivalence sweep old-vs-new over every block, with
every line treated as added: 0 decision changes, and the block count falls
2,853 -> 2,844, exactly the 9 phantoms and nothing else. Positive control on the
sweep harness: it reports a decision change on both witnesses, so the zero is a
finding rather than a dead probe.

DEPENDENCY DIRECTION, deliberately narrow: family (D) now imports the census
module's lexer (scripts/zone_authority_census.py). Single authority for
CODE-STREAM lexing -- explicitly NOT for literal matching. The detector reads
STRUCTURE (where does `alt((` open, where do its parens balance?) from the
stripped code stream, and CONTENT (which literals are the arms? is there an
allow-noncombinator annotation?) from the raw text. Two views, one grammar.

The same commit documents why the gate's OTHER families must NOT follow. (A),
(B), (E) and (F) match ON the string literal (`.contains("`, `"lit" =>`,
`== "long"`, `name: "..."`); routing them through strip_noncode would delete the
very quote they key on and BLIND the gate -- it would pass string-matching parser
code forever while reporting green. Measured during #76: 194 real match arms go
unmatched that way. Their exposure to this class is the benign mirror image, a
false hit that is loud and already escape-hatched (`// allow-noncombinator:`);
#76 measured 10 such lines in the whole parser scope, all doc comments describing
the forbidden pattern. A comment block at the grep definitions pins this where a
future "hardener" would edit.

The detector's seam suite runs from the gate (section D0), ahead of the scan it
protects -- the same shape as section (B0) of check-engine-authorities.sh, and
for the same reason: a lexing regression here does not FAIL this gate, it
silently mis-scopes it. Watched red (a deliberately broken suite fails the gate)
and green. Zone and draw baselines are untouched and byte-identical; this change
is gate-internal.

Audit outcome for the other scanners in #76: scripts/audit-parser.py is NOT A
MEMBER (it never opens a .rs file -- its only input is card-data.json), and
scripts/gen-test-fixture.py is benign-directional (over-harvest is fixture bloat;
a missed card is loud at test runtime). Neither is changed.
