### PR TITLE
fix(parser): lower the next-cast copy in the possessive word order (CR 603.7)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -1208,11 +1208,22 @@ fn try_parse_enters_this_way_additional_counter(lower: &str) -> Option<Effect> {
 fn try_parse_when_next_event(tp: TextPair) -> Option<ParsedEffectClause> {
     use crate::types::triggers::TriggerMode;
 
-    // Must start with "when you next cast a " or "when you next cast an ".
-    // Article choice depends on the payload — "a creature spell" vs "an instant or sorcery spell".
-    let article_result: nom::IResult<&str, &str, OracleError<'_>> =
-        alt((tag("when you next cast a "), tag("when you next cast an "))).parse(tp.lower);
-    let Ok((_, matched_prefix)) = article_result else {
+    // CR 603.7: the SAME one-shot next-cast delayed trigger is printed with two word
+    // orders, and they are grammar variants of one clause, not two clauses:
+    //   "when you NEXT CAST a[n] <spell> this turn"  — Galvanic Iteration, Doublecast
+    //   "when you CAST YOUR NEXT <spell> this turn"  — Twinferno
+    // One `alt` over the openings — parameterize the opening, don't proliferate the
+    // parser. The payload after either is the same "[type-phrase] spell
+    // [post-modifier]" shape, so every downstream stage is untouched. (The article is
+    // part of the first opening because it varies with the payload — "a creature
+    // spell" vs "an instant or sorcery spell"; the possessive opening takes none.)
+    let opening_result: nom::IResult<&str, &str, OracleError<'_>> = alt((
+        tag("when you next cast a "),
+        tag("when you next cast an "),
+        tag("when you cast your next "),
+    ))
+    .parse(tp.lower);
+    let Ok((_, matched_prefix)) = opening_result else {
         // CR 603.7: non-cast "when you next <event> this turn" one-shot delayed
         // triggers (e.g. All-Out Assault "When you next attack this turn, ...").
         // The spell-cast arm above owns the rich spell-filter / disjunction

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -10453,6 +10453,37 @@ fn effect_copy_retarget_binds_through_if_you_do_gate_spider_verse() {
     );
 }
 
+/// CR 603.7 + CR 707.10c: Twinferno — the next-cast delayed trigger printed in the
+/// POSSESSIVE word order ("when you CAST YOUR NEXT instant or sorcery spell this
+/// turn") rather than the adverbial one ("when you NEXT CAST an instant or sorcery
+/// spell this turn", Galvanic Iteration).
+///
+/// The two are the same clause wearing different grammar. Before the fix only the
+/// adverbial opening was recognized, so Twinferno produced NO delayed trigger at all
+/// — the copy was dropped outright and its retarget sentence was left as an honest
+/// `orphaned_copy_retarget` residual (a correct refusal to bind a copy that did not
+/// exist, which is why the orphan is the symptom and not the disease).
+#[test]
+fn effect_next_cast_copy_lowers_in_possessive_word_order_twinferno() {
+    let (retargets, orphaned) = copy_retarget_scan_card(
+        "Choose one —\n\
+         • When you cast your next instant or sorcery spell this turn, copy that spell. \
+         You may choose new targets for the copy.\n\
+         • Target creature you control gains double strike until end of turn.",
+        "Twinferno",
+        &["Instant"],
+        &[],
+    );
+    assert_eq!(
+        orphaned, 0,
+        "the copy must be lowered, so its retarget clause has something to bind to"
+    );
+    assert!(
+        retargets.contains(&CopyRetargetPermission::MayChooseNewTargets),
+        "the delayed-trigger CopySpell must carry MayChooseNewTargets, got {retargets:?}"
+    );
+}
+
 /// CR 707.10c: COVERAGE HONESTY — a "you may choose new targets for the copy"
 /// sentence with NO preceding `CopySpell` anywhere in the chain must stay an
 /// honest `orphaned_copy_retarget` residual, never a silently-wrong retarget.


### PR DESCRIPTION
Twinferno's "When you CAST YOUR NEXT instant or sorcery spell this turn, copy
that spell." produced no delayed trigger at all — the copy was dropped outright,
and its "You may choose new targets for the copy" sentence was left as an honest
`orphaned_copy_retarget` residual. The orphan was the symptom, not the disease:
the retarget clause was correctly refusing to bind to a copy that did not exist.

`try_parse_when_next_event` dispatched on `alt((tag("when you next cast a "),
tag("when you next cast an ")))`. Magic prints this one clause in two word orders
and we only accepted the adverbial one:

  "when you NEXT CAST a[n] <spell> this turn"   Galvanic Iteration, Doublecast
  "when you CAST YOUR NEXT <spell> this turn"   Twinferno

Add the possessive opening to that `alt`. The payload after either opening is the
same "[type-phrase] spell [post-modifier]" shape, so `extract_when_next_spell_filter`
and every downstream stage are untouched — this parameterizes the opening rather
than proliferating a second parser for the same clause.

Filed under #62, whose premise this partly FALSIFIES: the task described Twinferno
as a MODAL-nesting gap ("copy not lowered inside a modal delayed trigger"). It is
not. Modes are irrelevant — the identical text outside a mode fails the same way,
and the identical text in the adverbial word order inside a mode works. The gap is
purely the opening's word order.

Honest scope, measured rather than assumed: "cast your next" appears on 3 cards in
the pool, but Flaming Fist Duskguard and Valiant Farewell print it inside a quoted
boon with no " this turn, " delimiter, so they stay gapped and this fix does not
claim them. The measured delta is 1 face.

Full-pool dual export (35,396 faces), whole-face structural diff — every face's
ENTIRE tree compared, not just the copy-retarget channel:

  faces with ANY structural change: 1
    twinferno   retargets=[] orphans=1  ->  retargets=[MayChooseNewTargets] orphans=0

Zero regressions. Positive controls Galvanic Iteration and Doublecast unchanged.
Pool-wide `orphaned_copy_retarget` residuals: 7 -> 5.
