### PR TITLE
ship/cr614 instead branch

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -1910,6 +1910,8 @@ fn legacy_ability_condition(x: &AbilityCondition) -> bool {
         | AbilityCondition::CastVariantPaidInstead { .. }
         | AbilityCondition::HasMaxSpeed
         | AbilityCondition::IsMonarch
+        // CR 309.7: controller-state predicate; reads no object, writes nothing.
+        | AbilityCondition::CompletedDungeon { .. }
         | AbilityCondition::IsInitiative
         | AbilityCondition::HasCityBlessing
         | AbilityCondition::IsRingBearer
@@ -5886,6 +5888,8 @@ fn rw_ability_condition(x: &AbilityCondition) -> RwProfile {
         | AbilityCondition::CastVariantPaidInstead { .. }
         | AbilityCondition::HasMaxSpeed
         | AbilityCondition::IsMonarch
+        // CR 309.7: controller-state predicate; reads no object, writes nothing.
+        | AbilityCondition::CompletedDungeon { .. }
         | AbilityCondition::IsInitiative
         | AbilityCondition::HasCityBlessing
         | AbilityCondition::IsRingBearer

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -2233,6 +2233,8 @@ fn scan_ability_condition(x: &AbilityCondition) -> Axes {
         }
         AbilityCondition::HasMaxSpeed => Axes::NONE,
         AbilityCondition::IsMonarch => Axes::NONE,
+        // CR 309.7: controller-state predicate — touches no scan axis.
+        AbilityCondition::CompletedDungeon { .. } => Axes::NONE,
         AbilityCondition::IsInitiative => Axes::NONE,
         AbilityCondition::HasCityBlessing => Axes::NONE,
         AbilityCondition::IsRingBearer => Axes::NONE,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3715,6 +3715,10 @@ fn fmt_ability_condition(cond: &AbilityCondition) -> String {
         ),
         AbilityCondition::HasMaxSpeed => "has max speed".into(),
         AbilityCondition::IsMonarch => "is monarch".into(),
+        AbilityCondition::CompletedDungeon { specific } => match specific {
+            None => "you've completed a dungeon".into(),
+            Some(dungeon) => format!("you've completed {dungeon}"),
+        },
         AbilityCondition::IsInitiative => "has the initiative".into(),
         AbilityCondition::HasCityBlessing => "has the city's blessing".into(),
         AbilityCondition::IsRingBearer => "is the ring-bearer".into(),
@@ -7082,6 +7086,8 @@ fn condition_feature(cond: &AbilityCondition) -> (&'static str, FeatureSupport) 
         AbilityCondition::ManaColorSpent { .. } => ("ManaColorSpent", Handled),
         AbilityCondition::HasMaxSpeed => ("HasMaxSpeed", Handled),
         AbilityCondition::IsMonarch => ("IsMonarch", Handled),
+        // CR 309.7: evaluated at resolution via `dungeon::has_completed_dungeon`.
+        AbilityCondition::CompletedDungeon { .. } => ("CompletedDungeon", Handled),
         AbilityCondition::IsInitiative => ("IsInitiative", Handled),
         AbilityCondition::HasCityBlessing => ("HasCityBlessing", Handled),
         AbilityCondition::IsRingBearer => ("IsRingBearer", Handled),

--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -1457,6 +1457,30 @@ static BALDURS_GATE_WILDERNESS: DungeonDefinition = DungeonDefinition {
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
+/// CR 309.7: "A player completes a dungeon as that dungeon card is removed from
+/// the game." True when `player` has completed at least one dungeon
+/// (`specific: None`) or the named dungeon (`specific: Some(d)`).
+///
+/// SINGLE AUTHORITY for the "have you completed a dungeon" predicate. The same
+/// printed clause is read two ways — as a triggered ability's intervening-if
+/// (`TriggerCondition::CompletedDungeon`) and at resolution
+/// (`AbilityCondition::CompletedDungeon`, e.g. Tomb of Horrors Adventurer's "If
+/// you've completed a dungeon, copy that spell twice instead"). Both delegate
+/// here so the two readings can never disagree about what "completed" means.
+pub fn has_completed_dungeon(
+    state: &crate::types::game_state::GameState,
+    player: PlayerId,
+    specific: &Option<DungeonId>,
+) -> bool {
+    state
+        .dungeon_progress
+        .get(&player)
+        .is_some_and(|progress| match specific {
+            None => !progress.completed.is_empty(),
+            Some(dungeon) => progress.completed.contains(dungeon),
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2416,6 +2416,7 @@ fn should_resolve_subability_on_optional_decline(ability: &ResolvedAbility) -> b
             | AbilityCondition::PreviousEffectAmount { .. }
             | AbilityCondition::HasMaxSpeed
             | AbilityCondition::IsMonarch
+            | AbilityCondition::CompletedDungeon { .. }
             | AbilityCondition::IsInitiative
             | AbilityCondition::HasCityBlessing
             | AbilityCondition::IsRingBearer
@@ -8948,6 +8949,13 @@ pub(crate) fn evaluate_condition(
             crate::game::restrictions::spell_cast_with_variant_this_turn(state, variant)
         }
         AbilityCondition::IsMonarch => eval_is_monarch(state, ability.controller),
+        // CR 309.7: dungeon completion is a controller-state predicate, evaluated
+        // as the ability resolves. Delegates to the single truth function shared
+        // with `TriggerCondition::CompletedDungeon` so the intervening-if reading
+        // and the resolution reading of the same clause cannot drift.
+        AbilityCondition::CompletedDungeon { specific } => {
+            crate::game::dungeon::has_completed_dungeon(state, ability.controller, specific)
+        }
         // CR 726.3: The initiative is a player designation that effects can identify.
         AbilityCondition::IsInitiative => eval_is_initiative(state, ability.controller),
         // CR 702.131c: The city's blessing is a player designation that effects

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -7391,13 +7391,9 @@ pub(crate) fn check_trigger_condition(
         // CR 309.7: True when the controller has completed a dungeon. `specific: None`
         // matches "any dungeon"; `specific: Some(d)` matches dungeon `d`. Negation
         // ("haven't completed Tomb of Annihilation") wraps via `Not`.
-        TriggerCondition::CompletedDungeon { specific } => state
-            .dungeon_progress
-            .get(&controller)
-            .is_some_and(|p| match specific {
-                None => !p.completed.is_empty(),
-                Some(dungeon) => p.completed.contains(dungeon),
-            }),
+        TriggerCondition::CompletedDungeon { specific } => {
+            crate::game::dungeon::has_completed_dungeon(state, controller, specific)
+        }
         // CR 903.3 / CR 903.3d: Lieutenant ("your commander") requires ownership;
         // generic ("a commander") is controller-only.
         TriggerCondition::ControlsCommander { ownership } => match ownership {

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -4487,6 +4487,24 @@ pub(crate) fn static_condition_to_ability_condition(
                 ..Default::default()
             }),
         }),
+        // CR 309.7 ("A player completes a dungeon as that dungeon card is removed from the
+        // game") + CR 608.2c: "if you've completed a dungeon" is a plain game-state
+        // predicate about the CONTROLLER, evaluated as the ability resolves — it is not
+        // source-bound, layer-bound, or cost-bound like the unbridgeable statics below.
+        // `AbilityCondition::CompletedDungeon { specific }` is its exact effect-resolution
+        // equivalent and has existed all along; listing `CompletedADungeon` among the
+        // "no equivalent -> None" arms was a vocabulary asymmetry, not a real gap.
+        //
+        // It went unnoticed while an unlowerable condition merely fell through silently.
+        // Once the CR 614 branch guard started reporting such conditions honestly, the
+        // asymmetry surfaced as a regression: Tomb of Horrors Adventurer's "If you've
+        // completed a dungeon, copy that spell twice instead" lost its branch to
+        // `Unimplemented`. The `specific: None` form matches the bare "a dungeon" reading;
+        // a specific-dungeon static has no `StaticCondition` spelling today, so there is
+        // nothing else to map here.
+        StaticCondition::CompletedADungeon => {
+            Some(AbilityCondition::CompletedDungeon { specific: None })
+        }
         StaticCondition::DevotionGE { .. }
         // CR 702.176a + CR 611.3a: Persistent alternative-cost markers are
         // source-bound static predicates with no effect-resolution
@@ -4519,7 +4537,6 @@ pub(crate) fn static_condition_to_ability_condition(
         | StaticCondition::UnlessPay { .. }
         | StaticCondition::Unrecognized { .. }
         | StaticCondition::RingLevelAtLeast { .. }
-        | StaticCondition::CompletedADungeon
         | StaticCondition::ControlsCommander { .. }
         | StaticCondition::EnchantedIsFaceDown
         // CR 311.2 / CR 901.7: plane face-up status is a duration-only continuous-
@@ -4573,6 +4590,13 @@ pub(crate) fn ability_condition_to_static_condition(
 ) -> Option<StaticCondition> {
     match ac {
         AbilityCondition::IsYourTurn => Some(StaticCondition::DuringYourTurn),
+        // CR 309.7: round-trips the bridge in `static_condition_to_ability_condition`.
+        // Only the "any dungeon" reading round-trips — `StaticCondition` has no
+        // specific-dungeon spelling, so a specific one has no static form to bridge to.
+        AbilityCondition::CompletedDungeon { specific: None } => {
+            Some(StaticCondition::CompletedADungeon)
+        }
+        AbilityCondition::CompletedDungeon { specific: Some(_) } => None,
         // CR 301.5 + CR 303.4: round-trips the bidirectional bridge in
         // `static_condition_to_ability_condition` (a continuous "attached to a
         // creature" gate can ride per-`StaticDefinition`).

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -3765,11 +3765,34 @@ fn parse_paid_x_condition_text(text: &str) -> Option<AbilityCondition> {
     })
 }
 
+/// CR 614.1a + CR 614.6: the outcome of lowering an "instead" override clause.
+///
+/// The three-way split is load-bearing, and the middle arm is why this is not an
+/// `Option`. CR 614.6 ("If an event is replaced, it never happens") makes an
+/// "instead" override a **branch**, never a sequel: the engine does the override
+/// or the printed effect, never both. When the override grammar matches but its
+/// condition has no typed representation, returning a bare `None` let the caller
+/// fall through and re-emit the override BODY as an ordinary unconditional chain
+/// clause — so the engine ran the replaced effect AND its replacement, with the
+/// condition dropped (Anax, Hardened in the Forge: a 2/2 dying produced three
+/// Satyrs instead of one). `ConditionUnlowerable` forces the caller to fail
+/// honestly instead.
+pub(super) enum InsteadLowering {
+    /// The override lowered to a conditional branch (`AbilityCondition::ConditionInstead`).
+    Branch(Box<AbilityDefinition>),
+    /// The text IS an "instead" override, but its condition has no typed variant
+    /// yet. The caller MUST emit `Effect::unimplemented` — never the body.
+    ConditionUnlowerable,
+    /// Not the generic "instead" grammar, or deliberately owned by a more
+    /// specific lowering (see the additional-cost deferral in `build_instead_def`).
+    NotOwned,
+}
+
 pub(super) fn try_parse_generic_instead_clause(
     text: &str,
     kind: AbilityKind,
     ctx: &mut ParseContext,
-) -> Option<AbilityDefinition> {
+) -> InsteadLowering {
     // Forward form: "If <cond>, [body] instead." — split on the leading "If, "
     // and strip a trailing/leading "instead" from the body.
     if let Some((cond_text, effect_text)) = split_forward_instead_clause(text) {
@@ -3785,7 +3808,7 @@ pub(super) fn try_parse_generic_instead_clause(
         return build_instead_def(cond_text, effect_text, kind, ctx);
     }
 
-    None
+    InsteadLowering::NotOwned
 }
 
 /// Forward instead form: "If <cond>, [body] instead." Returns the trimmed
@@ -3833,6 +3856,32 @@ fn split_inverted_instead_clause(text: &str) -> Option<(String, String)> {
     Some((cond_text.to_string(), effect_text.to_string()))
 }
 
+/// CR 614.1: replacement effects "watch for a particular event that **would**
+/// happen and completely or partially replace that event." The modal "would" is
+/// the Comprehensive Rules' own marker for the EVENT reading of an "instead"
+/// clause, and it splits the grammar in two:
+///
+/// - **CR 614.1a EVENT replacement** — "If that spell *would* be put into your
+///   graveyard, exile it instead" (Torrential Gearhulk, Goblin Dark-Dwellers,
+///   Mission Briefing; ~68 faces). The clause names an event, not a game state.
+///   These are owned elsewhere — by a `ReplacementDefinition`, by the line-level
+///   replacement parser, or by the structural cast-then-exile rider chain that
+///   `swallow_check::any_ability_has_exile_parent_rider` recognizes as the "exile
+///   it instead" encoding. An unlowerable EVENT condition must therefore fall
+///   through UNCHANGED: reporting it as `ConditionUnlowerable` would make the
+///   caller replace a *working* rider encoding with `Effect::unimplemented`.
+///
+/// - **CR 608.2c STATE override** — "If the creature had power 4 or greater,
+///   create two of those tokens instead" (Anax, Hardened in the Forge). The
+///   clause is a game-state predicate evaluated as the ability resolves. These,
+///   and only these, are `ConditionUnlowerable` when they fail to lower.
+///
+/// The scan is word-boundary anchored (`scan_contains`), so "would" is matched
+/// as a word and never as a fragment of a longer token.
+fn condition_names_an_event(cond_text: &str) -> bool {
+    nom_primitives::scan_contains(&cond_text.to_lowercase(), "would")
+}
+
 /// Shared assembly: build an `AbilityDefinition` for an instead override.
 /// Tries the three condition parsers in priority order; bails if none match
 /// (so the chunk can fall through to other dispatch paths). Wraps the result
@@ -3843,20 +3892,35 @@ fn build_instead_def(
     effect_text: String,
     kind: AbilityKind,
     ctx: &mut ParseContext,
-) -> Option<AbilityDefinition> {
+) -> InsteadLowering {
     // CR 608.2c: An additional-cost-paid "instead" fold ("if it/this spell was
     // kicked, ... instead") is owned by `strip_additional_cost_conditional`,
     // which folds it to the dedicated `AdditionalCostPaidInstead`. Defer here so
     // the generic `parse_condition_text` recognizer (which now classifies "was
     // kicked" as the bare `AdditionalCostPaid`) does not pre-empt that fold by
     // producing a `ConditionInstead { inner: AdditionalCostPaid }` wrapper.
+    // This deferral is `NotOwned`, NOT `ConditionUnlowerable`: the clause has a
+    // typed home, just not this one, so the caller must fall through to it.
     if parse_additional_cost_instead_condition_fragment(&cond_text).is_some() {
-        return None;
+        return InsteadLowering::NotOwned;
     }
 
-    let condition = try_nom_condition_as_ability_condition(&cond_text, ctx)
+    // CR 614.6: a replaced event never happens. If the override's condition has
+    // no typed representation, the branch cannot be built — and emitting the
+    // override body anyway would run BOTH the replaced effect and its
+    // replacement. Everything that lowers today still lowers; only the failure
+    // path is split, by `condition_names_an_event`, into "defer" vs "fail
+    // honestly".
+    let Some(condition) = try_nom_condition_as_ability_condition(&cond_text, ctx)
         .or_else(|| parse_condition_text(&cond_text))
-        .or_else(|| parse_control_count_as_ability_condition(&cond_text))?;
+        .or_else(|| parse_control_count_as_ability_condition(&cond_text))
+    else {
+        return if condition_names_an_event(&cond_text) {
+            InsteadLowering::NotOwned
+        } else {
+            InsteadLowering::ConditionUnlowerable
+        };
+    };
 
     let instead_def = parse_effect_chain(&effect_text, kind);
     let mut result = instead_def;
@@ -3870,7 +3934,7 @@ fn build_instead_def(
     {
         super::rewrite_cost_paid_object_quantities_in_definition(&mut result);
     }
-    Some(result)
+    InsteadLowering::Branch(Box::new(result))
 }
 
 /// CR 608.2c: "If <cond>, you may instead <reveal-N-from-among-body>" — conditional
@@ -9218,12 +9282,13 @@ mod tests {
     /// CR 608.2c: Full instead-clause assembly for Fblthp's ETB draw rider.
     #[test]
     fn fblthp_library_origin_instead_clause() {
-        let instead = try_parse_generic_instead_clause(
+        let InsteadLowering::Branch(instead) = try_parse_generic_instead_clause(
             "If it entered from your library or was cast from your library, draw two cards instead.",
             AbilityKind::Spell,
             &mut ParseContext::default(),
-        )
-        .expect("instead clause must parse");
+        ) else {
+            panic!("instead clause must lower to a conditional branch");
+        };
         assert!(matches!(&*instead.effect, Effect::Draw { .. }));
         let cond = instead
             .condition

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -25567,21 +25567,39 @@ pub(crate) fn parse_effect_chain_ir(
         // CR 608.2c: "if [condition], [effect] instead" — the preceding ability's effect
         // is replaced when the condition holds. Keep the base effect as the root so
         // target collection stays anchored on the printed target-bearing clause.
-        if let Some(instead_def) = try_parse_generic_instead_clause(normalized_text, kind, ctx) {
-            if !builder.is_empty() {
-                builder
-                    .clause(
-                        normalized_text,
-                        placeholder_parsed_clause("instead_clause_placeholder"),
-                        chunk.boundary_after,
-                        ClauseDisposition::ReplaceMeaning {
-                            kind: ReplaceMeaningKind::Instead(Box::new(instead_def)),
-                        },
-                    )
-                    .push();
-                continue;
-            }
-        }
+        // CR 614.1a + CR 614.6: when the override's condition has NO typed variant,
+        // this chunk must never be emitted as an ordinary (unconditional) chain
+        // clause — that runs the replaced effect AND its replacement. But the
+        // decision cannot be made here: several handlers FURTHER DOWN this same
+        // ladder still own "instead" clauses and recover a condition for them
+        // (`strip_target_keyword_instead` → `TargetHasKeywordInstead` for Porcelain
+        // Zealot; `strip_additional_cost_conditional` → `AdditionalCostPaidInstead`
+        // for Sea Gate Stormcaller). Short-circuiting here would pre-empt them and
+        // destroy working branches. So we only remember the verdict, and enforce it
+        // at the LAST resort — immediately before the generic emission at the tail
+        // of this loop, where every other owner has already had its chance.
+        let instead_condition_unlowerable =
+            match try_parse_generic_instead_clause(normalized_text, kind, ctx) {
+                conditions::InsteadLowering::Branch(instead_def) if !builder.is_empty() => {
+                    builder
+                        .clause(
+                            normalized_text,
+                            placeholder_parsed_clause("instead_clause_placeholder"),
+                            chunk.boundary_after,
+                            ClauseDisposition::ReplaceMeaning {
+                                kind: ReplaceMeaningKind::Instead(instead_def),
+                            },
+                        )
+                        .push();
+                    continue;
+                }
+                // A branch with no antecedent in this chain (empty builder) keeps its
+                // historical fall-through, as does anything this grammar does not own.
+                conditions::InsteadLowering::Branch(_) | conditions::InsteadLowering::NotOwned => {
+                    false
+                }
+                conditions::InsteadLowering::ConditionUnlowerable => true,
+            };
 
         let has_card_predicate_guess = chain_has_card_predicate_guess(builder.clauses());
         let (predicate_guess_cond, predicate_guess_text) = if has_card_predicate_guess {
@@ -27454,6 +27472,26 @@ pub(crate) fn parse_effect_chain_ir(
         // self-reference clause is untouched.
         if matches!(condition, Some(AbilityCondition::ZoneChangedThisWay { .. })) {
             restore_this_way_trigger_anaphor(&mut clause.effect);
+        }
+
+        // CR 614.1a + CR 614.6: LAST RESORT for an "instead" override whose
+        // condition never found a typed home. Every specific owner above has now
+        // declined (they `continue`, or they set `condition`), so reaching here
+        // with `instead_condition_unlowerable` and no recovered condition means the
+        // override body is about to be emitted as an ordinary, UNCONDITIONAL chain
+        // clause — a sequel to the very effect it is supposed to REPLACE. A
+        // replaced event never happens (CR 614.6), so the engine would then run
+        // both branches with the condition silently dropped: Anax, Hardened in the
+        // Forge made 1 + 2 = three Satyrs on every nontoken creature death,
+        // regardless of its power. Fail honestly instead of lying.
+        if instead_condition_unlowerable && condition.is_none() {
+            unimplemented_clause(
+                &mut builder,
+                "instead_condition",
+                normalized_text,
+                chunk.boundary_after,
+            );
+            continue;
         }
 
         // CR 115.1 + CR 701.9b: `target_selection_mode` snapshots the parser's

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -45306,3 +45306,94 @@ fn transient_cost_reduction_arm_rejects_unsupported_shapes() {
         Effect::Unimplemented { .. }
     ));
 }
+
+// ── CR 614.1a + CR 614.6: an "instead" override is a BRANCH, never a sequel ──
+
+/// CR 614.6: "If an event is replaced, it never happens." An "instead" override
+/// whose CR 608.2c state condition has no typed variant must never be emitted as
+/// an ordinary chain clause — that makes the engine run the replaced effect AND
+/// its replacement. It fails honestly instead.
+///
+/// Anax, Hardened in the Forge is the witness: its base parse was
+/// `Token{count:1} -> sub_ability Token{count:2}` with no condition on either
+/// def, so every nontoken creature death created three Satyrs regardless of
+/// power. The building-block assertion is stronger than "Anax is fixed": NO
+/// second `Token` may appear anywhere in the chain as an unconditional sibling.
+#[test]
+fn instead_override_with_unlowerable_state_condition_is_not_an_unconditional_sibling() {
+    let def = parse_effect_chain(
+        "Create a 1/1 red Satyr creature token. If the creature had power 4 or greater, create two of those tokens instead.",
+        AbilityKind::Spell,
+    );
+    assert!(
+        matches!(&*def.effect, Effect::Token { .. }),
+        "the printed base clause still lowers to the token, got {:?}",
+        def.effect
+    );
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("the override clause still produces a def");
+    assert!(
+        matches!(&*sub.effect, Effect::Unimplemented { name, .. } if name == "instead_condition"),
+        "CR 614.6: an override whose condition cannot be lowered must be honestly \
+         Unimplemented, never a second Token that runs unconditionally — got {:?}",
+        sub.effect
+    );
+}
+
+/// CR 614.1: replacement effects "watch for a particular event that WOULD happen."
+/// The modal "would" marks the CR 614.1a EVENT reading, which is owned by the
+/// replacement machinery — here, by the structural cast-then-exile rider chain.
+/// Torrential Gearhulk must keep that chained `ChangeZone`-to-Exile rider: the
+/// honest-failure path must NOT swallow it.
+#[test]
+fn instead_override_naming_an_event_defers_to_the_replacement_machinery() {
+    let def = parse_effect_chain(
+        "You may cast target instant card from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
+        AbilityKind::Spell,
+    );
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("the exile rider must survive as a chained def");
+    assert!(
+        matches!(
+            &*sub.effect,
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                ..
+            }
+        ),
+        "CR 614.1a: a \"would\"-conditioned instead is an EVENT replacement owned by \
+         the exile-rider encoding — it must not be rewritten to Unimplemented, got {:?}",
+        sub.effect
+    );
+}
+
+/// The honest-failure path is a LAST resort: handlers further down the chunk
+/// ladder still own "instead" clauses and recover a typed condition for them.
+/// Porcelain Zealot's "If that creature has toxic, instead it gets +2/+2" is
+/// owned by `strip_target_keyword_instead`, so it must keep its real branch.
+#[test]
+fn instead_override_owned_by_a_later_handler_keeps_its_branch() {
+    let def = parse_effect_chain(
+        "Target creature you control gets +1/+1 until end of turn. If that creature has toxic, instead it gets +2/+2 until end of turn.",
+        AbilityKind::Spell,
+    );
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("the override clause must still produce a def");
+    assert!(
+        matches!(
+            sub.condition.as_ref(),
+            Some(AbilityCondition::TargetHasKeywordInstead {
+                keyword: Keyword::Toxic(_)
+            })
+        ),
+        "the later-handler branch (TargetHasKeywordInstead) must survive the \
+         honest-failure guard, got {:?}",
+        sub.condition
+    );
+}

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -45397,3 +45397,45 @@ fn instead_override_owned_by_a_later_handler_keeps_its_branch() {
         sub.condition
     );
 }
+
+/// CR 309.7 + CR 614.1a: "If you've completed a dungeon, copy that spell twice
+/// instead" (Tomb of Horrors Adventurer) must lower to a real conditional BRANCH
+/// carrying the TYPED dungeon predicate — never to an honest-but-inert
+/// `Unimplemented`, and never to an unconditional sibling.
+///
+/// This is the regression that exposed the vocabulary asymmetry: the condition
+/// parsed fine as `StaticCondition::CompletedADungeon`, but the
+/// StaticCondition -> AbilityCondition bridge declared it had "no
+/// effect-resolution equivalent" while `AbilityCondition::CompletedDungeon` did
+/// not yet exist. So the CR 614 branch guard — correctly — refused to emit the
+/// override body as an unconditional sequel, and the branch became Unimplemented.
+/// The fix is the condition lowering, not a weaker guard.
+#[test]
+fn instead_override_lowers_the_typed_completed_dungeon_condition() {
+    let def = parse_effect_chain(
+        "Copy that spell. If you've completed a dungeon, copy that spell twice instead.",
+        AbilityKind::Spell,
+    );
+    let branch = def
+        .sub_ability
+        .as_ref()
+        .expect("the override must attach to the base copy as a branch");
+    let Some(AbilityCondition::ConditionInstead { inner }) = branch.condition.as_ref() else {
+        panic!(
+            "the override must carry a ConditionInstead wrapper, got {:?}",
+            branch.condition
+        );
+    };
+    assert!(
+        matches!(
+            inner.as_ref(),
+            AbilityCondition::CompletedDungeon { specific: None }
+        ),
+        "CR 309.7: the dungeon predicate must lower to the TYPED \
+         AbilityCondition::CompletedDungeon, not fall through to Unimplemented — got {inner:?}"
+    );
+    assert!(
+        !matches!(&*branch.effect, Effect::Unimplemented { .. }),
+        "the override body must be the real second copy, not Unimplemented"
+    );
+}

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -322,6 +322,23 @@ fn detect_replacement(
     //   $ rg '^    \w*Enter\w*\s*[,{(]' crates/engine/src/types/
     //     StaticMode::EntersWithAdditionalCounters   StaticMode::CantEnterBattlefieldFrom
     //     ContinuousModification::AddCounterOnEnter  Effect::AddPendingEntersModifications
+    //
+    // That grep is exactly why `Effect::AddPendingETBCounters` was missing below: it keys
+    // on variants NAMED Enter*, and this one is named Add*. It is the DELAYED CR 614.1c
+    // carrier — the enters-with rider that binds to a LATER cast instead of to the source
+    // permanent. Yuna, Grand Summoner ("When you next cast a creature spell this turn,
+    // that creature enters with two additional +1/+1 counters on it") lowers to
+    // `CreateDelayedTrigger{ WhenNextEvent{SpellCast} -> AddPendingETBCounters }`;
+    // Osteomancer Adept's graveyard-cast rider lowers to a sequential
+    // `AddPendingETBCounters` consumed as `CastFromZone` permission metadata. Both ARE the
+    // replacement, and neither produces a `ReplacementDefinition`. Omitting it reported 5
+    // FALSE POSITIVES pool-wide: chocobo camp, kumano faces kakkazan, osteomancer adept,
+    // summon: fenrir, yuna.
+    //
+    // It must be probed via the tree-global typed evidence, NOT via the structural
+    // `effect_is_replacement_carrier` walk: that walk descends `sub_ability` / `else_ability`
+    // / `mode_abilities` only, so it cannot see a carrier nested inside an EFFECT — and
+    // Yuna's carrier lives inside `Effect::CreateDelayedTrigger`'s inner definition.
     if evidence.any_static_mode(|m| {
         matches!(
             m,
@@ -329,8 +346,12 @@ fn detect_replacement(
         )
     }) || evidence.any::<ContinuousModification>(|m| {
         matches!(m, ContinuousModification::AddCounterOnEnter { .. })
-    }) || evidence.any_effect(|e| matches!(e, Effect::AddPendingEntersModifications { .. }))
-    {
+    }) || evidence.any_effect(|e| {
+        matches!(
+            e,
+            Effect::AddPendingEntersModifications { .. } | Effect::AddPendingETBCounters { .. }
+        )
+    }) {
         return;
     }
     // CR 614.1c + CR 614.12: the per-object enters-modifier slots — an "as it enters"
@@ -7923,6 +7944,58 @@ this spell's mana cost.\nAttacking creatures get -3/-0 until end of turn.",
             has_owned_triggering(target),
             "Tinybones must restrict the cast to the damaged player's graveyard \
              via Owned{{TriggeringPlayer}}; got {target:?}"
+        );
+    }
+
+    /// CR 614.1c: `Effect::AddPendingETBCounters` IS the "enters with ..." replacement in
+    /// its DELAYED form — the rider binds to a later cast, not to the source permanent.
+    /// The `Replacement` detector reported 5 pool-wide FALSE POSITIVES until the shared
+    /// carrier helper accepted it (chocobo camp, kumano faces kakkazan, osteomancer adept,
+    /// summon: fenrir, yuna). Both producing grammars are pinned: the delayed
+    /// when-you-next-cast trigger (Yuna) and the cast-this-way graveyard rider
+    /// (Osteomancer Adept).
+    ///
+    /// The negative assertions cannot be vacuous: the detector only fires when the
+    /// "enters with " marker is present AND no carrier is found, and the POSITIVE CONTROL
+    /// below carries the same marker with no carrier — it must still fire. If the control
+    /// ever goes quiet, the detector is broken, not the cards.
+    #[test]
+    fn replacement_accepts_add_pending_etb_counters_as_a_614_1c_carrier() {
+        let yuna = parse_named(
+            "{T}: Add one mana of any color. When you next cast a creature spell this turn, that creature enters with two additional +1/+1 counters on it.",
+            "Yuna, Grand Summoner",
+            &["Creature"],
+        );
+        assert!(
+            !has_swallowed_detector(&yuna, "Replacement"),
+            "CR 614.1c: the delayed enters-with rider lowers to AddPendingETBCounters, which \
+             IS the replacement — it must not be reported as swallowed"
+        );
+
+        let osteomancer = parse_named(
+            "{T}: Until end of turn, you may cast creature spells from your graveyard. If you cast a spell this way, that creature enters with a finality counter on it.",
+            "Osteomancer Adept",
+            &["Creature"],
+        );
+        assert!(
+            !has_swallowed_detector(&osteomancer, "Replacement"),
+            "the cast-this-way graveyard rider is the same CR 614.1c carrier"
+        );
+
+        // POSITIVE CONTROL: the same "enters with" marker with NO carrier the parser can
+        // build. Undead Sprinter is a MEASURED true positive of this detector (its
+        // cast-permission is a STATIC, and the static path has no enters-with rider hook —
+        // see the CR 614.1c static-path gap). The detector MUST still fire on it, or the
+        // two assertions above prove nothing.
+        let uncarried = parse_named(
+            "Trample, haste\nYou may cast this card from your graveyard if a non-Zombie creature died this turn. If you do, this creature enters with a +1/+1 counter on it.",
+            "Undead Sprinter",
+            &["Creature"],
+        );
+        assert!(
+            has_swallowed_detector(&uncarried, "Replacement"),
+            "positive control: an enters-with clause with NO carrier must still be reported \
+             — if this goes quiet the detector is dead and the assertions above are vacuous"
         );
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -16487,6 +16487,22 @@ pub enum AbilityCondition {
     /// CR 701.54a: True when the ability's source permanent is its controller's
     /// Ring-bearer. For "unless ~ is your Ring-bearer", wrap with `Not`.
     IsRingBearer,
+    /// CR 309.7: "if you've completed a dungeon" — true when the ability's
+    /// controller has completed at least one dungeon (`specific: None`) or the
+    /// named dungeon (`specific: Some(d)`). Negation wraps with `Not`.
+    ///
+    /// The resolution-time sibling of `TriggerCondition::CompletedDungeon`, and
+    /// deliberately shaped identically: both delegate to the single truth
+    /// function `game::dungeon::has_completed_dungeon`, so the intervening-if
+    /// reading and the resolution reading of the same printed clause can never
+    /// drift. It belongs with the other controller-designation predicates above
+    /// (`IsMonarch` CR 725, `IsInitiative` CR 726, `HasCityBlessing` CR 702.131c)
+    /// rather than being folded into them — each is its own CR rule section, so
+    /// the categorical boundary keeps them siblings.
+    CompletedDungeon {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        specific: Option<crate::game::dungeon::DungeonId>,
+    },
     /// CR 608.2c: "If [target] has [keyword], [override effect] instead"
     /// Checked at resolution time against the first resolved object target's keywords.
     /// Uses "Instead" override semantics: swaps the parent effect when condition is met.

--- a/crates/engine/tests/integration/anax_instead_branch_not_chain.rs
+++ b/crates/engine/tests/integration/anax_instead_branch_not_chain.rs
@@ -1,0 +1,101 @@
+//! CR 614.1a + CR 614.6 — an "instead" override is a BRANCH, never a sequel.
+//!
+//! CR 614.1a: "Effects that use the word 'instead' are replacement effects."
+//! CR 614.6:  "If an event is replaced, it never happens. A modified event
+//!             occurs instead."
+//!
+//! The class defect this pins: when the parser recognizes the "if <cond>,
+//! <body> instead" override grammar but cannot lower <cond> into a typed
+//! `AbilityCondition`, it used to fall through and re-emit <body> as an
+//! ordinary unconditional chain clause. The engine then ran the replaced effect
+//! AND its replacement — both branches, every time — with the condition dropped
+//! entirely.
+//!
+//! Witness (Oracle read from the pool export, not from memory):
+//!   Anax, Hardened in the Forge —
+//!     "Whenever Anax or another nontoken creature you control dies, create a
+//!      1/1 red Satyr creature token with "This token can't block." If the
+//!      creature had power 4 or greater, create two of those tokens instead."
+//!
+//! Its base parse was `Token{count:1} -> sub_ability Token{count:2}` with
+//! `condition: null` on BOTH defs, so a 2/2 dying produced THREE Satyrs.
+//!
+//! The assertion below is the CR-correct outcome for the power < 4 case (one
+//! token), so it stays valid whether the override is honestly unimplemented or
+//! is later lowered to a real conditional branch. It only fails if the override
+//! body runs unconditionally — exactly the defect.
+
+use engine::game::sba::check_state_based_actions;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::triggers::process_triggers;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+/// Oracle text as printed (read from the full-pool export).
+const ANAX: &str = "Anax's power is equal to your devotion to red.\nWhenever Anax or another nontoken creature you control dies, create a 1/1 red Satyr creature token with \"This token can't block.\" If the creature had power 4 or greater, create two of those tokens instead.";
+
+fn satyr_token_count(runner: &GameRunner) -> usize {
+    runner
+        .state()
+        .battlefield
+        .iter()
+        .filter(|id| {
+            runner.state().objects.get(id).is_some_and(|obj| {
+                obj.is_token
+                    && obj
+                        .card_types
+                        .subtypes
+                        .iter()
+                        .any(|s| s.eq_ignore_ascii_case("Satyr"))
+            })
+        })
+        .count()
+}
+
+/// Mark `victim` with lethal damage, run SBAs so it dies, process the resulting
+/// triggers, then resolve the stack.
+fn kill_and_resolve(runner: &mut GameRunner, victim: ObjectId) {
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&victim)
+        .expect("victim exists")
+        .damage_marked = 99;
+
+    let mut events = Vec::new();
+    check_state_based_actions(runner.state_mut(), &mut events);
+    process_triggers(runner.state_mut(), &events);
+    runner.advance_until_stack_empty();
+}
+
+/// CR 614.6: a creature with power < 4 dies, so the "create two of those tokens
+/// instead" override does NOT apply. Exactly one Satyr must be created.
+///
+/// RED before the fix: the override body was chained unconditionally, so the
+/// engine created 1 + 2 = THREE Satyrs on every nontoken creature death.
+#[test]
+fn anax_instead_override_does_not_run_unconditionally() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Anax, Hardened in the Forge", 0, 7, ANAX);
+    // A nontoken creature with power < 4 — the override's condition is FALSE.
+    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let mut runner = scenario.build();
+
+    assert_eq!(
+        satyr_token_count(&runner),
+        0,
+        "no Satyr tokens before the trigger"
+    );
+
+    kill_and_resolve(&mut runner, bear);
+
+    assert_eq!(
+        satyr_token_count(&runner),
+        1,
+        "CR 614.6: the dying creature had power 2, so the \"create two of those \
+         tokens instead\" override must NOT apply — exactly one Satyr. Three \
+         Satyrs means the override body ran as an unconditional chain sibling \
+         (both branches), which is the CR 614 lowering defect this test pins."
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -7,6 +7,7 @@ mod ajani_nacatl_pariah_transform;
 mod alchemists_gift_pump_modal_keyword_choice;
 mod ambuscade_one_sided_fight_anaphoric;
 mod amphin_mutineer_regression;
+mod anax_instead_branch_not_chain;
 mod ancient_brass_dragon_roll_d20;
 mod ancient_bronze_dragon_roll_d20;
 mod ancient_copper_dragon_roll_d20;


### PR DESCRIPTION
- **fix(parser): CR 614 "instead" override must be a BRANCH, never an unconditional sibling**
- **fix(parser): the Replacement detector must accept AddPendingETBCounters (CR 614.1c)**
