### PR TITLE
fix(parser): port the phrasing-gap restriction families into the shared condition grammar (P02-U3b)

### DIFF
--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -39759,8 +39759,8 @@ fn hyldas_crown_cost_reduction_applies_only_during_your_turn() {
 /// reparse, mirroring production) and applied through `apply_cost_reduction`.
 ///
 /// Discriminating assertion: `generic_of(&def)` is 3 with a Spacecraft
-/// attacker declaration present and 6 without. Reverting the
-/// `YouAttackedWithAtLeast { filter }` parser arm leaves `condition: None`
+/// attacker declaration present and 6 without. Reverting the filtered
+/// attacked-with parser arm leaves `condition: None`
 /// (try_parse_cost_reduction returns None), so the positive case would read
 /// {6} and this assertion fails. Reverting the runtime filter arm in
 /// `restrictions::evaluate_condition` would treat the filtered count as the
@@ -39768,7 +39768,7 @@ fn hyldas_crown_cost_reduction_applies_only_during_your_turn() {
 #[test]
 fn thaumaton_torpedo_cost_reduction_requires_spacecraft_attacker() {
     use crate::parser::oracle_cost::try_parse_cost_reduction;
-    use crate::types::ability::{Effect, ParsedCondition};
+    use crate::types::ability::{Effect, ParsedCondition, QuantityExpr, QuantityRef};
     use crate::types::card_type::CoreType;
     use crate::types::identifiers::CardId;
     use crate::types::mana::ManaCost;
@@ -39783,9 +39783,14 @@ fn thaumaton_torpedo_cost_reduction_requires_spacecraft_attacker() {
     assert!(
         matches!(
             reduction.condition,
-            Some(ParsedCondition::YouAttackedWithAtLeast {
-                count: 1,
-                filter: Some(_)
+            Some(ParsedCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::AttackedThisTurn {
+                        filter: Some(_),
+                        ..
+                    },
+                },
+                ..
             })
         ),
         "must gate on a filtered attacked-with condition, got {:?}",

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -2945,9 +2945,16 @@ mod tests {
     #[test]
     fn evaluates_opponent_searched_library_this_turn_condition() {
         let mut state = crate::types::game_state::GameState::new_two_player(42);
+        // Production (`effects::search_library`) records the search in BOTH the
+        // legacy set and the `PlayerPerformedAction` ledger; the shared grammar
+        // now counts the latter, so this test must simulate both halves.
         state
             .players_who_searched_library_this_turn
             .insert(PlayerId(1));
+        state.player_actions_this_turn.push((
+            PlayerId(1),
+            crate::types::events::PlayerActionKind::SearchedLibrary,
+        ));
 
         assert!(parse_and_evaluate_condition(
             &state,
@@ -2960,8 +2967,34 @@ mod tests {
     #[test]
     fn evaluates_you_attacked_with_two_or_more_creatures_this_turn_condition() {
         let mut state = crate::types::game_state::GameState::new_two_player(42);
-        state.players_attacked_this_turn.insert(PlayerId(0));
-        state.attacking_creatures_this_turn.insert(PlayerId(0), 2);
+        state.active_player = PlayerId(0);
+        // The shared grammar counts `attacker_declarations_this_turn` snapshots;
+        // production `combat::declare_attackers` records those AND the summary
+        // counters, so this test must simulate both halves (see
+        // `zero_attacker_declaration_does_not_satisfy_you_attacked_this_turn`).
+        for card_id in [2, 3] {
+            let attacker = crate::game::zones::create_object(
+                &mut state,
+                crate::types::identifiers::CardId(card_id),
+                PlayerId(0),
+                format!("Attacker {card_id}"),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&attacker)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Creature);
+            let record = state
+                .objects
+                .get(&attacker)
+                .unwrap()
+                .snapshot_for_attack_declaration(attacker);
+            state.attacker_declarations_this_turn.push(record);
+        }
+        record_attackers_declared(&mut state, 2);
 
         assert!(parse_and_evaluate_condition(
             &state,

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -2722,6 +2722,96 @@ mod tests {
         ));
     }
 
+    /// P02-U3b RUNTIME WITNESS (CR 102.2 + CR 102.3 + CR 608.2h) — Whiplash Trap.
+    ///
+    /// "If **an opponent** had **two or more** creatures enter the battlefield under
+    /// **their** control this turn …". "An opponent" binds ONE player, and "their
+    /// control" binds the count to that same player. So the threshold is PER OPPONENT,
+    /// never a sum across opponents.
+    ///
+    /// This is the red-first witness for the multiplayer correction. BEFORE the port the
+    /// restriction fallback encoded the opponent INSIDE the TargetFilter
+    /// (`controller: Opponent`), so `evaluate_condition` counted every entry under ANY
+    /// opponent's control and compared the SUM — two DIFFERENT opponents with one creature
+    /// each wrongly satisfied "two or more". This test FAILS on that code. After the port
+    /// the phrase is a `QuantityComparison` over
+    /// `BattlefieldEntriesThisTurn { player: Opponent { aggregate: Max } }`, which counts
+    /// per opponent and takes the largest tally: max(1, 1) = 1 < 2 → correctly FALSE.
+    ///
+    /// The two readings coincide at two players, which is why this needs THREE seats.
+    ///
+    /// Placement note: this is a condition-SEMANTICS witness, and `evaluate_condition` is
+    /// `pub(crate)`. It lives beside the other runtime condition tests rather than in
+    /// `tests/integration/` because reaching it from an integration test would mean
+    /// widening the evaluator's visibility purely for a test. It still drives the real
+    /// runtime path — a real 3-player `GameState` through `game::quantity`'s
+    /// `resolve_per_player_scalar`, not a parse-tree assertion.
+    #[test]
+    fn opponent_entry_threshold_is_per_opponent_not_summed_across_opponents() {
+        const WHIPLASH_TRAP: &str = "an opponent had two or more creatures enter the battlefield under their control this turn";
+
+        fn state_with_entries(entries: &[(PlayerId, u32)]) -> crate::types::game_state::GameState {
+            // free-for-all, THREE seats: P1 and P2 are both genuine opponents of P0 (a
+            // team format would make one of them a teammate and defeat the point).
+            let mut state = crate::types::game_state::GameState::new(
+                crate::types::format::FormatConfig::free_for_all(),
+                3,
+                42,
+            );
+            let mut next_id = 100u64;
+            for (controller, count) in entries {
+                for _ in 0..*count {
+                    state
+                        .battlefield_entries_this_turn
+                        .push(BattlefieldEntryRecord {
+                            object_id: ObjectId(next_id),
+                            name: "Bear".to_string(),
+                            core_types: vec![CoreType::Creature],
+                            subtypes: vec![],
+                            supertypes: vec![],
+                            colors: vec![],
+                            keywords: vec![],
+                            controller: *controller,
+                        });
+                    next_id += 1;
+                }
+            }
+            state
+        }
+
+        // THE BUG: two DIFFERENT opponents, ONE creature each. No single opponent had two,
+        // so the condition must be FALSE. The pre-port fallback summed 1 + 1 = 2 and
+        // returned TRUE.
+        let split = state_with_entries(&[(PlayerId(1), 1), (PlayerId(2), 1)]);
+        assert!(
+            !parse_and_evaluate_condition(&split, PlayerId(0), ObjectId(10), WHIPLASH_TRAP),
+            "two DIFFERENT opponents with one creature each must NOT satisfy \"an opponent \
+             had two or more creatures enter\" — no single opponent had two (CR 102.2/102.3: \
+             \"an opponent\" binds one player; \"their control\" binds the count to that same \
+             player). Summing across opponents is the pre-port bug this test exists to catch."
+        );
+
+        // POSITIVE CONTROL (nonvacuity): ONE opponent with TWO creatures MUST satisfy it.
+        // Without this, the assertion above would also pass if the condition were broken to
+        // always-false — or if the parse silently stopped producing anything at all.
+        let concentrated = state_with_entries(&[(PlayerId(1), 2)]);
+        assert!(
+            parse_and_evaluate_condition(&concentrated, PlayerId(0), ObjectId(10), WHIPLASH_TRAP),
+            "a SINGLE opponent with two creatures entering MUST satisfy the condition — if \
+             this fails the per-opponent tally is broken (or the phrase stopped parsing), and \
+             the negative assertion above is vacuous"
+        );
+
+        // CONTROL: the controller's OWN entries are not an opponent's. Two creatures under
+        // the ability controller's control must not satisfy an opponent-scoped threshold.
+        let mine = state_with_entries(&[(PlayerId(0), 2)]);
+        assert!(
+            !parse_and_evaluate_condition(&mine, PlayerId(0), ObjectId(10), WHIPLASH_TRAP),
+            "the controller's own battlefield entries must not satisfy an OPPONENT-scoped \
+             entry threshold"
+        );
+    }
+
     #[test]
     fn evaluates_you_control_creature_with_flying_condition() {
         let mut state = crate::types::game_state::GameState::new_two_player(42);

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -767,9 +767,9 @@ fn scan_timing_restrictions(text: &str) -> Vec<CastingRestriction> {
 mod tests {
     use super::*;
     use crate::types::ability::{
-        AdditionalCostRepeatability, BeholdCostAction, CardSelectionMode, Comparator,
-        ControllerRef, CountScope, FilterProp, ParsedCondition, QuantityExpr, QuantityRef,
-        TargetFilter, TypeFilter,
+        AdditionalCostRepeatability, AggregateFunction, BeholdCostAction, CardSelectionMode,
+        Comparator, ControllerRef, CountScope, FilterProp, ParsedCondition, PlayerScope,
+        QuantityExpr, QuantityRef, TargetFilter, TypeFilter,
     };
     use crate::types::keywords::Keyword;
     use crate::types::mana::{ManaColor, ManaCost};
@@ -1701,11 +1701,25 @@ mod tests {
         )
         .expect("trap alt-cost should parse");
         match option.condition {
-            Some(ParsedCondition::BattlefieldEntriesThisTurn {
-                filter: TargetFilter::Typed(filter),
-                count: 1,
+            Some(ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::BattlefieldEntriesThisTurn {
+                                player:
+                                    PlayerScope::Opponent {
+                                        aggregate: AggregateFunction::Max,
+                                    },
+                                filter: TargetFilter::Typed(filter),
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
             }) => {
-                assert_eq!(filter.controller, Some(ControllerRef::Opponent));
+                // The per-opponent scope carries "under their control" (the
+                // resolver counts entries whose recorded controller is the
+                // scoped opponent), so the filter itself must stay type-only.
+                assert_eq!(filter.controller, None);
                 assert!(filter.type_filters.contains(&TypeFilter::Artifact));
             }
             other => panic!("expected opponent artifact entry condition, got {other:?}"),

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -1734,11 +1734,25 @@ mod tests {
         )
         .expect("trap alt-cost should parse");
         match option.condition {
-            Some(ParsedCondition::BattlefieldEntriesThisTurn {
-                filter: TargetFilter::Typed(filter),
-                count: 2,
+            Some(ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::BattlefieldEntriesThisTurn {
+                                player:
+                                    PlayerScope::Opponent {
+                                        aggregate: AggregateFunction::Max,
+                                    },
+                                filter: TargetFilter::Typed(filter),
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 2 },
             }) => {
-                assert_eq!(filter.controller, Some(ControllerRef::Opponent));
+                // Per-opponent Max is the semantic fix: "an opponent had two or
+                // more lands enter" means ONE opponent with 2+, never two
+                // opponents with 1 each (which a summed count would accept).
+                assert_eq!(filter.controller, None);
                 assert!(filter.type_filters.contains(&TypeFilter::Land));
             }
             other => panic!("expected opponent land entry condition, got {other:?}"),

--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -129,6 +129,7 @@ fn parse_shared_restriction_condition(text: &str) -> SharedRestrictionParse {
 /// A parser that exists merely because the shared grammar spells the phrase differently
 /// is NOT justified — teach `parse_inner_condition` the phrasing instead (that is where
 /// every static ability with the same words already looks).
+
 fn parse_restriction_only_condition(text: &str) -> Option<ParsedCondition> {
     // JUSTIFICATION 1 — restriction-context referent (CR 601.3d).
     //
@@ -162,129 +163,51 @@ fn parse_restriction_only_condition(text: &str) -> Option<ParsedCondition> {
         return Some(condition);
     }
 
-    // JUSTIFICATION 3 — PHRASING GAP, NOT A VOCABULARY GAP. Port pending.
+    // P02-U3b CLOSED the phrasing-gap class that used to live here. The five families
+    // named in that task (`you attacked with <N|filter>`, `an opponent had <N> <type>
+    // enter`, `lands with the same name`, `an opponent searched their library`, and the
+    // `exactly N or M cards in hand` disjunction) are now SPELLED by
+    // `parse_inner_condition` and reach the restriction evaluator through the ordinary
+    // `QuantityComparison` conversion. Their parsers are deleted, not moved.
     //
-    // Read this before adding anything below. Each parser here is UNJUSTIFIED under the
-    // rules above: the shared vocabulary CAN express its condition
-    // (`QuantityRef::{AttackedThisTurn { filter }, BattlefieldEntriesThisTurn { player,
-    // filter }, ObjectCountBySharedQuality, PlayerActionsThisTurn, HandSize}` all exist),
-    // and `static_condition_to_restriction_condition` would convert the result through
-    // `QuantityComparison` unchanged. They survive only because `parse_inner_condition`
-    // does not yet SPELL these phrasings — a gap in the grammar, not in the type system.
+    // Two residuals remain below, and NEITHER is a phrasing gap. Both are JUSTIFICATION 2
+    // (no shared vocabulary) — the same class as `parse_source_condition` above:
     //
-    // They are not deleted here because moving them is not a parser edit: each port
-    // changes the runtime condition representation for live cards (a fixed
-    // `ParsedCondition` leaf becomes a `QuantityComparison` resolved through
-    // `game::quantity`), which needs its own runtime-equivalence proof and full-pool
-    // dual-run. That work is tracked as **P02-U3b (shared-grammar phrasing parity)**;
-    // deleting them now would silently drop the cards listed beside each parser.
-    //
-    // NOTE for P02-U3b: the source-predicate family above is a PREREQUISITE, not a
-    // sibling. Until `ParsedCondition` can hold a filter for its source, teaching the
-    // shared grammar a new source phrasing REMOVES restriction support for it (the shared
-    // parse starts succeeding, the conversion then rejects it). Align the vocabularies
-    // first.
+    //  1. `BeenAttackedThisStep` — `StaticCondition` has no per-STEP attack history at
+    //     all. Its whole vocabulary is per-TURN. There is nothing to spell.
+    //  2. "you have no <kind> cards in hand" — an OWNER-relative count in a hidden zone.
+    //     The shared reading would be an `ObjectCount` over a `TargetFilter` carrying
+    //     `InZone { Hand }`, but `TargetFilter` has NO owner axis (see the
+    //     `CommanderOwnership::Own` rejection in
+    //     `static_condition_to_restriction_condition`), and `object_count_matching_ids`
+    //     discriminates by CONTROLLER via `matches_target_filter` — not by owner. In an
+    //     owner zone those differ precisely when a control-change effect has touched the
+    //     card, which is why `matches_target_filter_in_owner_zone` exists as a separate
+    //     entry point that the count path does not use. `ZoneCoreTypeCardCountAtLeast`
+    //     reads `player_zone_ids(player, Hand)` and is exactly right; an `ObjectCount`
+    //     would be a silently different predicate. Aligning this needs an owner axis on
+    //     `TargetFilter` (or an owner-zone-aware count ref) — a vocabulary change, not a
+    //     parser edit.
     //
     // The rule for anyone extending this file: a NEW restriction phrase never lands here.
     // Teach `parse_inner_condition` the phrasing — that is where every static ability
     // with the same words already looks.
 
-    // "you control three or more lands with the same name" (Endless Atlas, Sceptre of
-    // Eternal Glory). Shared target: `ObjectCountBySharedQuality { quality: Name }`.
-    if let Some(condition) = parse_you_control_condition(text) {
-        return Some(condition);
-    }
-
-    // "you have exactly zero or seven cards in hand"; "you have no land cards in hand".
-    // Shared target: `Or` over `QuantityComparison { HandSize, EQ }` / an `ObjectCount`
-    // filtered to `InZone { Hand }`.
+    // "you have no land cards in hand" (Land Grant). See residual (2) above.
     if let Some(condition) = parse_hand_condition(text) {
         return Some(condition);
     }
 
-    // "an opponent had two or more creatures enter the battlefield under their control
-    // this turn"; "an opponent searched their library this turn"; "you've been attacked
-    // this step". Shared targets: `BattlefieldEntriesThisTurn { player, filter }` and
-    // `PlayerActionsThisTurn { action }`. (`BeenAttackedThisStep` is the one leaf here
-    // with NO shared counterpart — `StaticCondition` has no per-STEP attack history.)
+    // "you've been attacked this step" (Assassin's Blade, Harsh Justice, …), plus the
+    // "[type] entered under your control this turn" surface that ELIDES "the battlefield"
+    // (Gargoyle Flock's "an artifact entered under your control this turn"). The shared
+    // entered-grammar's suffix spells "the battlefield" literally, so it does not match
+    // the elided form. See residual (1) above.
     if let Some(condition) = parse_event_condition(text) {
         return Some(condition);
     }
 
-    // CR 508.1a: "you attacked with [N or more creatures | a <filter>] this turn"
-    // (Thaumaton Torpedo). Shared target: `QuantityComparison` over
-    // `AttackedThisTurn { scope, filter }`, which already carries the attacker filter.
-    if let Some(condition) = parse_you_attacked_with(text) {
-        return Some(condition);
-    }
-
     None
-}
-
-/// CR 508.1a: "you attacked with [N or more creatures | a/an <filter>] [this turn]".
-/// One authority for the whole attacked-with family: the bare numeric threshold carries
-/// no type qualifier (`filter: None`), the typed form carries the attacker filter.
-fn parse_you_attacked_with(text: &str) -> Option<ParsedCondition> {
-    if let Some(count) = parse_numeric_threshold(text, "you attacked with ", " creatures this turn")
-    {
-        return Some(ParsedCondition::YouAttackedWithAtLeast {
-            count: count as u32,
-            filter: None,
-        });
-    }
-    if let Some(count) =
-        parse_numeric_threshold(text, "you attacked with ", " or more creatures this turn")
-    {
-        return Some(ParsedCondition::YouAttackedWithAtLeast {
-            count: count as u32,
-            filter: None,
-        });
-    }
-    // The trailing "this turn" may already be stripped upstream (an activated-ability
-    // duration parser peels it before the cost-reduction condition is reparsed), so the
-    // typed form accepts both the suffixed and bare shapes.
-    parse_you_attacked_with_filter(text)
-}
-
-/// CR 508.1a: Parse "you attacked with a/an <filter>[ this turn]" into a
-/// `ParsedCondition::YouAttackedWithAtLeast { count: 1, filter }`. The `<filter>`
-/// is delegated to `parse_type_phrase` so the whole class of attacker qualifiers
-/// (Spacecraft, Vehicle, a specific creature type, …) is covered by the shared
-/// type-phrase combinator rather than a per-card literal. Returns `None` unless
-/// the entire phrase after the filter is consumed (modulo an optional " this
-/// turn"), keeping unrecognized qualifiers an honest gap.
-fn parse_you_attacked_with_filter(text: &str) -> Option<ParsedCondition> {
-    let (rest, _) = tag::<_, _, OracleError<'_>>("you attacked with ")
-        .parse(text)
-        .ok()?;
-    let (filter, remainder) = parse_type_phrase(rest);
-    // Reject the bare/untyped case: `parse_type_phrase` returns `Any` when no
-    // type word matched, which would over-match "you attacked with three or more
-    // creatures this turn" (handled by the numeric thresholds above). Require a
-    // concrete typed filter here.
-    if matches!(filter, TargetFilter::Any) {
-        return None;
-    }
-    // Consume an optional trailing " this turn" and any trailing punctuation with
-    // combinators (no manual string trimming), then require the phrase to be fully
-    // consumed so unrecognized qualifiers stay an honest gap. The duration suffix
-    // may already be stripped upstream, so it is optional.
-    let (remainder, _) = multispace0::<_, OracleError<'_>>(remainder).ok()?;
-    let (remainder, _) = opt(tag::<_, _, OracleError<'_>>("this turn"))
-        .parse(remainder)
-        .ok()?;
-    let (remainder, _) = multispace0::<_, OracleError<'_>>(remainder).ok()?;
-    let (remainder, _) = opt(one_of::<_, _, OracleError<'_>>(".,;"))
-        .parse(remainder)
-        .ok()?;
-    let (remainder, _) = multispace0::<_, OracleError<'_>>(remainder).ok()?;
-    if !remainder.is_empty() {
-        return None;
-    }
-    Some(ParsedCondition::YouAttackedWithAtLeast {
-        count: 1,
-        filter: Some(filter),
-    })
 }
 
 /// CR 601.3 / CR 602.5: Convert a shared `StaticCondition` into the restriction
@@ -646,121 +569,62 @@ fn parse_source_power_threshold(text: &str) -> Option<i32> {
         .ok()?;
     rest.trim().is_empty().then_some(power as i32)
 }
-
-/// CR 601.3 / CR 602.5: The one board-state restriction leaf the shared grammar cannot
-/// yet produce — "you control N or more lands with the same name" (Endless Atlas,
-/// Sceptre of Eternal Glory).
+/// CR 402.1 + CR 601.3: "you have no <kind> cards in hand" (Land Grant) — the ONE hand
+/// predicate the shared grammar cannot own.
 ///
-/// Everything else this function used to parse is now produced by `parse_inner_condition`
-/// and converted through `QuantityComparison`, including four readings this parser got
-/// WRONG and which are therefore deliberately not reproduced here:
+/// Every other hand surface this parser used to hold ("no cards in hand", "exactly N",
+/// "exactly N or M", "one or fewer", "more cards in hand than each opponent") is now
+/// spelled by `parse_hand_size_predicate` in the shared grammar and converts through
+/// `QuantityComparison` / `Or`. They were deleted in P02-U3b, not moved.
 ///
-/// - the bare-subtype catch-all dumped any unrecognized qualifier into a stringly-typed
-///   `subtype` ("creature that fought this turn", "green permanents that share an
-///   artist"), producing a subtype no permanent has and a restriction that could never
-///   be satisfied;
-/// - "you control fewer creatures than each opponent" built a `QuantityVsEachOpponent`
-///   whose lhs and rhs were BOTH "creatures you control", so it compared a value to
-///   itself and was constant-false;
-/// - "you control a commander" became subtype `"commander"`, likewise unsatisfiable
-///   (the shared grammar now reads it as `ControlsCommander`, which converts per CR 903.3d);
-/// - "you control no creatures and only during your turn" returned
-///   `YouControlNoCreatures` and silently swallowed the timing half of the restriction.
-///
-/// Those phrases now fail this parser and reach the ordinary `Effect::Unimplemented`
-/// fallback, which is the honest answer for text the engine cannot represent.
-fn parse_you_control_condition(text: &str) -> Option<ParsedCondition> {
-    // Shared target once `parse_inner_condition` learns the phrasing:
-    // `QuantityRef::ObjectCountBySharedQuality { quality: Name }`.
-    parse_numeric_threshold(text, "you control ", " or more lands with the same name")
-        .map(|count| ParsedCondition::YouControlLandsWithSameNameAtLeast { count })
-}
-
+/// This leaf survives on JUSTIFICATION 2 (no shared vocabulary), NOT as a phrasing gap:
+/// it is an OWNER-relative count in a HIDDEN zone. `ZoneCoreTypeCardCountAtLeast` reads
+/// `player_zone_ids(player, Hand)` — the cards *this player owns* in hand. The shared
+/// reading would be an `ObjectCount` over a `TargetFilter` carrying `InZone { Hand }`,
+/// but `TargetFilter` has no owner axis, and the count path (`object_count_matching_ids`)
+/// discriminates by CONTROLLER through `matches_target_filter`. Those two predicates come
+/// apart exactly when a control-change effect has touched a card in an owner zone — the
+/// reason `matches_target_filter_in_owner_zone` exists as a separate entry point that the
+/// count path does not call. Converting this leaf would therefore not be a re-spelling; it
+/// would be a silently different question. Closing it needs an owner axis on
+/// `TargetFilter` (or an owner-zone-aware count ref).
 fn parse_hand_condition(text: &str) -> Option<ParsedCondition> {
-    // Quick reject: must reference "hand" somewhere
+    // Quick reject: must reference "hand" somewhere.
     if !text.contains("hand") {
         return None;
     }
-    // "you have no cards in hand"
-    if tag::<_, _, OracleError<'_>>("you have no cards")
-        .parse(text)
-        .is_ok()
-    {
-        return Some(ParsedCondition::HandSizeExact { count: 0 });
-    }
     // "you have no [kind] cards in hand" — e.g. "you have no land cards in hand".
-    // CR 601.3: Cast restriction — hand contains no cards of the given core type
-    // or subtype. Use count: 1 + Not because count-at-least 0 is always true.
-    // Verified: CR 601.3 (docs/MagicCompRules.txt:2475).
-    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("you have no ").parse(text) {
-        if let Ok((_, kind_raw)) = terminated(
-            take_until::<_, _, OracleError<'_>>(" card"),
-            alt((tag(" cards in hand"), tag(" card in hand"))),
-        )
-        .parse(rest)
-        {
-            let kind = kind_raw.trim();
-            if let Some(core_type) = parse_core_type_word(kind) {
-                return Some(ParsedCondition::Not {
-                    condition: Box::new(ParsedCondition::ZoneCoreTypeCardCountAtLeast {
-                        zone: Zone::Hand,
-                        core_type,
-                        count: 1,
-                    }),
-                });
-            }
-            if !kind.is_empty() {
-                return Some(ParsedCondition::Not {
-                    condition: Box::new(ParsedCondition::ZoneSubtypeCardCountAtLeast {
-                        zone: Zone::Hand,
-                        subtype: kind.to_string(),
-                        count: 1,
-                    }),
-                });
-            }
-        }
-    }
-    if tag::<_, _, OracleError<'_>>("you have one or fewer cards in hand")
+    // `Not(count >= 1)` rather than `count == 0` because a count-at-least-0 gate is
+    // always true. CR 601.3: cast restriction on hand contents.
+    let (rest, _) = tag::<_, _, OracleError<'_>>("you have no ")
         .parse(text)
-        .is_ok()
-    {
-        return Some(ParsedCondition::HandSizeOneOf { counts: vec![0, 1] });
-    }
-    // "you have more cards in hand than each opponent"
-    if tag::<_, _, OracleError<'_>>("you have more cards in hand than")
-        .parse(text)
-        .is_ok()
-    {
-        return Some(ParsedCondition::QuantityVsEachOpponent {
-            lhs: QuantityRef::HandSize {
-                player: PlayerScope::Controller,
-            },
-            comparator: Comparator::GT,
-            rhs: QuantityRef::HandSize {
-                player: PlayerScope::Controller,
-            },
+        .ok()?;
+    let (_, kind_raw) = terminated(
+        take_until::<_, _, OracleError<'_>>(" card"),
+        alt((tag(" cards in hand"), tag(" card in hand"))),
+    )
+    .parse(rest)
+    .ok()?;
+    let kind = kind_raw.trim();
+    if let Some(core_type) = parse_core_type_word(kind) {
+        return Some(ParsedCondition::Not {
+            condition: Box::new(ParsedCondition::ZoneCoreTypeCardCountAtLeast {
+                zone: Zone::Hand,
+                core_type,
+                count: 1,
+            }),
         });
     }
-    // "you have exactly N or M cards in hand"
-    if let Some(rest) = tag::<_, _, OracleError<'_>>("you have exactly ")
-        .parse(text)
-        .ok()
-        .and_then(|(rest, _)| rest.strip_suffix(" cards in hand"))
-    {
-        if rest.contains(" or ") {
-            let counts: Vec<usize> = rest
-                .split(" or ")
-                .filter_map(|s| parse_count_word(s.trim()))
-                .collect();
-            if counts.len() >= 2 {
-                return Some(ParsedCondition::HandSizeOneOf { counts });
-            }
-        }
-        if let Some(count) = parse_count_word(rest) {
-            return Some(ParsedCondition::HandSizeExact { count });
-        }
+    if kind.is_empty() {
+        return None;
     }
-    None
+    Some(ParsedCondition::Not {
+        condition: Box::new(ParsedCondition::ZoneSubtypeCardCountAtLeast {
+            zone: Zone::Hand,
+            subtype: kind.to_string(),
+            count: 1,
+        }),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -768,29 +632,25 @@ fn parse_hand_condition(text: &str) -> Option<ParsedCondition> {
 // ---------------------------------------------------------------------------
 
 /// CR 601.3 / CR 602.5: Event-history restriction leaves the shared conversion cannot
-/// produce today.
+/// produce.
 ///
-/// The self-scoped event predicates this function used to own ("you attacked this turn",
-/// "you gained life this turn", "a creature died this turn", "you've cast a <type> spell
-/// this turn", "an opponent lost life this turn", …) are now parsed by
-/// `parse_inner_condition` as `QuantityComparison`s over the event-history `QuantityRef`s
-/// and converted exactly, so they are gone from here.
+/// P02-U3b removed the two OPPONENT-scoped leaves this function used to own — "an
+/// opponent had N <type> enter the battlefield under their control this turn" and "an
+/// opponent searched their library this turn". Both are now spelled by
+/// `parse_inner_condition`, scoped with `PlayerScope::Opponent { aggregate: Max }`, and
+/// converted through `QuantityComparison`. (That port also FIXED them: the filter-carried
+/// `controller: Opponent` they used to build made the runtime SUM entries across all
+/// opponents, so in multiplayer two different opponents with one creature each satisfied
+/// "an opponent had TWO OR MORE creatures enter". `Opponent { Max }` counts per opponent.)
 ///
-/// What remains: opponent-scoped battlefield entries and library searches, and
-/// `BeenAttackedThisStep`. Of these only `BeenAttackedThisStep` is a true vocabulary gap
-/// (`StaticCondition` has no per-STEP attack history); the others are phrasing gaps whose
-/// shared targets are named in `parse_restriction_only_condition`.
+/// What remains has no shared counterpart:
+/// - `BeenAttackedThisStep` — `StaticCondition`'s attack history is per-TURN; there is no
+///   per-STEP vocabulary to spell at all.
+/// - the "[type] entered under your control this turn" surface that ELIDES "the
+///   battlefield" (Gargoyle Flock). The shared entered-grammar spells "entered the
+///   battlefield under your control this turn" literally, so the elided form never
+///   reaches it.
 fn parse_event_condition(text: &str) -> Option<ParsedCondition> {
-    // "an opponent [verb phrase]" — prefix dispatch
-    if let Ok((verb_phrase, _)) = tag::<_, _, OracleError<'_>>("an opponent ").parse(text) {
-        if let Some(condition) = parse_opponent_had_entered_this_turn(verb_phrase) {
-            return Some(condition);
-        }
-        if let Ok((_, condition)) = parse_opponent_event(verb_phrase) {
-            return Some(condition);
-        }
-    }
-
     // "you've been attacked this step"
     if let Ok((_, _)) = alt((
         terminated(
@@ -810,61 +670,6 @@ fn parse_event_condition(text: &str) -> Option<ParsedCondition> {
     }
 
     None
-}
-
-fn parse_opponent_had_entered_this_turn(verb_phrase: &str) -> Option<ParsedCondition> {
-    let (rest, _) = tag::<_, _, OracleError<'_>>("had ")
-        .parse(verb_phrase)
-        .ok()?;
-    parse_had_entered_this_turn(rest, ControllerRef::Opponent)
-}
-
-fn parse_had_entered_this_turn(text: &str, controller: ControllerRef) -> Option<ParsedCondition> {
-    let suffix = "enter the battlefield under their control this turn";
-    let (count, type_and_suffix) =
-        if let Some((count, after_count)) = super::oracle_util::parse_number(text) {
-            if let Ok((after_or_more, _)) =
-                tag::<_, _, OracleError<'_>>("or more ").parse(after_count.trim_start())
-            {
-                (count, after_or_more)
-            } else {
-                (1, text)
-            }
-        } else {
-            (1, text)
-        };
-    let (rest, type_text) = take_until::<_, _, OracleError<'_>>(suffix)
-        .parse(type_and_suffix)
-        .ok()?;
-    let (rest, _) = tag::<_, _, OracleError<'_>>(suffix).parse(rest).ok()?;
-    if !rest.is_empty() {
-        return None;
-    }
-    let (mut filter, _) = parse_type_phrase(type_text.trim());
-    if let TargetFilter::Typed(typed) = &mut filter {
-        typed.controller = Some(controller);
-        typed.properties.push(FilterProp::InZone {
-            zone: Zone::Battlefield,
-        });
-    }
-    Some(ParsedCondition::BattlefieldEntriesThisTurn { filter, count })
-}
-
-/// "an opponent [verb phrase]" → typed condition.
-///
-/// Only the library-search predicate survives: "an opponent lost/gained life this turn"
-/// is now produced by `parse_inner_condition` as a `QuantityComparison` and converted.
-/// Shared target for this one: `QuantityRef::PlayerActionsThisTurn { action }`.
-fn parse_opponent_event(verb_phrase: &str) -> nom::IResult<&str, ParsedCondition, OracleError<'_>> {
-    value(
-        ParsedCondition::OpponentSearchedLibraryThisTurn,
-        alt((
-            tag("searched their library this turn"),
-            tag("searched a library this turn"),
-            tag("has searched their library this turn"),
-        )),
-    )
-    .parse(verb_phrase)
 }
 
 /// CR 603.6a: modern enters templating is written "When [this object] enters"
@@ -1040,9 +845,12 @@ fn capitalize_condition_word(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{CountScope, TypeFilter};
+    use crate::types::ability::{
+        AggregateFunction, CountScope, PlayerScope, SharedQuality, TypeFilter,
+    };
     use crate::types::card_type::Supertype;
     use crate::types::counter::CounterType;
+    use crate::types::events::PlayerActionKind;
 
     /// Helper: assert the phrase reaches the SHARED grammar and converts.
     fn shared(text: &str) -> ParsedCondition {
@@ -1625,26 +1433,52 @@ mod tests {
     }
 
     /// CR 508.1a: the attacked-with family — numeric threshold and typed attacker filter.
+    ///
+    /// P02-U3b INVERTED this test's architecture assertion. It used to `falls_back(…)` —
+    /// pinning the family to the restriction-only fallback — and to expect the fixed
+    /// `YouAttackedWithAtLeast` leaf. The shared grammar now SPELLS both surfaces, so the
+    /// phrase must be OWNED by `parse_inner_condition` and arrive as the generic
+    /// `QuantityComparison` over the filter-carrying `AttackedThisTurn` ref. The old
+    /// assertions are kept only as this comment: reverting the port makes `shared(…)`
+    /// panic with "NoMatch (fell to restriction-only grammar)".
     #[test]
     fn retained_attacked_with_family() {
-        falls_back("you attacked with three or more creatures this turn");
-        assert_eq!(
-            parse_restriction_condition("you attacked with three or more creatures this turn"),
-            Some(ParsedCondition::YouAttackedWithAtLeast {
-                count: 3,
-                filter: None,
-            })
-        );
+        match shared("you attacked with three or more creatures this turn") {
+            ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::AttackedThisTurn {
+                                scope: CountScope::Controller,
+                                filter: None,
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 3 },
+            } => {}
+            other => panic!("expected unfiltered AttackedThisTurn >= 3, got {other:?}"),
+        }
         // Typed attacker (Thaumaton Torpedo). The trailing "this turn" may already be
         // stripped upstream, so both shapes must parse.
         for text in [
             "you attacked with a spacecraft this turn",
             "you attacked with a spacecraft",
         ] {
+            // P02-U3b: the shared grammar now owns this phrase, so it arrives as a
+            // QuantityComparison over the filter-carrying AttackedThisTurn ref rather
+            // than the retired fixed `YouAttackedWithAtLeast` leaf.
             match parse_restriction_condition(text) {
-                Some(ParsedCondition::YouAttackedWithAtLeast {
-                    count: 1,
-                    filter: Some(TargetFilter::Typed(tf)),
+                Some(ParsedCondition::QuantityComparison {
+                    lhs:
+                        QuantityExpr::Ref {
+                            qty:
+                                QuantityRef::AttackedThisTurn {
+                                    scope: CountScope::Controller,
+                                    filter: Some(TargetFilter::Typed(tf)),
+                                },
+                        },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: 1 },
                 }) => assert!(tf
                     .type_filters
                     .iter()
@@ -1659,31 +1493,32 @@ mod tests {
         );
     }
 
-    /// The remaining retained leaves, each with no exact shared counterpart today.
+    /// The leaves that genuinely have NO shared counterpart, and so stay in the
+    /// restriction-only fallback after P02-U3b.
+    ///
+    /// The four phrases this test used to also cover (lands-with-the-same-name, the
+    /// exact-hand-size disjunction, opponent library search, opponent battlefield
+    /// entries) moved to the shared grammar and are asserted there — see the
+    /// `shared_grammar_owns_*` tests.
     #[test]
-    fn retained_board_hand_and_event_leaves() {
-        assert_eq!(
-            parse_restriction_condition("you control three or more lands with the same name"),
-            Some(ParsedCondition::YouControlLandsWithSameNameAtLeast { count: 3 })
-        );
-        assert_eq!(
-            parse_restriction_condition("you have exactly zero or seven cards in hand"),
-            Some(ParsedCondition::HandSizeOneOf { counts: vec![0, 7] })
-        );
+    fn retained_leaves_with_no_shared_counterpart() {
+        // No per-STEP attack history exists in StaticCondition at all.
         assert_eq!(
             parse_restriction_condition("you've been attacked this step"),
             Some(ParsedCondition::BeenAttackedThisStep)
         );
+        // OWNER-relative count in a hidden zone: TargetFilter has no owner axis, so an
+        // ObjectCount would silently ask a controller-scoped question instead.
         assert_eq!(
-            parse_restriction_condition("an opponent searched their library this turn"),
-            Some(ParsedCondition::OpponentSearchedLibraryThisTurn)
+            parse_restriction_condition("you have no land cards in hand"),
+            Some(ParsedCondition::Not {
+                condition: Box::new(ParsedCondition::ZoneCoreTypeCardCountAtLeast {
+                    zone: Zone::Hand,
+                    core_type: CoreType::Land,
+                    count: 1,
+                })
+            })
         );
-        assert!(matches!(
-            parse_restriction_condition(
-                "an opponent had two or more creatures enter the battlefield under their control this turn"
-            ),
-            Some(ParsedCondition::BattlefieldEntriesThisTurn { count: 2, .. })
-        ));
     }
 
     /// Existential opponent comparisons (Weathered Wayfarer, Isolated Watchtower) flow
@@ -1730,6 +1565,198 @@ mod tests {
             other => panic!("expected filtered SpellsCastThisTurn >= 3, got {other:?}"),
         }
     }
+
+    // ---- P02-U3b: ported phrasing families now owned by the SHARED grammar ----
+    //
+    // Each of these asserts the phrase reaches `parse_inner_condition` AND converts.
+    // Pre-port every one of them panics with "NoMatch (fell to restriction-only
+    // grammar)" — that RED is the witness that the family was a real phrasing gap
+    // and not already-shadowed dead code.
+
+    /// CR 508.1a: the typed-attacker surface (Thaumaton Torpedo).
+    #[test]
+    fn shared_grammar_owns_you_attacked_with_typed_filter() {
+        match shared("you attacked with a Spacecraft this turn") {
+            ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::AttackedThisTurn {
+                                scope: CountScope::Controller,
+                                filter: Some(_),
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
+            } => {}
+            other => panic!("expected filtered AttackedThisTurn >= 1, got {other:?}"),
+        }
+    }
+
+    /// CR 508.1a: the numeric-threshold surface carries NO type qualifier.
+    #[test]
+    fn shared_grammar_owns_you_attacked_with_creature_count() {
+        match shared("you attacked with three or more creatures this turn") {
+            ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::AttackedThisTurn {
+                                scope: CountScope::Controller,
+                                filter: None,
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 3 },
+            } => {}
+            other => panic!("expected unfiltered AttackedThisTurn >= 3, got {other:?}"),
+        }
+    }
+
+    /// HOSTILE: an unrecognized attacker qualifier must stay an honest gap rather
+    /// than widening to "attacked with anything".
+    #[test]
+    fn unknown_attacker_qualifier_is_not_silently_widened() {
+        let parsed = parse_restriction_condition("you attacked with a frob the wobble this turn");
+        assert!(
+            parsed.is_none(),
+            "unknown attacker type must not produce a condition, got {parsed:?}"
+        );
+    }
+
+    /// CR 201.2 + CR 109.3: shared-name land count (Endless Atlas, Sceptre of Eternal Glory).
+    /// `aggregate: Max` is the load-bearing field — it is what makes this "some ONE
+    /// name is shared by three lands" instead of "you control three lands".
+    #[test]
+    fn shared_grammar_owns_lands_with_the_same_name() {
+        match shared("you control three or more lands with the same name") {
+            ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::ObjectCountBySharedQuality {
+                                quality: SharedQuality::Name,
+                                aggregate: AggregateFunction::Max,
+                                ..
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 3 },
+            } => {}
+            other => panic!("expected ObjectCountBySharedQuality[Name,Max] >= 3, got {other:?}"),
+        }
+    }
+
+    /// CR 102.2 + CR 608.2h: the opponent-scoped entry tally (Whiplash Trap).
+    ///
+    /// The scope MUST ride on `PlayerScope::Opponent{Max}`, not on a controller
+    /// injected into the type filter. A filter-carried controller sums entries
+    /// across ALL opponents, so in multiplayer two different opponents with one
+    /// creature each would satisfy "an opponent had TWO OR MORE creatures enter".
+    #[test]
+    fn shared_grammar_owns_opponent_battlefield_entries_per_opponent() {
+        match shared(
+            "an opponent had two or more creatures enter the battlefield under their control this turn",
+        ) {
+            ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::BattlefieldEntriesThisTurn {
+                                player:
+                                    PlayerScope::Opponent {
+                                        aggregate: AggregateFunction::Max,
+                                    },
+                                ..
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 2 },
+            } => {}
+            other => panic!("expected per-opponent BattlefieldEntriesThisTurn >= 2, got {other:?}"),
+        }
+    }
+
+    /// CR 701.23a: opponent library search (Archive Trap).
+    #[test]
+    fn shared_grammar_owns_opponent_searched_library() {
+        match shared("an opponent searched their library this turn") {
+            ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::PlayerActionsThisTurn {
+                                player:
+                                    PlayerScope::Opponent {
+                                        aggregate: AggregateFunction::Max,
+                                    },
+                                action: PlayerActionKind::SearchedLibrary,
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
+            } => {}
+            other => panic!("expected per-opponent SearchedLibrary >= 1, got {other:?}"),
+        }
+    }
+
+    /// CR 402.1 + CR 608.2c: the exact-hand-size DISJUNCTION (The Biblioplex).
+    /// Equivalent to the retired `HandSizeOneOf { counts }`, whose evaluator was
+    /// literally `counts.contains(&hand_size)`.
+    #[test]
+    fn shared_grammar_owns_exact_hand_size_disjunction() {
+        match shared("you have exactly zero or seven cards in hand") {
+            ParsedCondition::Or { conditions } => {
+                assert_eq!(conditions.len(), 2, "got {conditions:?}");
+                for (expected, cond) in [0, 7].iter().zip(conditions.iter()) {
+                    match cond {
+                        ParsedCondition::QuantityComparison {
+                            lhs:
+                                QuantityExpr::Ref {
+                                    qty: QuantityRef::HandSize { .. },
+                                },
+                            comparator: Comparator::EQ,
+                            rhs: QuantityExpr::Fixed { value },
+                        } => assert_eq!(value, expected),
+                        other => panic!("expected HandSize EQ leaf, got {other:?}"),
+                    }
+                }
+            }
+            other => panic!("expected Or over two HandSize EQ leaves, got {other:?}"),
+        }
+    }
+
+    /// The single-count "exactly N" surface must NOT become a one-armed `Or`
+    /// (Triskaidekaphile) — arity 1 stays a bare `EQ`, so the port is additive.
+    #[test]
+    fn exact_hand_size_single_count_stays_a_bare_eq() {
+        match shared("you have exactly seven cards in hand") {
+            ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::HandSize { .. },
+                    },
+                comparator: Comparator::EQ,
+                rhs: QuantityExpr::Fixed { value: 7 },
+            } => {}
+            other => panic!("expected a bare HandSize EQ 7, got {other:?}"),
+        }
+    }
+
+    /// RETAINED, NOT PORTED: `BeenAttackedThisStep` has no `StaticCondition`
+    /// counterpart (no per-STEP attack history), so it must still be produced by
+    /// the restriction-only fallback. This pins the boundary of the port.
+    #[test]
+    fn been_attacked_this_step_stays_in_the_restriction_only_fallback() {
+        assert!(matches!(
+            parse_shared_restriction_condition("you've been attacked this step"),
+            SharedRestrictionParse::NoMatch
+        ));
+        assert_eq!(
+            parse_restriction_condition("You've been attacked this step"),
+            Some(ParsedCondition::BeenAttackedThisStep)
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1749,19 +1776,28 @@ mod retained_family_gate {
     ///
     /// If you are here because this test went red: do not just append your parser to the
     /// list. Justify it, or teach the shared grammar the phrasing instead.
-    const PINNED_RETAINED_FAMILIES: [&str; 6] = [
+    const PINNED_RETAINED_FAMILIES: [&str; 4] = [
         // (a) restriction-context referent — the in-flight spell (CR 601.3d). PERMANENT.
         "parse_spell_targets_filter",
         // (b) vocabulary gap — ParsedCondition has no filter-carrying source predicate,
         //     so StaticCondition::SourceMatchesFilter cannot be converted. Root fix is a
         //     vocabulary alignment, not a parser edit.
         "parse_source_condition",
-        // (c) PHRASING GAPS — port pending (P02-U3b). Each has an existing shared target.
-        "parse_you_control_condition",
+        // (b) vocabulary gap — OWNER-relative count in a HIDDEN zone. TargetFilter has no
+        //     owner axis and the ObjectCount path discriminates by CONTROLLER, so the
+        //     shared reading would be a different predicate, not a re-spelling.
+        //     ("you have no <kind> cards in hand" — Land Grant.)
         "parse_hand_condition",
+        // (b) vocabulary gap — StaticCondition's attack history is per-TURN; there is no
+        //     per-STEP vocabulary for `BeenAttackedThisStep` to convert into.
         "parse_event_condition",
-        "parse_you_attacked_with",
     ];
+
+    // P02-U3b: the (c) PHRASING-GAP class is now EMPTY. `parse_you_control_condition` and
+    // `parse_you_attacked_with` were deleted outright, and `parse_hand_condition` /
+    // `parse_event_condition` were reduced to the (b) leaves above. Every family that
+    // remains is here because the shared vocabulary genuinely cannot express it — not
+    // because the grammar merely spells it differently.
 
     #[test]
     fn restriction_only_fallback_dispatches_exactly_the_pinned_families() {

--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -12,8 +12,8 @@ use super::oracle_nom::condition as nom_condition;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_target::parse_type_phrase;
 use crate::types::ability::{
-    CommanderOwnership, Comparator, ControllerRef, FilterProp, ParsedCondition, PlayerScope,
-    QuantityExpr, QuantityRef, StaticCondition, TargetFilter, TypedFilter,
+    CommanderOwnership, Comparator, ControllerRef, FilterProp, ParsedCondition, QuantityExpr,
+    QuantityRef, StaticCondition, TargetFilter, TypedFilter,
 };
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterMatch;
@@ -721,25 +721,6 @@ fn parse_etb_this_turn_condition(
 // ---------------------------------------------------------------------------
 // Helpers (moved from restrictions.rs)
 // ---------------------------------------------------------------------------
-
-fn parse_numeric_threshold(text: &str, prefix: &str, suffix: &str) -> Option<usize> {
-    let middle = text.strip_prefix(prefix)?.strip_suffix(suffix)?.trim();
-    parse_count_word(middle)
-}
-
-/// Parse a count word using nom combinator for digit/English number matching.
-fn parse_count_word(text: &str) -> Option<usize> {
-    let trimmed = text.trim();
-    if trimmed == "zero" {
-        return Some(0);
-    }
-    // Delegate to nom combinator for number parsing (handles digits and English words).
-    let lower = trimmed.to_lowercase();
-    nom_primitives::parse_number
-        .parse(&lower)
-        .ok()
-        .and_then(|(rest, n)| rest.is_empty().then_some(n as usize))
-}
 
 fn parse_core_type_word(text: &str) -> Option<CoreType> {
     CoreType::from_str(&capitalize_condition_word(

--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -129,7 +129,6 @@ fn parse_shared_restriction_condition(text: &str) -> SharedRestrictionParse {
 /// A parser that exists merely because the shared grammar spells the phrase differently
 /// is NOT justified — teach `parse_inner_condition` the phrasing instead (that is where
 /// every static ability with the same words already looks).
-
 fn parse_restriction_only_condition(text: &str) -> Option<ParsedCondition> {
     // JUSTIFICATION 1 — restriction-context referent (CR 601.3d).
     //

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -2843,12 +2843,13 @@ mod tests {
     }
 
     /// CR 508.1a + CR 601.2f: the conditional flat form gated by "you attacked
-    /// with a <filter>" extracts a filtered `YouAttackedWithAtLeast { count: 1 }`.
-    /// The trailing "this turn" is stripped upstream as a duration before the
-    /// reparse, so the bare form is what reaches the reducer (Thaumaton Torpedo).
+    /// with a <filter>" extracts a filtered `AttackedThisTurn` quantity gate
+    /// (GE 1). The trailing "this turn" is stripped upstream as a duration
+    /// before the reparse, so the bare form is what reaches the reducer
+    /// (Thaumaton Torpedo).
     #[test]
     fn cost_reduction_if_attacked_with_filter_gate() {
-        use crate::types::ability::ParsedCondition;
+        use crate::types::ability::{Comparator, CountScope, ParsedCondition, QuantityRef};
         let r = try_parse_cost_reduction(
             "this ability costs {3} less to activate if you attacked with a spacecraft",
         )
@@ -2856,9 +2857,17 @@ mod tests {
         assert_eq!(r.amount_per, 3);
         assert_eq!(r.count, QuantityExpr::Fixed { value: 1 });
         match r.condition {
-            Some(ParsedCondition::YouAttackedWithAtLeast {
-                count: 1,
-                filter: Some(TargetFilter::Typed(tf)),
+            Some(ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::AttackedThisTurn {
+                                scope: CountScope::Controller,
+                                filter: Some(TargetFilter::Typed(tf)),
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
             }) => assert!(
                 tf.type_filters
                     .iter()

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -250,6 +250,8 @@ fn parse_event_history_conditions(input: &str) -> OracleResult<'_, StaticConditi
         parse_source_didnt_this_turn,
         parse_was_cast_condition,
         parse_entered_this_turn,
+        // CR 102.2 + CR 608.2h: opponent-scoped entry tally (Zendikar trap cycle).
+        parse_opponent_had_entered_this_turn,
         parse_opponent_cast_spell_this_turn,
         parse_youve_this_turn,
         parse_first_spell_this_game_condition,
@@ -2470,6 +2472,35 @@ fn consume_cards_in_hand_suffix(input: &str) -> Option<&str> {
         })
 }
 
+/// CR 107.1 + CR 402.1: a hand-size count word, INCLUDING "zero".
+///
+/// `parse_number`'s English table starts at "one" — it does not know "zero" (the
+/// retired restriction fallback special-cased the word for exactly this reason).
+/// "Zero" is only ever printed as an EXACT size ("exactly zero or seven cards in
+/// hand" — The Biblioplex); a threshold never says "zero or more", so widening the
+/// shared `parse_number` primitive would change every numeric call site in the
+/// parser to buy one word. The zero-awareness stays local to the predicate that
+/// actually prints it.
+fn parse_hand_size_count(input: &str) -> OracleResult<'_, u32> {
+    alt((value(0u32, tag("zero")), parse_number)).parse(input)
+}
+
+/// CR 402.1: Parse the count list of an "exactly …" hand-size predicate — one or
+/// more counts joined by " or ", terminated by the cards-in-hand suffix.
+///
+/// `separated_list1` is the general shape: "exactly seven cards in hand" yields
+/// `[7]`, "exactly zero or seven cards in hand" yields `[0, 7]`. The caller turns
+/// arity 1 into a plain `EQ` and arity >= 2 into an `Or` over `EQ`s, so a card
+/// printing a three-way disjunction would need no further parser change.
+fn parse_exact_hand_size_disjunction(input: &str) -> Option<(&str, Vec<u32>)> {
+    let (rest, counts) =
+        nom::multi::separated_list1(tag::<_, _, OracleError<'_>>(" or "), parse_hand_size_count)
+            .parse(input)
+            .ok()?;
+    let rest = consume_cards_in_hand_suffix(rest)?;
+    Some((rest, counts))
+}
+
 fn parse_hand_size_predicate(rest: &str, player: PlayerScope) -> Option<(&str, StaticCondition)> {
     // "no cards in hand" → HandSize EQ 0
     if let Ok((rest, _)) = alt((
@@ -2506,14 +2537,33 @@ fn parse_hand_size_predicate(rest: &str, player: PlayerScope) -> Option<(&str, S
     }
 
     // "exactly N cards in hand" → HandSize EQ N (Triskaidekaphile).
+    //
+    // CR 402.1 + CR 608.2c: the threshold may be a DISJUNCTION of exact sizes —
+    // "exactly zero or seven cards in hand" (The Biblioplex). One "exactly" arm
+    // owns both surfaces: parse a `" or "`-separated list of counts, then emit a
+    // bare `EQ` for the single-count case (unchanged) and an `Or` over per-count
+    // `EQ`s for the disjunction. The list is the general shape; arity 1 is just
+    // its degenerate case, so no card-specific "zero or seven" literal is needed.
     if let Ok((after_exactly, _)) = tag::<_, _, OracleError<'_>>("exactly ").parse(rest) {
-        if let Ok((after_n, n)) = parse_number(after_exactly) {
-            if let Some(rest) = consume_cards_in_hand_suffix(after_n) {
-                return Some((
-                    rest,
-                    make_quantity_comparison(QuantityRef::HandSize { player }, Comparator::EQ, n),
-                ));
-            }
+        if let Some((rest, counts)) = parse_exact_hand_size_disjunction(after_exactly) {
+            let conditions: Vec<StaticCondition> = counts
+                .into_iter()
+                .map(|n| {
+                    make_quantity_comparison(
+                        QuantityRef::HandSize {
+                            player: player.clone(),
+                        },
+                        Comparator::EQ,
+                        n,
+                    )
+                })
+                .collect();
+            let mut conditions = conditions;
+            return match conditions.len() {
+                0 => None,
+                1 => Some((rest, conditions.remove(0))),
+                _ => Some((rest, StaticCondition::Or { conditions })),
+            };
         }
     }
 
@@ -3473,6 +3523,13 @@ pub(crate) fn parse_control_conditions(input: &str) -> OracleResult<'_, StaticCo
         // plain ObjectCount arm so the `with different names` suffix is not
         // mis-classified as a raw count threshold. Field of the Dead canonical.
         parse_control_count_ge_distinct_quality,
+        // CR 201.2 + CR 109.3: the SAME-quality mirror of the arm above — "you
+        // control N or more [type] with the same name" (Endless Atlas, Sceptre of
+        // Eternal Glory). Shares its ordering constraint: it must precede the plain
+        // `parse_control_count_ge` arm, which would otherwise consume "three or more
+        // lands" and silently DROP the shared-name constraint, turning a
+        // three-same-named-lands gate into a bare three-lands gate.
+        parse_control_count_ge_shared_quality,
         parse_control_count_ge_toughness_gt_power,
         parse_control_count_ge_subtype_disjunction,
         // "you control N or more [type]" → QuantityComparison(ObjectCount >= N)
@@ -3578,6 +3635,55 @@ fn parse_control_count_ge_distinct_quality(input: &str) -> OracleResult<'_, Stat
                 qty: QuantityRef::ObjectCountDistinct {
                     filter,
                     qualities: vec![quality],
+                },
+            },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: n as i32 },
+        },
+    ))
+}
+
+/// CR 201.2 + CR 109.3: Parse "you control N or more [type] with the same name"
+/// → `QuantityComparison(ObjectCountBySharedQuality[Name, Max] >= N)`.
+///
+/// The same-quality mirror of `parse_control_count_ge_distinct_quality`. Both read
+/// "you control " + a GE threshold + a type phrase + a shared-characteristic
+/// suffix; they differ only on the RELATION over that characteristic (`different`
+/// → count the distinct values; `the same` → group by value and take the largest
+/// group). `aggregate: Max` is what makes "three or more lands with the same name"
+/// mean "some ONE name is shared by at least three of your lands" rather than
+/// "you have at least three lands in total".
+///
+/// Name is the only quality printed with this relation today (Endless Atlas,
+/// Sceptre of Eternal Glory); the `alt` is the extension point for the rest of
+/// `SharedQuality` when a card prints one.
+fn parse_control_count_ge_shared_quality(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = tag("you control ").parse(input)?;
+    let (rest, n) = parse_ge_threshold(rest)?;
+    let type_text = rest.trim_end_matches('.');
+    let (filter, remainder) = parse_type_phrase(type_text);
+    if matches!(filter, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    let trimmed = remainder.trim_start();
+    let (after_suffix, quality) = preceded(
+        tag("with the same "),
+        alt((value(SharedQuality::Name, tag("name")),)),
+    )
+    .parse(trimmed)?;
+    let filter = inject_controller_you(filter);
+    let consumed = after_suffix.as_ptr() as usize - input.as_ptr() as usize;
+    Ok((
+        &input[consumed..],
+        StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCountBySharedQuality {
+                    filter,
+                    quality,
+                    aggregate: AggregateFunction::Max,
                 },
             },
             comparator: Comparator::GE,
@@ -5069,7 +5175,7 @@ fn parse_youve_player_action_history_condition(input: &str) -> OracleResult<'_, 
             make_quantity_ge(QuantityRef::CrimesCommittedThisTurn, 1),
             tag("committed a crime this turn"),
         ),
-        parse_player_action_this_turn_body,
+        |i| parse_player_action_this_turn_body(i, PlayerScope::Controller),
     ))
     .parse(input)
 }
@@ -5651,7 +5757,13 @@ fn parse_discard_history_condition(input: &str) -> OracleResult<'_, StaticCondit
 
 fn parse_combat_history_condition(input: &str) -> OracleResult<'_, StaticCondition> {
     alt((
-        // "you attacked this turn" (without "you've" prefix)
+        // "you attacked this turn" (without "you've" prefix).
+        //
+        // Ordering is load-bearing: the untyped surfaces are matched here FIRST so
+        // they keep producing `filter: None`. "a creature" is not a type QUALIFIER
+        // on these cards — it is the generic attacker noun (only creatures attack,
+        // CR 508.1a), so re-reading it as `Some(Creature)` would change the tree of
+        // every card already using this phrasing for no semantic gain.
         value(
             make_quantity_ge(
                 QuantityRef::AttackedThisTurn {
@@ -5665,8 +5777,86 @@ fn parse_combat_history_condition(input: &str) -> OracleResult<'_, StaticConditi
                 tag("you attacked this turn"),
             )),
         ),
+        parse_you_attacked_with_quantity,
     ))
     .parse(input)
+}
+
+/// CR 508.1a: "you attacked with [N | N or more] creatures this turn" (the
+/// numeric-threshold surface) and "you attacked with a/an <type> this turn" (the
+/// typed-attacker surface — Thaumaton Torpedo's "if you attacked with a
+/// Spacecraft this turn").
+///
+/// Both surfaces denote the same this-turn attack tally, so the only axes that
+/// vary are the threshold and the attacker filter — exactly the two fields
+/// `QuantityRef::AttackedThisTurn` already carries. The count arm is tried first
+/// because "three or more creatures" would otherwise be misread by the type-phrase
+/// parser as a bare Creature qualifier.
+fn parse_you_attacked_with_quantity(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = tag("you attacked with ").parse(input)?;
+    alt((
+        parse_attacked_with_creature_count,
+        parse_attacked_with_typed_filter,
+    ))
+    .parse(rest)
+}
+
+/// CR 508.1a: "[N | N or more] creatures this turn" — the untyped numeric
+/// threshold. Carries no type qualifier (`filter: None`), matching the bare
+/// surfaces above.
+fn parse_attacked_with_creature_count(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, n) = parse_number(input)?;
+    let (rest, _) = opt(tag(" or more")).parse(rest)?;
+    let (rest, _) = tag(" creatures this turn").parse(rest)?;
+    Ok((
+        rest,
+        make_quantity_ge(
+            QuantityRef::AttackedThisTurn {
+                scope: CountScope::Controller,
+                filter: None,
+            },
+            n,
+        ),
+    ))
+}
+
+/// CR 508.1a: "a/an <type>[ this turn]" — the typed-attacker surface. The qualifier
+/// is delegated to `parse_type_phrase` so the whole class of attacker types
+/// (Spacecraft, Vehicle, any creature type) is covered by the shared combinator
+/// rather than a per-card literal. An unrecognized qualifier yields
+/// `TargetFilter::Any`, which is REJECTED so the phrase stays an honest gap
+/// instead of silently widening to "attacked with anything".
+///
+/// The trailing " this turn" is OPTIONAL: an activated-ability duration parser can
+/// peel it upstream before the cost-reduction condition is re-parsed, so Thaumaton
+/// Torpedo reaches this combinator in both the suffixed and the bare shape. The
+/// phrase must otherwise be consumed in full, so an unabsorbed qualifying clause
+/// stays an honest gap rather than being silently truncated.
+fn parse_attacked_with_typed_filter(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (filter, leftover) = parse_type_phrase(input);
+    if matches!(filter, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    let (rest, _) = opt(tag("this turn")).parse(leftover.trim_start())?;
+    if !rest.trim().is_empty() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    Ok((
+        rest,
+        make_quantity_ge(
+            QuantityRef::AttackedThisTurn {
+                scope: CountScope::Controller,
+                filter: Some(filter),
+            },
+            1,
+        ),
+    ))
 }
 
 /// Parse "no [type] attacked this turn" → global AttackedThisTurn count EQ 0.
@@ -5764,29 +5954,41 @@ fn parse_board_state_condition(input: &str) -> OracleResult<'_, StaticCondition>
     parse_no_on_battlefield(input)
 }
 
-fn player_action_this_turn_condition(action: PlayerActionKind) -> StaticCondition {
-    make_quantity_ge(
-        QuantityRef::PlayerActionsThisTurn {
-            player: PlayerScope::Controller,
-            action,
-        },
-        1,
-    )
+fn player_action_this_turn_condition(
+    action: PlayerActionKind,
+    player: PlayerScope,
+) -> StaticCondition {
+    make_quantity_ge(QuantityRef::PlayerActionsThisTurn { player, action }, 1)
 }
 
-fn parse_player_action_this_turn_body(input: &str) -> OracleResult<'_, StaticCondition> {
+/// CR 603.4: The player-action history predicates, parameterized by WHOSE history
+/// is read. The subject dispatchers below bind `player`; the verb vocabulary is
+/// shared, so "an opponent searched their library this turn" and "you surveilled
+/// this turn" differ only on that scope — no duplicated verb list.
+fn parse_player_action_this_turn_body(
+    input: &str,
+    player: PlayerScope,
+) -> OracleResult<'_, StaticCondition> {
     alt((
         value(
-            player_action_this_turn_condition(PlayerActionKind::Surveil),
+            player_action_this_turn_condition(PlayerActionKind::Surveil, player.clone()),
             tag("surveilled this turn"),
         ),
         value(
-            player_action_this_turn_condition(PlayerActionKind::Scry),
+            player_action_this_turn_condition(PlayerActionKind::Scry, player.clone()),
             alt((tag("scried this turn"), tag("scryed this turn"))),
         ),
         value(
-            player_action_this_turn_condition(PlayerActionKind::CollectEvidence),
+            player_action_this_turn_condition(PlayerActionKind::CollectEvidence, player.clone()),
             tag("collected evidence this turn"),
+        ),
+        // CR 701.23a: "searched their/a library this turn" (Archive Trap).
+        value(
+            player_action_this_turn_condition(PlayerActionKind::SearchedLibrary, player.clone()),
+            alt((
+                tag("searched their library this turn"),
+                tag("searched a library this turn"),
+            )),
         ),
     ))
     .parse(input)
@@ -5800,11 +6002,35 @@ fn parse_player_action_this_turn_body(input: &str) -> OracleResult<'_, StaticCon
 /// because the apostrophe follows `you` directly, but it is ordered first for
 /// consistency.)
 fn parse_player_action_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
-    preceded(
-        alt((tag("you've "), tag("you have "), tag("you "))),
-        parse_player_action_this_turn_body,
-    )
+    alt((
+        parse_opponent_action_this_turn,
+        preceded(alt((tag("you've "), tag("you have "), tag("you "))), |i| {
+            parse_player_action_this_turn_body(i, PlayerScope::Controller)
+        }),
+    ))
     .parse(input)
+}
+
+/// CR 102.2 + CR 102.3 + CR 603.4: "an opponent [has] <action> this turn" — the
+/// opponent-scoped surface of the same action history (Archive Trap's "if an
+/// opponent searched their library this turn").
+///
+/// `PlayerScope::Opponent { aggregate: Max }` is the EXISTENTIAL reading of "an
+/// opponent": the predicate holds when the action count of the single
+/// highest-scoring opponent clears the threshold, i.e. when SOME opponent did it.
+/// Summing across opponents instead would let two opponents' separate actions add
+/// up to satisfy a threshold neither of them met alone. (The shared grammar uses
+/// the same idiom in the other direction — "more life than an opponent" takes Min
+/// for its existential "an".)
+fn parse_opponent_action_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = tag("an opponent ").parse(input)?;
+    let (rest, _) = opt(tag("has ")).parse(rest)?;
+    parse_player_action_this_turn_body(
+        rest,
+        PlayerScope::Opponent {
+            aggregate: AggregateFunction::Max,
+        },
+    )
 }
 
 /// CR 305.1 + CR 305.2a: "you[ have] played a land this turn" — the simple-past
@@ -7168,10 +7394,12 @@ fn parse_entered_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
         // "you had N or more [type] enter ..." (counted threshold, GE) — the
         // "you had" auxiliary reads the present-tense "enter" surface. Falls
         // back to the singular "you had a/an/another [type] enter ..." form.
-        if let Ok(result) = parse_or_more_entered_count(rest, had_enter_suffix) {
+        if let Ok(result) =
+            parse_or_more_entered_count(rest, had_enter_suffix, PlayerScope::Controller)
+        {
             return Ok(result);
         }
-        return parse_entered_this_turn_subject(rest, had_enter_suffix, 1);
+        return parse_entered_this_turn_subject(rest, had_enter_suffix, 1, PlayerScope::Controller);
     }
 
     // CR 403.3 + CR 608.2h: self-inclusive disjunct "~ or another/a <type>
@@ -7215,12 +7443,13 @@ fn parse_entered_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
     }
 
     // Branch 1: "N or more [type] entered..."
-    if let Ok(result) = parse_or_more_entered_count(input, entered_suffix) {
+    if let Ok(result) = parse_or_more_entered_count(input, entered_suffix, PlayerScope::Controller)
+    {
         return Ok(result);
     }
 
     // Branch 2: "a/an/another [type] entered..."
-    parse_entered_this_turn_subject(input, entered_suffix, 1)
+    parse_entered_this_turn_subject(input, entered_suffix, 1, PlayerScope::Controller)
 }
 
 /// CR 403.3 + CR 608.2h: Parse "N or more [type] <suffix>" into a GE threshold
@@ -7243,6 +7472,7 @@ fn parse_entered_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
 fn parse_or_more_entered_count<'a>(
     input: &'a str,
     suffix: &'static str,
+    player: PlayerScope,
 ) -> OracleResult<'a, StaticCondition> {
     let (after_n, n) = parse_number(input)?;
     let (type_and_rest, _) = tag("or more ").parse(after_n.trim_start())?;
@@ -7252,10 +7482,7 @@ fn parse_or_more_entered_count<'a>(
     Ok((
         rest,
         make_quantity_ge(
-            QuantityRef::BattlefieldEntriesThisTurn {
-                player: PlayerScope::Controller,
-                filter,
-            },
+            QuantityRef::BattlefieldEntriesThisTurn { player, filter },
             n,
         ),
     ))
@@ -7265,6 +7492,7 @@ fn parse_entered_this_turn_subject<'a>(
     input: &'a str,
     suffix: &'static str,
     count: u32,
+    player: PlayerScope,
 ) -> OracleResult<'a, StaticCondition> {
     let (rest, type_text) = take_until(suffix).parse(input)?;
     let (rest, _) = tag(suffix).parse(rest)?;
@@ -7275,20 +7503,53 @@ fn parse_entered_this_turn_subject<'a>(
         rest,
         make_quantity_ge(
             // CR 608.2i: "entered ... this turn" is a look-back count — a permanent
-            // that entered under your control this turn still counts after it has
-            // left the battlefield (died, was bounced, or sacrificed). The
-            // BattlefieldEntriesThisTurn snapshot survives departure; the live-board
-            // EnteredThisTurn read did not. PlayerScope::Controller supplies "under
-            // your control" (the runtime keys on record.controller); the filter
-            // carries no controller of its own — mirroring parse_or_more_entered_count,
-            // the count-shape sibling, which likewise omits inject_controller_you.
-            QuantityRef::BattlefieldEntriesThisTurn {
-                player: PlayerScope::Controller,
-                filter,
-            },
+            // that entered under the scoped player's control this turn still counts
+            // after it has left the battlefield (died, was bounced, or sacrificed).
+            // The BattlefieldEntriesThisTurn snapshot survives departure; the live-
+            // board EnteredThisTurn read did not. `player` supplies the "under
+            // <whose> control" scope (the runtime keys on record.controller); the
+            // filter carries no controller of its own — mirroring
+            // parse_or_more_entered_count, the count-shape sibling, which likewise
+            // omits inject_controller_you.
+            QuantityRef::BattlefieldEntriesThisTurn { player, filter },
             count,
         ),
     ))
+}
+
+/// CR 102.2 + CR 102.3 + CR 608.2h: "an opponent had [N or more] <type> enter the
+/// battlefield under their control this turn" — the opponent-scoped mirror of
+/// `parse_entered_this_turn`'s "you had …" auxiliary surface (the Zendikar trap
+/// cycle: Baloth Cage Trap, Lavaball Trap, Permafrost Trap, Whiplash Trap).
+///
+/// The scope is carried by `PlayerScope::Opponent { aggregate: Max }`, NOT by a
+/// `controller: Opponent` injected into the type filter. That distinction is
+/// load-bearing and is the whole point of routing this phrase through the shared
+/// grammar:
+///
+/// - A filter-carried controller makes the runtime count every matching entry
+///   under ANY opponent's control and compare the SUM to the threshold. In a
+///   multiplayer game two DIFFERENT opponents each having one creature enter
+///   would then satisfy "an opponent had TWO OR MORE creatures enter" — but no
+///   single opponent had two.
+/// - `Opponent { Max }` counts per opponent and takes the largest tally, which is
+///   the existential reading the card actually prints: "an opponent" binds one
+///   player, and "their control" binds the count to that same player.
+///
+/// The two readings coincide in a two-player game, so this is invisible there and
+/// only bites at three or more players. (The shared grammar already uses this
+/// aggregate idiom in the other direction — "more life than an opponent" takes
+/// `Min` for its existential "an".)
+fn parse_opponent_had_entered_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = tag("an opponent had ").parse(input)?;
+    let suffix = "enter the battlefield under their control this turn";
+    let player = PlayerScope::Opponent {
+        aggregate: AggregateFunction::Max,
+    };
+    if let Ok(result) = parse_or_more_entered_count(rest, suffix, player.clone()) {
+        return Ok(result);
+    }
+    parse_entered_this_turn_subject(rest, suffix, 1, player)
 }
 
 /// Parse "there are N [or more] [things] ..." conditions.

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -6883,7 +6883,18 @@ fn spell_casting_option_parses_trap_alternative_cost() {
                 shards: vec![],
             },
         })
-        .condition(crate::types::ability::ParsedCondition::OpponentSearchedLibraryThisTurn)
+        .condition(crate::types::ability::ParsedCondition::QuantityComparison {
+            lhs: crate::types::ability::QuantityExpr::Ref {
+                qty: crate::types::ability::QuantityRef::PlayerActionsThisTurn {
+                    player: crate::types::ability::PlayerScope::Opponent {
+                        aggregate: crate::types::ability::AggregateFunction::Max,
+                    },
+                    action: crate::types::events::PlayerActionKind::SearchedLibrary,
+                },
+            },
+            comparator: crate::types::ability::Comparator::GE,
+            rhs: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+        })
     );
     assert_eq!(r.abilities.len(), 1);
     assert!(!matches!(

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -2033,7 +2033,8 @@ fn hyldas_crown_full_card_supported_with_during_your_turn_cost_reduction() {
 /// unimplemented parts. The card is a single activated ability; the only
 /// previously-failing fragment was the "This ability costs {3} less to
 /// activate if you attacked with a Spacecraft this turn" cost-reduction
-/// clause, now extracted with a filtered `YouAttackedWithAtLeast` gate.
+/// clause, now extracted as a typed `QuantityComparison` over a filtered
+/// `AttackedThisTurn` count (GE 1).
 /// (Runtime discrimination — Spacecraft attacker required, opponent's
 /// Spacecraft excluded — lives in `game::casting::tests::
 /// thaumaton_torpedo_cost_reduction_requires_spacecraft_attacker`.)
@@ -2058,12 +2059,15 @@ fn thaumaton_torpedo_full_card_supported_with_spacecraft_attacked_cost_reduction
     assert!(
         matches!(
             ability.cost_reduction.as_ref().unwrap().condition,
-            Some(
-                crate::types::ability::ParsedCondition::YouAttackedWithAtLeast {
-                    count: 1,
-                    filter: Some(_)
-                }
-            )
+            Some(crate::types::ability::ParsedCondition::QuantityComparison {
+                lhs: crate::types::ability::QuantityExpr::Ref {
+                    qty: crate::types::ability::QuantityRef::AttackedThisTurn {
+                        filter: Some(_),
+                        ..
+                    },
+                },
+                ..
+            })
         ),
         "cost reduction must gate on a filtered attacked-with condition, got {:?}",
         ability.cost_reduction

--- a/crates/engine/tests/integration/conditional_cost_reduction_3223.rs
+++ b/crates/engine/tests/integration/conditional_cost_reduction_3223.rs
@@ -144,9 +144,10 @@ This ability costs {4} less to activate if an opponent controls four or more non
 
 #[test]
 fn thaumaton_torpedo_cost_reduction_carries_spacecraft_attacker_condition() {
-    // #3223 follow-up: this gap is now filled by PR #3950, which models the
-    // "if you attacked with a <filter> this turn" gate as a filtered
-    // `YouAttackedWithAtLeast { count: 1, filter: Some(Spacecraft) }` condition.
+    // #3223 follow-up: this gap is now filled by PR #3950; the shared grammar
+    // models the "if you attacked with a <filter> this turn" gate as a typed
+    // `QuantityComparison` over a filtered `AttackedThisTurn` count (GE 1,
+    // Spacecraft filter).
     let card = "Thaumaton Torpedo";
     let oracle = "{6}, {T}, Sacrifice this artifact: Destroy target nonland permanent. \
 This ability costs {3} less to activate if you attacked with a Spacecraft this turn.";


### PR DESCRIPTION
The restriction-only fallback held four parser families that the shared
static-condition grammar could already have expressed — it just did not SPELL
their phrasings. Teach `parse_inner_condition` the five surfaces and delete the
fallback parsers; the shared grammar runs first, so each phrase now converts
through the ordinary `QuantityComparison` vocabulary that every static ability
with the same words already uses.

Ported (population 35,396 faces; instrument: full-pool dual export, whole-face
structural diff over ALL channels):
  - CR 508.1a "you attacked with [N or more creatures | a <type>][ this turn]"
    -> AttackedThisTurn { scope, filter }.  The trailing " this turn" is OPTIONAL:
    a full-pool reachability probe showed Thaumaton Torpedo reaching the fallback
    WITHOUT it (an upstream duration parser peels it), so requiring the suffix
    would have silently dropped that face.
  - CR 201.2 + CR 109.3 "you control N or more lands with the same name"
    -> ObjectCountBySharedQuality { quality: Name, aggregate: Max }.  The
    same-quality mirror of the existing `with different names` arm; `Max` is what
    makes it "some ONE name is shared by N lands" and not "you control N lands".
  - CR 102.2 + CR 608.2h "an opponent had [N] <type> enter the battlefield under
    their control this turn" -> BattlefieldEntriesThisTurn { player: Opponent{Max} }.
  - CR 701.23a "an opponent [has] searched their library this turn"
    -> PlayerActionsThisTurn { player: Opponent{Max}, action: SearchedLibrary }.
  - CR 402.1 + CR 608.2c "you have exactly N or M cards in hand" -> Or over
    HandSize EQ leaves.  "zero" needs its own tag: `parse_number`'s English table
    starts at "one".

MULTIPLAYER SEMANTIC FIX (Whiplash Trap, Lavaball Trap).  The fallback encoded the
opponent INSIDE the TargetFilter (`controller: Opponent`), so the runtime SUMMED
battlefield entries across ALL opponents.  Two DIFFERENT opponents with one creature
each therefore satisfied "an opponent had TWO OR MORE creatures enter" — but no
single opponent had two.  "An opponent" binds one player and "their control" binds
the count to that same player, so the threshold is per-opponent: `Opponent { Max }`.
The two readings coincide at two players and only diverge at three or more, which is
why the runtime witness needs three seats.

Retained, with honest justifications — the (c) phrasing-gap class is now EMPTY and
`PINNED_RETAINED_FAMILIES` drops 6 -> 4.  Everything left is (a) a restriction-context
referent or (b) a real vocabulary gap:
  - parse_spell_targets_filter: CR 601.3d in-flight-spell referent. Permanent.
  - parse_source_condition: ParsedCondition has no filter-carrying source predicate,
    so StaticCondition::SourceMatchesFilter cannot be converted.  Teaching the shared
    grammar a source phrasing today would make the shared parse SUCCEED and the
    conversion then REJECT it — a NET LOSS of restriction support.
  - parse_event_condition: `BeenAttackedThisStep` has no per-STEP counterpart at all
    (StaticCondition's attack history is per-TURN), plus the ETB surface that elides
    "the battlefield".
  - parse_hand_condition: "you have no <kind> cards in hand" is an OWNER-relative count
    in a HIDDEN zone.  `ZoneCoreTypeCardCountAtLeast` reads player_zone_ids(player, Hand);
    the shared ObjectCount path discriminates by CONTROLLER and TargetFilter has NO owner
    axis.  Converting it would not re-spell the phrase, it would ask a different question.

Proven-dead code deleted, not ported: the shared `parse_hand_size_predicate` already
spelled "no cards in hand", "one or fewer", "exactly N", and "more cards in hand than
each opponent".  A full-pool reachability probe (nonvacuous — it registered hits on
every leaf kept) showed ZERO faces reaching those leaves across all 35,396.

Evidence: red-first — the six new `shared_grammar_owns_*` tests were watched FAILING on
a pristine worktree at this commit's base, each with "NoMatch (fell to restriction-only
grammar)".  The whole-face full-pool diff caught a regression this change first
introduced (The Biblioplex, supported -> Unimplemented, because "zero" did not parse)
and it is fixed here.
