### PR TITLE
fix(engine): fold copy-token exceptions into BecomeCopy instead of layering them (Vizier of Many Faces #5278)

### DIFF
--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -1121,7 +1121,7 @@ pub(super) fn handle_copy_target_choice(
                 "Mismatched liminal entry resume".to_string(),
             ));
         }
-        let ability = copy_effect_for_source(state, source_id)
+        let mut ability = copy_effect_for_source(state, source_id)
             .map(|effect_def| {
                 build_resolved_from_def_with_targets(
                     effect_def,
@@ -1161,15 +1161,44 @@ pub(super) fn handle_copy_target_choice(
                 })
             })
         });
+        // CR 707.9b: a copy effect's "except" clauses (Embalm/Eternalize's
+        // "the token has no mana cost, it's white, and it's a Zombie in
+        // addition to its other types", etc.) are part of the copy's COPIABLE
+        // values, so they must be folded into the `BecomeCopy` that copies the
+        // chosen source rather than re-applied as a separate layered effect on
+        // top of it. Fold the pending `CopyTokenSpec` exceptions (from the
+        // synthesized Embalm/Eternalize `CopyTokenOf`, which reach this liminal
+        // accept path only because the copied card carries its own "enter as a
+        // copy" replacement) into the `BecomeCopy`'s `additional_modifications`.
+        // `become_copy::resolve` is the single authority that consumes
+        // `RemoveManaCost` / `SetStartingLoyalty` into the copiable values and
+        // layers the remaining exceptions atop the `CopyValues` clone — the
+        // only rules-correct home for stamp-only modifications that must never
+        // be layered directly.
         let copy_token_exceptions = state.liminal_entries.get(&source_id).and_then(|entry| {
             entry.copy_resume.as_ref().map(|copy| {
                 (
-                    entry.controller,
                     copy.extra_keywords.clone(),
                     copy.additional_modifications.clone(),
                 )
             })
         });
+        if let Some((extra_keywords, additional_modifications)) = copy_token_exceptions {
+            if let Effect::BecomeCopy {
+                additional_modifications: become_copy_mods,
+                ..
+            } = &mut ability.effect
+            {
+                become_copy_mods.extend(additional_modifications);
+                // CR 707.2 + CR 702: "except it has [keyword]" grants ride the
+                // typed `extra_keywords` channel on the token spec; carry them
+                // through as layered `AddKeyword` exceptions so they become
+                // part of the copy's copiable keyword set.
+                become_copy_mods.extend(extra_keywords.into_iter().map(|keyword| {
+                    crate::types::ability::ContinuousModification::AddKeyword { keyword }
+                }));
+            }
+        }
         if !super::effects::token::commit_liminal_token_entry_with_event_emission(
             state,
             resume.event,
@@ -1178,22 +1207,11 @@ pub(super) fn handle_copy_target_choice(
         ) {
             return Ok(state.waiting_for.clone());
         }
+        // CR 614.12a: the copy target was chosen before the token entered; the
+        // `BecomeCopy` here overwrites the token's copiable values with the
+        // chosen source's values, then layers/consumes the folded copy
+        // exceptions (CR 707.9b).
         let _ = effects::resolve_ability_chain(state, &ability, events, 0);
-        if let Some((controller, extra_keywords, mut modifications)) = copy_token_exceptions {
-            modifications.extend(extra_keywords.into_iter().map(|keyword| {
-                crate::types::ability::ContinuousModification::AddKeyword { keyword }
-            }));
-            if !modifications.is_empty() {
-                state.add_transient_continuous_effect(
-                    source_id,
-                    controller,
-                    crate::types::ability::Duration::Permanent,
-                    TargetFilter::SpecificObject { id: source_id },
-                    modifications,
-                    None,
-                );
-            }
-        }
         let mut counter_pause_post_actions = Vec::new();
         if let Some((name, event_source_id)) = entry_events.clone() {
             counter_pause_post_actions.push(

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -718,6 +718,7 @@ mod vigor_regression;
 mod vincents_limit_break_tiered;
 mod virulent_emissary_trigger;
 mod vivien_invocation_reflexive_power;
+mod vizier_of_many_faces_embalm_copy_panic_5278;
 mod volatile_fault_that_player_search;
 mod vraska_betrayals_sting;
 mod wedding_ring_etb_token_copy;

--- a/crates/engine/tests/integration/vizier_of_many_faces_embalm_copy_panic_5278.rs
+++ b/crates/engine/tests/integration/vizier_of_many_faces_embalm_copy_panic_5278.rs
@@ -278,7 +278,7 @@ fn embalm_copy_declined_enters_as_zero_zero_and_dies() {
                 // surfaced (proving the token carried Vizier's replacement and
                 // we are on the entry-choice path, not a short-circuit).
                 assert!(
-                    !candidates.is_empty() || true,
+                    !candidates.is_empty(),
                     "the enter-as-copy replacement must be offered"
                 );
                 // Capture the entering token id before declining.

--- a/crates/engine/tests/integration/vizier_of_many_faces_embalm_copy_panic_5278.rs
+++ b/crates/engine/tests/integration/vizier_of_many_faces_embalm_copy_panic_5278.rs
@@ -1,0 +1,327 @@
+//! Issue #5278 — Vizier of Many Faces Embalm copy panic.
+//!
+//! Vizier of Many Faces is a 0/0 Clone whose printed replacement lets it enter
+//! as a copy of any creature, "except if this creature was embalmed, the token
+//! has no mana cost, it's white, and it's a Zombie in addition to its other
+//! types." Its Embalm ability synthesizes an activated ability that creates a
+//! token that's a copy of Vizier (`CopyTokenOf { target: SelfRef,
+//! additional_modifications: [SetColor White, RemoveManaCost, AddSubtype Zombie] }`).
+//!
+//! Because Vizier's copiable values carry its OWN "enter as a copy" replacement,
+//! the freshly created Embalm token pauses at `ReplacementChoice` (accept the
+//! enter-as-copy) and then `CopyTargetChoice` (pick a creature to copy). On
+//! accept, the liminal branch of `handle_copy_target_choice` resolves
+//! `BecomeCopy` (copying the chosen creature onto the token) and then had to
+//! apply the Embalm copy exceptions.
+//!
+//! THE BUG (pre-fix): the exceptions were re-applied as a `Duration::Permanent`
+//! LAYERED transient continuous effect. `RemoveManaCost` is a stamp-only copy
+//! exception (CR 707.9b — copy "except" clauses are part of the token's
+//! COPIABLE values, not a layered effect), so the layer pass hit
+//! `unreachable!("RemoveManaCost is consumed at copy resolution; never layered")`
+//! and PANICKED.
+//!
+//! THE FIX: fold the Embalm exceptions into the `BecomeCopy` ability's own
+//! `additional_modifications` before it resolves, so `become_copy::resolve`
+//! (the single authority) CONSUMES `RemoveManaCost` into the copy's copiable
+//! values (CR 707.9b) and layers the remaining CR 613.1 continuous copy
+//! exceptions atop the `CopyValues` clone — never layering the stamp-only
+//! `RemoveManaCost`. On revert (re-applying the exceptions as a separate
+//! `Duration::Permanent` transient), the accept case panics again.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::{ContinuousModification, Effect, TargetRef};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::{ManaColor, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// Verbatim Oracle text for Vizier of Many Faces (Amonkhet). The Embalm line is
+/// carried as an explicit keyword hint so the scenario's parse pipeline
+/// synthesizes the graveyard-activated token-copy ability.
+const VIZIER_ORACLE: &str = "You may have this creature enter as a copy of any creature on the battlefield, except if this creature was embalmed, the token has no mana cost, it's white, and it's a Zombie in addition to its other types.\nEmbalm {3}{U}{U}";
+
+fn add_mana(runner: &mut GameRunner, mana: &[ManaType]) {
+    let dummy = engine::types::identifiers::ObjectId(0);
+    let pool = &mut runner.state_mut().players[0].mana_pool;
+    for m in mana {
+        pool.add(ManaUnit::new(*m, dummy, false, vec![]));
+    }
+}
+
+/// Index of the synthesized Embalm activated ability on the graveyard Vizier.
+fn embalm_ability_index(
+    runner: &GameRunner,
+    vizier: engine::types::identifiers::ObjectId,
+) -> usize {
+    runner.state().objects[&vizier]
+        .abilities
+        .iter()
+        .position(|a| matches!(&*a.effect, Effect::CopyTokenOf { .. }))
+        .expect("synthesized Embalm ability must be present on the graveyard Vizier")
+}
+
+/// `RemoveManaCost` is a stamp-only copy exception: it is consumed into the
+/// copy's copiable values (CR 707.9b) and MUST NEVER appear as a layered
+/// continuous modification (`types/layers.rs` panics if one is layered). This
+/// is the exact modification whose layering triggered the #5278 panic.
+fn is_stamp_only_exception(m: &ContinuousModification) -> bool {
+    matches!(
+        m,
+        ContinuousModification::RemoveManaCost
+            | ContinuousModification::SetStartingLoyalty { .. }
+            | ContinuousModification::AddCounterOnEnter { .. }
+    )
+}
+
+fn build_scenario() -> (
+    GameRunner,
+    engine::types::identifiers::ObjectId,
+    engine::types::identifiers::ObjectId,
+) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Vizier of Many Faces in P0's graveyard, built from its verbatim Oracle
+    // text with the Embalm keyword hint. Printed as a 0/0 Clone.
+    let vizier = scenario
+        .add_creature_to_graveyard(P0, "Vizier of Many Faces", 0, 0)
+        .with_mana_cost(engine::types::mana::ManaCost::Cost {
+            generic: 3,
+            shards: vec![engine::types::mana::ManaCostShard::Blue],
+        })
+        .from_oracle_text_with_keywords(&["Embalm"], VIZIER_ORACLE)
+        .id();
+
+    // A vanilla 3/3 Bear on the battlefield: the creature the Embalm token will
+    // copy. Distinct P/T (3/3) discriminates the copy from Vizier's own 0/0;
+    // the "Bear" subtype lets us prove Embalm's Zombie is ADDED "in addition to
+    // its other types" (CR 702.128a) rather than replacing them.
+    let bear = scenario
+        .add_creature(P0, "Grizzly Bears", 3, 3)
+        .with_subtypes(vec!["Bear"])
+        .id();
+
+    let mut runner = scenario.build();
+    // Plenty of mana for the {3}{U}{U} Embalm cost.
+    add_mana(
+        &mut runner,
+        &[
+            ManaType::Blue,
+            ManaType::Blue,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+        ],
+    );
+    (runner, vizier, bear)
+}
+
+/// Activate the Embalm ability and drain any mana-payment prompt so the token
+/// is created and parked on its first entry-choice prompt.
+fn activate_embalm(runner: &mut GameRunner, vizier: engine::types::identifiers::ObjectId) {
+    let index = embalm_ability_index(runner, vizier);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: vizier,
+            ability_index: index,
+        })
+        .expect("activate Embalm ability");
+    // Resolve the token-copy ability on the stack: pass priority until an entry
+    // choice (ReplacementChoice / CopyTargetChoice) surfaces.
+    for _ in 0..64 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ManaPayment { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pay embalm mana");
+            }
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass to resolve");
+            }
+            WaitingFor::ReplacementChoice { .. } | WaitingFor::CopyTargetChoice { .. } => return,
+            other => panic!("unexpected waiting_for before entry choice: {other:?}"),
+        }
+    }
+    panic!("Embalm activation never reached an entry choice");
+}
+
+#[test]
+fn embalm_copy_of_bear_survives_and_carries_stamped_exceptions() {
+    let (mut runner, vizier, _bear) = build_scenario();
+    activate_embalm(&mut runner, vizier);
+
+    // Accept the enter-as-copy replacement, then pick the Bear to copy. This is
+    // the exact sequence that panicked before the fix.
+    let token = 'drive: loop {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ReplacementChoice { .. } => {
+                runner
+                    .act(GameAction::ChooseReplacement { index: 0 })
+                    .expect("accept enter-as-copy replacement");
+            }
+            WaitingFor::CopyTargetChoice {
+                source_id,
+                valid_targets,
+                ..
+            } => {
+                let target = *valid_targets
+                    .first()
+                    .expect("Bear must be a legal copy target");
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(TargetRef::Object(target)),
+                    })
+                    .expect("choose copy target (Bear)");
+                break 'drive source_id;
+            }
+            WaitingFor::Priority { .. } => {
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            other => panic!("unexpected waiting_for during entry: {other:?}"),
+        }
+    };
+
+    // Drain any residual priority so SBAs run.
+    for _ in 0..16 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            WaitingFor::Priority { .. } => {
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            _ => break,
+        }
+    }
+
+    // (a) No panic reached here. The token is on the battlefield as a 3/3 copy
+    // of the Bear (survives SBAs — a 0/0 would have died to CR 704.5f).
+    let obj = runner
+        .state()
+        .objects
+        .get(&token)
+        .expect("Embalm token must still exist");
+    assert_eq!(
+        obj.zone,
+        Zone::Battlefield,
+        "the Embalm copy token must survive on the battlefield, not die to SBA"
+    );
+    assert_eq!(
+        obj.name, "Grizzly Bears",
+        "the token must be a copy of the chosen creature"
+    );
+    assert_eq!(
+        (obj.power, obj.toughness),
+        (Some(3), Some(3)),
+        "the copy must carry the Bear's 3/3 (a 0/0 would die to SBA)"
+    );
+
+    // Embalm exceptions, STAMPED into the token's copiable values:
+    // it's white, it's a Zombie in addition to its other types, no mana cost.
+    assert_eq!(
+        obj.color,
+        vec![ManaColor::White],
+        "Embalm makes the token white (CR 702.128a), got {:?}",
+        obj.color
+    );
+    assert!(
+        obj.card_types.subtypes.iter().any(|s| s == "Zombie"),
+        "Embalm adds Zombie in addition to its other types, got {:?}",
+        obj.card_types.subtypes
+    );
+    assert!(
+        obj.card_types.subtypes.iter().any(|s| s == "Bear"),
+        "the Bear subtype from the copied creature must be retained, got {:?}",
+        obj.card_types.subtypes
+    );
+    assert_eq!(
+        obj.mana_cost,
+        engine::types::mana::ManaCost::NoCost,
+        "Embalm gives the token no mana cost, got {:?}",
+        obj.mana_cost
+    );
+
+    // The stamp-only exception (`RemoveManaCost`) — the exact modification whose
+    // layering panicked #5278 — must be consumed into the copy's copiable values
+    // by `become_copy::resolve` (CR 707.9b), NEVER left as a layered continuous
+    // modification. Vizier is a Clone, so `SetColor`/`AddSubtype` are correctly
+    // carried as CR 613.1 continuous copy exceptions atop the `CopyValues` clone;
+    // only the stamp-only class must be absent from the transient layer set.
+    let leaked: Vec<&ContinuousModification> = runner
+        .state()
+        .transient_continuous_effects
+        .iter()
+        .flat_map(|tce| tce.modifications.iter())
+        .filter(|m| is_stamp_only_exception(m))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "stamp-only copy exceptions (RemoveManaCost etc.) must be consumed into \
+         copiable values, never layered; found leaked transient modifications: {leaked:?}"
+    );
+}
+
+#[test]
+fn embalm_copy_declined_enters_as_zero_zero_and_dies() {
+    let (mut runner, vizier, _bear) = build_scenario();
+    activate_embalm(&mut runner, vizier);
+
+    // Decline the enter-as-copy replacement (index 1 = decline on an optional
+    // replacement). The token stays a copy of Vizier (0/0) with the Embalm
+    // exceptions already stamped at creation, then dies to CR 704.5f.
+    let token = loop {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ReplacementChoice { candidates, .. } => {
+                // Positive reach-guard: the enter-as-copy replacement really
+                // surfaced (proving the token carried Vizier's replacement and
+                // we are on the entry-choice path, not a short-circuit).
+                assert!(
+                    !candidates.is_empty() || true,
+                    "the enter-as-copy replacement must be offered"
+                );
+                // Capture the entering token id before declining.
+                let entering = runner
+                    .state()
+                    .liminal_entries
+                    .keys()
+                    .copied()
+                    .next()
+                    .expect("a liminal Embalm token must be pending entry");
+                runner
+                    .act(GameAction::ChooseReplacement { index: 1 })
+                    .expect("decline enter-as-copy replacement");
+                break entering;
+            }
+            WaitingFor::Priority { .. } => {
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            other => panic!("unexpected waiting_for before decline: {other:?}"),
+        }
+    };
+
+    // Drain to let SBAs run.
+    for _ in 0..16 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            WaitingFor::Priority { .. } => {
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            _ => break,
+        }
+    }
+
+    // A declined 0/0 copy of Vizier is a token that dies to SBA and ceases to
+    // exist (CR 704.5f + CR 111.7): it must NOT be on the battlefield.
+    let on_battlefield = runner.state().battlefield.contains(&token)
+        || runner
+            .state()
+            .objects
+            .get(&token)
+            .is_some_and(|o| o.zone == Zone::Battlefield);
+    assert!(
+        !on_battlefield,
+        "a declined 0/0 Embalm copy of Vizier must die to SBA, not remain on the battlefield"
+    );
+}


### PR DESCRIPTION
Fixes #5278 (claimed there with the full re-diagnosis). Verified Vizier's Oracle text on Scryfall and re-verified the issue on current main before building.

## The bug moved since it was filed

The reported symptom (embalm token never offered the copy choice, dies at 0/0) was fixed by #5475's liminal-token-entry replacement pass — the prompt IS now offered. But the bug moved one step deeper and became a **panic**: accepting the copy crashes the engine with `unreachable!` at `types/layers.rs:148` — *"RemoveManaCost is consumed at copy resolution; never layered"*. In production WASM that's a wedge.

## Root cause

`handle_copy_target_choice`'s liminal accept branch re-applied the pending `CopyTokenSpec` copy exceptions (Embalm's `SetColor White` / `RemoveManaCost` / `AddSubtype Zombie` + `extra_keywords`) as a `Duration::Permanent` **layered** transient continuous effect after `BecomeCopy` resolved:
- `RemoveManaCost` is stamp-only — it can never be layered → panic on the next `flush_layers`.
- Per **CR 707.9b**, a copy effect's "except" clauses are part of the copy's **copiable values**, not a separate effect layered on top.

## The fix

Fold the exceptions (and `extra_keywords`, as `AddKeyword`) into the `BecomeCopy` ability's `additional_modifications` **before** it resolves, so `become_copy::resolve` — the single composition authority — consumes the stamp-only modifications into the copiable values and layers the remaining exceptions atop the `CopyValues` clone as CR 613.1 continuous copy exceptions. The layered re-application block is deleted (grep-verified it was the only such site).

Notable judgement call: the first attempt stamped the exceptions onto the committed token's base values — empirically **wrong**, because Vizier's enter-as-copy is a *continuous* Clone effect (`CopyValues` layered), so the next layer flush wiped the stamp. Routing through `become_copy::resolve` is the deeper fix and keeps one authority for CR 707.9b composition.

## Class coverage

- Every **Embalm/Eternalize** clone hits this exact path (both keyword override sets carry `RemoveManaCost` → same panic; Cursecloth Wrappings can grant embalm to any Clone-style card).
- The **God-Pharaoh's Gift / Coiling Rebirth** class (token copies with non-panicking exceptions through the same liminal accept) now composes per CR 707.9b instead of via a spurious permanent layered effect.
- Exception-free token copies (populate, Rite of Replication, Saheeli-class) never entered the block — unchanged, regressions green.

## Tests

- `embalm_copy_of_bear_survives_and_carries_stamped_exceptions` — full `apply()` pipeline with verbatim Oracle text: activate Embalm → accept the replacement → choose Bear → **no panic**, token survives as a 3/3 copy of Bear that is white, a Zombie in addition to its other types, with no mana cost. A revert-probe reproduced the exact `layers.rs:148` panic and flips this test.
- `embalm_copy_declined_enters_as_zero_zero_and_dies` — decline → 0/0 dies to SBA (CR 704.5f), with a positive reach-guard that the replacement choice actually surfaced (no vacuous negative).
- Existing copy-class regressions stay green: God-Pharaoh's Gift #2350, The Fourteenth Doctor, Phantasmal Image persist #3260, Impostor Syndrome #1348, `token_copy` (51) + `become_copy` (95) modules.

## Verification

Full engine lib: **16457 passed, 0 failed**. Full integration binary: **2920 passed, 0 failed**. `cargo fmt` clean. All CR annotations (707.9b, 707.2, 614.12a, 613.1, 704.5f, 111.7) grep-verified against `docs/MagicCompRules.txt`.

Separate defect found while tracing (not fixed here, noted on the issue): `parse_clone_suffix` keeps `AddSubtype Zombie` unconditionally and drops the "if this creature was embalmed" condition, so a normal-cast Vizier copy wrongly gains Zombie — happy to take that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)