### PR TITLE
fix(parser): recognize "dealt damage to another creature this turn" intervening-if

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -324,7 +324,7 @@ fn parse_damage_dealt_this_turn_conditions(input: &str) -> OracleResult<'_, Stat
         parse_subject_was_dealt_excess_damage_this_turn,
         parse_player_was_dealt_damage_threshold_this_turn,
         parse_player_dealt_combat_damage_by_source_this_turn,
-        parse_source_dealt_damage_to_opponent_this_turn,
+        parse_source_dealt_damage_this_turn,
         parse_source_was_dealt_damage_this_turn,
     ))
     .parse(input)
@@ -503,12 +503,11 @@ fn parse_player_dealt_combat_damage_by_source_this_turn(
     ))
 }
 
-fn parse_source_dealt_damage_to_opponent_this_turn(
-    input: &str,
-) -> OracleResult<'_, StaticCondition> {
+fn parse_source_dealt_damage_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
     // CR 120.1 + CR 120.2a + CR 603.4: "<source-anaphor> dealt [combat] damage to a
-    // player/opponent this turn" — the *dealing* direction (source = the ability's
-    // own permanent). "it" is the source anaphor for triggered-ability
+    // player/opponent/creature this turn" — the *dealing* direction (source = the
+    // ability's own permanent). This covers player, opponent, AND creature (incl.
+    // "another creature") targets. "it" is the source anaphor for triggered-ability
     // intervening-ifs (Wave of Rats' dies trigger); "~"/"this creature"/"this
     // permanent" cover the self-ref forms. The optional "combat" qualifier narrows
     // the damage channel (CR 120.2a) so combat-only history is required.
@@ -528,6 +527,17 @@ fn parse_source_dealt_damage_to_opponent_this_turn(
             alt((tag("an opponent"), tag("opponent"))),
         ),
         value(TargetFilter::Player, alt((tag("a player"), tag("player")))),
+        // CR 120.1: the dealing-direction *creature* target (Wolverine, Best
+        // There Is: "if ~ dealt damage to another creature this turn"). "another"
+        // excludes the source itself (FilterProp::Another).
+        value(
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::Another])),
+            tag("another creature"),
+        ),
+        value(
+            TargetFilter::Typed(TypedFilter::creature()),
+            alt((tag("a creature"), tag("creature"))),
+        ),
     ))
     .parse(rest)?;
     let (rest, _) = tag(" this turn").parse(rest)?;
@@ -15261,6 +15271,44 @@ mod tests {
                 assert_eq!(typed.controller, Some(ControllerRef::Opponent));
             }
             other => panic!("expected opponent damage threshold quantity, got {other:?}"),
+        }
+    }
+
+    /// CR 120.1 + CR 603.4: "~ dealt damage to another creature this turn" — the
+    /// dealing-direction *creature* target (Wolverine, Best There Is). "another"
+    /// excludes the source (FilterProp::Another); no "combat" -> DamageKindFilter::Any.
+    #[test]
+    fn parse_source_dealt_damage_to_another_creature_this_turn() {
+        let (rest, c) =
+            parse_inner_condition("~ dealt damage to another creature this turn").unwrap();
+        assert_eq!(rest, "");
+        match c {
+            StaticCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::DamageDealtThisTurn {
+                                source,
+                                target,
+                                damage_kind,
+                                ..
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
+            } => {
+                assert_eq!(*source, TargetFilter::SelfRef);
+                assert_eq!(
+                    *target,
+                    TargetFilter::Typed(
+                        TypedFilter::creature().properties(vec![FilterProp::Another])
+                    )
+                );
+                assert_eq!(damage_kind, DamageKindFilter::Any);
+            }
+            other => {
+                panic!("expected DamageDealtThisTurn SelfRef->another-creature, got {other:?}")
+            }
         }
     }
 

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -1487,6 +1487,53 @@ fn trigger_dies_if_it_was_enchanted_attaches_attachment_lookback() {
     }
 }
 
+/// CR 603.4 + CR 120.1: Wolverine's end-step trigger puts a +1/+1 counter ONLY
+/// if it dealt damage to another creature this turn. Pre-fix the intervening-if
+/// (dealing-direction, creature target) was swallowed (`condition: None`).
+#[test]
+fn parse_wolverine_end_step_dealt_damage_to_creature_intervening_if() {
+    let def = parse_trigger_line(
+        "At the beginning of each end step, if Wolverine dealt damage to another creature \
+         this turn, put a +1/+1 counter on Wolverine.",
+        "Wolverine, Best There Is",
+    );
+
+    // Revert-guard: pre-fix `def.condition` is None.
+    match &def.condition {
+        Some(TriggerCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::DamageDealtThisTurn { source, target, .. },
+                },
+            comparator: Comparator::GE,
+            ..
+        }) => {
+            assert!(matches!(**source, TargetFilter::SelfRef));
+            match &**target {
+                TargetFilter::Typed(t) => {
+                    assert!(t
+                        .type_filters
+                        .iter()
+                        .any(|f| matches!(f, TypeFilter::Creature)));
+                    assert!(t
+                        .properties
+                        .iter()
+                        .any(|p| matches!(p, FilterProp::Another)));
+                }
+                other => panic!("expected Typed creature target, got {other:?}"),
+            }
+        }
+        other => panic!("expected DamageDealtThisTurn intervening-if, got {other:?}"),
+    }
+
+    let execute = def.execute.as_deref().expect("execute must be Some");
+    assert!(
+        matches!(*execute.effect, Effect::PutCounter { .. }),
+        "execute must be PutCounter, got {:?}",
+        execute.effect,
+    );
+}
+
 /// CR 208.1 + CR 603.4 + CR 603.10a + CR 608.2h: Deathknell Berserker -- a
 /// dies-trigger intervening "if" gated on the creature's last-known power
 /// ("if its power was 3 or greater"). The look-back reads the dying creature's

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -719,6 +719,7 @@ mod who_villainous_choice_scoped_player;
 mod willie_lumpkin_cant_attack;
 mod wise_mothman_milled_trigger;
 mod wise_mothman_target_distinctness;
+mod wolverine_best_there_is_dealt_damage_counter;
 mod wolverine_fierce_fighter_heal;
 mod wrenn_and_six_up_to_one_optout;
 mod yare_extra_blockers;

--- a/crates/engine/tests/integration/wolverine_best_there_is_dealt_damage_counter.rs
+++ b/crates/engine/tests/integration/wolverine_best_there_is_dealt_damage_counter.rs
@@ -1,0 +1,234 @@
+//! Wolverine, Best There Is — end-step self-growth trigger.
+//!
+//! Oracle (verbatim, card-data.json key "wolverine, best there is"):
+//!
+//! ```text
+//! Unrivaled Lethality — Double all damage Wolverine would deal.
+//! At the beginning of each end step, if Wolverine dealt damage to another
+//! creature this turn, put a +1/+1 counter on him.
+//! {1}{G}: Regenerate Wolverine. ...
+//! ```
+//!
+//! The regression these tests guard: the intervening-if "if Wolverine dealt
+//! damage to another creature this turn" (dealing-direction, *creature* target)
+//! used to be swallowed to `condition: None`, so the +1/+1 counter was placed on
+//! EVERY end step regardless of whether Wolverine actually hit a creature. The
+//! parser fix (`parse_source_dealt_damage_this_turn`) recognises the creature
+//! target; these tests prove the RUNTIME evaluates
+//! `QuantityRef::DamageDealtThisTurn { source: SelfRef, target: creature(Another) }`
+//! end-to-end through the real trigger pipeline (CR 603.4 intervening-if
+//! recheck + CR 120.1 damage history).
+//!
+//! Both tests build Wolverine identically from the FULL verbatim Oracle text via
+//! `add_creature_from_oracle`, so the difference in outcome (+1/+1 vs none) can
+//! only be the intervening-if gate, never a parse difference.
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// Wolverine, Best There Is — full verbatim Oracle text (card-data.json key
+/// "wolverine, best there is"). Built from the real card so the parsed trigger
+/// (and its intervening-if) is exercised exactly as production sees it.
+const WOLVERINE_ORACLE: &str = "Unrivaled Lethality — Double all damage Wolverine would deal.\n\
+     At the beginning of each end step, if Wolverine dealt damage to another creature \
+     this turn, put a +1/+1 counter on him.\n\
+     {1}{G}: Regenerate Wolverine.";
+
+/// Count of +1/+1 counters on an object (CR 122.1), `0` if absent.
+fn plus1_counters(runner: &GameRunner, obj: engine::types::ObjectId) -> u32 {
+    runner.state().objects[&obj]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+/// Effective power/toughness of a permanent (CR 208 / CR 209) — read off the
+/// post-layer object fields, mirroring `GameRunner::power_toughness`.
+fn power_toughness(runner: &GameRunner, obj: engine::types::ObjectId) -> (i32, i32) {
+    let o = &runner.state().objects[&obj];
+    (o.power.unwrap_or(0), o.toughness.unwrap_or(0))
+}
+
+/// Advance to the declare-blockers prompt, passing any priority window opened
+/// after attackers are declared (CR 508.2). Panics if the prompt never arrives
+/// — silently falling through would let the attacker go unblocked and deal no
+/// damage to the blocker, so the +1/+1 assertion would measure nothing.
+fn advance_to_declare_blockers(runner: &mut GameRunner) {
+    for _ in 0..32 {
+        match runner.state().waiting_for {
+            WaitingFor::DeclareBlockers { .. } => return,
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("passing priority before blockers must succeed");
+            }
+            ref other => panic!("expected DeclareBlockers or Priority, got {other:?}"),
+        }
+    }
+    panic!("never reached the DeclareBlockers prompt");
+}
+
+/// Drive from the current mid-turn state to the End step, then resolve the
+/// beginning-of-end-step trigger. The intervening-if is checked when the trigger
+/// would go on the stack (CR 603.4), so `advance_until_stack_empty` resolves it
+/// (placing the counter) only when the condition holds.
+fn resolve_end_step_trigger(runner: &mut GameRunner) {
+    runner.advance_to_end_step();
+    assert_eq!(
+        runner.state().phase,
+        Phase::End,
+        "must reach the End step so the beginning-of-end-step trigger can fire"
+    );
+    runner.advance_until_stack_empty();
+}
+
+/// POSITIVE: Wolverine deals combat damage to another creature this turn, so at
+/// the end step the intervening-if holds and Wolverine gains exactly one +1/+1
+/// counter. Revert-guard: if the runtime stopped evaluating
+/// `DamageDealtThisTurn(SelfRef -> creature(Another))` (the pre-fix `None`
+/// condition), the counter would either never appear (condition dropped) — this
+/// assertion flips.
+///
+/// CR 120.1 + CR 603.4 + CR 122.1.
+#[test]
+fn wolverine_gains_counter_after_dealing_damage_to_a_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // 2/4 so that even with "Double all damage Wolverine would deal" the blocker
+    // takes at most 4 — below the blocker's 6 toughness, so the blocker SURVIVES
+    // and stays a battlefield creature at end-step resolution (the damage-history
+    // target match reads the live object).
+    let wolverine = scenario
+        .add_creature_from_oracle(P0, "Wolverine, Best There Is", 2, 4, WOLVERINE_ORACLE)
+        .id();
+
+    // 1/6 blocker: survives Wolverine's (doubled) damage and deals only 1 back,
+    // so Wolverine (4 toughness) also survives. No death/SBA noise.
+    let blocker = scenario.add_creature(P1, "Stone Wall", 1, 6).id();
+
+    let mut runner = scenario.build();
+
+    // Precondition: no +1/+1 counters before combat.
+    assert_eq!(
+        plus1_counters(&runner, wolverine),
+        0,
+        "Wolverine starts with no +1/+1 counters"
+    );
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(wolverine, AttackTarget::Player(P1))])
+        .expect("P0 attacks with Wolverine");
+    advance_to_declare_blockers(&mut runner);
+    runner
+        .declare_blockers(&[(blocker, wolverine)])
+        .expect("P1 blocks Wolverine with the 1/6 wall");
+    runner.combat_damage();
+
+    // Reach-guard: Wolverine actually dealt damage to the blocker CREATURE this
+    // turn (so the end-step condition has something to be true about). Both
+    // creatures survived, so the record's target is a live battlefield creature.
+    assert!(
+        runner.state().objects[&blocker].damage_marked > 0,
+        "Wolverine must have dealt marked damage to the blocker creature this turn"
+    );
+    assert_eq!(
+        runner.state().objects[&blocker].zone,
+        Zone::Battlefield,
+        "the blocker survives and stays a creature on the battlefield"
+    );
+
+    resolve_end_step_trigger(&mut runner);
+
+    // The intervening-if held: exactly one +1/+1 counter.
+    assert_eq!(
+        plus1_counters(&runner, wolverine),
+        1,
+        "Wolverine gains exactly one +1/+1 counter after dealing damage to another creature"
+    );
+    // The counter is reflected in Wolverine's effective P/T (2/4 -> 3/5).
+    assert_eq!(
+        power_toughness(&runner, wolverine),
+        (3, 5),
+        "the +1/+1 counter raises Wolverine to 3/5"
+    );
+}
+
+/// NEGATIVE: same board and same Wolverine, but this turn Wolverine deals damage
+/// only to a PLAYER (an unblocked attack), never to a creature. The
+/// intervening-if is false, so NO +1/+1 counter is placed.
+///
+/// Non-vacuous: the reach-guard asserts P1 lost life — Wolverine DID deal damage
+/// this turn, so a bug that read the condition as "dealt ANY damage this turn"
+/// would place a counter here. It does not, proving the gate specifically
+/// requires a CREATURE target. A bystander creature is present (so "another
+/// creature Wolverine could have hit" exists on the board), isolating the
+/// player-vs-creature target axis. The positive sibling proves this exact
+/// trigger DOES place a counter when the target is a creature.
+///
+/// CR 120.1 + CR 603.4.
+#[test]
+fn wolverine_gains_no_counter_when_only_a_player_was_damaged() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let wolverine = scenario
+        .add_creature_from_oracle(P0, "Wolverine, Best There Is", 2, 4, WOLVERINE_ORACLE)
+        .id();
+
+    // A bystander creature that does NOT block — "another creature" is present on
+    // the board, but Wolverine never deals damage to it.
+    let bystander = scenario.add_creature(P1, "Grizzly Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    let p1_life_before = runner.life(P1);
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(wolverine, AttackTarget::Player(P1))])
+        .expect("P0 attacks P1 directly with Wolverine");
+    advance_to_declare_blockers(&mut runner);
+    // No blocks: Wolverine hits the PLAYER, not a creature.
+    runner
+        .declare_blockers(&[])
+        .expect("P1 declares no blockers");
+    runner.combat_damage();
+
+    // Reach-guard: Wolverine DID deal damage this turn — to the player. This is
+    // what makes the negative non-vacuous: the condition is not false because
+    // "no damage happened", it is false because the damage was not to a creature.
+    assert!(
+        runner.life(P1) < p1_life_before,
+        "reach-guard: Wolverine must have dealt damage to P1 this turn (life dropped)"
+    );
+    // The bystander creature is untouched and still a battlefield creature — a
+    // legal creature target existed, Wolverine simply never damaged it.
+    assert_eq!(
+        runner.state().objects[&bystander].damage_marked,
+        0,
+        "the bystander creature took no damage"
+    );
+    assert_eq!(runner.state().objects[&bystander].zone, Zone::Battlefield);
+
+    resolve_end_step_trigger(&mut runner);
+
+    // The intervening-if failed: NO +1/+1 counter, and Wolverine's P/T is still
+    // its printed 2/4.
+    assert_eq!(
+        plus1_counters(&runner, wolverine),
+        0,
+        "Wolverine gains NO +1/+1 counter when it only dealt damage to a player, not a creature"
+    );
+    assert_eq!(
+        power_toughness(&runner, wolverine),
+        (2, 4),
+        "Wolverine remains its printed 2/4 — the creature-target gate suppressed the counter"
+    );
+}


### PR DESCRIPTION
**Bug:** Wolverine, Best There Is ("At the beginning of each end step, if Wolverine dealt damage to another creature this turn, put a +1/+1 counter on him") parsed with `condition: null` — the intervening-if was **swallowed**, so the counter was placed **unconditionally**.

**Fix:** Extend the dealing-direction source-dealt-damage condition combinator's target axis with `"another creature"` / `"a creature"` (`Typed{Creature, [Another]}`), alongside the existing player/opponent targets. The clause now lifts to `TriggerCondition::QuantityComparison` over `QuantityRef::DamageDealtThisTurn(SelfRef → another creature) ≥ 1`; the runtime damage-record target matcher already handles creature targets. A pure-addition extension of one existing combinator — no new variant, no runtime change. Verified locally: both new parser tests pass, 96 `dealt`-family sibling tests stay green, clippy clean.

CR 120.1 (source of damage), CR 603.4 (intervening-if).
