### PR TITLE
ship/excess quantity channel

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -14594,7 +14594,7 @@ mod extort_synthesis_tests {
         assert!(matches!(
             amount,
             QuantityExpr::Ref {
-                qty: QuantityRef::PreviousEffectAmount
+                qty: QuantityRef::PreviousEffectAmount { .. }
             }
         ));
         assert!(matches!(player, TargetFilter::Controller));
@@ -14714,7 +14714,9 @@ mod extort_synthesis_tests {
         drain.sub_ability = Some(Box::new(ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Ref {
-                    qty: QuantityRef::PreviousEffectAmount,
+                    qty: QuantityRef::PreviousEffectAmount {
+                        channel: DamageChannel::Total,
+                    },
                 },
                 player: TargetFilter::Controller,
             },

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -5871,7 +5871,7 @@ fn is_extort_trigger(t: &TriggerDefinition) -> bool {
                                 &*gain.effect,
                                 Effect::GainLife {
                                     amount: QuantityExpr::Ref {
-                                        qty: QuantityRef::PreviousEffectAmount,
+                                        qty: QuantityRef::PreviousEffectAmount { .. },
                                     },
                                     player: TargetFilter::Controller,
                                 }
@@ -5976,7 +5976,9 @@ fn build_extort_trigger() -> TriggerDefinition {
         AbilityKind::Spell,
         Effect::GainLife {
             amount: QuantityExpr::Ref {
-                qty: QuantityRef::PreviousEffectAmount,
+                qty: QuantityRef::PreviousEffectAmount {
+                    channel: crate::types::ability::DamageChannel::Total,
+                },
             },
             player: TargetFilter::Controller,
         },

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2072,7 +2072,7 @@ fn legacy_quantity_ref(x: &QuantityRef) -> bool {
         | QuantityRef::FilteredTrackedSetSize { .. }
         | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
-        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::TurnsTaken
         | QuantityRef::CrimesCommittedThisTurn
         | QuantityRef::ChosenNumber
@@ -5663,7 +5663,7 @@ fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
         // Resolution-local / turn- / commander-scoped: no per-source binding
         // (member-invariant under uniformity).
         QuantityRef::ExiledFromHandThisResolution
-        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::TurnsTaken
         | QuantityRef::CrimesCommittedThisTurn
         | QuantityRef::AttackedThisTurn { .. }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1825,7 +1825,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             },
         },
         QuantityRef::ExiledFromHandThisResolution => Axes::NONE,
-        QuantityRef::PreviousEffectAmount => Axes::NONE,
+        QuantityRef::PreviousEffectAmount { .. } => Axes::NONE,
         QuantityRef::LifeLostThisTurn { player } => {
             let mut acc = Axes {
                 event: false,

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -5043,7 +5043,9 @@ fn x_spell_doubled_lose_life_drains_opponents_and_gains_controller() {
                 AbilityKind::Spell,
                 Effect::GainLife {
                     amount: QuantityExpr::Ref {
-                        qty: QuantityRef::PreviousEffectAmount,
+                        qty: QuantityRef::PreviousEffectAmount {
+                            channel: crate::types::ability::DamageChannel::Total,
+                        },
                     },
                     player: TargetFilter::Controller,
                 },
@@ -5178,7 +5180,7 @@ fn exsanguinate_oracle_text_drains_each_opponent_and_gains_controller() {
         Effect::GainLife {
             amount:
                 QuantityExpr::Ref {
-                    qty: QuantityRef::PreviousEffectAmount,
+                    qty: QuantityRef::PreviousEffectAmount { .. },
                 },
             player,
         } => assert_eq!(

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1537,7 +1537,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             format!("# of counter kinds among {}", fmt_target(filter))
         }
         QuantityRef::VoteCount { choice_index } => format!("# of votes for choice {choice_index}"),
-        QuantityRef::PreviousEffectAmount => "amount from preceding effect".into(),
+        QuantityRef::PreviousEffectAmount { .. } => "amount from preceding effect".into(),
         QuantityRef::TrackedSetSize => "cards moved".into(),
         QuantityRef::FilteredTrackedSetSize { filter, .. } => {
             format!("filtered tracked set ({})", fmt_target(filter))
@@ -7288,7 +7288,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         }
         QuantityRef::DistinctCounterKindsAmong { .. } => ("DistinctCounterKindsAmong", Handled),
         QuantityRef::VoteCount { .. } => ("VoteCount", Handled),
-        QuantityRef::PreviousEffectAmount => ("PreviousEffectAmount", Handled),
+        QuantityRef::PreviousEffectAmount { .. } => ("PreviousEffectAmount", Handled),
         QuantityRef::TrackedSetSize => ("TrackedSetSize", Handled),
         QuantityRef::FilteredTrackedSetSize { .. } => ("FilteredTrackedSetSize", Handled),
         QuantityRef::TrackedSetAggregate { .. } => ("TrackedSetAggregate", Handled),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -12992,7 +12992,9 @@ mod tests {
         let sub = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Ref {
-                    qty: QuantityRef::PreviousEffectAmount,
+                    qty: QuantityRef::PreviousEffectAmount {
+                        channel: crate::types::ability::DamageChannel::Total,
+                    },
                 },
                 player: TargetFilter::Controller,
             },
@@ -17313,7 +17315,9 @@ mod tests {
         let mut draw = ResolvedAbility::new(
             Effect::Draw {
                 count: QuantityExpr::Ref {
-                    qty: QuantityRef::PreviousEffectAmount,
+                    qty: QuantityRef::PreviousEffectAmount {
+                        channel: crate::types::ability::DamageChannel::Total,
+                    },
                 },
                 target: TargetFilter::Controller,
             },
@@ -17598,7 +17602,9 @@ mod tests {
         let mut draw = ResolvedAbility::new(
             Effect::Draw {
                 count: QuantityExpr::Ref {
-                    qty: QuantityRef::PreviousEffectAmount,
+                    qty: QuantityRef::PreviousEffectAmount {
+                        channel: crate::types::ability::DamageChannel::Total,
+                    },
                 },
                 target: TargetFilter::Controller,
             },

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2214,7 +2214,7 @@ fn quantity_ref_reads_zone(qty: &QuantityRef, zone: Zone) -> bool {
         | QuantityRef::FilteredTrackedSetSize { .. }
         | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
-        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::LifeLostThisTurn { .. }
         | QuantityRef::Speed { .. }
         | QuantityRef::EventContextAmount

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -384,7 +384,7 @@ fn quantity_ref_uses_unspent_mana(qty: &QuantityRef) -> bool {
         | QuantityRef::FilteredTrackedSetSize { .. }
         | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
-        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::LifeLostThisTurn { .. }
         | QuantityRef::PartySize { .. }
         | QuantityRef::Speed { .. }
@@ -654,7 +654,7 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::FilteredTrackedSetSize { .. }
         | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
-        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::LifeLostThisTurn { .. }
         | QuantityRef::Speed { .. }
         | QuantityRef::EventContextAmount
@@ -849,7 +849,7 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::FilteredTrackedSetSize { .. }
         | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
-        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::LifeLostThisTurn { .. }
         | QuantityRef::Speed { .. }
         | QuantityRef::EventContextAmount
@@ -2375,7 +2375,21 @@ fn resolve_ref(
         }
         // CR 608.2c: Numeric result from the preceding effect in a sub_ability chain.
         // The resolver stamps this from the parent effect's semantic event class.
-        QuantityRef::PreviousEffectAmount => state.last_effect_amount.unwrap_or(0),
+        //
+        // CR 120.6 / CR 120.10: `channel` picks WHICH tally the preceding effect
+        // left behind. Both are stamped by the damage effects and cleared at
+        // depth-0, so the two channels are read from the same resolution scope —
+        // this arm only chooses between them. Mirrors the condition peer
+        // `AbilityCondition::PreviousEffectAmount`, which already reads both.
+        QuantityRef::PreviousEffectAmount { channel } => match channel {
+            // CR 120.6: the total amount dealt/lost/removed.
+            DamageChannel::Total => state.last_effect_amount.unwrap_or(0),
+            // CR 120.10: only the damage dealt BEYOND lethal — "the amount of
+            // excess damage dealt to that creature this way" (Goblin
+            // Negotiation, Hell to Pay, Lacerate Flesh), "that excess damage"
+            // (Contest of Claws). 0 when the preceding effect dealt no excess.
+            DamageChannel::Excess => state.last_effect_excess_amount.unwrap_or(0),
+        },
         // CR 608.2c: "for each [thing] this way" — read the most recent tracked set size.
         QuantityRef::TrackedSetSize => state
             .tracked_object_sets

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -7999,7 +7999,7 @@ fn quantity_ref_refs_cost_paid_object(qty: &QuantityRef) -> bool {
         | QuantityRef::TrackedSetSize
         | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
-        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::LifeLostThisTurn { .. }
         | QuantityRef::PartySize { .. }
         | QuantityRef::UnspentMana { .. }

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -6919,7 +6919,7 @@ mod tests {
                 cond,
                 Some(AbilityCondition::QuantityCheck {
                     lhs: QuantityExpr::Ref {
-                        qty: QuantityRef::PreviousEffectAmount
+                        qty: QuantityRef::PreviousEffectAmount { .. }
                     },
                     comparator: Comparator::GE,
                     rhs: QuantityExpr::Fixed { value: 1 },

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1778,7 +1778,9 @@ pub(super) fn parse_targeted_action_ast(
                 }
             ) {
                 count = QuantityExpr::Ref {
-                    qty: QuantityRef::PreviousEffectAmount,
+                    qty: QuantityRef::PreviousEffectAmount {
+                        channel: crate::types::ability::DamageChannel::Total,
+                    },
                 };
             }
             let filter = parse_discard_card_filter(after_discard);

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -3283,7 +3283,9 @@ mod tests {
                 assert_eq!(
                     count,
                     QuantityExpr::Ref {
-                        qty: QuantityRef::PreviousEffectAmount
+                        qty: QuantityRef::PreviousEffectAmount {
+                            channel: crate::types::ability::DamageChannel::Total,
+                        }
                     },
                     "for-each tail must dispatch to PreviousEffectAmount"
                 );

--- a/crates/engine/src/parser/oracle_effect/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_effect/snapshot_tests.rs
@@ -188,7 +188,7 @@ fn hordewing_skaab_discard_that_many_uses_previous_effect_amount() {
         &*sub.effect,
         Effect::Discard {
             count: QuantityExpr::Ref {
-                qty: QuantityRef::PreviousEffectAmount,
+                qty: QuantityRef::PreviousEffectAmount { .. },
             },
             ..
         }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -11378,7 +11378,7 @@ fn windfall_draw_uses_previous_discard_max_for_each_player() {
         &*sub.effect,
         Effect::Draw {
             count: QuantityExpr::Ref {
-                qty: QuantityRef::PreviousEffectAmount
+                qty: QuantityRef::PreviousEffectAmount { .. }
             },
             target: TargetFilter::Controller,
         }
@@ -32905,7 +32905,9 @@ fn for_each_prefix_pump_threads_self_ref_target() {
     assert_eq!(
         def.repeat_for,
         Some(QuantityExpr::Ref {
-            qty: QuantityRef::PreviousEffectAmount,
+            qty: QuantityRef::PreviousEffectAmount {
+                channel: crate::types::ability::DamageChannel::Total,
+            },
         }),
         "repeat_for should scale by counters removed in the activation cost"
     );

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -1674,7 +1674,9 @@ mod tests {
             (
                 "Create an X/X green Ooze creature token, where X is the number of +1/+1 counters removed this way.",
                 QuantityExpr::Ref {
-                    qty: QuantityRef::PreviousEffectAmount,
+                    qty: QuantityRef::PreviousEffectAmount {
+                        channel: crate::types::ability::DamageChannel::Total,
+                    },
                 },
             ),
             (

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -8869,7 +8869,9 @@ pub fn parse_you_draw_this_way_condition(input: &str) -> OracleResult<'_, Abilit
         rest,
         AbilityCondition::QuantityCheck {
             lhs: QuantityExpr::Ref {
-                qty: QuantityRef::PreviousEffectAmount,
+                qty: QuantityRef::PreviousEffectAmount {
+                    channel: crate::types::ability::DamageChannel::Total,
+                },
             },
             comparator: Comparator::GE,
             rhs: QuantityExpr::Fixed { value: 1 },

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -619,6 +619,66 @@ fn parse_intensity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     .parse(input)
 }
 
+/// CR 120.10: The EXCESS damage the preceding effect in this resolution dealt —
+/// the damage beyond lethal ("If those sources together dealt an amount of
+/// damage to a creature greater than lethal damage, excess damage equal to the
+/// difference was dealt to that creature").
+///
+/// `QuantityRef::PreviousEffectAmount { channel: Excess }` reads
+/// `GameState::last_effect_excess_amount`, which the damage effects stamp
+/// alongside the total and which is cleared at depth-0 — the same
+/// resolution-local scope the "this way" wording denotes. The CONDITION peer
+/// (`AbilityCondition::PreviousEffectAmount { channel: Excess }`, "if excess
+/// damage was dealt this way") already read that channel; only the QUANTITY side
+/// was missing, so every one of these clauses was dropped whole.
+///
+/// Only the shape that carries an explicit "this way" is bound here:
+///
+///   `[the amount of ]excess damage dealt to <subject> this way`
+///   (Goblin Negotiation, Hell to Pay, Lacerate Flesh)
+///
+/// The bare demonstrative `"that excess damage"` is deliberately NOT bound, and
+/// that is a correctness constraint, not an oversight. Its antecedent is fixed by
+/// the sibling clause, and the two readings resolve from DIFFERENT state:
+///
+///   - Contest of Claws — "If excess damage was dealt THIS WAY, … where X is that
+///     excess damage." The antecedent is an effect in the SAME resolution, so
+///     `last_effect_excess_amount` is live. `PreviousEffectAmount { Excess }` is right.
+///   - Fall of Cair Andros — "Whenever a creature an opponent controls is dealt
+///     excess noncombat damage, amass Orcs X, where X is that excess damage." The
+///     antecedent is the TRIGGERING EVENT. The triggered ability resolves as its own
+///     top-level chain, and `last_effect_excess_amount` is cleared in the depth-0
+///     prelude (`effects/mod.rs`), so `PreviousEffectAmount { Excess }` reads
+///     `None` -> 0. Binding it there would render as supported and silently amass 0 —
+///     a BETTER-DISGUISED version of the raw-text `Variable` fabrication it replaced.
+///
+/// A context-free leaf combinator cannot tell those apart: the disambiguator is the
+/// sibling condition ("dealt this way") versus the trigger condition, which lives one
+/// layer up. Until that rebind exists at the clause layer, the bare demonstrative
+/// stays an honest red rather than a well-typed lie.
+fn parse_excess_damage_ref(input: &str) -> OracleResult<'_, QuantityRef> {
+    value(
+        QuantityRef::PreviousEffectAmount {
+            channel: DamageChannel::Excess,
+        },
+        (
+            opt(alt((tag("the amount of "), tag("the ")))),
+            tag("excess damage dealt to "),
+            // CR 120.10 enumerates the three permanent kinds that can be dealt
+            // excess damage (creature / planeswalker / battle).
+            alt((
+                tag("that creature"),
+                tag("that planeswalker"),
+                tag("that permanent"),
+                tag("that battle"),
+                tag("it"),
+            )),
+            tag(" this way"),
+        ),
+    )
+    .parse(input)
+}
+
 /// CR 107.3: "the chosen number" — the number a player named for this object
 /// (Liquid Fire's additional cost; Fluros of Myra's Marvels' as-enters choice).
 /// `QuantityRef::ChosenNumber` reads `ChosenAttribute::Number` off the source
@@ -634,6 +694,9 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
             parse_object_count_by_shared_quality,
             parse_chosen_number_ref,
             parse_intensity_ref,
+            // CR 120.10: must precede the generic damage/number arms so the
+            // "excess" channel wins over a plain damage reading.
+            parse_excess_damage_ref,
         )),
         parse_the_number_of,
         parse_object_property_aggregate_ref,

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1076,36 +1076,180 @@ fn parse_the_number_of(input: &str) -> OracleResult<'_, QuantityRef> {
     parse_number_of_inner(rest)
 }
 
+/// CR 107.1: The maximizing extremum adjective. Oracle text prints several
+/// interchangeable superlatives for the same `AggregateFunction::Max`
+/// ("greatest power", "highest mana value"); they are one axis, not one phrase
+/// each. Verdant Rejuvenation prints "highest".
+fn parse_max_extremum_adjective(input: &str) -> OracleResult<'_, ()> {
+    value((), alt((tag("greatest"), tag("highest"), tag("largest")))).parse(input)
+}
+
+/// CR 208.1 + CR 202.3: The aggregable object properties. Shared by every
+/// aggregate form so the property axis is declared once.
+fn parse_aggregate_property(input: &str) -> OracleResult<'_, ObjectProperty> {
+    alt((
+        value(ObjectProperty::Power, tag("power")),
+        value(ObjectProperty::Toughness, tag("toughness")),
+        parse_mana_value_phrase,
+    ))
+    .parse(input)
+}
+
+/// CR 608.2c: The nouns a chain-set anaphor can name. Plurals precede their
+/// singulars — otherwise `tag("card")` would match the prefix of "cards" and
+/// strand a trailing "s".
+fn parse_tracked_set_noun(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        alt((
+            tag("cards"),
+            tag("card"),
+            tag("permanents"),
+            tag("permanent"),
+            tag("creatures"),
+            tag("creature"),
+        )),
+    )
+    .parse(input)
+}
+
+/// CR 608.2c: The participles that name the action which PUBLISHED the chain
+/// tracked set.
+///
+/// This list is deliberately restricted to the causes the engine actually
+/// stamps (`ThisWayCause::{Exiled, Discarded, Sacrificed, Milled}`, stamped via
+/// `publish_tracked_set_with_causes`). "goaded" is **excluded on purpose**:
+/// `game/effects/goad.rs` publishes no tracked set, so binding "creatures
+/// goaded this way" (Havoc Eater) would aggregate over a stale or empty set and
+/// silently resolve to 0 — a well-typed lie. It stays an honest red until goad
+/// publishes its set.
+fn parse_this_way_participle(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        alt((
+            tag("exiled"),
+            tag("discarded"),
+            tag("sacrificed"),
+            tag("milled"),
+        )),
+    )
+    .parse(input)
+}
+
+/// CR 608.2c: The EXPLICIT chain-set anaphor — `[the ]<noun> <participle> this
+/// way`. The trailing "this way" is what makes it unambiguous: it names the set
+/// published by an effect in THIS resolution, so it cannot be confused with the
+/// linked-exile pool ("the exiled card" = exiled with the source, persistently)
+/// or the cost-paid referent ("the sacrificed permanent" = a cost). That is why
+/// this — and not the bare pre-nominal form — is the shape allowed to stand
+/// alone as a referent after "the <property> of ".
+fn parse_this_way_anaphor(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        (
+            opt(tag("the ")),
+            parse_tracked_set_noun,
+            tag(" "),
+            parse_this_way_participle,
+            tag(" this way"),
+        ),
+    )
+    .parse(input)
+}
+
+/// CR 608.2c: The anaphor that names the chain tracked set published by the
+/// immediately-preceding effect in the same ability ("those exiled cards", "the
+/// cards discarded this way", "the creatures sacrificed this way").
+///
+/// Single authority for chain-set anaphora, composed on two independent axes
+/// (noun x participle) rather than enumerated as a phrase table. Two
+/// grammatical shapes carry the same meaning:
+///
+/// - post-nominal participle: `[the ]<noun> <participle> this way`
+/// - pre-nominal adjective:   `{those|the} exiled <noun>`
+///
+/// The pre-nominal shape stays exile-only, exactly as before, and is reachable
+/// ONLY behind an aggregate prefix ("the total power of …"), where it is
+/// unambiguous. It must never be offered as a bare referent: outside that
+/// context "the exiled card" is claimed by two OTHER referents — the
+/// linked-exile pool (`parse_linked_exile_mana_value_ref` — "the mana value of
+/// the exiled card") and the craft-material pool ("… the exiled card used to
+/// craft it"). See [`parse_this_way_anaphor`] for the bare-referent form.
+fn parse_tracked_set_anaphor(input: &str) -> OracleResult<'_, ()> {
+    alt((
+        // Pre-nominal: "those exiled cards" / "the exiled cards". Unchanged.
+        value(
+            (),
+            (
+                alt((tag("those "), tag("the "))),
+                tag("exiled "),
+                parse_tracked_set_noun,
+            ),
+        ),
+        parse_this_way_anaphor,
+    ))
+    .parse(input)
+}
+
 /// CR 208.1 + CR 202.3: Parse object-property aggregate quantities such as
 /// "the greatest power among <filter>" and "the total mana value of <filter>".
 /// The aggregate axis and object-property axis are independent typed choices,
 /// so new siblings extend this combinator instead of adding one-off phrase
 /// recognition in the legacy quantity entry points.
 fn parse_object_property_aggregate_ref(input: &str) -> OracleResult<'_, QuantityRef> {
+    // CR 608.2c: the SINGULAR "this way" referent — "the <property> of <the
+    // noun <participle> this way>" (Ruinous Intrusion, Astarion's Thirst).
+    // There is no aggregate adjective here, so it cannot share the
+    // extremum/total prefix alt below. It is gated on the anaphor actually
+    // matching, which is what keeps it from stealing the cost-paid
+    // prepositional form ("the mana value of the sacrificed permanent" —
+    // pre-nominal participle, no "this way"; see
+    // `parse_cost_paid_object_prepositional_ref`).
+    //
+    // `Sum` over a one-member set is that member's value; this follows the
+    // precedent already set for the singular "the card exiled this way".
+    if let Ok((rest, property)) = (
+        tag::<_, _, OracleError<'_>>("the "),
+        parse_aggregate_property,
+        tag(" of "),
+    )
+        .parse(input)
+        .map(|(rest, (_, property, _))| (rest, property))
+    {
+        // Only the EXPLICIT "this way" anaphor may stand alone here — the bare
+        // pre-nominal "the exiled card" belongs to the linked-exile and
+        // craft-material referents (see `parse_this_way_anaphor`).
+        if let Ok((anaphor_rest, _)) = parse_this_way_anaphor(rest) {
+            return Ok((
+                anaphor_rest,
+                QuantityRef::TrackedSetAggregate {
+                    function: AggregateFunction::Sum,
+                    property,
+                    source: crate::types::ability::TrackedAnaphorSource::ChainSet,
+                },
+            ));
+        }
+    }
+
+    // The aggregate axis and the object-property axis are independent, so they
+    // are composed rather than enumerated: three properties x N extremum
+    // adjectives would otherwise be a permutation table.
     let (rest, (function, property)) = alt((
-        value(
-            (AggregateFunction::Max, ObjectProperty::Power),
-            tag("the greatest power among "),
+        // "the {greatest|highest|largest} <property> among "
+        map(
+            (
+                tag("the "),
+                parse_max_extremum_adjective,
+                tag(" "),
+                parse_aggregate_property,
+                tag(" among "),
+            ),
+            |(_, (), _, property, _)| (AggregateFunction::Max, property),
         ),
-        value(
-            (AggregateFunction::Max, ObjectProperty::Toughness),
-            tag("the greatest toughness among "),
-        ),
-        value(
-            (AggregateFunction::Max, ObjectProperty::ManaValue),
-            tag("the greatest mana value among "),
-        ),
-        value(
-            (AggregateFunction::Sum, ObjectProperty::Power),
-            tag("the total power of "),
-        ),
-        value(
-            (AggregateFunction::Sum, ObjectProperty::Toughness),
-            tag("the total toughness of "),
-        ),
-        value(
-            (AggregateFunction::Sum, ObjectProperty::ManaValue),
-            tag("the total mana value of "),
+        // "the total <property> of "
+        map(
+            (tag("the total "), parse_aggregate_property, tag(" of ")),
+            |(_, property, _)| (AggregateFunction::Sum, property),
         ),
     ))
     .parse(input)?;
@@ -1124,16 +1268,7 @@ fn parse_object_property_aggregate_ref(input: &str) -> OracleResult<'_, Quantity
             },
         ));
     }
-    if let Ok((anaphor_rest, _)) = alt((
-        tag::<_, _, OracleError<'_>>("those exiled cards"),
-        tag("the exiled cards"),
-        tag("the cards exiled this way"),
-        tag("cards exiled this way"),
-        tag("the card exiled this way"),
-        tag("card exiled this way"),
-    ))
-    .parse(rest)
-    {
+    if let Ok((anaphor_rest, _)) = parse_tracked_set_anaphor(rest) {
         return Ok((
             anaphor_rest,
             QuantityRef::TrackedSetAggregate {
@@ -9708,6 +9843,140 @@ mod tests {
                     ))
                 ),
             "\"that creature\" must not become a cost-paid demonstrative: {parsed:?}"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // t78 class D + C(ii): bindable quantity expressions whose typed home and
+    // live resolver both already exist. Each witness below is a full-pool face
+    // that currently fails to bind (honest red) or, worse, silently swallows
+    // its count.
+    // ---------------------------------------------------------------------
+
+    /// CR 202.3: "the HIGHEST mana value among <filter>" — the extremum
+    /// adjective is an independent axis from the property. Verdant
+    /// Rejuvenation prints "highest"; only "greatest" was recognized, so the
+    /// whole where-X clause fell to an honest red.
+    #[test]
+    fn aggregate_extremum_adjective_synonyms_bind() {
+        for phrase in [
+            "the highest mana value among creatures you control",
+            "the greatest mana value among creatures you control",
+            "the largest mana value among creatures you control",
+        ] {
+            let (rest, q) = parse_quantity_ref(phrase)
+                .unwrap_or_else(|e| panic!("{phrase:?} must bind: {e:?}"));
+            assert_eq!(rest, "", "{phrase:?} must fully consume");
+            assert!(
+                matches!(
+                    q,
+                    QuantityRef::Aggregate {
+                        function: AggregateFunction::Max,
+                        property: ObjectProperty::ManaValue,
+                        ..
+                    }
+                ),
+                "{phrase:?} -> {q:?}"
+            );
+        }
+    }
+
+    /// CR 608.2c: the "<noun> <participle> this way" anaphor names the chain
+    /// tracked set the immediately-preceding effect published. The participle
+    /// axis is independent of the noun axis; only `exiled` was recognized, so
+    /// `discarded` / `sacrificed` fell to honest reds.
+    ///
+    /// Restricted to causes the engine actually STAMPS
+    /// (`ThisWayCause::{Exiled,Discarded,Sacrificed,Milled}`). "goaded" is
+    /// deliberately absent — `effects/goad.rs` publishes no tracked set, so
+    /// binding it would resolve against a stale/empty set (a lying-green).
+    #[test]
+    fn tracked_set_anaphor_participle_axis_binds() {
+        // Ill-Timed Explosion (discarded), Sword of the Ages / Reign of the
+        // Pit (sacrificed), and the pre-existing exile forms.
+        for (phrase, function, property) in [
+            (
+                "the greatest mana value among cards discarded this way",
+                AggregateFunction::Max,
+                ObjectProperty::ManaValue,
+            ),
+            (
+                "the total power of the creatures sacrificed this way",
+                AggregateFunction::Sum,
+                ObjectProperty::Power,
+            ),
+            (
+                "the total power of the cards exiled this way",
+                AggregateFunction::Sum,
+                ObjectProperty::Power,
+            ),
+        ] {
+            let (rest, q) = parse_quantity_ref(phrase)
+                .unwrap_or_else(|e| panic!("{phrase:?} must bind: {e:?}"));
+            assert_eq!(rest, "", "{phrase:?} must fully consume");
+            match q {
+                QuantityRef::TrackedSetAggregate {
+                    function: f,
+                    property: p,
+                    source: crate::types::ability::TrackedAnaphorSource::ChainSet,
+                } => {
+                    assert_eq!(f, function, "{phrase:?} aggregate function");
+                    assert_eq!(p, property, "{phrase:?} property");
+                }
+                other => panic!("{phrase:?} must be a ChainSet TrackedSetAggregate, got {other:?}"),
+            }
+        }
+    }
+
+    /// CR 608.2c: a SINGULAR "this way" referent with no aggregate adjective —
+    /// "the mana value of the permanent exiled this way" (Ruinous Intrusion),
+    /// "the power of the creature exiled this way" (Astarion's Thirst). The
+    /// established precedent (`the card exiled this way`) reads these through
+    /// the chain tracked set; `Sum` over a one-member set is that member's
+    /// value.
+    #[test]
+    fn tracked_set_anaphor_singular_property_of_binds() {
+        for (phrase, property) in [
+            (
+                "the mana value of the permanent exiled this way",
+                ObjectProperty::ManaValue,
+            ),
+            (
+                "the power of the creature exiled this way",
+                ObjectProperty::Power,
+            ),
+        ] {
+            let (rest, q) = parse_quantity_ref(phrase)
+                .unwrap_or_else(|e| panic!("{phrase:?} must bind: {e:?}"));
+            assert_eq!(rest, "", "{phrase:?} must fully consume");
+            match q {
+                QuantityRef::TrackedSetAggregate {
+                    function: AggregateFunction::Sum,
+                    property: p,
+                    source: crate::types::ability::TrackedAnaphorSource::ChainSet,
+                } => assert_eq!(p, property, "{phrase:?} property"),
+                other => panic!("{phrase:?} must be a ChainSet TrackedSetAggregate, got {other:?}"),
+            }
+        }
+    }
+
+    /// CR 608.2c: the "sacrificed permanent" COST referent must keep resolving
+    /// to `CostPaidObject` — the new "this way" anaphor arm must not steal the
+    /// pre-nominal participle form (Morbid Curiosity). Negative control for
+    /// `tracked_set_anaphor_singular_property_of_binds`.
+    #[test]
+    fn cost_paid_prepositional_referent_is_not_stolen_by_anaphor() {
+        let (rest, q) = parse_quantity_ref("the mana value of the sacrificed permanent")
+            .expect("cost-paid prepositional must still bind");
+        assert_eq!(rest, "");
+        assert!(
+            matches!(
+                q,
+                QuantityRef::ObjectManaValue {
+                    scope: ObjectScope::CostPaidObject
+                }
+            ),
+            "the sacrificed-permanent COST referent must stay CostPaidObject, got {q:?}"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -3643,14 +3643,24 @@ mod tests {
     #[test]
     fn for_each_charge_counter_removed_this_way_is_previous_effect_amount() {
         let qty = parse_for_each_clause("charge counter removed this way").unwrap();
-        assert_eq!(qty, QuantityRef::PreviousEffectAmount);
+        assert_eq!(
+            qty,
+            QuantityRef::PreviousEffectAmount {
+                channel: crate::types::ability::DamageChannel::Total,
+            }
+        );
     }
 
     #[test]
     fn for_each_charge_counters_removed_this_way_is_previous_effect_amount() {
         // Plural variant — same dispatch.
         let qty = parse_for_each_clause("charge counters removed this way").unwrap();
-        assert_eq!(qty, QuantityRef::PreviousEffectAmount);
+        assert_eq!(
+            qty,
+            QuantityRef::PreviousEffectAmount {
+                channel: crate::types::ability::DamageChannel::Total,
+            }
+        );
     }
 
     #[test]
@@ -3658,7 +3668,12 @@ mod tests {
         // Untyped (no leading counter-type word). The runtime amount is whatever
         // the parent removed; the omitted English type word is informational.
         let qty = parse_for_each_clause("counter removed this way").unwrap();
-        assert_eq!(qty, QuantityRef::PreviousEffectAmount);
+        assert_eq!(
+            qty,
+            QuantityRef::PreviousEffectAmount {
+                channel: crate::types::ability::DamageChannel::Total,
+            }
+        );
     }
 
     #[test]
@@ -3666,7 +3681,12 @@ mod tests {
         // Storage Counter cycle (Saprazzan Cove etc.) — same shape, different
         // counter type. Must produce the same dispatch.
         let qty = parse_for_each_clause("storage counter removed this way").unwrap();
-        assert_eq!(qty, QuantityRef::PreviousEffectAmount);
+        assert_eq!(
+            qty,
+            QuantityRef::PreviousEffectAmount {
+                channel: crate::types::ability::DamageChannel::Total,
+            }
+        );
     }
 
     #[test]
@@ -3674,13 +3694,23 @@ mod tests {
         // Blademane Baku: "For each counter removed, this creature gets +2/+0
         // until end of turn" — no "this way" suffix on the activated tail.
         let qty = parse_for_each_clause("counter removed").unwrap();
-        assert_eq!(qty, QuantityRef::PreviousEffectAmount);
+        assert_eq!(
+            qty,
+            QuantityRef::PreviousEffectAmount {
+                channel: crate::types::ability::DamageChannel::Total,
+            }
+        );
     }
 
     #[test]
     fn quantity_ref_number_of_counters_removed_this_way_is_previous_effect_amount() {
         let qty = parse_quantity_ref("the number of study counters removed this way").unwrap();
-        assert_eq!(qty, QuantityRef::PreviousEffectAmount);
+        assert_eq!(
+            qty,
+            QuantityRef::PreviousEffectAmount {
+                channel: crate::types::ability::DamageChannel::Total,
+            }
+        );
     }
 
     #[test]
@@ -5060,7 +5090,9 @@ mod tests {
             assert_eq!(
                 parse_event_context_quantity(phrase),
                 Some(QuantityExpr::Ref {
-                    qty: QuantityRef::PreviousEffectAmount,
+                    qty: QuantityRef::PreviousEffectAmount {
+                        channel: crate::types::ability::DamageChannel::Total,
+                    },
                 }),
                 "phrase {phrase:?} must map to PreviousEffectAmount"
             );

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -160,7 +160,9 @@ pub(crate) fn parse_quantity_ref_with_context(
     // object count over a battlefield type phrase.
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("the number of ").parse(trimmed) {
         if try_parse_counters_removed_this_way(rest) {
-            return Some(QuantityRef::PreviousEffectAmount);
+            return Some(QuantityRef::PreviousEffectAmount {
+                channel: crate::types::ability::DamageChannel::Total,
+            });
         }
     }
 
@@ -1606,7 +1608,9 @@ pub(crate) fn parse_event_context_quantity(text: &str) -> Option<QuantityExpr> {
     // upstream effect (damage / counter removal / life loss) stamps.
     if parse_previous_effect_amount_this_way(lower).is_ok() {
         return Some(QuantityExpr::Ref {
-            qty: QuantityRef::PreviousEffectAmount,
+            qty: QuantityRef::PreviousEffectAmount {
+                channel: crate::types::ability::DamageChannel::Total,
+            },
         });
     }
 
@@ -1640,7 +1644,9 @@ pub(crate) fn parse_event_context_quantity(text: &str) -> Option<QuantityExpr> {
     .is_ok()
     {
         return Some(QuantityExpr::Ref {
-            qty: QuantityRef::PreviousEffectAmount,
+            qty: QuantityRef::PreviousEffectAmount {
+                channel: crate::types::ability::DamageChannel::Total,
+            },
         });
     }
 
@@ -2714,7 +2720,9 @@ fn parse_for_each_clause_with_they_controller(
         .parse(lower.as_str())
         .is_ok()
     {
-        return Some(QuantityRef::PreviousEffectAmount);
+        return Some(QuantityRef::PreviousEffectAmount {
+            channel: crate::types::ability::DamageChannel::Total,
+        });
     }
 
     // CR 406.6 + CR 607.1 + CR 614.1c: "[type phrase] card(s) exiled with it/~"
@@ -2805,7 +2813,9 @@ fn parse_for_each_clause_with_they_controller(
         // distinction. If a future card needs type-discriminated "removed this
         // way" quantities, this is the right place to extend.
         if try_parse_counters_removed_this_way(&lower) {
-            return Some(QuantityRef::PreviousEffectAmount);
+            return Some(QuantityRef::PreviousEffectAmount {
+                channel: crate::types::ability::DamageChannel::Total,
+            });
         }
         // CR 608.2c + CR 400.7: "nontoken creature you controlled that was
         // destroyed this way" — tracked set members matching the filter prefix.

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -16575,7 +16575,9 @@ fn trigger_coalition_relic_charge_counter_drain() {
                     assert_eq!(
                         *count,
                         QuantityExpr::Ref {
-                            qty: QuantityRef::PreviousEffectAmount
+                            qty: QuantityRef::PreviousEffectAmount {
+                                channel: crate::types::ability::DamageChannel::Total,
+                            }
                         },
                         "for-each tail must dispatch to PreviousEffectAmount"
                     );

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5275,7 +5275,31 @@ pub enum QuantityRef {
     /// CR 608.2c: Numeric amount produced by the preceding effect in the sub_ability chain.
     /// Used for patterns where a sub_ability references the parent effect's numeric
     /// result (life lost, damage dealt, counters removed).
-    PreviousEffectAmount,
+    ///
+    /// `channel` selects WHICH resolution-local tally the preceding effect left
+    /// behind — the same axis, and the same `DamageChannel`, already carried by
+    /// the condition peer [`AbilityCondition::PreviousEffectAmount`]:
+    ///
+    /// - [`DamageChannel::Total`] (default): the total amount (CR 120.6), via
+    ///   `GameState::last_effect_amount`. Every non-damage producer (life lost,
+    ///   counters removed, cards drawn) stamps only this channel.
+    /// - [`DamageChannel::Excess`]: the EXCESS amount (CR 120.10) — damage dealt
+    ///   beyond lethal — via `GameState::last_effect_excess_amount`. Reads "the
+    ///   amount of excess damage dealt to that creature this way" (Goblin
+    ///   Negotiation, Hell to Pay, Lacerate Flesh) and "that excess damage"
+    ///   (Contest of Claws).
+    ///
+    /// A sibling `PreviousEffectExcessAmount` variant would be the textbook
+    /// sibling-cluster smell: the channel is a leaf parameterization of one
+    /// structural axis, and it lies wholly inside CR 120 (120.6 total /
+    /// 120.10 excess), so it is a parameterization, not a new leaf.
+    ///
+    /// `Total` is serde-elided, so every pre-existing serialized card is
+    /// byte-identical.
+    PreviousEffectAmount {
+        #[serde(default, skip_serializing_if = "is_total_damage_channel")]
+        channel: DamageChannel,
+    },
     /// CR 118.4 + CR 119.3: Amount of life lost this turn, scoped by `player`
     /// per the workspace "Parameterize, don't proliferate" principle (Round Π-3).
     ///

--- a/crates/engine/tests/integration/coalition_relic_integration.rs
+++ b/crates/engine/tests/integration/coalition_relic_integration.rs
@@ -33,8 +33,8 @@
 use engine::game::effects;
 use engine::game::zones::create_object;
 use engine::types::ability::{
-    AbilityCondition, AbilityKind, Effect, ManaContribution, ManaProduction, QuantityExpr,
-    QuantityRef, ResolvedAbility, TargetFilter, TargetRef,
+    AbilityCondition, AbilityKind, DamageChannel, Effect, ManaContribution, ManaProduction,
+    QuantityExpr, QuantityRef, ResolvedAbility, TargetFilter, TargetRef,
 };
 use engine::types::card_type::CoreType;
 use engine::types::counter::CounterType;
@@ -59,7 +59,11 @@ fn build_coalition_relic_drain(controller: PlayerId, source: ObjectId) -> Resolv
         Effect::Mana {
             produced: ManaProduction::AnyOneColor {
                 count: QuantityExpr::Ref {
-                    qty: QuantityRef::PreviousEffectAmount,
+                    // CR 608.2c: the counters-removed count is a TOTAL-channel
+                    // amount (CR 120.6) — the excess channel is damage-only.
+                    qty: QuantityRef::PreviousEffectAmount {
+                        channel: DamageChannel::Total,
+                    },
                 },
                 color_options: vec![
                     ManaColor::White,

--- a/crates/engine/tests/integration/excess_damage_quantity_channel.rs
+++ b/crates/engine/tests/integration/excess_damage_quantity_channel.rs
@@ -1,0 +1,183 @@
+//! CR 120.10 — the EXCESS damage channel of the previous-effect quantity.
+//!
+//! `DamageChannel` existed, `GameState::last_effect_excess_amount` existed and was
+//! already stamped by the damage effects, and the CONDITION peer
+//! (`AbilityCondition::PreviousEffectAmount { channel: Excess }`, "if excess damage
+//! was dealt this way") already read it. Only the QUANTITY side was missing:
+//! `QuantityRef::PreviousEffectAmount` was a bare unit variant with no channel, so
+//! it could only ever read the TOTAL (`last_effect_amount`).
+//!
+//! The consequence was not a wrong number — it was a dropped clause. With no way to
+//! type "the amount of excess damage dealt to that creature this way", the whole
+//! surrounding instruction fell to an honest red:
+//!
+//!   Goblin Negotiation  "Create ... 1/1 red Goblin creature tokens equal to the
+//!                        amount of excess damage dealt to that creature this way."
+//!   Hell to Pay         (same shape, tapped Treasures)
+//!   Lacerate Flesh      (same shape, Blood tokens)
+//!   Contest of Claws    "... discover X, where X is that excess damage."
+//!
+//! and one face was WORSE than a red — Archaic's Agony ("Exile cards from the top of
+//! your library equal to the excess damage dealt to that creature this way") parsed
+//! GREEN to a `ChangeZone` with NO COUNT AT ALL. The quantity was silently swallowed
+//! and the card rendered as fully supported.
+//!
+//! These are RUNTIME witnesses: each parses the card's real Oracle clause through the
+//! production parser and hands the resulting `QuantityExpr` to the live resolver
+//! against a state where excess damage was actually dealt.
+//!
+//! Oracle text below is read from the card export, not from memory.
+
+use engine::game::quantity::resolve_quantity;
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{DamageChannel, Effect, QuantityExpr, QuantityRef};
+use engine::types::phase::Phase;
+
+/// Pull the single quantity a parsed one-clause ability carries.
+fn only_quantity(oracle: &str) -> QuantityExpr {
+    let parsed = parse_oracle_text(oracle, "~", &[], &["Creature".to_string()], &[]);
+    let def = parsed
+        .abilities
+        .first()
+        .unwrap_or_else(|| panic!("no ability parsed from {oracle:?}"));
+    match &*def.effect {
+        Effect::GainLife { amount, .. }
+        | Effect::LoseLife { amount, .. }
+        | Effect::DealDamage { amount, .. } => amount.clone(),
+        other => panic!("unexpected effect for {oracle:?}: {other:?}"),
+    }
+}
+
+/// CR 120.10: "the amount of excess damage dealt to that creature this way"
+/// (Goblin Negotiation, Hell to Pay, Lacerate Flesh).
+///
+/// 5 damage dealt to a 2-toughness creature is 3 excess (CR 120.10: "excess damage
+/// equal to the difference"). The quantity must read 3 — the EXCESS — not 5 (the
+/// total) and not 0 (the dropped clause).
+#[test]
+fn excess_damage_this_way_reads_the_excess_not_the_total_and_not_zero() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Goblin Negotiation", 1, 1).id();
+    let mut runner = scenario.build();
+
+    // The preceding effect dealt 5 damage to a 2-toughness creature: total 5,
+    // excess 3. Both channels are stamped by the damage effects; this witness
+    // discriminates between them.
+    runner.state_mut().last_effect_amount = Some(5);
+    runner.state_mut().last_effect_excess_amount = Some(3);
+
+    let expr = only_quantity(
+        "~ deals X damage to any target, where X is the amount of excess damage dealt to that creature this way.",
+    );
+    let resolved = resolve_quantity(runner.state(), &expr, P0, source);
+
+    assert_eq!(
+        resolved, 3,
+        "X must read the EXCESS channel (3 = 5 damage - 2 toughness, CR 120.10), not \
+         the total (5) and not the dropped-clause 0. Got {resolved} from {expr:?}"
+    );
+}
+
+/// NEGATIVE CONTROL — the bare demonstrative "that excess damage" must stay an
+/// honest red. This is a correctness constraint, not a coverage gap.
+///
+/// Its antecedent is fixed by the sibling clause, and the two readings resolve
+/// from DIFFERENT state:
+///
+///   - Contest of Claws — "If excess damage was dealt THIS WAY, … where X is that
+///     excess damage." Same resolution, so `last_effect_excess_amount` is live and
+///     `PreviousEffectAmount { Excess }` would be correct.
+///   - Fall of Cair Andros — "Whenever a creature an opponent controls is dealt
+///     excess noncombat damage, amass Orcs X, where X is that excess damage." The
+///     antecedent is the TRIGGERING EVENT. The triggered ability resolves as its own
+///     top-level chain and the depth-0 prelude CLEARS `last_effect_excess_amount`,
+///     so `PreviousEffectAmount { Excess }` would read None -> 0 and silently amass
+///     nothing — while rendering as fully supported.
+///
+/// A context-free leaf combinator cannot separate them; the disambiguator (the
+/// sibling "dealt this way" condition vs. the trigger condition) lives one layer up.
+/// Binding the bare demonstrative here would have swapped a crude raw-text
+/// fabrication for a better-disguised one. Until the clause-layer rebind exists,
+/// it stays red.
+#[test]
+fn bare_that_excess_damage_stays_an_honest_red_pending_clause_layer_rebind() {
+    let parsed = parse_oracle_text(
+        "You gain X life, where X is that excess damage.",
+        "~",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let has_unimplemented = parsed
+        .abilities
+        .iter()
+        .any(|def| matches!(&*def.effect, Effect::Unimplemented { .. }));
+
+    assert!(
+        has_unimplemented,
+        "the bare \"that excess damage\" demonstrative must remain an honest \
+         Effect::unimplemented gap: in a TRIGGER context (Fall of Cair Andros) the \
+         resolution-local excess channel is already cleared, so binding it would \
+         resolve to 0 while rendering as supported. Parsed: {:?}",
+        parsed.abilities
+    );
+}
+
+/// The TOTAL channel must be untouched: every pre-existing
+/// `PreviousEffectAmount` producer (life lost, counters removed, cards drawn)
+/// stamps only `last_effect_amount`, and must keep reading it.
+///
+/// Negative control for the two witnesses above — without this, a resolver that
+/// simply always read the excess field would pass them both.
+#[test]
+fn total_channel_is_unchanged_and_still_reads_last_effect_amount() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Coalition Relic", 1, 1).id();
+    let mut runner = scenario.build();
+
+    runner.state_mut().last_effect_amount = Some(7);
+    // Deliberately different, so a resolver reading the wrong channel is caught.
+    runner.state_mut().last_effect_excess_amount = Some(2);
+
+    let total = QuantityExpr::Ref {
+        qty: QuantityRef::PreviousEffectAmount {
+            channel: DamageChannel::Total,
+        },
+    };
+    let resolved = resolve_quantity(runner.state(), &total, P0, source);
+
+    assert_eq!(
+        resolved, 7,
+        "the Total channel must still read last_effect_amount (7), not the excess (2). \
+         Got {resolved}"
+    );
+}
+
+/// CR 120.10: excess is 0 when the damage did not exceed lethal. The clause is
+/// still bound (it is a real quantity), it simply resolves to 0 — which is the
+/// rules-correct answer, not a dropped clause.
+#[test]
+fn no_excess_dealt_resolves_to_zero() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Hell to Pay", 1, 1).id();
+    let mut runner = scenario.build();
+
+    // 2 damage to a 5-toughness creature: total 2, no excess.
+    runner.state_mut().last_effect_amount = Some(2);
+    runner.state_mut().last_effect_excess_amount = None;
+
+    let expr = only_quantity(
+        "~ deals X damage to any target, where X is the amount of excess damage dealt to that creature this way.",
+    );
+    let resolved = resolve_quantity(runner.state(), &expr, P0, source);
+
+    assert_eq!(
+        resolved, 0,
+        "no excess was dealt, so the excess channel is 0 — and it must NOT fall back \
+         to the total (2). Got {resolved} from {expr:?}"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -686,6 +686,7 @@ mod tobita_master_of_winds_flying_grant;
 mod tombstone_stairwell_per_player_tokens;
 mod top_of_library_mixed_permission;
 mod total_war_attacking_player_scope;
+mod tracked_set_anaphor_quantity_binds;
 mod treasured_find_regression;
 mod trespassers_curse_enchanted_player_trigger;
 mod true_conviction_double_keyword_grant;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -110,6 +110,7 @@ mod equipment_etb_attach_parent_target;
 mod ertai_trickery_counter_kicked;
 mod etali_primal_sickness_poison;
 mod evelyn_regression;
+mod excess_damage_quantity_channel;
 mod exchange_life_totals_cards;
 mod exhibition_tidecaller_target_player_mill;
 mod export_runtime_canaries;

--- a/crates/engine/tests/integration/tracked_set_anaphor_quantity_binds.rs
+++ b/crates/engine/tests/integration/tracked_set_anaphor_quantity_binds.rs
@@ -1,0 +1,199 @@
+//! CR 608.2c — the "<noun> <participle> this way" anaphor must aggregate over the
+//! chain tracked set the preceding effect published, not resolve to 0.
+//!
+//! Follow-up to #57 / PR #5721 (task #78). `QuantityRef::TrackedSetAggregate`
+//! and its live resolver both already existed, but the parser's anaphor list
+//! recognized only the EXILE forms ("those exiled cards", "the card exiled this
+//! way"). Every other participle — discarded, sacrificed, milled — fell through
+//! to the `where_x_binding` / effect-level honest red, so the surrounding clause
+//! was dropped entirely:
+//!
+//!   Ill-Timed Explosion    "the greatest mana value among cards discarded this way"
+//!   Sword of the Ages      "the total power of the creatures sacrificed this way"
+//!   Reign of the Pit       (same expression)
+//!   Fateful Tempest        "the total mana value of cards milled this way"
+//!   Shadowgrange Archfiend "the greatest power among creatures sacrificed this way"
+//!
+//! These are RUNTIME witnesses, not AST-shape assertions: each parses the card's
+//! real Oracle clause through the production parser and hands the resulting
+//! `QuantityExpr` to the live resolver (`game::quantity::resolve_quantity`)
+//! against a state whose chain tracked set is actually populated. Before the
+//! bind the clause never reached a `TrackedSetAggregate` at all, so the resolver
+//! saw a raw-text `QuantityRef::Variable` and returned 0 — which is exactly what
+//! each assertion discriminates against.
+//!
+//! The participle list is deliberately restricted to the causes the engine
+//! actually stamps. "goaded" is NOT bound: `game/effects/goad.rs` publishes no
+//! tracked set, so Havoc Eater's "the total power of creatures goaded this way"
+//! would aggregate over an empty set and silently read 0. It stays an honest red.
+//!
+//! Oracle text below is read from the card export, not from memory.
+
+use engine::game::quantity::resolve_quantity;
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{Effect, QuantityExpr};
+use engine::types::identifiers::TrackedSetId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+/// Pull the single quantity a parsed one-clause ability carries.
+///
+/// Deliberately matches only the effects these witnesses use, so a parse that
+/// silently lowers to something else (an `Unimplemented` gap, say) fails loudly
+/// here instead of being skipped.
+fn only_quantity(oracle: &str) -> QuantityExpr {
+    let parsed = parse_oracle_text(oracle, "~", &[], &["Creature".to_string()], &[]);
+    let def = parsed
+        .abilities
+        .first()
+        .unwrap_or_else(|| panic!("no ability parsed from {oracle:?}"));
+    match &*def.effect {
+        Effect::GainLife { amount, .. }
+        | Effect::LoseLife { amount, .. }
+        | Effect::DealDamage { amount, .. } => amount.clone(),
+        other => panic!("unexpected effect for {oracle:?}: {other:?}"),
+    }
+}
+
+/// CR 608.2c: "the total power of the creatures sacrificed this way"
+/// (Sword of the Ages, Reign of the Pit).
+///
+/// `Sum` over the chain-published set. Two creatures with power 3 and 4 were
+/// sacrificed, so X is 7 — not 0.
+#[test]
+fn this_way_sacrificed_aggregates_total_power_not_zero() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Sword of the Ages", 1, 1).id();
+    let a = scenario.add_creature(P0, "Grizzly Bears", 3, 3).id();
+    let b = scenario.add_creature(P0, "Hill Giant", 4, 4).id();
+    let mut runner = scenario.build();
+
+    // The preceding chain effect ("Sacrifice this artifact and any number of
+    // creatures you control") publishes the sacrificed members as the chain set.
+    runner
+        .state_mut()
+        .tracked_object_sets
+        .insert(TrackedSetId(1), vec![a, b]);
+
+    let expr = only_quantity(
+        "~ deals X damage to any target, where X is the total power of the creatures sacrificed this way.",
+    );
+    let resolved = resolve_quantity(runner.state(), &expr, P0, source);
+
+    assert_eq!(
+        resolved, 7,
+        "X must sum the power of the creatures actually sacrificed this way (3 + 4). \
+         Before the bind the clause never reached a TrackedSetAggregate and the \
+         raw-text QuantityRef::Variable resolved to 0 — a silent no-op that still \
+         read as supported. Got {resolved} from {expr:?}"
+    );
+}
+
+/// CR 608.2c + CR 202.3: "the greatest mana value among cards discarded this way"
+/// (Ill-Timed Explosion).
+///
+/// `Max` over the same chain set, on the ManaValue property. The discarded cards
+/// have mana value 2 and 5, so X is 5.
+#[test]
+fn this_way_discarded_aggregates_greatest_mana_value_not_zero() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Ill-Timed Explosion", 1, 1).id();
+    // The mana values must be established explicitly: `add_creature` leaves the
+    // mana cost empty, and `ObjectProperty::ManaValue` reads
+    // `GameObject::effective_mana_value()` off that cost. Without this the
+    // aggregate would read 0 for every member and the assertion below would
+    // pass for the WRONG reason (0 == 0) — a vacuous witness.
+    let cheap = scenario
+        .add_creature(P0, "Grizzly Bears", 2, 2)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let pricey = scenario
+        .add_creature(P0, "Serra Angel", 4, 4)
+        .with_mana_cost(ManaCost::generic(5))
+        .id();
+    let mut runner = scenario.build();
+
+    runner
+        .state_mut()
+        .tracked_object_sets
+        .insert(TrackedSetId(1), vec![cheap, pricey]);
+
+    let expr = only_quantity(
+        "~ deals X damage to any target, where X is the greatest mana value among cards discarded this way.",
+    );
+    let resolved = resolve_quantity(runner.state(), &expr, P0, source);
+
+    assert_eq!(
+        resolved, 5,
+        "X must be the GREATEST mana value among the cards actually discarded this \
+         way (max of 2 and 5), not 0. Got {resolved} from {expr:?}"
+    );
+}
+
+/// CR 608.2c: the SINGULAR "this way" referent — "the power of the creature
+/// exiled this way" (Astarion's Thirst) / "the mana value of the permanent
+/// exiled this way" (Ruinous Intrusion).
+///
+/// No aggregate adjective is printed, so this cannot ride the extremum/total
+/// prefix. It reads the same chain set; `Sum` over a one-member set is that
+/// member's value.
+#[test]
+fn this_way_singular_referent_reads_the_one_member_not_zero() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Astarion's Thirst", 1, 1).id();
+    let exiled = scenario.add_creature(P0, "Hill Giant", 6, 4).id();
+    let mut runner = scenario.build();
+
+    runner
+        .state_mut()
+        .tracked_object_sets
+        .insert(TrackedSetId(1), vec![exiled]);
+
+    let expr =
+        only_quantity("You gain X life, where X is the power of the creature exiled this way.");
+    let resolved = resolve_quantity(runner.state(), &expr, P0, source);
+
+    assert_eq!(
+        resolved, 6,
+        "X must read the power of the single creature exiled this way (6), not 0. \
+         Got {resolved} from {expr:?}"
+    );
+}
+
+/// Negative control: "creatures goaded this way" (Havoc Eater) must NOT bind.
+///
+/// `game/effects/goad.rs` publishes no tracked set, so a `TrackedSetAggregate`
+/// here would aggregate over whatever unrelated set happened to be published
+/// last — or over nothing — and silently resolve to 0 while reading as
+/// supported. Binding it would manufacture exactly the lying-green class that
+/// #57 exists to eliminate. It must stay an honest red until goad publishes its
+/// set.
+///
+/// This asserts the PARSE, not the resolve: the clause must not lower to a
+/// quantity at all.
+#[test]
+fn goaded_this_way_stays_an_honest_red_until_goad_publishes_a_set() {
+    let parsed = parse_oracle_text(
+        "Put X +1/+1 counters on ~, where X is the total power of creatures goaded this way.",
+        "~",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let has_unimplemented = parsed
+        .abilities
+        .iter()
+        .any(|def| matches!(&*def.effect, Effect::Unimplemented { .. }));
+
+    assert!(
+        has_unimplemented,
+        "\"creatures goaded this way\" must remain an honest Effect::unimplemented gap: \
+         goad publishes no tracked set, so binding it to TrackedSetAggregate would \
+         resolve to 0 while rendering as supported. Parsed: {:?}",
+        parsed.abilities
+    );
+}

--- a/crates/phase-ai/src/policies/x_cast_gate.rs
+++ b/crates/phase-ai/src/policies/x_cast_gate.rs
@@ -398,7 +398,9 @@ mod tests {
         });
         ability.sub_ability = Some(Box::new(spell(Effect::GainLife {
             amount: QuantityExpr::Ref {
-                qty: QuantityRef::PreviousEffectAmount,
+                qty: QuantityRef::PreviousEffectAmount {
+                    channel: engine::types::ability::DamageChannel::Total,
+                },
             },
             player: TargetFilter::Controller,
         })));
@@ -776,7 +778,9 @@ mod tests {
         });
         let mut draw = spell(Effect::Draw {
             count: QuantityExpr::Ref {
-                qty: QuantityRef::PreviousEffectAmount,
+                qty: QuantityRef::PreviousEffectAmount {
+                    channel: engine::types::ability::DamageChannel::Total,
+                },
             },
             target: TargetFilter::Controller,
         });

--- a/crates/phase-ai/src/policies/x_reference.rs
+++ b/crates/phase-ai/src/policies/x_reference.rs
@@ -343,7 +343,10 @@ fn is_cost_x_paid(qty: &QuantityRef) -> bool {
 }
 
 fn is_previous_amount(qty: &QuantityRef) -> bool {
-    matches!(qty, QuantityRef::PreviousEffectAmount)
+    // CR 120.6 / CR 120.10: both channels (total and excess) are amounts left by
+    // the preceding effect, so the AI's X-reference detection treats them alike —
+    // it cares that the value is chain-derived, not which tally it came from.
+    matches!(qty, QuantityRef::PreviousEffectAmount { .. })
 }
 
 /// Structural recursion over a `QuantityExpr` tree, returning true if any leaf


### PR DESCRIPTION
- **fix(parser): bind the chain-set anaphor across its participle axis (CR 608.2c)**
- **fix(engine): give the previous-effect quantity its EXCESS channel (CR 120.10)**
