### PR TITLE
ship/skip followup

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2556,6 +2556,23 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
         value((), tag("you surveil ")),
         value((), tag("you get ")),
         value((), tag("you may ")),
+        // CR 614.1b + CR 603.7a: "Effects that use the word 'skip' are
+        // replacement effects" — a skip is its own instruction, never a
+        // continuation of the conjunct before it. Ivory Gargoyle / Molten
+        // Firebird: "return it to the battlefield under its owner's control at
+        // the beginning of the next end step AND YOU SKIP YOUR NEXT DRAW STEP";
+        // Waterspout Elemental: "return all other creatures to their owners'
+        // hands and you skip your next turn."
+        //
+        // Without this arm the bare-and splitter left the whole sentence as ONE
+        // clause, which cost both halves at once: the skip tail was swallowed by
+        // the leading imperative (the CR 614.1b replacement vanished), AND the
+        // temporal phrase stopped being a suffix — so `strip_temporal_suffix`
+        // (lower.rs), which only matches a temporal phrase at the END of the
+        // clause, never fired and the delayed return collapsed into an immediate
+        // one. Splitting here restores the temporal phrase to clause-final
+        // position, so ONE arm recovers both behaviors.
+        value((), tag("you skip ")),
         // CR 707.10c: "[subject] may copy this spell and may choose a new
         // target for that copy" — the Chain cycle joins the optional copy and
         // its retarget grant with "and". "may choose" begins a verb phrase,

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -45507,3 +45507,67 @@ fn instead_override_lowers_the_typed_completed_dungeon_condition() {
         "the override body must be the real second copy, not Unimplemented"
     );
 }
+
+/// CR 608.2c + CR 614.6: the honest-failure path is CLAUSE-scoped — an "instead"
+/// override must never absorb the sentence BEFORE it, and must never be emitted
+/// as an unconditional sequel to the effect it is supposed to REPLACE.
+///
+/// Piece It Together is the live witness ("Draw a card. If Piece It Together's
+/// intensity is 4, instead take an extra turn after this one."). Two facts must
+/// hold together, and they are asserted as an INVARIANT rather than as one
+/// expected shape, because the override's shape legitimately changes as
+/// condition grammar lands:
+///
+///   1. the preceding `Draw a card.` always survives as the chain root — a
+///      line-level blob that swallowed it would silently cost a working effect;
+///   2. the override is EITHER a real conditional branch (`ConditionInstead`)
+///      OR an honest `Effect::Unimplemented` — but NEVER a bare effect with no
+///      condition, which is the CR 614.6 double-execution defect.
+///
+/// Pinning "must be Unimplemented" here would pin a TRANSIENT state: the
+/// intensity bind has since landed, so this card now takes the branch arm. The
+/// invariant below is true on both sides of that change, and on both sides of
+/// every future condition-grammar landing.
+fn assert_override_is_branch_or_honest(chain: &str) {
+    let def = parse_effect_chain(chain, AbilityKind::Spell);
+    assert!(
+        matches!(&*def.effect, Effect::Draw { .. }),
+        "the preceding Draw must survive as the chain root, never absorbed into the \
+         override — got {:?} for {chain:?}",
+        def.effect
+    );
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .unwrap_or_else(|| panic!("the override clause must produce a def for {chain:?}"));
+    if matches!(&*sub.effect, Effect::Unimplemented { .. }) {
+        return; // honest failure — clause-scoped, body never emitted
+    }
+    assert!(
+        matches!(
+            sub.condition.as_ref(),
+            Some(AbilityCondition::ConditionInstead { .. })
+        ),
+        "CR 614.6: a lowered override must be a ConditionInstead BRANCH, never an \
+         unconditional sequel — got effect={:?} condition={:?} for {chain:?}",
+        sub.effect,
+        sub.condition
+    );
+}
+
+#[test]
+fn instead_override_never_absorbs_the_preceding_sentence() {
+    // The intensity condition now LOWERS (the bind landed on main), so this card
+    // takes the branch arm: Draw root + ConditionInstead{QuantityCheck{Intensity}}.
+    assert_override_is_branch_or_honest(
+        "Draw a card. If this card's intensity is 4, instead take an extra turn after this one.",
+    );
+    // A condition with no typed variant takes the honest-failure arm instead.
+    assert_override_is_branch_or_honest(
+        "Draw a card. If the cracks in this artifact's art are completely covered, draw two cards instead.",
+    );
+    // A plainly lowerable condition takes the branch arm.
+    assert_override_is_branch_or_honest(
+        "Draw a card. If you control three or more artifacts, draw two cards instead.",
+    );
+}

--- a/crates/engine/tests/integration/ivory_gargoyle_temporal_and_skip_tail.rs
+++ b/crates/engine/tests/integration/ivory_gargoyle_temporal_and_skip_tail.rs
@@ -1,0 +1,115 @@
+//! CR 603.7a + CR 614.1b — one root cause, two swallowed clauses.
+//!
+//! Oracle (verified at source, MTGJSON `AtomicCards.json`, both cards identical):
+//!   Ivory Gargoyle  / Molten Firebird —
+//!     "When this creature dies, return it to the battlefield under its owner's
+//!      control at the beginning of the next end step and you skip your next
+//!      draw step."
+//!   (note: there is NO comma before "and you skip".)
+//!
+//! `strip_temporal_suffix` only strips a temporal phrase that sits at the END of
+//! the clause. Here a conjoined clause follows it, so the phrase is INFIX: the
+//! stripper never matched, and the `return it to the battlefield` imperative
+//! swallowed the whole remainder. Two independent clauses died together:
+//!
+//!   1. CR 603.7a — the delayed-return TIMING. The trigger lowered to a bare
+//!      `ChangeZone{destination: Battlefield}`, so the creature came back
+//!      IMMEDIATELY on death instead of at the next end step.
+//!   2. CR 614.1b — the SKIP ("Effects that use the word 'skip' are replacement
+//!      effects"). The "and you skip your next draw step" tail was dropped
+//!      outright; no `Effect::SkipNextStep` was ever produced.
+//!
+//! The two witnesses below are deliberately INDEPENDENT — each was watched red
+//! on its own, so a fix that recovered only one half could not hide behind the
+//! other.
+
+use engine::game::sba::check_state_based_actions;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::triggers::process_triggers;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const IVORY_GARGOYLE: &str = "Flying\nWhen this creature dies, return it to the battlefield under its owner's control at the beginning of the next end step and you skip your next draw step.\n{4}{W}: Exile this creature.";
+
+/// Put the Gargoyle on the battlefield, kill it, run SBAs so it dies, process
+/// the dies-trigger and resolve the stack. Returns the runner and the Gargoyle's
+/// (zone-stable) ObjectId.
+fn kill_gargoyle() -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let gargoyle = scenario
+        .add_creature_from_oracle(P0, "Ivory Gargoyle", 2, 2, IVORY_GARGOYLE)
+        .id();
+    let mut runner = scenario.build();
+
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&gargoyle)
+        .expect("gargoyle exists")
+        .damage_marked = 99;
+
+    let mut events = Vec::new();
+    check_state_based_actions(runner.state_mut(), &mut events);
+    process_triggers(runner.state_mut(), &events);
+    runner.advance_until_stack_empty();
+    (runner, gargoyle)
+}
+
+fn zone_of(runner: &GameRunner, id: ObjectId) -> Option<Zone> {
+    runner.state().objects.get(&id).map(|o| o.zone)
+}
+
+/// WITNESS 1 — CR 603.7a: the return is DELAYED to the next end step.
+///
+/// RED before the fix: the temporal phrase was swallowed, so the trigger
+/// resolved to an immediate `ChangeZone` and the Gargoyle was already back on
+/// the battlefield the moment the dies-trigger finished resolving.
+#[test]
+fn ivory_gargoyle_return_is_delayed_to_the_next_end_step() {
+    let (mut runner, gargoyle) = kill_gargoyle();
+
+    assert_eq!(
+        zone_of(&runner, gargoyle),
+        Some(Zone::Graveyard),
+        "CR 603.7a: the dies-trigger only SCHEDULES the return for the next end \
+         step — the Gargoyle must still be in the graveyard right after it \
+         resolves. Finding it on the battlefield here means the \"at the \
+         beginning of the next end step\" phrase was swallowed and the return \
+         fired immediately."
+    );
+
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        zone_of(&runner, gargoyle),
+        Some(Zone::Battlefield),
+        "the delayed trigger must fire at the next end step and return the \
+         Gargoyle to the battlefield"
+    );
+}
+
+/// WITNESS 2 — CR 614.1b: the "and you skip your next draw step" tail is a
+/// replacement effect and must be registered.
+///
+/// RED before the fix: the tail was dropped outright — no `SkipNextStep` was
+/// produced, so `steps_to_skip` stayed empty and the controller drew normally.
+#[test]
+fn ivory_gargoyle_skips_the_controllers_next_draw_step() {
+    let (runner, _gargoyle) = kill_gargoyle();
+
+    let pending = runner.state().steps_to_skip[P0.0 as usize]
+        .get(&Phase::Draw)
+        .copied()
+        .unwrap_or(0);
+
+    assert_eq!(
+        pending, 1,
+        "CR 614.1b: \"you skip your next draw step\" is a replacement effect — \
+         resolving the dies-trigger must register exactly one pending Draw-step \
+         skip for the controller. Zero means the conjoined tail was swallowed \
+         with the temporal phrase."
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -515,6 +515,7 @@ mod issue_bound_by_moonsilver_sacrifice_attach;
 mod issue_circle_of_protection_source_choice;
 mod issue_desperate_gambit_choose_damage_source;
 mod issue_haze_frog_other_creature_prevention;
+mod ivory_gargoyle_temporal_and_skip_tail;
 mod jace_wielder_empty_library_win;
 mod json_smoke_test;
 mod kaito_integration;


### PR DESCRIPTION
- **fix(parser): "and you skip …" is a clause start — recovers a swallowed skip AND a swallowed delayed return**
- **test(parser): pin that an "instead" override is always a branch or an honest failure — never an unconditional sequel**
