### PR TITLE
fix(parser): stop the damage scan swallowing the word "excess" (CR 120.10)

### DIFF
--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -38,9 +38,9 @@ use crate::parser::oracle_target::{parse_target, parse_type_phrase, parse_type_p
 use crate::parser::oracle_util::merge_or_filters;
 use crate::types::ability::{
     AggregateFunction, AttackScope, AttackSubject, Comparator, ControllerRef, CountScope,
-    DamageKindFilter, DevotionColors, FilterProp, ObjectProperty, ObjectScope, PlayerFilter,
-    PlayerRelation, PlayerScope, QuantityExpr, QuantityRef, RoundingMode, TargetFilter,
-    ThisWayCause, TrackedAnaphorSource, TypeFilter, TypedFilter, ZoneRef,
+    DamageChannel, DamageKindFilter, DevotionColors, FilterProp, ObjectProperty, ObjectScope,
+    PlayerFilter, PlayerRelation, PlayerScope, QuantityExpr, QuantityRef, RoundingMode,
+    TargetFilter, ThisWayCause, TrackedAnaphorSource, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::counter::CounterType;
 use crate::types::events::PlayerActionKind;
@@ -1236,21 +1236,26 @@ fn parse_owned_cards_in_zones_quantity(
     Ok((rest, expr))
 }
 
-fn parse_previous_effect_amount_this_way(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
-    all_consuming(value(
-        (),
-        terminated(
-            (
-                opt(tag("the ")),
-                alt((
-                    parse_life_paid_or_lost_phrase,
-                    parse_damage_dealt_phrase,
-                    parse_dealt_damage_phrase,
-                    parse_counters_removed_phrase,
-                )),
-            ),
-            tag(" this way"),
+/// CR 608.2c + CR 120.6 / CR 120.10: "[the] <numeric result> this way", reporting
+/// WHICH damage channel the phrase named.
+///
+/// The damage arm carries a channel because "excess" is an independent qualifier
+/// axis over the same verb phrase; every other arm (life, counters) has no excess
+/// reading and reports `Total`.
+fn parse_previous_effect_amount_this_way(
+    input: &str,
+) -> nom::IResult<&str, DamageChannel, OracleError<'_>> {
+    all_consuming(terminated(
+        preceded(
+            opt(tag("the ")),
+            alt((
+                value(DamageChannel::Total, parse_life_paid_or_lost_phrase),
+                parse_damage_dealt_phrase,
+                value(DamageChannel::Total, parse_dealt_damage_phrase),
+                value(DamageChannel::Total, parse_counters_removed_phrase),
+            )),
         ),
+        tag(" this way"),
     ))
     .parse(input)
 }
@@ -1262,10 +1267,35 @@ fn parse_life_paid_or_lost_phrase(input: &str) -> nom::IResult<&str, (), OracleE
     Ok((input, ()))
 }
 
-fn parse_damage_dealt_phrase(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
+/// CR 120.6 / CR 120.10: "[the] [amount of] [excess] damage dealt this way",
+/// reporting which channel the qualifier selected.
+///
+/// "excess" is a QUALIFIER on the damage, not part of the verb phrase. The prior
+/// implementation scanned with a single `take_until("damage dealt")`, which
+/// DISCARDS everything before the verb — including the word "excess" — so
+/// "the amount of excess damage dealt this way" matched the generic arm and read
+/// the TOTAL channel. Razor Rings gained the full 4 instead of the 3 excess; the
+/// same silent overcount hit Cramped Vents // Access Maze, Windswift Slice,
+/// Ravenous Pursuit, and Unleash the Inferno. An unanchored scan that swallows a
+/// semantically load-bearing qualifier reads as supported and is simply wrong.
+///
+/// The fix is to make the scan STOP AT the qualifier instead of swallowing it.
+/// The excess reading is tried first with a scan anchored on
+/// `"excess damage dealt"`; only if that fails does the pre-existing permissive
+/// total scan run, unchanged. Every phrase that matched before still matches —
+/// this is a pure channel correction, not a narrowing.
+fn parse_damage_dealt_phrase(input: &str) -> nom::IResult<&str, DamageChannel, OracleError<'_>> {
+    if let Ok((rest, _)) = (
+        opt(take_until::<_, _, OracleError<'_>>("excess damage dealt")),
+        tag::<_, _, OracleError<'_>>("excess damage dealt"),
+    )
+        .parse(input)
+    {
+        return Ok((rest, DamageChannel::Excess));
+    }
     let (input, _) = opt(take_until("damage dealt")).parse(input)?;
     let (input, _) = tag("damage dealt").parse(input)?;
-    Ok((input, ()))
+    Ok((input, DamageChannel::Total))
 }
 
 fn parse_dealt_damage_phrase(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
@@ -1604,13 +1634,14 @@ pub(crate) fn parse_event_context_quantity(text: &str) -> Option<QuantityExpr> {
     //   - counter-removal chains: "counters removed", "counter removed"
     //     (Sensational Spider-Man's "stun counters removed this way";
     //     `state.last_effect_amount` is stamped by the preceding RemoveCounter).
-    // PreviousEffectAmount reads `state.last_effect_amount`, which the
-    // upstream effect (damage / counter removal / life loss) stamps.
-    if parse_previous_effect_amount_this_way(lower).is_ok() {
+    // PreviousEffectAmount reads `state.last_effect_amount` (CR 120.6) or
+    // `state.last_effect_excess_amount` (CR 120.10), whichever channel the phrase
+    // named — the combinator reports it rather than the caller assuming `Total`.
+    // Assuming Total here is precisely what made "the excess damage dealt this
+    // way" gain the FULL damage instead of the overkill (Razor Rings).
+    if let Ok((_, channel)) = parse_previous_effect_amount_this_way(lower) {
         return Some(QuantityExpr::Ref {
-            qty: QuantityRef::PreviousEffectAmount {
-                channel: crate::types::ability::DamageChannel::Total,
-            },
+            qty: QuantityRef::PreviousEffectAmount { channel },
         });
     }
 
@@ -5077,13 +5108,14 @@ mod tests {
         );
     }
 
+    /// CR 120.6: the TOTAL channel. Every phrase here names an unqualified
+    /// numeric result — no "excess" qualifier — so it reads `last_effect_amount`.
     #[test]
     fn parse_event_context_quantity_previous_effect_this_way_variants() {
         for phrase in [
             "the life lost this way",
             "the amount of life paid this way",
             "the damage dealt this way",
-            "the amount of excess damage dealt this way",
             "opponents dealt damage this way",
             "the number of stun counters removed this way",
         ] {
@@ -5094,7 +5126,43 @@ mod tests {
                         channel: crate::types::ability::DamageChannel::Total,
                     },
                 }),
-                "phrase {phrase:?} must map to PreviousEffectAmount"
+                "phrase {phrase:?} must map to PreviousEffectAmount on the TOTAL channel"
+            );
+        }
+    }
+
+    /// CR 120.10: the EXCESS channel. "excess" is a QUALIFIER on the damage, and
+    /// it selects a different resolution-local tally
+    /// (`last_effect_excess_amount`) than the bare phrase does.
+    ///
+    /// REGRESSION PIN. This list previously sat in the TOTAL test above — the
+    /// pin PROTECTED the bug. `parse_damage_dealt_phrase` scanned with
+    /// `take_until("damage dealt")`, which discards every prefix INCLUDING the
+    /// word "excess", so an excess phrase matched the generic damage arm and read
+    /// the full damage. Razor Rings ("You gain life equal to the excess damage
+    /// dealt this way") gained 4 off a 1/1 instead of the 3 overkill; the same
+    /// silent overcount hit Cramped Vents // Access Maze, Windswift Slice,
+    /// Ravenous Pursuit, and Unleash the Inferno.
+    ///
+    /// The determiner ("the" / "the amount of") is an INDEPENDENT axis from the
+    /// qualifier, so both determiner forms are pinned — the channel must not
+    /// depend on which determiner was printed.
+    #[test]
+    fn parse_event_context_quantity_excess_damage_this_way_reads_the_excess_channel() {
+        for phrase in [
+            "the excess damage dealt this way",
+            "the amount of excess damage dealt this way",
+            "excess damage dealt this way",
+        ] {
+            assert_eq!(
+                parse_event_context_quantity(phrase),
+                Some(QuantityExpr::Ref {
+                    qty: QuantityRef::PreviousEffectAmount {
+                        channel: crate::types::ability::DamageChannel::Excess,
+                    },
+                }),
+                "phrase {phrase:?} names EXCESS damage (CR 120.10) and must read the \
+                 excess channel, not the total"
             );
         }
     }

--- a/crates/engine/tests/integration/excess_damage_quantity_channel.rs
+++ b/crates/engine/tests/integration/excess_damage_quantity_channel.rs
@@ -181,3 +181,112 @@ fn no_excess_dealt_resolves_to_zero() {
          to the total (2). Got {resolved} from {expr:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #85 item (1): the SUBJECT-LESS excess phrase — "the excess damage dealt this
+// way" — silently reads the TOTAL channel.
+//
+// Root cause (parser/oracle_quantity.rs, `parse_damage_dealt_phrase`):
+//
+//     let (input, _) = opt(take_until("damage dealt")).parse(input)?;
+//     let (input, _) = tag("damage dealt").parse(input)?;
+//
+// `take_until("damage dealt")` DISCARDS everything before the verb phrase —
+// including the word "excess". So the subject-less excess phrase matches the
+// generic damage arm and returns `PreviousEffectAmount { channel: Total }`.
+// An unanchored scan swallowing a semantically load-bearing qualifier.
+//
+// The t78 grammar (oracle_nom/quantity.rs) only bound the form that names its
+// subject ("...dealt TO that creature this way"), so the subject-less form was
+// never reached by it and kept falling to the swallowing arm. That asymmetry is
+// the bug.
+//
+// Faces (Oracle text read from MTGJSON, not memory):
+//   Razor Rings                  "...deals 4 damage to target attacking or blocking
+//                                 creature. You gain life equal to the excess damage
+//                                 dealt this way."
+//   Cramped Vents // Access Maze "...deals 6 damage ... You gain life equal to the
+//                                 excess damage dealt this way."
+//   Windswift Slice              "...equal to the amount of excess damage dealt this way."
+//   Ravenous Pursuit             "...where X is the amount of excess damage dealt this way."
+// ---------------------------------------------------------------------------
+
+/// CR 120.10: Razor Rings deals 4 to a 1/1 — total 4, excess 3. "You gain life
+/// equal to the excess damage dealt this way" must gain 3, not 4.
+///
+/// Pre-fix this reads the TOTAL channel and gains 4 — a live, silently-wrong
+/// result that renders as fully supported.
+#[test]
+fn subjectless_excess_phrase_reads_the_excess_not_the_total() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Razor Rings", 1, 1).id();
+    let mut runner = scenario.build();
+
+    // 4 damage into a 1/1: total 4, excess 3 (CR 120.10 — "excess damage equal
+    // to the difference").
+    runner.state_mut().last_effect_amount = Some(4);
+    runner.state_mut().last_effect_excess_amount = Some(3);
+
+    let expr = only_quantity("You gain X life, where X is the excess damage dealt this way.");
+    let resolved = resolve_quantity(runner.state(), &expr, P0, source);
+
+    assert_eq!(
+        resolved, 3,
+        "the SUBJECT-LESS excess phrase must read the EXCESS channel (3), not the \
+         total (4). `take_until(\"damage dealt\")` discards the word \"excess\", so \
+         this phrase falls to the generic damage arm and silently gains the full 4. \
+         Got {resolved} from {expr:?}"
+    );
+}
+
+/// Same defect via the "the amount of excess ..." determiner (Windswift Slice,
+/// Ravenous Pursuit). The "amount of" prefix is an independent axis from the
+/// "excess" qualifier and must not be what decides the channel.
+#[test]
+fn subjectless_amount_of_excess_phrase_reads_the_excess_channel() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Windswift Slice", 1, 1).id();
+    let mut runner = scenario.build();
+
+    runner.state_mut().last_effect_amount = Some(9);
+    runner.state_mut().last_effect_excess_amount = Some(5);
+
+    let expr =
+        only_quantity("You gain X life, where X is the amount of excess damage dealt this way.");
+    let resolved = resolve_quantity(runner.state(), &expr, P0, source);
+
+    assert_eq!(
+        resolved, 5,
+        "\"the amount of excess damage dealt this way\" must read the EXCESS channel \
+         (5), not the total (9). Got {resolved} from {expr:?}"
+    );
+}
+
+/// NEGATIVE CONTROL — the plain (non-excess) phrase must KEEP reading the total.
+///
+/// Without this, a fix that simply routed every "damage dealt this way" phrase to
+/// the excess channel would pass both witnesses above while breaking the 8 pool
+/// faces that correctly want the total ("you gain life equal to the damage dealt
+/// this way").
+#[test]
+fn plain_damage_dealt_this_way_still_reads_the_total_channel() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Sanguine Bond", 1, 1).id();
+    let mut runner = scenario.build();
+
+    runner.state_mut().last_effect_amount = Some(4);
+    // Deliberately different, so a resolver reading the wrong channel is caught.
+    runner.state_mut().last_effect_excess_amount = Some(3);
+
+    let expr = only_quantity("You gain X life, where X is the damage dealt this way.");
+    let resolved = resolve_quantity(runner.state(), &expr, P0, source);
+
+    assert_eq!(
+        resolved, 4,
+        "the PLAIN damage phrase must still read the TOTAL channel (4), not the \
+         excess (3). Got {resolved} from {expr:?}"
+    );
+}


### PR DESCRIPTION
`parse_damage_dealt_phrase` recognized the "<amount> this way" family with a
single unanchored scan:

    let (input, _) = opt(take_until("damage dealt")).parse(input)?;
    let (input, _) = tag("damage dealt").parse(input)?;

`take_until("damage dealt")` DISCARDS everything before the verb phrase —
including the word "excess". So "the amount of excess damage dealt this way"
matched the generic damage arm, and the caller stamped
`PreviousEffectAmount { channel: Total }` on it. An EXCESS phrase silently read
the TOTAL tally.

That is not a coverage gap. It is a live, shipped, wrong number, and it rendered
as fully supported:

  Razor Rings          4 damage into a 1/1 is 3 excess (CR 120.10). "You gain life
                       equal to the excess damage dealt this way" gained 4.
  Nahiri's Warcrafting "Look at the top X cards ... where X is the excess damage
                       dealt this way" looked at the full damage, not the overkill.
  Overwhelming Victory "+X/+0 ... the amount of excess damage dealt this way"
                       pumped by the full damage.
  Cramped Vents // Access Maze, Windswift Slice, Ravenous Pursuit — same overcount.

And a TEST PINNED IT: `parse_event_context_quantity_previous_effect_this_way_variants`
asserted the excess phrase mapped to the Total channel. The pin protected the bug.

The excess qualifier is an independent AXIS over the same verb phrase, not part of
it. The scan now STOPS AT the qualifier instead of swallowing it: the excess
reading is tried first with a scan anchored on "excess damage dealt", and only if
that fails does the pre-existing permissive total scan run, unchanged. Every phrase
that matched before still matches — this is a channel correction, not a narrowing.
The combinator now REPORTS the channel and the caller uses it, rather than assuming
`Total`; assuming Total at the call site is what made the bug invisible.

The Excess channel it needs already exists and is live — `QuantityRef::PreviousEffectAmount
{ channel }` and its resolver landed in #5728. No new engine types.

DISCLOSURE: the explicit `channel: Total` at both the production site and the pin was
my own mechanical migration in #5728. Behaviour did not change there (the site was
already total-only), but the widening stamped an explicit `Total` onto a wrong reading
and made it look deliberate. A mechanical migration that faithfully preserves behaviour
also faithfully preserves BUGS — and upgrades them from implicit to intentional-looking.

FULL-POOL LEDGER (35,396 faces; base d555cef582; WHOLE-FACE structural diff — a
red-count ledger CANNOT see this fix, because it changes a field inside an
already-bound quantity and clears no Unimplemented):
   6  faces changed
   0  gained binding
   0  gained honest red
   0  re-shaped unexplained
   6  CHANNEL CORRECTED (Total -> Excess): Razor Rings, Nahiri's Warcrafting,
      Overwhelming Victory, Cramped Vents // Access Maze, Windswift Slice,
      Ravenous Pursuit
  The 8 pool faces that legitimately want the TOTAL ("you gain life equal to the
  damage dealt this way") are untouched — the negative control holds at pool scale.
  Nahiri's Warcrafting and Overwhelming Victory were NOT in my predicted set; the
  ledger found them. My oracle-grep prediction was 4/6 (I wrongly expected Unleash
  the Inferno and Bottle-Cap Blast, which use a bare demonstrative and a condition
  respectively and correctly did not move). The ledger is the authority, not the grep.

Tests: 3 runtime witnesses (2 positive + 1 negative control), WATCHED FAILING pre-fix
(Razor Rings read 4 where it must read 3; the "amount of" variant read 9 where it must
read 5). The negative control — the plain non-excess phrase must KEEP reading the total
— passes in both states, so a fix that simply routed every damage phrase to the excess
channel would not survive it. The wrong pin is corrected into a channel-split pair.

Co-authored-by: matthewevans <matthewevans@users.noreply.github.com>
