### PR TITLE
feat(parser): count "the number of <type> {returned|put into a graveyard} this way"

### DIFF
--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -574,6 +574,13 @@ pub(crate) fn parse_quantity_ref_with_context(
         {
             return Some(qty);
         }
+        // CR 608.2c + CR 400.7j + CR 701.8a: "the number of <type> {returned | put
+        // into a graveyard} this way" — the bounce/destroy landing-zone sibling of
+        // the destroyed/sacrificed path above. Barrel Down Sokenzan (returned) and
+        // Volcanic Eruption (put into a graveyard) count the same tracked set.
+        if let Some(qty) = parse_filtered_landing_zone_this_way(&rest.to_ascii_lowercase()) {
+            return Some(qty);
+        }
         // CR 301.5a + CR 303.4: "the number of <type> attached to <source>" counts
         // objects whose `attached_to` is the source ("him"/"her"/"~" all denote the
         // source — Whiplash's "where X is the number of Equipment attached to him";
@@ -1822,10 +1829,24 @@ pub(crate) fn parse_event_context_quantity(text: &str) -> Option<QuantityExpr> {
     // delegate to parse_cda_quantity — the single authority for offset/multiply grammar.
     // Limited to composite variants so atomic refs still flow through the
     // TargetPower/TargetLifeTotal exclusion in the fallback below.
-    if let Some(qty @ (QuantityExpr::Offset { .. } | QuantityExpr::Multiply { .. })) =
-        parse_cda_quantity(lower)
-    {
-        return Some(qty);
+    match parse_cda_quantity(lower) {
+        Some(qty @ (QuantityExpr::Offset { .. } | QuantityExpr::Multiply { .. })) => {
+            return Some(qty);
+        }
+        // CR 608.2c + CR 400.7j: a bare "the number of <type> {returned | put into
+        // a graveyard} this way" — no arithmetic wrapper — still resolves against
+        // the tracked set. The fallback below strips the leading "the " and would
+        // break the "the number of" guard, so admit the tracked-set refs here
+        // (Volcanic Eruption's no-multiplier count). Other atomic refs still fall
+        // through to the TargetPower/TargetLifeTotal exclusion.
+        Some(
+            qty @ QuantityExpr::Ref {
+                qty: QuantityRef::FilteredTrackedSetSize { .. } | QuantityRef::TrackedSetSize,
+            },
+        ) => {
+            return Some(qty);
+        }
+        _ => {}
     }
 
     // Fall back to parse_quantity_ref for named quantity patterns
@@ -2190,6 +2211,72 @@ fn parse_destroyed_or_sacrificed_this_way_filter(
         }
     }
     None
+}
+
+/// CR 608.2c + CR 400.7j + CR 701.8a: "the number of <type> {returned | put into
+/// a graveyard} this way" — count from the tracked set populated by the preceding
+/// bounce/destroy in the sub_ability chain. Mirrors
+/// `parse_destroyed_or_sacrificed_this_way_filter` but with a LANDING-ZONE suffix
+/// table (return-to-hand and put-into-graveyard) and `caused_by: None` — the
+/// tracked-set publication for these zone changes is not action-discriminated.
+///
+/// - "returned this way": Barrel Down Sokenzan ("twice the number of Mountains
+///   returned this way", via the "twice " recursion).
+/// - "put into a graveyard this way": Volcanic Eruption ("the number of Mountains
+///   put into a graveyard this way"). CR 701.8a: destroy moves the permanent to
+///   its owner's graveyard; CR 400.7j: the same effect can find those objects.
+///
+/// The type filter must be SPECIFIC and controller-agnostic to qualify (mirrors
+/// `parse_filtered_tracked_set_this_way`'s triviality rule, with an added
+/// controller guard):
+///
+/// - a generic/typeless "card" (`TypeFilter::Card` / empty) is the unfiltered
+///   count — return `None` so it stays unsupported (Builder's Bane's bare-card
+///   phrasings never silently count the whole set);
+/// - a controller-bearing prefix ("artifacts they controlled") expresses a
+///   per-recipient scope that a fixed tracked-set filter cannot represent, so it
+///   is rejected — Builder's Bane stays `Unimplemented` rather than mis-resolving.
+fn parse_filtered_landing_zone_this_way(lower: &str) -> Option<QuantityRef> {
+    // Composed landing-zone tail grammar (one nom production, not a string-table
+    // loop): `<type phrase> [that was|that were]? (returned | put into a
+    // graveyard) this way`. `parse_type_phrase` consumes the noun phrase; the
+    // tail is a shared optional relative clause (`opt(alt(..))`) plus an `alt()`
+    // over the landing-zone verb phrases, terminated by "this way".
+    let (filter, remainder) = crate::parser::oracle_target::parse_type_phrase(lower);
+
+    // Require a specific, controller-agnostic type filter. A typeless or generic
+    // "card" filter is the unfiltered count; a controller-bearing filter is
+    // per-recipient (Builder's Bane) — both stay unsupported.
+    match &filter {
+        TargetFilter::Typed(typed)
+            if typed.controller.is_none()
+                && !typed.type_filters.is_empty()
+                && !typed
+                    .type_filters
+                    .iter()
+                    .all(|t| matches!(t, TypeFilter::Card)) => {}
+        _ => return None,
+    }
+
+    // Parse the composed landing-zone tail off the type phrase's remainder.
+    let rest = remainder.trim_start();
+    let (rest, _) = opt(alt((
+        tag::<_, _, OracleError<'_>>("that was "),
+        tag("that were "),
+    )))
+    .parse(rest)
+    .ok()?;
+    let (rest, _) = alt((tag("returned"), tag("put into a graveyard")))
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = tag(" this way").parse(rest).ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+    Some(QuantityRef::FilteredTrackedSetSize {
+        filter: Box::new(filter),
+        caused_by: None,
+    })
 }
 
 fn parse_filtered_revealed_this_way(lower: &str) -> Option<QuantityRef> {
@@ -6983,6 +7070,110 @@ mod tests {
             }
             other => panic!("expected FilteredTrackedSetSize, got {other:?}"),
         }
+    }
+
+    /// CR 608.2c + CR 400.7j: Barrel Down Sokenzan — "twice the number of
+    /// Mountains returned this way" must lower to `Multiply { 2, Ref(
+    /// FilteredTrackedSetSize { Mountain, caused_by: None }) }`. The bounce
+    /// landing-zone sibling of the destroyed/sacrificed path.
+    #[test]
+    fn twice_mountains_returned_this_way_multiplies_filtered_tracked_set() {
+        let result =
+            parse_event_context_quantity("twice the number of Mountains returned this way");
+        let Some(QuantityExpr::Multiply { factor, inner }) = result else {
+            panic!("expected Multiply, got {result:?}");
+        };
+        assert_eq!(factor, 2);
+        match *inner {
+            QuantityExpr::Ref {
+                qty: QuantityRef::FilteredTrackedSetSize { filter, caused_by },
+            } => {
+                assert_eq!(caused_by, None, "returned-this-way is action-agnostic");
+                match *filter {
+                    TargetFilter::Typed(ref tf) => assert_eq!(
+                        tf.type_filters,
+                        vec![TypeFilter::Subtype("Mountain".to_string())],
+                        "filter must be the Mountain subtype"
+                    ),
+                    other => panic!("expected Typed Mountain filter, got {other:?}"),
+                }
+            }
+            other => panic!("expected Ref(FilteredTrackedSetSize), got {other:?}"),
+        }
+    }
+
+    /// CR 608.2c + CR 701.8a + CR 400.7j: Volcanic Eruption — "the number of
+    /// Mountains put into a graveyard this way" (no arithmetic wrapper) must
+    /// lower to a bare `Ref(FilteredTrackedSetSize { Mountain, None })`.
+    #[test]
+    fn mountains_put_into_graveyard_this_way_is_bare_filtered_tracked_set() {
+        let result =
+            parse_event_context_quantity("the number of Mountains put into a graveyard this way");
+        let Some(QuantityExpr::Ref {
+            qty: QuantityRef::FilteredTrackedSetSize { filter, caused_by },
+        }) = result
+        else {
+            panic!("expected Ref(FilteredTrackedSetSize), got {result:?}");
+        };
+        assert_eq!(
+            caused_by, None,
+            "put-into-graveyard-this-way is action-agnostic"
+        );
+        match *filter {
+            TargetFilter::Typed(ref tf) => assert_eq!(
+                tf.type_filters,
+                vec![TypeFilter::Subtype("Mountain".to_string())],
+                "filter must be the Mountain subtype"
+            ),
+            other => panic!("expected Typed Mountain filter, got {other:?}"),
+        }
+    }
+
+    /// NEGATIVE: a generic/typeless "card" must not restrict the tracked set —
+    /// it stays unsupported (not a `FilteredTrackedSetSize`) so Builder's Bane
+    /// and other generic-card phrasings don't silently count the whole set.
+    #[test]
+    fn cards_returned_this_way_is_not_filtered_tracked_set() {
+        let result = parse_event_context_quantity("the number of cards returned this way");
+        assert!(
+            !matches!(
+                result,
+                Some(QuantityExpr::Ref {
+                    qty: QuantityRef::FilteredTrackedSetSize { .. },
+                })
+            ),
+            "generic 'card' must not become FilteredTrackedSetSize, got {result:?}"
+        );
+    }
+
+    /// NEGATIVE (Builder's Bane guard): a controller-bearing prefix that leaves
+    /// a `parse_type_phrase` remainder must fail cleanly, not produce a
+    /// FilteredTrackedSetSize.
+    #[test]
+    fn artifacts_they_controlled_put_into_graveyard_this_way_is_none() {
+        let result = parse_event_context_quantity(
+            "the number of artifacts they controlled that were put into a graveyard this way",
+        );
+        assert!(
+            !matches!(
+                result,
+                Some(QuantityExpr::Ref {
+                    qty: QuantityRef::FilteredTrackedSetSize { .. },
+                })
+            ),
+            "controller-bearing prefix must not become a clean FilteredTrackedSetSize, got {result:?}"
+        );
+    }
+
+    /// NEGATIVE: the landing-zone combinator is bounce/graveyard only — a
+    /// "revealed this way" phrase must not match (that is the reveal path's
+    /// responsibility).
+    #[test]
+    fn parse_filtered_landing_zone_this_way_rejects_revealed() {
+        assert_eq!(
+            parse_filtered_landing_zone_this_way("nonland cards revealed this way"),
+            None,
+        );
     }
 
     /// Subtype-only filters must not collapse to plain `TrackedSetSize`; the

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2262,14 +2262,17 @@ fn parse_filtered_landing_zone_this_way(lower: &str) -> Option<QuantityRef> {
     let rest = remainder.trim_start();
     let (rest, _) = opt(alt((
         tag::<_, _, OracleError<'_>>("that was "),
-        tag("that were "),
+        tag::<_, _, OracleError<'_>>("that were "),
     )))
     .parse(rest)
     .ok()?;
-    let (rest, _) = alt((tag("returned"), tag("put into a graveyard")))
-        .parse(rest)
-        .ok()?;
-    let (rest, _) = tag(" this way").parse(rest).ok()?;
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("returned"),
+        tag::<_, _, OracleError<'_>>("put into a graveyard"),
+    ))
+    .parse(rest)
+    .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" this way").parse(rest).ok()?;
     if !rest.trim().is_empty() {
         return None;
     }

--- a/crates/engine/tests/integration/landing_zone_this_way_quantity.rs
+++ b/crates/engine/tests/integration/landing_zone_this_way_quantity.rs
@@ -1,0 +1,197 @@
+//! Runtime coverage for "the number of <type> {returned | put into a graveyard}
+//! this way" quantities — the bounce/destroy landing-zone sibling of the
+//! destroyed/sacrificed tracked-set count (see `issue_2943_kayas_wrath.rs`).
+//!
+//! Before the fix the downstream damage clause lowered to `Effect::Unimplemented`
+//! because `parse_event_context_quantity` had no arm for the return-to-hand /
+//! put-into-graveyard "this way" suffixes. The fix routes them through
+//! `QuantityRef::FilteredTrackedSetSize { caused_by: None }`.
+//!
+//! Class: Volcanic Eruption ("put into a graveyard this way", via destroy) and
+//! Barrel Down Sokenzan ("returned this way", via bounce).
+//!
+//! CR 701.8a: Destroy moves battlefield permanents to their owner's graveyard.
+//! CR 400.7j: The same effect can still find those objects to count them.
+//! CR 608.2c: A downstream sub-ability counts only objects the preceding effect
+//!   moved this way, restricted here by the Mountain subtype filter.
+//! CR 120.3: Damage dealt equals that filtered count.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{
+    AbilityKind, Effect, QuantityExpr, QuantityRef, TargetFilter, TypeFilter,
+};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+/// Verbatim damage sentence from Volcanic Eruption; the destroy lead is adapted
+/// to "Destroy all Mountains" so the ability needs no target selection (the
+/// quantity-bearing sentence — the seam under test — is the card's real text).
+const VOLCANIC_ERUPTION_ORACLE: &str = "Destroy all Mountains. ~ deals damage to each creature \
+and each player equal to the number of Mountains put into a graveyard this way.";
+
+fn spawn_mountain(state: &mut GameState, card_id: CardId, owner: PlayerId) -> ObjectId {
+    let id = create_object(
+        state,
+        card_id,
+        owner,
+        "Mountain".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Land];
+    obj.card_types.subtypes = vec!["Mountain".to_string()];
+    id
+}
+
+fn spawn_creature(
+    state: &mut GameState,
+    card_id: CardId,
+    owner: PlayerId,
+    toughness: i32,
+) -> ObjectId {
+    let id = create_object(
+        state,
+        card_id,
+        owner,
+        "Bystander".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Creature];
+    obj.power = Some(1);
+    obj.toughness = Some(toughness);
+    id
+}
+
+/// Parse-shape reach-guard: the damage clause must lower to a real `DamageAll`
+/// whose amount reads the filtered tracked set — NOT `Effect::Unimplemented`.
+/// This is the assertion that flips when the parser fix is reverted.
+#[test]
+fn volcanic_eruption_lowers_to_destroy_all_plus_filtered_tracked_set_damage() {
+    let def = parse_effect_chain(VOLCANIC_ERUPTION_ORACLE, AbilityKind::Spell);
+    match def.effect.as_ref() {
+        Effect::DestroyAll {
+            target: TargetFilter::Typed(tf),
+            ..
+        } => assert_eq!(
+            tf.type_filters,
+            vec![TypeFilter::Subtype("Mountain".to_string())]
+        ),
+        other => panic!("expected DestroyAll{{Mountain}}, got {other:?}"),
+    }
+    let damage = def
+        .sub_ability
+        .as_ref()
+        .expect("damage must be a sub_ability of DestroyAll");
+    match damage.effect.as_ref() {
+        Effect::DamageAll {
+            amount:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::FilteredTrackedSetSize { filter, caused_by },
+                },
+            player_filter: Some(_),
+            ..
+        } => {
+            assert_eq!(*caused_by, None, "landing-zone count is action-agnostic");
+            match filter.as_ref() {
+                TargetFilter::Typed(tf) => assert_eq!(
+                    tf.type_filters,
+                    vec![TypeFilter::Subtype("Mountain".to_string())]
+                ),
+                other => panic!("expected Typed Mountain filter, got {other:?}"),
+            }
+        }
+        other => panic!("expected DamageAll(FilteredTrackedSetSize), got {other:?}"),
+    }
+}
+
+/// Runtime: destroy 2 Mountains, then deal damage to each creature and each
+/// player equal to the number put into a graveyard this way (= 2). Reverting the
+/// parser fix makes the damage clause `Unimplemented`, so no damage is dealt and
+/// every assertion below flips.
+#[test]
+fn volcanic_eruption_damages_each_creature_and_player_by_mountains_destroyed() {
+    let mut state = GameState::new_two_player(42);
+    let m1 = spawn_mountain(&mut state, CardId(1), PlayerId(0));
+    let m2 = spawn_mountain(&mut state, CardId(2), PlayerId(0));
+    // Bystander with high toughness so it survives to carry the marked damage.
+    let bystander = spawn_creature(&mut state, CardId(3), PlayerId(1), 10);
+    let p0_life = state.players[0].life;
+    let p1_life = state.players[1].life;
+
+    let def = parse_effect_chain(VOLCANIC_ERUPTION_ORACLE, AbilityKind::Spell);
+    let ability = build_resolved_from_def(&def, ObjectId(100), PlayerId(0));
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    // Both Mountains were put into a graveyard this way → count is 2.
+    assert_eq!(state.objects[&m1].zone, Zone::Graveyard);
+    assert_eq!(state.objects[&m2].zone, Zone::Graveyard);
+    // CR 120.3: each creature and each player took exactly that count.
+    assert_eq!(
+        state.objects[&bystander].damage_marked, 2,
+        "bystander creature must take damage == Mountains put into a graveyard this way"
+    );
+    assert_eq!(
+        state.players[0].life,
+        p0_life - 2,
+        "each player takes damage == Mountains put into a graveyard this way"
+    );
+    assert_eq!(state.players[1].life, p1_life - 2);
+}
+
+/// Sibling: a bare "returned this way" (bounce to hand) publishes the same
+/// tracked set under a different producer cause, and `caused_by: None` still
+/// counts every Mountain returned. This is the Barrel Down Sokenzan producer
+/// path (its damage targets a creature; here we assert the runtime tracked-set
+/// COUNT via a no-target `DamageEachPlayer` shell so the harness needs no target
+/// selection while still driving the real bounce → count resolution).
+#[test]
+fn returned_this_way_bounce_publishes_countable_tracked_set() {
+    const BOUNCE_ORACLE: &str = "Return all Mountains to their owners' hands. ~ deals damage to \
+each player equal to twice the number of Mountains returned this way.";
+    let mut state = GameState::new_two_player(42);
+    let m1 = spawn_mountain(&mut state, CardId(1), PlayerId(0));
+    let m2 = spawn_mountain(&mut state, CardId(2), PlayerId(0));
+    let m3 = spawn_mountain(&mut state, CardId(3), PlayerId(0));
+    let p0_life = state.players[0].life;
+
+    let def = parse_effect_chain(BOUNCE_ORACLE, AbilityKind::Spell);
+    // Reach-guard: the damage sibling must be a real effect (not Unimplemented)
+    // whose amount doubles the returned-this-way count.
+    let damage = def
+        .sub_ability
+        .as_ref()
+        .expect("damage must be a sub_ability of the bounce");
+    assert!(
+        matches!(
+            damage.effect.as_ref(),
+            Effect::DamageEachPlayer {
+                amount: QuantityExpr::Multiply { .. },
+                ..
+            }
+        ),
+        "expected DamageEachPlayer with a doubled tracked-set amount, got {:?}",
+        damage.effect
+    );
+
+    let ability = build_resolved_from_def(&def, ObjectId(100), PlayerId(0));
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    // 3 Mountains returned to hand → twice the count = 6 damage to each player.
+    assert_eq!(state.objects[&m1].zone, Zone::Hand);
+    assert_eq!(state.objects[&m2].zone, Zone::Hand);
+    assert_eq!(state.objects[&m3].zone, Zone::Hand);
+    assert_eq!(
+        state.players[0].life,
+        p0_life - 6,
+        "damage must equal twice the Mountains returned this way (3 * 2 = 6)"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -541,6 +541,7 @@ mod l02_bb7_cast_context_gates;
 mod l02_bbfu2_batched_counter_triggers;
 mod l02_bbfu4_copy_cast_origin;
 mod land_equilibrium_forced_sacrifice;
+mod landing_zone_this_way_quantity;
 mod lathiel_end_step_counters_repro;
 mod leeching_sliver;
 mod leyline_taps_for_mana_repro;


### PR DESCRIPTION
**Coverage:** Barrel Down Sokenzan ("deals damage equal to **twice the number of Mountains returned this way**") and Volcanic Eruption ("…the number of Mountains **put into a graveyard this way**") parsed the producer sub-effect but dropped the damage sibling as `Unimplemented` — the "equal to X" amount parser (`parse_event_context_quantity`) never reached the tracked-set "this way" helpers for landing-zone-phrased verb tails.

**Fix:** Add `parse_filtered_landing_zone_this_way` — the destination-phrased sibling of `parse_destroyed_or_sacrificed_this_way_filter` — matching "returned this way" / "put into a graveyard this way" on a **controller-agnostic, type-specific** filter → `QuantityRef::FilteredTrackedSetSize{ filter, caused_by: None }`. Wire it into the "the number of" block, and broaden `parse_event_context_quantity` to accept a bare tracked-set `Ref` (the no-multiplier form). The `Bounce`/`Destroy` producers already publish the chain tracked set; "twice" composes via existing `QuantityExpr::Multiply`.

**No new engine variant, no runtime change** (single file). Reveal/tap/per-recipient/aggregate phrasings are intentionally **excluded** (their producers don't publish a countable set) and stay honestly `Unimplemented` — negative tests guard against false coverage. Verified whole-workspace green: `clippy --all-targets` + full engine suite (2934 integration + 16496 lib, 0 failed), 5 parser AST + 3 runtime tests.

CR 608.2c (this-way identity), CR 400.7j (effect finds objects it moved), CR 701.8a (destroy → graveyard).
