### PR TITLE
feat(parser): mana-ability carve-out on filter-scoped can't-activate (Damping Matrix)

### DIFF
--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -392,20 +392,21 @@ pub(crate) fn parse_filter_scoped_cant_be_activated(
     // abilities of artifacts and creatures can't be activated unless they're mana
     // abilities") is parsed the same way as the chosen-name branch above.
     // CR 605.1a: accept both apostrophe glyphs on the type-list predicate too.
-    let (predicate_tp, after_predicate) = rest_tp
-        .split_around(" can't be activated") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-        .or_else(|| rest_tp.split_around(" can\u{2019}t be activated"))?; // allow-noncombinator: dual-apostrophe variant of the line above.
-                                                                          // `parse_type_phrase` consumes the filter and returns the unconsumed tail —
-                                                                          // for this pattern the tail should be empty (the whole predicate IS the filter).
-    let (source_filter, tail) = parse_type_phrase(predicate_tp.original);
-    if !tail.trim().is_empty() {
-        return None;
-    }
+    // `parse_type_phrase` consumes the filter and leaves the predicate. Re-wrap
+    // that tail as a TextPair so the predicate stays in the nom parser family.
+    let (source_filter, filter_tail) = parse_type_phrase(rest_tp.original);
+    let filter_end = rest_tp.original.len().checked_sub(filter_tail.len())?;
+    let filter_tail = TextPair::new(
+        &rest_tp.original[filter_end..],
+        &rest_tp.lower[filter_end..],
+    );
     // `parse_type_phrase` returns `SelfRef` for unparseable input — treat that as a
     // parse failure and fall through to the self-ref branch in parse_static_line.
     if matches!(source_filter, TargetFilter::SelfRef) {
         return None;
     }
+    let after_predicate = nom_tag_tp(&filter_tail, " can't be activated")
+        .or_else(|| nom_tag_tp(&filter_tail, " can\u{2019}t be activated"))?;
     // CR 605.1a: optional " unless they're mana abilities" carve-out (Damping
     // Matrix); the suffix combinator yields `ActivationExemption::None` when it is
     // absent (Karn, Clarion). Nothing but a trailing period may follow it.

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -385,16 +385,16 @@ pub(crate) fn parse_filter_scoped_cant_be_activated(
         }
     }
 
-    // Otherwise fall back to the type-list + controller-suffix form (Karn, Clarion).
-    // Require the predicate ending "... can't be activated[.]" at the tail.
-    // CR 605.1a: accept both apostrophe glyphs on the type-list predicate too
-    // (Karn, Clarion Conqueror) — same reason as the chosen-name branch above.
-    let predicate_tp = rest_tp
-        .strip_suffix(" can't be activated.") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-        .or_else(|| rest_tp.strip_suffix(" can\u{2019}t be activated.")) // allow-noncombinator: dual-apostrophe variant of the line above.
-        .or_else(|| rest_tp.strip_suffix(" can't be activated")) // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-        .or_else(|| rest_tp.strip_suffix(" can\u{2019}t be activated"))?; // allow-noncombinator: dual-apostrophe variant of the line above.
-                                                                          // Extract the type-list + optional controller suffix via the shared helper.
+    // Otherwise fall back to the type-list + controller-suffix form (Karn,
+    // Clarion, Damping Matrix, Sharkey). Split ON the "... can't be activated"
+    // predicate — rather than requiring the line to END there — so an optional
+    // " unless they're mana abilities" carve-out (Damping Matrix: "Activated
+    // abilities of artifacts and creatures can't be activated unless they're mana
+    // abilities") is parsed the same way as the chosen-name branch above.
+    // CR 605.1a: accept both apostrophe glyphs on the type-list predicate too.
+    let (predicate_tp, after_predicate) = rest_tp
+        .split_around(" can't be activated") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+        .or_else(|| rest_tp.split_around(" can\u{2019}t be activated"))?; // allow-noncombinator: dual-apostrophe variant of the line above.
                                                                           // `parse_type_phrase` consumes the filter and returns the unconsumed tail —
                                                                           // for this pattern the tail should be empty (the whole predicate IS the filter).
     let (source_filter, tail) = parse_type_phrase(predicate_tp.original);
@@ -406,12 +406,18 @@ pub(crate) fn parse_filter_scoped_cant_be_activated(
     if matches!(source_filter, TargetFilter::SelfRef) {
         return None;
     }
+    // CR 605.1a: optional " unless they're mana abilities" carve-out (Damping
+    // Matrix); the suffix combinator yields `ActivationExemption::None` when it is
+    // absent (Karn, Clarion). Nothing but a trailing period may follow it.
+    let (exempt_tail, exemption) = parse_activation_exemption_suffix(after_predicate.lower).ok()?;
+    if !exempt_tail.trim_end_matches('.').trim().is_empty() {
+        return None;
+    }
     Some(
         StaticDefinition::new(StaticMode::CantBeActivated {
             who: ProhibitionScope::AllPlayers,
             source_filter,
-            // CR 605.1a: Karn/Clarion class — no "unless they're..." suffix.
-            exemption: ActivationExemption::None,
+            exemption,
         })
         .description(text.to_string()),
     )

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -28739,3 +28739,42 @@ fn dynamic_pt_pump_scales_by_source_intensity() {
         s[0].modifications
     );
 }
+
+/// CR 605.1a: the filter-scoped "Activated abilities of <types> can't be
+/// activated" static now carries the optional "unless they're mana abilities"
+/// carve-out — Damping Matrix (artifacts and creatures) and Sharkey (lands).
+#[test]
+fn filter_scoped_cant_be_activated_parses_mana_ability_exemption() {
+    let s = super::shared::parse_static_line_multi(
+        "Activated abilities of artifacts and creatures can't be activated unless they're mana abilities.",
+    );
+    assert_eq!(s.len(), 1, "Damping Matrix: {s:?}");
+    assert!(
+        matches!(
+            s[0].mode,
+            StaticMode::CantBeActivated {
+                exemption: ActivationExemption::ManaAbilities,
+                ..
+            }
+        ),
+        "expected mana-ability exemption, got {:?}",
+        s[0].mode
+    );
+
+    // Regression: the Karn/Clarion form (no carve-out) still parses to None.
+    let s = super::shared::parse_static_line_multi(
+        "Activated abilities of artifacts your opponents control can't be activated.",
+    );
+    assert_eq!(s.len(), 1, "Karn/Clarion: {s:?}");
+    assert!(
+        matches!(
+            s[0].mode,
+            StaticMode::CantBeActivated {
+                exemption: ActivationExemption::None,
+                ..
+            }
+        ),
+        "expected no exemption, got {:?}",
+        s[0].mode
+    );
+}


### PR DESCRIPTION
## Summary

The filter-scoped `Activated abilities of <types> can't be activated` static now parses the optional `unless they're mana abilities` carve-out (CR 605.1a) — **Damping Matrix** and **Sharkey, Tyrant of the Underworld** previously dropped it entirely and produced no static.

## Implementation method

Hand-authored. The type-filter branch of `parse_filter_scoped_cant_be_activated` required the line to *end* at `... can't be activated`, hardcoding `ActivationExemption::None`. It now **splits on** that predicate and feeds the remainder to the existing `parse_activation_exemption_suffix` combinator — the same seam the chosen-name branch (Pithing Needle class) already uses. No new modeling: `StaticMode::CantBeActivated { exemption }` and `ActivationExemption::ManaAbilities` already exist and are runtime-enforced.

## CR references

CR 605.1a — mana abilities bypass the activation prohibition (the carve-out). Touched, not invented.

## Files changed

- `parser/oracle_static/restriction.rs` — type-filter branch: `split_around` the predicate + parse the optional exemption suffix (was: `strip_suffix` requiring end-of-line, `exemption: None`).
- `parser/oracle_static/tests.rs` — `filter_scoped_cant_be_activated_parses_mana_ability_exemption`.

## Verification (local, committed head `fcf7993607520fe18dd37d7f0e54ca020a0920f1`)

- `cargo test -p engine --lib filter_scoped_cant_be_activated_parses_mana_ability_exemption` — ok
- `cargo test -p engine --lib cant_be_activated` — ok (22 passed; Karn/Clarion regression intact, still `None`)
- `cargo test -p engine --lib parser::oracle_static` — ok (1127 passed, 0 failed)
- `cargo fmt -p engine -- --check` — clean
- `cargo clippy -p engine --lib` (`-D warnings`) — clean
- `scripts/check-parser-combinators.sh <base>` — pass
- `scripts/check-engine-authorities.sh <base>` — pass

Transparency: I did not run `scripts/ai-gate.sh` (Gate A) — it does a fresh `--release` build in a separate target dir and local disk is tight; not fabricating a PASS line. CI's parser gate + both test shards cover this head.

## Anchored on

- `crates/engine/src/parser/oracle_static/restriction.rs:372` — the chosen-name branch, which already parses `parse_activation_exemption_suffix` after the predicate (the pattern this reuses).
- `crates/engine/src/parser/oracle_static/restriction.rs:288` — `parse_activation_exemption_suffix`, the shared `opt`-wrapped carve-out combinator (yields `None` when absent).

## Claimed parse impact

- **Damping Matrix** — `can't be activated unless they're mana abilities` now parses (was dropped)
- **Sharkey, Tyrant of the Underworld** — same filter-scoped seam