### PR TITLE
ship/t85b set extractor

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3609,6 +3609,15 @@ fn effect_references_tracked_set(effect: &Effect) -> bool {
         Effect::ChangeSpeed { amount, .. } => quantity_hits_tracked(amount),
         Effect::PutCounter { count, .. } => quantity_hits_tracked(count),
         Effect::PutCounterAll { count, .. } => quantity_hits_tracked(count),
+        // CR 608.2c + CR 701.21a: an `ExileTop` whose count reduces the chain
+        // tracked set is a CONSUMER of that set, so the preceding producer must
+        // publish it. Kylox, Visionary Inventor ("sacrifice any number of other
+        // creatures, then exile the top X cards of your library, where X is
+        // their total power") is exactly this shape: without this arm
+        // `next_sub_needs_tracked_set` returned false, the sacrifice never
+        // published its affected ids, and the `TrackedSetAggregate` reduced an
+        // empty set to 0 — a fully-supported-looking card that exiles nothing.
+        Effect::ExileTop { count, .. } => quantity_hits_tracked(count),
         Effect::Token {
             count,
             power,

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2457,14 +2457,23 @@ fn resolve_ref(
                     .map(|(_, ids)| ids.clone())
                     .unwrap_or_default(),
                 // CR 603.2c + CR 603.10a: the current triggering event batch
-                // ("those creatures" on a batched dies trigger). The subjects are
+                // ("those creatures" on a batched dies trigger; "them" / "their
+                // total power" on a batched attack trigger). The subjects are
                 // read from `state.current_trigger_events`; each died creature's
                 // power comes from its last-known info (LKI), i.e. death-time
                 // power, via `aggregate_property_over`'s live-then-LKI extract.
+                //
+                // CR 508.1: `extract_sources_from_event` is the SET-valued
+                // extractor. The singleton `extract_source_from_event` collapses
+                // a multi-attacker `AttackersDeclared` to `None`, which reduced
+                // this aggregate over an EMPTY set — 0 attackers' worth of power
+                // on every board with 2+ attackers (Aloy, Shriekwood Devourer,
+                // Witch-king, Sky Scourge). Dies batches are unchanged: they
+                // arrive as one event per creature and are still collected here.
                 TrackedAnaphorSource::TriggeringBatch => state
                     .current_trigger_events
                     .iter()
-                    .filter_map(crate::game::targeting::extract_source_from_event)
+                    .flat_map(crate::game::targeting::extract_sources_from_event)
                     .collect(),
             };
             // Per-object aggregation delegated to the shared

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -1423,6 +1423,36 @@ pub(crate) fn extract_source_from_event(
     }
 }
 
+/// CR 603.2c + CR 508.1: Extract EVERY object the trigger event names as a
+/// subject — the set-valued widening of [`extract_source_from_event`].
+///
+/// A batched trigger's plural anaphor ("them", "those creatures", "their total
+/// power") refers to the whole triggering batch, so an aggregate reduced over
+/// that batch must see every member. `AttackersDeclared` is the only event that
+/// carries a multi-object batch *within a single event* (CR 508.1: attackers are
+/// declared together as one turn-based action), and the singleton extractor
+/// deliberately collapses a >1 attacker batch to `None` — there is no single
+/// "the" attacker to name. Reducing an aggregate over that `None` yields an
+/// empty set, i.e. 0: a silent wrong answer on every multi-attacker board.
+///
+/// Every other event names exactly one subject, so this widening DELEGATES to
+/// the singleton and lifts its answer into a 1-vec. That keeps the two
+/// extractors from drifting apart and leaves every existing singleton caller
+/// untouched.
+///
+/// CR 603.10a: batched *dies* triggers are unaffected — they emit one
+/// `ZoneChanged` event PER creature, so their batch is reconstructed by
+/// collecting ACROSS events, never within one. This function preserves that
+/// (each `ZoneChanged` contributes its own 1-vec).
+pub(crate) fn extract_sources_from_event(event: &crate::types::events::GameEvent) -> Vec<ObjectId> {
+    use crate::types::events::GameEvent;
+    match event {
+        // CR 508.1: the full declared-attackers batch.
+        GameEvent::AttackersDeclared { attacker_ids, .. } => attacker_ids.clone(),
+        _ => extract_source_from_event(event).into_iter().collect(),
+    }
+}
+
 /// CR 603.2 + CR 120.1: Extract the object that *received* the damage referenced
 /// by the current trigger event — the recipient counterpart to
 /// [`extract_source_from_event`]. Resolves `ObjectScope::EventTarget` ("that
@@ -4893,6 +4923,56 @@ mod tests {
         );
         // Suppress unused-variable warning when setup_with_creatures changes.
         let _ = &mut state;
+    }
+
+    /// CR 508.1 + CR 603.2c: the SET-valued extractor is a pure widening of the
+    /// singleton.
+    ///
+    /// The singleton deliberately collapses a MULTI-attacker `AttackersDeclared`
+    /// to `None` — there is no single "the" attacker — and every one of its
+    /// callers depends on that. But an aggregate reduced over that `None` sees an
+    /// EMPTY set, i.e. 0, on every multi-attacker board. `extract_sources_from_event`
+    /// returns the whole batch instead, and delegates every other event arm back
+    /// to the singleton so the two cannot drift.
+    #[test]
+    fn set_extractor_widens_the_multi_attacker_batch_that_the_singleton_drops() {
+        use crate::types::events::GameEvent;
+
+        let a = ObjectId(11);
+        let b = ObjectId(12);
+        let batch = GameEvent::AttackersDeclared {
+            attacker_ids: vec![a, b],
+            defending_player: PlayerId(1),
+            attacks: vec![],
+        };
+
+        assert_eq!(
+            extract_source_from_event(&batch),
+            None,
+            "the singleton must STILL collapse a 2-attacker batch to None — this \
+             is the behavior its existing callers rely on, and it is untouched"
+        );
+        assert_eq!(
+            extract_sources_from_event(&batch),
+            vec![a, b],
+            "the set extractor must return EVERY attacker"
+        );
+
+        // Pure widening: a 1-attacker batch agrees with the singleton, and a
+        // non-batch event is lifted to a 1-vec rather than losing its subject.
+        let solo = GameEvent::AttackersDeclared {
+            attacker_ids: vec![a],
+            defending_player: PlayerId(1),
+            attacks: vec![],
+        };
+        assert_eq!(extract_source_from_event(&solo), Some(a));
+        assert_eq!(extract_sources_from_event(&solo), vec![a]);
+
+        assert_eq!(
+            extract_sources_from_event(&GameEvent::PermanentUntapped { object_id: b }),
+            vec![b],
+            "a singleton-subject event must be lifted, not dropped"
+        );
     }
 
     /// CR 509.1g + CR 608.2c: for "When this creature blocks a creature,

--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -59,12 +59,13 @@ use super::{
     bind_anaphoric_damage_subject_keep_recipient, collapse_ephemeral_color_choice_mana,
     contains_explicit_tracked_set_pronoun, contains_implicit_tracked_set_pronoun,
     def_is_damage_dealer, def_is_dig_look, def_is_dig_or_mill, def_is_generic_effect_head,
-    def_is_keyword_counter_placement, fold_cast_copy_of_card_defs, has_explicit_player_target,
-    inject_chosen_color_choice_grant, mark_uses_tracked_set,
-    parse_spell_graveyard_replacement_rider, publishes_tracked_set_from_resolution,
-    retarget_counter_additional_cost_to_target, rewrite_parent_targets_to_tracked_set,
-    rewrite_rounding_mode, rewrite_that_type_mana_instead, stamp_delayed_returns,
-    try_fold_token_repeat_into_count, wire_optional_cast_decline_fallback,
+    def_is_keyword_counter_placement, demote_unbindable_batch_aggregate,
+    fold_cast_copy_of_card_defs, has_explicit_player_target, inject_chosen_color_choice_grant,
+    mark_uses_tracked_set, parse_spell_graveyard_replacement_rider,
+    publishes_aggregate_set_from_resolution, publishes_tracked_set_from_resolution,
+    rebind_tracked_aggregate_to_chain_set, retarget_counter_additional_cost_to_target,
+    rewrite_parent_targets_to_tracked_set, rewrite_rounding_mode, rewrite_that_type_mana_instead,
+    stamp_delayed_returns, try_fold_token_repeat_into_count, wire_optional_cast_decline_fallback,
 };
 
 // ===========================================================================
@@ -2038,6 +2039,50 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
                         mark_uses_tracked_set(current);
                         rewrite_parent_targets_to_tracked_set(&mut current.effect);
                     }
+                }
+            }
+
+            // CR 608.2c: Re-anchor this clause's set-anaphor AGGREGATE ("their
+            // total power", "the greatest power among them") to the set an
+            // EARLIER clause published, overriding the leaf combinator's
+            // context-free triggering-batch reading.
+            //
+            // Strictly prior by construction: `defs` holds only the clauses
+            // already emitted, so a clause does not count itself as its own
+            // publisher — which is what keeps Witch-king, Sky Scourge ("exile
+            // the top X cards …, where X is their total power", whose own
+            // `ExileTop` IS a publisher) on the triggering-batch reading while
+            // Kylox, Visionary Inventor (a preceding SACRIFICE clause) flips to
+            // the chain set.
+            //
+            // A separate scan from `any_prior_publishes` above, on its own
+            // predicate: this axis additionally counts `Effect::Sacrifice` as a
+            // producer, and it must not widen the pronoun→target rewrite that
+            // the gate above drives. See
+            // `publishes_aggregate_set_from_resolution`.
+            if defs
+                .iter()
+                .any(|d| publishes_aggregate_set_from_resolution(&d.effect))
+            {
+                for current in &mut current_defs {
+                    rebind_tracked_aggregate_to_chain_set(current);
+                }
+            }
+
+            // CR 603.2c: An anaphor left on the TRIGGERING-BATCH reading in a
+            // chain that has NO trigger event has nothing to refer to — the
+            // aggregate would reduce an empty set to a confident 0. Fail
+            // honestly instead. (Angrath, Minotaur Pirate's loyalty ability:
+            // "Destroy all creatures target opponent controls. Angrath deals
+            // damage to that player equal to their total power.")
+            if !ir.in_trigger {
+                let fragment = clause_ir
+                    .where_x_expression
+                    .as_deref()
+                    .map(|expr| format!("where X is {expr}"))
+                    .unwrap_or_else(|| clause_ir.source.fragment().unwrap_or_default().to_string());
+                for current in &mut current_defs {
+                    demote_unbindable_batch_aggregate(current, &fragment);
                 }
             }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -106,8 +106,8 @@ use crate::types::ability::{
     RevealUntilDisposition, RoundingMode, SharedQuality, SharedQualityRelation, SkipScope,
     SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition, StepSkipTarget,
     SubAbilityLink, TapStateChange, TargetFilter, TargetSelectionMode, ThisWayCause,
-    TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
-    UntilCondition, ZoneOwner,
+    TrackedAnaphorSource, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
+    UnlessPayModifier, UntilCondition, ZoneOwner,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -21800,6 +21800,188 @@ fn publishes_tracked_set_from_resolution(effect: &Effect) -> bool {
         )
 }
 
+/// CR 608.2c + CR 701.21a: Does this clause publish, at resolution, a chain
+/// tracked set that a LATER set-AGGREGATE anaphor ("their total power", "the
+/// greatest power among them") would reduce?
+///
+/// A superset of [`publishes_tracked_set_from_resolution`] by exactly one
+/// producer: `Effect::Sacrifice` (CR 701.21a). A sacrifice publishes its
+/// affected ids as the chain set at resolution
+/// (`game/effects/mod.rs::publish_tracked_set_with_causes`), and that set is the
+/// antecedent of Kylox, Visionary Inventor's "their" ("sacrifice any number of
+/// other creatures, then exile the top X cards of your library, where X is their
+/// total power").
+///
+/// Sacrifice is deliberately NOT added to
+/// [`publishes_tracked_set_from_resolution`] itself. That predicate drives
+/// `rewrite_parent_targets_to_tracked_set` — the pronoun→TARGET rewrite axis —
+/// where re-pointing a post-sacrifice clause's `ParentTarget` at the sacrificed
+/// set is a different question with a far wider blast radius. Two axes, two
+/// predicates; this one only ever re-anchors an aggregate's `source` field.
+fn publishes_aggregate_set_from_resolution(effect: &Effect) -> bool {
+    publishes_tracked_set_from_resolution(effect) || matches!(effect, Effect::Sacrifice { .. })
+}
+
+/// CR 608.2c: Re-anchor a batched set-anaphor aggregate to the CHAIN-published
+/// set.
+///
+/// The leaf quantity combinator is context-free: "their total power" and "the
+/// greatest power among them" both parse to `TrackedSetAggregate { source:
+/// TriggeringBatch }`, because the pronoun ALONE cannot say whether its
+/// antecedent is the triggering batch or a set that an earlier clause published.
+/// The two readings are byte-identical in the leaf text and resolve from
+/// different state:
+///
+///   Witch-king, Sky Scourge  "Whenever you attack with one or more Wraiths,
+///     exile the top X cards …, where X is their total power."
+///     -> TRIGGERING BATCH (the attacking Wraiths).
+///   Kylox, Visionary Inventor  "Whenever Kylox attacks, sacrifice any number of
+///     other creatures, then exile the top X cards …, where X is their total
+///     power."
+///     -> CHAIN SET (the creatures the PRECEDING clause sacrificed).
+///
+/// The disambiguator is therefore the SIBLING CLAUSE, which is only visible one
+/// layer up from the leaf — here, at chain assembly. CR 608.2c: an ability's
+/// instructions are followed in the order written, so when an earlier
+/// instruction has just established a set of objects, the pronoun refers to it.
+/// Binding the batch reading in a chain that published a set is a silent 0 (the
+/// event batch and the chain set are different state); this pass is what keeps
+/// that from shipping as a supported-looking card.
+///
+/// Mirrors `rebind_anaphoric_object_scope` (the object-scope analogue).
+pub(crate) fn rebind_tracked_aggregate_to_chain_set(def: &mut AbilityDefinition) {
+    each_quantity_expr_mut(&mut def.effect, &mut rebind_tracked_aggregate_expr);
+    if let Some(spec) = def.multi_target.as_mut() {
+        spec.map_quantities(|expr| {
+            let mut slot = expr;
+            rebind_tracked_aggregate_expr(&mut slot);
+            slot
+        });
+    }
+    if let Some(repeat_for) = def.repeat_for.as_mut() {
+        rebind_tracked_aggregate_expr(repeat_for);
+    }
+    if let Some(sub) = def.sub_ability.as_mut() {
+        rebind_tracked_aggregate_to_chain_set(sub);
+    }
+    if let Some(else_ability) = def.else_ability.as_mut() {
+        rebind_tracked_aggregate_to_chain_set(else_ability);
+    }
+}
+
+/// CR 603.2c: Demote an UNBINDABLE triggering-batch anaphor to an honest gap.
+///
+/// `TrackedSetAggregate { source: TriggeringBatch }` reduces the objects of the
+/// CURRENT TRIGGER EVENT. A chain that is not a triggered ability's body — a
+/// spell, or an activated/loyalty ability — has no trigger event, so the pronoun
+/// has no antecedent at all: the aggregate would reduce an EMPTY set to 0 while
+/// the card still rendered as fully supported. That is strictly worse than a
+/// gap, because a confident 0 is indistinguishable from a correct answer.
+///
+/// This is a live shape, not a hypothetical. Angrath, Minotaur Pirate's
+/// "−11: Destroy all creatures target opponent controls. Angrath deals damage to
+/// that player equal to their total power." carries the possessive anaphor in a
+/// LOYALTY ability. Its true antecedent is the creatures the preceding clause
+/// destroyed — a CHAIN set — but the clause ALSO needs "that player" to bind to
+/// the targeted opponent, which is a separate (player-anaphor) binding gap. With
+/// only half the clause representable, the honest answer is a gap, not a
+/// confident 0. The `Unimplemented` marker is the single authority for that
+/// (`Effect::unimplemented`), never a hand-rolled sentinel.
+///
+/// Demotes exactly the node that carries the unbindable anaphor, so sibling
+/// clauses that DID parse (Angrath's `DestroyAll`) are preserved.
+pub(crate) fn demote_unbindable_batch_aggregate(def: &mut AbilityDefinition, fragment: &str) {
+    if def_slots_reference_triggering_batch(def) {
+        *def.effect = Effect::unimplemented("tracked_set_anaphor", fragment);
+    }
+    if let Some(sub) = def.sub_ability.as_mut() {
+        demote_unbindable_batch_aggregate(sub, fragment);
+    }
+    if let Some(else_ability) = def.else_ability.as_mut() {
+        demote_unbindable_batch_aggregate(else_ability, fragment);
+    }
+}
+
+/// CR 603.2c: Does THIS def's own quantity slots (not its sub-abilities') carry
+/// a triggering-batch aggregate? Companion to
+/// [`demote_unbindable_batch_aggregate`], which recurses separately so it can
+/// demote the precise node that holds the anaphor.
+fn def_slots_reference_triggering_batch(def: &AbilityDefinition) -> bool {
+    fn expr_references_batch(expr: &QuantityExpr) -> bool {
+        match expr {
+            QuantityExpr::Ref {
+                qty:
+                    QuantityRef::TrackedSetAggregate {
+                        source: TrackedAnaphorSource::TriggeringBatch,
+                        ..
+                    },
+            } => true,
+            QuantityExpr::Ref { .. } | QuantityExpr::Fixed { .. } => false,
+            QuantityExpr::DivideRounded { inner, .. }
+            | QuantityExpr::Multiply { inner, .. }
+            | QuantityExpr::ClampMin { inner, .. }
+            | QuantityExpr::Offset { inner, .. }
+            | QuantityExpr::UpTo { max: inner }
+            | QuantityExpr::Power {
+                exponent: inner, ..
+            } => expr_references_batch(inner),
+            QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+                exprs.iter().any(expr_references_batch)
+            }
+            QuantityExpr::Difference { left, right } => {
+                expr_references_batch(left) || expr_references_batch(right)
+            }
+        }
+    }
+    // `each_quantity_expr_mut` is the only quantity visitor over `Effect`; it is
+    // mutable-only, so probe a throwaway clone (parse-time, and only on the
+    // no-trigger path).
+    let mut found = false;
+    let mut effect = def.effect.clone();
+    each_quantity_expr_mut(&mut effect, &mut |expr| {
+        found |= expr_references_batch(expr);
+    });
+    found
+        || def.repeat_for.as_ref().is_some_and(expr_references_batch)
+        || def.multi_target.as_ref().is_some_and(|spec| {
+            expr_references_batch(&spec.min) || spec.max.as_ref().is_some_and(expr_references_batch)
+        })
+}
+
+/// CR 608.2c: Retarget every `TrackedSetAggregate` in one `QuantityExpr` tree
+/// from the context-free `TriggeringBatch` default to the chain-published set.
+/// A `source` the parser already committed to `ChainSet` (the explicit "those
+/// exiled cards" anaphor) is left alone — it named its set outright.
+fn rebind_tracked_aggregate_expr(expr: &mut QuantityExpr) {
+    match expr {
+        QuantityExpr::Ref {
+            qty:
+                QuantityRef::TrackedSetAggregate {
+                    source: source @ TrackedAnaphorSource::TriggeringBatch,
+                    ..
+                },
+        } => *source = TrackedAnaphorSource::ChainSet,
+        QuantityExpr::Ref { .. } | QuantityExpr::Fixed { .. } => {}
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Multiply { inner, .. }
+        | QuantityExpr::ClampMin { inner, .. }
+        | QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::UpTo { max: inner }
+        | QuantityExpr::Power {
+            exponent: inner, ..
+        } => rebind_tracked_aggregate_expr(inner),
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            for inner in exprs {
+                rebind_tracked_aggregate_expr(inner);
+            }
+        }
+        QuantityExpr::Difference { left, right } => {
+            rebind_tracked_aggregate_expr(left);
+            rebind_tracked_aggregate_expr(right);
+        }
+    }
+}
+
 /// CR 508.1a + CR 508.1d + CR 608.2c: A mass "attack this turn if able" coercion —
 /// a `GenericEffect` carrying a `MustAttack` (CR 508.1a, attack-if-able) or
 /// `MustAttackPlayer` (CR 508.1d, directed attack) static over a BROADCAST
@@ -22264,6 +22446,17 @@ pub(crate) fn each_quantity_expr_mut(effect: &mut Effect, f: &mut impl FnMut(&mu
         | Effect::Surveil { count, .. }
         | Effect::PutCounter { count, .. } => f(count),
         Effect::Sacrifice { count, .. } => f(count),
+        // CR 608.2c: the two remaining `where X is …` quantity carriers reached
+        // by the set-anaphor grammar — `ExileTop` (Kylox, Visionary Inventor /
+        // Witch-king, Sky Scourge: "exile the top X cards … where X is their
+        // total power") and `Discover` (Aloy, Savior of Meridian: "discover X,
+        // where X is the greatest power among them"). Without these arms a
+        // `TrackedSetAggregate` bound into either slot is invisible to every
+        // caller of this visitor, including the chain-set re-anchor.
+        Effect::ExileTop { count, .. } => f(count),
+        Effect::Discover {
+            mana_value_limit, ..
+        } => f(mana_value_limit),
         _ => {}
     }
 }
@@ -24567,6 +24760,7 @@ pub(crate) fn parse_effect_chain_ir(
                 kind,
                 chain_rounding,
                 actor: ctx.actor.clone(),
+                in_trigger: ctx.in_trigger,
                 repeat_until: None,
             };
         }
@@ -27707,6 +27901,7 @@ pub(crate) fn parse_effect_chain_ir(
         kind,
         chain_rounding,
         actor: ctx.actor.clone(),
+        in_trigger: ctx.in_trigger,
         repeat_until: pending_repeat_until,
     }
 }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -45303,6 +45303,7 @@ fn drawn_this_turn_followup_overwrites_prior_life_payment() {
         kind: AbilityKind::Spell,
         chain_rounding: None,
         actor: None,
+        in_trigger: false,
         repeat_until: None,
     };
 

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -36,6 +36,16 @@ pub(crate) struct EffectChainIr {
     pub(crate) chain_rounding: Option<RoundingMode>,
     /// CR 701.21a: Actor context threaded from ParseContext (per D-07).
     pub(crate) actor: Option<ControllerRef>,
+    /// CR 603.2c: Whether this chain is the body of a TRIGGERED ability,
+    /// threaded from `ParseContext::in_trigger` (mirrors `actor`).
+    ///
+    /// Assembly needs it to reject an unbindable batch anaphor: a
+    /// `TrackedSetAggregate { source: TriggeringBatch }` names the objects of
+    /// the CURRENT TRIGGER EVENT, so in a chain with no trigger event (a spell,
+    /// or a loyalty/activated ability) the pronoun has no antecedent and would
+    /// silently reduce an empty set to 0. Such a chain must fail honestly
+    /// instead. See `assemble_effect_chain`.
+    pub(crate) in_trigger: bool,
     /// CR 608.2c + CR 107.1c: chain-level "repeat this process" loop predicate.
     /// Set when a trailing "you may repeat this process" / "if you do, repeat
     /// this process" directive is recognized. Lowering applies it to the root
@@ -757,6 +767,7 @@ mod tests {
             kind: AbilityKind::Spell,
             chain_rounding: None,
             actor: None,
+            in_trigger: false,
             repeat_until: None,
         };
         assert!(ir.clauses.is_empty());
@@ -871,6 +882,7 @@ mod tests {
             kind: AbilityKind::Spell,
             chain_rounding: None,
             actor: None,
+            in_trigger: false,
             repeat_until: None,
         };
         assert_eq!(ir.clauses.len(), 1);

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -281,6 +281,30 @@ pub(crate) fn parse_quantity_ref_with_context(
         }
     }
 
+    // CR 608.2c + CR 603.2c: the POSSESSIVE set anaphor — "their total <prop>".
+    // The pronoun IS the set reference (there is no trailing "of <set>" phrase),
+    // so it cannot go through the "the total <prop> of " prefix arm below.
+    //
+    // Like the demonstrative arms, this emits the context-free BATCH reading and
+    // lets the clause layer re-anchor it to the chain-published set when an
+    // earlier clause published one. Both readings are live and byte-identical in
+    // the leaf text — that is why the disambiguation cannot happen here:
+    //   Witch-king, Sky Scourge  "Whenever you attack with one or more Wraiths,
+    //     exile the top X cards …, where X is their total power."  -> the ATTACK
+    //     BATCH (no earlier clause; "their" = the triggering Wraiths).
+    //   Kylox, Visionary Inventor  "… sacrifice any number of other creatures,
+    //     then exile the top X cards …, where X is their total power."  -> the
+    //     CHAIN SET ("their" = the creatures the PRECEDING clause sacrificed).
+    if let Ok((rest, (func, prop))) = parse_possessive_batch_aggregate(trimmed) {
+        if rest.trim().is_empty() {
+            return Some(QuantityRef::TrackedSetAggregate {
+                function: func,
+                property: prop,
+                source: TrackedAnaphorSource::TriggeringBatch,
+            });
+        }
+    }
+
     // Aggregate patterns: "the greatest X among" / "the total power of"
     if let Ok((rest, (func, prop))) = alt((
         value(
@@ -345,35 +369,41 @@ pub(crate) fn parse_quantity_ref_with_context(
         // phrase (bare "creatures" would otherwise parse as a filter).
         //
         // Scoped narrowly because this parser is context-free and cannot see
-        // whether the enclosing ability is a batched *dies* trigger:
-        //   * "those creatures" ONLY (not "those cards"/"those permanents").
-        //     "those cards" is overloaded — it also names a mill set ("you mill
-        //     three cards, then … the total mana value of those cards":
-        //     Combustible Gearhulk, Palantír of Orthanc) or a chosen target set
-        //     (Command the Dreadhorde), where TriggeringBatch resolves to the
-        //     wrong/empty event set.
-        //   * Sum ("the total <prop> OF those creatures") ONLY, never Max/Min
-        //     ("the greatest <prop> AMONG those creatures"). The "greatest …
-        //     among those creatures" idiom is an ATTACK batch (Shriekwood
-        //     Devourer: "whenever you attack with one or more creatures … the
-        //     greatest power among those creatures"), whose multi-attacker
-        //     `AttackersDeclared` fan-out `extract_source_from_event` does not yet
-        //     resolve (it collapses >1 attacker to `None`). Plan §8 defers attack
-        //     batches; mapping it here would silently resolve to 0.
-        // With both gates, the sole card enabled is The Skullspore Nexus (Benthic
-        // Anomaly / Dracoplasm route their "those creatures" through the
-        // copy/"becomes" paths, not this quantity parser) — measured.
-        if matches!(func, AggregateFunction::Sum) {
-            if let Ok((anaphor_rest, _)) =
-                tag::<_, _, OracleError<'_>>("those creatures").parse(rest)
-            {
-                if anaphor_rest.trim().is_empty() {
-                    return Some(QuantityRef::TrackedSetAggregate {
-                        function: func,
-                        property: prop,
-                        source: TrackedAnaphorSource::TriggeringBatch,
-                    });
-                }
+        // whether the enclosing ability is a batched trigger. The anaphor set is
+        // limited to the two BATCH pronouns:
+        //   * "those creatures" — the batch subjects (The Skullspore Nexus's
+        //     dies batch; Shriekwood Devourer's attack batch).
+        //   * "them" — the same referent in the "greatest <prop> AMONG them"
+        //     idiom (Aloy, Savior of Meridian).
+        // and deliberately EXCLUDES "those cards", which is overloaded — it also
+        // names a mill set ("you mill three cards, then … the total mana value of
+        // those cards": Combustible Gearhulk, Palantír of Orthanc) or a chosen
+        // target set (Command the Dreadhorde), where TriggeringBatch resolves to
+        // the wrong/empty event set.
+        //
+        // CR 508.1: the Max/Min ("greatest <prop> AMONG …") forms are now
+        // admitted alongside Sum ("total <prop> OF …"). t78 gated them out
+        // because the "greatest … among those creatures" idiom is an ATTACK
+        // batch whose multi-attacker `AttackersDeclared` fan-out the SINGLETON
+        // `extract_source_from_event` collapsed to `None` — binding it then
+        // would have resolved to 0. The set-valued `extract_sources_from_event`
+        // (game/targeting.rs) now reduces the full attacker batch, so the gate
+        // is lifted and the aggregate computes over every attacker.
+        //
+        // The chain-published-set reading of these same pronouns is NOT decided
+        // here — this combinator is context-free. It emits the batch reading and
+        // the clause layer (`assembly.rs`) re-anchors it to `ChainSet` when an
+        // EARLIER clause in the chain publishes a set. See
+        // `rebind_tracked_aggregate_to_chain_set`.
+        if let Ok((anaphor_rest, _)) =
+            alt((tag::<_, _, OracleError<'_>>("those creatures"), tag("them"))).parse(rest)
+        {
+            if anaphor_rest.trim().is_empty() {
+                return Some(QuantityRef::TrackedSetAggregate {
+                    function: func,
+                    property: prop,
+                    source: TrackedAnaphorSource::TriggeringBatch,
+                });
             }
         }
         let (filter, remainder) = parse_type_phrase_with_ctx(rest, ctx);
@@ -1046,6 +1076,29 @@ pub(crate) fn parse_cda_quantity_with_context(
     }
 
     None
+}
+
+/// CR 608.2c + CR 208.1 + CR 202.3: the possessive set-anaphor aggregate —
+/// "their total <property>".
+///
+/// Composed on its two axes (the possessive Sum marker × the reduced property)
+/// rather than enumerated as one `tag()` per phrase, so a new property is one
+/// `value()` arm. `Sum` is intrinsic to the surface form: "their total X" is
+/// always a sum — the extremum reading has its own "the greatest X among …"
+/// grammar (`parse_greatest_among_prefix`).
+fn parse_possessive_batch_aggregate(
+    input: &str,
+) -> OracleResult<'_, (AggregateFunction, ObjectProperty)> {
+    preceded(
+        tag("their total "),
+        alt((
+            value(ObjectProperty::Power, tag("power")),
+            value(ObjectProperty::Toughness, tag("toughness")),
+            value(ObjectProperty::ManaValue, tag("mana value")),
+        )),
+    )
+    .map(|property| (AggregateFunction::Sum, property))
+    .parse(input)
 }
 
 /// CR 202.3: aggregate prefix for the cross-zone "greatest <prop> among"

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1321,6 +1321,31 @@ fn trigger_effect_requires_stack_time_targets(ability: &AbilityDefinition) -> bo
 ///
 /// Applies all post-extraction transforms: condition composition, target-player
 /// surfacing, constraint merging, trigger zone derivation, cost-X rewriting.
+/// CR 508.1 + CR 603.10a: Does this trigger's event carry the SET of objects
+/// that a batch anaphor ("them", "those creatures", "their total power") refers
+/// to — i.e. will `extract_sources_from_event` yield them at resolution?
+///
+/// Deliberately a PROVEN whitelist, not a blacklist. Only two event shapes carry
+/// their subjects into `state.current_trigger_events`:
+///
+///   * the declared-attackers batch (CR 508.1) — `AttackersDeclared` names every
+///     attacker (Witch-king, Sky Scourge; Aloy, Savior of Meridian; Shriekwood
+///     Devourer; Vulpine Harvester).
+///   * the per-object zone-change batch (CR 603.10a) — a batched "one or more …
+///     die/enter" trigger emits one `ZoneChanged` PER object, and the batch is
+///     reconstructed by collecting across them (The Skullspore Nexus).
+///
+/// Every other trigger event exposes NO object set, so an anaphor bound to its
+/// "batch" would reduce an EMPTY set to a confident 0 while the card still
+/// rendered as fully supported. A whitelist fails those honestly; a blacklist
+/// would silently admit each newly-added mode as a fresh 0.
+fn mode_exposes_subject_batch(mode: &TriggerMode) -> bool {
+    matches!(
+        mode,
+        TriggerMode::Attacks | TriggerMode::YouAttack | TriggerMode::ChangesZoneAll
+    )
+}
+
 pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
     let mut def = ir.partial_def.clone();
     let modifiers = &ir.modifiers;
@@ -1369,6 +1394,28 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
     // quantities to `PlayerScope::ScopedPlayer` so they resolve against the
     // damaged/attacked player rather than an absent chosen target.
     let mut execute = execute;
+    // CR 603.2c: A `TrackedSetAggregate { source: TriggeringBatch }` reduces the
+    // objects of THIS trigger's event, read back through
+    // `extract_sources_from_event`. That only yields anything for the events that
+    // actually carry their subjects — the declared-attackers batch (CR 508.1) and
+    // the per-object zone-change batch (CR 603.10a). Every other trigger event
+    // exposes NO object set, so an anaphor bound to its "batch" would reduce an
+    // EMPTY set to a confident 0 while the card rendered as fully supported.
+    //
+    // A Premonition of Your Demise is the live proof: "When you reveal one or
+    // more nonland cards this way, this scheme deals damage equal to their total
+    // mana value" is a `SetInMotion` scheme trigger. Its event carries no revealed
+    // cards, so binding "their" to the batch deals 0 damage — strictly worse than
+    // the honest gap it replaced. Bind only where the batch is PROVEN reachable;
+    // everything else fails honestly (`Effect::unimplemented`).
+    if !mode_exposes_subject_batch(&def.mode) {
+        if let Some(ability) = execute.as_deref_mut() {
+            crate::parser::oracle_effect::demote_unbindable_batch_aggregate(
+                ability,
+                &modifiers.effect_lower,
+            );
+        }
+    }
     if modifiers.relative_player_scope == Some(ControllerRef::TargetPlayer) {
         if let Some(ability) = execute.as_deref_mut() {
             crate::parser::oracle_effect::rewrite_event_player_quantity_refs_to_scoped(ability);

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -17470,6 +17470,7 @@ fn lower_effect_chain_ir_advances_boundary_past_special_clause() {
         kind: AbilityKind::Spell,
         chain_rounding: None,
         actor: None,
+        in_trigger: true,
         repeat_until: None,
     };
 
@@ -17548,6 +17549,7 @@ fn branch_otherwise_fallback_self_emits_unimplemented_marker_and_else() {
         kind: AbilityKind::Spell,
         chain_rounding: None,
         actor: None,
+        in_trigger: true,
         repeat_until: None,
     };
 
@@ -17640,6 +17642,7 @@ fn modify_prior_enters_tapped_attacking_patches_prior_token_with_condition_else(
         kind: AbilityKind::Spell,
         chain_rounding: None,
         actor: None,
+        in_trigger: true,
         repeat_until: None,
     };
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -933,6 +933,7 @@ mod tomb_cradle_atropal_deathtouch_runtime;
 mod tomb_oubliette_discard_sacrifice_runtime;
 mod tomb_sandfall_cell_life_loss_runtime;
 mod tomb_veils_of_fear_life_loss_runtime;
+mod tracked_set_anaphor_source;
 mod trench_behemoth_landfall_force_attack;
 mod triumphant_chomp;
 mod tromokratis;

--- a/crates/engine/tests/integration/tracked_set_anaphor_source.rs
+++ b/crates/engine/tests/integration/tracked_set_anaphor_source.rs
@@ -1,0 +1,438 @@
+//! CR 603.2c + CR 608.2c — WHICH set an anaphoric set-reference names.
+//!
+//! "their total power" / "the greatest power among them" / "… among those
+//! creatures" are byte-identical phrases with two different referents, and they
+//! resolve from two different pieces of state:
+//!
+//!   * the TRIGGERING BATCH — the objects of the current trigger event
+//!     (`state.current_trigger_events`). Witch-king, Sky Scourge; Aloy, Savior
+//!     of Meridian; Shriekwood Devourer; The Skullspore Nexus.
+//!   * the CHAIN SET — the objects a PRECEDING clause of the same resolution
+//!     published (`state.tracked_object_sets`). Kylox, Visionary Inventor, whose
+//!     "their" is the creatures its own earlier clause just sacrificed.
+//!
+//! The leaf quantity combinator cannot tell them apart (the text is identical),
+//! so it emits the batch reading and the clause layer re-anchors it to the chain
+//! set when an EARLIER clause published one — `rebind_tracked_aggregate_to_chain_set`.
+//!
+//! The two readings are MUTUALLY DESTRUCTIVE, and this file pins that in both
+//! directions: each card is asserted to produce the WRONG answer under the other
+//! card's binding. A future change that collapses the two sources fails here.
+//!
+//! Oracle text is quoted from Scryfall, not from memory.
+
+use engine::game::combat::AttackTarget;
+use engine::game::quantity::resolve_quantity;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{
+    AggregateFunction, Effect, ObjectProperty, QuantityExpr, QuantityRef, TrackedAnaphorSource,
+};
+use engine::types::events::GameEvent;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const KYLOX: &str = "Menace, ward {2}, haste\nWhenever Kylox attacks, sacrifice any number of other creatures, then exile the top X cards of your library, where X is their total power. You may cast any number of instant and/or sorcery spells from among the exiled cards without paying their mana costs.";
+const WITCH_KING: &str = "Flying\nWhenever you attack with one or more Wraiths, exile the top X cards of your library, where X is their total power. You may play those cards this turn.";
+const ALOY: &str = "Vigilance, reach\nWhenever one or more artifact creatures you control attack, discover X, where X is the greatest power among them.";
+const SHRIEKWOOD: &str = "Trample\nWhenever you attack with one or more creatures, untap up to X lands, where X is the greatest power among those creatures.";
+const SKULLSPORE: &str = "Whenever one or more nontoken creatures you control die, create a green Fungus Dinosaur creature token with base power and toughness each equal to the total power of those creatures.";
+const ANGRATH: &str =
+    "Destroy all creatures target opponent controls. Angrath deals damage to that player equal to their total power.";
+
+/// Every `TrackedSetAggregate` reachable in a card's parse, as
+/// `(function, property, source)`. Serialized so the walk is total — a new
+/// nesting site cannot hide a binding from this census.
+fn aggregates(
+    name: &str,
+    oracle: &str,
+) -> Vec<(AggregateFunction, ObjectProperty, TrackedAnaphorSource)> {
+    let parsed = parse_oracle_text(oracle, name, &[], &["Creature".to_string()], &[]);
+    let json = serde_json::to_value(&parsed).expect("ParsedAbilities serializes");
+    let mut out = Vec::new();
+    collect(&json, &mut out);
+    return out;
+
+    fn collect(
+        value: &serde_json::Value,
+        out: &mut Vec<(AggregateFunction, ObjectProperty, TrackedAnaphorSource)>,
+    ) {
+        match value {
+            serde_json::Value::Object(map) => {
+                if map.get("type").and_then(|t| t.as_str()) == Some("TrackedSetAggregate") {
+                    let qty: QuantityRef = serde_json::from_value(value.clone())
+                        .expect("TrackedSetAggregate round-trips");
+                    if let QuantityRef::TrackedSetAggregate {
+                        function,
+                        property,
+                        source,
+                    } = qty
+                    {
+                        out.push((function, property, source));
+                    }
+                }
+                for v in map.values() {
+                    collect(v, out);
+                }
+            }
+            serde_json::Value::Array(items) => items.iter().for_each(|v| collect(v, out)),
+            _ => {}
+        }
+    }
+}
+
+/// Does the card's parse contain an honest-failure marker?
+fn has_unimplemented(name: &str, oracle: &str) -> bool {
+    let parsed = parse_oracle_text(oracle, name, &[], &["Creature".to_string()], &[]);
+    serde_json::to_string(&parsed)
+        .expect("serializes")
+        .contains("\"Unimplemented\"")
+}
+
+// ===========================================================================
+// Parser: which source does each face bind?
+// ===========================================================================
+
+/// CR 608.2c: Kylox's "their" is the creatures its OWN PRECEDING CLAUSE
+/// sacrificed — the chain-published set, not the attack batch. The sacrifice is
+/// the publisher, and it sits earlier in the same resolution chain.
+#[test]
+fn kylox_their_total_power_binds_the_sacrificed_chain_set() {
+    let bound = aggregates("Kylox, Visionary Inventor", KYLOX);
+    assert_eq!(
+        bound,
+        vec![(
+            AggregateFunction::Sum,
+            ObjectProperty::Power,
+            TrackedAnaphorSource::ChainSet
+        )],
+        "Kylox's 'their total power' must reduce the SACRIFICED chain set. \
+         Binding it to the triggering batch reads the lone attacking Kylox \
+         (or nothing) — a silent wrong answer."
+    );
+}
+
+/// CR 603.2c: Witch-king's "their" is the ATTACKING WRAITHS — the triggering
+/// batch. Its own `ExileTop` clause is itself a set publisher, which is exactly
+/// why the chain scan must be STRICTLY PRIOR: a clause may not count itself as
+/// its own antecedent's publisher.
+#[test]
+fn witch_king_their_total_power_binds_the_attacking_trigger_batch() {
+    let bound = aggregates("Witch-king, Sky Scourge", WITCH_KING);
+    assert_eq!(
+        bound,
+        vec![(
+            AggregateFunction::Sum,
+            ObjectProperty::Power,
+            TrackedAnaphorSource::TriggeringBatch
+        )],
+        "Witch-king's 'their total power' must reduce the ATTACK BATCH. Its own \
+         ExileTop publishes a set; if the prior-publisher scan counted the \
+         current clause, this would flip to ChainSet and exile 0."
+    );
+}
+
+/// CR 603.2c: "the greatest power among them" — the same batch referent under
+/// the Max aggregate. t78 gated Max/Min out because the singleton event
+/// extractor collapsed a multi-attacker batch to `None`; the set-valued
+/// extractor lifts that gate.
+#[test]
+fn aloy_greatest_power_among_them_binds_the_trigger_batch() {
+    let bound = aggregates("Aloy, Savior of Meridian", ALOY);
+    assert_eq!(
+        bound,
+        vec![(
+            AggregateFunction::Max,
+            ObjectProperty::Power,
+            TrackedAnaphorSource::TriggeringBatch
+        )],
+        "'the greatest power among them' must be a Max over the attack batch"
+    );
+}
+
+/// CR 603.2c: the demonstrative twin of Aloy — "among those creatures".
+#[test]
+fn shriekwood_greatest_power_among_those_creatures_binds_the_trigger_batch() {
+    let bound = aggregates("Shriekwood Devourer", SHRIEKWOOD);
+    assert_eq!(
+        bound,
+        vec![(
+            AggregateFunction::Max,
+            ObjectProperty::Power,
+            TrackedAnaphorSource::TriggeringBatch
+        )],
+        "'the greatest power among those creatures' must be a Max over the attack batch"
+    );
+}
+
+/// NO-REGRESSION CONTROL. The Skullspore Nexus is the face t78 shipped on the
+/// batch reading (a DIES batch). It has no preceding publisher, so it must be
+/// byte-identical after the chain-set re-anchor lands: `Sum(Power)` over the
+/// triggering batch, twice (base power AND base toughness).
+#[test]
+fn skullspore_nexus_dies_batch_aggregate_is_unchanged() {
+    let bound = aggregates("The Skullspore Nexus", SKULLSPORE);
+    assert_eq!(
+        bound,
+        vec![
+            (
+                AggregateFunction::Sum,
+                ObjectProperty::Power,
+                TrackedAnaphorSource::TriggeringBatch
+            ),
+            (
+                AggregateFunction::Sum,
+                ObjectProperty::Power,
+                TrackedAnaphorSource::TriggeringBatch
+            )
+        ],
+        "the dies-batch face must keep the TriggeringBatch reading — the chain-set \
+         re-anchor must not touch a chain with no prior publisher"
+    );
+}
+
+/// CR 603.2c: HONEST-RED CONTROL. A triggering-batch anaphor in an ability with
+/// NO trigger event has no antecedent — there is no batch. Angrath, Minotaur
+/// Pirate carries "their total power" in a LOYALTY ability, so binding it to the
+/// batch would reduce an empty set to a confident 0 while the card rendered as
+/// fully supported. It must stay an honest gap.
+#[test]
+fn angrath_batch_anaphor_in_a_non_trigger_ability_stays_an_honest_red() {
+    let bound = aggregates("Angrath, Minotaur Pirate", ANGRATH);
+    assert!(
+        bound.is_empty(),
+        "a TriggeringBatch aggregate in a chain with no trigger event is unbindable \
+         — it must not be emitted. Got {bound:?}"
+    );
+    assert!(
+        has_unimplemented("Angrath, Minotaur Pirate", ANGRATH),
+        "the unbindable anaphor must fail honestly (Effect::unimplemented), not \
+         resolve to a silent 0"
+    );
+}
+
+// ===========================================================================
+// Runtime witnesses (real pipeline) + the MUTUAL RED controls
+// ===========================================================================
+
+/// RED-FIRST RUNTIME WITNESS (2+ attackers of DIFFERENT power).
+///
+/// CR 508.1 + CR 603.2c: Witch-king, Sky Scourge attacks with two Wraiths of
+/// power 2 and 3. "X is their total power" must reduce the WHOLE batch: 5 cards
+/// exiled, not 0 (the singleton extractor's empty set) and not 3 (one attacker).
+///
+/// Drives the real combat/trigger/resolution pipeline.
+#[test]
+fn witch_king_exiles_the_total_power_of_every_attacking_wraith() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let witch_king = scenario
+        .add_creature_from_oracle(P0, "Witch-king, Sky Scourge", 2, 4, WITCH_KING)
+        .with_subtypes(vec!["Wraith"])
+        .id();
+    let wraith = scenario
+        .add_creature(P0, "Nazgul", 3, 3)
+        .with_subtypes(vec!["Wraith"])
+        .id();
+    // A non-Wraith attacker of huge power: it is NOT in the trigger's subject
+    // set, so it must not contribute (guards against a live-board Aggregate
+    // misparse).
+    let bystander = scenario.add_creature(P0, "Bystander", 9, 9).id();
+
+    scenario.with_library_top(P0, &["L1", "L2", "L3", "L4", "L5", "L6", "L7"]);
+
+    let mut runner = scenario.build();
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[
+            (witch_king, AttackTarget::Player(P1)),
+            (wraith, AttackTarget::Player(P1)),
+            (bystander, AttackTarget::Player(P1)),
+        ])
+        .expect("declare attackers");
+    runner.advance_until_stack_empty();
+
+    let state = runner.state();
+    let exiled = state
+        .objects
+        .values()
+        .filter(|o| o.zone == Zone::Exile && o.owner == P0)
+        .count();
+
+    assert_eq!(
+        exiled, 5,
+        "X = the total power of the ATTACKING WRAITHS (2 + 3 = 5). 0 means the \
+         batch collapsed to an empty set (the singleton extractor); 14 would mean \
+         the non-Wraith bystander leaked in. Got {exiled}."
+    );
+}
+
+/// MUTUAL RED CONTROL #1 — Witch-king is RED under Kylox's binding.
+///
+/// Same state (an attack batch, NO chain-published set). The batch reading gives
+/// the right answer; the chain-set reading reduces an empty `tracked_object_sets`
+/// to 0. This is the assertion that fails if the two sources are ever collapsed.
+#[test]
+fn witch_king_state_is_red_under_the_chain_set_binding() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let witch_king = scenario
+        .add_creature_from_oracle(P0, "Witch-king, Sky Scourge", 2, 4, WITCH_KING)
+        .with_subtypes(vec!["Wraith"])
+        .id();
+    let wraith = scenario
+        .add_creature(P0, "Nazgul", 3, 3)
+        .with_subtypes(vec!["Wraith"])
+        .id();
+
+    let mut runner = scenario.build();
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[
+            (witch_king, AttackTarget::Player(P1)),
+            (wraith, AttackTarget::Player(P1)),
+        ])
+        .expect("declare attackers");
+
+    // Freeze the trigger context the way the resolver sees it mid-resolution.
+    let mut state = runner.state().clone();
+    state.current_trigger_events = vec![GameEvent::AttackersDeclared {
+        attacker_ids: vec![witch_king, wraith],
+        defending_player: P1,
+        attacks: vec![],
+    }];
+
+    let batch = QuantityExpr::Ref {
+        qty: QuantityRef::TrackedSetAggregate {
+            function: AggregateFunction::Sum,
+            property: ObjectProperty::Power,
+            source: TrackedAnaphorSource::TriggeringBatch,
+        },
+    };
+    let chain = QuantityExpr::Ref {
+        qty: QuantityRef::TrackedSetAggregate {
+            function: AggregateFunction::Sum,
+            property: ObjectProperty::Power,
+            source: TrackedAnaphorSource::ChainSet,
+        },
+    };
+
+    assert_eq!(
+        resolve_quantity(&state, &batch, P0, witch_king),
+        5,
+        "the CORRECT (batch) reading is the attackers' total power, 2 + 3"
+    );
+    assert_eq!(
+        resolve_quantity(&state, &chain, P0, witch_king),
+        0,
+        "Kylox's ChainSet binding applied to Witch-king's state is a silent 0 — \
+         no clause published a set. This is the lying-green the clause-layer \
+         disambiguation exists to prevent."
+    );
+}
+
+/// MUTUAL RED CONTROL #2 — Kylox is RED under Witch-king's binding.
+///
+/// CR 701.21a + CR 608.2c: Kylox attacks ALONE and sacrifices two other
+/// creatures (power 4 and 6). "their total power" = 10, read from the chain set
+/// the sacrifice published. Under the triggering-batch reading the same state
+/// yields the lone ATTACKER's power (Kylox's own 4) — a confident, plausible,
+/// wrong number. That is precisely the falsification t78 recorded, pinned here.
+#[test]
+fn kylox_state_is_red_under_the_triggering_batch_binding() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let kylox = scenario
+        .add_creature_from_oracle(P0, "Kylox, Visionary Inventor", 4, 4, KYLOX)
+        .id();
+    let fodder_a = scenario.add_creature(P0, "Fodder A", 4, 1).id();
+    let fodder_b = scenario.add_creature(P0, "Fodder B", 6, 1).id();
+
+    let mut runner = scenario.build();
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(kylox, AttackTarget::Player(P1))])
+        .expect("declare attackers");
+
+    // The state as the exile clause sees it: Kylox alone in the attack batch,
+    // and the preceding sacrifice clause has published its two victims as the
+    // chain tracked set.
+    let mut state = runner.state().clone();
+    state.current_trigger_events = vec![GameEvent::AttackersDeclared {
+        attacker_ids: vec![kylox],
+        defending_player: P1,
+        attacks: vec![],
+    }];
+    let set_id = engine::types::identifiers::TrackedSetId(state.next_tracked_set_id);
+    state.next_tracked_set_id += 1;
+    state
+        .tracked_object_sets
+        .insert(set_id, vec![fodder_a, fodder_b]);
+
+    let chain = QuantityExpr::Ref {
+        qty: QuantityRef::TrackedSetAggregate {
+            function: AggregateFunction::Sum,
+            property: ObjectProperty::Power,
+            source: TrackedAnaphorSource::ChainSet,
+        },
+    };
+    let batch = QuantityExpr::Ref {
+        qty: QuantityRef::TrackedSetAggregate {
+            function: AggregateFunction::Sum,
+            property: ObjectProperty::Power,
+            source: TrackedAnaphorSource::TriggeringBatch,
+        },
+    };
+
+    assert_eq!(
+        resolve_quantity(&state, &chain, P0, kylox),
+        10,
+        "the CORRECT (chain-set) reading is the SACRIFICED creatures' total power, 4 + 6"
+    );
+    assert_eq!(
+        resolve_quantity(&state, &batch, P0, kylox),
+        4,
+        "Witch-king's TriggeringBatch binding applied to Kylox's state reads the \
+         lone ATTACKER (Kylox's own power, 4) instead of the sacrificed 10 — a \
+         plausible-looking wrong answer, which is why the leaf combinator may not \
+         decide this axis"
+    );
+}
+
+/// CR 608.2c: the chain-set publish must actually REACH the aggregate. Kylox's
+/// `Sacrifice` only publishes its victims when the following sub-ability is
+/// recognized as a tracked-set consumer (`next_sub_needs_tracked_set`), and the
+/// consumer here is an `ExileTop` whose count is the aggregate. Without the
+/// `ExileTop` arm on that predicate the sacrifice publishes nothing and the
+/// aggregate reduces an empty set to 0 — green, and wrong.
+#[test]
+fn kylox_exile_top_is_recognized_as_a_tracked_set_consumer() {
+    let parsed = parse_oracle_text(
+        KYLOX,
+        "Kylox, Visionary Inventor",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let trigger = parsed
+        .triggers
+        .first()
+        .expect("Kylox's attack trigger parses");
+    let execute = trigger.execute.as_ref().expect("trigger has a body");
+
+    assert!(
+        matches!(*execute.effect, Effect::Sacrifice { .. }),
+        "the publisher clause is the sacrifice, got {:?}",
+        execute.effect
+    );
+    let sub = execute
+        .sub_ability
+        .as_ref()
+        .expect("the exile clause chains off the sacrifice");
+    assert!(
+        matches!(*sub.effect, Effect::ExileTop { .. }),
+        "the consumer clause is the ExileTop, got {:?}",
+        sub.effect
+    );
+}

--- a/crates/engine/tests/integration/tracked_set_anaphor_source.rs
+++ b/crates/engine/tests/integration/tracked_set_anaphor_source.rs
@@ -39,6 +39,7 @@ const SHRIEKWOOD: &str = "Trample\nWhenever you attack with one or more creature
 const SKULLSPORE: &str = "Whenever one or more nontoken creatures you control die, create a green Fungus Dinosaur creature token with base power and toughness each equal to the total power of those creatures.";
 const ANGRATH: &str =
     "Destroy all creatures target opponent controls. Angrath deals damage to that player equal to their total power.";
+const PREMONITION: &str = "When you set this scheme in motion, reveal the top two cards of your library and put them into your hand. When you reveal one or more nonland cards this way, this scheme deals damage equal to their total mana value to any target.";
 
 /// Every `TrackedSetAggregate` reachable in a card's parse, as
 /// `(function, property, source)`. Serialized so the walk is total — a new
@@ -208,6 +209,33 @@ fn angrath_batch_anaphor_in_a_non_trigger_ability_stays_an_honest_red() {
         has_unimplemented("Angrath, Minotaur Pirate", ANGRATH),
         "the unbindable anaphor must fail honestly (Effect::unimplemented), not \
          resolve to a silent 0"
+    );
+}
+
+/// CR 603.2c: HONEST-RED CONTROL #2 — a batch anaphor inside a trigger whose
+/// EVENT carries no object set.
+///
+/// Being inside a trigger is not enough: the triggering event must actually
+/// expose its subjects to `extract_sources_from_event`, which only the
+/// declared-attackers batch (CR 508.1) and the per-object zone-change batch
+/// (CR 603.10a) do. A Premonition of Your Demise's "their total mana value" sits
+/// in a `SetInMotion` scheme trigger, whose event carries no revealed cards — so
+/// binding it to "the batch" deals 0 damage while rendering as fully supported.
+///
+/// This face was caught by the full-pool ledger (it went RED -> GREEN as a
+/// silent 0), which is exactly what the ledger is for. It must stay an honest gap
+/// until the reveal batch is a real carrier.
+#[test]
+fn scheme_reveal_batch_anaphor_stays_an_honest_red() {
+    let bound = aggregates("A Premonition of Your Demise", PREMONITION);
+    assert!(
+        bound.is_empty(),
+        "a SetInMotion trigger's event exposes no revealed-card set, so the batch \
+         anaphor is unbindable and must not be emitted. Got {bound:?}"
+    );
+    assert!(
+        has_unimplemented("A Premonition of Your Demise", PREMONITION),
+        "the unbindable anaphor must fail honestly, not deal 0 damage as a green"
     );
 }
 


### PR DESCRIPTION
- **fix(engine): reduce a batched set anaphor over the WHOLE trigger batch (CR 508.1)**
- **fix(parser): bind the batch anaphor only where the trigger event carries its subjects (CR 603.2c)**
