### PR TITLE
feat(parser): +X/+Y dynamic pump with per-axis quantities (Aspect of Wolf)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -7302,9 +7302,9 @@ fn structurally_bound_where_x_clause<'a>(clause: TextPair<'a>) -> TextPair<'a> {
     // `parse_dynamic_pt_in_text` then splits it back and assigns each half to its
     // axis. Guarded on both halves parsing so a genuine "…, and <verb>" next
     // instruction still falls through to the comma-bounding below.
-    if let Some((x_part, y_part)) = clause.split_around(", and y is ") {
-        if parse_where_x_quantity_expression(x_part.original).is_some()
-            && parse_where_x_quantity_expression(y_part.original).is_some()
+    if let Ok((_, (x_part, y_part))) = nom_primitives::split_once_on(clause.lower, ", and y is ") {
+        if parse_where_x_quantity_expression(x_part).is_some()
+            && parse_where_x_quantity_expression(y_part).is_some()
         {
             return clause;
         }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -7295,6 +7295,20 @@ pub(crate) fn strip_trailing_where_x<'a>(tp: TextPair<'a>) -> (TextPair<'a>, Opt
 
 fn structurally_bound_where_x_clause<'a>(clause: TextPair<'a>) -> TextPair<'a> {
     let clause = clause.trim_start().trim_end_matches('.').trim_end();
+    // CR 613.4c: a "+X/+Y" pump binds each axis to its own quantity via
+    // "<X quantity>, and Y is <Y quantity>" (Aspect of Wolf). The "and Y is …"
+    // is a continuation of the SAME binding, not a new instruction, so keep the
+    // whole clause when both halves independently parse as where-X quantities —
+    // `parse_dynamic_pt_in_text` then splits it back and assigns each half to its
+    // axis. Guarded on both halves parsing so a genuine "…, and <verb>" next
+    // instruction still falls through to the comma-bounding below.
+    if let Some((x_part, y_part)) = clause.split_around(", and y is ") {
+        if parse_where_x_quantity_expression(x_part.original).is_some()
+            && parse_where_x_quantity_expression(y_part.original).is_some()
+        {
+            return clause;
+        }
+    }
     let mut has_comma = false;
     let mut best_end = None;
 

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -1197,6 +1197,14 @@ pub(crate) fn parse_dynamic_pt_in_text(
     // "gets -X/-Y" (X/Y defined by later conditional sentences, no `{X}` cost)
     // must not emit a bogus `-CostXPaid/-CostXPaid` static.
     let is_distinct_xy = p_mag == PtAxisMag::VarX && t_mag == PtAxisMag::VarY;
+    // `Y` is not a generic cost variable in this grammar. The only supported
+    // Y-bearing form is Aspect of Wolf's ordered `+X/+Y` pair, whose distinct
+    // bindings are carried by the structured where-clause below. Reject every
+    // other placement so `+Y/+X` or `+Y/+Y` cannot silently borrow `CostXPaid`
+    // or an X-only binding.
+    if (matches!(p_mag, PtAxisMag::VarY) || matches!(t_mag, PtAxisMag::VarY)) && !is_distinct_xy {
+        return None;
+    }
 
     // CR 706.2 + CR 706.3b: "where X is the result" binds X to the preceding
     // die roll's result. `parse_cda_quantity` has no "the result" arm; fall

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -1153,24 +1153,20 @@ fn strip_trailing_distributive_each(s: &str) -> &str {
     }
 }
 
-/// Split a compound "+X/+Y" pump binding clause `<A> and Y is <B>` into the
+/// Split a compound "+X/+Y" pump binding clause `<A>, and Y is <B>` into the
 /// X-axis expression (`A`) and Y-axis expression (`B`) when the two axes bind to
 /// different quantities (Aspect of Wolf: "X is half the number of Forests you
 /// control, rounded down, and Y is half the number of Forests you control,
-/// rounded up"). Returns `None` for the common single-quantity clause. `wx` is
-/// already lowercased, so the " and y is " boundary matches the printed
-/// "and Y is". The trailing comma left on `A` and the sentence period on `B` are
-/// trimmed so each half feeds `parse_cda_quantity` cleanly.
+/// rounded up"). Returns `None` for the common single-quantity clause. `wx`
+/// reaches here in original case (printed "and Y is"), so it is lowercased
+/// before locating the boundary via the `split_once_on` combinator. The
+/// separator `", and y is "` consumes the joining comma, and the sentence period
+/// is already stripped upstream by `strip_trailing_where_x`, so each half feeds
+/// the case-insensitive `parse_cda_quantity` after a plain whitespace trim.
 fn split_x_and_y_where_clause(wx: &str) -> Option<(String, String)> {
-    // `wx` arrives in original case (it is sliced from `.original`), so lowercase
-    // before locating the " and y is " boundary; the halves feed
-    // `parse_cda_quantity`, which is itself case-insensitive.
     let lower = wx.to_lowercase();
-    let (_, (x_expr, y_expr)) = nom_primitives::split_once_on(&lower, " and y is ").ok()?;
-    Some((
-        x_expr.trim().trim_end_matches(',').to_string(),
-        y_expr.trim().trim_end_matches('.').trim().to_string(),
-    ))
+    let (_, (x_expr, y_expr)) = nom_primitives::split_once_on(&lower, ", and y is ").ok()?;
+    Some((x_expr.trim().to_string(), y_expr.trim().to_string()))
 }
 
 pub(crate) fn parse_dynamic_pt_in_text(

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -1179,15 +1179,24 @@ pub(crate) fn parse_dynamic_pt_in_text(
     let after_verb = nom_tag_lower(after_gets, after_gets, "gets ")
         .or_else(|| nom_tag_lower(after_gets, after_gets, "get "))?;
 
-    // CR 613.4c: Parse variable P/T pattern via nom combinator. Each axis is
-    // either the variable X (`None`) or a fixed magnitude (`Some(n)`).
+    // CR 613.4c: Parse the variable P/T pattern. Each axis is a fixed magnitude,
+    // the variable X, or (toughness only, in a distinct "+X/+Y" pump) the
+    // variable Y.
     let (_, (p_sign, p_mag, t_sign, t_mag)) = parse_variable_pt_pattern(after_verb).ok()?;
-    let p_is_x = p_mag.is_none();
-    let t_is_x = t_mag.is_none();
+    let p_is_dynamic = matches!(p_mag, PtAxisMag::VarX | PtAxisMag::VarY);
+    let t_is_dynamic = matches!(t_mag, PtAxisMag::VarX | PtAxisMag::VarY);
 
-    if !p_is_x && !t_is_x {
-        return None; // No X variable — not a dynamic P/T pattern
+    if !p_is_dynamic && !t_is_dynamic {
+        return None; // No variable axis — not a dynamic P/T pattern
     }
+
+    // A distinct-letter "+X/+Y" pump (X on power, Y on toughness) is supported
+    // ONLY when a paired "where X is <A>, and Y is <B>" binding was structurally
+    // parsed — its two axes carry independent bindings. Without one the pattern
+    // stays UNSUPPORTED rather than synthesizing from cost-X: Snowblind's
+    // "gets -X/-Y" (X/Y defined by later conditional sentences, no `{X}` cost)
+    // must not emit a bogus `-CostXPaid/-CostXPaid` static.
+    let is_distinct_xy = p_mag == PtAxisMag::VarX && t_mag == PtAxisMag::VarY;
 
     // CR 706.2 + CR 706.3b: "where X is the result" binds X to the preceding
     // die roll's result. `parse_cda_quantity` has no "the result" arm; fall
@@ -1212,21 +1221,24 @@ pub(crate) fn parse_dynamic_pt_in_text(
     // clause is split on " and y is " and each half is parsed independently.
     let resolve_quantity =
         |wx: &str| parse_cda_quantity(wx).or_else(|| parse_event_context_quantity(wx));
-    let (p_quantity, t_quantity) = match where_x_expression {
-        Some(wx) => match split_x_and_y_where_clause(wx) {
-            Some((x_expr, y_expr)) => (resolve_quantity(&x_expr)?, resolve_quantity(&y_expr)?),
-            None => {
+    let (p_quantity, t_quantity) = if is_distinct_xy {
+        // Require the paired binding; a "+X/+Y" without it is unsupported.
+        let (x_expr, y_expr) = split_x_and_y_where_clause(where_x_expression?)?;
+        (resolve_quantity(&x_expr)?, resolve_quantity(&y_expr)?)
+    } else {
+        match where_x_expression {
+            Some(wx) => {
                 let q = resolve_quantity(wx)?;
                 (q.clone(), q)
             }
-        },
-        // CR 107.3a + CR 107.3i: no binding clause → X is the value chosen as the
-        // ability's cost-X was paid (Kessig Wolf Run).
-        None => {
-            let q = QuantityExpr::Ref {
-                qty: QuantityRef::CostXPaid,
-            };
-            (q.clone(), q)
+            // CR 107.3a + CR 107.3i: no binding clause → X is the value chosen as
+            // the ability's cost-X was paid (Kessig Wolf Run).
+            None => {
+                let q = QuantityExpr::Ref {
+                    qty: QuantityRef::CostXPaid,
+                };
+                (q.clone(), q)
+            }
         }
     };
 
@@ -1235,7 +1247,7 @@ pub(crate) fn parse_dynamic_pt_in_text(
     // fixed nonzero axis grants a constant modification alongside it (the mixed
     // "+X/+1" case). A fixed `0` axis contributes nothing.
     match p_mag {
-        None => {
+        PtAxisMag::VarX | PtAxisMag::VarY => {
             let value = if p_sign < 0 {
                 QuantityExpr::Multiply {
                     factor: -1,
@@ -1246,11 +1258,13 @@ pub(crate) fn parse_dynamic_pt_in_text(
             };
             mods.push(ContinuousModification::AddDynamicPower { value });
         }
-        Some(n) if n != 0 => mods.push(ContinuousModification::AddPower { value: p_sign * n }),
-        Some(_) => {}
+        PtAxisMag::Fixed(n) if n != 0 => {
+            mods.push(ContinuousModification::AddPower { value: p_sign * n })
+        }
+        PtAxisMag::Fixed(_) => {}
     }
     match t_mag {
-        None => {
+        PtAxisMag::VarX | PtAxisMag::VarY => {
             let value = if t_sign < 0 {
                 QuantityExpr::Multiply {
                     factor: -1,
@@ -1261,8 +1275,10 @@ pub(crate) fn parse_dynamic_pt_in_text(
             };
             mods.push(ContinuousModification::AddDynamicToughness { value });
         }
-        Some(n) if n != 0 => mods.push(ContinuousModification::AddToughness { value: t_sign * n }),
-        Some(_) => {}
+        PtAxisMag::Fixed(n) if n != 0 => {
+            mods.push(ContinuousModification::AddToughness { value: t_sign * n })
+        }
+        PtAxisMag::Fixed(_) => {}
     }
 
     Some(mods)

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -1153,6 +1153,26 @@ fn strip_trailing_distributive_each(s: &str) -> &str {
     }
 }
 
+/// Split a compound "+X/+Y" pump binding clause `<A> and Y is <B>` into the
+/// X-axis expression (`A`) and Y-axis expression (`B`) when the two axes bind to
+/// different quantities (Aspect of Wolf: "X is half the number of Forests you
+/// control, rounded down, and Y is half the number of Forests you control,
+/// rounded up"). Returns `None` for the common single-quantity clause. `wx` is
+/// already lowercased, so the " and y is " boundary matches the printed
+/// "and Y is". The trailing comma left on `A` and the sentence period on `B` are
+/// trimmed so each half feeds `parse_cda_quantity` cleanly.
+fn split_x_and_y_where_clause(wx: &str) -> Option<(String, String)> {
+    // `wx` arrives in original case (it is sliced from `.original`), so lowercase
+    // before locating the " and y is " boundary; the halves feed
+    // `parse_cda_quantity`, which is itself case-insensitive.
+    let lower = wx.to_lowercase();
+    let (_, (x_expr, y_expr)) = nom_primitives::split_once_on(&lower, " and y is ").ok()?;
+    Some((
+        x_expr.trim().trim_end_matches(',').to_string(),
+        y_expr.trim().trim_end_matches('.').trim().to_string(),
+    ))
+}
+
 pub(crate) fn parse_dynamic_pt_in_text(
     lower: &str,
     where_x_expression: Option<&str>,
@@ -1188,14 +1208,30 @@ pub(crate) fn parse_dynamic_pt_in_text(
     // case. This unblocks +X/+0 and +X/+X pump activations like Kessig Wolf
     // Run whose effect text has no binding clause — the X is bound to the
     // cost, not to a derived quantity.
-    let quantity = match where_x_expression {
-        // Intensity now lives in the shared `parse_quantity_ref` combinator
-        // (oracle_nom/quantity.rs), which `parse_cda_quantity` delegates to — so
-        // the local duplicate this arm used to carry is gone.
-        Some(wx) => parse_cda_quantity(wx).or_else(|| parse_event_context_quantity(wx))?,
-        None => QuantityExpr::Ref {
-            qty: QuantityRef::CostXPaid,
+    // Intensity and the other derived quantities live in the shared
+    // `parse_quantity_ref` combinator (oracle_nom/quantity.rs), which
+    // `parse_cda_quantity` delegates to. Most pumps bind X to a single quantity
+    // applied to both axes; a "+X/+Y" pump whose clause reads "where X is <A> and
+    // Y is <B>" (Aspect of Wolf) binds each axis to its own quantity, so the
+    // clause is split on " and y is " and each half is parsed independently.
+    let resolve_quantity =
+        |wx: &str| parse_cda_quantity(wx).or_else(|| parse_event_context_quantity(wx));
+    let (p_quantity, t_quantity) = match where_x_expression {
+        Some(wx) => match split_x_and_y_where_clause(wx) {
+            Some((x_expr, y_expr)) => (resolve_quantity(&x_expr)?, resolve_quantity(&y_expr)?),
+            None => {
+                let q = resolve_quantity(wx)?;
+                (q.clone(), q)
+            }
         },
+        // CR 107.3a + CR 107.3i: no binding clause → X is the value chosen as the
+        // ability's cost-X was paid (Kessig Wolf Run).
+        None => {
+            let q = QuantityExpr::Ref {
+                qty: QuantityRef::CostXPaid,
+            };
+            (q.clone(), q)
+        }
     };
 
     let mut mods = Vec::new();
@@ -1204,30 +1240,30 @@ pub(crate) fn parse_dynamic_pt_in_text(
     // "+X/+1" case). A fixed `0` axis contributes nothing.
     match p_mag {
         None => {
-            let qty = if p_sign < 0 {
+            let value = if p_sign < 0 {
                 QuantityExpr::Multiply {
                     factor: -1,
-                    inner: Box::new(quantity.clone()),
+                    inner: Box::new(p_quantity),
                 }
             } else {
-                quantity.clone()
+                p_quantity
             };
-            mods.push(ContinuousModification::AddDynamicPower { value: qty });
+            mods.push(ContinuousModification::AddDynamicPower { value });
         }
         Some(n) if n != 0 => mods.push(ContinuousModification::AddPower { value: p_sign * n }),
         Some(_) => {}
     }
     match t_mag {
         None => {
-            let qty = if t_sign < 0 {
+            let value = if t_sign < 0 {
                 QuantityExpr::Multiply {
                     factor: -1,
-                    inner: Box::new(quantity),
+                    inner: Box::new(t_quantity),
                 }
             } else {
-                quantity
+                t_quantity
             };
-            mods.push(ContinuousModification::AddDynamicToughness { value: qty });
+            mods.push(ContinuousModification::AddDynamicToughness { value });
         }
         Some(n) if n != 0 => mods.push(ContinuousModification::AddToughness { value: t_sign * n }),
         Some(_) => {}

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1116,10 +1116,11 @@ pub(crate) fn parse_variable_pt_pattern(
 ) -> nom::IResult<&str, VariablePtAxes, OracleError<'_>> {
     fn axis(input: &str) -> nom::IResult<&str, (i32, Option<i32>), OracleError<'_>> {
         let (rest, sign) = alt((value(-1i32, tag("-")), value(1i32, tag("+")))).parse(input)?;
-        // `None` == the variable X (dynamic); `Some(n)` == a fixed magnitude
-        // (`0` included, so "+x/+0" still yields no toughness modification).
+        // `None` == a dynamic variable axis (`x`, or `y` for a "+X/+Y" pump whose
+        // two axes bind to different quantities — Aspect of Wolf); `Some(n)` == a
+        // fixed magnitude (`0` included, so "+x/+0" still yields no toughness mod).
         let (rest, mag) = alt((
-            value(None, tag("x")),
+            value(None, alt((tag("x"), tag("y")))),
             map_res(digit1, |d: &str| d.parse::<i32>().map(Some)),
         ))
         .parse(rest)?;

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1105,23 +1105,32 @@ pub(crate) fn remove_trailing_quote_connector(text: &mut String) {
 /// was restricted to `x`/`0`, so the fixed `+1` failed `digit`-matching and the
 /// whole pattern was rejected, dropping the equip static. The sign is returned
 /// separately per axis so the caller applies it uniformly to the dynamic
-/// quantity or the fixed magnitude.
-/// Parsed axes of a variable P/T grant: `(p_sign, p_mag, t_sign, t_mag)` where
-/// each `*_mag` is `None` for the variable X (dynamic) or `Some(n)` for a fixed
-/// integer magnitude.
-type VariablePtAxes = (i32, Option<i32>, i32, Option<i32>);
+/// One axis of a variable P/T grant: a fixed integer magnitude, the primary
+/// variable `x`, or the secondary variable `y`. `y` is meaningful only on a
+/// "+X/+Y" pump whose two axes bind to different quantities (Aspect of Wolf);
+/// the caller must accept a distinct `y` axis only when a paired
+/// "where X is <A>, and Y is <B>" binding was structurally parsed — otherwise
+/// the pattern is left unsupported (Snowblind's `-X/-Y`, whose X/Y are defined
+/// by later conditional sentences, must NOT synthesize a cost-X static).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PtAxisMag {
+    Fixed(i32),
+    VarX,
+    VarY,
+}
+
+/// Parsed axes of a variable P/T grant: `(p_sign, p_mag, t_sign, t_mag)`.
+type VariablePtAxes = (i32, PtAxisMag, i32, PtAxisMag);
 
 pub(crate) fn parse_variable_pt_pattern(
     input: &str,
 ) -> nom::IResult<&str, VariablePtAxes, OracleError<'_>> {
-    fn axis(input: &str) -> nom::IResult<&str, (i32, Option<i32>), OracleError<'_>> {
+    fn axis(input: &str) -> nom::IResult<&str, (i32, PtAxisMag), OracleError<'_>> {
         let (rest, sign) = alt((value(-1i32, tag("-")), value(1i32, tag("+")))).parse(input)?;
-        // `None` == a dynamic variable axis (`x`, or `y` for a "+X/+Y" pump whose
-        // two axes bind to different quantities — Aspect of Wolf); `Some(n)` == a
-        // fixed magnitude (`0` included, so "+x/+0" still yields no toughness mod).
         let (rest, mag) = alt((
-            value(None, alt((tag("x"), tag("y")))),
-            map_res(digit1, |d: &str| d.parse::<i32>().map(Some)),
+            value(PtAxisMag::VarX, tag("x")),
+            value(PtAxisMag::VarY, tag("y")),
+            map_res(digit1, |d: &str| d.parse::<i32>().map(PtAxisMag::Fixed)),
         ))
         .parse(rest)?;
         Ok((rest, (sign, mag)))

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -48,8 +48,8 @@ mod prelude {
         AttachmentKind, BasicLandType, CardPlayMode, ChosenSubtypeKind, CombatRelation,
         CombatRelationSubject, Comparator, ContinuousModification, ControllerRef, CostCategory,
         CountScope, FilterProp, ObjectScope, ParsedCondition, PlayerFilter, PtStat, PtValueScope,
-        QuantityExpr, QuantityRef, SharedQuality, SharedQualityRelation, StaticCondition,
-        StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
+        QuantityExpr, QuantityRef, RoundingMode, SharedQuality, SharedQualityRelation,
+        StaticCondition, StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
     };
     pub(super) use crate::types::card_type::{
         noncreature_subtype_set, CoreType, SubtypeSet, Supertype,

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -28821,3 +28821,26 @@ fn dynamic_pt_pump_binds_x_and_y_axes_to_distinct_quantities() {
         "toughness axis must be half rounded UP, got {toughness:?}"
     );
 }
+
+/// #5743 review [HIGH] regression guard: a "+X/+Y" / "-X/-Y" pump WITHOUT a
+/// structured "where X is <A>, and Y is <B>" paired binding must stay
+/// unsupported — it must NOT synthesize a cost-X static. Snowblind's
+/// "Enchanted creature gets -X/-Y." defines X/Y in later conditional sentences
+/// (no `{X}` cost), so it previously regressed to a bogus -CostXPaid/-CostXPaid.
+#[test]
+fn distinct_xy_pump_without_paired_binding_is_unsupported() {
+    // Snowblind: no where-clause at all on the -X/-Y line.
+    assert!(
+        super::shared::parse_static_line_multi("Enchanted creature gets -X/-Y.").is_empty(),
+        "Snowblind -X/-Y must not synthesize a static without a paired binding"
+    );
+    // A +X/+Y line with a where-clause that binds only X (no ", and Y is") is
+    // likewise unsupported rather than reusing X's quantity for Y.
+    assert!(
+        super::shared::parse_static_line_multi(
+            "Enchanted creature gets +X/+Y, where X is the number of Forests you control."
+        )
+        .is_empty(),
+        "+X/+Y with an X-only binding must stay unsupported"
+    );
+}

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -28778,3 +28778,46 @@ fn filter_scoped_cant_be_activated_parses_mana_ability_exemption() {
         s[0].mode
     );
 }
+
+/// CR 613.4c: a "+X/+Y" pump whose two axes bind to DIFFERENT quantities —
+/// Aspect of Wolf: "X is half the number of Forests you control, rounded down,
+/// and Y is half ..., rounded up". Power scales by the rounded-DOWN half,
+/// toughness by the rounded-UP half (the discriminating detail: a single-quantity
+/// implementation would apply the same rounding to both axes).
+#[test]
+fn dynamic_pt_pump_binds_x_and_y_axes_to_distinct_quantities() {
+    let s = super::shared::parse_static_line_multi(
+        "Enchanted creature gets +X/+Y, where X is half the number of Forests you control, rounded down, and Y is half the number of Forests you control, rounded up.",
+    );
+    assert_eq!(s.len(), 1, "Aspect of Wolf: {s:?}");
+    let power = s[0].modifications.iter().find_map(|m| match m {
+        ContinuousModification::AddDynamicPower { value } => Some(value),
+        _ => None,
+    });
+    let toughness = s[0].modifications.iter().find_map(|m| match m {
+        ContinuousModification::AddDynamicToughness { value } => Some(value),
+        _ => None,
+    });
+    assert!(
+        matches!(
+            power,
+            Some(QuantityExpr::DivideRounded {
+                divisor: 2,
+                rounding: RoundingMode::Down,
+                ..
+            })
+        ),
+        "power axis must be half rounded DOWN, got {power:?}"
+    );
+    assert!(
+        matches!(
+            toughness,
+            Some(QuantityExpr::DivideRounded {
+                divisor: 2,
+                rounding: RoundingMode::Up,
+                ..
+            })
+        ),
+        "toughness axis must be half rounded UP, got {toughness:?}"
+    );
+}

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -28843,4 +28843,14 @@ fn distinct_xy_pump_without_paired_binding_is_unsupported() {
         .is_empty(),
         "+X/+Y with an X-only binding must stay unsupported"
     );
+    // `Y` is supported only as the toughness axis of the paired +X/+Y form;
+    // other Y placements cannot inherit X/cost-X semantics.
+    assert!(
+        super::shared::parse_static_line_multi("Enchanted creature gets +Y/+X.").is_empty(),
+        "+Y/+X must stay unsupported rather than treating Y as cost-X"
+    );
+    assert!(
+        super::shared::parse_static_line_multi("Enchanted creature gets +Y/+Y.").is_empty(),
+        "+Y/+Y must stay unsupported rather than treating Y as cost-X"
+    );
 }

--- a/crates/engine/tests/integration/aspect_of_wolf_per_axis_xy.rs
+++ b/crates/engine/tests/integration/aspect_of_wolf_per_axis_xy.rs
@@ -1,0 +1,56 @@
+//! CR 613.4c (#5743 review [HIGH]): Aspect of Wolf's "+X/+Y" pump binds each
+//! axis to a DIFFERENT quantity — X = half the number of Forests you control,
+//! rounded DOWN (power); Y = the same, rounded UP (toughness). With an ODD
+//! Forest count (3) X = floor(3/2) = 1 and Y = ceil(3/2) = 2, so a 2/2 enchanted
+//! creature resolves to 3/4 through the layer pipeline. A single-quantity
+//! (same-rounding) implementation would produce 3/3 or 4/4, and reverting the
+//! per-axis binding fails this test.
+
+use engine::game::derived::derive_display_state;
+use engine::game::effects::attach::attach_to;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+
+const ASPECT_OF_WOLF: &str = "Enchant creature\nEnchanted creature gets +X/+Y, \
+     where X is half the number of Forests you control, rounded down, and Y is \
+     half the number of Forests you control, rounded up.";
+
+fn power_toughness(
+    runner: &engine::game::scenario::GameRunner,
+    id: engine::types::identifiers::ObjectId,
+) -> (i32, i32) {
+    let obj = runner.state().objects.get(&id).expect("object present");
+    (obj.power.unwrap_or(0), obj.toughness.unwrap_or(0))
+}
+
+#[test]
+fn aspect_of_wolf_binds_x_down_y_up_with_odd_forest_count() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let creature = scenario.add_creature(P0, "Wolf Host", 2, 2).id();
+    let aura = scenario
+        .add_creature(P0, "Aspect of Wolf", 0, 0)
+        .from_oracle_text(ASPECT_OF_WOLF)
+        .as_enchantment()
+        .id();
+    // Odd Forest count (3): X = floor(3/2) = 1, Y = ceil(3/2) = 2 — the counts
+    // that distinguish the per-axis rounding from a single shared quantity.
+    for _ in 0..3 {
+        scenario.add_basic_land(P0, ManaColor::Green);
+    }
+
+    let mut runner = scenario.build();
+    attach_to(runner.state_mut(), aura, creature);
+    evaluate_layers(runner.state_mut());
+    derive_display_state(runner.state_mut());
+
+    assert_eq!(
+        power_toughness(&runner, creature),
+        (3, 4),
+        "3 Forests → X = half rounded DOWN = 1 (power), Y = half rounded UP = 2 \
+         (toughness): the 2/2 host becomes 3/4"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -15,6 +15,7 @@ mod another_round_repeat;
 mod ark_of_hunger_play_from_graveyard_751;
 mod armored_kincaller_or_condition;
 mod ashaya_nontoken_lands;
+mod aspect_of_wolf_per_axis_xy;
 mod athreos_god_of_passage_targeted_opponent_unless_pay;
 mod attack_qualifier_stack_conditions;
 mod auntie_ool_minus_one_counter_trigger;


### PR DESCRIPTION
## Summary

A dynamic P/T pump whose two axes bind to **different** quantities — `gets +X/+Y, where X is <A> and Y is <B>` — dropped entirely. **Aspect of Wolf** now grants `+X/+Y` where **X = half the number of Forests you control, rounded down** (power) and **Y = the same, rounded up** (toughness).

## Implementation method

Hand-authored, grammar-only — **no new engine variant**. Both quantities (`QuantityExpr::DivideRounded` over `ObjectCount`) already exist and are runtime-evaluated; the parser just couldn't reach the second axis.

Three seams:
- `grammar.rs` — `parse_variable_pt_pattern` accepts `y` as a dynamic axis (was `x`/digit only).
- `anthem.rs` — `parse_dynamic_pt_in_text` splits the binding clause on ` and y is ` (case-insensitively) and resolves each half via `parse_cda_quantity`, assigning X→power, Y→toughness. Single-quantity clauses (+X/+X, +X/+0, …) are unchanged.
- `lower.rs` — `structurally_bound_where_x_clause` keeps a `<X qty>, and Y is <Y qty>` continuation (a binding continuation, **not** a new instruction) only when both halves independently parse as where-X quantities, so a genuine `…, and <verb>` next-instruction still bounds off.

## CR references

CR 613.4c (Layer 7c additive P/T) + CR 107.1a (rounding). Touched, not invented.

## Files changed

- `parser/oracle_static/grammar.rs`, `parser/oracle_static/anthem.rs` (+ helper `split_x_and_y_where_clause`)
- `parser/oracle_effect/lower.rs` (where-X bounding)
- `parser/oracle_static/mod.rs` (prelude: `RoundingMode`), `tests.rs`

## Verification (local, committed head `f900c7dfdd42690dd03d4bd52b5c0c703b197145`)

- `cargo test -p engine --lib dynamic_pt_pump_binds_x_and_y_axes_to_distinct_quantities` — ok (power = DivideRounded/2/Down, toughness = DivideRounded/2/Up)
- `cargo test -p engine --lib parser::oracle` — ok (**7904 passed, 0 failed**) — full sweep, since the changed functions are core to every dynamic pump and where-X card
- `cargo fmt -p engine -- --check`, `cargo clippy -p engine --lib` (`-D warnings`) — clean
- `scripts/check-parser-combinators.sh <base>`, `scripts/check-engine-authorities.sh <base>` — pass

Transparency: did not run `scripts/ai-gate.sh` (Gate A) — fresh `--release` build, local disk tight; not fabricating a PASS line. CI covers this head.

## Anchored on

- `crates/engine/src/parser/oracle_static/anthem.rs` — the existing single-quantity `where X` resolution in `parse_dynamic_pt_in_text` this generalizes.
- `crates/engine/src/parser/oracle_effect/lower.rs` — the existing comma-bounded `structurally_bound_where_x_clause` (the `and Y is` case is added ahead of it).

## Claimed parse impact

- **Aspect of Wolf** — `+X/+Y` per-axis pump now parses (was dropped). (Phyrexian Ingester shares this `+X/+Y` shape but additionally needs an exiled-card toughness quantity — a separate follow-up.)