### PR TITLE
fix(oracle-gen): stop the card export rewriting the parser's own subtype vocabulary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,28 @@ jobs:
         run: |
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 
+      - name: Card export must not mutate the tracked parser vocabulary
+        # Regression guard: the export is a PURE READ of the tracked tree.
+        #
+        # It used to rewrite crates/engine/data/oracle-subtypes.json on every run,
+        # from CardTypes.json ∪ the AtomicCards harvest — but this job downloads
+        # only AtomicCards.json (see the mtgjson cache above), so CardTypes.json
+        # was always absent and the regeneration silently fell back to the harvest
+        # alone. That deletes the 26 token-only creature subtypes (Army, Servo,
+        # Pentavite, Sculpture, Tentacle, …) which are printed on no card face and
+        # so live in CardTypes.json alone. Because the engine `include_str!`s that
+        # file, the rewrite bumped its mtime and rebuilt the engine right here —
+        # leaving validate, coverage, and semantic-audit below to run against a
+        # parser whose subtype vocabulary was missing all 26.
+        #
+        # The refresh now lives behind `--write-subtypes`, passed only by
+        # scripts/gen-card-data.sh (the one caller that fetches the sidecar, and
+        # which hard-fails without it). This asserts the export stays a pure read.
+        # Scoped to the same condition as the generate step so it is never
+        # vacuous: it runs exactly when an export ran.
+        if: steps.cardgen-cache.outputs.cache-hit != 'true'
+        run: git diff --exit-code -- crates/engine/data/oracle-subtypes.json
+
       - name: Validate card-data against engine schema
         # PR-time gate — the same parse the WASM does at runtime, run against
         # the freshly produced card-data. If a parser/schema change makes the
@@ -265,11 +287,11 @@ jobs:
         # passed. card-data.json is byte-identical either way, restored from
         # cardgen or regenerated above.
         # Same [tool, cli] fingerprint as card-gen above → engine cache hit. That
-        # hit is only real because `oracle-gen` rewrites
-        # crates/engine/data/oracle-subtypes.json solely when its bytes change:
-        # the engine lib pulls that file in via `include_str!`, so an
-        # unconditional write would bump its mtime, dirty the crate's dep-info
-        # fingerprint, and force a full engine recompile right here.
+        # hit is real because the export never writes to crates/engine/data: the
+        # engine lib pulls oracle-subtypes.json in via `include_str!`, so any
+        # write would bump its mtime, dirty the crate's dep-info fingerprint, and
+        # force a full engine recompile right here — against a vocabulary this job
+        # has no CardTypes.json to regenerate correctly. The step above pins that.
         if: steps.gates-cache.outputs.cache-hit != 'true'
         run: cargo run --profile tool --features cli --bin card-data-validate -- data/card-data.json
 

--- a/crates/engine/src/bin/oracle_gen.rs
+++ b/crates/engine/src/bin/oracle_gen.rs
@@ -557,8 +557,11 @@ fn build_card_work<'a>(
 
 /// Write parser-authoritative creature subtypes: CardTypes.json ∪ corroborated
 /// AtomicCards harvest (token-only + newer card-printed types).
+///
+/// Runs only under `--write-subtypes` (see `main`), and takes `CardTypesFile` by
+/// reference rather than `Option` so a partial source set cannot reach it.
 fn write_oracle_subtypes(
-    card_types: Option<&engine::database::mtgjson::CardTypesFile>,
+    card_types: &engine::database::mtgjson::CardTypesFile,
     atomic: &engine::database::mtgjson::AtomicCardsFile,
 ) {
     use engine::database::subtype_vocab::build_creature_subtype_vocabulary;
@@ -888,6 +891,7 @@ fn main() {
     let mut output: Option<PathBuf> = None;
     let mut sidecar_dir: Option<PathBuf> = None;
     let mut stats = false;
+    let mut write_subtypes = false;
     let mut filter_names: Vec<String> = Vec::new();
     #[cfg(feature = "forge")]
     let mut forge_path: Option<PathBuf> = None;
@@ -929,6 +933,9 @@ fn main() {
             }
             "--stats" => {
                 stats = true;
+            }
+            "--write-subtypes" => {
+                write_subtypes = true;
             }
             "--filter" => {
                 i += 1;
@@ -973,6 +980,12 @@ fn main() {
                 );
                 eprintln!("  Parses Oracle text from MTGJSON and outputs card-data export JSON");
                 eprintln!("  --output <path>  Write the export to a file instead of stdout");
+                eprintln!(
+                    "  --write-subtypes Regenerate the committed creature-subtype vocabulary\n\
+                     \x20                 (crates/engine/data/oracle-subtypes.json). Requires\n\
+                     \x20                 CardTypes.json alongside AtomicCards.json. Without this\n\
+                     \x20                 flag the export never writes to the tracked tree."
+                );
                 process::exit(1);
             }
         },
@@ -999,18 +1012,42 @@ fn main() {
         }
     };
 
-    let card_types_path = mtgjson_path
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join("CardTypes.json");
-    let card_types = load_card_types(&card_types_path).ok();
-    if card_types.is_none() {
-        eprintln!(
-            "warning: CardTypes.json not found at {} — using AtomicCards harvest only",
-            card_types_path.display()
-        );
+    // The creature-subtype vocabulary is a COMMITTED parser input: the engine
+    // pulls `crates/engine/data/oracle-subtypes.json` in with `include_str!`.
+    // Regenerating it is therefore a deliberate data-pipeline act, not a side
+    // effect of exporting cards, and it happens only under `--write-subtypes`
+    // (passed by `scripts/gen-card-data.sh`, the one caller that fetches the
+    // MTGJSON sidecars). A plain export is a pure read: it must not mutate the
+    // tracked tree it is measuring, and it must not bump the mtime of a file the
+    // engine compiles in — that rebuilds the parser underneath the very export
+    // whose output is being compared.
+    //
+    // When the refresh IS requested, CardTypes.json is REQUIRED. It is the sole
+    // source of the token-only creature subtypes (Army, Servo, Pentavite,
+    // Sculpture, Tentacle, …), which are printed on no card face and so cannot
+    // be recovered from the AtomicCards harvest. Regenerating without it silently
+    // deletes all 26 and degrades every later parse, so a missing sidecar is a
+    // hard failure rather than a quiet downgrade.
+    if write_subtypes {
+        let card_types_path = mtgjson_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("CardTypes.json");
+        match load_card_types(&card_types_path) {
+            Ok(card_types) => write_oracle_subtypes(&card_types, &atomic),
+            Err(e) => {
+                eprintln!(
+                    "Error: --write-subtypes requires {}: {e}",
+                    card_types_path.display()
+                );
+                eprintln!(
+                    "  Run scripts/gen-card-data.sh, which downloads the MTGJSON sidecars, \
+                     or drop --write-subtypes to export without refreshing the vocabulary."
+                );
+                process::exit(1);
+            }
+        }
     }
-    write_oracle_subtypes(card_types.as_ref(), &atomic);
 
     // Scan per-set MTGJSON files to build a card name → rarities map.
     let rarity_map = build_rarity_map(&mtgjson_path);

--- a/crates/engine/src/database/subtype_vocab.rs
+++ b/crates/engine/src/database/subtype_vocab.rs
@@ -111,14 +111,20 @@ pub fn harvest_creature_subtypes_from_atomic(atomic: &AtomicCardsFile) -> BTreeS
 /// Parser-authoritative creature subtype set: canonical CardTypes ∪ corroborated
 /// AtomicCards. CardTypes supplies token-only types; AtomicCards supplies newer
 /// card-printed types before CardTypes.json is updated.
+///
+/// `card_types` is **required**, not optional. Token-only subtypes (Army, Servo,
+/// Pentavite, Sculpture, Tentacle, …) are printed on no card face, so they exist
+/// in `CardTypes.json` alone — the AtomicCards harvest cannot corroborate what a
+/// type line never carries. Building this vocabulary without the canonical half
+/// silently drops all 26 of them, and because the result is committed and
+/// `include_str!`d into the parser, the loss degrades every later parse. A caller
+/// that cannot load `CardTypes.json` must fail, never regenerate from a partial
+/// source set. See `atomic_harvest_alone_drops_token_only_subtypes`.
 pub fn build_creature_subtype_vocabulary(
-    card_types: Option<&CardTypesFile>,
+    card_types: &CardTypesFile,
     atomic: &AtomicCardsFile,
 ) -> BTreeSet<String> {
-    let mut subtypes = BTreeSet::new();
-    if let Some(card_types) = card_types {
-        subtypes.extend(canonical_creature_subtypes_from_card_types(card_types));
-    }
+    let mut subtypes = canonical_creature_subtypes_from_card_types(card_types);
     subtypes.extend(harvest_creature_subtypes_from_atomic(atomic));
     subtypes
 }
@@ -267,11 +273,32 @@ mod tests {
             }],
         );
         let atomic = crate::database::mtgjson::AtomicCardsFile { data: atomic_data };
-        let subtypes = build_creature_subtype_vocabulary(Some(&card_types), &atomic);
+        let subtypes = build_creature_subtype_vocabulary(&card_types, &atomic);
         for expected in ["Army", "Germ", "Mammoth"] {
             assert!(
                 subtypes.contains(expected),
                 "{expected} must be in union vocabulary"
+            );
+        }
+
+        // Regression pin: the AtomicCards harvest is corroborated against the
+        // printed type line, so it recovers card-printed subtypes (Mammoth) but
+        // can NEVER recover a token-only subtype — no card face prints "Army".
+        // CardTypes.json is therefore the sole source of that half of the
+        // vocabulary, which is why `build_creature_subtype_vocabulary` takes it
+        // by value rather than as an `Option`: regenerating the committed,
+        // `include_str!`d vocabulary from the harvest alone silently deletes
+        // every token-only subtype and degrades the parser on the next rebuild.
+        let harvested = harvest_creature_subtypes_from_atomic(&atomic);
+        assert!(
+            harvested.contains("Mammoth"),
+            "card-printed subtype must survive the harvest"
+        );
+        for token_only in ["Army", "Germ"] {
+            assert!(
+                !harvested.contains(token_only),
+                "{token_only} is printed on no card face — CardTypes.json is its only source, \
+                 so the harvest alone must not be treated as a complete vocabulary"
             );
         }
     }

--- a/scripts/gen-card-data.sh
+++ b/scripts/gen-card-data.sh
@@ -182,9 +182,17 @@ fi
 
 track_tmp "$OUTPUT_TMP"
 track_tmp "$NAMES_OUTPUT_TMP"
+# `--write-subtypes` refreshes the committed creature-subtype vocabulary
+# (crates/engine/data/oracle-subtypes.json, `include_str!`d by the parser).
+# This script is the only caller that may pass it: it is the only one that
+# downloads CardTypes.json above, and CardTypes.json is the sole source of the
+# token-only subtypes (Army, Servo, Pentavite, …). oracle-gen hard-fails under
+# this flag if that sidecar is missing, rather than regenerating a vocabulary
+# with all 26 of them silently deleted. Every other caller (CI, ai-gate, a bare
+# `cargo export-cards`) omits the flag and leaves the tracked file untouched.
 run_tool_with_recovery \
   "$OUTPUT_TMP" \
-  "$TOOL_BIN/oracle-gen" "$DATA_DIR" --stats --names-out "$NAMES_OUTPUT_TMP" --sidecar-dir "$OUTPUT_DIR"
+  "$TOOL_BIN/oracle-gen" "$DATA_DIR" --stats --names-out "$NAMES_OUTPUT_TMP" --sidecar-dir "$OUTPUT_DIR" --write-subtypes
 # Cheap presence guard only. The full JSON/object/non-empty/integrity
 # validation is done by card-data-validate below (CardDatabase::from_export),
 # which is strictly stronger than a jq shape check — so an extra jq parse of


### PR DESCRIPTION
`cargo export-cards` rewrote the tracked, committed parser input
crates/engine/data/oracle-subtypes.json on every run, deleting 26 creature
subtypes (Army, Servo, Pentavite, Sculpture, Tentacle, ...) and corrupting the
working tree of anyone who ran an export.

Root cause: the vocabulary is CardTypes.json (canonical) union the AtomicCards
harvest (type-line corroborated). Token-only subtypes are printed on no card
face, so they live in CardTypes.json alone -- the harvest can never corroborate
what a type line never carries. `load_card_types(..).ok()` silently swallowed a
missing sidecar and regenerated from the harvest alone, dropping exactly those
26. No CI workflow, and no bare `cargo export-cards`, ever downloads
CardTypes.json -- only scripts/gen-card-data.sh does -- so the degraded write
was the norm, not the exception.

The file is `include_str!`d by the parser, so the rewrite bumped its mtime and
rebuilt the engine against the degraded vocabulary. That gave the export a
feedback loop: run 1 parsed with the committed 392-entry vocabulary, run 2
rebuilt and parsed with the 366-entry one. Twenty token-subtype faces changed
between consecutive exports at identical source (Servo Exhibition's token name
flipping "~" <-> "Servo", Pentavus losing Subtype: Pentavite, Doomed Artisan
SelfRef <-> Typed(Sculpture)), moving the pool-wide Unimplemented count by 3.
This was previously read as nondeterminism in the token/subtype synthesis; it is
not. Three runs of a fixed binary are byte-identical. The export is
deterministic -- it was rebuilding itself between runs.

The same rewrite fires in CI, where it silently degraded the parser that
card-data-validate, coverage-report, and semantic-audit then ran against.

Fix:
- Gate the vocabulary refresh behind an explicit `--write-subtypes`. A plain
  export is now a pure read: it never mutates the tree it is measuring.
- Pass the flag from scripts/gen-card-data.sh, the sole caller that fetches the
  MTGJSON sidecars.
- Under the flag, CardTypes.json is REQUIRED: `build_creature_subtype_vocabulary`
  takes it by reference rather than `Option`, so a partial source set cannot
  reach the writer, and a missing sidecar is a hard, actionable failure instead
  of a quiet 26-subtype deletion.
- Guard it in CI: `git diff --exit-code` on oracle-subtypes.json after the
  export, scoped to run exactly when an export ran so it is never vacuous.
- Pin the invariant in subtype_vocab: the harvest recovers card-printed subtypes
  (Mammoth) but never token-only ones (Army, Germ).

Evidence (full pool, 35,396 faces, base 8aee471034):
- Before: one export deleted the 26 subtypes; three engine tests went red with
  no source change (is_subtype_word_recognizes_token_only_creature_subtypes,
  counter_plus_one_replacement_mauhur_scope, mauhur_does_not_add_counters_to_
  unlisted_creature_types). A second export diverged from the first on exactly
  20 faces, +3 Unimplemented.
- After: three consecutive exports are byte-identical to each other AND to the
  pre-fix first-run baseline (sha 857d3c68) -- the 20 faces are stabilised at
  their correct parse, and nothing else moved. oracle-subtypes.json is untouched
  throughout. With the sidecar present, --write-subtypes regenerates the file
  byte-identically ("Skipped write ... unchanged"): the refresh is lossless.
- The 3 tests pass with no checkout-revert.
