### PR TITLE
fix(ai): score the CR 732.2a loop-shortcut offer + cover the winner-liveness conjunct (#5672 follow-ups)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -3006,6 +3006,7 @@ pub fn candidate_actions_broad_with_probe(
         // CR 732.2a: proposing a shortcut is optional. Offer both legal actions so the
         // policy/search layer, rather than the candidate generator, decides whether an AI
         // proposer declares or returns to ordinary priority.
+        // (Scored by `phase_ai::policies::loop_shortcut::LoopShortcutPolicy`.)
         WaitingFor::LoopShortcut { proposer, .. } => vec![
             candidate(
                 GameAction::DeclareShortcut {

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -41,6 +41,14 @@ const KICKOFF: &str = "You gain 1 life.";
 const TARGETED_KICKOFF: &str = "Target player gains 1 life.";
 const SELF_LIFE_ENGINE: &str = "Whenever you gain life, you gain 1 life.";
 const LIFE_LOSS_IMMUNE: &str = "Your life total can't change.";
+/// Symmetric self-sustaining life-loss engine: each loss event re-triggers a loss for EVERYONE.
+/// The `Effect::LoseLife` AST is IDENTICAL to `DRAIN_CLERIC`'s (both `{ amount: Fixed(1), target }`);
+/// the each-player/each-opponent split rides the ability-level `player_scope` (`All` vs `Opponent`),
+/// and the TRIGGER differs — "a player loses life" here vs `DRAIN_CLERIC`'s "you gain life".
+const PLAGUE_ENGINE: &str = "Whenever a player loses life, each player loses 1 life.";
+/// Symmetric kick-off. NOT "Target player loses 1 life." — a targeted kickoff desynchronises the
+/// fallers' ABSOLUTE lives and trips `fallers_lives_pairwise_equal`, so no offer is ever raised.
+const LOSE_ALL_KICKOFF: &str = "Each player loses 1 life.";
 
 // Verbatim Oracle text (data/card-data.json) for the PR-7 gate-relax witness — the
 // REAL escalating TARGETED drain that only detects once item-3 (forced-unique) and
@@ -195,6 +203,42 @@ fn setup_3p_subset_lethal(mode: LoopDetectionMode) -> (GameRunner, ObjectId) {
     scenario.add_creature_from_oracle(P2, "Test Bulwark", 2, 2, LIFE_LOSS_IMMUNE);
     let kickoff = scenario
         .add_spell_to_hand_from_oracle(P0, "Test Lifegain Kickoff", false, KICKOFF)
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().loop_detection = mode;
+    (runner, kickoff)
+}
+
+/// 3-player BYSTANDER-WINNER loop. P0's `PLAGUE_ENGINE` turns any life loss into a symmetric
+/// loss for everyone, so a single symmetric kick-off self-sustains. Per-cycle: P0 = -1, P1 = -1
+/// (EQUAL — required by `live_mandatory_loop_winner`'s CR 704.3 simultaneity floor: fallers die in
+/// ONE SBA event, so unequal lives are not a determinate single-winner shape), P2 = 0
+/// (life-loss-immune: CR 101.2 — a "can't" effect takes precedence over the trigger's life-loss
+/// instruction; cf. CR 119.8 for the same const elsewhere in this file). Living partition each
+/// cycle: fallers = {P0, P1}, nonfallers = {P2} ⇒ len == 1 ⇒ the engine NATURALLY latches
+/// `predicted_winner = Some(P2)` — a winner who controls no loop enabler and is not the proposer.
+/// No injection.
+///
+/// P1's land + Bolt are LOAD-BEARING: they make the loop OPTIONAL (`mandatory: false`). Without
+/// them the loop is mandatory and the engine auto-crowns `GameOver { winner: Some(P2) }` with no
+/// offer at all (measured).
+///
+/// All three lives start EQUAL and high: `fallers_lives_pairwise_equal` gates on the fallers'
+/// ABSOLUTE lives, not just their per-cycle deltas.
+fn setup_3p_bystander_winner(mode: LoopDetectionMode) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new_n_player(3, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 1000);
+    scenario.with_life(P1, 1000);
+    scenario.with_life(P2, 1000);
+    scenario.add_creature_from_oracle(P0, "Test Plague Engine", 2, 2, PLAGUE_ENGINE);
+    scenario.add_creature_from_oracle(P2, "Test Bulwark", 2, 2, LIFE_LOSS_IMMUNE);
+    // Optionality: P1 holds a real interactive answer ⇒ `mandatory: false` ⇒ the engine OFFERS
+    // instead of auto-crowning (CR 104.4b: a loop with an optional action is not a draw either).
+    scenario.add_basic_land(P1, ManaColor::Red);
+    scenario.add_bolt_to_hand(P1);
+    let kickoff = scenario
+        .add_spell_to_hand_from_oracle(P0, "Test Symmetric Kickoff", false, LOSE_ALL_KICKOFF)
         .id();
     let mut runner = scenario.build();
     runner.state_mut().loop_detection = mode;
@@ -3256,4 +3300,156 @@ fn loop_shortcut_serializes_schema_under_data() {
     let schema_back: ShortcutDecisionSchema =
         serde_json::from_value(v["data"]["schema"].clone()).expect("deserialize schema");
     assert_eq!(&schema_back, schema, "the schema round-trips off the wire");
+}
+
+/// T-concede-winner — the `predicted_winner` conjunct of the `apply_confirmed_shortcut` liveness
+/// guard (`engine.rs:864-878`). The latched PREDICTED WINNER (not the proposer) concedes DURING the
+/// open CR 732.2b APNAP window. `GameAction::Concede` bypasses the `WaitingFor` dispatch, so the
+/// offer survives with a departed winner latched in `proposal.predicted_winner`. On the last living
+/// opponent's Accept, the guard must REFUSE to act on the stale proposal (CR 104.3a: the winner has
+/// left and lost; CR 104.2a: a departed player cannot be crowned; CR 800.4a: their objects are gone,
+/// so the sequence they were predicted to win is not the sequence on the board) and hand priority to
+/// a living seat — WITHOUT driving a single cycle.
+///
+/// # ⚠️ DO NOT "SIMPLIFY" THE LIFE ASSERTIONS. They are the only ones with teeth.
+///
+/// `waiting_for` is `Priority { P0 }` in BOTH arms of the revert-probe, and `GameOver` is reached in
+/// NEITHER (`Fixed(n)` materializes cycles; it does not crown). Therefore
+/// `assert!(!matches!(wf, GameOver{..}))` and "priority went to a living seat" PASS WITH THE GUARD
+/// DELETED — they are CR 800.4a post-remedy INVARIANTS (the remedy must leave a valid state), NOT
+/// discriminators. **The only assertion with teeth is the board: `life(P0)` / `life(P1)` unchanged.**
+/// Measured revert-probe: guard present ⇒ (998, 998, 1000); guard deleted ⇒ (995, 995, 1000).
+///
+/// # Why `Fixed(3)` and not `UntilLethal`
+///
+/// `apply_until_lethal_shortcut` re-derives the winner through `live_mandatory_loop_winner`, whose
+/// `!p.is_eliminated` living-filter ALREADY refuses to name a departed player — so on that path the
+/// conjunct is redundant defence-in-depth and any test would be vacuous.
+/// `materialize_fixed_shortcut` NEVER consults `predicted_winner` and COMMITS each driven cycle, so
+/// this conjunct is the ONLY thing between a departed winner and 3 committed loop cycles.
+///
+/// `Fixed(n)` is reachable via the public `GameAction` surface (UI, scripted client, server payload
+/// surface): `handle_declare_shortcut` moves `count` into the proposal with zero validation; the
+/// fail-closed firewall validates only `template` pins and is skipped entirely when `template` is
+/// `None`. It is NOT emitted by the AI's own candidate generator, which hardcodes `UntilLethal`.
+///
+/// # Why this test scripts `DeclareShortcut` directly instead of routing through the AI
+///
+/// This same board is ALSO a firing case for `phase_ai::policies::loop_shortcut::LoopShortcutPolicy`
+/// (proposer P0 is a faller; the winner P2 != proposer ⇒ the policy REJECTS `DeclareShortcut`). A
+/// future reader must not "fix" this test by routing it through the AI picker — the AI will now
+/// correctly refuse to declare, and the test would silently stop reaching the engine seam.
+///
+/// REVERT-PROBE: delete `|| proposal.predicted_winner.is_some_and(|winner| !is_alive(state, winner))`
+/// from `apply_confirmed_shortcut`. The proposer P0 is alive, so the guard no longer fires;
+/// `materialize_fixed_shortcut` drives and commits 3 cycles of the still-live plague engine. The
+/// `life(P1) == p1_before` assertion FAILS with left = 995, right = 998.
+#[test]
+fn predicted_winner_concede_mid_apnap_does_not_drive() {
+    let (mut runner, kickoff) = setup_3p_bystander_winner(LoopDetectionMode::Interactive);
+    let _ = runner.cast(kickoff).resolve();
+    let (_events, wf) = drive_collect(&mut runner, 600);
+
+    // ── REACH-GUARDS: the offer is ENGINE-LATCHED, not injected ────────────────────────────────
+    // This pair is what proves the fixture is real. If the engine ever stops naming a
+    // non-owner bystander as the winner, this test must FAIL LOUDLY, not silently degrade.
+    let WaitingFor::LoopShortcut {
+        proposer,
+        predicted_winner,
+        ..
+    } = wf
+    else {
+        panic!("the engine must OFFER on this board (optional loop), got {wf:?}");
+    };
+    assert_eq!(proposer, P0, "the priority holder proposes (CR 732.2a)");
+    assert_eq!(
+        predicted_winner,
+        Some(P2),
+        "the engine must latch the life-loss-immune BYSTANDER as winner — a player who controls \
+         no loop enabler and is not the proposer (CR 732.2a: the shortcut's ending point need not \
+         be the proposer)"
+    );
+    assert!(
+        life(&runner, P0) < 1000 && life(&runner, P1) < 1000,
+        "both fallers have bled"
+    );
+
+    // P0 declares `Fixed(3)` — the count whose apply path never re-consults `predicted_winner`.
+    // `template: None` skips `handle_declare_shortcut`'s pin firewall entirely.
+    runner
+        .act(GameAction::DeclareShortcut {
+            count: IterationCount::Fixed(3),
+            template: None,
+        })
+        .expect("P0 declares Fixed(3)");
+
+    // CR 732.2b: the window opens in turn order starting AFTER the proposer ⇒ P1, then P2.
+    let WaitingFor::RespondToShortcut {
+        player,
+        remaining_players,
+        ..
+    } = runner.state().waiting_for.clone()
+    else {
+        panic!(
+            "Declare must open the APNAP window, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(player, P1, "window opens on P1");
+    assert_eq!(
+        remaining_players,
+        vec![P2],
+        "P2 (the latched winner) is queued behind P1"
+    );
+
+    // CR 104.3a: the latched PREDICTED WINNER concedes mid-window. The acting responder (P1) is
+    // alive, so the elimination self-heal leaves the stale offer standing.
+    runner
+        .act(GameAction::Concede { player_id: P2 })
+        .expect("P2 (the predicted winner) concedes");
+    assert!(is_eliminated(&runner, P2), "P2 has left the game");
+    assert!(
+        !is_eliminated(&runner, P0) && !is_eliminated(&runner, P1),
+        "P0 and P1 remain — a living seat exists to receive priority (CR 800.4a)"
+    );
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::RespondToShortcut { player, .. } if player == P1),
+        "the offer survives the conceder (acting P1 is alive), got {:?}",
+        runner.state().waiting_for
+    );
+
+    let p0_before = life(&runner, P0);
+    let p1_before = life(&runner, P1);
+
+    // The last living opponent accepts ⇒ CR 732.2c ⇒ `apply_confirmed_shortcut` with a STALE
+    // `predicted_winner` (P2, departed) and a LIVING proposer (P0).
+    accept_all_opponents(&mut runner);
+
+    // ── (b) THE DISCRIMINATOR — the board is untouched. DO NOT DELETE. ─────────────────────────
+    assert_eq!(
+        life(&runner, P1),
+        p1_before,
+        "guard must REFUSE to drive: P1's life must be untouched by the refused shortcut"
+    );
+    assert_eq!(
+        life(&runner, P0),
+        p0_before,
+        "…and so must the proposer's (Fixed(n) COMMITS every cycle it drives)"
+    );
+
+    // ── POST-REMEDY INVARIANTS (necessary, NOT discriminating — see the doc comment) ───────────
+    // (a) CR 104.2a: no crown, for anyone.
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::GameOver { .. }),
+        "a stale proposal whose predicted winner has left must not end the game, got {:?}",
+        runner.state().waiting_for
+    );
+    // (c) CR 800.4a: priority lands on a LIVING seat.
+    match runner.state().waiting_for {
+        WaitingFor::Priority { player } => assert!(
+            !is_eliminated(&runner, player),
+            "CR 800.4a: priority must never land on a departed seat"
+        ),
+        ref other => panic!("the liveness guard hands priority back (manual play), got {other:?}"),
+    }
 }

--- a/crates/phase-ai/src/config.rs
+++ b/crates/phase-ai/src/config.rs
@@ -424,6 +424,15 @@ pub struct PolicyPenalties {
     /// Consumed by `SelfCostValuePolicy`.
     #[serde(default = "default_self_cost_exile_graveyard_per_card")]
     pub self_cost_exile_graveyard_per_card: f64,
+    /// CR 732.2a / CR 104.2a: bonus for proposing an `UntilLethal` loop shortcut whose latched
+    /// `predicted_winner` IS the proposer — the crown ends the game in their favor, and the only
+    /// other outcome (`until_lethal_fallback`) restores the board a decline would have produced.
+    /// Game-deciding ⇒ the default lands in the `critical` band (5.0, 15.0]. Consumed by
+    /// `LoopShortcutPolicy`; fed through `PolicyVerdict::score`, which auto-bands and clamps to
+    /// `CRITICAL_MAX`. (The losing / no-crown cases are `PolicyVerdict::reject`s and take no
+    /// scalar.)
+    #[serde(default = "default_loop_shortcut_winning_declare_bonus")]
+    pub loop_shortcut_winning_declare_bonus: f64,
 }
 
 impl Default for PolicyPenalties {
@@ -485,6 +494,7 @@ impl Default for PolicyPenalties {
             self_cost_pay_life_per_point: default_self_cost_pay_life_per_point(),
             self_cost_discard_per_card: default_self_cost_discard_per_card(),
             self_cost_exile_graveyard_per_card: default_self_cost_exile_graveyard_per_card(),
+            loop_shortcut_winning_declare_bonus: default_loop_shortcut_winning_declare_bonus(),
         }
     }
 }
@@ -512,6 +522,25 @@ fn default_self_cost_discard_per_card() -> f64 {
 }
 fn default_self_cost_exile_graveyard_per_card() -> f64 {
     0.15
+}
+
+/// 8.0 = mid-`critical` band. Sized for the HEURISTIC branch, which adds the tactical score RAW:
+/// it turns the measured 0.5-vs-0.4 coinflip on a GUARANTEED win into ~88% declare at VeryEasy
+/// (T = 4.0) and ~98% at Easy (T = 2.0). That is the branch where nothing else can differentiate
+/// the two candidates.
+///
+/// On the SEARCH branch (Medium and up) the score is multiplied by `tactical_weight`: 0.1 at a
+/// quiesced `LoopShortcut` node, or 0.35 if an opponent's object is on the stack (the offer is
+/// raised at a priority window, which does not imply an empty stack). So this becomes a
+/// +0.8..+2.8 move-ordering / tie-break nudge on top of the beam's own continuation value, which
+/// already sees the CR 104.2a crown. It is deliberately NOT sized to dominate that value, and
+/// deliberately NOT saturated to `CRITICAL_MAX`: a VeryEasy AI is allowed to miss a free win.
+///
+/// The symmetric losing case is a `Reject` (`-inf`), which is temperature- AND weight-IMMUNE
+/// (`-inf * 0.1 == -inf * 0.35 == -inf`; `exp(-inf / T) == 0` for every T > 0) — no difficulty
+/// ever throws the game away.
+fn default_loop_shortcut_winning_declare_bonus() -> f64 {
+    8.0
 }
 
 fn default_lethality_tapout_penalty() -> f64 {
@@ -735,6 +764,10 @@ pub const UNTUNED_POLICY_PENALTY_FIELDS: &[(&str, &str)] = &[
     (
         "self_cost_exile_graveyard_per_card",
         "new SelfCostValuePolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
+    ),
+    (
+        "loop_shortcut_winning_declare_bonus",
+        "LoopShortcutPolicy band selector for a game-deciding CR 104.2a crown; deliberately kept OUT of the CMA-ES penalties vector — win-rate gradients from games that never reach a WaitingFor::LoopShortcut node would tune a win-detector into noise",
     ),
 ];
 

--- a/crates/phase-ai/src/policies/loop_shortcut.rs
+++ b/crates/phase-ai/src/policies/loop_shortcut.rs
@@ -1,0 +1,524 @@
+//! CR 732.2a loop-shortcut proposal gate — decide whether the priority holder should
+//! propose the auto-detected loop shortcut, or return to ordinary priority.
+//!
+//! ## The defect this closes
+//!
+//! At `WaitingFor::LoopShortcut` the candidate generator (`engine::ai_support::candidates`)
+//! emits BOTH `GameAction::DeclareShortcut` (`TacticalClass::Utility`) and
+//! `GameAction::DeclineShortcut` (`TacticalClass::Pass`) and explicitly defers the choice
+//! "to the policy/search layer" — but no policy scored either action. `should_play_now_with_facts`
+//! (`card_hints.rs`, terminal arm `_ => 0.5`) gives both 0.5, and the class-bonus table
+//! (`planner/mod.rs`) then subtracts 0.1 (or 0.25) from `Pass` and nothing from `Utility`.
+//! Result: the TACTICAL score preferred `Declare` (0.5) over `Decline` (0.4) in every game state.
+//! On every path where the tactical score IS the whole score — the heuristic-only branch
+//! (VeryEasy/Easy, `SearchConfig::default()`, ≥5p pods at `<= Medium`) and the deadline-expired
+//! tactical floor (`search.rs:1956`) — that is the ENTIRE decision, so an AI holding priority on a
+//! loop that a DIFFERENT player wins proposed the shortcut and handed that player the game. Under
+//! search the final score is `cont + score * tactical_weight` (`search.rs:1990`), and there the
+//! beam's continuation value could already prefer `Decline` on its own (measured control at Hard,
+//! policy unregistered: Declare = -9999.925) — but nothing GUARANTEED it. The `Reject` makes the
+//! refusal total on every path.
+//!
+//! ## Why a `TacticalPolicy` and not a picker special-case
+//!
+//! `PlannerServices::tactical_score` is the single scoring authority consulted by BOTH branches
+//! of `score_candidates_core` — the search-ON ranked path and the heuristic-only path — plus the
+//! beam interior node and the rollout leaf's priors. A `TacticalPolicy` is therefore
+//! difficulty-independent BY CONSTRUCTION: it fires for VeryEasy / Easy (which force
+//! `search.enabled = false`), for large pods at `<= Medium`, for the `SearchConfig::default()`
+//! `enabled: false`, and for a pre-expired deadline — every path a picker special-case would
+//! have to be duplicated into.
+//!
+//! Note the two branches weight this policy DIFFERENTLY. The search-ON branch multiplies the
+//! tactical score by `tactical_weight` — `0.1` at a quiesced node, or `0.35` if an opponent's
+//! object is on the stack (the offer is raised at a priority window, which does not imply an
+//! empty stack); target-selection's `0.7` is unreachable here. The heuristic-only branch adds the
+//! score RAW. So the positive win bonus is attenuated up to 10x under search — deliberately,
+//! because there the beam's own continuation value already sees the crown. The REJECT is immune
+//! to the weight AND the temperature: `-inf * 0.1 == -inf * 0.35 == -inf`, and `exp(-inf / T) == 0`
+//! at every temperature, so no difficulty ever throws the game away.
+//!
+//! ## The three rulings the verdict encodes
+//!
+//! 1. `predicted_winner == Some(w), w != proposer` + `UntilLethal` ⇒ REJECT.
+//!    `loop_check::live_mandatory_loop_winner` partitions the living players into `fallers`
+//!    (per-cycle `delta.life < 0 || delta.poison > 0`) and `nonfallers`, and names a winner ONLY
+//!    when `nonfallers.len() == 1`. The two sets partition `living`, so a named winner other than
+//!    the proposer PROVES the proposer is a faller — a deterministic self-loss (CR 704.5a life /
+//!    CR 704.5c poison) with the other player crowned by CR 104.2a. The declare is WEAKLY
+//!    DOMINATED, not merely bad: the drive either reaches that crown, or aborts into
+//!    `until_lethal_fallback`, which restores exactly the board a decline would have left.
+//!    Loss-or-no-op — never a gain.
+//! 2. `predicted_winner == None` + `UntilLethal` ⇒ REJECT.
+//!    Only the object-growth offer carries `None`. The crown gate requires
+//!    `Some(winner) == proposal.predicted_winner`, false for every winner when the latch is `None`
+//!    ⇒ `until_lethal_fallback` full-rolls-back the board, clears `loop_detect_ring` +
+//!    `last_recast_context`, and hands priority back. Zero progress, the CR 732.2b APNAP window
+//!    burned, the re-offer signal destroyed — weakly dominated by declining.
+//! 3. `predicted_winner == Some(proposer)` + `UntilLethal` ⇒ positive (critical band).
+//!    The crown IS the win (CR 104.2a); the only other outcome is `until_lethal_fallback`, which
+//!    lands where declining lands. Dominant in outcome. (It is not costless: declaring opens the
+//!    CR 732.2b window, and an opponent's `Shorten` hands THEM a priority window they would not
+//!    get if the AI declined and kept priority. The crown is worth that risk; the phrase "no
+//!    downside" would not be true.)
+//!
+//! ## Why the `IterationCount` gate is load-bearing for the CLASS
+//!
+//! `materialize_fixed_shortcut` NEVER consults `predicted_winner`: it drives `n` whole cycles and
+//! COMMITS each atomically (an object-growth `None` offer is routed to
+//! `materialize_object_growth_shortcut`). A `Fixed(n)` declare is real, committed board progress
+//! needing no crown — so a reject that ignored the count would be wrong for the class. Today's AI
+//! candidate generator only ever emits `UntilLethal`, but `Fixed(n)` is reachable through the
+//! public `GameAction` surface: `handle_declare_shortcut` moves `count` into the proposal with
+//! ZERO validation (the fail-closed firewall validates only `template` pins, and is skipped
+//! entirely when `template` is `None`).
+//!
+//! ## Why the verdict reads `proposer` from the state, never `ctx.ai_player`
+//!
+//! `WaitingFor::acting_player()` returns `Some(proposer)` for `LoopShortcut`, and the beam/rollout
+//! paths bind `PolicyContext::ai_player` to exactly that, so the two coincide wherever both are
+//! defined. Reading `proposer` is fail-safe: the candidate is the proposer's action by
+//! construction (`metadata.actor == Some(proposer)`), so the veto stays correct even if a caller
+//! ever scores this state under a different seat's value lens — whereas gating on
+//! `ctx.ai_player == proposer` would silently DROP the veto in that case.
+
+use engine::analysis::decision_template::IterationCount;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::player::PlayerId;
+
+use crate::features::DeckFeatures;
+
+use super::context::PolicyContext;
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+
+pub struct LoopShortcutPolicy;
+
+impl TacticalPolicy for LoopShortcutPolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::LoopShortcut
+    }
+
+    /// `classify_decision` maps `WaitingFor::LoopShortcut` to `ActivateAbility` BEFORE inspecting
+    /// the action, so this single kind reaches both the `DeclareShortcut` and the
+    /// `DeclineShortcut` candidate.
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::ActivateAbility]
+    }
+
+    fn activation(
+        &self,
+        _features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        // A hard-veto backstop for the CR 732.2a shortcut protocol: a pure state-machine policy
+        // with no deck signal (mirrors `XCastGatePolicy` / `SelfCostValuePolicy`). `verdict`
+        // short-circuits on one enum-discriminant compare for every non-shortcut candidate, so the
+        // unconditional activation costs nothing in the search inner loop.
+        // activation-constant: unconditional Reject backstop; all gating lives in `verdict`.
+        Some(1.0)
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let na = || PolicyVerdict::neutral(PolicyReason::new("loop_shortcut_na"));
+
+        // Cheapest possible gate FIRST (one enum-discriminant compare): every `ActivateAbility`
+        // candidate in the game runs this. It is also this policy's contribution to NaN safety —
+        // `DeclineShortcut` exits here, so the policy can never reject BOTH candidates.
+        // (`softmax_select_pairs` also self-heals on an all-`-inf` vector via its
+        // `!total.is_finite()` argmax fallback — belt and braces.)
+        let GameAction::DeclareShortcut { count, .. } = &ctx.candidate.action else {
+            return na();
+        };
+        let WaitingFor::LoopShortcut {
+            proposer,
+            predicted_winner,
+            ..
+        } = &ctx.state.waiting_for
+        else {
+            return na();
+        };
+
+        match (predicted_winner, count) {
+            // CR 704.5a / CR 704.5c + CR 104.2a: the offer's winner is somebody else. The
+            // faller/non-faller partition in `loop_check::live_mandatory_loop_winner` is total over
+            // the living players, so a named winner != proposer PROVES the proposer's per-cycle
+            // life/poison delta is a loss. Declaring `UntilLethal` runs that loop to the SBA and
+            // crowns the other player. WEAKLY DOMINATED: the alternative branch is
+            // `until_lethal_fallback` (a rollback to exactly where a decline lands), so the
+            // outcome set is {self-loss, no-op} — never a gain.
+            (Some(winner), IterationCount::UntilLethal) if winner != proposer => {
+                PolicyVerdict::reject(
+                    PolicyReason::new("loop_shortcut_declare_hands_opponent_the_win")
+                        .with_fact("proposer", i64::from(proposer.0))
+                        .with_fact("predicted_winner", i64::from(winner.0)),
+                )
+            }
+
+            // CR 732.2a + CR 104.2a: the crown gate requires `Some(winner) == predicted_winner`, so
+            // an `UntilLethal` declare on an offer whose latched winner IS the proposer is the win.
+            // Worst case the gate refuses and `until_lethal_fallback` restores the pre-drive board.
+            // Game-deciding ⇒ critical band (`PolicyVerdict::score` auto-bands the config-routed
+            // value).
+            (Some(winner), IterationCount::UntilLethal) => PolicyVerdict::score(
+                ctx.penalties().loop_shortcut_winning_declare_bonus,
+                PolicyReason::new("loop_shortcut_declare_wins")
+                    .with_fact("winner", i64::from(winner.0)),
+            ),
+
+            // CR 732.2a: only the object-growth offer latches `None`. The crown gate can never
+            // match it, so `UntilLethal` always ends in `until_lethal_fallback`: full board
+            // rollback, `loop_detect_ring` + `last_recast_context` cleared, priority handed back.
+            // Zero progress AND the CR 732.2b response window spent — weakly dominated by
+            // declining.
+            (None, IterationCount::UntilLethal) => {
+                PolicyVerdict::reject(PolicyReason::new("loop_shortcut_untillethal_cannot_crown"))
+            }
+
+            // CR 732.2a "a loop that repeats a specified number of times": neither rejected nor
+            // boosted. Two independent reasons. (1) The AI never emits `Fixed` — its ONLY
+            // `DeclareShortcut` construction site (`candidates.rs:3012`) hardcodes `UntilLethal`.
+            // (2) A count-blind reject would be wrong for the CLASS: `materialize_fixed_shortcut`
+            // drives and COMMITS `n` whole cycles without ever reading `predicted_winner`, so a
+            // small-`n` `Fixed` is genuine committed board progress whoever is latched.
+            //
+            // NOTE (tripwire): a `Fixed(n)` large enough to cross lethal WOULD commit a `GameOver`
+            // crowning whoever the DRIVE's state-based actions crown (`drive_one_shortcut_cycle`,
+            // `engine.rs:1180-1186`, forwards the SBA's own `Option<PlayerId>` — which is the
+            // latched winner when the prediction was right, and can even be `None`, a CR 104.4b
+            // draw). `materialize_fixed_shortcut`'s `CrossLethal` arm (`engine.rs:1393-1402`)
+            // forwards it WITHOUT filtering on `proposal.predicted_winner`, unlike BOTH
+            // `UntilLethal` crown gates (`engine.rs:971`, `engine.rs:1000`). Such a declare by a
+            // faller proposer is therefore a committed self-loss — exactly what the `UntilLethal`
+            // arm above rejects. REVISIT THIS ARM if the candidate generator ever emits `Fixed`.
+            (_, IterationCount::Fixed(_)) => na(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{create_config, AiConfig, AiDifficulty, Platform};
+    use crate::policies::context::SearchDepth;
+    use crate::policies::registry::STRONG_MAX;
+    use crate::search::{choose_action, score_candidates_with_session};
+    use crate::session::AiSession;
+    use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+    use engine::analysis::decision_template::ShortcutDecisionSchema;
+    use engine::analysis::loop_check::{LoopCertificate, WinKind};
+    use engine::analysis::resource::BoardDelta;
+    use rand::rngs::SmallRng;
+    use rand::SeedableRng;
+
+    const P0: PlayerId = PlayerId(0);
+    const P1: PlayerId = PlayerId(1);
+
+    /// A synthetic optional-lethal certificate — the policy never reads it; only `proposer` and
+    /// `predicted_winner` drive the verdict.
+    fn cert() -> LoopCertificate {
+        LoopCertificate {
+            unbounded: vec![],
+            win_kind: WinKind::LethalDamage,
+            mandatory: false,
+            residual_board_delta: BoardDelta::default(),
+        }
+    }
+
+    fn offer_state(predicted_winner: Option<PlayerId>) -> GameState {
+        let mut state = GameState::new_two_player(0);
+        state.waiting_for = WaitingFor::LoopShortcut {
+            proposer: P0,
+            predicted_winner,
+            certificate: cert(),
+            schema: ShortcutDecisionSchema::default(),
+        };
+        state
+    }
+
+    fn declare(count: IterationCount) -> CandidateAction {
+        CandidateAction {
+            action: GameAction::DeclareShortcut {
+                count,
+                template: None,
+            },
+            metadata: ActionMetadata {
+                actor: Some(P0),
+                tactical_class: TacticalClass::Utility,
+            },
+        }
+    }
+
+    fn decline() -> CandidateAction {
+        CandidateAction {
+            action: GameAction::DeclineShortcut,
+            metadata: ActionMetadata {
+                actor: Some(P0),
+                tactical_class: TacticalClass::Pass,
+            },
+        }
+    }
+
+    fn verdict_for(state: &GameState, candidate: &CandidateAction) -> PolicyVerdict {
+        let config = create_config(AiDifficulty::Medium, Platform::Native);
+        let decision = AiDecisionContext {
+            waiting_for: state.waiting_for.clone(),
+            candidates: vec![declare(IterationCount::UntilLethal), decline()],
+        };
+        let context = crate::context::AiContext::empty(&config.weights);
+        LoopShortcutPolicy.verdict(&PolicyContext {
+            state,
+            decision: &decision,
+            candidate,
+            ai_player: P0,
+            config: &config,
+            context: &context,
+            cast_facts: None,
+            search_depth: SearchDepth::Root,
+        })
+    }
+
+    fn delta_of(v: &PolicyVerdict) -> f64 {
+        match v {
+            PolicyVerdict::Score { delta, .. } => *delta,
+            PolicyVerdict::Reject { reason } => {
+                panic!("expected Score, got Reject {}", reason.kind)
+            }
+        }
+    }
+
+    fn kind_of(v: &PolicyVerdict) -> &'static str {
+        match v {
+            PolicyVerdict::Score { reason, .. } | PolicyVerdict::Reject { reason } => reason.kind,
+        }
+    }
+
+    /// Reach-guard: prove the synthetic offer state actually reaches the SCORER with BOTH
+    /// candidates alive. `validate_candidates` simulates both shortcut actions, and a 1-element
+    /// survivor set makes `deterministic_choice` (`search.rs:2127-2129`, `if actions.len() == 1`)
+    /// short-circuit the scorer entirely — which would make the e2e tests below pass with the
+    /// policy deleted. Exactly 2 scored entries is the only proof that neither happened.
+    fn assert_both_candidates_reach_the_scorer(state: &GameState, config: &AiConfig) {
+        let session = AiSession::arc_from_game(state);
+        let scored = score_candidates_with_session(state, P0, config, &session);
+        assert_eq!(
+            scored.len(),
+            2,
+            "both shortcut candidates must survive validate_candidates + gate_candidates and reach \
+             the scorer (1 entry ⇒ deterministic_choice short-circuited ⇒ the test would be \
+             VACUOUS); got {scored:?}"
+        );
+        assert!(
+            scored
+                .iter()
+                .any(|(a, _)| matches!(a, GameAction::DeclareShortcut { .. })),
+            "DeclareShortcut must reach the scorer; got {scored:?}"
+        );
+        assert!(
+            scored
+                .iter()
+                .any(|(a, _)| matches!(a, GameAction::DeclineShortcut)),
+            "DeclineShortcut must reach the scorer; got {scored:?}"
+        );
+    }
+
+    /// The policy has NO `DeckFeatures` axis (it is a pure state-machine veto), so
+    /// `/add-ai-feature-policy`'s `activation_opts_out_below_floor` convention does not apply.
+    /// Non-vacuous: returning `None` silently disables the whole policy, and this fails on `None`.
+    #[test]
+    fn activation_is_an_unconditional_backstop() {
+        assert_eq!(
+            LoopShortcutPolicy.activation(&DeckFeatures::default(), &offer_state(Some(P1)), P0),
+            Some(1.0)
+        );
+    }
+
+    /// Rows 0/1 — the NaN-safety lock: `DeclineShortcut` is NEVER rejected, so the softmax always
+    /// sees at least one finite weight.
+    #[test]
+    fn decline_shortcut_is_never_rejected() {
+        let state = offer_state(Some(P1));
+        let v = verdict_for(&state, &decline());
+        assert_eq!(delta_of(&v), 0.0);
+        assert_eq!(kind_of(&v), "loop_shortcut_na");
+    }
+
+    /// Row 0 — a `DeclareShortcut` candidate scored at a NON-`LoopShortcut` state is neutral.
+    #[test]
+    fn declare_outside_loop_shortcut_returns_zero() {
+        let mut state = GameState::new_two_player(0);
+        state.waiting_for = WaitingFor::Priority { player: P0 };
+        let v = verdict_for(&state, &declare(IterationCount::UntilLethal));
+        assert_eq!(delta_of(&v), 0.0);
+        assert_eq!(kind_of(&v), "loop_shortcut_na");
+    }
+
+    /// Row 2 — THE BUG. The latched winner is an opponent ⇒ declaring `UntilLethal` runs a loop
+    /// whose SBA crowns them (CR 104.2a) and kills the proposer (CR 704.5a).
+    #[test]
+    fn declare_until_lethal_when_opponent_wins_is_rejected() {
+        let state = offer_state(Some(P1));
+        let v = verdict_for(&state, &declare(IterationCount::UntilLethal));
+        assert!(
+            matches!(v, PolicyVerdict::Reject { .. }),
+            "declaring a shortcut an OPPONENT wins must be vetoed, got {v:?}"
+        );
+        assert_eq!(kind_of(&v), "loop_shortcut_declare_hands_opponent_the_win");
+    }
+
+    /// Row 6 — the over-suppression guard: the proposer's OWN win must still be boosted.
+    #[test]
+    fn declare_until_lethal_when_self_wins_is_critical() {
+        let state = offer_state(Some(P0));
+        let v = verdict_for(&state, &declare(IterationCount::UntilLethal));
+        assert!(
+            delta_of(&v) > STRONG_MAX,
+            "a guaranteed CR 104.2a crown is critical-band, got {v:?}"
+        );
+        assert_eq!(kind_of(&v), "loop_shortcut_declare_wins");
+    }
+
+    /// Row 4 — an `UntilLethal` declare on a `None`-winner (object-growth) offer can never satisfy
+    /// the crown gate, so it always full-rolls-back: zero progress, CR 732.2b window burned.
+    #[test]
+    fn declare_until_lethal_with_no_predicted_winner_is_rejected() {
+        let state = offer_state(None);
+        let v = verdict_for(&state, &declare(IterationCount::UntilLethal));
+        assert!(
+            matches!(v, PolicyVerdict::Reject { .. }),
+            "an UntilLethal declare that cannot crown must be vetoed, got {v:?}"
+        );
+        assert_eq!(kind_of(&v), "loop_shortcut_untillethal_cannot_crown");
+    }
+
+    /// Rows 3 + 5 + 7 — THE CLASS GUARD: `materialize_fixed_shortcut` never reads
+    /// `predicted_winner` and COMMITS every cycle it drives, so a `Fixed(n)` declare is real board
+    /// progress for ANY latched winner. Proves the reject set is not one state too wide.
+    #[test]
+    fn declare_fixed_is_never_rejected() {
+        for predicted_winner in [None, Some(P0), Some(P1)] {
+            let state = offer_state(predicted_winner);
+            let v = verdict_for(&state, &declare(IterationCount::Fixed(3)));
+            assert_eq!(
+                delta_of(&v),
+                0.0,
+                "Fixed(n) is committed progress, never vetoed nor boosted (winner \
+                 {predicted_winner:?})"
+            );
+            assert_eq!(kind_of(&v), "loop_shortcut_na");
+        }
+    }
+
+    /// E2E, HEURISTIC branch (VeryEasy: `search.enabled == false` ⇒ the tactical score is added
+    /// RAW). Without the policy the class-bonus table makes Declare (0.5) beat Decline (0.4) in
+    /// every state; with it the `Reject` drives Declare's softmax weight to `exp(-inf/T) == 0`, so
+    /// the pick is deterministic across every seed.
+    #[test]
+    fn heuristic_picker_declines_a_losing_shortcut() {
+        let config = create_config(AiDifficulty::VeryEasy, Platform::Native);
+        assert!(
+            !config.search.enabled,
+            "reach-guard: VeryEasy must exercise the HEURISTIC branch"
+        );
+        let state = offer_state(Some(P1));
+        assert_both_candidates_reach_the_scorer(&state, &config);
+
+        for seed in 0..32u64 {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            assert_eq!(
+                choose_action(&state, P0, &config, &mut rng),
+                Some(GameAction::DeclineShortcut),
+                "seed {seed}: the AI must NOT propose a shortcut that crowns its opponent"
+            );
+        }
+    }
+
+    /// E2E, SEARCH branch (Hard). The TEETH are the two RNG-free SCORE assertions: the `-inf` must
+    /// survive the `tactical_weight` multiply (`-inf * 0.1 == -inf * 0.35 == -inf`).
+    ///
+    /// # ⚠️ DO NOT "SIMPLIFY" THIS DOWN TO THE SEED LOOP.
+    ///
+    /// The seed loop at the end is a POST-CONDITION INVARIANT (necessary, NOT discriminating). With
+    /// the policy unregistered the control Declare score here is a FINITE `-9999.925` (measured) —
+    /// which still loses the softmax to Decline — so a pick-only assertion PASSES WITH THE POLICY
+    /// DELETED. The only assertion with teeth is
+    /// `declare_score.is_infinite() && declare_score.is_sign_negative()`: that is what proves the
+    /// `Reject` (and not the beam's own continuation value) is doing the work.
+    #[test]
+    fn search_picker_declines_a_losing_shortcut() {
+        let mut config = create_config(AiDifficulty::Hard, Platform::Native);
+        assert!(
+            config.search.enabled,
+            "reach-guard: Hard must exercise the SEARCH branch"
+        );
+        // The verdict is state-only, so K determinization samples add nothing; 0 keeps the test on
+        // the deterministic core path.
+        config.search.determinization_samples = 0;
+        let state = offer_state(Some(P1));
+        assert_both_candidates_reach_the_scorer(&state, &config);
+
+        let session = AiSession::arc_from_game(&state);
+        let scored = score_candidates_with_session(&state, P0, &config, &session);
+        let declare_score = scored
+            .iter()
+            .find(|(a, _)| matches!(a, GameAction::DeclareShortcut { .. }))
+            .map(|(_, s)| *s)
+            .expect("DeclareShortcut is scored");
+        let decline_score = scored
+            .iter()
+            .find(|(a, _)| matches!(a, GameAction::DeclineShortcut))
+            .map(|(_, s)| *s)
+            .expect("DeclineShortcut is scored");
+        assert!(
+            declare_score.is_infinite() && declare_score.is_sign_negative(),
+            "the Reject must survive the tactical_weight multiply, got {declare_score}"
+        );
+        assert!(
+            decline_score.is_finite(),
+            "DeclineShortcut must stay finite (NaN safety), got {decline_score}"
+        );
+
+        // POST-CONDITION INVARIANT (necessary, NOT discriminating — see the doc comment): the
+        // `-inf` must actually reach the picker. This loop passes with the policy deleted (the
+        // control Declare score is a finite -9999.925, which also loses the softmax), so it proves
+        // the end-to-end wiring, never the policy.
+        for seed in 0..8u64 {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            assert_eq!(
+                choose_action(&state, P0, &config, &mut rng),
+                Some(GameAction::DeclineShortcut),
+                "seed {seed}: the search picker must decline too"
+            );
+        }
+    }
+
+    /// The over-suppression e2e guard. VeryEasy (heuristic ⇒ UNWEIGHTED) is the branch the `8.0`
+    /// default is sized for. Do NOT rewrite this against a search-ON difficulty: there the margin
+    /// is `8.1 * 0.1 = 0.81` (or `2.835` at `w = 0.35`), both `< STRONG_MAX`, and the assertion
+    /// would be false for a CORRECT implementation.
+    #[test]
+    fn winning_shortcut_is_still_declared() {
+        let config = create_config(AiDifficulty::VeryEasy, Platform::Native);
+        let state = offer_state(Some(P0));
+        assert_both_candidates_reach_the_scorer(&state, &config);
+
+        let session = AiSession::arc_from_game(&state);
+        let scored = score_candidates_with_session(&state, P0, &config, &session);
+        let declare_score = scored
+            .iter()
+            .find(|(a, _)| matches!(a, GameAction::DeclareShortcut { .. }))
+            .map(|(_, s)| *s)
+            .expect("DeclareShortcut is scored");
+        let decline_score = scored
+            .iter()
+            .find(|(a, _)| matches!(a, GameAction::DeclineShortcut))
+            .map(|(_, s)| *s)
+            .expect("DeclineShortcut is scored");
+        assert!(
+            declare_score - decline_score > STRONG_MAX,
+            "a shortcut the proposer WINS must stay strongly preferred; declare = \
+             {declare_score}, decline = {decline_score}"
+        );
+    }
+}

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -29,6 +29,7 @@ mod land_sequencing;
 mod landfall_timing;
 mod lethality_awareness;
 mod life_total_resource;
+mod loop_shortcut;
 mod mana_efficiency;
 mod mill_targeting;
 pub mod mulligan;

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -21,6 +21,7 @@ use super::interaction_reservation::InteractionReservationPolicy;
 use super::landfall_timing::LandfallTimingPolicy;
 use super::lethality_awareness::LethalityAwarenessPolicy;
 use super::life_total_resource::LifeTotalResourcePolicy;
+use super::loop_shortcut::LoopShortcutPolicy;
 use super::payment_selection::PaymentSelectionPolicy;
 use super::payoff::{
     PayoffPolicy, ARTIFACT_SYNERGY, BLINK_PAYOFF, ENCHANTMENTS_PAYOFF, ENERGY_PAYOFF,
@@ -125,6 +126,7 @@ pub enum PolicyId {
     PaymentSelection,
     SeparatePilesTiming,
     XCastGate,
+    LoopShortcut,
 }
 
 /// Coarse routing kind for a candidate decision. Each policy declares which
@@ -372,6 +374,7 @@ impl Default for PolicyRegistry {
             Box::new(SeparatePilesTimingPolicy),
             Box::new(PayoffPolicy::new(&REANIMATOR_PAYOFF)),
             Box::new(PayoffPolicy::new(&BLINK_PAYOFF)),
+            Box::new(LoopShortcutPolicy),
         ];
         let mut by_kind: HashMap<DecisionKind, Vec<usize>> = HashMap::new();
         for (idx, policy) in policies.iter().enumerate() {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Two follow-ups to the **merged** PR-7 (#5672). **D1** closes the Blocker-2 gap PR-7 left open: it exposed both loop-shortcut candidates and deferred the choice "to the policy/search layer", but no policy ever scored either — so the AI preferred to propose a shortcut that crowns its opponent. **D2** covers the winner-liveness conjunct PR-7's own tests miss (deleting it flipped no test).

No engine game logic changes. D1 is entirely in `phase-ai`; D2 is a test against an existing guard. The only `crates/engine/src` diff is a one-line comment pointing at the policy that now scores the candidates.

## Implementation method (required)

Method: /engine-implementer

## CR references

`CR 732.2a` (proposing a shortcut is optional; the offer routes to the priority holder, who need not be the winner), `CR 732.2b`/`CR 732.2c` (the APNAP accept-or-shorten window and its consumption), `CR 104.2a` (a player wins when their opponents have all left), `CR 104.3a` (concede = leave the game immediately), `CR 104.4b` (mandatory loop => draw), `CR 704.5a`/`CR 704.5c` (life/poison loss — the "faller" axes), `CR 800.4a` (priority passes to the next player still in the game), `CR 101.2` ("can't" takes precedence — the life-loss-immune bystander), `CR 119.8`, `CR 704.3`.

All grep-verified against `docs/MagicCompRules.txt` before being written. (`732.2d`/`732.2e` do not exist and are not cited.)

---

## D1 — the AI's conservative escape was the dispreferred candidate

`candidates.rs` emits **both** `DeclareShortcut` (`TacticalClass::Utility`) and `DeclineShortcut` (`TacticalClass::Pass`) at `WaitingFor::LoopShortcut`, with a comment deferring the choice to the policy layer. **No policy scored either.** Measured:

- `should_play_now_with_facts` -> `_ => 0.5` for both.
- class bonus: `Pass` -> -0.1 (-0.25 under `Develop`/`PushLethal`); `Utility` -> falls through, +0.0.

=> the **tactical score** preferred `Declare` **0.5 vs 0.4 in every game state**. On every path where the tactical score *is* the whole score — the heuristic-only branch (VeryEasy/Easy, `SearchConfig::default()`, 5-6p pods at <= Medium) and the deadline-expired tactical floor — that is the entire decision. An AI holding priority on a loop a *different* player wins would declare, and hand that player the game.

**Fix:** `LoopShortcutPolicy`, a `TacticalPolicy` in the one scoring layer that **both** the search-on and heuristic-only paths consult (`PlannerServices::tactical_score`) — difficulty-independent by construction, not a picker special case.

The verdict reads `proposer` from `state.waiting_for`, **never `ctx.ai_player`** (fail-safe: an `ai_player == proposer` gate would silently *drop* the veto on divergence). It rejects **exactly two** states:

| `predicted_winner` | `count` | verdict | why |
|---|---|---|---|
| `Some(w)`, `w != proposer` | `UntilLethal` | **reject** | `live_mandatory_loop_winner` partitions the living into fallers/nonfallers and names a winner **only** when `nonfallers.len() == 1` => a named winner != proposer **proves** the proposer is a faller => deterministic CR 704.5a/704.5c self-loss, opponent crowned per CR 104.2a |
| `None` | `UntilLethal` | **reject** | both crown gates test `Some(winner) == predicted_winner`, false for every winner when the latch is `None` => always `until_lethal_fallback` = full rollback that also clears the re-offer signal => weakly dominated by declining |
| `Some(proposer)` | `UntilLethal` | **+critical** | the crown IS the win (CR 104.2a) |
| any | `Fixed(n)` | **neutral** | `materialize_fixed_shortcut` never reads `predicted_winner` and **commits** each cycle => real board progress; a count-blind reject would be wrong for the class |

`DeclineShortcut` can **never** be rejected (the verdict exits on the first `let-else`), so a finite score always survives in the softmax. The `match` has **no wildcard on the count axis** — a future `IterationCount` variant is a compile error, not a silent mis-gate.

## D2 — the winner-liveness conjunct had zero coverage

`apply_confirmed_shortcut` gates the seam on both authorities:

```rust
if !is_alive(state, proposal.proposer)
    || proposal.predicted_winner.is_some_and(|w| !is_alive(state, w))
```

Both existing concede tests build offers where `proposer == predicted_winner`, so the **first** conjunct short-circuits and the second is never evaluated. **Deleting it flipped no test.**

Covering it requires three things at once, and the obvious fixtures fail all three:

1. **`Fixed(n)`, not `UntilLethal`.** On the `UntilLethal` path the conjunct is redundant — `live_mandatory_loop_winner` builds its living set from the *same* `!is_eliminated` predicate `is_alive` uses, so a departed winner can never be re-derived, and both crown gates re-filter anyway. `materialize_fixed_shortcut` never consults `predicted_winner` and **commits** each cycle, so there the conjunct is the only thing between a departed winner and `n` committed cycles.
2. **A predicted winner who owns no loop enabler.** If the winner owns the loop, CR 800.4a exiles it with them, the drive aborts, and the board is untouched with *or without* the guard — vacuous.
3. **Equal ABSOLUTE life across the fallers**, not just equal deltas, or the simultaneity floor raises no offer at all.

`setup_3p_bystander_winner` satisfies all three: P0's **symmetric** plague engine drains every player *including P0*, P1 is a second faller, and P2's life can't change — so P2 is the sole non-faller and **the engine itself latches `predicted_winner = Some(P2)`**, a winner who controls nothing. The test asserts that latch on the *engine-raised* offer, which is what makes the fixture engine-derived rather than hand-injected.

> **On `Fixed(n)`'s reachability, stated precisely:** `handle_declare_shortcut` moves `count` into the proposal with **zero validation** — the fail-closed firewall validates only `template` pins and is skipped entirely when `template` is `None`. The count is therefore **unvalidated at every layer**, which is exactly *why* this guard is reachable. It is **not** emitted by the AI's candidate generator, which hardcodes `UntilLethal`. See "Pre-existing issue found" below.

---

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

| Command | Result |
|---|---|
| `cargo fmt --all` | clean |
| `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` | **exit 0**, zero diagnostics |
| `cargo nextest run --profile ci --workspace --exclude phase-tauri --exclude mtgish-import --features engine/proptest` | **21380 passed, 0 failed** |
| `every_policy_penalty_is_tuning_registered_or_explicitly_untuned` | PASS (new field registered in `UNTUNED_POLICY_PENALTY_FIELDS`, not `ACTIVE_` — a game-deciding CR 104.2a crown scalar does not belong in the CMA-ES vector) |
| `score_contract_lint` + `activation_marker_lint` | PASS |
| `cargo ai-gate` | **exit 0** — and **it did not move**; see below |
| `./scripts/check-parser-combinators.sh` (Gate A) | PASS |
| `./scripts/check-engine-authorities.sh` (Gate B) | PASS — 86 raw zone hits, all classified |

### `cargo ai-gate` — zero delta, proven by a paired control

The gate emits **1 WARN** (red-mirror baseline 70% -> 80%; `W->L=1, L->W=2`; sign-test **p = 0.3125**). **Nothing was rebaselined.** Instead the gate was re-run with `LoopShortcutPolicy` **unregistered** on the same machine, and the control is **byte-identical**:

| | red-mirror | affinity | enchantress | verdict |
|---|---|---|---|---|
| with the policy | 80% / 14.7 | 30% / 11.4 | 50% / 12.6 | 0 FAIL, 1 WARN, 2 PASS |
| **control (policy unregistered)** | 80% / 14.7 | 30% / 11.4 | 50% / 12.6 | 0 FAIL, 1 WARN, 2 PASS |

=> **the WARN is pre-existing baseline-vs-machine drift, not this change.** (`ai-gate` is wall-clock-deadline bounded, so it is not bit-reproducible; one red-mirror seed also aborts on an unrelated, pre-existing `Kappa Cannoneer` `ManaPayment` panic — **pre-existing, not introduced here**.) Our delta is exactly zero, as expected: the policy returns `neutral(0.0)` at every non-`LoopShortcut` state, and no gate fixture reaches one.

### Discriminating tests — 10 revert-probes, all measured

Every behavioral claim has a test that **fails** without the change. Measured, not predicted:

| Probe (production term reverted) | Measured FAIL |
|---|---|
| D2: delete the `predicted_winner.is_some_and(..)` conjunct | engine commits **3 real cycles**: `life(P1)` `left: 995, right: 998` |
| D2: engine-latch guard (`Some(P2)`->`Some(P0)`) | `left: Some(PlayerId(2)), right: Some(PlayerId(0))` — proves the offer is engine-latched on a bystander winner |
| D1: unregister `LoopShortcutPolicy` (heuristic) | `left: Some(DeclareShortcut { .. }), right: Some(DeclineShortcut)` |
| D1: unregister (search) | `the Reject must survive the tactical_weight multiply, got -9999.925...` (finite, not `-inf`) |
| D1: unregister (win case) | **the original bug in situ:** `declare = 0.5, decline = 0.4` |
| widen the gate to reject `DeclineShortcut` | `expected Score, got Reject` (the NaN guard has teeth) |
| delete the opponent-wins reject arm | `must be vetoed, got Score { delta: 8.0, ... }` |
| drop the `winner != proposer` guard | `expected Score, got Reject ...hands_opponent_the_win` |
| neuter the `(None, UntilLethal)` reject | `must be vetoed, got Score { delta: 0.0, ... }` |
| strip the `IterationCount` gate from both reject arms | `expected Score, got Reject ...untillethal_cannot_crown` (the over-rejection class guard) |

Two assertions are deliberately labelled **non-discriminating invariants** in their own doc comments, because they pass with the change reverted and a future "simplification" could otherwise vacuum the tests out:
- D2's crown/priority assertions — `waiting_for` is `Priority { P0 }` in **both** arms and `GameOver` is reached in **neither**, so only the **life-delta** assertions discriminate.
- D1's search-path seed loop — the control score is a *finite* -9999.925, which still loses the softmax, so only the RNG-free `is_infinite() && is_sign_negative()` assertion discriminates.

## Gate A

Gate A PASS head=6898fba8bc0b66893763b6c6e6e9195b3c57cc15 base=3b52c67a9025cd20da8b68243667eb8cdad76060

## Anchored on

- `crates/phase-ai/src/policies/x_cast_gate.rs:55-72` — an `activation-constant` pure state-machine `TacticalPolicy` that routes a hard veto through `PolicyVerdict::reject` rather than a sentinel score. Same seam, same shape.
- `crates/phase-ai/src/policies/anti_self_harm.rs:100-136` — a reject gated on the *candidate action* (`let ... else { neutral }`), which is the pattern that keeps `DeclineShortcut` unrejectable here.

## Final review-impl

Final review-impl PASS head=6898fba8bc0b66893763b6c6e6e9195b3c57cc15

---

## Pre-existing issue found (NOT fixed here — out of scope, needs its own PR)

While proving D2's reachability we measured a **pre-existing DoS shipped with #5672**, untouched by this PR:

- `IterationCount::Fixed(u32)` carries an **unbounded `u32`**.
- `game_action_payload_guard.rs` destructures `count` **away** with `..` and bounds only `template.decisions`. Its comment asserts *"`count` is a small enum — nothing unbounded"* — **which is false, and is why the guard skips it.**
- `handle_declare_shortcut` adds no validation, and `materialize_fixed_shortcut`'s `for i in 0..n` has **no outer cap** (`cycle_beat_cap` bounds beats *within* a cycle, not the cycle count).

=> a hostile client can send `DeclareShortcut { count: Fixed(u32::MAX), template: None }` and drive ~4.3e9 `GameState` clones on the multiplayer server.

This PR **does not touch it** — a payload-guard change belongs in its own PR with its own review. It is flagged here rather than buried; the only thing changed is a comment **in our own test** that had wrongly claimed the server bounds `n`. **A follow-up should bound `count` at the payload guard.**

## Combo-detector series

| Pos | PR | Delivers |
|-----|----|----------|
| PR-3 | #4480 | Live mandatory-loop winner shortcut (drain-cascade, CR 704.5a). |
| PR-6.5 | #4904 | Growing-cascade detector (omega-coverability modulo growth). |
| PR-6.75 | #5072 | C0-full + C1 precision pass (`ability_rw.rs`, latent CR 603.3b fix). |
| PR-7 | #5672 **MERGED** | Loop-shortcut offer + APNAP response window + combo-declaration UI (CR 732.2a-c). |
| **PR-7 follow-up** | **(this PR)** | **Score the shortcut offer (closes PR-7's Blocker-2 scoring gap) + cover PR-7's untested winner-liveness conjunct.** |
| PR-8 | planned | Combo-corpus completion. |
| PR-9 | planned | AI coupling (`LoopCertificate` -> top line). |

**Predecessor: PR-7 — #5672 — https://github.com/phase-rs/phase/pull/5672** — which shipped the CR 732.2a offer, the APNAP window, and the consumption seam. This PR closes the scoring gap it left open (the candidates were exposed but never scored) and covers the liveness conjunct its tests miss.

> This is **not** PR-9. PR-9 couples `LoopCertificate` into the AI's top line (*consuming* certificates); this PR only makes the AI stop proposing a shortcut that loses it the game.
