### PR TITLE
fix(tilt): stop card-data's staging file from re-triggering its own resource

### DIFF
--- a/scripts/gen-card-data.sh
+++ b/scripts/gen-card-data.sh
@@ -163,8 +163,17 @@ cargo build --profile tool --features "$FEATURES" "${TOOL_BINS[@]}"
 echo "Generating token preset catalog from MTGJSON set files..."
 TOKENS_FILE="crates/engine/data/known-tokens.toml"
 # Temp beside the target so the replace below is an atomic same-filesystem
-# rename (Tilt's card-data resource may run this script concurrently).
-TOKENS_TMP="$(mktemp "${TOKENS_FILE}.XXXXXX")"
+# rename (Tilt's card-data resource may run this script concurrently). The
+# `.tmp.` infix is load-bearing: crates/engine/data/ is watched as part of the
+# Tiltfile's ENGINE_SRC, and only names matching its TMP_IGNORE (`**/*.tmp.*`)
+# are exempt from retriggering. Without it, creating this file re-triggers the
+# very resource that created it — an unbreakable card-data rebuild loop that
+# also drags every other ENGINE_SRC watcher (clippy, test-engine, wasm) with it.
+TOKENS_TMP="$(mktemp "${TOKENS_FILE}.tmp.XXXXXX")"
+# Register before tokens-gen runs: a failure or interrupt between here and the
+# promote below would otherwise strand the staging file in the watched data dir,
+# where nothing else would ever collect it.
+track_tmp "$TOKENS_TMP"
 "$TOOL_BIN/tokens-gen" --input "$DATA_DIR/mtgjson/sets" --output "$TOKENS_TMP"
 # tokens-gen output is deterministic, so only overwrite when content actually
 # changed — an unconditional copy bumps the file's mtime and forces a full
@@ -172,7 +181,9 @@ TOKENS_TMP="$(mktemp "${TOKENS_FILE}.XXXXXX")"
 if cmp -s "$TOKENS_TMP" "$TOKENS_FILE"; then
   rm -f "$TOKENS_TMP"
 else
-  mv -f "$TOKENS_TMP" "$TOKENS_FILE"
+  # promote_tmp, not a bare `mv`: it deregisters the path so the EXIT trap
+  # cannot delete the file it was just promoted onto.
+  promote_tmp "$TOKENS_TMP" "$TOKENS_FILE"
   # The catalog changed, so the generator bins built above embed the stale
   # copy. Rebuild them (same shape) to re-bake the new catalog — this is the
   # one case where an engine recompile is genuinely required.


### PR DESCRIPTION
`gen-card-data.sh` creates its token-catalog staging file beside the target for
an atomic same-filesystem rename: `mktemp crates/engine/data/known-tokens.toml.XXXXXX`
(#5482). That was inert until #5594 widened the Tiltfile's ENGINE_SRC to watch
`crates/engine/data/` — a necessary fix, since the card-data cache key hashes
data/ and anything hashed-but-unwatched let tilt-wait.sh report a false green.

The two are individually correct and jointly an infinite loop. Tilt's ignore
list is TMP_IGNORE = ['**/*.tmp.*'], and `known-tokens.toml.FQfkUj` carries no
`.tmp.` segment, so the staging file was NOT exempt. card-data's build wrote a
file into card-data's own deps: every run re-triggered itself, and dragged every
other ENGINE_SRC watcher (clippy, test-engine, wasm, server, tauri, build-native)
with it. Observed re-firing every ~4-6 min indefinitely (builds 9014, 9023, 9031,
9040), throttled only by run duration and cargo lock contention.

The write-skip guards were never the cause and are working: both data files kept
their pre-loop mtimes throughout (known-tokens.toml 07-06, oracle-subtypes.json
07-09), and oracle-gen logs "Skipped write of 392 creature subtypes (unchanged)".
The trigger is purely the mktemp *creation* event — content never changed.

Fix: give the staging file the `.tmp.` infix the Tiltfile's TMP_IGNORE already
documents as the repo convention for `<file>.tmp.<hash>` staging writes. Same
directory, same filesystem, same atomic `mv -f` — now ignored by the watcher.

Verified against live Tilt:
- fnmatch controls: `known-tokens.toml.FQfkUj` -> NOT ignored (the loop);
  `known-tokens.toml.tmp.FQfkUj` -> ignored. Positive and negative control.
- The loop caught mid-break in one log: two consecutive runs each ending
  "1 File Changed: [crates/engine/data/known-tokens.toml.hKhgU0 / .sLEYeD]",
  then build 9040 under the fixed script runs the same path (it logs the echo
  immediately above the mktemp, so the changed line executed) and emits no
  File Changed line at all.
- card-data, clippy, test-engine and wasm all settle to ok and hold for >4 min,
  longer than the loop's own period. Zero retriggers.
