### PR TITLE
ship/t91 where x authority

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -8040,12 +8040,68 @@ pub(super) fn apply_where_x_effect_expression(
         }
         _ => {}
     }
+    // CR 107.3c — TOTALITY GUARD. The match above rewrites the quantity slots of the
+    // `Effect` variants it enumerates. It is NOT exhaustive: of the 64 variants that
+    // carry a `QuantityExpr`, 42 fall through the `_ => {}` above (task #95 binds the
+    // representable ones). Without this guard the wildcard's failure mode is a
+    // FABRICATION rather than a red — the effect keeps its bare `Variable("X")`, which
+    // resolves to 0 at runtime (amass 0 / surveil 0 / discard 0) while the face still
+    // renders as fully supported. That lie is invisible BOTH to a red-count ledger
+    // (there is no `Unimplemented` node to count) and to the zero-raw-text invariant
+    // ("X" is the legitimate alias). So the pass asserts its own post-condition: if the
+    // clause DEFINED X and an unbound X survived the rewrite, report the gap. A control
+    // with an escape hatch is not a control.
+    //
+    // The guard is keyed on the EXPRESSION, never on tree-presence of `Variable("X")`.
+    // Some expressions legitimately bind TO the placeholder, and for those a surviving
+    // `Variable("X")` is the CORRECT binding, not a fabrication:
+    //   - Join Forces (CR 107.3i): "where X is the total amount of mana paid this way"
+    //     resolves through the `chosen_x` machinery.
+    //   - Constraint tails (CR 608.2g): "where X is less than or equal to <bound>"
+    //     BOUNDS the player's chosen X rather than defining it (Well of Lost Dreams).
+    // A tree-presence check would flip both families to red.
+    if let Some(expression) = where_x_expression.filter(|_| unbound_where_x.is_none()) {
+        if !where_x_binds_to_placeholder(expression) && effect_retains_unbound_x(effect) {
+            unbound_where_x = Some(expression.to_string());
+        }
+    }
     // CR 107.3c: the clause defines X, but we cannot represent that definition.
     // Report the gap instead of keeping a P/T placeholder that resolves to no
     // modification at all (a silent +0/+0 no-op that still reads as supported).
     if let Some(expression) = unbound_where_x {
         *effect = Effect::unimplemented("where_x_binding", format!("where X is {expression}"));
     }
+}
+
+/// CR 107.3i + CR 608.2g: does this where-X expression legitimately bind X to the
+/// PLACEHOLDER itself, rather than to a concrete quantity?
+///
+/// `parse_where_x_quantity_expression` deliberately returns `Variable("X")` for two
+/// families — Join Forces' "the total amount of mana paid this way" (resolved via
+/// `chosen_x`) and the comparator-shaped constraint tails ("where X is less than or
+/// equal to …", which bound rather than define X). For those, a residual
+/// `Variable("X")` in the effect is the CORRECT lowering, so the totality guard must
+/// not treat it as an unbound fabrication.
+fn where_x_binds_to_placeholder(expression: &str) -> bool {
+    matches!(
+        parse_where_x_quantity_expression(expression),
+        Some(QuantityExpr::Ref {
+            qty: QuantityRef::Variable { ref name },
+        }) if name.eq_ignore_ascii_case("X")
+    )
+}
+
+/// Does an unbound `QuantityRef::Variable { name: "X" }` survive anywhere in `effect`?
+///
+/// Uses the key-anchored typed-evidence probe (`QUANTITY_KEYS`) rather than a
+/// hand-rolled 64-variant visitor: a value reached through a quantity key IS a quantity
+/// by construction, so no cross-enum name collision is reachable. `QuantityRef` must
+/// never be probed unanchored — ten of its variant names are shared with other
+/// internally-tagged enums (see `swallow_evidence`).
+fn effect_retains_unbound_x(effect: &Effect) -> bool {
+    crate::parser::swallow_evidence::UnitEvidence::of_effect(effect).any_quantity_ref(
+        |qty| matches!(qty, QuantityRef::Variable { name } if name.eq_ignore_ascii_case("X")),
+    )
 }
 
 /// CR 107.3i + CR 611.2c: Substitute a "where X is <expression>" binding into a

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -29,12 +29,12 @@ use crate::parser::oracle_ir::effect_chain::{ClauseIr, EffectChainIr};
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
     AttackSubject, CastingPermission, Comparator, ConjureSource, ContinuousModification,
-    ControllerRef, DamageSource, DelayedTriggerCondition, Duration, Effect, EffectScope,
-    FilterProp, GameRestriction, LibraryPosition, ManaSpendPermission, MultiTargetSpec,
-    ObjectScope, PlayerFilter, PreventionAmount, PreventionScope, PtValue, QuantityExpr,
-    QuantityRef, RestrictionPlayerScope, RoundingMode, SpellStackToGraveyardReplacement,
-    StaticCondition, StaticDefinition, SubAbilityLink, TargetChoiceTiming, TargetFilter,
-    TypeFilter, TypedFilter,
+    ControllerRef, DamageChannel, DamageSource, DelayedTriggerCondition, Duration, Effect,
+    EffectScope, FilterProp, GameRestriction, LibraryPosition, ManaSpendPermission,
+    MultiTargetSpec, ObjectScope, PlayerFilter, PreventionAmount, PreventionScope, PtValue,
+    QuantityExpr, QuantityRef, RestrictionPlayerScope, RoundingMode,
+    SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition, SubAbilityLink,
+    TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::counter::CounterType;
 use crate::types::game_state::{DistributionUnit, TargetSelectionConstraint};
@@ -7869,6 +7869,14 @@ pub(super) fn apply_where_x_effect_expression(
             mana_value_limit: amount,
             ..
         }
+        // CR 701.47a: "amass Orcs X, where X is …" (Fall of Cair Andros) — "put N
+        // +1/+1 counters on that creature", so N is the bound quantity. Without
+        // this arm the where-X binding was never attempted and the bare
+        // `Variable("X")` SURVIVED — amassing 0 counters at runtime while the face
+        // still rendered as fully supported. This match is NOT exhaustive over the
+        // 64 `QuantityExpr`-carrying variants, and the `_ => {}` below turns every
+        // unenumerated one into that same silent fabrication rather than a red.
+        | Effect::Amass { count: amount, .. }
         | Effect::Incubate { count: amount } => {
             bind_where_x_quantity(amount, where_x_expression, &mut unbound_where_x);
         }
@@ -8560,10 +8568,77 @@ fn apply_where_x_to_filter_prop(
     })
 }
 
+/// CR 120.10: the BARE demonstrative "that excess damage" — no subject, no
+/// "dealt this way" tail to anchor it.
+///
+/// The shared quantity grammar deliberately declines this phrase, because out of
+/// context its antecedent is ambiguous and the two readings resolve from DIFFERENT
+/// state (see [`rebind_context_dependent_where_x`]). Only the def-level licence can
+/// bind it, so it is recognised here rather than in the leaf combinators.
+fn parse_bare_excess_demonstrative(input: &str) -> OracleResult<'_, ()> {
+    all_consuming(value((), (tag("that "), tag("excess damage")))).parse(input)
+}
+
+/// CR 120.10 + CR 107.3c: licence a resolution-local demonstrative where-X tail
+/// against the definition's OWN condition, normalizing it onto the explicit phrase
+/// the shared quantity grammar already binds.
+///
+/// "…, where X is that excess damage" has two readings, and a context-free leaf
+/// combinator cannot separate them:
+///
+///   - Contest of Claws — "IF EXCESS DAMAGE WAS DEALT THIS WAY, discover X, where X
+///     is that excess damage." The sibling condition lowers to
+///     `AbilityCondition::PreviousEffectAmount { channel: Excess }` on THIS def. That
+///     condition is the LICENCE: it proves the antecedent is this resolution's own
+///     excess tally, which `last_effect_excess_amount` is holding and which
+///     `QuantityRef::PreviousEffectAmount { channel: Excess }` reads correctly.
+///
+///   - Fall of Cair Andros — "Whenever a creature an opponent controls is dealt
+///     excess noncombat damage, amass Orcs X, where X is that excess damage." The
+///     antecedent is the TRIGGERING EVENT. The triggered ability resolves as its own
+///     top-level chain and the depth-0 prelude has already CLEARED
+///     `last_effect_excess_amount`, so the resolution-local read would silently
+///     amass 0 while rendering as supported. It carries no such condition, so it is
+///     not licensed, and CR 107.3c keeps it an honest gap.
+///
+/// The disambiguator therefore lives exactly one layer above the leaf — on the def,
+/// next to the effect — which is why this runs here and not in `oracle_nom`.
+/// Rewriting onto the explicit phrase (rather than binding a second leaf) keeps ONE
+/// grammar and ONE binding authority.
+///
+/// This mirrors the `rebind_target_anaphor` seam below, which likewise resolves a
+/// demonstrative anaphor at the lowering layer against a disambiguator the leaf
+/// cannot see.
+fn rebind_context_dependent_where_x(
+    def: &AbilityDefinition,
+    where_x_expression: Option<&str>,
+) -> Option<String> {
+    let expression = where_x_expression?;
+    let normalized = expression.trim().trim_end_matches('.').to_ascii_lowercase();
+    parse_bare_excess_demonstrative(normalized.as_str()).ok()?;
+    // The licence: this definition's own condition reads the resolution-local
+    // EXCESS channel ("if excess damage was dealt this way").
+    matches!(
+        def.condition.as_ref(),
+        Some(AbilityCondition::PreviousEffectAmount {
+            channel: DamageChannel::Excess,
+            ..
+        })
+    )
+    .then(|| "the amount of excess damage dealt this way".to_string())
+}
+
 pub(super) fn apply_where_x_ability_expression(
     def: &mut AbilityDefinition,
     where_x_expression: Option<&str>,
 ) {
+    // CR 120.10: a context-dependent demonstrative tail is licensed against this
+    // def's condition and normalized onto the phrase the shared grammar binds,
+    // BEFORE any of the rewrites below consume it. Unlicensed demonstratives fall
+    // through unchanged and are reported as CR 107.3c gaps by the passes below.
+    let licensed_where_x = rebind_context_dependent_where_x(def, where_x_expression);
+    let where_x_expression = licensed_where_x.as_deref().or(where_x_expression);
+
     // CR 107.3i: All instances of X on an object share one value at any given
     // time. Substitute X in this AbilityDefinition's condition before walking
     // into effect/sub_ability/etc. The recursion below visits every chained

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7968,21 +7968,24 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     // variant. An optional leading player subject ("you", "that player", "target
     // opponent", …) redirects who performs the discover (Zoyowa's Justice: "Then
     // that player discovers X"). Bare "discover N" defaults to the controller.
-    let (discover_tp, discover_where_x) = strip_trailing_where_x(tp);
+    // CR 107.3c: the trailing "where X is …" tail is consumed here ONLY so the
+    // discover phrase itself parses to its end. The BINDING is deliberately not
+    // decided at this layer: a clause parser cannot see the definition's
+    // condition, and the condition is exactly what licences a demonstrative
+    // ("If excess damage was dealt this way, discover X, where X is that excess
+    // damage" — Contest of Claws). Deciding here emitted the gap node before the
+    // condition was ever attached, which destroyed the Discover shape the
+    // def-level pass needed in order to disambiguate.
+    //
+    // `apply_where_x_effect_expression` (lower.rs) is the SINGLE AUTHORITY for
+    // this binding: it carries an `Effect::Discover` arm, binds the limit through
+    // `bind_where_x_quantity`, and converts a failed bind into an
+    // `Effect::unimplemented("where_x_binding", …)` gap — the identical payload
+    // this site used to emit, now raised one layer up where the condition is in
+    // scope.
+    let (discover_tp, _) = strip_trailing_where_x(tp);
     if let Some((discover_player, limit, rest_orig)) = parse_discover_with_player(discover_tp) {
         if rest_orig.trim().is_empty() {
-            // CR 107.3c: "discover X, where X is <expr>" — the clause DEFINES X.
-            // If the definition has no typed home, report the gap instead of
-            // fabricating a raw-text placeholder that resolves to 0 (a discover
-            // for mana value 0) while still reading as supported.
-            let Some(limit) = apply_where_x_quantity_expression(limit, discover_where_x.as_deref())
-            else {
-                let expression = discover_where_x.unwrap_or_default();
-                return parsed_clause(Effect::unimplemented(
-                    "where_x_binding",
-                    format!("where X is {expression}"),
-                ));
-            };
             return parsed_clause(Effect::Discover {
                 mana_value_limit: limit,
                 player: discover_player,

--- a/crates/engine/src/parser/swallow_evidence.rs
+++ b/crates/engine/src/parser/swallow_evidence.rs
@@ -422,6 +422,20 @@ impl UnitEvidence {
         }
     }
 
+    /// Build a probe tree over a single [`Effect`] subtree.
+    ///
+    /// Same contract as [`Self::of`] — a serialization failure yields an empty tree,
+    /// which yields NO evidence, which is the conservative direction for every probe
+    /// built on it. Used by the where-X lowering pass to assert its own post-condition
+    /// (CR 107.3c): the pass enumerates only some of the `QuantityExpr`-carrying
+    /// `Effect` variants, so it needs to ask whether an unbound X survived anywhere in
+    /// the effect it just rewrote, without hand-rolling a 64-variant visitor.
+    pub(crate) fn of_effect(effect: &crate::types::ability::Effect) -> Self {
+        Self {
+            root: serde_json::to_value(effect).unwrap_or(Value::Null),
+        }
+    }
+
     /// Visit nodes depth-first, short-circuiting on the first `true`.
     ///
     /// `key` is the object key the node is stored under (`None` at the root). Array

--- a/crates/engine/tests/integration/excess_damage_quantity_channel.rs
+++ b/crates/engine/tests/integration/excess_damage_quantity_channel.rs
@@ -29,9 +29,11 @@
 //! Oracle text below is read from the card export, not from memory.
 
 use engine::game::quantity::resolve_quantity;
-use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario::{GameScenario, P0, P1};
 use engine::parser::parse_oracle_text;
 use engine::types::ability::{DamageChannel, Effect, QuantityExpr, QuantityRef};
+use engine::types::game_state::{CastOfferKind, WaitingFor};
+use engine::types::mana::ManaCost;
 use engine::types::phase::Phase;
 
 /// Pull the single quantity a parsed one-clause ability carries.
@@ -99,10 +101,15 @@ fn excess_damage_this_way_reads_the_excess_not_the_total_and_not_zero() {
 /// A context-free leaf combinator cannot separate them; the disambiguator (the
 /// sibling "dealt this way" condition vs. the trigger condition) lives one layer up.
 /// Binding the bare demonstrative here would have swapped a crude raw-text
-/// fabrication for a better-disguised one. Until the clause-layer rebind exists,
-/// it stays red.
+/// fabrication for a better-disguised one.
+///
+/// The def-level licence now EXISTS (`rebind_context_dependent_where_x`), so this
+/// case is no longer "pending" — it is the standing NEGATIVE side of that licence.
+/// This oracle text carries NO condition, so nothing licences a resolution-local
+/// read and CR 107.3c keeps it a gap. If the licence were ever widened to bind the
+/// demonstrative unconditionally, this test is what turns red.
 #[test]
-fn bare_that_excess_damage_stays_an_honest_red_pending_clause_layer_rebind() {
+fn bare_that_excess_damage_stays_an_honest_red_without_a_licensing_condition() {
     let parsed = parse_oracle_text(
         "You gain X life, where X is that excess damage.",
         "~",
@@ -261,6 +268,152 @@ fn subjectless_amount_of_excess_phrase_reads_the_excess_channel() {
         resolved, 5,
         "\"the amount of excess damage dealt this way\" must read the EXCESS channel \
          (5), not the total (9). Got {resolved} from {expr:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #91: the where-X binding is a DEF-LEVEL single authority.
+//
+// "that excess damage" is a demonstrative whose antecedent a context-free leaf
+// combinator cannot resolve. The disambiguator is the DEF's own condition:
+//
+//   Contest of Claws     "IF EXCESS DAMAGE WAS DEALT THIS WAY, discover X, where
+//                         X is that excess damage."
+//                        -> AbilityCondition::PreviousEffectAmount { channel:
+//                           Excess } sits on the same def. That condition is the
+//                           LICENCE: it proves the antecedent is this resolution's
+//                           own excess tally, which is live and correct to read.
+//
+//   Fall of Cair Andros  "Whenever a creature an opponent controls is dealt excess
+//                         noncombat damage, amass Orcs X, where X is that excess
+//                         damage."
+//                        -> NO such condition. The antecedent is the TRIGGERING
+//                           EVENT, and the depth-0 prelude has already cleared
+//                           `last_effect_excess_amount`. Binding here would amass 0
+//                           while rendering as supported. It stays an honest red.
+//
+// The licence check therefore has to run where the condition is visible — the
+// def-level pass (`apply_where_x_ability_expression`). It could not, because the
+// Discover clause parser made its OWN bind-or-red decision at clause-parse time,
+// before any condition was attached, and by def-level time the Discover shape was
+// already gone (replaced by the gap node).
+// ---------------------------------------------------------------------------
+
+/// CR 120.10 + CR 701.57a — Contest of Claws, driven through the REAL cast
+/// pipeline (Oracle text verbatim from MTGJSON, not paraphrased).
+///
+/// A 5-power creature dealt into a 2-toughness creature deals 3 excess (CR 120.10:
+/// "excess damage equal to the difference"). The excess is stamped by the LIVE
+/// damage effect during the same resolution — not hand-written onto the state —
+/// and the discover in the very next instruction must run for exactly that 3.
+///
+/// The discover offer carries the RESOLVED N (`discover_value`), so this reads the
+/// bound quantity straight out of live pause-state. The two outcomes are cleanly
+/// separable:
+///   - bound: `discover_value == 3` and the mana-value-3 card is the hit.
+///   - fabricated: discover for 0 — no nonland card has mana value <= 0, so the
+///     library is milled to exile and NO offer is ever raised.
+#[test]
+fn contest_of_claws_discovers_for_the_resolution_chain_excess() {
+    // Verbatim Oracle text (MTGJSON `AtomicCards.json`).
+    const CONTEST_OF_CLAWS: &str = "Target creature you control deals damage equal to its power to another target creature. If excess damage was dealt this way, discover X, where X is that excess damage. (Exile cards from the top of your library until you exile a nonland card with that mana value or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.)";
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // 5 power into 2 toughness => 3 excess (CR 120.10).
+    let dealer = scenario.add_creature(P0, "Dealer", 5, 5).id();
+    let victim = scenario.add_creature(P1, "Victim", 0, 2).id();
+    // The discover hit: a nonland card whose mana value equals the excess.
+    let hit = scenario
+        .add_spell_to_library_top(P0, "Discover Hit", false)
+        .with_mana_cost(ManaCost::generic(3))
+        .id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Contest of Claws", false, CONTEST_OF_CLAWS)
+        .id();
+    let mut runner = scenario.build();
+
+    let outcome = runner
+        .cast(spell)
+        .target_objects(&[dealer, victim])
+        .resolve();
+
+    // CR 120.10: the live damage effect stamped the excess channel.
+    assert_eq!(
+        outcome.state().last_effect_excess_amount,
+        Some(3),
+        "the real resolution chain must stamp 3 excess (5 power dealt into 2 toughness)",
+    );
+
+    match outcome.final_waiting_for() {
+        WaitingFor::CastOffer {
+            kind:
+                CastOfferKind::Discover {
+                    hit_card,
+                    discover_value,
+                    ..
+                },
+            ..
+        } => {
+            assert_eq!(
+                *discover_value, 3,
+                "CR 107.3c + CR 120.10: \"where X is that excess damage\" must bind X to the \
+                 3 excess this resolution actually dealt, not fabricate 0",
+            );
+            assert_eq!(
+                *hit_card, hit,
+                "discover 3 must hit the mana-value-3 card on top of the library",
+            );
+        }
+        other => panic!(
+            "expected a Discover offer for 3 — \"where X is that excess damage\" did not bind. \
+             The resolution halted at: {other:?}",
+        ),
+    }
+}
+
+/// GATE — Fall of Cair Andros must stay an HONEST RED (Oracle text verbatim).
+///
+/// Its "that excess damage" reads the TRIGGERING EVENT, and the def carries no
+/// "dealt this way" condition to licence a resolution-local read. The licence
+/// check is the condition, so this face has none and must not bind. Binding it
+/// would silently amass 0 while rendering as fully supported — strictly worse
+/// than the gap node.
+///
+/// This is the negative control that keeps the def-level rebind honest: a fix that
+/// bound the demonstrative unconditionally would turn this red green and pass every
+/// positive witness above.
+#[test]
+fn fall_of_cair_andros_trigger_excess_stays_an_honest_red() {
+    let parsed = parse_oracle_text(
+        "Whenever a creature an opponent controls is dealt excess noncombat damage, amass Orcs X, \
+         where X is that excess damage. (Put X +1/+1 counters on an Army you control. It's also an \
+         Orc. If you don't control an Army, create a 0/0 black Orc Army creature token first.)",
+        "Fall of Cair Andros",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+
+    // The clause lives in the trigger's execute step, so look there as well as in
+    // the top-level abilities — a gap in either place is the honest red.
+    let has_gap = parsed
+        .abilities
+        .iter()
+        .any(|def| matches!(&*def.effect, Effect::Unimplemented { .. }))
+        || parsed
+            .triggers
+            .iter()
+            .filter_map(|t| t.execute.as_ref())
+            .any(|e| matches!(&*e.effect, Effect::Unimplemented { .. }));
+
+    assert!(
+        has_gap,
+        "Fall of Cair Andros' \"that excess damage\" names the TRIGGERING EVENT's excess, not a \
+         resolution-local tally, and the def carries no \"dealt this way\" condition to licence \
+         one. It must stay an Effect::unimplemented gap — binding it would amass 0 while \
+         rendering as supported. Parsed abilities: {:?} triggers: {:?}",
+        parsed.abilities, parsed.triggers,
     );
 }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -947,6 +947,7 @@ mod vannifar_cloak_from_hand;
 mod veteran_bodyguard_tap_redirect;
 mod weeping_angel_combat_prevention;
 mod where_x_quantity_channel_binds;
+mod where_x_totality_guard;
 mod winding_way_reveal_partition_2931;
 mod witchs_oven_food_tokens;
 mod xantid_swarm_defending_player_cant_cast;

--- a/crates/engine/tests/integration/where_x_totality_guard.rs
+++ b/crates/engine/tests/integration/where_x_totality_guard.rs
@@ -1,0 +1,224 @@
+//! CR 107.3c — the where-X lowering pass must assert its OWN post-condition.
+//!
+//! `apply_where_x_effect_expression` rewrites the quantity slots of the `Effect`
+//! variants it enumerates. That match is NOT exhaustive: of the 64 variants carrying a
+//! `QuantityExpr`, only 22 are enumerated — the other 42 fall through a `_ => {}`
+//! (task #95 binds the representable ones).
+//!
+//! Before the totality guard, the wildcard's failure mode was a FABRICATION, not a red:
+//! the effect kept its bare `QuantityRef::Variable { name: "X" }`, which resolves to 0
+//! at runtime (amass 0 / surveil 0 / discard 0) while the face still rendered as fully
+//! supported. That lie is invisible to a red-count ledger (there is no `Unimplemented`
+//! node to count) AND to the zero-raw-text invariant ("X" is the legitimate alias). A
+//! control with an escape hatch is not a control.
+//!
+//! THE TRAP THIS FILE EXISTS TO GUARD: the guard must be keyed on the EXPRESSION, never
+//! on tree-presence of `Variable("X")`. Two families legitimately bind X TO the
+//! placeholder, and for them a residual `Variable("X")` is the CORRECT lowering:
+//!
+//!   Join Forces (CR 107.3i)   "where X is the total amount of mana paid this way"
+//!                             -> resolved through the `chosen_x` machinery.
+//!   Constraint tails (608.2g) "where X is less than or equal to <bound>"
+//!                             -> BOUNDS the player's chosen X rather than defining it.
+//!
+//! A naive tree-presence guard would flip BOTH families from green to red. The control
+//! tests below prove that: each asserts the face still carries a residual `Variable("X")`
+//! (so a tree-presence guard WOULD fire on it) and that it nonetheless stays bound. The
+//! control can fail, which is what makes it a control.
+//!
+//! Oracle text below is verbatim from MTGJSON, never paraphrased.
+
+use engine::parser::parse_oracle_text;
+use engine::types::ability::Effect;
+use serde_json::Value;
+
+/// Every `QuantityRef::Variable { name: "X" }` reachable in a parsed face.
+///
+/// This is deliberately the NAIVE predicate — tree-presence, exactly what the totality
+/// guard must NOT key on. The preserve tests use it to prove a naive guard would fire.
+fn retains_variable_x(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            let is_x = map.get("type").and_then(Value::as_str) == Some("Variable")
+                && map
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .is_some_and(|n| n.eq_ignore_ascii_case("X"));
+            is_x || map.values().any(retains_variable_x)
+        }
+        Value::Array(items) => items.iter().any(retains_variable_x),
+        _ => false,
+    }
+}
+
+struct Parsed {
+    tree: Value,
+    has_where_x_gap: bool,
+}
+
+fn parse(oracle: &str, name: &str, types: &[&str]) -> Parsed {
+    let types: Vec<String> = types.iter().map(|t| (*t).to_string()).collect();
+    let parsed = parse_oracle_text(oracle, name, &[], &types, &[]);
+    let tree = serde_json::to_value(&parsed).expect("parse tree serializes");
+
+    fn gap(v: &Value) -> bool {
+        match v {
+            Value::Object(m) => {
+                let hit = m.get("type").and_then(Value::as_str) == Some("Unimplemented")
+                    && m.get("name").and_then(Value::as_str) == Some("where_x_binding");
+                hit || m.values().any(gap)
+            }
+            Value::Array(a) => a.iter().any(gap),
+            _ => false,
+        }
+    }
+    let has_where_x_gap = gap(&tree);
+    Parsed {
+        tree,
+        has_where_x_gap,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PRESERVE CONTROLS — the naive guard MUST be able to fail these.
+// ---------------------------------------------------------------------------
+
+/// CR 107.3i — Join Forces. "where X is the total amount of mana paid this way" binds X
+/// to the PLACEHOLDER on purpose: the value arrives through `chosen_x` after the
+/// pay-any-amount loop, so `Variable("X")` IS the correct lowering.
+///
+/// This is one of exactly 6 faces in the pool (5 Join Forces + Well of Lost Dreams) for
+/// which a residual `Variable("X")` is legitimate. A tree-presence guard flips it to red.
+#[test]
+fn join_forces_placeholder_bind_survives_the_totality_guard() {
+    let parsed = parse(
+        "Join forces — Starting with you, each player may pay any amount of mana. Each player \
+         searches their library for up to X basic land cards, where X is the total amount of \
+         mana paid this way, puts them onto the battlefield tapped, then shuffles.",
+        "Collective Voyage",
+        &["Sorcery"],
+    );
+
+    assert!(
+        !parsed.has_where_x_gap,
+        "CR 107.3i: Join Forces binds X to the placeholder deliberately (the value arrives via \
+         chosen_x after the pay-any-amount loop). The totality guard is keyed on the EXPRESSION, \
+         so it must leave this face bound. A where_x_binding gap here means the guard regressed \
+         to NAIVE tree-presence — which is exactly the failure this control exists to catch. \
+         Tree: {:?}",
+        parsed.tree
+    );
+
+    // NON-VACUITY: the face genuinely still carries a residual Variable("X"), which is what a
+    // naive tree-presence guard would have fired on. Without this, "no gap" could pass for the
+    // wrong reason (e.g. the clause never parsed) and the control would prove nothing.
+    assert!(
+        retains_variable_x(&parsed.tree),
+        "control is vacuous: Collective Voyage no longer carries a residual Variable(\"X\"), so \
+         it is no longer a witness that a tree-presence guard would misfire. Tree: {:?}",
+        parsed.tree
+    );
+}
+
+/// CR 608.2g — a comparator-shaped tail CONSTRAINS the player's chosen X rather than
+/// defining it. Well of Lost Dreams pays {X} and draws X; the bound only limits what may
+/// be chosen, and the drawn count is the amount actually paid (via `chosen_x`).
+#[test]
+fn constraint_tail_placeholder_bind_survives_the_totality_guard() {
+    let parsed = parse(
+        "Whenever you gain life, you may pay {X}, where X is less than or equal to the amount \
+         of life you gained. If you do, draw X cards.",
+        "Well of Lost Dreams",
+        &["Artifact"],
+    );
+
+    assert!(
+        !parsed.has_where_x_gap,
+        "CR 608.2g: the comparator tail BOUNDS the chosen X, it does not define it, so \
+         Variable(\"X\") is the correct lowering and the face must stay bound. A gap here means \
+         the guard regressed to NAIVE tree-presence. Tree: {:?}",
+        parsed.tree
+    );
+
+    // NON-VACUITY, as above: this face really is a witness a tree-presence guard would misfire on.
+    assert!(
+        retains_variable_x(&parsed.tree),
+        "control is vacuous: Well of Lost Dreams no longer carries a residual Variable(\"X\"). \
+         Tree: {:?}",
+        parsed.tree
+    );
+}
+
+// ---------------------------------------------------------------------------
+// THE GUARD ITSELF — an unenumerated variant must RED, never fabricate.
+// ---------------------------------------------------------------------------
+
+/// CR 107.3c — `Effect::Surveil` is one of the 42 `QuantityExpr` carriers the pass does
+/// NOT enumerate. Its where-X expression is perfectly representable, but until #95 binds
+/// it the pass cannot rewrite the slot — so the totality guard must turn it into an
+/// honest gap rather than leave `surveil Variable("X")`, which surveils 0 while reading
+/// as fully supported.
+///
+/// This is the positive witness for the guard: without it, this face is a lying green.
+#[test]
+fn unenumerated_effect_variant_reds_instead_of_fabricating() {
+    let parsed = parse(
+        "Flying\nWhenever you attack, surveil X, where X is the number of opponents being \
+         attacked.",
+        "Dimir Strandcatcher",
+        &["Creature"],
+    );
+
+    assert!(
+        parsed.has_where_x_gap,
+        "CR 107.3c: Surveil is NOT among the effect variants apply_where_x_effect_expression \
+         enumerates, so the where-X slot was never rewritten. The totality guard must report \
+         the gap. Leaving Variable(\"X\") here surveils 0 at runtime while rendering as fully \
+         supported — a fabrication invisible to both the red-count ledger and the \
+         zero-raw-text invariant. Tree: {:?}",
+        parsed.tree
+    );
+
+    // And the fabrication is genuinely gone, not merely accompanied by a gap.
+    assert!(
+        !retains_variable_x(&parsed.tree),
+        "the bare Variable(\"X\") must be REPLACED by the gap node, not left beside it. Tree: {:?}",
+        parsed.tree
+    );
+}
+
+/// NEGATIVE CONTROL for the guard — an ENUMERATED variant whose expression IS
+/// representable must still bind to green. Without this, a guard that simply redded every
+/// where-X face would pass every test above.
+#[test]
+fn enumerated_bindable_where_x_still_binds_green() {
+    let parsed = parse(
+        "You gain X life, where X is the number of creatures you control.",
+        "~",
+        &["Sorcery"],
+    );
+
+    assert!(
+        !parsed.has_where_x_gap,
+        "an enumerated variant (GainLife) with a representable expression must still BIND. A \
+         gap here means the totality guard is over-firing and redding good faces. Tree: {:?}",
+        parsed.tree
+    );
+
+    let abilities = parse_oracle_text(
+        "You gain X life, where X is the number of creatures you control.",
+        "~",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+    assert!(
+        abilities
+            .abilities
+            .iter()
+            .any(|d| matches!(&*d.effect, Effect::GainLife { .. })),
+        "reach-guard: the face must actually parse to GainLife, so the assertion above is not \
+         passing because the clause failed to parse at all. Parsed: {:?}",
+        abilities.abilities
+    );
+}


### PR DESCRIPTION
- **refactor(parser): make where-X binding a def-level single authority (Discover stops deciding)**
- **feat(parser): licence the resolution-local "that excess damage" demonstrative at the def-level seam**
- **fix(parser): make the where-X pass TOTAL — an unenumerated effect must red, never fabricate**
