### PR TITLE
fix(security): bound the loop-shortcut iteration count (pre-existing remote DoS in #5672)

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1095,6 +1095,12 @@ fn until_lethal_fallback(state: &mut GameState, result: &mut ActionResult, commi
 /// player drain pins ALL opponents every cycle (`TargetPin::Player` is constant, period 1). The
 /// seam is built for generality; a multi-cycle aggregation is fail-safe (an object loop reaching
 /// the arm measures 1 cycle, finds no faller, does not crown).
+///
+/// CR 732.2a SAFETY LIMIT: the returned period is clamped to `MAX_SHORTCUT_CYCLES`. Both
+/// consumers derive their `0..period` range from this one helper (`validate_pins` and
+/// `apply_until_lethal_shortcut`), so the clamp bounds validate + drive coherently;
+/// crown-soundness holds — every crownable loop has period 1, so the clamp only truncates a
+/// hostile over-cap schedule into the conservative manual-fallback arm, never a mis-crown.
 fn shortcut_drive_period(
     template: Option<&crate::analysis::decision_template::DecisionTemplate>,
 ) -> crate::analysis::decision_template::IterationIndex {
@@ -1117,7 +1123,16 @@ fn shortcut_drive_period(
         })
         .max()
         .unwrap_or(1)
-        .max(1)
+        // CR 732.2a SAFETY LIMIT: the drive period is STRUCTURALLY unbounded in the engine —
+        // its length is the client template schedule's own length. On the WS transport the
+        // 8 KB inbound-frame cap (phase-server/src/main.rs:409/1420) already bounds a hostile
+        // schedule to a few hundred entries (~1-2 s stall, not a million-cycle remote DoS),
+        // but in-process callers (WASM/Tauri/local) bypass that cap, so clamp here AT THE
+        // SOURCE for every caller. Real schedules rotate over a handful of object sources
+        // (period ≪ cap), so this is invisible to every legitimate loop; a clamped-shorter
+        // drive measures a smaller (more conservative) delta ⇒ FEWER crowns / more manual
+        // fallbacks, never a wrong crown.
+        .clamp(1, MAX_SHORTCUT_CYCLES)
 }
 
 /// PR-7 Combo-UI Stage 2: the typed result of driving ONE whole loop-shortcut cycle on a
@@ -1863,6 +1878,35 @@ fn handle_declare_shortcut(
             }
         }
     }
+    // CR 732.2a SAFETY LIMIT (see MAX_SHORTCUT_CYCLES): reject an over-cap Fixed count at
+    // the single authority — BEFORE the proposal is built — into the same fail-closed
+    // manual-play handback the pin validation above uses. This is THE catastrophic remote
+    // vector: `Fixed(u32)` scalar-encodes up to ~4.3e9 cycles in ~10 bytes, sailing through
+    // the 8 KB WS frame cap → one GameState clone + drive per cycle. Both confirmation paths
+    // (solitaire-immediate below, APNAP Accept) consume this one proposal, and both drive
+    // helpers (materialize_fixed_shortcut / materialize_object_growth_shortcut) read `n` from
+    // it, so this one check bounds every Fixed drive on every transport. The drive helpers do
+    // NOT re-check.
+    // Exhaustive (no wildcard) so a future `IterationCount` variant — e.g. the reserved
+    // `UntilResource`, which would carry its OWN unbounded count — build-breaks HERE and
+    // forces a bound decision rather than silently regressing this cap.
+    match &count {
+        crate::analysis::decision_template::IterationCount::Fixed(n)
+            if *n > MAX_SHORTCUT_CYCLES =>
+        {
+            priority::reset_priority(state);
+            // CR 800.4a: hand priority to the next living seat.
+            state.waiting_for = WaitingFor::Priority {
+                player: living_priority_seat(state),
+            };
+            result.waiting_for = state.waiting_for.clone();
+            return Ok(result);
+        }
+        // Under-cap `Fixed` and `UntilLethal` (period-bounded by `shortcut_drive_period`)
+        // proceed to the proposal.
+        crate::analysis::decision_template::IterationCount::Fixed(_)
+        | crate::analysis::decision_template::IterationCount::UntilLethal => {}
+    }
     let proposal = crate::analysis::loop_check::ShortcutProposal {
         proposer: offer.proposer,
         predicted_winner: offer.predicted_winner,
@@ -2354,6 +2398,17 @@ fn finish_completed_or_interrupted_until_stack_empty_sessions(state: &mut GameSt
 
     !finished.is_empty()
 }
+
+// CR 732.2a SAFETY LIMIT: a shortcut is "a loop that repeats a specified number of times";
+// the CR places NO board-relative upper bound, so this is an engine implementation cap
+// against an absurd/hostile count — NOT a rules constraint. It bounds both a `Fixed(n)`
+// cycle count (handle_declare_shortcut) and a template drive period (shortcut_drive_period).
+// Motivating vector: a `u32` count scalar-encodes up to ~4.3e9 cycles in ~10 JSON bytes, so
+// it sails through the 8 KB inbound WS frame cap (phase-server/src/main.rs:409/1420) yet
+// would force ~4.3e9 GameState clones — a byte cap cannot see it, only this count cap can.
+// 1_000 is generous vs any honest Fixed count (~10x KCI-style loops); worst-case bounded
+// cost is 1_000 cycles x <=10_000 beats = 1e7.
+const MAX_SHORTCUT_CYCLES: u32 = 1_000;
 
 fn auto_pass_loop_max_iterations(state: &GameState) -> usize {
     let living_players = state
@@ -9507,5 +9562,16 @@ mod stage2_injector_tests {
             (5, b.clone()),
         ]))]);
         assert_eq!(shortcut_drive_period(Some(&pw)), 2, "Piecewise(2) ⇒ 2");
+
+        // CR 732.2a SAFETY LIMIT: an over-cap schedule clamps to MAX_SHORTCUT_CYCLES.
+        // Revert-probe: restore `.max(1)` (drop the `.clamp`) ⇒ returns MAX+5 (1005) ≠ 1000.
+        let oversized = mk(vec![TargetPin::Scheduled(TargetSchedule::RoundRobin(
+            vec![a.clone(); (MAX_SHORTCUT_CYCLES + 5) as usize],
+        ))]);
+        assert_eq!(
+            shortcut_drive_period(Some(&oversized)),
+            MAX_SHORTCUT_CYCLES,
+            "RoundRobin(MAX+5) clamps to MAX_SHORTCUT_CYCLES"
+        );
     }
 }

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -1686,6 +1686,67 @@ fn b3_materialize_stop_short() {
     );
 }
 
+/// PR-7 DoS cap (CR 732.2a SAFETY LIMIT): a `Fixed` count over `MAX_SHORTCUT_CYCLES` is
+/// handed back to manual play with NO drive. This is the engine-side count cap that stops the
+/// catastrophic 4-byte remote vector — `Fixed(u32)` scalar-encodes ~4.3e9 cycles in ~10 bytes,
+/// sailing through the 8 KB WS frame cap. The count is HARDCODED as `Fixed(u32::MAX)`; the cap
+/// const is private to the engine crate and invisible across this integration-test boundary.
+///
+/// VACUITY TRAP (PR-7): a handback lands on `WaitingFor::Priority`, and so does the cap-ABSENT
+/// stop-short path (a drive commits + stops there too). So `waiting_for` alone is an INVARIANT,
+/// not a discriminator. The DISCRIMINATOR is the observable DRIVE: `life(P1) == l0` proves the
+/// cap fired before any cycle ran. The revert-probe (delete Edit B's guard body) opens APNAP,
+/// Accept drives, and on this life-DRAIN fixture P1 crosses lethal in ~l0/delta cycles (tens —
+/// `materialize_fixed_shortcut`'s CrossLethal arm commits + stops, so `u32::MAX` does NOT hang)
+/// ⇒ `life(P1) ≤ 0` + GameOver ⇒ `assert_eq!(life(P1), l0)` FAILS.
+///
+/// Positive reach-guard: `b3_materialize_stop_short` (n=3) proves the harness DOES drive when
+/// n ≤ cap, so T1's no-drive is the cap firing, not a dead fixture.
+#[test]
+fn over_cap_fixed_count_hands_back_with_no_drive() {
+    let (mut runner, l0, _cleric) = reach_2p_optional_drain_offer();
+
+    runner
+        .act(GameAction::DeclareShortcut {
+            count: IterationCount::Fixed(u32::MAX),
+            template: None,
+        })
+        .expect("declare Fixed(u32::MAX)");
+
+    // Symmetric-across-revert Accept: with Edit B active the declare hands back immediately
+    // (APNAP never opens), so the Accept would be illegal — issue it ONLY when actually parked
+    // at RespondToShortcut (the cap-absent revert path).
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::RespondToShortcut { .. }
+    ) {
+        runner
+            .act(GameAction::RespondToShortcut {
+                response: ShortcutResponse::Accept,
+            })
+            .expect("accept");
+    }
+
+    // DRIVE discriminator: the cap fired BEFORE any cycle ran, so P1's life is untouched.
+    assert_eq!(
+        life(&runner, P1),
+        l0,
+        "over-cap Fixed hands back with NO drive — P1 life unchanged (the discriminator)"
+    );
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::GameOver { .. }),
+        "no crown — the drive never ran, got {:?}",
+        runner.state().waiting_for
+    );
+    // SANITY CHECK ONLY (not the discriminator — see the vacuity trap in the doc): the handback
+    // lands on the living seat, mirroring the stop-short manual fallback.
+    assert_eq!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { player: P0 },
+        "handback to living_priority_seat (P0)"
+    );
+}
+
 /// B3-materialize-cross-lethal ⭐ (N ≥ cycles-to-lethal, un-clamped per Q2): commits and
 /// stops at a determinate GameOver mid-drive instead of rolling back to manual play.
 /// Revert-failing / discriminating vs stop-short: under a flat "non-Priority ⇒ rollback"

--- a/crates/server-core/src/game_action_payload_guard.rs
+++ b/crates/server-core/src/game_action_payload_guard.rs
@@ -281,12 +281,54 @@ pub fn guard_game_action_payload(action: &GameAction) -> Result<(), String> {
         GameAction::SelectModes { indices } => {
             bound_list("SelectModes.indices", indices.len())?;
         }
-        // CR 732.2a: a client-supplied loop-shortcut declaration. Phase 3 requires
-        // `template: None`; when present (Phase 4), bound its pin list (mirrors the
-        // `SelectModes.indices` list bound). `count` is a small enum — nothing unbounded.
-        GameAction::DeclareShortcut { template, .. } => {
+        // CR 732.2a: a client-supplied loop-shortcut declaration. The prior comment here
+        // ("`count` is a small enum — nothing unbounded") was FALSE: `IterationCount::Fixed`
+        // wraps an unbounded `u32` and IS the real DoS vector — bounded here as a coarse
+        // WS-level belt (mirrors `ChooseManaColor.count`; the engine's MAX_SHORTCUT_CYCLES is
+        // the authoritative cap). The nested template vecs (a `Targets` pin's `Vec<TargetPin>`
+        // and each `Scheduled` pin's schedule `Vec`) are bounded as DEFENSE-IN-DEPTH: the
+        // 8 KB inbound WS frame cap (phase-server/src/main.rs:409/1420) already keeps a remote
+        // nested payload to a few hundred structs, and this guard runs POST-deserialize
+        // (client_message_wire_guard.rs:50), so it bounds downstream compute/clone work — not
+        // the transient serde allocation — for in-process callers that bypass the frame cap.
+        // Exhaustive matches (no wildcard) force a future variant to be classified here.
+        GameAction::DeclareShortcut { count, template } => {
+            use engine::analysis::decision_template::{
+                IterationCount, PinnedDecision, TargetPin, TargetSchedule,
+            };
+            // Exhaustive (no wildcard): a future `IterationCount` count variant build-breaks
+            // here so its wire bound is a conscious decision, not a silent gap.
+            match count {
+                IterationCount::Fixed(n) => bound_batch_count("DeclareShortcut.count", *n)?,
+                IterationCount::UntilLethal => {}
+            }
             if let Some(template) = template {
                 bound_list("DeclareShortcut.template.decisions", template.decisions.len())?;
+                for decision in &template.decisions {
+                    match decision {
+                        PinnedDecision::Targets { targets, .. } => {
+                            bound_list("DeclareShortcut.template.targets", targets.len())?;
+                            for target in targets {
+                                match target {
+                                    TargetPin::Scheduled(TargetSchedule::RoundRobin(v)) => {
+                                        bound_list("DeclareShortcut.template.schedule", v.len())?;
+                                    }
+                                    TargetPin::Scheduled(TargetSchedule::Piecewise(v)) => {
+                                        bound_list("DeclareShortcut.template.schedule", v.len())?;
+                                    }
+                                    TargetPin::Scheduled(TargetSchedule::Constant(_))
+                                    | TargetPin::ByIdentity(_)
+                                    | TargetPin::Player(_) => {}
+                                }
+                            }
+                        }
+                        PinnedDecision::Order { .. }
+                        | PinnedDecision::Mode { .. }
+                        | PinnedDecision::MayChoice { .. }
+                        | PinnedDecision::UnlessBreak { .. }
+                        | PinnedDecision::ConvokeTaps { .. } => {}
+                    }
+                }
             }
         }
         GameAction::ChooseOutsideGameCards { selections } => {

--- a/crates/server-core/tests/game_action_payload_guard.rs
+++ b/crates/server-core/tests/game_action_payload_guard.rs
@@ -3,7 +3,7 @@
 
 use engine::analysis::decision_template::{
     DecisionGroupKey, DecisionKind, DecisionSlot, DecisionTemplate, IterationCount,
-    MayChoiceOption, PinnedDecision, ReplayMode,
+    MayChoiceOption, PinnedDecision, ReplayMode, TargetPin, TargetSchedule,
 };
 use engine::types::actions::{DebugAction, DebugTokenRequest};
 use engine::types::counter::CounterType;
@@ -249,4 +249,70 @@ fn accepts_within_bound_declare_shortcut_template() {
         template: None,
     })
     .is_ok());
+}
+
+#[test]
+fn rejects_over_cap_fixed_shortcut_count() {
+    // T3a (CR 732.2a): `Fixed(u32::MAX)` is the real Vector-1 count; the WS belt must reject
+    // it. Revert-probe: restore the `..` that discarded `count` ⇒ guard returns Ok ⇒ FAIL.
+    let action = GameAction::DeclareShortcut {
+        count: IterationCount::Fixed(u32::MAX),
+        template: None,
+    };
+    assert!(
+        guard_game_action_payload(&action).is_err(),
+        "an over-cap Fixed shortcut count must be rejected at the wire belt"
+    );
+}
+
+#[test]
+fn accepts_realistic_fixed_shortcut_count() {
+    // T3b: a plausible honest count must pass — proves the bound is real, not vacuous /
+    // wrong-direction. Revert-probe: tighten the threshold to 0 ⇒ Fixed(50) rejects ⇒ FAIL.
+    let action = GameAction::DeclareShortcut {
+        count: IterationCount::Fixed(50),
+        template: None,
+    };
+    assert!(
+        guard_game_action_payload(&action).is_ok(),
+        "a realistically sized Fixed shortcut count must be accepted"
+    );
+}
+
+#[test]
+fn rejects_over_cap_shortcut_schedule() {
+    // T3c (REV-1 nested memory bound): the decision list and the targets list are both under
+    // cap, so ONLY the oversized RoundRobin schedule vec can reject — a discriminating check
+    // of the nested `Scheduled` bound (defense-in-depth for in-process callers past the WS
+    // frame cap). Revert-probe: drop the schedule `bound_list` ⇒ guard returns Ok ⇒ FAIL.
+    let src = YieldTarget::AllCopies {
+        card_id: CardId(1),
+        trigger_description: None,
+    };
+    let slot = DecisionSlot {
+        source: src.clone(),
+        index: 0,
+    };
+    let action = GameAction::DeclareShortcut {
+        count: IterationCount::UntilLethal,
+        template: Some(DecisionTemplate {
+            owner: PlayerId(0),
+            decisions: vec![PinnedDecision::Targets {
+                slot,
+                targets: vec![TargetPin::Scheduled(TargetSchedule::RoundRobin(vec![
+                    src;
+                    MAX_ACTION_LIST_LEN + 1
+                ]))],
+            }],
+            replay: ReplayMode::Static,
+            key: DecisionGroupKey {
+                sources: vec![],
+                kind: DecisionKind::LoopChoice,
+            },
+        }),
+    };
+    assert!(
+        guard_game_action_payload(&action).is_err(),
+        "an over-cap loop-shortcut schedule vec must be rejected (nested memory bound)"
+    );
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Bounds the loop-shortcut iteration count — a **pre-existing remote DoS merged in #5672**. `GameAction::DeclareShortcut` carried an unvalidated `IterationCount::Fixed(u32)`: the server payload guard discarded `count` with `..` (its "`count` is a small enum — nothing unbounded" comment was false), `handle_declare_shortcut` moved it into the proposal unchecked, and `materialize_fixed_shortcut` drove `for i in 0..n` — one `GameState` clone + beat drive per cycle, up to ~4.3e9. The fix is **engine-authoritative** (one `MAX_SHORTCUT_CYCLES` cap enforced at the single proposal-build authority, so every transport — WS, WASM, Tauri, local — is covered) with a **wire defense-in-depth belt** on the multiplayer server.

Predecessor: #5672 (this is a security follow-up to that merged PR).

### Threat model (honest, three-way — the multiplayer server applies an 8 KB inbound WS frame cap, `crates/phase-server/src/main.rs:409`/`:1420`, before deserialize; `guard_game_action_payload` runs post-deserialize, `client_message_wire_guard.rs:50`)

1. **`Fixed(u32::MAX)` — the one catastrophic remote vector.** A `u32` scalar-encodes up to ~4.3e9 cycles in ~10 JSON bytes, so it sails through the 8 KB frame cap and forces ~4.3e9 `GameState` clones. A byte cap cannot see it; only a count cap can. **Closed** by the engine `MAX_SHORTCUT_CYCLES` reject-to-handback + a wire `bound_batch_count` belt.
2. **Templated `UntilLethal` drive period** (`shortcut_drive_period` = the client template schedule length, driving `apply_until_lethal_shortcut`'s `for i in 0..period`). **Structurally unbounded in the engine**, but the 8 KB WS frame cap bounds a hostile schedule to a few hundred entries (~1–2 s stall) on the remote transport — not a million-cycle remote DoS. **Closed at the source for all callers** (incl. in-process WASM/Tauri/local that bypass the WS cap) by clamping the shared `shortcut_drive_period` helper.
3. **Nested template vecs** (a `Targets` pin's `Vec<TargetPin>`, each `RoundRobin`/`Piecewise` schedule vec). **Defense-in-depth only:** the 8 KB WS cap already keeps a remote nested payload to a few hundred structs, and the guard runs post-deserialize, so the added `bound_list`s bound downstream compute/clone work (not the transient serde allocation) for in-process callers past the frame cap.

Single-authority: the cap is checked once, before the sole `ShortcutProposal` build site; both confirmation paths and both materializers (`materialize_fixed_shortcut`, `materialize_object_growth_shortcut`) read the bounded `n` and never re-check.

## Implementation method (required)

Method: /engine-implementer

## CR references

- `CR 732.2a` — a shortcut is "a loop that repeats a specified number of times"; the CR places **no** board-relative upper bound, so `MAX_SHORTCUT_CYCLES` is annotated as an implementation **safety limit**, not a rules limit.
- `CR 800.4a` — an over-cap count hands priority to the next living seat (`living_priority_seat`).
- `CR 704.5a` — referenced by the unchanged `UntilLethal` terminator.

## Verification

- [x] Required checks ran clean (worktree cargo — own `target/`, no Tilt lock contention).
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean
- `cargo clippy -p engine -p server-core --all-targets --features engine/proptest -- -D warnings` — exit 0, no diagnostics (rebased head)
- `cargo nextest run -p engine -p server-core` (loop_shortcut + guard suite) — 63/63 pass, 0 failed (rebased head; includes the 5 new tests + the co-resident sibling-#5748 tests merged in by the rebase)
- **Discriminating tests (5 new, each revert-probe MEASURED FAIL→PASS):**
  - `over_cap_fixed_count_hands_back_with_no_drive` (engine integration) — asserts the DRIVE did not run (`life(P1)==l0`, no `GameOver`); `waiting_for` is a sanity check only (handback and cap-absent stop-short both land on `Priority` — vacuity trap documented in the test `///`). Revert-probe (delete the engine cap, measured pre-rebase on byte-identical code): `assert_eq!(life(P1), l0)` FAILS `left: 0, right: 19` — the drain drove to lethal in 0.128 s (`CrossLethal` commits+stops, so `u32::MAX` reverted does not hang). Re-confirmed on the rebased head by the passing discrimination pair on the same fixture: `b3_materialize_stop_short` (`Fixed(3)`, under-cap → **drives**) vs this test (`Fixed(u32::MAX)`, over-cap → **no drive**) — only the count relative to the cap differs.
  - `shortcut_drive_period_is_schedule_max` (engine unit) — `RoundRobin(MAX+5) ⇒ MAX_SHORTCUT_CYCLES`. Revert-probe (drop `.clamp`): FAILS `1005 ≠ 1000`.
  - `rejects_over_cap_fixed_shortcut_count` (server-core) — `Fixed(u32::MAX)` rejected. Revert-probe (restore `..`): returns `Ok` → FAILS.
  - `accepts_realistic_fixed_shortcut_count` (server-core) — `Fixed(50)` accepted (non-vacuous). Revert-probe (threshold→0): FAILS.
  - `rejects_over_cap_shortcut_schedule` (server-core) — over-cap nested `RoundRobin` rejected. Revert-probe (disable schedule bounds): FAILS.
- **Stated residual:** no end-to-end runtime drive test of the templated-`UntilLethal` `for i in 0..period` path — a real over-cap drive would *be* the DoS. Coverage rests on the `shortcut_drive_period` clamp unit test + the structural fact that both consumers (`validate_pins`, `apply_until_lethal_shortcut`) are literally `for i in 0..period`, so a bounded period ⇒ a bounded drive by construction.

## Gate A

Gate A PASS head=e8a857bdf5eebf15ad49858564c176d683e40748 base=8a1dfd7041297b48f7d3dfea6095b06c730edfd2
<!-- diff touches zero parser files -->
<!-- Gate B PASS (engine authorities): 46 tests, 86 zone hits classified, baselines frozen -->
<!-- Note: IterationCount is now matched exhaustively (no wildcard) at both bound sites so a future count variant build-breaks rather than silently regressing the cap. -->
<!-- Rebased cleanly onto upstream/main (8a1dfd704); sibling PR #5748 merged concurrently and added helpers to loop_shortcut.rs — single definitions, no E0428, distinct test names. Code hunks byte-identical pre/post rebase. -->
<!-- The revert-probe re-run that would neuter the live cap is blocked by the harness security classifier (it protects the mitigation); re-measurement rests on the executor's pre-rebase measured FLIPs + byte-identical hunks + the rebased-head positive discrimination pair above. -->
<!-- head/base to be updated by the pusher if a further rebase moves HEAD. -->

## Anchored on

- `crates/engine/src/game/engine.rs` (`handle_declare_shortcut` pin-validation handback) — existing fail-closed `reset_priority` → `WaitingFor::Priority { living_priority_seat }` → `Ok` idiom reused for the over-cap count handback.
- `crates/server-core/src/game_action_payload_guard.rs` (`ChooseManaColor.count` → `bound_batch_count`) — existing `u32`-count wire bound reused for `DeclareShortcut.count`.

## Final review-impl

Final review-impl PASS head=e8a857bdf5eebf15ad49858564c176d683e40748
