### PR TITLE
fix(scripts): stop gen-card-data.sh's EXIT trap from failing a successful run

### DIFF
--- a/scripts/gen-card-data.sh
+++ b/scripts/gen-card-data.sh
@@ -97,7 +97,11 @@ cleanup_tmp() {
   # possibly-empty array under `set -u` (macOS default is bash 3.2).
   local f
   for f in ${PENDING_TMP[@]+"${PENDING_TMP[@]}"}; do
-    [ -e "$f" ] && rm -f "$f"
+    # Bare `rm -f`, never `[ -e "$f" ] && rm -f "$f"`: a false `[ -e ]` on the
+    # final iteration makes the AND-list — and therefore this trap, and
+    # therefore the whole script — exit non-zero after a fully successful run.
+    # `rm -f` already ignores a missing path, so the guard was only a landmine.
+    rm -f "$f"
   done
 }
 trap cleanup_tmp EXIT
@@ -107,18 +111,26 @@ track_tmp() {
   PENDING_TMP+=("$1")
 }
 
-# Atomically rename tmp → final and remove the path from the pending list
-# so the EXIT trap won't touch the now-promoted file.
-promote_tmp() {
+# Drop a path from the pending list. Every caller that disposes of a tracked
+# .tmp itself (promote, or an early `rm` once the file is known redundant) must
+# call this, or the EXIT trap is left holding a path it no longer owns.
+untrack_tmp() {
   local tmp="$1"
-  local final="$2"
-  mv -f "$tmp" "$final"
   local i
   local new=()
   for i in ${PENDING_TMP[@]+"${PENDING_TMP[@]}"}; do
     [ "$i" = "$tmp" ] || new+=("$i")
   done
   PENDING_TMP=(${new[@]+"${new[@]}"})
+}
+
+# Atomically rename tmp → final and remove the path from the pending list
+# so the EXIT trap won't touch the now-promoted file.
+promote_tmp() {
+  local tmp="$1"
+  local final="$2"
+  mv -f "$tmp" "$final"
+  untrack_tmp "$tmp"
 }
 
 run_tool_with_recovery() {
@@ -180,6 +192,7 @@ track_tmp "$TOKENS_TMP"
 # (40-65s) engine recompile via build.rs's rerun-if-changed for nothing.
 if cmp -s "$TOKENS_TMP" "$TOKENS_FILE"; then
   rm -f "$TOKENS_TMP"
+  untrack_tmp "$TOKENS_TMP"
 else
   # promote_tmp, not a bare `mv`: it deregisters the path so the EXIT trap
   # cannot delete the file it was just promoted onto.


### PR DESCRIPTION
card-data has failed on every run since #5749 despite generating and promoting
every artifact correctly — the script exited 1 from its own EXIT trap, after
its final summary line.

Two defects, both introduced/exposed by #5749:

1. `cleanup_tmp`'s loop body was `[ -e "$f" ] && rm -f "$f"`. A missing file
   makes the AND-list return 1; as the loop's (and function's) last command
   that becomes the trap's status, and bash propagates a non-exiting EXIT
   trap's status to the script. `rm -f` already ignores a missing path, so the
   guard bought nothing and only armed this landmine. Drop it.

2. #5749 registered the token-catalog staging file with `track_tmp` and fixed
   the *changed* branch to use `promote_tmp` (which deregisters), but left the
   *unchanged* branch as a bare `rm -f` that deletes the file while leaving its
   path in PENDING_TMP. tokens-gen output is deterministic, so that branch is
   the steady-state path — and since every other tracked tmp gets promoted (and
   thus deregistered), the ghost was the sole, final loop iteration, landing its
   `[ -e ]` failure squarely on the exit code. Extract `untrack_tmp` (which
   `promote_tmp` now delegates to) and call it from the `rm -f` branch.

Blast radius beyond Tilt's card-data resource (which also gates `coverage` via
resource_deps): scripts/setup.sh's agent mode does `wait $PID_CARDS || FAIL=1`
-> `exit 1`, so AI-CONTRIBUTOR onboarding hard-failed with "setup step failed";
README/docs tell contributors to run the script directly.

Verified: card-data went error -> ok on the Tilt resource with this as the only
delta. Unit-checked the trap against the real edited functions — the
steady-state path exits 0, a re-introduced ghost path still exits 0, a genuinely
orphaned staging file is still deleted (the trap is not neutered), and
promote_tmp still deregisters so promoted files survive.
