### PR TITLE
fix(parser): UNSUPPORTED seam: Each-player simultaneous choice of a left-neighbor's creature + copy-

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1563,6 +1563,12 @@ export type WaitingFor =
       choose_filter: TargetFilter;
       copy_modifications?: unknown[];
       scale?: unknown;
+      // CR 102.1 + CR 103.1: whose battlefield the chooser's pool was drawn from
+      // (their own or a seat-neighbor's). Resolver-internal; the modal renders the
+      // precomputed public `eligible` list and ignores this.
+      choose_scope?:
+        | { type: "Chooser" }
+        | { type: "Neighbor"; direction: { type: "Left" | "Right" } };
       source_id: ObjectId;
       source_controller: PlayerId;
       remaining_players: PlayerId[];

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -3035,6 +3035,7 @@ fn legacy_effect(x: &Effect) -> bool {
             max: _,
             copy_modifications,
             scale: _,
+            choose_scope: _,
         } => {
             legacy_target_filter(choose_filter)
                 || copy_modifications

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -541,6 +541,7 @@ fn scan_effect(x: &Effect) -> Axes {
             max: _,
             copy_modifications: _,
             scale: _,
+            choose_scope: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(choose_filter));

--- a/crates/engine/src/game/effects/each_player_copy_chosen.rs
+++ b/crates/engine/src/game/effects/each_player_copy_chosen.rs
@@ -25,8 +25,8 @@ use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::players;
 use crate::game::quantity::aggregate_property_over;
 use crate::types::ability::{
-    AggregateFunction, ContinuousModification, CopyScale, Effect, EffectError, EffectKind,
-    PlayerFilter, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef,
+    AggregateFunction, ContinuousModification, CopyChooseScope, CopyScale, Effect, EffectError,
+    EffectKind, PlayerFilter, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
@@ -45,6 +45,9 @@ pub(crate) struct CopyChosenParams {
     pub max: u32,
     pub copy_modifications: Vec<ContinuousModification>,
     pub scale: Option<CopyScale>,
+    /// CR 102.1 + CR 103.1: whose battlefield each chooser draws eligible objects
+    /// from, relative to the chooser.
+    pub choose_scope: CopyChooseScope,
     pub source_id: ObjectId,
     pub source_controller: PlayerId,
     pub scoped_players: Vec<PlayerId>,
@@ -59,6 +62,7 @@ impl CopyChosenParams {
             max: p.max,
             copy_modifications: p.copy_modifications.clone(),
             scale: p.scale.clone(),
+            choose_scope: p.choose_scope,
             source_id: p.source_id,
             source_controller: p.source_controller,
             scoped_players: p.scoped_players.clone(),
@@ -74,19 +78,21 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (choose_filter, min, max, copy_modifications, scale) = match &ability.effect {
+    let (choose_filter, min, max, copy_modifications, scale, choose_scope) = match &ability.effect {
         Effect::EachPlayerCopyChosen {
             choose_filter,
             min,
             max,
             copy_modifications,
             scale,
+            choose_scope,
         } => (
             choose_filter.clone(),
             *min,
             *max,
             copy_modifications.clone(),
             scale.clone(),
+            *choose_scope,
         ),
         _ => {
             return Err(EffectError::MissingParam(
@@ -112,6 +118,7 @@ pub fn resolve(
         max,
         copy_modifications,
         scale,
+        choose_scope,
         source_id: ability.source_id,
         source_controller: ability.controller,
         scoped_players: player_order.clone(),
@@ -147,7 +154,13 @@ pub(crate) fn advance_to_next_player(
 
         let ctx =
             FilterContext::from_source_with_controller(params.source_id, params.source_controller);
-        let eligible = compute_eligible(state, player, &params.choose_filter, &ctx);
+        let eligible = compute_eligible(
+            state,
+            player,
+            &params.choose_filter,
+            params.choose_scope,
+            &ctx,
+        );
 
         // CR 101.3: a player with no eligible object does nothing — skip.
         if eligible.is_empty() {
@@ -176,6 +189,7 @@ pub(crate) fn advance_to_next_player(
             choose_filter: params.choose_filter.clone(),
             copy_modifications: params.copy_modifications.clone(),
             scale: params.scale.clone(),
+            choose_scope: params.choose_scope,
             source_id: params.source_id,
             source_controller: params.source_controller,
             remaining_players: rest,
@@ -365,20 +379,34 @@ pub(crate) fn drain_pending(state: &mut GameState, events: &mut Vec<GameEvent>) 
     let _ = result;
 }
 
-/// Compute a player's own battlefield objects matching `choose_filter`.
+/// CR 102.1 + CR 103.1: The battlefield controller a chooser draws their
+/// eligible pool from, given the effect's `choose_scope`. `Chooser` = the
+/// chooser themselves; `Neighbor { direction }` = the seat-neighbor resolved by
+/// the `players::neighbor` authority.
+fn pool_controller(state: &GameState, chooser: PlayerId, scope: CopyChooseScope) -> PlayerId {
+    match scope {
+        CopyChooseScope::Chooser => chooser,
+        CopyChooseScope::Neighbor { direction } => players::neighbor(state, chooser, direction),
+    }
+}
+
+/// Compute the objects matching `choose_filter` on the battlefield of the
+/// controller `scope` designates relative to `player` (their own or a neighbor's).
 fn compute_eligible(
     state: &GameState,
     player: PlayerId,
     choose_filter: &TargetFilter,
+    scope: CopyChooseScope,
     ctx: &FilterContext<'_>,
 ) -> Vec<ObjectId> {
+    let controller = pool_controller(state, player, scope);
     state
         .battlefield
         .iter()
         .copied()
         .filter(|id| {
             state.objects.get(id).is_some_and(|obj| {
-                obj.controller == player
+                obj.controller == controller
                     && !obj.is_emblem
                     && matches_target_filter(state, *id, choose_filter, ctx)
             })
@@ -393,12 +421,16 @@ pub(crate) fn is_live_eligible_choice(
     player: PlayerId,
     id: ObjectId,
     choose_filter: &TargetFilter,
+    scope: CopyChooseScope,
     source_id: ObjectId,
     source_controller: PlayerId,
 ) -> bool {
     let ctx = FilterContext::from_source_with_controller(source_id, source_controller);
+    // CR 102.1 + CR 103.1: re-resolve the eligibility controller live so a
+    // seat-relative pool tracks any control change since the prompt was seeded.
+    let controller = pool_controller(state, player, scope);
     state.objects.get(&id).is_some_and(|obj| {
-        obj.controller == player
+        obj.controller == controller
             && !obj.is_emblem
             && state.battlefield.contains(&id)
             && matches_target_filter(state, id, choose_filter, &ctx)
@@ -422,6 +454,7 @@ fn make_pending(
         max: params.max,
         copy_modifications: params.copy_modifications.clone(),
         scale: params.scale.clone(),
+        choose_scope: params.choose_scope,
         source_id: params.source_id,
         source_controller: params.source_controller,
         scoped_players: params.scoped_players.clone(),
@@ -482,6 +515,22 @@ mod tests {
         copy_modifications: Vec<ContinuousModification>,
         scale: Option<CopyScale>,
     ) -> ResolvedAbility {
+        ability_scoped(
+            min,
+            max,
+            copy_modifications,
+            scale,
+            CopyChooseScope::Chooser,
+        )
+    }
+
+    fn ability_scoped(
+        min: u32,
+        max: u32,
+        copy_modifications: Vec<ContinuousModification>,
+        scale: Option<CopyScale>,
+        choose_scope: CopyChooseScope,
+    ) -> ResolvedAbility {
         ResolvedAbility::new(
             Effect::EachPlayerCopyChosen {
                 choose_filter: creature_filter(),
@@ -489,6 +538,7 @@ mod tests {
                 max,
                 copy_modifications,
                 scale,
+                choose_scope,
             },
             vec![],
             ObjectId(500),
@@ -779,6 +829,207 @@ mod tests {
         assert!(
             token.has_keyword(&crate::types::keywords::Keyword::Menace),
             "menace granted to the copy"
+        );
+    }
+
+    /// Runtime direction proof (Caught in a Parallel Universe class): with
+    /// `choose_scope: Neighbor { Left }` in a THREE-player ring, each chooser's
+    /// pool is their LEFT neighbor's battlefield — a case a 2-player ring cannot
+    /// distinguish (there `neighbor(_,Left) == neighbor(_,Right)`). In seat ring
+    /// [P0,P1,P2], `neighbor(_,Left) = next_player`: P0←P1, P1←P2, P2←P0 (wrap).
+    /// Each chooser has a single distinct creature → all forced singles → the
+    /// walk auto-resolves with no prompt. A Left→Right swap in the resolver map
+    /// would make P0 copy P2's creature (power 7) instead of P1's (power 6),
+    /// failing these assertions.
+    #[test]
+    fn neighbor_left_scope_draws_from_left_neighbor_three_player() {
+        use crate::types::keywords::Keyword;
+
+        let mut state = GameState::new(crate::types::format::FormatConfig::standard(), 3, 42);
+        state.active_player = PlayerId(0);
+        // One distinct creature per player, distinct base power for a load-bearing
+        // direction signal.
+        add_creature(&mut state, CardId(1), PlayerId(0), "Alpha", 5, false);
+        add_creature(&mut state, CardId(2), PlayerId(1), "Bravo", 6, false);
+        add_creature(&mut state, CardId(3), PlayerId(2), "Charlie", 7, false);
+
+        let ab = ability_scoped(
+            1,
+            1,
+            vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Menace,
+            }],
+            None,
+            CopyChooseScope::Neighbor {
+                direction: crate::types::ability::SeatDirection::Left,
+            },
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ab, &mut events).unwrap();
+
+        // Forced singles across the ring → no interactive prompt.
+        assert!(
+            !matches!(
+                state.waiting_for,
+                WaitingFor::EachPlayerCopyChosenSelection { .. }
+            ),
+            "every chooser's left-neighbor pool is a forced single → no prompt"
+        );
+
+        // Each player's token copies their LEFT neighbor's creature.
+        let token_for = |state: &GameState, owner: PlayerId| -> ObjectId {
+            let ids: Vec<ObjectId> = state
+                .battlefield
+                .iter()
+                .copied()
+                .filter(|id| {
+                    state
+                        .objects
+                        .get(id)
+                        .is_some_and(|o| o.is_token && o.controller == owner)
+                })
+                .collect();
+            assert_eq!(ids.len(), 1, "exactly one token for {owner:?}");
+            ids[0]
+        };
+        for (owner, want_name, want_power) in [
+            (PlayerId(0), "Bravo", 6),   // P0's left neighbor is P1
+            (PlayerId(1), "Charlie", 7), // P1's left neighbor is P2
+            (PlayerId(2), "Alpha", 5),   // P2's left neighbor is P0 (wrap)
+        ] {
+            let tok = state.objects.get(&token_for(&state, owner)).unwrap();
+            assert_eq!(tok.name, want_name, "{owner:?} copies left neighbor");
+            assert_eq!(
+                tok.base_power,
+                Some(want_power),
+                "{owner:?} copies left neighbor's power"
+            );
+            assert!(
+                tok.has_keyword(&Keyword::Menace),
+                "copy modification (menace) applied for {owner:?}"
+            );
+        }
+    }
+
+    /// Runtime proof of the neighbor pool + CR 608.2c live revalidation
+    /// (2-player). P0's `Neighbor { Left }` pool is P1's battlefield: with P1
+    /// controlling two creatures P0 is prompted from P1's creatures (NOT P0's
+    /// own). `is_live_eligible_choice` accepts a neighbor's object and rejects a
+    /// non-neighbor (P0-controlled) object; the resolved token copies the chosen
+    /// neighbor creature.
+    #[test]
+    fn neighbor_left_scope_prompts_from_neighbor_pool_and_revalidates() {
+        use crate::game::engine::apply;
+        use crate::types::actions::GameAction;
+        use crate::types::keywords::Keyword;
+
+        let mut state = setup();
+        let p0c = add_creature(&mut state, CardId(1), PlayerId(0), "Mine", 2, false);
+        let p1a = add_creature(&mut state, CardId(2), PlayerId(1), "NeighborA", 4, false);
+        let p1b = add_creature(&mut state, CardId(3), PlayerId(1), "NeighborB", 5, false);
+
+        let ab = ability_scoped(
+            1,
+            1,
+            vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Menace,
+            }],
+            None,
+            CopyChooseScope::Neighbor {
+                direction: crate::types::ability::SeatDirection::Left,
+            },
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ab, &mut events).unwrap();
+
+        // P0 is prompted from P1's (left-neighbor's) two creatures — not P0's own.
+        match &state.waiting_for {
+            WaitingFor::EachPlayerCopyChosenSelection {
+                player, eligible, ..
+            } => {
+                assert_eq!(*player, PlayerId(0));
+                let ids: Vec<ObjectId> = eligible
+                    .iter()
+                    .filter_map(|t| match t {
+                        TargetRef::Object(id) => Some(*id),
+                        _ => None,
+                    })
+                    .collect();
+                assert!(
+                    ids.contains(&p1a) && ids.contains(&p1b),
+                    "P1's two creatures"
+                );
+                assert!(!ids.contains(&p0c), "P0's own creature is NOT eligible");
+            }
+            other => panic!("expected P0 EachPlayerCopyChosenSelection, got {other:?}"),
+        }
+
+        // CR 608.2c: neighbor revalidation — a non-neighbor (P0-controlled) object
+        // is rejected; the neighbor's object is accepted.
+        let scope = CopyChooseScope::Neighbor {
+            direction: crate::types::ability::SeatDirection::Left,
+        };
+        let filter = creature_filter();
+        assert!(
+            !is_live_eligible_choice(
+                &state,
+                PlayerId(0),
+                p0c,
+                &filter,
+                scope,
+                ObjectId(500),
+                PlayerId(0)
+            ),
+            "P0's own creature is not in P0's left-neighbor pool"
+        );
+        assert!(
+            is_live_eligible_choice(
+                &state,
+                PlayerId(0),
+                p1a,
+                &filter,
+                scope,
+                ObjectId(500),
+                PlayerId(0)
+            ),
+            "the left neighbor's creature is eligible"
+        );
+
+        // P0 chooses one of P1's creatures → P0's token copies it.
+        apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::SelectTargets {
+                targets: vec![TargetRef::Object(p1a)],
+            },
+        )
+        .expect("selection applies");
+
+        let p0_tokens: Vec<ObjectId> = state
+            .battlefield
+            .iter()
+            .copied()
+            .filter(|id| {
+                state
+                    .objects
+                    .get(id)
+                    .is_some_and(|o| o.is_token && o.controller == PlayerId(0))
+            })
+            .collect();
+        assert_eq!(p0_tokens.len(), 1, "one P0 token");
+        let tok = state.objects.get(&p0_tokens[0]).unwrap();
+        assert_eq!(
+            tok.name, "NeighborA",
+            "P0's token copies the chosen neighbor creature"
+        );
+        assert_eq!(tok.base_power, Some(4));
+        assert!(tok.has_keyword(&Keyword::Menace));
+        assert!(
+            !matches!(
+                state.waiting_for,
+                WaitingFor::EachPlayerCopyChosenSelection { .. }
+            ),
+            "walk completes after the only prompted chooser resolves"
         );
     }
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -4590,6 +4590,7 @@ pub(super) fn handle_resolution_choice(
                 choose_filter,
                 copy_modifications,
                 scale,
+                choose_scope,
                 source_id,
                 source_controller,
                 remaining_players,
@@ -4630,6 +4631,7 @@ pub(super) fn handle_resolution_choice(
                     player,
                     *id,
                     &choose_filter,
+                    choose_scope,
                     source_id,
                     source_controller,
                 ) {
@@ -4646,6 +4648,7 @@ pub(super) fn handle_resolution_choice(
                 max,
                 copy_modifications,
                 scale,
+                choose_scope,
                 source_id,
                 source_controller,
                 scoped_players,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -95,8 +95,8 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AggregateFunction,
     BounceSelection, CardPlayMode, CastPermissionConstraint, CastingPermission, ChoiceType,
     ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard, ConjureSource,
-    ContinuousModification, ControlWindow, ControllerRef, CopyRetargetPermission, CopyScale,
-    DamageModification, DamageSource, DelayedTriggerCondition, DelayedTriggerLifetime,
+    ContinuousModification, ControlWindow, ControllerRef, CopyChooseScope, CopyRetargetPermission,
+    CopyScale, DamageModification, DamageSource, DelayedTriggerCondition, DelayedTriggerLifetime,
     DoubleTarget, Duration, Effect, EffectOutcomeSignal, EffectScope, FilterProp, GameRestriction,
     GuessSubject, IntensityScope, IterationKindBinding, LibraryPosition, ManaProduction,
     ManaSpendPermission, MultiTargetSpec, NumberDistinctness, ObjectProperty, ObjectScope,
@@ -23682,10 +23682,10 @@ fn try_parse_conditional_protection_grant_ability(
 /// declines (returns `None`) unless the full multi-sentence shape parses, so an
 /// unrecognized variant stays an honest `Unimplemented` rather than misparsing.
 /// The scale sentence is optional (`scale: None` for the single-choice shape
-/// that never selects a second object). Note: Caught in a Parallel Universe is
-/// NOT covered by this path — it selects "a creature controlled by the player to
-/// their left" (a chooser-relative eligibility scope), so its choose clause does
-/// not match the `<type> they control` shape below and it stays `Unimplemented`.
+/// that never selects a second object). The choose clause is parameterized by a
+/// [`CopyChooseScope`]: "<type> they control" → `Chooser` (Human—Time Lord
+/// Meta-Crisis), "<type> controlled by the player to their {left|right}" →
+/// `Neighbor { direction }` (Caught in a Parallel Universe).
 pub(crate) fn try_parse_each_player_copy_chosen(
     text: &str,
     kind: AbilityKind,
@@ -23693,7 +23693,10 @@ pub(crate) fn try_parse_each_player_copy_chosen(
     let lower = text.to_ascii_lowercase();
     let i = lower.as_str();
 
-    // Segment 1: "each player chooses <cardinality> <type> they control."
+    // Segment 1: "each player chooses <cardinality> <type> <controller-clause>."
+    // The controller clause is either "they control" (each chooser's own
+    // battlefield → CopyChooseScope::Chooser) or "controlled by the player to
+    // their {left|right}" (a seat-neighbor's battlefield → Neighbor).
     let (i, _) = tag::<_, _, OracleError<'_>>("each player chooses ")
         .parse(i)
         .ok()?;
@@ -23703,18 +23706,36 @@ pub(crate) fn try_parse_each_player_copy_chosen(
     ))
     .parse(i)
     .ok()?;
-    // The type noun runs up to the controller clause; feed it to the shared
-    // type-phrase parser so any object class (not just "creature") is supported.
-    let (i, noun) = take_until::<_, _, OracleError<'_>>(" they control")
-        .parse(i)
-        .ok()?;
+    // The type noun runs up to whichever controller clause follows; feed it to
+    // the shared type-phrase parser so any object class (not just "creature") is
+    // supported.
+    let (i, noun) = alt((
+        take_until::<_, _, OracleError<'_>>(" they control"),
+        take_until::<_, _, OracleError<'_>>(" controlled by "),
+    ))
+    .parse(i)
+    .ok()?;
     let (choose_filter, noun_rest) = parse_type_phrase(noun);
     if !noun_rest.trim().is_empty() {
         return None;
     }
-    let (i, _) = tag::<_, _, OracleError<'_>>(" they control")
-        .parse(i)
-        .ok()?;
+    // Classify the controller clause into a typed CopyChooseScope. Fail-closed:
+    // an unrecognized clause fails both arms → None → honest Unimplemented.
+    let (i, choose_scope) = alt((
+        value(
+            CopyChooseScope::Chooser,
+            tag::<_, _, OracleError<'_>>(" they control"),
+        ),
+        map(
+            preceded(
+                tag::<_, _, OracleError<'_>>(" controlled by "),
+                super::oracle_target::parse_neighbor_seat_direction,
+            ),
+            |direction| CopyChooseScope::Neighbor { direction },
+        ),
+    ))
+    .parse(i)
+    .ok()?;
     let (i, _) = opt(tag::<_, _, OracleError<'_>>(".")).parse(i).ok()?;
     let i = i.trim_start();
 
@@ -23764,6 +23785,7 @@ pub(crate) fn try_parse_each_player_copy_chosen(
             max,
             copy_modifications,
             scale,
+            choose_scope,
         },
     );
     // CR 101.4: "each player" → scope over all players; the self-iterating

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -4,7 +4,7 @@ use crate::types::ability::CardPlayMode::{Cast, Play};
 use crate::types::ability::CastFromZoneDriver::{DuringResolution, LingeringPermission};
 use crate::types::ability::{
     AttachmentKind, CastManaObjectScope, CastManaSpentMetric, ExcessRecipient,
-    ForEachCategoryAction, PerpetualModification,
+    ForEachCategoryAction, PerpetualModification, SeatDirection,
 };
 use crate::types::card_type::CoreType;
 use crate::types::mana::{ManaCost, ManaCostShard};
@@ -43646,7 +43646,13 @@ fn each_player_copy_chosen_human_time_lord_trigger() {
             max,
             copy_modifications,
             scale,
+            choose_scope,
         } => {
+            assert_eq!(
+                *choose_scope,
+                CopyChooseScope::Chooser,
+                "\"they control\" → each chooser's own battlefield"
+            );
             assert_eq!((*min, *max), (1, 2), "chooses one or two");
             assert!(
                 matches!(choose_filter, TargetFilter::Typed(tf)
@@ -43698,6 +43704,50 @@ fn each_player_copy_chosen_no_scale_menace_sibling() {
                     keyword: Keyword::Menace
                 }],
                 "except it has menace → AddKeyword(Menace)"
+            );
+            assert_eq!(scale, &None, "no scaling sentence → scale None");
+        }
+        other => panic!("expected EachPlayerCopyChosen, got {other:?}"),
+    }
+}
+
+/// CR 102.1 + CR 103.1 + CR 707.2: the seat-relative choose clause. "controlled
+/// by the player to their {left|right}" lowers to `choose_scope: Neighbor` with
+/// the parsed direction, independent of the copy modification (flying here, not
+/// menace) — proving the parser covers the whole class, both directions, not one
+/// card. This is the Caught in a Parallel Universe shape with the direction and
+/// keyword swapped.
+#[test]
+fn each_player_copy_chosen_neighbor_right_scope() {
+    let def = parse_effect_chain(
+        "Each player chooses a creature controlled by the player to their right. Each player creates a token that's a copy of the creature they chose, except it has flying.",
+        AbilityKind::Spell,
+    );
+    assert!(def.sub_ability.is_none(), "single self-contained effect");
+    assert_eq!(def.player_scope, Some(PlayerFilter::All));
+    match &*def.effect {
+        Effect::EachPlayerCopyChosen {
+            min,
+            max,
+            copy_modifications,
+            scale,
+            choose_scope,
+            ..
+        } => {
+            assert_eq!((*min, *max), (1, 1), "chooses a (single) creature");
+            assert_eq!(
+                *choose_scope,
+                CopyChooseScope::Neighbor {
+                    direction: SeatDirection::Right
+                },
+                "\"controlled by the player to their right\" → Neighbor{{Right}}"
+            );
+            assert_eq!(
+                copy_modifications,
+                &vec![ContinuousModification::AddKeyword {
+                    keyword: Keyword::Flying
+                }],
+                "except it has flying → AddKeyword(Flying)"
             );
             assert_eq!(scale, &None, "no scaling sentence → scale None");
         }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till, take_till1};
 use nom::character::complete::space1;
-use nom::combinator::{eof, not, opt, peek, success, value};
+use nom::combinator::{eof, map, not, opt, peek, success, value};
 use nom::multi::many0;
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
@@ -410,6 +410,24 @@ fn parse_disjunct_mana_value(
             value: mv,
         },
     ))
+}
+
+/// CR 102.1 + CR 103.1: seat-relative neighbor phrase → [`SeatDirection`].
+/// Matches "the player to {their|your} {left|right}" — the reflexive "their"
+/// form for "each player …" chooser scopes, the "your" form for
+/// controller-relative references. Single authority for seat-direction phrase
+/// parsing on already-lowercased text; the `TargetFilter::Neighbor` arms and the
+/// `EachPlayerCopyChosen` controller-clause dispatch both delegate here so the
+/// phrase lives in exactly one combinator.
+pub(crate) fn parse_neighbor_seat_direction(input: &str) -> OracleResult<'_, SeatDirection> {
+    preceded(
+        (tag("the player to "), alt((tag("their "), tag("your ")))),
+        alt((
+            value(SeatDirection::Left, tag("left")),
+            value(SeatDirection::Right, tag("right")),
+        )),
+    )
+    .parse(input)
 }
 
 /// Context-aware variant of `parse_target`. TargetFallback diagnostics are
@@ -1189,22 +1207,14 @@ pub fn parse_target_with_syntax<'a>(
                 TargetFilter::ParentTargetSlot { index: 0 },
                 tag("the second player"),
             ),
-            // CR 102.1 + CR 103.1: "the player to your right/left" —
+            // CR 102.1 + CR 103.1: "the player to {your|their} {right|left}" —
             // seating-relative neighbor. Right = previous seat (clockwise turn
             // order proceeds to the left). Placed before the bare "the player"
             // arm so the longer phrase wins under longest-match-first dispatch.
-            value(
-                TargetFilter::Neighbor {
-                    direction: SeatDirection::Right,
-                },
-                tag("the player to your right"),
-            ),
-            value(
-                TargetFilter::Neighbor {
-                    direction: SeatDirection::Left,
-                },
-                tag("the player to your left"),
-            ),
+            // Delegates to the single `parse_neighbor_seat_direction` authority.
+            map(parse_neighbor_seat_direction, |direction| {
+                TargetFilter::Neighbor { direction }
+            }),
             value(TargetFilter::ParentTarget, tag("the player")),
             value(TargetFilter::ParentTarget, tag("the creature")),
             value(TargetFilter::ParentTarget, tag("the spell")),
@@ -15292,6 +15302,26 @@ mod tests {
             }
         );
         assert_eq!(rest, "");
+    }
+
+    /// CR 102.1 + CR 103.1: the shared seat-direction combinator accepts both the
+    /// reflexive "their" (each-player chooser scopes) and the "your"
+    /// (controller-relative) possessives, in both directions.
+    #[test]
+    fn parse_neighbor_seat_direction_covers_their_your_left_right() {
+        for (phrase, expected) in [
+            ("the player to their left", SeatDirection::Left),
+            ("the player to their right", SeatDirection::Right),
+            ("the player to your left", SeatDirection::Left),
+            ("the player to your right", SeatDirection::Right),
+        ] {
+            let (rest, dir) =
+                parse_neighbor_seat_direction(phrase).expect("seat direction phrase parses");
+            assert_eq!(dir, expected, "{phrase}");
+            assert_eq!(rest, "", "{phrase} fully consumed");
+        }
+        // A non-neighbor phrase is declined (fail-closed).
+        assert!(parse_neighbor_seat_direction("the player who cast it").is_err());
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -7,12 +7,12 @@ use crate::parser::oracle_ir::doc::PrintedTriggerIndex;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
     AttackSubject, BounceSelection, CardSelectionMode, CastingPermission, ChosenAttribute,
-    Comparator, ContinuousModification, ControllerRef, CopyRetargetPermission, CountScope,
-    DamageChannel, DamageModification, DamageSource, DelayedTriggerCondition, DiscardSelfScope,
-    Duration, Effect, EffectScope, FilterProp, ManaContribution, ManaProduction,
+    Comparator, ContinuousModification, ControllerRef, CopyChooseScope, CopyRetargetPermission,
+    CountScope, DamageChannel, DamageModification, DamageSource, DelayedTriggerCondition,
+    DiscardSelfScope, Duration, Effect, EffectScope, FilterProp, ManaContribution, ManaProduction,
     ManaSpendPermission, ObjectScope, PerpetualModification, PlayerFilter, PlayerScope, PtStat,
-    PtValue, PtValueScope, QuantityExpr, QuantityRef, SharedQuality, TapStateChange, TargetFilter,
-    TriggerCondition, TypeFilter, TypedFilter, ZoneRef,
+    PtValue, PtValueScope, QuantityExpr, QuantityRef, SeatDirection, SharedQuality, TapStateChange,
+    TargetFilter, TriggerCondition, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::card_type::Supertype;
 use crate::types::counter::{CounterMatch, CounterType};
@@ -12212,34 +12212,20 @@ fn trigger_encounter_maps_to_planeswalked_to() {
     assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
 }
 
-/// DEFERRED GAP (documented, not fixed): Caught in a Parallel Universe is a
+/// CR 101.4 + CR 102.1 + CR 103.1 + CR 707.2: Caught in a Parallel Universe is a
 /// Planechase phenomenon whose encounter effect is a per-player, left-neighbor,
 /// many-to-many choose-and-copy — "each player chooses a creature controlled by
 /// the player to their left. Each player creates a token that's a copy of the
 /// creature they chose, except it has menace."
 ///
-/// Modeling this correctly needs infrastructure the engine does not yet have:
-///   * a left-neighbor `ControllerRef` — CR 103.1 fixes turn order (starting
-///     player, proceeding clockwise) and thus "the player to their left", but no
-///     filter controller ref resolves it (`ControllerRef` has no
-///     `PlayerToTheLeft`/left-neighbor variant);
-///   * a per-player PARALLEL selection where every player is simultaneously a
-///     chooser binding their own creature — `Effect::ChooseObjectsIntoTrackedSet`
-///     has a single `chooser` and one tracked set (CR 608.2c), not one binding
-///     per player; and
-///   * a per-player token copy keyed to each chooser's own binding —
-///     `CopyTokenOf { target: ParentTarget }` inherits ONE parent target, not a
-///     per-player selection (CR 707.2).
-///
-/// This is a single Planechase phenomenon, not a card class, so the per-player
-/// left-neighbor choose head is deliberately left as a strict-failure
-/// `Unimplemented { name: "choose" }` gap rather than mis-modeled with the
-/// single-chooser machinery. This test LOCKS that documented state so the card
-/// is not silently counted as fixed and a future change can't quietly alter the
-/// shape. When per-player parallel-selection infrastructure lands, replace this
-/// with a positive end-to-end test.
+/// This now lowers to a single self-contained [`Effect::EachPlayerCopyChosen`]
+/// with `choose_scope: Neighbor { Left }` (each chooser's pool is drawn from the
+/// player seated to their left, resolved by `game::players::neighbor`), the same
+/// shape as Human—Time Lord Meta-Crisis but with the seat-relative eligibility
+/// scope and a single choice + menace grant. No chained tail: the whole body
+/// collapses into one effect (`sub_ability.is_none()`).
 #[test]
-fn caught_in_a_parallel_universe_per_player_left_neighbor_choose_is_deferred_gap() {
+fn caught_in_a_parallel_universe_lowers_to_left_neighbor_copy_chosen() {
     let def = parse_trigger_line(
         "When you encounter Caught in a Parallel Universe, each player chooses a \
          creature controlled by the player to their left. Each player creates a \
@@ -12258,17 +12244,53 @@ fn caught_in_a_parallel_universe_per_player_left_neighbor_choose_is_deferred_gap
         .execute
         .as_deref()
         .expect("the encounter trigger must carry an execute body");
-    // The per-player left-neighbor selection head is unsupported: it must remain
-    // a documented `Unimplemented { name: "choose" }` strict-failure, NOT be
-    // mis-converted into a single-chooser `ChooseObjectsIntoTrackedSet`.
+    // CR 101.4: "each player" → scope over all players.
+    assert_eq!(
+        execute.player_scope,
+        Some(PlayerFilter::All),
+        "\"each player\" → player_scope All"
+    );
+    // The whole body collapses into a single self-contained effect (no chained
+    // tail); the pre-fix `SequentialSibling` CopyTokenOf head is gone.
+    assert!(
+        execute.sub_ability.is_none(),
+        "the body must collapse into a single EachPlayerCopyChosen, got sub {:?}",
+        execute.sub_ability
+    );
     match &*execute.effect {
-        Effect::Unimplemented { name, .. } => assert_eq!(
-            name, "choose",
-            "the deferred per-player choose head must stay an Unimplemented choose gap"
-        ),
+        Effect::EachPlayerCopyChosen {
+            choose_filter,
+            min,
+            max,
+            copy_modifications,
+            scale,
+            choose_scope,
+        } => {
+            assert_eq!((*min, *max), (1, 1), "chooses a (single) creature");
+            assert!(
+                matches!(choose_filter, TargetFilter::Typed(tf)
+                    if tf.type_filters.contains(&TypeFilter::Creature)),
+                "choose_filter must be a creature filter, got {choose_filter:?}"
+            );
+            assert_eq!(
+                *choose_scope,
+                CopyChooseScope::Neighbor {
+                    direction: SeatDirection::Left
+                },
+                "\"controlled by the player to their left\" → Neighbor{{Left}}"
+            );
+            assert_eq!(
+                copy_modifications,
+                &vec![ContinuousModification::AddKeyword {
+                    keyword: Keyword::Menace
+                }],
+                "except it has menace → AddKeyword(Menace)"
+            );
+            assert_eq!(scale, &None, "single-choice shape → no scaling clause");
+        }
         other => panic!(
-            "Caught in a Parallel Universe's per-player left-neighbor choose is a \
-             deferred gap and must remain Unimplemented, got {other:?}"
+            "Caught in a Parallel Universe must lower to a left-neighbor \
+             EachPlayerCopyChosen, got {other:?}"
         ),
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5852,6 +5852,38 @@ impl SeatDirection {
     }
 }
 
+/// CR 102.1 + CR 103.1 + CR 707.2: In [`Effect::EachPlayerCopyChosen`], whose
+/// battlefield each chooser draws their eligible objects from, stated relative
+/// to the chooser. `Chooser` (default) = objects the chooser controls ("… they
+/// control", Human—Time Lord Meta-Crisis); `Neighbor { direction }` = objects
+/// controlled by the player seated to the chooser's left/right ("… controlled by
+/// the player to their left", Caught in a Parallel Universe), resolved live
+/// (CR 608.2c) via [`crate::game::players::neighbor`].
+///
+/// DISCOVERABILITY / DIVERGENCE FROM `ControllerRef`: `Chooser` is the semantic
+/// twin of [`ControllerRef::ScopedPlayer`], and `Neighbor` mirrors a hypothetical
+/// `ControllerRef::Neighbor`. This is deliberately a separate leaf enum, NOT a
+/// `ControllerRef` field, because (1) `EachPlayerCopyChosen` eligibility is
+/// generative battlefield enumeration in the self-iterating resolver, which
+/// bypasses the `controller_ref_player` / `matches_target_filter` filter-predicate
+/// path that all `ControllerRef` variants use; and (2) adding a seat variant to
+/// `ControllerRef` (13 variants, ~177 exhaustive match arms across ~15 files:
+/// filter / sba / replacement / targeting / layers / quantity / coverage / …)
+/// would force a fail-closed arm in every unrelated subsystem for this 2-card
+/// class. This enum is matched only by the resolver. The seat resolution itself
+/// is not duplicated — `Neighbor` composes the same [`SeatDirection`] primitive
+/// and resolves through the same `players::neighbor` authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "type")]
+pub enum CopyChooseScope {
+    /// Each chooser draws from the objects they themselves control.
+    #[default]
+    Chooser,
+    /// Each chooser draws from the objects controlled by their seat-neighbor in
+    /// `direction` (CR 102.1 + CR 103.1).
+    Neighbor { direction: SeatDirection },
+}
+
 /// CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that
 /// compose with an independent condition.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -11668,19 +11700,16 @@ pub enum Effect {
     /// threaded through `GameState::pending_each_player_copy_chosen` (see
     /// `game/effects/each_player_copy_chosen.rs`).
     ///
-    /// Real consumer (WHO phenomena): Human—Time Lord Meta-Crisis
+    /// Real consumers (WHO phenomena): Human—Time Lord Meta-Crisis
     /// (`min:1, max:2`, `[RemoveSupertype(Legendary)]`, scale by 2nd creature's
-    /// power).
-    ///
-    /// NOT yet covered: Caught in a Parallel Universe (`min:1, max:1`,
-    /// `[AddKeyword(Menace)]`, `scale: None`). It selects "a creature controlled
-    /// by the player to their left", a chooser-relative eligibility scope this
-    /// effect cannot represent — `choose_filter` resolves against each chooser's
-    /// own battlefield only. Covering it needs a chooser-relative scope on the
-    /// choose step; the single-choice `scale: None` shape here is forward-looking
-    /// infrastructure, not exercised by a covered card yet.
+    /// power, `choose_scope: Chooser`) and Caught in a Parallel Universe
+    /// (`min:1, max:1`, `[AddKeyword(Menace)]`, `scale: None`,
+    /// `choose_scope: Neighbor { Left }` — each player chooses from "the player to
+    /// their left"'s battlefield). The chooser-relative eligibility scope is the
+    /// [`CopyChooseScope`] `choose_scope` field.
     EachPlayerCopyChosen {
-        /// Objects eligible to be chosen from each player's own battlefield.
+        /// Objects eligible to be chosen, drawn from each chooser's own or their
+        /// seat-neighbor's battlefield per `choose_scope`.
         choose_filter: TargetFilter,
         /// Minimum number of objects each player must choose (1).
         min: u32,
@@ -11694,6 +11723,11 @@ pub enum Effect {
         /// ever chosen (the effect never places counters).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         scale: Option<CopyScale>,
+        /// CR 102.1 + CR 103.1: whose objects each chooser may choose from,
+        /// relative to the chooser. Defaults to `Chooser` ("they control") so
+        /// existing records and Human—Time Lord Meta-Crisis are unchanged.
+        #[serde(default)]
+        choose_scope: CopyChooseScope,
     },
     /// CR 702.110b: Exploit — sacrifice a creature you control (optional).
     /// The controller may sacrifice any creature they control, including the exploiter itself.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -9,12 +9,12 @@ use super::ability::{
     default_target_filter_permanent, AbilityCost, AbilityDefinition, AdditionalCost,
     AdditionalCostInstance, AdditionalCostInstancePayment, AttackSubject, BeholdCostAction,
     CastVariantPaid, CategoryChooserScope, ChoiceType, ChoiceValue, ChooseFromZoneConstraint,
-    ChosenAttribute, CoinFlipResult, Comparator, ContinuousModification, ControlWindow, CopyScale,
-    CostPaidObjectSnapshot, CounterCostSelection, DelayedTriggerCondition, Duration, EffectKind,
-    GameRestriction, KeywordAction, KickerVariant, LibraryPosition, ModalChoice, PileSource,
-    QuantityExpr, ResolvedAbility, SearchDestinationSplit, SearchSelectionConstraint,
-    StaticCondition, TapCreaturesAggregate, TargetFilter, TargetRef, ThisWayCause,
-    TriggerCondition, TriggerDefinition,
+    ChosenAttribute, CoinFlipResult, Comparator, ContinuousModification, ControlWindow,
+    CopyChooseScope, CopyScale, CostPaidObjectSnapshot, CounterCostSelection,
+    DelayedTriggerCondition, Duration, EffectKind, GameRestriction, KeywordAction, KickerVariant,
+    LibraryPosition, ModalChoice, PileSource, QuantityExpr, ResolvedAbility,
+    SearchDestinationSplit, SearchSelectionConstraint, StaticCondition, TapCreaturesAggregate,
+    TargetFilter, TargetRef, ThisWayCause, TriggerCondition, TriggerDefinition,
 };
 use super::attribution::ObjectAttribution;
 use super::card::{CardFace, TokenImageRef};
@@ -1363,6 +1363,10 @@ pub struct PendingEachPlayerCopyChosen {
     pub copy_modifications: Vec<ContinuousModification>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scale: Option<CopyScale>,
+    /// CR 102.1 + CR 103.1: whose battlefield the paused chooser drew from, so a
+    /// mid-flight save/reload reconstructs the correct eligibility controller.
+    #[serde(default)]
+    pub choose_scope: CopyChooseScope,
     pub source_id: ObjectId,
     pub source_controller: PlayerId,
     /// APNAP-ordered scoped player set (for a mid-choice save/reload).
@@ -4933,7 +4937,8 @@ pub enum WaitingFor {
     /// each subsequent player in APNAP order.
     EachPlayerCopyChosenSelection {
         player: PlayerId,
-        /// The choosing player's own eligible objects (public battlefield info).
+        /// Eligible objects for this chooser — either their own or their
+        /// seat-neighbor's, per `choose_scope` (all public battlefield info).
         eligible: Vec<TargetRef>,
         min: u32,
         max: u32,
@@ -4942,6 +4947,10 @@ pub enum WaitingFor {
         copy_modifications: Vec<ContinuousModification>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         scale: Option<CopyScale>,
+        /// CR 102.1 + CR 103.1: whose battlefield this chooser's pool was drawn
+        /// from, so live re-validation (CR 608.2c) uses the right controller.
+        #[serde(default)]
+        choose_scope: CopyChooseScope,
         source_id: ObjectId,
         source_controller: PlayerId,
         /// Players still to choose after the current one (APNAP order).


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** UNSUPPORTED seam: Each-player simultaneous choice of a left-neighbor's creature + copy-token with an added ability

## Cards corrected
- Caught in a Parallel Universe

## Fix
Implemented cluster 114 (Caught in a Parallel Universe) per the approved plan by parameterizing the single hardcoded eligibility axis of Effect::EachPlayerCopyChosen with a new typed leaf enum CopyChooseScope { Chooser, Neighbor { direction: SeatDirection } } and extending the whole-body parser to recognize the seat-relative choose clause.

Layers touched: (1) types/ability.rs — added CopyChooseScope enum (documenting the deliberate divergence from ControllerRef: generative battlefield enumeration bypasses the controller_ref_player filter-predicate path, and adding a seat variant to ControllerRef's ~177 exhaustive arms would cost every unrelated subsystem for a 2-card class) plus a #[serde(default)] choose_scope field on the variant; (2) types/game_state.rs — mirrored choose_scope onto WaitingFor::EachPlayerCopyChosenSelection and PendingEachPlayerCopyChosen for live revalidation and replacement-pause resume; (3) game/effects/each_player_copy_chosen.rs — new pool_controller() resolving scope+chooser via the existing players::neighbor CR 102.1/103.1 authority, threaded through compute_eligible / is_live_eligible_choice / CopyChosenParams / make_pending; (4) game/engine_resolution_choices.rs — SelectTargets round-trip threads choose_scope; (5) parser/oracle_target.rs — new shared pub(crate) parse_neighbor_seat_direction combinator (accepts their|your × left|right) with the two inline TargetFilter::Neighbor arms refactored to delegate (Boy-Scout dedup); (6) parser/oracle_effect/mod.rs — controller-clause dispatch via composed nom alt (they control -> Chooser, controlled by the player to their L/R -> Neighbor), fail-closed; (7) full-field arm updates in ability_scan.rs and ability_rw.rs; (8) frontend types.ts optional choose_scope field (modal ignores it).

The parser is nom-combinator-only (no string dispatch added). oracle-gen export confirms Caught now lowers to EachPlayerCopyChosen{choose_scope: Neighbor{Left}, copy_modifications:[AddKeyword(Menace)], min:1, max:1}, player_scope All, sub_ability None, with no Unimplemented.

Tests: converted the locked deferred-gap trigger test into a positive test asserting the true post-fix shape; updated the Human—Time Lord full-field destructure to assert CopyChooseScope::Chooser; added a parser building-block test (Neighbor{Right} + flying, class-level not card-level); added a parse_neighbor_seat_direction unit test (both possessives x both directions + fail-closed); added a 3-player resolver direction-correctness runtime proof (each token copies the left neighbor's distinct creature — a Left->Right swap would fail it) and a 2-player neighbor-pool prompt + CR 608.2c live-revalidation runtime proof.

Verification (worktree runs cargo directly, no Tilt): cargo fmt clean; cargo clippy -p engine -p phase-ai -p engine-wasm -- -D warnings finished clean (no --all-targets per disk ceiling, still compiles the phase-ai/engine-wasm libs where non-exhaustive matches surface); cargo test -p engine each_player_copy_chosen = 13 passed incl 3 new; caught/neighbor/existing-target tests pass; cargo test -p phase-ai passes; check-parser-combinators.sh exit 0; parser diff gate clean (only a typed Vec<TypeFilter>::contains in a test assertion). CR annotations grep-verified against docs/MagicCompRules.txt: 101.4 (APNAP), 102.1, 103.1, 707.2, 608.2c. Deviation: cargo coverage / cargo semantic-audit not run due to the worktree disk ceiling (100% used, ~3-4GiB free; they recompile under different feature flags and risk ENOSPC) — their signal for this card (no Unimplemented) is confirmed directly by the oracle-gen full-card export. No stop-and-return items, no CR ambiguity, no scope expansion. Changes left uncommitted.

## Files changed
- crates/engine/src/types/ability.rs
- crates/engine/src/types/game_state.rs
- crates/engine/src/game/effects/each_player_copy_chosen.rs
- crates/engine/src/game/engine_resolution_choices.rs
- crates/engine/src/game/ability_scan.rs
- crates/engine/src/game/ability_rw.rs
- crates/engine/src/parser/oracle_target.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/parser/oracle_effect/tests.rs
- crates/engine/src/parser/oracle_trigger_tests.rs
- client/src/adapter/types.ts

## CR references
- CR 101.4
- CR 102.1
- CR 103.1
- CR 707.2
- CR 608.2c
- CR 312.5
- CR 205.4
- CR 702.111a

## Verification
- `cargo fmt --all` — clean — no files changed, nothing to commit
- `check-parser-combinators.sh (base=7e1ddc9b merge-base upstream/main)` — Gate A PASS, exit 0
- `cargo clippy -p engine -p phase-ai -p engine-wasm -- -D warnings` — clean, exit 0 — all four crates (engine, phase-ai, seat-reducer, engine-wasm) checked, no warnings; exhaustive matches over EachPlayerCopyChosen variant compile
- `cargo test -p engine -p phase-ai` — exit 0 — all tests passed, 0 failed across every suite
- `oracle-gen data --filter 'caught in a parallel universe'` — parses correctly — AST matches oracle text
Cards confirmed re-parsed correctly: caught in a parallel universe

🤖 Generated with [Claude Code](https://claude.com/claude-code)
