### PR TITLE
Fix Mishra, Claimed by Gix and attacking Meld resolution

### DIFF
--- a/client/src/adapter/__tests__/waiting-for-handler-parity.test.ts
+++ b/client/src/adapter/__tests__/waiting-for-handler-parity.test.ts
@@ -27,6 +27,11 @@ const INTERNAL_NEVER_PLAYER_FACING: ReadonlySet<WaitingFor["type"]> =
   new Set<WaitingFor["type"]>([]);
 
 describe("WaitingFor handler parity", () => {
+  it("registers both interactive meld waiting states", () => {
+    expect(HANDLED_WAITING_FOR_TYPES.has("MeldPairChoice")).toBe(true);
+    expect(HANDLED_WAITING_FOR_TYPES.has("MeldAttackTargetChoice")).toBe(true);
+  });
+
   it("every engine WaitingFor variant has a frontend UI handler", () => {
     const rustSource = readFileSync(
       resolve(repoRoot(), "crates/engine/src/types/game_state.rs"),

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -298,6 +298,25 @@ export type AttackTarget =
   | { type: "Planeswalker"; data: ObjectId }
   | { type: "Battle"; data: ObjectId };
 
+export type EntryAttackDestination =
+  | { type: "AnyDefender" }
+  | { type: "PlayerOrPlaneswalker" }
+  | { type: "Exact"; data: { target: AttackTarget } };
+
+export type PermanentEntryMode =
+  | { type: "Normal" }
+  | { type: "TappedAndAttacking"; data: { destination: EntryAttackDestination } };
+
+export interface MeldSelection {
+  source_id: ObjectId;
+  partner_id: ObjectId;
+  controller: PlayerId;
+  expected_source: string;
+  expected_partner: string;
+  result: string;
+  entry: PermanentEntryMode;
+}
+
 // CR 508.1c/d + CR 509.1b/c: per-creature combat requirement/restriction the
 // engine surfaces on the declare-attackers/blockers waiting payloads for
 // display-only badges + Confirm gating. `#[serde(tag = "kind")]` in the engine.
@@ -1317,6 +1336,8 @@ export type MulliganDecisionPhase =
 
 export type WaitingFor =
   | { type: "Priority"; data: { player: PlayerId } }
+  | { type: "MeldPairChoice"; data: { player: PlayerId; choices: MeldSelection[] } }
+  | { type: "MeldAttackTargetChoice"; data: { player: PlayerId; context: MeldSelection; valid_targets: AttackTarget[] } }
   | { type: "ActivationCostOneOfChoice"; data: { player: PlayerId; costs: SerializedAbilityCost[]; pending_cast: PendingCast } }
   | {
       type: "MulliganDecision";
@@ -1841,6 +1862,8 @@ export type PrecastCopyShortcutResponse =
 
 export type GameAction =
   | { type: "PassPriority" }
+  | { type: "ChooseMeldPair"; data: { source_id: ObjectId; partner_id: ObjectId } }
+  | { type: "ChooseEntryAttackTarget"; data: { target: AttackTarget } }
   | { type: "RollPlanarDie" }
   | { type: "ChooseActivationCostBranch"; data: { index: number } }
   | { type: "PlayLand"; data: { object_id: ObjectId; card_id: CardId } }

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -37,13 +37,13 @@ export interface DeckData {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
- * 15 — Meld pair/attacking-entry choices and mana-payment preview variants.
+ * 16 — Meld pair/attacking-entry choices after the mana-payment preview variants.
  * 14 — PrecastCopyShortcut action and its two WaitingFor variants.
  * 13 — WaitingFor::MulliganBottomCards removed; mulligan bottoming folded
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 15;
+export const PROTOCOL_VERSION = 16;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -38,6 +38,7 @@ export interface DeckData {
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
  * 16 — Meld pair/attacking-entry choices after the mana-payment preview variants.
+ * 15 — Mana-payment preview request/response variants.
  * 14 — PrecastCopyShortcut action and its two WaitingFor variants.
  * 13 — WaitingFor::MulliganBottomCards removed; mulligan bottoming folded
  *      into a MulliganDecisionPhase::BottomCards sub-phase on

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -37,7 +37,7 @@ export interface DeckData {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
- * 15 — Mana-payment preview request/response variants.
+ * 15 — Meld pair/attacking-entry choices and mana-payment preview variants.
  * 14 — PrecastCopyShortcut action and its two WaitingFor variants.
  * 13 — WaitingFor::MulliganBottomCards removed; mulligan bottoming folded
  *      into a MulliganDecisionPhase::BottomCards sub-phase on

--- a/client/src/game/waitingForRegistry.ts
+++ b/client/src/game/waitingForRegistry.ts
@@ -33,6 +33,9 @@ export const HANDLED_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> =
   new Set<WaitingFor["type"]>([
     // Active priority — passes via PassButton / mana payment / cast.
     "Priority",
+    // CR 701.42 / CR 508.4: meld pair and attacking-entry destination dialogs.
+    "MeldPairChoice",
+    "MeldAttackTargetChoice",
     // Cast / activation chain — ManaPayment + PhyrexianPayment share ManaPaymentUI.
     ...MANA_PAYMENT_WAITING_FOR_TYPES,
     "ChooseXValue",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1036,6 +1036,13 @@
     "activationCost": {
       "title": "Aktivierungskosten wählen"
     },
+    "meld": {
+      "choosePair": "Wähle die zu verschmelzenden Karten",
+      "into": "Zu {{result}} verschmelzen",
+      "chooseAttackTarget": "Wähle, was angegriffen wird",
+      "player": "Spieler {{id}}",
+      "permanent": "Bleibende Karte {{id}}"
+    },
     "debug": {
       "modeBanner": "DEBUG-MODUS - Klicke eine beliebige Karte",
       "modeButtonOff": "KLICKMODUS AUS"

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1068,6 +1068,13 @@
     "activationCost": {
       "title": "Choose Activation Cost"
     },
+    "meld": {
+      "choosePair": "Choose Cards to Meld",
+      "into": "Meld into {{result}}",
+      "chooseAttackTarget": "Choose What It Attacks",
+      "player": "Player {{id}}",
+      "permanent": "Permanent {{id}}"
+    },
     "debug": {
       "modeBanner": "DEBUG MODE - Click any card",
       "modeButtonOff": "CLICK MODE OFF"

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1036,6 +1036,13 @@
     "activationCost": {
       "title": "Elegir coste de activación"
     },
+    "meld": {
+      "choosePair": "Elige las cartas que se fusionarán",
+      "into": "Fusionar en {{result}}",
+      "chooseAttackTarget": "Elige qué atacará",
+      "player": "Jugador {{id}}",
+      "permanent": "Permanente {{id}}"
+    },
     "debug": {
       "modeBanner": "MODO DEPURACIÓN - Haz clic en cualquier carta",
       "modeButtonOff": "MODO CLIC DESACTIVADO"

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1036,6 +1036,13 @@
     "activationCost": {
       "title": "Choisir le coût d'activation"
     },
+    "meld": {
+      "choosePair": "Choisissez les cartes à assimiler",
+      "into": "Assimiler en {{result}}",
+      "chooseAttackTarget": "Choisissez ce qu’il attaque",
+      "player": "Joueur {{id}}",
+      "permanent": "Permanent {{id}}"
+    },
     "debug": {
       "modeBanner": "MODE DÉBOGAGE - Cliquez sur n'importe quelle carte",
       "modeButtonOff": "MODE CLIC DÉSACTIVÉ"

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1036,6 +1036,13 @@
     "activationCost": {
       "title": "Scegli il costo di attivazione"
     },
+    "meld": {
+      "choosePair": "Scegli le carte da combinare",
+      "into": "Combina in {{result}}",
+      "chooseAttackTarget": "Scegli cosa attacca",
+      "player": "Giocatore {{id}}",
+      "permanent": "Permanente {{id}}"
+    },
     "debug": {
       "modeBanner": "MODALITÀ DEBUG - Clicca qualsiasi carta",
       "modeButtonOff": "MODALITÀ CLIC DISATTIVATA"

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1036,6 +1036,13 @@
     "activationCost": {
       "title": "Wybierz koszt aktywacji"
     },
+    "meld": {
+      "choosePair": "Wybierz karty do scalenia",
+      "into": "Scal w {{result}}",
+      "chooseAttackTarget": "Wybierz, co atakuje",
+      "player": "Gracz {{id}}",
+      "permanent": "Permanent {{id}}"
+    },
     "debug": {
       "modeBanner": "TRYB DEBUGOWANIA - Kliknij dowolną kartę",
       "modeButtonOff": "TRYB KLIKNIĘCIA WYŁĄCZONY"

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1036,6 +1036,13 @@
     "activationCost": {
       "title": "Escolher Custo de Ativação"
     },
+    "meld": {
+      "choosePair": "Escolha os cards para fundir",
+      "into": "Fundir em {{result}}",
+      "chooseAttackTarget": "Escolha o que ele ataca",
+      "player": "Jogador {{id}}",
+      "permanent": "Permanente {{id}}"
+    },
     "debug": {
       "modeBanner": "MODO DE DEPURAÇÃO - Clique em qualquer carta",
       "modeButtonOff": "MODO DE CLIQUE DESLIGADO"

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -47,6 +47,19 @@ describe("encodeWireMessage / decodeWireMessage", () => {
       action: { type: "PassPriority" },
     },
     {
+      type: "action",
+      senderPlayerId: 0,
+      action: { type: "ChooseMeldPair", data: { source_id: 42, partner_id: 43 } },
+    },
+    {
+      type: "action",
+      senderPlayerId: 0,
+      action: {
+        type: "ChooseEntryAttackTarget",
+        data: { target: { type: "Battle", data: 44 } },
+      },
+    },
+    {
       type: "game_setup",
       wireProtocolVersion: WIRE_PROTOCOL_VERSION,
       assignedPlayerId: 1,

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -61,7 +61,7 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *   3 — Planechase state and action payloads in game_setup/reconnect snapshots
  *   4 — Archenemy derived view and scheme deck payloads
  *   5 — CardPredicateGuessMade game event shape
- *   8 — Mana-payment preview request/response variants.
+ *   8 — Meld pair/attacking-entry choices and mana-payment preview variants.
  *   7 — PrecastCopyShortcut action and its two WaitingFor variants.
  *   6 — Mulligan bottoming folded into a MulliganDecisionPhase::BottomCards
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -61,13 +61,14 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *   3 — Planechase state and action payloads in game_setup/reconnect snapshots
  *   4 — Archenemy derived view and scheme deck payloads
  *   5 — CardPredicateGuessMade game event shape
- *   8 — Meld pair/attacking-entry choices and mana-payment preview variants.
+ *   9 — Meld pair and attacking-entry choices after mana-payment preview variants.
+ *   8 — Mana-payment preview request/response variants.
  *   7 — PrecastCopyShortcut action and its two WaitingFor variants.
  *   6 — Mulligan bottoming folded into a MulliganDecisionPhase::BottomCards
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
  *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 8 as const;
+export const WIRE_PROTOCOL_VERSION = 9 as const;
 
 export type P2PMessage =
   | { type: "guest_deck"; deckData: unknown; displayName?: string; reservationToken?: string }

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1702,6 +1702,7 @@ function GamePageContent({
         {waitingFor?.type === "OrderTriggers" &&
           canActForWaitingState && <TriggerOrderModal />}
         <BattleProtectorModal />
+        <MeldChoiceModal />
         <AssistChoosePlayerModal />
         <ClashOpponentModal />
         <PileOpponentModal />
@@ -3324,6 +3325,57 @@ function ActivationCostOneOfChoiceModal() {
       }
     />
   );
+}
+
+function MeldChoiceModal() {
+  const { t } = useTranslation("game");
+  const dispatch = useGameDispatch();
+  const waitingFor = useGameStore((s) => s.waitingFor);
+  const objects = useGameStore((s) => s.gameState?.objects);
+
+  if (waitingFor?.type === "MeldPairChoice") {
+    const choices = waitingFor.data.choices;
+    return (
+      <ChoiceModal
+        title={t("gamePage.meld.choosePair")}
+        options={choices.map((choice, index) => ({
+          id: String(index),
+          label: `${objects?.[choice.source_id]?.name ?? choice.expected_source} + ${objects?.[choice.partner_id]?.name ?? choice.expected_partner}`,
+          description: t("gamePage.meld.into", { result: choice.result }),
+        }))}
+        onChoose={(id) => {
+          const choice = choices[Number.parseInt(id, 10)];
+          if (!choice) return;
+          dispatch({
+            type: "ChooseMeldPair",
+            data: { source_id: choice.source_id, partner_id: choice.partner_id },
+          });
+        }}
+      />
+    );
+  }
+
+  if (waitingFor?.type === "MeldAttackTargetChoice") {
+    const targets = waitingFor.data.valid_targets;
+    return (
+      <ChoiceModal
+        title={t("gamePage.meld.chooseAttackTarget")}
+        options={targets.map((target, index) => {
+          const label = target.type === "Player"
+            ? t("gamePage.meld.player", { id: target.data })
+            : objects?.[target.data]?.name ?? t("gamePage.meld.permanent", { id: target.data });
+          return { id: String(index), label };
+        })}
+        onChoose={(id) => {
+          const target = targets[Number.parseInt(id, 10)];
+          if (!target) return;
+          dispatch({ type: "ChooseEntryAttackTarget", data: { target } });
+        }}
+      />
+    );
+  }
+
+  return null;
 }
 
 function DebugModeBanner() {

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -355,6 +355,33 @@ fn permute_into(
 /// constructing `GameAction::Concede { player_id }` directly.
 pub fn candidate_actions_exact(state: &GameState) -> Vec<CandidateAction> {
     match &state.waiting_for {
+        WaitingFor::MeldPairChoice { player, choices } => choices
+            .iter()
+            .map(|choice| {
+                candidate(
+                    GameAction::ChooseMeldPair {
+                        source_id: choice.source_id,
+                        partner_id: choice.partner_id,
+                    },
+                    TacticalClass::Selection,
+                    Some(*player),
+                )
+            })
+            .collect(),
+        WaitingFor::MeldAttackTargetChoice {
+            player,
+            valid_targets,
+            ..
+        } => valid_targets
+            .iter()
+            .map(|target| {
+                candidate(
+                    GameAction::ChooseEntryAttackTarget { target: *target },
+                    TacticalClass::Attack,
+                    Some(*player),
+                )
+            })
+            .collect(),
         WaitingFor::ReplacementChoice {
             candidate_count,
             player,
@@ -744,6 +771,9 @@ pub fn candidate_actions_broad_with_probe(
     probe: Option<&casting::PriorityCastProbe>,
 ) -> Vec<CandidateAction> {
     let actions = match &state.waiting_for {
+        WaitingFor::MeldPairChoice { .. } | WaitingFor::MeldAttackTargetChoice { .. } => {
+            candidate_actions_exact(state)
+        }
         WaitingFor::Priority { player } => priority_actions_with_probe(state, *player, probe),
         WaitingFor::ManaPayment {
             player,

--- a/crates/engine/src/database/card_db.rs
+++ b/crates/engine/src/database/card_db.rs
@@ -171,7 +171,12 @@ impl CardDatabase {
                     .copied()
                     .unwrap_or_default(),
             };
-            out.insert(face.name.clone(), entry);
+            // Preserve the database storage key, not merely the printed face
+            // name. Meld pairs have two distinct combined-back records with the
+            // same printed name and different oracle ids; oracle-gen keeps the
+            // loser under a hidden `[oracle-id]` key. Re-keying both by
+            // `face.name` here collapsed one half in AI-worker subsets.
+            out.insert(key, entry);
         }
         serde_json::to_string(&out).expect("CardExportEntry serialization is infallible")
     }

--- a/crates/engine/src/database/meld_tests.rs
+++ b/crates/engine/src/database/meld_tests.rs
@@ -62,6 +62,7 @@ fn find_meld(face: &CardFace) -> Option<(String, String, String)> {
             source,
             partner,
             result,
+            ..
         } = def.effect.as_ref()
         {
             return Some((source.clone(), partner.clone(), result.clone()));
@@ -94,6 +95,10 @@ const HANWEIR_TEXT: &str = "{T}: Add {R}.\n\
     {3}{R}{R}, {T}: If you both own and control this land and a creature named Hanweir Garrison, \
     exile them, then meld them into Hanweir, the Writhing Township. Activate only as a sorcery.";
 
+const URZA_TEXT: &str = "Artifact, instant, and sorcery spells you cast cost {1} less to cast.\n\
+    {7}: If you both own and control Urza, Lord Protector and an artifact named The Mightstone and \
+    Weakstone, exile them, then meld them into Urza, Planeswalker. Activate only as a sorcery.";
+
 /// The optional-cost triggered meld form (Vanille / Fang): the own/control gate
 /// is followed by a reflexive "you may pay {C}. If you do," additional cost before
 /// the meld sentinel. The gate models this (CR 118.12): the own/control gate
@@ -105,18 +110,91 @@ const VANILLE_TEXT: &str = "When Vanille enters, mill two cards, then return a p
     creature named Fang, Fearless l'Cie, you may pay {3}{B}{G}. If you do, exile them, then \
     meld them into Ragnarok, Divine Deliverance.";
 
+const MISHRA_TEXT: &str = "Whenever you attack, each opponent loses X life and you gain X life, \
+    where X is the number of attacking creatures. If Mishra, Claimed by Gix and a creature named \
+    Phyrexian Dragon Engine are attacking, and you both own and control them, exile them, then meld \
+    them into Mishra, Lost to Phyrexia. It enters tapped and attacking.";
+
+/// CR 608.2d + CR 701.42 + CR 508.4: Mishra's later conditional remains a
+/// resolution-time child after the unconditional life-swing, and carries the
+/// live attacking pair filters plus the typed tapped-and-attacking entry mode.
+#[test]
+fn mishra_later_conditional_meld_is_fully_lowered() {
+    use crate::types::ability::{
+        EntryAttackDestination, FilterProp, PermanentEntryMode, TargetFilter,
+    };
+
+    fn in_def(def: &crate::types::ability::AbilityDefinition) -> Option<&Effect> {
+        if matches!(def.effect.as_ref(), Effect::Meld { .. }) {
+            return Some(def.effect.as_ref());
+        }
+        def.sub_ability
+            .as_deref()
+            .and_then(in_def)
+            .or_else(|| def.else_ability.as_deref().and_then(in_def))
+            .or_else(|| def.mode_abilities.iter().find_map(in_def))
+    }
+
+    let mishra = parse_face(&atomic(
+        "Mishra, Claimed by Gix",
+        "Legendary Creature — Phyrexian Human Artificer",
+        &["Creature"],
+        MISHRA_TEXT,
+    ));
+    let meld = mishra
+        .triggers
+        .iter()
+        .filter_map(|trigger| trigger.execute.as_deref())
+        .find_map(in_def)
+        .expect("Mishra's attack trigger contains a meld child");
+    let Effect::Meld {
+        source,
+        partner,
+        result,
+        source_filter,
+        partner_filter,
+        entry,
+    } = meld
+    else {
+        unreachable!("finder only returns Meld")
+    };
+    assert_eq!(source, "Mishra, Claimed by Gix");
+    assert_eq!(partner, "Phyrexian Dragon Engine");
+    assert_eq!(result, "Mishra, Lost to Phyrexia");
+    assert!(matches!(
+        entry,
+        PermanentEntryMode::TappedAndAttacking {
+            destination: EntryAttackDestination::AnyDefender
+        }
+    ));
+    assert!(matches!(source_filter, TargetFilter::And { .. }));
+    let TargetFilter::Typed(partner_typed) = partner_filter else {
+        panic!("partner filter must be one typed live-filter")
+    };
+    assert!(partner_typed
+        .properties
+        .iter()
+        .any(|prop| matches!(prop, FilterProp::Attacking { .. })));
+    assert!(partner_typed.properties.iter().any(|prop| matches!(
+        prop,
+        FilterProp::Owned {
+            controller: crate::types::ability::ControllerRef::You
+        }
+    )));
+    assert!(
+        !crate::game::coverage::card_face_has_unimplemented_parts(&mishra),
+        "Mishra's attack trigger must not retain an Unimplemented residual"
+    );
+}
+
 /// CR 701.42a: the triggered instigator (Gisela, creature partner) parses to an
 /// `Effect::Meld { source, partner, result }` carrying the correct source,
 /// partner, and result names. The own/control gate is hoisted to the trigger's
 /// intervening-if, so the bare residual "exile them, then meld them into R"
 /// parses cleanly.
 ///
-/// The activated / inline-gate form (Hanweir Battlements) is DEFERRED: its text
-/// leads with the inline "if you both own and control ..." gate, which the meld
-/// effect interception does not strip (stripping it would swallow the
-/// `Condition_If` — a coverage-honesty regression). It therefore yields NO
-/// `Effect::Meld` and remains Unimplemented until a real activated-ability
-/// condition node is added (follow-up).
+/// Activated inline gates lower through the same typed AbilityCondition seam as
+/// other resolution-time conditions; they are not intervening-if triggers.
 #[test]
 fn synthesize_or_parse_derives_self_partner_result() {
     let gisela = parse_face(&atomic(
@@ -136,11 +214,23 @@ fn synthesize_or_parse_derives_self_partner_result() {
         &["Land"],
         HANWEIR_TEXT,
     ));
-    assert!(
-        find_meld(&hanweir).is_none(),
-        "the activated/inline-gate form is deferred (must NOT swallow the inline \
-         Condition_If by emitting an Effect::Meld)"
-    );
+    let (source, partner, result) =
+        find_meld(&hanweir).expect("Hanweir's activated inline gate parses Meld");
+    assert_eq!(source, "Hanweir Battlements");
+    assert_eq!(partner, "Hanweir Garrison");
+    assert_eq!(result, "Hanweir, the Writhing Township");
+
+    let urza = parse_face(&atomic(
+        "Urza, Lord Protector",
+        "Legendary Creature — Human Artificer",
+        &["Creature"],
+        URZA_TEXT,
+    ));
+    let (source, partner, result) =
+        find_meld(&urza).expect("Urza's activated inline gate parses Meld");
+    assert_eq!(source, "Urza, Lord Protector");
+    assert_eq!(partner, "The Mightstone and Weakstone");
+    assert_eq!(result, "Urza, Planeswalker");
 }
 
 /// CR 118.12 + CR 701.42a: the optional-cost meld form (Vanille / Fang) carries a
@@ -217,10 +307,14 @@ fn triggered_vs_activated_shape() {
         HANWEIR_TEXT,
     ));
     assert!(
-        !hanweir.abilities.iter().any(|a| {
-            a.kind == AbilityKind::Activated && matches!(a.effect.as_ref(), Effect::Meld { .. })
+        hanweir.abilities.iter().any(|a| {
+            a.kind == AbilityKind::Activated
+                && (matches!(a.effect.as_ref(), Effect::Meld { .. })
+                    || a.sub_ability
+                        .as_ref()
+                        .is_some_and(|sub| matches!(sub.effect.as_ref(), Effect::Meld { .. })))
         }),
-        "the activated/inline-gate form is deferred — no activated Effect::Meld is emitted"
+        "the activated inline-gate form emits a conditioned Meld"
     );
 }
 

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -4658,10 +4658,15 @@ fn rw_effect(
             source: _,
             partner: _,
             result: _,
+            source_filter,
+            partner_filter,
+            entry: _,
         } => {
             let mut p = ext_write(StateKind::SetMembership);
             p.writes_membership_external_census.merge(Census::Any);
             p.writes_membership_external_zones.merge(ZoneSpan::Any);
+            p.merge(rw_target_filter(source_filter));
+            p.merge(rw_target_filter(partner_filter));
             (p, None)
         }
         Effect::PhaseOut { target } => obj_membership_scope(target, chain_root),

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -740,7 +740,10 @@ fn scan_effect(x: &Effect) -> Axes {
             source: _,
             partner: _,
             result: _,
-        } => Axes::NONE,
+            source_filter,
+            partner_filter,
+            entry: _,
+        } => scan_target_filter(source_filter).or(scan_target_filter(partner_filter)),
         Effect::ExileHaunting { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));

--- a/crates/engine/src/game/card_subset.rs
+++ b/crates/engine/src/game/card_subset.rs
@@ -427,4 +427,34 @@ mod tests {
         );
         assert!(subset.get_face_by_name("Plain Card").is_some());
     }
+
+    #[test]
+    fn subset_preserves_duplicate_meld_back_storage_keys() {
+        let front_a = creature_face("Meld Front A", "meld-a");
+        let front_b = creature_face("Meld Front B", "meld-b");
+        let back_a = creature_face("Shared Meld Back", "meld-a");
+        let back_b = creature_face("Shared Meld Back", "meld-b");
+        let export = serde_json::json!({
+            "meld front a": entry_value(&front_a, Some("meld"), &[], &[], false),
+            "meld front b": entry_value(&front_b, Some("meld"), &[], &[], false),
+            "shared meld back": entry_value(&back_a, Some("meld"), &[], &[], false),
+            "shared meld back [meld-b]": entry_value(&back_b, Some("meld"), &[], &[], false),
+        })
+        .to_string();
+        let db = CardDatabase::from_json_str(&export).expect("meld export parses");
+        let names = db.face_index.keys().cloned().collect();
+        let subset = CardDatabase::from_json_str(&db.export_subset_json(&names))
+            .expect("meld subset parses");
+
+        for front in [&front_a, &front_b] {
+            let printed = printed_ref_from_face(front).expect("front has printed identity");
+            assert_eq!(
+                subset
+                    .get_other_face_by_printed_ref(&printed)
+                    .map(|face| face.name.as_str()),
+                Some("Shared Meld Back"),
+                "each front oracle id retains its own shared-name back"
+            );
+        }
+    }
 }

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -4290,6 +4290,116 @@ pub fn get_valid_attack_targets(state: &GameState) -> Vec<AttackTarget> {
     targets
 }
 
+/// CR 508.4 + CR 508.4c: destinations for a creature put onto the battlefield
+/// attacking. This intentionally does not call attack-declaration legality:
+/// requirements, restrictions, costs, protection, goad, summoning sickness,
+/// and taxes do not apply to an object that was never declared as an attacker.
+pub fn valid_entry_attack_targets(
+    state: &GameState,
+    controller: PlayerId,
+    domain: &crate::types::ability::EntryAttackDestination,
+) -> Vec<AttackTarget> {
+    let attacking_players: Vec<PlayerId> = std::iter::once(state.active_player)
+        .chain(players::teammates(state, state.active_player))
+        .collect();
+    if state.combat.is_none() || !attacking_players.contains(&controller) {
+        return Vec::new();
+    }
+    let allies = players::teammates(state, controller);
+    let defending_players: Vec<PlayerId> = state
+        .players
+        .iter()
+        .filter(|player| {
+            player.id != controller
+                && !allies.contains(&player.id)
+                && !state.eliminated_players.contains(&player.id)
+                && player.is_phased_in()
+        })
+        .map(|player| player.id)
+        .collect();
+    let mut targets: Vec<AttackTarget> = defending_players
+        .iter()
+        .copied()
+        .map(AttackTarget::Player)
+        .collect();
+    for &id in &state.battlefield {
+        let Some(object) = state.objects.get(&id) else {
+            continue;
+        };
+        if defending_players.contains(&object.controller)
+            && object
+                .card_types
+                .core_types
+                .contains(&CoreType::Planeswalker)
+        {
+            targets.push(AttackTarget::Planeswalker(id));
+        }
+        if object.card_types.core_types.contains(&CoreType::Battle)
+            && object
+                .protector()
+                .is_some_and(|protector| defending_players.contains(&protector))
+        {
+            targets.push(AttackTarget::Battle(id));
+        }
+    }
+
+    match domain {
+        crate::types::ability::EntryAttackDestination::AnyDefender => targets,
+        crate::types::ability::EntryAttackDestination::PlayerOrPlaneswalker => targets
+            .into_iter()
+            .filter(|candidate| !matches!(candidate, AttackTarget::Battle(_)))
+            .collect(),
+        crate::types::ability::EntryAttackDestination::Exact { target } => targets
+            .into_iter()
+            .filter(|candidate| candidate == target)
+            .collect(),
+    }
+}
+
+/// CR 508.4a: resolve a still-valid entry-attack target to its defending
+/// player. Returns `None` when the selected player/permanent is no longer a
+/// legal combat destination, in which case the permanent enters nonattacking.
+pub fn entry_attack_target_defender(
+    state: &GameState,
+    controller: PlayerId,
+    target: AttackTarget,
+) -> Option<PlayerId> {
+    if !valid_entry_attack_targets(
+        state,
+        controller,
+        &crate::types::ability::EntryAttackDestination::AnyDefender,
+    )
+    .contains(&target)
+    {
+        return None;
+    }
+    match target {
+        AttackTarget::Player(player) => state
+            .players
+            .iter()
+            .any(|candidate| {
+                candidate.id == player
+                    && candidate.is_phased_in()
+                    && !state.eliminated_players.contains(&player)
+            })
+            .then_some(player),
+        AttackTarget::Planeswalker(id) => state.objects.get(&id).and_then(|object| {
+            (object.zone == Zone::Battlefield
+                && object
+                    .card_types
+                    .core_types
+                    .contains(&CoreType::Planeswalker))
+            .then_some(object.controller)
+        }),
+        AttackTarget::Battle(id) => state.objects.get(&id).and_then(|object| {
+            (object.zone == Zone::Battlefield
+                && object.card_types.core_types.contains(&CoreType::Battle))
+            .then(|| object.protector())
+            .flatten()
+        }),
+    }
+}
+
 /// CR 506.4: A creature stops being an attacker when it leaves the battlefield
 /// or phases out. Attackers that left during the declare-attackers step may
 /// remain listed until pruned.
@@ -5928,6 +6038,83 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("cannot attack player"), "err={err}");
+    }
+
+    #[test]
+    fn entry_attacker_controlled_by_active_teammate_uses_defending_team() {
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+        state.turn_number = 2;
+        state.active_player = PlayerId(0);
+        state.combat = Some(CombatState::default());
+
+        let targets = valid_entry_attack_targets(
+            &state,
+            PlayerId(1),
+            &crate::types::ability::EntryAttackDestination::AnyDefender,
+        );
+        assert!(targets.contains(&AttackTarget::Player(PlayerId(2))));
+        assert!(targets.contains(&AttackTarget::Player(PlayerId(3))));
+        assert!(!targets.contains(&AttackTarget::Player(PlayerId(0))));
+        assert!(!targets.contains(&AttackTarget::Player(PlayerId(1))));
+        assert_eq!(
+            entry_attack_target_defender(&state, PlayerId(1), AttackTarget::Player(PlayerId(2)),),
+            Some(PlayerId(2))
+        );
+    }
+
+    /// CR 508.4a-c: an effect may specify the player, planeswalker, or battle
+    /// that an entering creature attacks. Exact destinations use the same live
+    /// defender validation as the open choice domain, including protected
+    /// battles, and disappear when the specified destination becomes stale.
+    #[test]
+    fn exact_entry_attack_destination_validates_all_target_kinds_and_staleness() {
+        use crate::types::ability::EntryAttackDestination;
+
+        let mut state = setup();
+        state.combat = Some(CombatState::default());
+        let planeswalker = create_planeswalker(&mut state, PlayerId(1), "Defending Jace");
+        let battle = create_battle(&mut state, PlayerId(0), "Protected Invasion", PlayerId(1));
+
+        for target in [
+            AttackTarget::Player(PlayerId(1)),
+            AttackTarget::Planeswalker(planeswalker),
+            AttackTarget::Battle(battle),
+        ] {
+            assert_eq!(
+                valid_entry_attack_targets(
+                    &state,
+                    PlayerId(0),
+                    &EntryAttackDestination::Exact { target },
+                ),
+                vec![target],
+                "each exact live defender kind must remain available"
+            );
+        }
+
+        crate::game::zones::move_to_zone(
+            &mut state,
+            planeswalker,
+            Zone::Graveyard,
+            &mut Vec::new(),
+        );
+        crate::game::zones::move_to_zone(&mut state, battle, Zone::Graveyard, &mut Vec::new());
+        state.eliminated_players.push(PlayerId(1));
+
+        for target in [
+            AttackTarget::Player(PlayerId(1)),
+            AttackTarget::Planeswalker(planeswalker),
+            AttackTarget::Battle(battle),
+        ] {
+            assert!(
+                valid_entry_attack_targets(
+                    &state,
+                    PlayerId(0),
+                    &EntryAttackDestination::Exact { target },
+                )
+                .is_empty(),
+                "a stale exact destination must produce a nonattacking entry"
+            );
+        }
     }
 
     /// CR 805.10d: "Creatures controlled by the defending players can block

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -627,6 +627,10 @@ fn apply_pending_counter_post_action(
             }
             true
         }
+        PendingCounterPostAction::FinishMeldEntry { context } => {
+            crate::game::meld::finish_deferred_meld_entry(state, context, events);
+            true
+        }
         PendingCounterPostAction::ClearPendingEtbCounters { object_id } => {
             state
                 .pending_etb_counters

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1932,7 +1932,9 @@ fn apply_parent_chain_context(
 fn waits_for_resolution_choice(waiting_for: &WaitingFor) -> bool {
     matches!(
         waiting_for,
-        WaitingFor::ScryChoice { .. }
+        WaitingFor::MeldPairChoice { .. }
+            | WaitingFor::MeldAttackTargetChoice { .. }
+            | WaitingFor::ScryChoice { .. }
             | WaitingFor::RedistributeLifeTotals { .. }
             | WaitingFor::CoinFlipKeepChoice { .. }
             | WaitingFor::DigChoice { .. }

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -5904,6 +5904,8 @@ mod tests {
                 spec_resume: None,
                 enter_tapped: EtbTapState::Unspecified,
                 enter_with_counters: Vec::new(),
+                kind: crate::types::game_state::LiminalEntryKind::Token,
+                replacement_applied: std::collections::HashSet::new(),
             },
         );
 

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -552,6 +552,8 @@ pub(crate) fn apply_copy_token_after_replacement_with_created_ids(
                     spec_resume: None,
                     enter_tapped,
                     enter_with_counters: Vec::new(),
+                    kind: crate::types::game_state::LiminalEntryKind::Token,
+                    replacement_applied: std::collections::HashSet::new(),
                 },
             );
 
@@ -573,11 +575,12 @@ pub(crate) fn apply_copy_token_after_replacement_with_created_ids(
                                 events,
                             )
                         {
-                            state.pending_liminal_entry_resume = Some(PendingLiminalEntryResume {
-                                source_id: token_id,
-                                player: waiting_for.acting_player().unwrap_or(controller),
-                                event: event.clone(),
-                            });
+                            state.pending_liminal_entry_resume =
+                                Some(PendingLiminalEntryResume::Token {
+                                    source_id: token_id,
+                                    player: waiting_for.acting_player().unwrap_or(controller),
+                                    event: event.clone(),
+                                });
                             state.waiting_for = waiting_for;
                             state.last_created_token_ids = created_ids.clone();
                             return CopyTokenApplyStatus {

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -290,7 +290,7 @@ pub(super) fn handle_replacement_choice(
                             events,
                         ) {
                             state.pending_liminal_entry_resume =
-                                Some(crate::types::game_state::PendingLiminalEntryResume {
+                                Some(crate::types::game_state::PendingLiminalEntryResume::Token {
                                     source_id: entry_ref,
                                     player: waiting_for
                                         .acting_player()
@@ -1154,7 +1154,17 @@ pub(super) fn handle_copy_target_choice(
                 "Missing liminal entry resume".to_string(),
             ));
         };
-        if resume.source_id != source_id || resume.player != player {
+        let (resume_source_id, resume_player) = match &resume {
+            crate::types::game_state::PendingLiminalEntryResume::Token {
+                source_id,
+                player,
+                ..
+            }
+            | crate::types::game_state::PendingLiminalEntryResume::Meld {
+                source_id, player, ..
+            } => (*source_id, *player),
+        };
+        if resume_source_id != source_id || resume_player != player {
             return Err(EngineError::InvalidAction(
                 "Mismatched liminal entry resume".to_string(),
             ));
@@ -1182,6 +1192,53 @@ pub(super) fn handle_copy_target_choice(
                     player,
                 )
             });
+        if let crate::types::game_state::PendingLiminalEntryResume::Meld { context, .. } = resume {
+            // The empty batch record only carried `MeldEntry` across the copy
+            // choice. The typed liminal resume now owns completion, including a
+            // possible counter-replacement pause, so remove that superseded
+            // record before the generic copy finisher tries to drain it.
+            if state
+                .pending_batch_deliveries
+                .as_ref()
+                .is_some_and(|pending| {
+                    pending.remaining.is_empty()
+                        && matches!(
+                            &pending.completion,
+                            Some(crate::types::game_state::BatchCompletion::MeldEntry { .. })
+                        )
+                })
+            {
+                state.pending_batch_deliveries = None;
+            }
+            if !crate::game::meld::commit_meld_battlefield(state, &context) {
+                crate::game::meld::finish_deferred_meld_resolution(state, source_id, events);
+                return Ok(state.waiting_for.clone());
+            }
+            // CR 707.9: the copy effect is installed after the meld result's
+            // layer-1 identity, so its later timestamp determines the entering
+            // permanent's copiable values.
+            let _ = effects::resolve_ability_chain(state, &ability, events, 0);
+            let post_actions = vec![PendingCounterPostAction::FinishMeldEntry {
+                context: context.clone(),
+            }];
+            if let Some(waiting_for) =
+                finish_copy_target_choice_entry(state, source_id, events, post_actions, false)?
+            {
+                if state.pending_counter_additions.is_none() {
+                    crate::game::meld::finish_deferred_meld_entry(state, context, events);
+                }
+                return Ok(waiting_for);
+            }
+            crate::game::meld::finish_deferred_meld_entry(state, context, events);
+            return Ok(state.waiting_for.clone());
+        }
+        let crate::types::game_state::PendingLiminalEntryResume::Token {
+            event: resume_event,
+            ..
+        } = resume
+        else {
+            unreachable!("meld resume returned above")
+        };
         let entry_events = state
             .liminal_entries
             .get(&source_id)
@@ -1239,7 +1296,7 @@ pub(super) fn handle_copy_target_choice(
         }
         if !super::effects::token::commit_liminal_token_entry_with_event_emission(
             state,
-            resume.event,
+            resume_event,
             events,
             TokenEntryEventEmission::Suppress,
         ) {
@@ -1271,9 +1328,13 @@ pub(super) fn handle_copy_target_choice(
                 remaining_count,
             });
         }
-        if let Some(waiting_for) =
-            finish_copy_target_choice_entry(state, source_id, events, counter_pause_post_actions)?
-        {
+        if let Some(waiting_for) = finish_copy_target_choice_entry(
+            state,
+            source_id,
+            events,
+            counter_pause_post_actions,
+            true,
+        )? {
             return Ok(waiting_for);
         }
         if let Some((name, event_source_id)) = entry_events {
@@ -1347,7 +1408,7 @@ pub(super) fn handle_copy_target_choice(
         });
     let _ = effects::resolve_ability_chain(state, &ability, events, 0);
     if let Some(waiting_for) =
-        finish_copy_target_choice_entry(state, source_id, events, Vec::new())?
+        finish_copy_target_choice_entry(state, source_id, events, Vec::new(), true)?
     {
         return Ok(waiting_for);
     }
@@ -1361,6 +1422,7 @@ fn finish_copy_target_choice_entry(
     source_id: ObjectId,
     events: &mut Vec<GameEvent>,
     counter_pause_post_actions: Vec<PendingCounterPostAction>,
+    replay_entry_events: bool,
 ) -> Result<Option<WaitingFor>, EngineError> {
     // Force a full layer pass after the copy chain so the realized
     // characteristics below (enter-tapped, ETB counters) read post-copy state.
@@ -1395,13 +1457,15 @@ fn finish_copy_target_choice_entry(
     // on the battlefield — concede / error / chained-replacement paths can
     // leave a stale event in the vec, and we discard rather than fire a
     // phantom entry trigger.
-    if let Some(waiting_for) = replay_deferred_entry_events(state, source_id, events)? {
-        return Ok(Some(waiting_for));
+    if replay_entry_events {
+        if let Some(waiting_for) = replay_deferred_entry_events(state, source_id, events)? {
+            return Ok(Some(waiting_for));
+        }
     }
     // CR 702.49c: a ninjutsu entry that deferred `BatchCompletion::NinjutsuPlacement`
     // while paused on `CopyTargetChoice` must run combat placement after the copy
     // resolves (mirrors the `ReturnAsAuraTarget` batch drain in engine.rs).
-    if state.pending_batch_deliveries.is_some() {
+    if replay_entry_events && state.pending_batch_deliveries.is_some() {
         crate::game::zone_pipeline::drain_pending_batch_deliveries(state, events);
         if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
             return Ok(Some(state.waiting_for.clone()));
@@ -1798,7 +1862,7 @@ fn is_enters_counter_choice(branches: &[AbilityDefinition]) -> bool {
 fn capture_deferred_entry_events_if_mid_entry_choice(
     state: &mut GameState,
     waiting_for: Option<&WaitingFor>,
-    events: &[GameEvent],
+    events: &mut Vec<GameEvent>,
 ) {
     let source_id = match waiting_for {
         Some(WaitingFor::CopyTargetChoice { source_id, .. }) => *source_id,
@@ -1831,7 +1895,7 @@ fn capture_deferred_entry_events_if_mid_entry_choice(
     // events. This already affects CopyTargetChoice today, is unreachable in real
     // cards, and is the CR 614.12b simultaneous-entry boundary.
     state.deferred_entry_events.clear();
-    for event in events {
+    for event in events.iter() {
         if matches!(
             event,
             GameEvent::ZoneChanged { object_id, to, .. }
@@ -1839,6 +1903,27 @@ fn capture_deferred_entry_events_if_mid_entry_choice(
         ) {
             state.deferred_entry_events.push(event.clone());
         }
+    }
+    let is_meld_entry = state.liminal_entries.get(&source_id).is_some_and(|entry| {
+        matches!(
+            entry.kind,
+            crate::types::game_state::LiminalEntryKind::Meld { .. }
+        )
+    });
+    if is_meld_entry {
+        // The final copy characteristics and CR 508.4 combat status are not
+        // known yet. Unlike ordinary copy entry animation, emit this meld entry
+        // only after its final snapshot has been refreshed.
+        events.retain(|event| {
+            !matches!(
+                event,
+                GameEvent::ZoneChanged {
+                    object_id,
+                    to: Zone::Battlefield,
+                    ..
+                } if *object_id == source_id
+            )
+        });
     }
 }
 

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -109,7 +109,9 @@ fn park_search_observer_triggers(
 pub(super) fn handles(waiting_for: &WaitingFor) -> bool {
     matches!(
         waiting_for,
-        WaitingFor::ScryChoice { .. }
+        WaitingFor::MeldPairChoice { .. }
+            | WaitingFor::MeldAttackTargetChoice { .. }
+            | WaitingFor::ScryChoice { .. }
             | WaitingFor::RedistributeLifeTotals { .. }
             | WaitingFor::CoinFlipKeepChoice { .. }
             | WaitingFor::ManifestDreadChoice { .. }
@@ -560,6 +562,42 @@ pub(super) fn handle_resolution_choice(
     events: &mut Vec<GameEvent>,
 ) -> Result<ResolutionChoiceOutcome, EngineError> {
     let outcome = match (waiting_for, action) {
+        (
+            WaitingFor::MeldPairChoice { player, choices },
+            GameAction::ChooseMeldPair {
+                source_id,
+                partner_id,
+            },
+        ) => {
+            let context = choices
+                .into_iter()
+                .find(|choice| choice.source_id == source_id && choice.partner_id == partner_id)
+                .ok_or_else(|| {
+                    EngineError::InvalidAction(
+                        "meld selection is not one of the offered pairs".to_string(),
+                    )
+                })?;
+            state.waiting_for = WaitingFor::Priority { player };
+            crate::game::meld::begin_selected_meld(state, context, events);
+            ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
+        }
+        (
+            WaitingFor::MeldAttackTargetChoice {
+                player,
+                context,
+                valid_targets,
+            },
+            GameAction::ChooseEntryAttackTarget { target },
+        ) => {
+            if !valid_targets.contains(&target) {
+                return Err(EngineError::InvalidAction(
+                    "entry attack target is not one of the offered destinations".to_string(),
+                ));
+            }
+            state.waiting_for = WaitingFor::Priority { player };
+            crate::game::meld::finish_meld_attack_choice(state, context, target, events);
+            ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
+        }
         (
             WaitingFor::ScryChoice { player, cards },
             GameAction::SelectCards { cards: top_cards },
@@ -5188,6 +5226,18 @@ pub(crate) fn run_batch_completion(
                 events,
             )
             .expect("scoped library search batch completion must resolve");
+        }
+        BatchCompletion::MeldExile { context } => {
+            crate::game::meld::finish_meld_exile(state, context, events);
+        }
+        BatchCompletion::MeldEntry {
+            context,
+            attack_target,
+        } => {
+            crate::game::meld::finish_meld_delivery(state, context, attack_target, events);
+        }
+        BatchCompletion::MeldRedirect { source_id } => {
+            crate::game::meld::finish_deferred_meld_resolution(state, source_id, events);
         }
     }
 }

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -1277,7 +1277,22 @@ pub fn matches_target_filter_on_battlefield_entry(
 ) -> bool {
     match event {
         ProposedEvent::ZoneChange { object_id, to, .. } if *to == Zone::Battlefield => {
-            matches_target_filter(state, *object_id, filter, ctx)
+            if let Some(entry) = state.liminal_entries.get(object_id) {
+                filter_inner_for_object(
+                    state,
+                    &entry.object,
+                    *object_id,
+                    filter,
+                    ctx.source_id,
+                    ctx.source_controller,
+                    ctx.ability,
+                    ctx.recipient_id,
+                    ctx.scoped_iteration_player,
+                    ControllerLookup::LiveOrLki,
+                )
+            } else {
+                matches_target_filter(state, *object_id, filter, ctx)
+            }
         }
         ProposedEvent::TokenEntry { entry_ref, .. } => {
             state.liminal_entries.get(entry_ref).is_some_and(|entry| {

--- a/crates/engine/src/game/meld.rs
+++ b/crates/engine/src/game/meld.rs
@@ -1,50 +1,32 @@
-//! Meld (CR 701.42 / CR 712.4) — runtime resolver for the meld keyword action.
+//! Meld resolution (CR 701.42 / CR 712.4).
 //!
-//! A meld instigator's ability (triggered or activated) resolves to
-//! [`Effect::Meld`], dispatched here via [`perform_meld`]. When the controller
-//! both OWNS and CONTROLS the instigator (`source_id`) AND a battlefield object
-//! named `partner` (CR 701.42b), both cards are exiled and a single melded
-//! permanent is put onto the battlefield presenting the `result` card's
-//! characteristics (the combined back faces, exposed in card-data as the named
-//! result card). If either half is missing/illegal the objects stay in place
-//! (CR 701.42c, a silent no-op).
-//!
-//! ## LAYER-ONLY characteristics (never mutate the survivor's base)
-//!
-//! Unlike a naive "apply the result face onto the survivor", this resolver is
-//! LAYER-ONLY: it NEVER calls `apply_card_face_to_object` on the survivor (that
-//! would overwrite the survivor's `base_*`, permanently replacing Gisela's
-//! printed identity with Brisela). Instead it builds a [`CopiableValues`] from
-//! the result `CardFace` via [`copiable_values_from_face`] and installs it as a
-//! layer-1 `CopyValues` continuous effect through
-//! [`merge::install_merge_layer_effect`] — exactly mirroring `merge_object_onto`'s
-//! never-touch-base discipline. On leave, `split_merged_permanent_on_leave`
-//! returns each card as its own FRONT face (Gisela / Bruna), satisfying
-//! CR 712.4b / CR 712.21.
-//!
-//! ## Meld DOES enter the battlefield (unlike Mutate)
-//!
-//! `merge_object_onto` (Mutate) SUPPRESSES ETB per CR 730.2b; meld does NOT
-//! (CR 701.42a / CR 712.4a — "put them onto the battlefield"). The survivor's
-//! exile→battlefield entry is therefore driven through the NORMAL
-//! `zones::move_to_zone` path so the `ZoneChanged { to: Battlefield }` event
-//! fires and ETB triggers match (CR 603.6a). This is why `merge_object_onto`
-//! is NOT reused wholesale — only its `merged_components` bookkeeping, its
-//! layer-install pattern, and `split_merged_permanent_on_leave` are shared.
+//! Live Oracle referents are selected from current layered characteristics.
+//! The selected objects are then exiled simultaneously; only afterward are
+//! their physical front-face identities checked. This distinction is required
+//! for copied/renamed/token objects: they may satisfy the instruction's live
+//! condition while still being unable to form the printed meld pair.
 
+use crate::game::combat::{self, AttackTarget, AttackerInfo};
 use crate::game::game_object::MergeKind;
 use crate::game::merge;
-use crate::game::printed_cards::{copiable_values_from_face, printed_ref_from_face};
-use crate::game::zone_pipeline::{self, ZoneMoveRequest};
-use crate::types::ability::{Effect, EffectError, ResolvedAbility};
+use crate::game::printed_cards::{
+    apply_card_face_to_object, copiable_values_from_face, printed_ref_from_face,
+};
+use crate::game::zone_pipeline::{self, BatchMoveResult, ZoneMoveRequest, ZoneMoveResult};
+use crate::types::ability::{
+    ControllerRef, Effect, EffectError, FilterProp, PermanentEntryMode, ResolvedAbility,
+    TargetFilter, TypedFilter,
+};
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{
+    BatchCompletion, GameState, LiminalEntry, LiminalEntryKind, MeldSelection, WaitingFor,
+};
+use crate::types::identifiers::ObjectId;
+use crate::types::proposed_event::EtbTapState;
 use crate::types::zones::Zone;
 
-/// CR 701.42 / CR 712.4: Resolve a meld instigator ability. Exiles both halves
-/// (CR 701.42a) and puts a single melded permanent onto the battlefield
-/// presenting the `result` card's characteristics, or no-ops if the meld is
-/// illegal (CR 701.42c).
+/// CR 701.42a-b: choose the live referents for a meld instruction. Physical
+/// pair validation deliberately occurs after the exile instruction.
 pub fn perform_meld(
     state: &mut GameState,
     ability: &ResolvedAbility,
@@ -52,121 +34,358 @@ pub fn perform_meld(
 ) -> Result<(), EffectError> {
     let Effect::Meld {
         source: expected_source,
-        partner,
+        partner: expected_partner,
         result,
+        source_filter,
+        partner_filter,
+        entry,
     } = &ability.effect
     else {
         return Err(EffectError::MissingParam("Meld".to_string()));
     };
 
-    let source = ability.source_id;
+    let source_id = ability.source_id;
     let controller = ability.controller;
-
-    // CR 701.42b: the controller must both OWN and CONTROL the instigator, and
-    // the instigator must be the real meld card — only a card (CR 111.1: not a
-    // token; CR 707.10: not a copy) printed with the meld instruction can be
-    // melded. A token copy or a renamed non-meld impostor carrying the same name
-    // is NOT a valid meld half. The instigator must be on the battlefield (it was
-    // put there to activate/trigger this ability).
-    let source_ok = state.objects.get(&source).is_some_and(|o| {
-        o.zone == Zone::Battlefield
-            && o.controller == controller
-            && o.owner == controller
-            && o.is_represented_by_a_card()
-            && o.base_name.eq_ignore_ascii_case(expected_source.as_str())
+    let filter_ctx = crate::game::filter::FilterContext::from_ability(ability);
+    let source_matches = state.objects.get(&source_id).is_some_and(|object| {
+        object.zone == Zone::Battlefield
+            && object.owner == controller
+            && object.controller == controller
+            && crate::game::filter::matches_target_filter(
+                state,
+                source_id,
+                source_filter,
+                &filter_ctx,
+            )
     });
-    if !source_ok {
-        // CR 701.42c: objects that can't be melded stay in their current zone.
+    if !source_matches {
+        emit_resolved(state, ability.source_id, events);
         return Ok(());
     }
 
-    // CR 701.42b: find a battlefield object that is the real `partner` meld card,
-    // co-owned and co-controlled. We match `base_name` (the object's PRINTED
-    // identity), NOT the layer-modified current `name`: `FilterProp::Named`
-    // matches the post-layer `name` (filter.rs:2812), which (i) would let a
-    // renamed non-meld impostor whose current name equals the partner pass, and
-    // (ii) would wrongly REJECT a real partner whose name was changed by an
-    // effect. `base_name` is rename-proof — `ContinuousModification::SetName`
-    // overwrites `name` but never `base_name`, and layers reset `name =
-    // base_name` each pass — so a `base_name` match proves the object IS the real
-    // pair card (closing the token/copy/rename impostor classes and the
-    // real-partner-renamed inverse). It must also be card-backed (CR 111.1 /
-    // CR 707.10) for the same reason as the source.
-    let Some(partner_id) = state.battlefield.iter().copied().find(|&id| {
-        id != source
-            && state.objects.get(&id).is_some_and(|o| {
-                o.controller == controller
-                    && o.owner == controller
-                    && o.is_represented_by_a_card()
-                    && o.base_name.eq_ignore_ascii_case(partner.as_str())
+    let effective_partner_filter = if matches!(partner_filter, TargetFilter::Any) {
+        legacy_partner_filter(expected_partner)
+    } else {
+        partner_filter.clone()
+    };
+    let choices: Vec<MeldSelection> = state
+        .battlefield
+        .iter()
+        .copied()
+        .filter(|candidate| *candidate != source_id)
+        .filter(|candidate| {
+            state.objects.get(candidate).is_some_and(|object| {
+                object.owner == controller
+                    && object.controller == controller
+                    && crate::game::filter::matches_target_filter(
+                        state,
+                        *candidate,
+                        &effective_partner_filter,
+                        &filter_ctx,
+                    )
             })
-    }) else {
-        // CR 701.42c: no real co-owned/controlled partner → no-op.
-        return Ok(());
-    };
+        })
+        .map(|partner_id| MeldSelection {
+            source_id,
+            partner_id,
+            controller,
+            expected_source: expected_source.clone(),
+            expected_partner: expected_partner.clone(),
+            result: result.clone(),
+            entry: entry.clone(),
+        })
+        .collect();
 
-    // CR 712.4b: resolve the result `CardFace` from the registry (seeded at init
-    // via `walk_effect` → `build_conjure_registry`; conjure lookup pattern). If
-    // the result card is unknown, the meld cannot produce its permanent — no-op.
-    let Some(result_face) = state
-        .card_face_registry
-        .get(&result.to_lowercase())
-        .cloned()
-    else {
-        return Ok(());
-    };
-
-    // CR 701.42a / CR 614.6: exile BOTH halves. Route through the zone-change
-    // pipeline so any exile `Moved` redirect is consulted (none target Exile
-    // today — behavior-preserving, future-proof), mirroring `haunt::resolve`.
-    for &id in &[source, partner_id] {
-        let res = zone_pipeline::move_object(
-            state,
-            ZoneMoveRequest::effect(id, Zone::Exile, source),
-            events,
-        );
-        if let zone_pipeline::ZoneMoveResult::NeedsChoice(player) = res {
-            // CR 616.1: a future Exile-targeting redirect could surface an
-            // ordering choice. Park the prompt and return (no redirect targets
-            // Exile today, so this is behavior-preserving).
-            state.waiting_for =
-                crate::game::replacement::replacement_choice_waiting_for(player, state);
-            return Ok(());
+    match choices.as_slice() {
+        [] => emit_resolved(state, ability.source_id, events),
+        [only] => begin_selected_meld(state, only.clone(), events),
+        _ => {
+            state.waiting_for = WaitingFor::MeldPairChoice {
+                player: controller,
+                choices,
+            };
         }
     }
+    Ok(())
+}
 
-    // CR 730.2c-analogue: the survivor is the instigator (`source`), keeping its
-    // `ObjectId`. Record the merge identity (CR 712.21 leave-split reads it) and
-    // the TYPED meld discriminator (CR 712.4c transform guard keys on it).
-    // DO NOT call `apply_card_face_to_object` — meld is LAYER-ONLY; the
-    // survivor's `base_*` (its front face, Gisela) must stay intact so it returns
-    // as its own front face on leave (CR 712.4b / CR 712.21).
-    if let Some(survivor) = state.objects.get_mut(&source) {
-        survivor.merged_components = vec![source, partner_id];
-        survivor.merge_kind = Some(MergeKind::Meld);
+fn legacy_partner_filter(name: &str) -> TargetFilter {
+    TargetFilter::Typed(TypedFilter {
+        type_filters: Vec::new(),
+        controller: Some(ControllerRef::You),
+        properties: vec![
+            FilterProp::Named {
+                name: name.to_string(),
+            },
+            FilterProp::Owned {
+                controller: ControllerRef::You,
+            },
+        ],
+    })
+}
+
+/// Start the exact selected pair's simultaneous exile batch.
+pub(crate) fn begin_selected_meld(
+    state: &mut GameState,
+    context: MeldSelection,
+    events: &mut Vec<GameEvent>,
+) {
+    let requests = vec![
+        ZoneMoveRequest::effect(context.source_id, Zone::Exile, context.source_id),
+        ZoneMoveRequest::effect(context.partner_id, Zone::Exile, context.source_id),
+    ];
+    let completion = BatchCompletion::MeldExile {
+        context: context.clone(),
+    };
+    match zone_pipeline::move_objects_simultaneously_then(state, requests, Some(completion), events)
+    {
+        BatchMoveResult::Done | BatchMoveResult::NeedsChoice => {}
+    }
+}
+
+/// CR 701.42b-c + CR 400.7j: after both exile attempts settle, validate the
+/// tracked physical cards in whatever public zones the instruction put them.
+pub(crate) fn finish_meld_exile(
+    state: &mut GameState,
+    context: MeldSelection,
+    events: &mut Vec<GameEvent>,
+) {
+    if !is_canonical_physical_meld_pair(state, &context)
+        || !state
+            .card_face_registry
+            .contains_key(&context.result.to_lowercase())
+    {
+        finish_resolution(state, context.source_id, events);
+        return;
     }
 
-    // CR 712.4b: install the result characteristics (combined back faces) as a
-    // layer-1 copy effect WITHOUT mutating the survivor's base identity, so each
-    // card returns as its own front face on leave (CR 712.21). Build the values
-    // directly from the result face (LAYER-ONLY) — never from the survivor's base
-    // (which is intentionally never written here). `install_merge_layer_effect`
-    // calls `flush_layers`, so the survivor already presents the result
-    // characteristics BEFORE the ETB-emitting entry below — mirroring
-    // `merge_object_onto`'s install-then-observe ordering and the conjure entry
-    // path, so the ETB scan sees the melded permanent.
+    // CR 508.4 + CR 614.12a: replacement effects can determine the entrant's
+    // controller. The attack-destination choice is therefore made by the final
+    // controller after the replacement pipeline has produced its approved
+    // event, immediately before delivery.
+    finish_meld_entry(state, context, None, events);
+}
+
+/// CR 701.42b + CR 400.2 + CR 400.7j: whether a selected pair is the canonical
+/// physical meld pair and remains findable after the preceding exile
+/// instruction. Replacement effects may leave a card where it was or move it
+/// to a different public zone; neither changes the tracked card identity.
+pub fn is_canonical_physical_meld_pair(state: &GameState, context: &MeldSelection) -> bool {
+    let pair_key = format!(
+        "{}\0{}",
+        context.expected_source.to_lowercase(),
+        context.expected_partner.to_lowercase()
+    );
+    let canonical_pair = state
+        .meld_pair_registry
+        .get(&pair_key)
+        .is_some_and(|record| {
+            record.source.eq_ignore_ascii_case(&context.expected_source)
+                && record
+                    .partner
+                    .eq_ignore_ascii_case(&context.expected_partner)
+                && record.result.eq_ignore_ascii_case(&context.result)
+        });
+    let physical_pair = state.objects.get(&context.source_id).is_some_and(|object| {
+        is_public_zone(object.zone)
+            && object.is_represented_by_a_card()
+            && object
+                .base_name
+                .eq_ignore_ascii_case(&context.expected_source)
+    }) && state
+        .objects
+        .get(&context.partner_id)
+        .is_some_and(|object| {
+            is_public_zone(object.zone)
+                && object.is_represented_by_a_card()
+                && object
+                    .base_name
+                    .eq_ignore_ascii_case(&context.expected_partner)
+        });
+    canonical_pair && physical_pair
+}
+
+/// CR 400.2: graveyard, battlefield, stack, exile, and command are public
+/// zones. Hand and library remain hidden even when their cards are revealed.
+fn is_public_zone(zone: Zone) -> bool {
+    match zone {
+        Zone::Battlefield | Zone::Graveyard | Zone::Stack | Zone::Exile | Zone::Command => true,
+        Zone::Library | Zone::Hand => false,
+    }
+}
+
+/// Commit the projected result entry, then atomically make the second card a
+/// component if (and only if) the result actually reached the battlefield.
+pub(crate) fn finish_meld_entry(
+    state: &mut GameState,
+    context: MeldSelection,
+    attack_target: Option<AttackTarget>,
+    events: &mut Vec<GameEvent>,
+) {
+    let Some(result_face) = state
+        .card_face_registry
+        .get(&context.result.to_lowercase())
+        .cloned()
+    else {
+        finish_resolution(state, context.source_id, events);
+        return;
+    };
+
+    // CR 614.12: replacement effects inspect the characteristics the meld result
+    // will have on the battlefield. Keep that projection detached while choices
+    // are pending: the two physical component cards remain ordinary objects in
+    // their post-instruction public zones until the entry actually commits.
+    let Some(mut projected) = state.objects.get(&context.source_id).cloned() else {
+        finish_resolution(state, context.source_id, events);
+        return;
+    };
+    apply_card_face_to_object(&mut projected, &result_face);
+    projected.controller = context.controller;
+    let enters_tapped = matches!(context.entry, PermanentEntryMode::TappedAndAttacking { .. });
+    if enters_tapped {
+        projected.tapped = true;
+    }
+    state.liminal_entries.insert(
+        context.source_id,
+        LiminalEntry {
+            object: projected,
+            name: context.result.clone(),
+            source_id: context.source_id,
+            controller: context.controller,
+            enters_attacking: attack_target.is_some(),
+            attach_to: None,
+            sacrifice_at: None,
+            remaining_count: 0,
+            created_ids: Vec::new(),
+            copy_resume: None,
+            spec_resume: None,
+            enter_tapped: if enters_tapped {
+                EtbTapState::Tapped
+            } else {
+                EtbTapState::Unspecified
+            },
+            enter_with_counters: Vec::new(),
+            kind: LiminalEntryKind::Meld {
+                context: context.clone(),
+                attack_target,
+            },
+            replacement_applied: std::collections::HashSet::new(),
+        },
+    );
+
+    let mut request =
+        ZoneMoveRequest::effect(context.source_id, Zone::Battlefield, context.source_id);
+    if enters_tapped {
+        request = request.tapped();
+    }
+    match zone_pipeline::move_object(state, request, events) {
+        ZoneMoveResult::NeedsChoice(_) | ZoneMoveResult::NeedsAuraAttachmentChoice => {
+            zone_pipeline::defer_completion_on_pause(
+                state,
+                BatchCompletion::MeldEntry {
+                    context,
+                    attack_target,
+                },
+            );
+        }
+        ZoneMoveResult::Done => finish_meld_delivery(state, context, attack_target, events),
+    }
+}
+
+/// Finish a synchronously delivered or replacement-resumed meld entry.
+pub(crate) fn finish_meld_delivery(
+    state: &mut GameState,
+    context: MeldSelection,
+    attack_target: Option<AttackTarget>,
+    events: &mut Vec<GameEvent>,
+) {
+    // The approved entry event may have changed the entrant's controller and
+    // may have auto-selected the only CR 508.4 destination after replacement
+    // processing. That post-replacement liminal state is authoritative for both
+    // synchronous delivery and a deferred BatchCompletion resume.
+    let (context, _attack_target, replacement_applied) = state
+        .liminal_entries
+        .get(&context.source_id)
+        .and_then(|entry| match &entry.kind {
+            LiminalEntryKind::Meld {
+                context,
+                attack_target,
+                ..
+            } => Some((
+                context.clone(),
+                *attack_target,
+                entry.replacement_applied.clone(),
+            )),
+            LiminalEntryKind::Token => None,
+        })
+        .unwrap_or((context, attack_target, Default::default()));
+    state.liminal_entries.remove(&context.source_id);
+    let destination = state
+        .objects
+        .get(&context.source_id)
+        .map(|object| object.zone);
+    if destination != Some(Zone::Battlefield) {
+        // CR 701.42c: a prevented entry leaves both cards in exile. If a
+        // replacement sent the result elsewhere, route the second physical card
+        // through its own CR 400.6 replacement consult to the same destination.
+        // CR 614.5: seed that modified event with the result event's applied set
+        // so the redirect that fixed the shared destination cannot apply again.
+        if let Some(zone) = destination.filter(|zone| *zone != Zone::Exile) {
+            let request = ZoneMoveRequest::effect(context.partner_id, zone, context.source_id)
+                .with_replacement_applied(replacement_applied);
+            let completion = BatchCompletion::MeldRedirect {
+                source_id: context.source_id,
+            };
+            match zone_pipeline::move_objects_simultaneously_then(
+                state,
+                vec![request],
+                Some(completion),
+                events,
+            ) {
+                BatchMoveResult::Done | BatchMoveResult::NeedsChoice => {}
+            }
+            return;
+        }
+        finish_resolution(state, context.source_id, events);
+        return;
+    }
+
+    if commit_meld_battlefield(state, &context) {
+        finish_deferred_meld_entry(state, context, events);
+    } else {
+        finish_resolution(state, context.source_id, events);
+    }
+}
+
+/// Materialize the meld result's layer-1 identity and physical component set.
+/// This is separate from resolution completion so a CR 707.9 copy-as-enters
+/// choice can install its later-timestamp copy effect after the meld identity.
+pub(crate) fn commit_meld_battlefield(state: &mut GameState, context: &MeldSelection) -> bool {
+    state.liminal_entries.remove(&context.source_id);
+
+    let Some(result_face) = state
+        .card_face_registry
+        .get(&context.result.to_lowercase())
+        .cloned()
+    else {
+        return false;
+    };
+    let entry_controller = state
+        .objects
+        .get(&context.source_id)
+        .map(|object| object.controller)
+        .unwrap_or(context.controller);
     let values = copiable_values_from_face(&result_face);
     let printed_ref = printed_ref_from_face(&result_face);
     merge::install_merge_layer_effect(
         state,
-        source,
-        controller,
+        context.source_id,
+        entry_controller,
         values,
         crate::game::game_object::DisplaySource::Card,
         printed_ref,
         None,
     );
-
     // CR 701.42a / CR 730.2: absorb the partner into the single melded permanent
     // — it is no longer an independent object; remove it from the exile list and
     // mark it absorbed (zone == Battlefield, in no zone list), mirroring
@@ -175,45 +394,257 @@ pub fn perform_meld(
     // entry-replacement consult (CR 614.1c) can park a `NeedsChoice` pause, and
     // absorbing first guarantees the partner is never stranded in exile across
     // that pause.
-    crate::game::zones::absorb_component(state, partner_id, Some(Zone::Exile));
-
-    // CR 603.6a / CR 701.42a: drive the survivor's exile→battlefield entry through
-    // the zone-change pipeline so the `ZoneChanged { to: Battlefield }` event
-    // fires and ETB triggers match (unlike Mutate's CR 730.2b suppression). The
-    // `Effect` cause is non-exempt, so `execute_zone_move` runs the entry
-    // replacement consult (CR 614.1c entries-with-counters / CR 614.12a
-    // enters-tapped) that a raw `move_to_zone` would skip. The leave-split
-    // (CR 712.21) is wired automatically into the exit seam via
-    // `split_merged_permanent_on_leave` — no leave code needed here.
-    // `reset_for_battlefield_entry` does NOT clear merged_components / merge_kind
-    // / merge_layer_effect_id, so the merge identity survives the entry.
-    match zone_pipeline::move_object(
-        state,
-        ZoneMoveRequest::effect(source, Zone::Battlefield, source),
-        events,
-    ) {
-        zone_pipeline::ZoneMoveResult::Done => {
-            // CR 613.1 + CR 400.7: the battlefield entry re-derived the survivor's
-            // characteristics from its (intact) base, so re-flush the layers to
-            // re-apply the installed meld `CopyValues` on top — the melded
-            // permanent presents the result identity (Brisela) once it is on the
-            // battlefield (the same re-flush the prior raw path performed). The
-            // transient continuous effect persists across the move (its id is
-            // keyed to the survivor and not cleared on entry).
-            crate::game::layers::flush_layers(state);
-            Ok(())
-        }
-        zone_pipeline::ZoneMoveResult::NeedsChoice(player) => {
-            // CR 616.1: an entry replacement surfaced an ordering choice. Park the
-            // prompt and return; the partner is already absorbed (above), so it is
-            // not stranded across the pause.
-            state.waiting_for =
-                crate::game::replacement::replacement_choice_waiting_for(player, state);
-            Ok(())
-        }
-        // CR 303.4f: only an Aura entering via a non-spell effect needs an
-        // enchant-host choice. A melded permanent is never an Aura, so this arm is
-        // documented-unreachable — handled exhaustively rather than wildcarded.
-        zone_pipeline::ZoneMoveResult::NeedsAuraAttachmentChoice => Ok(()),
+    crate::game::zones::absorb_component(state, context.partner_id, Some(Zone::Exile));
+    if let Some(survivor) = state.objects.get_mut(&context.source_id) {
+        survivor.merged_components = vec![context.source_id, context.partner_id];
+        survivor.merge_kind = Some(MergeKind::Meld);
     }
+    crate::game::layers::flush_layers(state);
+
+    if matches!(context.entry, PermanentEntryMode::TappedAndAttacking { .. }) {
+        if let Some(object) = state.objects.get_mut(&context.source_id) {
+            object.tapped = true;
+        }
+    }
+    true
+}
+
+/// CR 508.4 + CR 611.3: after every as-enters choice and continuous-effect
+/// layer has finalized the melded permanent, use its current creature status
+/// and controller to determine whether and where it enters attacking.
+pub(crate) fn finish_deferred_meld_entry(
+    state: &mut GameState,
+    mut context: MeldSelection,
+    events: &mut Vec<GameEvent>,
+) {
+    crate::game::layers::mark_layers_full(state);
+    crate::game::layers::flush_layers(state);
+
+    let Some(object) = state.objects.get(&context.source_id) else {
+        finish_resolution(state, context.source_id, events);
+        return;
+    };
+    if object.zone != Zone::Battlefield {
+        finish_resolution(state, context.source_id, events);
+        return;
+    }
+    let controller = object.controller;
+    let is_creature = object
+        .card_types
+        .core_types
+        .contains(&crate::types::card_type::CoreType::Creature);
+    context.controller = controller;
+
+    let targets = match &context.entry {
+        PermanentEntryMode::TappedAndAttacking { destination } if is_creature => {
+            combat::valid_entry_attack_targets(state, controller, destination)
+        }
+        PermanentEntryMode::Normal | PermanentEntryMode::TappedAndAttacking { .. } => Vec::new(),
+    };
+
+    if targets.len() > 1 {
+        park_meld_entry_event(state, context.source_id, events);
+        state.waiting_for = WaitingFor::MeldAttackTargetChoice {
+            player: controller,
+            context,
+            valid_targets: targets,
+        };
+        return;
+    }
+
+    let attack_target = targets.first().copied();
+    commit_final_attack_status(state, &context, attack_target);
+    finalize_meld_entry_snapshot(state, context.source_id, attack_target, events);
+    finish_resolution(state, context.source_id, events);
+}
+
+/// Finish the CR 508.4 destination choice against the permanent's final live
+/// controller and creature characteristics. A destination that became stale
+/// leaves the permanent tapped but nonattacking (CR 508.4a).
+pub(crate) fn finish_meld_attack_choice(
+    state: &mut GameState,
+    mut context: MeldSelection,
+    selected: AttackTarget,
+    events: &mut Vec<GameEvent>,
+) {
+    crate::game::layers::mark_layers_full(state);
+    crate::game::layers::flush_layers(state);
+    let (controller, is_creature) = state
+        .objects
+        .get(&context.source_id)
+        .map(|object| {
+            (
+                object.controller,
+                object
+                    .card_types
+                    .core_types
+                    .contains(&crate::types::card_type::CoreType::Creature),
+            )
+        })
+        .unwrap_or((context.controller, false));
+    context.controller = controller;
+    let still_valid = match &context.entry {
+        PermanentEntryMode::TappedAndAttacking { destination } if is_creature => {
+            combat::valid_entry_attack_targets(state, controller, destination).contains(&selected)
+        }
+        PermanentEntryMode::Normal | PermanentEntryMode::TappedAndAttacking { .. } => false,
+    };
+    let attack_target = still_valid.then_some(selected);
+    commit_final_attack_status(state, &context, attack_target);
+    finalize_meld_entry_snapshot(state, context.source_id, attack_target, events);
+    finish_resolution(state, context.source_id, events);
+}
+
+fn commit_final_attack_status(
+    state: &mut GameState,
+    context: &MeldSelection,
+    attack_target: Option<AttackTarget>,
+) {
+    if let Some(combat_state) = state.combat.as_mut() {
+        combat_state
+            .attackers
+            .retain(|attacker| attacker.object_id != context.source_id);
+    }
+    let Some(target) = attack_target else {
+        return;
+    };
+    let Some(defending_player) =
+        combat::entry_attack_target_defender(state, context.controller, target)
+    else {
+        return;
+    };
+    if let Some(combat_state) = state.combat.as_mut() {
+        combat_state.attackers.push(AttackerInfo::new(
+            context.source_id,
+            target,
+            defending_player,
+        ));
+        state.layers_dirty.mark_full();
+    }
+}
+
+fn park_meld_entry_event(state: &mut GameState, source_id: ObjectId, events: &mut Vec<GameEvent>) {
+    if let Some(index) = events.iter().rposition(|event| {
+        matches!(
+            event,
+            GameEvent::ZoneChanged {
+                object_id,
+                to: Zone::Battlefield,
+                ..
+            } if *object_id == source_id
+        )
+    }) {
+        state.deferred_entry_events.push(events.remove(index));
+    }
+}
+
+fn finalize_meld_entry_snapshot(
+    state: &mut GameState,
+    source_id: ObjectId,
+    attack_target: Option<AttackTarget>,
+    events: &mut Vec<GameEvent>,
+) {
+    let defending_player = attack_target.and_then(|target| {
+        state.objects.get(&source_id).and_then(|object| {
+            combat::entry_attack_target_defender(state, object.controller, target)
+        })
+    });
+    let combat_status = crate::types::game_state::ZoneChangeCombatStatus {
+        attacking: defending_player.is_some(),
+        defending_player,
+        ..Default::default()
+    };
+    refresh_meld_entry_records(state, source_id, combat_status, events);
+
+    if !state.deferred_entry_events.is_empty() {
+        events.extend(state.deferred_entry_events.iter().cloned());
+        let _ =
+            crate::game::engine_replacement::replay_deferred_entry_events(state, source_id, events);
+    }
+}
+
+fn refresh_meld_entry_records(
+    state: &mut GameState,
+    source_id: ObjectId,
+    combat_status: crate::types::game_state::ZoneChangeCombatStatus,
+    events: &mut [GameEvent],
+) {
+    let Some(object) = state.objects.get(&source_id).cloned() else {
+        return;
+    };
+    let refresh = |record: &mut crate::types::game_state::ZoneChangeRecord| {
+        let old = record.clone();
+        let mut realized = object.snapshot_for_zone_change(source_id, old.from_zone, old.to_zone);
+        realized.cast_from_zone = old.cast_from_zone;
+        realized.played_from_zone = old.played_from_zone;
+        realized.attachments = old.attachments;
+        realized.linked_exile_snapshot = old.linked_exile_snapshot;
+        realized.co_departed = old.co_departed;
+        realized.entered_incarnation = old.entered_incarnation;
+        realized.attached_to = old.attached_to;
+        realized.turn_zone_change_index = old.turn_zone_change_index;
+        realized.combat_status = combat_status;
+        *record = realized;
+    };
+
+    for event in events
+        .iter_mut()
+        .chain(state.deferred_entry_events.iter_mut())
+    {
+        if let GameEvent::ZoneChanged {
+            object_id,
+            to: Zone::Battlefield,
+            record,
+            ..
+        } = event
+        {
+            if *object_id == source_id {
+                refresh(record);
+            }
+        }
+    }
+    if let Some(record) = state
+        .zone_changes_this_turn
+        .iter_mut()
+        .rev()
+        .find(|record| record.object_id == source_id && record.to_zone == Zone::Battlefield)
+    {
+        refresh(record);
+    }
+    if let Some(record) = state
+        .battlefield_entries_this_turn
+        .iter_mut()
+        .rev()
+        .find(|record| record.object_id == source_id)
+    {
+        record.name = object.name.clone();
+        record.core_types = object.card_types.core_types.clone();
+        record.subtypes = object.card_types.subtypes.clone();
+        record.supertypes = object.card_types.supertypes.clone();
+        record.colors = object.color.clone();
+        record.keywords = object.keywords.clone();
+        record.controller = object.controller;
+    }
+}
+
+pub(crate) fn finish_deferred_meld_resolution(
+    state: &mut GameState,
+    source_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) {
+    finish_resolution(state, source_id, events);
+}
+
+fn emit_resolved(state: &mut GameState, source_id: ObjectId, events: &mut Vec<GameEvent>) {
+    events.push(GameEvent::EffectResolved {
+        kind: crate::types::ability::EffectKind::Meld,
+        source_id,
+        subject: None,
+    });
+    state.last_effect_count = Some(1);
+}
+
+fn finish_resolution(state: &mut GameState, source_id: ObjectId, events: &mut Vec<GameEvent>) {
+    emit_resolved(state, source_id, events);
+    crate::game::effects::drain_pending_continuation(state, events);
 }

--- a/crates/engine/src/game/meld_tests.rs
+++ b/crates/engine/src/game/meld_tests.rs
@@ -15,6 +15,7 @@ use crate::types::ability::{Effect, PtValue, ResolvedAbility};
 use crate::types::card::CardFace;
 use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
+use crate::types::game_state::WaitingFor;
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
@@ -34,6 +35,29 @@ fn seed_result_face(state: &mut crate::types::game_state::GameState) {
     face.card_type.core_types.push(CoreType::Creature);
     let registry = Arc::make_mut(&mut state.card_face_registry);
     registry.insert(RESULT_NAME.to_lowercase(), face);
+    seed_meld_pair(
+        state,
+        "Gisela, the Broken Blade",
+        "Bruna, the Fading Light",
+        RESULT_NAME,
+    );
+}
+
+fn seed_meld_pair(
+    state: &mut crate::types::game_state::GameState,
+    source: &str,
+    partner: &str,
+    result: &str,
+) {
+    let key = format!("{}\0{}", source.to_lowercase(), partner.to_lowercase());
+    Arc::make_mut(&mut state.meld_pair_registry).insert(
+        key,
+        crate::types::game_state::MeldPairRecord {
+            source: source.to_string(),
+            partner: partner.to_string(),
+            result: result.to_string(),
+        },
+    );
 }
 
 /// A meld `ResolvedAbility` whose source is `source`, controlled by `controller`,
@@ -44,6 +68,9 @@ fn meld_ability(source: ObjectId, controller: PlayerId, partner: &str) -> Resolv
             source: "Gisela, the Broken Blade".to_string(),
             partner: partner.to_string(),
             result: RESULT_NAME.to_string(),
+            source_filter: crate::types::ability::TargetFilter::SelfRef,
+            partner_filter: crate::types::ability::TargetFilter::Any,
+            entry: crate::types::ability::PermanentEntryMode::Normal,
         },
         Vec::new(),
         source,
@@ -63,6 +90,9 @@ fn meld_ability_from(
             source: source.to_string(),
             partner: partner.to_string(),
             result: RESULT_NAME.to_string(),
+            source_filter: crate::types::ability::TargetFilter::SelfRef,
+            partner_filter: crate::types::ability::TargetFilter::Any,
+            entry: crate::types::ability::PermanentEntryMode::Normal,
         },
         Vec::new(),
         source_id,
@@ -362,8 +392,9 @@ fn meld_production_shaped_real_cards_single_permanent() {
 }
 
 /// CR 701.42b (CR 111.1): a TOKEN copy named like a meld half is NOT a real meld
-/// card and cannot be melded — the resolver no-ops. DISCRIMINATING: the pre-fix
-/// finder gated only on name, so the token partner was melded.
+/// card and cannot be melded. The live name condition is checked before the
+/// exile instruction; physical-card validation happens afterward, so both
+/// selected objects remain in exile without becoming a melded permanent.
 #[test]
 fn meld_token_partner_is_noop() {
     let (mut state, source, partner) = both_halves();
@@ -377,18 +408,14 @@ fn meld_token_partner_is_noop() {
     .unwrap();
 
     let src = state.objects.get(&source).expect("source persists");
-    assert_eq!(
-        src.zone,
-        Zone::Battlefield,
-        "no-op: a token partner is not a real meld card, so the source stays put"
-    );
+    assert_eq!(src.zone, Zone::Exile);
     assert!(
         src.merged_components.is_empty(),
         "no meld occurred with a token partner"
     );
     assert!(
-        state.exile.is_empty(),
-        "nothing was exiled — the token partner is not a meld half"
+        state.exile.contains(&source) && state.exile.contains(&partner),
+        "CR 701.42: the instruction exiles the selected live referents before physical validation"
     );
 }
 
@@ -406,18 +433,14 @@ fn meld_copy_partner_is_noop() {
     .unwrap();
 
     let src = state.objects.get(&source).expect("source persists");
-    assert_eq!(
-        src.zone,
-        Zone::Battlefield,
-        "no-op: a copy partner is not a real meld card"
-    );
+    assert_eq!(src.zone, Zone::Exile);
     assert!(
         src.merged_components.is_empty(),
         "no meld occurred with a copy partner"
     );
     assert!(
-        state.exile.is_empty(),
-        "nothing was exiled — the copy partner is not a meld half"
+        state.exile.contains(&source) && state.exile.contains(&partner),
+        "the selected copy is rejected only after both objects are exiled"
     );
 }
 
@@ -478,13 +501,10 @@ fn meld_renamed_non_meld_partner_is_noop() {
     )
     .unwrap();
 
-    // No-op: the impostor's printed identity is not the meld half.
+    // The live renamed object satisfies the instruction and is exiled; its
+    // physical identity then fails the post-exile meld validation.
     let src = state.objects.get(&source).expect("source persists");
-    assert_eq!(
-        src.zone,
-        Zone::Battlefield,
-        "no-op: the renamed non-meld impostor is rejected by the base_name gate"
-    );
+    assert_eq!(src.zone, Zone::Exile);
     assert!(
         src.merged_components.is_empty(),
         "no meld occurred against a renamed impostor"
@@ -492,12 +512,12 @@ fn meld_renamed_non_meld_partner_is_noop() {
     let imp = state.objects.get(&impostor).expect("impostor persists");
     assert_eq!(
         imp.zone,
-        Zone::Battlefield,
-        "the impostor is not exiled or absorbed"
+        Zone::Exile,
+        "the live named referent is exiled before its physical identity is checked"
     );
     assert!(
-        state.exile.is_empty(),
-        "nothing was exiled — the impostor is not a real meld half"
+        state.exile.contains(&source) && state.exile.contains(&impostor),
+        "both selected objects remain exiled when they cannot physically meld"
     );
 }
 
@@ -526,29 +546,237 @@ fn meld_non_meld_source_is_noop() {
     .unwrap();
 
     let src = state.objects.get(&source).expect("source persists");
-    assert_eq!(
-        src.zone,
-        Zone::Battlefield,
-        "no-op: the source's printed identity is not the meld instigator"
-    );
+    assert_eq!(src.zone, Zone::Exile);
     assert!(
         src.merged_components.is_empty(),
         "no meld occurred with a non-meld source"
     );
     assert_eq!(
         state.objects.get(&partner).expect("partner persists").zone,
-        Zone::Battlefield,
-        "the real partner is not exiled or absorbed"
+        Zone::Exile,
+        "the live partner is exiled before the source's physical identity fails validation"
     );
     assert!(
-        state.exile.is_empty(),
-        "nothing was exiled — the source is not the real meld instigator"
+        state.exile.contains(&source) && state.exile.contains(&partner),
+        "both selected objects remain exiled after physical validation fails"
+    );
+}
+
+fn install_exile_redirect(
+    state: &mut crate::types::game_state::GameState,
+    name: Option<&str>,
+    destination: Zone,
+    optional: bool,
+) {
+    use crate::game::zones::create_object;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, FilterProp, ReplacementDefinition, ReplacementMode,
+        TargetFilter, TypedFilter,
+    };
+    use crate::types::identifiers::CardId;
+    use crate::types::replacements::ReplacementEvent;
+
+    let redirector = create_object(
+        state,
+        CardId(state.next_object_id),
+        P1,
+        format!("Exile Redirector to {destination:?}"),
+        Zone::Battlefield,
+    );
+    let target = name.map_or(TargetFilter::Any, |name| {
+        TargetFilter::Typed(TypedFilter {
+            type_filters: Vec::new(),
+            controller: None,
+            properties: vec![FilterProp::Named {
+                name: name.to_string(),
+            }],
+        })
+    });
+    let mut redirect = ReplacementDefinition::new(ReplacementEvent::Moved)
+        .valid_card(target)
+        .destination_zone(Zone::Exile)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                destination,
+                origin: None,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+        ));
+    if optional {
+        redirect = redirect.mode(ReplacementMode::Optional { decline: None });
+    }
+    state
+        .objects
+        .get_mut(&redirector)
+        .unwrap()
+        .replacement_definitions
+        .push(redirect);
+}
+
+fn assert_redirected_exile_pair_melds(redirects: &[(&str, Zone)]) {
+    let (mut state, source, partner) = both_halves();
+    for (name, destination) in redirects {
+        install_exile_redirect(&mut state, Some(name), *destination, false);
+    }
+
+    let mut events = Vec::new();
+    perform_meld(
+        &mut state,
+        &meld_ability(source, P0, "Bruna, the Fading Light"),
+        &mut events,
+    )
+    .unwrap();
+
+    assert_eq!(state.objects[&source].zone, Zone::Battlefield);
+    assert_eq!(state.objects[&source].name, RESULT_NAME);
+    assert_eq!(
+        state.objects[&source].merged_components,
+        vec![source, partner]
+    );
+    for (name, destination) in redirects {
+        if *destination == Zone::Battlefield {
+            assert!(!events.iter().any(|event| matches!(
+                event,
+                GameEvent::ZoneChanged { object_id, to: Zone::Exile, .. }
+                    if state.objects[object_id].base_name.eq_ignore_ascii_case(name)
+            )));
+        } else {
+            assert!(events.iter().any(|event| matches!(
+                event,
+                GameEvent::ZoneChanged { object_id, to, .. }
+                    if state.objects[object_id].base_name.eq_ignore_ascii_case(name)
+                        && *to == *destination
+            )));
+        }
+    }
+}
+
+/// CR 400.7j + CR 701.42b: replacing the first exile attempt with the card
+/// remaining on the battlefield does not lose the tracked physical referent.
+#[test]
+fn meld_first_exile_prevented_by_battlefield_redirect_still_melds() {
+    assert_redirected_exile_pair_melds(&[("Gisela, the Broken Blade", Zone::Battlefield)]);
+}
+
+/// CR 400.2 + CR 400.7j + CR 701.42b: redirecting the second selected card's
+/// exile move to another public zone still leaves that physical card findable.
+#[test]
+fn meld_second_exile_redirected_to_graveyard_still_melds() {
+    assert_redirected_exile_pair_melds(&[("Bruna, the Fading Light", Zone::Graveyard)]);
+}
+
+/// CR 400.2 + CR 400.7j + CR 701.42b: independent redirects of both exile
+/// attempts to public zones still allow exactly those two tracked cards to meld.
+#[test]
+fn meld_both_exiles_redirected_to_public_zones_still_melds() {
+    assert_redirected_exile_pair_melds(&[
+        ("Gisela, the Broken Blade", Zone::Graveyard),
+        ("Bruna, the Fading Light", Zone::Command),
+    ]);
+}
+
+/// CR 400.2 + CR 400.7j + CR 701.42c: a redirect into a hidden zone makes that
+/// card unavailable to the later meld instruction, so both selected cards stay
+/// in the zones produced by the exile instruction.
+#[test]
+fn meld_hidden_zone_redirect_is_not_findable_and_preserves_current_zones() {
+    let (mut state, source, partner) = both_halves();
+    install_exile_redirect(
+        &mut state,
+        Some("Gisela, the Broken Blade"),
+        Zone::Hand,
+        false,
+    );
+
+    let mut events = Vec::new();
+    perform_meld(
+        &mut state,
+        &meld_ability(source, P0, "Bruna, the Fading Light"),
+        &mut events,
+    )
+    .unwrap();
+
+    assert_eq!(state.objects[&source].zone, Zone::Hand);
+    assert_eq!(state.objects[&partner].zone, Zone::Exile);
+    assert!(state.objects[&source].merged_components.is_empty());
+    assert!(state.exile.contains(&partner));
+}
+
+/// CR 616.1 + CR 400.7j + CR 701.42b: when each exile attempt independently
+/// pauses for an optional public-zone redirect, the parked simultaneous batch
+/// preserves the selected IDs and runs physical-pair validation only after the
+/// second pause resolves.
+#[test]
+fn meld_exile_batch_survives_repeated_replacement_pauses() {
+    use crate::game::engine::apply_as_current;
+    use crate::types::actions::GameAction;
+
+    let (mut state, source, partner) = both_halves();
+    install_exile_redirect(&mut state, None, Zone::Graveyard, true);
+
+    let mut events = Vec::new();
+    perform_meld(
+        &mut state,
+        &meld_ability(source, P0, "Bruna, the Fading Light"),
+        &mut events,
+    )
+    .unwrap();
+    assert!(matches!(
+        state.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(state.objects[&source].zone, Zone::Battlefield);
+    assert_eq!(state.objects[&partner].zone, Zone::Battlefield);
+
+    apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 })
+        .expect("accept the first exile redirect");
+    assert!(matches!(
+        state.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(state.objects[&source].zone, Zone::Graveyard);
+    assert_eq!(state.objects[&partner].zone, Zone::Battlefield);
+
+    let result = apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 })
+        .expect("accept the second exile redirect");
+    assert_eq!(state.objects[&source].zone, Zone::Battlefield);
+    assert_eq!(state.objects[&source].name, RESULT_NAME);
+    assert_eq!(
+        state.objects[&source].merged_components,
+        vec![source, partner]
+    );
+    assert_eq!(
+        events
+            .iter()
+            .chain(result.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: crate::types::ability::EffectKind::Meld,
+                    ..
+                }
+            ))
+            .count(),
+        1,
+        "the twice-paused exile batch must complete the meld exactly once"
     );
 }
 
 /// CR 614.1c / CR 614.12a: the survivor's exile→battlefield entry is routed
-/// through the zone-change pipeline, so an entry replacement effect on the
-/// survivor (here: enters-tapped) is consulted. DISCRIMINATING: the pre-fix raw
+/// through the zone-change pipeline using the result card's projected
+/// characteristics, so its intrinsic enters-tapped replacement is consulted.
+/// DISCRIMINATING: the pre-fix raw
 /// `move_to_zone` skipped the entry consult, so the survivor would NOT enter
 /// tapped; the pipeline runs the consult.
 #[test]
@@ -561,7 +789,7 @@ fn meld_entry_consults_enters_with_replacement() {
 
     let (mut state, source, _partner) = both_halves();
 
-    // A self-scoped "enters tapped" replacement on the survivor (CR 614.1c /
+    // A self-scoped "enters tapped" replacement on the result face (CR 614.1c /
     // CR 614.12a): the replacement's execute is the canonical SelfRef single
     // `SetTapState { Tap }` that `event_modifiers_for_ability` reads as the
     // enters-tapped modifier (CR 701.26a). Its exile→battlefield entry is the
@@ -578,16 +806,10 @@ fn meld_entry_consults_enters_with_replacement() {
             },
         ))
         .description("This permanent enters the battlefield tapped.".to_string());
-    {
-        let obj = state.objects.get_mut(&source).unwrap();
-        obj.replacement_definitions.push(enters_tapped.clone());
-        // The survivor is reverted to its base characteristics on the exile leg
-        // of the meld (CR 613.1 zone-exit reset restores `replacement_definitions`
-        // from `base_replacement_definitions`). Seed the base too so this printed
-        // replacement survives the exile→battlefield round-trip — a real meld
-        // card's printed "enters tapped" replacement lives in its base.
-        obj.base_replacement_definitions = std::sync::Arc::new(vec![enters_tapped]);
-    }
+    let result_face = Arc::make_mut(&mut state.card_face_registry)
+        .get_mut(&RESULT_NAME.to_lowercase())
+        .expect("seeded result face");
+    result_face.replacements.push(enters_tapped);
 
     // Precondition: the survivor is currently untapped.
     assert!(
@@ -616,6 +838,406 @@ fn meld_entry_consults_enters_with_replacement() {
     );
 }
 
+/// Drive a meld whose battlefield entry is redirected to hand while both
+/// physical components are commanders, then make the requested independent
+/// commander-zone decisions for the source and partner.
+fn run_redirected_meld_commander_choices(source_accepts: bool) {
+    use std::collections::HashSet;
+
+    use crate::game::scenario::GameRunner;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, Effect as AbilEffect, FilterProp, ReplacementDefinition,
+        TargetFilter, TypedFilter,
+    };
+    use crate::types::actions::GameAction;
+    use crate::types::replacements::ReplacementEvent;
+
+    let mut sc = GameScenario::new();
+    let source = sc.add_creature(P0, "Gisela, the Broken Blade", 4, 3).id();
+    let partner = sc.add_creature(P0, "Bruna, the Fading Light", 5, 4).id();
+    let redirector = sc.add_creature(P1, "Entry Redirector", 2, 2).id();
+    seed_result_face(&mut sc.state);
+    sc.state.format_config.command_zone = true;
+    sc.state.objects.get_mut(&source).unwrap().is_commander = true;
+    sc.state.objects.get_mut(&partner).unwrap().is_commander = true;
+
+    // CR 614.5: the same replacement effect gets only one opportunity to
+    // modify the result-entry event. The partner delivery inherits that
+    // applied-effect set, so this battlefield-to-hand redirect cannot loop or
+    // pause between the two physical components.
+    let redirect = ReplacementDefinition::new(ReplacementEvent::Moved)
+        .valid_card(TargetFilter::Any)
+        .destination_zone(Zone::Battlefield)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            AbilEffect::ChangeZone {
+                destination: Zone::Hand,
+                origin: None,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+        ))
+        .description("If a permanent would enter, put it into its owner's hand instead.".into());
+    sc.state
+        .objects
+        .get_mut(&redirector)
+        .unwrap()
+        .replacement_definitions
+        .push(redirect);
+
+    // CR 400.6 + CR 614.5: the physical partner's derived Exile→Hand move is a
+    // separately replaceable event, seeded with the result redirect's applied
+    // set. The original Battlefield→Hand redirect cannot recur, while this
+    // partner-specific Hand→Graveyard replacement still gets one opportunity.
+    let split_partner = ReplacementDefinition::new(ReplacementEvent::Moved)
+        .valid_card(TargetFilter::Typed(TypedFilter::default().properties(
+            vec![FilterProp::Named {
+                name: "Bruna, the Fading Light".to_string(),
+            }],
+        )))
+        .destination_zone(Zone::Hand)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            AbilEffect::ChangeZone {
+                destination: Zone::Graveyard,
+                origin: None,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+        ))
+        .description(
+            "If Bruna would move to hand, put it into its owner's graveyard instead.".into(),
+        );
+    sc.state
+        .objects
+        .get_mut(&redirector)
+        .unwrap()
+        .replacement_definitions
+        .push(split_partner);
+
+    let mut meld_events = Vec::new();
+    perform_meld(
+        &mut sc.state,
+        &meld_ability(source, P0, "Bruna, the Fading Light"),
+        &mut meld_events,
+    )
+    .unwrap();
+
+    assert_eq!(sc.state.objects[&source].zone, Zone::Hand);
+    assert_eq!(sc.state.objects[&partner].zone, Zone::Graveyard);
+    assert_eq!(
+        meld_events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: crate::types::ability::EffectKind::Meld,
+                    ..
+                }
+            ))
+            .count(),
+        1,
+        "the redirected meld finishes exactly once after both component deliveries"
+    );
+
+    // CR 903.9a / CR 903.9b: each commander component receives its own choice
+    // from its independently replaced destination. Choice order is engine-
+    // defined, so decide by component identity while proving neither is
+    // prompted twice and the second prompt follows the first decision.
+    crate::game::sba::check_state_based_actions(&mut sc.state, &mut meld_events);
+    let mut runner = GameRunner::from_state(sc.state);
+    let mut prompted = HashSet::new();
+    let mut choice_events = Vec::new();
+    for _ in 0..2 {
+        let WaitingFor::CommanderZoneChoice {
+            commander_id,
+            current_zone,
+            ..
+        } = runner.state().waiting_for
+        else {
+            panic!(
+                "expected one commander prompt per meld component, got {:?}",
+                runner.state().waiting_for
+            );
+        };
+        assert_eq!(
+            current_zone,
+            if commander_id == source {
+                Zone::Hand
+            } else {
+                Zone::Graveyard
+            }
+        );
+        assert!(
+            prompted.insert(commander_id),
+            "a meld component must not receive the commander choice twice"
+        );
+        let accept = if commander_id == source {
+            source_accepts
+        } else {
+            assert_eq!(commander_id, partner);
+            !source_accepts
+        };
+        let result = runner
+            .act(GameAction::DecideOptionalEffect { accept })
+            .expect("commander-zone decision resolves");
+        choice_events.extend(result.events);
+    }
+
+    assert_eq!(prompted, HashSet::from([source, partner]));
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+    assert!(
+        choice_events.iter().all(|event| !matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: crate::types::ability::EffectKind::Meld,
+                ..
+            }
+        )),
+        "commander choices must not resume the already-finished meld"
+    );
+
+    let expected_source_zone = if source_accepts {
+        Zone::Command
+    } else {
+        Zone::Hand
+    };
+    let expected_partner_zone = if source_accepts {
+        Zone::Graveyard
+    } else {
+        Zone::Command
+    };
+    assert_eq!(runner.state().objects[&source].zone, expected_source_zone);
+    assert_eq!(runner.state().objects[&partner].zone, expected_partner_zone);
+}
+
+#[test]
+fn redirected_meld_source_commander_accepts_partner_declines() {
+    run_redirected_meld_commander_choices(true);
+}
+
+#[test]
+fn redirected_meld_source_commander_declines_partner_accepts() {
+    run_redirected_meld_commander_choices(false);
+}
+
+/// CR 614.12 + CR 701.42: while an as-enters replacement choice is pending,
+/// the meld result exists only as a private liminal projection. Both physical
+/// cards remain unchanged public exile objects until the entry commits.
+#[test]
+fn meld_replacement_pause_keeps_result_projection_detached() {
+    use crate::types::ability::{ReplacementDefinition, ReplacementMode, TargetFilter};
+    use crate::types::replacements::ReplacementEvent;
+
+    let (mut state, source, partner) = both_halves();
+    let optional_entry = ReplacementDefinition::new(ReplacementEvent::Moved)
+        .mode(ReplacementMode::Optional { decline: None })
+        .valid_card(TargetFilter::SelfRef)
+        .destination_zone(Zone::Battlefield)
+        .description("You may apply this result entry replacement.".to_string());
+    Arc::make_mut(&mut state.card_face_registry)
+        .get_mut(&RESULT_NAME.to_lowercase())
+        .expect("seeded result face")
+        .replacements
+        .push(optional_entry);
+
+    let mut events = Vec::new();
+    perform_meld(
+        &mut state,
+        &meld_ability(source, P0, "Bruna, the Fading Light"),
+        &mut events,
+    )
+    .unwrap();
+
+    assert!(matches!(
+        state.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(state.objects[&source].zone, Zone::Exile);
+    assert_eq!(state.objects[&partner].zone, Zone::Exile);
+    assert_eq!(state.objects[&source].name, "Gisela, the Broken Blade");
+    assert_eq!(state.objects[&partner].name, "Bruna, the Fading Light");
+    assert_eq!(
+        state.liminal_entries[&source].object.name, RESULT_NAME,
+        "replacement matching sees the detached result projection"
+    );
+
+    let public = crate::game::visibility::filter_state_for_viewer(&state, P0);
+    assert!(public.liminal_entries.is_empty());
+    assert_eq!(public.objects[&source].name, "Gisela, the Broken Blade");
+    assert_eq!(public.objects[&partner].name, "Bruna, the Fading Light");
+}
+
+/// CR 306.5b + CR 614.12 + CR 701.42: a planeswalker meld result seeds its
+/// intrinsic loyalty counters from the projected result face, not the exiled
+/// source component's creature face.
+#[test]
+fn meld_result_seeds_intrinsic_loyalty_counters() {
+    use crate::types::counter::CounterType;
+
+    const SOURCE: &str = "Urza, Lord Protector";
+    const PARTNER: &str = "The Mightstone and Weakstone";
+    const RESULT: &str = "Urza, Planeswalker";
+
+    let mut sc = GameScenario::new();
+    let source = sc.add_creature(P0, SOURCE, 2, 4).id();
+    let partner = sc.add_creature(P0, PARTNER, 0, 0).as_artifact().id();
+    let mut result_face = CardFace {
+        name: RESULT.to_string(),
+        loyalty: Some("7".to_string()),
+        ..CardFace::default()
+    };
+    result_face
+        .card_type
+        .core_types
+        .push(CoreType::Planeswalker);
+    Arc::make_mut(&mut sc.state.card_face_registry).insert(RESULT.to_lowercase(), result_face);
+    seed_meld_pair(&mut sc.state, SOURCE, PARTNER, RESULT);
+    let ability = ResolvedAbility::new(
+        Effect::Meld {
+            source: SOURCE.to_string(),
+            partner: PARTNER.to_string(),
+            result: RESULT.to_string(),
+            source_filter: crate::types::ability::TargetFilter::SelfRef,
+            partner_filter: crate::types::ability::TargetFilter::Any,
+            entry: crate::types::ability::PermanentEntryMode::Normal,
+        },
+        Vec::new(),
+        source,
+        P0,
+    );
+
+    let mut events = Vec::new();
+    perform_meld(&mut sc.state, &ability, &mut events).unwrap();
+
+    let result = &sc.state.objects[&source];
+    assert_eq!(result.zone, Zone::Battlefield);
+    assert_eq!(result.name, RESULT);
+    assert_eq!(result.counters.get(&CounterType::Loyalty), Some(&7));
+    assert_eq!(result.loyalty, Some(7));
+    assert_eq!(result.merged_components, vec![source, partner]);
+}
+
+/// CR 608.2c + CR 701.42a: Hanweir and Urza's production activated ability
+/// definitions retain their inline own/control condition through the ordinary
+/// resolved-ability chain and meld the two qualifying physical cards.
+#[test]
+fn production_activated_inline_gates_resolve_hanweir_and_urza() {
+    use crate::game::ability_utils::build_resolved_from_def;
+    use crate::game::effects::resolve_ability_chain;
+
+    const HANWEIR_TEXT: &str = "{T}: Add {R}.\n\
+        {3}{R}{R}, {T}: If you both own and control this land and a creature named Hanweir \
+        Garrison, exile them, then meld them into Hanweir, the Writhing Township. Activate only \
+        as a sorcery.";
+    const URZA_TEXT: &str = "Artifact, instant, and sorcery spells you cast cost {1} less to \
+        cast.\n{7}: If you both own and control Urza, Lord Protector and an artifact named The \
+        Mightstone and Weakstone, exile them, then meld them into Urza, Planeswalker. Activate \
+        only as a sorcery.";
+
+    fn contains_meld(def: &crate::types::ability::AbilityDefinition) -> bool {
+        matches!(def.effect.as_ref(), Effect::Meld { .. })
+            || def.sub_ability.as_deref().is_some_and(contains_meld)
+            || def.else_ability.as_deref().is_some_and(contains_meld)
+            || def.mode_abilities.iter().any(contains_meld)
+    }
+
+    fn activated_meld(
+        state: &crate::types::game_state::GameState,
+        source: ObjectId,
+    ) -> crate::types::ability::AbilityDefinition {
+        state.objects[&source]
+            .abilities
+            .iter()
+            .find(|ability| contains_meld(ability))
+            .cloned()
+            .expect("production Oracle text exposes an activated Meld ability")
+    }
+
+    {
+        const SOURCE: &str = "Hanweir Battlements";
+        const PARTNER: &str = "Hanweir Garrison";
+        const RESULT: &str = "Hanweir, the Writhing Township";
+
+        let mut sc = GameScenario::new();
+        let source = sc.add_land_from_oracle(P0, SOURCE, HANWEIR_TEXT).id();
+        let partner = sc.add_creature(P0, PARTNER, 2, 3).id();
+        let mut result_face = CardFace {
+            name: RESULT.to_string(),
+            power: Some(PtValue::Fixed(7)),
+            toughness: Some(PtValue::Fixed(4)),
+            ..CardFace::default()
+        };
+        result_face.card_type.core_types.push(CoreType::Creature);
+        Arc::make_mut(&mut sc.state.card_face_registry).insert(RESULT.to_lowercase(), result_face);
+        seed_meld_pair(&mut sc.state, SOURCE, PARTNER, RESULT);
+
+        let ability = activated_meld(&sc.state, source);
+        let resolved = build_resolved_from_def(&ability, source, P0);
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut sc.state, &resolved, &mut events, 0)
+            .expect("Hanweir's activated Meld ability resolves");
+
+        let survivor = &sc.state.objects[&source];
+        assert_eq!(survivor.name, RESULT);
+        assert_eq!(survivor.merged_components, vec![source, partner]);
+    }
+
+    {
+        const SOURCE: &str = "Urza, Lord Protector";
+        const PARTNER: &str = "The Mightstone and Weakstone";
+        const RESULT: &str = "Urza, Planeswalker";
+
+        let mut sc = GameScenario::new();
+        let source = sc
+            .add_creature_from_oracle(P0, SOURCE, 2, 4, URZA_TEXT)
+            .id();
+        let partner = sc.add_creature(P0, PARTNER, 0, 0).as_artifact().id();
+        let mut result_face = CardFace {
+            name: RESULT.to_string(),
+            loyalty: Some("7".to_string()),
+            ..CardFace::default()
+        };
+        result_face
+            .card_type
+            .core_types
+            .push(CoreType::Planeswalker);
+        Arc::make_mut(&mut sc.state.card_face_registry).insert(RESULT.to_lowercase(), result_face);
+        seed_meld_pair(&mut sc.state, SOURCE, PARTNER, RESULT);
+
+        let ability = activated_meld(&sc.state, source);
+        let resolved = build_resolved_from_def(&ability, source, P0);
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut sc.state, &resolved, &mut events, 0)
+            .expect("Urza's activated Meld ability resolves");
+
+        let survivor = &sc.state.objects[&source];
+        assert_eq!(survivor.name, RESULT);
+        assert_eq!(survivor.merged_components, vec![source, partner]);
+    }
+}
+
 /// CR 201.2a + CR 201.5c: end-to-end proof that the FIX-3 self-ref mask makes a
 /// shared-token meld RESULT resolvable at runtime. Drives the real parser
 /// (`parse_oracle_text`) → resolver (`perform_meld`) seam for Titania, whose
@@ -642,6 +1264,7 @@ fn parsed_meld_result_name_resolves_through_registry() {
             source,
             partner,
             result,
+            ..
         } = def.effect.as_ref()
         {
             return Some((source.clone(), partner.clone(), result.clone()));
@@ -684,6 +1307,7 @@ fn parsed_meld_result_name_resolves_through_registry() {
     };
     face.card_type.core_types.push(CoreType::Creature);
     Arc::make_mut(&mut sc.state.card_face_registry).insert(RESULT.to_lowercase(), face);
+    seed_meld_pair(&mut sc.state, &src_name, &partner_name, RESULT);
     let mut state = sc.state;
 
     let ability = ResolvedAbility::new(
@@ -691,6 +1315,9 @@ fn parsed_meld_result_name_resolves_through_registry() {
             source: src_name,
             partner: partner_name,
             result: result_name,
+            source_filter: crate::types::ability::TargetFilter::SelfRef,
+            partner_filter: crate::types::ability::TargetFilter::Any,
+            entry: crate::types::ability::PermanentEntryMode::Normal,
         },
         Vec::new(),
         source,
@@ -790,6 +1417,12 @@ fn vanille_optional_pay_gates_meld_accept_vs_decline() {
         };
         face.card_type.core_types.push(CoreType::Creature);
         Arc::make_mut(&mut sc.state.card_face_registry).insert(RESULT.to_lowercase(), face);
+        seed_meld_pair(
+            &mut sc.state,
+            "Vanille, Cheerful l'Cie",
+            "Fang, Fearless l'Cie",
+            RESULT,
+        );
         sc.with_mana_pool(
             P0,
             vec![
@@ -897,4 +1530,564 @@ fn vanille_optional_pay_gates_meld_accept_vs_decline() {
             "decline: no mana was spent (CR 118.12: the cost is not paid)"
         );
     }
+}
+
+/// CR 508.4 / CR 701.42: Mishra's production Oracle ability selects every
+/// legal defending player, planeswalker, and protected battle; the meld result
+/// enters tapped and attacking the chosen destination without becoming a
+/// declared attacker. A destination that disappears while the choice is open
+/// produces a nonattacking entry that is still tapped.
+#[test]
+fn mishra_production_meld_entry_attack_destination_matrix() {
+    use crate::game::combat::{AttackTarget, AttackerInfo, CombatState};
+    use crate::game::scenario::{GameRunner, P0, P1};
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::{ChosenAttribute, EntryAttackDestination, PermanentEntryMode};
+    use crate::types::actions::GameAction;
+
+    const MISHRA: &str = "Whenever you attack, each opponent loses X life and you gain X life, \
+        where X is the number of attacking creatures. If Mishra, Claimed by Gix and a creature \
+        named Phyrexian Dragon Engine are attacking, and you both own and control them, exile \
+        them, then meld them into Mishra, Lost to Phyrexia. It enters tapped and attacking.";
+    const MISHRA_RESULT: &str = "Mishra, Lost to Phyrexia";
+
+    fn find_meld(def: &crate::types::ability::AbilityDefinition) -> Option<Effect> {
+        if matches!(def.effect.as_ref(), Effect::Meld { .. }) {
+            return Some((*def.effect).clone());
+        }
+        def.sub_ability
+            .as_deref()
+            .and_then(find_meld)
+            .or_else(|| def.else_ability.as_deref().and_then(find_meld))
+            .or_else(|| def.mode_abilities.iter().find_map(find_meld))
+    }
+
+    fn production_effect() -> Effect {
+        let parsed = parse_oracle_text(
+            MISHRA,
+            "Mishra, Claimed by Gix",
+            &[],
+            &["Legendary".to_string(), "Creature".to_string()],
+            &[],
+        );
+        let effect = parsed
+            .triggers
+            .iter()
+            .filter_map(|trigger| trigger.execute.as_deref())
+            .find_map(find_meld)
+            .expect("production Mishra Oracle text contains a meld child");
+        assert!(matches!(
+            effect,
+            Effect::Meld {
+                entry: PermanentEntryMode::TappedAndAttacking {
+                    destination: EntryAttackDestination::AnyDefender
+                },
+                ..
+            }
+        ));
+        effect
+    }
+
+    fn setup(effect: Effect) -> (GameRunner, ObjectId, ObjectId, ObjectId, ObjectId) {
+        let mut sc = GameScenario::new();
+        let mishra = sc.add_creature(P0, "Mishra, Claimed by Gix", 3, 5).id();
+        let engine = sc.add_creature(P0, "Phyrexian Dragon Engine", 2, 2).id();
+        let planeswalker = sc.add_creature(P1, "Defending Planeswalker", 1, 1).id();
+        let battle = sc.add_creature(P0, "Protected Battle", 1, 1).id();
+
+        {
+            let object = sc.state.objects.get_mut(&planeswalker).unwrap();
+            object.card_types.core_types.clear();
+            object.card_types.core_types.push(CoreType::Planeswalker);
+            object.base_card_types.core_types.clear();
+            object
+                .base_card_types
+                .core_types
+                .push(CoreType::Planeswalker);
+        }
+        {
+            let object = sc.state.objects.get_mut(&battle).unwrap();
+            object.card_types.core_types.clear();
+            object.card_types.core_types.push(CoreType::Battle);
+            object.base_card_types.core_types.clear();
+            object.base_card_types.core_types.push(CoreType::Battle);
+        }
+        sc.state
+            .objects
+            .get_mut(&battle)
+            .unwrap()
+            .chosen_attributes
+            .push(ChosenAttribute::Player(P1));
+
+        let mut result = CardFace {
+            name: MISHRA_RESULT.to_string(),
+            power: Some(PtValue::Fixed(9)),
+            toughness: Some(PtValue::Fixed(9)),
+            ..CardFace::default()
+        };
+        result.card_type.core_types.push(CoreType::Creature);
+        Arc::make_mut(&mut sc.state.card_face_registry)
+            .insert(MISHRA_RESULT.to_lowercase(), result);
+        seed_meld_pair(
+            &mut sc.state,
+            "Mishra, Claimed by Gix",
+            "Phyrexian Dragon Engine",
+            MISHRA_RESULT,
+        );
+        sc.state.combat = Some(CombatState {
+            attackers: vec![
+                AttackerInfo::new(mishra, AttackTarget::Player(P1), P1),
+                AttackerInfo::new(engine, AttackTarget::Player(P1), P1),
+            ],
+            ..CombatState::default()
+        });
+        let mut events = Vec::new();
+        perform_meld(
+            &mut sc.state,
+            &ResolvedAbility::new(effect, Vec::new(), mishra, P0),
+            &mut events,
+        )
+        .expect("production Mishra meld begins");
+        assert!(matches!(
+            sc.state.waiting_for,
+            WaitingFor::MeldAttackTargetChoice { .. }
+        ));
+        (sc.build(), mishra, engine, planeswalker, battle)
+    }
+
+    let effect = production_effect();
+    for destination in [
+        AttackTarget::Player(P1),
+        AttackTarget::Planeswalker(ObjectId(0)),
+        AttackTarget::Battle(ObjectId(0)),
+    ] {
+        let (mut runner, mishra, _engine, planeswalker, battle) = setup(effect.clone());
+        let destination = match destination {
+            AttackTarget::Planeswalker(_) => AttackTarget::Planeswalker(planeswalker),
+            AttackTarget::Battle(_) => AttackTarget::Battle(battle),
+            player => player,
+        };
+        let result = runner
+            .act(GameAction::ChooseEntryAttackTarget {
+                target: destination,
+            })
+            .expect("engine accepts an offered Mishra attack destination");
+        let melded = &runner.state().objects[&mishra];
+        assert!(melded.tapped);
+        assert_eq!(melded.name, MISHRA_RESULT);
+        assert!(runner
+            .state()
+            .combat
+            .as_ref()
+            .unwrap()
+            .attackers
+            .iter()
+            .any(|attacker| attacker.object_id == mishra && attacker.attack_target == destination));
+        assert!(!result
+            .events
+            .iter()
+            .any(|event| matches!(event, GameEvent::AttackersDeclared { .. })));
+        let entry_record = result.events.iter().find_map(|event| match event {
+            GameEvent::ZoneChanged {
+                object_id,
+                to: Zone::Battlefield,
+                record,
+                ..
+            } if *object_id == mishra => Some(record.as_ref()),
+            _ => None,
+        });
+        let entry_record = entry_record.expect("meld entry emits its authoritative snapshot");
+        assert_eq!(entry_record.name, MISHRA_RESULT);
+        assert!(entry_record.combat_status.attacking);
+        assert_eq!(
+            entry_record.combat_status.defending_player,
+            Some(P1),
+            "ETB observers must see the result already attacking"
+        );
+    }
+
+    let (mut runner, mishra, _engine, planeswalker, _battle) = setup(effect);
+    crate::game::zones::move_to_zone(
+        runner.state_mut(),
+        planeswalker,
+        Zone::Graveyard,
+        &mut Vec::new(),
+    );
+    let result = runner
+        .act(GameAction::ChooseEntryAttackTarget {
+            target: AttackTarget::Planeswalker(planeswalker),
+        })
+        .expect("a formerly offered destination resolves through the stale fallback");
+    assert!(
+        runner.state().objects[&mishra].tapped,
+        "the independent tapped entry modifier survives a stale attack destination"
+    );
+    assert!(!runner
+        .state()
+        .combat
+        .as_ref()
+        .unwrap()
+        .attackers
+        .iter()
+        .any(|attacker| attacker.object_id == mishra));
+    assert!(!result
+        .events
+        .iter()
+        .any(|event| matches!(event, GameEvent::AttackersDeclared { .. })));
+}
+
+/// CR 508.4 + CR 701.42: when the defending opponent is the only legal
+/// destination, Mishra's production Oracle ability chooses it automatically.
+/// The post-replacement liminal choice must reach both the ETB snapshot and the
+/// committed combat state; no player prompt is needed for a singleton domain.
+#[test]
+fn mishra_single_defender_auto_target_enters_attacking() {
+    use crate::game::combat::{AttackTarget, AttackerInfo, CombatState};
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::{EntryAttackDestination, PermanentEntryMode};
+
+    const MISHRA: &str = "Whenever you attack, each opponent loses X life and you gain X life, \
+        where X is the number of attacking creatures. If Mishra, Claimed by Gix and a creature \
+        named Phyrexian Dragon Engine are attacking, and you both own and control them, exile \
+        them, then meld them into Mishra, Lost to Phyrexia. It enters tapped and attacking.";
+    const MISHRA_RESULT: &str = "Mishra, Lost to Phyrexia";
+
+    fn find_meld(def: &crate::types::ability::AbilityDefinition) -> Option<Effect> {
+        if matches!(def.effect.as_ref(), Effect::Meld { .. }) {
+            return Some((*def.effect).clone());
+        }
+        def.sub_ability
+            .as_deref()
+            .and_then(find_meld)
+            .or_else(|| def.else_ability.as_deref().and_then(find_meld))
+            .or_else(|| def.mode_abilities.iter().find_map(find_meld))
+    }
+
+    let parsed = parse_oracle_text(
+        MISHRA,
+        "Mishra, Claimed by Gix",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &[],
+    );
+    let effect = parsed
+        .triggers
+        .iter()
+        .filter_map(|trigger| trigger.execute.as_deref())
+        .find_map(find_meld)
+        .expect("production Mishra Oracle text contains a meld child");
+    assert!(matches!(
+        effect,
+        Effect::Meld {
+            entry: PermanentEntryMode::TappedAndAttacking {
+                destination: EntryAttackDestination::AnyDefender
+            },
+            ..
+        }
+    ));
+
+    let mut sc = GameScenario::new();
+    let mishra = sc.add_creature(P0, "Mishra, Claimed by Gix", 3, 5).id();
+    let engine = sc.add_creature(P0, "Phyrexian Dragon Engine", 2, 2).id();
+    let mut result_face = CardFace {
+        name: MISHRA_RESULT.to_string(),
+        power: Some(PtValue::Fixed(9)),
+        toughness: Some(PtValue::Fixed(9)),
+        ..CardFace::default()
+    };
+    result_face.card_type.core_types.push(CoreType::Creature);
+    Arc::make_mut(&mut sc.state.card_face_registry)
+        .insert(MISHRA_RESULT.to_lowercase(), result_face);
+    seed_meld_pair(
+        &mut sc.state,
+        "Mishra, Claimed by Gix",
+        "Phyrexian Dragon Engine",
+        MISHRA_RESULT,
+    );
+    sc.state.combat = Some(CombatState {
+        attackers: vec![
+            AttackerInfo::new(mishra, AttackTarget::Player(P1), P1),
+            AttackerInfo::new(engine, AttackTarget::Player(P1), P1),
+        ],
+        ..CombatState::default()
+    });
+
+    let mut events = Vec::new();
+    perform_meld(
+        &mut sc.state,
+        &ResolvedAbility::new(effect, Vec::new(), mishra, P0),
+        &mut events,
+    )
+    .expect("production Mishra meld resolves with its singleton destination");
+
+    assert!(matches!(sc.state.waiting_for, WaitingFor::Priority { .. }));
+    assert!(sc.state.objects[&mishra].tapped);
+    assert_eq!(sc.state.objects[&mishra].name, MISHRA_RESULT);
+    assert!(sc
+        .state
+        .combat
+        .as_ref()
+        .unwrap()
+        .attackers
+        .iter()
+        .any(|attacker| {
+            attacker.object_id == mishra
+                && attacker.attack_target == AttackTarget::Player(P1)
+                && attacker.defending_player == P1
+        }));
+    let entry_record = events.iter().find_map(|event| match event {
+        GameEvent::ZoneChanged {
+            object_id,
+            to: Zone::Battlefield,
+            record,
+            ..
+        } if *object_id == mishra => Some(record.as_ref()),
+        _ => None,
+    });
+    let entry_record = entry_record.expect("meld entry emits its authoritative snapshot");
+    assert!(entry_record.combat_status.attacking);
+    assert_eq!(entry_record.combat_status.defending_player, Some(P1));
+}
+
+/// CR 614.12a + CR 707.9 + CR 508.4: an as-enters copy choice is finalized
+/// before the meld entry's attacking status. Copying a noncreature therefore
+/// produces a tapped, nonattacking permanent and a realized ETB snapshot.
+#[test]
+fn mishra_copy_as_enters_noncreature_is_not_attacking() {
+    use crate::game::combat::{AttackTarget, AttackerInfo, CombatState};
+    use crate::game::scenario::GameRunner;
+    use crate::types::ability::TargetRef;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, EntryAttackDestination, PermanentEntryMode,
+        ReplacementDefinition, TargetFilter,
+    };
+    use crate::types::actions::GameAction;
+    use crate::types::card_type::CardType;
+    use crate::types::replacements::ReplacementEvent;
+
+    const SOURCE: &str = "Mishra, Claimed by Gix";
+    const PARTNER: &str = "Phyrexian Dragon Engine";
+    const RESULT: &str = "Mishra, Lost to Phyrexia";
+
+    let mut sc = GameScenario::new();
+    let source = sc.add_creature(P0, SOURCE, 3, 5).id();
+    let partner = sc.add_creature(P0, PARTNER, 2, 2).id();
+    let copy_target = sc.add_creature(P1, "Powerstone Relic", 0, 0).id();
+    {
+        let target = sc.state.objects.get_mut(&copy_target).unwrap();
+        target.card_types = CardType::default();
+        target.card_types.core_types.push(CoreType::Artifact);
+        target.base_card_types = target.card_types.clone();
+        target.name = "Powerstone Relic".to_string();
+        target.base_name = target.name.clone();
+    }
+
+    let mut result_face = CardFace {
+        name: RESULT.to_string(),
+        power: Some(PtValue::Fixed(9)),
+        toughness: Some(PtValue::Fixed(9)),
+        ..CardFace::default()
+    };
+    result_face.card_type.core_types.push(CoreType::Creature);
+    result_face.replacements.push(
+        ReplacementDefinition::new(ReplacementEvent::Moved)
+            .valid_card(TargetFilter::SelfRef)
+            .destination_zone(Zone::Battlefield)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::BecomeCopy {
+                    target: TargetFilter::SpecificObject { id: copy_target },
+                    recipient: TargetFilter::SelfRef,
+                    duration: None,
+                    mana_value_limit: None,
+                    additional_modifications: Vec::new(),
+                },
+            )),
+    );
+    Arc::make_mut(&mut sc.state.card_face_registry).insert(RESULT.to_lowercase(), result_face);
+    seed_meld_pair(&mut sc.state, SOURCE, PARTNER, RESULT);
+    sc.state.combat = Some(CombatState {
+        attackers: vec![
+            AttackerInfo::new(source, AttackTarget::Player(P1), P1),
+            AttackerInfo::new(partner, AttackTarget::Player(P1), P1),
+        ],
+        ..CombatState::default()
+    });
+    let effect = Effect::Meld {
+        source: SOURCE.to_string(),
+        partner: PARTNER.to_string(),
+        result: RESULT.to_string(),
+        source_filter: TargetFilter::SelfRef,
+        partner_filter: TargetFilter::Any,
+        entry: PermanentEntryMode::TappedAndAttacking {
+            destination: EntryAttackDestination::AnyDefender,
+        },
+    };
+
+    let mut first_events = Vec::new();
+    perform_meld(
+        &mut sc.state,
+        &ResolvedAbility::new(effect, Vec::new(), source, P0),
+        &mut first_events,
+    )
+    .unwrap();
+    assert!(matches!(
+        sc.state.waiting_for,
+        WaitingFor::CopyTargetChoice { .. }
+    ));
+    assert!(
+        !first_events.iter().any(|event| matches!(
+            event,
+            GameEvent::ZoneChanged {
+                object_id,
+                to: Zone::Battlefield,
+                ..
+            } if *object_id == source
+        )),
+        "the frontend entry event waits for the final copy snapshot"
+    );
+
+    let mut runner = GameRunner::from_state(sc.state);
+    let result = runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(copy_target)),
+        })
+        .expect("copy target choice resolves");
+    let copied = &runner.state().objects[&source];
+    assert_eq!(copied.name, "Powerstone Relic");
+    assert!(copied.tapped);
+    assert!(!copied.card_types.core_types.contains(&CoreType::Creature));
+    assert!(!runner
+        .state()
+        .combat
+        .as_ref()
+        .unwrap()
+        .attackers
+        .iter()
+        .any(|attacker| attacker.object_id == source));
+    let record = result.events.iter().find_map(|event| match event {
+        GameEvent::ZoneChanged {
+            object_id,
+            to: Zone::Battlefield,
+            record,
+            ..
+        } if *object_id == source => Some(record.as_ref()),
+        _ => None,
+    });
+    let record = record.expect("the realized entry snapshot is emitted after the copy choice");
+    assert_eq!(record.name, "Powerstone Relic");
+    assert!(!record.combat_status.attacking);
+}
+
+/// CR 613.1b + CR 508.4: a layer-2 control effect that starts applying only
+/// after the meld identity exists makes the final controller choose among that
+/// attacking team's legal destinations.
+#[test]
+fn mishra_final_controller_owns_attack_destination_choice() {
+    use crate::game::combat::{AttackTarget, AttackerInfo, CombatState};
+    use crate::game::scenario::GameRunner;
+    use crate::types::ability::{
+        ContinuousModification, Duration, EntryAttackDestination, FilterProp, PermanentEntryMode,
+        TargetFilter, TypedFilter,
+    };
+    use crate::types::actions::GameAction;
+    use crate::types::format::FormatConfig;
+
+    const SOURCE: &str = "Mishra, Claimed by Gix";
+    const PARTNER: &str = "Phyrexian Dragon Engine";
+    const RESULT: &str = "Mishra, Lost to Phyrexia";
+
+    let mut sc = GameScenario::new();
+    sc.state = crate::types::game_state::GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+    sc.state.active_player = PlayerId(0);
+    let source = sc.add_creature(PlayerId(0), SOURCE, 3, 5).id();
+    let partner = sc.add_creature(PlayerId(0), PARTNER, 2, 2).id();
+    let control_source = sc.add_creature(PlayerId(1), "Result Controller", 1, 1).id();
+    let mut result_face = CardFace {
+        name: RESULT.to_string(),
+        power: Some(PtValue::Fixed(9)),
+        toughness: Some(PtValue::Fixed(9)),
+        ..CardFace::default()
+    };
+    result_face.card_type.core_types.push(CoreType::Creature);
+    Arc::make_mut(&mut sc.state.card_face_registry).insert(RESULT.to_lowercase(), result_face);
+    seed_meld_pair(&mut sc.state, SOURCE, PARTNER, RESULT);
+    sc.state.add_transient_continuous_effect(
+        control_source,
+        PlayerId(1),
+        Duration::Permanent,
+        TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Named {
+            name: RESULT.to_string(),
+        }])),
+        vec![ContinuousModification::ChangeController],
+        None,
+    );
+    sc.state.combat = Some(CombatState {
+        attackers: vec![
+            AttackerInfo::new(source, AttackTarget::Player(PlayerId(2)), PlayerId(2)),
+            AttackerInfo::new(partner, AttackTarget::Player(PlayerId(2)), PlayerId(2)),
+        ],
+        ..CombatState::default()
+    });
+    let effect = Effect::Meld {
+        source: SOURCE.to_string(),
+        partner: PARTNER.to_string(),
+        result: RESULT.to_string(),
+        source_filter: TargetFilter::SelfRef,
+        partner_filter: TargetFilter::Any,
+        entry: PermanentEntryMode::TappedAndAttacking {
+            destination: EntryAttackDestination::AnyDefender,
+        },
+    };
+
+    let mut events = Vec::new();
+    perform_meld(
+        &mut sc.state,
+        &ResolvedAbility::new(effect, Vec::new(), source, PlayerId(0)),
+        &mut events,
+    )
+    .unwrap();
+    let WaitingFor::MeldAttackTargetChoice {
+        player,
+        ref valid_targets,
+        ..
+    } = sc.state.waiting_for
+    else {
+        panic!("final controller must receive the attack-destination choice")
+    };
+    assert_eq!(player, PlayerId(1));
+    assert!(valid_targets.contains(&AttackTarget::Player(PlayerId(2))));
+    assert!(valid_targets.contains(&AttackTarget::Player(PlayerId(3))));
+    assert_eq!(sc.state.objects[&source].controller, PlayerId(1));
+
+    let mut runner = GameRunner::from_state(sc.state);
+    let result = runner
+        .act(GameAction::ChooseEntryAttackTarget {
+            target: AttackTarget::Player(PlayerId(3)),
+        })
+        .expect("final controller chooses a defending-team destination");
+    assert!(runner
+        .state()
+        .combat
+        .as_ref()
+        .unwrap()
+        .attackers
+        .iter()
+        .any(|attacker| {
+            attacker.object_id == source
+                && attacker.attack_target == AttackTarget::Player(PlayerId(3))
+        }));
+    let record = result.events.iter().find_map(|event| match event {
+        GameEvent::ZoneChanged {
+            object_id,
+            to: Zone::Battlefield,
+            record,
+            ..
+        } if *object_id == source => Some(record.as_ref()),
+        _ => None,
+    });
+    let record = record.expect("choice emits the finalized entry snapshot");
+    assert_eq!(record.controller, PlayerId(1));
+    assert!(record.combat_status.attacking);
+    assert_eq!(record.combat_status.defending_player, Some(PlayerId(3)));
 }

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -8,7 +8,7 @@ use crate::types::ability::{
 use crate::types::card::{CardFace, CardLayout, LayoutKind, PrintedCardRef};
 use crate::types::card_type::{CardType, CoreType};
 use crate::types::counter::CounterType;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, MeldPairRecord};
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
 use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
@@ -1382,6 +1382,9 @@ pub fn rehydrate_game_from_card_db(state: &mut GameState, db: &CardDatabase) {
 
 /// Populate Conjure registry and card-name validation lists on first rehydrate.
 fn rehydrate_card_db_metadata(state: &mut GameState, db: &CardDatabase) {
+    if state.meld_pair_registry.is_empty() {
+        state.meld_pair_registry = Arc::new(build_meld_pair_registry(db));
+    }
     // Populate the Conjure card-face registry (used by the Conjure effect
     // handler). Scoped to exactly the faces reachable as Conjure targets so we
     // never clone the entire database into per-game state. Decks with no
@@ -1463,6 +1466,107 @@ fn rehydrate_card_db_metadata(state: &mut GameState, db: &CardDatabase) {
         }
         state.momir_pool = pool;
         state.momir_pool_faces = std::sync::Arc::new(faces);
+    }
+}
+
+/// CR 701.42b + CR 712.4: derive the physical meld-pair authority from card
+/// database layout metadata and the parsed meld instruction. A forged effect
+/// whose three named faces are not all database-backed meld faces is excluded.
+fn build_meld_pair_registry(db: &CardDatabase) -> HashMap<String, MeldPairRecord> {
+    let mut registry = HashMap::new();
+    for (_, face) in db.face_iter() {
+        let mut effects = Vec::new();
+        collect_meld_effects_from_face(face, &mut effects);
+        for (source, partner, result) in effects {
+            if !meld_front_maps_to_result(db, source, result)
+                || !meld_front_maps_to_result(db, partner, result)
+            {
+                continue;
+            }
+            let key = meld_pair_key(source, partner);
+            registry.insert(
+                key,
+                MeldPairRecord {
+                    source: source.clone(),
+                    partner: partner.clone(),
+                    result: result.clone(),
+                },
+            );
+        }
+    }
+    registry
+}
+
+fn meld_pair_key(source: &str, partner: &str) -> String {
+    format!("{}\0{}", source.to_lowercase(), partner.to_lowercase())
+}
+
+fn meld_front_maps_to_result(db: &CardDatabase, front: &str, result: &str) -> bool {
+    let mtgjson_layout_matches = db.get_by_name(front).is_some_and(|rules| {
+        matches!(
+            &rules.layout,
+            CardLayout::Meld(printed_front, combined_back)
+                if printed_front.name.eq_ignore_ascii_case(front)
+                    && combined_back.name.eq_ignore_ascii_case(result)
+        )
+    });
+    if mtgjson_layout_matches {
+        return true;
+    }
+
+    // The production card-data export intentionally stores faces rather than
+    // reconstructed `CardRules`. Recover the same exact front -> combined-back
+    // relation from the shared oracle id and layout discriminant; checking only
+    // `LayoutKind::Meld` would admit a forged result from a different meld pair.
+    let Some(front_face) = db.get_face_by_name(front) else {
+        return false;
+    };
+    let Some(printed_ref) = printed_ref_from_face(front_face) else {
+        return false;
+    };
+    matches!(
+        db.get_layout_kind(&printed_ref.oracle_id),
+        Some(LayoutKind::Meld)
+    ) && db
+        .get_other_face_by_printed_ref(&printed_ref)
+        .is_some_and(|combined_back| combined_back.name.eq_ignore_ascii_case(result))
+}
+
+fn collect_meld_effects_from_face<'a>(
+    face: &'a CardFace,
+    out: &mut Vec<(&'a String, &'a String, &'a String)>,
+) {
+    for ability in &face.abilities {
+        collect_meld_effects_from_ability(ability, out);
+    }
+    for trigger in &face.triggers {
+        if let Some(execute) = trigger.execute.as_deref() {
+            collect_meld_effects_from_ability(execute, out);
+        }
+    }
+}
+
+fn collect_meld_effects_from_ability<'a>(
+    ability: &'a AbilityDefinition,
+    out: &mut Vec<(&'a String, &'a String, &'a String)>,
+) {
+    if let Effect::Meld {
+        source,
+        partner,
+        result,
+        ..
+    } = ability.effect.as_ref()
+    {
+        out.push((source, partner, result));
+    }
+    if let Some(sub) = ability.sub_ability.as_deref() {
+        collect_meld_effects_from_ability(sub, out);
+    }
+    if let Some(otherwise) = ability.else_ability.as_deref() {
+        collect_meld_effects_from_ability(otherwise, out);
+    }
+    for mode in &ability.mode_abilities {
+        collect_meld_effects_from_ability(mode, out);
     }
 }
 
@@ -2643,6 +2747,117 @@ mod tests {
         }
         let json = serde_json::Value::Object(map).to_string();
         CardDatabase::from_json_str(&json).expect("export db should parse")
+    }
+
+    /// CR 701.42b + CR 712.4: the production JSON loader's layout metadata,
+    /// not arbitrary effect text, is the authority for canonical meld pairs.
+    #[test]
+    fn real_card_database_builds_only_canonical_meld_pair_registry_entries() {
+        let source_name = "Registry Meld Source";
+        let partner_name = "Registry Meld Partner";
+        let result_name = "Registry Meld Result";
+        let forged_result_name = "Ordinary Forged Result";
+        let cross_pair_result_name = "Other Pair Meld Result";
+        let mut source = test_face(
+            source_name,
+            "registry-meld-source-oracle",
+            vec![CoreType::Creature],
+            ManaCost::default(),
+        );
+        for result in [result_name, forged_result_name, cross_pair_result_name] {
+            source.abilities.push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Meld {
+                    source: source_name.to_string(),
+                    partner: partner_name.to_string(),
+                    result: result.to_string(),
+                    source_filter: TargetFilter::SelfRef,
+                    partner_filter: TargetFilter::Any,
+                    entry: crate::types::ability::PermanentEntryMode::Normal,
+                },
+            ));
+        }
+        let partner = test_face(
+            partner_name,
+            "registry-meld-partner-oracle",
+            vec![CoreType::Creature],
+            ManaCost::default(),
+        );
+        let result_for_source = test_face(
+            result_name,
+            "registry-meld-source-oracle",
+            vec![CoreType::Creature],
+            ManaCost::default(),
+        );
+        let result_for_partner = test_face(
+            result_name,
+            "registry-meld-partner-oracle",
+            vec![CoreType::Creature],
+            ManaCost::default(),
+        );
+        let other_front = test_face(
+            "Other Pair Meld Front",
+            "other-pair-meld-oracle",
+            vec![CoreType::Creature],
+            ManaCost::default(),
+        );
+        let cross_pair_result = test_face(
+            cross_pair_result_name,
+            "other-pair-meld-oracle",
+            vec![CoreType::Creature],
+            ManaCost::default(),
+        );
+        let forged = test_face(
+            forged_result_name,
+            "ordinary-forged-result-oracle",
+            vec![CoreType::Creature],
+            ManaCost::default(),
+        );
+
+        let mut export = serde_json::Map::new();
+        for (key, face, layout) in [
+            (source.name.to_lowercase(), &source, "meld"),
+            (
+                result_for_source.name.to_lowercase(),
+                &result_for_source,
+                "meld",
+            ),
+            (partner.name.to_lowercase(), &partner, "meld"),
+            (
+                "hidden partner meld result".to_string(),
+                &result_for_partner,
+                "meld",
+            ),
+            (other_front.name.to_lowercase(), &other_front, "meld"),
+            (
+                cross_pair_result.name.to_lowercase(),
+                &cross_pair_result,
+                "meld",
+            ),
+            (forged.name.to_lowercase(), &forged, "normal"),
+        ] {
+            let mut json = serde_json::to_value(face).unwrap();
+            json["layout"] = serde_json::json!(layout);
+            export.insert(key, json);
+        }
+        let db = CardDatabase::from_json_str(&serde_json::Value::Object(export).to_string())
+            .expect("production CardDatabase export should parse");
+
+        let registry = build_meld_pair_registry(&db);
+        let key = meld_pair_key(source_name, partner_name);
+        assert_eq!(registry.len(), 1, "non-meld result faces are rejected");
+        assert_eq!(
+            registry.get(&key),
+            Some(&MeldPairRecord {
+                source: source_name.to_string(),
+                partner: partner_name.to_string(),
+                result: result_name.to_string(),
+            })
+        );
+
+        let mut state = GameState::new_two_player(42);
+        rehydrate_game_from_card_db(&mut state, &db);
+        assert_eq!(state.meld_pair_registry.as_ref(), &registry);
     }
 
     fn conjure_ability(target_name: &str, destination: Zone) -> AbilityDefinition {

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -4832,11 +4832,11 @@ fn object_replacement_candidate_applies(
     registry: &IndexMap<ReplacementEvent, ReplacementHandlerEntry>,
     rid: ReplacementId,
 ) -> bool {
-    let liminal_obj = state
-        .liminal_entries
-        .get(&rid.source)
+    let liminal_obj = liminal_entry_ref(event)
+        .filter(|entry_ref| *entry_ref == rid.source)
+        .and_then(|entry_ref| state.liminal_entries.get(&entry_ref))
         .map(|entry| &entry.object);
-    let Some(obj) = state.objects.get(&rid.source).or(liminal_obj) else {
+    let Some(obj) = liminal_obj.or_else(|| state.objects.get(&rid.source)) else {
         return false;
     };
     let Some(repl_def) = obj.replacement_definitions.get(rid.index) else {
@@ -5236,6 +5236,20 @@ fn object_replacement_candidate_applies(
     true
 }
 
+/// CR 614.12: identify a not-yet-committed battlefield entry whose projected
+/// characteristics live in `GameState::liminal_entries`.
+fn liminal_entry_ref(event: &ProposedEvent) -> Option<ObjectId> {
+    match event {
+        ProposedEvent::TokenEntry { entry_ref, .. } => Some(*entry_ref),
+        ProposedEvent::ZoneChange {
+            object_id,
+            to: Zone::Battlefield,
+            ..
+        } => Some(*object_id),
+        _ => None,
+    }
+}
+
 fn legacy_object_replacement_candidates(
     state: &GameState,
     event: &ProposedEvent,
@@ -5250,8 +5264,8 @@ fn legacy_object_replacement_candidates(
             object_replacement_candidate_applies(state, event, registry, rid).then_some(rid)
         })
         .collect();
-    if let ProposedEvent::TokenEntry { entry_ref, .. } = event {
-        if let Some(entry) = state.liminal_entries.get(entry_ref) {
+    if let Some(entry_ref) = liminal_entry_ref(event) {
+        if let Some(entry) = state.liminal_entries.get(&entry_ref) {
             candidates.extend(
                 entry
                     .object
@@ -5260,7 +5274,7 @@ fn legacy_object_replacement_candidates(
                     .enumerate()
                     .filter_map(|(index, _)| {
                         let rid = ReplacementId {
-                            source: *entry_ref,
+                            source: entry_ref,
                             index,
                         };
                         object_replacement_candidate_applies(state, event, registry, rid)
@@ -5299,8 +5313,8 @@ fn indexed_object_replacement_candidates_from_index(
         })
         .collect();
 
-    if let ProposedEvent::TokenEntry { entry_ref, .. } = event {
-        if let Some(entry) = state.liminal_entries.get(entry_ref) {
+    if let Some(entry_ref) = liminal_entry_ref(event) {
+        if let Some(entry) = state.liminal_entries.get(&entry_ref) {
             candidates.extend(
                 entry
                     .object
@@ -5309,7 +5323,7 @@ fn indexed_object_replacement_candidates_from_index(
                     .enumerate()
                     .filter_map(|(index, _)| {
                         let rid = ReplacementId {
-                            source: *entry_ref,
+                            source: entry_ref,
                             index,
                         };
                         object_replacement_candidate_applies(state, event, registry, rid)
@@ -6207,14 +6221,10 @@ fn apply_single_replacement(
         state.pending_damage_replacements.get(rid.index)
     } else {
         state
-            .objects
+            .liminal_entries
             .get(&rid.source)
-            .or_else(|| {
-                state
-                    .liminal_entries
-                    .get(&rid.source)
-                    .map(|entry| &entry.object)
-            })
+            .map(|entry| &entry.object)
+            .or_else(|| state.objects.get(&rid.source))
             .and_then(|obj| obj.replacement_definitions.get(rid.index))
     };
 
@@ -7054,14 +7064,10 @@ fn replacement_definition_for_id(
     rid: ReplacementId,
 ) -> Option<&ReplacementDefinition> {
     state
-        .objects
+        .liminal_entries
         .get(&rid.source)
-        .or_else(|| {
-            state
-                .liminal_entries
-                .get(&rid.source)
-                .map(|entry| &entry.object)
-        })
+        .map(|entry| &entry.object)
+        .or_else(|| state.objects.get(&rid.source))
         .and_then(|obj| obj.replacement_definitions.get(rid.index))
         // CR 121.2: an instruction to draw multiple cards is performed as that many
         // individual draws, and CR 121.2a modifies the instruction's count *before* any
@@ -8217,6 +8223,8 @@ mod tests {
                 spec_resume: None,
                 enter_tapped: EtbTapState::Unspecified,
                 enter_with_counters: Vec::new(),
+                kind: crate::types::game_state::LiminalEntryKind::Token,
+                replacement_applied: HashSet::new(),
             },
         );
         assert!(!state.objects.contains_key(&entry_ref));

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1522,6 +1522,8 @@ impl GameRunner {
     pub fn waiting_for_kind(&self) -> &'static str {
         match &self.state.waiting_for {
             WaitingFor::Priority { .. } => "Priority",
+            WaitingFor::MeldPairChoice { .. } => "MeldPairChoice",
+            WaitingFor::MeldAttackTargetChoice { .. } => "MeldAttackTargetChoice",
             WaitingFor::MulliganDecision { .. } => "MulliganDecision",
             WaitingFor::OpeningHandBottomCards { .. } => "OpeningHandBottomCards",
             WaitingFor::ManaPayment { .. } => "ManaPayment",

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1578,10 +1578,12 @@ mod tests {
                 spec_resume: None,
                 enter_tapped: crate::types::proposed_event::EtbTapState::Unspecified,
                 enter_with_counters: Vec::new(),
+                kind: crate::types::game_state::LiminalEntryKind::Token,
+                replacement_applied: std::collections::HashSet::new(),
             },
         );
         state.pending_liminal_entry_resume =
-            Some(crate::types::game_state::PendingLiminalEntryResume {
+            Some(crate::types::game_state::PendingLiminalEntryResume::Token {
                 source_id: entry_ref,
                 player: PlayerId(0),
                 event: crate::types::proposed_event::ProposedEvent::TokenEntry {

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -238,6 +238,7 @@ impl ZoneMoveRequest {
             mods: EntryMods::default(),
             placement: None,
             exile_links: ExileLinkSpec::default(),
+            replacement_applied: HashSet::new(),
         }
     }
 

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -15,8 +15,9 @@ use crate::types::ability::{
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    BatchCompletion, ExileLinkKind, GameState, MergedCardComponentRoute, PendingBatchDeliveries,
-    PendingCounterPostAction, PostReplacementDrainOwner, WaitingFor, ZoneDeliveryExileTracking,
+    BatchCompletion, ExileLinkKind, GameState, LiminalEntryKind, MergedCardComponentRoute,
+    PendingBatchDeliveries, PendingCounterPostAction, PendingLiminalEntryResume,
+    PostReplacementDrainOwner, WaitingFor, ZoneDeliveryExileTracking,
 };
 use std::collections::HashSet;
 
@@ -179,6 +180,9 @@ pub struct ZoneMoveRequest {
     pub placement: Option<LibraryPosition>,
     /// Exile-link context (duration-bound returns + exiled-by-source tracking).
     pub exile_links: ExileLinkSpec,
+    /// CR 614.5: replacement definitions already applied to the event or
+    /// modified event from which this physical-card move was derived.
+    pub replacement_applied: HashSet<AppliedReplacementKey>,
 }
 
 impl ZoneMoveRequest {
@@ -191,6 +195,7 @@ impl ZoneMoveRequest {
             mods: EntryMods::default(),
             placement: None,
             exile_links: ExileLinkSpec::default(),
+            replacement_applied: HashSet::new(),
         }
     }
 
@@ -203,6 +208,7 @@ impl ZoneMoveRequest {
             mods: EntryMods::default(),
             placement: None,
             exile_links: ExileLinkSpec::default(),
+            replacement_applied: HashSet::new(),
         }
     }
 
@@ -219,6 +225,7 @@ impl ZoneMoveRequest {
             mods: EntryMods::default(),
             placement: None,
             exile_links: ExileLinkSpec::default(),
+            replacement_applied: HashSet::new(),
         }
     }
 
@@ -247,10 +254,13 @@ impl ZoneMoveRequest {
         Self {
             object_id,
             to: Zone::Hand,
-            cause: ZoneChangeCause::Draw { seed_applied },
+            cause: ZoneChangeCause::Draw {
+                seed_applied: seed_applied.clone(),
+            },
             mods: EntryMods::default(),
             placement: None,
             exile_links: ExileLinkSpec::default(),
+            replacement_applied: seed_applied,
         }
     }
 
@@ -264,6 +274,7 @@ impl ZoneMoveRequest {
             mods: EntryMods::default(),
             placement: None,
             exile_links: ExileLinkSpec::default(),
+            replacement_applied: HashSet::new(),
         }
     }
 
@@ -279,6 +290,7 @@ impl ZoneMoveRequest {
             mods: EntryMods::default(),
             placement: None,
             exile_links: ExileLinkSpec::default(),
+            replacement_applied: HashSet::new(),
         }
     }
 
@@ -292,6 +304,7 @@ impl ZoneMoveRequest {
             mods: EntryMods::default(),
             placement: None,
             exile_links: ExileLinkSpec::default(),
+            replacement_applied: HashSet::new(),
         }
     }
 
@@ -304,6 +317,7 @@ impl ZoneMoveRequest {
             mods: EntryMods::default(),
             placement: None,
             exile_links: ExileLinkSpec::default(),
+            replacement_applied: HashSet::new(),
         }
     }
 
@@ -350,6 +364,13 @@ impl ZoneMoveRequest {
     /// `NthFromTop`). Only meaningful when `to == Zone::Library`.
     pub fn at_library_position(mut self, position: LibraryPosition) -> Self {
         self.placement = Some(position);
+        self
+    }
+
+    /// CR 614.5: seed a child/modified move with the replacements already
+    /// applied to its originating event.
+    pub fn with_replacement_applied(mut self, applied: HashSet<AppliedReplacementKey>) -> Self {
+        self.replacement_applied = applied;
         self
     }
 
@@ -609,8 +630,11 @@ pub(crate) fn move_object(
                 return ZoneMoveResult::Done;
             }
             let source_id = req.source();
-            let proposed =
+            let mut proposed =
                 ProposedEvent::zone_change(req.object_id, from_zone, Zone::Library, source_id);
+            if let ProposedEvent::ZoneChange { applied, .. } = &mut proposed {
+                *applied = req.replacement_applied.clone();
+            }
             return match replacement::replace_event(state, proposed, events) {
                 ReplacementResult::Execute(event) => {
                     match deliver_replaced_zone_change(
@@ -677,7 +701,8 @@ pub(crate) fn move_object(
     if let ZoneChangeCause::Draw { seed_applied } = req.cause {
         let mut proposed = ProposedEvent::zone_change(req.object_id, from_zone, req.to, source_id);
         if let ProposedEvent::ZoneChange { applied, .. } = &mut proposed {
-            *applied = seed_applied;
+            *applied = req.replacement_applied;
+            applied.extend(seed_applied);
         }
         return match replacement::replace_event(state, proposed, events) {
             ReplacementResult::Execute(event) => match deliver_replaced_zone_change(
@@ -745,6 +770,7 @@ pub(crate) fn move_object(
             controller_override,
             enter_with_counters,
             face_down_profile,
+            applied,
             ..
         } = &mut proposed
         {
@@ -755,6 +781,7 @@ pub(crate) fn move_object(
             *controller_override = req.mods.controller_override;
             enter_with_counters.extend(req.mods.enter_with_counters.iter().cloned());
             *face_down_profile = req.mods.face_down_profile.clone().map(Box::new);
+            *applied = req.replacement_applied;
         }
         let approved = ApprovedZoneChange::seal(proposed);
         return match deliver(
@@ -776,7 +803,7 @@ pub(crate) fn move_object(
         };
     }
 
-    execute_zone_move(
+    execute_zone_move_with_applied(
         state,
         req.object_id,
         from_zone,
@@ -794,6 +821,7 @@ pub(crate) fn move_object(
         track_exiled_by_source,
         None,
         None,
+        req.replacement_applied,
         events,
     )
 }
@@ -919,6 +947,7 @@ fn ensure_batch_record(state: &mut GameState, destination: Zone) -> &mut Pending
             exile_tracking: ZoneDeliveryExileTracking::None,
             library_placement: None,
             completion: None,
+            replacement_applied: HashSet::new(),
         })
 }
 
@@ -1005,6 +1034,7 @@ fn stash_batch_tail(state: &mut GameState, tail: Vec<ZoneMoveRequest>, destinati
     let enter_tapped = first.mods.enter_tapped;
     let exile_tracking = first.exile_links.tracking;
     let library_placement = first.placement.clone();
+    let replacement_applied = first.replacement_applied.clone();
     state.pending_batch_deliveries = Some(PendingBatchDeliveries {
         remaining: tail.into_iter().map(|r| r.object_id).collect(),
         destination,
@@ -1012,6 +1042,7 @@ fn stash_batch_tail(state: &mut GameState, tail: Vec<ZoneMoveRequest>, destinati
         enter_tapped,
         exile_tracking,
         library_placement,
+        replacement_applied,
         // The post-loop cleanup (if any) is attached by the batch caller after
         // it observes the `NeedsChoice`; `move_objects_simultaneously` itself
         // has no completion to stash.
@@ -1067,6 +1098,7 @@ pub(crate) fn drain_pending_batch_deliveries(state: &mut GameState, events: &mut
                 if let Some(position) = pending.library_placement.clone() {
                     req = req.at_library_position(position);
                 }
+                req.replacement_applied = pending.replacement_applied.clone();
                 req
             })
             .collect();
@@ -1305,6 +1337,25 @@ pub(crate) fn apply_zone_delivery_tail(
         );
         if let Some(wf) = waiting_for {
             if !matches!(wf, WaitingFor::Priority { .. }) {
+                if matches!(wf, WaitingFor::CopyTargetChoice { .. }) {
+                    if let Some(LiminalEntryKind::Meld {
+                        context,
+                        attack_target,
+                        ..
+                    }) = state
+                        .liminal_entries
+                        .get(&object_id)
+                        .map(|entry| entry.kind.clone())
+                    {
+                        state.pending_liminal_entry_resume =
+                            Some(PendingLiminalEntryResume::Meld {
+                                source_id: object_id,
+                                player: wf.acting_player().unwrap_or(state.active_player),
+                                context,
+                                attack_target,
+                            });
+                    }
+                }
                 state.waiting_for = wf;
                 return replacement_pause_delivery_result(state);
             }
@@ -1618,9 +1669,13 @@ pub(crate) fn deliver_replaced_zone_change(
         enter_with_counters,
         controller_override: ctrl_override,
         face_down_profile,
+        applied,
         ..
     } = event
     {
+        if let Some(entry) = state.liminal_entries.get_mut(&object_id) {
+            entry.replacement_applied = applied;
+        }
         let exile_tracking = if track_exiled_by_source {
             ZoneDeliveryExileTracking::TrackBySource
         } else {
@@ -2038,7 +2093,49 @@ pub(crate) fn execute_zone_move(
     enter_attached_to: Option<AttachTarget>,
     events: &mut Vec<GameEvent>,
 ) -> ZoneMoveResult {
+    execute_zone_move_with_applied(
+        state,
+        obj_id,
+        from_zone,
+        dest_zone,
+        source_id,
+        duration,
+        enter_transformed,
+        enter_tapped,
+        controller_override,
+        effect_enter_with_counters,
+        face_down_profile,
+        track_exiled_by_source,
+        library_placement,
+        enter_attached_to,
+        HashSet::new(),
+        events,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn execute_zone_move_with_applied(
+    state: &mut GameState,
+    obj_id: ObjectId,
+    from_zone: Zone,
+    dest_zone: Zone,
+    source_id: ObjectId,
+    duration: Option<&Duration>,
+    enter_transformed: bool,
+    enter_tapped: EtbTapState,
+    controller_override: Option<PlayerId>,
+    effect_enter_with_counters: &[(CounterType, u32)],
+    face_down_profile: Option<&crate::types::ability::FaceDownProfile>,
+    track_exiled_by_source: bool,
+    library_placement: Option<LibraryPosition>,
+    enter_attached_to: Option<AttachTarget>,
+    replacement_applied: HashSet<AppliedReplacementKey>,
+    events: &mut Vec<GameEvent>,
+) -> ZoneMoveResult {
     let mut proposed = ProposedEvent::zone_change(obj_id, from_zone, dest_zone, Some(source_id));
+    if let ProposedEvent::ZoneChange { applied, .. } = &mut proposed {
+        *applied = replacement_applied;
+    }
 
     // CR 712.14a: Set enter_transformed on the proposed event so replacement effects
     // preserve it through the pipeline.
@@ -2108,7 +2205,12 @@ pub(crate) fn execute_zone_move(
     // battlefield from any source (effect-driven entry — bounce-return,
     // reanimate, blink, etc.). Spell-cast entry is handled in stack.rs.
     if dest_zone == Zone::Battlefield {
-        if let Some(obj) = state.objects.get(&obj_id) {
+        if let Some(obj) = state
+            .liminal_entries
+            .get(&obj_id)
+            .map(|entry| &entry.object)
+            .or_else(|| state.objects.get(&obj_id))
+        {
             // CR 712.14a + CR 712.18: A permanent entering transformed (e.g. a
             // double-faced card exiled and returned with its back face up, like
             // a creature-front // planeswalker-back DFC) will have its back

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -667,6 +667,33 @@ pub fn move_to_zone(
         return;
     }
 
+    // CR 614.12 + CR 701.42: a meld result is projected while its two physical
+    // cards remain in exile. Once its approved battlefield delivery commits,
+    // that projection is the authority for the entry snapshot; the source
+    // card's front-face object remains the storage authority so the meld can
+    // later split back into its physical fronts.
+    let liminal_entry_projection = (to == Zone::Battlefield)
+        .then(|| {
+            state
+                .liminal_entries
+                .get(&object_id)
+                .map(|entry| entry.object.clone())
+        })
+        .flatten();
+    let liminal_attack_target = (to == Zone::Battlefield)
+        .then(|| {
+            state
+                .liminal_entries
+                .get(&object_id)
+                .and_then(|entry| match &entry.kind {
+                    crate::types::game_state::LiminalEntryKind::Meld { attack_target, .. } => {
+                        *attack_target
+                    }
+                    crate::types::game_state::LiminalEntryKind::Token => None,
+                })
+        })
+        .flatten();
+
     // CR 903.9a: A fresh zone change resets the "declined zone return" flag
     // so the owner gets a new choice opportunity if the commander moves again.
     state.commander_declined_zone_return.remove(&object_id);
@@ -674,7 +701,10 @@ pub fn move_to_zone(
     // CR 614.1d: Check CantEnterBattlefieldFrom statics before allowing the move.
     // e.g., Grafdigger's Cage: "Creature cards in graveyards and libraries can't enter the battlefield."
     if to == Zone::Battlefield {
-        if let Some(obj) = state.objects.get(&object_id) {
+        if let Some(obj) = liminal_entry_projection
+            .as_ref()
+            .or_else(|| state.objects.get(&object_id))
+        {
             if is_blocked_from_entering_battlefield(state, obj) {
                 return;
             }
@@ -750,7 +780,9 @@ pub fn move_to_zone(
         obj.attached_to
             .map(super::effects::attach::target_ref_from_attach_target)
     });
-    let mut zone_change_record = obj.snapshot_for_zone_change(object_id, Some(from), to);
+    let snapshot_object = liminal_entry_projection.as_ref().unwrap_or(obj);
+    let mut zone_change_record =
+        snapshot_object.snapshot_for_zone_change(object_id, Some(from), to);
     // CR 603.10a + CR 603.6e: Capture attachment snapshot before SBA can detach.
     zone_change_record.attachments = capture_attachment_snapshot(state, obj);
     // CR 603.10a + CR 607.2a: Leaves-the-battlefield triggers look back to the
@@ -767,7 +799,19 @@ pub fn move_to_zone(
             .linked_exile_lki
             .insert(object_id, zone_change_record.linked_exile_snapshot.clone());
     }
-    zone_change_record.combat_status = capture_combat_status(state, object_id);
+    zone_change_record.combat_status = if let Some(target) = liminal_attack_target {
+        ZoneChangeCombatStatus {
+            attacking: true,
+            defending_player: super::combat::entry_attack_target_defender(
+                state,
+                snapshot_object.controller,
+                target,
+            ),
+            ..ZoneChangeCombatStatus::default()
+        }
+    } else {
+        capture_combat_status(state, object_id)
+    };
 
     sever_battlefield_attachment_graph_on_exit(state, object_id, &unattached_from);
 

--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -770,7 +770,7 @@ pub(super) enum BindGuard {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum EffectClass {
-    /// `CopyTokenOf` | `Token` | `ChangeZone` — the only effects
+    /// `CopyTokenOf` | `Token` | `ChangeZone` | `Meld` — the effects
     /// `ModifyPrior::EntersTappedAttacking` can patch.
     PermanentCreator,
     /// `ChooseDrawnThisTurnPayOrTopdeck` — the only effect
@@ -1000,7 +1000,10 @@ impl AssemblyEnv {
             Some(BindGuard::NoSubAbility) => defs[index].sub_ability.is_none(),
             Some(BindGuard::EffectShape(EffectClass::PermanentCreator)) => matches!(
                 &*defs[index].effect,
-                Effect::CopyTokenOf { .. } | Effect::Token { .. } | Effect::ChangeZone { .. }
+                Effect::CopyTokenOf { .. }
+                    | Effect::Token { .. }
+                    | Effect::ChangeZone { .. }
+                    | Effect::Meld { .. }
             ),
             Some(BindGuard::EffectShape(EffectClass::DrawnThisTurnChoice)) => matches!(
                 &*defs[index].effect,
@@ -1340,6 +1343,11 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
                                         *enters_attacking = true;
                                         *enter_tapped = crate::types::zones::EtbTapState::Tapped;
                                     }
+                                    Effect::Meld { entry, .. } => {
+                                        *entry = crate::types::ability::PermanentEntryMode::TappedAndAttacking {
+                                            destination: crate::types::ability::EntryAttackDestination::AnyDefender,
+                                        };
+                                    }
                                     _ => {}
                                 }
                                 let original = {
@@ -1369,6 +1377,10 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
                                             *enters_attacking = false;
                                             *enter_tapped =
                                                 crate::types::zones::EtbTapState::Unspecified;
+                                        }
+                                        Effect::Meld { entry, .. } => {
+                                            *entry =
+                                                crate::types::ability::PermanentEntryMode::Normal;
                                         }
                                         _ => {}
                                     }

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -238,6 +238,24 @@ pub(crate) fn strip_leading_general_conditional(
     text: &str,
     ctx: &mut ParseContext,
 ) -> (Option<AbilityCondition>, String) {
+    // CR 508.4 + CR 608.2c + CR 701.42: this condition contains an internal
+    // comma before its second conjunct ("are attacking, and you both own and
+    // control them"). Peel it through the shared condition production before
+    // the generic first-comma splitter, then leave the imperative body to the
+    // normal effect-chain parser.
+    if let Some((condition, _, _, partner, body)) = super::meld::strip_live_pair_conditional(text) {
+        ctx.pending_meld_partner = Some(partner);
+        return (Some(condition), body);
+    }
+    // CR 603.4: an inline `If` in an activated ability has its normal English
+    // meaning. Parse the shared own/control pair grammar as an AbilityCondition;
+    // this covers Hanweir Battlements and Urza, Lord Protector without a
+    // card-name dispatch.
+    if let Some((condition, _, _, partner, body)) = super::meld::strip_owned_pair_conditional(text)
+    {
+        ctx.pending_meld_partner = Some(partner);
+        return (Some(condition), body);
+    }
     if let Some((condition_fragment, body)) = split_leading_conditional(text) {
         let condition_lower = condition_fragment.to_lowercase();
         let cond_text = nom_on_lower(&condition_fragment, &condition_lower, |i| {
@@ -5120,6 +5138,14 @@ pub(super) fn try_nom_condition_as_ability_condition(
     use crate::parser::oracle_nom::condition::parse_inner_condition;
 
     let lower = text.to_lowercase();
+
+    // CR 508.4 + CR 608.2c + CR 701.42: attacking meld-pair conditions are
+    // resolution-time leading conditions. Keep them in the shared condition
+    // dispatcher so trigger, activated-ability, and ordinary effect chains all
+    // obtain the same typed source/partner predicates.
+    if let Some((condition, ..)) = super::meld::parse_live_pair_ability_condition(text) {
+        return Some(condition);
+    }
 
     // CR 608.2c: "<condition A> or if <condition B>" disjunction (Reptilian
     // Recruiter: "If that creature's power is 2 or less or if you control another

--- a/crates/engine/src/parser/oracle_effect/meld.rs
+++ b/crates/engine/src/parser/oracle_effect/meld.rs
@@ -28,6 +28,7 @@
 //!    `ParseContext::pending_meld_partner`).
 
 use nom::bytes::complete::{tag, take_until};
+use nom::combinator::all_consuming;
 use nom::Parser;
 
 use crate::parser::oracle_ir::context::ParseContext;
@@ -36,7 +37,8 @@ use crate::parser::oracle_nom::error::OracleError;
 use crate::parser::oracle_target::parse_target;
 use crate::parser::oracle_trigger::static_condition_to_trigger_condition;
 use crate::types::ability::{
-    ControllerRef, Effect, FilterProp, TargetFilter, TriggerCondition, TypedFilter,
+    AbilityCondition, ControllerRef, Effect, FilterProp, TargetFilter, TriggerCondition,
+    TypedFilter,
 };
 
 /// The fixed sentinel that separates the gate from the meld effect clause.
@@ -52,6 +54,10 @@ const MELD_SENTINEL: &str = ", exile them, then meld them into ";
 /// which remain nom-combinator-based and remain the sole authority on whether
 /// the text actually forms a meld clause.
 pub(crate) const MELD_EFFECT_MARKER: &str = "meld them into ";
+
+/// Parsed semantic fields shared by the attacking meld-pair condition entry
+/// points.
+type LivePairCondition = (AbilityCondition, TargetFilter, TargetFilter, String);
 
 /// CR 701.42b: A `Typed` filter carrying only the `FilterProp::Owned { You }`
 /// ownership constraint, to AND with a self-reference filter.
@@ -254,7 +260,184 @@ pub(crate) fn parse_meld_effect_clause(text: &str, ctx: &ParseContext) -> Option
         source,
         partner,
         result: result_name.to_string(),
+        source_filter: TargetFilter::SelfRef,
+        partner_filter: TargetFilter::Any,
+        entry: crate::types::ability::PermanentEntryMode::Normal,
     })
+}
+
+/// CR 508.4 + CR 608.2c + CR 701.42: parse the resolution-time condition
+/// shared by the attacking meld-pair class. This parser owns only the condition
+/// production; `clause_shell::peel_clause` remains the authority that separates
+/// a leading condition from its imperative body, and the ordinary effect-chain
+/// assembler handles any following entry modifier.
+pub(crate) fn parse_live_pair_ability_condition(text: &str) -> Option<LivePairCondition> {
+    let (rest, fields) = parse_live_pair_condition_prefix(text)?;
+    all_consuming(nom::character::complete::multispace0::<_, OracleError<'_>>)
+        .parse(rest)
+        .ok()?;
+    Some(fields)
+}
+
+/// Peel the attacking-pair condition from a leading `if` clause while leaving
+/// the imperative body to the ordinary effect-chain parser. This is the
+/// condition-prefix sibling of [`parse_live_pair_ability_condition`]: neither
+/// parser knows or matches the body (meld or otherwise).
+pub(crate) fn strip_live_pair_conditional(
+    text: &str,
+) -> Option<(AbilityCondition, TargetFilter, TargetFilter, String, String)> {
+    let lower = text.to_lowercase();
+    let (after_if_lower, _) = tag::<_, _, OracleError<'_>>("if ")
+        .parse(lower.as_str())
+        .ok()?;
+    let after_if_offset = lower.len() - after_if_lower.len();
+    let after_if = &text[after_if_offset..];
+    let (rest, (condition, source, partner, partner_name)) =
+        parse_live_pair_condition_prefix(after_if)?;
+    let rest_lower = rest.to_lowercase();
+    let (body_lower, _) = tag::<_, _, OracleError<'_>>(", ")
+        .parse(rest_lower.as_str())
+        .ok()?;
+    let body_offset = rest_lower.len() - body_lower.len();
+    let body = rest[body_offset..].to_string();
+    Some((condition, source, partner, partner_name, body))
+}
+
+/// Parse the ordinary meld-pair ownership gate used by both triggered and
+/// activated instigators. Unlike [`parse_meld_gate`], this production returns
+/// an [`AbilityCondition`], so an inline `If ...` in an activated ability is
+/// checked only as that instruction resolves rather than being promoted to an
+/// intervening-if trigger condition (CR 603.4).
+pub(crate) fn strip_owned_pair_conditional(
+    text: &str,
+) -> Option<(AbilityCondition, TargetFilter, TargetFilter, String, String)> {
+    let lower = text.to_lowercase();
+    let (sentinel_lower, gate_region_lower): (&str, &str) =
+        take_until::<_, _, OracleError<'_>>(MELD_SENTINEL)
+            .parse(lower.as_str())
+            .ok()?;
+    let (after_prefix_lower, _) = tag::<_, _, OracleError<'_>>("if you both own and control ")
+        .parse(gate_region_lower)
+        .ok()?;
+    let gate_len = gate_region_lower.len();
+    let source_partner_start = gate_len - after_prefix_lower.len();
+    let source_partner = &text[source_partner_start..gate_len];
+
+    let (source_base, after_source) = parse_target(source_partner);
+    let after_source_lower = after_source.to_lowercase();
+    let (after_and_lower, _) = tag::<_, _, OracleError<'_>>("and ")
+        .parse(after_source_lower.trim_start())
+        .ok()?;
+    let partner_offset = after_source_lower.len() - after_and_lower.len();
+    let partner_original = &after_source[partner_offset..];
+    let (partner_base, partner_rest) = parse_target(partner_original);
+    let partner_name = named_of(&partner_base)?;
+    all_consuming(nom::character::complete::multispace0::<_, OracleError<'_>>)
+        .parse(partner_rest)
+        .ok()?;
+
+    let sentinel_offset = lower.len() - sentinel_lower.len();
+    let sentinel_original = &text[sentinel_offset..];
+    let (body_lower, _) = tag::<_, _, OracleError<'_>>(", ")
+        .parse(sentinel_lower)
+        .ok()?;
+    let body_offset = sentinel_lower.len() - body_lower.len();
+    let body = sentinel_original[body_offset..].to_string();
+
+    let source_filter = with_owned_you(source_base);
+    let partner_filter = with_owned_you(partner_base);
+    let condition = AbilityCondition::And {
+        conditions: vec![
+            AbilityCondition::SourceMatchesFilter {
+                filter: source_filter.clone(),
+            },
+            AbilityCondition::ControllerControlsMatching {
+                filter: partner_filter.clone(),
+            },
+        ],
+    };
+    Some((condition, source_filter, partner_filter, partner_name, body))
+}
+
+fn parse_live_pair_condition_prefix(text: &str) -> Option<(&str, LivePairCondition)> {
+    let (source_filter, after_source) = parse_target(text);
+    let after_source_lower = after_source.to_lowercase();
+    let (after_and, _) = tag::<_, _, OracleError<'_>>("and ")
+        .parse(after_source_lower.trim_start())
+        .ok()?;
+    let partner_offset = after_source_lower.len() - after_and.len();
+    let partner_original = &after_source[partner_offset..];
+    let (partner_base, partner_rest) = parse_target(partner_original);
+    let partner = named_of(&partner_base)?;
+    let partner_rest_lower = partner_rest.to_lowercase();
+    let (after_condition_lower, _) =
+        tag::<_, _, OracleError<'_>>(" are attacking, and you both own and control them")
+            .parse(partner_rest_lower.as_str())
+            .ok()?;
+    let after_condition_offset = partner_rest_lower.len() - after_condition_lower.len();
+    let after_condition = &partner_rest[after_condition_offset..];
+
+    let source_filter = TargetFilter::And {
+        filters: vec![
+            source_filter,
+            TargetFilter::Typed(TypedFilter::default().properties(vec![
+                FilterProp::Attacking { defender: None },
+                FilterProp::Owned {
+                    controller: ControllerRef::You,
+                },
+            ])),
+        ],
+    };
+    let partner_filter = with_owned_you(partner_base);
+    let partner_filter = match partner_filter {
+        TargetFilter::Typed(mut typed) => {
+            typed
+                .properties
+                .push(FilterProp::Attacking { defender: None });
+            TargetFilter::Typed(typed)
+        }
+        other => TargetFilter::And {
+            filters: vec![
+                other,
+                TargetFilter::Typed(
+                    TypedFilter::default()
+                        .properties(vec![FilterProp::Attacking { defender: None }]),
+                ),
+            ],
+        },
+    };
+    let condition = AbilityCondition::And {
+        conditions: vec![
+            AbilityCondition::SourceMatchesFilter {
+                filter: source_filter.clone(),
+            },
+            AbilityCondition::ControllerControlsMatching {
+                filter: partner_filter.clone(),
+            },
+        ],
+    };
+    Some((
+        after_condition,
+        (condition, source_filter, partner_filter, partner),
+    ))
+}
+
+pub(crate) fn live_pair_fields_from_condition(
+    condition: &AbilityCondition,
+) -> Option<(TargetFilter, TargetFilter, String)> {
+    let AbilityCondition::And { conditions } = condition else {
+        return None;
+    };
+    let source_filter = conditions.iter().find_map(|condition| match condition {
+        AbilityCondition::SourceMatchesFilter { filter } => Some(filter.clone()),
+        _ => None,
+    })?;
+    let partner_filter = conditions.iter().find_map(|condition| match condition {
+        AbilityCondition::ControllerControlsMatching { filter } => Some(filter.clone()),
+        _ => None,
+    })?;
+    let partner = named_of(&partner_filter)?;
+    Some((source_filter, partner_filter, partner))
 }
 
 #[cfg(test)]
@@ -355,5 +538,32 @@ mod tests {
         let text = "if you both own and control ~ and a creature named Fang, Fearless l'Cie, \
              it gains flying until end of turn.";
         assert!(parse_meld_gate(text).is_none());
+    }
+
+    #[test]
+    fn attacking_meld_pair_condition_uses_shared_typed_filters() {
+        let text = "~ and a creature named Phyrexian Dragon Engine are attacking, and you both own and control them";
+        let (condition, source, partner, name) =
+            parse_live_pair_ability_condition(text).expect("attacking meld-pair condition parses");
+        assert_eq!(name, "Phyrexian Dragon Engine");
+        assert!(matches!(condition, AbilityCondition::And { .. }));
+        assert!(matches!(source, TargetFilter::And { .. }));
+        assert!(matches!(partner, TargetFilter::Typed(_)));
+    }
+
+    #[test]
+    fn activated_owned_pair_condition_is_generic() {
+        let text = "if you both own and control ~ and a creature named Hanweir Garrison, \
+            exile them, then meld them into Hanweir, the Writhing Township.";
+        let (condition, source, partner, name, body) =
+            strip_owned_pair_conditional(text).expect("activated pair condition parses");
+        assert_eq!(name, "Hanweir Garrison");
+        assert!(matches!(condition, AbilityCondition::And { .. }));
+        assert!(!matches!(source, TargetFilter::Any));
+        assert!(!matches!(partner, TargetFilter::Any));
+        assert_eq!(
+            body,
+            "exile them, then meld them into Hanweir, the Writhing Township."
+        );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6100,6 +6100,12 @@ pub(crate) fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedE
             return attach_unless_slots(clause, None, unless_pay_deferred);
         }
     }
+    let live_meld_fields = peel_ctx
+        .condition()
+        .and_then(meld::live_pair_fields_from_condition);
+    if let Some((_, _, partner)) = &live_meld_fields {
+        ctx.pending_meld_partner = Some(partner.clone());
+    }
     let mut clause = parse_effect_clause_inner(&peeled_text, ctx);
     // Trial-parse fallback: peeling may have removed disambiguation signal
     // a specialized parser depends on (e.g., `the next spell you cast this
@@ -6130,6 +6136,18 @@ pub(crate) fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedE
         if let Some(cond) = peel_ctx.condition().cloned().or(unless_condition) {
             clause.condition = Some(cond);
         }
+    }
+    if let (
+        Effect::Meld {
+            source_filter,
+            partner_filter,
+            ..
+        },
+        Some((live_source, live_partner, _)),
+    ) = (&mut clause.effect, live_meld_fields)
+    {
+        *source_filter = live_source;
+        *partner_filter = live_partner;
     }
     attach_unless_slots(clause, None, unless_pay_deferred)
 }
@@ -27405,6 +27423,26 @@ pub(crate) fn parse_effect_chain_ir(
         // carries the caster default (Controller). Per D-04, this is parse-time
         // pronoun resolution that belongs in IR production.
         let mut clause = clause;
+        // CR 508.4 + CR 701.42: the shared leading-condition pass owns the live
+        // attacking/ownership predicates, while the bare Meld body parser owns
+        // the effect. Join those independently parsed building blocks here at
+        // the generic clause-IR seam.
+        if let (
+            Effect::Meld {
+                source_filter,
+                partner_filter,
+                ..
+            },
+            Some((live_source, live_partner, _)),
+        ) = (
+            &mut clause.effect,
+            condition
+                .as_ref()
+                .and_then(meld::live_pair_fields_from_condition),
+        ) {
+            *source_filter = live_source;
+            *partner_filter = live_partner;
+        }
         // CR 608.2c + CR 400.7: Carry the source zone of a "choose card(s) in
         // <zone>" producer forward to the NEXT chunk. The chosen cards stay in
         // that zone until a downstream "put those cards onto the battlefield"

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -4452,6 +4452,11 @@ pub(super) fn apply_clause_continuation(
                     // applying them unconditionally.
                     *enters_modified_if = moved_filter;
                 }
+                Effect::Meld { entry, .. } => {
+                    *entry = crate::types::ability::PermanentEntryMode::TappedAndAttacking {
+                        destination: crate::types::ability::EntryAttackDestination::AnyDefender,
+                    };
+                }
                 _ => {}
             }
         }
@@ -6888,9 +6893,12 @@ pub(super) fn parse_followup_continuation_ast(
         }
         // CR 508.4 / CR 614.1: "It/The token enters tapped and attacking" (singular)
         // or "They/Those tokens enter tapped and attacking" (plural)
-        // after CopyTokenOf or Token. Tokens/copies always enter
+        // after CopyTokenOf, Token, or Meld. Tokens/copies always enter
         // unconditionally — no moved-object type gate applies.
-        Effect::CopyTokenOf { .. } | Effect::Token { .. }
+        // CR 701.42c: a successfully melded permanent is the single object
+        // entering in the follow-up sentence, so the same entry modifier is
+        // applied to the preceding Meld effect.
+        Effect::CopyTokenOf { .. } | Effect::Token { .. } | Effect::Meld { .. }
             if nom_primitives::scan_contains(&lower, "enters tapped and attacking")
                 || nom_primitives::scan_contains(&lower, "enter tapped and attacking") =>
         {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -9377,6 +9377,37 @@ pub enum ControlWindow {
     NextCombatPhase,
 }
 
+/// CR 508.4: How a permanent put onto the battlefield by an effect enters
+/// combat. This is a typed axis because attacking entry has a destination
+/// choice and validation contract that ordinary entry does not.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum PermanentEntryMode {
+    #[default]
+    Normal,
+    /// The permanent enters tapped and attacking a destination chosen under
+    /// CR 508.4. It was not declared as an attacker.
+    TappedAndAttacking {
+        #[serde(default)]
+        destination: EntryAttackDestination,
+    },
+}
+
+/// CR 508.4a: Domain from which an attacking-entry destination is selected.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum EntryAttackDestination {
+    /// Any defending player, planeswalker they control, or battle they protect.
+    #[default]
+    AnyDefender,
+    /// A defending player or planeswalker they control (battle excluded).
+    PlayerOrPlaneswalker,
+    /// The instruction fixes a single destination.
+    Exact {
+        target: crate::game::combat::AttackTarget,
+    },
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, strum::IntoStaticStr)]
 #[serde(tag = "type")]
@@ -10364,17 +10395,28 @@ pub enum Effect {
         filter: Box<TargetFilter>,
         host: Box<TargetFilter>,
     },
-    /// CR 701.42a / CR 712.4a: Meld — exile both the real meld instigator
-    /// (`source`) and a battlefield object named `partner` that the controller
-    /// both owns and controls, then put a single melded permanent onto the
-    /// battlefield whose characteristics are the `result` card (the combined back
-    /// faces, exposed in card-data as the named result). No player-selectable
-    /// target — the partner is found by name + ownership at resolution. Resolver:
-    /// `game/meld.rs`.
+    /// CR 701.42: Meld the chosen pair after both objects are exiled.
+    ///
+    /// The string fields retain the stable card-data representation and identify
+    /// the canonical physical pair/result. The filters describe the live Oracle
+    /// referents used before exile: copies, tokens, and name-changing effects can
+    /// therefore affect which objects are offered without changing which printed
+    /// cards can actually meld after exile (CR 701.42b).
     Meld {
         source: String,
         partner: String,
         result: String,
+        /// Live characteristics required of the instigator at resolution.
+        #[serde(default = "default_target_filter_self_ref")]
+        source_filter: TargetFilter,
+        /// Live characteristics required of a possible partner at resolution.
+        /// `Any` is the legacy serialized shape; the resolver derives the named,
+        /// owned, and controlled filter from `partner` in that case.
+        #[serde(default = "default_target_filter_any")]
+        partner_filter: TargetFilter,
+        /// Entry modifiers printed after the meld instruction.
+        #[serde(default)]
+        entry: PermanentEntryMode,
     },
     /// CR 702.55a: Haunt — exile the source card (currently in a graveyard, put
     /// there by dying or by resolving) from the graveyard, *haunting* the target

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -123,6 +123,16 @@ pub enum OutsideGameSelection {
 #[serde(tag = "type", content = "data")]
 pub enum GameAction {
     PassPriority,
+    /// CR 608.2d + CR 701.42: select the exact pair to process for meld.
+    ChooseMeldPair {
+        source_id: ObjectId,
+        partner_id: ObjectId,
+    },
+    /// CR 508.4a: select the engine-enumerated destination for a permanent
+    /// entering the battlefield attacking.
+    ChooseEntryAttackTarget {
+        target: AttackTarget,
+    },
     PlayLand {
         object_id: ObjectId,
         card_id: CardId,
@@ -1430,6 +1440,8 @@ impl GameAction {
     /// without updating this method is a compile-time error.
     pub fn source_object(&self) -> Option<ObjectId> {
         match self {
+            GameAction::ChooseMeldPair { source_id, .. } => Some(*source_id),
+            GameAction::ChooseEntryAttackTarget { .. } => None,
             GameAction::PlayLand { object_id, .. } => Some(*object_id),
             GameAction::CastSpell { object_id, .. } => Some(*object_id),
             GameAction::Foretell { object_id, .. } => Some(*object_id),

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -12,7 +12,7 @@ use super::ability::{
     ChosenAttribute, CoinFlipResult, Comparator, ContinuousModification, ControlWindow,
     CopyChooseScope, CopyScale, CostPaidObjectSnapshot, CounterCostSelection,
     DelayedTriggerCondition, Duration, EffectKind, GameRestriction, KeywordAction, KickerVariant,
-    LibraryPosition, ModalChoice, PileSource, QuantityExpr, ResolvedAbility,
+    LibraryPosition, ModalChoice, PermanentEntryMode, PileSource, QuantityExpr, ResolvedAbility,
     SearchDestinationSplit, SearchSelectionConstraint, StaticCondition, TapCreaturesAggregate,
     TargetFilter, TargetRef, ThisWayCause, TriggerCondition, TriggerDefinition,
 };
@@ -1704,6 +1704,12 @@ pub struct PendingBatchDeliveries {
     /// is the moves themselves (mill, mass bounce). See [`BatchCompletion`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completion: Option<BatchCompletion>,
+    /// CR 614.5: replacement definitions already applied to the event whose
+    /// physical-card delivery is being resumed. Meld result redirects reuse
+    /// this set for each component move so the redirect cannot apply again to
+    /// either modified event.
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    pub replacement_applied: HashSet<AppliedReplacementKey>,
 }
 
 /// CR 701.25a / manifest dread: the post-loop cleanup a rest-pile batch must run
@@ -1824,6 +1830,47 @@ pub enum BatchCompletion {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         after_scope: Option<Box<ResolvedAbility>>,
     },
+    /// CR 701.42 + CR 616.1: both selected meld referents have completed their
+    /// simultaneous exile attempts. The typed context survives any replacement
+    /// ordering pauses so physical-pair validation runs exactly once afterward.
+    MeldExile { context: MeldSelection },
+    /// CR 701.42 + CR 508.4: the meld result's battlefield entry paused on an
+    /// as-enters replacement. Finish result layers/combat placement and emit the
+    /// resolution marker exactly once after delivery.
+    MeldEntry {
+        context: MeldSelection,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        attack_target: Option<AttackTarget>,
+    },
+    /// CR 400.6 + CR 614.5: finish a redirected meld instruction after the
+    /// second physical card has completed its independently replaceable move,
+    /// carrying the originating event's applied-set through every pause.
+    MeldRedirect { source_id: ObjectId },
+}
+
+/// Resolution-stable identity for one selected meld pair. Live filters choose
+/// these object IDs before exile; the canonical names validate their physical
+/// card identities only after the simultaneous exile instruction completes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MeldSelection {
+    pub source_id: ObjectId,
+    pub partner_id: ObjectId,
+    pub controller: PlayerId,
+    pub expected_source: String,
+    pub expected_partner: String,
+    pub result: String,
+    #[serde(default)]
+    pub entry: PermanentEntryMode,
+}
+
+/// Canonical meld relation derived from the loaded [`CardDatabase`]'s meld
+/// layouts and parsed instigator instruction. Runtime resolution uses this
+/// registry after exile instead of trusting live names or arbitrary effect data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeldPairRecord {
+    pub source: String,
+    pub partner: String,
+    pub result: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2006,6 +2053,11 @@ pub enum PendingCounterPostAction {
         object_id: ObjectId,
         name: String,
         source_id: ObjectId,
+    },
+    /// CR 701.42 + CR 707.9: finish a meld instruction after a copy-as-enters
+    /// choice whose entry counters paused on their own replacement choice.
+    FinishMeldEntry {
+        context: MeldSelection,
     },
     ClearPendingEtbCounters {
         object_id: ObjectId,
@@ -3597,6 +3649,20 @@ impl PersistedGameState {
 pub enum WaitingFor {
     Priority {
         player: PlayerId,
+    },
+    /// CR 608.2d + CR 701.42: choose the exact pair of current battlefield
+    /// referents the meld instruction will exile. Candidate identity is frozen
+    /// in the tuples; the physical meld-card check intentionally happens later.
+    MeldPairChoice {
+        player: PlayerId,
+        choices: Vec<MeldSelection>,
+    },
+    /// CR 508.4a: choose what the meld result enters attacking. The engine
+    /// supplies the complete legal topology; clients only return one member.
+    MeldAttackTargetChoice {
+        player: PlayerId,
+        context: MeldSelection,
+        valid_targets: Vec<AttackTarget>,
     },
     /// CR 103.5 + 103.5b: London mulligan — each un-kept player decides
     /// simultaneously. The `pending` list holds every player who has not yet
@@ -5559,6 +5625,8 @@ impl WaitingFor {
     pub fn variant_name(&self) -> &'static str {
         match self {
             WaitingFor::Priority { .. } => "Priority",
+            WaitingFor::MeldPairChoice { .. } => "MeldPairChoice",
+            WaitingFor::MeldAttackTargetChoice { .. } => "MeldAttackTargetChoice",
             WaitingFor::MulliganDecision { .. } => "MulliganDecision",
             WaitingFor::OpeningHandBottomCards { .. } => "OpeningHandBottomCards",
             WaitingFor::ManaPayment { .. } => "ManaPayment",
@@ -5705,6 +5773,8 @@ impl WaitingFor {
                 }
             }
             WaitingFor::Priority { player }
+            | WaitingFor::MeldPairChoice { player, .. }
+            | WaitingFor::MeldAttackTargetChoice { player, .. }
             | WaitingFor::ManaPayment { player, .. }
             | WaitingFor::ChooseXValue { player, .. }
             | WaitingFor::TargetSelection { player, .. }
@@ -6937,13 +7007,107 @@ pub struct LiminalEntry {
     pub spec_resume: Option<Box<TokenSpec>>,
     pub enter_tapped: EtbTapState,
     pub enter_with_counters: Vec<(CounterType, u32)>,
+    #[serde(default)]
+    pub kind: LiminalEntryKind,
+    /// CR 614.5: applied replacement identities from the projected entry. Meld
+    /// redirects seed both physical component moves with this shared set.
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    pub replacement_applied: HashSet<AppliedReplacementKey>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PendingLiminalEntryResume {
-    pub source_id: ObjectId,
-    pub player: PlayerId,
-    pub event: ProposedEvent,
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub enum LiminalEntryKind {
+    #[default]
+    Token,
+    Meld {
+        context: MeldSelection,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        attack_target: Option<AttackTarget>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub enum PendingLiminalEntryResume {
+    Token {
+        source_id: ObjectId,
+        player: PlayerId,
+        event: ProposedEvent,
+    },
+    Meld {
+        source_id: ObjectId,
+        player: PlayerId,
+        context: MeldSelection,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        attack_target: Option<AttackTarget>,
+    },
+}
+
+#[derive(Deserialize)]
+enum TaggedPendingLiminalEntryResume {
+    Token {
+        source_id: ObjectId,
+        player: PlayerId,
+        event: ProposedEvent,
+    },
+    Meld {
+        source_id: ObjectId,
+        player: PlayerId,
+        context: MeldSelection,
+        #[serde(default)]
+        attack_target: Option<AttackTarget>,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PendingLiminalEntryResumeCompat {
+    Tagged(TaggedPendingLiminalEntryResume),
+    LegacyToken {
+        source_id: ObjectId,
+        player: PlayerId,
+        event: ProposedEvent,
+    },
+}
+
+impl<'de> Deserialize<'de> for PendingLiminalEntryResume {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(
+            match PendingLiminalEntryResumeCompat::deserialize(deserializer)? {
+                PendingLiminalEntryResumeCompat::Tagged(
+                    TaggedPendingLiminalEntryResume::Token {
+                        source_id,
+                        player,
+                        event,
+                    },
+                )
+                | PendingLiminalEntryResumeCompat::LegacyToken {
+                    source_id,
+                    player,
+                    event,
+                } => Self::Token {
+                    source_id,
+                    player,
+                    event,
+                },
+                PendingLiminalEntryResumeCompat::Tagged(
+                    TaggedPendingLiminalEntryResume::Meld {
+                        source_id,
+                        player,
+                        context,
+                        attack_target,
+                    },
+                ) => Self::Meld {
+                    source_id,
+                    player,
+                    context,
+                    attack_target,
+                },
+            },
+        )
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -8407,6 +8571,11 @@ pub struct GameState {
     /// Wrapped in `Arc` so `GameState::clone()` during AI search is O(1).
     #[serde(skip)]
     pub card_face_registry: Arc<HashMap<String, CardFace>>,
+
+    /// CR 701.42b: canonical physical meld pairs derived from the loaded card
+    /// database. Key is `lowercase(source) + NUL + lowercase(partner)`.
+    #[serde(skip)]
+    pub meld_pair_registry: Arc<HashMap<String, MeldPairRecord>>,
 
     /// Momir Basic selection index: mana value -> sorted creature face names.
     /// CR 707.2 + CR 202.3: the random-token pool, keyed by mana value so the
@@ -10167,6 +10336,7 @@ impl GameState {
             all_creature_types: Vec::new(),
             all_card_names: Arc::from([]),
             card_face_registry: Arc::new(HashMap::new()),
+            meld_pair_registry: Arc::new(HashMap::new()),
             momir_pool: BTreeMap::new(),
             momir_pool_faces: Arc::new(HashMap::new()),
             log_player_names: Vec::new(),
@@ -11165,6 +11335,7 @@ fn _gamestate_partition_is_total(s: &GameState) {
         all_creature_types: _,
         all_card_names: _,
         card_face_registry: _,
+        meld_pair_registry: _,
         momir_pool: _,
         momir_pool_faces: _,
         log_player_names: _,
@@ -11696,6 +11867,29 @@ mod tests {
         AbilityDefinition, AbilityKind, Effect, PostReplacementContinuation, QuantityExpr,
         ResolvedAbility, TargetFilter,
     };
+
+    #[test]
+    fn pending_liminal_entry_resume_accepts_legacy_token_struct_shape() {
+        let event = ProposedEvent::zone_change(
+            ObjectId(7),
+            Zone::Exile,
+            Zone::Battlefield,
+            Some(ObjectId(7)),
+        );
+        let legacy = serde_json::json!({
+            "source_id": ObjectId(7),
+            "player": PlayerId(1),
+            "event": event,
+        });
+        assert!(matches!(
+            serde_json::from_value::<PendingLiminalEntryResume>(legacy).unwrap(),
+            PendingLiminalEntryResume::Token {
+                source_id: ObjectId(7),
+                player: PlayerId(1),
+                ..
+            }
+        ));
+    }
 
     /// V1: legacy persisted `{"type":"UntilEndOfTurn"}` (pre-parameterization
     /// wire form) must deserialize to `UntilTurnBoundary { EndOfCurrentTurn }`

--- a/crates/engine/tests/integration/vanille_meld_optional_cost.rs
+++ b/crates/engine/tests/integration/vanille_meld_optional_cost.rs
@@ -66,6 +66,7 @@ fn meld_of(trigger: &TriggerDefinition) -> (String, String, String) {
                 source,
                 partner,
                 result,
+                ..
             } => Some((source.clone(), partner.clone(), result.clone())),
             _ => None,
         })
@@ -139,6 +140,7 @@ fn vanille_optional_cost_gate_lowers_to_meld() {
         source,
         partner,
         result,
+        ..
     } = gated.effect.as_ref()
     else {
         panic!(

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -31,13 +31,14 @@ use serde::{Deserialize, Serialize};
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
-/// 15 — Meld pair/attacking-entry choices and mana-payment preview variants.
+/// 16 — Meld pair/attacking-entry choices after mana-payment preview variants.
+/// 15 — Mana-payment preview request/response variants.
 /// 14 — `PrecastCopyShortcut` action and its two `WaitingFor` variants.
 /// 13 — `WaitingFor::MulliganBottomCards` removed from the full-game state
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 15;
+pub const PROTOCOL_VERSION: u32 = 16;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake. Lobby traffic has a one-version rollout window; full game servers
@@ -363,8 +364,8 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_meld_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 15);
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 14);
+        assert_eq!(PROTOCOL_VERSION, 16);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 15);
     }
 
     #[test]

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
-/// 15 — Mana-payment preview request/response variants.
+/// 15 — Meld pair/attacking-entry choices and mana-payment preview variants.
 /// 14 — `PrecastCopyShortcut` action and its two `WaitingFor` variants.
 /// 13 — `WaitingFor::MulliganBottomCards` removed from the full-game state
 ///      payload; mulligan bottoming folded into a
@@ -360,6 +360,12 @@ fn json_string(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn protocol_version_tracks_meld_wire_additions() {
+        assert_eq!(PROTOCOL_VERSION, 15);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 14);
+    }
 
     #[test]
     fn known_tags_parse_to_messages() {

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -1025,7 +1025,7 @@ pub fn unsupported_protocol_capabilities() -> &'static [UnsupportedCapability] {
     &UNSUPPORTED_PROTOCOL_CAPABILITIES
 }
 
-static UNSUPPORTED_PROTOCOL_CAPABILITIES: [UnsupportedCapability; 16] = [
+static UNSUPPORTED_PROTOCOL_CAPABILITIES: [UnsupportedCapability; 18] = [
     UnsupportedCapability {
         code: "upstream.response-envelope-mismatch",
         area: "transport",
@@ -1121,6 +1121,18 @@ static UNSUPPORTED_PROTOCOL_CAPABILITIES: [UnsupportedCapability; 16] = [
         area: "responses",
         reason: "The previous adapter accepted direct engine action ids, but the updated protocol requires prompt-id-correlated PromptResponse payloads.",
         suggested_protocol_extension: "Use canonical PromptResponse for all client decisions and keep engine action tables adapter-private.",
+    },
+    UnsupportedCapability {
+        code: "local.meld-pair-choice-unsupported",
+        area: "prompts",
+        reason: "The pinned protocol has no typed choice for selecting one physical meld pair from multiple live-name candidates.",
+        suggested_protocol_extension: "Add a non-target object-pair choice carrying stable card ids.",
+    },
+    UnsupportedCapability {
+        code: "local.entry-attack-target-choice-unsupported",
+        area: "combat",
+        reason: "The pinned protocol has no response shape for choosing the player, planeswalker, or battle attacked by an entering creature.",
+        suggested_protocol_extension: "Add an entry-attack destination choice using the existing attack-target reference shape.",
     },
 ];
 
@@ -1671,6 +1683,12 @@ pub fn convert_available_action(action: &GameAction, id: String) -> AvailableAct
         }
         GameAction::ChooseEnlist { .. } => {
             AvailableActionConversion::Unsupported("local.enlist-unsupported")
+        }
+        GameAction::ChooseMeldPair { .. } => {
+            AvailableActionConversion::Unsupported("local.meld-pair-choice-unsupported")
+        }
+        GameAction::ChooseEntryAttackTarget { .. } => {
+            AvailableActionConversion::Unsupported("local.entry-attack-target-choice-unsupported")
         }
         GameAction::ChooseClashOpponent { .. } => {
             AvailableActionConversion::Unsupported("local.clash-unsupported")
@@ -3509,6 +3527,8 @@ mod tests {
         assert!(codes.contains("local.pass-until-unsupported"));
         assert!(codes.contains("local.auto-pay-unsupported"));
         assert!(codes.contains("local.legacy-engine-action-unsupported"));
+        assert!(codes.contains("local.meld-pair-choice-unsupported"));
+        assert!(codes.contains("local.entry-attack-target-choice-unsupported"));
     }
 
     #[test]
@@ -3557,6 +3577,42 @@ mod tests {
             kept: vec![ObjectId(1)]
         }])
         .is_empty());
+    }
+
+    #[test]
+    fn meld_actions_return_stable_unsupported_capability_codes() {
+        assert!(matches!(
+            convert_available_action(
+                &GameAction::ChooseMeldPair {
+                    source_id: ObjectId(1),
+                    partner_id: ObjectId(2),
+                },
+                "action-0".to_string(),
+            ),
+            AvailableActionConversion::Unsupported("local.meld-pair-choice-unsupported")
+        ));
+        assert!(matches!(
+            convert_available_action(
+                &GameAction::ChooseEntryAttackTarget {
+                    target: AttackTarget::Battle(ObjectId(3)),
+                },
+                "action-1".to_string(),
+            ),
+            AvailableActionConversion::Unsupported("local.entry-attack-target-choice-unsupported")
+        ));
+        assert!(
+            available_actions(&[
+                GameAction::ChooseMeldPair {
+                    source_id: ObjectId(1),
+                    partner_id: ObjectId(2),
+                },
+                GameAction::ChooseEntryAttackTarget {
+                    target: AttackTarget::Player(PlayerId(1)),
+                },
+            ])
+            .is_empty(),
+            "unsupported meld decisions must never be serialized as generic custom actions"
+        );
     }
 
     #[test]

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -4175,13 +4175,13 @@ mod protocol_wire_tests {
     #[test]
     fn unsupported_capability_registry_is_well_formed() {
         let capabilities = unsupported_protocol_capabilities();
-        assert_eq!(capabilities.len(), 16);
+        assert_eq!(capabilities.len(), 18);
 
         let codes: HashSet<_> = capabilities
             .iter()
             .map(|capability| capability.code)
             .collect();
-        assert_eq!(codes.len(), 16, "capability codes must be unique");
+        assert_eq!(codes.len(), 18, "capability codes must be unique");
 
         for capability in capabilities {
             assert!(

--- a/crates/phase-ai/src/decision_kind.rs
+++ b/crates/phase-ai/src/decision_kind.rs
@@ -70,6 +70,8 @@ pub fn classify(waiting_for: &WaitingFor, action: &GameAction) -> DecisionKind {
         // tactical policy currently routes on. Map them to ActivateAbility as
         // the catch-all bucket so policies that explicitly opt in still run.
         WaitingFor::ReplacementChoice { .. }
+        | WaitingFor::MeldPairChoice { .. }
+        | WaitingFor::MeldAttackTargetChoice { .. }
         | WaitingFor::OrderTriggers { .. }
         | WaitingFor::CopyTargetChoice { .. }
         | WaitingFor::ExploreChoice { .. }

--- a/crates/phase-ai/src/projection.rs
+++ b/crates/phase-ai/src/projection.rs
@@ -333,6 +333,16 @@ fn resolve_choice(
             pick_empty_blockers(&actions)
         }
 
+        // CR 701.42b / CR 508.4: deterministic projection for the two Meld
+        // resolution choices. Tactical public play uses the policy/search path;
+        // projection only needs a stable legal branch.
+        WaitingFor::MeldPairChoice { .. } | WaitingFor::MeldAttackTargetChoice { .. } => actions
+            .first()
+            .cloned()
+            .ok_or_else(|| BailReason::NoLegalAction {
+                waiting_for: format!("{:?}", state.waiting_for),
+            })?,
+
         // CR 118.3 + CR 605.3b: ReturnToHand, Behold, and TapCreatures cost
         // payments project as "first legal payment" (matching the pre-collapse
         // behavior — Discard / Sacrifice / Exile / RemoveCounter PayCost kinds

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -844,6 +844,23 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
         // fallback declines while normal search evaluates legal tap choices.
         WaitingFor::EnlistChoice { .. } => Some(GameAction::ChooseEnlist { target: None }),
 
+        // CR 701.42b / CR 508.4: deadlock-safe deterministic fallbacks. Normal
+        // public `choose_action` evaluates these legal actions through search;
+        // when time expires, preserve the engine's canonical physical-pair
+        // authority before falling back to the first legal live-name choice.
+        WaitingFor::MeldPairChoice { choices, .. } => choices
+            .iter()
+            .find(|choice| engine::game::meld::is_canonical_physical_meld_pair(state, choice))
+            .or_else(|| choices.first())
+            .map(|choice| GameAction::ChooseMeldPair {
+                source_id: choice.source_id,
+                partner_id: choice.partner_id,
+            }),
+        WaitingFor::MeldAttackTargetChoice { valid_targets, .. } => valid_targets
+            .first()
+            .copied()
+            .map(|target| GameAction::ChooseEntryAttackTarget { target }),
+
         // Target selection: skip optional slots, fizzle mandatory ones.
         // TriggerTargetSelection is not a pending cast — the trigger is
         // already on the stack. ChooseTarget { target: None } signals
@@ -3014,6 +3031,137 @@ mod tests {
             fallback_action(&state),
             Some(GameAction::DeclineShortcut),
             "the no-score fallback must select DeclineShortcut from engine legal actions"
+        );
+    }
+
+    /// CR 701.42b: the public search path prefers the physical canonical meld
+    /// pair over an earlier live-name impostor that would exile both selected
+    /// objects without producing the result permanent. This proves the choice
+    /// is handled by ordinary simulation/evaluation, not bespoke name scoring.
+    #[test]
+    fn choose_action_simulates_meld_pair_outcomes() {
+        use engine::types::ability::{PermanentEntryMode, PtValue};
+        use engine::types::card::CardFace;
+        use engine::types::game_state::{MeldPairRecord, MeldSelection};
+
+        const SOURCE: &str = "AI Meld Source";
+        const PARTNER: &str = "AI Meld Partner";
+        const RESULT: &str = "AI Meld Result";
+
+        let mut state = make_state();
+        let impostor_source = add_creature(&mut state, PlayerId(0), 3, 3);
+        let impostor_partner = add_creature(&mut state, PlayerId(0), 3, 3);
+        let real_source = add_creature(&mut state, PlayerId(0), 3, 3);
+        let real_partner = add_creature(&mut state, PlayerId(0), 3, 3);
+        for (id, live_name, base_name) in [
+            (impostor_source, SOURCE, "Printed Impostor Source"),
+            (impostor_partner, PARTNER, "Printed Impostor Partner"),
+            (real_source, SOURCE, SOURCE),
+            (real_partner, PARTNER, PARTNER),
+        ] {
+            let object = state.objects.get_mut(&id).unwrap();
+            object.name = live_name.to_string();
+            object.base_name = base_name.to_string();
+        }
+        let mut result = CardFace {
+            name: RESULT.to_string(),
+            power: Some(PtValue::Fixed(9)),
+            toughness: Some(PtValue::Fixed(9)),
+            ..CardFace::default()
+        };
+        result.card_type.core_types.push(CoreType::Creature);
+        Arc::make_mut(&mut state.card_face_registry).insert(RESULT.to_lowercase(), result);
+        Arc::make_mut(&mut state.meld_pair_registry).insert(
+            format!("{}\0{}", SOURCE.to_lowercase(), PARTNER.to_lowercase()),
+            MeldPairRecord {
+                source: SOURCE.to_string(),
+                partner: PARTNER.to_string(),
+                result: RESULT.to_string(),
+            },
+        );
+        let selection = |source_id, partner_id| MeldSelection {
+            source_id,
+            partner_id,
+            controller: PlayerId(0),
+            expected_source: SOURCE.to_string(),
+            expected_partner: PARTNER.to_string(),
+            result: RESULT.to_string(),
+            entry: PermanentEntryMode::Normal,
+        };
+        state.waiting_for = WaitingFor::MeldPairChoice {
+            player: PlayerId(0),
+            choices: vec![
+                selection(impostor_source, impostor_partner),
+                selection(real_source, real_partner),
+            ],
+        };
+
+        let config = create_config(AiDifficulty::Medium, Platform::Native).into_measurement(9);
+        let mut rng = SmallRng::seed_from_u64(9);
+        assert_eq!(
+            choose_action(&state, PlayerId(0), &config, &mut rng),
+            Some(GameAction::ChooseMeldPair {
+                source_id: real_source,
+                partner_id: real_partner,
+            })
+        );
+    }
+
+    /// CR 701.42b: even when search cannot run, the deterministic fallback
+    /// prefers the canonical physical pair over an earlier live-name impostor.
+    #[test]
+    fn meld_pair_fallback_prefers_canonical_pair_in_hostile_order() {
+        use engine::types::ability::PermanentEntryMode;
+        use engine::types::game_state::{MeldPairRecord, MeldSelection};
+
+        const SOURCE: &str = "Fallback Meld Source";
+        const PARTNER: &str = "Fallback Meld Partner";
+        const RESULT: &str = "Fallback Meld Result";
+
+        let mut state = make_state();
+        let impostor_source = add_creature(&mut state, PlayerId(0), 3, 3);
+        let impostor_partner = add_creature(&mut state, PlayerId(0), 3, 3);
+        let real_source = add_creature(&mut state, PlayerId(0), 3, 3);
+        let real_partner = add_creature(&mut state, PlayerId(0), 3, 3);
+        for (id, base_name) in [
+            (impostor_source, "Printed Impostor Source"),
+            (impostor_partner, "Printed Impostor Partner"),
+            (real_source, SOURCE),
+            (real_partner, PARTNER),
+        ] {
+            state.objects.get_mut(&id).unwrap().base_name = base_name.to_string();
+        }
+        Arc::make_mut(&mut state.meld_pair_registry).insert(
+            format!("{}\0{}", SOURCE.to_lowercase(), PARTNER.to_lowercase()),
+            MeldPairRecord {
+                source: SOURCE.to_string(),
+                partner: PARTNER.to_string(),
+                result: RESULT.to_string(),
+            },
+        );
+        let selection = |source_id, partner_id| MeldSelection {
+            source_id,
+            partner_id,
+            controller: PlayerId(0),
+            expected_source: SOURCE.to_string(),
+            expected_partner: PARTNER.to_string(),
+            result: RESULT.to_string(),
+            entry: PermanentEntryMode::Normal,
+        };
+        state.waiting_for = WaitingFor::MeldPairChoice {
+            player: PlayerId(0),
+            choices: vec![
+                selection(impostor_source, impostor_partner),
+                selection(real_source, real_partner),
+            ],
+        };
+
+        assert_eq!(
+            fallback_action(&state),
+            Some(GameAction::ChooseMeldPair {
+                source_id: real_source,
+                partner_id: real_partner,
+            })
         );
     }
 

--- a/crates/server-core/src/game_action_payload_guard.rs
+++ b/crates/server-core/src/game_action_payload_guard.rs
@@ -485,6 +485,8 @@ pub fn guard_game_action_payload(action: &GameAction) -> Result<(), String> {
         | GameAction::RippleChoice { .. }
         | GameAction::FreeCastWindowChoice { .. }
         | GameAction::ChooseTopOrBottom { .. }
+        | GameAction::ChooseMeldPair { .. }
+        | GameAction::ChooseEntryAttackTarget { .. }
         // CR 702.140c: mutate merge side carries a single typed enum — nothing
         // client-controlled to bound.
         | GameAction::ChooseMutateMergeSide { .. }
@@ -517,4 +519,26 @@ pub fn guard_game_action_payload(action: &GameAction) -> Result<(), String> {
         | GameAction::Concede { .. } => {}
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::game::combat::AttackTarget;
+    use engine::types::identifiers::ObjectId;
+
+    #[test]
+    fn bounded_meld_actions_are_accepted() {
+        for action in [
+            GameAction::ChooseMeldPair {
+                source_id: ObjectId(1),
+                partner_id: ObjectId(2),
+            },
+            GameAction::ChooseEntryAttackTarget {
+                target: AttackTarget::Planeswalker(ObjectId(3)),
+            },
+        ] {
+            assert_eq!(guard_game_action_payload(&action), Ok(()));
+        }
+    }
 }

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -1884,8 +1884,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_15() {
-        assert_eq!(PROTOCOL_VERSION, 15);
+    fn protocol_version_is_16() {
+        assert_eq!(PROTOCOL_VERSION, 16);
     }
 
     #[test]

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -607,6 +607,31 @@ mod tests {
     }
 
     #[test]
+    fn meld_actions_roundtrip() {
+        use engine::game::combat::AttackTarget;
+        use engine::types::identifiers::ObjectId;
+
+        for action in [
+            GameAction::ChooseMeldPair {
+                source_id: ObjectId(10),
+                partner_id: ObjectId(11),
+            },
+            GameAction::ChooseEntryAttackTarget {
+                target: AttackTarget::Battle(ObjectId(12)),
+            },
+        ] {
+            let json = serde_json::to_string(&ClientMessage::Action {
+                action: action.clone(),
+            })
+            .unwrap();
+            let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+            assert!(
+                matches!(parsed, ClientMessage::Action { action: parsed_action } if parsed_action == action)
+            );
+        }
+    }
+
+    #[test]
     fn server_message_game_created_roundtrips() {
         let msg = ServerMessage::GameCreated {
             game_code: "XYZ789".to_string(),

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -57,10 +57,6 @@ crates/engine/src/game/engine_resolution_choices.rs	handle_resolution_choice	mov
 crates/engine/src/game/engine_resolution_choices.rs	route_rest_partition	mover	2
 crates/engine/src/game/mana_abilities.rs	exile_self_for_mana_cost	mover	1
 crates/engine/src/game/mana_abilities.rs	pay_selected_exile_cost_for_mana_ability	mover	1
-crates/engine/src/game/meld.rs	commit_meld_battlefield	exempt	2
-crates/engine/src/game/merge.rs	merge_object_onto	zone-assign	1
-crates/engine/src/game/merge.rs	put_component_into_zone	mover	2
-crates/engine/src/game/merge.rs	put_component_into_zone	zone-assign	1
 crates/engine/src/game/planechase.rs	finish_player_left_game_handoff	container	1
 crates/engine/src/game/planechase.rs	finish_player_left_game_handoff	zone-assign	1
 crates/engine/src/game/planechase.rs	planeswalk	container	2

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -57,6 +57,10 @@ crates/engine/src/game/engine_resolution_choices.rs	handle_resolution_choice	mov
 crates/engine/src/game/engine_resolution_choices.rs	route_rest_partition	mover	2
 crates/engine/src/game/mana_abilities.rs	exile_self_for_mana_cost	mover	1
 crates/engine/src/game/mana_abilities.rs	pay_selected_exile_cost_for_mana_ability	mover	1
+crates/engine/src/game/meld.rs	commit_meld_battlefield	exempt	2
+crates/engine/src/game/merge.rs	merge_object_onto	zone-assign	1
+crates/engine/src/game/merge.rs	put_component_into_zone	mover	2
+crates/engine/src/game/merge.rs	put_component_into_zone	zone-assign	1
 crates/engine/src/game/planechase.rs	finish_player_left_game_handoff	container	1
 crates/engine/src/game/planechase.rs	finish_player_left_game_handoff	zone-assign	1
 crates/engine/src/game/planechase.rs	planeswalk	container	2


### PR DESCRIPTION
## Summary

Fixes **Mishra, Claimed by Gix** by preserving its resolution-time attacking-pair condition, selecting the canonical physical Meld pair, and carrying the resulting permanent through the ordinary zone-change, replacement, as-enters, and combat-entry pipelines. The implementation generalizes to every current Meld instigator, including replacement pauses, copy-as-enters choices, commander redirects, final-controller attack destinations, AI decisions, protocol transport, and frontend choice handling.

The prior path represented Meld primarily by printed names and completed it through a bespoke entry path. That lost Mishra's inline condition and could not correctly model physical-card validation after exile, replacement provenance, deferred entry characteristics, or the CR 508.4 attacking destination. This PR moves those responsibilities to typed engine state and the existing authoritative seams.

WebSocket protocol version advances from 14 to 15 and P2P wire protocol from 7 to 8 for the two new typed choices.

Closes #5693

## Files changed

- `crates/engine/src/parser/oracle_effect/`
- `crates/engine/src/types/`
- `crates/engine/src/game/`
- `crates/engine/src/database/`
- `crates/engine/src/ai_support/`
- `crates/engine/tests/integration/vanille_meld_optional_cost.rs`
- `crates/phase-ai/src/`
- `crates/server-core/src/`
- `crates/lobby-broker/src/protocol.rs`
- `crates/manabrew-compat/src/lib.rs`
- `client/src/adapter/`
- `client/src/game/waitingForRegistry.ts`
- `client/src/network/`
- `client/src/pages/GamePage.tsx`
- `client/src/i18n/locales/*/game.json`

## CR references

- `CR 701.42`, `CR 701.42a`, `CR 701.42b`, `CR 701.42c`, `CR 712.4` — Meld instruction, physical-pair validation, and combined result.
- `CR 400.2`, `CR 400.6`, `CR 400.7j` — public-zone tracking and zone-change identity.
- `CR 508.4`, `CR 508.4a`, `CR 508.4c` — entering tapped and attacking and selecting a defending destination.
- `CR 603.4`, `CR 608.2c`, `CR 608.2d` — resolution-time conditions and exact choices.
- `CR 614.1c`, `CR 614.5`, `CR 614.12`, `CR 614.12a`, `CR 616.1` — entry replacement projection, provenance, and ordering pauses.
- `CR 611.3`, `CR 613.1b`, `CR 707.9` — final continuous/copy characteristics before combat entry.
- `CR 306.5b`, `CR 903.9a`, `CR 903.9b` — intrinsic loyalty counters and per-component commander choices.

## Implementation method (required)

Method: /engine-implementer

## Track

Developer

## LLM

Model: codex-5
Thinking: high
Tier: Standard

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — passed.
- `cargo clippy-strict` — passed on the final tree.
- `cargo test -p engine` — passed after the upstream rebase: 16,560 unit tests and 2,998 integration tests, with zero failures.
- `cargo test -p engine meld` — final-tree focused pass: 45 unit tests and 4 integration tests, with zero failures.
- `cargo test -p phase-ai meld_pair` — 2 passed.
- `cargo test -p manabrew-compat meld` — 1 passed.
- `cargo test -p server-core meld` — 2 passed.
- `cargo test -p lobby-broker protocol_version_tracks_meld_wire_additions` — 1 passed.
- `./scripts/gen-card-data.sh` — passed; both target cards are `supported: true` with `gap_count: 0`.
- `cargo coverage` — passed; 31,346/35,397 cards supported (88.6%).
- `cargo semantic-audit` — completed across 32,417 cards; neither target card has a finding.
- `pnpm run type-check` — passed, including protocol parity.
- `pnpm exec vitest run src/i18n/resources.test.ts src/adapter/__tests__/waiting-for-handler-parity.test.ts src/network/__tests__/protocol.test.ts` — 3 files and 102 tests passed.
- `git diff --check origin/main...HEAD` — passed.

## Gate A

Gate A PASS head=89490ffddffd8f70c645cdb1a0b13307bd73b5dc base=efe74096ba6c2185446b5ef319bbdd0e46c7f5e5

## Anchored on

- `crates/engine/src/parser/oracle_effect/meld.rs:140` — existing nom-based Meld ownership-gate authority.
- `crates/engine/src/game/zone_pipeline.rs:891` — existing simultaneous zone-move and typed completion seam.
- `crates/engine/src/game/engine_replacement.rs:1086` — existing liminal as-enters copy-choice resume seam.

## Final review-impl

Final review-impl PASS head=89490ffddffd8f70c645cdb1a0b13307bd73b5dc

## Claimed parse impact

- Mishra, Claimed by Gix
- Phyrexian Dragon Engine

## Validation Failures

None.

## CI Failures

None.
