### PR TITLE
ship/t97 cost x carrier

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -3463,6 +3463,16 @@ fn push_ability_entry(
     let entry_id = ObjectId(state.next_object_id);
     state.next_object_id += 1;
 
+    // CR 107.3a + CR 602.2b: this is the single authority where an activated ability
+    // reaches the stack, so it is where its announced X is published. CR 107.3i then
+    // lets a triggered ability of the SAME object that this activation causes read the
+    // same X — the `Cycled` event emitted a few lines below (Shark Typhoon: "When you
+    // cycle this card, create an X/X blue Shark") is collected into triggers while this
+    // publication is live, and `triggers::build_triggered_ability` stamps it onto the
+    // trigger's `chosen_x`. An activation with no announced X publishes `None`, which
+    // also clears any stale value.
+    state.activated_ability_x = resolved.chosen_x.map(|x| (source_id, x));
+
     // CR 603.4: Stamp the printed-ability index for per-turn resolution tracking.
     resolved.ability_index = Some(ability_index);
     stack::push_to_stack(

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -192,6 +192,10 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
     // CR 400.7j: the self-move re-latch is resolution-scoped; clear it alongside
     // `resolving_stack_entry` so it never leaks into the next resolution.
     state.resolution_source_relatch = None;
+    // CR 107.3a: the announced activation-X carrier is scoped to the activation that
+    // published it. Clear it here so it never leaks into an unrelated resolution; it is
+    // republished below for an `ActivatedAbility` entry (and only for that kind).
+    state.activated_ability_x = None;
 
     // CR 405.5: When all players pass in succession, the top object on the stack resolves.
     let entry = match state.stack.pop_back() {
@@ -463,6 +467,20 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
     // optional copy decision is pending. Cleared at the start of the next
     // `resolve_top`.
     state.resolving_stack_entry = Some(entry.clone());
+    // CR 107.3a + CR 107.3i: republish the resolving activated ability's announced X for
+    // the duration of its own resolution, so a triggered ability of the SAME object that
+    // this resolution causes (Hydra Broodmaster / Polukranos: "when this becomes
+    // monstrous, …X…", fired off the `EffectResolved{Monstrosity}` emitted below) reads
+    // that X. Deliberately restricted to `ActivatedAbility`: a resolving SPELL must NOT
+    // publish, because a permanent it puts onto the battlefield has X = 0 (CR 107.3m) and
+    // its ETB trigger reads the spell's X through `GameObject::cost_x_paid` instead.
+    if let StackEntryKind::ActivatedAbility {
+        source_id,
+        ability: activated,
+    } = &entry.kind
+    {
+        state.activated_ability_x = activated.chosen_x.map(|x| (*source_id, x));
+    }
     let resolution_start_phase = state.phase;
 
     // Only run targeting validation and effect execution when an ability exists.

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -8108,6 +8108,34 @@ pub(super) fn build_triggered_ability(
                 }
             }
         }
+        // CR 107.3i + CR 107.3a: bind this trigger's X to the announced X of an
+        // activated ability OF THIS SAME OBJECT that is currently publishing events —
+        // the activation that caused this trigger to fire. CR 107.3i: "Normally, all
+        // instances of X on an object have the same value at any given time", and CR
+        // 107.3a fixes that value at announcement. This is the read path for the whole
+        // activated-ability-X class: Hydra Broodmaster / Polukranos / Death Kiss /
+        // Vitality Hunter ("when this becomes monstrous, …X…") and Shark Typhoon /
+        // Webstrike Elite / Rampaging War Mammoth / Valor's Flagship ("when you cycle
+        // this card, …X…").
+        //
+        // The stamp lands HERE, at trigger instantiation, rather than at resolution,
+        // because several faces in the class carry X in a target-count or filter slot
+        // (Rampaging War Mammoth's "up to X target artifacts"; Webstrike Elite's "mana
+        // value X") which is consumed during target selection — before the trigger ever
+        // resolves.
+        //
+        // SCOPED BY SOURCE, and this scoping is load-bearing: `activated_ability_x` is
+        // published only by an activated ability (never by a resolving spell — see
+        // `stack::resolve_top`), so a permanent put onto the battlefield by an unrelated
+        // X-spell keeps X = 0 (CR 107.3m) rather than inheriting that spell's X. It also
+        // keeps `QuantityRef::CostXPaid` — the CR 107.3m *cast* channel, which falls back
+        // to `chosen_x` — reading the cast X, never an activation X (CR 107.3k: the two
+        // are independent).
+        if let Some((activating_source, announced_x)) = state.activated_ability_x {
+            if activating_source == source_id {
+                resolved.set_chosen_x_recursive(announced_x);
+            }
+        }
         // CR 118.12: Carry unless_pay modifier from trigger definition.
         if trig_def.unless_pay.is_some() {
             resolved.unless_pay = trig_def.unless_pay.clone();

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -475,21 +475,172 @@ fn rewrite_cost_x_in_effect(effect: &mut crate::types::ability::Effect) {
 ///
 /// Rewrite an `AbilityCondition`'s quantity operands. Mirrors
 /// `apply_where_x_ability_condition` (`oracle_effect/lower.rs`).
+/// CR 107.3i: bind every `X` an intervening-if condition can carry.
+///
+/// EXHAUSTIVE BY CONSTRUCTION — no `_` arm. A trigger's condition is checked when the trigger
+/// would go on the stack (CR 603.4), which is BEFORE `current_trigger_event` is set, so the
+/// `resolve_ref` fallback that rescues `effect` quantities is dead here: an unbound `X` in a
+/// condition silently compares against **0** and the intervening-if takes the wrong branch.
+/// The previous `_ => {}` wildcard therefore had real teeth, and it was dropping three things:
+/// `PreviousEffectAmount`'s `rhs`, and any `X` nested inside `ConditionInstead` / `Not`.
+/// Listing every variant is deliberate: when a new condition gains a `QuantityExpr`, the
+/// compiler makes someone decide, instead of the value silently fabricating a zero.
 fn rewrite_cost_x_in_condition(cond: &mut crate::types::ability::AbilityCondition) {
     use super::oracle_replacement::rewrite_variable_x_to_cost_x_paid;
     use crate::types::ability::AbilityCondition;
     match cond {
+        // Quantity-carrying: bind the X.
         AbilityCondition::QuantityCheck { lhs, rhs, .. } => {
             rewrite_variable_x_to_cost_x_paid(lhs);
             rewrite_variable_x_to_cost_x_paid(rhs);
         }
+        AbilityCondition::PreviousEffectAmount { rhs, .. } => {
+            rewrite_variable_x_to_cost_x_paid(rhs);
+        }
+        // Nested conditions: recurse, or an X inside them is never reached.
         AbilityCondition::And { conditions } | AbilityCondition::Or { conditions } => {
             for c in conditions.iter_mut() {
                 rewrite_cost_x_in_condition(c);
             }
         }
-        _ => {}
+        AbilityCondition::ConditionInstead { inner } => rewrite_cost_x_in_condition(inner),
+        AbilityCondition::Not { condition } => rewrite_cost_x_in_condition(condition),
+        // Carry no `QuantityExpr` and nest no condition — nothing to bind.
+        AbilityCondition::AdditionalCostPaid { .. }
+        | AbilityCondition::AdditionalCostPaidInstead
+        | AbilityCondition::AlternativeManaCostPaid
+        | AbilityCondition::EffectOutcome { .. }
+        | AbilityCondition::EventOutcomeWon
+        | AbilityCondition::CoinFlipOutcome { .. }
+        | AbilityCondition::WhenYouDo
+        | AbilityCondition::WasCast { .. }
+        | AbilityCondition::CastDuringPhase { .. }
+        | AbilityCondition::CurrentPhaseIs { .. }
+        | AbilityCondition::CastTimingPermission { .. }
+        | AbilityCondition::ManaColorSpent { .. }
+        | AbilityCondition::RevealedHasCardType { .. }
+        | AbilityCondition::ObjectsShareQuality { .. }
+        | AbilityCondition::TargetSharesNameWithOtherExiledThisWay { .. }
+        | AbilityCondition::SourceEnteredThisTurn
+        | AbilityCondition::CastVariantPaid { .. }
+        | AbilityCondition::CastVariantPaidInstead { .. }
+        | AbilityCondition::HasMaxSpeed
+        | AbilityCondition::IsMonarch
+        | AbilityCondition::IsInitiative
+        | AbilityCondition::HasCityBlessing
+        | AbilityCondition::IsRingBearer
+        | AbilityCondition::CompletedDungeon { .. }
+        | AbilityCondition::TargetHasKeywordInstead { .. }
+        | AbilityCondition::TargetMatchesFilter { .. }
+        | AbilityCondition::HasObjectTarget
+        | AbilityCondition::TriggeringSpellTargetsFilter { .. }
+        | AbilityCondition::SourceMatchesFilter { .. }
+        | AbilityCondition::ZoneChangeObjectMatchesFilter { .. }
+        | AbilityCondition::ControllerControlsMatching { .. }
+        | AbilityCondition::ControllerControlledMatchingAsCast { .. }
+        | AbilityCondition::IsYourTurn
+        | AbilityCondition::WasStartingPlayer { .. }
+        | AbilityCondition::SpellCastWithVariantThisTurn { .. }
+        | AbilityCondition::FirstCombatPhaseOfTurn
+        | AbilityCondition::FirstEndStepOfTurn
+        | AbilityCondition::ZoneChangedThisWay { .. }
+        | AbilityCondition::CostPaidObjectMatchesFilter { .. }
+        | AbilityCondition::SourceIsTapped
+        | AbilityCondition::SourceAttachedToCreature
+        | AbilityCondition::DayNightIsNeither
+        | AbilityCondition::DayNightIs { .. }
+        | AbilityCondition::NthResolutionThisTurn { .. }
+        | AbilityCondition::SourceLacksKeyword { .. }
+        | AbilityCondition::ScopedPlayerMatches { .. } => {}
     }
+}
+
+/// CR 107.3i TOTALITY GUARD — does a bare `X` still survive in a slot that FABRICATES?
+///
+/// Keyed on the fabricating slots ONLY, and that scoping is the whole design. These four are
+/// consumed during TARGET SELECTION / intervening-if checking, i.e. before the trigger resolves
+/// and before `current_trigger_event` is set — so `resolve_ref`'s
+/// `Variable{"X"} -> current_trigger_event -> cost_x_paid` fallback is DEAD for them and an
+/// unbound X silently resolves to **0**: "distribute 0 counters", "up to 0 targets". The card
+/// still renders as fully supported. That is the lying green.
+///
+/// It deliberately does NOT look at (each verdict MEASURED end-to-end, not assumed):
+///  * the `effect` subtree's own quantities — a residual X there IS bound at resolution by the
+///    `cost_x_paid` fallback (Hugs, Grisly Guardian exiles X cards correctly);
+///  * filter mana-value bounds inside an effect — also bound at runtime (Kinetic Ooze destroys
+///    an MV-3 artifact for X=3, and CANNOT target it for X=1);
+///  * ungated triggers — the walk never runs there. Their X is a cast-X read through the trigger
+///    event (Hydroid Krasis), or an activated ability's announced X (Shark Typhoon), which
+///    `GameState::activated_ability_x` now carries;
+///  * pay-any-amount sentinels (CR 107.3f) — a bare X in a `PayLife`/`PayEnergy` amount is the
+///    engine's "pay any amount" marker, not a fabrication.
+///
+/// Redding any of those would manufacture honest-looking reds out of cards that work — the
+/// mirror image of the lying green, and just as dishonest.
+fn cost_x_sibling_slot_still_unbound(def: &crate::types::ability::AbilityDefinition) -> bool {
+    use crate::types::ability::AbilityCondition;
+    use crate::types::game_state::TargetSelectionConstraint;
+
+    fn condition_has_bare_x(cond: &AbilityCondition) -> bool {
+        match cond {
+            AbilityCondition::QuantityCheck { lhs, rhs, .. } => {
+                lhs.contains_x() || rhs.contains_x()
+            }
+            AbilityCondition::PreviousEffectAmount { rhs, .. } => rhs.contains_x(),
+            AbilityCondition::And { conditions } | AbilityCondition::Or { conditions } => {
+                conditions.iter().any(condition_has_bare_x)
+            }
+            AbilityCondition::ConditionInstead { inner } => condition_has_bare_x(inner),
+            AbilityCondition::Not { condition } => condition_has_bare_x(condition),
+            _ => false,
+        }
+    }
+
+    if def.condition.as_ref().is_some_and(condition_has_bare_x) {
+        return true;
+    }
+    if def
+        .repeat_for
+        .as_ref()
+        .is_some_and(crate::types::ability::QuantityExpr::contains_x)
+    {
+        return true;
+    }
+    if let Some(spec) = def.multi_target.as_ref() {
+        if spec.min.contains_x()
+            || spec
+                .max
+                .as_ref()
+                .is_some_and(crate::types::ability::QuantityExpr::contains_x)
+        {
+            return true;
+        }
+    }
+    for constraint in &def.target_constraints {
+        match constraint {
+            TargetSelectionConstraint::TotalManaValue { value, .. } => {
+                if value.contains_x() {
+                    return true;
+                }
+            }
+            // Carry no `QuantityExpr`. Exhaustive on purpose: a future constraint that carries
+            // one must be handled here or the build breaks — it cannot silently fabricate.
+            TargetSelectionConstraint::DifferentTargetPlayers
+            | TargetSelectionConstraint::DifferentObjectControllers
+            | TargetSelectionConstraint::SameZoneOwner { .. } => {}
+        }
+    }
+    def.sub_ability
+        .as_deref()
+        .is_some_and(cost_x_sibling_slot_still_unbound)
+        || def
+            .else_ability
+            .as_deref()
+            .is_some_and(cost_x_sibling_slot_still_unbound)
+        || def
+            .mode_abilities
+            .iter()
+            .any(cost_x_sibling_slot_still_unbound)
 }
 
 /// Walk an `AbilityDefinition` tree and rewrite Variable("X") → CostXPaid.
@@ -1727,6 +1878,19 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
     if trigger_should_rewrite_cost_x(&def) {
         if let Some(execute) = def.execute.as_deref_mut() {
             rewrite_cost_x_in_ability(execute);
+            // CR 107.3i TOTALITY GUARD. If the walk above left a bare `X` in a slot consumed at
+            // TARGET-SELECTION time, that X has no runtime fallback and resolves to 0 — the card
+            // would keep rendering as fully supported while distributing zero counters or
+            // offering "up to 0" targets. Fail LOUDLY as an honest red instead of shipping the
+            // silent zero. This is a REGRESSION RATCHET: it flips 0 cards in the current pool
+            // (measured, 35,396 faces / 5,129 gated-ETB faces), because the walk now binds every
+            // such slot. Its job is to make the fabrication un-reintroducible.
+            if cost_x_sibling_slot_still_unbound(execute) {
+                *execute.effect = Effect::unimplemented(
+                    "cost_x_sibling_slot",
+                    "X in a target-selection slot was left unbound by the cost-X rewrite",
+                );
+            }
         }
     }
 
@@ -16625,6 +16789,131 @@ mod ood_sphere_tests {
         assert!(
             has_unimplemented,
             "a non-attacker 'unless' rider must fail closed to Unimplemented, not be silently dropped"
+        );
+    }
+}
+
+/// CR 107.3i totality guard (`cost_x_sibling_slot_still_unbound`) — is it real, and is it
+/// SCOPED? A guard that cannot fire is not a guard; a guard that reds working cards is worse
+/// than none, because it manufactures honest-looking reds out of cards that play correctly.
+#[cfg(test)]
+mod cost_x_totality_guard_tests {
+    use super::{cost_x_sibling_slot_still_unbound, rewrite_cost_x_in_ability};
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, Effect, MultiTargetSpec, QuantityExpr, QuantityRef,
+        TargetFilter,
+    };
+    use crate::types::TriggerMode;
+
+    fn bare_x() -> QuantityExpr {
+        QuantityExpr::Ref {
+            qty: QuantityRef::Variable {
+                name: "X".to_string(),
+            },
+        }
+    }
+
+    /// A def whose `multi_target.max` is a bare X — Broodlord's exact shape ("distribute X
+    /// +1/+1 counters among any number of other target creatures"), the slot t96 MEASURED
+    /// fabricating a silent 0.
+    fn broodlord_shaped_def() -> AbilityDefinition {
+        let mut def = AbilityDefinition::new(
+            AbilityKind::Database,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        );
+        def.multi_target = Some(MultiTargetSpec {
+            min: QuantityExpr::Fixed { value: 0 },
+            max: Some(bare_x()),
+        });
+        def
+    }
+
+    /// NON-VACUITY. The guard must FIRE on an unbound sibling slot. If this ever passes with the
+    /// detector returning `false`, the guard has become decorative and the silent zero is back.
+    #[test]
+    fn guard_fires_on_an_unbound_target_selection_slot() {
+        assert!(
+            cost_x_sibling_slot_still_unbound(&broodlord_shaped_def()),
+            "the guard must DETECT a bare X in multi_target.max — that slot is consumed at target \
+             selection, where the cost_x_paid fallback is dead, so it silently resolves to 0"
+        );
+    }
+
+    /// ...and must FALL SILENT once the rewrite has bound that same slot. Together with the test
+    /// above this shows the guard discriminates (rather than always firing or never firing), and
+    /// that `rewrite_cost_x_in_ability` is what makes it fall silent.
+    #[test]
+    fn guard_falls_silent_once_the_rewrite_binds_the_slot() {
+        let mut def = broodlord_shaped_def();
+        assert!(
+            cost_x_sibling_slot_still_unbound(&def),
+            "red-first: unbound before the rewrite"
+        );
+        rewrite_cost_x_in_ability(&mut def);
+        assert!(
+            !cost_x_sibling_slot_still_unbound(&def),
+            "after the cost-X rewrite the slot is CostXPaid, not a bare X — the guard must not \
+             red a card the rewrite already fixed"
+        );
+    }
+
+    /// GREEN CONTROL — the one that matters most. Kinetic Ooze is a GATED self-ETB face that
+    /// still carries a bare `Variable{X}` in its effect's TARGET FILTER mana-value bound. A
+    /// guard keyed on tree-PRESENCE of an X would red it. It must not: measured end-to-end, that
+    /// filter binds correctly at runtime (X=3 destroys an MV-3 artifact; X=1 cannot target it).
+    /// See `cost_x_carrier_runtime`. Redding this face would be a manufactured red.
+    #[test]
+    fn guard_does_not_red_the_filter_mana_value_class() {
+        let parsed = parse_oracle_text(
+            "This creature enters with X +1/+1 counters on it.\nWhen this creature enters, \
+             destroy up to one target artifact or enchantment with mana value X or less.",
+            "Kinetic Ooze",
+            &[],
+            &["Creature".into()],
+            &["Ooze".into()],
+        );
+        let etb = parsed
+            .triggers
+            .iter()
+            .find(|t| t.mode == TriggerMode::ChangesZone)
+            .expect("the self-ETB trigger must parse");
+        let execute = etb.execute.as_ref().expect("execute");
+        assert!(
+            !matches!(*execute.effect, Effect::Unimplemented { .. }),
+            "the filter-mana-value class must stay GREEN — its X binds at runtime. Redding it \
+             would manufacture an honest-looking red out of a card that plays correctly. Got: {:?}",
+            execute.effect
+        );
+    }
+
+    /// GREEN CONTROL — an UNGATED trigger (the walk never runs on it). Shark Typhoon's cycle
+    /// trigger keeps a bare X by design: it is the ACTIVATED ability's announced X, carried at
+    /// runtime by `GameState::activated_ability_x` (CR 107.3k — it is NOT the cast-X, so the
+    /// parser must not rewrite it to `CostXPaid`). The guard must not reach it.
+    #[test]
+    fn guard_does_not_red_an_ungated_activated_ability_x() {
+        let parsed = parse_oracle_text(
+            "Cycling {X}{1}{U} ({X}{1}{U}, Discard this card: Draw a card.)\nWhen you cycle this \
+             card, create an X/X blue Shark creature token with flying.",
+            "Shark Typhoon",
+            &[],
+            &["Enchantment".into()],
+            &[],
+        );
+        let cycled = parsed
+            .triggers
+            .iter()
+            .find(|t| t.mode == TriggerMode::Cycled)
+            .expect("the Cycled trigger must parse");
+        let execute = cycled.execute.as_ref().expect("execute");
+        assert!(
+            !matches!(*execute.effect, Effect::Unimplemented { .. }),
+            "an ungated activated-ability X must stay GREEN — the engine carrier binds it. Got: {:?}",
+            execute.effect
         );
     }
 }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -8543,6 +8543,33 @@ pub struct GameState {
     /// `current_trigger_event`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolving_stack_entry: Option<StackEntry>,
+    /// CR 107.3a + CR 107.3i: the announced X of an **activated ability**, keyed by
+    /// the object that ability is on. CR 107.3a: "While an activated ability is on
+    /// the stack, any X in its activation cost equals the announced value." CR
+    /// 107.3i: "Normally, all instances of X on an object have the same value at any
+    /// given time" — so a triggered ability of that SAME object which fires because
+    /// of that activation (Hydra Broodmaster's "when this becomes monstrous, create X
+    /// X/X tokens"; Shark Typhoon's "when you cycle this card, create an X/X Shark")
+    /// reads the same X. `triggers::build_triggered_ability` consumes this and stamps
+    /// it onto the triggered ability's `chosen_x`.
+    ///
+    /// This MUST be a channel of its own and must NOT reuse `GameObject::cost_x_paid`:
+    /// that field is the CR 107.3m *cast*-X channel (`QuantityRef::CostXPaid`), and CR
+    /// 107.3k makes an activated ability's X "independent of any other values of X
+    /// chosen for that object". Writing an activation X there would read the wrong X
+    /// by rule, not merely a missing one.
+    ///
+    /// Published at exactly the two moments an activated ability can produce a trigger
+    /// event — announcement (`casting_costs::push_ability_entry`, which emits `Cycled`
+    /// / `KeywordAbilityActivated`) and its own resolution (`stack::resolve_top`, which
+    /// covers `EffectResolved` emitters such as Monstrosity). Set to `None` for every
+    /// other stack-entry kind and cleared at the start of each `resolve_top` alongside
+    /// `resolving_stack_entry`, so a resolving SPELL never publishes: that is what keeps
+    /// a permanent put onto the battlefield by an unrelated X-spell at X=0 (CR 107.3m:
+    /// "the value of X for that permanent is 0") instead of inheriting the spell's X.
+    /// Transient decision context, serialized so a mid-activation pause round-trips.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activated_ability_x: Option<(ObjectId, u32)>,
     /// CR 400.7j (+ CR 400.7g/h cast hop): a resolution-scoped record of a source
     /// object that the currently-resolving ability moved as part of its own
     /// resolution (Siege "exile it, then you may cast it"). It lets
@@ -9910,6 +9937,7 @@ impl GameState {
             pending_team_draw_step: Vec::new(),
             pending_untap_declines: Vec::new(),
             current_trigger_event: None,
+            activated_ability_x: None,
             current_trigger_match_count: None,
             resolving_stack_entry: None,
             resolution_source_relatch: None,
@@ -10917,6 +10945,10 @@ fn _gamestate_partition_is_total(s: &GameState) {
         pending_untap_declines: _,
         current_trigger_event: _,
         current_trigger_match_count: _,
+        // CR 107.3a announce-scoped carrier, cleared at each `resolve_top`; a decision
+        // context, not durable board state — like `current_trigger_event`, it is not a
+        // per-cycle accumulator and PartialEq does not compare it.
+        activated_ability_x: _,
         resolving_stack_entry: _,
         current_trigger_events: _,
         stack_trigger_event_batches: _,

--- a/crates/engine/tests/integration/cost_x_carrier_runtime.rs
+++ b/crates/engine/tests/integration/cost_x_carrier_runtime.rs
@@ -18,8 +18,11 @@
 //! VERBATIM Oracle text (pool export, `cargo export-cards`) via the `*_from_oracle` builders,
 //! and the control below exists precisely to catch a regression back into that vacuum.
 
-use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::AbilityTag;
+use engine::types::actions::GameAction;
 use engine::types::counter::CounterType;
+use engine::types::game_state::{StackEntryKind, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
@@ -237,15 +240,12 @@ fn gated_etb_multi_target_sibling_field() {
 /// This is the SAME defect as Shark Typhoon's cycling trigger on a different trigger mode,
 /// which is what makes it a CLASS rather than a Shark Typhoon special case.
 ///
-/// IGNORED — and it is IGNORED BECAUSE IT FAILS, not because it is unimportant. The engine
-/// carrier for an activated ability's announced X does not exist yet (task #96, commit 2). The
-/// assertion below is the CORRECT expectation and is deliberately left in place, red, as the
-/// ready-made red-first witness: whoever lands the carrier deletes this `#[ignore]` and watches
-/// it go 0 -> 2 tokens. Do NOT "fix" it by weakening the assertion to 0 — that would pin the
-/// fabrication as expected behaviour, which is exactly the defect class this work exists to kill.
+/// t96 left this `#[ignore]`d as a verified-red witness. t97 built the carrier
+/// (`GameState::activated_ability_x`, published by `casting_costs::push_ability_entry` and
+/// `stack::resolve_top`, consumed by `triggers::build_triggered_ability`) and the `#[ignore]`
+/// is removed here: MEASURED 0 -> 2 tokens. Monstrosity emits its `EffectResolved` during
+/// RESOLUTION of the activated ability, so this exercises the resolution-scoped publication.
 #[test]
-#[ignore = "t96 commit 2: the activated-ability X carrier (CR 107.3k) is not built yet — this \
-            witness is the red-first artifact for it, not a bug in the test"]
 fn ungated_monstrosity_trigger_reads_the_activated_ability_x() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
@@ -281,5 +281,334 @@ fn ungated_monstrosity_trigger_reads_the_activated_ability_x() {
     assert!(
         tokens.iter().all(|(_, p, t)| (*p, *t) == (2, 2)),
         "CR 107.3k: each Hydra token is X/X = 2/2. MEASURED: {tokens:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UNGATED, CYCLED CHANNEL — the other half of the class. `Cycled` is emitted at
+// ACTIVATION (`push_ability_entry`), not at resolution, so these exercise the
+// announce-scoped publication rather than the resolution-scoped one.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SHARK_TYPHOON: &str = "Whenever you cast a noncreature spell, create an X/X blue Shark \
+                             creature token with flying, where X is that spell's mana value.\n\
+                             Cycling {X}{1}{U} ({X}{1}{U}, Discard this card: Draw a card.)\n\
+                             When you cycle this card, create an X/X blue Shark creature token \
+                             with flying.";
+
+fn cycling_index(state: &engine::types::game_state::GameState, card: ObjectId) -> usize {
+    state.objects[&card]
+        .abilities
+        .iter()
+        .position(|ability| ability.ability_tag == Some(AbilityTag::Cycling))
+        .expect("synthesized cycling ability")
+}
+
+/// CR 107.3a + CR 107.3i — Shark Typhoon, `Cycling {X}{1}{U}`:
+/// "When you cycle this card, create an X/X blue Shark creature token with flying."
+///
+/// The X of the cycling ACTIVATION cost (CR 107.3a) is the X the trigger reads (CR 107.3i).
+/// It cannot ride `cost_x_paid`: that is the CR 107.3m *cast* channel, and Shark Typhoon was
+/// never cast — it was discarded as a cycling cost. Before the carrier this created a 0/0.
+#[test]
+fn cycling_trigger_reads_the_activated_ability_x() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_card_to_library_top(P0, "Cycled Draw");
+    let typhoon = scenario
+        .add_spell_to_hand_from_oracle(P0, "Shark Typhoon", false, SHARK_TYPHOON)
+        .id();
+    let mut runner = scenario.build();
+    add_mana(&mut runner, ManaType::Blue, 8);
+
+    let idx = cycling_index(runner.state(), typhoon);
+    runner.activate(typhoon, idx).x(3).resolve();
+
+    let sharks = named_on_battlefield(&runner, "Shark");
+    assert_eq!(
+        sharks.len(),
+        1,
+        "cycling Shark Typhoon must create exactly one Shark token. MEASURED: {sharks:?}"
+    );
+    assert_eq!(
+        (sharks[0].1, sharks[0].2),
+        (3, 3),
+        "CR 107.3a + CR 107.3i: cycled for X=3, the Shark is X/X = 3/3. A 0/0 here means the \
+         cycling ability's announced X was DROPPED. MEASURED: {sharks:?}"
+    );
+}
+
+/// Drive a cycling activation for a given X by hand. The `AbilityActivation` builder cannot be
+/// used for these: a `Cycled` trigger that needs targets raises `TriggerTargetSelection` during
+/// the ANNOUNCEMENT loop (before the post-announcement Priority window the builder waits for),
+/// and the builder panics on that state. This is a harness limit, not engine behaviour.
+fn cycle_for_x(runner: &mut engine::game::scenario::GameRunner, card: ObjectId, x: u32) {
+    cycle_announce(runner, card, x);
+    runner.advance_until_stack_empty();
+}
+
+/// Announce + pay a cycling activation for `x` and stop at the Priority window — the point
+/// where the `Cycled` triggered ability is ON THE STACK but has not resolved, so its bound
+/// `chosen_x` can be observed directly.
+fn cycle_announce(runner: &mut engine::game::scenario::GameRunner, card: ObjectId, x: u32) {
+    let idx = cycling_index(runner.state(), card);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: card,
+            ability_index: idx,
+        })
+        .expect("activate cycling");
+
+    // CR 601.2c: each target slot takes a DISTINCT object, so the picks must be tracked —
+    // `choose_first_legal_target` would re-offer the object already chosen for slot 0 and
+    // the engine rejects it.
+    let mut chosen: Vec<engine::types::ability::TargetRef> = Vec::new();
+    for _ in 0..32 {
+        match &runner.state().waiting_for {
+            // CR 107.3a + CR 601.2f (via CR 602.2b): announce X for the activation cost.
+            WaitingFor::ChooseXValue { .. } => {
+                runner
+                    .act(GameAction::ChooseX { value: x })
+                    .expect("announce X for the cycling cost");
+            }
+            // CR 602.2b + CR 601.2h: finalize mana payment.
+            WaitingFor::ManaPayment { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("finalize the cycling mana payment");
+            }
+            // CR 603.3d: the Cycled trigger picks its targets as it goes on the stack.
+            WaitingFor::TriggerTargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                let slot = &target_slots[selection.current_slot];
+                let pick = slot
+                    .legal_targets
+                    .iter()
+                    .find(|t| !chosen.contains(t))
+                    .cloned();
+                if let Some(target) = pick.clone() {
+                    chosen.push(target);
+                }
+                runner
+                    .act(GameAction::ChooseTarget { target: pick })
+                    .expect("choose a legal target for the cycle trigger");
+            }
+            _ => break,
+        }
+    }
+}
+
+/// NEGATIVE CONTROL, from the card's own official ruling (read from the pool export, never from
+/// memory): "You can choose 0 as the value of X in Shark Typhoon's cycling cost. The last
+/// ability will trigger, and you'll create a 0/0 blue Shark creature token with flying."
+///
+/// So for X=0 a 0/0 Shark is CORRECT. Zero is the one value where the correct board and the
+/// FABRICATED board coincide — an unbound X also resolves to 0 — so the board alone cannot
+/// discriminate here, and the 0/0 token dies to SBA (CR 704.5f) and is purged (CR 111.7) before
+/// it can even be read. The discriminating observation is therefore taken while the trigger is
+/// ON THE STACK: it must carry `chosen_x == Some(0)` — an announcement of zero — and NOT `None`.
+/// That is what pins `Option<u32>` as the right carrier type: a carrier that treated 0 as
+/// "nothing announced" would leave `None` here and pass a board-only test by luck.
+/// The board is then checked too: a survivor would mean some non-zero X was fabricated.
+#[test]
+fn cycling_trigger_x_zero_announces_a_real_zero_and_the_shark_dies() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_card_to_library_top(P0, "Cycled Draw");
+    let typhoon = scenario
+        .add_spell_to_hand_from_oracle(P0, "Shark Typhoon", false, SHARK_TYPHOON)
+        .id();
+    let mut runner = scenario.build();
+    add_mana(&mut runner, ManaType::Blue, 4);
+
+    cycle_announce(&mut runner, typhoon, 0);
+
+    let bound_x = runner
+        .state()
+        .stack
+        .iter()
+        .find_map(|entry| match &entry.kind {
+            StackEntryKind::TriggeredAbility {
+                source_id, ability, ..
+            } if *source_id == typhoon => Some(ability.chosen_x),
+            _ => None,
+        })
+        .expect("the Cycled trigger must be on the stack (if it is not, nothing below is a test)");
+    assert_eq!(
+        bound_x,
+        Some(0),
+        "WotC ruling: X=0 is a legal cycling announcement and creates a 0/0 Shark. The trigger \
+         must carry an ANNOUNCED zero, not `None` — `None` means the carrier collapsed 0 into \
+         'no X announced' and the correct board here would be a coincidence. MEASURED: {bound_x:?}"
+    );
+
+    runner.advance_until_stack_empty();
+    let surviving = named_on_battlefield(&runner, "Shark");
+    assert!(
+        surviving.is_empty(),
+        "cycled for X=0 the Shark is 0/0 and must die to SBA. A survivor means a NON-ZERO X was \
+         fabricated — a value the player never announced. MEASURED: {surviving:?}"
+    );
+}
+
+/// The stamp must land at trigger INSTANTIATION, not at trigger resolution: Rampaging War
+/// Mammoth's "destroy up to X target artifacts" spends X in `multi_target.max`, which is
+/// consumed during TARGET SELECTION — before the triggered ability ever resolves. With X
+/// unbound the trigger offers "up to 0" targets and destroys nothing, which is exactly the
+/// silent zero this campaign exists to kill. Cycled for X=2, both artifacts must die.
+#[test]
+fn cycling_trigger_x_reaches_the_target_count_slot() {
+    const MAMMOTH: &str = "Trample\nCycling {X}{2}{R} ({X}{2}{R}, Discard this card: Draw a \
+                           card.)\nWhen you cycle this card, destroy up to X target artifacts.";
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_card_to_library_top(P0, "Cycled Draw");
+    let relic_a = scenario
+        .add_creature(P1, "Relic A", 0, 0)
+        .as_artifact()
+        .id();
+    let relic_b = scenario
+        .add_creature(P1, "Relic B", 0, 0)
+        .as_artifact()
+        .id();
+    let mammoth = scenario
+        .add_spell_to_hand_from_oracle(P0, "Rampaging War Mammoth", false, MAMMOTH)
+        .id();
+    let mut runner = scenario.build();
+    add_mana(&mut runner, ManaType::Red, 8);
+
+    cycle_for_x(&mut runner, mammoth, 2);
+
+    let survivors: Vec<_> = [relic_a, relic_b]
+        .into_iter()
+        .filter(|id| {
+            runner
+                .state()
+                .objects
+                .get(id)
+                .is_some_and(|o| o.zone == Zone::Battlefield)
+        })
+        .collect();
+    assert!(
+        survivors.is_empty(),
+        "cycled for X=2, 'destroy up to X target artifacts' must destroy BOTH. A survivor means \
+         `multi_target.max` never saw the announced X, so the trigger offered 'up to 0' targets. \
+         MEASURED survivors: {survivors:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GREEN CONTROLS — the carrier MUST NOT reach these.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// THE HAZARD CONTROL (CR 107.3m + CR 107.3k). A resolving SPELL must never publish an
+/// activation X. Two things depend on this and both are load-bearing:
+///
+///  1. A permanent PUT onto the battlefield by an unrelated resolving X-spell (the
+///     Sneak-Attack-for-X shape) must have X = 0 — CR 107.3m: "the value of X for that
+///     permanent is 0". If a spell published its X, that permanent's ETB would inherit it.
+///  2. `QuantityRef::CostXPaid` — the cast channel that commit 1 rewrites gated-ETB sibling
+///     slots to — falls back to `chosen_x` when the object has no `cost_x_paid`. A published
+///     spell-X would leak into that fallback and poison exactly the slots commit 1 fixed.
+///
+/// `stack::resolve_top` publishes for `StackEntryKind::ActivatedAbility` ONLY, so the carrier
+/// is provably `None` for the whole of a spell's resolution. This asserts that directly, and
+/// asserts the cast-X path still works (Krasis gains half X), so it cannot pass vacuously by
+/// the carrier being dead everywhere.
+#[test]
+fn a_resolving_spell_never_publishes_an_activation_x() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = {
+        let mut b = scenario.add_creature_to_hand_from_oracle(
+            P0,
+            "Hydroid Krasis",
+            0,
+            0,
+            "When you cast this spell, you gain half X life and draw half X cards. Round down \
+             each time.\nFlying, trample",
+        );
+        b.with_mana_cost(cost(
+            vec![ManaCostShard::X, ManaCostShard::Green, ManaCostShard::Blue],
+            0,
+        ));
+        b.id()
+    };
+    let mut runner = scenario.build();
+    let life_before = runner.state().players[0].life;
+    add_mana(&mut runner, ManaType::Green, 4);
+    add_mana(&mut runner, ManaType::Blue, 4);
+
+    runner.cast(spell).x(4).resolve();
+
+    assert_eq!(
+        runner.state().players[0].life - life_before,
+        2,
+        "non-vacuity: the cast-X channel (cost_x_paid) must still bind — Krasis cast for X=4 \
+         gains half X = 2 life. If this is 0 the assertion below proves nothing."
+    );
+    assert_eq!(
+        runner.state().activated_ability_x,
+        None,
+        "CR 107.3m + CR 107.3k: a resolving SPELL must never publish an activation X. A \
+         published value here would (a) let a permanent this spell puts onto the battlefield \
+         inherit X instead of 0, and (b) leak into the CostXPaid -> chosen_x fallback and \
+         poison the gated-ETB sibling slots. MEASURED: {:?}",
+        runner.state().activated_ability_x
+    );
+}
+
+/// RULING CONDITION 2 — save/wire compatibility, CHECKED rather than asserted.
+///
+/// `activated_ability_x` is NEW PERSISTED `GameState` (it is serialized so a mid-activation
+/// pause — e.g. an interactive cost payment between announcement and the trigger going on the
+/// stack — round-trips). It is therefore a save-format change and must be shown compatible:
+///
+///  1. A save written by an OLDER binary has no `activated_ability_x` key at all. `#[serde(default)]`
+///     must make that load as `None` rather than fail. Because `skip_serializing_if` omits the key
+///     whenever it is `None`, a fresh serialization of a state with no live activation IS
+///     byte-identical to an old save on this axis — so serializing a `None` state and reloading it
+///     exercises exactly the old-save path.
+///  2. A live value must survive a round-trip.
+///
+/// (`GameState` does not use `deny_unknown_fields`, so the reverse direction — an OLD binary
+/// reading a NEW save that carries the key — ignores it rather than erroring.)
+#[test]
+fn activated_ability_x_is_save_compatible() {
+    let scenario = GameScenario::new();
+    let runner = scenario.build();
+    let mut state = runner.state().clone();
+
+    // (1) OLD-SAVE SHAPE: `None` omits the key entirely.
+    state.activated_ability_x = None;
+    let old_shape = serde_json::to_value(&state).expect("serialize");
+    assert!(
+        old_shape.get("activated_ability_x").is_none(),
+        "a `None` carrier must omit the key, so pre-field saves are byte-identical on this axis"
+    );
+    let reloaded: engine::types::game_state::GameState =
+        serde_json::from_value(old_shape).expect("an old save (no key) must load, not fail");
+    assert_eq!(
+        reloaded.activated_ability_x, None,
+        "a save with no `activated_ability_x` key must default to None"
+    );
+
+    // (2) LIVE VALUE: round-trips intact.
+    state.activated_ability_x = Some((ObjectId(4242), 7));
+    let new_shape = serde_json::to_value(&state).expect("serialize");
+    assert!(
+        new_shape.get("activated_ability_x").is_some(),
+        "a live announced X must be persisted (it must survive a mid-activation pause)"
+    );
+    let reloaded: engine::types::game_state::GameState =
+        serde_json::from_value(new_shape).expect("deserialize");
+    assert_eq!(
+        reloaded.activated_ability_x,
+        Some((ObjectId(4242), 7)),
+        "the announced X and its source must round-trip through a save"
     );
 }

--- a/crates/engine/tests/integration/cost_x_carrier_runtime.rs
+++ b/crates/engine/tests/integration/cost_x_carrier_runtime.rs
@@ -612,3 +612,148 @@ fn activated_ability_x_is_save_compatible() {
         "the announced X and its source must round-trip through a save"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE FILTER-MANA-VALUE SUB-CLASS — t96 left this MEASURED-UNKNOWN, and the totality
+// guard's scoping depends on the answer. These two pin it in BOTH directions.
+//
+// ~9 gated-ETB faces (Dune Drifter, Kinetic Ooze, Thieving Skydiver, Halo Forager, In
+// Residence, Invasion of Ikoria, Knickknack Ouphe, Rocco, Taj-Nar Swordsmith) keep a bare
+// `Variable{"X"}` in a filter's mana-value bound INSIDE the effect. The cost-X walk does not
+// rewrite it — the AST residual is real. The question is whether it FABRICATES.
+//
+// MEASURED: it does not. The runtime binds it. So these faces WORK, and a totality guard keyed
+// on tree-presence of an X would red all nine of them — manufacturing honest-looking reds out
+// of cards that play correctly. That is why the guard is keyed on the target-selection sibling
+// slots ONLY. These tests are the evidence for that scoping; if they ever go red, the guard's
+// scope must be revisited.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kinetic Ooze `{X}{G}`, MEASURED — direction 1: an object WITHIN the bound is a legal target.
+/// "This creature enters with X +1/+1 counters on it.
+///  When this creature enters, destroy up to one target artifact or enchantment with mana value
+///  X or less."
+///
+/// BUILT-IN NON-VACUITY CONTROL: one card, one X, two slots. "Enters with X +1/+1 counters"
+/// reads the spell's X (CR 107.3m); if that reads 3, X was available and the harness is live.
+/// A 3-counter Ooze beside a SURVIVING artifact would isolate the filter slot as fabricating.
+#[test]
+fn filter_mana_value_bound_binds_x_and_destroys_within_bound() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let relic = scenario
+        .add_creature(P1, "Worn Powerstone", 0, 0)
+        .as_artifact()
+        .id();
+    let ooze = {
+        let mut b = scenario.add_creature_to_hand_from_oracle(
+            P0,
+            "Kinetic Ooze",
+            0,
+            0,
+            "This creature enters with X +1/+1 counters on it.\nWhen this creature enters, \
+             destroy up to one target artifact or enchantment with mana value X or less.",
+        );
+        b.with_mana_cost(cost(vec![ManaCostShard::X, ManaCostShard::Green], 0));
+        b.id()
+    };
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&relic)
+        .unwrap()
+        .mana_cost = ManaCost::Cost {
+        shards: vec![],
+        generic: 3,
+    };
+    add_mana(&mut runner, ManaType::Green, 8);
+
+    runner.cast(ooze).x(3).target_object(relic).resolve();
+
+    let counters = runner
+        .state()
+        .objects
+        .get(&ooze)
+        .and_then(|o| o.counters.get(&CounterType::Plus1Plus1).copied())
+        .unwrap_or(0);
+    let relic_alive = runner
+        .state()
+        .objects
+        .get(&relic)
+        .is_some_and(|o| o.zone == Zone::Battlefield);
+    assert_eq!(
+        counters, 3,
+        "NON-VACUITY CONTROL: the enters-with-X counters read the spell's X (CR 107.3m). If this \
+         is not 3 the X never reached the card at all and the filter verdict below is void. \
+         MEASURED: {counters}"
+    );
+    assert!(
+        !relic_alive,
+        "the filter's mana-value bound must bind X: cast for X=3, an MV-3 artifact IS a legal \
+         target and must be destroyed. A survivor here means the bound fabricated 0 ('mana value \
+         0 or less' matches nothing) — and the totality guard would then need to red this class."
+    );
+}
+
+/// Kinetic Ooze, MEASURED — direction 2, THE DISCRIMINATOR. Direction 1 alone is ambiguous: a
+/// filter whose mana-value prop was DROPPED ENTIRELY (over-permissive — a different bug) would
+/// also destroy the artifact. Here X=1 against an MV-3 artifact. Bound to X => MV 3 > 1 is an
+/// ILLEGAL target and it survives. Prop dropped => it dies anyway. It survives, so the bound is
+/// really bound to X — not fabricated, and not dropped.
+#[test]
+fn filter_mana_value_bound_excludes_targets_above_x() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let relic = scenario
+        .add_creature(P1, "Worn Powerstone", 0, 0)
+        .as_artifact()
+        .id();
+    let ooze = {
+        let mut b = scenario.add_creature_to_hand_from_oracle(
+            P0,
+            "Kinetic Ooze",
+            0,
+            0,
+            "This creature enters with X +1/+1 counters on it.\nWhen this creature enters, \
+             destroy up to one target artifact or enchantment with mana value X or less.",
+        );
+        b.with_mana_cost(cost(vec![ManaCostShard::X, ManaCostShard::Green], 0));
+        b.id()
+    };
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&relic)
+        .unwrap()
+        .mana_cost = ManaCost::Cost {
+        shards: vec![],
+        generic: 3,
+    };
+    add_mana(&mut runner, ManaType::Green, 8);
+
+    runner.cast(ooze).x(1).resolve();
+
+    let counters = runner
+        .state()
+        .objects
+        .get(&ooze)
+        .and_then(|o| o.counters.get(&CounterType::Plus1Plus1).copied())
+        .unwrap_or(0);
+    let relic_alive = runner
+        .state()
+        .objects
+        .get(&relic)
+        .is_some_and(|o| o.zone == Zone::Battlefield);
+    assert_eq!(
+        counters, 1,
+        "NON-VACUITY CONTROL: the enters-with-X counters must read 1. MEASURED: {counters}"
+    );
+    assert!(
+        relic_alive,
+        "cast for X=1, an MV-3 artifact is NOT a legal target and must survive. Its destruction \
+         would mean the mana-value prop was dropped entirely — an over-permissive filter that \
+         destroys anything, which direction 1 alone cannot distinguish from a correct bind."
+    );
+}


### PR DESCRIPTION
- **fix(engine): carry an activated ability's announced X to the trigger it causes (CR 107.3i)**
- **fix(parser): totality guard for cost-X target-selection slots + kill the condition wildcard (CR 107.3i)**
