### PR TITLE
fix(engine): exile-and-return resolving-spell replacement for Feather, the Redeemed (#4825)

### DIFF
--- a/crates/engine/src/analysis/ability_graph.rs
+++ b/crates/engine/src/analysis/ability_graph.rs
@@ -928,7 +928,7 @@ fn effect_projection(effect: &Effect) -> Projection {
         | Effect::AddPendingEntersModifications { .. }
         | Effect::CreateEmblem { .. }
         | Effect::PayCost { .. }
-        | Effect::ExileResolvingSpellInsteadOfGraveyard
+        | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
         | Effect::PreventDamage { .. }
         | Effect::CreateDamageReplacement { .. }
         | Effect::CreateDrawReplacement { .. }

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -5030,7 +5030,7 @@ fn rw_effect(
             p.writes_external.set(StateKind::StackShape);
             (p, None)
         }
-        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return: _ } => {
+        Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile: _ } => {
             (ext_write(StateKind::StackShape), None)
         }
 

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -3302,7 +3302,7 @@ fn legacy_effect(x: &Effect) -> bool {
         | Effect::SolveCase
         | Effect::SetClassLevel { .. }
         | Effect::AddRestriction { .. }
-        | Effect::ExileResolvingSpellInsteadOfGraveyard
+        | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
         | Effect::RingTemptsYou
         | Effect::VentureIntoDungeon
         | Effect::VentureInto { .. }
@@ -5030,7 +5030,9 @@ fn rw_effect(
             p.writes_external.set(StateKind::StackShape);
             (p, None)
         }
-        Effect::ExileResolvingSpellInsteadOfGraveyard => (ext_write(StateKind::StackShape), None),
+        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return: _ } => {
+            (ext_write(StateKind::StackShape), None)
+        }
 
         // ---- Pool ----
         Effect::Mana {

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1071,7 +1071,10 @@ fn scan_effect(x: &Effect) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        Effect::ExileResolvingSpellInsteadOfGraveyard => Axes::NONE,
+        // The `then_return` rider is fixed at parse time and only read by the
+        // stack-resolution router when the replacement applies — no game-state
+        // read happens at scan time, so NONE stays correct.
+        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return: _ } => Axes::NONE,
         Effect::PreventDamage {
             amount_dynamic,
             target,
@@ -4299,7 +4302,7 @@ fn effect_resolution_choice_freedom(e: &Effect) -> ResolutionChoiceFreedom {
         | Effect::PayCost { .. }
         | Effect::CastFromZone { .. }
         | Effect::FreeCastFromZones { .. }
-        | Effect::ExileResolvingSpellInsteadOfGraveyard
+        | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
         | Effect::PreventDamage { .. }
         | Effect::CreateDamageReplacement { .. }
         | Effect::CreateDrawReplacement { .. }
@@ -4562,7 +4565,7 @@ pub(crate) fn effect_is_randomness_bearing(e: &Effect) -> bool {
         | Effect::PayCost { .. }
         | Effect::CastFromZone { .. }
         | Effect::FreeCastFromZones { .. }
-        | Effect::ExileResolvingSpellInsteadOfGraveyard
+        | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
         | Effect::PreventDamage { .. }
         | Effect::CreateDamageReplacement { .. }
         | Effect::CreateDrawReplacement { .. }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1071,10 +1071,10 @@ fn scan_effect(x: &Effect) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        // The `then_return` rider is fixed at parse time and only read by the
+        // The `on_exile` rider is fixed at parse time and only read by the
         // stack-resolution router when the replacement applies — no game-state
         // read happens at scan time, so NONE stays correct.
-        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return: _ } => Axes::NONE,
+        Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile: _ } => Axes::NONE,
         Effect::PreventDamage {
             amount_dynamic,
             target,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3282,8 +3282,14 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         Effect::Cascade => {}
         Effect::Ripple { .. } => {}
         // CR 614.1a: the "exile it instead of putting it into a graveyard as it
-        // resolves" rider acts on the triggering spell; no displayable parameter.
-        Effect::ExileResolvingSpellInsteadOfGraveyard => {}
+        // resolves" rider acts on the triggering spell; the only displayable
+        // parameter is the optional Feather-class return rider.
+        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } => {
+            if let Some(rider) = then_return {
+                d.push(("return to".into(), format!("{:?}", rider.destination)));
+                d.push(("return at".into(), format!("{:?}", rider.timing)));
+            }
+        }
         // CR 702.94a: MiracleCast is an internal engine effect, not parsed from Oracle text.
         Effect::MiracleCast { .. } => {}
         // CR 702.35a: MadnessCast is synthesized from Keyword::Madness.

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3283,13 +3283,21 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         Effect::Ripple { .. } => {}
         // CR 614.1a: the "exile it instead of putting it into a graveyard as it
         // resolves" rider acts on the triggering spell; the only displayable
-        // parameter is the optional Feather-class return rider.
-        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } => {
-            if let Some(rider) = then_return {
-                d.push(("return to".into(), format!("{:?}", rider.destination)));
-                d.push(("return at".into(), format!("{:?}", rider.timing)));
+        // parameter is the optional "If you do, ..." consequence rider.
+        Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile } => match on_exile {
+            Some(crate::types::ability::ExiledSpellRider::ReturnTo {
+                destination,
+                timing,
+            }) => {
+                d.push(("return to".into(), format!("{destination:?}")));
+                d.push(("return at".into(), format!("{timing:?}")));
             }
-        }
+            // CR 702.170c: Lilah's exiled spell becomes plotted.
+            Some(crate::types::ability::ExiledSpellRider::BecomePlotted) => {
+                d.push(("then".into(), "becomes plotted".into()));
+            }
+            None => {}
+        },
         // CR 702.94a: MiracleCast is an internal engine effect, not parsed from Oracle text.
         Effect::MiracleCast { .. } => {}
         // CR 702.35a: MadnessCast is synthesized from Keyword::Madness.

--- a/crates/engine/src/game/effects/exile_resolving_spell.rs
+++ b/crates/engine/src/game/effects/exile_resolving_spell.rs
@@ -11,9 +11,14 @@
 //! set.
 
 use crate::game::targeting::extract_source_from_event;
-use crate::types::ability::{EffectError, EffectKind, ResolvedAbility};
+use crate::types::ability::{
+    DelayedTriggerCondition, Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter,
+    TargetRef,
+};
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{DelayedTrigger, GameState};
+use crate::types::identifiers::ObjectId;
+use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 
 /// Stamp the per-object exile-instead-of-graveyard rider on the triggering spell
@@ -38,6 +43,15 @@ pub fn resolve(
         .as_ref()
         .and_then(extract_source_from_event);
 
+    // CR 603.7a: whether the exiled spell should also be returned (destination
+    // + timing carried on the typed rider) after the exile applies — Feather,
+    // the Redeemed's "If you do, return it to your hand at the beginning of
+    // the next end step".
+    let then_return = match &ability.effect {
+        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } => then_return.clone(),
+        _ => None,
+    };
+
     if let Some(spell_id) = spell_id {
         // CR 614.1a: only a spell still on the stack can be redirected as it
         // resolves; if it already left the stack (countered, fizzled) there is
@@ -48,6 +62,14 @@ pub fn resolve(
                 // tracked as "exiled with [this source]". Presence of this
                 // typed source is also the CR 614.1a exile-instead marker.
                 obj.exile_from_stack_linked_source = Some(ability.source_id);
+                if let Some(rider) = then_return {
+                    // CR 603.7a: stamp the typed rider so the stack router arms
+                    // the return delayed trigger when the replacement is
+                    // actually APPLIED (the spell lands in exile) — not now.
+                    // Cleared on any zone exit (zones.rs), so a counter in
+                    // response makes this a no-op.
+                    obj.exile_from_stack_return_rider = Some(rider);
+                }
             }
         }
     }
@@ -58,4 +80,81 @@ pub fn resolve(
         subject: None,
     });
     Ok(())
+}
+
+/// CR 603.7a: On-application arming hook for the Feather, the Redeemed return
+/// rider — called from `stack.rs::resolve_top` after the exiled-instead
+/// replacement has actually been APPLIED (the resolving spell landed in the
+/// exile zone) and the spell carried the `exile_from_stack_return_rider`
+/// marker, whose `destination`/`timing` axes parameterize the return.
+///
+/// CR 603.7a: a delayed triggered ability created "as the result of a
+/// replacement effect being applied" exists only once the replacement applies,
+/// so this must NOT run when Feather's trigger resolves (a spell countered in
+/// response never reaches this hook — the marker is cleared on its zone exit).
+///
+/// Action: push a one-shot `DelayedTrigger` keyed on `timing` (CR 603.7b:
+/// fires once — Feather's `AtNextPhase { End }` fires at the beginning of the
+/// next end step, whoever's turn it is) whose body returns the concrete exiled
+/// card to `destination`. `origin: Some(Zone::Exile)` is the CR 603.7c
+/// residency guard: if the card left exile before the trigger fires it is a
+/// new object and is not returned.
+pub fn arm_return_to_hand(
+    state: &mut GameState,
+    exiled_id: ObjectId,
+    controller: PlayerId,
+    source_id: ObjectId,
+    destination: Zone,
+    timing: DelayedTriggerCondition,
+) {
+    let ability = ResolvedAbility::new(
+        Effect::ChangeZone {
+            // CR 603.7c: only return the card if it is still in exile.
+            origin: Some(Zone::Exile),
+            destination,
+            // CR 603.7c + CR 115.1: the exiled card is pre-bound in `targets`
+            // below — it is never a player-chosen target. `ParentTarget` is a
+            // context ref (no target slot is surfaced when the delayed trigger
+            // fires; `resolved_targets` reads the pre-bound `targets`),
+            // mirroring the Flickerwisp-class delayed return pattern. A
+            // `SpecificObject` filter would surface a mandatory target slot
+            // whose exiled candidate is not a legal target, dropping the
+            // trigger as target-unresolved.
+            target: TargetFilter::ParentTarget,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        },
+        vec![TargetRef::Object(exiled_id)],
+        // CR 603.7e: the source of the delayed trigger is the source of the
+        // triggered ability whose replacement created it (Feather).
+        source_id,
+        // CR 603.7e: the delayed trigger's controller is the player who
+        // controlled the triggered ability as it resolved. The `controller`
+        // passed in is the resolving SPELL's controller (`entry.controller` at
+        // the stack.rs call site), which equals the CR 603.7e ability
+        // controller only for the current "whenever you cast" carrier class
+        // (spell controller == trigger controller by the trigger condition).
+        // A future opponent-cast carrier of this rider would need the stamping
+        // ability's controller carried on the marker instead.
+        controller,
+    );
+
+    state.delayed_triggers.push(DelayedTrigger {
+        // CR 603.7b: when the one-shot return fires (Feather: "at the
+        // beginning of the next end step").
+        condition: timing,
+        ability,
+        controller,
+        source_id,
+        // CR 603.7b: one-shot — removed after it fires.
+        one_shot: true,
+    });
 }

--- a/crates/engine/src/game/effects/exile_resolving_spell.rs
+++ b/crates/engine/src/game/effects/exile_resolving_spell.rs
@@ -12,8 +12,8 @@
 
 use crate::game::targeting::extract_source_from_event;
 use crate::types::ability::{
-    DelayedTriggerCondition, Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter,
-    TargetRef,
+    CastingPermission, DelayedTriggerCondition, Effect, EffectError, EffectKind, ExiledSpellRider,
+    PermissionGrantee, ResolvedAbility, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{DelayedTrigger, GameState};
@@ -43,12 +43,12 @@ pub fn resolve(
         .as_ref()
         .and_then(extract_source_from_event);
 
-    // CR 603.7a: whether the exiled spell should also be returned (destination
-    // + timing carried on the typed rider) after the exile applies — Feather,
-    // the Redeemed's "If you do, return it to your hand at the beginning of
-    // the next end step".
-    let then_return = match &ability.effect {
-        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } => then_return.clone(),
+    // CR 603.7a + CR 702.170c: the "If you do, ..." consequence to apply once
+    // the exile actually happens — Feather's return-to-hand or Lilah's
+    // become-plotted. Carried on the typed rider; `None` for the riderless Rod
+    // of Absorption form.
+    let on_exile = match &ability.effect {
+        Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile } => on_exile.clone(),
         _ => None,
     };
 
@@ -62,13 +62,13 @@ pub fn resolve(
                 // tracked as "exiled with [this source]". Presence of this
                 // typed source is also the CR 614.1a exile-instead marker.
                 obj.exile_from_stack_linked_source = Some(ability.source_id);
-                if let Some(rider) = then_return {
-                    // CR 603.7a: stamp the typed rider so the stack router arms
-                    // the return delayed trigger when the replacement is
-                    // actually APPLIED (the spell lands in exile) — not now.
-                    // Cleared on any zone exit (zones.rs), so a counter in
+                if let Some(rider) = on_exile {
+                    // CR 603.7a: stamp the typed rider so the stack router
+                    // applies the consequence when the replacement is actually
+                    // APPLIED (the spell lands in exile) — not now. Cleared on
+                    // any zone exit (zones.rs), so a counter or fizzle in
                     // response makes this a no-op.
-                    obj.exile_from_stack_return_rider = Some(rider);
+                    obj.exile_from_stack_rider = Some(rider);
                 }
             }
         }
@@ -82,24 +82,78 @@ pub fn resolve(
     Ok(())
 }
 
-/// CR 603.7a: On-application arming hook for the Feather, the Redeemed return
-/// rider — called from `stack.rs::resolve_top` after the exiled-instead
+/// CR 603.7a + CR 702.170c: On-application hook for the exile-instead
+/// consequence — called from `stack.rs::resolve_top` after the exiled-instead
 /// replacement has actually been APPLIED (the resolving spell landed in the
-/// exile zone) and the spell carried the `exile_from_stack_return_rider`
-/// marker, whose `destination`/`timing` axes parameterize the return.
+/// exile zone) and the spell carried the `exile_from_stack_rider` marker.
 ///
-/// CR 603.7a: a delayed triggered ability created "as the result of a
-/// replacement effect being applied" exists only once the replacement applies,
-/// so this must NOT run when Feather's trigger resolves (a spell countered in
-/// response never reaches this hook — the marker is cleared on its zone exit).
-///
-/// Action: push a one-shot `DelayedTrigger` keyed on `timing` (CR 603.7b:
-/// fires once — Feather's `AtNextPhase { End }` fires at the beginning of the
-/// next end step, whoever's turn it is) whose body returns the concrete exiled
-/// card to `destination`. `origin: Some(Zone::Exile)` is the CR 603.7c
-/// residency guard: if the card left exile before the trigger fires it is a
-/// new object and is not returned.
-pub fn arm_return_to_hand(
+/// CR 603.7a: a consequence created "as the result of a replacement effect
+/// being applied" exists only once the replacement applies, so this must NOT
+/// run when the trigger resolves (a spell countered or fizzled in response
+/// never reaches this hook — the marker is cleared on its zone exit). Dispatch:
+/// Feather arms a delayed return; Lilah grants the plotted permission.
+pub fn apply_exile_rider(
+    state: &mut GameState,
+    exiled_id: ObjectId,
+    controller: PlayerId,
+    source_id: ObjectId,
+    rider: ExiledSpellRider,
+    events: &mut Vec<GameEvent>,
+) {
+    match rider {
+        ExiledSpellRider::ReturnTo {
+            destination,
+            timing,
+        } => arm_return_to(state, exiled_id, controller, source_id, destination, timing),
+        // CR 702.170c: the card is now in exile, so it may become plotted. Route
+        // through the single grant-permission authority so `turn_plotted` is
+        // stamped and the `BecomesPlotted` event fires exactly as for the
+        // Aven Interrupter-class "exile ... it becomes plotted" grant.
+        ExiledSpellRider::BecomePlotted => {
+            grant_plotted(state, exiled_id, controller, source_id, events)
+        }
+    }
+}
+
+/// CR 702.170c: grant the exiled card the Plotted casting permission bound to
+/// its owner and emit `BecomesPlotted` (CR 702.170d makes it castable without
+/// paying its mana cost on a later turn). Delegates to
+/// `grant_permission::resolve`, the single authority for casting-permission
+/// grants — `turn_plotted` is stamped from `state.turn_number` there.
+fn grant_plotted(
+    state: &mut GameState,
+    exiled_id: ObjectId,
+    controller: PlayerId,
+    source_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) {
+    let ability = ResolvedAbility::new(
+        Effect::GrantCastingPermission {
+            // CR 702.170a: `turn_plotted` is a placeholder here — the grant
+            // resolver stamps the concrete `state.turn_number`.
+            permission: CastingPermission::Plotted { turn_plotted: 0 },
+            // CR 608.2c: the exiled card is pre-bound in `targets` below;
+            // `ParentTarget` reads it (never a player-chosen target slot).
+            target: TargetFilter::ParentTarget,
+            // CR 702.170d: a plotted card's *owner* may later cast it.
+            grantee: PermissionGrantee::ObjectOwner,
+        },
+        vec![TargetRef::Object(exiled_id)],
+        source_id,
+        controller,
+    );
+    // The grant resolver is infallible for a bound object target; a missing
+    // object (already left exile) yields an empty grant, which is correct.
+    let _ = crate::game::effects::grant_permission::resolve(state, &ability, events);
+}
+
+/// CR 603.7a + CR 603.7b: arm Feather's one-shot delayed return. Pushes a
+/// `DelayedTrigger` keyed on `timing` (Feather's `AtNextPhase { End }` fires at
+/// the beginning of the next end step, whoever's turn it is) whose body returns
+/// the concrete exiled card to `destination`. `origin: Some(Zone::Exile)` is
+/// the CR 603.7c residency guard: if the card left exile before the trigger
+/// fires it is a new object and is not returned.
+fn arm_return_to(
     state: &mut GameState,
     exiled_id: ObjectId,
     controller: PlayerId,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3370,7 +3370,7 @@ pub fn resolve_effect(
         Effect::PayCost { .. } => pay::resolve(state, ability, events),
         Effect::CastFromZone { .. } => cast_from_zone::resolve(state, ability, events),
         Effect::FreeCastFromZones { .. } => free_cast_from_zones::resolve(state, ability, events),
-        Effect::ExileResolvingSpellInsteadOfGraveyard => {
+        Effect::ExileResolvingSpellInsteadOfGraveyard { .. } => {
             exile_resolving_spell::resolve(state, ability, events)
         }
         Effect::PreventDamage { .. } => prevent_damage::resolve(state, ability, events),

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -7,7 +7,7 @@ use crate::types::ability::{
     additional_cost_instance_payment_count, additional_cost_instance_payment_count_for_ordinal,
     AbilityDefinition, AdditionalCost, AdditionalCostInstancePayment, AdditionalCostOrigin,
     BasicLandType, CastTimingPermission, CastVariantPaid, CastingPermission, CastingRestriction,
-    ChosenAttribute, ChosenSubtypeKind, CostPaidObjectSnapshot, ExiledSpellReturn, ModalChoice,
+    ChosenAttribute, ChosenSubtypeKind, CostPaidObjectSnapshot, ExiledSpellRider, ModalChoice,
     ReplacementDefinition, SeatDirection, SolveCondition, SpellCastingOption, StaticDefinition,
     TriggerDefinition,
 };
@@ -970,17 +970,17 @@ pub struct GameObject {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exile_from_stack_linked_source: Option<ObjectId>,
 
-    /// CR 603.7a + CR 614.1a: While set alongside the exile-instead rider, the
-    /// stack-resolution router arms a one-shot delayed trigger returning this
-    /// spell to the rider's `destination` at its `timing` — at the moment the
-    /// replacement is actually APPLIED (the spell lands in exile), per
-    /// CR 603.7a. Set by `Effect::ExileResolvingSpellInsteadOfGraveyard
-    /// { then_return: Some(..) }` (Feather, the Redeemed's "If you do, return
-    /// it to your hand at the beginning of the next end step"). Transient:
-    /// cleared on any zone exit, so a spell countered before it would have
-    /// resolved never arms a return.
+    /// CR 603.7a + CR 614.1a + CR 702.170c: While set alongside the
+    /// exile-instead rider, the stack-resolution router applies the "If you do,
+    /// ..." consequence at the moment the replacement is actually APPLIED (the
+    /// spell lands in exile), per CR 603.7a — arming Feather, the Redeemed's
+    /// return-to-hand delayed trigger, or granting Lilah, Undefeated
+    /// Slickshot's plotted permission. Set by
+    /// `Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile: Some(..) }`.
+    /// Transient: cleared on any zone exit, so a spell countered or fizzled
+    /// before it would have resolved never takes the consequence.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub exile_from_stack_return_rider: Option<ExiledSpellReturn>,
+    pub exile_from_stack_rider: Option<ExiledSpellRider>,
 
     /// CR 305.1 + CR 603.4: Transient field tracking the zone a land was played
     /// from. Consumed by ETB trigger processing for conditions like "without
@@ -1179,7 +1179,7 @@ fn _gameobject_partition_is_total(o: &GameObject) {
         cast_controller: _,
         cast_spell_keywords: _,
         exile_from_stack_linked_source: _,
-        exile_from_stack_return_rider: _,
+        exile_from_stack_rider: _,
         played_from_zone: _,
         mana_spent_to_cast: _,
         colors_spent_to_cast: _,
@@ -1771,7 +1771,7 @@ impl GameObject {
             cast_controller: None,
             cast_spell_keywords: Vec::new(),
             exile_from_stack_linked_source: None,
-            exile_from_stack_return_rider: None,
+            exile_from_stack_rider: None,
             played_from_zone: None,
             mana_spent_to_cast: false,
             colors_spent_to_cast: ColoredManaCount::default(),

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -7,8 +7,9 @@ use crate::types::ability::{
     additional_cost_instance_payment_count, additional_cost_instance_payment_count_for_ordinal,
     AbilityDefinition, AdditionalCost, AdditionalCostInstancePayment, AdditionalCostOrigin,
     BasicLandType, CastTimingPermission, CastVariantPaid, CastingPermission, CastingRestriction,
-    ChosenAttribute, ChosenSubtypeKind, CostPaidObjectSnapshot, ModalChoice, ReplacementDefinition,
-    SeatDirection, SolveCondition, SpellCastingOption, StaticDefinition, TriggerDefinition,
+    ChosenAttribute, ChosenSubtypeKind, CostPaidObjectSnapshot, ExiledSpellReturn, ModalChoice,
+    ReplacementDefinition, SeatDirection, SolveCondition, SpellCastingOption, StaticDefinition,
+    TriggerDefinition,
 };
 use crate::types::card::{LayoutKind, PrintedCardRef, TokenImageRef};
 use crate::types::card_type::{CardType, CoreType};
@@ -969,6 +970,18 @@ pub struct GameObject {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exile_from_stack_linked_source: Option<ObjectId>,
 
+    /// CR 603.7a + CR 614.1a: While set alongside the exile-instead rider, the
+    /// stack-resolution router arms a one-shot delayed trigger returning this
+    /// spell to the rider's `destination` at its `timing` — at the moment the
+    /// replacement is actually APPLIED (the spell lands in exile), per
+    /// CR 603.7a. Set by `Effect::ExileResolvingSpellInsteadOfGraveyard
+    /// { then_return: Some(..) }` (Feather, the Redeemed's "If you do, return
+    /// it to your hand at the beginning of the next end step"). Transient:
+    /// cleared on any zone exit, so a spell countered before it would have
+    /// resolved never arms a return.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exile_from_stack_return_rider: Option<ExiledSpellReturn>,
+
     /// CR 305.1 + CR 603.4: Transient field tracking the zone a land was played
     /// from. Consumed by ETB trigger processing for conditions like "without
     /// being played"; permanents put onto the battlefield by effects leave this
@@ -1166,6 +1179,7 @@ fn _gameobject_partition_is_total(o: &GameObject) {
         cast_controller: _,
         cast_spell_keywords: _,
         exile_from_stack_linked_source: _,
+        exile_from_stack_return_rider: _,
         played_from_zone: _,
         mana_spent_to_cast: _,
         colors_spent_to_cast: _,
@@ -1757,6 +1771,7 @@ impl GameObject {
             cast_controller: None,
             cast_spell_keywords: Vec::new(),
             exile_from_stack_linked_source: None,
+            exile_from_stack_return_rider: None,
             played_from_zone: None,
             mana_spent_to_cast: false,
             colors_spent_to_cast: ColoredManaCount::default(),

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -1135,7 +1135,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::PayCost { .. }
         | Effect::CastFromZone { .. }
         | Effect::FreeCastFromZones { .. }
-        | Effect::ExileResolvingSpellInsteadOfGraveyard
+        | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
         | Effect::PreventDamage { .. }
         | Effect::LoseTheGame { .. }
         | Effect::WinTheGame { .. }

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1275,6 +1275,14 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                 // trigger context, then bail so the replacement-choice resume
                 // path delivers the redirected move.
                 let stack_exile_link_source = stack_exile_linked_source(state, entry.id);
+                // CR 603.7a: snapshot the Feather return-rider marker BEFORE the
+                // move — every zone exit clears the transient rider fields
+                // (zones.rs), so the post-move arm site below must read the
+                // pre-move value.
+                let return_rider = state
+                    .objects
+                    .get(&entry.id)
+                    .and_then(|o| o.exile_from_stack_return_rider.clone());
                 let req = ZoneMoveRequest::spell_resolution_default(entry.id, dest);
                 match zone_pipeline::move_object(state, req, events) {
                     ZoneMoveResult::Done => {
@@ -1297,9 +1305,35 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                                     link_source,
                                 );
                             }
+                            // CR 603.7a: the exile-instead replacement has now
+                            // actually been APPLIED (the spell landed in
+                            // exile), so this is the moment Feather's "If you
+                            // do, return it to your hand at the beginning of
+                            // the next end step" delayed trigger is created —
+                            // never earlier (a countered spell's marker was
+                            // cleared on its stack exit and never reaches
+                            // here).
+                            if let Some(rider) = return_rider {
+                                effects::exile_resolving_spell::arm_return_to_hand(
+                                    state,
+                                    entry.id,
+                                    entry.controller,
+                                    stack_exile_link_source.unwrap_or(entry.id),
+                                    rider.destination,
+                                    rider.timing,
+                                );
+                            }
                         }
                     }
                     ZoneMoveResult::NeedsChoice(_) | ZoneMoveResult::NeedsAuraAttachmentChoice => {
+                        // NOTE: the `return_rider` snapshot is intentionally
+                        // dropped on this bail — a parked move here can only be
+                        // a Graveyard-destination replacement-ordering prompt
+                        // (RIP/Leyline redirects match Graveyard destinations
+                        // only), so no stack→Exile move that could arm the
+                        // return rider can currently park. If a stack→Exile
+                        // replacement choice is ever added, the rider must be
+                        // carried through the pending-resolution resume path.
                         events.push(GameEvent::StackResolved {
                             object_id: entry.id,
                         });

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1275,14 +1275,14 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                 // trigger context, then bail so the replacement-choice resume
                 // path delivers the redirected move.
                 let stack_exile_link_source = stack_exile_linked_source(state, entry.id);
-                // CR 603.7a: snapshot the Feather return-rider marker BEFORE the
-                // move — every zone exit clears the transient rider fields
-                // (zones.rs), so the post-move arm site below must read the
-                // pre-move value.
-                let return_rider = state
+                // CR 603.7a + CR 702.170c: snapshot the exile-instead
+                // consequence rider BEFORE the move — every zone exit clears the
+                // transient rider fields (zones.rs), so the post-move apply site
+                // below must read the pre-move value.
+                let exile_rider = state
                     .objects
                     .get(&entry.id)
-                    .and_then(|o| o.exile_from_stack_return_rider.clone());
+                    .and_then(|o| o.exile_from_stack_rider.clone());
                 let req = ZoneMoveRequest::spell_resolution_default(entry.id, dest);
                 match zone_pipeline::move_object(state, req, events) {
                     ZoneMoveResult::Done => {
@@ -1305,33 +1305,33 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                                     link_source,
                                 );
                             }
-                            // CR 603.7a: the exile-instead replacement has now
-                            // actually been APPLIED (the spell landed in
-                            // exile), so this is the moment Feather's "If you
-                            // do, return it to your hand at the beginning of
-                            // the next end step" delayed trigger is created —
-                            // never earlier (a countered spell's marker was
-                            // cleared on its stack exit and never reaches
-                            // here).
-                            if let Some(rider) = return_rider {
-                                effects::exile_resolving_spell::arm_return_to_hand(
+                            // CR 603.7a + CR 702.170c: the exile-instead
+                            // replacement has now actually been APPLIED (the
+                            // spell landed in exile), so this is the moment the
+                            // "If you do, ..." consequence is applied — Feather's
+                            // return-to-hand delayed trigger, or Lilah's plotted
+                            // grant — never earlier (a countered or fizzled
+                            // spell's marker was cleared on its stack exit and
+                            // never reaches here).
+                            if let Some(rider) = exile_rider {
+                                effects::exile_resolving_spell::apply_exile_rider(
                                     state,
                                     entry.id,
                                     entry.controller,
                                     stack_exile_link_source.unwrap_or(entry.id),
-                                    rider.destination,
-                                    rider.timing,
+                                    rider,
+                                    events,
                                 );
                             }
                         }
                     }
                     ZoneMoveResult::NeedsChoice(_) | ZoneMoveResult::NeedsAuraAttachmentChoice => {
-                        // NOTE: the `return_rider` snapshot is intentionally
+                        // NOTE: the `exile_rider` snapshot is intentionally
                         // dropped on this bail — a parked move here can only be
                         // a Graveyard-destination replacement-ordering prompt
                         // (RIP/Leyline redirects match Graveyard destinations
-                        // only), so no stack→Exile move that could arm the
-                        // return rider can currently park. If a stack→Exile
+                        // only), so no stack→Exile move that could apply the
+                        // consequence rider can currently park. If a stack→Exile
                         // replacement choice is ever added, the rider must be
                         // carried through the pending-resolution resume path.
                         events.push(GameEvent::StackResolved {

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -224,10 +224,11 @@ pub(crate) fn apply_zone_exit_cleanup(
         // transient marker on the spell object. The stack resolver snapshots it
         // before moving the spell, so all zone exits can clear the field here.
         obj_mut.exile_from_stack_linked_source = None;
-        // CR 400.7 + CR 603.7a: Feather's return rider clears in lockstep — a
-        // spell that leaves the stack any other way (countered, fizzled) never
-        // arms the return delayed trigger.
-        obj_mut.exile_from_stack_return_rider = None;
+        // CR 400.7 + CR 603.7a + CR 702.170c: the exile-instead consequence
+        // rider clears in lockstep — a spell that leaves the stack any other
+        // way (countered, fizzled) never takes the consequence (Feather's
+        // return, Lilah's plot).
+        obj_mut.exile_from_stack_rider = None;
 
         // CR 400.7 + CR 730.3c: a component split out of a merged permanent is a
         // new object on every zone change, so its survivor back-link is

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -224,6 +224,10 @@ pub(crate) fn apply_zone_exit_cleanup(
         // transient marker on the spell object. The stack resolver snapshots it
         // before moving the spell, so all zone exits can clear the field here.
         obj_mut.exile_from_stack_linked_source = None;
+        // CR 400.7 + CR 603.7a: Feather's return rider clears in lockstep — a
+        // spell that leaves the stack any other way (countered, fizzled) never
+        // arms the return delayed trigger.
+        obj_mut.exile_from_stack_return_rider = None;
 
         // CR 400.7 + CR 730.3c: a component split out of a merged permanent is a
         // new object on every zone change, so its survivor back-link is

--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -33,7 +33,7 @@ use super::lower::{
     effect_publishes_revealed_subject, extract_bounded_target_multi_target,
     extract_exact_target_multi_target, extract_optional_target_multi_target,
     extract_verb_up_to_multi_target, fold_copy_spell_gains_haste_and_quoted_grant,
-    fold_enters_this_way_counter_rider, fold_exile_resolving_return_rider,
+    fold_enters_this_way_counter_rider, fold_exile_resolving_rider,
     fold_search_choose_type_conditional_destination, fold_token_it_has_grants_into_token_statics,
     gate_other_revealed_card_on_multiplayer_reveal,
     gate_reflexive_rider_on_declined_optional_target, is_exile_until_cast_bottom_cleanup,
@@ -2382,12 +2382,12 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
     // attaching object.
     rewire_result_anchored_subchain(&mut result);
     fold_enters_this_way_counter_rider(&mut result);
-    // CR 603.7a + CR 608.2c: fold Feather's "If you do, return it to your hand
-    // at the beginning of the next end step" rider onto the exile-resolving
-    // carrier's typed `then_return` rider so the return trigger is armed when
-    // the replacement is APPLIED (spell lands in exile), not when the trigger
-    // resolves.
-    fold_exile_resolving_return_rider(&mut result);
+    // CR 603.7a + CR 608.2c + CR 702.170c: fold the exile-instead "If you do,
+    // ..." continuation (Feather's return-to-hand, Lilah's become-plotted) onto
+    // the exile-resolving carrier's typed `on_exile` rider so the consequence is
+    // applied when the replacement is APPLIED (spell lands in exile), not when
+    // the trigger resolves.
+    fold_exile_resolving_rider(&mut result);
     wire_optional_cast_decline_fallback(&mut result);
     retarget_counter_additional_cost_to_target(&mut result);
     // CR 608.2c: two-target "put a counter on the you-control creature, then those

--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -33,8 +33,9 @@ use super::lower::{
     effect_publishes_revealed_subject, extract_bounded_target_multi_target,
     extract_exact_target_multi_target, extract_optional_target_multi_target,
     extract_verb_up_to_multi_target, fold_copy_spell_gains_haste_and_quoted_grant,
-    fold_enters_this_way_counter_rider, fold_search_choose_type_conditional_destination,
-    fold_token_it_has_grants_into_token_statics, gate_other_revealed_card_on_multiplayer_reveal,
+    fold_enters_this_way_counter_rider, fold_exile_resolving_return_rider,
+    fold_search_choose_type_conditional_destination, fold_token_it_has_grants_into_token_statics,
+    gate_other_revealed_card_on_multiplayer_reveal,
     gate_reflexive_rider_on_declined_optional_target, is_exile_until_cast_bottom_cleanup,
     is_land_enters_tapped_rider, is_linked_exile_cast_bottom_cleanup,
     is_spend_mana_as_any_color_rider, is_stable_branch_amount,
@@ -2381,6 +2382,12 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
     // attaching object.
     rewire_result_anchored_subchain(&mut result);
     fold_enters_this_way_counter_rider(&mut result);
+    // CR 603.7a + CR 608.2c: fold Feather's "If you do, return it to your hand
+    // at the beginning of the next end step" rider onto the exile-resolving
+    // carrier's typed `then_return` rider so the return trigger is armed when
+    // the replacement is APPLIED (spell lands in exile), not when the trigger
+    // resolves.
+    fold_exile_resolving_return_rider(&mut result);
     wire_optional_cast_decline_fallback(&mut result);
     retarget_counter_additional_cost_to_target(&mut result);
     // CR 608.2c: two-target "put a counter on the you-control creature, then those

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -30,7 +30,7 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
     AttackSubject, CastPermissionConstraint, CastingPermission, Comparator, ConjureSource,
     ContinuousModification, ControllerRef, DamageChannel, DamageSource, DelayedTriggerCondition,
-    Duration, Effect, EffectScope, FilterProp, GameRestriction, LibraryPosition,
+    Duration, Effect, EffectScope, ExiledSpellReturn, FilterProp, GameRestriction, LibraryPosition,
     ManaSpendPermission, MultiTargetSpec, ObjectScope, PlayerFilter, PreventionAmount,
     PreventionScope, PtValue, QuantityExpr, QuantityRef, RestrictionPlayerScope, RoundingMode,
     SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition, SubAbilityLink,
@@ -1879,6 +1879,117 @@ pub(super) fn fold_enters_this_way_counter_rider(def: &mut AbilityDefinition) {
     if let Some(sub) = def.sub_ability.as_mut() {
         fold_enters_this_way_counter_rider(sub);
     }
+}
+
+/// CR 603.7a + CR 608.2c: fold the "If you do, return it to your hand at the
+/// beginning of the next end step" continuation of an "exile [the resolving
+/// spell] instead of putting it into [a/your] graveyard as it resolves" clause
+/// (Feather, the Redeemed class) into the carrier effect's typed `then_return`
+/// rider (`ExiledSpellReturn { destination, timing }`).
+///
+/// The generic `CreateDelayedTrigger`-at-trigger-resolution lowering is wrong
+/// for this class: per CR 603.7a a delayed trigger created "as the result of a
+/// replacement effect being applied" exists only once the replacement is
+/// APPLIED — i.e. when the spell actually lands in exile during its own stack
+/// resolution — not when Feather's trigger resolves. Creating it eagerly would
+/// return a spell that was countered in response (the replacement never
+/// applied). The rider routes through the per-object marker so the stack
+/// router arms the one-shot return trigger at replacement-application time.
+///
+/// Deliberately conservative: any structural mismatch leaves the sub-ability
+/// unfolded, so `swallow_check` keeps flagging unrepresented text instead of
+/// silently dropping it.
+pub(super) fn fold_exile_resolving_return_rider(def: &mut AbilityDefinition) {
+    if matches!(
+        *def.effect,
+        Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
+    ) {
+        if let Some(sub) = def.sub_ability.take() {
+            if is_exile_resolving_return_rider(&sub) {
+                if let Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } =
+                    &mut *def.effect
+                {
+                    // CR 603.7a: Feather's return axes — owner's hand, at the
+                    // beginning of the next end step.
+                    *then_return = Some(ExiledSpellReturn {
+                        destination: Zone::Hand,
+                        timing: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+                    });
+                }
+                // The rider is fully represented by the typed rider — consume
+                // the sub.
+            } else {
+                def.sub_ability = Some(sub);
+            }
+        }
+    }
+    if let Some(sub) = def.sub_ability.as_mut() {
+        fold_exile_resolving_return_rider(sub);
+    }
+    if let Some(else_branch) = def.else_ability.as_mut() {
+        fold_exile_resolving_return_rider(else_branch);
+    }
+}
+
+/// Structural match for the return rider: an "if you do"-gated
+/// `CreateDelayedTrigger` at the next end step whose sole body returns the
+/// resolving spell (the `ParentTarget`/`SelfRef` anaphor) to its owner's hand.
+fn is_exile_resolving_return_rider(sub: &AbilityDefinition) -> bool {
+    // CR 608.2c: "If you do" — the optional-effect-performed gate on the rider.
+    if !sub
+        .condition
+        .as_ref()
+        .is_some_and(AbilityCondition::is_optional_effect_performed)
+    {
+        return false;
+    }
+    if sub.sub_ability.is_some() || sub.else_ability.is_some() {
+        return false;
+    }
+    let Effect::CreateDelayedTrigger {
+        condition,
+        effect: inner,
+        uses_tracked_set,
+    } = &*sub.effect
+    else {
+        return false;
+    };
+    if *uses_tracked_set {
+        return false;
+    }
+    // CR 603.7a: "at the beginning of the next end step".
+    if !matches!(
+        condition,
+        DelayedTriggerCondition::AtNextPhase { phase: Phase::End }
+    ) {
+        return false;
+    }
+    // CR 603.7a: the fold produces an UNCONDITIONAL return — a delayed-trigger
+    // body carrying its own condition, else-branch, or continuation would be
+    // silently promoted to unconditional if folded, so bail. One tolerated
+    // exception: the assembly-pass wrapper lift CLONES (not moves) the outer
+    // "if you do" gate, so the inner body legitimately carries a duplicate
+    // `is_optional_effect_performed` condition — already enforced on the sub
+    // above, hence unconditional once folded.
+    if inner.sub_ability.is_some() || inner.else_ability.is_some() {
+        return false;
+    }
+    if !inner
+        .condition
+        .as_ref()
+        .is_none_or(AbilityCondition::is_optional_effect_performed)
+    {
+        return false;
+    }
+    // "return it to your hand" — the anaphoric return-to-hand of the spell.
+    matches!(
+        &*inner.effect,
+        Effect::Bounce {
+            target: TargetFilter::ParentTarget | TargetFilter::SelfRef,
+            destination: None | Some(Zone::Hand),
+            ..
+        }
+    )
 }
 
 pub(super) fn rewire_result_anchored_subchain(def: &mut AbilityDefinition) {

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -30,11 +30,11 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
     AttackSubject, CastPermissionConstraint, CastingPermission, Comparator, ConjureSource,
     ContinuousModification, ControllerRef, DamageChannel, DamageSource, DelayedTriggerCondition,
-    Duration, Effect, EffectScope, ExiledSpellReturn, FilterProp, GameRestriction, LibraryPosition,
-    ManaSpendPermission, MultiTargetSpec, ObjectScope, PlayerFilter, PreventionAmount,
-    PreventionScope, PtValue, QuantityExpr, QuantityRef, RestrictionPlayerScope, RoundingMode,
-    SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition, SubAbilityLink,
-    TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
+    Duration, Effect, EffectScope, ExiledSpellRider, FilterProp, GameRestriction, LibraryPosition,
+    ManaSpendPermission, MultiTargetSpec, ObjectScope, PermissionGrantee, PlayerFilter,
+    PreventionAmount, PreventionScope, PtValue, QuantityExpr, QuantityRef, RestrictionPlayerScope,
+    RoundingMode, SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition,
+    SubAbilityLink, TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::counter::CounterType;
 use crate::types::game_state::{DistributionUnit, TargetSelectionConstraint};
@@ -1881,54 +1881,101 @@ pub(super) fn fold_enters_this_way_counter_rider(def: &mut AbilityDefinition) {
     }
 }
 
-/// CR 603.7a + CR 608.2c: fold the "If you do, return it to your hand at the
-/// beginning of the next end step" continuation of an "exile [the resolving
-/// spell] instead of putting it into [a/your] graveyard as it resolves" clause
-/// (Feather, the Redeemed class) into the carrier effect's typed `then_return`
-/// rider (`ExiledSpellReturn { destination, timing }`).
+/// CR 603.7a + CR 608.2c + CR 702.170c: fold the "If you do, ..." continuation
+/// of an "exile [the resolving spell] instead of putting it into [a/your]
+/// graveyard as it resolves" clause into the carrier effect's typed `on_exile`
+/// rider (`ExiledSpellRider`). Two members:
+///   - Feather, the Redeemed: "return it to your hand at the beginning of the
+///     next end step" → `ReturnTo { Hand, AtNextPhase { End } }`.
+///   - Lilah, Undefeated Slickshot: "it becomes plotted" → `BecomePlotted`.
 ///
-/// The generic `CreateDelayedTrigger`-at-trigger-resolution lowering is wrong
-/// for this class: per CR 603.7a a delayed trigger created "as the result of a
-/// replacement effect being applied" exists only once the replacement is
-/// APPLIED — i.e. when the spell actually lands in exile during its own stack
-/// resolution — not when Feather's trigger resolves. Creating it eagerly would
-/// return a spell that was countered in response (the replacement never
-/// applied). The rider routes through the per-object marker so the stack
-/// router arms the one-shot return trigger at replacement-application time.
+/// The generic at-trigger-resolution lowering is wrong for this class: per
+/// CR 603.7a a consequence created "as the result of a replacement effect being
+/// applied" exists only once the replacement is APPLIED — i.e. when the spell
+/// actually lands in exile during its own stack resolution — not when the
+/// trigger resolves. Leaving Feather's `CreateDelayedTrigger` (or Lilah's
+/// `GrantCastingPermission { Plotted }`) as an ordinary chained effect would
+/// apply it to a spell that was later countered in response (the replacement
+/// never applied). The rider routes through the per-object marker so the stack
+/// router applies the consequence at replacement-application time.
 ///
 /// Deliberately conservative: any structural mismatch leaves the sub-ability
 /// unfolded, so `swallow_check` keeps flagging unrepresented text instead of
 /// silently dropping it.
-pub(super) fn fold_exile_resolving_return_rider(def: &mut AbilityDefinition) {
+pub(super) fn fold_exile_resolving_rider(def: &mut AbilityDefinition) {
     if matches!(
         *def.effect,
         Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
     ) {
         if let Some(sub) = def.sub_ability.take() {
-            if is_exile_resolving_return_rider(&sub) {
-                if let Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } =
-                    &mut *def.effect
+            if let Some(rider) = detect_exile_resolving_rider(&sub) {
+                if let Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile } = &mut *def.effect
                 {
-                    // CR 603.7a: Feather's return axes — owner's hand, at the
-                    // beginning of the next end step.
-                    *then_return = Some(ExiledSpellReturn {
-                        destination: Zone::Hand,
-                        timing: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
-                    });
+                    *on_exile = Some(rider);
                 }
-                // The rider is fully represented by the typed rider — consume
-                // the sub.
+                // The continuation is fully represented by the typed rider —
+                // consume the sub.
             } else {
                 def.sub_ability = Some(sub);
             }
         }
     }
     if let Some(sub) = def.sub_ability.as_mut() {
-        fold_exile_resolving_return_rider(sub);
+        fold_exile_resolving_rider(sub);
     }
     if let Some(else_branch) = def.else_ability.as_mut() {
-        fold_exile_resolving_return_rider(else_branch);
+        fold_exile_resolving_rider(else_branch);
     }
+}
+
+/// CR 603.7a + CR 702.170c: classify the exile-instead continuation sub-ability
+/// into its typed rider, or `None` if it is not a recognized consequence. The
+/// per-member matchers stay conservative so unrecognized text is left unfolded
+/// for `swallow_check` to flag.
+fn detect_exile_resolving_rider(sub: &AbilityDefinition) -> Option<ExiledSpellRider> {
+    if is_exile_resolving_return_rider(sub) {
+        // CR 603.7a: Feather's return axes — owner's hand, at the beginning of
+        // the next end step.
+        return Some(ExiledSpellRider::ReturnTo {
+            destination: Zone::Hand,
+            timing: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+        });
+    }
+    if is_exile_resolving_plotted_rider(sub) {
+        // CR 702.170c: Lilah's "it becomes plotted".
+        return Some(ExiledSpellRider::BecomePlotted);
+    }
+    None
+}
+
+/// Structural match for Lilah's plotted rider: an optionally "if you do"-gated
+/// `GrantCastingPermission { Plotted }` on the resolving spell (the
+/// `ParentTarget`/`SelfRef` anaphor), granting to the card's owner.
+///
+/// CR 608.2c: the "if you do" back-reference is absorbed by the plotted-grant
+/// continuation grammar (see `parse_becomes_plotted_continuation`), so the
+/// grant may carry either no condition or a duplicate optional-effect-performed
+/// gate — but never an independent game-state condition, which would make the
+/// plot genuinely conditional and wrong to fold to an unconditional rider.
+fn is_exile_resolving_plotted_rider(sub: &AbilityDefinition) -> bool {
+    if !sub
+        .condition
+        .as_ref()
+        .is_none_or(AbilityCondition::is_optional_effect_performed)
+    {
+        return false;
+    }
+    if sub.sub_ability.is_some() || sub.else_ability.is_some() {
+        return false;
+    }
+    matches!(
+        &*sub.effect,
+        Effect::GrantCastingPermission {
+            permission: CastingPermission::Plotted { .. },
+            target: TargetFilter::ParentTarget | TargetFilter::SelfRef,
+            grantee: PermissionGrantee::ObjectOwner,
+        }
+    )
 }
 
 /// Structural match for the return rider: an "if you do"-gated

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7282,7 +7282,11 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     // to a no-op `ChangeZone { origin: Graveyard }` that never finds the spell
     // (it is on the stack, not in a graveyard, when the trigger resolves).
     if try_parse_exile_resolving_spell_instead_of_graveyard(&lower) {
-        return parsed_clause(Effect::ExileResolvingSpellInsteadOfGraveyard);
+        // CR 603.7a: the Feather-class "If you do, return it to your hand at the
+        // beginning of the next end step" rider is folded onto `then_return`
+        // later by `fold_exile_resolving_return_rider` in the assembly pass; the
+        // bare clause always lowers with no return rider.
+        return parsed_clause(Effect::ExileResolvingSpellInsteadOfGraveyard { then_return: None });
     }
     // CR 614.1a + CR 514.2: Global "If [source] would deal damage this turn,
     // it deals that much damage plus N instead" pattern (Rankle and Torbran,
@@ -16664,16 +16668,19 @@ fn parse_spell_graveyard_replacement_rider(
 
 /// CR 614.1a + CR 608.2n + CR 607.2b: Detect the resolving-spell exile rider —
 /// "exile it instead of putting it into a graveyard as it resolves". This is the
-/// trigger BODY of a `WhenAPlayerCasts` trigger (Rod of Absorption), distinct
+/// trigger BODY of a `WhenAPlayerCasts` trigger (Rod of Absorption) or a
+/// `WhenYouCast` trigger ("exile that card instead of putting it into your
+/// graveyard as it resolves" — the Feather, the Redeemed class), distinct
 /// from the post-cast rider clause `parse_spell_graveyard_replacement_rider`
 /// ("if that spell would be put into a graveyard, exile it instead") that trails
 /// a `CastFromZone`/`Counter` effect.
 ///
 /// Composed as a single nom chain over the independent axes: the bare anaphor
 /// ("it" / "that spell") and the graveyard determiner. "a graveyard" /
-/// "its owner's graveyard" / "a player's graveyard" are leaf variants of the
-/// same slot. The trailing "as it resolves" is the resolution-timing marker that
-/// distinguishes this from the immediate "exile it" zone-move.
+/// "its owner's graveyard" / "a player's graveyard" / "your graveyard" are leaf
+/// variants of the same slot. The trailing "as it resolves" is the
+/// resolution-timing marker that distinguishes this from the immediate
+/// "exile it" zone-move.
 fn try_parse_exile_resolving_spell_instead_of_graveyard(lower: &str) -> bool {
     use nom::branch::alt;
     use nom::bytes::complete::tag;
@@ -16690,6 +16697,7 @@ fn try_parse_exile_resolving_spell_instead_of_graveyard(lower: &str) -> bool {
             tag("its owner's graveyard"),
             tag("a player's graveyard"),
             tag("their graveyard"),
+            tag("your graveyard"),
         )),
         tag(" as it resolves"),
     ))
@@ -22118,7 +22126,7 @@ fn chain_clause_is_exile_producer(effect: &Effect) -> bool {
         )
         || matches!(effect, Effect::HeistExile)
         || matches!(effect, Effect::ExileHaunting { .. })
-        || matches!(effect, Effect::ExileResolvingSpellInsteadOfGraveyard)
+        || matches!(effect, Effect::ExileResolvingSpellInsteadOfGraveyard { .. })
         || matches!(
             effect,
             Effect::RevealUntil {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7275,6 +7275,23 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     if let Some(effect) = try_parse_cant_become_untapped_target_rider(&lower) {
         return parsed_clause(effect);
     }
+    // CR 702.170c: "it becomes plotted" / "that card becomes plotted" as a
+    // standalone anaphoric clause — the exiled card becomes plotted. The
+    // sequence splitter's continuation path only patches this onto a directly
+    // preceding Exile `ChangeZone`; when the designation stands alone (e.g. as
+    // the body of an "if you do, it becomes plotted" reflexive rider — Lilah,
+    // Undefeated Slickshot), it reaches this dispatch instead and must lower to
+    // the Plotted casting-permission grant rather than falling through to
+    // `Effect::Unimplemented`. The anaphoric "it" binds to the parent target
+    // (falling back to the source), granted to the card's owner (CR 702.170d),
+    // matching `ContinuationAst::BecomesPlotted`.
+    if try_parse_becomes_plotted_clause(&lower) {
+        return parsed_clause(Effect::GrantCastingPermission {
+            permission: CastingPermission::Plotted { turn_plotted: 0 },
+            target: TargetFilter::ParentTarget,
+            grantee: crate::types::ability::PermissionGrantee::ObjectOwner,
+        });
+    }
     // CR 614.1a + CR 608.2n + CR 607.2b: "exile it instead of putting it into a
     // graveyard as it resolves" — the resolving-spell exile rider applied by a
     // `WhenAPlayerCasts` trigger to the triggering spell (Rod of Absorption).
@@ -7282,11 +7299,11 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     // to a no-op `ChangeZone { origin: Graveyard }` that never finds the spell
     // (it is on the stack, not in a graveyard, when the trigger resolves).
     if try_parse_exile_resolving_spell_instead_of_graveyard(&lower) {
-        // CR 603.7a: the Feather-class "If you do, return it to your hand at the
-        // beginning of the next end step" rider is folded onto `then_return`
-        // later by `fold_exile_resolving_return_rider` in the assembly pass; the
-        // bare clause always lowers with no return rider.
-        return parsed_clause(Effect::ExileResolvingSpellInsteadOfGraveyard { then_return: None });
+        // CR 603.7a + CR 702.170c: the "If you do, ..." continuation (Feather's
+        // return-to-hand, Lilah's become-plotted) is folded onto `on_exile`
+        // later by `fold_exile_resolving_rider` in the assembly pass; the bare
+        // clause always lowers with no consequence rider.
+        return parsed_clause(Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile: None });
     }
     // CR 614.1a + CR 514.2: Global "If [source] would deal damage this turn,
     // it deals that much damage plus N instead" pattern (Rankle and Torbran,
@@ -16701,6 +16718,33 @@ fn try_parse_exile_resolving_spell_instead_of_graveyard(lower: &str) -> bool {
         )),
         tag(" as it resolves"),
     ))
+    .parse(trimmed)
+    .is_ok()
+}
+
+/// CR 702.170c: Detect a standalone anaphoric "becomes plotted" designation
+/// clause — "it becomes plotted" / "that {card,spell} becomes plotted" / "they
+/// become plotted". The exiled card is designated plotted (castable from exile
+/// without paying its mana cost on a later turn, CR 702.170d).
+///
+/// Mirrors the tag set of `sequence::parse_becomes_plotted_continuation` (the
+/// continuation-patch path used after an Exile `ChangeZone`); this standalone
+/// form covers the same designation when it is NOT a continuation — e.g. the
+/// body of an "if you do, it becomes plotted" reflexive rider (Lilah). The "if
+/// you do" gate is stripped before this runs (it becomes the sub-ability's
+/// condition), so no optional-prefix arm is needed here.
+fn try_parse_becomes_plotted_clause(lower: &str) -> bool {
+    use nom::branch::alt;
+    use nom::bytes::complete::tag;
+    use nom::combinator::{all_consuming, value};
+    use nom::Parser;
+    let trimmed = lower.trim().trim_end_matches('.').trim();
+    all_consuming(alt((
+        value((), tag::<_, _, OracleError<'_>>("it becomes plotted")),
+        value((), tag("that card becomes plotted")),
+        value((), tag("that spell becomes plotted")),
+        value((), tag("they become plotted")),
+    )))
     .parse(trimmed)
     .is_ok()
 }

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -5869,7 +5869,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::CreateEmblem { .. }
         | Effect::CastFromZone { .. }
         | Effect::FreeCastFromZones { .. }
-        | Effect::ExileResolvingSpellInsteadOfGraveyard
+        | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
         | Effect::PreventDamage { .. }
         | Effect::CreateDamageReplacement { .. }
         | Effect::CreateDrawReplacement { .. }

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -1308,7 +1308,7 @@ fn stamp_effect_printed_slot(effect: &mut Effect, slot: usize, kind: PrintedItem
         Effect::PayCost { .. } => {}
         Effect::CastFromZone { .. } => {}
         Effect::FreeCastFromZones { .. } => {}
-        Effect::ExileResolvingSpellInsteadOfGraveyard => {}
+        Effect::ExileResolvingSpellInsteadOfGraveyard { .. } => {}
         Effect::PreventDamage { .. } => {}
         Effect::CreateDamageReplacement { .. } => {}
         // Nested-definition boundary — intentionally NOT recursed. Both carry a

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -1423,9 +1423,9 @@ fn effect_is_replacement_carrier(effect: &Effect) -> bool {
         | Effect::CreatePlaneswalkReplacement { .. }
         // CR 614.1a + CR 608.2n: "exile it instead of putting it into its owner's
         // graveyard" replaces the CR 608.2n graveyard-put default — the variant
-        // name IS the replacement, with or without the `then_return` rider (the
-        // Feather return-rider parameterization is a second replacement folded
-        // into the same carrier, so it stays exempt either way).
+        // name IS the replacement, with or without the `on_exile` rider (the
+        // Feather return / Lilah plot parameterization is a second consequence
+        // folded into the same carrier, so it stays exempt either way).
         | Effect::ExileResolvingSpellInsteadOfGraveyard { .. } => true,
         _ => false,
     }
@@ -2646,52 +2646,52 @@ fn dig_if_you_do_is_only_if_marker(stripped: &str) -> bool {
     !(has_if_marker && !has_as_if_marker && !has_even_if_marker)
 }
 
-/// CR 603.7a + CR 608.2c: the Feather, the Redeemed class carries a
-/// `then_return` rider on `Effect::ExileResolvingSpellInsteadOfGraveyard`
-/// representing "If you do, return it to your hand at the beginning of the next
-/// end step". `then_return: Some(_)` means the return clause is modelled (the
-/// riderless Rod of Absorption form is `None` and has no "if you do" text to
-/// account for).
-fn any_ability_has_exile_resolving_return_rider(parsed: &ParsedAbilities) -> bool {
+/// CR 603.7a + CR 608.2c + CR 702.170c: the exile-instead carrier
+/// (`Effect::ExileResolvingSpellInsteadOfGraveyard`) carries an `on_exile`
+/// rider representing the "If you do, ..." consequence — Feather, the Redeemed's
+/// "return it to your hand at the beginning of the next end step" or Lilah,
+/// Undefeated Slickshot's "it becomes plotted". `on_exile: Some(_)` means the
+/// consequence clause is modelled (the riderless Rod of Absorption form is
+/// `None` and has no "if you do" text to account for).
+fn any_ability_has_exile_resolving_rider(parsed: &ParsedAbilities) -> bool {
     parsed.triggers.iter().any(|t| {
         t.execute
             .as_deref()
-            .is_some_and(def_tree_has_exile_resolving_return_rider)
+            .is_some_and(def_tree_has_exile_resolving_rider)
     }) || parsed
         .abilities
         .iter()
-        .any(def_tree_has_exile_resolving_return_rider)
+        .any(def_tree_has_exile_resolving_rider)
 }
 
-fn def_tree_has_exile_resolving_return_rider(def: &AbilityDefinition) -> bool {
+fn def_tree_has_exile_resolving_rider(def: &AbilityDefinition) -> bool {
     if matches!(
         &*def.effect,
-        Effect::ExileResolvingSpellInsteadOfGraveyard {
-            then_return: Some(_)
-        }
+        Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile: Some(_) }
     ) {
         return true;
     }
     if let Some(ref sub) = def.sub_ability {
-        if def_tree_has_exile_resolving_return_rider(sub) {
+        if def_tree_has_exile_resolving_rider(sub) {
             return true;
         }
     }
     if let Some(ref else_ab) = def.else_ability {
-        if def_tree_has_exile_resolving_return_rider(else_ab) {
+        if def_tree_has_exile_resolving_rider(else_ab) {
             return true;
         }
     }
     def.mode_abilities
         .iter()
-        .any(def_tree_has_exile_resolving_return_rider)
+        .any(def_tree_has_exile_resolving_rider)
 }
 
-/// CR 608.2c: the "if you do" linking Feather's return to its exile is a
-/// back-reference, not an independent game-state condition — represented by the
-/// `then_return` rider. Suppress only when "if you do" is the sole bare "if"
-/// marker left in the classified text (mirrors `dig_if_you_do_is_only_if_marker`).
-fn exile_resolving_return_if_you_do_is_only_if_marker(stripped: &str) -> bool {
+/// CR 608.2c: the "if you do" linking the exile-instead consequence (Feather's
+/// return, Lilah's plot) to its exile is a back-reference, not an independent
+/// game-state condition — represented by the `on_exile` rider. Suppress only
+/// when "if you do" is the sole bare "if" marker left in the classified text
+/// (mirrors `dig_if_you_do_is_only_if_marker`).
+fn exile_resolving_rider_if_you_do_is_only_if_marker(stripped: &str) -> bool {
     // allow-noncombinator: swallow detector marker scan on classified text
     if !stripped.contains("if you do") {
         return false;
@@ -3103,16 +3103,17 @@ fn detect_condition_if(
     if any_optional_ability_has_dig(parsed) && dig_if_you_do_is_only_if_marker(&stripped) {
         return;
     }
-    // CR 603.7a + CR 608.2c: "exile that card instead of putting it into your
-    // graveyard as it resolves. If you do, return it to your hand at the
-    // beginning of the next end step" (Feather, the Redeemed). The "if you do"
-    // is the CR 608.2c back-reference linking the return to the exile actually
-    // being applied — represented by the typed `then_return` rider on
-    // `Effect::ExileResolvingSpellInsteadOfGraveyard` (the one-shot return
-    // trigger is armed only when the replacement applies). Not a swallowed
-    // game-state condition.
-    if any_ability_has_exile_resolving_return_rider(parsed)
-        && exile_resolving_return_if_you_do_is_only_if_marker(&stripped)
+    // CR 603.7a + CR 608.2c + CR 702.170c: "exile that {card,spell} instead of
+    // putting it into your graveyard as it resolves. If you do, [return it to
+    // your hand at the beginning of the next end step | it becomes plotted]"
+    // (Feather, the Redeemed / Lilah, Undefeated Slickshot). The "if you do" is
+    // the CR 608.2c back-reference linking the consequence to the exile actually
+    // being applied — represented by the typed `on_exile` rider on
+    // `Effect::ExileResolvingSpellInsteadOfGraveyard` (the consequence is
+    // applied only when the replacement applies). Not a swallowed game-state
+    // condition.
+    if any_ability_has_exile_resolving_rider(parsed)
+        && exile_resolving_rider_if_you_do_is_only_if_marker(&stripped)
     {
         return;
     }
@@ -4609,9 +4610,9 @@ mod tests {
 
     /// CR 603.7a + CR 608.2c: Feather, the Redeemed's "If you do, return it to
     /// your hand at the beginning of the next end step" is represented by the
-    /// `then_return` rider on `Effect::ExileResolvingSpellInsteadOfGraveyard`,
+    /// `on_exile` rider on `Effect::ExileResolvingSpellInsteadOfGraveyard`,
     /// so Detector G must NOT flag it as a swallowed `Condition_If`. Reverting
-    /// the `any_ability_has_exile_resolving_return_rider` exemption re-fires the
+    /// the `any_ability_has_exile_resolving_rider` exemption re-fires the
     /// swallow (the coverage-honesty regression this guards against).
     #[test]
     fn feather_return_rider_is_not_a_swallowed_condition_if() {
@@ -4625,6 +4626,29 @@ mod tests {
         assert!(
             !has_swallowed_detector(&parsed, "Condition_If"),
             "Feather's folded return rider must not surface as a swallowed Condition_If: {:?}",
+            parsed.parse_warnings
+        );
+    }
+
+    /// CR 702.170c + CR 608.2c: Lilah, Undefeated Slickshot's "If you do, it
+    /// becomes plotted" folds onto the same `on_exile` rider (as
+    /// `ExiledSpellRider::BecomePlotted`), so — like Feather — Detector G must
+    /// NOT flag its "if you do" as a swallowed `Condition_If`. This guards the
+    /// coverage-honesty regression that the plot-grant fold could otherwise
+    /// introduce (the folded grant leaves no `GrantCastingPermission { Plotted }`
+    /// node for the `any_ability_has_plotted_grant` suppression to see).
+    #[test]
+    fn lilah_plotted_rider_is_not_a_swallowed_condition_if() {
+        let parsed = parse_named(
+            "Prowess\nWhenever you cast a multicolored instant or sorcery spell from your hand, \
+             exile that spell instead of putting it into your graveyard as it resolves. If you \
+             do, it becomes plotted.",
+            "Lilah, Undefeated Slickshot",
+            &["Legendary", "Creature"],
+        );
+        assert!(
+            !has_swallowed_detector(&parsed, "Condition_If"),
+            "Lilah's folded plotted rider must not surface as a swallowed Condition_If: {:?}",
             parsed.parse_warnings
         );
     }

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -2646,6 +2646,63 @@ fn dig_if_you_do_is_only_if_marker(stripped: &str) -> bool {
     !(has_if_marker && !has_as_if_marker && !has_even_if_marker)
 }
 
+/// CR 603.7a + CR 608.2c: the Feather, the Redeemed class carries a
+/// `then_return` rider on `Effect::ExileResolvingSpellInsteadOfGraveyard`
+/// representing "If you do, return it to your hand at the beginning of the next
+/// end step". `then_return: Some(_)` means the return clause is modelled (the
+/// riderless Rod of Absorption form is `None` and has no "if you do" text to
+/// account for).
+fn any_ability_has_exile_resolving_return_rider(parsed: &ParsedAbilities) -> bool {
+    parsed.triggers.iter().any(|t| {
+        t.execute
+            .as_deref()
+            .is_some_and(def_tree_has_exile_resolving_return_rider)
+    }) || parsed
+        .abilities
+        .iter()
+        .any(def_tree_has_exile_resolving_return_rider)
+}
+
+fn def_tree_has_exile_resolving_return_rider(def: &AbilityDefinition) -> bool {
+    if matches!(
+        &*def.effect,
+        Effect::ExileResolvingSpellInsteadOfGraveyard {
+            then_return: Some(_)
+        }
+    ) {
+        return true;
+    }
+    if let Some(ref sub) = def.sub_ability {
+        if def_tree_has_exile_resolving_return_rider(sub) {
+            return true;
+        }
+    }
+    if let Some(ref else_ab) = def.else_ability {
+        if def_tree_has_exile_resolving_return_rider(else_ab) {
+            return true;
+        }
+    }
+    def.mode_abilities
+        .iter()
+        .any(def_tree_has_exile_resolving_return_rider)
+}
+
+/// CR 608.2c: the "if you do" linking Feather's return to its exile is a
+/// back-reference, not an independent game-state condition — represented by the
+/// `then_return` rider. Suppress only when "if you do" is the sole bare "if"
+/// marker left in the classified text (mirrors `dig_if_you_do_is_only_if_marker`).
+fn exile_resolving_return_if_you_do_is_only_if_marker(stripped: &str) -> bool {
+    // allow-noncombinator: swallow detector marker scan on classified text
+    if !stripped.contains("if you do") {
+        return false;
+    }
+    let without_link = stripped.replace("if you do", "");
+    let has_if_marker = without_link.contains(" if "); // allow-noncombinator: swallow detector marker scan on classified text
+    let has_as_if_marker = without_link.contains(" as if "); // allow-noncombinator: swallow detector marker scan on classified text
+    let has_even_if_marker = without_link.contains(" even if "); // allow-noncombinator: swallow detector marker scan on classified text
+    !(has_if_marker && !has_as_if_marker && !has_even_if_marker)
+}
+
 /// CR 614.12: "[you may] put a creature card from your hand onto the
 /// battlefield. If that card is an enchantment card, it enters tapped and
 /// attacking." (Summoner's Grimoire). The leading moved-object type condition
@@ -3044,6 +3101,19 @@ fn detect_condition_if(
     // same `Dig`; the "if you do" linkage IS represented by the optional `Dig`
     // (declining the look stops the whole chain), not swallowed.
     if any_optional_ability_has_dig(parsed) && dig_if_you_do_is_only_if_marker(&stripped) {
+        return;
+    }
+    // CR 603.7a + CR 608.2c: "exile that card instead of putting it into your
+    // graveyard as it resolves. If you do, return it to your hand at the
+    // beginning of the next end step" (Feather, the Redeemed). The "if you do"
+    // is the CR 608.2c back-reference linking the return to the exile actually
+    // being applied — represented by the typed `then_return` rider on
+    // `Effect::ExileResolvingSpellInsteadOfGraveyard` (the one-shot return
+    // trigger is armed only when the replacement applies). Not a swallowed
+    // game-state condition.
+    if any_ability_has_exile_resolving_return_rider(parsed)
+        && exile_resolving_return_if_you_do_is_only_if_marker(&stripped)
+    {
         return;
     }
     // CR 614.12: "[you may] put a creature card ... If that card is an
@@ -4534,6 +4604,28 @@ mod tests {
         assert_eq!(
             items[0], items[1],
             "both findings came from ONE unit, so they carry ONE evidence set",
+        );
+    }
+
+    /// CR 603.7a + CR 608.2c: Feather, the Redeemed's "If you do, return it to
+    /// your hand at the beginning of the next end step" is represented by the
+    /// `then_return` rider on `Effect::ExileResolvingSpellInsteadOfGraveyard`,
+    /// so Detector G must NOT flag it as a swallowed `Condition_If`. Reverting
+    /// the `any_ability_has_exile_resolving_return_rider` exemption re-fires the
+    /// swallow (the coverage-honesty regression this guards against).
+    #[test]
+    fn feather_return_rider_is_not_a_swallowed_condition_if() {
+        let parsed = parse_named(
+            "Flying\nWhenever you cast an instant or sorcery spell that targets a creature you \
+             control, exile that card instead of putting it into your graveyard as it resolves. \
+             If you do, return it to your hand at the beginning of the next end step.",
+            "Feather, the Redeemed",
+            &["Legendary", "Creature"],
+        );
+        assert!(
+            !has_swallowed_detector(&parsed, "Condition_If"),
+            "Feather's folded return rider must not surface as a swallowed Condition_If: {:?}",
+            parsed.parse_warnings
         );
     }
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -1421,9 +1421,12 @@ fn effect_is_replacement_carrier(effect: &Effect) -> bool {
         // CR 614.1a + CR 901.9c: "if a player would planeswalk as a result of rolling
         // the planar die, [effect] instead" (Fixed Point in Time).
         | Effect::CreatePlaneswalkReplacement { .. }
-        // CR 608.2m: "exile it instead of putting it into its owner's graveyard" — the
-        // variant name IS the replacement, and it takes no parameters to inspect.
-        | Effect::ExileResolvingSpellInsteadOfGraveyard => true,
+        // CR 614.1a + CR 608.2n: "exile it instead of putting it into its owner's
+        // graveyard" replaces the CR 608.2n graveyard-put default — the variant
+        // name IS the replacement, with or without the `then_return` rider (the
+        // Feather return-rider parameterization is a second replacement folded
+        // into the same carrier, so it stays exempt either way).
+        | Effect::ExileResolvingSpellInsteadOfGraveyard { .. } => true,
         _ => false,
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -9408,6 +9408,25 @@ pub enum EntryAttackDestination {
     },
 }
 
+/// CR 603.7a + CR 400.7: rider on the "exile [the resolving spell] instead of
+/// putting it into a graveyard as it resolves" replacement
+/// (`Effect::ExileResolvingSpellInsteadOfGraveyard`) — after the spell is
+/// actually exiled, return it to `destination` at `timing`. `None` on the
+/// carrier = plain exile with no return (Rod of Absorption). `Some` = the
+/// Feather, the Redeemed class (`Zone::Hand`, `AtNextPhase { End }`). The two
+/// axes (destination zone, return timing) are typed so a future class member
+/// ("return it to the battlefield" / "at the beginning of the next upkeep")
+/// is a parameter value, not a new variant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExiledSpellReturn {
+    /// CR 603.7a: zone the exiled card is returned to when the delayed trigger
+    /// fires (Feather: its owner's hand).
+    pub destination: Zone,
+    /// CR 603.7b: when the one-shot return trigger fires (Feather: at the
+    /// beginning of the next end step).
+    pub timing: DelayedTriggerCondition,
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, strum::IntoStaticStr)]
 #[serde(tag = "type")]
@@ -11345,7 +11364,20 @@ pub enum Effect {
     /// (which stamps the same rider on a spell *cast during resolution*, with no
     /// linked-exile payoff). This effect is the trigger-driven, link-establishing
     /// form for the resolving spell itself.
-    ExileResolvingSpellInsteadOfGraveyard,
+    ExileResolvingSpellInsteadOfGraveyard {
+        /// CR 614.1a + CR 603.7a: "If you do, return it to your hand at the
+        /// beginning of the next end step" (Feather, the Redeemed). When
+        /// `Some`, the stamped rider also marks the spell so that — at the
+        /// moment the replacement is actually applied and the spell lands in
+        /// exile — the stack router arms a one-shot delayed trigger returning
+        /// the exiled card to the rider's `destination` at its `timing`.
+        /// The delayed trigger is created when the replacement is APPLIED
+        /// (CR 603.7a), not when this effect resolves, so a spell countered in
+        /// response never arms a return. `None` = plain exile, no return
+        /// (Rod of Absorption).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        then_return: Option<ExiledSpellReturn>,
+    },
     /// CR 615: Prevent damage to a target.
     PreventDamage {
         amount: PreventionAmount,
@@ -13902,7 +13934,7 @@ impl Effect {
             | Effect::FreeCastFromZones { .. }
             // CR 614.1a: acts on the triggering spell (the trigger source), not a
             // player-declared target.
-            | Effect::ExileResolvingSpellInsteadOfGraveyard
+            | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
             | Effect::Manifest { .. }
             | Effect::ManifestDread
             | Effect::Cloak { .. }
@@ -14248,7 +14280,7 @@ impl Effect {
             | Effect::ExchangeLifeWithStat { .. }
             | Effect::ExchangeLifeTotals { .. }
             | Effect::ExileFromTopUntil { .. }
-            | Effect::ExileResolvingSpellInsteadOfGraveyard
+            | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
             | Effect::FlipCoin { .. }
             | Effect::FlipCoinUntilLose { .. }
             | Effect::Forage
@@ -14500,7 +14532,7 @@ impl Effect {
             | Effect::ExchangeLifeWithStat { .. }
             | Effect::ExchangeLifeTotals { .. }
             | Effect::ExileFromTopUntil { .. }
-            | Effect::ExileResolvingSpellInsteadOfGraveyard
+            | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
             | Effect::FlipCoin { .. }
             | Effect::FlipCoinUntilLose { .. }
             | Effect::Forage
@@ -14688,7 +14720,9 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::PayCost { .. } => "PayCost",
         Effect::CastFromZone { .. } => "CastFromZone",
         Effect::FreeCastFromZones { .. } => "FreeCastFromZones",
-        Effect::ExileResolvingSpellInsteadOfGraveyard => "ExileResolvingSpellInsteadOfGraveyard",
+        Effect::ExileResolvingSpellInsteadOfGraveyard { .. } => {
+            "ExileResolvingSpellInsteadOfGraveyard"
+        }
         Effect::PreventDamage { .. } => "PreventDamage",
         Effect::CreateDamageReplacement { .. } => "CreateDamageReplacement",
         Effect::CreateDrawReplacement { .. } => "CreateDrawReplacement",
@@ -15189,7 +15223,7 @@ impl From<&Effect> for EffectKind {
             Effect::PayCost { .. } => EffectKind::PayCost,
             Effect::CastFromZone { .. } => EffectKind::CastFromZone,
             Effect::FreeCastFromZones { .. } => EffectKind::FreeCastFromZones,
-            Effect::ExileResolvingSpellInsteadOfGraveyard => {
+            Effect::ExileResolvingSpellInsteadOfGraveyard { .. } => {
                 EffectKind::ExileResolvingSpellInsteadOfGraveyard
             }
             Effect::PreventDamage { .. } => EffectKind::PreventDamage,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -9408,23 +9408,41 @@ pub enum EntryAttackDestination {
     },
 }
 
-/// CR 603.7a + CR 400.7: rider on the "exile [the resolving spell] instead of
-/// putting it into a graveyard as it resolves" replacement
-/// (`Effect::ExileResolvingSpellInsteadOfGraveyard`) — after the spell is
-/// actually exiled, return it to `destination` at `timing`. `None` on the
-/// carrier = plain exile with no return (Rod of Absorption). `Some` = the
-/// Feather, the Redeemed class (`Zone::Hand`, `AtNextPhase { End }`). The two
-/// axes (destination zone, return timing) are typed so a future class member
-/// ("return it to the battlefield" / "at the beginning of the next upkeep")
-/// is a parameter value, not a new variant.
+/// CR 603.7a + CR 702.170c: the "If you do, ..." consequence of the
+/// "exile [the resolving spell] instead of putting it into a graveyard as it
+/// resolves" replacement (`Effect::ExileResolvingSpellInsteadOfGraveyard`),
+/// applied ONLY at the moment the replacement is actually applied — i.e. when
+/// the spell lands in exile during its own stack resolution. A spell countered
+/// or fizzled in response never reaches the exile-instead move, so it never
+/// takes the rider (CR 603.7a: a consequence created "as the result of a
+/// replacement effect being applied" exists only once the replacement applies).
+///
+/// `None` on the carrier = plain exile with no consequence (Rod of Absorption).
+/// The two members are distinct post-application actions on the exiled card, so
+/// they are a sum type, not a struct with more fields — but both live within the
+/// same CR 603.7a application moment.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ExiledSpellReturn {
-    /// CR 603.7a: zone the exiled card is returned to when the delayed trigger
-    /// fires (Feather: its owner's hand).
-    pub destination: Zone,
-    /// CR 603.7b: when the one-shot return trigger fires (Feather: at the
-    /// beginning of the next end step).
-    pub timing: DelayedTriggerCondition,
+pub enum ExiledSpellRider {
+    /// CR 603.7a + CR 603.7b: Feather, the Redeemed — "return it to your hand
+    /// at the beginning of the next end step". Arms a one-shot delayed trigger
+    /// returning the exiled card to `destination` at `timing`. The two axes are
+    /// typed so a future class member ("return it to the battlefield" / "at the
+    /// beginning of the next upkeep") is a parameter value, not a new variant.
+    ReturnTo {
+        /// CR 603.7a: zone the exiled card is returned to when the delayed
+        /// trigger fires (Feather: its owner's hand).
+        destination: Zone,
+        /// CR 603.7b: when the one-shot return trigger fires (Feather: at the
+        /// beginning of the next end step).
+        timing: DelayedTriggerCondition,
+    },
+    /// CR 702.170c: Lilah, Undefeated Slickshot — "it becomes plotted". Grants
+    /// the Plotted casting permission to the exiled card's owner and emits
+    /// `BecomesPlotted`, so the card is castable from exile without paying its
+    /// mana cost on a later turn (CR 702.170d). Because plotting requires the
+    /// card to already be in exile (CR 702.170c), this too must run only at
+    /// replacement-application time — never when the trigger resolves.
+    BecomePlotted,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -11365,18 +11383,20 @@ pub enum Effect {
     /// linked-exile payoff). This effect is the trigger-driven, link-establishing
     /// form for the resolving spell itself.
     ExileResolvingSpellInsteadOfGraveyard {
-        /// CR 614.1a + CR 603.7a: "If you do, return it to your hand at the
-        /// beginning of the next end step" (Feather, the Redeemed). When
+        /// CR 614.1a + CR 603.7a + CR 702.170c: the "If you do, ..."
+        /// consequence of the exile-instead replacement (Feather, the
+        /// Redeemed's "return it to your hand at the beginning of the next end
+        /// step"; Lilah, Undefeated Slickshot's "it becomes plotted"). When
         /// `Some`, the stamped rider also marks the spell so that — at the
         /// moment the replacement is actually applied and the spell lands in
-        /// exile — the stack router arms a one-shot delayed trigger returning
-        /// the exiled card to the rider's `destination` at its `timing`.
-        /// The delayed trigger is created when the replacement is APPLIED
-        /// (CR 603.7a), not when this effect resolves, so a spell countered in
-        /// response never arms a return. `None` = plain exile, no return
+        /// exile — the stack router applies the rider (arming Feather's return
+        /// delayed trigger, or granting Lilah's plotted permission). The
+        /// consequence is applied when the replacement is APPLIED (CR 603.7a),
+        /// not when this effect resolves, so a spell countered or fizzled in
+        /// response never takes it. `None` = plain exile, no consequence
         /// (Rod of Absorption).
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        then_return: Option<ExiledSpellReturn>,
+        on_exile: Option<ExiledSpellRider>,
     },
     /// CR 615: Prevent damage to a target.
     PreventDamage {

--- a/crates/engine/tests/integration/issue_4825_feather_the_redeemed.rs
+++ b/crates/engine/tests/integration/issue_4825_feather_the_redeemed.rs
@@ -1,0 +1,484 @@
+//! Regression: GitHub issue #4825 — Feather, the Redeemed.
+//!
+//! Oracle:
+//!   "Flying
+//!    Whenever you cast an instant or sorcery spell that targets a creature you
+//!    control, exile that card instead of putting it into your graveyard as it
+//!    resolves. If you do, return it to your hand at the beginning of the next
+//!    end step."
+//!
+//! Defect: targeted instants/sorceries went to the graveyard instead of being
+//! exiled and returned at the next end step. Clause 1 lowered to a no-op
+//! `ChangeZone { origin: Graveyard }` (the spell is on the Stack when the
+//! trigger resolves, so the CR 400.7 origin guard skipped the move) and the
+//! spell then took the CR 608.2n graveyard default.
+//!
+//! Fix (class: "exile the resolving spell instead of putting it into a
+//! graveyard as it resolves", optionally with "return it at the next end
+//! step"):
+//!   - the parser gate for `Effect::ExileResolvingSpellInsteadOfGraveyard`
+//!     accepts the "your graveyard" determiner (CR 614.1a);
+//!   - the "If you do, return it …" rider folds onto the carrier as the typed
+//!     `then_return: Some(ExiledSpellReturn { destination: Hand, timing:
+//!     AtNextPhase { End } })` rider (CR 603.7a + CR 608.2c);
+//!   - the return delayed trigger is armed only when the replacement is
+//!     actually APPLIED (the spell lands in exile during its own stack
+//!     resolution), per CR 603.7a — so a spell countered in response never
+//!     arms a return.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{AbilityDefinition, DelayedTriggerCondition, Effect};
+use engine::types::actions::GameAction;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const FEATHER_TEXT: &str = "Flying\nWhenever you cast an instant or sorcery spell that targets a \
+     creature you control, exile that card instead of putting it into your graveyard as it \
+     resolves. If you do, return it to your hand at the beginning of the next end step.";
+
+/// Feather's trigger body without the second-sentence return rider — the
+/// riderless form of the same class (Rod-shaped, "your graveyard" determiner).
+const FEATHER_RIDERLESS_TEXT: &str = "Whenever you cast an instant or sorcery spell that targets \
+     a creature you control, exile that card instead of putting it into your graveyard as it \
+     resolves.";
+
+/// Rod of Absorption's exile clause (regression guard for the pre-existing
+/// riderless class — see issue_2359_rod_of_absorption.rs for its runtime tests).
+const ROD_TEXT: &str = "Whenever a player casts an instant or sorcery spell, exile it instead of \
+     putting it into a graveyard as it resolves.\n{X}, {T}, Sacrifice this artifact: You may cast \
+     any number of spells from among cards exiled with this artifact with total mana value X or \
+     less without paying their mana costs.";
+
+/// Walk a def tree (sub/else chains AND `CreateDelayedTrigger` inner bodies)
+/// checking whether any node's effect matches the predicate.
+fn tree_any(def: &AbilityDefinition, pred: &dyn Fn(&Effect) -> bool) -> bool {
+    if pred(&def.effect) {
+        return true;
+    }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if tree_any(effect, pred) {
+            return true;
+        }
+    }
+    def.sub_ability
+        .as_deref()
+        .is_some_and(|s| tree_any(s, pred))
+        || def
+            .else_ability
+            .as_deref()
+            .is_some_and(|e| tree_any(e, pred))
+}
+
+/// SHAPE: the full Feather text lowers to ONE cast trigger whose entire body is
+/// the parameterized carrier — the return rider is the typed `then_return`
+/// payload, not an eagerly created `CreateDelayedTrigger` (CR 603.7a: the
+/// delayed trigger must be created when the replacement is APPLIED, not when
+/// Feather's trigger resolves).
+#[test]
+fn feather_parses_return_rider_onto_exile_flag() {
+    let parsed = parse_oracle_text(
+        FEATHER_TEXT,
+        "Feather, the Redeemed",
+        &["Flying".to_string()],
+        &["Creature".to_string()],
+        &["Bird".to_string(), "Soldier".to_string()],
+    );
+
+    assert_eq!(
+        parsed.triggers.len(),
+        1,
+        "expected exactly one cast trigger, got {:?}",
+        parsed.triggers
+    );
+    let execute = parsed.triggers[0]
+        .execute
+        .as_deref()
+        .expect("the cast trigger must have an execute body");
+
+    // Positive reach-guard: the body parsed to the exact carrier with the
+    // rider folded in (this also proves the parse did not degrade to
+    // Effect::Unimplemented, so the negative assertions below are non-vacuous).
+    match &*execute.effect {
+        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } => {
+            let rider = then_return
+                .as_ref()
+                .expect("the 'If you do, return it …' rider must fold onto the carrier");
+            assert_eq!(
+                rider.destination,
+                Zone::Hand,
+                "the rider returns the exiled card to its owner's hand"
+            );
+            assert_eq!(
+                rider.timing,
+                DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+                "the rider fires at the beginning of the next end step"
+            );
+        }
+        other => panic!("expected ExileResolvingSpellInsteadOfGraveyard, got {other:?}"),
+    }
+    assert!(
+        execute.sub_ability.is_none(),
+        "the folded rider must leave no residual sub-ability: {:?}",
+        execute.sub_ability
+    );
+    assert!(
+        !tree_any(execute, &|e| matches!(
+            e,
+            Effect::CreateDelayedTrigger { .. }
+        )),
+        "no eager CreateDelayedTrigger may remain anywhere in the chain (CR 603.7a)"
+    );
+    assert!(
+        !tree_any(execute, &|e| matches!(e, Effect::Unimplemented { .. })),
+        "the folded chain must contain no Unimplemented node"
+    );
+}
+
+/// SHAPE: the riderless clause (no second sentence) keeps the rider absent.
+#[test]
+fn feather_riderless_clause_parses_with_flag_off() {
+    let parsed = parse_oracle_text(
+        FEATHER_RIDERLESS_TEXT,
+        "Riderless Feather",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    assert_eq!(parsed.triggers.len(), 1, "triggers: {:?}", parsed.triggers);
+    let execute = parsed.triggers[0]
+        .execute
+        .as_deref()
+        .expect("the cast trigger must have an execute body");
+    match &*execute.effect {
+        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } => assert!(
+            then_return.is_none(),
+            "without the return sentence the rider must stay absent"
+        ),
+        other => panic!("expected ExileResolvingSpellInsteadOfGraveyard, got {other:?}"),
+    }
+    assert!(execute.sub_ability.is_none());
+}
+
+/// SHAPE regression: Rod of Absorption's clause (no return rider) still lowers
+/// with no rider — the Feather parameterization must not disturb the
+/// pre-existing riderless class.
+#[test]
+fn rod_of_absorption_clause_keeps_flag_off() {
+    let parsed = parse_oracle_text(
+        ROD_TEXT,
+        "Rod of Absorption",
+        &[],
+        &["Artifact".to_string()],
+        &[],
+    );
+    let execute = parsed
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_deref())
+        .expect("Rod must have a cast trigger with an execute body");
+    match &*execute.effect {
+        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } => assert!(
+            then_return.is_none(),
+            "Rod has no return rider; the rider must stay absent"
+        ),
+        other => panic!("expected ExileResolvingSpellInsteadOfGraveyard, got {other:?}"),
+    }
+}
+
+/// SHAPE (serde compat): the unit→struct parameterization must keep old
+/// card-data records deserializing (`{"type":"…"}` with no field → rider
+/// `None`) and keep the riderless form's serialization byte-identical (the
+/// rider is `skip_serializing_if` when `None`), so Rod of Absorption's
+/// exported record does not change. The Feather form must round-trip its
+/// typed rider.
+#[test]
+fn exile_resolving_effect_serde_stays_compatible() {
+    let old_record = r#"{"type":"ExileResolvingSpellInsteadOfGraveyard"}"#;
+    let effect: Effect = serde_json::from_str(old_record).expect("old unit-variant record");
+    assert!(matches!(
+        effect,
+        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return: None }
+    ));
+    let reserialized = serde_json::to_string(&effect).expect("serialize");
+    assert_eq!(
+        reserialized, old_record,
+        "riderless serialization must stay byte-identical to the pre-change record"
+    );
+
+    // Round-trip the Feather form: the typed rider must survive serde intact.
+    let feather = Effect::ExileResolvingSpellInsteadOfGraveyard {
+        then_return: Some(engine::types::ability::ExiledSpellReturn {
+            destination: Zone::Hand,
+            timing: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+        }),
+    };
+    let json = serde_json::to_string(&feather).expect("serialize Feather form");
+    let back: Effect = serde_json::from_str(&json).expect("round-trip Feather form");
+    assert_eq!(back, feather, "the typed rider must round-trip losslessly");
+}
+
+/// Positive runtime path: a targeted instant resolves, is exiled instead of
+/// going to the graveyard (CR 614.1a), and returns to its owner's hand at the
+/// beginning of the next end step (CR 603.7a), with the one-shot delayed
+/// trigger consumed (CR 603.7b).
+#[test]
+fn feather_exiles_targeted_spell_and_returns_it_at_end_step() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let _feather = scenario
+        .add_creature(P0, "Feather, the Redeemed", 3, 4)
+        .from_oracle_text(FEATHER_TEXT)
+        .id();
+    let soldier = scenario.add_creature(P0, "Loyal Soldier", 1, 1).id();
+    let pump = scenario
+        .add_spell_to_hand(P0, "Combat Trick", true)
+        .with_mana_cost(ManaCost::zero())
+        .from_oracle_text("Target creature gets +1/+0 until end of turn.")
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Cast the instant targeting P0's own creature; Feather's trigger resolves
+    // above it, stamping the exile-instead + return riders; the spell then
+    // resolves and is exiled instead of hitting the graveyard.
+    let outcome = runner.cast(pump).target_object(soldier).resolve();
+    // CR 614.1a: exiled instead of the CR 608.2n graveyard default.
+    outcome.assert_zone(&[pump], Zone::Exile);
+
+    // CR 603.7a: the return delayed trigger was armed when the replacement was
+    // applied (the spell landed in exile).
+    assert_eq!(
+        runner.state().delayed_triggers.len(),
+        1,
+        "arming must create exactly one return delayed trigger"
+    );
+
+    // CR 603.7a: "at the beginning of the next end step" — cross combat by
+    // declaring no attackers (a turn-based action plain priority passes cannot
+    // answer), advance to the end step, and drain the fired trigger.
+    runner.advance_to_combat();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![],
+            bands: vec![],
+        })
+        .expect("declare no attackers to cross combat");
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&pump].zone,
+        Zone::Hand,
+        "the exiled spell must return to its owner's hand at the next end step (CR 603.7a)"
+    );
+    // CR 603.7b: one-shot — the delayed trigger is gone after firing.
+    assert!(
+        runner.state().delayed_triggers.is_empty(),
+        "the one-shot return trigger must be consumed"
+    );
+}
+
+/// Counter-negative: if the targeted spell is countered after Feather's
+/// trigger resolves, the spell goes to the graveyard (CR 701.6a) and NO return
+/// is armed — per CR 603.7a the return delayed trigger only exists once the
+/// exile-instead replacement is actually applied, which never happens for a
+/// countered spell.
+#[test]
+fn countered_spell_goes_to_graveyard_and_never_returns() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let _feather = scenario
+        .add_creature(P0, "Feather, the Redeemed", 3, 4)
+        .from_oracle_text(FEATHER_TEXT)
+        .id();
+    let soldier = scenario.add_creature(P0, "Loyal Soldier", 1, 1).id();
+    let pump = scenario
+        .add_spell_to_hand(P0, "Combat Trick", true)
+        .with_mana_cost(ManaCost::zero())
+        .from_oracle_text("Target creature gets +1/+0 until end of turn.")
+        .id();
+    let counter = scenario
+        .add_spell_to_hand(P1, "Cancel It", true)
+        .with_mana_cost(ManaCost::zero())
+        .from_oracle_text("Counter target spell.")
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Commit the pump spell to the stack (Feather's trigger goes on top of it).
+    let _ = runner.cast(pump).target_object(soldier).commit();
+
+    // CR 603.3b + CR 608.2: both players pass once — the TOP entry (Feather's
+    // trigger) resolves, stamping the riders on the still-on-stack spell.
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P0 passes priority");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P1 passes priority");
+
+    // Positive reach-guard: the trigger really stamped the return marker on
+    // the spell — the negative assertions below are about the COUNTER path,
+    // not about the marker never being set.
+    assert!(
+        runner.state().objects[&pump]
+            .exile_from_stack_return_rider
+            .is_some(),
+        "Feather's resolved trigger must stamp the return rider on the spell"
+    );
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "only the pump spell remains on the stack after the trigger resolves"
+    );
+
+    // Give P1 priority, then counter the pump spell.
+    for _ in 0..4 {
+        if runner.state().priority_player == P1 {
+            break;
+        }
+        runner.act(GameAction::PassPriority).expect("pass to P1");
+    }
+    let outcome = runner.cast(counter).target_object(pump).resolve();
+
+    // CR 701.6a: the countered spell is put into its owner's graveyard — the
+    // replacement never applied, so no exile and no return.
+    outcome.assert_zone(&[pump], Zone::Graveyard);
+    // CR 400.7: the stack exit cleared the transient rider (zones.rs) — this
+    // makes the zone-exit clear non-vacuous, not just the absence of arming.
+    assert!(
+        runner.state().objects[&pump]
+            .exile_from_stack_return_rider
+            .is_none(),
+        "the zone-exit cleanup must clear the return rider on the countered spell"
+    );
+    assert!(
+        runner.state().delayed_triggers.is_empty(),
+        "a countered spell must never arm the return delayed trigger (CR 603.7a)"
+    );
+
+    // Advance to end step (crossing combat with no attackers) and drain — the
+    // spell must stay in the graveyard.
+    runner.advance_to_combat();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![],
+            bands: vec![],
+        })
+        .expect("declare no attackers to cross combat");
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+    assert_eq!(
+        runner.state().objects[&pump].zone,
+        Zone::Graveyard,
+        "no return may fire for a countered spell"
+    );
+}
+
+/// Fizzle-negative: if the targeted spell's SOLE target becomes illegal after
+/// Feather's trigger resolves (the creature is destroyed in response), the
+/// spell doesn't resolve (CR 608.2b) and is put into its owner's graveyard —
+/// NOT exiled — and no return is armed: per CR 603.7a the return delayed
+/// trigger only exists once the exile-instead replacement is actually applied,
+/// and a fizzled spell never reaches the exile-instead move. This exercises
+/// the fizzle early-return path in `stack.rs`, distinct from the counter path.
+#[test]
+fn fizzled_spell_goes_to_graveyard_and_never_returns() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let _feather = scenario
+        .add_creature(P0, "Feather, the Redeemed", 3, 4)
+        .from_oracle_text(FEATHER_TEXT)
+        .id();
+    let soldier = scenario.add_creature(P0, "Loyal Soldier", 1, 1).id();
+    let pump = scenario
+        .add_spell_to_hand(P0, "Combat Trick", true)
+        .with_mana_cost(ManaCost::zero())
+        .from_oracle_text("Target creature gets +1/+0 until end of turn.")
+        .id();
+    let removal = scenario
+        .add_spell_to_hand(P1, "Sudden Demise", true)
+        .with_mana_cost(ManaCost::zero())
+        .from_oracle_text("Destroy target creature.")
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Commit the pump spell to the stack (Feather's trigger goes on top of it).
+    let _ = runner.cast(pump).target_object(soldier).commit();
+
+    // CR 603.3b + CR 608.2: both players pass once — the TOP entry (Feather's
+    // trigger) resolves, stamping the riders on the still-on-stack spell.
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P0 passes priority");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P1 passes priority");
+
+    // Positive reach-guard: the trigger really stamped the return rider on the
+    // spell — the negative assertions below are about the FIZZLE path, not
+    // about the rider never being set.
+    assert!(
+        runner.state().objects[&pump]
+            .exile_from_stack_return_rider
+            .is_some(),
+        "Feather's resolved trigger must stamp the return rider on the spell"
+    );
+
+    // Give P1 priority, then destroy the pump spell's sole target in response.
+    for _ in 0..4 {
+        if runner.state().priority_player == P1 {
+            break;
+        }
+        runner.act(GameAction::PassPriority).expect("pass to P1");
+    }
+    let _ = runner.cast(removal).target_object(soldier).resolve();
+    assert_eq!(
+        runner.state().objects[&soldier].zone,
+        Zone::Graveyard,
+        "the pump spell's sole target must be gone before it tries to resolve"
+    );
+
+    // CR 608.2b: all targets illegal — the spell doesn't resolve; it's removed
+    // from the stack and put into its owner's graveyard.
+    runner.advance_until_stack_empty();
+    assert_eq!(
+        runner.state().objects[&pump].zone,
+        Zone::Graveyard,
+        "a fizzled spell takes the CR 608.2b graveyard put, never the exile replacement"
+    );
+    // CR 400.7: the stack exit cleared the transient rider (zones.rs).
+    assert!(
+        runner.state().objects[&pump]
+            .exile_from_stack_return_rider
+            .is_none(),
+        "the zone-exit cleanup must clear the return rider on the fizzled spell"
+    );
+    assert!(
+        runner.state().delayed_triggers.is_empty(),
+        "a fizzled spell must never arm the return delayed trigger (CR 603.7a)"
+    );
+
+    // Advance to end step (crossing combat with no attackers) and drain — the
+    // spell must stay in the graveyard.
+    runner.advance_to_combat();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![],
+            bands: vec![],
+        })
+        .expect("declare no attackers to cross combat");
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+    assert_eq!(
+        runner.state().objects[&pump].zone,
+        Zone::Graveyard,
+        "no return may fire for a fizzled spell"
+    );
+}

--- a/crates/engine/tests/integration/issue_4825_feather_the_redeemed.rs
+++ b/crates/engine/tests/integration/issue_4825_feather_the_redeemed.rs
@@ -19,20 +19,73 @@
 //!   - the parser gate for `Effect::ExileResolvingSpellInsteadOfGraveyard`
 //!     accepts the "your graveyard" determiner (CR 614.1a);
 //!   - the "If you do, return it …" rider folds onto the carrier as the typed
-//!     `then_return: Some(ExiledSpellReturn { destination: Hand, timing:
+//!     `on_exile: Some(ExiledSpellRider::ReturnTo { destination: Hand, timing:
 //!     AtNextPhase { End } })` rider (CR 603.7a + CR 608.2c);
 //!   - the return delayed trigger is armed only when the replacement is
 //!     actually APPLIED (the spell lands in exile during its own stack
 //!     resolution), per CR 603.7a — so a spell countered in response never
 //!     arms a return.
+//!
+//! Also covers the become-plotted sibling of the same class, Lilah, Undefeated
+//! Slickshot ("... exile that spell instead of putting it into your graveyard
+//! as it resolves. If you do, it becomes plotted."). Its "it becomes plotted"
+//! continuation folds onto the same carrier as
+//! `ExiledSpellRider::BecomePlotted` (CR 702.170c) and, like Feather's return,
+//! is applied only when the exile-instead replacement is actually applied — so
+//! a countered or fizzled Lilah spell is never plotted.
 
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::parser::oracle::parse_oracle_text;
-use engine::types::ability::{AbilityDefinition, DelayedTriggerCondition, Effect};
+use engine::types::ability::{
+    AbilityDefinition, CastingPermission, DelayedTriggerCondition, Effect, ExiledSpellRider,
+};
 use engine::types::actions::GameAction;
-use engine::types::mana::ManaCost;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
+
+/// Lilah, Undefeated Slickshot — the become-plotted sibling of the same
+/// exile-instead class. "If you do, it becomes plotted" folds onto the carrier
+/// as `ExiledSpellRider::BecomePlotted` (CR 702.170c), applied only when the
+/// exile replacement is actually applied.
+const LILAH_TEXT: &str = "Prowess\nWhenever you cast a multicolored instant or sorcery spell from \
+     your hand, exile that spell instead of putting it into your graveyard as it resolves. If you \
+     do, it becomes plotted.";
+
+/// Lilah's exile trigger in isolation (no Prowess) for runtime tests — casting
+/// the multicolored spell then fires exactly ONE trigger, so the cast harness
+/// never hits an `OrderTriggers` prompt. The exile-and-plot behavior under test
+/// is independent of Prowess.
+const LILAH_RUNTIME_TEXT: &str = "Whenever you cast a multicolored instant or sorcery spell from \
+     your hand, exile that spell instead of putting it into your graveyard as it resolves. If you \
+     do, it becomes plotted.";
+
+/// A multicolored ({R}{W}) cost so the cast satisfies Lilah's "multicolored
+/// instant or sorcery" trigger condition; the colors are derived from the cost.
+fn multicolor_rw_cost() -> ManaCost {
+    ManaCost::Cost {
+        shards: vec![ManaCostShard::Red, ManaCostShard::White],
+        generic: 0,
+    }
+}
+
+/// Seed a player's pool with one red and one white mana so the {R}{W} spell
+/// auto-pays through the cast harness.
+fn rw_pool() -> Vec<ManaUnit> {
+    vec![
+        ManaUnit::new(ManaType::Red, ObjectId(0), false, Vec::new()),
+        ManaUnit::new(ManaType::White, ObjectId(0), false, Vec::new()),
+    ]
+}
+
+/// True if `obj_id` currently carries a `Plotted` casting permission.
+fn is_plotted(runner: &engine::game::scenario::GameRunner, obj_id: ObjectId) -> bool {
+    runner.state().objects[&obj_id]
+        .casting_permissions
+        .iter()
+        .any(|p| matches!(p, CastingPermission::Plotted { .. }))
+}
 
 const FEATHER_TEXT: &str = "Flying\nWhenever you cast an instant or sorcery spell that targets a \
      creature you control, exile that card instead of putting it into your graveyard as it \
@@ -72,7 +125,7 @@ fn tree_any(def: &AbilityDefinition, pred: &dyn Fn(&Effect) -> bool) -> bool {
 }
 
 /// SHAPE: the full Feather text lowers to ONE cast trigger whose entire body is
-/// the parameterized carrier — the return rider is the typed `then_return`
+/// the parameterized carrier — the return rider is the typed `on_exile`
 /// payload, not an eagerly created `CreateDelayedTrigger` (CR 603.7a: the
 /// delayed trigger must be created when the replacement is APPLIED, not when
 /// Feather's trigger resolves).
@@ -101,20 +154,28 @@ fn feather_parses_return_rider_onto_exile_flag() {
     // rider folded in (this also proves the parse did not degrade to
     // Effect::Unimplemented, so the negative assertions below are non-vacuous).
     match &*execute.effect {
-        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } => {
-            let rider = then_return
+        Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile } => {
+            match on_exile
                 .as_ref()
-                .expect("the 'If you do, return it …' rider must fold onto the carrier");
-            assert_eq!(
-                rider.destination,
-                Zone::Hand,
-                "the rider returns the exiled card to its owner's hand"
-            );
-            assert_eq!(
-                rider.timing,
-                DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
-                "the rider fires at the beginning of the next end step"
-            );
+                .expect("the 'If you do, return it …' rider must fold onto the carrier")
+            {
+                ExiledSpellRider::ReturnTo {
+                    destination,
+                    timing,
+                } => {
+                    assert_eq!(
+                        *destination,
+                        Zone::Hand,
+                        "the rider returns the exiled card to its owner's hand"
+                    );
+                    assert_eq!(
+                        *timing,
+                        DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+                        "the rider fires at the beginning of the next end step"
+                    );
+                }
+                other => panic!("expected ReturnTo rider, got {other:?}"),
+            }
         }
         other => panic!("expected ExileResolvingSpellInsteadOfGraveyard, got {other:?}"),
     }
@@ -152,8 +213,8 @@ fn feather_riderless_clause_parses_with_flag_off() {
         .as_deref()
         .expect("the cast trigger must have an execute body");
     match &*execute.effect {
-        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } => assert!(
-            then_return.is_none(),
+        Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile } => assert!(
+            on_exile.is_none(),
             "without the return sentence the rider must stay absent"
         ),
         other => panic!("expected ExileResolvingSpellInsteadOfGraveyard, got {other:?}"),
@@ -179,8 +240,8 @@ fn rod_of_absorption_clause_keeps_flag_off() {
         .find_map(|t| t.execute.as_deref())
         .expect("Rod must have a cast trigger with an execute body");
     match &*execute.effect {
-        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return } => assert!(
-            then_return.is_none(),
+        Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile } => assert!(
+            on_exile.is_none(),
             "Rod has no return rider; the rider must stay absent"
         ),
         other => panic!("expected ExileResolvingSpellInsteadOfGraveyard, got {other:?}"),
@@ -191,15 +252,15 @@ fn rod_of_absorption_clause_keeps_flag_off() {
 /// card-data records deserializing (`{"type":"…"}` with no field → rider
 /// `None`) and keep the riderless form's serialization byte-identical (the
 /// rider is `skip_serializing_if` when `None`), so Rod of Absorption's
-/// exported record does not change. The Feather form must round-trip its
-/// typed rider.
+/// exported record does not change. Both the Feather (`ReturnTo`) and Lilah
+/// (`BecomePlotted`) forms must round-trip their typed rider.
 #[test]
 fn exile_resolving_effect_serde_stays_compatible() {
     let old_record = r#"{"type":"ExileResolvingSpellInsteadOfGraveyard"}"#;
     let effect: Effect = serde_json::from_str(old_record).expect("old unit-variant record");
     assert!(matches!(
         effect,
-        Effect::ExileResolvingSpellInsteadOfGraveyard { then_return: None }
+        Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile: None }
     ));
     let reserialized = serde_json::to_string(&effect).expect("serialize");
     assert_eq!(
@@ -207,16 +268,21 @@ fn exile_resolving_effect_serde_stays_compatible() {
         "riderless serialization must stay byte-identical to the pre-change record"
     );
 
-    // Round-trip the Feather form: the typed rider must survive serde intact.
-    let feather = Effect::ExileResolvingSpellInsteadOfGraveyard {
-        then_return: Some(engine::types::ability::ExiledSpellReturn {
+    // Round-trip both rider forms: the typed rider must survive serde intact.
+    for rider in [
+        ExiledSpellRider::ReturnTo {
             destination: Zone::Hand,
             timing: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
-        }),
-    };
-    let json = serde_json::to_string(&feather).expect("serialize Feather form");
-    let back: Effect = serde_json::from_str(&json).expect("round-trip Feather form");
-    assert_eq!(back, feather, "the typed rider must round-trip losslessly");
+        },
+        ExiledSpellRider::BecomePlotted,
+    ] {
+        let effect = Effect::ExileResolvingSpellInsteadOfGraveyard {
+            on_exile: Some(rider),
+        };
+        let json = serde_json::to_string(&effect).expect("serialize rider form");
+        let back: Effect = serde_json::from_str(&json).expect("round-trip rider form");
+        assert_eq!(back, effect, "the typed rider must round-trip losslessly");
+    }
 }
 
 /// Positive runtime path: a targeted instant resolves, is exiled instead of
@@ -326,7 +392,7 @@ fn countered_spell_goes_to_graveyard_and_never_returns() {
     // not about the marker never being set.
     assert!(
         runner.state().objects[&pump]
-            .exile_from_stack_return_rider
+            .exile_from_stack_rider
             .is_some(),
         "Feather's resolved trigger must stamp the return rider on the spell"
     );
@@ -352,7 +418,7 @@ fn countered_spell_goes_to_graveyard_and_never_returns() {
     // makes the zone-exit clear non-vacuous, not just the absence of arming.
     assert!(
         runner.state().objects[&pump]
-            .exile_from_stack_return_rider
+            .exile_from_stack_rider
             .is_none(),
         "the zone-exit cleanup must clear the return rider on the countered spell"
     );
@@ -426,7 +492,7 @@ fn fizzled_spell_goes_to_graveyard_and_never_returns() {
     // about the rider never being set.
     assert!(
         runner.state().objects[&pump]
-            .exile_from_stack_return_rider
+            .exile_from_stack_rider
             .is_some(),
         "Feather's resolved trigger must stamp the return rider on the spell"
     );
@@ -456,7 +522,7 @@ fn fizzled_spell_goes_to_graveyard_and_never_returns() {
     // CR 400.7: the stack exit cleared the transient rider (zones.rs).
     assert!(
         runner.state().objects[&pump]
-            .exile_from_stack_return_rider
+            .exile_from_stack_rider
             .is_none(),
         "the zone-exit cleanup must clear the return rider on the fizzled spell"
     );
@@ -480,5 +546,194 @@ fn fizzled_spell_goes_to_graveyard_and_never_returns() {
         runner.state().objects[&pump].zone,
         Zone::Graveyard,
         "no return may fire for a fizzled spell"
+    );
+}
+
+/// SHAPE: Lilah, Undefeated Slickshot's full text lowers to a cast trigger whose
+/// body is the parameterized carrier with `on_exile: Some(BecomePlotted)` — the
+/// "it becomes plotted" continuation is folded onto the typed rider, NOT left as
+/// an eagerly resolved `GrantCastingPermission { Plotted }` sub-ability
+/// (CR 702.170c: the card must be in exile to become plotted, so the grant must
+/// wait for the replacement to apply, not run when the trigger resolves).
+#[test]
+fn lilah_parses_plotted_rider_onto_carrier() {
+    let parsed = parse_oracle_text(
+        LILAH_TEXT,
+        "Lilah, Undefeated Slickshot",
+        &["Prowess".to_string()],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Rogue".to_string()],
+    );
+
+    let execute = parsed
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_deref())
+        .expect("Lilah must have a cast trigger with an execute body");
+
+    match &*execute.effect {
+        Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile } => {
+            assert_eq!(
+                on_exile.as_ref(),
+                Some(&ExiledSpellRider::BecomePlotted),
+                "the 'If you do, it becomes plotted' rider must fold onto the carrier"
+            );
+        }
+        other => panic!("expected ExileResolvingSpellInsteadOfGraveyard, got {other:?}"),
+    }
+    assert!(
+        execute.sub_ability.is_none(),
+        "the folded plotted rider must leave no residual sub-ability: {:?}",
+        execute.sub_ability
+    );
+    // CR 702.170c: no eager plotted grant may remain — the fold must have
+    // consumed it into the rider (else the grant would run on the stack object).
+    assert!(
+        !tree_any(execute, &|e| matches!(
+            e,
+            Effect::GrantCastingPermission {
+                permission: CastingPermission::Plotted { .. },
+                ..
+            }
+        )),
+        "no eager GrantCastingPermission {{ Plotted }} may remain in the chain (CR 702.170c)"
+    );
+    assert!(
+        !tree_any(execute, &|e| matches!(e, Effect::Unimplemented { .. })),
+        "the folded chain must contain no Unimplemented node"
+    );
+}
+
+/// Positive runtime path: a multicolored instant cast from hand resolves, is
+/// exiled instead of going to the graveyard (CR 614.1a), and becomes plotted
+/// (CR 702.170c) — the exiled card gains the `Plotted` casting permission bound
+/// to its owner. No delayed trigger is armed (plot is immediate, unlike
+/// Feather's return).
+#[test]
+fn lilah_exiles_multicolored_spell_and_plots_it() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let lilah = scenario
+        .add_creature(P0, "Lilah, Undefeated Slickshot", 2, 2)
+        .from_oracle_text(LILAH_RUNTIME_TEXT)
+        .id();
+    let bolt = scenario
+        .add_spell_to_hand(P0, "Boros Charm Bolt", true)
+        .with_mana_cost(multicolor_rw_cost())
+        .from_oracle_text("Target creature gets +1/+0 until end of turn.")
+        .id();
+    scenario.with_mana_pool(P0, rw_pool());
+
+    let mut runner = scenario.build();
+
+    // Cast the multicolored instant targeting Lilah; Lilah's exile trigger
+    // resolves above it, stamping the exile-instead + plotted riders; the spell
+    // then resolves and is exiled instead of hitting the graveyard.
+    let outcome = runner.cast(bolt).target_object(lilah).resolve();
+    // CR 614.1a: exiled instead of the CR 608.2n graveyard default.
+    outcome.assert_zone(&[bolt], Zone::Exile);
+
+    // CR 702.170c: the exiled card became plotted — the grant was applied when
+    // the replacement was applied (the spell landed in exile), bound to its
+    // owner (CR 702.170d).
+    assert!(
+        is_plotted(&runner, bolt),
+        "the exiled spell must gain the Plotted casting permission (CR 702.170c): {:?}",
+        runner.state().objects[&bolt].casting_permissions
+    );
+    // Plot is immediate — no delayed trigger is armed (distinguishes it from
+    // Feather's return rider).
+    assert!(
+        runner.state().delayed_triggers.is_empty(),
+        "becoming plotted must not arm a delayed trigger"
+    );
+    // CR 400.7: the transient rider was cleared when the spell left the stack.
+    assert!(
+        runner.state().objects[&bolt]
+            .exile_from_stack_rider
+            .is_none(),
+        "the exile-instead rider must clear on the stack→exile move"
+    );
+}
+
+/// Counter-negative: if the multicolored spell is countered after Lilah's
+/// trigger resolves, the spell goes to the graveyard (CR 701.6a) and is NOT
+/// plotted — per CR 702.170c a card becomes plotted only while in exile, and
+/// the exile-instead replacement never applies to a countered spell. This is
+/// the regression the review flagged: the plot grant must never touch a spell
+/// that leaves the stack any way other than the exile-instead move.
+#[test]
+fn countered_lilah_spell_goes_to_graveyard_and_is_not_plotted() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let lilah = scenario
+        .add_creature(P0, "Lilah, Undefeated Slickshot", 2, 2)
+        .from_oracle_text(LILAH_RUNTIME_TEXT)
+        .id();
+    let bolt = scenario
+        .add_spell_to_hand(P0, "Boros Charm Bolt", true)
+        .with_mana_cost(multicolor_rw_cost())
+        .from_oracle_text("Target creature gets +1/+0 until end of turn.")
+        .id();
+    scenario.with_mana_pool(P0, rw_pool());
+    let counter = scenario
+        .add_spell_to_hand(P1, "Cancel It", true)
+        .with_mana_cost(ManaCost::zero())
+        .from_oracle_text("Counter target spell.")
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Commit the multicolored spell (Lilah's triggers stack on top of it).
+    let _ = runner.cast(bolt).target_object(lilah).commit();
+
+    // Pass priority until only the spell remains on the stack — Lilah's
+    // triggers (Prowess + the exile-instead trigger) have all resolved,
+    // stamping the become-plotted rider on the still-on-stack spell.
+    for _ in 0..12 {
+        if runner.state().stack.len() == 1 {
+            break;
+        }
+        runner
+            .act(GameAction::PassPriority)
+            .expect("pass priority to resolve Lilah's triggers");
+    }
+
+    // Positive reach-guard: the trigger really stamped the become-plotted rider
+    // — the negative assertions below are about the COUNTER path, not about the
+    // marker never being set.
+    assert_eq!(
+        runner.state().objects[&bolt].exile_from_stack_rider,
+        Some(ExiledSpellRider::BecomePlotted),
+        "Lilah's resolved trigger must stamp the become-plotted rider on the spell"
+    );
+
+    // Give P1 priority, then counter the spell.
+    for _ in 0..4 {
+        if runner.state().priority_player == P1 {
+            break;
+        }
+        runner.act(GameAction::PassPriority).expect("pass to P1");
+    }
+    let outcome = runner.cast(counter).target_object(bolt).resolve();
+
+    // CR 701.6a: the countered spell is put into its owner's graveyard — the
+    // exile-instead replacement never applied, so no plot.
+    outcome.assert_zone(&[bolt], Zone::Graveyard);
+    // CR 702.170c: a spell that never reached exile must NOT be plotted.
+    assert!(
+        !is_plotted(&runner, bolt),
+        "a countered spell must never become plotted (CR 702.170c): {:?}",
+        runner.state().objects[&bolt].casting_permissions
+    );
+    // CR 400.7: the stack exit cleared the transient rider (zones.rs) — makes
+    // the zone-exit clear non-vacuous, not just the absence of the grant.
+    assert!(
+        runner.state().objects[&bolt]
+            .exile_from_stack_rider
+            .is_none(),
+        "the zone-exit cleanup must clear the rider on the countered spell"
     );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -448,6 +448,7 @@ mod issue_4752_blood_artist_each_player_sacrifice;
 mod issue_4786_wrenn_realmbreaker;
 mod issue_4792_isochron_scepter;
 mod issue_4824_light_paws_aura_attach;
+mod issue_4825_feather_the_redeemed;
 mod issue_4829_zenith_chronicler;
 mod issue_4830_orvar_land_copy;
 mod issue_4831_bloodthorn_flail_equip;

--- a/crates/phase-ai/src/policies/effect_classify.rs
+++ b/crates/phase-ai/src/policies/effect_classify.rs
@@ -279,7 +279,7 @@ pub(crate) fn effect_polarity(effect: &Effect) -> EffectPolarity {
         | Effect::ExchangeLifeWithStat { .. }
         | Effect::ExileFromTopUntil { .. }
         | Effect::ExileHaunting { .. }
-        | Effect::ExileResolvingSpellInsteadOfGraveyard
+        | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
         | Effect::ExileTop { .. }
         | Effect::Exploit { .. }
         | Effect::ExploreAll { .. }

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -442,7 +442,7 @@ fn redundancy_delta(
         // spell with an exile-instead/linked-source rider. Its value is realized
         // by the stack resolution replacement path, so this policy has no static
         // redundancy signal to score.
-        | Effect::ExileResolvingSpellInsteadOfGraveyard
+        | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }
         | Effect::GainActivatedAbilitiesOfTarget { .. }


### PR DESCRIPTION
Fixes #4825. Instant/sorcery spells that triggered Feather, the Redeemed went to the graveyard instead of being exiled and returned to hand at the next end step.

## Root cause
The "exile that card instead of putting it into your graveyard as it resolves" clause lowered to `ChangeZone{origin:Graveyard, dest:Exile, ParentTarget}`, a runtime no-op (CR 400.7 origin guard) because the spell is still on the stack when Feather's trigger resolves — so it took the CR 608.2n graveyard default.

## Fix (built for the class, not the card)
Lower the clause to the existing `Effect::ExileResolvingSpellInsteadOfGraveyard` (the stack-exile-marker mechanism consulted at spell resolution, already used by Rod of Absorption). Parameterized it with a typed `then_return: Option<ExiledSpellReturn>{ destination, timing }` so the "If you do, return it at the next end step" rider is a parameter value, not a new variant — covering the whole class. A conservative AST fold consumes the rider clause.

The one-shot return delayed trigger is armed **when the replacement is actually applied** (the spell lands in exile) per CR 603.7a, keyed on the concrete exiled object. The marker is cleared on any zone exit (CR 400.7), so a spell **countered or fizzled in response** correctly goes to the graveyard and never returns.

## Testing
- Full engine suite green: 16516 lib + 2972 integration tests.
- New `issue_4825` module (7 tests): parser shape (rider folded, no no-op `ChangeZone`), riderless negative, Rod-of-Absorption regression, serde back-compat, runtime exile→return, counter-negative, fizzle-negative.
- Card-data export regenerated: Feather faithful (`ExileResolvingSpellInsteadOfGraveyard{then_return:{Hand, AtNextPhase{End}}}`, no leftover sub); Rod byte-identical (riderless form).
- Rebased onto latest `main`; targeted suite re-run green post-rebase.

## Non-blocking follow-ups (noted, out of scope)
- CR 616.1 flashback + Feather replacement-ordering choice is collapsed to the strictly-dominant choice (pre-existing static-dest architecture).
- Cross-controller attribution would only matter for a hypothetical opponent-cast carrier of this rider (current class is all "whenever you cast").
- `cargo coverage` / LLM `semantic-audit` deferred to CI / primary-checkout Tilt resources (parse faithfulness already confirmed by tests + regenerated card-data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
