### PR TITLE
Fix Necromancy ETB reanimation (#640)

### DIFF
--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -36376,12 +36376,12 @@ fn animate_dead_full_pipeline_reanimates_and_reattaches() {
     );
 }
 
-/// CR 701.17a + CR 603.7c regression (issue #4767): the delayed "When ~ leaves the
+/// CR 701.21a + CR 603.7c regression (issue #4767): the delayed "When ~ leaves the
 /// battlefield, that creature's controller sacrifices it" trigger must sacrifice
 /// the reanimated creature when the Aura leaves the battlefield.
 ///
 /// LIVE-REVERT EVIDENCE: removing the `CreateDelayedTrigger` node from
-/// `build_reanimator_aura_etb_chain` leaves no delayed trigger, so destroying the
+/// `build_aura_attach_chain` leaves no delayed trigger, so destroying the
 /// Aura no longer puts a sacrifice ability on the stack and the final assertion
 /// fails (creature stays on the battlefield).
 #[test]
@@ -36416,7 +36416,7 @@ fn animate_dead_delayed_sacrifice_when_aura_leaves() {
     );
 }
 
-/// CR 701.17a regression (issue #4767, `sacrifice.rs` controller-scope relaxation):
+/// CR 701.21a regression (issue #4767, `sacrifice.rs` controller-scope relaxation):
 /// "that creature's controller sacrifices it" must be performed by the creature's
 /// CURRENT controller even if control changed after Animate Dead reanimated it and
 /// before the delayed leaves-battlefield trigger fires.
@@ -36467,6 +36467,378 @@ fn animate_dead_delayed_sacrifice_follows_new_controller() {
         Zone::Graveyard,
         "sacrificed creature must go to its owner's graveyard"
     );
+}
+
+/// Verbatim Necromancy Oracle text (Scryfall, 2026-07). Necromancy is a plain
+/// (non-Aura) Enchantment: its ETB ability BOTH becomes an Aura AND targets a
+/// creature card in a graveyard to reanimate (issue #640).
+const NECROMANCY_ORACLE_FULL: &str = "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.\nWhen this enchantment enters, if it's on the battlefield, it becomes an Aura with \"enchant creature put onto the battlefield with Necromancy.\" Put target creature card from a graveyard onto the battlefield under your control and attach this enchantment to it. When this enchantment leaves the battlefield, that creature's controller sacrifices it.";
+
+/// Cast Necromancy (a plain Enchantment) through the real pipeline and fire its
+/// ETB reanimation trigger onto the stack (auto-targeting the single legal
+/// graveyard creature), leaving it UNRESOLVED. Shared by the resolve-path tests
+/// and the fizzle test.
+///
+/// Only the reanimator ETB trigger is installed on the object — Necromancy's
+/// first ability (flash-cast permission + cleanup-step sacrifice, separately
+/// supported and verified) is orthogonal to the #640 ETB reanimation fix and
+/// would add an intervening-if / same-controller trigger-ordering path that this
+/// seam does not exercise. The trigger installed IS the live parser output for
+/// the ETB ability, so this drives the exact chain production ships.
+///
+/// Returns `(state, necromancy_id, creature_id)` with the ETB trigger on the
+/// stack and the caster's enters-event batch already consumed.
+fn cast_necromancy_and_fire_etb() -> (GameState, ObjectId, ObjectId) {
+    use crate::parser::oracle::parse_oracle_text;
+
+    let mut state = setup_game_at_main_phase();
+
+    let necromancy_id = create_object(
+        &mut state,
+        CardId(701),
+        PlayerId(0),
+        "Necromancy".to_string(),
+        Zone::Hand,
+    );
+    // Real parser output — same construction path a fresh card-data export uses.
+    let parsed = parse_oracle_text(
+        NECROMANCY_ORACLE_FULL,
+        "Necromancy",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    // Reach-guard: the live parser MUST produce the reanimator ETB trigger (a
+    // root `Effect::ChangeZone`). If the GRANT-shape recognizer's dispatch is
+    // reverted, this filter is empty and the helper panics here, so no
+    // downstream assertion can pass vacuously.
+    let reanimator_triggers: Vec<_> = parsed
+        .triggers
+        .iter()
+        .filter(|t| {
+            matches!(
+                t.execute.as_deref().map(|d| d.effect.as_ref()),
+                Some(Effect::ChangeZone { .. })
+            )
+        })
+        .cloned()
+        .collect();
+    assert_eq!(
+        reanimator_triggers.len(),
+        1,
+        "parser must produce exactly one reanimator ETB trigger (root ChangeZone); got {}",
+        reanimator_triggers.len()
+    );
+    {
+        let obj = state.objects.get_mut(&necromancy_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        // NO "Aura" subtype and NO Enchant keyword: Necromancy is a plain
+        // Enchantment until its own ETB grants both (the #640 GRANT shape).
+        obj.base_card_types = obj.card_types.clone();
+        obj.base_trigger_definitions = Arc::new(reanimator_triggers.clone());
+        obj.trigger_definitions = reanimator_triggers.into();
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Black],
+            generic: 2,
+        };
+        obj.base_mana_cost = obj.mana_cost.clone();
+    }
+    add_mana(&mut state, PlayerId(0), ManaType::Black, 3);
+
+    // Grizzly Bears (2/2) in the OPPONENT's graveyard, so reanimation genuinely
+    // moves control to the caster.
+    let creature_id = create_object(
+        &mut state,
+        CardId(702),
+        PlayerId(1),
+        "Grizzly Bears".to_string(),
+        Zone::Graveyard,
+    );
+    {
+        let obj = state.objects.get_mut(&creature_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = Some(2);
+        obj.toughness = Some(2);
+        obj.base_power = Some(2);
+        obj.base_toughness = Some(2);
+    }
+
+    let mut events = Vec::new();
+    let result = handle_cast_spell(
+        &mut state,
+        PlayerId(0),
+        necromancy_id,
+        CardId(701),
+        &mut events,
+    )
+    .unwrap();
+    // Necromancy has no cast-time target → straight onto the stack.
+    assert!(
+        matches!(result, WaitingFor::Priority { .. }),
+        "expected the plain enchantment to go straight to the stack; got {result:?}"
+    );
+    assert_eq!(
+        state.stack.len(),
+        1,
+        "Necromancy spell must be on the stack"
+    );
+
+    // (1) Resolve the Necromancy spell → it enters the battlefield as a plain
+    // (non-Aura) Enchantment.
+    stack::resolve_top(&mut state, &mut events);
+    assert!(
+        state.battlefield.contains(&necromancy_id),
+        "Necromancy must resolve onto the battlefield"
+    );
+    // Pre-ETB reach guard: it is NOT yet an Aura and has NO Enchant keyword, so
+    // the post-ETB AddSubtype/AddKeyword assertions are not vacuous.
+    assert!(
+        !state.objects[&necromancy_id]
+            .card_types
+            .subtypes
+            .contains(&"Aura".to_string()),
+        "Necromancy must NOT be an Aura before its ETB resolves (reach guard)"
+    );
+    assert!(
+        !state.objects[&necromancy_id]
+            .keywords
+            .iter()
+            .any(|k| matches!(k, Keyword::Enchant(_))),
+        "Necromancy must NOT have an Enchant keyword before its ETB resolves (reach guard)"
+    );
+
+    // (2) Fire the ETB reanimation trigger through the real trigger pipeline.
+    // Exactly one creature card in any graveyard → the targeted trigger
+    // auto-selects it (CR 603.3d) and pushes to the stack.
+    crate::game::triggers::process_triggers(&mut state, &events);
+    assert_eq!(
+        state.stack.len(),
+        1,
+        "the reanimator ETB trigger must auto-target and be on the stack after process_triggers"
+    );
+
+    (state, necromancy_id, creature_id)
+}
+
+/// Drives Necromancy's FULL end-to-end reanimation pipeline (issue #640): the
+/// ETB targets a creature card in a graveyard, reanimates it under the caster's
+/// control, grants Necromancy the Aura subtype and the Enchant keyword for the
+/// first time, and attaches it — mirroring the Animate Dead cluster's harness.
+fn reanimate_grizzly_via_necromancy() -> (GameState, ObjectId, ObjectId) {
+    let (mut state, necromancy_id, creature_id) = cast_necromancy_and_fire_etb();
+
+    // (3) Resolve the 4-node reanimation chain
+    // (ChangeZone -> GenericEffect grant -> Attach -> CreateDelayedTrigger).
+    let mut etb_events = Vec::new();
+    stack::resolve_top(&mut state, &mut etb_events);
+    crate::game::layers::evaluate_layers(&mut state);
+
+    (state, necromancy_id, creature_id)
+}
+
+/// CR 603.3d + CR 608.2c + CR 613.1d + CR 613.1f + CR 701.3a regression (issue
+/// #640, "Necromancy can't target any creature in a graveyard"): the ETB
+/// reanimation chain must move the targeted creature card from the graveyard
+/// onto the battlefield under the caster's control, GRANT Necromancy the Aura
+/// subtype and Enchant keyword for the first time, attach it, and survive SBAs.
+///
+/// LIVE-REVERT EVIDENCE: reverting the GRANT-shape dispatch in `oracle_trigger`
+/// leaves the ETB body an `Effect::Unimplemented`, so `cast_necromancy_and_fire_etb`'s
+/// reach-guard (exactly one root-ChangeZone trigger) fails and the reanimation
+/// never runs — assertion (a) can never pass.
+#[test]
+fn necromancy_full_pipeline_reanimates_and_becomes_aura() {
+    use crate::game::game_object::AttachTarget;
+
+    let (mut state, necromancy_id, creature_id) = reanimate_grizzly_via_necromancy();
+
+    // (a) The creature was reanimated: it left the graveyard for the battlefield.
+    assert_eq!(
+        state.objects[&creature_id].zone,
+        Zone::Battlefield,
+        "reanimated creature must be on the battlefield, not the graveyard"
+    );
+    assert!(
+        !state.players[1].graveyard.contains(&creature_id),
+        "reanimated creature must no longer be in its owner's graveyard"
+    );
+
+    // (b) Necromancy GAINED the Aura subtype (proves AddSubtype, not a pre-existing
+    // subtype — the pre-ETB reach guard in the helper asserted it was not an Aura).
+    assert!(
+        state.objects[&necromancy_id]
+            .card_types
+            .subtypes
+            .contains(&"Aura".to_string()),
+        "Necromancy must become an Aura (AddSubtype grant) after its ETB resolves"
+    );
+
+    // (c) Necromancy is attached to the SPECIFIC reanimated creature.
+    assert_eq!(
+        state.objects[&necromancy_id].attached_to,
+        Some(AttachTarget::Object(creature_id)),
+        "Necromancy must be attached to the reanimated creature"
+    );
+
+    // (d) Necromancy GAINED an Enchant keyword (it had none before — the helper's
+    // reach guard asserted that). The AddKeyword grant re-targets its Enchant
+    // restriction to the reanimated creature.
+    assert!(
+        state.objects[&necromancy_id]
+            .keywords
+            .iter()
+            .any(|k| matches!(k, Keyword::Enchant(_))),
+        "Necromancy must gain an Enchant keyword (AddKeyword grant)"
+    );
+
+    // (e) An explicit SBA pass does NOT re-graveyard Necromancy (CR 704.5m): it is
+    // an Aura correctly attached to a legal creature, so it survives.
+    let mut sba_events = Vec::new();
+    crate::game::sba::check_state_based_actions(&mut state, &mut sba_events);
+    assert!(
+        state.battlefield.contains(&necromancy_id),
+        "Necromancy must survive SBAs (Aura attached to a legal creature, CR 704.5m)"
+    );
+    assert_eq!(
+        state.objects[&necromancy_id].attached_to,
+        Some(AttachTarget::Object(creature_id)),
+        "Necromancy must stay attached to the reanimated creature after SBAs"
+    );
+}
+
+/// CR 608.2c + CR 400.7 hostile fixture (issue #640): the targeted creature card
+/// lives in the OPPONENT's graveyard, but "under your control" must reanimate it
+/// under the CASTER's control — not silently default to the owner. Discriminates
+/// a `enters_under` regression that ships the owner as controller.
+#[test]
+fn necromancy_cross_controller_target_reanimates_under_caster_control() {
+    let (state, _necromancy_id, creature_id) = reanimate_grizzly_via_necromancy();
+
+    // Owner is P1 (the graveyard it came from); controller must be the caster P0.
+    assert_eq!(
+        state.objects[&creature_id].owner,
+        PlayerId(1),
+        "precondition: the reanimated creature is owned by the opponent"
+    );
+    assert_eq!(
+        state.objects[&creature_id].controller,
+        PlayerId(0),
+        "reanimated creature must be controlled by the CASTER (under your control), not the owner"
+    );
+}
+
+/// CR 701.21a + CR 603.7c regression (issue #640): the delayed "When ~ leaves the
+/// battlefield, that creature's controller sacrifices it" trigger must sacrifice
+/// the reanimated creature when Necromancy leaves the battlefield.
+#[test]
+fn necromancy_delayed_sacrifice_when_leaves() {
+    let (mut state, necromancy_id, creature_id) = reanimate_grizzly_via_necromancy();
+    // Baseline reach-guard: the creature is on the battlefield before we remove
+    // Necromancy, so the sacrifice assertion below is not vacuous.
+    assert_eq!(state.objects[&creature_id].zone, Zone::Battlefield);
+
+    // Remove Necromancy from the battlefield → fires the delayed leaves-play trigger.
+    let mut events = Vec::new();
+    zones::move_to_zone(&mut state, necromancy_id, Zone::Graveyard, &mut events);
+    crate::game::triggers::check_delayed_triggers(&mut state, &events);
+    assert_eq!(
+        state.stack.len(),
+        1,
+        "the delayed leaves-battlefield sacrifice must be on the stack"
+    );
+
+    // Resolve the sacrifice.
+    let mut sac_events = Vec::new();
+    stack::resolve_top(&mut state, &mut sac_events);
+    assert!(
+        !state.battlefield.contains(&creature_id),
+        "reanimated creature must be sacrificed when Necromancy leaves the battlefield"
+    );
+    assert_eq!(
+        state.objects[&creature_id].zone,
+        Zone::Graveyard,
+        "sacrificed creature must go to its owner's graveyard"
+    );
+}
+
+/// CR 608.2b regression (issue #640): if the ETB trigger's chosen target leaves
+/// the graveyard before the trigger resolves, the trigger is removed from the
+/// stack and does nothing — Necromancy stays a plain (non-Aura) Enchantment with
+/// no attachment and no delayed trigger, and SBAs must not panic or misfire.
+#[test]
+fn necromancy_etb_trigger_fizzles_when_target_creature_leaves_graveyard() {
+    let (mut state, necromancy_id, creature_id) = cast_necromancy_and_fire_etb();
+    // Reach guard: the trigger is on the stack with its target chosen.
+    assert_eq!(state.stack.len(), 1, "ETB trigger must be on the stack");
+
+    // Remove the exact targeted card from the graveyard BEFORE the trigger
+    // resolves (CR 608.2b: it is no longer in the zone it was targeted in).
+    let mut events = Vec::new();
+    zones::move_to_zone(&mut state, creature_id, Zone::Exile, &mut events);
+
+    // Resolve the (now illegal-target) trigger → it is removed from the stack.
+    let mut etb_events = Vec::new();
+    stack::resolve_top(&mut state, &mut etb_events);
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.stack.len(),
+        0,
+        "the ETB trigger must be removed from the stack when its only target became illegal"
+    );
+
+    // The creature did NOT come back to the battlefield.
+    assert!(
+        !state.battlefield.contains(&creature_id),
+        "creature must not be reanimated when the trigger fizzled"
+    );
+    assert_eq!(
+        state.objects[&creature_id].zone,
+        Zone::Exile,
+        "the target stays where it was moved (exile), not reanimated"
+    );
+
+    // Necromancy stayed a plain Enchantment: no Aura subtype, no Enchant keyword,
+    // no attachment.
+    assert!(
+        !state.objects[&necromancy_id]
+            .card_types
+            .subtypes
+            .contains(&"Aura".to_string()),
+        "Necromancy must remain a non-Aura Enchantment when the ETB fizzles"
+    );
+    assert!(
+        !state.objects[&necromancy_id]
+            .keywords
+            .iter()
+            .any(|k| matches!(k, Keyword::Enchant(_))),
+        "Necromancy must gain no Enchant keyword when the ETB fizzles"
+    );
+    assert!(
+        state.objects[&necromancy_id].attached_to.is_none(),
+        "Necromancy must not be attached to anything when the ETB fizzles"
+    );
+
+    // No delayed leaves-battlefield trigger was registered: moving Necromancy to
+    // the graveyard fires nothing.
+    let mut leave_events = Vec::new();
+    zones::move_to_zone(
+        &mut state,
+        necromancy_id,
+        Zone::Graveyard,
+        &mut leave_events,
+    );
+    crate::game::triggers::check_delayed_triggers(&mut state, &leave_events);
+    assert_eq!(
+        state.stack.len(),
+        0,
+        "no delayed sacrifice trigger must exist after a fizzled ETB"
+    );
+
+    // SBAs run cleanly (no panic, nothing spurious happens to Necromancy in the
+    // graveyard).
+    let mut sba_events = Vec::new();
+    crate::game::sba::check_state_based_actions(&mut state, &mut sba_events);
 }
 
 /// CR 702.103b regression: drives the full cast pipeline end-to-end —

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11765,11 +11765,11 @@ pub(crate) fn try_parse_grant_graveyard_keyword_to_target(
     Some(AbilityDefinition::new(kind, effect))
 }
 
-/// CR 608.2c + CR 613.1f + CR 701.3a + CR 701.17a: Whole-body, fail-closed recognizer
+/// CR 608.2c + CR 613.1f + CR 701.3a + CR 701.21a: Whole-body, fail-closed recognizer
 /// for the reanimator-Aura ETB effect shared by Animate Dead and Dance of the Dead.
 /// The chain it builds implements a reanimation instruction (CR 608.2c), a layer-6
 /// keyword swap (CR 613.1f), an attach (CR 701.3a), and a delayed sacrifice
-/// (CR 701.17a). Note: CR 303.4f does NOT apply — the Aura is not entering the
+/// (CR 701.21a). Note: CR 303.4f does NOT apply — the Aura is not entering the
 /// battlefield "by a means other than resolving as an Aura spell"; it resolved
 /// normally and this triggered ability then specifies the object to enchant.
 ///
@@ -11794,7 +11794,7 @@ pub(crate) fn try_parse_grant_graveyard_keyword_to_target(
 /// per-clause chunker. Declines (returns `None`) unless the ENTIRE body matches,
 /// so any card whose text deviates stays an honest `Effect::Unimplemented`.
 ///
-/// See `build_reanimator_aura_etb_chain` for why each node uses the anaphor it
+/// See `build_aura_attach_chain` for why each node uses the anaphor it
 /// does (source-rebind interplay with `ChangeZone { forward_result: true }`).
 pub(crate) fn try_parse_reanimator_aura_etb_effect(
     text: &str,
@@ -11804,7 +11804,15 @@ pub(crate) fn try_parse_reanimator_aura_etb_effect(
     let lower = stripped.to_lowercase();
     let tap_state =
         super::oracle_nom::bridge::nom_parse_lower(&lower, parse_reanimator_aura_etb_body)?;
-    Some(build_reanimator_aura_etb_chain(kind, tap_state))
+    // CR 613.1f: Animate Dead / Dance of the Dead are printed as Auras, so the
+    // ETB swaps the printed Enchant restriction (Swap) and refers back to the
+    // already-established attachment via `TargetFilter::AttachedTo`.
+    Some(build_aura_attach_chain(
+        kind,
+        tap_state,
+        EnchantGrantShape::Swap,
+        TargetFilter::AttachedTo,
+    ))
 }
 
 /// Shape-check one `"enchant <...>"` quoted keyword-grant span, discarding its
@@ -11847,7 +11855,125 @@ fn parse_reanimator_aura_etb_body(i: &str) -> OracleResult<'_, crate::types::zon
     Ok((i, tap))
 }
 
-/// Build the reanimator-Aura ETB effect chain (see `try_parse_reanimator_aura_etb_effect`).
+/// CR 603.3d + CR 608.2c + CR 613.1d + CR 613.1f + CR 701.3a + CR 701.21a:
+/// Whole-body, fail-closed recognizer for the reanimator-Aura GRANT-shape ETB
+/// effect (Necromancy). Unlike `try_parse_reanimator_aura_etb_effect` (shared
+/// by Animate Dead / Dance of the Dead, which target at CAST time via their
+/// printed Enchant restriction and refer back to `TargetFilter::AttachedTo`
+/// here), this object is a plain (non-Aura) Enchantment before its own ETB
+/// fires — the ETB ability itself becomes an Aura AND targets the graveyard
+/// creature to reanimate (CR 603.3d: a triggered ability's targets are chosen
+/// when it's put on the stack).
+///
+/// By the time this runs, the trigger condition ("When ~ enters") and the
+/// intervening-if ("if it's on the battlefield, ") have already been peeled by
+/// `oracle_trigger`, and every "this enchantment"/"this Aura" self-reference
+/// has been normalized to `~`. The remaining effect body (character-for-
+/// character, lowercased) is:
+///
+/// ```text
+/// it becomes an aura with "enchant <...>." <verb> target creature card from a
+/// graveyard <destination> under your control and attach ~ to it. when ~
+/// leaves the battlefield, that creature's controller sacrifices it
+/// ```
+///
+/// where `<verb>` is `return `/`put ` and `<destination>` is ` to the
+/// battlefield`/` onto the battlefield` optionally followed by ` tapped` — verb,
+/// preposition, and tap state are three independent `alt`/`opt` combinators,
+/// not enumerated permutations. The quoted enchant clause is shape-checked
+/// only via the shared `parse_quoted_enchant_clause` (never semantically
+/// parsed), matching the swap shape.
+///
+/// Returns the fully-constructed 4-node chain via `build_aura_attach_chain`
+/// with `EnchantGrantShape::GrantOnly` and the genuinely-parsed target.
+/// Declines (returns `None`) unless the ENTIRE body matches, so any card whose
+/// text deviates stays an honest `Effect::Unimplemented`.
+pub(crate) fn try_parse_reanimator_aura_grant_etb_effect(
+    text: &str,
+    kind: AbilityKind,
+) -> Option<AbilityDefinition> {
+    let stripped = super::oracle_util::strip_reminder_text(text);
+    let lower = stripped.to_lowercase();
+    let (target, tap_state) =
+        super::oracle_nom::bridge::nom_parse_lower(&lower, parse_reanimator_aura_grant_etb_shape)?;
+    Some(build_aura_attach_chain(
+        kind,
+        tap_state,
+        EnchantGrantShape::GrantOnly,
+        target,
+    ))
+}
+
+/// Consume the whole reanimator-Aura GRANT-shape body, returning the
+/// genuinely-parsed target filter (CR 603.3d) and the entry tap state derived
+/// from the destination phrase. `eof` at the end makes it fail-closed: a
+/// partial match yields no chain.
+fn parse_reanimator_aura_grant_etb_shape(
+    i: &str,
+) -> OracleResult<'_, (TargetFilter, crate::types::zones::EtbTapState)> {
+    use crate::types::zones::EtbTapState;
+    let (i, _) = tag("it becomes an aura with ").parse(i)?;
+    let (i, _) = parse_quoted_enchant_clause(i)?;
+    let (i, _) = space1.parse(i)?;
+    // CR 608.2c: verb axis — "return"/"put" both move the targeted creature card.
+    let (i, _) = alt((tag("return "), tag("put "))).parse(i)?;
+    // CR 603.3d: the creature to reanimate is THIS triggered ability's own
+    // target, chosen when it is put on the stack — unlike the swap shape,
+    // there is no prior attachment to refer back to (`TargetFilter::AttachedTo`),
+    // because this object has no Enchant keyword (and no target) until this
+    // ETB fires. `parse_target` stops cleanly at the zone-suffix boundary
+    // ("...graveyard"), returning everything after as remainder. IMPORTANT:
+    // do not truncate or pre-slice this input before calling parse_target —
+    // hand it the full remainder.
+    let (target, i) = parse_target(i);
+    // CR 614.1 / CR 110.5b: destination axis — preposition and tap state are
+    // independent combinators, not enumerated permutations.
+    let (i, _) = alt((tag(" to the battlefield"), tag(" onto the battlefield"))).parse(i)?;
+    let (i, tapped) = opt(tag(" tapped")).parse(i)?;
+    let tap = if tapped.is_some() {
+        EtbTapState::Tapped
+    } else {
+        EtbTapState::Unspecified
+    };
+    let (i, _) = tag(
+        " under your control and attach ~ to it. when ~ leaves the battlefield, \
+         that creature's controller sacrifices it",
+    )
+    .parse(i)?;
+    let (i, _) = multispace0.parse(i)?;
+    let (i, _) = eof.parse(i)?;
+    Ok((i, (target, tap)))
+}
+
+/// Which keyword/subtype continuous modifications the reanimator-Aura ETB
+/// chain's `GenericEffect` node installs. Parser-internal only — never stored
+/// in an `AbilityDefinition`/`Effect`, discarded once `build_aura_attach_chain`
+/// emits plain `ContinuousModification`s. Not an engine-wide enum; not subject
+/// to the `/add-engine-variant` exhaustive-match-surface gate (precedent:
+/// `EqualizeVerb` in this same file is an identical parser-internal-only
+/// 2-arm selector).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnchantGrantShape {
+    /// Animate Dead / Dance of the Dead: already printed as an Aura, so the
+    /// ETB swaps its printed Enchant restriction for the post-reanimation one
+    /// (RemoveKeyword + AddKeyword). CR 613.1f only.
+    Swap,
+    /// Necromancy (and templated siblings): a plain Enchantment before this
+    /// ETB fires — grants the Aura subtype for the first time (CR 613.1d,
+    /// Layer 4) AND the Enchant keyword for the first time (CR 613.1f, Layer
+    /// 6). AddSubtype + AddKeyword, no RemoveKeyword (nothing to remove).
+    GrantOnly,
+}
+
+/// Build the reanimator-Aura attach chain shared by the two ETB shapes:
+/// `try_parse_reanimator_aura_etb_effect` (swap; Animate Dead / Dance of the
+/// Dead) and `try_parse_reanimator_aura_grant_etb_effect` (grant; Necromancy).
+/// Two documented parameters vary across call sites: the producer target of the
+/// root `ChangeZone` (`root_target` — `AttachedTo` for the swap shape, whose
+/// creature was chosen at cast time via the printed Enchant restriction; a
+/// genuinely-parsed graveyard-creature `Typed` filter for the grant shape, per
+/// CR 603.3d) and the layer-4/6 `shape` of the `GenericEffect`'s modifications
+/// (see `EnchantGrantShape`).
 ///
 /// Structure — ChangeZone at the ROOT, with the other three nodes nested
 /// progressively deeper — is a deliberate source-rebind choice:
@@ -11856,9 +11982,11 @@ fn parse_reanimator_aura_etb_body(i: &str) -> OracleResult<'_, crate::types::zon
 ///   rebinds the sub-chain's `source_id` to that creature, so trailing anaphora
 ///   bind to it. It is the ONLY forwarding node in the chain.
 /// * `GenericEffect` is ChangeZone's direct sub, so its `source_id` IS rebound to
-///   the creature. Its keyword-swap static must therefore reference the Aura via
+///   the creature. Its keyword modifications must therefore reference the Aura via
 ///   `TargetFilter::OriginalSource` (concretized to the pre-rebind source in
-///   `effects/mod.rs`'s forward_result block), NOT `SelfRef`.
+///   `effects/mod.rs`'s forward_result block), NOT `SelfRef`. The swap shape
+///   emits RemoveKeyword+AddKeyword (CR 613.1f); the grant shape emits
+///   AddSubtype (CR 613.1d, Layer 4)+AddKeyword (CR 613.1f, Layer 6).
 /// * `Attach` is `GenericEffect`'s sub, not `ChangeZone`'s. Because `GenericEffect`
 ///   itself never sets `forward_result`, this hop forwards no objects, so Attach's
 ///   `source_id` is never rebound — `attachment: SelfRef` correctly stays the Aura.
@@ -11866,13 +11994,15 @@ fn parse_reanimator_aura_etb_body(i: &str) -> OracleResult<'_, crate::types::zon
 ///   (CR 701.3a: the Aura attaches to the reanimated creature — the #4767 bug).
 /// * `CreateDelayedTrigger` likewise keeps `SelfRef` (never rebound) so the
 ///   leaves-battlefield condition watches the Aura, and its `Sacrifice { ParentTarget }`
-///   snapshots the creature at delayed-trigger creation time (CR 701.17a /
+///   snapshots the creature at delayed-trigger creation time (CR 701.21a /
 ///   CR 603.7c: "that creature's controller sacrifices it").
-fn build_reanimator_aura_etb_chain(
+fn build_aura_attach_chain(
     kind: AbilityKind,
     tap_state: crate::types::zones::EtbTapState,
+    shape: EnchantGrantShape,
+    root_target: TargetFilter,
 ) -> AbilityDefinition {
-    // CR 701.17a + CR 603.7c: "When ~ leaves the battlefield, that creature's
+    // CR 701.21a + CR 603.7c: "When ~ leaves the battlefield, that creature's
     // controller sacrifices it." — delayed leaves-battlefield sacrifice of the
     // reanimated creature (ParentTarget, snapshotted at creation).
     let sacrifice = AbilityDefinition::new(
@@ -11903,25 +12033,35 @@ fn build_reanimator_aura_etb_chain(
         },
     )
     .sub_ability(delayed);
-    // CR 613.1f + CR 611.2a: the Aura's own keyword swap ("it loses ... and
-    // gains ...") is a layer-6 ability-removing/adding continuous effect (CR
-    // 613.1f) with no stated duration, so it lasts until end of game (CR 611.2a).
+    // CR 613.1d + CR 613.1f + CR 611.2a: the Aura's own layer-4/6 continuous
+    // grant with no stated duration lasts until end of game (CR 611.2a).
     // `OriginalSource` references the Aura even though this node's
     // source_id is rebound to the creature by the parent ChangeZone's
     // forward_result. `duration: None` — an unstated-duration continuous grant.
+    //
+    // Swap shape (Animate Dead / Dance of the Dead, already printed as Auras):
+    // remove the printed Enchant restriction and add the post-reanimation one
+    // (CR 613.1f, Layer 6). Grant shape (Necromancy, a plain Enchantment before
+    // this ETB): grant the Aura subtype for the first time (CR 613.1d, Layer 4)
+    // — there is no printed Enchant restriction to remove — then add the Enchant
+    // keyword (CR 613.1f, Layer 6).
+    let mut modifications = match shape {
+        EnchantGrantShape::Swap => vec![ContinuousModification::RemoveKeyword {
+            keyword: Keyword::Enchant(TargetFilter::Any),
+        }],
+        EnchantGrantShape::GrantOnly => vec![ContinuousModification::AddSubtype {
+            subtype: "Aura".to_string(),
+        }],
+    };
+    modifications.push(ContinuousModification::AddKeyword {
+        keyword: Keyword::Enchant(TargetFilter::ParentTarget),
+    });
     let generic = AbilityDefinition::new(
         kind,
         Effect::GenericEffect {
             static_abilities: vec![StaticDefinition::continuous()
                 .affected(TargetFilter::OriginalSource)
-                .modifications(vec![
-                    ContinuousModification::RemoveKeyword {
-                        keyword: Keyword::Enchant(TargetFilter::Any),
-                    },
-                    ContinuousModification::AddKeyword {
-                        keyword: Keyword::Enchant(TargetFilter::ParentTarget),
-                    },
-                ])],
+                .modifications(modifications)],
             duration: None,
             target: None,
         },
@@ -11937,7 +12077,7 @@ fn build_reanimator_aura_etb_chain(
         Effect::ChangeZone {
             origin: Some(Zone::Graveyard),
             destination: Zone::Battlefield,
-            target: TargetFilter::AttachedTo,
+            target: root_target,
             owner_library: false,
             enter_transformed: false,
             enters_under: Some(ControllerRef::You),
@@ -28058,7 +28198,7 @@ fn try_fold_token_repeat_into_count(effect: &mut Effect, qty: &QuantityExpr) -> 
 /// [`ThisWayCause`] the tracked-set consumer should bind to (`caused_by`):
 ///
 ///   - "exiled this way" → `Some(Exiled)` (CR 701.13a — exile).
-///   - "sacrificed this way" → `Some(Sacrificed)` (CR 701.17a).
+///   - "sacrificed this way" → `Some(Sacrificed)` (CR 701.21a).
 ///   - "destroyed this way" → `Some(Destroyed)` (CR 701.8a).
 ///   - "milled this way" → `Some(Milled)` (CR 701.17a).
 ///   - "discarded this way" → `Some(Discarded)` (CR 701.9a).

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -10027,6 +10027,22 @@ mod tests {
         assert_eq!(rest.trim(), "");
     }
 
+    // Necromancy building block (#640): "target creature card from a graveyard"
+    // must parse to a creature+card `Typed` filter, zone Graveyard, with NO owner
+    // constraint ("a graveyard", not "your graveyard"). This is the target the
+    // reanimator-Aura GRANT-shape ETB chain feeds into its root ChangeZone.
+    #[test]
+    fn target_creature_card_from_a_graveyard() {
+        let (f, rest) = parse_target("target creature card from a graveyard");
+        assert_eq!(
+            f,
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::InZone {
+                zone: Zone::Graveyard
+            }]))
+        );
+        assert_eq!(rest.trim(), "");
+    }
+
     #[test]
     fn target_card_from_exile() {
         let (f, rest) = parse_target("target card from exile");

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -11,6 +11,7 @@ use super::oracle_effect::{
     condition_text_is_rehomeable, lower_effect_chain_ir, parse_effect_chain_ir,
     try_parse_each_player_copy_chosen, try_parse_exile_top_each_library_with_collection_counter,
     try_parse_grant_graveyard_keyword_to_target, try_parse_reanimator_aura_etb_effect,
+    try_parse_reanimator_aura_grant_etb_effect,
 };
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::doc::PrintedTriggerIndex;
@@ -1464,7 +1465,7 @@ pub(crate) fn parse_trigger_line_with_index_ir(
                     .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
             })
             .or_else(|| {
-                // CR 608.2c + CR 613.1f + CR 701.3a + CR 701.17a: whole-body
+                // CR 608.2c + CR 613.1f + CR 701.3a + CR 701.21a: whole-body
                 // reanimator-Aura ETB effect (Animate Dead / Dance of the Dead) —
                 // "it loses ... and gains ...", return/put the enchanted creature
                 // card to the battlefield under your control, attach the Aura to
@@ -1472,6 +1473,18 @@ pub(crate) fn parse_trigger_line_with_index_ir(
                 // declines unless the entire body matches, so a deviating card
                 // stays an honest Unimplemented rather than misparsing.
                 try_parse_reanimator_aura_etb_effect(&effect_for_parse, AbilityKind::Spell)
+                    .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
+            })
+            .or_else(|| {
+                // CR 603.3d + CR 608.2c + CR 613.1d + CR 613.1f + CR 701.3a + CR 701.21a:
+                // whole-body reanimator-Aura GRANT-shape ETB effect (Necromancy) — a plain
+                // (non-Aura) enchantment whose ETB ability becomes an Aura AND targets the
+                // graveyard creature to reanimate itself (unlike the swap shape above,
+                // which targets at CAST time via its printed Enchant restriction and
+                // refers back to `TargetFilter::AttachedTo` here). Fail-closed: declines
+                // unless the entire body matches, so a deviating card stays an honest
+                // Unimplemented rather than misparsing.
+                try_parse_reanimator_aura_grant_etb_effect(&effect_for_parse, AbilityKind::Spell)
                     .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
             })
             .or_else(|| {

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -23559,6 +23559,187 @@ fn dance_of_the_dead_etb_lowers_to_reanimator_chain_tapped_4767() {
     );
 }
 
+// --- issue #640: reanimator-Aura GRANT-shape ETB whole-body recognizer (Necromancy) ---
+
+/// Verbatim Necromancy Oracle text (Scryfall, 2026-07). Unlike Animate Dead,
+/// Necromancy is a plain (non-Aura) Enchantment whose ETB ability BOTH becomes
+/// an Aura AND targets the graveyard creature to reanimate ("Put target creature
+/// card from a graveyard onto the battlefield ...").
+const NECROMANCY_ORACLE: &str = "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.\nWhen this enchantment enters, if it's on the battlefield, it becomes an Aura with \"enchant creature put onto the battlefield with Necromancy.\" Put target creature card from a graveyard onto the battlefield under your control and attach this enchantment to it. When this enchantment leaves the battlefield, that creature's controller sacrifices it.";
+
+/// SHAPE test — assert Necromancy's ETB trigger lowers to the 4-node
+/// reanimator-Aura chain with the GRANT shape: the root `ChangeZone` targets a
+/// genuinely-parsed creature-card-in-a-graveyard `Typed` filter (NOT
+/// `AttachedTo`, unlike the swap shape — this is the #640 fix), and the
+/// `GenericEffect` grants the Aura subtype and the Enchant keyword for the first
+/// time (`AddSubtype` + `AddKeyword`, with NO `RemoveKeyword`). Runtime behavior
+/// is exercised separately in `casting_tests.rs`.
+#[test]
+fn necromancy_etb_lowers_to_reanimator_grant_chain_640() {
+    use crate::types::zones::Zone;
+
+    let parsed = parse_oracle_text(
+        NECROMANCY_ORACLE,
+        "Necromancy",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    // Necromancy has TWO enters-battlefield triggers: its first ability (the
+    // cleanup-step sacrifice for flash-casts) and this reanimator ETB. Select
+    // the reanimator one by its root `Effect::ChangeZone` body.
+    let root = parsed
+        .triggers
+        .iter()
+        .filter(|t| t.mode == TriggerMode::ChangesZone && t.destination == Some(Zone::Battlefield))
+        .filter_map(|t| t.execute.as_deref())
+        .find(|def| matches!(def.effect.as_ref(), Effect::ChangeZone { .. }))
+        .unwrap_or_else(|| {
+            panic!(
+                "Necromancy: expected a reanimator ETB trigger with a root ChangeZone, got {:?}",
+                parsed.triggers
+            )
+        });
+
+    // Node 1: ChangeZone at the root, forward_result set, targeting a real
+    // graveyard-creature-card filter (NOT AttachedTo).
+    assert!(
+        root.forward_result,
+        "Necromancy: root ChangeZone must set forward_result"
+    );
+    let Effect::ChangeZone {
+        origin,
+        destination,
+        target,
+        enters_under,
+        enter_tapped,
+        ..
+    } = root.effect.as_ref()
+    else {
+        panic!(
+            "Necromancy: expected root Effect::ChangeZone, got {:?}",
+            root.effect
+        );
+    };
+    assert_eq!(*origin, Some(Zone::Graveyard), "Necromancy: origin");
+    assert_eq!(*destination, Zone::Battlefield, "Necromancy: destination");
+    assert_eq!(
+        *enters_under,
+        Some(ControllerRef::You),
+        "Necromancy: enters_under"
+    );
+    // Untapped: "onto the battlefield" with no trailing " tapped".
+    assert!(
+        !enter_tapped.is_tapped(),
+        "Necromancy: creature enters untapped ({enter_tapped:?})"
+    );
+    // The #640 fix: the target is a genuinely-parsed creature-card-in-a-graveyard
+    // filter (owner-agnostic — "a graveyard"), NOT `TargetFilter::AttachedTo`.
+    assert_ne!(
+        *target,
+        TargetFilter::AttachedTo,
+        "Necromancy: ETB must target the graveyard creature itself, not AttachedTo"
+    );
+    assert_eq!(
+        *target,
+        TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::InZone {
+            zone: Zone::Graveyard
+        }])),
+        "Necromancy: ETB ChangeZone target"
+    );
+
+    // Node 2: GenericEffect grants (not swaps) — AddSubtype{Aura} + AddKeyword,
+    // referencing OriginalSource, no duration.
+    let generic = root
+        .sub_ability
+        .as_deref()
+        .expect("Necromancy: ChangeZone has no GenericEffect sub");
+    let Effect::GenericEffect {
+        static_abilities,
+        duration,
+        ..
+    } = generic.effect.as_ref()
+    else {
+        panic!(
+            "Necromancy: expected GenericEffect, got {:?}",
+            generic.effect
+        );
+    };
+    assert_eq!(*duration, None, "Necromancy: grant has no stated duration");
+    assert_eq!(static_abilities.len(), 1, "Necromancy: one grant static");
+    let sd = &static_abilities[0];
+    assert_eq!(
+        sd.affected,
+        Some(TargetFilter::OriginalSource),
+        "Necromancy: grant must target OriginalSource (the enchantment), not SelfRef"
+    );
+    assert_eq!(
+        sd.modifications,
+        vec![
+            ContinuousModification::AddSubtype {
+                subtype: "Aura".to_string(),
+            },
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Enchant(TargetFilter::ParentTarget),
+            },
+        ],
+        "Necromancy: grant modifications (AddSubtype + AddKeyword, no RemoveKeyword)"
+    );
+
+    // Node 3: Attach — SelfRef (the enchantment) onto ParentTarget (the creature).
+    let attach = generic
+        .sub_ability
+        .as_deref()
+        .expect("Necromancy: GenericEffect has no Attach sub");
+    let Effect::Attach { attachment, target } = attach.effect.as_ref() else {
+        panic!("Necromancy: expected Attach, got {:?}", attach.effect);
+    };
+    assert_eq!(
+        *attachment,
+        TargetFilter::SelfRef,
+        "Necromancy: attach attachment"
+    );
+    assert_eq!(
+        *target,
+        TargetFilter::ParentTarget,
+        "Necromancy: attach host"
+    );
+
+    // Node 4: CreateDelayedTrigger — WhenLeavesPlayFiltered{SelfRef} -> Sacrifice{ParentTarget}.
+    let delayed = attach
+        .sub_ability
+        .as_deref()
+        .expect("Necromancy: Attach has no CreateDelayedTrigger sub");
+    let Effect::CreateDelayedTrigger {
+        condition, effect, ..
+    } = delayed.effect.as_ref()
+    else {
+        panic!(
+            "Necromancy: expected CreateDelayedTrigger, got {:?}",
+            delayed.effect
+        );
+    };
+    assert_eq!(
+        *condition,
+        DelayedTriggerCondition::WhenLeavesPlayFiltered {
+            filter: TargetFilter::SelfRef,
+        },
+        "Necromancy: delayed leaves-battlefield condition on the enchantment (SelfRef)"
+    );
+    let Effect::Sacrifice { target, .. } = effect.effect.as_ref() else {
+        panic!("Necromancy: expected Sacrifice, got {:?}", effect.effect);
+    };
+    assert_eq!(
+        *target,
+        TargetFilter::ParentTarget,
+        "Necromancy: sacrifice targets the reanimated creature"
+    );
+    assert!(
+        delayed.sub_ability.is_none(),
+        "Necromancy: chain ends at the delayed trigger"
+    );
+}
+
 /// #5253 (Railway Brawler): "Whenever another creature you control enters, put
 /// X +1/+1 counters on it, where X is its power." The "its" in the count clause
 /// is the ENTERING creature (the counter recipient), not the ability carrier.


### PR DESCRIPTION
## Summary

Necromancy's ETB ability ("it becomes an Aura with \"...\". Put target creature card from a graveyard onto the battlefield under your control and attach this enchantment to it...") was parsing via the Animate Dead-class combinator (`try_parse_reanimator_aura_etb_effect`), which only handles the quoted keyword-adoption clause and silently dropped the entire targeted-reanimation sentence — no `TargetFilter`, no zone reference, no reanimation effect node anywhere in the AST. This is exactly why #640 reports zero targetable creatures: no target-bearing effect was ever built.

Root cause: Necromancy is printed as a **plain Enchantment** (no `Enchant` keyword line), unlike Animate Dead which is cast as an Aura and targets at cast time via its printed Enchant restriction. Necromancy's reanimation target is a genuine CR 603.3d stack target chosen when its own ETB triggered ability goes on the stack — a structurally different shape that needed its own recognizer, not a parameter tweak to the existing one.

## Fix

- Added `try_parse_reanimator_aura_grant_etb_effect` + `parse_reanimator_aura_grant_etb_shape`, a new whole-body, fail-closed nom recognizer for the "grant" sub-class (plain Enchantment ETB grants Aura-hood + targets its own reanimation), wired into `oracle_trigger.rs`'s dispatch chain alongside the existing Animate Dead arm.
- Generalized the shared reanimator-Aura chain builder (`build_reanimator_aura_etb_chain` → `build_aura_attach_chain`), parameterized by a new parser-internal `EnchantGrantShape` enum (`Swap` for Animate Dead's existing RemoveKeyword+AddKeyword behavior, `GrantOnly` for Necromancy's AddSubtype+AddKeyword — since Necromancy has no prior Aura subtype/Enchant restriction to swap) and a `root_target: TargetFilter` parameter (Animate Dead keeps its existing `AttachedTo` reference; Necromancy gets a genuinely-parsed target).
- Corrected several `701.17a` (Mill) → `701.21a` (Sacrifice) CR mis-citations found in the touched functions.

A confirmed 5-card class shares a similar "becomes an Aura with X, [producer effect], attach self to result" template (Necromancy, Last Voyage of the Uncharted, Cloudform, Lightform, Rageform). This PR scopes to Necromancy; the other 4 use an unquoted restriction clause and different producer/sacrifice phrasing, so they correctly stay `Unimplemented` and are tracked separately for a future follow-up.

## CR references
- CR 603.3d (triggered ability targets chosen when put on the stack)
- CR 608.2b (fizzle on illegal target)
- CR 608.2c (follow the reanimation instruction)
- CR 613.1d (Layer 4 type-changing — AddSubtype)
- CR 613.1f (Layer 6 ability-granting — AddKeyword)
- CR 701.3a/b (Attach)
- CR 701.21a (Sacrifice — corrects prior 701.17a Mill mis-citations)
- CR 704.5m (unattached Aura → graveyard SBA)

## Verification
- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- New tests (parser shape test, `parse_target` building-block regression test, 4 runtime pipeline tests covering full reanimation+attach+SBA-survival, cross-controller reanimation, delayed sacrifice, and CR 608.2b fizzle) — all pass
- Existing Animate Dead/Dance of the Dead test suite (10 tests) — all pass unmodified, confirming the shared builder's generalization is behavior-preserving
- `cargo semantic-audit`/`cargo coverage` — not run locally (cold MTGJSON download didn't complete in this worktree); relying on CI for corpus-level signal

Closes #640