### PR TITLE
ship/t79 instead else

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5382,6 +5382,30 @@ pub(crate) fn parse_oracle_ir(
             // replaces the preceding ability's effect. Compose them so the engine
             // resolves the binary choice: the "instead" sub carries the condition;
             // the base ability becomes the fallback when it is not met.
+            // CR 614.15: the residual self-replacement printings. The three gates above
+            // recognize the shapes we can BIND: the whole-clause forms (bare trailing
+            // "instead", ", instead <effect>", "<effect> instead if <cond>") and the
+            // partial quantity form with a Dig antecedent. Everything else that is
+            // still a self-replacement override reaches here — e.g. a partial override
+            // whose antecedent is NOT a Dig ("search your library for up to three basic
+            // Forest cards instead of two"), or one that replaces a NON-first clause of
+            // the base chain ("You may put that card onto the battlefield instead of
+            // putting it into your hand").
+            //
+            // Those need a clause-level antecedent selection and a tail that survives in
+            // BOTH branches, which the FirstEmitted binder cannot express. We do NOT
+            // guess at them — but neither may they be published as independent abilities,
+            // which is what happened before and made the engine run the base effect AND
+            // the replacement (CR 614.6). They fall to the honest-failure floor below.
+            //
+            // The "would" exclusion is CR 614.1: a replacement effect watches for an
+            // event that WOULD happen. A "would" clause names an EVENT (CR 614.1a) and is
+            // owned by the replacement machinery, not by this self-replacement binder —
+            // claiming it here would replace a working rider encoding with an honest red.
+            let effect_line_lower = effect_line.to_lowercase();
+            let is_unbindable_self_replacement = scan_contains(&effect_line_lower, "instead")
+                && !scan_contains(&effect_line_lower, "would");
+
             if is_instead || is_cross_line_dig_alt || is_instead_replacement_line(&effect_line) {
                 if let Some(condition) = def.condition.take() {
                     if let Some(base_item) = emitter.pop_last_spell() {
@@ -5433,6 +5457,30 @@ pub(crate) fn parse_oracle_ir(
                     def.sub_ability = None;
                     def.else_ability = None;
                 }
+            } else if is_unbindable_self_replacement && emitter.builder.peek_last_spell().is_some()
+            {
+                // CR 614.6 + CR 614.15: the residual self-replacement printings — a
+                // PARTIAL override whose antecedent is not a Dig ("search your library
+                // for up to three basic Forest cards instead of two"), or one that
+                // replaces a NON-FIRST clause of the base chain ("You may put that card
+                // onto the battlefield instead of putting it into your hand").
+                //
+                // These have a perfectly good condition, so it is tempting to hand them to
+                // the binder above. That would be WRONG, and silently so: the binder binds
+                // the FIRST emitted clause and parks the base's tail in `else_ability`,
+                // which the runtime walks ONLY when the swap does not fire. Nissa's
+                // Pilgrimage would search for three basic Forests and then never reveal
+                // them, put one onto the battlefield, or shuffle. That trades a
+                // double-execution for an effect LOSS — a different silent wrong.
+                //
+                // A faithful bind needs clause-level antecedent selection plus a tail that
+                // survives in BOTH branches. Until that exists, fail honestly: the base
+                // ability stands exactly as printed and the override is reported
+                // unimplemented. Never an independent ability.
+                def.effect = Box::new(Effect::unimplemented("instead_override", &effect_line));
+                def.condition = None;
+                def.sub_ability = None;
+                def.else_ability = None;
             }
             emitter.ability_at(item_line, def);
             continue;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -28,7 +28,7 @@ use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 
 use super::oracle_nom::bridge::{nom_on_lower, split_once_on_lower};
-use super::oracle_nom::condition::{parse_graveyard_keyword_grant_sentence, parse_inner_condition};
+use super::oracle_nom::condition::parse_graveyard_keyword_grant_sentence;
 use super::oracle_nom::primitives::{parse_number as nom_parse_number, scan_contains};
 
 use super::oracle_attraction::parse_attraction_visit_triggers;
@@ -1943,9 +1943,14 @@ use crate::parser::oracle_ir::ast::ActivatedConstraintAst;
 /// 2. "[effect] instead if [condition]" — mid-line "instead", condition AFTER
 /// 3. "[effect] instead" — trailing "instead"
 ///
-/// Any extracted "if [condition]" clause is parsed through the shared condition
-/// grammar (`parse_inner_condition`) and composed with any ability-word condition
-/// at the caller.
+/// Any extracted "if [condition]" clause is lowered through
+/// `conditions::lower_instead_condition` — the SINGLE AUTHORITY shared with the
+/// intra-chain override path (`build_instead_def`) — and composed with any
+/// ability-word condition at the caller. This path previously ran only the nom
+/// `StaticCondition` grammar, a strictly narrower vocabulary that cannot express
+/// a target-relative predicate; conditions the chain path lowers fine ("its
+/// controller has three or more poison counters") were silently dropped here, and
+/// the override was then published as an UNCONDITIONAL sibling ability.
 fn strip_instead_clause(
     text: &str,
     ctx: &mut ParseContext,
@@ -1961,10 +1966,11 @@ fn strip_instead_clause(
         if let Ok((cond_text, ())) =
             value::<_, _, OracleError<'_>, _>((), tag("if ")).parse(before.lower.trim_start())
         {
-            if let Some(condition) = parse_inner_condition(cond_text.trim())
-                .ok()
-                .and_then(|(rest, condition)| rest.trim().is_empty().then_some(condition))
-                .and_then(|condition| ability_word_to_ability_condition(&Some(condition), ctx))
+            if let Some(condition) =
+                crate::parser::oracle_effect::conditions::lower_instead_condition(
+                    cond_text.trim(),
+                    ctx,
+                )
             {
                 return (after.original.trim().to_string(), Some(condition), true);
             }
@@ -2008,10 +2014,8 @@ fn strip_instead_clause(
             // allow-noncombinator: structural sentence-boundary split, not parsing dispatch
             return (text.to_string(), None, false);
         }
-        let condition = parse_inner_condition(condition_text)
-            .ok()
-            .and_then(|(rest, condition)| rest.trim().is_empty().then_some(condition))
-            .and_then(|condition| ability_word_to_ability_condition(&Some(condition), ctx));
+        let condition =
+            crate::parser::oracle_effect::conditions::lower_instead_condition(condition_text, ctx);
         return (before.original.trim().to_string(), condition, true);
     }
 
@@ -5336,10 +5340,11 @@ pub(crate) fn parse_oracle_ir(
             if has_roll_die_pattern(&lower) {
                 i = attach_die_result_branches_to_chain(&mut def, &lines, i);
             }
-            // CR 608.2c: Cross-line "instead" replacement — when a conditional line
-            // replaces the entire preceding ability, compose them so the engine resolves
-            // the binary choice correctly. The "instead" sub has the condition; the base
-            // ability becomes the fallback when the condition is not met.
+            // CR 608.2c + CR 614.15: Cross-line "instead" self-replacement — a
+            // separate printed line (usually an ability word, per CR 614.15)
+            // replaces the preceding ability's effect. Compose them so the engine
+            // resolves the binary choice: the "instead" sub carries the condition;
+            // the base ability becomes the fallback when it is not met.
             if is_instead || is_instead_replacement_line(&effect_line) {
                 if let Some(condition) = def.condition.take() {
                     if let Some(base_item) = emitter.pop_last_spell() {
@@ -5367,6 +5372,29 @@ pub(crate) fn parse_oracle_ir(
                     }
                     // No previous ability to compose with — restore condition and push standalone.
                     def.condition = Some(condition);
+                } else if emitter.builder.peek_last_spell().is_some() {
+                    // CR 614.6: "If an event is replaced, it never happens."
+                    //
+                    // The line IS a self-replacement override of the preceding
+                    // ability, but no condition lowered for it (from the clause, the
+                    // trailing "instead if <cond>", or an ability word), so there is
+                    // nothing to branch on and the override CANNOT be bound.
+                    //
+                    // Publishing it as an independent ability — which is what used to
+                    // happen — is the one thing we must never do: the engine then
+                    // performs the base effect AND the replacement, unconditionally.
+                    // Anoint with Affliction ("Corrupted — Exile that creature instead
+                    // if its controller has three or more poison counters") published a
+                    // second, condition-less `ChangeZone -> Exile` and exiled the target
+                    // even when the printed "mana value 3 or less" gate had already
+                    // refused to, and even with zero poison counters in play.
+                    //
+                    // Fail honestly instead: the base ability stands as printed and the
+                    // unbindable override is reported as unimplemented. This mirrors the
+                    // intra-chain `InsteadLowering::ConditionUnlowerable` floor.
+                    def.effect = Box::new(Effect::unimplemented("instead_override", &effect_line));
+                    def.sub_ability = None;
+                    def.else_ability = None;
                 }
             }
             emitter.ability_at(item_line, def);

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5308,6 +5308,43 @@ pub(crate) fn parse_oracle_ir(
             } else {
                 parse_effect_chain_with_context(parse_line, AbilityKind::Spell, &mut ctx)
             };
+
+            // CR 614.15 + CR 608.2c: a PARTIAL cross-line self-replacement whose
+            // antecedent is a `Dig` ("Reveal the top five cards of your library. You
+            // may put a creature card from among them into your hand. Put the rest
+            // into your graveyard." / "Spell mastery — If <cond>, put up to TWO
+            // creature cards from among the revealed cards into your hand INSTEAD OF
+            // ONE.").
+            //
+            // The override's body cannot stand on its own: parsed in isolation it
+            // lowers to a bare `ChangeZone`, dropping the reveal, the library source
+            // and the rest-to-graveyard rider that the printed Dig carries. Binding
+            // THAT as the replacement would trade the double-execution for an effect
+            // LOSS. `try_parse_dig_instead_alternative` is the existing
+            // antecedent-parameterized handler for exactly this: it rebuilds the
+            // alternative as a full `Dig` that reuses the preceding Dig's source and
+            // reveal-mode and swaps only what the override actually changes
+            // (keep_count / up_to / filter / destination). It is reached intra-chain
+            // via the chunk ladder; here we hand it the previous LINE's def as the
+            // antecedent, which is the same relationship across a line boundary.
+            //
+            // The resulting alternative carries its own condition, so it flows into
+            // the ability-word merge and the cross-line binder below exactly like any
+            // other override — the binder wraps it in `ConditionInstead` and parks the
+            // printed Dig as the `else_ability` fallback.
+            let dig_alt = emitter.builder.peek_last_spell().and_then(|previous| {
+                crate::parser::oracle_effect::conditions::try_parse_dig_instead_alternative(
+                    &effect_line,
+                    Some(previous),
+                    AbilityKind::Spell,
+                    &mut ctx,
+                )
+            });
+            let is_cross_line_dig_alt = dig_alt.is_some();
+            if let Some(alt) = dig_alt {
+                def = alt;
+            }
+
             def.min_x_value = spell_min_x_value;
             def.description = Some(description);
             // CR 608.2c: Compose ability word condition with chain-extracted condition.
@@ -5345,7 +5382,7 @@ pub(crate) fn parse_oracle_ir(
             // replaces the preceding ability's effect. Compose them so the engine
             // resolves the binary choice: the "instead" sub carries the condition;
             // the base ability becomes the fallback when it is not met.
-            if is_instead || is_instead_replacement_line(&effect_line) {
+            if is_instead || is_cross_line_dig_alt || is_instead_replacement_line(&effect_line) {
                 if let Some(condition) = def.condition.take() {
                     if let Some(base_item) = emitter.pop_last_spell() {
                         // Re-emit the merged ability at the BASE item's ORIGINAL

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -3983,6 +3983,32 @@ fn build_instead_def(
     InsteadLowering::Branch(Box::new(result))
 }
 
+/// CR 614.15: an "instead" marker replaces "part or all" of the ability's effect,
+/// and the printed grammar says WHICH. A bare trailing "instead" replaces the whole
+/// clause ("create two of those tokens instead"). A trailing "instead of <N>"
+/// replaces only a PART — the antecedent's quantity — and names the OLD value it is
+/// displacing ("put up to two creature cards … into your hand instead of one",
+/// "search your library for up to three basic Forest cards instead of two").
+///
+/// That trailing "of <N>" is redundant with the antecedent, which still holds the old
+/// value, so it carries nothing the branch needs: it is a marker, not an operand.
+/// This recognizes both printings as the same replacement marker so the alternative
+/// grammar is not blocked by the one that spells out what it replaces.
+///
+/// Anything else after "instead" ("instead of putting it into your hand") names a
+/// non-quantity part and is NOT accepted here — that is a different replacement axis,
+/// and silently treating it as a whole-clause marker would drop the part it names.
+fn is_replacement_marker_tail(after_instead_lower: &str) -> bool {
+    let tail = after_instead_lower.trim().trim_end_matches('.').trim();
+    if tail.is_empty() {
+        return true;
+    }
+    nom_parse_lower(tail, |input| {
+        all_consuming(preceded(tag("of "), nom_primitives::parse_number)).parse(input)
+    })
+    .is_some()
+}
+
 /// CR 608.2c: "If <cond>, you may instead <reveal-N-from-among-body>" — conditional
 /// alternative selection for a preceding `Effect::Dig`. The "instead" body re-uses
 /// the preceding Dig's source (top N cards) but swaps keep_count/up_to/filter/destination.
@@ -3997,7 +4023,7 @@ fn build_instead_def(
 /// caller wraps the preceding Dig as `else_ability`. Class coverage: any card of form
 /// "look at top N / reveal a <filter> card from among them ... if <cond>, you may
 /// instead reveal M <filter'> cards from among them" (CR 608.2c replacement effect).
-pub(super) fn try_parse_dig_instead_alternative(
+pub(crate) fn try_parse_dig_instead_alternative(
     text: &str,
     previous: Option<&AbilityDefinition>,
     kind: AbilityKind,
@@ -4048,7 +4074,7 @@ pub(super) fn try_parse_dig_instead_alternative(
             let body_rest_pair = TextPair::new(body_rest, &body_rest_lower);
             let (body_rest, suffix_had_instead) =
                 if let Some((before, after)) = body_rest_pair.split_around(" instead") {
-                    if after.original.trim().is_empty() {
+                    if is_replacement_marker_tail(after.lower) {
                         (before.original.trim(), true)
                     } else {
                         (body_rest, false)

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -3270,13 +3270,15 @@ fn parse_mana_spent_vs_mana_value_target_condition(
     ))
 }
 
-/// CR 122.1f + CR 109.4 + CR 608.2c: "if its controller is poisoned" on a
-/// targeted spell effect — a player is "poisoned" iff they have one or more
-/// poison counters (CR 122.1f), and "its controller" anaphors to the controller
-/// of the ability's first object target (the countered spell). Corrupted
-/// Resolve. Mirrors `parse_no_mana_spent_to_cast_target_condition_text`: reuses
-/// `QuantityCheck` over an existing `QuantityRef` building block rather than a
-/// bespoke condition variant, the poison threshold `>= 1` expressing "poisoned".
+/// CR 122.1f + CR 109.4 + CR 608.2c: a poison predicate on the controller of the
+/// ability's first object target — "if its controller is poisoned" (Corrupted
+/// Resolve) and "if its controller has three or more poison counters" (the
+/// Corrupted ability word: Bring the Ending, Anoint with Affliction). Both read
+/// the SAME player counter through the SAME `QuantityRef` and the SAME `GE`
+/// comparator; only the threshold differs, so the predicate is parameterized on
+/// its threshold rather than split into sibling combinators. Mirrors
+/// `parse_no_mana_spent_to_cast_target_condition_text`: reuses `QuantityCheck`
+/// over an existing `QuantityRef` building block rather than a bespoke variant.
 fn parse_target_controller_poisoned_condition_text(text: &str) -> Option<AbilityCondition> {
     let lower = text.to_ascii_lowercase();
     nom_parse_lower(&lower, |input| {
@@ -3294,9 +3296,10 @@ fn parse_target_controller_poisoned_condition(input: &str) -> OracleResult<'_, A
             tag("this spell's "),
             tag("the spell's "),
         )),
-        tag("controller is poisoned"),
+        tag("controller "),
     )
         .parse(input)?;
+    let (rest, threshold) = parse_target_controller_poison_threshold(rest)?;
     Ok((
         rest,
         AbilityCondition::QuantityCheck {
@@ -3305,11 +3308,31 @@ fn parse_target_controller_poisoned_condition(input: &str) -> OracleResult<'_, A
                     kind: crate::types::player::PlayerCounterKind::Poison,
                 },
             },
-            // CR 122.1f: "poisoned" == one or more poison counters.
             comparator: Comparator::GE,
-            rhs: QuantityExpr::Fixed { value: 1 },
+            rhs: QuantityExpr::Fixed { value: threshold },
         },
     ))
+}
+
+/// CR 122.1f: the poison threshold the predicate compares against. "poisoned" is
+/// DEFINED as one or more poison counters, so it is exactly the `>= 1` case of
+/// the same `<N> or more poison counters` shape the Corrupted ability word spells
+/// out — one axis, two printings, not two combinators.
+fn parse_target_controller_poison_threshold(input: &str) -> OracleResult<'_, i32> {
+    alt((
+        value(1, tag("is poisoned")),
+        map(
+            preceded(
+                tag("has "),
+                terminated(
+                    nom_primitives::parse_number,
+                    tag(" or more poison counters"),
+                ),
+            ),
+            |count| count as i32,
+        ),
+    ))
+    .parse(input)
 }
 
 pub(super) fn parse_condition_text(text: &str) -> Option<AbilityCondition> {
@@ -3882,9 +3905,35 @@ fn condition_names_an_event(cond_text: &str) -> bool {
     nom_primitives::scan_contains(&cond_text.to_lowercase(), "would")
 }
 
+/// CR 608.2c + CR 614.15: the SINGLE AUTHORITY for lowering the condition of an
+/// "instead" self-replacement override — wherever that override is printed.
+///
+/// A self-replacement override can be printed inside the clause chain it replaces
+/// ("… create two of those tokens instead", handled by `build_instead_def`) or as
+/// a SEPARATE ability on its own line, "particularly when preceded by an ability
+/// word" (CR 614.15 — "Corrupted — Counter that spell instead if …", handled by
+/// the cross-line binder in `oracle.rs`). Both callers MUST lower the condition
+/// through here.
+///
+/// They previously did not: the cross-line path ran only the nom `StaticCondition`
+/// grammar, which cannot express a target-relative predicate, so a condition this
+/// ladder lowers fine ("its controller has three or more poison counters") was
+/// dropped there. The override then reached the emitter with `condition: None`
+/// and was published as an UNCONDITIONAL sibling ability — the engine ran the base
+/// effect AND the replacement, every time (CR 614.6). One authority, one
+/// vocabulary, so the two paths cannot drift apart again.
+pub(crate) fn lower_instead_condition(
+    cond_text: &str,
+    ctx: &mut ParseContext,
+) -> Option<AbilityCondition> {
+    try_nom_condition_as_ability_condition(cond_text, ctx)
+        .or_else(|| parse_condition_text(cond_text))
+        .or_else(|| parse_control_count_as_ability_condition(cond_text))
+}
+
 /// Shared assembly: build an `AbilityDefinition` for an instead override.
-/// Tries the three condition parsers in priority order; bails if none match
-/// (so the chunk can fall through to other dispatch paths). Wraps the result
+/// Lowers the condition through `lower_instead_condition`; bails if it does not
+/// lower (so the chunk can fall through to other dispatch paths). Wraps the result
 /// in `ConditionInstead` per CR 608.2c and rewrites cost-paid-object quantity
 /// references when needed.
 fn build_instead_def(
@@ -3911,10 +3960,7 @@ fn build_instead_def(
     // replacement. Everything that lowers today still lowers; only the failure
     // path is split, by `condition_names_an_event`, into "defer" vs "fail
     // honestly".
-    let Some(condition) = try_nom_condition_as_ability_condition(&cond_text, ctx)
-        .or_else(|| parse_condition_text(&cond_text))
-        .or_else(|| parse_control_count_as_ability_condition(&cond_text))
-    else {
+    let Some(condition) = lower_instead_condition(&cond_text, ctx) else {
         return if condition_names_an_event(&cond_text) {
             InsteadLowering::NotOwned
         } else {

--- a/crates/engine/tests/integration/cross_line_instead_override_branch.rs
+++ b/crates/engine/tests/integration/cross_line_instead_override_branch.rs
@@ -31,6 +31,9 @@ use engine::types::PlayerId;
 /// Anoint with Affliction {1}{B} — Instant. Verbatim Oracle text.
 const ANOINT: &str = "Exile target creature if it has mana value 3 or less.\nCorrupted — Exile that creature instead if its controller has three or more poison counters.";
 
+/// Gather the Pack {1}{G} — Sorcery. Verbatim Oracle text.
+const GATHER_THE_PACK: &str = "Reveal the top five cards of your library. You may put a creature card from among them into your hand. Put the rest into your graveyard.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, put up to two creature cards from among the revealed cards into your hand instead of one.";
+
 /// CR 614.6 DOUBLE-EXECUTION WITNESS (board state).
 ///
 /// Anoint with Affliction exiles the target ONLY if its mana value is 3 or less.
@@ -85,6 +88,104 @@ fn anoint_with_affliction_cross_line_override_does_not_exile_unconditionally() {
 
 fn poison_counters(runner: &GameRunner, player: PlayerId) -> u32 {
     runner.state().players[player.0 as usize].poison_counters
+}
+
+/// SHAPE (CR 614.15 PARTIAL replacement): "… instead of one" replaces only the
+/// COUNT of the printed Dig — not the whole instruction.
+///
+/// RED before the fix: the "Spell mastery —" line matched none of the cross-line
+/// gate's whole-clause forms (it ends "instead of one", not a bare "instead"), so it
+/// was published as a SECOND top-level ability — and its body, parsed in isolation,
+/// had lowered to `ChangeZone { destination: Hand, target: Creature, up_to,
+/// multi_target: 0..2 }`: a targeted BOUNCE of up to two creatures off the
+/// battlefield. With spell mastery on, casting Gather the Pack both dug AND offered
+/// to bounce two creatures — an effect the card does not have.
+///
+/// The override must instead bind as an alternative `Dig` that keeps the printed
+/// Dig's source (top five), its `reveal`, and its rest-to-graveyard rider, changing
+/// only the keep count (1 -> 2). Asserting the effect KIND is what discriminates a
+/// faithful rebuild from a naive whole-effect swap that would silently drop the
+/// reveal and the rest-to-graveyard.
+#[test]
+fn gather_the_pack_binds_the_partial_override_as_an_alternative_dig() {
+    use engine::types::ability::Effect;
+
+    let parsed = parse_oracle_text(
+        GATHER_THE_PACK,
+        "Gather the Pack",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+
+    assert_eq!(
+        parsed.abilities.len(),
+        1,
+        "CR 614.6: the spell-mastery override replaces the printed Dig's count; it \
+         must be bound INTO that Dig, never published as a second ability (which \
+         resolved as a stray creature bounce). Got: {:#?}",
+        parsed.abilities
+    );
+
+    let base = &parsed.abilities[0];
+    let Effect::Dig {
+        keep_count: base_keep,
+        count: base_count,
+        reveal: base_reveal,
+        rest_destination: base_rest,
+        ..
+    } = base.effect.as_ref()
+    else {
+        panic!("base must remain the printed Dig, got {:?}", base.effect);
+    };
+    assert_eq!(*base_keep, Some(1), "printed Dig keeps one creature card");
+    assert!(*base_reveal, "printed Dig reveals");
+
+    let sub = base
+        .sub_ability
+        .as_ref()
+        .expect("the override must be bound as the Dig's sub_ability");
+    assert!(
+        matches!(
+            sub.condition,
+            Some(AbilityCondition::ConditionInstead { .. })
+        ),
+        "CR 614.1a: the override must be a ConditionInstead branch so the runtime \
+         SWAPS the Dig rather than running both. Got: {:?}",
+        sub.condition
+    );
+
+    // CR 614.15: the override replaces only the PART it names ("instead of one").
+    // Everything else about the Dig — source size, reveal, rest destination — must
+    // survive the rebuild, which is exactly what a bare ChangeZone would have lost.
+    let Effect::Dig {
+        keep_count: alt_keep,
+        count: alt_count,
+        reveal: alt_reveal,
+        rest_destination: alt_rest,
+        ..
+    } = sub.effect.as_ref()
+    else {
+        panic!(
+            "the alternative must be a full Dig, not a bare ChangeZone (that drops \
+             the reveal, the library source and the rest-to-graveyard rider). Got: {:?}",
+            sub.effect
+        );
+    };
+    assert_eq!(
+        *alt_keep,
+        Some(2),
+        "spell mastery keeps TWO creature cards, not one"
+    );
+    assert_eq!(
+        alt_count, base_count,
+        "the alternative reuses the printed Dig's source (top five)"
+    );
+    assert_eq!(alt_reveal, base_reveal, "the alternative still reveals");
+    assert_eq!(
+        alt_rest, base_rest,
+        "the alternative still puts the rest into the graveyard"
+    );
 }
 
 /// SHAPE (CR 614.15 + CR 614.6): the cross-line override must be BOUND to the

--- a/crates/engine/tests/integration/cross_line_instead_override_branch.rs
+++ b/crates/engine/tests/integration/cross_line_instead_override_branch.rs
@@ -243,6 +243,7 @@ fn gather_the_pack_binds_the_partial_override_as_an_alternative_dig() {
 /// This discriminates the two ways the runtime witness above could go green:
 ///   * BOUND (what we want): one ability, override as a ConditionInstead branch.
 ///   * merely NEUTERED: two abilities, the second an inert `Unimplemented`.
+///
 /// Without this, a regression that degraded the branch back to an honest-red
 /// sibling would still pass the runtime assertion.
 #[test]

--- a/crates/engine/tests/integration/cross_line_instead_override_branch.rs
+++ b/crates/engine/tests/integration/cross_line_instead_override_branch.rs
@@ -90,6 +90,54 @@ fn poison_counters(runner: &GameRunner, player: PlayerId) -> u32 {
     runner.state().players[player.0 as usize].poison_counters
 }
 
+/// CR 614.6 REGRESSION GUARD — the override's OWN tail must not leak into the
+/// not-replaced branch.
+///
+/// Precognitive Perception {3}{U}{U} — Instant:
+///   "Draw three cards.
+///    Addendum — If you cast this spell during your main phase, instead scry 3,
+///    then draw three cards."
+///
+/// The override body is a TWO-clause chain ("scry 3, then draw three cards") and
+/// BOTH clauses belong to the replacement. When the Addendum condition is false,
+/// the printed "Draw three cards" runs and NOTHING of the override may run.
+///
+/// This face is the one the full-pool ledger surfaced that this unit did not
+/// predict: widening the condition vocabulary made the line take the
+/// strip-the-body path, which moved the override's second clause out from under
+/// the condition the chain had been stamping on it. The engine runs an unswapped
+/// `ConditionInstead` sub's `sub_ability` tail when it has no `else_ability`
+/// (effects/mod.rs — a clause printed AFTER an "instead" sentence is an
+/// independent instruction), so an unguarded tail here would draw three MORE
+/// cards outside your main phase. Six cards off a card that draws three.
+///
+/// Cast in the UPKEEP (not a main phase) — exactly three cards, never six.
+#[test]
+fn precognitive_perception_override_tail_does_not_run_when_addendum_is_false() {
+    const PRECOG: &str = "Draw three cards.\nAddendum — If you cast this spell during your main phase, instead scry 3, then draw three cards.";
+
+    let mut scenario = GameScenario::new();
+    // NOT a main phase — the Addendum condition is false.
+    scenario.at_phase(Phase::Upkeep);
+    scenario.with_mana_pool(
+        P0,
+        (0..6)
+            .map(|_| ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]))
+            .collect(),
+    );
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Precognitive Perception", true, PRECOG)
+        .id();
+    for i in 0..12 {
+        scenario.add_card_to_library_top(P0, &format!("Filler {i}"));
+    }
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(spell).resolve();
+
+    outcome.assert_hand_drawn(P0, 3);
+}
+
 /// SHAPE (CR 614.15 PARTIAL replacement): "… instead of one" replaces only the
 /// COUNT of the printed Dig — not the whole instruction.
 ///

--- a/crates/engine/tests/integration/cross_line_instead_override_branch.rs
+++ b/crates/engine/tests/integration/cross_line_instead_override_branch.rs
@@ -1,0 +1,132 @@
+//! CR 614.6 + CR 614.15 — a CROSS-LINE "instead" self-replacement override is a
+//! BRANCH of the ability it replaces, never an independent sibling ability.
+//!
+//! CR 614.6:  "If an event is replaced, it never happens. A modified event
+//!             occurs instead."
+//! CR 614.15: self-replacement effects "replace part or all of that spell or
+//!             ability's own effect(s) … the text can be a separate ability,
+//!             particularly when preceded by an ability word."
+//!
+//! CR 614.15 is the authority for this class: the override is printed as its own
+//! ability-word LINE ("Corrupted — …", "Spell mastery — …"), but it replaces the
+//! PREVIOUS printed line's effect. The parser has a cross-line binder for exactly
+//! this (oracle.rs), but its gate recognized only WHOLE-clause overrides (a bare
+//! trailing "instead"). It did not recognize the CR 614.15 PARTIAL forms —
+//! "… instead of <N>" / "… instead of <phrase>" — nor an override whose condition
+//! failed to lower. Those lines fell through and were emitted as INDEPENDENT
+//! top-level abilities, so the engine performed the base effect AND the override.
+//!
+//! Oracle text below is verbatim from the full-pool export (never a paraphrase):
+//! a paraphrase can take a different parser branch and leave the real card broken.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::AbilityCondition;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+use engine::types::PlayerId;
+
+/// Anoint with Affliction {1}{B} — Instant. Verbatim Oracle text.
+const ANOINT: &str = "Exile target creature if it has mana value 3 or less.\nCorrupted — Exile that creature instead if its controller has three or more poison counters.";
+
+/// CR 614.6 DOUBLE-EXECUTION WITNESS (board state).
+///
+/// Anoint with Affliction exiles the target ONLY if its mana value is 3 or less.
+/// The "Corrupted —" line replaces that conditional exile with an unconditional
+/// one, but ONLY while the target's controller has three or more poison counters.
+///
+/// Here the target has mana value 5 and its controller has ZERO poison counters,
+/// so BOTH the printed condition (CR 608.2c) and the Corrupted override are false:
+/// the creature must survive.
+///
+/// RED before the fix: the "Corrupted —" line was emitted as an INDEPENDENT second
+/// top-level ability — `ChangeZone { destination: Exile, target: ParentTarget }`
+/// with `condition: None`, because its condition ("its controller has three or
+/// more poison counters") never lowered. The engine therefore exiled the creature
+/// UNCONDITIONALLY, ignoring both the mana-value gate and the poison gate.
+/// This assertion flips the moment that sibling is reintroduced.
+#[test]
+fn anoint_with_affliction_cross_line_override_does_not_exile_unconditionally() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(
+        P0,
+        (0..4)
+            .map(|_| ManaUnit::new(ManaType::Black, ObjectId(0), false, vec![]))
+            .collect(),
+    );
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Anoint with Affliction", true, ANOINT)
+        .id();
+    // Mana value 5 — OUTSIDE the printed "mana value 3 or less" gate.
+    let victim = {
+        let mut b = scenario.add_creature(P1, "Serra Angel", 4, 4);
+        b.with_mana_cost(ManaCost::generic(5));
+        b.id()
+    };
+    let mut runner = scenario.build();
+
+    // Control: the target's controller has no poison counters, so the Corrupted
+    // override cannot apply either.
+    assert_eq!(
+        poison_counters(&runner, P1),
+        0,
+        "precondition: the Corrupted override must be OFF for this witness to \
+         discriminate — if P1 had 3+ poison, exiling would be correct and the \
+         test could not fail"
+    );
+
+    let outcome = runner.cast(spell).target_objects(&[victim]).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Battlefield);
+}
+
+fn poison_counters(runner: &GameRunner, player: PlayerId) -> u32 {
+    runner.state().players[player.0 as usize].poison_counters
+}
+
+/// SHAPE (CR 614.15 + CR 614.6): the cross-line override must be BOUND to the
+/// ability it replaces — one top-level ability whose `sub_ability` is the override,
+/// gated by `ConditionInstead` — never a second, independent top-level ability.
+///
+/// This discriminates the two ways the runtime witness above could go green:
+///   * BOUND (what we want): one ability, override as a ConditionInstead branch.
+///   * merely NEUTERED: two abilities, the second an inert `Unimplemented`.
+/// Without this, a regression that degraded the branch back to an honest-red
+/// sibling would still pass the runtime assertion.
+#[test]
+fn anoint_with_affliction_binds_the_cross_line_override_as_a_branch() {
+    let parsed = parse_oracle_text(
+        ANOINT,
+        "Anoint with Affliction",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+
+    assert_eq!(
+        parsed.abilities.len(),
+        1,
+        "CR 614.6: the \"Corrupted —\" override replaces the printed exile; it must \
+         be bound INTO that ability, not published as a second independent one. \
+         Two top-level abilities = the engine performs both. Got: {:#?}",
+        parsed.abilities
+    );
+
+    let base = &parsed.abilities[0];
+    let sub = base
+        .sub_ability
+        .as_ref()
+        .expect("the override must be bound as the base ability's sub_ability");
+    assert!(
+        matches!(
+            sub.condition,
+            Some(AbilityCondition::ConditionInstead { .. })
+        ),
+        "CR 614.1a: the bound override must carry ConditionInstead so the runtime \
+         SWAPS the base effect rather than running both. Got: {:?}",
+        sub.condition
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -67,6 +67,7 @@ mod counter_spell_zone_redirect;
 mod court_of_cunning_multi_target_mill;
 mod cr_annotations;
 mod craft_tithing_blade_transform;
+mod cross_line_instead_override_branch;
 mod crossway_troublemakers_attacking_keywords;
 mod cultivate_split_destination;
 mod cumber_stone_opponent_debuff;


### PR DESCRIPTION
- **fix(parser): a cross-LINE "instead" override must BIND or FAIL — never publish as a sibling**
- **fix(parser): bind the CR 614.15 PARTIAL cross-line override ("… instead of <N>")**
- **fix(parser): the residual cross-line overrides fail honestly — no face double-executes**
