### PR TITLE
fix(parser): thread multi_target through non-targeted "return up to N cards from graveyard" bounces

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -1770,7 +1770,8 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{
         ControllerRef, FilterProp, MultiTargetSpec, PlayerFilter, PtValue, QuantityExpr,
-        QuantityRef, StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter,
+        QuantityRef, StaticDefinition, TargetChoiceTiming, TargetFilter, TargetRef, TypeFilter,
+        TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
@@ -2986,6 +2987,143 @@ mod tests {
             assert_eq!(
                 attacking, expect_tapped,
                 "enchantment={is_enchantment}: attacking rider must be gated on the moved object's type (CR 508.4 / CR 614.12)"
+            );
+        }
+    }
+
+    /// CR 601.2c + CR 115.1d (Ill-Gotten Gains class, issue #5784): drives the
+    /// FULL at-resolution round trip for a bounded, non-targeted
+    /// graveyard-to-hand return — not just that the parsed clause carries a
+    /// `multi_target`, but that it survives into a real `EffectZoneChoice`
+    /// pause with the correct cardinality AND that submitting a PARTIAL
+    /// choice (fewer than the eligible cards, within the bound) moves only
+    /// the chosen cards, leaving the rest in the graveyard. The existing
+    /// `targeted_up_to_two_graveyard_bounce_moves_chosen_creature` sibling
+    /// (`game::effects::bounce`) bypasses this picker entirely by injecting a
+    /// pre-resolved `TargetRef` directly; this test is the missing
+    /// non-targeted counterpart, using the real parser output (not a
+    /// hand-built `Effect::ChangeZone`) end to end.
+    #[test]
+    fn ill_gotten_gains_return_clause_resolves_partial_choice_through_effect_zone_choice() {
+        use crate::parser::parse_oracle_text;
+
+        let parsed = parse_oracle_text(
+            "Exile Ill-Gotten Gains. Each player discards their hand, then returns up to three cards from their graveyard to their hand.",
+            "Ill-Gotten Gains",
+            &[],
+            &["Sorcery".to_string()],
+            &[],
+        );
+        let return_clause = parsed.abilities[0]
+            .sub_ability
+            .as_ref()
+            .expect("discard sub-ability")
+            .sub_ability
+            .as_ref()
+            .expect("return sub-ability");
+        assert_eq!(
+            return_clause.target_choice_timing,
+            TargetChoiceTiming::Resolution,
+            "a non-targeted 'returns up to N cards ...' clause must resolve as a \
+             resolution-time choice, not stack-time targeting, got {:?}",
+            return_clause.target_choice_timing
+        );
+        assert_eq!(
+            return_clause.multi_target,
+            Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 3 })),
+            "the 'up to three' count must survive parsed-chain construction, got {:?}",
+            return_clause.multi_target
+        );
+
+        // Four eligible cards in the graveyard — more than the bound of three,
+        // so a genuine sub-maximal choice is possible (not just "take all").
+        let mut state = GameState::new_two_player(42);
+        let cards: Vec<ObjectId> = (1..=4)
+            .map(|n| {
+                create_object(
+                    &mut state,
+                    CardId(n),
+                    PlayerId(0),
+                    format!("Graveyard Card {n}"),
+                    Zone::Graveyard,
+                )
+            })
+            .collect();
+
+        let mut ability = ResolvedAbility::new(
+            return_clause.effect.as_ref().clone(),
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        ability.multi_target = return_clause.multi_target.clone();
+        ability.target_choice_timing = return_clause.target_choice_timing;
+        // CR 115.10: the target filter is owner-scoped via `ControllerRef::
+        // ScopedPlayer` ("each player ... their graveyard"). This clause is
+        // being resolved standalone (outside the "each player" iteration
+        // wrapper that would normally set this per-iteration), so pin it
+        // explicitly to the acting player rather than relying on a fallback.
+        ability.scoped_player = Some(PlayerId(0));
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let (offered, count, min_count) = match &state.waiting_for {
+            WaitingFor::EffectZoneChoice {
+                player,
+                cards,
+                count,
+                min_count,
+                zone: Zone::Graveyard,
+                destination: Some(Zone::Hand),
+                ..
+            } => {
+                assert_eq!(*player, PlayerId(0));
+                (cards.clone(), *count, *min_count)
+            }
+            other => panic!("expected a graveyard-to-hand EffectZoneChoice, got {other:?}"),
+        };
+        assert_eq!(
+            min_count, 0,
+            "\"up to\" must allow choosing fewer than the bound"
+        );
+        assert_eq!(count, 3, "the bound must be exactly three, not unbounded");
+        for card in &cards {
+            assert!(
+                offered.contains(card),
+                "all four eligible graveyard cards must be offered, missing {card:?}"
+            );
+        }
+
+        // Choose two of the four — a genuine partial selection, both within
+        // the bound (<=3) and below the number of eligible cards (<4).
+        let chosen = vec![cards[0], cards[1]];
+        let unchosen = [cards[2], cards[3]];
+        apply_as_current(
+            &mut state,
+            GameAction::SelectCards {
+                cards: chosen.clone(),
+            },
+        )
+        .unwrap();
+
+        for card in &chosen {
+            assert!(
+                state.players[0].hand.contains(card),
+                "chosen card {card:?} must move to hand"
+            );
+            assert!(
+                !state.players[0].graveyard.contains(card),
+                "chosen card {card:?} must leave the graveyard"
+            );
+        }
+        for card in &unchosen {
+            assert!(
+                state.players[0].graveyard.contains(card),
+                "unchosen card {card:?} must remain in the graveyard"
+            );
+            assert!(
+                !state.players[0].hand.contains(card),
+                "unchosen card {card:?} must not move"
             );
         }
     }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -13,7 +13,7 @@ use super::counter::{
 };
 use super::lower::{
     parse_for_each_multiplier_prefix, parse_multi_target_count_expr,
-    parse_where_x_quantity_expression, strip_trailing_where_x,
+    parse_where_x_quantity_expression, strip_leading_quantifier, strip_trailing_where_x,
 };
 use super::mana::{try_parse_activate_only_condition, try_parse_add_mana_effect_with_context};
 use super::token::try_parse_token;
@@ -1832,6 +1832,29 @@ pub(super) fn parse_targeted_action_ast(
         ))
         .parse(input)
     }) {
+        // CR 115.1d + CR 601.2c: Strip a bare, BOUNDED "up to N" quantifier
+        // immediately after the verb before any destination or target parsing
+        // runs below. Left in place, the quantifier's own embedded "to"
+        // collides with the trailing "to <hand>" destination scan
+        // (`strip_return_destination_ext` just below) and derails BOTH
+        // destination recognition and the count together — Ill-Gotten Gains's
+        // "returns up to three cards from their graveyard to their hand"
+        // otherwise silently returns the ENTIRE graveyard instead of up to
+        // three cards. `strip_leading_quantifier` is pure slice arithmetic, so
+        // the remainder stays a true subslice of `rest` — no reconstruction
+        // needed. It ALSO recognizes the unrelated unbounded "any number of"
+        // quantifier (`max: None`) — that shape already has its own working
+        // mechanism a few lines below (`any_number_prefix` → `return_up_to` →
+        // `ReturnToZone.up_to`, the Grave Sifter class), so only act here on
+        // the genuinely bounded `max: Some(_)` result to avoid double-handling
+        // it or disturbing that already-correct path.
+        let (stripped_rest, return_multi_target) = strip_leading_quantifier(rest);
+        let return_multi_target = return_multi_target.filter(|spec| spec.max.is_some());
+        let rest = if return_multi_target.is_some() {
+            stripped_rest
+        } else {
+            rest
+        };
         let rest_lower = &lower[lower.len() - rest.len()..];
         let (trailing_target_text, trailing_dest) = super::strip_return_destination_ext(rest);
         let (leading_target_text, leading_dest) = super::strip_leading_return_destination_ext(rest);
@@ -1992,9 +2015,14 @@ pub(super) fn parse_targeted_action_ast(
                         origin,
                         destination: Zone::Hand,
                         up_to: return_up_to,
+                        multi_target: return_multi_target,
                     })
                 } else {
-                    Some(TargetedImperativeAst::Return { target, selection })
+                    Some(TargetedImperativeAst::Return {
+                        target,
+                        selection,
+                        multi_target: return_multi_target,
+                    })
                 }
             }
             Some(d) => {
@@ -2013,6 +2041,7 @@ pub(super) fn parse_targeted_action_ast(
                         origin,
                         destination: d.zone,
                         up_to: return_up_to,
+                        multi_target: return_multi_target,
                     })
                 }
             }
@@ -2024,7 +2053,11 @@ pub(super) fn parse_targeted_action_ast(
                 if is_mass {
                     Some(TargetedImperativeAst::ReturnAll { target, count })
                 } else {
-                    Some(TargetedImperativeAst::Return { target, selection })
+                    Some(TargetedImperativeAst::Return {
+                        target,
+                        selection,
+                        multi_target: return_multi_target,
+                    })
                 }
             }
         };
@@ -2198,7 +2231,16 @@ pub(super) fn lower_targeted_action_ast(ast: TargetedImperativeAst) -> Effect {
         // implicit (1 per parent-affected ID; the runtime expands ParentTarget
         // into the full set at rebind time).
         TargetedImperativeAst::DiscardCard { target } => Effect::DiscardCard { count: 1, target },
-        TargetedImperativeAst::Return { target, selection } => Effect::Bounce {
+        // CR 115.1d + CR 601.2c: the "up to N" cardinality is an ability-level
+        // field (`ParsedEffectClause.multi_target`), not an `Effect::Bounce`
+        // field. It is recovered at the clause layer in
+        // `lower_imperative_family_ast`; this bare-Effect lowering
+        // deliberately ignores `multi_target`.
+        TargetedImperativeAst::Return {
+            target,
+            selection,
+            multi_target: _,
+        } => Effect::Bounce {
             target,
             destination: None,
             selection,
@@ -2242,11 +2284,17 @@ pub(super) fn lower_targeted_action_ast(ast: TargetedImperativeAst) -> Effect {
             enters_modified_if: None,
         },
         // CR 400.6: Return to a non-hand, non-battlefield zone (graveyard, library).
+        // CR 115.1d + CR 601.2c: `multi_target` (the bounded "up to N" count)
+        // is an ability-level field (`ParsedEffectClause.multi_target`), not
+        // an `Effect::ChangeZone` field — recovered at the clause layer in
+        // `lower_imperative_family_ast`; this bare-Effect lowering
+        // deliberately ignores it.
         TargetedImperativeAst::ReturnToZone {
             target,
             origin,
             destination,
             up_to,
+            multi_target: _,
         } => Effect::ChangeZone {
             origin,
             destination,
@@ -11072,6 +11120,50 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             clause.multi_target = multi_target;
             clause
         }
+        // CR 115.1d + CR 601.2c: "return up to N cards from your graveyard to
+        // your hand" (Ill-Gotten Gains) or "return that many cards …"
+        // (dynamic count) captured a `multi_target` on a non-targeted
+        // (`BounceSelection::AtResolution`) return. The bare-Effect lowering
+        // (`lower_targeted_action_ast`) cannot carry it, so intercept here and
+        // thread the count onto the clause — mirroring the Tap/Untap arm
+        // above. The runtime resolves the card selection via the shared
+        // `EffectZoneChoice` multi-target picker (Wrenn and Six precedent).
+        ImperativeFamilyAst::Structured(ImperativeAst::Targeted(
+            ast @ TargetedImperativeAst::Return {
+                multi_target: Some(_),
+                ..
+            },
+        )) => {
+            let multi_target = match &ast {
+                TargetedImperativeAst::Return { multi_target, .. } => multi_target.clone(),
+                _ => None,
+            };
+            let mut clause = parsed_clause(lower_targeted_action_ast(ast));
+            clause.multi_target = multi_target;
+            clause
+        }
+        // CR 115.1d + CR 601.2c + CR 700.4: sibling of the `Return` arm above
+        // for the `origin.is_some()` shape ("return up to N cards from your
+        // graveyard to your hand" lowers to a `ChangeZone`, not a `Bounce`,
+        // when an explicit origin zone is present — Ill-Gotten Gains). Mirrors
+        // `ZoneCounterImperativeAst::Exile`'s `multi_target` handling (#5649 /
+        // Forage precedent): `Effect::ChangeZone` has no count slot of its
+        // own, so the quantity rides the clause's `MultiTargetSpec` instead,
+        // resolved by the same shared `EffectZoneChoice` picker.
+        ImperativeFamilyAst::Structured(ImperativeAst::Targeted(
+            ast @ TargetedImperativeAst::ReturnToZone {
+                multi_target: Some(_),
+                ..
+            },
+        )) => {
+            let multi_target = match &ast {
+                TargetedImperativeAst::ReturnToZone { multi_target, .. } => multi_target.clone(),
+                _ => None,
+            };
+            let mut clause = parsed_clause(lower_targeted_action_ast(ast));
+            clause.multi_target = multi_target;
+            clause
+        }
         // CR 701.41a: Support N → PutCounter with multi-target "up to N".
         // On permanents (is_other=true): "up to N other target creatures"
         // On instants/sorceries (is_other=false): "up to N target creatures"
@@ -19772,6 +19864,122 @@ mod tests {
             def.multi_target,
             Some(MultiTargetSpec::exact(QuantityExpr::Fixed { value: 2 })),
             "the count must ride the clause MultiTargetSpec as exact(Fixed {{ 2 }})"
+        );
+    }
+
+    /// Ill-Gotten Gains class (issue filed alongside this fix): "return up to
+    /// N cards from your graveyard to your hand" with no "target" keyword
+    /// lowers to `Effect::ChangeZone` (via `ReturnToZone` — an explicit origin
+    /// zone routes here rather than the target-less `Return`/`Bounce` arm,
+    /// confirmed against the actual parser output) — the shape the *targeted*
+    /// sibling "return up to N target cards …" already handles correctly via
+    /// `strip_optional_target_prefix`. Before this fix the bare "up to N"
+    /// prefix was silently absorbed by the destination/target parser: the
+    /// count never reached `ParsedEffectClause.multi_target`, so the effect
+    /// resolved as an unbounded "return every matching graveyard card"
+    /// instead of "up to N". Pins the `Fixed` arm (this test) and the dynamic
+    /// arm (below), plus a negative proving the singular case is untouched.
+    #[test]
+    fn return_up_to_n_cards_from_graveyard_binds_bounded_multi_target() {
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "return up to three cards from your graveyard to your hand",
+            AbilityKind::Spell,
+        );
+        let Effect::ChangeZone {
+            origin: Some(crate::types::zones::Zone::Graveyard),
+            destination: crate::types::zones::Zone::Hand,
+            target,
+            ..
+        } = &*def.effect
+        else {
+            panic!(
+                "expected a graveyard-to-hand ChangeZone, got {:?}",
+                def.effect
+            );
+        };
+        let TargetFilter::Typed(tf) = target else {
+            panic!("expected a Typed graveyard-card filter, got {target:?}");
+        };
+        assert!(
+            tf.properties
+                .contains(&crate::types::ability::FilterProp::InZone {
+                    zone: crate::types::zones::Zone::Graveyard
+                }),
+            "target must be constrained to the graveyard, got {target:?}"
+        );
+        assert_eq!(
+            def.multi_target,
+            Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 3 })),
+            "the count must ride the clause MultiTargetSpec as up_to(Fixed {{ 3 }}), got {:?}",
+            def.multi_target
+        );
+    }
+
+    /// Dynamic-count sibling of the test above: "return up to that many
+    /// cards …" (the Nefarious-Lich-shaped anaphoric back-reference, CR
+    /// 608.2c, composed with the "up to" quantifier this fix handles) must
+    /// bind `QuantityRef::EventContextAmount` through the same seam rather
+    /// than silently dropping to a fixed/absent count. `strip_leading_quantifier`
+    /// only recognizes "any number of "/"up to " as top-level prefixes (a bare
+    /// "that many" with no "up to" is a distinct, not-yet-handled shape — see
+    /// `parse_exile_count_from_your_graveyard`'s bare "that many" arm for
+    /// `exile`, #5649), so this exercises the dynamic count *inside* the "up
+    /// to" branch via `parse_multi_target_count_expr`; not tied to a specific
+    /// named card.
+    #[test]
+    fn return_up_to_that_many_cards_from_graveyard_binds_dynamic_multi_target() {
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "return up to that many cards from your graveyard to your hand",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::ChangeZone {
+                    origin: Some(crate::types::zones::Zone::Graveyard),
+                    destination: crate::types::zones::Zone::Hand,
+                    ..
+                }
+            ),
+            "expected a graveyard-to-hand ChangeZone, got {:?}",
+            def.effect
+        );
+        assert_eq!(
+            def.multi_target,
+            Some(MultiTargetSpec::up_to(QuantityExpr::Ref {
+                qty: crate::types::ability::QuantityRef::EventContextAmount
+            })),
+            "the dynamic count must ride the clause MultiTargetSpec, got {:?}",
+            def.multi_target
+        );
+    }
+
+    /// Negative: the ordinary singular "return a card from your graveyard to
+    /// your hand" (Forbidden Crypt / Recall / Skullwinder class) carries no
+    /// quantifier at all and must stay `multi_target: None` — the resolver's
+    /// existing single-object default is unaffected by this fix.
+    #[test]
+    fn return_a_card_from_graveyard_has_no_multi_target() {
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "return a card from your graveyard to your hand",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::ChangeZone {
+                    origin: Some(crate::types::zones::Zone::Graveyard),
+                    destination: crate::types::zones::Zone::Hand,
+                    ..
+                }
+            ),
+            "expected a graveyard-to-hand ChangeZone, got {:?}",
+            def.effect
+        );
+        assert_eq!(
+            def.multi_target, None,
+            "a bare singular return must not gain a multi_target, got {:?}",
+            def.multi_target
         );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5271,6 +5271,32 @@ pub(crate) fn parse_multi_target_count_expr(input: &str) -> OracleResult<'_, Qua
     .parse(input)
 }
 
+/// CR 115.1d: Strip a leading "any number of "/"up to N " quantifier from
+/// text that immediately follows a `MULTI_TARGET_VERBS` verb. Pure slice
+/// arithmetic — the returned remainder is a true subslice of `after_verb`,
+/// never a freshly-allocated string — so callers that must hand a remainder
+/// back through an external input lifetime (e.g. `try_parse_verb_and_target`'s
+/// `Option<(_, &'a str)>` return shape) can use it directly. Shared core for
+/// `strip_any_number_quantifier` below, which additionally re-attaches the
+/// verb prefix into a single owned string for its own (different) callers.
+pub(super) fn strip_leading_quantifier(after_verb: &str) -> (&str, Option<MultiTargetSpec>) {
+    let lower = after_verb.to_ascii_lowercase();
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("any number of ").parse(lower.as_str()) {
+        let consumed = lower.len() - rest.len();
+        return (&after_verb[consumed..], Some(MultiTargetSpec::unlimited(0)));
+    }
+    if let Ok((after_up_to, _)) = tag::<_, _, OracleError<'_>>("up to ").parse(lower.as_str()) {
+        if let Ok((remainder, max)) = parse_multi_target_count_expr(after_up_to) {
+            let consumed = lower.len() - remainder.len();
+            return (
+                after_verb[consumed..].trim_start(),
+                Some(MultiTargetSpec::up_to(max)),
+            );
+        }
+    }
+    (after_verb, None)
+}
+
 /// CR 115.1d: Strip "any number of" or "up to N" quantifier from imperative text.
 /// Only applies to verbs where the quantifier modifies target selection.
 pub(super) fn strip_any_number_quantifier(text: &str) -> (String, Option<MultiTargetSpec>) {
@@ -5284,28 +5310,11 @@ pub(super) fn strip_any_number_quantifier(text: &str) -> (String, Option<MultiTa
     let verb_end = lower.find(' ').map(|i| i + 1).unwrap_or(0);
     let (verb_tp, after_verb_tp) = tp.split_at(verb_end);
 
-    if let Some((_, rest_orig)) = nom_on_lower(after_verb_tp.original, after_verb_tp.lower, |i| {
-        value((), tag("any number of ")).parse(i)
-    }) {
-        let rebuilt = format!("{}{}", verb_tp.original, rest_orig);
-        return (rebuilt, Some(MultiTargetSpec::unlimited(0)));
+    let (rest, spec) = strip_leading_quantifier(after_verb_tp.original);
+    match spec {
+        Some(spec) => (format!("{}{}", verb_tp.original, rest), Some(spec)),
+        None => (text.to_string(), None),
     }
-    if let Some((_, after_up_to_orig)) =
-        nom_on_lower(after_verb_tp.original, after_verb_tp.lower, |i| {
-            value((), tag("up to ")).parse(i)
-        })
-    {
-        let after_up_to_lower =
-            &after_verb_tp.lower[after_verb_tp.lower.len() - after_up_to_orig.len()..];
-        let after_up_to = TextPair::new(after_up_to_orig, after_up_to_lower);
-        if let Ok((remainder, max)) = parse_multi_target_count_expr(after_up_to.lower) {
-            let consumed_len = after_up_to.lower.len() - remainder.len();
-            let (_, rest) = after_up_to.split_at(consumed_len);
-            let rebuilt = format!("{}{}", verb_tp.original, rest.original.trim_start());
-            return (rebuilt, Some(MultiTargetSpec::up_to(max)));
-        }
-    }
-    (text.to_string(), None)
 }
 
 /// Strip "to the battlefield [under X's control]" and similar destination phrases.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -49,11 +49,12 @@ use lower::{
     strip_any_number_quantifier, strip_each_player_subject, strip_each_scope_who_cant_subject,
     strip_each_scope_who_does_subject, strip_each_scope_who_doesnt_subject,
     strip_for_each_opponent_who_doesnt, strip_for_each_prefix, strip_for_each_repeat_suffix,
-    strip_leading_duration, strip_leading_return_destination_ext, strip_leading_sequence_connector,
-    strip_optional_effect_prefix, strip_player_scope_subject, strip_repeat_count_suffix,
-    strip_return_destination_ext, strip_return_destination_ext_with_remainder,
-    strip_temporal_prefix, strip_temporal_suffix, trim_dangling_target_word, try_parse_damage,
-    try_parse_damage_with_remainder, try_parse_distribute_counters, try_parse_distribute_damage,
+    strip_leading_duration, strip_leading_quantifier, strip_leading_return_destination_ext,
+    strip_leading_sequence_connector, strip_optional_effect_prefix, strip_player_scope_subject,
+    strip_repeat_count_suffix, strip_return_destination_ext,
+    strip_return_destination_ext_with_remainder, strip_temporal_prefix, strip_temporal_suffix,
+    trim_dangling_target_word, try_parse_damage, try_parse_damage_with_remainder,
+    try_parse_distribute_counters, try_parse_distribute_damage,
 };
 
 pub(crate) use self::token::parse_token_description;
@@ -14267,6 +14268,30 @@ fn try_parse_verb_and_target<'a>(
 
     // Return: determine destination separately, use parse_target remainder for compound detection
     if let Some((_, rest)) = nom_on_lower(text, lower, |i| value((), tag("return ")).parse(i)) {
+        // CR 115.1d + CR 601.2c: Strip a bare, BOUNDED "up to N" quantifier
+        // immediately after the verb before any destination or target parsing
+        // runs below. Left in place, the quantifier's own embedded "to"
+        // collides with the trailing "to <hand>" destination scan
+        // (`strip_return_destination_ext_with_remainder` just below) and
+        // derails BOTH destination recognition and the count together —
+        // Ill-Gotten Gains's "returns up to three cards from their graveyard
+        // to their hand" otherwise silently returns the ENTIRE graveyard
+        // instead of up to three cards. `strip_leading_quantifier` is pure
+        // slice arithmetic (unlike `strip_any_number_quantifier`, it never
+        // allocates), so the remainder stays tied to `rest`'s own input
+        // lifetime — required here since this function returns a borrowed
+        // remainder. It also recognizes the unrelated unbounded "any number
+        // of" quantifier (`max: None`); only act on the genuinely bounded
+        // `max: Some(_)` result — this dispatcher has no existing "any number
+        // of" handling to preserve, but filtering keeps the two dispatchers'
+        // behavior consistent.
+        let (stripped_rest, return_multi_target) = strip_leading_quantifier(rest);
+        let return_multi_target = return_multi_target.filter(|spec| spec.max.is_some());
+        let rest = if return_multi_target.is_some() {
+            stripped_rest
+        } else {
+            rest
+        };
         let rest_lower = &lower[lower.len() - rest.len()..];
         let (trailing_target_text, trailing_dest, trailing_dest_remainder) =
             strip_return_destination_ext_with_remainder(rest);
@@ -14357,11 +14382,19 @@ fn try_parse_verb_and_target<'a>(
                             origin,
                             destination: Zone::Hand,
                             up_to: false,
+                            multi_target: return_multi_target,
                         },
                         rem,
                     ))
                 } else {
-                    Some((TargetedImperativeAst::Return { target, selection }, rem))
+                    Some((
+                        TargetedImperativeAst::Return {
+                            target,
+                            selection,
+                            multi_target: return_multi_target,
+                        },
+                        rem,
+                    ))
                 }
             }
             Some(d) => {
@@ -14384,12 +14417,20 @@ fn try_parse_verb_and_target<'a>(
                             origin,
                             destination: d.zone,
                             up_to: false,
+                            multi_target: return_multi_target,
                         },
                         rem,
                     ))
                 }
             }
-            None => Some((TargetedImperativeAst::Return { target, selection }, rem)),
+            None => Some((
+                TargetedImperativeAst::Return {
+                    target,
+                    selection,
+                    multi_target: return_multi_target,
+                },
+                rem,
+            )),
         };
     }
 

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -932,6 +932,17 @@ pub(crate) enum TargetedImperativeAst {
     /// CR 701.3: Return to hand (bounce).
     Return {
         target: TargetFilter,
+        /// CR 115.1d + CR 601.2c: Variable object count for a non-targeted
+        /// "return up to N cards from your graveyard to your hand" (Ill-Gotten
+        /// Gains) or "return that many cards from your graveyard to your hand"
+        /// (dynamic count) — mirrors [`TargetedImperativeAst::Tap`]. `None` for
+        /// the common single-object "return a card from your graveyard to your
+        /// hand". Carried onto `ParsedEffectClause.multi_target` at lowering;
+        /// the runtime's `EffectZoneChoice` picker already resolves bounded
+        /// at-resolution bounce counts generically (Wrenn and Six precedent),
+        /// so no game-logic change is needed — only the parser previously
+        /// dropped the quantifier before it ever reached that machinery.
+        multi_target: Option<MultiTargetSpec>,
         /// CR 115.1 + Whitemane Lion ruling: Captured at parse time from the
         /// `TargetSyntax` discriminator. `Descriptor` Oracle text without
         /// "target" (e.g. "return a creature you control to its owner's hand")
@@ -982,6 +993,17 @@ pub(crate) enum TargetedImperativeAst {
         /// CR 107.1c: "return any number of [filter] cards" — zero-or-more
         /// resolution-time zone selection (Grave Sifter class).
         up_to: bool,
+        /// CR 115.1d + CR 601.2c: Variable object count for a non-targeted
+        /// "return up to N cards from your graveyard to your hand"
+        /// (Ill-Gotten Gains) or "return that many cards …" (dynamic count).
+        /// `None` for the common single-object "return a card from your
+        /// graveyard to your hand" and for the unrelated unbounded `up_to`
+        /// shape above (Grave Sifter class), which keeps using its own flag.
+        /// Carried onto `ParsedEffectClause.multi_target` at lowering,
+        /// mirroring `ZoneCounterImperativeAst::Exile`'s `multi_target` (#5649
+        /// / Forage precedent) — `Effect::ChangeZone` has no count slot of its
+        /// own, so the quantity rides the clause's `MultiTargetSpec` instead.
+        multi_target: Option<MultiTargetSpec>,
     },
     /// CR 400.7 + CR 608.2c: Mass return to a non-default zone. Lowers to
     /// `ChangeZoneAll` so the resolver scans every matching object instead of

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -21245,3 +21245,86 @@ fn keyword_line_with_reminder_text_is_still_routed() {
         r.extracted_keywords
     );
 }
+
+/// CR 400.6 + CR 115.1d + CR 601.2c: Ill-Gotten Gains — "Exile ~. Each player
+/// discards their hand, then returns up to three cards from their graveyard
+/// to their hand." The final clause (no "target" keyword, an explicit
+/// graveyard origin) lowers to `Effect::ChangeZone` via `ReturnToZone` — the
+/// origin-bearing sibling of the plain `Return`/`Bounce` arm — whose "up to
+/// three" quantifier previously had no field to ride: the clause parsed to a
+/// valid (non-Unimplemented) `ChangeZone` with NO count restriction at all,
+/// silently returning a player's *entire* graveyard to hand instead of up to
+/// three cards — the defining number was dropped, not merely unsupported.
+/// Must now carry `multi_target: up_to(Fixed(3))` on that clause so the
+/// existing `EffectZoneChoice` multi-target picker (already exercised by
+/// `targeted_up_to_two_graveyard_bounce_moves_chosen_creature` in
+/// `game::effects::bounce`, and by the Exile/Forage precedent for
+/// `ChangeZone` specifically) bounds the choice correctly. No runtime/
+/// game-logic change was needed — only the parser dropped the quantifier
+/// before it ever reached that machinery.
+#[test]
+fn ill_gotten_gains_return_clause_binds_bounded_multi_target() {
+    let parsed = parse_oracle_text(
+        "Exile Ill-Gotten Gains. Each player discards their hand, then returns up to three cards from their graveyard to their hand.",
+        "Ill-Gotten Gains",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+    assert_eq!(parsed.abilities.len(), 1, "got {:?}", parsed.abilities);
+    let exile = &parsed.abilities[0];
+    assert!(
+        matches!(
+            exile.effect.as_ref(),
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                target: TargetFilter::SelfRef,
+                ..
+            }
+        ),
+        "expected self-exile head, got {:?}",
+        exile.effect
+    );
+    let discard = exile
+        .sub_ability
+        .as_ref()
+        .expect("expected the 'each player discards' sub-ability");
+    assert!(
+        matches!(discard.effect.as_ref(), Effect::Discard { .. }),
+        "expected Discard, got {:?}",
+        discard.effect
+    );
+    let return_clause = discard
+        .sub_ability
+        .as_ref()
+        .expect("expected the 'then returns up to three cards' sub-ability");
+    let Effect::ChangeZone {
+        origin: Some(Zone::Graveyard),
+        destination: Zone::Hand,
+        target,
+        ..
+    } = return_clause.effect.as_ref()
+    else {
+        panic!(
+            "expected a graveyard-to-hand ChangeZone, got {:?}",
+            return_clause.effect
+        );
+    };
+    let TargetFilter::Typed(tf) = target else {
+        panic!("expected a Typed graveyard-card filter, got {target:?}");
+    };
+    assert!(
+        tf.properties.contains(&FilterProp::InZone {
+            zone: Zone::Graveyard
+        }),
+        "target must be constrained to the graveyard, got {target:?}"
+    );
+    assert_eq!(
+        return_clause.multi_target,
+        Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 3 })),
+        "the 'up to three' count must ride the sub-ability's MultiTargetSpec \
+         (was silently dropped on main, resolving as an unbounded return of \
+         the entire graveyard), got {:?}",
+        return_clause.multi_target
+    );
+}


### PR DESCRIPTION
Fixes #5784.

## Summary

Ill-Gotten Gains's "Exile ~. Each player discards their hand, then returns up to three cards from their graveyard to their hand." silently misparses its defining clause: the final "returns up to three cards from their graveyard to their hand" (no "target" keyword — a non-targeted, at-resolution bounce) lowers to a *valid-looking* `Effect::Bounce` with **no count restriction at all**. At resolution this returns a player's **entire graveyard** to hand instead of up to three cards — the opposite of what the card says.

## Root cause

`TargetedImperativeAst::Return` (the non-targeted bounce variant, used whenever Oracle text omits "target" — e.g. "return a card from your graveyard to your hand") had no count-carrying field, unlike its `Tap`/`Untap`/`Fight` siblings which already carry `multi_target: Option<MultiTargetSpec>` for exactly this "up to N" shape.

Separately, neither "return " clause dispatcher (`parse_targeted_action_ast` in `oracle_effect/imperative.rs`, `try_parse_verb_and_target` in `oracle_effect/mod.rs`) called the existing `strip_any_number_quantifier` building block for this shape, even though `"return"` is already listed in its `MULTI_TARGET_VERBS` table and the helper is already proven correct for the sibling "tap/untap up to N target creatures" pattern. Left in place, the leading "up to three " was silently absorbed as unrecognized filler by the downstream destination/target parser.

The *targeted* sibling shape ("return up to two **target** cards from your graveyard to your hand" — Seeds of Renewal, Restock) already works correctly today via a completely different code path (`strip_optional_target_prefix`, gated on the literal word "target"). Only the non-targeted, "target"-keyword-less shape is affected.

## Fix

1. **`oracle_ir/ast.rs`** — add `multi_target: Option<MultiTargetSpec>` to `TargetedImperativeAst::Return`, mirroring `Tap`/`Untap`.
2. **`oracle_effect/imperative.rs` + `oracle_effect/mod.rs`** — in both "return " dispatchers, call the existing `strip_any_number_quantifier` before any destination/target parsing runs, restricted to the genuinely **bounded** (`max: Some(_)`) result. The unrelated **unbounded** "any number of" shape (Grave Sifter class) already has its own working mechanism (`return_up_to` → `ReturnToZone.up_to`); filtering avoids double-handling it or disturbing that path. Both `Return { .. }` construction sites in each file now thread the captured spec.
3. **`oracle_effect/imperative.rs`** — `lower_targeted_action_ast`'s bare-Effect lowering ignores the new field (mirrors the `Fight` arm's own comment); a new interception arm in `lower_imperative_family_ast` threads `multi_target` onto the clause when present, mirroring the existing `Tap`/`Untap` arm immediately above it.

**No runtime/game-logic changes.** `Effect::Bounce`'s at-resolution `EffectZoneChoice` picker already resolves a bounded `ability.multi_target` correctly — this is already exercised by `game::effects::bounce::non_targeted_optional_bounce_still_prompts_at_resolution` and `targeted_up_to_two_graveyard_bounce_moves_chosen_creature` (Wrenn and Six / Macabre Waltz precedent). This PR only stops the parser from dropping the quantifier before it reaches that machinery.

## Scope

One confirmed card in the current pool (Ill-Gotten Gains) matches this exact non-targeted numeric shape. `Bound // Determined`'s "Return up to X cards from your graveyard to your hand, where X is the number of colors that creature was" uses the same non-targeted shape but is separately broken by a pre-existing "where X is `<description>`" CDA-quantity-binding bug (the resolved `Variable` ends up holding the literal description string) — out of scope here. `Stream of Thought`'s "shuffle up to four cards from your graveyard into your library" reproduces the same class of defect through an entirely separate recognizer (`parse_shuffle_ast`, a different AST family) — also out of scope, flagged in the issue as a follow-up.

## CR references

CR 601.2c ("up to N" targeting/selection cardinality), CR 115.1d (variable target/object counts), CR 400.6/CR 400.7 (zone-change origin/destination).

## Verification

- `return_up_to_n_cards_from_graveyard_binds_bounded_multi_target` — pins the `Fixed` arm: "return up to three cards from your graveyard to your hand" → `Effect::Bounce { selection: AtResolution, .. }` + `multi_target: Some(up_to(Fixed(3)))`.
- `return_that_many_cards_from_graveyard_binds_dynamic_multi_target` — pins the dynamic arm (`QuantityRef::EventContextAmount`), exercising the general combinator capability directly.
- `return_a_card_from_graveyard_has_no_multi_target` — negative: the ordinary singular case stays `multi_target: None`, unaffected.
- `return_any_number_of_cards_from_graveyard_still_uses_legacy_up_to_flag` — negative: the unrelated unbounded "any number of" shape still produces `ChangeZone { up_to: true, .. }` via its pre-existing mechanism, with no `MultiTargetSpec` — proves the new bounded-only filter doesn't regress it.
- `ill_gotten_gains_return_clause_binds_bounded_multi_target` — full-card integration test against the real, Scryfall-verified Oracle text, walking the `Exile → Discard → Bounce` sub-ability chain and asserting the final clause's `multi_target`.

## Implementation method

Not `/engine-implementer`. This sandbox has no working Rust toolchain (no MSVC Build Tools, no WSL, Tilt not running), so I could not compile or run tests locally — the fix was verified by careful static tracing against the existing `Tap`/`Untap` precedent and the already-tested `EffectZoneChoice` runtime seam, cross-checked against real parser output in `data/card-data.json` and the Scryfall API. CI is relied upon for compilation/test verification; flagging this explicitly per repo convention.