### PR TITLE
fix(parser): parse Total War's continuity exemption on the destroy filter

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -2920,28 +2920,18 @@ fn sub_ability_is_continuity_exemption(sub: Option<&AbilityDefinition>) -> bool 
     parse_continuity_exemption_clause(text.trim()).is_ok_and(|(rest, ())| rest.trim().is_empty())
 }
 
-// KNOWN GAP (Total War, tracked as a separate follow-up): this recognizer
-// covers only Siren's Call's "ignore this effect for each creature ... didn't
-// control continuously since the beginning of the turn" phrasing. Total War
-// carries the SAME CR 302.6 + CR 508.1a continuity exemption, but through a
-// DIFFERENT shape:
-//   - it is a triggered ability ("Whenever a player attacks with one or more
-//     creatures ..."), NOT an `ActivePlayerPunisher` delayed trigger, so it
-//     never reaches `apply_active_player_punisher`, the only caller of
-//     `sub_ability_is_continuity_exemption` above; and
-//   - it phrases the exemption as "except for creatures the player hasn't
-//     controlled continuously ...", which the "ignore this effect for each
-//     creature ..." tag below does not match.
-// As a result Total War's continuity exemption is currently silently dropped —
-// its DestroyAll filter parses only as [Untapped, Not(AttackedThisTurn)] with
-// no `ControlledContinuouslySinceTurnBegan` restriction and no `Unimplemented`
-// marker. This is a distinct dropped-modifier root cause (NOT the player-scope
-// bug fixed alongside it in `condition_introduces_attacking_player`) and is
-// intentionally left unfixed here. Fixing it means recognizing the "except for
-// <continuity>" clause on the triggered-ability DestroyAll effect body and
-// attaching `FilterProp::ControlledContinuouslySinceTurnBegan` — either by
-// generalizing this recognizer's phrasing or adding a sibling on the effect
-// parse path.
+// CR 302.6 + CR 508.1a: this recognizer covers only Siren's Call's "ignore this
+// effect for each creature ... didn't control continuously since the beginning
+// of the turn" phrasing, reached via `apply_active_player_punisher` (the only
+// caller of `sub_ability_is_continuity_exemption` above). Total War carries the
+// SAME continuity exemption but through a DIFFERENT shape — a triggered ability
+// ("Whenever a player attacks with one or more creatures ...") whose exemption
+// is phrased "except for creatures the player hasn't controlled continuously
+// ..." trailing the target population. That form is now handled at the target
+// filter parse path by `oracle_target::parse_except_continuity_exemption_suffix`
+// (attaching the same `FilterProp::ControlledContinuouslySinceTurnBegan`), so
+// this `ignore this effect ...` recognizer stays deliberately narrow to Siren's
+// Call's ActivePlayerPunisher shape.
 fn parse_continuity_exemption_clause(i: &str) -> OracleResult<'_, ()> {
     let (i, _) = tag::<_, _, OracleError<'_>>("ignore this effect for each creature").parse(i)?;
     // Optional subject anaphor: " the player" / " that player" / "".

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2964,6 +2964,21 @@ pub fn parse_type_phrase_with_ctx<'a>(
         pos += consumed;
     }
 
+    // CR 302.6 + CR 508.1a: trailing continuity exemption "..., except for
+    // creatures [the/that player] hasn't controlled continuously since the
+    // beginning of the turn" (Total War). The exempted set — creatures NOT
+    // controlled continuously — is removed from the population, so only
+    // creatures the player HAS controlled continuously are affected. Placed
+    // after the controller/"didn't attack" relative clauses because the
+    // exemption trails them; the early `except for <type-list>` block sees the
+    // text before those clauses are consumed and does not reach it. Reuses the
+    // same `ControlledContinuouslySinceTurnBegan` restriction Siren's Call
+    // attaches via the ActivePlayerPunisher continuity path.
+    if let Some((prop, consumed)) = parse_except_continuity_exemption_suffix(&lower[pos..]) {
+        properties.push(prop);
+        pos += consumed;
+    }
+
     // Check zone suffix: "card from a graveyard", "card in your graveyard", "from exile", etc.
     if let Some((zone_props, zone_ctrl, consumed)) = parse_zone_suffix(&lower[pos..]) {
         properties.extend(zone_props);
@@ -6780,6 +6795,49 @@ fn parse_except_for_type_list_suffix(
     }
 
     Some((neg_types, props, consumed))
+}
+
+/// CR 302.6 + CR 508.1a: a trailing continuity exemption on a target filter —
+/// "..., except for creatures [the/that player] hasn't controlled continuously
+/// since the beginning of the turn" (Total War). The exempted set is the
+/// creatures NOT controlled continuously since the turn began, so excluding it
+/// restricts the population to creatures the player HAS controlled continuously:
+/// `FilterProp::ControlledContinuouslySinceTurnBegan`. This is the "except
+/// for <predicate>" sibling of the type-list exclusion above; it reaches the
+/// same restriction Siren's Call attaches via its `ignore this effect for each
+/// creature ... didn't control continuously ...` ActivePlayerPunisher path
+/// (`parser/oracle.rs::parse_continuity_exemption_clause`), for the destroy /
+/// affect-all shape that trails the population phrase instead.
+fn parse_except_continuity_exemption_suffix(text: &str) -> Option<(FilterProp, usize)> {
+    let trimmed = text.trim_start();
+    // Optional list/clause comma the exemption trails ("didn't attack, except…").
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>(",")).parse(trimmed).ok()?;
+    let rest = rest.trim_start();
+    let (rest, _) = tag::<_, _, OracleError<'_>>("except for creatures")
+        .parse(rest)
+        .ok()?;
+    // Optional subject anaphor: " the player" / " that player" / "".
+    let (rest, _) = opt(alt((
+        tag::<_, _, OracleError<'_>>(" the player"),
+        tag(" that player"),
+    )))
+    .parse(rest)
+    .ok()?;
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>(" hasn't controlled"),
+        tag(" haven't controlled"),
+        tag(" didn't control"),
+        tag(" doesn't control"),
+    ))
+    .parse(rest)
+    .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" continuously since the beginning of the turn")
+        .parse(rest)
+        .ok()?;
+    Some((
+        FilterProp::ControlledContinuouslySinceTurnBegan,
+        text.len() - rest.len(),
+    ))
 }
 
 /// CR 205.3 + CR 205.4b: "that isn't a <Subtype>" / "that's not a <Subtype>"

--- a/crates/engine/tests/integration/total_war_attacking_player_scope.rs
+++ b/crates/engine/tests/integration/total_war_attacking_player_scope.rs
@@ -159,3 +159,67 @@ fn total_war_destroys_attacking_players_idle_creatures_only() {
         "a non-attacking third party (P2) must keep its idle creature"
     );
 }
+
+/// Discriminating regression for the continuity exemption (#5641 follow-up):
+/// "..., except for creatures the player hasn't controlled continuously since
+/// the beginning of the turn." Total War must SPARE an idle creature the
+/// attacking player gained this turn (summoning-sick → not controlled
+/// continuously, CR 508.1a) while still destroying one it has controlled since
+/// the turn began.
+///
+/// Revert-failing: without the `parse_except_continuity_exemption_suffix` arm
+/// the DestroyAll filter carries no `ControlledContinuouslySinceTurnBegan`
+/// restriction, so the freshly-gained creature is destroyed too — flipping the
+/// "Fresh Idler survives" assertion.
+#[test]
+fn total_war_spares_creatures_not_controlled_since_turn_began() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    {
+        let mut b = scenario.add_creature(P0, "Total War", 0, 1);
+        b.as_enchantment().from_oracle_text(TOTAL_WAR);
+    }
+
+    // P1 (attacker): an attacker, an idle creature controlled since the turn
+    // began (destroyed), and an idle creature gained THIS turn (spared).
+    let p1_attacker = scenario.add_creature(P1, "P1 Attacker", 2, 2).id();
+    scenario.add_creature(P1, "P1 Established Idler", 2, 2);
+    let p1_fresh = scenario.add_creature(P1, "P1 Fresh Idler", 2, 2).id();
+
+    let mut runner = scenario.build();
+
+    hand_turn_to(&mut runner, P1);
+    // Mark the fresh creature summoning-sick AFTER the turn advance (so the untap
+    // step can't clear it): at Total War's resolution it reads as not controlled
+    // continuously since the turn began.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&p1_fresh)
+        .unwrap()
+        .summoning_sick = true;
+
+    runner
+        .declare_attackers(&[(p1_attacker, AttackTarget::Player(P0))])
+        .expect("P1's attacker should be a legal attack declaration");
+    order_triggers_if_needed(&mut runner);
+    runner.advance_until_stack_empty();
+
+    // Controlled since the turn began → destroyed.
+    assert!(
+        !on_battlefield_named(&runner, "P1 Established Idler"),
+        "an idle creature the attacking player controlled since the turn began must be destroyed"
+    );
+    // THE CONTINUITY EXEMPTION: gained this turn → spared.
+    assert!(
+        on_battlefield_named(&runner, "P1 Fresh Idler"),
+        "a creature the attacking player hasn't controlled continuously since the beginning of \
+         the turn must be exempt from Total War's destruction"
+    );
+    // The attacker itself attacked (tapped) — excluded regardless.
+    assert!(
+        on_battlefield_named(&runner, "P1 Attacker"),
+        "the attacker attacked and is excluded by the didn't-attack filter"
+    );
+}


### PR DESCRIPTION
Tier: Frontier
Model: claude-opus-4-8

## Summary

Total War — *"Whenever a player attacks with one or more creatures, destroy all untapped non-Wall creatures that player controls that didn't attack, **except for creatures the player hasn't controlled continuously since the beginning of the turn**."* — silently dropped its trailing continuity exemption. The `DestroyAll` filter parsed only as `[Untapped, Not(AttackedThisTurn)]`, so Total War also destroyed creatures the attacking player **gained this turn**, which CR 302.6 + CR 508.1a exempt.

This was a **documented KNOWN GAP** (the comment at `oracle.rs`, above `parse_continuity_exemption_clause`): the existing continuity recognizer covers only Siren's Call's `"ignore this effect for each creature … didn't control continuously …"` ActivePlayerPunisher shape. Total War phrases the same exemption as a trailing `"except for creatures the player hasn't controlled continuously …"` on the target population, which never reached that recognizer.

The player-scope half of this card (`"that player"` binding to the attacking player) was fixed separately in #5646; this completes Total War's parse.

## Implementation method

Additive, single seam, reuses existing machinery — no new engine variant:

- Add `parse_except_continuity_exemption_suffix` on the target-filter parse path (`oracle_target.rs`), a sibling of the existing `"except for <type-list>"` exclusion. It is placed **after** the controller / `"didn't attack"` relative clauses because the exemption trails them (the early type-list `except for` block runs before those clauses are consumed and never reaches it).
- The exempted set — creatures **not** controlled continuously — is removed from the population, so only creatures the player **has** controlled continuously since the turn began are affected. It attaches the existing `FilterProp::ControlledContinuouslySinceTurnBegan` — the same restriction Siren's Call reaches by its own ActivePlayerPunisher path (runtime: `filter.rs` evaluates it as `!obj.summoning_sick`, CR 508.1a).
- Updated the now-stale KNOWN GAP comment in `oracle.rs` to point at the new recognizer.

## CR references

- **CR 302.6 / CR 508.1a** — a creature the player hasn't controlled continuously since their most recent turn began (i.e. summoning-sick) is exempt.

## Verification

- **Discriminating runtime test** (`total_war_spares_creatures_not_controlled_since_turn_began`): the attacking player controls one idle creature since the turn began (destroyed) and one gained this turn (summoning-sick → **spared**). Reverting the recognizer flips the "Fresh Idler survives" assertion (the filter loses the restriction and destroys it too).
- The existing scope test (`total_war_destroys_attacking_players_idle_creatures_only`, #5646) still passes.
- Parse footprint: **Total War alone** — the sole card with this exemption phrasing (verified against the pool), so the coverage-parse-diff is a clean one-card improvement.
- Parser lib suite: **8101 passed, 0 failed**. `cargo fmt --check` clean; parser-combinator gate passes.
