### PR TITLE
ship/t104 special action x

### DIFF
--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -142,7 +142,7 @@ fn cheap_reject_candidate(state: &GameState, action: &GameAction) -> bool {
         | (WaitingFor::Priority { .. }, GameAction::PlayLand { object_id, .. })
         | (WaitingFor::Priority { .. }, GameAction::UnlockRoomDoor { object_id, .. })
         | (WaitingFor::Priority { .. }, GameAction::Transform { object_id })
-        | (WaitingFor::Priority { .. }, GameAction::TurnFaceUp { object_id })
+        | (WaitingFor::Priority { .. }, GameAction::TurnFaceUp { object_id, .. })
         | (WaitingFor::Priority { .. }, GameAction::PlayFaceDown { object_id, .. })
         | (WaitingFor::Priority { .. }, GameAction::TapLandForMana { object_id })
         | (WaitingFor::Priority { .. }, GameAction::UntapLandForMana { object_id })

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -3471,7 +3471,7 @@ fn push_ability_entry(
     // publication is live, and `triggers::build_triggered_ability` stamps it onto the
     // trigger's `chosen_x`. An activation with no announced X publishes `None`, which
     // also clears any stale value.
-    state.activated_ability_x = resolved.chosen_x.map(|x| (source_id, x));
+    state.announced_source_x = resolved.chosen_x.map(|x| (source_id, x));
 
     // CR 603.4: Stamp the printed-ability index for per-turn resolution tracking.
     resolved.ability_index = Some(ability_index);

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -6071,13 +6071,14 @@ fn apply_action(
             super::morph::play_face_down(state, p, object_id, &mut events)?;
             WaitingFor::Priority { player: p }
         }
-        (WaitingFor::Priority { player }, GameAction::TurnFaceUp { object_id }) => {
+        (WaitingFor::Priority { player }, GameAction::TurnFaceUp { object_id, x }) => {
             if state.priority_player
                 != turn_control::authorized_submitter_for_player(state, *player)
             {
                 return Err(EngineError::NotYourPriority);
             }
             let p = *player;
+            let announced_x = x;
             // CR 116.2b + CR 702.37e / CR 702.168d / CR 701.40b + CR 106.6: turning
             // a face-down permanent face up is a special action whose morph/disguise/
             // manifest cost must be paid *before* the flip. `turn_face_up_prepare`
@@ -6087,12 +6088,47 @@ fn apply_action(
             // Gossip) is eligible here while other-context mana is rejected. Mirrors
             // the `UnlockDoor` special-action handler.
             let cost = super::morph::turn_face_up_prepare(state, object_id, p)?;
-            let cost = casting::apply_special_action_cost_reduction(
+            let mut cost = casting::apply_special_action_cost_reduction(
                 state,
                 p,
                 crate::types::mana::SpecialAction::TurnFaceUp,
                 cost,
             );
+
+            // CR 107.3d: "If a cost associated with a special action, such as a suspend
+            // cost or a morph cost, has an {X} ... in it, the value of X is chosen by the
+            // player taking the special action immediately before they pay that cost."
+            // The announcement happens HERE — inside the action, with no priority window
+            // between choosing X and paying it, exactly as the rule describes.
+            //
+            // Warbreak Trumpeter (Morph {X}{X}{R}), Bane of the Living (Morph {X}{B}{B})
+            // and Aurelia's Vindicator (Disguise {X}{3}{W}) are the live faces.
+            let has_x = casting_costs::cost_has_x(&cost);
+            if has_x {
+                // CR 118.3: a player can't announce an X they cannot pay for. The cap is
+                // computed with `object_id: None` deliberately — this is a SPECIAL ACTION,
+                // not a cast, so cast-time cost modifiers and floors must not apply (the
+                // special-action reduction was already applied above).
+                let max_x = casting_costs::max_x_value(state, p, &cost, None);
+                if announced_x > max_x {
+                    return Err(EngineError::InvalidAction(format!(
+                        "X={announced_x} exceeds the maximum payable value of {max_x} for this \
+                         turn-face-up cost"
+                    )));
+                }
+                // CR 107.1b + CR 601.2f: each `{X}` shard becomes `announced_x` generic, so
+                // Warbreak Trumpeter's `{X}{X}{R}` costs 2X + {R}. Without this the X shards
+                // reach mana payment unresolved and are dropped — the permanent flips for
+                // its non-X remainder alone.
+                cost.concretize_x(announced_x);
+            } else if announced_x != 0 {
+                // A cost with no {X} admits no choice: CR 107.3d only grants one "if a cost
+                // ... has an {X} ... in it". Reject rather than silently ignore, so a client
+                // bug cannot masquerade as a legal flip.
+                return Err(EngineError::InvalidAction(
+                    "This permanent's turn-face-up cost has no {X}, so X must be 0".to_string(),
+                ));
+            }
             casting::pay_special_action_mana_cost(
                 state,
                 p,
@@ -6101,6 +6137,29 @@ fn apply_action(
                 crate::types::mana::SpecialAction::TurnFaceUp,
                 &mut events,
             )?;
+
+            // CR 702.37f (morph) / CR 702.168e (disguise): "If a permanent's morph cost
+            // includes X, other abilities of that permanent may also refer to X. The value
+            // of X in those abilities is equal to the value of X chosen as the morph special
+            // action was taken." Publish the announced X on the source-keyed carrier BEFORE
+            // the flip emits `TurnedFaceUp`, so `triggers::build_triggered_ability` — the
+            // single trigger-instantiation authority — stamps it onto the turn-face-up
+            // trigger's `chosen_x`.
+            //
+            // The stamp must land at INSTANTIATION, not resolution: Aurelia's Vindicator
+            // spends its X in `multi_target.max` ("exile up to X other target creatures"),
+            // which is consumed during target selection, before the trigger ever resolves.
+            //
+            // Published only when the cost actually HAS an {X} (CR 107.3d grants a choice
+            // only then). A no-X flip leaves the carrier untouched rather than clobbering it
+            // with `Some((.., 0))`: an unrelated activated ability of ANOTHER object may be
+            // on the stack with its own announced X in flight, and that value must survive.
+            // The carrier is cleared at the start of the next `resolve_top`, so this
+            // publication cannot outlive the trigger it is for.
+            if has_x {
+                state.announced_source_x = Some((object_id, announced_x));
+            }
+
             super::morph::turn_face_up(state, p, object_id, &mut events)?;
             WaitingFor::Priority { player: p }
         }

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -1699,8 +1699,14 @@ fn turn_face_up_restricted_mana_funds_special_action() {
         ManaRestriction::OnlyForSpecialAction(SpecialAction::TurnFaceUp),
     );
 
-    let result = apply_as_current(&mut state, GameAction::TurnFaceUp { object_id: morph })
-        .expect("turn-face-up-restricted mana must fund the morph turn-up special action");
+    let result = apply_as_current(
+        &mut state,
+        GameAction::TurnFaceUp {
+            object_id: morph,
+            x: 0,
+        },
+    )
+    .expect("turn-face-up-restricted mana must fund the morph turn-up special action");
 
     assert!(
         !state.objects[&morph].face_down,
@@ -1739,7 +1745,13 @@ fn turn_face_up_empty_pool_cannot_pay_and_stays_face_down() {
     let mut state = setup_game_at_main_phase();
     let morph = setup_face_down_morph(&mut state, PlayerId(0));
 
-    let result = apply_as_current(&mut state, GameAction::TurnFaceUp { object_id: morph });
+    let result = apply_as_current(
+        &mut state,
+        GameAction::TurnFaceUp {
+            object_id: morph,
+            x: 0,
+        },
+    );
     assert!(
         result.is_err(),
         "with no mana the {{3}} morph turn-up cost must be unpayable: {result:?}"
@@ -1772,7 +1784,13 @@ fn turn_face_up_rejects_unlock_door_restricted_mana() {
         ManaRestriction::OnlyForSpecialAction(SpecialAction::UnlockDoor),
     );
 
-    let result = apply_as_current(&mut state, GameAction::TurnFaceUp { object_id: morph });
+    let result = apply_as_current(
+        &mut state,
+        GameAction::TurnFaceUp {
+            object_id: morph,
+            x: 0,
+        },
+    );
     assert!(
         result.is_err(),
         "door-unlock-restricted mana must not pay a turn-face-up: {result:?}"

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -195,7 +195,7 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
     // CR 107.3a: the announced activation-X carrier is scoped to the activation that
     // published it. Clear it here so it never leaks into an unrelated resolution; it is
     // republished below for an `ActivatedAbility` entry (and only for that kind).
-    state.activated_ability_x = None;
+    state.announced_source_x = None;
 
     // CR 405.5: When all players pass in succession, the top object on the stack resolves.
     let entry = match state.stack.pop_back() {
@@ -479,7 +479,7 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
         ability: activated,
     } = &entry.kind
     {
-        state.activated_ability_x = activated.chosen_x.map(|x| (*source_id, x));
+        state.announced_source_x = activated.chosen_x.map(|x| (*source_id, x));
     }
     let resolution_start_phase = state.phase;
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -8124,14 +8124,14 @@ pub(super) fn build_triggered_ability(
         // value X") which is consumed during target selection — before the trigger ever
         // resolves.
         //
-        // SCOPED BY SOURCE, and this scoping is load-bearing: `activated_ability_x` is
+        // SCOPED BY SOURCE, and this scoping is load-bearing: `announced_source_x` is
         // published only by an activated ability (never by a resolving spell — see
         // `stack::resolve_top`), so a permanent put onto the battlefield by an unrelated
         // X-spell keeps X = 0 (CR 107.3m) rather than inheriting that spell's X. It also
         // keeps `QuantityRef::CostXPaid` — the CR 107.3m *cast* channel, which falls back
         // to `chosen_x` — reading the cast X, never an activation X (CR 107.3k: the two
         // are independent).
-        if let Some((activating_source, announced_x)) = state.activated_ability_x {
+        if let Some((activating_source, announced_x)) = state.announced_source_x {
             if activating_source == source_id {
                 resolved.set_chosen_x_recursive(announced_x);
             }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -572,7 +572,7 @@ fn rewrite_cost_x_in_condition(cond: &mut crate::types::ability::AbilityConditio
 ///    an MV-3 artifact for X=3, and CANNOT target it for X=1);
 ///  * ungated triggers — the walk never runs there. Their X is a cast-X read through the trigger
 ///    event (Hydroid Krasis), or an activated ability's announced X (Shark Typhoon), which
-///    `GameState::activated_ability_x` now carries;
+///    `GameState::announced_source_x` now carries;
 ///  * pay-any-amount sentinels (CR 107.3f) — a bare X in a `PayLife`/`PayEnergy` amount is the
 ///    engine's "pay any amount" marker, not a fabrication.
 ///
@@ -16905,7 +16905,7 @@ mod cost_x_totality_guard_tests {
 
     /// GREEN CONTROL — an UNGATED trigger (the walk never runs on it). Shark Typhoon's cycle
     /// trigger keeps a bare X by design: it is the ACTIVATED ability's announced X, carried at
-    /// runtime by `GameState::activated_ability_x` (CR 107.3k — it is NOT the cast-X, so the
+    /// runtime by `GameState::announced_source_x` (CR 107.3k — it is NOT the cast-X, so the
     /// parser must not rewrite it to `CostXPaid`). The guard must not reach it.
     #[test]
     fn guard_does_not_red_an_ungated_activated_ability_x() {

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -306,8 +306,26 @@ pub enum GameAction {
         object_id: ObjectId,
         card_id: CardId,
     },
+    /// CR 116.2b: turning a face-down permanent face up is a SPECIAL ACTION — it uses
+    /// no stack and gets no priority window of its own.
+    ///
+    /// CR 107.3d: "If a cost associated with a special action, such as a suspend cost or a
+    /// morph cost, has an {X} or an X in it, the value of X is chosen by the player taking
+    /// the special action **immediately before they pay that cost**." Because the rules put
+    /// that choice inside the action itself — with no pause between choosing and paying —
+    /// X rides on the action rather than on a `WaitingFor` round-trip (which would model a
+    /// window the rules do not have).
+    ///
+    /// `x` is ignored when the turn-face-up cost has no `{X}` (it must then be 0). For a cost
+    /// that does have one, `x` is the announced value bound by CR 702.37f (morph) /
+    /// CR 702.168e (disguise): "other abilities of that permanent may also refer to X."
+    ///
+    /// `#[serde(default)]`: a client that omits the field announces **X = 0**, which is a legal
+    /// choice under CR 107.3d — never an error.
     TurnFaceUp {
         object_id: ObjectId,
+        #[serde(default)]
+        x: u32,
     },
     SubmitSideboard {
         main: Vec<DeckCardCount>,
@@ -1438,7 +1456,7 @@ impl GameAction {
             GameAction::UnlockRoomDoor { object_id, .. } => Some(*object_id),
             GameAction::ChooseRoomDoor { object_id, .. } => Some(*object_id),
             GameAction::PlayFaceDown { object_id, .. } => Some(*object_id),
-            GameAction::TurnFaceUp { object_id } => Some(*object_id),
+            GameAction::TurnFaceUp { object_id, .. } => Some(*object_id),
             GameAction::ChooseRingBearer { target } => Some(*target),
             GameAction::ChoosePair { partner } => *partner,
             GameAction::ChooseDamageSource { source } => Some(*source),
@@ -1733,7 +1751,13 @@ mod tests {
                 },
                 Some(oid),
             ),
-            (GameAction::TurnFaceUp { object_id: oid }, Some(oid)),
+            (
+                GameAction::TurnFaceUp {
+                    object_id: oid,
+                    x: 0,
+                },
+                Some(oid),
+            ),
             (
                 GameAction::TapForConvoke {
                     object_id: oid,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -8543,33 +8543,59 @@ pub struct GameState {
     /// `current_trigger_event`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolving_stack_entry: Option<StackEntry>,
-    /// CR 107.3a + CR 107.3i: the announced X of an **activated ability**, keyed by
-    /// the object that ability is on. CR 107.3a: "While an activated ability is on
-    /// the stack, any X in its activation cost equals the announced value." CR
-    /// 107.3i: "Normally, all instances of X on an object have the same value at any
-    /// given time" — so a triggered ability of that SAME object which fires because
-    /// of that activation (Hydra Broodmaster's "when this becomes monstrous, create X
-    /// X/X tokens"; Shark Typhoon's "when you cycle this card, create an X/X Shark")
-    /// reads the same X. `triggers::build_triggered_ability` consumes this and stamps
-    /// it onto the triggered ability's `chosen_x`.
+    /// CR 107.3i: the X announced for an in-flight COST, keyed by the object whose cost
+    /// it is. CR 107.3i: "Normally, all instances of X on an object have the same value
+    /// at any given time" — so a triggered ability of that SAME object which fires
+    /// because of that announcement reads the same X.
+    /// `triggers::build_triggered_ability` consumes this and stamps it onto the
+    /// triggered ability's `chosen_x`.
+    ///
+    /// There are exactly TWO announce surfaces, and this one field serves both — they
+    /// differ only in *which* rule fixes the value, never in what is carried:
+    ///
+    /// * **CR 107.3a — an activated ability.** "While an activated ability is on the
+    ///   stack, any X in its activation cost equals the announced value." Covers Hydra
+    ///   Broodmaster ("when this becomes monstrous, create X X/X tokens") and Shark
+    ///   Typhoon ("when you cycle this card, create an X/X Shark").
+    /// * **CR 107.3d — a SPECIAL ACTION.** "If a cost associated with a special action,
+    ///   such as a suspend cost or a morph cost, has an {X} … in it, the value of X is
+    ///   chosen by the player taking the special action immediately before they pay that
+    ///   cost." A turn-face-up (CR 116.2b) is such a special action: it uses no stack and
+    ///   never passes through `push_ability_entry`, so it needs its own publication.
+    ///   **CR 702.37f** (morph) / **CR 702.168e** (disguise) then bind it: "If a
+    ///   permanent's morph cost includes X, other abilities of that permanent may also
+    ///   refer to X. The value of X in those abilities is equal to the value of X chosen
+    ///   as the morph special action was taken." Covers Warbreak Trumpeter, Bane of the
+    ///   Living, and Aurelia's Vindicator.
     ///
     /// This MUST be a channel of its own and must NOT reuse `GameObject::cost_x_paid`:
     /// that field is the CR 107.3m *cast*-X channel (`QuantityRef::CostXPaid`), and CR
     /// 107.3k makes an activated ability's X "independent of any other values of X
-    /// chosen for that object". Writing an activation X there would read the wrong X
+    /// chosen for that object". Writing an announced X there would read the wrong X
     /// by rule, not merely a missing one.
     ///
-    /// Published at exactly the two moments an activated ability can produce a trigger
-    /// event — announcement (`casting_costs::push_ability_entry`, which emits `Cycled`
-    /// / `KeywordAbilityActivated`) and its own resolution (`stack::resolve_top`, which
-    /// covers `EffectResolved` emitters such as Monstrosity). Set to `None` for every
-    /// other stack-entry kind and cleared at the start of each `resolve_top` alongside
-    /// `resolving_stack_entry`, so a resolving SPELL never publishes: that is what keeps
-    /// a permanent put onto the battlefield by an unrelated X-spell at X=0 (CR 107.3m:
-    /// "the value of X for that permanent is 0") instead of inheriting the spell's X.
+    /// Published at exactly the three moments an announced X can precede a trigger event
+    /// — an activated ability's announcement (`casting_costs::push_ability_entry`, which
+    /// emits `Cycled` / `KeywordAbilityActivated`), its own resolution
+    /// (`stack::resolve_top`, covering `EffectResolved` emitters such as Monstrosity),
+    /// and the turn-face-up special action (`engine`'s `GameAction::TurnFaceUp` handler,
+    /// which emits `TurnedFaceUp`). Set to `None` for every other stack-entry kind and
+    /// cleared at the start of each `resolve_top` alongside `resolving_stack_entry`, so a
+    /// resolving SPELL never publishes: that is what keeps a permanent put onto the
+    /// battlefield by an unrelated X-spell at X=0 (CR 107.3m: "the value of X for that
+    /// permanent is 0") instead of inheriting the spell's X.
     /// Transient decision context, serialized so a mid-activation pause round-trips.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub activated_ability_x: Option<(ObjectId, u32)>,
+    ///
+    /// `serde(alias)`: this field was named `activated_ability_x` before the special-action
+    /// surface was added. `GameState` sets no `deny_unknown_fields`, so without the alias an
+    /// older save written mid-activation would have its live X **silently dropped** rather
+    /// than rejected.
+    #[serde(
+        default,
+        alias = "activated_ability_x",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub announced_source_x: Option<(ObjectId, u32)>,
     /// CR 400.7j (+ CR 400.7g/h cast hop): a resolution-scoped record of a source
     /// object that the currently-resolving ability moved as part of its own
     /// resolution (Siege "exile it, then you may cast it"). It lets
@@ -9937,7 +9963,7 @@ impl GameState {
             pending_team_draw_step: Vec::new(),
             pending_untap_declines: Vec::new(),
             current_trigger_event: None,
-            activated_ability_x: None,
+            announced_source_x: None,
             current_trigger_match_count: None,
             resolving_stack_entry: None,
             resolution_source_relatch: None,
@@ -10948,7 +10974,7 @@ fn _gamestate_partition_is_total(s: &GameState) {
         // CR 107.3a announce-scoped carrier, cleared at each `resolve_top`; a decision
         // context, not durable board state — like `current_trigger_event`, it is not a
         // per-cycle accumulator and PartialEq does not compare it.
-        activated_ability_x: _,
+        announced_source_x: _,
         resolving_stack_entry: _,
         current_trigger_events: _,
         stack_trigger_event_batches: _,

--- a/crates/engine/tests/integration/cost_x_carrier_runtime.rs
+++ b/crates/engine/tests/integration/cost_x_carrier_runtime.rs
@@ -241,7 +241,7 @@ fn gated_etb_multi_target_sibling_field() {
 /// which is what makes it a CLASS rather than a Shark Typhoon special case.
 ///
 /// t96 left this `#[ignore]`d as a verified-red witness. t97 built the carrier
-/// (`GameState::activated_ability_x`, published by `casting_costs::push_ability_entry` and
+/// (`GameState::announced_source_x`, published by `casting_costs::push_ability_entry` and
 /// `stack::resolve_top`, consumed by `triggers::build_triggered_ability`) and the `#[ignore]`
 /// is removed here: MEASURED 0 -> 2 tokens. Monstrosity emits its `EffectResolved` during
 /// RESOLUTION of the activated ability, so this exercises the resolution-scoped publication.
@@ -552,64 +552,95 @@ fn a_resolving_spell_never_publishes_an_activation_x() {
          gains half X = 2 life. If this is 0 the assertion below proves nothing."
     );
     assert_eq!(
-        runner.state().activated_ability_x,
+        runner.state().announced_source_x,
         None,
         "CR 107.3m + CR 107.3k: a resolving SPELL must never publish an activation X. A \
          published value here would (a) let a permanent this spell puts onto the battlefield \
          inherit X instead of 0, and (b) leak into the CostXPaid -> chosen_x fallback and \
          poison the gated-ETB sibling slots. MEASURED: {:?}",
-        runner.state().activated_ability_x
+        runner.state().announced_source_x
     );
 }
 
 /// RULING CONDITION 2 — save/wire compatibility, CHECKED rather than asserted.
 ///
-/// `activated_ability_x` is NEW PERSISTED `GameState` (it is serialized so a mid-activation
+/// `announced_source_x` is PERSISTED `GameState` (it is serialized so a mid-activation
 /// pause — e.g. an interactive cost payment between announcement and the trigger going on the
 /// stack — round-trips). It is therefore a save-format change and must be shown compatible:
 ///
-///  1. A save written by an OLDER binary has no `activated_ability_x` key at all. `#[serde(default)]`
+///  1. A save written by an OLDER binary has no key at all. `#[serde(default)]`
 ///     must make that load as `None` rather than fail. Because `skip_serializing_if` omits the key
 ///     whenever it is `None`, a fresh serialization of a state with no live activation IS
 ///     byte-identical to an old save on this axis — so serializing a `None` state and reloading it
 ///     exercises exactly the old-save path.
 ///  2. A live value must survive a round-trip.
+///  3. **A save written under the OLD FIELD NAME (`activated_ability_x`) must still load its
+///     value.** t104 renamed this field when it gained its second announce surface (CR 107.3d
+///     special actions, alongside CR 107.3a activated abilities). `GameState` sets no
+///     `deny_unknown_fields`, so WITHOUT `#[serde(alias = "activated_ability_x")]` an old
+///     mid-activation save would be accepted and its live X **silently dropped** — the worst
+///     failure mode, since it looks like a clean load. The alias is what makes this direction
+///     pass; delete it and this assertion fails while (1) and (2) still pass.
 ///
-/// (`GameState` does not use `deny_unknown_fields`, so the reverse direction — an OLD binary
-/// reading a NEW save that carries the key — ignores it rather than erroring.)
+/// (The reverse direction — an OLD binary reading a NEW save carrying the new key — ignores the
+/// unknown key rather than erroring, for the same `deny_unknown_fields` reason.)
 #[test]
-fn activated_ability_x_is_save_compatible() {
+fn announced_source_x_is_save_compatible() {
     let scenario = GameScenario::new();
     let runner = scenario.build();
     let mut state = runner.state().clone();
 
     // (1) OLD-SAVE SHAPE: `None` omits the key entirely.
-    state.activated_ability_x = None;
+    state.announced_source_x = None;
     let old_shape = serde_json::to_value(&state).expect("serialize");
     assert!(
-        old_shape.get("activated_ability_x").is_none(),
+        old_shape.get("announced_source_x").is_none(),
         "a `None` carrier must omit the key, so pre-field saves are byte-identical on this axis"
     );
     let reloaded: engine::types::game_state::GameState =
         serde_json::from_value(old_shape).expect("an old save (no key) must load, not fail");
     assert_eq!(
-        reloaded.activated_ability_x, None,
-        "a save with no `activated_ability_x` key must default to None"
+        reloaded.announced_source_x, None,
+        "a save with no `announced_source_x` key must default to None"
     );
 
     // (2) LIVE VALUE: round-trips intact.
-    state.activated_ability_x = Some((ObjectId(4242), 7));
+    state.announced_source_x = Some((ObjectId(4242), 7));
     let new_shape = serde_json::to_value(&state).expect("serialize");
     assert!(
-        new_shape.get("activated_ability_x").is_some(),
+        new_shape.get("announced_source_x").is_some(),
         "a live announced X must be persisted (it must survive a mid-activation pause)"
     );
     let reloaded: engine::types::game_state::GameState =
         serde_json::from_value(new_shape).expect("deserialize");
     assert_eq!(
-        reloaded.activated_ability_x,
+        reloaded.announced_source_x,
         Some((ObjectId(4242), 7)),
         "the announced X and its source must round-trip through a save"
+    );
+
+    // (3) PRE-RENAME SAVE: the old key must still bind, via `#[serde(alias)]`.
+    // Build a real save, then rewrite the key back to its pre-t104 name — this is exactly the
+    // JSON an older binary would have written while an activation was in flight.
+    let mut pre_rename = serde_json::to_value(&state).expect("serialize");
+    let carried = pre_rename
+        .as_object_mut()
+        .expect("GameState serializes as a JSON object")
+        .remove("announced_source_x")
+        .expect("the live carrier was just set, so the key must be present");
+    pre_rename
+        .as_object_mut()
+        .expect("GameState serializes as a JSON object")
+        .insert("activated_ability_x".to_string(), carried);
+
+    let reloaded: engine::types::game_state::GameState = serde_json::from_value(pre_rename)
+        .expect("a pre-rename save must still deserialize (no deny_unknown_fields)");
+    assert_eq!(
+        reloaded.announced_source_x,
+        Some((ObjectId(4242), 7)),
+        "CR 107.3a/107.3d: a mid-activation save written under the OLD field name must still load \
+         its announced X. Without `#[serde(alias = \"activated_ability_x\")]` the unknown key is \
+         SILENTLY IGNORED and this reads None — a live X lost on load, with no error."
     );
 }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -659,6 +659,7 @@ mod skullwinder_chosen_opponent;
 mod slaughter_the_strong_total_power_4380;
 mod sliver_static_grants;
 mod sothera_supervoid_edict_reanimate;
+mod special_action_x_runtime;
 mod specialize_runtime;
 mod spellstutter_sprite_counter_with_x;
 mod sphinx_of_uthuun_etb_pile_separation;

--- a/crates/engine/tests/integration/special_action_x_runtime.rs
+++ b/crates/engine/tests/integration/special_action_x_runtime.rs
@@ -1,0 +1,517 @@
+//! t104 — RUNTIME WITNESSES for the SPECIAL-ACTION X channel (CR 107.3d / CR 702.37f).
+//!
+//! Turning a face-down permanent face up is a SPECIAL ACTION (CR 116.2b): it uses no stack and
+//! never passes through `push_ability_entry`. So neither pre-existing X channel could reach it,
+//! BY CONSTRUCTION:
+//!   * `GameObject::cost_x_paid` is the CR 107.3m *cast* channel — and a face-down permanent was
+//!     cast for {3} (CR 702.37c), so its `cost_x_paid` is 0.
+//!   * t97's source-keyed carrier published only for an *activated ability*.
+//!
+//! CR 107.3d: "If a cost associated with a special action, such as a suspend cost or a morph
+//! cost, has an {X} or an X in it, the value of X is chosen by the player taking the special
+//! action immediately before they pay that cost."
+//! CR 702.37f (morph) / CR 702.168e (disguise): "If a permanent's morph cost includes X, other
+//! abilities of that permanent may also refer to X. The value of X in those abilities is equal to
+//! the value of X chosen as the morph special action was taken."
+//!
+//! The three live faces put X in three DIFFERENT AST slots, consumed at three different times —
+//! and all three bind through the SAME field, `ResolvedAbility::chosen_x`, stamped at trigger
+//! INSTANTIATION by `triggers::build_triggered_ability`:
+//!
+//!   | face                | slot                                  | consumed at      |
+//!   |---------------------|---------------------------------------|------------------|
+//!   | Warbreak Trumpeter  | `Token.count`                         | resolution       |
+//!   | Aurelia's Vindicator| `multi_target.max`                    | TARGET SELECTION |
+//!   | Bane of the Living  | `PumpAll.power/toughness = Var("-X")` | resolution       |
+//!
+//! MEASURED ON PRISTINE MAIN, through this same path (before the channel existed): flipping
+//! Warbreak Trumpeter (Morph {X}{X}{R}) cost **1 mana** — the {X} shards were dropped entirely,
+//! not merely unbound — and created **0 goblins**. Both halves are fixed here and pinned below.
+//!
+//! HARNESS NOTE (inherited from t96/t97, learned the hard way): `add_card_to_hand` builds a
+//! name-only object "without rules text" — a probe built on it is VACUOUS and reads 0 for
+//! everything, which looks exactly like a fabrication. Every card below is therefore synthesized
+//! from its VERBATIM Oracle text (pool export), and the Hooded Hydra control exists precisely to
+//! catch a regression back into that vacuum.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{StackEntryKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// VERBATIM Oracle text (pool export — NOT paraphrased, NOT from memory).
+//
+// NOTE: Warbreak Trumpeter's trigger is bare "create X 1/1 red Goblin creature tokens". There is
+// NO "where X is the amount of mana spent" clause on the card — the X binds implicitly via
+// CR 702.37f. This matters: the morph cost is {X}{X}{R}, so "the amount of mana spent" would be
+// 2X+1, not X. A fix built to that (mis)quote would be wrong by a factor of two.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const WARBREAK_TRUMPETER: &str = "Morph {X}{X}{R} (You may cast this card face down as a 2/2 \
+                                  creature for {3}. Turn it face up any time for its morph \
+                                  cost.)\nWhen this creature is turned face up, create X 1/1 red \
+                                  Goblin creature tokens.";
+
+const BANE_OF_THE_LIVING: &str = "Morph {X}{B}{B} (You may cast this card face down as a 2/2 \
+                                  creature for {3}. Turn it face up any time for its morph \
+                                  cost.)\nWhen this creature is turned face up, all creatures get \
+                                  -X/-X until end of turn.";
+
+const AURELIAS_VINDICATOR: &str = "Flying, lifelink, ward {2}\nDisguise {X}{3}{W}\nWhen this \
+                                   creature is turned face up, exile up to X other target \
+                                   creatures from the battlefield and/or creature cards from \
+                                   graveyards.\nWhen this creature leaves the battlefield, return \
+                                   the exiled cards to their owners' hands.";
+
+/// CONTROL card — its morph cost has NO X ({3}{G}{G}). Its X is the CAST-X channel (CR 107.3m),
+/// and its turn-face-up rider is a REPLACEMENT, not a trigger.
+const HOODED_HYDRA: &str = "This creature enters with X +1/+1 counters on it.\nWhen this creature \
+                            dies, create a 1/1 green Snake creature token for each +1/+1 counter \
+                            on it.\nMorph {3}{G}{G}\nAs this creature is turned face up, put five \
+                            +1/+1 counters on it.";
+
+fn add_mana(runner: &mut engine::game::scenario::GameRunner, ty: ManaType, count: usize) {
+    for _ in 0..count {
+        let unit = ManaUnit::new(ty, ObjectId(0), false, vec![]);
+        runner.state_mut().players[0].mana_pool.add(unit);
+    }
+}
+
+fn pool_total(runner: &engine::game::scenario::GameRunner) -> usize {
+    runner.state().players[0].mana_pool.total()
+}
+
+/// Battlefield objects whose name contains `needle`, as (name, power, toughness).
+fn named_on_battlefield(
+    runner: &engine::game::scenario::GameRunner,
+    needle: &str,
+) -> Vec<(String, i32, i32)> {
+    let state = runner.state();
+    state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .filter(|o| o.name.contains(needle))
+        .map(|o| {
+            (
+                o.name.clone(),
+                o.power.unwrap_or(0),
+                o.toughness.unwrap_or(0),
+            )
+        })
+        .collect()
+}
+
+fn zone_size(runner: &engine::game::scenario::GameRunner, zone: Zone) -> usize {
+    runner
+        .state()
+        .objects
+        .values()
+        .filter(|o| o.zone == zone)
+        .count()
+}
+
+/// CR 702.37c: cast `card` face down as a 2/2, landing it on the battlefield.
+fn play_face_down(runner: &mut engine::game::scenario::GameRunner, card: ObjectId) {
+    let card_id = runner.state().objects[&card].card_id;
+    runner
+        .act(GameAction::PlayFaceDown {
+            object_id: card,
+            card_id,
+        })
+        .expect("play face down");
+    assert!(
+        runner.state().objects[&card].face_down,
+        "reach-guard: the card must actually be FACE DOWN on the battlefield, or nothing below \
+         is a test of the turn-face-up path"
+    );
+}
+
+/// CR 116.2b + CR 107.3d: take the turn-face-up special action, announcing `x`, then drive any
+/// resulting trigger (including its target selection) to resolution.
+fn turn_face_up_for_x(runner: &mut engine::game::scenario::GameRunner, card: ObjectId, x: u32) {
+    runner
+        .act(GameAction::TurnFaceUp { object_id: card, x })
+        .expect("turn face up for the announced X");
+    drain_trigger_targets(runner);
+    runner.advance_until_stack_empty();
+}
+
+/// CR 603.3d: a turn-face-up trigger picks its targets as it goes on the stack.
+fn drain_trigger_targets(runner: &mut engine::game::scenario::GameRunner) {
+    let mut chosen: Vec<engine::types::ability::TargetRef> = Vec::new();
+    for _ in 0..32 {
+        match &runner.state().waiting_for {
+            WaitingFor::TriggerTargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                // CR 601.2c: each slot takes a DISTINCT object, so track the picks.
+                let slot = &target_slots[selection.current_slot];
+                let pick = slot
+                    .legal_targets
+                    .iter()
+                    .find(|t| !chosen.contains(t))
+                    .cloned();
+                if let Some(target) = pick.clone() {
+                    chosen.push(target);
+                }
+                runner
+                    .act(GameAction::ChooseTarget { target: pick })
+                    .expect("choose a legal target for the turn-face-up trigger");
+            }
+            _ => break,
+        }
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// THE THREE FACES — one per X slot.
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// CR 107.3d + CR 702.37f — Warbreak Trumpeter, Morph `{X}{X}{R}`:
+/// "When this creature is turned face up, create X 1/1 red Goblin creature tokens."
+///
+/// The X lives in `Token.count` (an *effect* slot, consumed at resolution). Turned face up for
+/// X=3, it must create 3 Goblins. On pristine main this created **0** — the announced X had
+/// nowhere to live.
+#[test]
+fn warbreak_trumpeter_turned_face_up_for_x_creates_x_goblins() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let trumpeter = scenario
+        .add_creature_to_hand_from_oracle(P0, "Warbreak Trumpeter", 1, 1, WARBREAK_TRUMPETER)
+        .id();
+    let mut runner = scenario.build();
+
+    play_face_down(&mut runner, trumpeter);
+    add_mana(&mut runner, ManaType::Red, 12);
+
+    turn_face_up_for_x(&mut runner, trumpeter, 3);
+
+    assert!(
+        !runner.state().objects[&trumpeter].face_down,
+        "reach-guard: the permanent must actually be face up"
+    );
+    let goblins = named_on_battlefield(&runner, "Goblin");
+    assert_eq!(
+        goblins.len(),
+        3,
+        "CR 702.37f: turned face up for X=3, Warbreak Trumpeter creates X = 3 Goblins. 0 here \
+         means the special action's announced X was DROPPED (the pre-t104 behaviour). \
+         MEASURED: {goblins:?}"
+    );
+    assert!(
+        goblins.iter().all(|(_, p, t)| (*p, *t) == (1, 1)),
+        "the tokens are 1/1 red Goblins. MEASURED: {goblins:?}"
+    );
+}
+
+/// CR 107.3d + CR 702.37f — Bane of the Living, Morph `{X}{B}{B}`:
+/// "When this creature is turned face up, all creatures get -X/-X until end of turn."
+///
+/// The X lives in `PumpAll.power/toughness` as `PtValue::Variable("-X")` — a NEGATED placeholder
+/// resolved by `pump::resolve_variable_pt`, which reads `ability.chosen_x` and negates it. With
+/// `chosen_x` unset that helper returns `None` and the wrath is a silent 0/0 — the board does not
+/// move at all. Turned face up for X=2 it must be a -2/-2 sweep.
+#[test]
+fn bane_of_the_living_turned_face_up_for_x_wraths_for_minus_x() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let bane = scenario
+        .add_creature_to_hand_from_oracle(P0, "Bane of the Living", 4, 3, BANE_OF_THE_LIVING)
+        .id();
+    let victim = scenario.add_creature(P1, "Grizzly Bears", 3, 3).id();
+    let mut runner = scenario.build();
+
+    play_face_down(&mut runner, bane);
+    add_mana(&mut runner, ManaType::Black, 12);
+
+    turn_face_up_for_x(&mut runner, bane, 2);
+
+    let bears = runner.state().objects.get(&victim);
+    assert_eq!(
+        bears.map(|o| (o.power.unwrap_or(0), o.toughness.unwrap_or(0))),
+        Some((1, 1)),
+        "CR 702.37f: turned face up for X=2, ALL creatures get -2/-2 — the 3/3 becomes a 1/1. \
+         A 3/3 here means the negated X (`PtValue::Variable(\"-X\")`) resolved to 0 and the wrath \
+         did nothing. MEASURED: {:?}",
+        bears.map(|o| (o.power, o.toughness))
+    );
+    // The sweep hits Bane itself too (CR 611.2c — "all creatures", no exclusion): 4/3 -> 2/1.
+    let self_pt = runner
+        .state()
+        .objects
+        .get(&bane)
+        .map(|o| (o.power, o.toughness));
+    assert_eq!(
+        self_pt,
+        Some((Some(2), Some(1))),
+        "\"all creatures\" includes Bane of the Living itself: 4/3 - 2/2 = 2/1. MEASURED: \
+         {self_pt:?}"
+    );
+}
+
+/// CR 107.3d + CR 702.168e — Aurelia's Vindicator, Disguise `{X}{3}{W}`:
+/// "When this creature is turned face up, exile up to X other target creatures ..."
+///
+/// THIS is the face that forces the stamp to land at trigger INSTANTIATION rather than at
+/// resolution: its X lives in `multi_target.max`, which is consumed during TARGET SELECTION —
+/// before the trigger ever resolves. With X unbound the trigger offers "up to 0" targets and
+/// exiles nothing, the same silent zero this campaign exists to kill.
+#[test]
+fn aurelias_vindicator_turned_face_up_for_x_exiles_up_to_x() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let vindicator = scenario
+        .add_creature_to_hand_from_oracle(P0, "Aurelia's Vindicator", 4, 2, AURELIAS_VINDICATOR)
+        .id();
+    scenario.add_creature(P1, "Doomed Traveler", 1, 1);
+    scenario.add_creature(P1, "Grizzly Bears", 2, 2);
+    let mut runner = scenario.build();
+
+    play_face_down(&mut runner, vindicator);
+    add_mana(&mut runner, ManaType::White, 12);
+
+    let exiled_before = zone_size(&runner, Zone::Exile);
+    turn_face_up_for_x(&mut runner, vindicator, 2);
+
+    let exiled = zone_size(&runner, Zone::Exile) - exiled_before;
+    assert_eq!(
+        exiled, 2,
+        "CR 702.168e: turned face up for X=2, the trigger exiles up to X = 2 other target \
+         creatures. 0 here means `multi_target.max` read an unbound X and offered 'up to 0' \
+         targets — the target-count slot is consumed at SELECTION, so a stamp applied at \
+         resolution would arrive too late. MEASURED: {exiled}"
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// DEFECT B — the COST. Announcing X must actually charge 2X + {R}.
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// CR 107.1b + CR 601.2f + CR 702.37e: the morph cost's `{X}` shards must be CONCRETIZED before
+/// payment. Warbreak Trumpeter is `{X}{X}{R}` — TWO X shards — so X=3 costs 2*3 + {R} = 7 mana.
+///
+/// MEASURED on pristine main: the flip cost **1 mana**. The unconcretized `ManaCostShard::X`
+/// reached mana payment, where `ShardRequirement::X` is not payable and the shard was dropped, so
+/// the permanent flipped for its non-X remainder ({R}) alone. That is a strictly worse bug than
+/// the missing carrier: without this, binding X would let a player pay {R} and collect X goblins.
+#[test]
+fn turn_face_up_charges_the_announced_x_for_every_x_shard() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let trumpeter = scenario
+        .add_creature_to_hand_from_oracle(P0, "Warbreak Trumpeter", 1, 1, WARBREAK_TRUMPETER)
+        .id();
+    let mut runner = scenario.build();
+
+    play_face_down(&mut runner, trumpeter);
+    add_mana(&mut runner, ManaType::Red, 12);
+    let before = pool_total(&runner);
+
+    turn_face_up_for_x(&mut runner, trumpeter, 3);
+
+    let spent = before - pool_total(&runner);
+    assert_eq!(
+        spent, 7,
+        "CR 107.1b: EACH `{{X}}` shard costs the announced X, so Morph {{X}}{{X}}{{R}} at X=3 is \
+         2*3 + {{R}} = 7 mana. A 1 here is the pre-t104 behaviour: both X shards silently dropped \
+         at payment. MEASURED: {spent}"
+    );
+}
+
+/// CR 118.3: a player can't announce an X they cannot pay for. With only 3 mana available, X=3 on
+/// `{X}{X}{R}` (a 7-mana cost) must be REJECTED — and the permanent must stay face down.
+#[test]
+fn turn_face_up_rejects_an_unpayable_announced_x() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let trumpeter = scenario
+        .add_creature_to_hand_from_oracle(P0, "Warbreak Trumpeter", 1, 1, WARBREAK_TRUMPETER)
+        .id();
+    let mut runner = scenario.build();
+
+    play_face_down(&mut runner, trumpeter);
+    add_mana(&mut runner, ManaType::Red, 3);
+
+    let result = runner.act(GameAction::TurnFaceUp {
+        object_id: trumpeter,
+        x: 3,
+    });
+    assert!(
+        result.is_err(),
+        "X=3 on Morph {{X}}{{X}}{{R}} needs 7 mana; with 3 available the announcement is illegal \
+         (CR 118.3). Accepting it would flip the permanent for free."
+    );
+    assert!(
+        runner.state().objects[&trumpeter].face_down,
+        "a rejected announcement must leave the permanent FACE DOWN"
+    );
+    assert!(
+        named_on_battlefield(&runner, "Goblin").is_empty(),
+        "a rejected announcement must create no tokens"
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// CONTROLS — each must be able to FAIL, and each pins a different way to get this wrong.
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// CR 107.3d — the ANNOUNCED ZERO. X=0 is a legal announcement, and it is the one value where the
+/// correct board and the FABRICATED board coincide (an unbound X also resolves to 0). A
+/// board-only assertion here would therefore be VACUOUS.
+///
+/// The discriminating observation is taken while the trigger is ON THE STACK: it must carry
+/// `chosen_x == Some(0)` — an announcement of zero — and NOT `None`. That is what pins
+/// `Option<u32>` as the right carrier type: a carrier that collapsed 0 into "nothing announced"
+/// would leave `None` here and pass a board-only test by luck. The cost is checked too: at X=0,
+/// `{X}{X}{R}` costs exactly {R} — 1 mana.
+#[test]
+fn turn_face_up_for_x_zero_announces_a_real_zero() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let trumpeter = scenario
+        .add_creature_to_hand_from_oracle(P0, "Warbreak Trumpeter", 1, 1, WARBREAK_TRUMPETER)
+        .id();
+    let mut runner = scenario.build();
+
+    play_face_down(&mut runner, trumpeter);
+    add_mana(&mut runner, ManaType::Red, 12);
+    let before = pool_total(&runner);
+
+    runner
+        .act(GameAction::TurnFaceUp {
+            object_id: trumpeter,
+            x: 0,
+        })
+        .expect("X=0 is a legal announcement (CR 107.3d)");
+
+    let spent = before - pool_total(&runner);
+    assert_eq!(
+        spent, 1,
+        "at X=0, Morph {{X}}{{X}}{{R}} costs just {{R}} = 1 mana. MEASURED: {spent}"
+    );
+
+    let bound_x = runner
+        .state()
+        .stack
+        .iter()
+        .find_map(|entry| match &entry.kind {
+            StackEntryKind::TriggeredAbility {
+                source_id, ability, ..
+            } if *source_id == trumpeter => Some(ability.chosen_x),
+            _ => None,
+        })
+        .expect("the turn-face-up trigger must be on the stack (if not, nothing here is a test)");
+    assert_eq!(
+        bound_x,
+        Some(0),
+        "X=0 is an ANNOUNCED zero, not 'no X announced'. `None` here means the carrier collapsed \
+         0 into absence — the board (0 goblins) would then be correct only by coincidence. \
+         MEASURED: {bound_x:?}"
+    );
+
+    runner.advance_until_stack_empty();
+    let goblins = named_on_battlefield(&runner, "Goblin");
+    assert!(
+        goblins.is_empty(),
+        "announced X=0 creates zero Goblins. Any token here means a non-zero X was FABRICATED — a \
+         value the player never announced. MEASURED: {goblins:?}"
+    );
+}
+
+/// NON-VACUITY + NO-SPURIOUS-PUBLICATION control — Hooded Hydra, Morph `{3}{G}{G}` (**no X**).
+///
+/// Two jobs, and it can fail at either:
+///  1. **The harness really flips permanents.** Hooded Hydra's "As this creature is turned face
+///     up, put five +1/+1 counters on it" is a REPLACEMENT (CR 614.1e), independent of any X. If
+///     this reads 0 counters, the harness is not turning anything face up and every verdict in
+///     this file is void (the `add_card_to_hand` vacuum trap that bit t96).
+///  2. **A no-X flip publishes NOTHING.** The carrier must stay `None`: publishing `Some((id, 0))`
+///     for a cost with no `{X}` would assert an X that CR 107.3d never granted, and could clobber
+///     an unrelated activated ability's in-flight X on another object.
+#[test]
+fn no_x_morph_flip_publishes_nothing_and_still_turns_face_up() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let hydra = scenario
+        .add_creature_to_hand_from_oracle(P0, "Hooded Hydra", 0, 0, HOODED_HYDRA)
+        .id();
+    let mut runner = scenario.build();
+
+    play_face_down(&mut runner, hydra);
+    add_mana(&mut runner, ManaType::Green, 12);
+
+    runner
+        .act(GameAction::TurnFaceUp {
+            object_id: hydra,
+            x: 0,
+        })
+        .expect("a no-X morph flips with X=0");
+    runner.advance_until_stack_empty();
+
+    // (1) NON-VACUITY: the flip really happened and its replacement really applied.
+    assert!(
+        !runner.state().objects[&hydra].face_down,
+        "NON-VACUITY: the permanent must actually be face up"
+    );
+    let counters = runner.state().objects[&hydra]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        counters, 5,
+        "NON-VACUITY (CR 614.1e): Hooded Hydra's 'As this creature is turned face up, put five \
+         +1/+1 counters on it' must apply. A 0 here means the harness never really flipped it and \
+         EVERY verdict in this file is void. MEASURED: {counters}"
+    );
+
+    // (2) NO SPURIOUS PUBLICATION: a cost with no {X} announces no X.
+    assert_eq!(
+        runner.state().announced_source_x,
+        None,
+        "CR 107.3d grants an X choice only 'if a cost ... has an {{X}} ... in it'. Hooded Hydra's \
+         Morph {{3}}{{G}}{{G}} has none, so the carrier must stay None. A `Some((.., 0))` here \
+         would assert an X the rules never granted and could clobber an unrelated activated \
+         ability's in-flight X. MEASURED: {:?}",
+        runner.state().announced_source_x
+    );
+}
+
+/// CR 107.3d is scoped to costs that HAVE an {X}: "if a cost ... has an {X} ... in it". A client
+/// announcing X != 0 on a no-X cost is a bug, and must be rejected rather than silently ignored —
+/// silently ignoring it would let a malformed action look like a legal flip.
+#[test]
+fn turn_face_up_rejects_a_nonzero_x_on_a_cost_with_no_x() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let hydra = scenario
+        .add_creature_to_hand_from_oracle(P0, "Hooded Hydra", 0, 0, HOODED_HYDRA)
+        .id();
+    let mut runner = scenario.build();
+
+    play_face_down(&mut runner, hydra);
+    add_mana(&mut runner, ManaType::Green, 12);
+
+    let result = runner.act(GameAction::TurnFaceUp {
+        object_id: hydra,
+        x: 4,
+    });
+    assert!(
+        result.is_err(),
+        "Morph {{3}}{{G}}{{G}} has no {{X}}, so CR 107.3d grants no choice — X=4 is not a legal \
+         announcement and must be rejected, not ignored."
+    );
+    assert!(
+        runner.state().objects[&hydra].face_down,
+        "a rejected announcement must leave the permanent FACE DOWN"
+    );
+}


### PR DESCRIPTION
- **refactor(engine): rename activated_ability_x -> announced_source_x (CR 107.3a + CR 107.3d)**
- **fix(engine): announce, pay, and carry X for the turn-face-up special action (CR 107.3d + CR 702.37f)**
