### PR TITLE
feat(engine): support same-is-true type statics

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -706,6 +706,7 @@ fn filterprop_reads_only_candidate_fp(p: &FilterProp) -> bool {
         // SAFE — read only candidate fingerprint fields.
         FilterProp::Token
         | FilterProp::NonToken
+        | FilterProp::RepresentedByCard
         | FilterProp::WasPlayed
         | FilterProp::Tapped
         | FilterProp::Untapped

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -1526,6 +1526,9 @@ fn census_of_typed(tf: &TypedFilter) -> Census {
             FilterProp::NonToken => {
                 tags.insert("nontoken".into());
             }
+            FilterProp::RepresentedByCard => {
+                tags.insert("represented-card".into());
+            }
             _ => {}
         }
     }
@@ -2308,6 +2311,7 @@ fn legacy_filter_prop(p: &FilterProp) -> bool {
         FilterProp::InTrackedSet { .. } => false,
         FilterProp::Token
         | FilterProp::NonToken
+        | FilterProp::RepresentedByCard
         | FilterProp::WasPlayed
         | FilterProp::Blocking
         | FilterProp::BlockingSource
@@ -2565,6 +2569,7 @@ fn member_bound_filter_prop(p: &FilterProp) -> bool {
         FilterProp::InTrackedSet { .. } => true,
         FilterProp::Token
         | FilterProp::NonToken
+        | FilterProp::RepresentedByCard
         | FilterProp::WasPlayed
         | FilterProp::Blocking
         | FilterProp::BlockingSource

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -3099,6 +3099,7 @@ fn scan_filter_prop(x: &FilterProp) -> Axes {
         // Their drift breaks the board-equality gate (item 1), not the item-4 scan.
         FilterProp::Token
         | FilterProp::NonToken
+        | FilterProp::RepresentedByCard
         | FilterProp::WasPlayed
         | FilterProp::Blocking
         | FilterProp::BlockingSource

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -7055,28 +7055,7 @@ fn finalize_cast_with_phyrexian_choices_inner(
     // protection all see the merged characteristics while the spell resolves.
     if casting_variant == CastingVariant::Fuse {
         if let Some(obj) = state.objects.get_mut(&object_id) {
-            // `fused_split_spell` was already set before mana payment (above). Here
-            // we union the right (Split back face) half's card types (CR 709.4c) and
-            // colors (CR 105.2) into the on-stack object so counterspell filters,
-            // type-matters effects, and protection that read `card_types`/`color`
-            // directly see the merged characteristics while the spell resolves.
-            let right_half_characteristics = obj
-                .back_face
-                .as_ref()
-                .filter(|bf| bf.layout_kind == Some(crate::types::card::LayoutKind::Split))
-                .map(|back| (back.card_types.core_types.clone(), back.color.clone()));
-            if let Some((core_types, colors)) = right_half_characteristics {
-                for ct in core_types {
-                    if !obj.card_types.core_types.contains(&ct) {
-                        obj.card_types.core_types.push(ct);
-                    }
-                }
-                for color in colors {
-                    if !obj.color.contains(&color) {
-                        obj.color.push(color);
-                    }
-                }
-            }
+            obj.restore_fused_split_characteristics();
         }
     }
 

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -657,6 +657,7 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
         match prop {
             FilterProp::Token => parts.push("token".into()),
             FilterProp::NonToken => parts.push("nontoken".into()),
+            FilterProp::RepresentedByCard => parts.push("represented by a card".into()),
             FilterProp::ControllerChoseLabel { label } => {
                 parts.push(format!("controlled by a player who last chose {label}"))
             }

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -167,6 +167,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::ManaValueParity { .. }
         | FilterProp::Token
         | FilterProp::NonToken
+        | FilterProp::RepresentedByCard
         | FilterProp::ControllerChoseLabel { .. }
         | FilterProp::ControllerMatches { .. }
         | FilterProp::WasPlayed
@@ -405,6 +406,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::ManaValueParity { .. }
         | FilterProp::Token
         | FilterProp::NonToken
+        | FilterProp::RepresentedByCard
         | FilterProp::ControllerChoseLabel { .. }
         | FilterProp::ControllerMatches { .. }
         | FilterProp::WasPlayed
@@ -3240,6 +3242,9 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         // for this snapshot shape.
         FilterProp::Token => false,
         FilterProp::NonToken => true,
+        // SpellCastRecord does not retain the copy/representation bit. Fail
+        // closed rather than treating every cast spell as card-represented.
+        FilterProp::RepresentedByCard => false,
         FilterProp::WasPlayed => true,
         FilterProp::InZone { zone: required } => record.from_zone == *required,
         // CR 400.1 + CR 601.2a: cast-origin membership — the record's captured
@@ -3622,6 +3627,9 @@ fn matches_filter_prop(
         FilterProp::Token => obj.is_token,
         // CR 111.1: Nontoken identity of the matched object or event-time snapshot.
         FilterProp::NonToken => !obj.is_token,
+        // CR 108.2 + CR 108.2b: A card-represented object is neither a token
+        // nor an object copy. This is deliberately stricter than `NonToken`.
+        FilterProp::RepresentedByCard => obj.is_represented_by_a_card(),
         // CR 607.2d / CR 607.2m (by analogy): the object's CONTROLLER last chose
         // this anchor label ("creatures controlled by players who last chose
         // red waterfall", Two Streams Facility).
@@ -4635,6 +4643,9 @@ fn zone_change_record_matches_property(
         FilterProp::Token => record.is_token,
         // CR 111.1 + CR 603.6a: Nontoken identity as of the zone change.
         FilterProp::NonToken => !record.is_token,
+        // Zone-change records do not currently snapshot copy identity. Fail
+        // closed; live layer filters use the object path above.
+        FilterProp::RepresentedByCard => false,
         // CR 305.1 + CR 601.2a: zone-change snapshots carry cast/play provenance
         // when the object was cast or played — not mere zone moves (reanimate).
         FilterProp::WasPlayed => {

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1486,6 +1486,33 @@ impl GameObject {
         }
     }
 
+    /// CR 702.102b + CR 709.4d: Restore the combined card types and colors of
+    /// a fused split spell after a characteristic reset. The fusion marker is
+    /// cast-state, while the union is a derived stack characteristic and must
+    /// therefore be re-applied on every layer pass.
+    pub fn restore_fused_split_characteristics(&mut self) {
+        if self.zone != Zone::Stack || !self.fused_split_spell {
+            return;
+        }
+        let right_half_characteristics = self
+            .back_face
+            .as_ref()
+            .filter(|back| back.layout_kind == Some(LayoutKind::Split))
+            .map(|back| (back.card_types.core_types.clone(), back.color.clone()));
+        if let Some((core_types, colors)) = right_half_characteristics {
+            for core_type in core_types {
+                if !self.card_types.core_types.contains(&core_type) {
+                    self.card_types.core_types.push(core_type);
+                }
+            }
+            for color in colors {
+                if !self.color.contains(&color) {
+                    self.color.push(color);
+                }
+            }
+        }
+    }
+
     /// CR 603.10 + CR 400.7: Snapshot this object's public characteristics
     /// for a zone-change event. The record captures state *at the moment of
     /// the move* so zone-change trigger filters and past-tense conditions

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1689,31 +1689,49 @@ fn seed_live_characteristics_from_base(obj: &mut crate::game::game_object::GameO
     }
 }
 
-/// CR 400.1 + CR 613.1: Every object in a zone that a continuous effect can
-/// explicitly affect must be re-seeded before the next layer pass. Battlefield
-/// recipients exclude phased-out permanents (CR 702.26b); the card zones remain
-/// eligible because a static such as Maskwood Nexus can modify cards and spells
-/// there. Keep the first-seen order stable for deterministic layer application.
-fn full_layer_reset_ids(state: &GameState, battlefield_ids: &[ObjectId]) -> Vec<ObjectId> {
-    let mut ids = Vec::new();
-    let mut seen = HashSet::new();
-    for id in battlefield_ids.iter().copied().chain(
-        [
-            Zone::Library,
-            Zone::Hand,
-            Zone::Graveyard,
-            Zone::Stack,
-            Zone::Exile,
-            Zone::Command,
-        ]
-        .into_iter()
-        .flat_map(|zone| super::targeting::zone_object_ids(state, zone)),
-    ) {
-        if seen.insert(id) {
-            ids.push(id);
-        }
+/// CR 613.1d: Recover the off-battlefield objects whose types were derived in
+/// the preceding Layer-4 evaluation. The cache is normally populated directly
+/// by the layer application pipeline. Attribution is its persisted, derived
+/// fallback after a save/load boundary, before the first new pass repopulates
+/// the cache.
+fn take_remote_type_layer_recipients(state: &mut GameState) -> im::HashSet<ObjectId> {
+    let mut recipients = std::mem::take(&mut state.remote_type_layer_recipients);
+    if recipients.is_empty() {
+        recipients.extend(
+            state
+                .attribution
+                .iter()
+                .filter(|(id, attribution)| {
+                    state
+                        .objects
+                        .get(*id)
+                        .is_some_and(|object| object.zone != Zone::Battlefield)
+                        && attribution.by_layer.contains_key(&Layer::Type)
+                })
+                .map(|(id, _)| *id),
+        );
     }
-    ids
+    recipients
+}
+
+/// CR 613.1 + CR 613.1d: Reset only remote objects previously changed in the
+/// type layer. Unlike a whole-characteristics reset, this preserves independent
+/// object state that is not a continuous effect, such as a spell's cast-time
+/// `CantBeCountered` grant or a searched card's pre-existing subtype.
+fn reset_remote_type_layer_recipients(
+    state: &mut GameState,
+    recipients: impl IntoIterator<Item = ObjectId>,
+) {
+    for id in recipients {
+        let Some(object) = state.objects.get_mut(&id) else {
+            continue;
+        };
+        if object.zone == Zone::Battlefield {
+            continue;
+        }
+        object.card_types = object.base_card_types.clone();
+        object.restore_fused_split_characteristics();
+    }
 }
 
 /// Unconditional full layer evaluation (CR 613.1).
@@ -1748,6 +1766,7 @@ pub fn evaluate_layers(state: &mut GameState) {
     // `im::HashMap::clear()` drops the cleared map's own root Arc; clones
     // taken by AI search or snapshot diffing retain their own roots, so this
     // does not break structural sharing across `GameState` clones.
+    let remote_type_layer_recipients = take_remote_type_layer_recipients(state);
     state.attribution.clear();
     let mut abilities_suppressed = HashSet::new();
     // CR 702.26b + CR 702.26e: Phased-out permanents are treated as though
@@ -1756,34 +1775,50 @@ pub fn evaluate_layers(state: &mut GameState) {
     // remains intact; they are frozen until phase-in marks layers dirty and
     // re-includes them.
     let bf_ids: Vec<ObjectId> = state.battlefield_phased_in_ids();
-    let reset_ids = full_layer_reset_ids(state, &bf_ids);
     // CR 613.2b: collect face-down permanents to re-apply their CR 708.2 profile
     // after Layer 1a.
     let mut face_down_ids: Vec<ObjectId> = Vec::new();
-    for &id in &reset_ids {
+    for &id in &bf_ids {
         if let Some(obj) = state.objects.get_mut(&id) {
             obj.sync_missing_base_characteristics();
             seed_live_characteristics_from_base(obj);
-            if obj.zone == Zone::Battlefield {
-                if obj.face_down {
-                    face_down_ids.push(id);
-                }
-                // CR 613.1b: Reset controller to the object's base controller;
-                // Layer 2 re-applies continuous control-changing effects.
-                obj.controller = obj.base_controller.unwrap_or(obj.owner);
-                // CR 613.11 + CR 510.1a: Reset combat-assignment rule flags;
-                // re-applied after object-characteristic layers are complete.
-                obj.assigns_damage_from_toughness = false;
-                obj.assigns_damage_as_though_unblocked = false;
-                obj.assigns_no_combat_damage = false;
-                // CR 701.60c: re-derive the suspected designation's menace +
-                // "can't block" onto the just-reset live fields (not base), so
-                // the grant lasts exactly as long as the designation.
-                derive_suspected_abilities(obj);
+            if obj.face_down {
+                face_down_ids.push(id);
             }
+            // CR 613.1b: Reset controller to the object's base controller;
+            // Layer 2 re-applies continuous control-changing effects.
+            obj.controller = obj.base_controller.unwrap_or(obj.owner);
+            // CR 613.11 + CR 510.1a: Reset combat-assignment rule flags;
+            // re-applied after object-characteristic layers are complete.
+            obj.assigns_damage_from_toughness = false;
+            obj.assigns_damage_as_though_unblocked = false;
+            obj.assigns_no_combat_damage = false;
+            // CR 701.60c: re-derive the suspected designation's menace +
+            // "can't block" onto the just-reset live fields (not base), so
+            // the grant lasts exactly as long as the designation.
+            derive_suspected_abilities(obj);
         }
     }
-    rehydrate_cast_form_characteristics(state, reset_ids.iter().copied());
+    // CR 702.94a + CR 400.3: Hand-zone continuous effects (Lorehold-style
+    // "Each [filter] card in your hand has [keyword]") grant keywords to hand
+    // objects. Reset those hand objects' keywords to their base set each layers
+    // pass so hand-zone grants don't accumulate across evaluations. Scoped
+    // narrowly to `keywords` because A6 only supports keyword grants to hand
+    // objects; other characteristics (P/T, types, abilities) are not granted to
+    // hand objects by any currently-supported static. Extend this reset set
+    // before landing a static that modifies them.
+    let hand_ids: Vec<ObjectId> = state
+        .players
+        .iter()
+        .flat_map(|p| p.hand.iter().copied())
+        .collect();
+    for id in hand_ids {
+        if let Some(obj) = state.objects.get_mut(&id) {
+            obj.sync_missing_base_characteristics();
+            obj.keywords = obj.base_keywords.clone();
+        }
+    }
+    reset_remote_type_layer_recipients(state, remote_type_layer_recipients);
 
     // CR 613.1 + CR 611.2c: Stack-zone continuous effects grant keywords to objects ON THE
     // STACK — a spell that "gains rebound" (Taigam, Ojutai Master; CR 702.88a: rebound
@@ -1797,9 +1832,11 @@ pub fn evaluate_layers(state: &mut GameState) {
     // Toxic) would accumulate one instance per evaluation, and a grant would outlive the
     // transient continuous effect that produced it.
     //
-    // Scoped narrowly to `keywords` for the same reason as the hand loop: keyword grants are
-    // the only characteristic any currently-supported static modifies on a stack object.
-    // Extend this reset set before landing a static that modifies them.
+    // Scoped narrowly to `keywords`: remote type-changing effects use
+    // `reset_remote_type_layer_recipients` above, which resets only their prior
+    // recipients and therefore preserves independent cast-time state on every
+    // other stack object. Extend the relevant reset authority before landing a
+    // static that modifies another stack characteristic.
     let stack_ids = super::targeting::zone_object_ids(state, crate::types::zones::Zone::Stack);
     for id in stack_ids {
         if let Some(obj) = state.objects.get_mut(&id) {
@@ -1893,6 +1930,7 @@ pub fn evaluate_layers(state: &mut GameState) {
         }
 
         if *layer == Layer::Type {
+            apply_prototype_characteristics(state, bf_ids.iter().copied());
             apply_intrinsic_basic_land_mana_abilities(state, &bf_ids);
         }
         if matches!(*layer, Layer::Control | Layer::Type) {
@@ -2500,8 +2538,6 @@ fn prepare_incremental_flush(
             derive_suspected_abilities(obj);
         }
     }
-    rehydrate_cast_form_characteristics(state, recipient_ids.iter().copied());
-
     crate::types::game_state::StaticSourceIndex::rebuild_from_state(state);
 
     let active_effects = collect_shared_active_continuous_effects(state);
@@ -2955,6 +2991,7 @@ fn apply_layers_incremental(state: &mut GameState, prepared: PreparedIncremental
             apply_pt_counter_modifications(state, recipient_ids.iter().copied());
         }
         if *layer == Layer::Type {
+            apply_prototype_characteristics(state, recipient_ids.iter().copied());
             apply_intrinsic_basic_land_mana_abilities(state, &recipient_vec);
         }
     }
@@ -3036,32 +3073,22 @@ pub(crate) fn has_active_copy_layer_effects(state: &GameState) -> bool {
     !gather_active_effects_for_layer(state, Layer::Copy).is_empty()
 }
 
-/// Rehydrate any persistent non-base cast-form characteristic overlay before
-/// Layer 1. Fuse retains a cast marker whose combined type/color profile is
-/// restored here; alternative/back/modal faces write their selected face into
-/// `base_*`, face-down objects re-seed their CR 708.2 profile at Layer 1b, and
-/// Bestow/Cleave likewise establish their base characteristics during casting.
-/// Mutate has no independent overlay.
-///
-/// CR 718.2a + CR 718.3b: Prototype is the remaining persistent overlay: its
-/// alternative mana cost, P/T, and resulting colors must be present before
-/// continuous effects inspect spell/permanent characteristics, not injected
-/// after Layer 4.
-fn rehydrate_cast_form_characteristics(
-    state: &mut GameState,
-    ids: impl IntoIterator<Item = ObjectId>,
-) {
+/// CR 718.3b: A prototyped spell and the permanent it becomes have only their
+/// alternative mana cost and P/T characteristics. If that mana cost contains
+/// colored mana symbols, the spell/permanent is those colors. Reapply this after
+/// layer reset so the prototype marker survives normal layer recomputation.
+fn apply_prototype_characteristics(state: &mut GameState, ids: impl IntoIterator<Item = ObjectId>) {
     for id in ids {
         let Some(obj) = state.objects.get_mut(&id) else {
             continue;
         };
-        if let Some(form) = obj.prototype_form.clone() {
-            obj.mana_cost = form.mana_cost;
-            obj.power = Some(form.power);
-            obj.toughness = Some(form.toughness);
-            obj.color = form.colors;
-        }
-        obj.restore_fused_split_characteristics();
+        let Some(form) = obj.prototype_form.clone() else {
+            continue;
+        };
+        obj.mana_cost = form.mana_cost;
+        obj.power = Some(form.power);
+        obj.toughness = Some(form.toughness);
+        obj.color = form.colors;
     }
 }
 
@@ -4605,6 +4632,29 @@ fn record_attribution(
     }
 }
 
+/// CR 613.1d: Record remote Layer-4 recipients for the next full evaluation.
+/// This derived-state bookkeeping deliberately sits beside effect application,
+/// rather than in display attribution, because it controls the narrow type
+/// baseline reset when a static effect changes or expires.
+fn record_remote_type_layer_recipients(
+    state: &mut GameState,
+    effect: &ActiveContinuousEffect,
+    affected_ids: &[ObjectId],
+) {
+    if effect.layer != Layer::Type {
+        return;
+    }
+    for &target in affected_ids {
+        if state
+            .objects
+            .get(&target)
+            .is_some_and(|object| object.zone != Zone::Battlefield)
+        {
+            state.remote_type_layer_recipients.insert(target);
+        }
+    }
+}
+
 fn apply_continuous_effect(
     state: &mut GameState,
     effect: &ActiveContinuousEffect,
@@ -4825,6 +4875,7 @@ fn apply_continuous_effect_filtered(
         .copied()
         .collect();
 
+    record_remote_type_layer_recipients(state, effect, &affected_ids);
     record_attribution(state, effect, &affected_ids);
 
     // Pre-read chosen subtype from source (avoids borrow conflict in the loop).

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -72,6 +72,27 @@ impl LayerZoneObjectCache {
     }
 }
 
+/// CR 400.1 + CR 611.3a: Gather candidate recipients from every zone implied
+/// by a continuous effect's filter. This distributes the implicit battlefield
+/// default across disjuncts and stably deduplicates candidate objects.
+fn effect_candidate_ids(
+    state: &GameState,
+    filter: &TargetFilter,
+    zone_cache: &mut LayerZoneObjectCache,
+) -> Vec<ObjectId> {
+    let zones = continuous_effect_scan_zones(state, filter);
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+    for zone in zones {
+        for &id in zone_cache.ids_for(state, zone) {
+            if seen.insert(id) {
+                candidates.push(id);
+            }
+        }
+    }
+    candidates
+}
+
 struct PreparedIncrementalFlush {
     recipient_ids: HashSet<ObjectId>,
     active_effects: Vec<ActiveContinuousEffect>,
@@ -1668,6 +1689,33 @@ fn seed_live_characteristics_from_base(obj: &mut crate::game::game_object::GameO
     }
 }
 
+/// CR 400.1 + CR 613.1: Every object in a zone that a continuous effect can
+/// explicitly affect must be re-seeded before the next layer pass. Battlefield
+/// recipients exclude phased-out permanents (CR 702.26b); the card zones remain
+/// eligible because a static such as Maskwood Nexus can modify cards and spells
+/// there. Keep the first-seen order stable for deterministic layer application.
+fn full_layer_reset_ids(state: &GameState, battlefield_ids: &[ObjectId]) -> Vec<ObjectId> {
+    let mut ids = Vec::new();
+    let mut seen = HashSet::new();
+    for id in battlefield_ids.iter().copied().chain(
+        [
+            Zone::Library,
+            Zone::Hand,
+            Zone::Graveyard,
+            Zone::Stack,
+            Zone::Exile,
+            Zone::Command,
+        ]
+        .into_iter()
+        .flat_map(|zone| super::targeting::zone_object_ids(state, zone)),
+    ) {
+        if seen.insert(id) {
+            ids.push(id);
+        }
+    }
+    ids
+}
+
 /// Unconditional full layer evaluation (CR 613.1).
 ///
 /// Production code must NOT call this directly — go through [`flush_layers`],
@@ -1708,49 +1756,34 @@ pub fn evaluate_layers(state: &mut GameState) {
     // remains intact; they are frozen until phase-in marks layers dirty and
     // re-includes them.
     let bf_ids: Vec<ObjectId> = state.battlefield_phased_in_ids();
+    let reset_ids = full_layer_reset_ids(state, &bf_ids);
     // CR 613.2b: collect face-down permanents to re-apply their CR 708.2 profile
     // after Layer 1a.
     let mut face_down_ids: Vec<ObjectId> = Vec::new();
-    for &id in &bf_ids {
+    for &id in &reset_ids {
         if let Some(obj) = state.objects.get_mut(&id) {
             obj.sync_missing_base_characteristics();
             seed_live_characteristics_from_base(obj);
-            if obj.face_down {
-                face_down_ids.push(id);
+            if obj.zone == Zone::Battlefield {
+                if obj.face_down {
+                    face_down_ids.push(id);
+                }
+                // CR 613.1b: Reset controller to the object's base controller;
+                // Layer 2 re-applies continuous control-changing effects.
+                obj.controller = obj.base_controller.unwrap_or(obj.owner);
+                // CR 613.11 + CR 510.1a: Reset combat-assignment rule flags;
+                // re-applied after object-characteristic layers are complete.
+                obj.assigns_damage_from_toughness = false;
+                obj.assigns_damage_as_though_unblocked = false;
+                obj.assigns_no_combat_damage = false;
+                // CR 701.60c: re-derive the suspected designation's menace +
+                // "can't block" onto the just-reset live fields (not base), so
+                // the grant lasts exactly as long as the designation.
+                derive_suspected_abilities(obj);
             }
-            // CR 613.1b: Reset controller to the object's base controller;
-            // Layer 2 re-applies continuous control-changing effects.
-            obj.controller = obj.base_controller.unwrap_or(obj.owner);
-            // CR 613.11 + CR 510.1a: Reset combat-assignment rule flags;
-            // re-applied after object-characteristic layers are complete.
-            obj.assigns_damage_from_toughness = false;
-            obj.assigns_damage_as_though_unblocked = false;
-            obj.assigns_no_combat_damage = false;
-            // CR 701.60c: re-derive the suspected designation's menace +
-            // "can't block" onto the just-reset live fields (not base), so the
-            // grant lasts exactly as long as the designation.
-            derive_suspected_abilities(obj);
         }
     }
-    // CR 702.94a + CR 400.3: Hand-zone continuous effects (Lorehold-style
-    // "Each [filter] card in your hand has [keyword]") grant keywords to hand
-    // objects. Reset those hand objects' keywords to their base set each layers
-    // pass so hand-zone grants don't accumulate across evaluations. Scoped
-    // narrowly to `keywords` because A6 only supports keyword grants to hand
-    // objects; other characteristics (P/T, types, abilities) are not granted to
-    // hand objects by any currently-supported static. Extend this reset set
-    // before landing a static that modifies them.
-    let hand_ids: Vec<ObjectId> = state
-        .players
-        .iter()
-        .flat_map(|p| p.hand.iter().copied())
-        .collect();
-    for id in hand_ids {
-        if let Some(obj) = state.objects.get_mut(&id) {
-            obj.sync_missing_base_characteristics();
-            obj.keywords = obj.base_keywords.clone();
-        }
-    }
+    rehydrate_cast_form_characteristics(state, reset_ids.iter().copied());
 
     // CR 613.1 + CR 611.2c: Stack-zone continuous effects grant keywords to objects ON THE
     // STACK — a spell that "gains rebound" (Taigam, Ojutai Master; CR 702.88a: rebound
@@ -1860,7 +1893,6 @@ pub fn evaluate_layers(state: &mut GameState) {
         }
 
         if *layer == Layer::Type {
-            apply_prototype_characteristics(state, bf_ids.iter().copied());
             apply_intrinsic_basic_land_mana_abilities(state, &bf_ids);
         }
         if matches!(*layer, Layer::Control | Layer::Type) {
@@ -2070,14 +2102,16 @@ pub fn evaluate_layers(state: &mut GameState) {
     state.layers_dirty = LayersDirty::Clean;
 }
 
-/// CR 404 + CR 611.3a: Does a `TargetFilter` test membership of a specific
-/// `zone` (a `FilterProp::InZone { zone }`)? Recurses `Or`/`And`/`Not` compounds.
+/// CR 400.1 + CR 404 + CR 611.3a: Does a `TargetFilter` test membership of a
+/// specific `zone`? Recurses `Or`/`And`/`Not` compounds and preserves the
+/// multiple-zone semantics of `InAnyZone`.
 fn target_filter_reads_zone(filter: &TargetFilter, zone: Zone) -> bool {
     match filter {
-        TargetFilter::Typed(typed) => typed
-            .properties
-            .iter()
-            .any(|prop| matches!(prop, FilterProp::InZone { zone: z } if *z == zone)),
+        TargetFilter::Typed(typed) => typed.properties.iter().any(|prop| match prop {
+            FilterProp::InZone { zone: z } => *z == zone,
+            FilterProp::InAnyZone { zones } => zones.contains(&zone),
+            _ => false,
+        }),
         TargetFilter::Or { filters } | TargetFilter::And { filters } => {
             filters.iter().any(|f| target_filter_reads_zone(f, zone))
         }
@@ -2280,34 +2314,41 @@ fn quantity_ref_reads_zone(qty: &QuantityRef, zone: Zone) -> bool {
     }
 }
 
-/// CR 611.3a: Is any ACTIVE static-ability continuous effect gated on membership
-/// of `zone`? Consulted at the zone-change seam (`zones::move_to_zone`) so a card
-/// entering or leaving `zone` re-evaluates layers ONLY when a matching gate is
-/// live. This keeps routine off-battlefield churn (deaths, mill, discard) cheap
-/// in the common case where no `zone`-membership-gated static exists. Scans the
-/// static-effect-source index — O(generators), not O(zone).
+/// CR 611.3a + CR 613.1: Does a continuous static definition depend on the
+/// membership of `zone` through its recipient filter, enabling condition, or a
+/// dynamic quantity? All three surfaces must participate in zone invalidation.
+fn static_definition_reads_zone_membership(def: &StaticDefinition, zone: Zone) -> bool {
+    def.mode == StaticMode::Continuous
+        && (def
+            .affected
+            .as_ref()
+            .is_some_and(|filter| target_filter_reads_zone(filter, zone))
+            || def
+                .condition
+                .as_ref()
+                .is_some_and(|condition| static_condition_reads_zone_membership(condition, zone))
+            || def.modifications.iter().any(|modification| {
+                continuous_modification_dynamic_quantity(modification)
+                    .is_some_and(|quantity| quantity_expr_reads_zone(quantity, zone))
+            }))
+}
+
+/// CR 611.3a: Is any functioning continuous static dependent on membership of
+/// `zone`? Consulted at the zone-change seam (`zones::move_to_zone`) so a card
+/// entering or leaving a relevant zone re-evaluates layers. This scans live
+/// static sources, including currently-false gates, because the transition may
+/// be exactly what flips a gate's truth.
 pub(crate) fn any_active_static_reads_zone_membership(state: &GameState, zone: Zone) -> bool {
     let mut found = false;
     for_each_static_effect_source(state, |_state, obj| {
         if found {
             return;
         }
-        if obj.static_definitions.iter_all().any(|def| {
-            def.mode == StaticMode::Continuous
-                && (def
-                    .condition
-                    .as_ref()
-                    .is_some_and(|c| static_condition_reads_zone_membership(c, zone))
-                    // CR 604.3 + CR 613: a continuous MODIFICATION whose dynamic
-                    // quantity reads this zone's membership also depends on it —
-                    // e.g. Subgoyf's CDA `SetDynamicPower`/`SetDynamicToughness`
-                    // counting distinct subtypes among cards in all graveyards.
-                    // The static's `condition` is not the only zone-reading surface.
-                    || def.modifications.iter().any(|m| {
-                        continuous_modification_dynamic_quantity(m)
-                            .is_some_and(|q| quantity_expr_reads_zone(q, zone))
-                    }))
-        }) {
+        if obj
+            .static_definitions
+            .iter_all()
+            .any(|def| static_definition_reads_zone_membership(def, zone))
+        {
             found = true;
         }
     });
@@ -2360,6 +2401,19 @@ pub(crate) fn mark_layers_full_if_top_of_library_static_live(state: &mut GameSta
     if any_active_static_reads_top_of_library(state) {
         mark_layers_full(state);
     }
+}
+
+/// CR 400.7 + CR 611.3a: Query zone-sensitive static dependencies on both sides
+/// of a move. A source or recipient can become visible only after the move, so a
+/// pre-move scan alone is insufficient; the post-move scan runs before trigger
+/// collection, ensuring spell-cast triggers see derived spell characteristics.
+pub(crate) fn static_layer_dependency_for_zone_transition(
+    state: &GameState,
+    from: Zone,
+    to: Zone,
+) -> bool {
+    any_active_static_reads_zone_membership(state, from)
+        || any_active_static_reads_zone_membership(state, to)
 }
 
 /// Mark the layer system as requiring a FULL battlefield re-evaluation. The
@@ -2446,6 +2500,7 @@ fn prepare_incremental_flush(
             derive_suspected_abilities(obj);
         }
     }
+    rehydrate_cast_form_characteristics(state, recipient_ids.iter().copied());
 
     crate::types::game_state::StaticSourceIndex::rebuild_from_state(state);
 
@@ -2900,7 +2955,6 @@ fn apply_layers_incremental(state: &mut GameState, prepared: PreparedIncremental
             apply_pt_counter_modifications(state, recipient_ids.iter().copied());
         }
         if *layer == Layer::Type {
-            apply_prototype_characteristics(state, recipient_ids.iter().copied());
             apply_intrinsic_basic_land_mana_abilities(state, &recipient_vec);
         }
     }
@@ -2982,22 +3036,32 @@ pub(crate) fn has_active_copy_layer_effects(state: &GameState) -> bool {
     !gather_active_effects_for_layer(state, Layer::Copy).is_empty()
 }
 
-/// CR 718.3b: A prototyped spell and the permanent it becomes have only their
-/// alternative mana cost and P/T characteristics. If that mana cost contains
-/// colored mana symbols, the spell/permanent is those colors. Reapply this after
-/// layer reset so the prototype marker survives normal layer recomputation.
-fn apply_prototype_characteristics(state: &mut GameState, ids: impl IntoIterator<Item = ObjectId>) {
+/// Rehydrate any persistent non-base cast-form characteristic overlay before
+/// Layer 1. Fuse retains a cast marker whose combined type/color profile is
+/// restored here; alternative/back/modal faces write their selected face into
+/// `base_*`, face-down objects re-seed their CR 708.2 profile at Layer 1b, and
+/// Bestow/Cleave likewise establish their base characteristics during casting.
+/// Mutate has no independent overlay.
+///
+/// CR 718.2a + CR 718.3b: Prototype is the remaining persistent overlay: its
+/// alternative mana cost, P/T, and resulting colors must be present before
+/// continuous effects inspect spell/permanent characteristics, not injected
+/// after Layer 4.
+fn rehydrate_cast_form_characteristics(
+    state: &mut GameState,
+    ids: impl IntoIterator<Item = ObjectId>,
+) {
     for id in ids {
         let Some(obj) = state.objects.get_mut(&id) else {
             continue;
         };
-        let Some(form) = obj.prototype_form.clone() else {
-            continue;
-        };
-        obj.mana_cost = form.mana_cost;
-        obj.power = Some(form.power);
-        obj.toughness = Some(form.toughness);
-        obj.color = form.colors;
+        if let Some(form) = obj.prototype_form.clone() {
+            obj.mana_cost = form.mana_cost;
+            obj.power = Some(form.power);
+            obj.toughness = Some(form.toughness);
+            obj.color = form.colors;
+        }
+        obj.restore_fused_split_characteristics();
     }
 }
 
@@ -3890,13 +3954,10 @@ fn apply_combat_assignment_rule_effects_filtered(
 ) {
     let mut effects = collect_active_combat_assignment_rule_effects(state);
     effects.sort_by_key(|effect| (effect.timestamp, effect.controller.0, effect.source_id.0));
+    let mut zone_cache = LayerZoneObjectCache::default();
 
     for effect in effects {
-        let scan_zone = effect
-            .affected_filter
-            .extract_in_zone()
-            .unwrap_or(crate::types::zones::Zone::Battlefield);
-        let scan_ids = super::targeting::zone_object_ids(state, scan_zone);
+        let scan_ids = effect_candidate_ids(state, &effect.affected_filter, &mut zone_cache);
         let ctx = FilterContext::from_source(state, effect.source_id);
         let affected_ids: Vec<ObjectId> = scan_ids
             .iter()
@@ -4628,10 +4689,11 @@ fn continuous_effect_scan_zones(state: &GameState, filter: &TargetFilter) -> Vec
 /// `And`/`Not` propagate their child/children's zones into the same
 /// accumulator unmodified — an unzoned `And` sibling narrows type, color, etc.,
 /// not zone, so it must not erase a zone an already-scoped sibling requires.
-/// A leaf contributes its own explicit zone, if any, mirroring
-/// [`TargetFilter::extract_in_zone`] (which this function supersedes for
-/// affected-filter scanning specifically; `extract_in_zone` keeps its
-/// existing single-zone contract for its other callers).
+/// A leaf contributes every explicit zone it carries, preserving
+/// [`FilterProp::InAnyZone`] rather than collapsing it to the first zone. Stack
+/// filters retain their implicit `Zone::Stack` interpretation through
+/// [`TargetFilter::extract_in_zone`].
+/// `SpecificObject` resolves its recipient's actual zone from `state`.
 fn collect_scan_zones(state: &GameState, filter: &TargetFilter, out: &mut Vec<Zone>) {
     match filter {
         TargetFilter::Or { filters } => {
@@ -4740,37 +4802,17 @@ fn apply_continuous_effect_filtered(
         return;
     }
 
-    // CR 611.3a: a compound affected filter may combine disjuncts that imply
-    // different zones — Secret Arcade's "nonland permanents you control and
-    // permanent spells you control" unions a battlefield-implicit disjunct
-    // with a stack-scoped one — and an `Or` can itself be nested under an
-    // `And` (the static-subject grammar's own qualifier-wrapping helper,
-    // `add_property`, produces exactly that shape for e.g. "`<compound
-    // subject>` with a mana ability"). `continuous_effect_scan_zones` walks
-    // the whole tree so every disjunct's zone defaults independently,
-    // however deeply it's nested, rather than a single `extract_in_zone()`
-    // call stopping at the first explicit zone marker found anywhere and
-    // silently dropping a sibling disjunct's implicit-battlefield
-    // population. For a filter with no `Or` anywhere this produces exactly
-    // one zone, identical to the previous single-zone behavior.
-    let scan_zones = continuous_effect_scan_zones(state, &effect.affected_filter);
-
+    let scan_ids = effect_candidate_ids(state, &effect.affected_filter, zone_cache);
     let ctx = FilterContext::from_source(state, effect.source_id);
-    let mut affected_ids: Vec<ObjectId> = Vec::new();
-    for &zone in &scan_zones {
-        let zone_ids = zone_cache.ids_for(state, zone);
-        for &id in zone_ids {
-            // Incremental fast path: re-apply only to the freshly-entered
-            // objects. The rest of the battlefield was not reset and keeps
-            // its prior derived values, so re-applying to it would
-            // double-apply.
-            if !restrict_to.is_none_or(|ids| ids.contains(&id)) {
-                continue;
-            }
-            if !matches_target_filter(state, id, &effect.affected_filter, &ctx) {
-                continue;
-            }
-            let condition_ok = effect.condition.as_ref().is_none_or(|condition| {
+    let affected_ids: Vec<ObjectId> = scan_ids
+        .iter()
+        // Incremental fast path: re-apply only to the freshly-entered objects.
+        // The rest of the battlefield was not reset and keeps its prior derived
+        // values, so re-applying to it would double-apply.
+        .filter(|&&id| restrict_to.is_none_or(|ids| ids.contains(&id)))
+        .filter(|&&id| matches_target_filter(state, id, &effect.affected_filter, &ctx))
+        .filter(|&&id| {
+            effect.condition.as_ref().is_none_or(|condition| {
                 evaluate_condition_with_recipient(
                     state,
                     condition,
@@ -4778,12 +4820,10 @@ fn apply_continuous_effect_filtered(
                     effect.source_id,
                     id,
                 )
-            });
-            if condition_ok {
-                affected_ids.push(id);
-            }
-        }
-    }
+            })
+        })
+        .copied()
+        .collect();
 
     record_attribution(state, effect, &affected_ids);
 
@@ -6023,13 +6063,11 @@ mod tests {
     }
 
     // Non-`Or` filters (the overwhelming majority of existing static
-    // abilities) must still resolve to exactly the single zone
-    // `extract_in_zone` would have produced — no behavior change for the
-    // common case.
+    // abilities) retain their existing single-zone resolution, while a typed
+    // `InAnyZone` recipient filter keeps every explicitly named card zone.
     #[test]
-    fn continuous_effect_scan_zones_matches_extract_in_zone_for_non_or_filters() {
+    fn continuous_effect_scan_zones_preserves_non_or_zone_semantics() {
         let state = GameState::new_two_player(0);
-
         let no_zone = TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You));
         assert_eq!(
             continuous_effect_scan_zones(&state, &no_zone),
@@ -6054,6 +6092,17 @@ mod tests {
         assert_eq!(
             continuous_effect_scan_zones(&state, &flat_stack_and),
             vec![Zone::Stack]
+        );
+
+        let card_zones =
+            TargetFilter::Typed(
+                TypedFilter::default().properties(vec![FilterProp::InAnyZone {
+                    zones: vec![Zone::Library, Zone::Hand, Zone::Graveyard],
+                }]),
+            );
+        assert_eq!(
+            continuous_effect_scan_zones(&state, &card_zones),
+            vec![Zone::Library, Zone::Hand, Zone::Graveyard]
         );
     }
 

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -740,6 +740,12 @@ pub fn move_to_zone(
         // than battlefield, exile, or command move to command instead.
         to = Zone::Command;
     }
+    // CR 400.7 + CR 611.3a: a static may depend on an object's membership in
+    // either the leaving or destination zone through its recipient filter,
+    // condition, or dynamic quantity. Query before the move and repeat below
+    // after the object reaches its destination, before any trigger collection.
+    let static_dependency_before =
+        crate::game::layers::static_layer_dependency_for_zone_transition(state, from, to);
     let unattached_from = state.objects.get(&object_id).and_then(|obj| {
         obj.attached_to
             .map(super::effects::attach::target_ref_from_attach_target)
@@ -864,24 +870,18 @@ pub fn move_to_zone(
         });
     }
 
+    let static_dependency_after =
+        crate::game::layers::static_layer_dependency_for_zone_transition(state, from, to);
+
     // CR 611.3a + CR 400.3: Hand size affects continuous effects gated on the
     // controller's hand (Carnage Interpreter, issue #3991) and hand-zone
     // effects (Miracle in hand). Re-evaluate layers on any hand entry/exit.
-    if to == Zone::Battlefield || to == Zone::Hand || from == Zone::Hand {
-        crate::game::layers::mark_layers_full(state);
-    }
-
-    // CR 404 + CR 611.3a: A card entering or leaving a graveyard changes
-    // graveyard population, which can flip a static condition gated on graveyard
-    // membership (Tarmogoyf, Cairn Wanderer: "as long as a creature card with
-    // <keyword> is in a graveyard, ~ has <keyword>"). The incremental layer path
-    // is battlefield-entry scoped and the hand/battlefield mark above does not
-    // cover graveyard moves (mill, discard, a death that lands in the graveyard),
-    // so re-evaluate layers on a graveyard membership change — but only when such
-    // a static is actually live, so routine graveyard churn stays cheap when no
-    // graveyard-gated static exists.
-    if (to == Zone::Graveyard || from == Zone::Graveyard)
-        && crate::game::layers::any_active_static_reads_zone_membership(state, Zone::Graveyard)
+    if to == Zone::Battlefield
+        || from == Zone::Battlefield
+        || to == Zone::Hand
+        || from == Zone::Hand
+        || static_dependency_before
+        || static_dependency_after
     {
         crate::game::layers::mark_layers_full(state);
     }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -90,12 +90,11 @@ use super::oracle_special::{
 };
 use super::oracle_static::{
     is_speed_unlock_sentence, lower_static_ir, parse_alternative_keyword_cost,
-    parse_cast_spells_alternative_cost_multi, parse_chosen_creature_type_static_prefix,
-    parse_collect_evidence_alt_cost, parse_compound_you_control_chosen_type_static_prefix,
-    parse_every_creature_type_static_prefix, parse_flashback_trailing_self_spell_cost_reduction,
-    parse_spells_alternative_cost, parse_static_line, parse_static_line_multi,
-    try_parse_graveyard_keyword_grant_clause, try_parse_graveyard_keyword_grant_static,
-    try_parse_top_of_library_cast_permission, GrantedCastKeywordKind,
+    parse_cast_spells_alternative_cost_multi, parse_collect_evidence_alt_cost,
+    parse_flashback_trailing_self_spell_cost_reduction, parse_spells_alternative_cost,
+    parse_static_line, parse_static_line_multi, try_parse_graveyard_keyword_grant_clause,
+    try_parse_graveyard_keyword_grant_static, try_parse_top_of_library_cast_permission,
+    GrantedCastKeywordKind,
 };
 use super::oracle_trigger::{lower_trigger_ir, parse_trigger_lines_at_index};
 use super::oracle_util::{
@@ -1816,31 +1815,6 @@ fn is_self_chosen_type_description(description: &str) -> bool {
     .parse(lower.as_str())
     .and_then(|(rest, _)| tag(" the chosen type").parse(rest));
     parsed.is_ok()
-}
-
-fn push_same_is_true_static_tail<F>(
-    emitter: &mut DocEmitter<'_>,
-    item_line: usize,
-    line: &str,
-    lower: &str,
-    parse_modeled_sentence: F,
-) -> bool
-where
-    F: for<'i> FnMut(&'i str) -> OracleResult<'i, ()>,
-{
-    if let Some((modeled_sentence, unmodeled_tail)) =
-        split_same_is_true_static_tail(line, lower, parse_modeled_sentence)
-    {
-        for __item in
-            parse_static_line_with_graveyard_keyword_continuation(modeled_sentence, None, None)
-        {
-            emitter.static_at(item_line, __item);
-        }
-        emitter.ability_at(item_line, make_unimplemented(unmodeled_tail));
-        return true;
-    }
-
-    false
 }
 
 /// CR 611.3a + CR 702: Distribute a "The same is true for <keyword list>"
@@ -3820,41 +3794,6 @@ pub(crate) fn parse_oracle_ir(
             item_line,
             &static_line,
             &static_line_lower,
-        ) {
-            i += 1;
-            continue;
-        }
-        if push_same_is_true_static_tail(
-            &mut emitter,
-            item_line,
-            &static_line,
-            &static_line_lower,
-            parse_chosen_creature_type_static_prefix,
-        ) {
-            i += 1;
-            continue;
-        }
-        if push_same_is_true_static_tail(
-            &mut emitter,
-            item_line,
-            &static_line,
-            &static_line_lower,
-            parse_every_creature_type_static_prefix,
-        ) {
-            i += 1;
-            continue;
-        }
-        // CR 611.3 + CR 607.2d: compound-subject chosen-type static with a
-        // "The same is true for ..." tail (Rukarumel, Biologist). Models the
-        // "X you control and Y you control are the chosen type ..." sentence and
-        // leaves the non-battlefield-zone tail as an `Unimplemented` residual,
-        // mirroring Arcane Adaptation / Maskwood Nexus.
-        if push_same_is_true_static_tail(
-            &mut emitter,
-            item_line,
-            &static_line,
-            &static_line_lower,
-            parse_compound_you_control_chosen_type_static_prefix,
         ) {
             i += 1;
             continue;

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -199,6 +199,16 @@ fn parse_state_presence_conditions(input: &str) -> OracleResult<'_, StaticCondit
         // ("the number of A plus the number of B is N or greater").
         parse_additive_two_term_count_threshold,
         parse_there_are_conditions,
+        parse_control_presence_conditions,
+        parse_remaining_state_presence_conditions,
+    ))
+    .parse(input)
+}
+
+/// Keeps the top-level state-condition grammar below nom's tuple-arity limit
+/// while preserving the precedence of its control-related productions.
+fn parse_control_presence_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
+    alt((
         // CR 201.2: Named-control clauses MUST precede the generic compound
         // control combinator so " and " between named cards binds to the
         // names list, not interpreted as a second `you control` clause.
@@ -209,10 +219,41 @@ fn parse_state_presence_conditions(input: &str) -> OracleResult<'_, StaticCondit
         // `parse_control_conditions` so the bare count phrase is not mis-read as
         // "you control N or more creatures".
         parse_creatures_are_attacking_count_ge,
+        parse_source_controlled_or_your_commander,
         parse_control_conditions,
-        parse_remaining_state_presence_conditions,
     ))
     .parse(input)
+}
+
+/// CR 903.3 + CR 903.3d + CR 611.3a: "you control ~ or it's your commander"
+/// gates a source's static ability by either its current controller or its
+/// owner-relative commander designation. The two arms remain explicit because a
+/// stolen commander still satisfies "it's your commander" for its owner, while
+/// a noncommander source controlled by you satisfies the first arm.
+fn parse_source_controlled_or_your_commander(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (input, _) = tag("you control ~ or ").parse(input)?;
+    let (input, _) = alt((tag("it's your commander"), tag("it is your commander"))).parse(input)?;
+
+    Ok((
+        input,
+        StaticCondition::Or {
+            conditions: vec![
+                StaticCondition::SourceMatchesFilter {
+                    filter: TargetFilter::Typed(
+                        TypedFilter::default().controller(ControllerRef::You),
+                    ),
+                },
+                StaticCondition::SourceMatchesFilter {
+                    filter: TargetFilter::Typed(TypedFilter::default().properties(vec![
+                        FilterProp::Owned {
+                            controller: ControllerRef::You,
+                        },
+                        FilterProp::IsCommander,
+                    ])),
+                },
+            ],
+        },
+    ))
 }
 
 fn parse_remaining_state_presence_conditions(input: &str) -> OracleResult<'_, StaticCondition> {

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -6,7 +6,7 @@ use super::prelude::*;
 use super::support::*;
 use super::{
     anthem::*, cda::*, cost_mod::*, evasion::*, keyword_grant::*, loyalty::*, mana_transform::*,
-    restriction::*, type_change::*,
+    restriction::*, same_is_true::*, type_change::*,
 };
 use crate::types::statics::ProhibitionScope;
 
@@ -704,6 +704,16 @@ pub(crate) fn parse_static_line_inner(
     let lower = text.to_lowercase();
     let tp = TextPair::new(&text, &lower);
 
+    if let Some(def) = parse_same_is_true_type_static(&text, &lower) {
+        return Some(def);
+    }
+    if is_same_is_true_type_static_candidate(&text, &lower) {
+        // The dedicated all-consuming parser recognized this as a malformed
+        // continuation. Fail closed so a battlefield-only legacy parser cannot
+        // silently drop the unmodeled tail; the document dispatcher will retain
+        // the full line as an honest `Unimplemented` residual.
+        return None;
+    }
     if let Some(def) = parse_arcane_adaptation_chosen_type_static(&tp, &text) {
         return Some(def);
     }

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -86,6 +86,7 @@ mod keyword_grant;
 mod loyalty;
 mod mana_transform;
 mod restriction;
+mod same_is_true;
 mod shared;
 mod static_helpers;
 mod type_change;
@@ -176,10 +177,7 @@ pub(crate) use shared::{
 pub(crate) use static_helpers::apply_raw_parenthetical_cant_cast_gate;
 pub(crate) use static_helpers::parse_basic_land_type_plural;
 pub(crate) use static_helpers::peel_compound_all_quantified_conjuncts;
-pub(crate) use type_change::{
-    parse_additive_type_clause_modifications, parse_chosen_creature_type_static_prefix,
-    parse_compound_you_control_chosen_type_static_prefix, parse_every_creature_type_static_prefix,
-};
+pub(crate) use type_change::parse_additive_type_clause_modifications;
 
 /// Parse a static/continuous ability line into a `StaticDefinition`.
 #[tracing::instrument(level = "debug")]

--- a/crates/engine/src/parser/oracle_static/same_is_true.rs
+++ b/crates/engine/src/parser/oracle_static/same_is_true.rs
@@ -1,0 +1,290 @@
+//! CR 611.3a + CR 613.1d: type-changing statics with a "The same is true"
+//! continuation, including Maskwood Nexus and the chosen-type family.
+
+#[allow(unused_imports)]
+use super::prelude::*;
+use crate::parser::oracle_nom::error::oracle_err;
+
+/// The grammatical scope named by the continuation's spell/card subjects.
+/// This is deliberately separate from the battlefield antecedent: Oracle's
+/// continuation supplies its own scope (for example, "creature spells"), so
+/// it must not accidentally inherit `Other`, `Nontoken`, or `Sliver` from the
+/// permanent-only antecedent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContinuationScope {
+    Creature,
+    NonlandPermanent,
+    Card,
+}
+
+/// Parse the full, all-consuming two-sentence type-changing grammar:
+///
+/// "[As long as <condition>, ]<battlefield subjects> are <type change>. The
+/// same is true for <spell subjects> and <owned card subjects>."
+///
+/// The result is intentionally ONE `StaticDefinition`. A static ability's
+/// affected set is dynamic (CR 611.3a), including its battlefield, stack, and
+/// card-zone arms, and the arms share one source/dependency timestamp.
+pub(crate) fn parse_same_is_true_type_static(text: &str, lower: &str) -> Option<StaticDefinition> {
+    let (parsed, _) = nom_on_lower(text, lower, |input| {
+        all_consuming(parse_sentence).parse(input)
+    })?;
+
+    let mut definition = StaticDefinition::continuous()
+        .affected(parsed.affected)
+        .modifications(parsed.modifications)
+        .description(text.to_string());
+    if let Some(condition) = parsed.condition {
+        definition = definition.condition(condition);
+    }
+    Some(definition)
+}
+
+/// Recognize the grammar prefix that belongs exclusively to this two-sentence
+/// type-changing family. This deliberately does not consume the continuation
+/// subjects: callers use it after [`parse_same_is_true_type_static`] fails to
+/// prevent an older battlefield-only parser from accepting the antecedent and
+/// silently discarding an incomplete "The same is true" tail.
+///
+/// CR 611.3a + CR 613.1d: a static continuous effect applies exactly to the
+/// objects its complete text identifies; a malformed continuation must not
+/// degrade into a narrower, partially modeled effect.
+pub(crate) fn is_same_is_true_type_static_candidate(text: &str, lower: &str) -> bool {
+    nom_on_lower(text, lower, parse_same_is_true_type_static_candidate_prefix).is_some()
+}
+
+fn parse_same_is_true_type_static_candidate_prefix(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        recognize((
+            opt(terminated(
+                preceded(tag("as long as "), nom_condition::parse_inner_condition),
+                tag(", "),
+            )),
+            separated_list1(tag(" and "), parse_battlefield_subject),
+            tag(" are "),
+            parse_type_change,
+            tag(". the same is true for "),
+        )),
+    )
+    .parse(input)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedSameIsTrue {
+    affected: TargetFilter,
+    modifications: Vec<ContinuousModification>,
+    condition: Option<StaticCondition>,
+}
+
+fn parse_sentence(input: &str) -> OracleResult<'_, ParsedSameIsTrue> {
+    let (input, condition) = opt(terminated(
+        preceded(tag("as long as "), nom_condition::parse_inner_condition),
+        tag(", "),
+    ))
+    .parse(input)?;
+    let (input, battlefield_filters) =
+        separated_list1(tag(" and "), parse_battlefield_subject).parse(input)?;
+    let (input, _) = tag(" are ").parse(input)?;
+    let (input, modifications) = parse_type_change(input)?;
+    let (input, _) = tag(". the same is true for ").parse(input)?;
+    let (input, scope) = parse_spell_subject(input)?;
+    let (input, _) = tag(" and ").parse(input)?;
+    let (input, _) = parse_card_subject(scope, input)?;
+    let (input, _) = opt(tag(".")).parse(input)?;
+
+    let battlefield = union_filters(battlefield_filters);
+    let spells = controlled_spell_filter(scope);
+    let cards = owned_card_filter(scope);
+
+    Ok((
+        input,
+        ParsedSameIsTrue {
+            affected: TargetFilter::Or {
+                filters: vec![battlefield, spells, cards],
+            },
+            modifications,
+            condition,
+        },
+    ))
+}
+
+/// Parse the permanent-only antecedent and give every alternative an explicit
+/// battlefield constraint. The continuation arms below have their own scopes.
+fn parse_battlefield_subject(input: &str) -> OracleResult<'_, TargetFilter> {
+    let (input, other) = opt(tag("other ")).parse(input)?;
+    let (input, nontoken) = opt(tag("nontoken ")).parse(input)?;
+    let (input, nonland) = opt(tag("nonland ")).parse(input)?;
+    let (input, card_type) = nom_target::parse_type_filter_word(input)?;
+    let (input, _) = tag(" you control").parse(input)?;
+
+    let mut typed = TypedFilter::new(card_type).controller(ControllerRef::You);
+    if nonland.is_some() {
+        typed = typed.with_type(TypeFilter::Non(Box::new(TypeFilter::Land)));
+    }
+
+    let mut properties = vec![FilterProp::InZone {
+        zone: Zone::Battlefield,
+    }];
+    if nontoken.is_some() {
+        properties.push(FilterProp::NonToken);
+    }
+    if other.is_some() {
+        properties.push(FilterProp::Another);
+    }
+
+    Ok((input, TargetFilter::Typed(typed.properties(properties))))
+}
+
+fn parse_type_change(input: &str) -> OracleResult<'_, Vec<ContinuousModification>> {
+    alt((
+        value(
+            vec![ContinuousModification::AddAllCreatureTypes],
+            tag("every creature type"),
+        ),
+        parse_chosen_type_change,
+        value(
+            vec![ContinuousModification::AddType {
+                core_type: CoreType::Artifact,
+            }],
+            terminated(tag("artifacts"), tag(" in addition to their other types")),
+        ),
+        parse_additive_subtype_change,
+        value(
+            vec![
+                ContinuousModification::AddType {
+                    core_type: CoreType::Kindred,
+                },
+                ContinuousModification::AddSubtype {
+                    subtype: "Goblin".to_string(),
+                },
+            ],
+            terminated(
+                tag("kindred goblins"),
+                tag(" in addition to their other types"),
+            ),
+        ),
+    ))
+    .parse(input)
+}
+
+/// CR 205.3: An additive bare word that is neither an existing card type nor
+/// the two-word Kindred Goblin conclusion is a subtype grant (Roshan's
+/// "Assassins in addition to their other types"). `parse_type_filter_word`
+/// supplies canonical subtype spelling and word-boundary validation.
+fn parse_additive_subtype_change(input: &str) -> OracleResult<'_, Vec<ContinuousModification>> {
+    let (input, type_filter) = nom_target::parse_type_filter_word(input)?;
+    let (input, _) = tag(" in addition to their other types").parse(input)?;
+    let TypeFilter::Subtype(subtype) = type_filter else {
+        return Err(oracle_err(input));
+    };
+    Ok((input, vec![ContinuousModification::AddSubtype { subtype }]))
+}
+
+fn parse_chosen_type_change(input: &str) -> OracleResult<'_, Vec<ContinuousModification>> {
+    let (input, _) = tag("the chosen ").parse(input)?;
+    let (input, _) = opt(tag("creature ")).parse(input)?;
+    let (input, _) = tag("type").parse(input)?;
+    let (input, additive) = opt(preceded(
+        tag(" in addition to "),
+        alt((
+            tag("their other creature types"),
+            tag("their other types"),
+            tag("its other creature types"),
+            tag("its other types"),
+        )),
+    ))
+    .parse(input)?;
+
+    let modifications = if additive.is_some() {
+        vec![ContinuousModification::AddChosenSubtype {
+            kind: ChosenSubtypeKind::CreatureType,
+        }]
+    } else {
+        vec![
+            ContinuousModification::RemoveAllSubtypes {
+                set: SubtypeSet::Creature,
+            },
+            ContinuousModification::AddChosenSubtype {
+                kind: ChosenSubtypeKind::CreatureType,
+            },
+        ]
+    };
+    Ok((input, modifications))
+}
+
+fn parse_spell_subject(input: &str) -> OracleResult<'_, ContinuationScope> {
+    alt((
+        value(
+            ContinuationScope::Creature,
+            tag("creature spells you control"),
+        ),
+        value(
+            ContinuationScope::NonlandPermanent,
+            tag("permanent spells you control"),
+        ),
+        value(ContinuationScope::Card, tag("spells you control")),
+    ))
+    .parse(input)
+}
+
+fn parse_card_subject(scope: ContinuationScope, input: &str) -> OracleResult<'_, ()> {
+    match scope {
+        ContinuationScope::Creature => value(
+            (),
+            tag("creature cards you own that aren't on the battlefield"),
+        )
+        .parse(input),
+        ContinuationScope::NonlandPermanent => value(
+            (),
+            tag("nonland permanent cards you own that aren't on the battlefield"),
+        )
+        .parse(input),
+        ContinuationScope::Card => {
+            value((), tag("cards that you own that aren't on the battlefield")).parse(input)
+        }
+    }
+}
+
+fn union_filters(filters: Vec<TargetFilter>) -> TargetFilter {
+    match filters.as_slice() {
+        [only] => only.clone(),
+        _ => TargetFilter::Or { filters },
+    }
+}
+
+fn controlled_spell_filter(scope: ContinuationScope) -> TargetFilter {
+    let mut typed = continuation_typed_filter(scope).controller(ControllerRef::You);
+    typed = typed.properties(vec![FilterProp::InZone { zone: Zone::Stack }]);
+    TargetFilter::Typed(typed)
+}
+
+fn owned_card_filter(scope: ContinuationScope) -> TargetFilter {
+    let typed = continuation_typed_filter(scope).properties(vec![
+        FilterProp::Owned {
+            controller: ControllerRef::You,
+        },
+        FilterProp::RepresentedByCard,
+        FilterProp::InAnyZone {
+            zones: vec![
+                Zone::Library,
+                Zone::Hand,
+                Zone::Graveyard,
+                Zone::Stack,
+                Zone::Exile,
+                Zone::Command,
+            ],
+        },
+    ]);
+    TargetFilter::Typed(typed)
+}
+
+fn continuation_typed_filter(scope: ContinuationScope) -> TypedFilter {
+    match scope {
+        ContinuationScope::Creature => TypedFilter::creature(),
+        ContinuationScope::NonlandPermanent => {
+            TypedFilter::permanent().with_type(TypeFilter::Non(Box::new(TypeFilter::Land)))
+        }
+        ContinuationScope::Card => TypedFilter::card(),
+    }
+}

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -20928,12 +20928,11 @@ fn parse_chosen_land_type_adds_chosen_basic_land_type() {
     );
 }
 
-// CR 205.1a + CR 607.2d: full Conspiracy oracle. The battlefield SET static must be
-// present (composed RemoveAllSubtypes + AddChosenSubtype) AND the non-battlefield
-// "the same is true for ..." tail must surface as an Unimplemented residual (the
-// multi-zone type application is honestly gapped).
+// CR 205.1a + CR 607.2d + CR 611.3a + CR 613.1d: Conspiracy's full static
+// replaces battlefield creature subtypes and applies the same effect to its
+// controlled creature spells and owned creature cards outside the battlefield.
 #[test]
-fn parse_conspiracy_full_oracle_sets_static_and_gaps_tail() {
+fn parse_conspiracy_full_oracle_models_all_same_is_true_recipients() {
     let oracle = "As this enchantment enters, choose a creature type.\nCreatures you control are the chosen type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
     let result = crate::parser::oracle::parse_oracle_text(
         oracle,
@@ -20942,7 +20941,9 @@ fn parse_conspiracy_full_oracle_sets_static_and_gaps_tail() {
         &["Enchantment".to_string()],
         &[],
     );
-    let has_set_static = result.statics.iter().any(|def| {
+    assert_eq!(result.statics.len(), 1, "Conspiracy must have one static");
+    let def = &result.statics[0];
+    assert!(
         def.modifications
             .contains(&ContinuousModification::RemoveAllSubtypes {
                 set: crate::types::card_type::SubtypeSet::Creature,
@@ -20951,32 +20952,27 @@ fn parse_conspiracy_full_oracle_sets_static_and_gaps_tail() {
                 .modifications
                 .contains(&ContinuousModification::AddChosenSubtype {
                     kind: ChosenSubtypeKind::CreatureType,
-                })
-    });
-    assert!(
-        has_set_static,
-        "Conspiracy must produce the composed SET static: {:?}",
-        result.statics
+                }),
+        "Conspiracy must produce the composed SET static: {def:?}"
     );
-    let tail_gapped = result.abilities.iter().any(|ability| {
-        matches!(
-            *ability.effect,
-            crate::types::ability::Effect::Unimplemented { description: Some(ref frag), .. }
-                // allow-noncombinator: test assertion on a gapped Unimplemented fragment, not parser dispatch
-                if frag.contains("creature spells you control")
-        )
-    });
     assert!(
-        tail_gapped,
-        "the 'same is true for ...' multi-zone tail must be gapped as Unimplemented: {:?}",
+        matches!(def.affected, Some(TargetFilter::Or { ref filters }) if filters.len() == 3),
+        "Conspiracy must retain battlefield, spell, and owned-card recipient arms: {def:?}"
+    );
+    assert!(
+        !result.abilities.iter().any(|ability| matches!(
+            *ability.effect,
+            crate::types::ability::Effect::Unimplemented { .. }
+        )),
+        "Conspiracy's continuation must not leave an Unimplemented residual: {:?}",
         result.abilities
     );
 }
 
-// CR 205.1b: full Arcane Adaptation oracle (regression). The additive static must be
-// present (AddChosenSubtype, no RemoveAllSubtypes) AND the tail gapped.
+// CR 205.1b + CR 611.3a + CR 613.1d: Arcane Adaptation's additive static
+// applies to all three complete recipient arms.
 #[test]
-fn parse_arcane_adaptation_full_oracle_adds_static_and_gaps_tail() {
+fn parse_arcane_adaptation_full_oracle_models_all_same_is_true_recipients() {
     let oracle = "As Arcane Adaptation enters, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
     let result = crate::parser::oracle::parse_oracle_text(
         oracle,
@@ -20985,7 +20981,13 @@ fn parse_arcane_adaptation_full_oracle_adds_static_and_gaps_tail() {
         &["Enchantment".to_string()],
         &[],
     );
-    let has_additive_static = result.statics.iter().any(|def| {
+    assert_eq!(
+        result.statics.len(),
+        1,
+        "Arcane Adaptation must have one static"
+    );
+    let def = &result.statics[0];
+    assert!(
         def.modifications
             .contains(&ContinuousModification::AddChosenSubtype {
                 kind: ChosenSubtypeKind::CreatureType,
@@ -20993,24 +20995,19 @@ fn parse_arcane_adaptation_full_oracle_adds_static_and_gaps_tail() {
             && !def
                 .modifications
                 .iter()
-                .any(|m| matches!(m, ContinuousModification::RemoveAllSubtypes { .. }))
-    });
-    assert!(
-        has_additive_static,
-        "Arcane Adaptation must produce the additive static: {:?}",
-        result.statics
+                .any(|m| matches!(m, ContinuousModification::RemoveAllSubtypes { .. })),
+        "Arcane Adaptation must produce only the additive chosen-type modification: {def:?}"
     );
-    let tail_gapped = result.abilities.iter().any(|ability| {
-        matches!(
-            *ability.effect,
-            crate::types::ability::Effect::Unimplemented { description: Some(ref frag), .. }
-                // allow-noncombinator: test assertion on a gapped Unimplemented fragment, not parser dispatch
-                if frag.contains("creature spells you control")
-        )
-    });
     assert!(
-        tail_gapped,
-        "the 'same is true for ...' tail must be gapped as Unimplemented: {:?}",
+        matches!(def.affected, Some(TargetFilter::Or { ref filters }) if filters.len() == 3),
+        "Arcane Adaptation must retain battlefield, spell, and owned-card recipient arms: {def:?}"
+    );
+    assert!(
+        !result.abilities.iter().any(|ability| matches!(
+            *ability.effect,
+            crate::types::ability::Effect::Unimplemented { .. }
+        )),
+        "Arcane Adaptation's continuation must not leave an Unimplemented residual: {:?}",
         result.abilities
     );
 }
@@ -21043,12 +21040,11 @@ fn parser_shape_rukarumel_compound_subject_chosen_type_static() {
     }
 }
 
-// Issue #5246: full Rukarumel oracle. The compound-subject additive static must be
-// present AND the trailing "The same is true for ..." (non-battlefield-zone)
-// sentence must surface as an Unimplemented residual — mirroring Arcane
-// Adaptation / Maskwood Nexus, not collapsing the whole line into a strict-fail.
+// CR 205.1b + CR 611.3a + CR 613.1d + issue #5246: Rukarumel's compound
+// battlefield antecedent and two nonbattlefield continuation arms form one
+// additive continuous static.
 #[test]
-fn parse_rukarumel_full_oracle_adds_compound_static_and_gaps_tail() {
+fn parse_rukarumel_full_oracle_models_all_same_is_true_recipients() {
     let oracle = "As Rukarumel enters, choose a creature type.\nSlivers you control and nontoken creatures you control are the chosen type in addition to their other creature types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 1/1 colorless Sliver creature token.";
     let result = crate::parser::oracle::parse_oracle_text(
         oracle,
@@ -21057,34 +21053,30 @@ fn parse_rukarumel_full_oracle_adds_compound_static_and_gaps_tail() {
         &["Legendary".to_string(), "Creature".to_string()],
         &[],
     );
-    let has_compound_static = result.statics.iter().any(|def| {
-        matches!(def.affected, Some(TargetFilter::Or { ref filters }) if filters.len() >= 2)
-            && def
-                .modifications
-                .contains(&ContinuousModification::AddChosenSubtype {
-                    kind: ChosenSubtypeKind::CreatureType,
-                })
+    assert_eq!(result.statics.len(), 1, "Rukarumel must have one static");
+    let def = &result.statics[0];
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::AddChosenSubtype {
+                kind: ChosenSubtypeKind::CreatureType,
+            })
             && !def
                 .modifications
                 .iter()
-                .any(|m| matches!(m, ContinuousModification::RemoveAllSubtypes { .. }))
-    });
-    assert!(
-        has_compound_static,
-        "Rukarumel must produce the compound-subject additive static: {:?}",
-        result.statics
+                .any(|m| matches!(m, ContinuousModification::RemoveAllSubtypes { .. })),
+        "Rukarumel must produce only the additive chosen-type modification: {def:?}"
     );
-    let tail_gapped = result.abilities.iter().any(|ability| {
-        matches!(
-            *ability.effect,
-            crate::types::ability::Effect::Unimplemented { description: Some(ref frag), .. }
-                // allow-noncombinator: test assertion on a gapped Unimplemented fragment, not parser dispatch
-                if frag.contains("creature spells you control")
-        )
-    });
     assert!(
-        tail_gapped,
-        "the 'same is true for ...' tail must be gapped as Unimplemented: {:?}",
+        matches!(def.affected, Some(TargetFilter::Or { ref filters })
+            if filters.len() == 3 && matches!(&filters[0], TargetFilter::Or { filters } if filters.len() == 2)),
+        "Rukarumel must retain its two-part battlefield antecedent plus spell/card arms: {def:?}"
+    );
+    assert!(
+        !result.abilities.iter().any(|ability| matches!(
+            *ability.effect,
+            crate::types::ability::Effect::Unimplemented { .. }
+        )),
+        "Rukarumel's continuation must not leave an Unimplemented residual: {:?}",
         result.abilities
     );
 }
@@ -21165,9 +21157,9 @@ fn parser_shape_lifecraft_engine_vehicle_chosen_creature_type_static() {
 // CR 613.1d + CR 205.3m: Maskwood Nexus's battlefield static — "Creatures
 // you control are every creature type." — must lower to a Layer 4
 // type-changing effect that adds every creature type (CR 205.3m) to each
-// creature the controller has on the battlefield. The non-battlefield
-// "the same is true for ..." tail is stripped by the dispatcher in
-// `oracle.rs`; this test pins the battlefield-only static directly.
+// creature the controller has on the battlefield. The complete multi-zone
+// grammar is covered above; this direct unit test intentionally pins only the
+// standalone battlefield antecedent parser.
 #[test]
 fn parser_shape_maskwood_nexus_every_creature_type_applies_to_creatures_you_control() {
     let def = parse_static_line("Creatures you control are every creature type.").unwrap();

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -197,11 +197,6 @@ fn parse_chosen_creature_type_static_sentence_with_scope(
     Ok((input, (scope, application)))
 }
 
-pub(crate) fn parse_chosen_creature_type_static_prefix(input: &str) -> OracleResult<'_, ()> {
-    let (input, _) = parse_chosen_creature_type_static_scope_body(input)?;
-    Ok((input, ()))
-}
-
 /// CR 205.1a / CR 205.1b + CR 607.2d: Parse the "<scope> are the chosen [creature]
 /// type [in addition to their other types]" body, returning the affected scope and
 /// whether the effect is additive (CR 205.1b "in addition") or replacing (CR 205.1a
@@ -326,43 +321,14 @@ fn parse_compound_chosen_type_additive_predicate(input: &str) -> OracleResult<'_
     Ok((input, ()))
 }
 
-/// Prefix matcher for the `oracle.rs` "The same is true for ..." tail splitter:
-/// consumes "`<compound subject>` are the chosen [creature ]type in addition to
-/// their other [creature ]types[.]" so Rukarumel's trailing sentence is preserved
-/// as an `Unimplemented` residual (matching Arcane Adaptation / Maskwood Nexus)
-/// rather than collapsing the whole line into a strict-fail. Verifies the subject
-/// is a genuine compound `Or` before claiming, so single-subject chosen-type lines
-/// stay with [`parse_chosen_creature_type_static_prefix`].
-pub(crate) fn parse_compound_you_control_chosen_type_static_prefix(
-    input: &str,
-) -> OracleResult<'_, ()> {
-    let (after_subject, subject) =
-        take_until::<_, _, OracleError<'_>>(" are the chosen").parse(input)?;
-    match parse_continuous_subject_filter(subject) {
-        Some(TargetFilter::Or { filters }) if filters.len() >= 2 => {}
-        _ => {
-            return Err(nom::Err::Error(OracleError::new(
-                input,
-                nom::error::ErrorKind::Verify,
-            )));
-        }
-    }
-    let (input, _) = tag(" are ").parse(after_subject)?;
-    let (input, _) = alt((tag("the chosen creature type"), tag("the chosen type"))).parse(input)?;
-    let (input, ()) = parse_chosen_type_additive_suffix(input, "their")?;
-    let (input, _) = opt(tag(".")).parse(input)?;
-    Ok((input, ()))
-}
-
 // CR 613.1d + CR 205.3m: "<creatures you control are> every creature type" —
 // Layer 4 type-changing effect that adds every creature type (CR 205.3m) to each
 // creature the controller has on the battlefield. Maskwood Nexus is the
 // canonical printing; the static is the class of "<your creatures> are every
 // creature type" effects, paralleling `parse_arcane_adaptation_chosen_type_static`
-// for "the chosen type". Maskwood's "The same is true for creature spells you
-// control and creature cards you own that aren't on the battlefield" tail is
-// stripped upstream by `oracle.rs` (it's reported as `Unimplemented` because
-// continuous effects on non-battlefield zones aren't currently modeled).
+// for "the chosen type". The full two-sentence continuation is recognized by
+// `same_is_true::parse_same_is_true_type_static` before this battlefield-only
+// parser, so this function remains the single-sentence form's fallback.
 pub(crate) fn parse_every_creature_type_static(
     tp: &TextPair<'_>,
     description: &str,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3365,6 +3365,10 @@ pub enum FilterProp {
     Token,
     /// CR 111.1: Matches objects that are not tokens.
     NonToken,
+    /// CR 108.2 + CR 108.2b: Matches an object represented by a Magic card,
+    /// excluding tokens and object copies. This is distinct from `NonToken`:
+    /// a non-token copy is not represented by a card.
+    RepresentedByCard,
     /// CR 607.2d / CR 607.2m (by analogy) + CR 611.2c: matches objects whose
     /// CONTROLLER's durable per-player choice records the anchor `label`
     /// ("creatures controlled by players who last chose red waterfall …", Two
@@ -22036,6 +22040,7 @@ mod tests {
     fn filter_prop_roundtrip() {
         let props = vec![
             FilterProp::Token,
+            FilterProp::RepresentedByCard,
             FilterProp::Attacking { defender: None },
             FilterProp::Attacking {
                 defender: Some(ControllerRef::You),

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -630,6 +630,9 @@ impl EventObjectSnapshot {
             // Not reachable from the subject grammar today. Reaching one fails the gate,
             // which is the designed signal to extend the snapshot + evaluator together.
             FilterProp::WasPlayed
+            // CR 108.2 + CR 108.2b: event snapshots retain token status but not whether
+            // a nontoken object is a copy, so card representation cannot be reconstructed.
+            | FilterProp::RepresentedByCard
             | FilterProp::ControllerChoseLabel { .. }
             | FilterProp::ControllerMatches { .. }
             | FilterProp::BlockingSource

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -7136,6 +7136,19 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "im::HashMap::is_empty")]
     pub attribution: im::HashMap<ObjectId, ObjectAttribution>,
 
+    /// CR 613.1d: Remote recipients whose live card types were derived by a
+    /// Layer-4 continuous effect during the preceding evaluation. The next
+    /// full pass restores only these objects' type baselines before applying
+    /// the new Layer-4 effect set, leaving independent spell/card state (such
+    /// as cast-time ability grants) untouched.
+    ///
+    /// This is an engine-only derived cache. It is reconstructed from the
+    /// serialized attribution side-table on the first post-deserialization
+    /// layer pass, then rebuilt directly by the layer application pipeline.
+    /// It is intentionally excluded from equality like the other layer caches.
+    #[serde(skip, default)]
+    pub(crate) remote_type_layer_recipients: im::HashSet<ObjectId>,
+
     // Day/night tracking
     #[serde(default)]
     pub day_night: Option<DayNight>,
@@ -9798,6 +9811,7 @@ impl GameState {
             transient_continuous_effects: im::Vector::new(),
             next_continuous_effect_id: 1,
             attribution: im::HashMap::new(),
+            remote_type_layer_recipients: im::HashSet::new(),
             day_night: None,
             spells_cast_this_turn: 0,
             spells_cast_last_turn: None,
@@ -10788,6 +10802,7 @@ fn _gamestate_partition_is_total(s: &GameState) {
         transient_continuous_effects: _,
         next_continuous_effect_id: _,
         attribution: _,
+        remote_type_layer_recipients: _,
         day_night: _,
         spells_cast_this_turn: _,
         spells_cast_last_turn: _,

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -910,6 +910,7 @@ mod s07_coiling_rebirth_full_cast;
 mod s07_create_token_sequence_middle;
 mod s07_malamet_castpath;
 mod s07_this_way_conditions;
+mod same_is_true_type_statics;
 mod sandman_reanimate_self_and_land_s25;
 mod sandswirl_wanderglyph_attacked_you_cant_cast;
 mod sarkhan_dragon_ascendant_behold;

--- a/crates/engine/tests/integration/oracle_parser.rs
+++ b/crates/engine/tests/integration/oracle_parser.rs
@@ -6,6 +6,7 @@ use engine::types::ability::{
 };
 use engine::types::keywords::Keyword;
 use engine::types::statics::StaticMode;
+use engine::types::zones::Zone;
 
 fn parse(
     oracle_text: &str,
@@ -134,8 +135,53 @@ fn snapshot_rancor() {
     insta::assert_json_snapshot!(result);
 }
 
+fn assert_same_is_true_type_recipients(affected: &Option<TargetFilter>) {
+    let Some(TargetFilter::Or { filters }) = affected else {
+        panic!("expected battlefield, stack, and owned-card recipient arms, got {affected:?}");
+    };
+    assert_eq!(filters.len(), 3);
+
+    let TargetFilter::Typed(battlefield) = &filters[0] else {
+        panic!("expected a typed battlefield recipient arm")
+    };
+    assert_eq!(battlefield.controller, Some(ControllerRef::You));
+    assert!(battlefield.type_filters.contains(&TypeFilter::Creature));
+    assert!(battlefield.properties.contains(&FilterProp::InZone {
+        zone: Zone::Battlefield,
+    }));
+
+    let TargetFilter::Typed(stack) = &filters[1] else {
+        panic!("expected a typed stack recipient arm")
+    };
+    assert_eq!(stack.controller, Some(ControllerRef::You));
+    assert!(stack.type_filters.contains(&TypeFilter::Creature));
+    assert!(stack
+        .properties
+        .contains(&FilterProp::InZone { zone: Zone::Stack }));
+
+    let TargetFilter::Typed(cards) = &filters[2] else {
+        panic!("expected a typed owned-card recipient arm")
+    };
+    assert_eq!(cards.controller, None);
+    assert!(cards.type_filters.contains(&TypeFilter::Creature));
+    assert!(cards.properties.contains(&FilterProp::Owned {
+        controller: ControllerRef::You,
+    }));
+    assert!(cards.properties.contains(&FilterProp::RepresentedByCard));
+    assert!(cards.properties.contains(&FilterProp::InAnyZone {
+        zones: vec![
+            Zone::Library,
+            Zone::Hand,
+            Zone::Graveyard,
+            Zone::Stack,
+            Zone::Exile,
+            Zone::Command,
+        ],
+    }));
+}
+
 #[test]
-fn arcane_adaptation_full_oracle_splits_battlefield_static_and_unimplemented_tail() {
+fn arcane_adaptation_full_oracle_models_all_same_is_true_recipients() {
     let result = parse(
         "As Arcane Adaptation enters, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
         "Arcane Adaptation",
@@ -154,13 +200,7 @@ fn arcane_adaptation_full_oracle_splits_battlefield_static_and_unimplemented_tai
             kind: ChosenSubtypeKind::CreatureType
         }
     )));
-    match &static_def.affected {
-        Some(TargetFilter::Typed(filter)) => {
-            assert_eq!(filter.controller, Some(ControllerRef::You));
-            assert!(filter.type_filters.contains(&TypeFilter::Creature));
-        }
-        other => panic!("expected battlefield creature filter, got {other:?}"),
-    }
+    assert_same_is_true_type_recipients(&static_def.affected);
 
     let unimplemented: Vec<_> = result
         .abilities
@@ -173,24 +213,17 @@ fn arcane_adaptation_full_oracle_splits_battlefield_static_and_unimplemented_tai
             _ => None,
         })
         .collect();
-    assert_eq!(
-        unimplemented,
-        vec![
-            "The same is true for creature spells you control and creature cards you own that aren't on the battlefield."
-        ]
+    assert!(
+        unimplemented.is_empty(),
+        "Arcane Adaptation's continuation is fully modeled: {unimplemented:?}"
     );
 }
 
-// CR 613.1d + CR 205.3m: Maskwood Nexus's full Oracle text shares Arcane
-// Adaptation's two-sentence shape — a battlefield static plus the
-// "the same is true for creature spells / creature cards you own that aren't
-// on the battlefield" tail. The dispatcher in `oracle.rs` must split the
-// battlefield static (Layer 4 `AddAllCreatureTypes` on creatures you
-// control) from the non-battlefield tail, which is parked as
-// `Unimplemented` because layer-applied type changes outside the
-// battlefield aren't modeled.
+// CR 611.3a + CR 613.1d + CR 205.3m: Maskwood Nexus's complete two-sentence
+// static reaches controlled permanents and spells plus owned cards outside the
+// battlefield through one Layer-4 continuous effect.
 #[test]
-fn maskwood_nexus_full_oracle_splits_battlefield_static_and_unimplemented_tail() {
+fn maskwood_nexus_full_oracle_models_all_same_is_true_recipients() {
     let result = parse(
         "Creatures you control are every creature type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\n{3}, {T}: Create a 2/2 blue Shapeshifter creature token with changeling.",
         "Maskwood Nexus",
@@ -206,13 +239,7 @@ fn maskwood_nexus_full_oracle_splits_battlefield_static_and_unimplemented_tail()
         .modifications
         .iter()
         .any(|modification| matches!(modification, ContinuousModification::AddAllCreatureTypes)));
-    match &static_def.affected {
-        Some(TargetFilter::Typed(filter)) => {
-            assert_eq!(filter.controller, Some(ControllerRef::You));
-            assert!(filter.type_filters.contains(&TypeFilter::Creature));
-        }
-        other => panic!("expected battlefield creature filter, got {other:?}"),
-    }
+    assert_same_is_true_type_recipients(&static_def.affected);
 
     let unimplemented: Vec<_> = result
         .abilities
@@ -225,11 +252,9 @@ fn maskwood_nexus_full_oracle_splits_battlefield_static_and_unimplemented_tail()
             _ => None,
         })
         .collect();
-    assert_eq!(
-        unimplemented,
-        vec![
-            "The same is true for creature spells you control and creature cards you own that aren't on the battlefield."
-        ]
+    assert!(
+        unimplemented.is_empty(),
+        "Maskwood Nexus's continuation is fully modeled: {unimplemented:?}"
     );
 }
 

--- a/crates/engine/tests/integration/same_is_true_type_statics.rs
+++ b/crates/engine/tests/integration/same_is_true_type_statics.rs
@@ -6,18 +6,18 @@
 
 use engine::game::layers::{evaluate_layers, flush_layers};
 use engine::game::scenario::{GameScenario, P0, P1};
-use engine::game::scenario_db::GameScenarioDbExt;
 use engine::game::zones::move_to_zone;
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{
     ChosenSubtypeKind, ContinuousModification, ControllerRef, Duration, FilterProp,
-    StaticCondition, TargetFilter, TypeFilter,
+    StaticCondition, StaticDefinition, TargetFilter, TypeFilter,
 };
 use engine::types::card_type::{CoreType, SubtypeSet};
 use engine::types::game_state::{CastingVariant, StackEntry, StackEntryKind};
 use engine::types::identifiers::ObjectId;
-use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::mana::ManaColor;
 use engine::types::phase::Phase;
+use engine::types::statics::StaticMode;
 use engine::types::zones::Zone;
 
 const MASKWOOD_NEXUS: &str = "Creatures you control are every creature type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
@@ -334,7 +334,7 @@ fn push_test_spell(
 
 /// CR 108.2b + CR 109.2b + CR 400.1: Biotransference reaches each supported
 /// card zone and both stack arms. This also proves off-battlefield controllers
-/// survive a full characteristic reset.
+/// survive a remote type reset.
 #[test]
 fn biotransference_applies_to_card_zones_and_distinguishes_stack_arms() {
     let mut scenario = GameScenario::new();
@@ -416,12 +416,13 @@ fn biotransference_applies_to_card_zones_and_distinguishes_stack_arms() {
     assert_eq!(
         runner.state().objects[&owner_arm].controller,
         P1,
-        "off-battlefield controller must survive the full characteristic reset"
+        "off-battlefield controller must survive the remote type reset"
     );
 
     // CR 400.1 + CR 611.3a + CR 613.1d: When the static source leaves the
-    // battlefield, a forced full layer pass must re-seed every previously
-    // affected remote-zone object and remove the now-inapplicable type change.
+    // battlefield, a forced full layer pass must reset every previously
+    // affected remote-zone object's types and remove the now-inapplicable
+    // type change.
     let mut events = Vec::new();
     move_to_zone(runner.state_mut(), source, Zone::Graveyard, &mut events);
     flush_layers(runner.state_mut());
@@ -440,6 +441,48 @@ fn biotransference_applies_to_card_zones_and_distinguishes_stack_arms() {
             "{id:?} must reset when Biotransference leaves the battlefield"
         );
     }
+}
+
+/// CR 400.7g + CR 613.1d: A spell's cast-time static grant is independent of
+/// a same-is-true type effect. Recomputing its remote Layer-4 characteristics
+/// must not reseed its ability definitions from the printed-card baseline.
+#[test]
+fn remote_type_reset_preserves_cast_time_spell_grants() {
+    let mut scenario = GameScenario::new();
+    scenario
+        .add_creature_from_oracle(P0, "Biotransference", 1, 1, BIOTRANSFERENCE)
+        .id();
+    let spell = scenario
+        .add_creature_to_hand(P0, "Granted Spell", 1, 1)
+        .id();
+    let mut runner = scenario.build();
+
+    {
+        let state = runner.state_mut();
+        let mut events = Vec::new();
+        move_to_zone(state, spell, Zone::Stack, &mut events);
+        push_test_spell(state, spell, P0);
+        state
+            .objects
+            .get_mut(&spell)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::CantBeCountered));
+        state.layers_dirty.mark_full();
+        evaluate_layers(state);
+    }
+
+    assert!(
+        is_artifact(&runner, spell),
+        "Biotransference must still modify the creature spell's type"
+    );
+    assert!(
+        runner.state().objects[&spell]
+            .static_definitions
+            .iter_unchecked()
+            .any(|definition| definition.mode == StaticMode::CantBeCountered),
+        "the remote type pass must preserve the spell's cast-time grant"
+    );
 }
 
 /// CR 613.1b + CR 611.3a + CR 613.1d: a Layer-2 theft changes the source's
@@ -561,67 +604,4 @@ fn biotransference_casts_a_creature_spell_as_an_artifact() {
             "Biotransference's token must have the printed {subtype} subtype: {token:#?}"
         );
     }
-}
-
-/// CR 702.160a + CR 702.102b + CR 709.4d: non-base prototype and fused-split
-/// cast forms must be restored after the full reset that precedes layer
-/// application, including when another static makes remote stack objects
-/// layer candidates.
-#[test]
-fn prototype_and_fused_cast_form_overlays_survive_forced_full_layer_reset() {
-    let db = crate::support::shared_card_db()
-        .expect("integration fixture must include the Breaking split card");
-    let mut scenario = GameScenario::new();
-    let prototype = scenario.add_creature(P0, "Prototype Test", 7, 7).id();
-    let fused = scenario.add_real_card(P0, "Breaking", Zone::Stack, db);
-    let mut runner = scenario.build();
-
-    {
-        let state = runner.state_mut();
-        let prototype_object = state.objects.get_mut(&prototype).unwrap();
-        prototype_object.prototype_form = Some(engine::game::game_object::PrototypeFormState {
-            mana_cost: ManaCost::Cost {
-                shards: vec![ManaCostShard::White],
-                generic: 2,
-            },
-            power: 1,
-            toughness: 1,
-            colors: vec![ManaColor::White],
-        });
-
-        let fused_object = state.objects.get_mut(&fused).unwrap();
-        fused_object.fused_split_spell = true;
-        // `Breaking` supplies its real red split half. Add a second core type
-        // to the back-face fixture so this test also discriminates the type
-        // union restored from the fused cast-form marker.
-        let back = fused_object
-            .back_face
-            .as_mut()
-            .expect("Breaking must carry its split back-face data");
-        if !back.card_types.core_types.contains(&CoreType::Artifact) {
-            back.card_types.core_types.push(CoreType::Artifact);
-        }
-        push_test_spell(state, fused, P0);
-        state.layers_dirty.mark_full();
-        evaluate_layers(state);
-    }
-
-    let prototype_object = &runner.state().objects[&prototype];
-    assert_eq!(prototype_object.mana_cost.mana_value(), 3);
-    assert_eq!(prototype_object.power, Some(1));
-    assert_eq!(prototype_object.toughness, Some(1));
-    assert_eq!(prototype_object.color, vec![ManaColor::White]);
-
-    let fused_object = &runner.state().objects[&fused];
-    assert!(
-        fused_object.color.contains(&ManaColor::Red),
-        "a full layer reset must restore the real red half of fused Breaking"
-    );
-    assert!(
-        fused_object
-            .card_types
-            .core_types
-            .contains(&CoreType::Artifact),
-        "a full layer reset must restore the fused split type union"
-    );
 }

--- a/crates/engine/tests/integration/same_is_true_type_statics.rs
+++ b/crates/engine/tests/integration/same_is_true_type_statics.rs
@@ -1,0 +1,627 @@
+//! "The same is true" type-changing static abilities.
+//!
+//! These tests exercise parser → static definition → layer application. The
+//! stack cases distinguish a controlled spell from an owned card and prove that
+//! a non-token object copy is excluded from the card arm (CR 108.2b).
+
+use engine::game::layers::{evaluate_layers, flush_layers};
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::game::zones::move_to_zone;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    ChosenSubtypeKind, ContinuousModification, ControllerRef, Duration, FilterProp,
+    StaticCondition, TargetFilter, TypeFilter,
+};
+use engine::types::card_type::{CoreType, SubtypeSet};
+use engine::types::game_state::{CastingVariant, StackEntry, StackEntryKind};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const MASKWOOD_NEXUS: &str = "Creatures you control are every creature type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
+const ARCANE_ADAPTATION: &str = "Creatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
+const LEYLINE_OF_TRANSFORMATION: &str = "Creatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
+const CONSPIRACY: &str = "Creatures you control are the chosen type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
+const RUKARUMEL: &str = "Slivers you control and nontoken creatures you control are the chosen type in addition to their other creature types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
+const ROSHAN: &str = "Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
+const BIOTRANSFERENCE: &str = "Creatures you control are artifacts in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
+const BIOTRANSFERENCE_FULL: &str = "Creatures you control are artifacts in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\nWhenever you cast an artifact spell, you lose 1 life and create a 2/2 black Necron Warrior artifact creature token.";
+const ENCROACHING_MYCOSYNTH: &str = "Nonland permanents you control are artifacts in addition to their other types. The same is true for permanent spells you control and nonland permanent cards you own that aren't on the battlefield.";
+const GOBLIN_MASTERMIND: &str = "As long as you control The Goblin Mastermind or it's your commander, permanents you control are Kindred Goblins in addition to their other types. The same is true for spells you control and cards that you own that aren't on the battlefield.";
+
+fn parsed_static(oracle: &str, name: &str) -> engine::types::ability::StaticDefinition {
+    let parsed = parse_oracle_text(oracle, name, &[], &[], &[]);
+    let debug = format!("{parsed:#?}");
+    assert!(
+        !debug.contains("Unimplemented"),
+        "{name} must have no residual continuation gap:\n{debug}"
+    );
+    assert_eq!(
+        parsed.statics.len(),
+        1,
+        "{name} must lower its complete continuation into one static definition"
+    );
+    parsed.statics.into_iter().next().unwrap()
+}
+
+fn typed(filter: &TargetFilter) -> &engine::types::ability::TypedFilter {
+    let TargetFilter::Typed(filter) = filter else {
+        panic!("expected a typed continuation arm, got {filter:?}")
+    };
+    filter
+}
+
+fn assert_battlefield_filter(filter: &TargetFilter) {
+    match filter {
+        TargetFilter::Typed(filter) => assert!(filter.properties.iter().any(|property| {
+            matches!(
+                property,
+                FilterProp::InZone {
+                    zone: Zone::Battlefield
+                }
+            )
+        })),
+        TargetFilter::Or { filters } => {
+            assert!(
+                !filters.is_empty(),
+                "compound antecedent must retain its arms"
+            );
+            for filter in filters {
+                assert_battlefield_filter(filter);
+            }
+        }
+        other => panic!("unexpected battlefield antecedent: {other:?}"),
+    }
+}
+
+fn assert_three_recipient_arms(definition: &engine::types::ability::StaticDefinition, name: &str) {
+    let Some(TargetFilter::Or { filters }) = definition.affected.as_ref() else {
+        panic!("{name}: expected three recipient arms, got {definition:#?}")
+    };
+    assert_eq!(filters.len(), 3, "battlefield, spell, and card arms");
+    assert_battlefield_filter(&filters[0]);
+
+    let spells = typed(&filters[1]);
+    assert_eq!(spells.controller, Some(ControllerRef::You));
+    assert!(spells
+        .properties
+        .iter()
+        .any(|property| { matches!(property, FilterProp::InZone { zone: Zone::Stack }) }));
+
+    let cards = typed(&filters[2]);
+    assert!(cards.properties.iter().any(|property| {
+        matches!(
+            property,
+            FilterProp::Owned {
+                controller: ControllerRef::You
+            }
+        )
+    }));
+    assert!(
+        cards
+            .properties
+            .iter()
+            .any(|property| matches!(property, FilterProp::RepresentedByCard)),
+        "the card arm must exclude tokens and non-token copies"
+    );
+    assert!(cards.properties.iter().any(|property| {
+        matches!(
+            property,
+            FilterProp::InAnyZone { zones }
+                if zones == &vec![
+                    Zone::Library,
+                    Zone::Hand,
+                    Zone::Graveyard,
+                    Zone::Stack,
+                    Zone::Exile,
+                    Zone::Command,
+                ]
+        )
+    }));
+}
+
+/// Every exact supported Oracle form lowers to one complete continuous static;
+/// none retains the former `Unimplemented` continuation tail.
+#[test]
+fn all_supported_same_is_true_type_forms_parse_to_one_static() {
+    for (name, oracle) in [
+        ("Maskwood Nexus", MASKWOOD_NEXUS),
+        ("Arcane Adaptation", ARCANE_ADAPTATION),
+        ("Leyline of Transformation", LEYLINE_OF_TRANSFORMATION),
+        ("Conspiracy", CONSPIRACY),
+        ("Rukarumel, Biologist", RUKARUMEL),
+        ("Roshan, Hidden Magister", ROSHAN),
+        ("Biotransference", BIOTRANSFERENCE),
+        ("Encroaching Mycosynth", ENCROACHING_MYCOSYNTH),
+        ("The Goblin Mastermind", GOBLIN_MASTERMIND),
+    ] {
+        let definition = parsed_static(oracle, name);
+        assert_three_recipient_arms(&definition, name);
+    }
+}
+
+/// Conspiracy's chosen-type sentence replaces creature subtypes. Arcane
+/// Adaptation and Leyline of Transformation use the additive modification.
+#[test]
+fn conspiracy_uses_replacing_chosen_creature_type_modifications() {
+    let definition = parsed_static(CONSPIRACY, "Conspiracy");
+    assert_eq!(
+        definition.modifications,
+        vec![
+            ContinuousModification::RemoveAllSubtypes {
+                set: SubtypeSet::Creature,
+            },
+            ContinuousModification::AddChosenSubtype {
+                kind: ChosenSubtypeKind::CreatureType,
+            },
+        ]
+    );
+}
+
+/// The Goblin Mastermind's optional gate is source-relative and has its two
+/// semantic alternatives typed, rather than degrading to `Unrecognized`.
+#[test]
+fn goblin_mastermind_uses_explicit_source_or_commander_gate() {
+    let definition = parsed_static(GOBLIN_MASTERMIND, "The Goblin Mastermind");
+    let Some(StaticCondition::Or { conditions }) = definition.condition else {
+        panic!("expected an explicit source/commander Or condition")
+    };
+    assert_eq!(conditions.len(), 2);
+    let StaticCondition::SourceMatchesFilter {
+        filter: TargetFilter::Typed(first),
+    } = &conditions[0]
+    else {
+        panic!("first gate arm must match the source")
+    };
+    assert_eq!(first.controller, Some(ControllerRef::You));
+    let StaticCondition::SourceMatchesFilter {
+        filter: TargetFilter::Typed(second),
+    } = &conditions[1]
+    else {
+        panic!("second gate arm must match the source")
+    };
+    assert_eq!(
+        second.properties,
+        vec![
+            FilterProp::Owned {
+                controller: ControllerRef::You,
+            },
+            FilterProp::IsCommander,
+        ]
+    );
+}
+
+/// The recognizer is all-consuming: a malformed continuation cannot silently
+/// claim the battlefield sentence through an older prefix parser. It remains a
+/// whole-line `Unimplemented` residual until the full grammar is supported.
+#[test]
+fn malformed_same_is_true_continuation_is_an_honest_whole_line_residual() {
+    let oracle = "Creatures you control are artifacts in addition to their other types. The same is true for creature spells you control.";
+    let parsed = parse_oracle_text(oracle, "Malformed Same Is True", &[], &[], &[]);
+    assert!(
+        parsed.statics.is_empty(),
+        "an incomplete continuation must not retain a narrower static: {parsed:#?}"
+    );
+    assert!(
+        parsed.abilities.iter().any(|ability| matches!(
+            ability.effect.as_ref(),
+            engine::types::ability::Effect::Unimplemented {
+                description: Some(fragment),
+                ..
+            } if fragment.contains(oracle)
+        )),
+        "the complete malformed line must be retained as an Unimplemented residual: {parsed:#?}"
+    );
+}
+
+/// The subject and modification axes vary independently across this grammar:
+/// Rukarumel retains its two battlefield subject arms, Roshan preserves
+/// `Other` plus Assassin, and Mycosynth retains nonland permanent scope.
+#[test]
+fn specialized_same_is_true_forms_preserve_scopes_and_modifications() {
+    let rukarumel = parsed_static(RUKARUMEL, "Rukarumel, Biologist");
+    assert_eq!(
+        rukarumel.modifications,
+        vec![ContinuousModification::AddChosenSubtype {
+            kind: ChosenSubtypeKind::CreatureType,
+        }],
+        "Rukarumel must add, rather than replace, the chosen creature type"
+    );
+    let Some(TargetFilter::Or {
+        filters: rukarumel_arms,
+    }) = rukarumel.affected.as_ref()
+    else {
+        panic!("Rukarumel must have the complete recipient union: {rukarumel:#?}")
+    };
+    let TargetFilter::Or {
+        filters: battlefield_arms,
+    } = &rukarumel_arms[0]
+    else {
+        panic!("Rukarumel must retain its compound battlefield antecedent")
+    };
+    assert_eq!(battlefield_arms.len(), 2);
+    assert!(matches!(
+        &battlefield_arms[0],
+        TargetFilter::Typed(filter)
+            if filter.controller == Some(ControllerRef::You)
+                && filter.type_filters.contains(&TypeFilter::Subtype("Sliver".to_string()))
+    ));
+    assert!(matches!(
+        &battlefield_arms[1],
+        TargetFilter::Typed(filter)
+            if filter.controller == Some(ControllerRef::You)
+                && filter.type_filters.contains(&TypeFilter::Creature)
+                && filter.properties.contains(&FilterProp::NonToken)
+    ));
+
+    let roshan = parsed_static(ROSHAN, "Roshan, Hidden Magister");
+    assert_eq!(
+        roshan.modifications,
+        vec![ContinuousModification::AddSubtype {
+            subtype: "Assassin".to_string(),
+        }],
+        "Roshan must add Assassin rather than replace existing types"
+    );
+    let Some(TargetFilter::Or {
+        filters: roshan_arms,
+    }) = roshan.affected.as_ref()
+    else {
+        panic!("Roshan must have the complete recipient union: {roshan:#?}")
+    };
+    assert!(matches!(
+        &roshan_arms[0],
+        TargetFilter::Typed(filter)
+            if filter.controller == Some(ControllerRef::You)
+                && filter.type_filters.contains(&TypeFilter::Creature)
+                && filter.properties.contains(&FilterProp::Another)
+    ));
+
+    let mycosynth = parsed_static(ENCROACHING_MYCOSYNTH, "Encroaching Mycosynth");
+    assert_eq!(
+        mycosynth.modifications,
+        vec![ContinuousModification::AddType {
+            core_type: CoreType::Artifact,
+        }],
+        "Mycosynth must add Artifact in Layer 4"
+    );
+    let Some(TargetFilter::Or {
+        filters: mycosynth_arms,
+    }) = mycosynth.affected.as_ref()
+    else {
+        panic!("Mycosynth must have the complete recipient union: {mycosynth:#?}")
+    };
+    for filter in mycosynth_arms {
+        let TargetFilter::Typed(filter) = filter else {
+            panic!("Mycosynth recipient arm must be typed: {filter:?}")
+        };
+        assert!(filter.type_filters.contains(&TypeFilter::Permanent));
+        assert!(filter
+            .type_filters
+            .contains(&TypeFilter::Non(Box::new(TypeFilter::Land))));
+    }
+}
+
+fn is_artifact(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> bool {
+    runner.state().objects[&id]
+        .card_types
+        .core_types
+        .contains(&CoreType::Artifact)
+}
+
+/// Install the canonical stack membership record for a test spell. A live
+/// object's `Zone::Stack` field alone is intentionally insufficient: the Stack
+/// is represented by `GameState::stack` entries (CR 405.1).
+fn push_test_spell(
+    state: &mut engine::types::game_state::GameState,
+    id: ObjectId,
+    controller: engine::types::player::PlayerId,
+) {
+    let card_id = state.objects[&id].card_id;
+    state.stack.push_back(StackEntry {
+        id,
+        source_id: id,
+        controller,
+        kind: StackEntryKind::Spell {
+            card_id,
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+}
+
+/// CR 108.2b + CR 109.2b + CR 400.1: Biotransference reaches each supported
+/// card zone and both stack arms. This also proves off-battlefield controllers
+/// survive a full characteristic reset.
+#[test]
+fn biotransference_applies_to_card_zones_and_distinguishes_stack_arms() {
+    let mut scenario = GameScenario::new();
+    let source = scenario
+        .add_creature_from_oracle(P0, "Biotransference", 1, 1, BIOTRANSFERENCE)
+        .id();
+    let battlefield = scenario.add_creature(P0, "Battlefield Test", 1, 1).id();
+    let opponent_battlefield = scenario.add_creature(P1, "Opponent Test", 1, 1).id();
+    let hand = scenario.add_creature_to_hand(P0, "Hand Test", 1, 1).id();
+    let graveyard = scenario
+        .add_creature_to_graveyard(P0, "Graveyard Test", 1, 1)
+        .id();
+    let library = scenario.add_creature_to_hand(P0, "Library Test", 1, 1).id();
+    let exile = scenario.add_creature_to_hand(P0, "Exile Test", 1, 1).id();
+    let command = scenario.add_creature_to_hand(P0, "Command Test", 1, 1).id();
+    let owner_arm = scenario.add_creature_to_hand(P0, "Owner Arm", 1, 1).id();
+    let control_arm = scenario.add_creature_to_hand(P1, "Control Arm", 1, 1).id();
+    let copied_card = scenario
+        .add_creature_to_hand(P0, "Copy Exclusion", 1, 1)
+        .id();
+
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        let mut events = Vec::new();
+        move_to_zone(state, library, Zone::Library, &mut events);
+        move_to_zone(state, exile, Zone::Exile, &mut events);
+        move_to_zone(state, command, Zone::Command, &mut events);
+        move_to_zone(state, owner_arm, Zone::Stack, &mut events);
+        move_to_zone(state, control_arm, Zone::Stack, &mut events);
+        move_to_zone(state, copied_card, Zone::Stack, &mut events);
+
+        // Owner arm: card owned by P0 but cast/controlled by P1.
+        state.objects.get_mut(&owner_arm).unwrap().controller = P1;
+        // Controlled-spell arm: card owned by P1 but cast/controlled by P0.
+        state.objects.get_mut(&control_arm).unwrap().controller = P0;
+        // A non-token copy is neither a token nor a card (CR 108.2b). It is
+        // deliberately not controlled by P0, so neither continuation arm fits.
+        let copied = state.objects.get_mut(&copied_card).unwrap();
+        copied.controller = P1;
+        copied.is_copy = true;
+
+        // `move_to_zone` deliberately does not synthesize a StackEntry: real
+        // casts create one through the casting pipeline. Populate the canonical
+        // Stack list so this fixture models three live spells (CR 405.1).
+        push_test_spell(state, owner_arm, P1);
+        push_test_spell(state, control_arm, P0);
+        push_test_spell(state, copied_card, P1);
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(state);
+    }
+
+    for id in [
+        battlefield,
+        hand,
+        graveyard,
+        library,
+        exile,
+        command,
+        owner_arm,
+        control_arm,
+    ] {
+        assert!(
+            is_artifact(&runner, id),
+            "{id:?} should gain Artifact; source={:#?}; object={:#?}",
+            runner.state().objects[&source].static_definitions,
+            runner.state().objects[&id]
+        );
+    }
+    assert!(
+        !is_artifact(&runner, opponent_battlefield),
+        "opponent-controlled battlefield creature is outside the antecedent"
+    );
+    assert!(
+        !is_artifact(&runner, copied_card),
+        "a non-token object copy is not represented by a card"
+    );
+    assert_eq!(
+        runner.state().objects[&owner_arm].controller,
+        P1,
+        "off-battlefield controller must survive the full characteristic reset"
+    );
+
+    // CR 400.1 + CR 611.3a + CR 613.1d: When the static source leaves the
+    // battlefield, a forced full layer pass must re-seed every previously
+    // affected remote-zone object and remove the now-inapplicable type change.
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), source, Zone::Graveyard, &mut events);
+    flush_layers(runner.state_mut());
+    for id in [
+        battlefield,
+        hand,
+        graveyard,
+        library,
+        exile,
+        command,
+        owner_arm,
+        control_arm,
+    ] {
+        assert!(
+            !is_artifact(&runner, id),
+            "{id:?} must reset when Biotransference leaves the battlefield"
+        );
+    }
+}
+
+/// CR 613.1b + CR 611.3a + CR 613.1d: a Layer-2 theft changes the source's
+/// controller before its controller-relative type static is evaluated. `You`
+/// must rebind to the new controller for both battlefield and remote-zone arms.
+#[test]
+fn source_control_change_rebinds_same_is_true_you_scope() {
+    let mut scenario = GameScenario::new();
+    let source = scenario
+        .add_creature_from_oracle(P0, "Biotransference", 1, 1, BIOTRANSFERENCE)
+        .id();
+    let thief = scenario
+        .add_creature(P1, "Control Effect Source", 1, 1)
+        .id();
+    let p0_hand = scenario.add_creature_to_hand(P0, "P0 Hand", 1, 1).id();
+    let p1_hand = scenario.add_creature_to_hand(P1, "P1 Hand", 1, 1).id();
+    let mut runner = scenario.build();
+
+    runner.state_mut().add_transient_continuous_effect(
+        thief,
+        P1,
+        Duration::Permanent,
+        TargetFilter::SpecificObject { id: source },
+        vec![ContinuousModification::ChangeController],
+        None,
+    );
+    evaluate_layers(runner.state_mut());
+
+    assert_eq!(runner.state().objects[&source].controller, P1);
+    assert!(
+        is_artifact(&runner, p1_hand),
+        "the stolen source's `you` must resolve as P1 for the owned-card arm"
+    );
+    assert!(
+        !is_artifact(&runner, p0_hand),
+        "the former controller's card must lose the source-relative effect"
+    );
+}
+
+/// CR 205.3m + CR 611.3a + CR 613.1d: Maskwood Nexus's owned-card arm gives
+/// a creature card in hand every creature type, while an opponent's hand card
+/// remains outside the source-relative effect.
+#[test]
+fn maskwood_nexus_changes_owned_creature_cards_outside_the_battlefield() {
+    let mut scenario = GameScenario::new();
+    scenario
+        .add_creature_from_oracle(P0, "Maskwood Nexus", 1, 1, MASKWOOD_NEXUS)
+        .id();
+    let owned_card = scenario.add_creature_to_hand(P0, "Owned Test", 1, 1).id();
+    let opponent_card = scenario
+        .add_creature_to_hand(P1, "Opponent Test", 1, 1)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().all_creature_types = vec!["Elf".to_string(), "Goblin".to_string()];
+    evaluate_layers(runner.state_mut());
+
+    for subtype in ["Elf", "Goblin"] {
+        assert!(
+            runner.state().objects[&owned_card]
+                .card_types
+                .subtypes
+                .contains(&subtype.to_string()),
+            "owned hand card must gain {subtype}"
+        );
+        assert!(
+            !runner.state().objects[&opponent_card]
+                .card_types
+                .subtypes
+                .contains(&subtype.to_string()),
+            "opponent hand card must not gain {subtype}"
+        );
+    }
+}
+
+/// CR 601.2a + CR 603.2 + CR 613.1d: a creature spell becomes an Artifact on
+/// the stack before Biotransference's cast trigger is collected, so the real
+/// cast pipeline loses one life and creates the printed Necron Warrior token.
+#[test]
+fn biotransference_casts_a_creature_spell_as_an_artifact() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature_from_oracle(P0, "Biotransference", 1, 1, BIOTRANSFERENCE_FULL)
+        .id();
+    let creature_spell = scenario
+        .add_creature_to_hand(P0, "Artifact Trigger Test", 1, 1)
+        .id();
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(creature_spell).resolve();
+
+    outcome.assert_life_delta(P0, -1);
+    assert!(
+        is_artifact(&runner, creature_spell),
+        "the creature spell must become an artifact while it is on the stack"
+    );
+    let tokens: Vec<_> = runner
+        .state()
+        .objects
+        .values()
+        .filter(|object| object.is_token && object.zone == Zone::Battlefield)
+        .collect();
+    assert_eq!(
+        tokens.len(),
+        1,
+        "Biotransference must create exactly one token"
+    );
+    let token = tokens[0];
+    assert_eq!(token.name, "Necron Warrior");
+    assert_eq!(token.power, Some(2));
+    assert_eq!(token.toughness, Some(2));
+    assert_eq!(token.color, vec![ManaColor::Black]);
+    assert!(token.card_types.core_types.contains(&CoreType::Artifact));
+    assert!(token.card_types.core_types.contains(&CoreType::Creature));
+    for subtype in ["Necron", "Warrior"] {
+        assert!(
+            token.card_types.subtypes.contains(&subtype.to_string()),
+            "Biotransference's token must have the printed {subtype} subtype: {token:#?}"
+        );
+    }
+}
+
+/// CR 702.160a + CR 702.102b + CR 709.4d: non-base prototype and fused-split
+/// cast forms must be restored after the full reset that precedes layer
+/// application, including when another static makes remote stack objects
+/// layer candidates.
+#[test]
+fn prototype_and_fused_cast_form_overlays_survive_forced_full_layer_reset() {
+    let db = crate::support::shared_card_db()
+        .expect("integration fixture must include the Breaking split card");
+    let mut scenario = GameScenario::new();
+    let prototype = scenario.add_creature(P0, "Prototype Test", 7, 7).id();
+    let fused = scenario.add_real_card(P0, "Breaking", Zone::Stack, db);
+    let mut runner = scenario.build();
+
+    {
+        let state = runner.state_mut();
+        let prototype_object = state.objects.get_mut(&prototype).unwrap();
+        prototype_object.prototype_form = Some(engine::game::game_object::PrototypeFormState {
+            mana_cost: ManaCost::Cost {
+                shards: vec![ManaCostShard::White],
+                generic: 2,
+            },
+            power: 1,
+            toughness: 1,
+            colors: vec![ManaColor::White],
+        });
+
+        let fused_object = state.objects.get_mut(&fused).unwrap();
+        fused_object.fused_split_spell = true;
+        // `Breaking` supplies its real red split half. Add a second core type
+        // to the back-face fixture so this test also discriminates the type
+        // union restored from the fused cast-form marker.
+        let back = fused_object
+            .back_face
+            .as_mut()
+            .expect("Breaking must carry its split back-face data");
+        if !back.card_types.core_types.contains(&CoreType::Artifact) {
+            back.card_types.core_types.push(CoreType::Artifact);
+        }
+        push_test_spell(state, fused, P0);
+        state.layers_dirty.mark_full();
+        evaluate_layers(state);
+    }
+
+    let prototype_object = &runner.state().objects[&prototype];
+    assert_eq!(prototype_object.mana_cost.mana_value(), 3);
+    assert_eq!(prototype_object.power, Some(1));
+    assert_eq!(prototype_object.toughness, Some(1));
+    assert_eq!(prototype_object.color, vec![ManaColor::White]);
+
+    let fused_object = &runner.state().objects[&fused];
+    assert!(
+        fused_object.color.contains(&ManaColor::Red),
+        "a full layer reset must restore the real red half of fused Breaking"
+    );
+    assert!(
+        fused_object
+            .card_types
+            .core_types
+            .contains(&CoreType::Artifact),
+        "a full layer reset must restore the fused split type union"
+    );
+}

--- a/crates/engine/tests/integration/std_longtail_d_batch.rs
+++ b/crates/engine/tests/integration/std_longtail_d_batch.rs
@@ -591,11 +591,10 @@ fn choreographed_sparks_copy_grant_is_supported() {
 }
 
 #[test]
-fn leyline_of_transformation_nonbattlefield_grant_is_deferred() {
-    // The first clause (creatures you control are the chosen type) parses; the
-    // "same is true for creature spells you control and creature cards you own
-    // that aren't on the battlefield" continuous non-battlefield grant is not
-    // modeled.
+fn leyline_of_transformation_nonbattlefield_grant_is_modeled() {
+    // The complete same-is-true static has one dynamic recipient filter spanning
+    // creatures on the battlefield, creature spells, and owned creature cards in
+    // the other card zones.
     let dbg = parsed_debug(
         "If this card is in your opening hand, you may begin the game with it on the battlefield.\nAs this enchantment enters, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
         "Leyline of Transformation",
@@ -603,8 +602,8 @@ fn leyline_of_transformation_nonbattlefield_grant_is_deferred() {
         &[],
     );
     assert!(
-        dbg.contains("Unimplemented"),
-        "Leyline of Transformation non-battlefield grant must remain honestly Unimplemented"
+        !dbg.contains("Unimplemented"),
+        "Leyline of Transformation's same-is-true continuation must be fully modeled: {dbg}"
     );
 }
 


### PR DESCRIPTION
## Summary

Implements the type-changing The same is true static-ability family for Maskwood Nexus and eight related cards. It parses the complete continuation into one continuous static, applies it across the battlefield, stack, and owned card zones, and leaves malformed continuations explicitly unsupported.

## Files changed

- `crates/engine/src/ai_support/filter.rs`
- `crates/engine/src/game/ability_rw.rs`
- `crates/engine/src/game/ability_scan.rs`
- `crates/engine/src/game/casting_costs.rs`
- `crates/engine/src/game/coverage.rs`
- `crates/engine/src/game/filter.rs`
- `crates/engine/src/game/game_object.rs`
- `crates/engine/src/game/layers.rs`
- `crates/engine/src/game/zones.rs`
- `crates/engine/src/parser/oracle.rs`
- `crates/engine/src/parser/oracle_nom/condition.rs`
- `crates/engine/src/parser/oracle_static/dispatch.rs`
- `crates/engine/src/parser/oracle_static/mod.rs`
- `crates/engine/src/parser/oracle_static/same_is_true.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`
- `crates/engine/src/parser/oracle_static/type_change.rs`
- `crates/engine/src/types/ability.rs`
- `crates/engine/src/types/events.rs`
- `crates/engine/src/types/game_state.rs`
- `crates/engine/tests/integration/main.rs`
- `crates/engine/tests/integration/oracle_parser.rs`
- `crates/engine/tests/integration/same_is_true_type_statics.rs`
- `crates/engine/tests/integration/std_longtail_d_batch.rs`

## CR references

- `CR 108.2b`, `CR 109.2b`, and `CR 400.1` — card representation and card-zone recipients.
- `CR 205.3`, `CR 405.1`, `CR 611.3a/b`, and `CR 613.1d` — type-changing continuous effects, their stack/card scope, and layer application.
- `CR 400.7g` — independent cast-time spell grants survive a remote type-layer reset.

## Implementation method (required)

Method: /engine-implementer

## Track

Developer

## LLM

Tier: Standard
Model: gpt-5.6 Terra
Thinking: Extra-high

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — passed.
- `cargo clippy -p engine --all-targets -- -D warnings` — passed.
- `cargo test -p engine` — passed.
- `./scripts/check-parser-combinators.sh` — passed; Gate G and Gate A passed.
- GitHub required CI: Rust and Frontend — passed for `45e083dc33e92b1df66efef8126ec14fbbbf03c9`.
- Local pre-push oracle generation was unavailable because this checkout lacks untracked `data/mtgjson/AtomicCards.json`; the required CI coverage gate passed for the current head.

## Gate A

Gate A PASS head=45e083dc33e92b1df66efef8126ec14fbbbf03c9 base=bf7ba5beb1f1b2d41700201a7f48bb9f43fab8f9

## Anchored on

- `crates/engine/src/parser/oracle_static/type_change.rs:94` — existing chosen-type static construction and Layer 4 modification composition.
- `crates/engine/src/game/layers.rs:2903` — existing reset-then-reapply ownership boundary for layer evaluation.
- `crates/engine/src/game/quantity.rs:1490` — existing multi-zone `TargetFilter::extract_zones` consumer.

## Final review-impl

Final review-impl PASS head=45e083dc33e92b1df66efef8126ec14fbbbf03c9

## Claimed parse impact

- Arcane Adaptation
- Biotransference
- Conspiracy
- Encroaching Mycosynth
- Leyline of Transformation
- Maskwood Nexus
- Roshan, Hidden Magister
- Rukarumel, Biologist
- The Goblin Mastermind

## Validation Failures

None.

## CI Failures

None.