### PR TITLE
fix(engine): answer a purged source's SourceMatchesFilter intervening-if from LKI (CR 608.2h)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -12421,6 +12421,7 @@ mod tests {
                 counters: std::collections::HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         });
 

--- a/crates/engine/src/game/augment.rs
+++ b/crates/engine/src/game/augment.rs
@@ -293,7 +293,14 @@ fn combine_card_with_host(
 ) {
     if let Some(zone) = state.objects.get(&augment_id).map(|obj| obj.zone) {
         let owner = state.objects[&augment_id].owner;
-        zones::apply_zone_exit_cleanup(state, augment_id, zone, Zone::Battlefield);
+        // CR 608.2h: no sever has run on this path, so the live attachment list is still
+        // intact — capture it here for the LKI, through the one shared authority.
+        let attachments = state
+            .objects
+            .get(&augment_id)
+            .map(|obj| zones::capture_attachment_snapshot(state, obj))
+            .unwrap_or_default();
+        zones::apply_zone_exit_cleanup(state, augment_id, zone, Zone::Battlefield, attachments);
         zones::remove_from_zone(state, augment_id, zone, owner);
     }
     if let Some(augment) = state.objects.get_mut(&augment_id) {

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -3241,6 +3241,7 @@ mod tests {
                 counters: Default::default(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         });
 

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -3763,6 +3763,7 @@ mod tests {
                 counters: lki_counters,
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
 

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -2418,6 +2418,7 @@ mod tests {
                 counters: lki_counters,
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
 

--- a/crates/engine/src/game/effects/manifest.rs
+++ b/crates/engine/src/game/effects/manifest.rs
@@ -310,6 +310,7 @@ mod tests {
                 counters: std::collections::HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         });
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1510,6 +1510,10 @@ fn lki_snapshot_from_zone_change_record(record: &ZoneChangeRecord) -> LKISnapsho
         tapped: false,
         // CR 701.60b: Carry suspected status from the zone-change snapshot.
         is_suspected: record.is_suspected,
+        // CR 608.2h: The zone-change record already froze the exit-time attachment set
+        // (SBA unattaches everything the instant the host leaves, CR 704.5m/n), so carry
+        // it through rather than dropping it on the way into the LKI.
+        attachments: record.attachments.clone(),
     }
 }
 
@@ -10171,6 +10175,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
 
@@ -12441,6 +12446,7 @@ mod tests {
                 counters: Default::default(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
         let events = vec![

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -1454,7 +1454,12 @@ pub fn matches_target_filter_on_lki_snapshot(
         cast_from_zone: None,
         played_from_zone: None,
         to_zone: Zone::Battlefield,
-        attachments: vec![],
+        // CR 608.2h: Carry the exit-time attachment set so a source-referential
+        // predicate ("if this creature is enchanted" — Dreampod Druid) reads LAST
+        // KNOWN INFORMATION rather than the empty set. SBA unattaches everything the
+        // instant the host leaves the battlefield (CR 704.5m/n), so the live board can
+        // never answer this for a source that is already gone.
+        attachments: lki.attachments.clone(),
         linked_exile_snapshot: vec![],
         is_token: false,
         combat_status: Default::default(),
@@ -5929,6 +5934,7 @@ mod tests {
                 counters: Default::default(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
 
@@ -10204,6 +10210,7 @@ mod tests {
             counters: Default::default(),
             tapped: false,
             is_suspected: false,
+            attachments: Vec::new(),
         };
         let filter =
             TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::Cmc {
@@ -10249,6 +10256,7 @@ mod tests {
             counters: Default::default(),
             tapped: false,
             is_suspected: false,
+            attachments: Vec::new(),
         };
         let filter =
             TargetFilter::Typed(
@@ -10396,6 +10404,7 @@ mod tests {
             counters: Default::default(),
             tapped,
             is_suspected: false,
+            attachments: Vec::new(),
         };
 
         // Left the battlefield TAPPED.
@@ -11312,6 +11321,7 @@ mod tests {
             counters: HashMap::new(),
             tapped: false,
             is_suspected: false,
+            attachments: Vec::new(),
         };
         let land_lki = LKISnapshot {
             name: "Test Land".to_string(),
@@ -11332,6 +11342,7 @@ mod tests {
             counters: HashMap::new(),
             tapped: false,
             is_suspected: false,
+            attachments: Vec::new(),
         };
 
         let filter =
@@ -11477,6 +11488,7 @@ mod tests {
                 chosen_attributes: vec![],
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
 
@@ -11547,6 +11559,7 @@ mod tests {
                 chosen_attributes: vec![],
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
 

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1773,6 +1773,15 @@ impl GameObject {
             // still on the battlefield (cost-paid snapshot precedes the sacrifice
             // zone-change that resets the flag), so `self.is_suspected` is authoritative.
             is_suspected: self.is_suspected,
+            // Empty by construction, NOT by choice: classifying an attachment as
+            // Aura/Equipment requires looking each attached object up in `GameState`
+            // (see `zones::capture_attachment_snapshot`), and this method has only
+            // `&self`. Callers that need the attachment look-back (the CR 608.2h
+            // battlefield-exit LKI) go through `apply_zone_exit_cleanup`, which does
+            // have `&GameState` and populates it. The damage-source and mana-spent
+            // snapshots that use this method never ask an attachment predicate, so an
+            // empty set here is the same fail-closed answer they got before.
+            attachments: Vec::new(),
         }
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -15679,6 +15679,7 @@ mod tests {
                 counters: std::collections::HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
 

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -1418,6 +1418,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
         assert_eq!(resolve_object_name(&state, ObjectId(42)), "Grizzly Bears");

--- a/crates/engine/src/game/merge.rs
+++ b/crates/engine/src/game/merge.rs
@@ -612,7 +612,20 @@ fn put_component_into_zone(
     // existence (clears revealed/activation history, captures last-known info).
     // It was part of a battlefield permanent, so its prior context is the
     // battlefield — but no battlefield-exit event is emitted for it.
-    crate::game::zones::apply_zone_exit_cleanup(state, component_id, Zone::Battlefield, dest);
+    // CR 608.2h: no sever has run on this path, so the component's live attachment list is
+    // still intact — capture it here for the LKI, through the one shared authority.
+    let attachments = state
+        .objects
+        .get(&component_id)
+        .map(|obj| crate::game::zones::capture_attachment_snapshot(state, obj))
+        .unwrap_or_default();
+    crate::game::zones::apply_zone_exit_cleanup(
+        state,
+        component_id,
+        Zone::Battlefield,
+        dest,
+        attachments,
+    );
 
     // CR 730.2: the component is absorbed into the survivor and is not an
     // independent member of the battlefield list; defensively ensure it is not

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -5436,6 +5436,7 @@ mod tests {
             counters: HashMap::new(),
             tapped: false,
             is_suspected: false,
+            attachments: Vec::new(),
         };
 
         state.attacker_declarations_this_turn = vec![
@@ -11296,6 +11297,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
         state.current_trigger_event =
@@ -11359,6 +11361,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         });
         let power = resolve_quantity_with_targets(
@@ -11507,6 +11510,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         });
         let resolved = resolve_quantity_with_targets(
@@ -11586,6 +11590,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         });
         assert!(
@@ -11664,6 +11669,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         });
         assert!(
@@ -11728,6 +11734,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         };
         // Both fields set, with DIFFERENT mana values so the winning path is
@@ -11789,6 +11796,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         });
         let expr = QuantityExpr::Ref {
@@ -11843,6 +11851,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         };
         ability.set_effect_context_object_recursive(snapshot("Effect Context", 7));
@@ -11908,6 +11917,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         };
         ability.set_effect_context_object_recursive(snapshot("Effect Context", 5));
@@ -11950,6 +11960,7 @@ mod tests {
                 counters: HashMap::new(),
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
         assert!(!state.lki_cache.is_empty());
@@ -12587,6 +12598,7 @@ mod tests {
                     chosen_attributes: vec![],
                     tapped: false,
                     is_suspected: false,
+                    attachments: Vec::new(),
                 },
             );
             state.exile_links.push(ExileLink {

--- a/crates/engine/src/game/specialize.rs
+++ b/crates/engine/src/game/specialize.rs
@@ -188,6 +188,7 @@ mod tests {
             counters: Default::default(),
             tapped: false,
             is_suspected: false,
+            attachments: Vec::new(),
         }
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -6918,8 +6918,23 @@ pub(crate) fn check_trigger_condition(
         // the engine's normal TargetFilter matcher so properties such as
         // enchanted/equipped, attacked this turn, and other composable
         // source-state checks do not need bespoke TriggerCondition siblings.
+        //
+        // CR 608.2h + CR 113.7a: this arm asks the filter about the SOURCE ITSELF as
+        // the subject, and the CR 603.4 re-check happens at RESOLUTION — by which time
+        // the source may be gone. A token that has left the battlefield ceased to exist
+        // (CR 111.7 / CR 704.5d) and was purged from `state.objects`, so a live-only
+        // lookup cannot see the subject at all and fails closed for EVERY property.
+        // That is not a rules answer: CR 608.2h routes information about a source that
+        // is "no longer in the public zone it was expected to be in" to its LAST KNOWN
+        // INFORMATION, and CR 113.7a keeps the ability resolving regardless.
+        //
+        // `subject_filter_matches_with_lki` is the single authority for that fallback
+        // (shared with `match_sacrificed` / `match_connives` / the exploit matcher): it
+        // matches the LIVE object first and consults `state.lki_cache` only when the
+        // object no longer carries its battlefield appearance. Live state always wins,
+        // so this is a strict no-op for any source that still exists on the battlefield.
         TriggerCondition::SourceMatchesFilter { filter } => source_id.is_some_and(|id| {
-            matches_target_filter(state, id, filter, &FilterContext::from_source(state, id))
+            super::trigger_matchers::subject_filter_matches_with_lki(state, id, filter, id)
         }),
         // CR 603.4 + CR 120.1: "if any of that damage was dealt by a [filter]"
         // evaluates the triggering damage source as it was when the damage was
@@ -12198,6 +12213,7 @@ pub mod tests {
                 counters,
                 tapped: false,
                 is_suspected: false,
+                attachments: Vec::new(),
             },
         );
 

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -123,11 +123,18 @@ pub(crate) fn capture_attachment_snapshot(
 /// revert (CR 712.14), exile permission clearing (CR 113.6e), monstrous reset
 /// (CR 701.37b), counter clearing (CR 122.2), layer pruning, and mana-tap
 /// cleanup.
+/// `attachments` MUST be captured by the caller BEFORE
+/// `sever_battlefield_attachment_graph_on_exit` runs. This function cannot capture it
+/// itself: in `move_to_zone` the sever happens first, so by the time we get here the
+/// live object's attachment list is already empty. CR 608.2h needs the pre-sever set
+/// (see the `LKISnapshot::attachments` doc comment), so the caller — which is the only
+/// code that still has it — supplies it.
 pub(crate) fn apply_zone_exit_cleanup(
     state: &mut GameState,
     object_id: ObjectId,
     from: Zone,
     to: Zone,
+    attachments: Vec<crate::types::game_state::AttachmentSnapshot>,
 ) {
     // CR 400.7: An object that changes zones becomes a new object with no
     // memory of its previous existence. Both the short-lived `revealed_cards`
@@ -194,6 +201,12 @@ pub(crate) fn apply_zone_exit_cleanup(
                 // CR 701.60b: Capture suspected status at zone exit for
                 // "was suspected" look-back riders.
                 is_suspected: obj.is_suspected,
+                // CR 608.2h: The attachment set as it stood BEFORE SBA unattached it
+                // (CR 704.5m/n), so a source-referential intervening-if re-checked at
+                // resolution ("if this creature is enchanted" — Dreampod Druid) reads
+                // last known information once its source has left the battlefield.
+                // Supplied by the caller: the sever already ran by the time we get here.
+                attachments,
             };
             state.lki_cache.insert(object_id, lki);
         }
@@ -759,7 +772,15 @@ pub fn move_to_zone(
     // exist without corrupting leave-trigger filters.
     super::merge::restore_pre_merge_tokenness_for_leave(state, object_id);
 
-    apply_zone_exit_cleanup(state, object_id, from, to);
+    // CR 608.2h: hand the LKI the PRE-SEVER attachment set captured above — the sever
+    // has already emptied the live object's attachment list by this point.
+    apply_zone_exit_cleanup(
+        state,
+        object_id,
+        from,
+        to,
+        zone_change_record.attachments.clone(),
+    );
 
     remove_from_zone(state, object_id, from, owner);
     if redirect_attraction_to_command {
@@ -1153,7 +1174,14 @@ pub fn move_to_library_at_index(
 
     sever_battlefield_attachment_graph_on_exit(state, object_id, &unattached_from);
 
-    apply_zone_exit_cleanup(state, object_id, from, Zone::Library);
+    // CR 608.2h: hand the LKI the PRE-SEVER attachment set captured above.
+    apply_zone_exit_cleanup(
+        state,
+        object_id,
+        from,
+        Zone::Library,
+        zone_change_record.attachments.clone(),
+    );
 
     remove_from_zone(state, object_id, from, owner);
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -261,6 +261,23 @@ pub struct LKISnapshot {
     /// `#[serde(default)]` ⇒ pre-existing saved states deserialize to `false`.
     #[serde(default)]
     pub is_suspected: bool,
+    /// CR 608.2h + CR 400.7: Attachments (Auras/Equipment) as they last existed on
+    /// the battlefield. Attachment is a battlefield-only relationship — SBA unattaches
+    /// everything the instant the host leaves (CR 704.5m/n) — so a source-referential
+    /// intervening-if ("if this creature is enchanted" — Dreampod Druid; "if he's
+    /// equipped" — Whiplash) re-checked at resolution (CR 603.4) has nothing live to
+    /// read once its source is gone. CR 608.2h routes that question to LAST KNOWN
+    /// INFORMATION, so the attachment set must be captured on battlefield exit like
+    /// every other look-back characteristic here.
+    ///
+    /// Captured via [`capture_attachment_snapshot`](crate::game::zones::capture_attachment_snapshot),
+    /// the same authority that fills `ZoneChangeRecord::attachments` — one snapshot
+    /// shape, one capture site.
+    ///
+    /// `#[serde(default)]` ⇒ pre-existing saved states deserialize to an empty set,
+    /// which is exactly the pre-change fail-closed behavior.
+    #[serde(default)]
+    pub attachments: Vec<AttachmentSnapshot>,
 }
 
 /// CR 106.3 + CR 601.2h: Snapshot of the source of one mana spent to cast a spell.

--- a/crates/engine/tests/integration/issue_2890_reality_shift.rs
+++ b/crates/engine/tests/integration/issue_2890_reality_shift.rs
@@ -159,6 +159,7 @@ fn reality_shift_manifest_resolves_via_effect_context_object_snapshot() {
             counters: HashMap::new(),
             tapped: false,
             is_suspected: false,
+            attachments: Vec::new(),
         },
     });
 

--- a/crates/engine/tests/integration/madame_null_integration.rs
+++ b/crates/engine/tests/integration/madame_null_integration.rs
@@ -225,6 +225,7 @@ fn lki_fallback_resolves_source_power_after_zone_change() {
             counters: HashMap::new(),
             tapped: false,
             is_suspected: false,
+            attachments: Vec::new(),
         },
     );
     set_etb_event(&mut state, dead_id);

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -630,6 +630,7 @@ mod primo_unbounded_fractal_counters;
 mod printed_ability_order;
 mod proliferate_zero_counter;
 mod purged_source_intervening_if_lki;
+mod purged_source_matches_filter_lki;
 mod quirion_ranger_activation;
 mod rage_reflection_double_strike_grant;
 mod refurbished_familiar;

--- a/crates/engine/tests/integration/purged_source_matches_filter_lki.rs
+++ b/crates/engine/tests/integration/purged_source_matches_filter_lki.rs
@@ -1,0 +1,362 @@
+//! CR 608.2h + CR 113.7a + CR 111.7 + CR 603.4: a `SourceMatchesFilter`
+//! intervening-if must still be answerable when the triggered ability's SOURCE has
+//! ceased to exist.
+//!
+//! Oracle text (Dreampod Druid — 2/2 creature, verbatim):
+//!   "At the beginning of each upkeep, if this creature is enchanted, create a 1/1
+//!    green Saproling creature token."
+//!
+//! WHY THIS CARD. Of the 65 faces in the pool carrying a
+//! `TriggerCondition::SourceMatchesFilter` intervening-if, 62 have an effect that acts
+//! only on the SOURCE (pair it / it becomes an N/N creature / put a counter on it /
+//! transform it / return it to hand / shuffle it in / suspect it). Once the source is
+//! gone those effects are inert no matter what the condition answers, so the condition's
+//! answer is unobservable and cannot be witnessed at all. Dreampod Druid is the one face
+//! in the class whose gate is source-referential while its EFFECT acts on the game — it
+//! creates a token — so the condition's answer is directly observable as a board change.
+//! (Whiplash, Vengeful Engineer is the near-miss: its effect is observable too, but its
+//! `X = the number of Equipment attached to him` also reads the attachment set, so it
+//! needs a second fix. Taigam, Ojutai Master looks like a candidate but is a LYING GREEN
+//! — its `that spell gains rebound` grant never lands on the stack object even with a
+//! living source, so it cannot witness anything. Filed separately.)
+//!
+//! THE DEFECT. The `SourceMatchesFilter` arm (`check_trigger_condition`, triggers.rs)
+//! asks the filter about the SOURCE ITSELF as the subject. t73 (PR #5779) repaired the
+//! CONTEXT half of this class — the source's CONTROLLER now answers from LKI. The
+//! SUBJECT half remained: `filter_inner` looks the subject up in `state.objects`, and a
+//! token that left the battlefield ceased to exist (CR 111.7 / CR 704.5d) and was purged
+//! from `state.objects` outright. The filter cannot see the subject at all, so it fails
+//! closed for EVERY property.
+//!
+//! Worse, the property this card gates on could not be answered even once the subject was
+//! visible: attachment is a battlefield-only relationship, and SBA unattaches everything
+//! the instant the host leaves (CR 704.5m/n), so the live board has nothing left to read.
+//! `LKISnapshot` did not capture the attachment set, and the LKI→`ZoneChangeRecord`
+//! synthesizer hardcoded `attachments: vec![]`. Both halves are needed: the subject must
+//! be visible via LKI, AND the LKI must actually carry what the filter asks for.
+//!
+//! CR 608.2h is explicit that fail-closed is wrong here: "If the effect requires
+//! information from a specific object, INCLUDING THE SOURCE OF THE ABILITY ITSELF, the
+//! effect uses the current information of that object if it's in the public zone it was
+//! expected to be in; if it's no longer in that zone ... the effect uses the object's
+//! LAST KNOWN INFORMATION." And CR 113.7a: "Once activated or triggered, an ability
+//! exists on the stack independently of its source. Destruction or removal of the source
+//! after that time won't affect the ability."
+//!
+//! THE DISCRIMINATING VECTOR IS THE CR 111.7 PURGE. A nontoken Druid that dies stays in
+//! `state.objects` (graveyard), so the subject is still visible to `filter_inner` — but
+//! its attachments are gone either way, so BOTH legs need the LKI attachment capture.
+//! Both are asserted below.
+//!
+//! This drives the REAL pipeline end to end: the card is synthesized from verbatim Oracle
+//! text, the Aura is attached through the engine's `attach::attach_to` authority, the
+//! upkeep trigger fires off the real phase machinery, the source is killed through the
+//! real zone-change pipeline (`move_to_zone`, which snapshots LKI) and purged by the real
+//! SBA (`check_state_based_actions`), and the trigger resolves off the real stack. The
+//! observable is the number of Saproling tokens on the battlefield.
+
+use engine::game::effects::attach;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::game::{sba, zones};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+/// Dreampod Druid — 2/2. Verbatim Oracle text.
+const DREAMPOD_DRUID: &str =
+    "At the beginning of each upkeep, if this creature is enchanted, create a 1/1 green Saproling creature token.";
+
+/// Whether the Druid is a token copy or the printed card. Only a token ceases to exist
+/// under CR 111.7 — this is the axis that separates a purged subject from a merely dead one.
+#[derive(Clone, Copy, PartialEq)]
+enum SourceKind {
+    Token,
+    Nontoken,
+}
+
+/// Whether an Aura is attached to the Druid, i.e. whether the intervening-if is
+/// genuinely TRUE.
+#[derive(Clone, Copy, PartialEq)]
+enum Enchanted {
+    Yes,
+    No,
+}
+
+/// Whether the source dies with its trigger on the stack, or simply survives.
+/// `Survives` is the HARNESS POSITIVE CONTROL.
+#[derive(Clone, Copy, PartialEq)]
+enum SourceFate {
+    Survives,
+    Dies,
+}
+
+/// An Aura on the battlefield. Built the same way `aura_graft_enchant_restriction.rs`
+/// builds one, so `capture_attachment_snapshot` classifies it as `AttachmentKind::Aura`.
+fn make_aura(state: &mut GameState, controller: PlayerId) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(state.next_object_id),
+        controller,
+        "Test Aura".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Enchantment);
+    obj.card_types.subtypes.push("Aura".to_string());
+    id
+}
+
+/// Count the Saproling tokens P0 controls on the battlefield — the observable.
+fn saprolings(state: &GameState) -> usize {
+    state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .filter(|o| o.controller == P0 && o.name == "Saproling")
+        .count()
+}
+
+/// Put a (possibly enchanted) Dreampod Druid on the battlefield, run the upkeep trigger,
+/// optionally kill the source while that trigger is on the stack, and resolve.
+///
+/// The intervening-if is TRUE when it triggers (CR 603.4, first check) whenever
+/// `enchanted == Yes`; the question under test is whether it is still ANSWERABLE at the
+/// CR 603.4 re-check at RESOLUTION, once the source is gone.
+fn upkeep_trigger_then_kill_druid(
+    kind: SourceKind,
+    enchanted: Enchanted,
+    fate: SourceFate,
+) -> usize {
+    let mut scenario = GameScenario::new();
+
+    let druid = scenario
+        .add_creature_from_oracle(P0, "Dreampod Druid", 2, 2, DREAMPOD_DRUID)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // In BOTH arms an Aura exists on the battlefield. Only the ATTACHMENT differs. Without
+    // this, the `No` arm would have no Aura at all, and a "no token" result could mean
+    // "there was no Aura anywhere" rather than "the source was genuinely not enchanted" —
+    // a control that cannot tell those apart is not a control.
+    let aura = make_aura(runner.state_mut(), P0);
+    if enchanted == Enchanted::Yes {
+        // CR 303.4: attach through the engine's own authority, not by hand-editing state.
+        attach::attach_to(runner.state_mut(), aura, druid);
+    }
+
+    // CR 111.7 / CR 704.5d: only a token ceases to exist on leaving the battlefield.
+    if kind == SourceKind::Token {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&druid)
+            .expect("the source must exist at setup")
+            .is_token = true;
+    }
+
+    // PREMISE GUARD: the attachment must actually be established, or the Yes arm proves
+    // nothing about attachment look-back.
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&druid)
+            .expect("druid at setup")
+            .attachments
+            .contains(&aura),
+        enchanted == Enchanted::Yes,
+        "the Aura's attachment to the Druid is the single axis under test"
+    );
+
+    // CR 603.4 (first check): the upkeep trigger fires only if the Druid is enchanted.
+    runner.advance_to_upkeep();
+
+    let expected_stack = usize::from(enchanted == Enchanted::Yes);
+    assert_eq!(
+        runner.state().stack.len(),
+        expected_stack,
+        "CR 603.4: the upkeep trigger must be on the stack exactly when the intervening-if \
+         was TRUE at trigger time. If it were absent in the Yes arm we would be testing the \
+         COLLECTION path, not the re-check at RESOLUTION."
+    );
+
+    if fate == SourceFate::Dies {
+        // Kill the Druid with its trigger already on the stack, through the REAL zone-change
+        // pipeline (which snapshots LKI) and the REAL SBA (which purges a token under
+        // CR 111.7 / CR 704.5d).
+        let mut events = Vec::new();
+        zones::move_to_zone(runner.state_mut(), druid, Zone::Graveyard, &mut events);
+        sba::check_state_based_actions(runner.state_mut(), &mut events);
+
+        assert!(
+            runner.state().lki_cache.contains_key(&druid),
+            "CR 400.7: battlefield exit must snapshot LKI for the source in both arms"
+        );
+        match kind {
+            SourceKind::Token => assert!(
+                !runner.state().objects.contains_key(&druid),
+                "CR 111.7: the token source must have CEASED TO EXIST — if it is still in \
+                 state.objects this test is vacuous and proves nothing"
+            ),
+            SourceKind::Nontoken => assert!(
+                runner.state().objects.contains_key(&druid),
+                "a nontoken source stays in state.objects (in the graveyard)"
+            ),
+        }
+    }
+
+    runner.advance_until_stack_empty();
+    saprolings(runner.state())
+}
+
+/// HARNESS POSITIVE CONTROL — green before and after.
+///
+/// An enchanted Druid that SURVIVES makes its Saproling. This is the test that makes every
+/// zero below meaningful: without it, a probe that could never create a token — a card
+/// whose effect does not work, a trigger the harness never really resolves — would make the
+/// "defect" assertions pass for entirely the wrong reason.
+#[test]
+fn premise_living_enchanted_druid_creates_a_saproling() {
+    let tokens =
+        upkeep_trigger_then_kill_druid(SourceKind::Nontoken, Enchanted::Yes, SourceFate::Survives);
+    assert_eq!(
+        tokens, 1,
+        "a living enchanted Dreampod Druid MUST create its Saproling at upkeep. If this is \
+         0 the probe is broken and every other assertion in this file is void."
+    );
+}
+
+/// CR 603.4 FIRST-CHECK CONTROL — green before and after.
+///
+/// An UNenchanted Druid never triggers at all: the intervening-if is false when the trigger
+/// event occurs. An Aura is on the battlefield here (just not attached), so a zero proves
+/// the predicate ran and rejected the Druid, not that no Aura existed to find.
+#[test]
+fn unenchanted_druid_never_triggers() {
+    let tokens =
+        upkeep_trigger_then_kill_druid(SourceKind::Nontoken, Enchanted::No, SourceFate::Survives);
+    assert_eq!(
+        tokens, 0,
+        "CR 603.4: the ability triggers only if the condition is true at the trigger event"
+    );
+}
+
+/// PRIMARY WITNESS — RED before the fix.
+///
+/// A token copy of an enchanted Dreampod Druid dies while its upkeep trigger is on the
+/// stack. The Druid WAS enchanted, so the intervening-if is TRUE and the Saproling must
+/// still be created (CR 603.4: re-checked at resolution; CR 113.7a: the ability exists
+/// independently of its source; CR 608.2h: the source's information comes from LAST KNOWN
+/// INFORMATION once it is no longer in its expected zone).
+///
+/// Before the fix the purged token was absent from `state.objects` — `filter_inner` could
+/// not see the subject — and even the LKI record carried `attachments: vec![]`, so the
+/// condition read FALSE, the trigger was silently removed from the stack, and no token was
+/// created.
+#[test]
+fn purged_token_source_still_answers_source_matches_filter_via_lki() {
+    let tokens =
+        upkeep_trigger_then_kill_druid(SourceKind::Token, Enchanted::Yes, SourceFate::Dies);
+    assert_eq!(
+        tokens, 1,
+        "CR 608.2h: the intervening-if must resolve against the purged source's LAST KNOWN \
+         INFORMATION — the Druid was enchanted when it last existed, so the Saproling is created"
+    );
+}
+
+/// SECOND WITNESS — the NONTOKEN dead source.
+///
+/// The printed card dies the same way. It stays in `state.objects` (graveyard), so the
+/// SUBJECT was always visible — but SBA unattached its Aura (CR 704.5m/n), so the live board
+/// could not answer "is it enchanted" either. This leg is repaired by the LKI attachment
+/// capture rather than by the subject fallback.
+#[test]
+fn nontoken_dead_source_still_answers_source_matches_filter_via_lki() {
+    let tokens =
+        upkeep_trigger_then_kill_druid(SourceKind::Nontoken, Enchanted::Yes, SourceFate::Dies);
+    assert_eq!(
+        tokens, 1,
+        "CR 608.2h + CR 704.5m: the Aura is unattached the instant the host leaves, so 'is it \
+         enchanted' must be answered from LAST KNOWN INFORMATION, not from the live board"
+    );
+}
+
+/// NEGATIVE CONTROL — the fix must not FABRICATE a match.
+///
+/// This is the arm that proves the LKI fallback restores the source's ability to ANSWER the
+/// question rather than to always answer "yes". It cannot be expressed through the upkeep
+/// trigger (an unenchanted Druid never triggers at all, per CR 603.4's first check), so it
+/// interrogates the seam directly: a purged token that was NOT enchanted must answer FALSE
+/// for `HasAttachment(Aura)` even though its LKI snapshot exists and is consulted.
+///
+/// Non-vacuity: the sibling arm below runs the identical code path with the Aura ATTACHED
+/// and asserts TRUE. A predicate that always returned false would fail that one.
+#[test]
+fn purged_token_source_that_was_not_enchanted_answers_false() {
+    use engine::game::filter::{matches_target_filter_on_lki_snapshot, FilterContext};
+    use engine::types::ability::TriggerCondition;
+
+    for (enchanted, expected) in [(Enchanted::No, false), (Enchanted::Yes, true)] {
+        let mut scenario = GameScenario::new();
+        let druid = scenario
+            .add_creature_from_oracle(P0, "Dreampod Druid", 2, 2, DREAMPOD_DRUID)
+            .id();
+        let mut runner = scenario.build();
+
+        // Take the filter from the CARD'S OWN PARSED TRIGGER, not a hand-rolled
+        // approximation — this probe must interrogate the seam with exactly the predicate
+        // Dreampod Druid actually carries, or it proves nothing about Dreampod Druid.
+        let druid_obj = runner.state().objects.get(&druid).expect("druid at setup");
+        let condition = druid_obj
+            .trigger_definitions
+            .first()
+            .expect("PREMISE: Dreampod Druid must parse to exactly one triggered ability")
+            .condition
+            .as_ref()
+            .expect("PREMISE: that trigger must carry an intervening-if");
+        let filter = match condition {
+            TriggerCondition::SourceMatchesFilter { filter } => filter.clone(),
+            other => panic!(
+                "PREMISE: Dreampod Druid's intervening-if must be a SourceMatchesFilter — if the \
+                 parse changed to {other:?}, this whole file is testing nothing"
+            ),
+        };
+
+        let aura = make_aura(runner.state_mut(), P0);
+        if enchanted == Enchanted::Yes {
+            attach::attach_to(runner.state_mut(), aura, druid);
+        }
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&druid)
+            .expect("druid")
+            .is_token = true;
+
+        let mut events = Vec::new();
+        zones::move_to_zone(runner.state_mut(), druid, Zone::Graveyard, &mut events);
+        sba::check_state_based_actions(runner.state_mut(), &mut events);
+        assert!(
+            !runner.state().objects.contains_key(&druid),
+            "CR 111.7: the token must have ceased to exist, or this probe is vacuous"
+        );
+
+        let state = runner.state();
+        let lki = state
+            .lki_cache
+            .get(&druid)
+            .expect("CR 400.7: the purged token must still have an LKI snapshot");
+        let ctx = FilterContext::from_source(state, druid);
+
+        assert_eq!(
+            matches_target_filter_on_lki_snapshot(state, druid, lki, &filter, &ctx),
+            expected,
+            "the LKI attachment look-back must ANSWER the question honestly, not fabricate a \
+             match — a purged token that was never enchanted must still read FALSE"
+        );
+    }
+}


### PR DESCRIPTION
`TriggerCondition::SourceMatchesFilter` asks the filter about the SOURCE ITSELF as
the subject, and CR 603.4 re-checks the intervening-if at RESOLUTION — by which time
the source may be gone. A token that has left the battlefield ceased to exist
(CR 111.7 / CR 704.5d) and was purged from `state.objects`, so the live-only lookup
could not see the subject at all and failed closed for every property. t73 (#5779)
repaired the CONTEXT half of this class (the source's controller now answers from
LKI); this is the SUBJECT half.

CR 608.2h: "If the effect requires information from a specific object, INCLUDING THE
SOURCE OF THE ABILITY ITSELF, the effect uses the current information of that object
if it's in the public zone it was expected to be in; if it's no longer in that zone
... the effect uses the object's LAST KNOWN INFORMATION." CR 113.7a keeps the ability
resolving regardless of its source's fate.

Two halves, each independently necessary (proven by ablation — neither alone turns the
witness green):

1. The trigger arm now routes through `subject_filter_matches_with_lki`, the existing
   single authority for this fallback (shared with match_sacrificed / match_connives /
   the exploit matcher). It matches the LIVE object first and consults `lki_cache` only
   when the object no longer carries its battlefield appearance — a strict no-op for any
   source still on the battlefield.

2. `LKISnapshot` now carries the exit-time attachment set. Attachment is a
   battlefield-only relationship — SBA unattaches everything the instant the host leaves
   (CR 704.5m/n) — so "if this creature is enchanted" had nothing live to read even once
   the subject was visible, and the LKI→ZoneChangeRecord synthesizer hardcoded
   `attachments: vec![]`. `apply_zone_exit_cleanup` cannot capture this itself: in
   `move_to_zone` the sever runs first, so the attachment list is already empty by then.
   The caller — the only code that still holds it — now supplies it, reusing the one
   shared `capture_attachment_snapshot` authority.

Soulbond (50 defs / 25 faces, the largest slice of the class) is structurally unaffected
and must stay FALSE for a dead source (CR 702.95b: pairing exists only between
battlefield creatures): `InZone` reads `record.from_zone`, which the LKI synthesizer
leaves `None`, and `Unpaired` reads live `state.objects`.

Witness: `purged_source_matches_filter_lki` — Dreampod Druid ("At the beginning of each
upkeep, if this creature is enchanted, create a 1/1 green Saproling creature token"),
the one face in the 65-face class whose gate is source-referential while its effect acts
on the game rather than on the vanished source. Drives the real pipeline end to end;
the observable is the Saproling. Carries a harness positive control (a living Druid must
create the token — the control that proves the probe can reach the observable at all), a
CR 603.4 first-check control, and a negative control asserting a purged token that was
never enchanted still answers FALSE.
