### PR TITLE
fix(engine): make mana payments atomic

### DIFF
--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -503,9 +503,9 @@ fn shard_single_color(shard: ManaCostShard) -> Option<crate::types::mana::ManaCo
 /// can resolve the payment deterministically, and the `WaitingFor::ManaPayment` state
 /// adds no information — it is pure ceremony.
 ///
-/// The other variants name which rules decision a player still owes. CR 601.2h requires
-/// these to be resolved by the caster before mana is paid, so we must surface the
-/// `ManaPayment` UI for them.
+/// The other variants name which rules decision a player still owes. CR 118.13a +
+/// CR 601.2b require these choices while proposing the spell or ability, so we must
+/// surface the `ManaPayment` UI for them before payment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PaymentClassification {
     /// No hybrid or Phyrexian shards remain — `pay_mana_cost` can auto-tap and spend.
@@ -523,9 +523,9 @@ pub enum PaymentClassification {
 /// shards are always unambiguous — `pay_mana_cost` already picks sources deterministically
 /// and handles auto-tap of free producers.
 ///
-/// CR 601.2h: The player must choose how to pay for hybrid and Phyrexian mana as part
-/// of determining total cost. This predicate is the single authority on whether that
-/// choice is actually present in a given cost.
+/// CR 118.13a + CR 601.2b: The player chooses how to pay for hybrid and Phyrexian mana
+/// while proposing the spell or ability. This predicate is the single authority on
+/// whether that choice is actually present in a given cost.
 pub fn classify_payment(cost: &ManaCost) -> PaymentClassification {
     let ManaCost::Cost { shards, .. } = cost else {
         return PaymentClassification::Unambiguous;
@@ -992,11 +992,12 @@ pub(crate) fn reduce_cost_by_pool(
     }
 }
 
-/// Pay a mana cost with hand-demand-aware hybrid resolution (CR 601.2f + CR 601.2h).
+/// Pay a mana cost with hand-demand-aware hybrid resolution (CR 601.2h).
 ///
-/// CR 601.2f: If a cost includes hybrid mana symbols, the player announces the nonhybrid
-/// equivalent cost they intend to pay. If it includes Phyrexian mana symbols, the player
-/// announces whether to pay 2 life or the corresponding colored mana for each.
+/// CR 118.13a + CR 601.2b: If a cost includes hybrid mana symbols, the player announces
+/// the nonhybrid equivalent cost they intend to pay. If it includes Phyrexian mana
+/// symbols, the player announces whether to pay 2 life or the corresponding colored
+/// mana for each.
 ///
 /// CR 609.4b: When `any_color` is true, colored mana requirements can be paid with
 /// mana of any color (e.g., Chromatic Orrery).
@@ -1021,12 +1022,13 @@ pub fn pay_cost_with_demand(
 
 /// Pay a mana cost with an optional explicit Phyrexian choice vector.
 ///
-/// CR 107.4f + CR 601.2f: When `phyrexian_choices` is `Some`, the caller has pre-resolved
-/// the per-shard mana-vs-2-life decision (see `WaitingFor::PhyrexianPayment`). Each
-/// Phyrexian shard consumes one choice from the vector in order; `PayLife` produces a
-/// `LifePayment`, `PayMana` spends one mana of the shard's color (hybrid-Phyrexian picks
-/// via `auto_pay_hybrid`). A `None` choice vector preserves the existing auto-decision
-/// behavior: prefer mana when available, fall back to 2 life.
+/// CR 107.4f + CR 118.13a + CR 601.2b: When `phyrexian_choices` is `Some`, the caller has
+/// pre-resolved the per-shard mana-vs-2-life decision (see
+/// `WaitingFor::PhyrexianPayment`). Each Phyrexian shard consumes one choice from the
+/// vector in order; `PayLife` produces a `LifePayment`, `PayMana` spends one mana of the
+/// shard's color (hybrid-Phyrexian picks via `auto_pay_hybrid`). A `None` choice vector
+/// preserves the existing auto-decision behavior: prefer mana when available, fall back
+/// to 2 life.
 #[allow(clippy::too_many_arguments)]
 pub fn pay_cost_with_demand_and_choices(
     pool: &mut ManaPool,
@@ -1039,6 +1041,57 @@ pub fn pay_cost_with_demand_and_choices(
     // CR 118.3a: player-directed pin hints. At the real finalize spend this is
     // `pending_cast.pinned_pool_units`; every dry-run/test caller passes `&[]`,
     // which makes the spend byte-identical to the pre-feature ordering.
+    pins: &[ManaPipId],
+) -> Result<(Vec<ManaUnit>, Vec<LifePayment>), PaymentError> {
+    // CR 601.2h: Partial payments are not allowed. Spend from scratch pools so a
+    // failed attempt never leaks a partial payment into the caller's mana pool.
+    let mut scratch = pool.clone();
+    match pay_cost_with_demand_and_choices_once(
+        &mut scratch,
+        cost,
+        hand_demand,
+        spell,
+        any_color,
+        phyrexian_choices,
+        life_colors,
+        pins,
+    ) {
+        Ok(payment) => {
+            *pool = scratch;
+            Ok(payment)
+        }
+        Err(PaymentError::InsufficientMana) if hand_demand.is_some() => {
+            let mut fallback = pool.clone();
+            match pay_cost_with_demand_and_choices_once(
+                &mut fallback,
+                cost,
+                None,
+                spell,
+                any_color,
+                phyrexian_choices,
+                life_colors,
+                pins,
+            ) {
+                Ok(payment) => {
+                    *pool = fallback;
+                    Ok(payment)
+                }
+                Err(error) => Err(error),
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pay_cost_with_demand_and_choices_once(
+    pool: &mut ManaPool,
+    cost: &ManaCost,
+    hand_demand: Option<&ColorDemand>,
+    spell: Option<&PaymentContext<'_>>,
+    any_color: bool,
+    phyrexian_choices: Option<&[ShardChoice]>,
+    life_colors: crate::types::mana::LifePaymentColors,
     pins: &[ManaPipId],
 ) -> Result<(Vec<ManaUnit>, Vec<LifePayment>), PaymentError> {
     match cost {
@@ -1379,8 +1432,9 @@ pub fn pay_cost_with_demand_and_choices(
     }
 }
 
-/// CR 107.4f + CR 601.2f: Compute the per-shard `ShardOptions` for each Phyrexian shard
-/// in `cost`, given the caster's post-auto-tap pool, spell context, and life budget.
+/// CR 107.4f + CR 118.13a + CR 601.2b: Compute the per-shard `ShardOptions` for each
+/// Phyrexian shard in `cost`, given the caster's post-auto-tap pool, spell context, and
+/// life budget.
 ///
 /// Returns `Vec<PhyrexianShard>` aligned with the order of Phyrexian shards in `cost`.
 /// Each shard records the colored mana availability (`ManaOnly`, `LifeOnly`, or `ManaOrLife`)
@@ -2506,6 +2560,48 @@ mod tests {
         pool
     }
 
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ManaUnitFingerprint {
+        color: ManaType,
+        source_id: ObjectId,
+        pip_id: ManaPipId,
+        supertype: Option<crate::types::mana::ManaSupertype>,
+        source_could_produce_two_or_more_colors: bool,
+        restrictions: Vec<ManaRestriction>,
+        grants: Vec<ManaSpellGrant>,
+        expiry: Option<ManaExpiry>,
+    }
+
+    fn fingerprint(units: &[ManaUnit]) -> Vec<ManaUnitFingerprint> {
+        units
+            .iter()
+            .map(|unit| ManaUnitFingerprint {
+                color: unit.color,
+                source_id: unit.source_id,
+                pip_id: unit.pip_id,
+                supertype: unit.supertype,
+                source_could_produce_two_or_more_colors: unit
+                    .source_could_produce_two_or_more_colors,
+                restrictions: unit.restrictions.clone(),
+                grants: unit.grants.clone(),
+                expiry: unit.expiry,
+            })
+            .collect()
+    }
+
+    fn rich_unit(color: ManaType, source: u64, pip: u64) -> ManaUnit {
+        ManaUnit {
+            color,
+            source_id: ObjectId(source),
+            pip_id: ManaPipId(pip),
+            supertype: Some(crate::types::mana::ManaSupertype::Snow),
+            source_could_produce_two_or_more_colors: true,
+            restrictions: vec![ManaRestriction::OnlyForSpell],
+            grants: vec![ManaSpellGrant::CantBeCountered],
+            expiry: Some(ManaExpiry::EndOfTurn),
+        }
+    }
+
     fn make_two_or_more_color_source_unit(color: ManaType) -> ManaUnit {
         ManaUnit {
             source_could_produce_two_or_more_colors: true,
@@ -3192,9 +3288,10 @@ mod tests {
 
     #[test]
     fn compute_phyrexian_shards_defers_to_strict_reports_life_only() {
-        // CR 107.4f + CR 601.2f: {B/P}{B} with one black source. Because the
-        // strict {B} consumes the lone black, the {B/P} shard's only legal option
-        // is life — the UI must not surface ManaOrLife (regression for #3306).
+        // CR 107.4f + CR 118.13a + CR 601.2b: {B/P}{B} with one black source.
+        // Because the strict {B} consumes the lone black, the {B/P} shard's only
+        // legal announced option is life — the UI must not surface ManaOrLife
+        // (regression for #3306).
         let pool = pool_with(&[(ManaType::Black, 1)]);
         let cost = ManaCost::Cost {
             shards: vec![ManaCostShard::PhyrexianBlack, ManaCostShard::Black],
@@ -3241,6 +3338,141 @@ mod tests {
         };
         let (spent, _) = pay_from_pool(&mut pool, &cost).unwrap();
         assert_eq!(spent[0].color, ManaType::Colorless);
+    }
+
+    #[test]
+    fn pay_cost_demand_fallback_commits_complete_payment() {
+        let mut pool = pool_with(&[(ManaType::Green, 2), (ManaType::Blue, 1)]);
+        let cost = ManaCost::Cost {
+            shards: vec![
+                ManaCostShard::Green,
+                ManaCostShard::GreenBlue,
+                ManaCostShard::Blue,
+            ],
+            generic: 0,
+        };
+        let demand = [0, 1, 0, 0, 3];
+
+        let (spent, life) =
+            pay_cost_with_demand(&mut pool, &cost, Some(&demand), None, false).unwrap();
+
+        assert_eq!(spent.len(), 3);
+        assert!(life.is_empty());
+        assert!(pool.mana.is_empty());
+    }
+
+    #[test]
+    fn pay_cost_without_demand_failure_preserves_full_pool() {
+        let mut pool = ManaPool {
+            mana: vec![rich_unit(ManaType::Green, 101, 11)],
+        };
+        let before = fingerprint(&pool.mana);
+        let cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Green, ManaCostShard::Blue],
+            generic: 0,
+        };
+
+        assert_eq!(
+            pay_cost_with_demand(&mut pool, &cost, None, None, false),
+            Err(PaymentError::InsufficientMana)
+        );
+        assert_eq!(fingerprint(&pool.mana), before);
+    }
+
+    #[test]
+    fn pay_cost_with_demand_double_failure_preserves_full_pool() {
+        let mut pool = ManaPool {
+            mana: vec![
+                rich_unit(ManaType::Green, 101, 11),
+                rich_unit(ManaType::Blue, 102, 12),
+            ],
+        };
+        let before = fingerprint(&pool.mana);
+        let cost = ManaCost::Cost {
+            shards: vec![
+                ManaCostShard::Green,
+                ManaCostShard::GreenBlue,
+                ManaCostShard::Blue,
+            ],
+            generic: 0,
+        };
+        let demand = [0, 1, 0, 0, 3];
+
+        assert_eq!(
+            pay_cost_with_demand(&mut pool, &cost, Some(&demand), None, false),
+            Err(PaymentError::InsufficientMana)
+        );
+        assert_eq!(fingerprint(&pool.mana), before);
+    }
+
+    #[test]
+    fn pay_cost_explicit_phyrexian_pay_mana_failure_preserves_full_pool() {
+        let mut pool = ManaPool {
+            mana: vec![rich_unit(ManaType::Green, 101, 11)],
+        };
+        let before = fingerprint(&pool.mana);
+        let cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Green, ManaCostShard::PhyrexianBlue],
+            generic: 0,
+        };
+
+        assert_eq!(
+            pay_cost_with_demand_and_choices(
+                &mut pool,
+                &cost,
+                None,
+                None,
+                false,
+                Some(&[ShardChoice::PayMana]),
+                crate::types::mana::LifePaymentColors::EMPTY,
+                &[],
+            ),
+            Err(PaymentError::InsufficientMana)
+        );
+        assert_eq!(fingerprint(&pool.mana), before);
+    }
+
+    #[test]
+    fn pay_cost_success_commits_exact_spent_unit_provenance() {
+        let retained = rich_unit(ManaType::Green, 101, 11);
+        let pinned_green = ManaUnit {
+            supertype: None,
+            source_could_produce_two_or_more_colors: false,
+            restrictions: vec![ManaRestriction::OnlyForActivation],
+            grants: Vec::new(),
+            expiry: Some(ManaExpiry::EndOfCombat),
+            ..rich_unit(ManaType::Green, 102, 12)
+        };
+        let blue = ManaUnit {
+            restrictions: Vec::new(),
+            grants: Vec::new(),
+            ..rich_unit(ManaType::Blue, 103, 13)
+        };
+        let expected_spent = fingerprint(&[pinned_green.clone(), blue.clone()]);
+        let expected_pool = fingerprint(std::slice::from_ref(&retained));
+        let mut pool = ManaPool {
+            mana: vec![retained, pinned_green, blue],
+        };
+        let cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Green, ManaCostShard::Blue],
+            generic: 0,
+        };
+
+        let (spent, life) = pay_cost_with_demand_and_choices(
+            &mut pool,
+            &cost,
+            None,
+            None,
+            false,
+            None,
+            crate::types::mana::LifePaymentColors::EMPTY,
+            &[ManaPipId(12)],
+        )
+        .unwrap();
+
+        assert_eq!(fingerprint(&spent), expected_spent);
+        assert_eq!(fingerprint(&pool.mana), expected_pool);
+        assert!(life.is_empty());
     }
 
     // --- hand-demand-aware hybrid tests ---

--- a/crates/engine/tests/integration/atomic_mana_payment.rs
+++ b/crates/engine/tests/integration/atomic_mana_payment.rs
@@ -1,0 +1,86 @@
+use engine::game::mana_payment::{can_pay, compute_hand_color_demand};
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const PARADOX_SURVEYOR_ORACLE: &str = "Reach\nWhen this creature enters, look at the top five \
+cards of your library. You may reveal a land card or a card with {X} in its mana cost from among \
+them and put it into your hand. Put the rest on the bottom of your library in a random order.";
+
+fn mana(color: ManaType, source: u64) -> ManaUnit {
+    ManaUnit::new(color, ObjectId(source), false, Vec::new())
+}
+
+#[test]
+fn paradox_surveyor_demand_fallback_casts_and_resolves() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let surveyor_cost = ManaCost::Cost {
+        shards: vec![
+            ManaCostShard::Green,
+            ManaCostShard::GreenBlue,
+            ManaCostShard::Blue,
+        ],
+        generic: 0,
+    };
+    let surveyor = scenario
+        .add_creature_to_hand_from_oracle(P0, "Paradox Surveyor", 3, 3, PARADOX_SURVEYOR_ORACLE)
+        .with_mana_cost(surveyor_cost.clone())
+        .id();
+
+    scenario
+        .add_creature_to_hand(P0, "Demanding Creature", 1, 1)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![
+                ManaCostShard::Blue,
+                ManaCostShard::Green,
+                ManaCostShard::Green,
+                ManaCostShard::Green,
+            ],
+            generic: 0,
+        });
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            mana(ManaType::Green, 10_001),
+            mana(ManaType::Green, 10_002),
+            mana(ManaType::Blue, 10_003),
+        ],
+    );
+    for name in [
+        "Card One",
+        "Card Two",
+        "Card Three",
+        "Card Four",
+        "Card Five",
+    ] {
+        scenario.add_card_to_library_top(P0, name);
+    }
+
+    let mut runner = scenario.build();
+    assert_eq!(
+        compute_hand_color_demand(runner.state(), P0, surveyor),
+        [0, 1, 0, 0, 3]
+    );
+    let player = runner
+        .state()
+        .players
+        .iter()
+        .find(|player| player.id == P0)
+        .expect("P0 exists");
+    assert!(can_pay(&player.mana_pool, &surveyor_cost));
+
+    runner.cast(surveyor).resolve();
+
+    assert_eq!(runner.state().objects[&surveyor].zone, Zone::Battlefield);
+    let player = runner
+        .state()
+        .players
+        .iter()
+        .find(|player| player.id == P0)
+        .expect("P0 exists");
+    assert!(player.mana_pool.mana.is_empty());
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -19,6 +19,7 @@ mod armored_kincaller_or_condition;
 mod ashaya_nontoken_lands;
 mod aspect_of_wolf_per_axis_xy;
 mod athreos_god_of_passage_targeted_opponent_unless_pay;
+mod atomic_mana_payment;
 mod attack_qualifier_stack_conditions;
 mod auntie_ool_minus_one_counter_trigger;
 mod aura_graft_enchant_restriction;


### PR DESCRIPTION
## Summary
Makes mana payment atomic when demand-aware hybrid selection has to retry without the demand hint. A failed first spend now rolls back completely before the fallback attempt, so a payable spell is not rejected because the failed attempt consumed part of the caller's pool.

## Files changed
- crates/engine/src/game/mana_payment.rs
- crates/engine/tests/integration/atomic_mana_payment.rs
- crates/engine/tests/integration/main.rs

## CR references
- CR 107.4f
- CR 118.13a
- CR 601.2b
- CR 601.2h
- CR 609.4b

## Implementation method (required)
Method: /engine-implementer

## Track
Developer

## LLM
Model: codex-5
Thinking: high
Tier: Standard

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `tilt get uiresource clippy` - Tilt unavailable in this worktree; used the documented direct fallback.
- `cargo fmt --all` - passed.
- `cargo fmt --all -- --check` - passed.
- `git diff --check` - passed.
- `cargo clippy-strict` - passed on head `a4788b91e612640b5422382bc8cd81d31c59441a`.
- `cargo test -p engine` - passed on head `a4788b91e612640b5422382bc8cd81d31c59441a`: 16573 unit tests passed; 6 `coverage_parse_diff` tests passed; 9 `set_check` tests passed; 3041 integration tests passed; doc tests passed with 7 ignored.
- `cargo test -p engine atomic_mana_payment::paradox_surveyor_demand_fallback_casts_and_resolves` - passed on head `a4788b91e612640b5422382bc8cd81d31c59441a`: 1 integration test passed.
- `./scripts/gen-card-data.sh` - passed on head `a4788b91e612640b5422382bc8cd81d31c59441a`: generated card data for 35397 faces; coverage summary 31335/35397 cards supported (88.5%); 1072 parser warnings.
- `cargo coverage` - passed on head `a4788b91e612640b5422382bc8cd81d31c59441a`: 31335/35397 cards supported (88.5%).
- `cargo semantic-audit` - passed on head `a4788b91e612640b5422382bc8cd81d31c59441a`: 32389 cards audited, 292 existing findings.

## Gate A
Gate A PASS head=a4788b91e612640b5422382bc8cd81d31c59441a base=6d7821dced9623609edea342b47dd9c704ff0b36

## Anchored on
- crates/engine/src/game/mana_payment.rs:853 - existing `reduce_cost_by_pool` scratch-pool dry run keeps affordability simulation separate from caller pool mutation.
- crates/engine/src/game/mana_payment.rs:1033 - existing `pay_cost_with_demand_and_choices` payment authority owns demand-aware hybrid and Phyrexian payment selection.

## Final review-impl
Final review-impl PASS head=a4788b91e612640b5422382bc8cd81d31c59441a

## Claimed parse impact
None.

## Validation Failures
Resolved local environment issue: the first direct clippy fallback attempt hit `No space left on device` in the generated harness target. I removed that generated target cache and reran the required checks cleanly.

## CI Failures
None.
