### PR TITLE
fix(coverage): project ReplacementDefinition scoping into the parse-diff signature

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -4274,6 +4274,15 @@ fn static_details(stat: &StaticDefinition) -> Vec<(String, String)> {
 /// distinct `ParsedItem`s. Without this, a scope-only fix (e.g. a self-scoped
 /// damage shield flipping `valid_card` from `None` to `Some(SelfRef)`) shows a
 /// false "no card-parse changes detected" diff.
+///
+/// Covers every parse-time semantic axis on the struct: recipient/player
+/// scope, mode, shield kind, damage source/target/combat/modification,
+/// quantity modification, destination zone, condition, redirect target, draw
+/// scope, token owner scope/redirect, mana modification/scope, additional and
+/// ensure-all token specs, counter match, and controller overrides
+/// (`enters_under`) and expiry. Deliberately excludes runtime-only state
+/// (`execute`, `runtime_execute`, `consume_on_apply`, `is_consumed`,
+/// `source_controller`) which carries no parse-time signal of its own.
 fn replacement_details(repl: &ReplacementDefinition) -> Vec<(String, String)> {
     let mut d = Vec::new();
     // Recipient scope — the field a shield-scoping fix changes.
@@ -4319,6 +4328,36 @@ fn replacement_details(repl: &ReplacementDefinition) -> Vec<(String, String)> {
     }
     if let Some(scope) = &repl.draw_scope {
         d.push(("draw scope".into(), format!("{scope:?}")));
+    }
+    if let Some(scope) = &repl.token_owner_scope {
+        d.push(("token owner scope".into(), format!("{scope:?}")));
+    }
+    if let Some(redirect) = &repl.token_owner_redirect {
+        d.push(("token owner redirect".into(), format!("{redirect:?}")));
+    }
+    if let Some(mm) = &repl.mana_modification {
+        d.push(("mana mod".into(), format!("{mm:?}")));
+    }
+    if !repl.mana_replacement_scope.is_any() {
+        d.push((
+            "mana scope".into(),
+            format!("{:?}", repl.mana_replacement_scope),
+        ));
+    }
+    if let Some(spec) = &repl.additional_token_spec {
+        d.push(("additional token".into(), format!("{spec:?}")));
+    }
+    if let Some(specs) = &repl.ensure_token_specs {
+        d.push(("ensure tokens".into(), format!("{specs:?}")));
+    }
+    if let Some(cm) = &repl.counter_match {
+        d.push(("counter match".into(), format!("{cm:?}")));
+    }
+    if let Some(cref) = &repl.enters_under {
+        d.push(("enters under".into(), format!("{cref:?}")));
+    }
+    if let Some(expiry) = &repl.expiry {
+        d.push(("expiry".into(), format!("{expiry:?}")));
     }
     d
 }
@@ -10671,6 +10710,74 @@ mod tests {
         assert!(
             !unscoped.iter().any(|(k, _)| k == "scope"),
             "an absent valid_card must not appear, so unqualified signatures stay stable",
+        );
+    }
+
+    #[test]
+    fn replacement_signature_exposes_enters_under_and_token_owner_scope() {
+        // Review follow-up on #5673/#5800: the first projection pass covered
+        // `valid_card` but still left other parse-time semantic axes
+        // (`enters_under`, `token_owner_scope`, `mana_modification`, etc.)
+        // unprojected, so a fix that only changes one of those still produced
+        // a byte-identical signature. Guard the two axes matthewevans called
+        // out by name so this class of omission cannot silently recur.
+        let details = |enters_under: Option<ControllerRef>| -> Vec<(String, String)> {
+            let mut repl = ReplacementDefinition::new(ReplacementEvent::Moved)
+                .valid_card(TargetFilter::SelfRef)
+                .destination_zone(Zone::Battlefield);
+            if let Some(cref) = enters_under {
+                repl = repl.enters_under(cref);
+            }
+            let mut face = make_face();
+            face.replacements = vec![repl];
+            let items = build_parse_details_for_face(&face);
+            let repl_item = items
+                .iter()
+                .find(|i| i.category == ParseCategory::Replacement)
+                .expect("replacement item must be projected");
+            repl_item.details.clone()
+        };
+
+        let owner_controlled = details(None);
+        let opponent_redirected = details(Some(ControllerRef::Opponent));
+
+        assert_ne!(
+            owner_controlled, opponent_redirected,
+            "an enters_under controller override must produce a different replacement signature",
+        );
+        assert!(
+            opponent_redirected.iter().any(|(k, _)| k == "enters under"),
+            "a set enters_under must appear as an `enters under` detail row; got {opponent_redirected:?}",
+        );
+        assert!(
+            !owner_controlled.iter().any(|(k, _)| k == "enters under"),
+            "an absent enters_under must not appear, so unqualified signatures stay stable",
+        );
+
+        let mut token_repl = ReplacementDefinition::new(ReplacementEvent::CreateToken)
+            .token_owner_scope(ControllerRef::Opponent);
+        let mut token_face = make_face();
+        token_face.replacements = vec![token_repl.clone()];
+        let scoped = build_parse_details_for_face(&token_face)
+            .into_iter()
+            .find(|i| i.category == ParseCategory::Replacement)
+            .expect("replacement item must be projected")
+            .details;
+        token_repl.token_owner_scope = None;
+        token_face.replacements = vec![token_repl];
+        let unscoped_token = build_parse_details_for_face(&token_face)
+            .into_iter()
+            .find(|i| i.category == ParseCategory::Replacement)
+            .expect("replacement item must be projected")
+            .details;
+
+        assert!(
+            scoped.iter().any(|(k, _)| k == "token owner scope"),
+            "a set token_owner_scope must appear as a `token owner scope` detail row; got {scoped:?}",
+        );
+        assert!(
+            !unscoped_token.iter().any(|(k, _)| k == "token owner scope"),
+            "an absent token_owner_scope must not appear",
         );
     }
 

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -4266,6 +4266,63 @@ fn static_details(stat: &StaticDefinition) -> Vec<(String, String)> {
     d
 }
 
+/// Extract detail pairs from a `ReplacementDefinition` (non-effect fields).
+///
+/// Mirrors `trigger_details`/`static_details`: the replacement's scoping and
+/// modification fields must be projected into the parse signature so two
+/// replacements that differ only in *whom* or *what* they apply to produce
+/// distinct `ParsedItem`s. Without this, a scope-only fix (e.g. a self-scoped
+/// damage shield flipping `valid_card` from `None` to `Some(SelfRef)`) shows a
+/// false "no card-parse changes detected" diff.
+fn replacement_details(repl: &ReplacementDefinition) -> Vec<(String, String)> {
+    let mut d = Vec::new();
+    // Recipient scope — the field a shield-scoping fix changes.
+    if let Some(vc) = &repl.valid_card {
+        d.push(("scope".into(), fmt_target(vc)));
+    }
+    if let Some(vp) = &repl.valid_player {
+        d.push(("player scope".into(), format!("{vp:?}")));
+    }
+    // Mode discriminant (Mandatory / Optional / MayCost).
+    match &repl.mode {
+        ReplacementMode::Mandatory => {}
+        ReplacementMode::Optional { .. } => d.push(("mode".into(), "optional".into())),
+        ReplacementMode::MayCost { .. } => d.push(("mode".into(), "may pay cost".into())),
+    }
+    // Shield kind, including the prevented amount (ShieldKind::Prevention).
+    if !repl.shield_kind.is_none() {
+        d.push(("shield".into(), format!("{:?}", repl.shield_kind)));
+    }
+    if let Some(src) = &repl.damage_source_filter {
+        d.push(("damage from".into(), fmt_target(src)));
+    }
+    if let Some(tgt) = &repl.damage_target_filter {
+        d.push(("damage to".into(), format!("{tgt:?}")));
+    }
+    if let Some(scope) = &repl.combat_scope {
+        d.push(("combat".into(), format!("{scope:?}")));
+    }
+    if let Some(dm) = &repl.damage_modification {
+        d.push(("damage mod".into(), format!("{dm:?}")));
+    }
+    if let Some(qm) = &repl.quantity_modification {
+        d.push(("quantity mod".into(), format!("{qm:?}")));
+    }
+    if let Some(zone) = &repl.destination_zone {
+        d.push(("to zone".into(), fmt_zone(zone)));
+    }
+    if let Some(cond) = &repl.condition {
+        d.push(("condition".into(), format!("{cond:?}")));
+    }
+    if let Some(redirect) = &repl.redirect_target {
+        d.push(("redirect to".into(), fmt_target(redirect)));
+    }
+    if let Some(scope) = &repl.draw_scope {
+        d.push(("draw scope".into(), format!("{scope:?}")));
+    }
+    d
+}
+
 /// Extract a human-readable label for a keyword.
 fn keyword_label(kw: &Keyword) -> String {
     serde_json::to_value(kw)
@@ -4377,7 +4434,7 @@ pub fn build_parse_details(
             label: format!("{}", repl.event),
             source_text: repl.description.clone(),
             supported: execute_supported,
-            details: vec![],
+            details: replacement_details(repl),
             children,
         });
     }
@@ -10574,6 +10631,46 @@ mod tests {
                 .iter()
                 .any(|k| k == "damage_source_filter"),
             "an absent damage_source_filter must not appear",
+        );
+    }
+
+    #[test]
+    fn replacement_signature_exposes_valid_card_scope() {
+        // #5673: the replacement projection hardcoded `details: vec![]` and never
+        // projected `valid_card`, so a fix that changes *whom* a shield applies to
+        // (e.g. a self-scoped damage shield flipping `valid_card` from `None` to
+        // `Some(SelfRef)`, Swans of Bryn Argoll / #5652) produced a byte-identical
+        // parse signature — a false "No card-parse changes detected" sticky.
+        let details = |vc: Option<TargetFilter>| -> Vec<(String, String)> {
+            let mut repl = ReplacementDefinition::new(ReplacementEvent::DealtDamage);
+            if let Some(vc) = vc {
+                repl = repl.valid_card(vc);
+            }
+            let mut face = make_face();
+            face.replacements = vec![repl];
+            let items = build_parse_details_for_face(&face);
+            let repl_item = items
+                .iter()
+                .find(|i| i.category == ParseCategory::Replacement)
+                .expect("replacement item must be projected");
+            repl_item.details.clone()
+        };
+
+        let unscoped = details(None);
+        let self_scoped = details(Some(TargetFilter::SelfRef));
+
+        // The scoping fix must change the projected signature, not be swallowed.
+        assert_ne!(
+            unscoped, self_scoped,
+            "a valid_card scope change must produce a different replacement signature",
+        );
+        assert!(
+            self_scoped.iter().any(|(k, _)| k == "scope"),
+            "a set valid_card must appear as a `scope` detail row; got {self_scoped:?}",
+        );
+        assert!(
+            !unscoped.iter().any(|(k, _)| k == "scope"),
+            "an absent valid_card must not appear, so unqualified signatures stay stable",
         );
     }
 


### PR DESCRIPTION
The replacement projection in `build_parse_details` (`coverage.rs`) hardcoded `details: vec![]` and never projected `repl.valid_card`. So two `ReplacementDefinition`s differing only in scope — `valid_card: None` (fires for damage the object *deals* as well as damage dealt *to* it) versus `Some(TargetFilter::SelfRef)` (correctly self-scoped) — produced a **byte-identical** signature.

Any PR that fixes *whom* a replacement or prevention shield applies to therefore showed a false **"✓ No card-parse changes detected"** sticky — the false signature of an inert fix. This is the same class as the trigger/static/`FlipCoin` projection holes (#5492, #5495, #5501, #5507, #5585, #5634): projection is per-position and per-field, and the replacement position dropped it.

## Fix

Add `replacement_details()`, mirroring `trigger_details` / `static_details`, and wire it into the replacement `ParsedItem` in place of `vec![]`. It projects the discriminating scope/modification fields:

- `valid_card` (recipient scope — the field the shield-scoping fixes change) via the existing `fmt_target`
- `valid_player`, the `ReplacementMode` discriminant, and `shield_kind` (including `PreventionAmount`)
- `damage_source_filter` / `damage_target_filter` / `combat_scope`, `damage_modification` / `quantity_modification`, `destination_zone`, `condition`, `redirect_target`, `draw_scope`

Each field is emitted only when set, so an unqualified replacement keeps a byte-identical signature — only a genuine scoping/modification change moves it.

## Test

`replacement_signature_exposes_valid_card_scope` drives the production `build_parse_details_for_face` path: two replacements differing only in `valid_card` (`None` vs `Some(SelfRef)`) must now produce **different** `ParsedItem` signatures, the set scope must appear as a `scope` detail row, and the absent one must not (so unqualified signatures stay stable). Reverting the projection change fails it.

## Verification

Tilt was down locally, so ran cargo directly:

- `cargo test -p engine --lib game::coverage::` — **103 passed, 0 failed** (includes the new test)
- `cargo clippy -p engine --lib` — clean (`-D warnings`)
- `cargo fmt --all` — clean

No support-status or item counts change (details is purely additive), so coverage totals and the draw-replacement census are unaffected. Expected side effect: the parse-diff sticky on this PR will now show a `scope`/scope-field row added to every replacement card — that is the projection landing, not a regression.

Closes #5673
