### PR TITLE
fix(parser): map standalone + combat-damage activation-timing gates to enforced variants

### DIFF
--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -4476,4 +4476,67 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn parsed_combat_window_activation_gates_reach_production_enforcement() {
+        let check_window = |oracle: &str,
+                            expected: &[ActivationRestriction],
+                            legal_phase: Phase,
+                            illegal_phase: Phase| {
+            let parsed = crate::parser::oracle::parse_oracle_text(
+                oracle,
+                "Combat Window Test",
+                &[],
+                &["Artifact".to_string()],
+                &[],
+            );
+            let restrictions = &parsed.abilities[0].activation_restrictions;
+            assert_eq!(
+                restrictions, expected,
+                "parser must expose the enforced gate"
+            );
+
+            let mut state = crate::types::game_state::GameState::new_two_player(42);
+            let player = PlayerId(0);
+            state.active_player = player;
+            state.priority_player = player;
+            state.waiting_for = WaitingFor::Priority { player };
+
+            state.phase = legal_phase;
+            assert!(
+                check_activation_restrictions(&state, player, ObjectId(10), 0, restrictions)
+                    .is_ok(),
+                "activation must be legal in {legal_phase:?}"
+            );
+
+            state.phase = illegal_phase;
+            assert!(
+                check_activation_restrictions(&state, player, ObjectId(10), 0, restrictions)
+                    .is_err(),
+                "activation must be illegal in {illegal_phase:?}"
+            );
+        };
+
+        check_window(
+            "{T}: Draw a card. Activate only before attackers are declared.",
+            &[ActivationRestriction::BeforeAttackersDeclared],
+            Phase::BeginCombat,
+            Phase::DeclareAttackers,
+        );
+        check_window(
+            "{T}: Draw a card. Activate only before combat damage has been dealt.",
+            &[ActivationRestriction::BeforeCombatDamage],
+            Phase::DeclareBlockers,
+            Phase::CombatDamage,
+        );
+        check_window(
+            "{T}: Draw a card. Activate only during combat before combat damage has been dealt.",
+            &[
+                ActivationRestriction::DuringCombat,
+                ActivationRestriction::BeforeCombatDamage,
+            ],
+            Phase::DeclareBlockers,
+            Phase::CombatDamage,
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -6441,16 +6441,34 @@ fn parse_activation_during_role_gate(i: &str) -> OracleResult<'_, ActivationRest
     .parse(i)
 }
 
-/// CR 508.1 + CR 509.1: the combat-window half of a compound activation-timing
-/// gate — "before combat" / "before attackers are declared" both map to the
-/// EXISTING `BeforeAttackersDeclared` variant (enforced via
-/// `is_before_attackers_declared` = `PreCombatMain | BeginCombat`), so no new
-/// variant is introduced.
+/// CR 508.1 + CR 509.1 + CR 510: the combat-window half of an activation-timing
+/// gate. Each phrasing maps to an EXISTING enforced variant, so no new variant is
+/// introduced:
+/// - "before the combat damage step" / "before combat damage [has been dealt]"
+///   → `BeforeCombatDamage` (CR 510; enforced = `BeginCombat | DeclareAttackers
+///   | DeclareBlockers`) — Angus Mackenzie, Save Point.
+/// - "before attackers are declared" / "before combat" → `BeforeAttackersDeclared`
+///   (CR 508.1; enforced = `PreCombatMain | BeginCombat`) — Arcum's Whistle.
+///
+/// The combat-damage arm is tried BEFORE the `before combat` arm, which is a
+/// prefix of "before combat damage" and would otherwise shadow it; within that
+/// arm the longest phrasing is first so it consumes fully rather than leaving a
+/// "has been dealt" / "step" residual for the caller's whole-consumption check.
 fn parse_activation_before_window_gate(i: &str) -> OracleResult<'_, ActivationRestriction> {
-    value(
-        ActivationRestriction::BeforeAttackersDeclared,
-        alt((tag("before combat"), tag("before attackers are declared"))),
-    )
+    alt((
+        value(
+            ActivationRestriction::BeforeCombatDamage,
+            alt((
+                tag("before combat damage has been dealt"),
+                tag("before the combat damage step"),
+                tag("before combat damage"),
+            )),
+        ),
+        value(
+            ActivationRestriction::BeforeAttackersDeclared,
+            alt((tag("before attackers are declared"), tag("before combat"))),
+        ),
+    ))
     .parse(i)
 }
 
@@ -6480,6 +6498,32 @@ fn parse_activation_timing_restriction(phrase: &str) -> Option<Vec<ActivationRes
         if let Ok((tail, (_sep, window))) = compound {
             if tail.trim().is_empty() {
                 return Some(vec![restr, window]);
+            }
+        }
+    }
+    // CR 508.1: a STANDALONE combat-window gate with no "during <role>" first
+    // half — "Activate only before attackers are declared" / "before combat"
+    // (Arcum's Whistle, Arcum's Sleigh). Reuses the same enforced
+    // `BeforeAttackersDeclared` variant as the compound form above; it only fires
+    // when the whole phrase is a bare before-window that would otherwise fall
+    // through to `Effect::Unimplemented`.
+    if let Ok((tail, window)) = parse_activation_before_window_gate(lower.as_str()) {
+        if tail.trim().is_empty() {
+            return Some(vec![window]);
+        }
+    }
+    // CR 509.1 + CR 510: "during combat, before <window>" — the leading half is the
+    // combat phase itself (not a turn-role), so it pairs `DuringCombat` with the
+    // before-window gate. Save Point: "during combat before combat damage has been
+    // dealt" → [DuringCombat, BeforeCombatDamage]. Replaces the former verbatim
+    // strip_suffix special case; bare "during combat" (no trailing window) is left
+    // to its own single-restriction branch because `tag` requires the space.
+    if let Ok((rest, ())) =
+        value((), tag::<_, _, OracleError<'_>>("during combat ")).parse(lower.as_str())
+    {
+        if let Ok((tail, window)) = parse_activation_before_window_gate(rest) {
+            if tail.trim().is_empty() {
+                return Some(vec![ActivationRestriction::DuringCombat, window]);
             }
         }
     }
@@ -6771,32 +6815,14 @@ pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConst
             continue;
         }
 
-        // CR 602.5b + CR 102.1 + CR 509.1: The former verbatim-string hack for
-        // "activate only during your turn, before attackers are declared" is
-        // subsumed by the compound `parse_activation_timing_restriction` grammar,
-        // which the `activate only ` routing arm above reaches BEFORE this point
-        // (it emits `[DuringYourTurn, BeforeAttackersDeclared]` via the
-        // during-role + before-window sub-combinators). Pinned by Test 10c.
-
-        if let Some(prefix) =
-            lower.strip_suffix("activate only during combat before combat damage has been dealt")
-        {
-            let end = remaining.len()
-                - "activate only during combat before combat damage has been dealt".len();
-            remaining = remaining[..end]
-                .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
-                .to_string();
-            constraints
-                .restrictions
-                .push(ActivationRestriction::DuringCombat);
-            constraints
-                .restrictions
-                .push(ActivationRestriction::BeforeCombatDamage);
-            if prefix.trim().is_empty() {
-                break;
-            }
-            continue;
-        }
+        // CR 602.5b + CR 102.1 + CR 509.1 + CR 510: The former verbatim-string
+        // hacks for "activate only during your turn, before attackers are declared"
+        // and "activate only during combat before combat damage has been dealt" are
+        // both subsumed by the `parse_activation_timing_restriction` grammar, which
+        // the `activate only ` routing arm above reaches BEFORE this point (it emits
+        // `[DuringYourTurn, BeforeAttackersDeclared]` / `[DuringCombat,
+        // BeforeCombatDamage]` via the during-role + before-window sub-combinators).
+        // Pinned by Test 10c and the combat-damage building-block tests.
 
         if let Some(prefix) = lower.strip_suffix("activate only once each turn") {
             let end = remaining.len() - "activate only once each turn".len();

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -246,6 +246,65 @@ fn activated_ability_opponent_turn_restriction_uses_not_your_turn_condition() {
     );
 }
 
+/// CR 508.1: a STANDALONE combat-window activation gate — "Activate only before
+/// attackers are declared" / "Activate only before combat" (Arcum's Whistle,
+/// Arcum's Sleigh) with no "during <role>" first half — must map to the enforced
+/// `BeforeAttackersDeclared` variant instead of falling through to
+/// `Effect::Unimplemented`. The compound "during <role> … before combat" form
+/// already bound the window; this covers the bare-window class.
+#[test]
+fn standalone_before_attackers_activation_gate_maps_to_before_attackers_declared() {
+    for text in [
+        "{T}: Draw a card. Activate only before attackers are declared.",
+        "{T}: Draw a card. Activate only before combat.",
+    ] {
+        let r = parse(text, "Arcum's Whistle", &[], &["Artifact"], &[]);
+        assert_eq!(r.abilities.len(), 1, "got {:#?}", r.abilities);
+        let restrictions = &r.abilities[0].activation_restrictions;
+        assert!(
+            restrictions.contains(&ActivationRestriction::BeforeAttackersDeclared),
+            "{text:?} must yield BeforeAttackersDeclared, got {restrictions:?}"
+        );
+    }
+}
+
+/// CR 510: standalone "activate only before the combat damage step" / "before
+/// combat damage" (Angus Mackenzie) maps to the enforced `BeforeCombatDamage`
+/// variant, and the "during combat before combat damage has been dealt" compound
+/// (Save Point) yields `[DuringCombat, BeforeCombatDamage]` through the combinator
+/// grammar that replaced the former verbatim-string special case.
+#[test]
+fn combat_damage_window_activation_gate_maps_to_before_combat_damage() {
+    for text in [
+        "{T}: Draw a card. Activate only before the combat damage step.",
+        "{T}: Draw a card. Activate only before combat damage.",
+    ] {
+        let r = parse(text, "Angus Mackenzie", &[], &["Creature"], &[]);
+        assert_eq!(r.abilities.len(), 1, "got {:#?}", r.abilities);
+        let restrictions = &r.abilities[0].activation_restrictions;
+        assert!(
+            restrictions.contains(&ActivationRestriction::BeforeCombatDamage),
+            "{text:?} must yield BeforeCombatDamage, got {restrictions:?}"
+        );
+    }
+
+    let r = parse(
+        "{T}: Draw a card. Activate only during combat before combat damage has been dealt.",
+        "Save Point",
+        &[],
+        &["Enchantment"],
+        &[],
+    );
+    assert_eq!(r.abilities.len(), 1, "got {:#?}", r.abilities);
+    let restrictions = &r.abilities[0].activation_restrictions;
+    assert!(
+        restrictions.contains(&ActivationRestriction::DuringCombat)
+            && restrictions.contains(&ActivationRestriction::BeforeCombatDamage),
+        "'during combat before combat damage' must yield both DuringCombat and \
+         BeforeCombatDamage, got {restrictions:?}"
+    );
+}
+
 #[test]
 fn legacy_play_this_ability_as_sorcery_records_activation_restriction() {
     let r = parse(


### PR DESCRIPTION
A combat-window activation gate with no `during <role>` first half fell through to `Effect::Unimplemented`, dropping the ability's timing restriction entirely. This binds every such phrasing to an **existing** enforced `ActivationRestriction` via the shared `parse_activation_before_window_gate` combinator — no new enum variant, no new helper, pure building-block reuse:

| Oracle phrasing | Restriction | CR | Cards |
|---|---|---|---|
| "before attackers are declared" / "before combat" | `BeforeAttackersDeclared` | 508.1 | Arcum's Whistle, Arcum's Sleigh |
| "before combat damage has been dealt" / "before the combat damage step" / "before combat damage" | `BeforeCombatDamage` | 510 | Angus Mackenzie, Save Point |

### What changed
- The before-window combinator tries the **combat-damage arm before** the `before combat` arm (which is a prefix of `before combat damage` and would otherwise shadow it), longest phrasing first so it consumes fully.
- A new `during combat <window>` branch in `parse_activation_timing_restriction` pairs `DuringCombat` with the before-window gate (CR 509.1 + CR 510) → Save Point yields `[DuringCombat, BeforeCombatDamage]`.
- **Two verbatim-string `strip_suffix` hacks are deleted** ("during your turn, before attackers are declared" and "during combat before combat damage has been dealt") — both are now subsumed by the compound grammar, which the `activate only ` routing arm reaches before those strip points.

Each branch is guarded to fire only when the whole phrase is consumed; the `during your turn` and existing compound forms are untouched.

### Tests
Building-block coverage that the standalone and combat-damage phrasings map to their respective enforced variants. Full engine suite green locally: **16526 passed, 0 failed**.