### PR TITLE
fix(engine): run the base chain when a teamwork-instead swap doesn't fire

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -8043,43 +8043,28 @@ fn resolve_chain_body(
         if let Some(ref condition) = sub.condition {
             // CR 608.2c: "Instead" overrides are terminal — the Cow swap above either
             // replaced the parent's effect (condition met) or didn't (condition not met).
-            // For kicker/ninjutsu/keyword-instead, the base has no continuation chain.
-            // For ConditionInstead, the base chain (else_ability) must run when NOT swapped.
+            // When NOT swapped, the base chain (else_ability) runs after the parent's own
+            // effect. This is shared by EVERY "instead" condition kind — additional-cost /
+            // cast-variant / target-keyword gated overrides, and the general
+            // `ConditionInstead` wrapper — because the swap check above (~line 6444)
+            // already treats all four uniformly; the not-swap continuation must too.
+            // Issue #4772 (Too Evil to Stay Dead): "Choose target creature card … with
+            // mana value 4 or less. If this spell was cast using teamwork, instead choose
+            // target creature card in your graveyard. Return the chosen card to the
+            // battlefield." lowers to a base `TargetOnly` clause whose sub is the
+            // teamwork-gated override (`AdditionalCostPaidInstead`), whose own sub is the
+            // trailing `ChangeZone` (`SequentialSibling`, no `else_ability`). Before this
+            // fix, only the `ConditionInstead` arm below had the `sub.sub_ability`
+            // tail-runner fallback, so when teamwork was NOT paid the swap correctly did
+            // not fire but the trailing `ChangeZone` was silently dropped along with the
+            // consumed override node — the spell targeted a card and did nothing.
             if matches!(
                 condition,
                 AbilityCondition::AdditionalCostPaidInstead
                     | AbilityCondition::CastVariantPaidInstead { .. }
                     | AbilityCondition::TargetHasKeywordInstead { .. }
+                    | AbilityCondition::ConditionInstead { .. }
             ) {
-                if let Some(ref base_chain) = sub.else_ability {
-                    let mut resolved = base_chain.as_ref().clone();
-                    if resolved.targets.is_empty() && !ability.targets.is_empty() {
-                        resolved.targets = ability.targets.clone();
-                    }
-                    apply_parent_chain_context(
-                        &mut resolved,
-                        ability,
-                        effect_context_object.as_ref(),
-                        state,
-                    );
-                    if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                        debug_assert!(
-                            state.pending_continuation.is_none(),
-                            "pending_continuation overwritten before consumption — else_ability chain will be lost"
-                        );
-                        state.pending_continuation =
-                            Some(PendingContinuation::new(Box::new(resolved), state));
-                    } else {
-                        resolve_ability_chain(state, &resolved, events, depth + 1)?;
-                    }
-                }
-                return Ok(());
-            }
-            if matches!(condition, AbilityCondition::ConditionInstead { .. }) {
-                // CR 608.2c: Swap didn't fire (condition not met). The parent's own
-                // effect has already executed; now run the base continuation chain
-                // stored in else_ability (e.g., the "put into hand, then shuffle"
-                // that follows the base SearchLibrary).
                 if let Some(ref base_chain) = sub.else_ability {
                     let mut resolved = base_chain.as_ref().clone();
                     if resolved.targets.is_empty() && !ability.targets.is_empty() {
@@ -8113,14 +8098,14 @@ fn resolve_chain_body(
                     // (including the one-sided-fight source prepend at the swap block ~6844);
                     // mirror that delivery here for the not-swap branch so the tail is not
                     // silently dropped (Throw from the Saddle / Evil's Thrall / Take the
-                    // Fall / That's Rough Buddy). This `else if` fires only when
-                    // `else_ability` is None: a card carrying a distinct else-chain (From
-                    // Father to Son: else = ChangeZone→Hand, a DISTINCT node from its
-                    // Shuffle sibling) takes the else path above and never reaches here, so
-                    // there is no double-run. Such a card's trailing sibling is deliberately
-                    // not run in this branch (out of scope; the only corpus member is From
-                    // Father to Son, whose from-hand shuffle is supplied by SearchLibrary's
-                    // auto-shuffle).
+                    // Fall / That's Rough Buddy / Too Evil to Stay Dead — issue #4772). This
+                    // `else if` fires only when `else_ability` is None: a card carrying a
+                    // distinct else-chain (From Father to Son: else = ChangeZone→Hand, a
+                    // DISTINCT node from its Shuffle sibling) takes the else path above and
+                    // never reaches here, so there is no double-run. Such a card's trailing
+                    // sibling is deliberately not run in this branch (out of scope; the only
+                    // corpus member is From Father to Son, whose from-hand shuffle is
+                    // supplied by SearchLibrary's auto-shuffle).
                     // GUARDS: (1) `SequentialSibling` only — a `ContinuationStep` sub is part
                     // of the REPLACED clause and must NOT run when the swap didn't fire;
                     // (2) never run an `Unimplemented` tail — no speculative semantics

--- a/crates/engine/tests/integration/issue_4772_too_evil_to_stay_dead.rs
+++ b/crates/engine/tests/integration/issue_4772_too_evil_to_stay_dead.rs
@@ -1,0 +1,218 @@
+//! Issue #4772: Too Evil to Stay Dead did nothing when cast WITHOUT paying its
+//! Teamwork cost — it spent the mana, let the caster choose a target, and then
+//! never returned the creature card to the battlefield.
+//!
+//! Oracle text (verified against Scryfall, MSH):
+//!   "Teamwork 4 (As an additional cost to cast this spell, you may tap any
+//!   number of creatures you control with total power 4 or more.)
+//!   Choose target creature card in your graveyard with mana value 4 or less.
+//!   If this spell was cast using teamwork, instead choose target creature
+//!   card in your graveyard. Return the chosen card to the battlefield."
+//!
+//! Root cause: this lowers to a 3-node chain — a base `TargetOnly` clause (the
+//! narrow, mana-value-gated "choose target"), whose `sub_ability` is the
+//! teamwork-gated override (`AbilityCondition::AdditionalCostPaidInstead`, the
+//! broader "choose target" from `strip_additional_cost_conditional`), whose OWN
+//! `sub_ability` is the trailing `Effect::ChangeZone` (`SubAbilityLink::
+//! SequentialSibling`, no `else_ability`) that actually returns the card to the
+//! battlefield. `resolve_ability_chain` in `crates/engine/src/game/effects/mod.rs`
+//! correctly declines to swap the base's effect for the override's when Teamwork
+//! was NOT paid, but — before this fix — only its `ConditionInstead` arm had a
+//! fallback that walks into `sub.sub_ability` when `sub.else_ability` is `None`.
+//! The `AdditionalCostPaidInstead` / `CastVariantPaidInstead` /
+//! `TargetHasKeywordInstead` arm had no such fallback: it checked `else_ability`
+//! and then unconditionally returned, so the not-swapped branch silently dropped
+//! the `ChangeZone` reanimation effect. The fix merges the two arms so all four
+//! "instead" condition kinds share the same not-swap tail-runner (mirroring the
+//! existing `condition_instead_not_swap_tail_runner_honors_gates` coverage in
+//! `crates/engine/src/game/effects/mod.rs`).
+//!
+//! This test pins BOTH branches:
+//!   - WITHOUT teamwork: the mana-value-gated target is returned to the
+//!     battlefield (was previously a complete no-op — the bug).
+//!   - WITH teamwork: the broader (no mana-value restriction) target is
+//!     returned to the battlefield (already worked before this fix, kept here
+//!     as a differential control so a revert of either branch fails a test).
+
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, PayCostKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+
+const TOO_EVIL_TO_STAY_DEAD: &str = "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 4 or more.)\nChoose target creature card in your graveyard with mana value 4 or less. If this spell was cast using teamwork, instead choose target creature card in your graveyard. Return the chosen card to the battlefield.";
+
+/// Build a scenario with Too Evil to Stay Dead in P0's hand (cost {0} so the
+/// test doesn't need to model mana payment), a mana-value-3 creature card in
+/// P0's graveyard (a legal target under BOTH the narrow and broad filters),
+/// and (if `tapper_power` is `Some`) an eligible teamwork tap creature.
+fn setup(tapper_power: Option<i32>) -> (GameRunner, ObjectId, ObjectId, Option<ObjectId>) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let mut gy_creature = scenario.add_creature_to_graveyard(P0, "Fallen Champion", 3, 3);
+    gy_creature.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 3,
+    });
+    let gy_creature_id = gy_creature.id();
+
+    let tapper_id =
+        tapper_power.map(|power| scenario.add_creature(P0, "Tapper", power, power).id());
+
+    let mut builder = scenario.add_spell_to_hand_from_oracle(
+        P0,
+        "Too Evil to Stay Dead",
+        false,
+        TOO_EVIL_TO_STAY_DEAD,
+    );
+    builder.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 0,
+    });
+    let spell = builder.id();
+
+    let runner = scenario.build();
+    (runner, spell, gy_creature_id, tapper_id)
+}
+
+/// Cast `spell`, decline the optional Teamwork cost at the first opportunity,
+/// and choose `target` at the first target-selection window.
+fn drive_cast_declining_teamwork(runner: &mut GameRunner, target: ObjectId) {
+    for _ in 0..16 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalCostChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalCost { pay: false })
+                    .expect("declining teamwork must be accepted");
+            }
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(TargetRef::Object(target)),
+                    })
+                    .expect("choosing the target must be accepted");
+            }
+            WaitingFor::Priority { .. } => return,
+            _ => return,
+        }
+    }
+}
+
+/// Cast `spell`, ACCEPT the optional Teamwork cost, tap `tapper` to pay the
+/// aggregate power requirement, and choose `target` at the first
+/// target-selection window.
+fn drive_cast_paying_teamwork(runner: &mut GameRunner, tapper: ObjectId, target: ObjectId) {
+    for _ in 0..16 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalCostChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalCost { pay: true })
+                    .expect("paying teamwork must be accepted");
+            }
+            WaitingFor::PayCost {
+                kind: PayCostKind::TapCreatures { .. },
+                ..
+            } => {
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![tapper],
+                    })
+                    .expect("tapping the teamwork creature must be accepted");
+            }
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(TargetRef::Object(target)),
+                    })
+                    .expect("choosing the target must be accepted");
+            }
+            WaitingFor::Priority { .. } => return,
+            _ => return,
+        }
+    }
+}
+
+/// Resolve the stack to empty by passing priority.
+fn resolve_stack(runner: &mut GameRunner) {
+    for _ in 0..40 {
+        if runner.state().stack.is_empty() {
+            break;
+        }
+        if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+    }
+}
+
+/// Regression for issue #4772: WITHOUT paying Teamwork, the targeted graveyard
+/// creature must still be returned to the battlefield. Before the fix, the
+/// `ChangeZone` step was silently dropped and the creature stayed in the
+/// graveyard — the spell "spent the mana with no effect".
+#[test]
+fn too_evil_to_stay_dead_without_teamwork_still_reanimates() {
+    let (mut runner, spell, gy_creature, _tapper) = setup(None);
+    let card_id = runner.state().objects[&spell].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting Too Evil to Stay Dead must be accepted");
+
+    drive_cast_declining_teamwork(&mut runner, gy_creature);
+    resolve_stack(&mut runner);
+
+    assert!(
+        runner.state().battlefield.contains(&gy_creature),
+        "WITHOUT teamwork, the targeted graveyard creature must be returned to \
+         the battlefield — this is the exact issue #4772 symptom (spell resolved, \
+         mana was spent, but nothing happened)"
+    );
+    assert!(
+        !runner.state().players[0].graveyard.contains(&gy_creature),
+        "the reanimated creature must have left the graveyard"
+    );
+}
+
+/// Differential control: WITH Teamwork paid, the broader (no mana-value
+/// restriction) target is chosen and still returned to the battlefield. This
+/// branch already worked before the fix (the Cow-swap correctly adopts the
+/// override's own `sub_ability` as its continuation); it is pinned here
+/// alongside the without-teamwork case so a revert of either the swap path or
+/// the new not-swap tail-runner is caught.
+#[test]
+fn too_evil_to_stay_dead_with_teamwork_still_reanimates() {
+    let (mut runner, spell, gy_creature, tapper) = setup(Some(4));
+    let tapper = tapper.expect("tapper requested");
+    let card_id = runner.state().objects[&spell].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting Too Evil to Stay Dead must be accepted");
+
+    drive_cast_paying_teamwork(&mut runner, tapper, gy_creature);
+    resolve_stack(&mut runner);
+
+    assert!(
+        runner.state().objects[&tapper].tapped,
+        "the teamwork tap creature must be tapped"
+    );
+    assert!(
+        runner.state().battlefield.contains(&gy_creature),
+        "WITH teamwork, the targeted graveyard creature must be returned to the battlefield"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -445,6 +445,7 @@ mod issue_4564_captain_america_team_leader;
 mod issue_4566_jocasta;
 mod issue_4663_chosen_x_ptcomparison_targets;
 mod issue_4752_blood_artist_each_player_sacrifice;
+mod issue_4772_too_evil_to_stay_dead;
 mod issue_4786_wrenn_realmbreaker;
 mod issue_4792_isochron_scepter;
 mod issue_4824_light_paws_aura_attach;


### PR DESCRIPTION
## Summary

Fixes #4772. Too Evil to Stay Dead ("Choose target creature card in your graveyard with
mana value 4 or less. If this spell was cast using teamwork, instead choose target creature
card in your graveyard. Return the chosen card to the battlefield.") silently did nothing
when cast **without** paying the optional Teamwork additional cost — mana was spent, the
spell resolved, but the targeted creature never returned to the battlefield.

## Root cause

The not-swapped path for three of the four "instead" condition kinds
(`AdditionalCostPaidInstead`, `CastVariantPaidInstead`, `TargetHasKeywordInstead`) only ever
checked `sub.else_ability`, returning early when it was `None` — silently dropping
`sub.sub_ability` (here, the trailing `ChangeZone` that returns the card to the battlefield)
entirely. The sibling `ConditionInstead` arm already had the correct
`sub.sub_ability` tail-runner fallback (added for Throw from the Saddle / Evil's Thrall /
Take the Fall / That's Rough Buddy) — this merges all four condition kinds onto that single,
already-tested path, since the swap-decision check just above already evaluates all four
uniformly.

## Anchored on

- `crates/engine/src/game/effects/mod.rs:7830-7921` (pre-fix) — the `ConditionInstead`
  not-swap tail-runner this change generalizes, with its own existing regression coverage
  (`condition_instead_not_swap_tail_runner_honors_gates`,
  `condition_instead_runs_base_chain_when_not_met`).
- `crates/engine/src/game/effects/mod.rs:6444-6473` — the swap-decision block, which already
  evaluates `AdditionalCostPaidInstead`/`CastVariantPaidInstead`/`TargetHasKeywordInstead`/
  `ConditionInstead` symmetrically, establishing that the not-swap path should be symmetric
  too.

## Testing

Added `crates/engine/tests/integration/issue_4772_too_evil_to_stay_dead.rs`:
- `too_evil_to_stay_dead_without_teamwork_still_reanimates` — the actual regression (fails
  on pre-fix code with the exact reported symptom).
- `too_evil_to_stay_dead_with_teamwork_still_reanimates` — differential control, confirms
  the already-working swap path doesn't regress.

Verified the new test is load-bearing by reverting just the `effects/mod.rs` change and
re-running — it fails with the exact issue #4772 symptom, then passes again with the fix
restored. Both tests pass on a clean, isolated `cargo test -p engine --test integration
issue_4772` run (not relying on any shared/incremental build cache).

```
running 2 tests
test issue_4772_too_evil_to_stay_dead::too_evil_to_stay_dead_without_teamwork_still_reanimates ... ok
test issue_4772_too_evil_to_stay_dead::too_evil_to_stay_dead_with_teamwork_still_reanimates ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 3051 filtered out
```

`cargo fmt --all` run, no diff beyond the change above.

## Validation Failures (honesty disclosure, per docs/AI-CONTRIBUTOR.md)

This was implemented and verified by a Claude Code agent (diagnosis via real code reading
+ empirical test-driven verification, minimal fix reusing an existing tested code path,
regression test proven load-bearing by revert/restore, `cargo fmt` clean), but **not**
through the formal `/engine-implementer` multi-agent plan → review-plan → implement →
review-impl pipeline — that skill wasn't available in the environment this was built in.
No `Gate A` combinator-purity script output or discriminating-test coverage map /
maintainer-simulation matrix is included. Flagging this plainly rather than claiming a
review loop that didn't run.

Model: claude-sonnet-5
Tier: Standard
