### PR TITLE
fix(parser): bind "cast a spell from among those cards" to the revealed hand

### DIFF
--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -9,6 +9,23 @@ use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaCost;
 use crate::types::zones::Zone;
 
+/// CR 400.1/400.2: Recursively extract a filter's own `controller` axis,
+/// looking through the composed forms (`Not`/`And`/`Or`) a real card's target
+/// filter may be built from rather than only matching a bare `Typed`. `And`/
+/// `Or` return the first branch that carries a controller axis — composed
+/// filters in this codebase don't mix two different explicit player axes on
+/// the same object filter, so first-found is unambiguous.
+fn extract_controller_ref(filter: &TargetFilter) -> Option<&crate::types::ability::ControllerRef> {
+    match filter {
+        TargetFilter::Typed(tf) => tf.controller.as_ref(),
+        TargetFilter::Not { filter } => extract_controller_ref(filter),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().find_map(extract_controller_ref)
+        }
+        _ => None,
+    }
+}
+
 /// CR 115.1 + CR 601.2c: "You may cast a spell ... from your hand without paying
 /// its mana cost" (Electrodominance, Baral's Expertise) has no "target" word —
 /// the spell is chosen at resolution from the granting player's hand via
@@ -29,23 +46,21 @@ fn open_private_zone_cast_selection(
     // `ControllerRef::TriggeringPlayer`, issue #5240) needs a DIFFERENT
     // player's hand as the pool — `ability.controller` alone can't express
     // that, so resolve the filter's own controller axis through the single
-    // `ControllerRef` authority instead of hardcoding the caster.
-    let hand_owner = match target_filter {
-        TargetFilter::Typed(tf) => tf
-            .controller
-            .as_ref()
-            .and_then(|cref| {
-                crate::game::filter::controller_ref_player(
-                    state,
-                    ability.source_id,
-                    Some(ability.controller),
-                    Some(ability),
-                    cref,
-                )
-            })
-            .unwrap_or(ability.controller),
-        _ => ability.controller,
-    };
+    // `ControllerRef` authority instead of hardcoding the caster. Recurses
+    // through `Not`/`And`/`Or` (extract_controller_ref) so a composed filter
+    // (e.g. a future card combining a type restriction with a player axis via
+    // `And`) isn't silently treated as caster-scoped.
+    let hand_owner = extract_controller_ref(target_filter)
+        .and_then(|cref| {
+            crate::game::filter::controller_ref_player(
+                state,
+                ability.source_id,
+                Some(ability.controller),
+                Some(ability),
+                cref,
+            )
+        })
+        .unwrap_or(ability.controller);
     let Some(player) = state.players.iter().find(|p| p.id == hand_owner) else {
         return Err(EffectError::PlayerNotFound);
     };

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -21,7 +21,32 @@ fn open_private_zone_cast_selection(
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
     let ctx = crate::game::filter::FilterContext::from_ability(ability);
-    let Some(player) = state.players.iter().find(|p| p.id == ability.controller) else {
+    // CR 400.1/400.2 + CR 109.4: A hand-scoped cast filter's own `controller`
+    // axis names WHOSE hand is the candidate pool. Buster-Sword-class filters
+    // ("cast a spell from your hand") carry no controller (or `You`) and keep
+    // scanning the caster's own hand. Silent-Blade Oni's "cast a spell from
+    // among those cards" (bound to the damaged player's hand via
+    // `ControllerRef::TriggeringPlayer`, issue #5240) needs a DIFFERENT
+    // player's hand as the pool — `ability.controller` alone can't express
+    // that, so resolve the filter's own controller axis through the single
+    // `ControllerRef` authority instead of hardcoding the caster.
+    let hand_owner = match target_filter {
+        TargetFilter::Typed(tf) => tf
+            .controller
+            .as_ref()
+            .and_then(|cref| {
+                crate::game::filter::controller_ref_player(
+                    state,
+                    ability.source_id,
+                    Some(ability.controller),
+                    Some(ability),
+                    cref,
+                )
+            })
+            .unwrap_or(ability.controller),
+        _ => ability.controller,
+    };
+    let Some(player) = state.players.iter().find(|p| p.id == hand_owner) else {
         return Err(EffectError::PlayerNotFound);
     };
     let cards_iter = match source_zone {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -19947,9 +19947,59 @@ fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
             mana_spend_permission: None,
         });
     }
+    // CR 400.1/400.2 + CR 608.2c: The bare "them"/"those cards" anaphor is
+    // ambiguous — it usually refers to an exile the chain produced
+    // (ExiledBySource), but when no exile ever occurred and the SAME chain's
+    // most recent producer merely looked at/revealed a PLAYER'S HAND
+    // (Silent-Blade Oni: "look at that player's hand. You may cast a spell
+    // from among those cards without paying its mana cost."), the cards
+    // never left that hand. Binding to `ExiledBySource` there resolves
+    // against an empty tracked-exile set and silently swallows the cast
+    // permission (issue #5240) — no prompt is ever offered. Bind to that
+    // player's hand instead, mirroring Branch 2's own "cast a spell from
+    // your hand" shape (`TypedFilter::new(Card).controller(..)` + `InZone{Hand}`)
+    // with the revealed player's `ControllerRef` swapped in for `You`.
+    // "...exiled cards" phrasings are unambiguous (the antecedent noun is
+    // explicitly "exiled") and always keep the `ExiledBySource` binding.
     if scan_contains_phrase(rest, "from among them")
         || scan_contains_phrase(rest, "from among those cards")
-        || scan_contains_phrase(rest, "from among those exiled cards")
+    {
+        if !ctx.chain_has_prior_exile_producer {
+            if let Some(controller) = ctx
+                .chain_prior_hand_reveal_target
+                .as_ref()
+                .and_then(hand_reveal_target_to_controller_ref)
+            {
+                let mut hand_filter = TypedFilter::new(TypeFilter::Card).controller(controller);
+                hand_filter
+                    .properties
+                    .push(FilterProp::InZone { zone: Zone::Hand });
+                return Some(Effect::CastFromZone {
+                    target: TargetFilter::Typed(hand_filter),
+                    without_paying_mana_cost: without_paying,
+                    mode,
+                    cast_transformed: false,
+                    alt_ability_cost: None,
+                    constraint,
+                    duration: None,
+                    driver: crate::types::ability::CastFromZoneDriver::LingeringPermission,
+                    mana_spend_permission: None,
+                });
+            }
+        }
+        return Some(Effect::CastFromZone {
+            target: TargetFilter::ExiledBySource,
+            without_paying_mana_cost: without_paying,
+            mode,
+            cast_transformed: false,
+            alt_ability_cost: None,
+            constraint,
+            duration: None,
+            driver: crate::types::ability::CastFromZoneDriver::LingeringPermission,
+            mana_spend_permission: None,
+        });
+    }
+    if scan_contains_phrase(rest, "from among those exiled cards")
         || scan_contains_phrase(rest, "from among the exiled cards")
     {
         return Some(Effect::CastFromZone {
@@ -21957,6 +22007,36 @@ fn clause_ir_is_exile_producer(clause: &ClauseIr) -> bool {
     chain_clause_is_exile_producer(&clause.parsed.effect)
         || continuation_is_exile_producer(clause.disposition.followup())
         || continuation_is_exile_producer(clause.disposition.intrinsic())
+}
+
+/// CR 400.1/400.2 + CR 608.2c: If this clause is an `Effect::RevealHand`
+/// ("look at"/"reveal" a possessive hand), return the player it looked at.
+/// Feeds `ParseContext::chain_prior_hand_reveal_target` so a later same-chain
+/// "cast a spell from among those cards" anaphor (Silent-Blade Oni) can bind
+/// to that player's hand instead of the exile-only `ExiledBySource` default.
+fn clause_ir_hand_reveal_target(clause: &ClauseIr) -> Option<TargetFilter> {
+    match &clause.parsed.effect {
+        Effect::RevealHand { target, .. } => Some(target.clone()),
+        _ => None,
+    }
+}
+
+/// CR 400.1/400.2 + CR 601.2a: Map a possessive-hand player reference (as
+/// produced by `parse_hand_possessive_target`) to the `ControllerRef` axis
+/// used to scope a card filter to that same player's hand. Exhaustive over
+/// the closed set of forms `parse_hand_possessive_target` can produce — a
+/// bounded translation table, not per-card special-casing.
+fn hand_reveal_target_to_controller_ref(target: &TargetFilter) -> Option<ControllerRef> {
+    match target {
+        TargetFilter::Controller => Some(ControllerRef::You),
+        TargetFilter::Player => Some(ControllerRef::TargetPlayer),
+        TargetFilter::TriggeringPlayer => Some(ControllerRef::TriggeringPlayer),
+        TargetFilter::DefendingPlayer => Some(ControllerRef::DefendingPlayer),
+        TargetFilter::Typed(tf) if tf.controller == Some(ControllerRef::Opponent) => {
+            Some(ControllerRef::Opponent)
+        }
+        _ => None,
+    }
 }
 
 fn publishes_tracked_set_from_resolution(effect: &Effect) -> bool {
@@ -26793,6 +26873,15 @@ pub(crate) fn parse_effect_chain_ir(
                 .clauses()
                 .iter()
                 .any(clause_ir_is_exile_producer),
+            // CR 400.1/400.2 + CR 608.2c: most-recent earlier same-chain
+            // `RevealHand` target, so a later "cast a spell from among those
+            // cards" anaphor (Silent-Blade Oni) binds to that player's hand
+            // instead of the exile-only `ExiledBySource` default.
+            chain_prior_hand_reveal_target: builder
+                .clauses()
+                .iter()
+                .rev()
+                .find_map(clause_ir_hand_reveal_target),
             // CR 608.2c: bind a bare "it" in this chunk's counter/anaphor to the
             // token created by an earlier clause when that token is the chain's
             // most-recent object referent (Esper Terra's "put up to three lore

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -236,6 +236,19 @@ pub(crate) struct ParseContext {
     /// top-level morph reminder/special-action text). Set by
     /// `parse_quoted_ability`; defaults to `false` everywhere else.
     pub in_granted_activated_ability: bool,
+    /// CR 400.1/400.2 + CR 601.2a + CR 608.2c: The player-referencing target of
+    /// an EARLIER same-chain `Effect::RevealHand` clause ("look at that
+    /// player's hand" / "reveal their hand"), e.g. `TriggeringPlayer`. When a
+    /// LATER clause in the SAME chain references "them"/"those cards" in a
+    /// cast-permission clause (Silent-Blade Oni: "You may cast a spell from
+    /// among those cards without paying its mana cost"), the anaphor binds to
+    /// THIS revealed player's hand instead of the exile-only
+    /// `TargetFilter::ExiledBySource` default — no exile ever happened, so
+    /// `ExiledBySource` would resolve to an empty set and silently swallow the
+    /// cast permission. Mirrors `chain_has_prior_exile_producer`'s same-chain
+    /// scan, but for the hand-reveal producer shape. `None` when no such
+    /// producer exists in this chain, or during standalone clause parsing.
+    pub chain_prior_hand_reveal_target: Option<TargetFilter>,
 }
 
 impl ParseContext {

--- a/crates/engine/tests/integration/issue_5240_silent_blade_oni.rs
+++ b/crates/engine/tests/integration/issue_5240_silent_blade_oni.rs
@@ -1,0 +1,239 @@
+//! Regression for issue #5240: Silent-Blade Oni gives no prompt to choose or
+//! cast a spell after dealing combat damage to a player.
+//!
+//! https://github.com/phase-rs/phase/issues/5240
+//!
+//! Oracle text (Scryfall-verified):
+//!   Ninjutsu {4}{U}{B} ({4}{U}{B}, Return an unblocked attacker you control
+//!   to hand: Put this card onto the battlefield from your hand tapped and
+//!   attacking.)
+//!   Whenever this creature deals combat damage to a player, look at that
+//!   player's hand. You may cast a spell from among those cards without
+//!   paying its mana cost.
+//!
+//! Root cause: the trigger parses correctly into `RevealHand { target:
+//! TriggeringPlayer, reveal: false }` (the private "look at that player's
+//! hand" clause) followed by a `CastFromZone` sub-ability for "cast a spell
+//! from among those cards ... without paying its mana cost." But
+//! `try_parse_cast_effect`'s "from among them"/"from among those cards" arm
+//! unconditionally bound the cast target to `TargetFilter::ExiledBySource` —
+//! correct for the exile-then-cast class (Improvisation Capstone, Etali) this
+//! anaphor was originally built for, but wrong here: Silent-Blade Oni never
+//! exiles anything, so at runtime `ExiledBySource` resolves against an empty
+//! tracked-exile set and the cast permission silently offers nothing — no
+//! prompt is ever raised, matching the reported bug exactly.
+//!
+//! The fix threads a same-chain "prior RevealHand producer" signal
+//! (`ParseContext::chain_prior_hand_reveal_target`, mirroring the existing
+//! `chain_has_prior_exile_producer` precedent for the singular "the exiled
+//! card" anaphor) so the plural anaphor binds to the REVEALED PLAYER'S HAND
+//! instead when no exile occurred in the chain. The runtime hand-cast
+//! resolver (`open_private_zone_cast_selection` in
+//! `game/effects/cast_from_zone.rs`) previously also hardcoded the ability's
+//! OWN controller as the hand to scan; it now resolves the candidate hand via
+//! the cast filter's own `ControllerRef` (here `TriggeringPlayer`, the
+//! damaged player) through the single `controller_ref_player` authority.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{ControllerRef, Effect, FilterProp, TargetFilter, TypeFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+use super::rules::run_combat;
+
+const SILENT_BLADE_ONI_ORACLE: &str = "Ninjutsu {4}{U}{B} ({4}{U}{B}, Return an unblocked \
+attacker you control to hand: Put this card onto the battlefield from your hand tapped and \
+attacking.)\nWhenever this creature deals combat damage to a player, look at that player's \
+hand. You may cast a spell from among those cards without paying its mana cost.";
+
+/// CR 603.2 + CR 701.20a + CR 118.9: the DamageDone trigger's execute chain
+/// must be `RevealHand { TriggeringPlayer, reveal: false }` followed by a
+/// `CastFromZone` sub-ability whose target is the DAMAGED PLAYER'S hand (a
+/// `Typed` filter: `Card` + `controller: TriggeringPlayer` + `InZone(Hand)`),
+/// not `TargetFilter::ExiledBySource`. This is the direct root-cause
+/// assertion: before the fix, `target` here was `ExiledBySource`, which
+/// resolves to an empty set because Silent-Blade Oni never exiles anything.
+#[test]
+fn silent_blade_oni_parses_hand_scoped_free_cast() {
+    let parsed = parse_oracle_text(
+        SILENT_BLADE_ONI_ORACLE,
+        "Silent-Blade Oni",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Ninja".to_string()],
+    );
+
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::DamageDone)
+        .expect("Silent-Blade Oni must parse a combat-damage-to-player trigger");
+    assert_eq!(
+        trigger.valid_target,
+        Some(TargetFilter::Player),
+        "trigger must fire on damage dealt to a player"
+    );
+
+    let execute = trigger
+        .execute
+        .as_ref()
+        .expect("DamageDone trigger must have an execute chain");
+    assert!(
+        matches!(
+            execute.effect.as_ref(),
+            Effect::RevealHand {
+                target: TargetFilter::TriggeringPlayer,
+                reveal: false,
+                ..
+            }
+        ),
+        "expected a private look at the damaged player's hand, got {:?}",
+        execute.effect
+    );
+
+    let cast_sub = execute
+        .sub_ability
+        .as_ref()
+        .expect("RevealHand must be followed by the free-cast sub-ability");
+    let Effect::CastFromZone {
+        target,
+        without_paying_mana_cost: true,
+        ..
+    } = cast_sub.effect.as_ref()
+    else {
+        panic!(
+            "expected a without-paying CastFromZone sub-ability, got {:?}",
+            cast_sub.effect
+        );
+    };
+    let TargetFilter::Typed(tf) = target else {
+        panic!(
+            "expected the cast target to be a Typed hand filter, got {target:?} \
+             (ExiledBySource here is the issue #5240 regression: nothing was ever exiled)"
+        );
+    };
+    assert_eq!(tf.type_filters, vec![TypeFilter::Card]);
+    assert_eq!(tf.controller, Some(ControllerRef::TriggeringPlayer));
+    assert!(
+        tf.properties
+            .contains(&FilterProp::InZone { zone: Zone::Hand }),
+        "cast pool must be scoped to the Hand zone, got {:?}",
+        tf.properties
+    );
+}
+
+/// Full end-to-end discriminator: Silent-Blade Oni connects with combat
+/// damage, the controller accepts the "you may cast" prompt, and the
+/// resulting `EffectZoneChoice` offers cards from the DEFENDING player's hand
+/// (not an empty exile set). Selecting one casts it onto the stack for the
+/// Oni's controller without paying its mana cost.
+#[test]
+fn silent_blade_oni_offers_free_cast_from_damaged_players_hand() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let oni = scenario
+        .add_creature(P0, "Silent-Blade Oni", 3, 2)
+        .with_subtypes(vec!["Human", "Ninja"])
+        .from_oracle_text(SILENT_BLADE_ONI_ORACLE)
+        .id();
+
+    // P1 (the player who will take combat damage) has a nonland card in hand
+    // that P0 should be offered to cast for free.
+    let opp_spell = scenario.add_creature_to_hand(P1, "Opp Creature", 2, 2).id();
+
+    let mut runner = scenario.build();
+    let p1_life_before = runner.life(P1);
+
+    run_combat(&mut runner, vec![oni], vec![]);
+
+    assert_eq!(
+        runner.life(P1),
+        p1_life_before - 3,
+        "unblocked Oni must deal 3 combat damage to P1"
+    );
+
+    // Drain priority passes until the "you may cast" prompt surfaces. The
+    // private RevealHand look is non-interactive and resolves silently; the
+    // optional CastFromZone sub-ability is what raises a prompt.
+    let mut reached_optional = false;
+    for _ in 0..40 {
+        match runner.state().waiting_for {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                reached_optional = true;
+                break;
+            }
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("PassPriority should succeed while draining the stack");
+            }
+            ref other => panic!("unexpected waiting state while draining: {other:?}"),
+        }
+    }
+    assert!(
+        reached_optional,
+        "expected the 'you may cast a spell' prompt to appear; waiting_for={:?}",
+        runner.state().waiting_for
+    );
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { player: p, .. } if p == P0
+        ),
+        "the Oni's controller (P0), not the damaged player, decides whether to cast"
+    );
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept the may-cast sub-ability");
+
+    let waiting = runner.state().waiting_for.clone();
+    let WaitingFor::EffectZoneChoice {
+        cards,
+        zone,
+        player,
+        ..
+    } = waiting
+    else {
+        panic!(
+            "expected EffectZoneChoice after accepting the free-cast offer — before the fix this \
+             prompt never appeared because the cast target resolved against an empty \
+             ExiledBySource set; got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(
+        zone,
+        Zone::Hand,
+        "the free-cast pool must be drawn from a hand, not exile"
+    );
+    assert_eq!(player, P0, "P0 (the Oni's controller) makes the choice");
+    assert!(
+        cards.contains(&opp_spell),
+        "P1's hand card must be offered as a free-cast candidate; eligible={cards:?}"
+    );
+
+    let p0_mana_before = runner.state().players[0].mana_pool.total();
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![opp_spell],
+        })
+        .expect("select the opponent's card to cast for free");
+
+    assert_eq!(
+        runner.state().objects[&opp_spell].zone,
+        Zone::Stack,
+        "the selected card must be cast onto the stack"
+    );
+    assert_eq!(
+        runner.state().players[0].mana_pool.total(),
+        p0_mana_before,
+        "the cast must be free — no mana spent"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -456,6 +456,7 @@ mod issue_4962_volo_guide_to_monsters;
 mod issue_4999_treasure_cruise_delve_tokens;
 mod issue_5145_violent_eruption_choose_target_distribution;
 mod issue_5159_attacks_alone_investigate;
+mod issue_5240_silent_blade_oni;
 mod issue_5247_kinetic_ooze_conditional_multi_target;
 mod issue_5252_additional_sacrifice_after_mana_abilities;
 mod issue_5254_declaration_in_stone_clue_owner;


### PR DESCRIPTION
## Summary

Fixes #5240. Silent-Blade Oni ("Whenever this creature deals combat damage to a player,
look at that player's hand. You may cast a spell from among those cards without paying its
mana cost.") never offered a prompt to cast anything after the damage trigger resolved.

## Root cause

Two-part bug in the `"them"`/`"those cards"` anaphor resolution:

1. **Parser** (`try_parse_cast_effect`): the `"from among them"`/`"from among those
   cards"` match arm unconditionally bound the cast target to
   `TargetFilter::ExiledBySource`. That's correct for the exile-then-cast idiom (Key to the
   Vault, Etali) but Silent-Blade Oni's ability chain is `RevealHand{TriggeringPlayer,
   reveal:false} → CastFromZone` — nothing is ever exiled. At runtime, `ExiledBySource`
   resolves against an empty tracked-exile set, so the "may cast" permission silently
   offered zero candidates and no prompt was ever raised.
2. **Runtime** (`open_private_zone_cast_selection`): even with a correctly hand-scoped
   filter, the resolver hardcoded `ability.controller` as the hand to scan — it had no way
   to target a *different* player's hand (the damaged player's, not the Oni's controller's).

## Fix

Track the most recent same-chain `RevealHand` producer's target
(`chain_prior_hand_reveal_target`, mirroring the existing `chain_has_prior_exile_producer`
scan), bind the `"them"`/`"those cards"` anaphor to that player's hand when no exile
producer exists earlier in the chain, and resolve the cast-from-zone hand owner through the
filter's own `ControllerRef` axis instead of always assuming the caster.

## Anchored on

- `crates/engine/tests/integration/issue_2348_key_to_the_vault.rs` — the exile-then-cast
  idiom this fix's `ExiledBySource` fallback path continues to serve unchanged when a real
  exile producer exists in the chain.
- `crates/engine/src/parser/oracle_effect/mod.rs` (`chain_has_prior_exile_producer` scan) +
  `crates/engine/src/parser/oracle_ir/context.rs` — the existing same-chain-producer-scan
  pattern already used for the singular "the exiled card" anaphor, directly mirrored here
  for the plural "them"/"those cards" anaphor against a `RevealHand` producer instead of an
  exile producer.

## Testing

Added `crates/engine/tests/integration/issue_5240_silent_blade_oni.rs`:
- `silent_blade_oni_parses_hand_scoped_free_cast` — asserts the parsed chain is
  `RevealHand{TriggeringPlayer} → CastFromZone{Typed(Card, controller: TriggeringPlayer,
  InZone(Hand))}` (pre-fix: `target` was `ExiledBySource`).
- `silent_blade_oni_offers_free_cast_from_damaged_players_hand` — full end-to-end: real
  combat, real `WaitingFor::OptionalEffectChoice` → `WaitingFor::EffectZoneChoice{zone:
  Hand, player: <damaged player>}` prompt flow, card moves to the stack with no mana spent.

Both pass on a clean, isolated `cargo test -p engine --test integration issue_5240` run:

```
running 2 tests
test issue_5240_silent_blade_oni::silent_blade_oni_parses_hand_scoped_free_cast ... ok
test issue_5240_silent_blade_oni::silent_blade_oni_offers_free_cast_from_damaged_players_hand ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 3051 filtered out
```

Also ran the two anchor tests plus 15 other tests touching the same `try_parse_cast_effect`
"from among them/those cards" branch (Etali, Key to the Vault, Sanwell, Fertile Thicket,
Lead the Stampede, Birthing Ritual variants, etc.) — all 73 tests in that batch passed,
confirming the shared-branch change doesn't regress the pre-existing exile-then-cast idiom.
`cargo fmt --all` clean.

## Validation Failures (honesty disclosure, per docs/AI-CONTRIBUTOR.md)

Implemented and verified by a Claude Code agent (real diagnosis via reading + exercising
the parser/runtime, minimal fix following an established in-codebase precedent, unit +
end-to-end test coverage, 73-test regression sample, `cargo fmt` clean), but **not**
through the formal `/engine-implementer` multi-agent plan → review-plan → implement →
review-impl pipeline — that skill wasn't available in the environment this was built in.
No `Gate A` combinator-purity script output or discriminating-test coverage map /
maintainer-simulation matrix is included. Flagging this plainly rather than claiming a
review loop that didn't run.

Model: claude-sonnet-5
Tier: Standard
