### PR TITLE
docs(skills): bring contributor-facing skills up to the merged campaign invariants

### DIFF
--- a/.claude/skills/add-engine-effect/SKILL.md
+++ b/.claude/skills/add-engine-effect/SKILL.md
@@ -74,6 +74,9 @@ When you build a helper like this, you're not adding complexity — you're **red
 - [ ] **`crates/engine/src/types/ability.rs` — `EffectKind` enum + `From<&Effect>`**
   Add an `EffectKind` variant and the corresponding `From<&Effect>` match arm. `EffectKind` is used for effect categorization and coverage tracking.
 
+- [ ] **Does the effect carry an amount that can be X?** Use a `QuantityExpr` field — never a bare `i32` you resolve yourself.
+  X is **locked at announcement** (CR 601.2b / CR 602.2b), not at resolution: CR 107.3c lets the value drift while the object is on the stack, so re-measuring X in a resolver reads a different, legal board and silently produces a wrong number. `publish_announced_x()` (`game/ability_utils.rs`) is the single publish authority; it writes `ResolvedAbility::chosen_x`, which every `QuantityRef::Variable("X")` already reads. The three carriers (`GameObject::cost_x_paid` = CR 107.3m cast-X, `GameState::announced_source_x` = CR 107.3a/d announce-X, `chosen_x` = the object's published channel, CR 107.3i) are **not** interchangeable — see `/casting-stack-conditions` § "The X Channels". If you are computing X inside an effect handler, you are in the wrong layer.
+
 ### Phase 2 — Effect Handler (Resolver)
 
 **Goal:** The engine can execute the effect at runtime.
@@ -296,6 +299,7 @@ Tilt-preferred / direct-cargo fallback (see CLAUDE.md § "Canonical verification
 | Missing AI legal action generation | AI hangs on `WaitingFor` with no valid response | Add the `WaitingFor` variant to `engine/src/ai_support/candidates.rs` |
 | Shape-only or vacuous-negative tests | Effect parses but is never proven to resolve; negatives pass via `Effect::Unimplemented` early-returns | Add a `/card-test` runtime test with a revert-failing assertion; pair every negative with a positive reach-guard |
 | New field on an existing variant dropped at one seam | Field parses but is a silent no-op in production (resume paths, batch handlers, adapter constructors) | Grep every construction/consumption site of the variant; thread the field or justify the default at each |
+| Resolving X inside the effect handler | Rules-wrong (CR 107.3c): X is fixed at announce, and the resolving board differs — a silently wrong amount, not a crash | Carry a `QuantityExpr`; read the published `chosen_x`. See `/casting-stack-conditions` § "The X Channels" |
 
 ---
 

--- a/.claude/skills/add-keyword/SKILL.md
+++ b/.claude/skills/add-keyword/SKILL.md
@@ -130,9 +130,39 @@ Keywords are granted/removed via `ContinuousModification::AddKeyword` / `RemoveK
 
 ### Phase 4 — Parser Integration
 
-- [ ] **Oracle text parsing** — Keywords on their own line (e.g., "Flying\nTrample") are handled by the line classifier in `oracle.rs` which calls `Keyword::from_str()`. No parser changes needed if `FromStr` is correct.
+> **Read this first if your keyword takes a cost or a parameter** ("Kicker {2}", "Ward {1}",
+> "Cycling {2}"). The keyword router is **strict**, and getting the surface wrong is the
+> silent-swallow bug class. Full surface table: `/oracle-parser` SKILL.md §3a.
 
-- [ ] **`crates/engine/src/parser/oracle_static.rs` — `map_keyword()`**
+**The two surfaces (`parser/oracle_keyword.rs`).** They are not interchangeable:
+
+| Surface | Contract | Where it may be used |
+|---|---|---|
+| `parse_router_keyword_line()` / `parse_router_keyword_fragment()` / `parse_router_keyword_list()` | **STRICT / all-consuming.** Return a typed keyword only when the text parses *completely* (keyword + permitted P/R/M tail). | The **only** surfaces that may license a router — or a routing classifier — to CONSUME a line. |
+| `parse_granted_keyword_fragment()` / `extract_granted_keyword_list()` | **PERMISSIVE.** Take the leading keyword and **discard the remainder** — by design. | **Embedded grant contexts only** (static / token / vote / class-level payloads), where the trailing clause belongs to the *enclosing* sentence: "… gains vanishing 3 if that creature doesn't have vanishing". |
+
+The axis is typed: `KeywordRemainderPolicy::{DiscardRemainder, RequireAllConsuming}`, one
+list walk parameterized by the per-part remainder contract.
+
+**Consume-on-success.** A router may advance past a line only after a strict surface returns
+a keyword all-consumingly, or after it emits `Effect::unimplemented`. A line with an
+unconsumed semantic tail must **DECLINE**, not commit: `Cycling {2} if you control an
+artifact` falls through to an honest, exact-unit `Effect::Unimplemented` rather than
+vanishing with no keyword and no diagnostic. Consuming it on a permissive parse drops the
+tail's semantics and the card then renders as **fully supported** while its text was never
+modelled.
+
+**The gate.** `scripts/check-parser-combinators.sh` **Gate G** is a whole-file invariant: a
+permissive keyword-parser symbol appearing anywhere inside `parse_oracle_ir`,
+`is_semicolon_keyword_line`, or `is_spell_resolution_instruction_line` fails the build, at
+any count. The migration is complete (task #123) — do not reintroduce it.
+
+- [ ] **Oracle text parsing** — Keywords on their own line (e.g., "Flying\nTrample") are handled by the line classifier in `oracle.rs`, which routes through `parse_router_keyword_list()` and ultimately `Keyword::from_str()`. No parser changes needed if `FromStr` is correct.
+
+- [ ] **`crates/engine/src/parser/oracle_keyword.rs` — the router registry** (parameterized/cost-bearing keywords only)
+  Add the keyword's prefix to the candidate recognizer `is_keyword_cost_line()` **and** a matching case to `ROUTER_KEYWORD_CASES` (the `#[cfg(test)]` typed family registry) in the same change. A set-equality test pins the two against each other: a prefix added to the recognizer without a strict parser, a valid fixture, a semantic-suffix rejection, and a declared production reach fails the build. That test is deliberate friction — it is the exact hole silent swallowing comes back through.
+
+- [ ] **`crates/engine/src/parser/oracle_static/grammar.rs` — `map_keyword()`**
   This delegates to `Keyword::from_str()`. No changes needed unless the keyword has non-standard Oracle text.
 
 - [ ] **`crates/engine/src/parser/oracle_effect/token.rs` — `parse_token_keyword_clause()`** (if applicable)
@@ -193,6 +223,8 @@ Some keywords require synthesis in `synthesis.rs` — converting the keyword int
 | Adding runtime behavior but no synthesis | Keyword parsed but its implied abilities (like Equip → Attach) never created | Add synthesis function in `synthesis.rs` |
 | Leaving keyword as `Unknown(String)` with partial support | Coverage report flags it as missing, but it partially works | Add proper enum variant |
 | Not testing parameterized parsing | `"ward:{W}"` might fail due to mana cost format | Test both `"Ward:{W}"` and `"Ward:W"` formats |
+| Consuming a keyword line via a **permissive** helper in a router | Silent swallow: the trailing clause's semantics are dropped, no keyword recorded, no `Unimplemented` raised — the card renders as fully supported | Use `parse_router_keyword_line` / `_list` / `_fragment`. `scripts/check-parser-combinators.sh` Gate G fails the build on any permissive symbol in a router context |
+| Adding a prefix to `is_keyword_cost_line()` without a `ROUTER_KEYWORD_CASES` entry | The recognizer nominates a line no strict parser can fully parse | The set-equality test reds. Add the case, a valid fixture, and a semantic-suffix rejection in the same change |
 
 ---
 
@@ -216,7 +248,12 @@ rg -q "fn parse_keywords" crates/engine/src/game/keywords.rs && \
 rg -q "fn synthesize_equip" crates/engine/src/database/synthesis.rs && \
 rg -q "fn synthesize_changeling_cda" crates/engine/src/database/synthesis.rs && \
 rg -q "fn check_keywords" crates/engine/src/game/coverage.rs && \
-rg -q "fn map_keyword" crates/engine/src/parser/oracle_static.rs && \
+rg -q "fn map_keyword" crates/engine/src/parser/oracle_static/grammar.rs && \
+rg -q "fn parse_router_keyword_list" crates/engine/src/parser/oracle_keyword.rs && \
+rg -q "fn parse_router_keyword_fragment" crates/engine/src/parser/oracle_keyword.rs && \
+rg -q "enum KeywordRemainderPolicy" crates/engine/src/parser/oracle_keyword.rs && \
+rg -q "fn is_keyword_cost_line" crates/engine/src/parser/oracle_keyword.rs && \
+rg -q "ROUTER_KEYWORD_CASES" crates/engine/src/parser/oracle_keyword.rs && \
 rg -q "AddKeyword" crates/engine/src/types/ability.rs && \
 echo "✓ add-keyword skill references valid" || \
 echo "✗ STALE — update skill references"

--- a/.claude/skills/add-replacement-effect/SKILL.md
+++ b/.claude/skills/add-replacement-effect/SKILL.md
@@ -160,9 +160,48 @@ ReplacementResult::Execute(modified_event) → caller processes the event
 
 ---
 
+## "Instead" Lowers to a BRANCH, Never Two Effects
+
+**CR 614.1a: effects that use the word "instead" are replacement effects. CR 614.6: if an
+event is replaced, it never happens.** So an override clause is a *branch*, not a sibling —
+emitting it as a second, independent effect makes the engine execute BOTH the original and
+the replacement. That is the #44 / #79 defect class, and it was ~40 faces.
+
+This bites hardest **across lines**, where the "instead" clause is a separate printed line
+from the effect it overrides:
+
+```
+Destroy target creature.
+If that creature would die this turn, exile it instead.   ← NOT a second ability
+```
+
+The correct lowering is an `AbilityDefinition` whose `else_ability` carries the *displaced*
+branch — one def, two mutually exclusive outcomes. In the IR this is a **clause
+disposition**, not an emitted sibling:
+
+| IR carrier (`parser/oracle_ir/effect_chain.rs`) | Shape |
+|---|---|
+| `ClauseDisposition::ReplaceMeaning { kind }` | The clause replaces/overrides the meaning of the **prior emitted def(s)** rather than emitting an independent sibling (CR 608.2c: "later text on the card may modify the meaning of earlier text") |
+| `ReplaceMeaningKind::Instead(..)` | Multi-clause base + "instead" override; the tail clauses are stashed in the override's `else_ability` |
+| `ReplaceMeaningKind::DigAlt(..)` / `KeywordOverride` | The other two override shapes — the prior def is popped/wrapped, or attached as `sub_ability` |
+
+**The rule for contributors:** if your new pattern's Oracle text contains an override
+("instead", "rather than"), you are extending a `ReplaceMeaning` disposition — you are not
+adding a second `AbilityDefinition` to `result.abilities`. If you find yourself emitting a
+conditional ability whose condition duplicates the override's antecedent, stop: the engine
+will run both branches.
+
+**Test it at runtime, not at parse shape.** A parse test asserting two defs exist proves
+nothing about which ones *execute*. Cast the card and assert the overridden effect did
+**not** happen (see `/card-test`).
+
+---
+
 ## Interactive Replacements (Pre-Zone-Change Choices)
 
-**MTG Rule 614.16**: "As [permanent] enters the battlefield, choose..." is a replacement effect. The choice modifies the entering event itself — the permanent enters with the choice already made.
+**CR 614.1c** ("As [this permanent] enters . . ." is a replacement effect) **+ CR 614.12a**
+(a replacement that modifies how a permanent enters and requires a choice makes that choice
+as part of the replacement): the choice modifies the entering event itself — the permanent enters with the choice already made.
 
 This is architecturally harder than standard replacements because it requires player input *during* the replacement pipeline, *before* the zone change completes.
 
@@ -204,6 +243,7 @@ The `ProposedEvent::ZoneChange` can carry additional data (or the choice can be 
 | Missing `#[serde(default)]` on new ProposedEvent fields | Deserialization breaks for existing card data | Always default new optional fields |
 | Rescanning replacement candidates after player choice | Multiple matching replacements can apply the wrong execute/decline/rider/effect | Consume the stored `PendingReplacement` / `ReplacementId` identity selected by the player |
 | Handler returns `Modified` but doesn't modify anything | Event processed as-is but marked as "replaced" | Either modify the event or return the original unchanged |
+| Lowering an "instead" override as a second, independent ability | The engine executes **both** the original and the replacement — CR 614.6 says the replaced event never happens (~40 faces, #44/#79) | Lower to a BRANCH: `ClauseDisposition::ReplaceMeaning` → `else_ability`. Prove it with a runtime test asserting the overridden effect did NOT happen |
 
 ---
 
@@ -231,6 +271,9 @@ rg -q "enum ReplacementMode" crates/engine/src/types/ability.rs && \
 rg -q "post_replacement_effect" crates/engine/src/types/game_state.rs && \
 rg -q "enum ProposedEvent" crates/engine/src/types/proposed_event.rs && \
 rg -q "fn parse_shock_land" crates/engine/src/parser/oracle_replacement.rs && \
+rg -q "enum ClauseDisposition" crates/engine/src/parser/oracle_ir/effect_chain.rs && \
+rg -q "enum ReplaceMeaningKind" crates/engine/src/parser/oracle_ir/effect_chain.rs && \
+rg -q "else_ability" crates/engine/src/types/ability.rs && \
 echo "✓ add-replacement-effect skill references valid" || \
 echo "✗ STALE — update skill references"
 ```

--- a/.claude/skills/add-static-ability/SKILL.md
+++ b/.claude/skills/add-static-ability/SKILL.md
@@ -5,7 +5,9 @@ description: Use when adding or modifying static abilities, continuous effects, 
 
 # Adding a Static Ability
 
-Static abilities produce continuous effects that modify game objects through the layer system (MTG Rule 613). Unlike triggered or activated abilities, they don't use the stack — they simply exist while their source is on the battlefield.
+Static abilities produce continuous effects that modify game objects through the layer system (CR 613). Unlike triggered or activated abilities, they don't use the stack — they apply continuously while their source is in the zone that ability functions in (CR 611.3b).
+
+> **The affected population is OBJECTS, not permanents.** CR 613.1 computes the characteristics of an *object*, so a static can modify a card in hand, a spell on the stack, or a card in a graveyard — not just a battlefield permanent. The layer pass does **not** own every zone, though: read [Zone Boundary](#zone-boundary--which-zones-the-layer-pass-owns) before you assume your modification will land.
 
 **Before you start:** Trace how Changeling's `AddAllCreatureTypes` works from parser to layers. It's the best reference for type-changing effects: `synthesize_changeling_cda()` in `synthesis.rs` → `StaticDefinition` with `ContinuousModification::AddAllCreatureTypes` → `gather_active_continuous_effects()` → `apply_continuous_effect()` in `layers.rs`.
 
@@ -111,12 +113,15 @@ state.layers_dirty = true  (set after zone changes, control changes, etc.)
     ↓
 evaluate_layers() in crates/engine/src/game/layers.rs:
     ↓
-Step 1: Reset all battlefield objects to base characteristics
-    power ← base_power, toughness ← base_toughness
-    keywords ← base_keywords, color ← base_color
+Step 1: Reset every object in a zone THIS PASS OWNS to base characteristics
+    Battlefield: full characteristic set
+        power ← base_power, toughness ← base_toughness
+        keywords ← base_keywords, color ← base_color
+    Hand / Stack: keywords only
+    (library / graveyard / exile are NOT reset here — see Zone Boundary below)
     ↓
 Step 2: gather_active_continuous_effects()
-    For each battlefield object:
+    For each object in a scanned zone:
         For each static_definition where mode == Continuous:
             Check condition (devotion, presence, during-your-turn)
             Get affected filter
@@ -141,6 +146,44 @@ Step 4: Apply counter-based P/T (layer 7e)
     ↓
 Step 5: Clear layers_dirty flag
 ```
+
+## Zone Boundary — Which Zones the Layer Pass Owns
+
+**There are TWO keyword authorities, split by zone. Writing into the wrong one is a silent
+no-op, and it is the defect class PR #5803 (Taigam's stack-keyword grant) was opened for.**
+
+`layer_pass_materializes_keywords(zone)` (`game/layers.rs`) is the boundary:
+
+```rust
+fn layer_pass_materializes_keywords(zone: Zone) -> bool {
+    matches!(zone, Zone::Battlefield | Zone::Hand | Zone::Stack)
+}
+```
+
+| Zone | Who computes keywords | Notes |
+|------|----------------------|-------|
+| `Battlefield` | **Layer pass** — materialized onto the object | Full characteristic reset (`seed_live_characteristics_from_base`) |
+| `Hand` | **Layer pass** — materialized | Keywords-only reset (hand-functioning grants, e.g. Miracle, CR 702.94a) |
+| `Stack` | **Layer pass** — materialized | Keywords-only reset (CR 613.1 stack-object grants: Taigam's rebound, `StackSpell`-filtered statics) |
+| `Library` / `Graveyard` / `Exile` | **`game/off_zone_characteristics`** — computed ON DEMAND from base + active effects; never materialized | `keywords::object_has_effective_keyword_kind` is the reader that routes by exactly this split |
+
+**The materialize set and the reset set are the same set by construction** — the pass may
+only write a characteristic into a zone where it also clears it at the top of the next
+pass, or the write is a leak nothing ever reclaims.
+
+**What this means for you:**
+
+- Adding a static whose `affected` filter reaches a zone the pass does *not* own
+  (`InZone(Graveyard)`, `InZone(Exile)`, …)? The keyword will **not** appear on the object.
+  Either route the read through `off_zone_characteristics`, or extend
+  `layer_pass_materializes_keywords` **and** the Step-1 reset in `evaluate_layers` **in the
+  same change**. Extending one without the other is the leak.
+- Never read keywords off `obj.keywords` directly for a non-battlefield object. Go through
+  `keywords::object_has_effective_keyword_kind()`, which routes to the correct authority for
+  the object's current zone (it delegates to
+  `off_zone_characteristics::off_zone_has_keyword_kind` when the object is off-zone).
+- CR 611.3b is the rules basis for a static functioning outside the battlefield at all
+  ("…or the object generating it is in the appropriate zone").
 
 ### `apply_continuous_effect()` — `layers.rs`
 
@@ -181,6 +224,9 @@ match modification {
 
 - [ ] **`crates/engine/src/game/layers.rs` — `gather_active_continuous_effects()`** (if new condition)
   If you added a new `StaticCondition`, add evaluation logic in the condition-checking block.
+
+- [ ] **`crates/engine/src/game/layers.rs` — `layer_pass_materializes_keywords()`** (if the static reaches a new zone)
+  If your `affected` filter targets a zone the pass does not already own, extend this predicate **and** the Step-1 reset in `evaluate_layers()` in the same change — see [Zone Boundary](#zone-boundary--which-zones-the-layer-pass-owns). A grant into an unowned zone is a silent no-op that still reports as supported.
 
 - [ ] **`crates/engine/src/game/layers.rs` — post-fixup** (if interaction with keywords)
   If your modification interacts with keywords that might be granted in layer 6, check whether the post-fixup block (Changeling handling) needs extension.
@@ -261,6 +307,7 @@ It handles:
 | Missing `apply_continuous_effect()` arm | New modification variant compiles but no-ops at runtime | Add the match arm in `layers.rs` |
 | `affected: None` instead of `Some(SelfRef)` | Effect applies to everything, not just the source | Set `affected` correctly |
 | Forgetting `characteristic_defining: true` for CDAs | CDA doesn't function in non-battlefield zones | Set the flag for CDAs |
+| Granting a keyword to an object in a zone the layer pass doesn't materialize | Static parses, effect gathers, resolution runs — and the keyword never appears. A LYING GREEN: the card renders as fully supported | Check `layer_pass_materializes_keywords` (`layers.rs`). Read via `keywords::object_has_effective_keyword_kind`, or extend the materialize set **and** the Step-1 reset together |
 | Using `StaticMode::Continuous` for restrictions | Restriction evaluated through layers but needs direct checks | Use `CantAttack`/`CantBlock`/etc. modes |
 | Not resetting to base values in step 1 | Modifications stack additively across evaluations | `evaluate_layers()` handles reset — just ensure base values are set correctly |
 | Layer 7c modification with dependency ordering | P/T modifications should use timestamp, not dependency | The `Layer` impl handles this — just map to correct sub-layer |
@@ -281,8 +328,10 @@ After completing work using this skill:
 rg -q "fn evaluate_layers" crates/engine/src/game/layers.rs && \
 rg -q "fn gather_active_continuous_effects" crates/engine/src/game/layers.rs && \
 rg -q "fn apply_continuous_effect" crates/engine/src/game/layers.rs && \
-rg -q "fn parse_static_line" crates/engine/src/parser/oracle_static.rs && \
-rg -q "fn parse_continuous_modifications" crates/engine/src/parser/oracle_static.rs && \
+rg -q "fn layer_pass_materializes_keywords" crates/engine/src/game/layers.rs && \
+rg -q "off_zone_characteristics" crates/engine/src/game/keywords.rs && \
+rg -q "fn parse_static_line" crates/engine/src/parser/oracle_static/mod.rs && \
+rg -q "fn parse_continuous_modifications" crates/engine/src/parser/oracle_static/keyword_grant.rs && \
 rg -q "fn is_static_pattern" crates/engine/src/parser/oracle_classifier.rs && \
 rg -q "enum ContinuousModification" crates/engine/src/types/ability.rs && \
 rg -q "struct StaticDefinition" crates/engine/src/types/ability.rs && \

--- a/.claude/skills/add-trigger/SKILL.md
+++ b/.claude/skills/add-trigger/SKILL.md
@@ -122,6 +122,53 @@ Stack resolves later:
 
 ---
 
+## The Purged Source — Last Known Information (CR 608.2h)
+
+**A trigger routinely has to answer questions about an object that no longer exists.** The
+source dies and its own dies-trigger asks "if you control a Zombie"; a token sacrifices
+itself and the CR 111.7 SBA purges it from `state.objects` before the ability resolves. A
+live-only lookup answers `false`/`None` there, and the ability silently fails to fire or is
+removed from the stack — CR 113.7a says the ability on the stack exists independently of its
+source, so the source's death must **not** make its own predicates unanswerable.
+
+**CR 608.2h is the rule:** if the object is no longer in the public zone the effect expected
+it in, "the effect uses the object's **last known information**." (CR 608.2i is the
+narrower look-back rule for effects that ask about *previous game states* — attacked this
+turn, etc.)
+
+**The mechanism.** `apply_zone_exit_cleanup()` (`game/zones.rs`) captures an `LKISnapshot`
+into `state.lki_cache` on every battlefield/exile exit — name, P/T, base P/T, core types,
+counters, controller, and the **pre-sever attachment set**. Live state always wins; LKI
+answers only when the object is gone, so every LKI-aware helper is a strict no-op for a
+source that still exists.
+
+**Use the LKI-aware helpers — never a bare live lookup:**
+
+| Question | Helper | Where |
+|---|---|---|
+| Does the trigger's **subject** match this filter? | `subject_filter_matches_with_lki()` | `game/trigger_matchers.rs` — single authority for `match_sacrificed`, `exploiter_matches_subject_filter`, `match_connives` |
+| Who is "you" for a source-relative `ControllerRef::You`? | `source_controller_or_lki()` | `game/filter.rs` — feeds `FilterContext`; the CR 603.4 intervening-if re-check runs *after* the SBA purge |
+
+**Two traps that decide whether your test proves anything:**
+
+- **Attachments do NOT survive on the live object.** CR 704.5m/n unattach an Aura/Equipment
+  as an SBA the moment the permanent leaves, and
+  `sever_battlefield_attachment_graph_on_exit` empties the list *before* cleanup runs. Only
+  `LKISnapshot::attachments` still holds it — an "if it was equipped" predicate that reads
+  the live object reads an empty set, and always answers `false`.
+- **Attack/block history DOES survive.** It lives in durable, `ObjectId`-keyed ledgers on
+  `GameState` (`creatures_attacked_this_turn`,
+  `creature_attacked_defenders_this_turn`, `creatures_blocked_this_turn`), not on the
+  object, so a purged source's `AttackedThisTurn` (CR 508.1a) is still answerable.
+
+**Non-vacuity:** a printed card keeps its `core_types` and `controller` across a zone change
+and `filter_inner` has no zone gate, so a regression test that merely moves a printed
+creature to the graveyard **passes either way and proves nothing**. The vector that actually
+discriminates an LKI path from a bare live match is the **ceased-to-exist token** (CR 111.7)
+— use one.
+
+---
+
 ## Checklist — Adding a New Trigger
 
 ### Phase 1 — Type Definition
@@ -207,6 +254,9 @@ The trigger pipeline responds to `GameEvent` variants. If no existing event cove
 - [ ] **`crates/engine/src/types/game_state.rs` — tracking state** (if new constraint)
   `OncePerTurn` uses `triggers_fired_this_turn: HashSet`. `OncePerGame` uses `triggers_fired_this_game: HashSet`. If you need new tracking, add it to `GameState`.
 
+- [ ] **LKI: can the source or subject be GONE when this condition is checked?**
+  If yes (dies triggers, sacrifice triggers, self-exploiting tokens, any intervening-if re-checked at resolution per CR 603.4), route the lookup through `subject_filter_matches_with_lki()` / `source_controller_or_lki()` — see [The Purged Source](#the-purged-source--last-known-information-cr-6082h). A bare live lookup fails closed and the ability silently never fires.
+
 ### Phase 7 — Stack Resolution
 
 - [ ] **`crates/engine/src/game/stack.rs` — `resolve_top()`**
@@ -261,6 +311,9 @@ Used by all matchers — always call this instead of reimplementing filter logic
 | APNAP ordering wrong | Triggers resolve in wrong player order | `process_triggers()` handles this — don't manually reorder |
 | `trigger_zones` empty (default) | Trigger only fires from battlefield, not graveyard | Set `trigger_zones: vec![Zone::Graveyard]` for dies triggers that work from graveyard |
 | Forgetting `valid_card: Some(SelfRef)` on "When ~" triggers | Trigger fires for any permanent, not just the source | Set valid_card for self-triggers |
+| Live-only lookup for a source/subject that may be purged | Fails closed (CR 608.2h): a dies/sacrifice trigger's own intervening-if reads `false` and the ability is removed from the stack | Use `subject_filter_matches_with_lki()` / `source_controller_or_lki()` |
+| Reading attachments off a purged object | CR 704.5m/n already unattached them; the live list is empty and "if it was equipped" always answers `false` | Read `LKISnapshot::attachments` (the pre-sever set) |
+| LKI regression test that moves a printed creature to the graveyard | **Vacuous** — the card keeps `core_types`/`controller` across zones, so the test passes without the LKI path | Discriminate with a ceased-to-exist **token** (CR 111.7) |
 
 ---
 
@@ -279,6 +332,10 @@ rg -q "fn process_triggers" crates/engine/src/game/triggers.rs && \
 rg -q "fn collect_matching_triggers" crates/engine/src/game/triggers.rs && \
 rg -q "fn extract_target_filter_from_effect" crates/engine/src/game/triggers.rs && \
 rg -q "fn build_trigger_registry" crates/engine/src/game/trigger_matchers.rs && \
+rg -q "fn subject_filter_matches_with_lki" crates/engine/src/game/trigger_matchers.rs && \
+rg -q "fn source_controller_or_lki" crates/engine/src/game/filter.rs && \
+rg -q "fn apply_zone_exit_cleanup" crates/engine/src/game/zones.rs && \
+rg -q "struct LKISnapshot" crates/engine/src/types/game_state.rs && \
 rg -q "struct TriggerDefinition" crates/engine/src/types/ability.rs && \
 rg -q "enum TriggerMode" crates/engine/src/types/triggers.rs && \
 rg -q "enum TriggerConstraint" crates/engine/src/types/ability.rs && \

--- a/.claude/skills/card-test/SKILL.md
+++ b/.claude/skills/card-test/SKILL.md
@@ -156,3 +156,13 @@ fn my_card_does_the_thing() {
   Paraphrased text can take a different parser branch than the real card, so
   the test goes green while the actual card stays broken until card-data is
   regenerated (see `project_parser_fix_inert_until_data_regen`).
+- **Regenerate the integration fixture when your parser change touches a card
+  it contains.** `add_real_card` reads the committed
+  `crates/engine/tests/fixtures/integration_cards.json` snapshot.
+  `python3 scripts/gen-test-fixture.py --check` verifies **coverage only — that every
+  referenced card is PRESENT (a key-set comparison). It never compares the stored parse
+  VALUES against a fresh export.** So a parser change that alters a fixture card's parse
+  leaves the fixture stale while the gate stays green: the integration test then asserts
+  against the *old* parse and proves nothing about the code you shipped. If your change
+  alters how any fixture card parses, re-run `python3 scripts/gen-test-fixture.py` (no
+  `--check`) and commit the regenerated fixture in the same PR.

--- a/.claude/skills/casting-stack-conditions/SKILL.md
+++ b/.claude/skills/casting-stack-conditions/SKILL.md
@@ -84,6 +84,43 @@ Key functions: `handle_cast_spell()`, `pay_and_push()`, `pay_mana_cost()`, `pay_
 
 ---
 
+## The X Channels — X Is Locked at ANNOUNCE, Never at Resolution
+
+**Rebinding X at resolution time is rules-wrong, not merely late.** CR 107.3c says the value
+of X may change while the spell or ability is on the stack; CR 601.2b (and CR 602.2b, which
+makes an activated ability's announcement identical to a spell's) fixes it at announcement.
+An effect that re-measures X when it resolves reads a *different, legal* board and produces
+a *different, wrong* number — and it does so silently.
+
+There are **three carriers**. They are not interchangeable, and choosing wrong reads the
+wrong X *by rule*, not merely a missing one:
+
+| Carrier | Where | Rule | What it holds |
+|---|---|---|---|
+| `GameObject::cost_x_paid` (`game/game_object.rs`) | on the OBJECT | **CR 107.3m** — the cast-X channel; read by `QuantityRef::CostXPaid` | X paid for the object's **mana cost** as it was cast |
+| `GameState::announced_source_x: Option<(ObjectId, u32)>` (`types/game_state.rs`) | on the STATE, keyed by object | **CR 107.3a** (activated ability) + **CR 107.3d** (special action: morph/suspend) | The X announced for an **in-flight cost**, so a trigger of that same object fired *by* the announcement reads the same X (CR 107.3i) |
+| `ResolvedAbility::chosen_x: Option<u32>` (`types/game_state.rs`) | on the ABILITY | **CR 107.3i** — all instances of X on an object have the same value | The object's single, published X channel. Every `QuantityRef::Variable("X")` reads it |
+
+**Do NOT reuse `cost_x_paid` for an activated ability's announced X.** CR 107.3k makes an
+activated ability's X *independent* of any other X chosen for that object — writing the
+announced X into the cast-X channel would answer with the wrong number by rule.
+
+**`publish_announced_x()` (`game/ability_utils.rs`) is the SINGLE publish authority.** It
+resolves the announce-time expression once and calls `set_chosen_x_recursive`, so the
+announced target count (CR 601.2c), the divided-damage pool (CR 601.2d), and every
+resolution-time amount all observe the *same* number. Two contracts you cannot break:
+
+- **Call it BEFORE target selection.** CR 601.2b precedes CR 601.2c;
+  `resolve_multi_target_bounds` fails closed rather than counting an unresolved X as 0.
+- **It is idempotent** (gated on `chosen_x.is_some()`), so a resumed/re-announced cast
+  cannot re-measure the count against a board that has since changed.
+
+If your effect carries a `QuantityExpr` that can hold X, it reads `chosen_x` — you do not
+add a new channel. If you find yourself computing X inside an effect handler, you are in the
+wrong layer.
+
+---
+
 ## Activated Ability Cost Payment — Building Blocks
 
 Three composable helpers handle all ability cost payment:
@@ -366,6 +403,9 @@ if let Some((_, rest)) = nom_on_lower(text, lower, tag("you may ")) {
 | New interactive state without `pending_continuation` support | Sub_ability chain breaks when player choice interrupts resolution |
 | Modifying `abilities[0]` selection in casting.rs | Changes which ability goes on stack for ALL spells |
 | Modal spell/ability targeting ignores modal target constraints | Illegal same-player or same-object selections slip through | Derive constraints with `target_constraints_from_modal()` and validate them during selection |
+| Re-measuring X when the ability resolves | Rules-wrong (CR 107.3c): X is fixed at announcement, and the resolving board is a *different, legal* board — silently wrong number | Publish once via `publish_announced_x()`; effects read `chosen_x` |
+| Writing an activated ability's announced X into `GameObject::cost_x_paid` | Reads the wrong X **by rule** — CR 107.3k makes an activated ability's X independent of the object's cast-X | Use `announced_source_x` (CR 107.3a/d); `cost_x_paid` is the CR 107.3m cast channel |
+| Publishing X after target selection | `resolve_multi_target_bounds` fails closed ("target count requires a resolved quantity") | CR 601.2b precedes CR 601.2c — publish before targeting |
 
 ---
 
@@ -373,11 +413,15 @@ if let Some((_, rest)) = nom_on_lower(text, lower, tag("you may ")) {
 
 ```bash
 rg -q "fn handle_cast_spell" crates/engine/src/game/casting.rs && \
-rg -q "fn pay_and_push" crates/engine/src/game/casting.rs && \
+rg -q "fn pay_and_push" crates/engine/src/game/casting_costs.rs && \
 rg -q "fn pay_mana_cost" crates/engine/src/game/casting.rs && \
-rg -q "fn pay_ability_cost" crates/engine/src/game/casting.rs && \
+rg -q "fn pay_ability_cost" crates/engine/src/game/costs.rs && \
 rg -q "fn requires_untapped" crates/engine/src/game/casting.rs && \
 rg -q "fn handle_ability_mode_choice" crates/engine/src/game/engine_modes.rs && \
+rg -q "fn publish_announced_x" crates/engine/src/game/ability_utils.rs && \
+rg -q "fn set_chosen_x_recursive" crates/engine/src/types/ability.rs && \
+rg -q "announced_source_x" crates/engine/src/types/game_state.rs && \
+rg -q "cost_x_paid" crates/engine/src/game/game_object.rs && \
 test -f crates/engine/src/game/engine_casting.rs && \
 test -f crates/engine/src/game/engine_resolution_choices.rs && \
 test -f crates/engine/src/game/engine_payment_choices.rs && \

--- a/.claude/skills/project-reference/SKILL.md
+++ b/.claude/skills/project-reference/SKILL.md
@@ -143,6 +143,21 @@ cargo run --bin oracle-gen -- data --filter "card name"             # single car
 cargo run --bin oracle-gen -- data --filter "name1|name2|name3"     # multiple cards (pipe-separated, substring match)
 ```
 
+#### Measurement hazards — read before you export, diff, or commit
+
+The export **writes to tracked files** and is **not fully deterministic**. Three consequences,
+all of which have burned real measurement campaigns:
+
+| Hazard | What you'll see | What to do |
+|---|---|---|
+| **`cargo export-cards` rewrites `crates/engine/data/oracle-subtypes.json`** — a tracked *parser input*, and the rewrite is non-idempotent (it can drop subtypes) | An unexplained diff in a file you never edited | **Never commit it as a side effect.** `git checkout -- crates/engine/data/oracle-subtypes.json` after the export unless changing the vocabulary is your actual intent. It is a parser input: a lossy rewrite silently changes how *every* card parses |
+| **`gen-card-data.sh` dirties `crates/engine/data/known-tokens.toml`** (also tracked) | Same — a diff you didn't author | Same: leave it out of the commit. Commit by explicit pathspec, never `git add -A` |
+| **The export is nondeterministic on ~20 faces** | Two exports of the same tree differ | **That is the noise floor of any whole-pool ledger.** A delta of ≲20 faces between two full-pool runs is not signal. Re-run, or diff against a snapshot taken from the *same* binary — never claim a sub-noise-floor coverage win |
+
+Corollary for coverage work: **snapshot `card-data.json` BEFORE you touch the parser**, and
+diff generated-vs-generated. Diffing a fresh export against a stale committed artifact
+attributes the artifact's own drift to your change.
+
 ### Card Data Lookup
 ```bash
 jq '.["lightning bolt"]' client/public/card-data.json                    # Full card data


### PR DESCRIPTION
The add-* skills lagged five invariants that have landed on main, and one of
them (add-static-ability) stated the opposite of what the engine now does.

- add-static-ability: continuous effects apply to OBJECTS (CR 613.1), not only
  battlefield permanents. New "Zone Boundary" section: the layer pass
  materializes keywords ONLY into the zones it also resets
  ({Battlefield, Hand, Stack} — layer_pass_materializes_keywords); library /
  graveyard / exile are owned by off_zone_characteristics and computed on
  demand. A grant into an unowned zone is a silent no-op that still reports as
  supported (the PR #5803 defect class).
- add-keyword: document the strict keyword router (PR #5813 / task #123).
  Router slots and routing classifiers must parse through
  parse_router_keyword_line / _list / _fragment (all-consuming); the permissive
  parse_granted_keyword_fragment / extract_granted_keyword_list are for
  EMBEDDED GRANT contexts only. A line with an unconsumed semantic tail must
  DECLINE, not commit. Gate G in scripts/check-parser-combinators.sh is the
  whole-file invariant. New router-registry checklist item
  (is_keyword_cost_line + ROUTER_KEYWORD_CASES set-equality test).
- add-trigger: new "Purged Source" section (CR 608.2h). LKI look-back via
  subject_filter_matches_with_lki / source_controller_or_lki; attachments do
  NOT survive on the live object (CR 704.5m/n sever them — only
  LKISnapshot::attachments holds the pre-sever set) while attack/block history
  DOES (durable id-keyed ledgers on GameState). Names the non-vacuity vector:
  a ceased-to-exist token (CR 111.7), not a printed creature.
- casting-stack-conditions + add-engine-effect: the three X carriers
  (GameObject::cost_x_paid = CR 107.3m cast-X, GameState::announced_source_x =
  CR 107.3a/d announce-X, ResolvedAbility::chosen_x = the published channel,
  CR 107.3i) and publish_announced_x as the single publish authority.
  Re-measuring X at resolution is rules-wrong (CR 107.3c), not merely late.
- add-replacement-effect: cross-line "instead" lowers to a BRANCH
  (ClauseDisposition::ReplaceMeaning → else_ability), never two independent
  effects — CR 614.1a + CR 614.6, the #44/#79 double-execution class.
- project-reference: card-export measurement hazards — export-cards rewrites
  the tracked parser input oracle-subtypes.json (non-idempotent),
  gen-card-data dirties known-tokens.toml, and the export is nondeterministic
  on ~20 faces (the noise floor of any whole-pool ledger).
- card-test: gen-test-fixture.py --check verifies COVERAGE only (a key-set
  comparison), never the stored parse VALUES — a parser change can leave the
  integration fixture stale while the gate stays green.

Also fixes stale anchors found while verifying the self-check blocks (all five
now pass; two were red before this change):
- add-static-ability / add-keyword cited crates/engine/src/parser/oracle_static.rs,
  which is a directory now (oracle_static/mod.rs, oracle_static/grammar.rs,
  oracle_static/keyword_grant.rs).
- casting-stack-conditions cited pay_and_push and pay_ability_cost in casting.rs;
  they live in casting_costs.rs and costs.rs.
- add-replacement-effect cited "MTG Rule 614.16" for as-enters choices; 614.16
  is the token/counter-creation replacement rule. The correct citations are
  CR 614.1c + CR 614.12a.

Every symbol grep-verified against the tree at 5f4fbcd4c5; every CR number
grep-verified against docs/MagicCompRules.txt. scripts/check-skill-doc.sh and
Gate G both pass.
