### PR TITLE
ship/t126 lki residuals

### DIFF
--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -4849,19 +4849,75 @@ fn zone_change_record_matches_property(
             .lki_cache
             .get(&record.object_id)
             .is_some_and(|lki| !lki.tapped),
+        // CR 508.1a + CR 608.2h: "attacked this turn" is a turn-scoped HISTORICAL FACT about
+        // the object as it most recently existed, not a query against live combat state.
+        // `creatures_attacked_this_turn` (and the per-defender
+        // `creature_attacked_defenders_this_turn`) are keyed by the battlefield ObjectId,
+        // written at attacker declaration (combat.rs) and cleared ONLY at turn cleanup
+        // (turns.rs) — never on a zone change. The ledger therefore already outlives the
+        // object, and the record carries the very id it is keyed by, so a look-back rider
+        // ("if Taigam attacked this turn" — Taigam, Ojutai Master, re-checked at resolution
+        // per CR 603.4 after the source has died) reads the SAME ledger the live evaluator
+        // uses. Mirrors the live arm exactly, and the `WasDealtDamageThisTurn` arm above.
+        //
+        // NOT A CR 400.7 VIOLATION. CR 400.7 says the object that ARRIVES in the new zone is
+        // a new object with no memory of its previous existence — and that stays true: this
+        // arm is only ever reached for a subject that is NOT on the battlefield, and it
+        // reports what the object did while it WAS there. CR 608.2h names exactly that
+        // subject: "the effect uses the object's last known information ... If an ability
+        // states that an object does something, it's the object as it exists — OR AS IT MOST
+        // RECENTLY EXISTED — that does it." Failing closed here does not protect CR 400.7; it
+        // just refuses to answer a question the game still has the record for.
+        // CR 508.1a + CR 608.2h: "attacked this turn" is a turn-scoped HISTORICAL FACT about the
+        // object as it most recently existed, not a query against live combat state.
+        // `creatures_attacked_this_turn` (and the per-defender
+        // `creature_attacked_defenders_this_turn`) are keyed by the battlefield ObjectId, written
+        // at attacker declaration (combat.rs) and cleared ONLY at turn cleanup (turns.rs) — never
+        // on a zone change. The ledger therefore already outlives the object, and the record
+        // carries the very id it is keyed by, so a look-back rider ("if Taigam attacked this
+        // turn" — Taigam, Ojutai Master, re-checked at resolution per CR 603.4 after the source
+        // has died) reads the SAME ledger the live evaluator uses. Mirrors the live arm, and the
+        // `WasDealtDamageThisTurn` arm above.
+        //
+        // NOT A CR 400.7 VIOLATION (the rationale this arm previously fail-closed on). CR 400.7
+        // governs the object that ARRIVES in the new zone — it is a new object with no memory of
+        // its previous existence, and that stays true: this arm is reached only for a subject
+        // that is NOT on the battlefield, and it reports what the object did while it WAS there.
+        // CR 608.2h names exactly that subject: "the effect uses the object's last known
+        // information ... If an ability states that an object does something, it's the object as
+        // it exists — OR AS IT MOST RECENTLY EXISTED — that does it." Failing closed did not
+        // protect CR 400.7; it declined to answer a question the game still had the record for.
+        FilterProp::AttackedThisTurn { defender } => match defender {
+            None => state
+                .creatures_attacked_this_turn
+                .contains(&record.object_id),
+            // CR 508.6 + CR 508.1b: defender-scoped — the object attacked THAT player.
+            Some(_) => state
+                .creature_attacked_defenders_this_turn
+                .get(&record.object_id)
+                .is_some_and(|defs| {
+                    defs.iter()
+                        .any(|&d| attacking_defender_matches(state, source, d, defender.as_ref()))
+                }),
+        },
+        // CR 509.1a + CR 608.2h: sibling of `AttackedThisTurn` — same durable id-keyed ledger,
+        // same look-back reasoning.
+        FilterProp::BlockedThisTurn => state.creatures_blocked_this_turn.contains(&record.object_id),
+        // CR 508.1a + CR 509.1a + CR 608.2h: disjunction of the two ledgers above.
+        FilterProp::AttackedOrBlockedThisTurn => {
+            state
+                .creatures_attacked_this_turn
+                .contains(&record.object_id)
+                || state
+                    .creatures_blocked_this_turn
+                    .contains(&record.object_id)
+        }
+
         FilterProp::IsSaddled
         | FilterProp::SaddledSource
         | FilterProp::ConvokedSource
         | FilterProp::ProtectorMatches { .. }
         | FilterProp::HasHasteOrControlledSinceTurnBegan
-        // CR 400.7: a permanent that changes zones becomes a new object with no
-        // memory of its previous existence, so the zone-change snapshot captures
-        // no attack history. Intentionally fail-closed for both `None` (board-wide)
-        // and `Some` (defender-scoped), matching the `Attacking { defender }`
-        // look-back behavior.
-        | FilterProp::AttackedThisTurn { .. }
-        | FilterProp::BlockedThisTurn
-        | FilterProp::AttackedOrBlockedThisTurn
         | FilterProp::EnchantedBy
         | FilterProp::EquippedBy
         | FilterProp::AttachedToSource

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -802,6 +802,58 @@ fn effective_controller(
     obj.controller
 }
 
+/// CR 608.2h + CR 704.5m/n: Is `candidate` attached to `referent`, as of the moment the
+/// question is asked?
+///
+/// SINGLE AUTHORITY for the attachment back-reference. Both `FilterProp::AttachedToSource`
+/// and `FilterProp::AttachedToRecipient` ask this same question and differ only in which
+/// object is the referent, so both route here rather than each re-deriving the lookup.
+///
+/// Attachment is a BATTLEFIELD-ONLY relationship, and the state-based actions tear it down
+/// the instant the host leaves: an Aura attached to an illegal object is put into its owner's
+/// graveyard (CR 704.5m) and an Equipment attached to an illegal permanent becomes unattached
+/// (CR 704.5n). So once the referent is off the battlefield, every candidate's live
+/// `attached_to` back-reference has ALREADY been cleared, and the live board cannot answer
+/// this question at all — it can only answer "no".
+///
+/// CR 608.2h routes exactly that case to last known information: "If the effect requires
+/// information from a specific object, INCLUDING THE SOURCE OF THE ABILITY ITSELF, the effect
+/// uses the current information of that object if it's in the public zone it was expected to
+/// be in; if it's no longer in that zone ... the effect uses the object's LAST KNOWN
+/// INFORMATION." The referent's expected zone is the battlefield, so:
+///
+/// * referent ON the battlefield — live: the candidate's own `attached_to` back-reference.
+/// * referent anywhere else — the exit-time attachment set captured into `state.lki_cache`
+///   by `capture_attachment_snapshot` (zones.rs) on battlefield exit.
+///
+/// The off-battlefield leg covers a merely-dead referent (nontoken, now in the graveyard) and
+/// a purged one (a token, which ceased to exist under CR 111.7 and is absent from
+/// `state.objects` entirely) with one predicate: SBA unattaches on ANY battlefield exit, so
+/// the zone — not the object's continued existence — is what decides.
+///
+/// The snapshot's `object_id` is compared for IDENTITY only and is never dereferenced, so an
+/// attachment that has itself ceased to exist since the snapshot cannot break the look-back.
+fn attached_to_referent(
+    state: &GameState,
+    referent: ObjectId,
+    candidate: &GameObject,
+    candidate_id: ObjectId,
+) -> bool {
+    let referent_on_battlefield = state
+        .objects
+        .get(&referent)
+        .is_some_and(|r| r.zone == Zone::Battlefield);
+
+    if referent_on_battlefield {
+        return candidate.attached_to.and_then(|t| t.as_object()) == Some(referent);
+    }
+
+    state
+        .lki_cache
+        .get(&referent)
+        .is_some_and(|lki| lki.attachments.iter().any(|a| a.object_id == candidate_id))
+}
+
 pub(crate) fn controller_ref_player(
     state: &GameState,
     source_id: ObjectId,
@@ -3957,12 +4009,10 @@ fn matches_filter_prop(
             }
         }
         // CR 301.5 + CR 303.4: Inverse of `EnchantedBy`/`EquippedBy` — matches
-        // when THIS object is attached TO the source (`obj.attached_to ==
-        // Some(source.id)`). Used for "Aura and Equipment attached to ~"
-        // quantity clauses on the source object (Kellan, the Fae-Blooded).
-        FilterProp::AttachedToSource => {
-            obj.attached_to.and_then(|t| t.as_object()) == Some(source.id)
-        }
+        // when THIS object is attached TO the source. Used for "Aura and
+        // Equipment attached to ~" quantity clauses on the source object
+        // (Kellan, the Fae-Blooded; Whiplash, Vengeful Engineer).
+        FilterProp::AttachedToSource => attached_to_referent(state, source.id, obj, object_id),
         // CR 301.5 + CR 303.4 + CR 613.4c + CR 109.3: Anaphoric "it" referent
         // in "for each X attached to it". Two contextual referents share the
         // same parser-emitted prop:
@@ -3984,7 +4034,7 @@ fn matches_filter_prop(
         // surrounding effect.
         FilterProp::AttachedToRecipient => {
             let referent = source.recipient_id.unwrap_or(source.id);
-            obj.attached_to.and_then(|t| t.as_object()) == Some(referent)
+            attached_to_referent(state, referent, obj, object_id)
         }
         // CR 303.4 + CR 301.5: Attachment predicate. Matches objects that have
         // at least one attachment of the given kind whose controller satisfies

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -630,6 +630,7 @@ mod precast_copy_shortcut;
 mod primo_unbounded_fractal_counters;
 mod printed_ability_order;
 mod proliferate_zero_counter;
+mod purged_source_attachment_count_lki;
 mod purged_source_intervening_if_lki;
 mod purged_source_matches_filter_lki;
 mod quirion_ranger_activation;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -631,6 +631,7 @@ mod primo_unbounded_fractal_counters;
 mod printed_ability_order;
 mod proliferate_zero_counter;
 mod purged_source_attachment_count_lki;
+mod purged_source_attacked_this_turn_lki;
 mod purged_source_intervening_if_lki;
 mod purged_source_matches_filter_lki;
 mod quirion_ranger_activation;

--- a/crates/engine/tests/integration/purged_source_attachment_count_lki.rs
+++ b/crates/engine/tests/integration/purged_source_attachment_count_lki.rs
@@ -1,0 +1,353 @@
+//! CR 608.2h + CR 113.7a + CR 111.7: an effect's QUANTITY that counts the source's
+//! attachments must still be answerable when the source has ceased to exist.
+//!
+//! Oracle text (Whiplash, Vengeful Engineer — 2/2 Legendary Creature, verbatim from
+//! card-data):
+//!   "Whiplash enters tapped.
+//!    Whenever Whiplash attacks, if he's equipped, each opponent loses X life and you gain
+//!    X life, where X is the number of Equipment attached to him."
+//!
+//! WHY THIS CARD. PR #5792 (t105) repaired the GATE for this class: a
+//! `TriggerCondition::SourceMatchesFilter` intervening-if ("if he's equipped") now answers
+//! from `LKISnapshot::attachments` when the source is gone. Whiplash was called out there
+//! as the known near-miss — its gate opens, but its EFFECT then asks a second, independent
+//! question at the QUANTITY layer:
+//!
+//!   X = ObjectCount { Typed[Subtype(Equipment)] + FilterProp::AttachedToSource }
+//!
+//! That count enumerates the LIVE battlefield and asks each Equipment "are you attached to
+//! the source?" — i.e. `obj.attached_to == Some(source.id)`. SBA unattaches every Equipment
+//! the instant its host leaves the battlefield (CR 704.5n), so every candidate answers NO
+//! and X resolves to 0. The gate opens onto an effect that does nothing.
+//!
+//! THE DISCRIMINATING AXIS IS NOT THE CR 111.7 PURGE. Unlike the gate half (where a token's
+//! purge from `state.objects` was the whole defect), the quantity half breaks for a NONTOKEN
+//! dead source too: the unattachment is done by SBA on ANY battlefield exit, so the Equipment's
+//! `attached_to` is cleared whether the host went to the graveyard or ceased to exist. Both
+//! legs are witnessed below; both were red.
+//!
+//! CR 608.2h is the governing rule and it is explicit: "If the effect requires information
+//! from a specific object, INCLUDING THE SOURCE OF THE ABILITY ITSELF, the effect uses the
+//! current information of that object if it's in the public zone it was expected to be in;
+//! if it's no longer in that zone ... the effect uses the object's LAST KNOWN INFORMATION."
+//! The source's expected zone is the battlefield. Once it is not there, the attachment set
+//! must be read from `LKISnapshot::attachments`, exactly as the gate half already does.
+//!
+//! This drives the REAL pipeline end to end: the card is synthesized from verbatim Oracle
+//! text, Equipment is attached through the engine's `attach::attach_to` authority, the attack
+//! trigger fires off the real combat machinery (`declare_attackers`), the source is killed
+//! through the real zone-change pipeline (`move_to_zone`, which snapshots LKI) and purged by
+//! the real SBA (`check_state_based_actions`), and the trigger resolves off the real stack.
+//! The observable is the opponent's life total (and the controller's, for the paired gain).
+
+use engine::game::combat::AttackTarget;
+use engine::game::effects::attach;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::zones::create_object;
+use engine::game::{sba, zones};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+/// Whiplash, Vengeful Engineer — 2/2. Verbatim Oracle text from card-data.
+const WHIPLASH: &str = "Whiplash enters tapped.\nWhenever Whiplash attacks, if he's equipped, each opponent loses X life and you gain X life, where X is the number of Equipment attached to him.";
+
+/// Only a token ceases to exist under CR 111.7. For the GATE half (#5792) that was the
+/// discriminating axis; for the QUANTITY half under test here BOTH legs are broken, because
+/// SBA unattaches on any battlefield exit (CR 704.5n).
+#[derive(Clone, Copy, PartialEq)]
+enum SourceKind {
+    Token,
+    Nontoken,
+}
+
+/// Whether the source dies with its attack trigger on the stack, or survives to resolution.
+/// `Survives` is the HARNESS POSITIVE CONTROL — it exercises the live path, which must be
+/// untouched by this change.
+#[derive(Clone, Copy, PartialEq)]
+enum SourceFate {
+    Survives,
+    Dies,
+}
+
+/// An Equipment on the battlefield. Built so `capture_attachment_snapshot` (zones.rs)
+/// classifies it as `AttachmentKind::Equipment` — it keys off the "Equipment" subtype.
+fn make_equipment(state: &mut GameState, controller: PlayerId) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(state.next_object_id),
+        controller,
+        "Test Equipment".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Artifact);
+    obj.card_types.subtypes.push("Equipment".to_string());
+    id
+}
+
+/// The outcome of one run: life lost by the opponent, and life gained by the controller.
+/// Whiplash's two clauses read the SAME X, so asserting both catches a fix that repairs only
+/// one of the two `QuantityExpr` sites.
+struct Drain {
+    opponent_lost: i32,
+    controller_gained: i32,
+}
+
+/// Put a Whiplash on the battlefield with `attached` Equipment attached to him (and
+/// `unattached_decoys` further Equipment on the battlefield attached to NOTHING), attack,
+/// optionally kill him while the attack trigger is on the stack, and resolve.
+fn whiplash_attacks_then_dies(
+    kind: SourceKind,
+    attached: usize,
+    unattached_decoys: usize,
+    fate: SourceFate,
+) -> Drain {
+    let mut scenario = GameScenario::new();
+    // PLACE the scenario at PreCombatMain rather than advancing into it from turn 1: the draw
+    // step would deck P0 against an empty library and end the game before combat
+    // (`stack_object_keyword_grants.rs` documents the same foot-gun).
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let whiplash = scenario
+        .add_creature_from_oracle(P0, "Whiplash, Vengeful Engineer", 2, 2, WHIPLASH)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // DECOYS FIRST. Equipment that exists on the battlefield but is attached to nothing.
+    // Without these, a "count every Equipment on the battlefield" fix — which would be
+    // rules-wrong — would pass every assertion below. Their presence is what makes each
+    // count a statement about ATTACHMENT rather than about mere existence.
+    for _ in 0..unattached_decoys {
+        make_equipment(runner.state_mut(), P0);
+    }
+
+    let mut equipped = Vec::new();
+    for _ in 0..attached {
+        let eq = make_equipment(runner.state_mut(), P0);
+        // CR 301.5: attach through the engine's own authority, not by hand-editing state.
+        attach::attach_to(runner.state_mut(), eq, whiplash);
+        equipped.push(eq);
+    }
+
+    // CR 111.7 / CR 704.5d: only a token ceases to exist on leaving the battlefield.
+    if kind == SourceKind::Token {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&whiplash)
+            .expect("the source must exist at setup")
+            .is_token = true;
+    }
+
+    // PREMISE GUARD: the attachments must actually be established, or every count below is
+    // measuring nothing.
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&whiplash)
+            .expect("whiplash at setup")
+            .attachments
+            .len(),
+        attached,
+        "PREMISE: exactly {attached} Equipment must be attached to Whiplash at setup — the \
+         attachment set is the single axis under test"
+    );
+
+    // "Whiplash enters tapped" — but he is placed directly on the battlefield by the
+    // scenario builder, so untap him explicitly; a tapped creature cannot be declared as an
+    // attacker (CR 508.1a) and the trigger would never fire at all.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&whiplash)
+        .expect("whiplash")
+        .tapped = false;
+
+    // CR 508.1: declaring Whiplash as an attacker is what fires the trigger.
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(whiplash, AttackTarget::Player(P1))])
+        .expect("Whiplash must be able to attack");
+
+    // CR 603.4 (first check): "if he's equipped" gates the trigger at trigger time. With no
+    // Equipment attached the ability never goes on the stack at all.
+    let expected_stack = usize::from(attached > 0);
+    assert_eq!(
+        runner.state().stack.len(),
+        expected_stack,
+        "CR 603.4: the attack trigger must be on the stack exactly when 'if he's equipped' was \
+         TRUE at trigger time. If it were absent when equipped, we would be testing the \
+         COLLECTION path, not the quantity resolved at RESOLUTION."
+    );
+
+    if fate == SourceFate::Dies {
+        // Kill Whiplash with his trigger already on the stack, through the REAL zone-change
+        // pipeline (which snapshots LKI) and the REAL SBA (which purges a token under
+        // CR 111.7 / CR 704.5d and unattaches the Equipment under CR 704.5n).
+        let mut events = Vec::new();
+        zones::move_to_zone(runner.state_mut(), whiplash, Zone::Graveyard, &mut events);
+        sba::check_state_based_actions(runner.state_mut(), &mut events);
+
+        assert!(
+            runner.state().lki_cache.contains_key(&whiplash),
+            "CR 400.7: battlefield exit must snapshot LKI for the source in both arms"
+        );
+        match kind {
+            SourceKind::Token => assert!(
+                !runner.state().objects.contains_key(&whiplash),
+                "CR 111.7: the token source must have CEASED TO EXIST — if it is still in \
+                 state.objects this leg is vacuous"
+            ),
+            SourceKind::Nontoken => assert!(
+                runner.state().objects.contains_key(&whiplash),
+                "a nontoken source stays in state.objects (in the graveyard)"
+            ),
+        }
+
+        // THE DEFECT, STATED AS A FACT ABOUT THE BOARD. Every Equipment has been unattached
+        // by SBA (CR 704.5n). This is what makes the live count read 0 — and it is true for
+        // the NONTOKEN leg as well, which is why both legs are red.
+        for eq in &equipped {
+            assert!(
+                runner
+                    .state()
+                    .objects
+                    .get(eq)
+                    .expect("the Equipment itself survives its host — it is not a token")
+                    .attached_to
+                    .is_none(),
+                "CR 704.5n: SBA unattaches Equipment the instant its host leaves the \
+                 battlefield. The live board therefore CANNOT answer 'how many Equipment are \
+                 attached to him' — that is precisely why CR 608.2h routes the question to \
+                 LAST KNOWN INFORMATION."
+            );
+        }
+    }
+
+    let life_before_p0 = runner.life(P0);
+    let life_before_p1 = runner.life(P1);
+    runner.advance_until_stack_empty();
+
+    Drain {
+        opponent_lost: life_before_p1 - runner.life(P1),
+        controller_gained: runner.life(P0) - life_before_p0,
+    }
+}
+
+/// HARNESS POSITIVE CONTROL — green before and after.
+///
+/// A living Whiplash with 2 Equipment drains 2. This is the assertion that makes every zero
+/// below meaningful: without it, a probe whose trigger never resolves at all would make the
+/// "defect" assertions pass for entirely the wrong reason.
+///
+/// A third Equipment sits on the battlefield unattached, so `2` also proves the count FILTERED
+/// rather than merely counting Equipment.
+#[test]
+fn premise_living_equipped_whiplash_drains_for_its_equipment_count() {
+    let drain = whiplash_attacks_then_dies(SourceKind::Nontoken, 2, 1, SourceFate::Survives);
+    assert_eq!(
+        drain.opponent_lost, 2,
+        "a living Whiplash with 2 Equipment attached (and 1 unattached elsewhere) MUST drain \
+         exactly 2. If this is 0 the probe is broken and every other assertion here is void; \
+         if it is 3 the count is not filtering on attachment at all."
+    );
+    assert_eq!(
+        drain.controller_gained, 2,
+        "the paired 'you gain X life' clause reads the SAME X and must agree"
+    );
+}
+
+/// CR 603.4 FIRST-CHECK CONTROL — green before and after.
+///
+/// An UNEQUIPPED Whiplash never triggers: "if he's equipped" is false when the attack event
+/// occurs. An Equipment is on the battlefield here (just not attached), so a zero proves the
+/// gate ran and rejected him — not that no Equipment existed to find.
+#[test]
+fn unequipped_whiplash_never_triggers() {
+    let drain = whiplash_attacks_then_dies(SourceKind::Nontoken, 0, 1, SourceFate::Survives);
+    assert_eq!(
+        drain.opponent_lost, 0,
+        "CR 603.4: the ability triggers only if 'he's equipped' is true at the trigger event"
+    );
+}
+
+/// PRIMARY WITNESS — RED before the fix (read 0, must be 2).
+///
+/// A token copy of Whiplash with 2 Equipment attacks and dies with his trigger on the stack.
+/// CR 113.7a: the ability exists on the stack independently of its source. CR 608.2h: the
+/// source's information — including the attachment set its own X counts — comes from LAST
+/// KNOWN INFORMATION once the source is no longer in the zone it was expected in. He was
+/// equipped with 2 Equipment when he last existed, so X = 2.
+///
+/// Before the fix, `FilterProp::AttachedToSource` asked each LIVE Equipment
+/// `attached_to == Some(source)`, SBA had already cleared that field (CR 704.5n), X resolved
+/// to 0, and the drain silently did nothing.
+#[test]
+fn purged_token_source_counts_its_attachments_from_lki() {
+    let drain = whiplash_attacks_then_dies(SourceKind::Token, 2, 0, SourceFate::Dies);
+    assert_eq!(
+        drain.opponent_lost, 2,
+        "CR 608.2h: X counts the Equipment attached to the source as it LAST EXISTED — 2"
+    );
+    assert_eq!(
+        drain.controller_gained, 2,
+        "the paired 'you gain X life' clause reads the SAME X and must agree"
+    );
+}
+
+/// SECOND WITNESS — the NONTOKEN dead source. RED before the fix (read 0, must be 2).
+///
+/// This leg is the one the task charter did not predict. The printed card dies the same way
+/// and STAYS in `state.objects` (graveyard), so — unlike the gate half repaired by #5792 —
+/// the subject was never invisible. But SBA unattached its Equipment all the same
+/// (CR 704.5n), so the live board could not answer the count either. The quantity half is
+/// therefore broken on BOTH legs, and the CR 111.7 purge is NOT its discriminating axis.
+#[test]
+fn nontoken_dead_source_counts_its_attachments_from_lki() {
+    let drain = whiplash_attacks_then_dies(SourceKind::Nontoken, 2, 0, SourceFate::Dies);
+    assert_eq!(
+        drain.opponent_lost, 2,
+        "CR 608.2h + CR 704.5n: the Equipment is unattached the instant the host leaves, so \
+         'how many Equipment are attached to him' must be answered from LAST KNOWN \
+         INFORMATION even for a source that is merely dead rather than purged"
+    );
+    assert_eq!(
+        drain.controller_gained, 2,
+        "the paired 'you gain X life' clause reads the SAME X and must agree"
+    );
+}
+
+/// DISCRIMINATING CONTROL — the fix must COUNT, not FABRICATE.
+///
+/// This is the arm that proves the LKI fallback restores the source's ability to ANSWER the
+/// question honestly rather than to answer "all the Equipment on the board".
+///
+/// A purged token Whiplash had exactly ONE Equipment attached; TWO more sit on the battlefield
+/// attached to nothing. X must be exactly 1.
+///
+/// * A fail-closed count (the defect) reads 0 — fails.
+/// * A count that reads the LKI snapshot but ignores the filter reads 1 — passes, correctly.
+/// * A count that enumerates every Equipment on the battlefield reads 3 — fails.
+///
+/// Without this arm, the primary witness alone could be satisfied by a fix that simply counted
+/// all Equipment, which happens to equal 2 there.
+#[test]
+fn purged_token_source_counts_only_its_own_attachments_not_every_equipment() {
+    let drain = whiplash_attacks_then_dies(SourceKind::Token, 1, 2, SourceFate::Dies);
+    assert_eq!(
+        drain.opponent_lost, 1,
+        "X is the number of Equipment attached to HIM — 1 — not the number of Equipment in \
+         existence (3), and not the fail-closed 0. The LKI look-back must restore the ability \
+         to COUNT, not the licence to over-count."
+    );
+    assert_eq!(
+        drain.controller_gained, 1,
+        "the paired 'you gain X life' clause reads the SAME X and must agree"
+    );
+}

--- a/crates/engine/tests/integration/purged_source_attacked_this_turn_lki.rs
+++ b/crates/engine/tests/integration/purged_source_attacked_this_turn_lki.rs
@@ -1,0 +1,380 @@
+//! CR 508.1a + CR 608.2h + CR 113.7a + CR 111.7: "attacked this turn" must still be
+//! answerable when the ability's SOURCE has ceased to exist.
+//!
+//! Oracle text (Taigam, Ojutai Master — 3/4, verbatim from card-data):
+//!   "Instant, sorcery, and Dragon spells you control can't be countered.
+//!    Whenever you cast an instant or sorcery spell from your hand, if Taigam attacked this
+//!    turn, that spell gains rebound."
+//!
+//! Parsed condition (verbatim from card-data `parse_details`):
+//!   TriggerCondition::SourceMatchesFilter {
+//!       filter: Typed { type_filters: [Creature], properties: [AttackedThisTurn] } }
+//!
+//! THE DEFECT. `FilterProp::AttackedThisTurn` (and its `BlockedThisTurn` /
+//! `AttackedOrBlockedThisTurn` siblings) sat in the explicit FAIL-CLOSED group of
+//! `zone_change_record_matches_property` (filter.rs). A purged token source is absent from
+//! `state.objects`, so `subject_filter_matches_with_lki` (trigger_matchers.rs) falls back to
+//! the LKI snapshot, which synthesizes a `ZoneChangeRecord` and lands in exactly that group.
+//! The CR 603.4 re-check at RESOLUTION therefore read FALSE, the trigger was silently removed
+//! from the stack, and the spell never gained rebound.
+//!
+//! WHY FAIL-CLOSED WAS WRONG. The old rationale cited CR 400.7: "a permanent that changes
+//! zones becomes a new object with no memory of its previous existence, so the zone-change
+//! snapshot captures no attack history."
+//!
+//! That conflates two different objects. CR 400.7 governs the object that ARRIVES in the new
+//! zone — and it stays true; nothing here gives the graveyard card an attack history of its
+//! own. But the object this ability asks about is the one that ATTACKED, and CR 608.2h names
+//! it precisely: "the effect uses the object's LAST KNOWN INFORMATION ... If an ability states
+//! that an object does something, it's the object as it exists — OR AS IT MOST RECENTLY
+//! EXISTED — that does it."
+//!
+//! And the game still has that record. `state.creatures_attacked_this_turn` is a
+//! `HashSet<ObjectId>` written at attacker declaration (combat.rs) and cleared ONLY at turn
+//! cleanup (turns.rs) — never on a zone change. It is keyed by the battlefield ObjectId, which
+//! is exactly the id the LKI record carries. The ledger already outlives the source; the
+//! filter simply refused to read it. Failing closed did not protect CR 400.7 — it declined to
+//! answer a question the game had the answer to. (The `WasDealtDamageThisTurn` arm immediately
+//! above in the same match already reads its turn-scoped ledger by `record.object_id` for
+//! exactly this reason.)
+//!
+//! CONTRAST WITH THE ATTACHMENT HALF (sibling commit, Whiplash). There the underlying FACT is
+//! destroyed on exit — SBA unattaches every Equipment the instant its host leaves (CR 704.5n) —
+//! so BOTH a purged token and a merely-dead nontoken read wrong, and the repair had to restore
+//! the fact from a snapshot. Here the fact SURVIVES in a live ledger, so a merely-dead NONTOKEN
+//! source is already answered correctly by the live path (it stays in `state.objects` and the
+//! ledger still holds its id). Only the leg where the subject cannot be SEEN at all — the
+//! CR 111.7 purged token — was broken. That asymmetry is asserted below, in both directions.
+//!
+//! SEQUENCING. Taigam is the only observable carrier of this condition in the pool, and his
+//! rebound grant was itself inert until PR #5803 (#125) taught the layer pass to reach STACK
+//! objects. Landing this fix before that one would have been unwitnessable. This file builds on
+//! the harness that PR established (`stack_object_keyword_grants.rs`).
+//!
+//! The observable is downstream and end-to-end: a spell that has rebound as it resolves is
+//! EXILED instead of going to its owner's graveyard (CR 702.88a displacing CR 608.2n), and arms
+//! exactly one next-upkeep recast (CR 603.7a).
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::{sba, zones};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// Taigam, Ojutai Master — 3/4. VERBATIM Oracle text (verified against card-data.json).
+const TAIGAM: &str = "Instant, sorcery, and Dragon spells you control can't be countered.\nWhenever you cast an instant or sorcery spell from your hand, if Taigam attacked this turn, that spell gains rebound.";
+
+/// Only a token ceases to exist under CR 111.7 — this is the axis that separates a subject the
+/// filter cannot SEE from one that is merely dead.
+#[derive(Clone, Copy, PartialEq)]
+enum SourceKind {
+    Token,
+    Nontoken,
+}
+
+/// Whether Taigam was declared as an attacker — the axis that turns the intervening-if on and
+/// off.
+#[derive(Clone, Copy, PartialEq)]
+enum Attacked {
+    Yes,
+    No,
+}
+
+/// Whether Taigam dies with his trigger on the stack, or survives to its resolution.
+/// `Survives` is the HARNESS POSITIVE CONTROL.
+#[derive(Clone, Copy, PartialEq)]
+enum SourceFate {
+    Survives,
+    Dies,
+}
+
+/// Kill `id` through the REAL pipeline: `move_to_zone` (which snapshots LKI) followed by the
+/// REAL SBA (which purges a token under CR 111.7 / CR 704.5d).
+fn kill(runner: &mut GameRunner, id: ObjectId) {
+    let mut events = Vec::new();
+    zones::move_to_zone(runner.state_mut(), id, Zone::Graveyard, &mut events);
+    sba::check_state_based_actions(runner.state_mut(), &mut events);
+}
+
+/// Put Taigam on the battlefield, optionally swing with him, cast an instant from hand,
+/// optionally kill him while his trigger is on the stack, and resolve everything.
+///
+/// Returns the spell's final zone. Rebound EXILES the spell as it resolves (CR 702.88a);
+/// without rebound it goes to the graveyard (CR 608.2n). That is the observable.
+fn taigam_attacks_then_dies(kind: SourceKind, attacked: Attacked, fate: SourceFate) -> Zone {
+    let mut scenario = GameScenario::new();
+    // PLACE the scenario at PreCombatMain rather than advancing into it from turn 1: the draw
+    // step would deck P0 against an empty library and end the game before combat.
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let taigam = scenario
+        .add_creature_from_oracle(P0, "Taigam, Ojutai Master", 3, 4, TAIGAM)
+        .id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Test Instant", true, "You gain 3 life.")
+        .id();
+
+    let mut runner = scenario.build();
+
+    // CR 111.7 / CR 704.5d: only a token ceases to exist on leaving the battlefield.
+    if kind == SourceKind::Token {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&taigam)
+            .expect("the source must exist at setup")
+            .is_token = true;
+    }
+
+    if attacked == Attacked::Yes {
+        // CR 508.1a: declaring Taigam as an attacker is what writes his id into
+        // `state.creatures_attacked_this_turn`.
+        runner.advance_to_combat();
+        runner
+            .declare_attackers(&[(taigam, AttackTarget::Player(P1))])
+            .expect("Taigam must be able to attack");
+        runner.combat_damage();
+        runner.advance_to_phase(Phase::PostCombatMain);
+    }
+
+    // PREMISE GUARD: the ledger is the whole subject of this test. Assert it says what we think
+    // it says BEFORE the source dies — otherwise a green below could mean "the ledger was
+    // consulted" or "the ledger was empty and something else answered".
+    assert_eq!(
+        runner
+            .state()
+            .creatures_attacked_this_turn
+            .contains(&taigam),
+        attacked == Attacked::Yes,
+        "PREMISE: `creatures_attacked_this_turn` must hold Taigam's id exactly when he attacked"
+    );
+
+    // CR 603.4 (first check): casting the instant is the trigger event.
+    runner.cast(spell).commit();
+
+    if fate == SourceFate::Dies {
+        // Kill Taigam with his trigger ALREADY on the stack. CR 113.7a: the ability exists on
+        // the stack independently of its source.
+        kill(&mut runner, taigam);
+
+        assert!(
+            runner.state().lki_cache.contains_key(&taigam),
+            "CR 400.7: battlefield exit must snapshot LKI for the source in both arms"
+        );
+        match kind {
+            SourceKind::Token => assert!(
+                !runner.state().objects.contains_key(&taigam),
+                "CR 111.7: the token source must have CEASED TO EXIST — if it is still in \
+                 state.objects this leg is vacuous and proves nothing about the LKI path"
+            ),
+            SourceKind::Nontoken => assert!(
+                runner.state().objects.contains_key(&taigam),
+                "a nontoken source stays in state.objects (in the graveyard)"
+            ),
+        }
+
+        // THE LEDGER SURVIVED THE SOURCE. This is the fact the fix rests on, stated as an
+        // assertion rather than a claim: the attack history is NOT cleared by the zone change.
+        assert_eq!(
+            runner
+                .state()
+                .creatures_attacked_this_turn
+                .contains(&taigam),
+            attacked == Attacked::Yes,
+            "`creatures_attacked_this_turn` is cleared ONLY at turn cleanup (turns.rs), never on \
+             a zone change — the attack history must still be there after the source is gone. \
+             That is precisely why fail-closed was the wrong answer."
+        );
+    }
+
+    runner.advance_until_stack_empty();
+    runner.state().objects[&spell].zone
+}
+
+/// HARNESS POSITIVE CONTROL — green before and after.
+///
+/// A LIVING Taigam who attacked grants rebound, so the spell is exiled. Without this, a probe
+/// whose spell could never be exiled — a broken cast, a trigger that never resolves — would
+/// make every "defect" assertion below pass for entirely the wrong reason.
+#[test]
+fn premise_living_taigam_who_attacked_grants_rebound() {
+    let zone = taigam_attacks_then_dies(SourceKind::Nontoken, Attacked::Yes, SourceFate::Survives);
+    assert_eq!(
+        zone,
+        Zone::Exile,
+        "CR 702.88a: a living Taigam who attacked MUST grant rebound, exiling the spell as it \
+         resolves. If this is Graveyard the probe is broken and every assertion here is void."
+    );
+}
+
+/// CR 603.4 FIRST-CHECK CONTROL — green before and after.
+///
+/// A Taigam who did NOT attack never triggers: the intervening-if is false when the spell is
+/// cast. The spell resolves normally into the graveyard (CR 608.2n).
+#[test]
+fn living_taigam_who_did_not_attack_grants_nothing() {
+    let zone = taigam_attacks_then_dies(SourceKind::Nontoken, Attacked::No, SourceFate::Survives);
+    assert_eq!(
+        zone,
+        Zone::Graveyard,
+        "CR 603.4: the ability triggers only if 'Taigam attacked this turn' is true at the \
+         trigger event"
+    );
+}
+
+/// PRIMARY WITNESS — RED before the fix (spell went to the Graveyard; must be Exile).
+///
+/// A token copy of Taigam attacks, then DIES in response to the spell his own trigger is
+/// watching. CR 113.7a: the ability exists on the stack independently of its source. CR 603.4:
+/// the intervening-if is re-checked at resolution. CR 608.2h: that re-check reads the source's
+/// LAST KNOWN INFORMATION — and Taigam, as he most recently existed, attacked this turn. So the
+/// spell still gains rebound and is exiled (CR 702.88a).
+///
+/// Before the fix, the purged token was invisible to the live filter, the LKI fallback
+/// synthesized a `ZoneChangeRecord`, and `AttackedThisTurn` fail-closed to FALSE — even though
+/// `state.creatures_attacked_this_turn` still held his id the whole time.
+#[test]
+fn purged_token_taigam_still_answers_attacked_this_turn_via_lki() {
+    let zone = taigam_attacks_then_dies(SourceKind::Token, Attacked::Yes, SourceFate::Dies);
+    assert_eq!(
+        zone,
+        Zone::Exile,
+        "CR 608.2h + CR 508.1a: 'if Taigam attacked this turn' must be answered from the source \
+         as it MOST RECENTLY EXISTED. He attacked; the turn-scoped ledger still holds his id; \
+         the spell gains rebound and is EXILED as it resolves (CR 702.88a)."
+    );
+}
+
+/// THE ASYMMETRY — green before AND after. This is a CONTROL, not a witness.
+///
+/// A NONTOKEN Taigam who dies the same way stays in `state.objects` (graveyard), so the LIVE
+/// filter can still see the subject and read the surviving ledger by his id. This leg was
+/// therefore ALREADY correct before the fix — unlike the attachment half of this class
+/// (Whiplash), where SBA destroys the underlying fact on exit and BOTH legs were broken.
+///
+/// It is asserted here so that the difference between "the fact survives, the subject is
+/// invisible" (this defect) and "the fact itself is destroyed" (the attachment defect) is
+/// pinned rather than assumed.
+#[test]
+fn nontoken_dead_taigam_was_already_correct_via_the_live_path() {
+    let zone = taigam_attacks_then_dies(SourceKind::Nontoken, Attacked::Yes, SourceFate::Dies);
+    assert_eq!(
+        zone,
+        Zone::Exile,
+        "a merely-dead nontoken source is still in state.objects, so the LIVE path reads the \
+         surviving `creatures_attacked_this_turn` ledger by his id. This must hold both before \
+         and after the fix."
+    );
+}
+
+/// NEGATIVE CONTROL — a purged token that did NOT attack must still grant nothing.
+///
+/// The fix must restore the source's ability to ANSWER the question, not to always answer
+/// "yes". A purged token Taigam who never attacked must not fabricate rebound.
+#[test]
+fn purged_token_taigam_that_did_not_attack_grants_nothing() {
+    let zone = taigam_attacks_then_dies(SourceKind::Token, Attacked::No, SourceFate::Dies);
+    assert_eq!(
+        zone,
+        Zone::Graveyard,
+        "the LKI look-back must answer HONESTLY — a Taigam who never attacked grants no rebound, \
+         purged or not"
+    );
+}
+
+/// DISCRIMINATING CONTROL — the look-back is keyed by the SOURCE'S id, not by the board.
+///
+/// The runtime negative control above cannot reach the code under test: a Taigam who did not
+/// attack never triggers at all (CR 603.4 first check), so the resolution-time re-check never
+/// runs. This probe therefore interrogates the seam directly, with Taigam's OWN parsed filter,
+/// and asks the question the runtime cannot:
+///
+///   A purged token Taigam who did NOT attack, while ANOTHER creature DID attack this turn.
+///
+/// The ledger is non-empty, so a fix that consulted it without keying on the record's id — say
+/// `!state.creatures_attacked_this_turn.is_empty()` — would answer TRUE here and fabricate
+/// rebound for a Taigam who never swung. It must answer FALSE.
+///
+/// Non-vacuity: the sibling leg runs the identical code path with TAIGAM as the attacker and
+/// asserts TRUE. A predicate that always returned false would fail that one.
+#[test]
+fn purged_token_attack_lookback_is_keyed_by_the_source_not_the_board() {
+    use engine::game::filter::{matches_target_filter_on_lki_snapshot, FilterContext};
+    use engine::types::ability::TriggerCondition;
+
+    for (taigam_attacks, expected) in [(false, false), (true, true)] {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let taigam = scenario
+            .add_creature_from_oracle(P0, "Taigam, Ojutai Master", 3, 4, TAIGAM)
+            .id();
+        // THE DECOY. A second creature that attacks in the arm where Taigam does not, so the
+        // ledger is NON-EMPTY either way. Without it, a `!is_empty()` fix would pass.
+        let decoy = scenario.add_creature(P0, "Decoy Attacker", 2, 2).id();
+        let mut runner = scenario.build();
+
+        // Take the filter from the CARD'S OWN PARSED TRIGGER, not a hand-rolled approximation —
+        // this probe must interrogate the seam with exactly the predicate Taigam actually
+        // carries, or it proves nothing about Taigam.
+        let condition = runner
+            .state()
+            .objects
+            .get(&taigam)
+            .expect("taigam at setup")
+            .trigger_definitions
+            .first()
+            .expect("PREMISE: Taigam must parse to exactly one triggered ability")
+            .condition
+            .clone()
+            .expect("PREMISE: that trigger must carry an intervening-if");
+        let filter = match condition {
+            TriggerCondition::SourceMatchesFilter { filter } => filter,
+            other => panic!(
+                "PREMISE: Taigam's intervening-if must be a SourceMatchesFilter — if the parse \
+                 changed to {other:?}, this whole file is testing nothing"
+            ),
+        };
+
+        let attacker = if taigam_attacks { taigam } else { decoy };
+        runner.advance_to_combat();
+        runner
+            .declare_attackers(&[(attacker, AttackTarget::Player(P1))])
+            .expect("the chosen attacker must be able to attack");
+        runner.combat_damage();
+        runner.advance_to_phase(Phase::PostCombatMain);
+
+        // The ledger is NON-EMPTY in BOTH arms — that is the point of the decoy.
+        assert!(
+            !runner.state().creatures_attacked_this_turn.is_empty(),
+            "PREMISE: something must have attacked in both arms, or the decoy proves nothing"
+        );
+
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&taigam)
+            .expect("taigam")
+            .is_token = true;
+        kill(&mut runner, taigam);
+        assert!(
+            !runner.state().objects.contains_key(&taigam),
+            "CR 111.7: the token must have ceased to exist, or this probe is vacuous"
+        );
+
+        let state = runner.state();
+        let lki = state
+            .lki_cache
+            .get(&taigam)
+            .expect("CR 400.7: the purged token must still have an LKI snapshot");
+        let ctx = FilterContext::from_source(state, taigam);
+
+        assert_eq!(
+            matches_target_filter_on_lki_snapshot(state, taigam, lki, &filter, &ctx),
+            expected,
+            "the attack look-back must be keyed by the RECORD'S OBJECT ID. With Taigam \
+             attacking it must read TRUE; with only a decoy attacking it must read FALSE even \
+             though `creatures_attacked_this_turn` is non-empty."
+        );
+    }
+}


### PR DESCRIPTION
- **fix(filter): count the source's attachments from LKI once it leaves the battlefield (CR 608.2h)**
- **fix(filter): answer the AttackedThisTurn family from the surviving ledger on the LKI path (CR 608.2h)**
