### PR TITLE
fix(parser): attach the just-created Equipment/Aura token instead of swapping attach/target

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2291,13 +2291,15 @@ fn parse_trailing_where_x_quantity(tail: &str) -> Option<QuantityExpr> {
 ///    `state.last_created_token_ids` into the delayed ability's targets.
 pub(super) fn resolve_populated_token_anaphors(defs: &mut [AbilityDefinition]) {
     for i in 0..defs.len() {
-        if !defs[..i]
+        let Some(nearest_creator) = defs[..i]
             .iter()
-            .any(|d| is_token_creating_effect(&d.effect))
-        {
+            .rev()
+            .find(|d| is_token_creating_effect(&d.effect))
+        else {
             continue;
-        }
-        rewrite_populated_anaphor_in_def(&mut defs[i]);
+        };
+        let token_is_attachable = token_creator_is_attachable(&nearest_creator.effect);
+        rewrite_populated_anaphor_in_def(&mut defs[i], token_is_attachable);
     }
 }
 
@@ -2305,6 +2307,21 @@ pub(super) fn is_token_creating_effect(effect: &Effect) -> bool {
     matches!(
         effect,
         Effect::Populate | Effect::Token { .. } | Effect::CopyTokenOf { .. }
+    )
+}
+
+/// CR 301.5 + CR 303.4: True when the nearest preceding token creator makes
+/// an Equipment or Aura token — a permanent that can only ever be the
+/// *attachment* in an `Attach` effect, never the host. Used to route the
+/// post-token anaphor rewrite (`rewrite_parent_target_to_last_created`) at the
+/// correct slot: an ambiguous "it" following an Equipment/Aura token creator
+/// (U.S.Agent, John Walker: "create ... Equipment ... token ... Attach it to
+/// ~") names the just-created token as the *attachment*, not the target.
+fn token_creator_is_attachable(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::Token { types, .. }
+            if types.iter().any(|t| t.eq_ignore_ascii_case("Equipment") || t.eq_ignore_ascii_case("Aura"))
     )
 }
 
@@ -2339,7 +2356,7 @@ fn rebind_self_ref_grant_to_last_created(effect: &mut Effect) {
 /// Walk an ability definition, rewriting the populated-token anaphor at
 /// whichever level it appears. Recurses into `CreateDelayedTrigger.effect` so
 /// the "sacrifice it" pattern inside a delayed trigger also rewrites.
-fn rewrite_populated_anaphor_in_def(def: &mut AbilityDefinition) {
+fn rewrite_populated_anaphor_in_def(def: &mut AbilityDefinition, token_is_attachable: bool) {
     if let Some(new_effect) =
         rewrite_token_created_this_way_unimplemented(&def.effect, def.duration.clone())
     {
@@ -2348,11 +2365,11 @@ fn rewrite_populated_anaphor_in_def(def: &mut AbilityDefinition) {
         return;
     }
 
-    rewrite_populated_anaphor_in_effect(&mut def.effect);
+    rewrite_populated_anaphor_in_effect(&mut def.effect, token_is_attachable);
     // CR 608.2c + CR 701.36a: recurse into sub_ability chains so anaphoric
     // rewrites apply to sibling followups (Fractal Harness PutCounter/Attach).
     if let Some(sub) = def.sub_ability.as_mut() {
-        rewrite_populated_anaphor_in_def(sub);
+        rewrite_populated_anaphor_in_def(sub, token_is_attachable);
     }
 }
 
@@ -2450,7 +2467,7 @@ pub(super) fn fold_token_it_has_grants_into_token_statics(def: &mut AbilityDefin
 /// Walk an effect, rewriting the populated-token anaphor at whichever level
 /// it appears. Recurses into `CreateDelayedTrigger.effect` so the "sacrifice
 /// it" pattern inside a delayed trigger also rewrites.
-fn rewrite_populated_anaphor_in_effect(effect: &mut Effect) {
+fn rewrite_populated_anaphor_in_effect(effect: &mut Effect, token_is_attachable: bool) {
     // Case 1: bare Unimplemented anaphor at the top level (e.g., "the token
     // created this way gains haste").
     if let Some(new_effect) = rewrite_token_created_this_way_unimplemented(effect, None) {
@@ -2462,7 +2479,7 @@ fn rewrite_populated_anaphor_in_effect(effect: &mut Effect) {
     // via ParentTarget. Rewrite to LastCreated and recurse into the inner
     // effect for any nested anaphors.
     if let Effect::CreateDelayedTrigger { effect: inner, .. } = effect {
-        rewrite_parent_target_to_last_created(&mut inner.effect);
+        rewrite_parent_target_to_last_created(&mut inner.effect, token_is_attachable);
         // CR 603.7c + CR 608.2c (issue #4601): a PHASE-triggered token-copier
         // (Mishra, Eminent One — "At the beginning of combat on your turn,
         // create a token …, Sacrifice it at the beginning of the next end step")
@@ -2470,7 +2487,7 @@ fn rewrite_populated_anaphor_in_effect(effect: &mut Effect) {
         // `SelfRef` (the source) rather than `ParentTarget`/`TriggeringSource`.
         // In this gated post-token scope the antecedent is the created token.
         rewrite_delayed_cleanup_self_ref_to_last_created(&mut inner.effect);
-        rewrite_populated_anaphor_in_effect(&mut inner.effect);
+        rewrite_populated_anaphor_in_effect(&mut inner.effect, token_is_attachable);
     }
 
     // Case 3: a bare "it gains/gets X" grant that parsed to a `GenericEffect`
@@ -2482,8 +2499,10 @@ fn rewrite_populated_anaphor_in_effect(effect: &mut Effect) {
 
     // Case 4 (CR 301.5b + CR 122.6a): imperative followups like Fractal Harness's
     // "attach this Equipment to it" parse "it" as ParentTarget (Self-ETB trigger
-    // subject). After a token creator in the same chain, rewrite to LastCreated.
-    rewrite_parent_target_to_last_created(effect);
+    // subject). After a token creator in the same chain, rewrite to LastCreated —
+    // on the `attachment` slot when the created token is itself an Equipment/Aura
+    // (U.S.Agent, John Walker: "Attach it to ~"), or the `target` slot otherwise.
+    rewrite_parent_target_to_last_created(effect, token_is_attachable);
 }
 
 /// If `effect` is `Unimplemented { description: "<anaphor> <verb-phrase>" }`,
@@ -2710,7 +2729,10 @@ pub(super) fn thread_chosen_damage_source_into_oneshot_effects(defs: &mut [Abili
     }
 }
 
-pub(super) fn rewrite_parent_target_to_last_created(effect: &mut Effect) {
+pub(super) fn rewrite_parent_target_to_last_created(
+    effect: &mut Effect,
+    token_is_attachable: bool,
+) {
     match effect {
         Effect::GenericEffect {
             static_abilities,
@@ -2757,14 +2779,32 @@ pub(super) fn rewrite_parent_target_to_last_created(effect: &mut Effect) {
                 *duration = Some(Duration::Permanent);
             }
         }
-        Effect::Attach { target, .. } => {
-            // CR 608.2c + CR 301.5b: after a token creator, "attach this
-            // Equipment to it" may have resolved the host pronoun through the
-            // source-default `SelfRef` path before this gated post-token pass.
-            if matches!(
+        Effect::Attach {
+            attachment,
+            target,
+        } => {
+            if token_is_attachable {
+                // CR 301.5 + CR 303.4: the just-created token is itself an
+                // Equipment/Aura, so it can only be the *attachment* — an
+                // Equipment/Aura can never be an attachment's host. A bare
+                // "it" here (U.S.Agent, John Walker: "Attach it to ~") parses
+                // through the attachment-anaphor fallback as `ParentTarget`;
+                // rebind it to the created token and leave `target`'s
+                // explicit self-reference alone.
+                if matches!(
+                    attachment,
+                    TargetFilter::ParentTarget | TargetFilter::TriggeringSource
+                ) {
+                    *attachment = TargetFilter::LastCreated;
+                }
+            } else if matches!(
                 target,
                 TargetFilter::SelfRef | TargetFilter::ParentTarget | TargetFilter::TriggeringSource
             ) {
+                // CR 608.2c + CR 301.5b: after a token creator, "attach this
+                // Equipment to it" may have resolved the host pronoun through
+                // the source-default `SelfRef` path before this gated
+                // post-token pass.
                 *target = TargetFilter::LastCreated;
             }
         }
@@ -2917,7 +2957,7 @@ pub(super) fn nest_whenever_this_turn_token_cleanup_delayed_trigger(def: &mut Ab
         ..
     } = &mut *cleanup_sub.effect
     {
-        rewrite_parent_target_to_last_created(&mut cleanup_effect.effect);
+        rewrite_parent_target_to_last_created(&mut cleanup_effect.effect, false);
     }
 
     let mut cursor = inner.as_mut();
@@ -11101,7 +11141,7 @@ mod token_anaphor_rewrite_tests {
             target: Some(TargetFilter::ParentTarget),
         };
 
-        rewrite_parent_target_to_last_created(&mut effect);
+        rewrite_parent_target_to_last_created(&mut effect, false);
 
         match effect {
             Effect::GenericEffect {

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2311,12 +2311,11 @@ pub(super) fn is_token_creating_effect(effect: &Effect) -> bool {
 }
 
 /// CR 301.5 + CR 303.4: True when the nearest preceding token creator makes
-/// an Equipment or Aura token — a permanent that can only ever be the
-/// *attachment* in an `Attach` effect, never the host. Used to route the
-/// post-token anaphor rewrite (`rewrite_parent_target_to_last_created`) at the
-/// correct slot: an ambiguous "it" following an Equipment/Aura token creator
-/// (U.S.Agent, John Walker: "create ... Equipment ... token ... Attach it to
-/// ~") names the just-created token as the *attachment*, not the target.
+/// an Equipment or Aura token. Used to prefer the `attachment` slot for the
+/// post-token anaphor rewrite (`rewrite_parent_target_to_last_created`): in
+/// U.S.Agent, John Walker's "create ... Equipment ... token ... Attach it to
+/// ~", the created token is the attachment. If that slot is explicit, the
+/// target-side anaphor remains eligible for the normal fallback rewrite.
 fn token_creator_is_attachable(effect: &Effect) -> bool {
     matches!(
         effect,
@@ -2783,20 +2782,17 @@ pub(super) fn rewrite_parent_target_to_last_created(
             attachment,
             target,
         } => {
-            if token_is_attachable {
-                // CR 301.5 + CR 303.4: the just-created token is itself an
-                // Equipment/Aura, so it can only be the *attachment* — an
-                // Equipment/Aura can never be an attachment's host. A bare
-                // "it" here (U.S.Agent, John Walker: "Attach it to ~") parses
-                // through the attachment-anaphor fallback as `ParentTarget`;
-                // rebind it to the created token and leave `target`'s
-                // explicit self-reference alone.
-                if matches!(
+            if token_is_attachable
+                && matches!(
                     attachment,
                     TargetFilter::ParentTarget | TargetFilter::TriggeringSource
-                ) {
-                    *attachment = TargetFilter::LastCreated;
-                }
+                )
+            {
+                // CR 301.5 + CR 303.4: the just-created token is itself an
+                // Equipment/Aura, and the attachment slot is the anaphor in
+                // U.S.Agent's "Attach it to ~". Rebind that slot and leave the
+                // explicit host alone.
+                *attachment = TargetFilter::LastCreated;
             } else if matches!(
                 target,
                 TargetFilter::SelfRef | TargetFilter::ParentTarget | TargetFilter::TriggeringSource

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -45947,8 +45947,8 @@ fn threshold_land_balance_rejects_nonbasic_search_variant() {
 /// `target` slot as the ambiguous anaphor (correct for Fractal Harness-style
 /// "attach this Equipment to it", where the *source* is the Equipment being
 /// attached and the created token is the host) — which swapped the roles
-/// here, since U.S.Agent's created token IS the Equipment (CR 301.5: an
-/// Equipment can only ever be an `attachment`, never a host).
+/// here, since U.S.Agent's created token IS the Equipment and the attachment
+/// slot carries the anaphor.
 #[test]
 fn us_agent_attaches_created_equipment_token_to_self() {
     let parsed = parse_oracle_text(
@@ -45984,4 +45984,22 @@ fn us_agent_attaches_created_equipment_token_to_self() {
         TargetFilter::SelfRef,
         "U.S.Agent must remain the attachment's host"
     );
+}
+
+/// An attachable created token prefers an anaphor in the attachment slot, but
+/// must not suppress the target-side rewrite when that slot is explicit.
+#[test]
+fn attachable_token_creator_still_rewrites_target_side_anaphor() {
+    let mut effect = Effect::Attach {
+        attachment: TargetFilter::SelfRef,
+        target: TargetFilter::ParentTarget,
+    };
+
+    rewrite_parent_target_to_last_created(&mut effect, true);
+
+    let Effect::Attach { attachment, target } = effect else {
+        panic!("expected Attach effect");
+    };
+    assert_eq!(attachment, TargetFilter::SelfRef);
+    assert_eq!(target, TargetFilter::LastCreated);
 }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -1,3 +1,4 @@
+use super::lower::rewrite_parent_target_to_last_created;
 use super::*;
 use crate::parser::parse_oracle_text;
 use crate::types::ability::CardPlayMode::{Cast, Play};

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -45939,3 +45939,49 @@ fn threshold_land_balance_rejects_nonbasic_search_variant() {
     );
     assert!(matches!(def.effect.as_ref(), Effect::Unimplemented { .. }));
 }
+
+/// Issue #5760: U.S.Agent, John Walker creates an Equipment token, then
+/// "Attach it to ~" in a following sentence. "It" is the just-created
+/// Equipment (`LastCreated`); "~" is U.S.Agent itself (`SelfRef`). Before the
+/// fix, the post-token anaphor rewrite unconditionally treated the `Attach`'s
+/// `target` slot as the ambiguous anaphor (correct for Fractal Harness-style
+/// "attach this Equipment to it", where the *source* is the Equipment being
+/// attached and the created token is the host) — which swapped the roles
+/// here, since U.S.Agent's created token IS the Equipment (CR 301.5: an
+/// Equipment can only ever be an `attachment`, never a host).
+#[test]
+fn us_agent_attaches_created_equipment_token_to_self() {
+    let parsed = parse_oracle_text(
+        "When U.S.Agent enters, create a colorless Equipment artifact token named Sturdy Shield with \"Equipped creature gets +1/+2\" and equip {2}. Attach it to U.S.Agent.",
+        "U.S.Agent, John Walker",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Human".to_string(), "Soldier".to_string(), "Hero".to_string()],
+    );
+    let execute = parsed.triggers[0]
+        .execute
+        .as_ref()
+        .expect("ETB trigger must have an execute chain");
+    assert!(
+        matches!(*execute.effect, Effect::Token { .. }),
+        "expected the ETB root to create the Equipment token, got {:?}",
+        execute.effect
+    );
+    let attach = execute
+        .sub_ability
+        .as_ref()
+        .expect("Attach must follow the token creation");
+    let Effect::Attach { attachment, target } = attach.effect.as_ref() else {
+        panic!("expected Attach sub-ability, got {:?}", attach.effect);
+    };
+    assert_eq!(
+        *attachment,
+        TargetFilter::LastCreated,
+        "the created Equipment token must be the attachment, not U.S.Agent"
+    );
+    assert_eq!(
+        *target,
+        TargetFilter::SelfRef,
+        "U.S.Agent must remain the attachment's host"
+    );
+}

--- a/crates/engine/tests/integration/issue_5760_us_agent_equipment_attach.rs
+++ b/crates/engine/tests/integration/issue_5760_us_agent_equipment_attach.rs
@@ -1,0 +1,64 @@
+//! Issue #5760 — U.S.Agent, John Walker must attach the Sturdy Shield
+//! Equipment token it creates on ETB to itself, not leave it unattached.
+
+use engine::game::game_object::AttachTarget;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const US_AGENT_ORACLE: &str = "When U.S.Agent enters, create a colorless Equipment artifact token named Sturdy Shield with \"Equipped creature gets +1/+2\" and equip {2}. Attach it to U.S.Agent.";
+
+#[test]
+fn us_agent_attaches_created_sturdy_shield_on_etb() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::White, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+        ],
+    );
+
+    let us_agent = scenario
+        .add_creature_to_hand_from_oracle(P0, "U.S.Agent, John Walker", 4, 4, US_AGENT_ORACLE)
+        .as_legendary()
+        .with_subtypes(vec!["Human", "Soldier", "Hero"])
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::WhiteBlack],
+            generic: 3,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    runner.cast(us_agent).resolve();
+
+    let us_agent_obj = runner.state().objects.get(&us_agent).expect("U.S.Agent");
+    assert_eq!(
+        us_agent_obj.zone,
+        Zone::Battlefield,
+        "U.S.Agent should enter the battlefield"
+    );
+
+    let token_id = *us_agent_obj
+        .attachments
+        .first()
+        .expect("U.S.Agent should have the created Equipment token attached");
+
+    let token = runner
+        .state()
+        .objects
+        .get(&token_id)
+        .expect("created Sturdy Shield token");
+    assert!(token.is_token, "attachment should be the created token");
+    assert_eq!(token.name, "Sturdy Shield");
+    assert_eq!(
+        token.attached_to,
+        Some(AttachTarget::Object(us_agent)),
+        "the Sturdy Shield token should be attached to U.S.Agent"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -490,6 +490,7 @@ mod issue_564_wishclaw_talisman_control;
 mod issue_5657_zurs_weirding;
 mod issue_565_birthing_ritual_end_step_trigger;
 mod issue_566_ragavan_dash_cast;
+mod issue_5760_us_agent_equipment_attach;
 mod issue_580_solitude_evoke_prompt;
 mod issue_581_mystic_remora_cumulative_upkeep;
 mod issue_583_vivi_ornitier_mana_source;


### PR DESCRIPTION
## Summary
- Fixes #5760: U.S.Agent, John Walker created its Sturdy Shield Equipment token on ETB but never attached it, because the post-token anaphor rewrite (`rewrite_parent_target_to_last_created`) assumed the ambiguous "it" always lands in the `Attach` effect's `target` slot (correct for Fractal Harness-style "attach this Equipment to it", where the ability's own source is the Equipment). For "Attach it to ~" after creating an Equipment/Aura token, the roles are reversed — the token is the attachment, `~` is the host — so the rewrite was flipping `attachment`/`target` and pointing the Attach at a `ParentTarget` with no bound target, silently no-oping.
- The fix threads whether the nearest preceding token creator made an Equipment/Aura token (CR 301.5 / CR 303.4: an Equipment/Aura can only ever be an attachment, never a host) through the rewrite pass, so it corrects the right slot for either card shape.

## Test plan
- [x] `cargo test -p engine --lib` (16589 passed)
- [x] `cargo test -p engine --test integration` (3059 passed, including new `issue_5760_us_agent_equipment_attach` and the existing Fractal Harness regression suite)
- [x] `cargo clippy -p engine --lib --tests -- -D warnings`
- [x] `cargo fmt --all`
- [x] Verified the new integration test fails without the fix and passes with it
