### PR TITLE
feat(parser): unit-scoped provenance on SwallowedClause diagnostics

### DIFF
--- a/crates/engine/src/bin/coverage_report.rs
+++ b/crates/engine/src/bin/coverage_report.rs
@@ -7,7 +7,7 @@ use engine::game::coverage::{
     analyze_coverage, audit_resolver_features, audit_silent_drops, parse_warning_pattern,
     CardCoverageResult, CoverageSummary, GapDetail, ParsedItem,
 };
-use engine::parser::oracle_ir::diagnostic::OracleDiagnostic;
+use engine::parser::oracle_ir::diagnostic::{OracleDiagnostic, OracleItemId, OracleSourceSpan};
 use engine::types::card::CardFace;
 use serde::Serialize;
 
@@ -45,6 +45,15 @@ struct WarningDrilldownWarning {
     pattern: String,
     line_index: usize,
     text: String,
+    /// Unit provenance, present only on stamped swallow-audit findings. The span is the
+    /// card-absolute byte range of the audit unit's OWN lines — line-granular today, so
+    /// two clauses on one line share it (see `OracleDiagnostic::SwallowedClause`).
+    /// `items` is the unit's pooled evidence set, legitimately empty for a card that
+    /// lowered to no items.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unit_span: Option<OracleSourceSpan>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    evidence_items: Vec<OracleItemId>,
 }
 
 fn build_warning_drilldown(
@@ -85,6 +94,8 @@ fn build_warning_drilldown(
                     pattern: warning_pattern,
                     line_index: warning.line_index(),
                     text: warning_text(warning),
+                    unit_span: warning.unit_span().cloned(),
+                    evidence_items: warning.evidence_items().to_vec(),
                 })
             })
             .collect();

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -11128,12 +11128,10 @@ mod tests {
 
     #[test]
     fn apnap_swallowed_clause_warning_counts_as_coverage_gap() {
-        let warnings = vec![OracleDiagnostic::SwallowedClause {
-            detector: "APNAP".to_string(),
-            description: "Repeat the following process for each opponent in turn order."
-                .to_string(),
-            line_index: 0,
-        }];
+        let warnings = vec![OracleDiagnostic::swallowed_clause(
+            "APNAP",
+            "Repeat the following process for each opponent in turn order.",
+        )];
         let mut missing = Vec::new();
         check_parse_warnings(&warnings, &mut missing);
         assert_eq!(missing, vec!["Swallow:APNAP"]);
@@ -11142,11 +11140,10 @@ mod tests {
     #[test]
     fn swallowed_clause_warning_counts_as_coverage_gap() {
         let warnings = vec![
-            crate::parser::oracle_ir::diagnostic::OracleDiagnostic::SwallowedClause {
-                detector: "Condition_If".to_string(),
-                description: "If foo, draw a card.".to_string(),
-                line_index: 0,
-            },
+            crate::parser::oracle_ir::diagnostic::OracleDiagnostic::swallowed_clause(
+                "Condition_If",
+                "If foo, draw a card.",
+            ),
         ];
         let mut missing = Vec::new();
         check_parse_warnings(&warnings, &mut missing);
@@ -11248,11 +11245,10 @@ mod tests {
     /// exactly `"Swallow:{detector}"`, so this locks it.
     #[test]
     fn check_parse_warnings_flags_swallowed_clause() {
-        let warnings = vec![OracleDiagnostic::SwallowedClause {
-            detector: "Condition_If".into(),
-            description: "if you control a creature, …".into(),
-            line_index: 0,
-        }];
+        let warnings = vec![OracleDiagnostic::swallowed_clause(
+            "Condition_If",
+            "if you control a creature, …",
+        )];
         let mut missing = Vec::new();
         check_parse_warnings(&warnings, &mut missing);
         assert_eq!(missing, vec!["Swallow:Condition_If".to_string()]);
@@ -11263,16 +11259,11 @@ mod tests {
     #[test]
     fn check_parse_warnings_dedupes_same_detector() {
         let warnings = vec![
-            OracleDiagnostic::SwallowedClause {
-                detector: "DynamicQty".into(),
-                description: "equal to the number of charge counters".into(),
-                line_index: 0,
-            },
-            OracleDiagnostic::SwallowedClause {
-                detector: "DynamicQty".into(),
-                description: "equal to that card's mana value".into(),
-                line_index: 1,
-            },
+            OracleDiagnostic::swallowed_clause(
+                "DynamicQty",
+                "equal to the number of charge counters",
+            ),
+            OracleDiagnostic::swallowed_clause("DynamicQty", "equal to that card's mana value"),
         ];
         let mut missing = Vec::new();
         check_parse_warnings(&warnings, &mut missing);
@@ -11285,11 +11276,10 @@ mod tests {
     /// sub-effects must not be counted as supported.
     #[test]
     fn check_parse_warnings_flags_optional_you_may() {
-        let warnings = vec![OracleDiagnostic::SwallowedClause {
-            detector: "Optional_YouMay".into(),
-            description: "you may reveal that card and put it into your hand".into(),
-            line_index: 0,
-        }];
+        let warnings = vec![OracleDiagnostic::swallowed_clause(
+            "Optional_YouMay",
+            "you may reveal that card and put it into your hand",
+        )];
         let mut missing = Vec::new();
         check_parse_warnings(&warnings, &mut missing);
         assert_eq!(missing, vec!["Swallow:Optional_YouMay".to_string()]);

--- a/crates/engine/src/parser/oracle_ir/diagnostic.rs
+++ b/crates/engine/src/parser/oracle_ir/diagnostic.rs
@@ -5,6 +5,13 @@
 
 use std::fmt;
 
+// Source-identity types live in `doc` (the document IR that mints them). They are
+// re-exported here because they are part of this module's PUBLIC wire payload:
+// `SwallowedClause` carries them into `CardFace::parse_warnings` → `card-data.json`,
+// and `doc` is a crate-private module, so without this a consumer outside the crate
+// could deserialize the diagnostic but could not name the types inside it.
+pub use super::doc::{OracleItemId, OracleSourceSpan, SpanPrecision};
+
 /// Severity level for parse diagnostics (D-05).
 /// Derived from the variant — not stored as a field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -49,10 +56,53 @@ pub enum OracleDiagnostic {
     },
 
     /// Swallow-check detector found Oracle text not represented in parsed output.
+    ///
+    /// # Provenance is UNIT-scoped, and that is the honest scope — not a shortcut
+    ///
+    /// The swallow audit's question is per-**audit unit**: *does the Oracle text of this
+    /// unit raise a semantic expectation that the parse of this same unit does not
+    /// represent?* An audit unit is a block of source lines owning `0..N` items, and
+    /// `scope_to_unit` pools **all** of those items as the evidence half — deliberately,
+    /// because a sibling's evidence legitimately satisfies a neighbour's expectation
+    /// (`Kicker {2}{G}` emits a `Keyword` item *and* an `AdditionalCost` item on one
+    /// line; the latter answers the expectation the former's text raises).
+    ///
+    /// Two consequences the payload must not lie about:
+    ///
+    /// 1. **No single `OracleItemId`.** The audit cannot attribute a finding to one item
+    ///    — the evidence is the union. `items` is therefore the unit's whole evidence
+    ///    set, honestly `0..N`. It is legitimately EMPTY for a card that lowered to no
+    ///    items at all (Chorus of the Conclave), which is the case the audit exists for.
+    /// 2. **No `OracleUnitId`.** `OracleUnitId` is `{item, ordinal}` — item-scoped by
+    ///    construction. An audit unit spanning `0..N` items has no such id, and minting
+    ///    one from `items[0]` would name a line-block by one item's header unit: a
+    ///    precise-looking wrong answer.
+    ///
+    /// `unit_span` locates the unit exactly; it is LINE-GRANULAR today (see
+    /// `OracleSourceSpan`), so two clauses on one physical line SHARE it. That collapse
+    /// is pinned by name in `swallow_check`'s tests and lifts when items gain sub-line
+    /// spans.
+    ///
+    /// `line_index` is retained: it is the unit's first ITEM line, it predates this
+    /// payload, and it is what every existing consumer reads. Invariant:
+    /// `unit_span.first_line <= line_index <= unit_span.last_line` (they differ when a
+    /// unit absorbs leading lines no item claimed).
     SwallowedClause {
         detector: String,
         description: String,
         line_index: usize,
+        /// The audit unit's card-absolute byte range. `None` on a payload written before
+        /// provenance existed — deliberately an `Option` rather than a defaulted span,
+        /// because a zeroed span does not read as "unattributed", it reads as *line 1,
+        /// bytes 0..0, exactly located*. It is also the state a detector emits in: the
+        /// audit loop stamps provenance afterwards (see `stamp_provenance`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        unit_span: Option<OracleSourceSpan>,
+        /// Every item the unit pooled as evidence. Empty on a pre-provenance payload AND
+        /// on a genuinely item-less unit — `unit_span.is_none()` is the discriminator
+        /// between the two.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        items: Vec<OracleItemId>,
     },
 
     /// Cascade-diff: a cascade slot was populated but did not land on the final def.
@@ -64,6 +114,51 @@ pub enum OracleDiagnostic {
 }
 
 impl OracleDiagnostic {
+    /// The single authority for constructing a swallow-audit finding.
+    ///
+    /// Emitted UNATTRIBUTED — `line_index: 0`, no span, no items — because a detector
+    /// knows *evidence*, not provenance: it is handed one unit's text and one unit's
+    /// definitions and cannot see which unit that was. The audit loop that scoped the
+    /// unit is the only thing that can attribute the finding, and it does so via
+    /// `stamp_provenance`. Routing every construction through here (rather than 28
+    /// struct literals) means a future provenance field cannot be silently defaulted at
+    /// one forgotten call site — the same reason `Effect::unimplemented` exists.
+    pub(crate) fn swallowed_clause(
+        detector: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self::SwallowedClause {
+            detector: detector.into(),
+            description: description.into(),
+            line_index: 0,
+            unit_span: None,
+            items: Vec::new(),
+        }
+    }
+
+    /// The audit unit's source span, for a `SwallowedClause` that has been stamped.
+    ///
+    /// `None` for every other variant (they are parse-time diagnostics that carry no unit
+    /// — they never pass through the audit) and for a pre-provenance payload.
+    pub fn unit_span(&self) -> Option<&OracleSourceSpan> {
+        match self {
+            Self::SwallowedClause { unit_span, .. } => unit_span.as_ref(),
+            Self::TargetFallback { .. }
+            | Self::IgnoredRemainder { .. }
+            | Self::CascadeLoss { .. } => None,
+        }
+    }
+
+    /// The items the audit unit pooled as evidence. Empty for every other variant.
+    pub fn evidence_items(&self) -> &[OracleItemId] {
+        match self {
+            Self::SwallowedClause { items, .. } => items,
+            Self::TargetFallback { .. }
+            | Self::IgnoredRemainder { .. }
+            | Self::CascadeLoss { .. } => &[],
+        }
+    }
+
     /// Severity level, determined by variant (D-05).
     pub fn severity(&self) -> DiagnosticSeverity {
         match self {
@@ -149,6 +244,74 @@ mod tests {
             line_index: 0,
         };
         assert_eq!(diag.severity(), DiagnosticSeverity::Info);
+    }
+
+    /// A stamped diagnostic, as the audit emits one.
+    fn stamped() -> OracleDiagnostic {
+        OracleDiagnostic::SwallowedClause {
+            detector: "Condition_If".into(),
+            description: "if you do, draw a card".into(),
+            line_index: 1,
+            unit_span: Some(OracleSourceSpan::exact(1, 2, 14, 61, 0)),
+            items: vec![OracleItemId(3), OracleItemId(4)],
+        }
+    }
+
+    /// Plan 02 step 6, half 1: the NEW shape survives a serde round-trip intact.
+    #[test]
+    fn new_provenance_shape_round_trips() {
+        let diag = stamped();
+        let json = serde_json::to_string(&diag).expect("serialize");
+        let back: OracleDiagnostic = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, diag);
+
+        let span = back
+            .unit_span()
+            .expect("stamped diagnostic carries a unit span");
+        assert_eq!((span.first_line, span.last_line), (1, 2));
+        assert_eq!((span.start_byte, span.end_byte), (14, 61));
+        assert_eq!(span.precision, SpanPrecision::Exact);
+        assert_eq!(back.evidence_items(), &[OracleItemId(3), OracleItemId(4)]);
+    }
+
+    /// Plan 02 step 6, half 2: the OLD `{detector, description, line_index}` payload —
+    /// the shape sitting in every already-exported `card-data.json` — still deserializes.
+    /// The new fields default to "unattributed" rather than to a zeroed span.
+    #[test]
+    fn old_payload_without_provenance_still_deserializes() {
+        let old = r#"{
+            "type": "SwallowedClause",
+            "detector": "Replacement",
+            "description": "as ~ enters, choose a creature type",
+            "line_index": 2
+        }"#;
+        let diag: OracleDiagnostic = serde_json::from_str(old).expect("legacy payload");
+
+        assert_eq!(diag.line_index(), 2);
+        assert_eq!(diag.category_name(), "swallowed-clause");
+        // Absent, NOT zeroed: a pre-provenance payload must not claim line 1, bytes 0..0.
+        assert!(diag.unit_span().is_none());
+        assert!(diag.evidence_items().is_empty());
+    }
+
+    /// The other compatibility direction: an UNATTRIBUTED diagnostic serializes to
+    /// exactly the old three-field shape, so new code writing one an old reader can
+    /// still parse is possible. (`skip_serializing_if` is what buys this.)
+    #[test]
+    fn unattributed_diagnostic_serializes_to_the_old_shape() {
+        let diag = OracleDiagnostic::swallowed_clause("Optional_YouMay", "you may draw");
+        let json: serde_json::Value = serde_json::to_value(&diag).expect("serialize unattributed");
+
+        let obj = json.as_object().expect("object");
+        assert!(
+            !obj.contains_key("unit_span"),
+            "absent span must not be written"
+        );
+        assert!(
+            !obj.contains_key("items"),
+            "empty evidence must not be written"
+        );
+        assert_eq!(obj["line_index"], 0);
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -45,8 +45,15 @@ use crate::types::mana::ManaCost;
 ///
 /// Reserved by `OracleDocBuilder::begin_item` *before* branch parsing, so a
 /// nested parser can name its owning item without the item existing yet.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
-pub(crate) struct OracleItemId(pub(crate) u32);
+///
+/// `Deserialize` + `pub`: this id is part of the `OracleDiagnostic::SwallowedClause`
+/// wire payload (`CardFace::parse_warnings` → `card-data.json`), so it must survive a
+/// round-trip through the card DB loaders. Re-exported from `oracle_ir::diagnostic`
+/// so consumers outside this crate-private module can name it.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub struct OracleItemId(pub u32);
 
 /// Document-global identity for one independently auditable unit: an item, a
 /// clause, a modal mode, a trigger/static/replacement execute body, a granted
@@ -71,8 +78,8 @@ pub(crate) struct OracleUnitId {
 /// known, byte range not) is an enum value, not a second flag.
 // No `Ord`: `Exact < ChainRelative` would be a meaningless magnitude claim on a
 // qualifier this enum's own docs call orthogonal to containment.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
-pub(crate) enum SpanPrecision {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum SpanPrecision {
     /// The span is the unit's exact byte/line extent. Safe to render.
     Exact,
     /// The span's byte range is exact **within the effect chain** it was parsed
@@ -106,15 +113,31 @@ pub(crate) enum SpanPrecision {
 // the item map is keyed by an explicit `(usize, u32)` tuple, not by this type.
 // If a future unit needs ordering, hand-implement it over
 // `(start_byte, end_byte, ordinal_within_span)` and never over `precision`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
-pub(crate) struct OracleSourceSpan {
-    pub(crate) first_line: usize,
-    pub(crate) last_line: usize,
-    pub(crate) start_byte: usize,
-    pub(crate) end_byte: usize,
+///
+/// `Deserialize` + `pub`: a span is part of the `OracleDiagnostic::SwallowedClause` wire
+/// payload (`CardFace::parse_warnings` → `card-data.json`), so it must survive a
+/// round-trip through the card DB loaders. Re-exported from `oracle_ir::diagnostic`.
+///
+/// # The span an audit diagnostic carries is a UNIT span, and it is LINE-GRANULAR
+///
+/// `Exact` on a diagnostic's `unit_span` means the bounds locate **the audit unit**
+/// exactly — not a clause within it. No producer mints a sub-line ITEM span:
+/// `DocEmitter::exact_span` hands every item on a line the whole line's byte range
+/// (`byte_range(line)`), so two clauses on one physical line are addressed by the same
+/// bytes and are distinguished only by `ordinal_within_span`. `audit_units` therefore
+/// groups them into ONE unit, and both share one `unit_span` — the line-granularity
+/// ceiling `feature.rs` documents. A renderer must not present a `unit_span` as a
+/// *clause* position. When the recognizer bring-up gives items real sub-line spans, the
+/// units subdivide on their own and this narrows with no change here.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct OracleSourceSpan {
+    pub first_line: usize,
+    pub last_line: usize,
+    pub start_byte: usize,
+    pub end_byte: usize,
     /// Whether the bounds above locate this unit exactly. See `SpanPrecision`.
-    pub(crate) precision: SpanPrecision,
-    pub(crate) ordinal_within_span: u32,
+    pub precision: SpanPrecision,
+    pub ordinal_within_span: u32,
 }
 
 impl OracleSourceSpan {

--- a/crates/engine/src/parser/oracle_ir/feature.rs
+++ b/crates/engine/src/parser/oracle_ir/feature.rs
@@ -43,7 +43,7 @@
 //! `OracleUnitId`s are not document-unique. Restoring sub-item granularity is the
 //! recognizer bring-up plan's job.
 
-use super::doc::{OracleItemId, OracleItemIr, OracleNodeIr};
+use super::doc::{OracleItemId, OracleItemIr, OracleNodeIr, OracleSourceSpan};
 use crate::parser::oracle::ParsedAbilities;
 
 /// A semantic that Oracle text can raise an expectation for, and that the parsed
@@ -221,8 +221,26 @@ pub(crate) struct AuditUnit<'a> {
     pub(crate) text: String,
     /// The line this unit's diagnostics are attributed to.
     pub(crate) first_line: usize,
+    /// The card-absolute byte range of the lines this unit OWNS — i.e. of `text`, the
+    /// exact source the detectors were handed.
+    ///
+    /// `Exact` locates the **unit**, not a clause inside it: item spans are whole-line
+    /// (`DocEmitter::exact_span`), so every clause on one line lands in this one unit and
+    /// shares this one span. It is not `first_line`-derived by accident either — the
+    /// first unit absorbs any leading lines no item claimed, so `span.first_line` can be
+    /// SMALLER than `first_line`, and the span is the honest extent of the audited text
+    /// while `first_line` remains the item-start line the diagnostics are attributed to.
+    pub(crate) span: OracleSourceSpan,
     /// Every item starting in this block. Supplies the evidence half.
     items: Vec<&'a OracleItemIr>,
+}
+
+impl AuditUnit<'_> {
+    /// The unit's pooled evidence set, as ids — the provenance a diagnostic carries.
+    /// Legitimately EMPTY for a card that lowered to no items at all.
+    pub(crate) fn item_ids(&self) -> Vec<OracleItemId> {
+        self.items.iter().map(|item| item.id).collect()
+    }
 }
 
 /// Partition a document into audit units: one per source line that starts an item,
@@ -242,22 +260,43 @@ pub(crate) fn audit_units<'a>(
         return Vec::new();
     }
 
+    // Byte offset of the start of each line, mirroring `DocEmitter::line_start` (one
+    // '\n' per prior line). A unit's span must live in the SAME coordinate system as the
+    // item spans it owns, or a consumer cannot relate the two.
+    let mut line_start: Vec<usize> = Vec::with_capacity(lines.len());
+    let mut acc = 0usize;
+    for line in &lines {
+        line_start.push(acc);
+        acc += line.len() + 1;
+    }
+    // The exactly-located card-absolute span of the line block `[start, end)`.
+    let span_of = |start: usize, end: usize| -> OracleSourceSpan {
+        let last = end.max(start + 1) - 1;
+        OracleSourceSpan::exact(
+            start,
+            last,
+            line_start[start],
+            line_start[last] + lines[last].len(),
+            0,
+        )
+    };
+
     // One unit per distinct starting line, in source order. `ir.items` is already in
     // Oracle source order (the document is keyed by source position), so a single pass
-    // suffices and the resulting starts are ascending.
-    let mut units: Vec<AuditUnit<'a>> = Vec::new();
+    // suffices and the resulting starts are ascending. Collected as (line, items) pairs
+    // rather than as `AuditUnit`s because a unit's `text` and `span` are both functions
+    // of the NEXT unit's start, which is not known until the pass is done — and a
+    // half-built `AuditUnit` carrying a placeholder span is exactly the fabrication the
+    // span type exists to prevent.
+    let mut starts: Vec<(usize, Vec<&'a OracleItemIr>)> = Vec::new();
     for item in items {
         let first_line = item.source.span().first_line;
         if first_line >= lines.len() {
             continue;
         }
-        match units.last_mut() {
-            Some(unit) if unit.first_line == first_line => unit.items.push(item),
-            _ => units.push(AuditUnit {
-                text: String::new(),
-                first_line,
-                items: vec![item],
-            }),
+        match starts.last_mut() {
+            Some((line, unit_items)) if *line == first_line => unit_items.push(item),
+            _ => starts.push((first_line, vec![item])),
         }
     }
 
@@ -272,24 +311,32 @@ pub(crate) fn audit_units<'a>(
     // So such a card becomes ONE unit owning all of its text, with no items and
     // therefore NO evidence. Every semantic its text raises is then correctly reported
     // as swallowed, because nothing represents any of it.
-    if units.is_empty() {
-        units.push(AuditUnit {
+    if starts.is_empty() {
+        return vec![AuditUnit {
             text: source_text.to_string(),
             first_line: 0,
+            span: span_of(0, lines.len()),
             items: Vec::new(),
-        });
-        return units;
+        }];
     }
 
     // Give each unit the lines it owns: its own start through the line before the next
     // unit's start. The first unit absorbs any leading lines, and the last unit runs to
     // the end of the card, so the partition covers every line.
-    for i in 0..units.len() {
-        let start = if i == 0 { 0 } else { units[i].first_line };
-        let end = units
+    let mut units: Vec<AuditUnit<'a>> = Vec::with_capacity(starts.len());
+    for i in 0..starts.len() {
+        let first_line = starts[i].0;
+        let start = if i == 0 { 0 } else { first_line };
+        let end = starts
             .get(i + 1)
-            .map_or(lines.len(), |next| next.first_line.min(lines.len()));
-        units[i].text = lines[start..end.max(start)].join("\n");
+            .map_or(lines.len(), |(next, _)| (*next).min(lines.len()))
+            .max(start + 1);
+        units.push(AuditUnit {
+            text: lines[start..end].join("\n"),
+            first_line,
+            span: span_of(start, end),
+            items: std::mem::take(&mut starts[i].1),
+        });
     }
     units
 }

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -25,7 +25,9 @@ use super::oracle::{is_draft_matters_sentence, ParsedAbilities};
 use super::oracle_effect::player_lookback_relative_clause_owns_suffix;
 use super::oracle_ir::diagnostic::{CascadeSlot, OracleDiagnostic};
 use super::oracle_ir::doc::OracleItemIr;
-use super::oracle_ir::feature::{audit_units, scope_to_unit, ItemIdTracks, OracleSemanticFeature};
+use super::oracle_ir::feature::{
+    audit_units, scope_to_unit, AuditUnit, ItemIdTracks, OracleSemanticFeature,
+};
 use super::swallow_evidence::UnitEvidence;
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, ActivationRestriction, CastingPermission, Comparator,
@@ -82,23 +84,42 @@ fn truncate(s: &str, max: usize) -> &str {
     }
 }
 
-/// Stamp the owning item's source line onto everything that item's detectors
-/// emitted.
+/// Stamp the owning unit's provenance — line, span, and evidence items — onto
+/// everything that unit's detectors emitted.
 ///
-/// Detectors are deliberately provenance-agnostic: a detector knows *evidence*,
-/// not line numbers. Attribution belongs to the loop that scoped the item, because
-/// that loop is the only thing that knows which line it scoped. Threading a
-/// `line_index` parameter through all fourteen detectors instead would mean a
-/// single forgotten call site silently keeps `line_index: 0` — which does not read
-/// as "unattributed", it reads as *line 1*.
+/// Detectors are deliberately provenance-agnostic: a detector knows *evidence*, not
+/// where it is. Attribution belongs to the loop that scoped the unit, because that loop
+/// is the only thing that knows which unit it scoped. Threading provenance through all
+/// fifteen detectors instead would mean a single forgotten call site silently keeps the
+/// unattributed default — and `line_index: 0` does not read as "unattributed", it reads
+/// as *line 1*. (That is also why the span is an `Option` and not a zeroed
+/// `OracleSourceSpan`: absence must be expressible.)
+///
+/// The provenance is the UNIT's, not an item's, and that is the honest scope: the
+/// audit's evidence half is the unit's pooled items, so no single item can be named. See
+/// `OracleDiagnostic::SwallowedClause`.
 ///
 /// Exhaustive on purpose: a future audit-emitted diagnostic variant must make a
-/// deliberate decision about how it carries provenance rather than silently
-/// inheriting line 0.
-fn stamp_line(item_diagnostics: &mut [OracleDiagnostic], first_line: usize) {
-    for diagnostic in item_diagnostics {
+/// deliberate decision about how it carries provenance rather than silently inheriting
+/// the unattributed default.
+fn stamp_provenance(unit_diagnostics: &mut [OracleDiagnostic], unit: &AuditUnit<'_>) {
+    for diagnostic in unit_diagnostics {
         match diagnostic {
-            OracleDiagnostic::SwallowedClause { line_index, .. } => *line_index = first_line,
+            OracleDiagnostic::SwallowedClause {
+                line_index,
+                unit_span,
+                items,
+                ..
+            } => {
+                *line_index = unit.first_line;
+                *unit_span = Some(unit.span.clone());
+                *items = unit.item_ids();
+                debug_assert!(
+                    unit.span.first_line <= unit.first_line
+                        && unit.first_line <= unit.span.last_line,
+                    "a unit's attributed line must lie inside the span of the text it owns",
+                );
+            }
             // The swallow audit emits `SwallowedClause` and nothing else. These
             // three are parse-time diagnostics that reach the document's channel by
             // other routes and are never constructed here.
@@ -197,7 +218,7 @@ pub(crate) fn check_swallowed_clauses(
         detect_apnap(&cleaned, fragment, &scoped, &mut found);
         detect_modal_dynamic_max_dropped(&cleaned, fragment, &evidence, &mut found);
 
-        stamp_line(&mut found, unit.first_line);
+        stamp_provenance(&mut found, &unit);
         diagnostics.append(&mut found);
     }
 }
@@ -363,11 +384,10 @@ fn detect_replacement(
     {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::Replacement.detector_label().into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::Replacement.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── Detector A: Replacement_Instead ─────────────────────────────────────
@@ -418,13 +438,10 @@ fn detect_replacement_instead(
     if any_ability_has_replacement_carrier(parsed) {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::ReplacementInstead
-            .detector_label()
-            .into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::ReplacementInstead.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── Detector B: ActivateOnlyDuring ──────────────────────────────────────
@@ -445,13 +462,10 @@ fn detect_activate_only_during(
     if any_ability_has_constraint(parsed) {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::ActivateOnlyDuring
-            .detector_label()
-            .into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::ActivateOnlyDuring.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── Detector C: ActivateLimit ───────────────────────────────────────────
@@ -476,11 +490,10 @@ fn detect_activate_limit(
     if any_ability_has_limit(parsed) {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::ActivateLimit.detector_label().into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::ActivateLimit.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── Detector D: Duration_UntilEndOfTurn ─────────────────────────────────
@@ -543,13 +556,10 @@ fn detect_duration_until_eot(
     {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::DurationUntilEndOfTurn
-            .detector_label()
-            .into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::DurationUntilEndOfTurn.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── Detector E: Optional_YouMay ─────────────────────────────────────────
@@ -624,13 +634,10 @@ fn detect_optional_you_may(
     if any_static_has_granted_trigger_with_optional(parsed) {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::OptionalYouMay
-            .detector_label()
-            .into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::OptionalYouMay.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── AST predicates ──────────────────────────────────────────────────────
@@ -2288,11 +2295,10 @@ fn detect_dynamic_qty(
             return;
         }
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::DynamicQty.detector_label().into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::DynamicQty.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── Detector M: Modal_DynamicMaxDropped ─────────────────────────────────
@@ -2353,13 +2359,10 @@ fn detect_modal_dynamic_max_dropped(
     if evidence.has_slot("dynamic_max_choices") {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::ModalDynamicMaxDropped
-            .detector_label()
-            .into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::ModalDynamicMaxDropped.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 /// CR 701.38: True when every dynamic-quantity marker in `cleaned` belongs to a
@@ -3239,11 +3242,10 @@ fn detect_condition_if(
     {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::ConditionIf.detector_label().into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::ConditionIf.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 /// Remove sentences containing CR-implicit "if" phrases. These do not
@@ -3487,13 +3489,10 @@ fn detect_condition_unless(
     {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::ConditionUnless
-            .detector_label()
-            .into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::ConditionUnless.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── Detector I: Condition_AsLongAs ──────────────────────────────────────
@@ -3556,13 +3555,10 @@ fn detect_condition_as_long_as(
     if any_static_has_attached_subject_qualifier_grant(parsed) {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::ConditionAsLongAs
-            .detector_label()
-            .into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::ConditionAsLongAs.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 /// CR 611.3a + CR 613: an inverted attached-subject grant
@@ -4066,13 +4062,10 @@ fn detect_duration_this_turn(
     }) {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::DurationThisTurn
-            .detector_label()
-            .into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::DurationThisTurn.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── Detector K: Duration_NextTurn ───────────────────────────────────────
@@ -4115,13 +4108,10 @@ fn detect_duration_next_turn(
     }) {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::DurationNextTurn
-            .detector_label()
-            .into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::DurationNextTurn.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── Detector L: Optional_MayHave ────────────────────────────────────────
@@ -4164,13 +4154,10 @@ fn detect_optional_may_have(
     }) {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::OptionalMayHave
-            .detector_label()
-            .into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::OptionalMayHave.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── Detector M: APNAP ───────────────────────────────────────────────────
@@ -4195,11 +4182,10 @@ fn detect_apnap(
     if any_ability_has_apnap_ordering(parsed) {
         return;
     }
-    diagnostics.push(OracleDiagnostic::SwallowedClause {
-        detector: OracleSemanticFeature::Apnap.detector_label().into(),
-        description: truncate(original, 140).into(),
-        line_index: 0,
-    });
+    diagnostics.push(OracleDiagnostic::swallowed_clause(
+        OracleSemanticFeature::Apnap.detector_label(),
+        truncate(original, 140),
+    ));
 }
 
 // ── Cascade-vs-AST structural diff (option 3) ──────────────────────────
@@ -4400,6 +4386,152 @@ mod tests {
                 } if warning_detector == detector
             )
         })
+    }
+
+    /// Every swallow finding on this face, with its stamped unit provenance.
+    fn swallows(
+        parsed: &crate::parser::oracle::ParsedAbilities,
+    ) -> Vec<(
+        &str,
+        usize,
+        &crate::parser::oracle_ir::diagnostic::OracleSourceSpan,
+    )> {
+        parsed
+            .parse_warnings
+            .iter()
+            .filter_map(|warning| match warning {
+                OracleDiagnostic::SwallowedClause {
+                    detector,
+                    line_index,
+                    unit_span,
+                    ..
+                } => Some((
+                    detector.as_str(),
+                    *line_index,
+                    unit_span
+                        .as_ref()
+                        .expect("the audit stamps a unit span on every finding it emits"),
+                )),
+                _ => None,
+            })
+            .collect()
+    }
+
+    // ── Unit provenance (Plan 02 gate 5, as amended by the t124 ruling) ──────────
+
+    /// THE COLLAPSE, PINNED BY NAME.
+    ///
+    /// Aether Revolt raises TWO swallowed semantics from ONE physical source line: an
+    /// `as long as` revolt condition and an `if … would … instead` replacement condition.
+    /// They are genuinely distinct clauses — and their diagnostics carry the SAME
+    /// `unit_span`, so a consumer cannot locate them separately.
+    ///
+    /// That is NOT a defect in this payload. It is the line-granularity ceiling of the
+    /// span SUBSTRATE: `DocEmitter::exact_span` hands every item on a line the whole
+    /// line's byte range, so `audit_units` groups both clauses into one unit, and one
+    /// unit has exactly one span. Sub-line item spans are the prerequisite that lifts it;
+    /// when they land, the units subdivide on their own and these two spans separate.
+    ///
+    /// Asserted BY NAME so that whoever lands sub-line spans must consciously flip this
+    /// test, rather than leave a silently stale collapse behind.
+    #[test]
+    fn same_line_clauses_share_the_unit_span_until_subline_item_spans_exist() {
+        let text = "Revolt — As long as a permanent left the battlefield under your control \
+                    this turn, if a source you control would deal noncombat damage to an \
+                    opponent or a permanent an opponent controls, it deals that much damage \
+                    plus 2 instead.\nWhenever you get one or more {E}, this enchantment deals \
+                    that much damage to any target.";
+        let parsed = parse_named(text, "Aether Revolt", &["Enchantment"]);
+
+        let found = swallows(&parsed);
+        assert_eq!(
+            found.len(),
+            2,
+            "two clauses on line 0 each swallow a semantic: {found:?}"
+        );
+        assert_ne!(
+            found[0].0, found[1].0,
+            "the two findings are DIFFERENT detectors — distinct clauses, not one clause twice",
+        );
+
+        // Both are attributed to line 0 …
+        assert_eq!((found[0].1, found[1].1), (0, 0));
+        // … and — the ceiling — they SHARE one span. Distinct byte spans for the two
+        // clauses are unreachable until items carry sub-line spans.
+        assert_eq!(
+            found[0].2, found[1].2,
+            "same-line clauses share the unit span; flip this only when items carry sub-line spans",
+        );
+        // The span is the unit's own line, exactly located and card-absolute.
+        let span = found[0].2;
+        assert_eq!((span.first_line, span.last_line), (0, 0));
+        assert_eq!(span.start_byte, 0);
+        assert_eq!(
+            span.end_byte,
+            text.lines().next().expect("line 0").len(),
+            "the unit span is the exact byte extent of the line it owns",
+        );
+    }
+
+    /// NON-VACUITY for the collapse above: the span is not a constant.
+    ///
+    /// Captain Eberhart swallows a `this turn` duration on line 1 AND another on line 2.
+    /// Those are two units, so they must carry DIFFERENT, non-overlapping spans. Without
+    /// this, `same_line_clauses_share_the_unit_span…` would pass just as happily against
+    /// a span that never varied at all.
+    #[test]
+    fn different_units_carry_different_spans() {
+        let text = "Double strike\nSpells cast from among cards you drew this turn cost {1} \
+                    less to cast.\nSpells cast from among cards your opponents drew this turn \
+                    cost {1} more to cast.";
+        let parsed = parse_named(text, "Captain Eberhart", &["Creature"]);
+
+        let found = swallows(&parsed);
+        assert_eq!(found.len(), 2, "one finding per line: {found:?}");
+        assert_eq!(
+            (found[0].1, found[1].1),
+            (1, 2),
+            "attributed to lines 1 and 2"
+        );
+        assert_ne!(
+            found[0].2, found[1].2,
+            "distinct units must carry distinct spans — otherwise the span is inert",
+        );
+        assert!(
+            found[0].2.end_byte <= found[1].2.start_byte,
+            "unit spans are disjoint and in source order: {:?} then {:?}",
+            found[0].2,
+            found[1].2,
+        );
+    }
+
+    /// The evidence set is the unit's POOLED items, and it is honestly `0..N`.
+    /// A finding names every item the audit consulted — never one hand-picked id.
+    #[test]
+    fn findings_carry_the_units_pooled_evidence_items() {
+        let text = "Revolt — As long as a permanent left the battlefield under your control \
+                    this turn, if a source you control would deal noncombat damage to an \
+                    opponent or a permanent an opponent controls, it deals that much damage \
+                    plus 2 instead.\nWhenever you get one or more {E}, this enchantment deals \
+                    that much damage to any target.";
+        let parsed = parse_named(text, "Aether Revolt", &["Enchantment"]);
+
+        let items: Vec<_> = parsed
+            .parse_warnings
+            .iter()
+            .filter(|warning| matches!(warning, OracleDiagnostic::SwallowedClause { .. }))
+            .map(|warning| warning.evidence_items().to_vec())
+            .collect();
+
+        assert_eq!(items.len(), 2);
+        assert!(
+            !items[0].is_empty(),
+            "line 0 lowered an item; the finding must name the evidence it was judged against",
+        );
+        assert_eq!(
+            items[0], items[1],
+            "both findings came from ONE unit, so they carry ONE evidence set",
+        );
     }
 
     fn find_search_outside_game(def: &AbilityDefinition) -> Option<&Effect> {

--- a/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_bronzehide_lion.snap
+++ b/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_bronzehide_lion.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/tests/integration/oracle_parser.rs
-assertion_line: 662
 expression: result
 ---
 {
@@ -195,7 +194,18 @@ expression: result
       "type": "SwallowedClause",
       "detector": "Duration_UntilEndOfTurn",
       "description": "When this creature dies, return it to the battlefield. It's an Aura enchantment with enchant creature you control and \"{G}{W}: Enchanted cre",
-      "line_index": 1
+      "line_index": 1,
+      "unit_span": {
+        "first_line": 1,
+        "last_line": 1,
+        "start_byte": 62,
+        "end_byte": 282,
+        "precision": "Exact",
+        "ordinal_within_span": 0
+      },
+      "items": [
+        1
+      ]
     }
   ]
 }


### PR DESCRIPTION
Plan 02 gate 5 (as amended). A swallow-audit finding now carries the audit
unit it came from: `unit_span` (the card-absolute byte range of the lines the
unit owns) and `items` (the unit's pooled evidence set). A consumer can finally
see WHICH unit a warning came from, not just a bare line number.

The provenance is UNIT-scoped, and that is the honest scope. The plan asked for
`item_id` + `unit_id` + `source_span`; two of those three have no single-valued
referent in this substrate:

- No single `OracleItemId`. An AuditUnit owns 0..N items and `scope_to_unit`
  POOLS them all as the evidence half, deliberately — a sibling's evidence
  legitimately satisfies a neighbour's expectation (Kicker {2}{G} emits a
  Keyword item and an AdditionalCost item on one line). The audit cannot
  attribute a finding to one item; naming items[0] would be a fabrication.
  The worst case has ZERO items (Chorus of the Conclave). Hence Vec, 0..N.
- No `OracleUnitId`. It is `{item, ordinal}` — item-scoped by construction. An
  audit unit spanning 0..N items has no such id; minting one would name a
  line-block by one item's header unit. Dropped, not deferred.

`unit_span` is LINE-GRANULAR: `DocEmitter::exact_span` hands every item on a
line the whole line's byte range, so `audit_units` groups all clauses on a line
into ONE unit, and one unit has one span. Two clauses on one line therefore
SHARE it — pinned by name in
`same_line_clauses_share_the_unit_span_until_subline_item_spans_exist` so that
whoever lands sub-line item spans must consciously flip it.

Back-compat: both new fields are `#[serde(default, skip_serializing_if = ...)]`.
Old `{detector, description, line_index}` payloads still deserialize — to an
ABSENT span, not a zeroed one: a zeroed span reads as "line 1, bytes 0..0,
exactly located", a precise-looking wrong answer. An unstamped diagnostic also
still serializes to the old three-field shape (reverse compatibility).

All 15 detector emissions now route through one `OracleDiagnostic::swallowed_clause`
constructor (the `Effect::unimplemented` precedent), so a future provenance
field cannot be silently defaulted at a forgotten call site.
