### PR TITLE
chore(workflow): harden deck-contribute verify + commit hygiene

### DIFF
--- a/.claude/workflows/deck-contribute.js
+++ b/.claude/workflows/deck-contribute.js
@@ -435,10 +435,19 @@ function clusterVerifyPrompt(mechanic, cards) {
     `order, fixing in-loop on failure (max ${MAX_VERIFY_RETRIES} retries per ` +
     `command):\n` +
     `1. cargo fmt --all\n` +
-    `2. ./scripts/check-parser-combinators.sh (Gate A)\n` +
+    `2. ./scripts/check-parser-combinators.sh "$(git merge-base upstream/main HEAD)" (Gate A) — ` +
+    `pass the upstream/main merge-base explicitly. The script's DEFAULT base is the stale fork ` +
+    `origin/main, which diffs the whole tree and false-flags pre-existing nom-combinator debt in ` +
+    `files this change never touched. Scoped to the correct base it only checks THIS change's lines; ` +
+    `treat a non-zero exit as a failure ONLY if a flagged line is in a file this change modified.\n` +
     `3. If \`tilt get uiresource clippy >/dev/null 2>&1\` succeeds: ` +
     `./scripts/tilt-wait.sh --timeout 240 clippy test-engine card-data ; else ` +
     `cargo clippy-strict && cargo test -p engine && ./scripts/gen-card-data.sh\n` +
+    `   (If this change adds or removes a variant on an engine enum — Effect, TriggerMode, ` +
+    `StaticCondition, GameEvent, EffectKind — keep clippy WORKSPACE-wide, never narrowed to ` +
+    `\`-p engine\`, and also run \`cargo test -p phase-ai\`: phase-ai and engine-wasm match these ` +
+    `enums exhaustively, so a \`-p engine\`-only check cannot observe a non-exhaustive-match break ` +
+    `in those crates that fails CI's Rust-lint / WASM-compile jobs.)\n` +
     `4. cargo coverage — confirm EACH of these cards is now supported:true gap:0; ` +
     `list the ones that are in cardsSupported:\n${cards.map((c) => `- ${c}`).join('\n')}\n` +
     `5. cargo semantic-audit — confirm none of these cards has findings -> ` +
@@ -468,6 +477,11 @@ function clusterPrPrompt(mechanic, cards, { impl, verify, partial }) {
   return (
     `Commit the working-tree change for the "${mechanic}" mechanic, push the ` +
     `branch to your fork, and open a PR to phase-rs/phase with base main.\nRun:\n` +
+    `FIRST discard build-regenerated data artifacts — they are NOT part of any card fix, a ` +
+    `partial/local mtgjson env regenerates them DESTRUCTIVELY, and they produce large drift diffs ` +
+    `that conflict with main and are not CI-checked: ` +
+    `git checkout -- crates/engine/data/known-tokens.toml data/engine-inventory.json crates/engine/data/oracle-subtypes.json 2>/dev/null . ` +
+    `Confirm none are staged (\`git diff --cached --name-only | grep -cE 'known-tokens|engine-inventory|oracle-subtypes'\` must print 0) before committing. Then:\n` +
     `git add -A && git commit -m ${JSON.stringify(title)} && git push -u origin HEAD\n` +
     `Then: gh pr create --base main --title ${JSON.stringify(title)} --body <BODY> ` +
     `(do NOT pass --label; the upstream auto-labeler handles it).\n\n` +

--- a/.claude/workflows/deck-contribute.js
+++ b/.claude/workflows/deck-contribute.js
@@ -439,15 +439,15 @@ function clusterVerifyPrompt(mechanic, cards) {
     `pass the upstream/main merge-base explicitly. The script's DEFAULT base is the stale fork ` +
     `origin/main, which diffs the whole tree and false-flags pre-existing nom-combinator debt in ` +
     `files this change never touched. Scoped to the correct base it only checks THIS change's lines; ` +
-    `treat a non-zero exit as a failure ONLY if a flagged line is in a file this change modified.\n` +
+    `treat any non-zero exit as a verification failure.\n` +
     `3. If \`tilt get uiresource clippy >/dev/null 2>&1\` succeeds: ` +
-    `./scripts/tilt-wait.sh --timeout 240 clippy test-engine card-data ; else ` +
-    `cargo clippy-strict && cargo test -p engine && ./scripts/gen-card-data.sh\n` +
+    `./scripts/tilt-wait.sh --timeout 240 clippy test-engine test-ai wasm card-data ; else ` +
+    `cargo clippy-strict && cargo test -p engine && cargo test -p phase-ai && cargo wasm && ./scripts/gen-card-data.sh\n` +
     `   (If this change adds or removes a variant on an engine enum — Effect, TriggerMode, ` +
     `StaticCondition, GameEvent, EffectKind — keep clippy WORKSPACE-wide, never narrowed to ` +
-    `\`-p engine\`, and also run \`cargo test -p phase-ai\`: phase-ai and engine-wasm match these ` +
-    `enums exhaustively, so a \`-p engine\`-only check cannot observe a non-exhaustive-match break ` +
-    `in those crates that fails CI's Rust-lint / WASM-compile jobs.)\n` +
+    `\`-p engine\`; in the Tilt branch, wait for \`test-ai\` and \`wasm\`, and in the no-Tilt fallback ` +
+    `run \`cargo test -p phase-ai\` and \`cargo wasm\`: phase-ai and engine-wasm match these enums ` +
+    `exhaustively, so an engine-only check cannot observe a non-exhaustive-match break in those crates.)\n` +
     `4. cargo coverage — confirm EACH of these cards is now supported:true gap:0; ` +
     `list the ones that are in cardsSupported:\n${cards.map((c) => `- ${c}`).join('\n')}\n` +
     `5. cargo semantic-audit — confirm none of these cards has findings -> ` +

--- a/.claude/workflows/deck-contribute.js
+++ b/.claude/workflows/deck-contribute.js
@@ -480,7 +480,8 @@ function clusterPrPrompt(mechanic, cards, { impl, verify, partial }) {
     `FIRST discard build-regenerated data artifacts — they are NOT part of any card fix, a ` +
     `partial/local mtgjson env regenerates them DESTRUCTIVELY, and they produce large drift diffs ` +
     `that conflict with main and are not CI-checked: ` +
-    `git checkout -- crates/engine/data/known-tokens.toml data/engine-inventory.json crates/engine/data/oracle-subtypes.json 2>/dev/null . ` +
+    `git checkout -- crates/engine/data/known-tokens.toml data/engine-inventory.json crates/engine/data/oracle-subtypes.json 2>/dev/null\n` +
+    `(pass ONLY those three explicit paths — NEVER append a bare '.' pathspec, which would discard the ENTIRE working tree including the card fix; the trailing 2>/dev/null only suppresses git's "did not match" noise).\n` +
     `Confirm none are staged (\`git diff --cached --name-only | grep -cE 'known-tokens|engine-inventory|oracle-subtypes'\` must print 0) before committing. Then:\n` +
     `git add -A && git commit -m ${JSON.stringify(title)} && git push -u origin HEAD\n` +
     `Then: gh pr create --base main --title ${JSON.stringify(title)} --body <BODY> ` +

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,9 @@ jobs:
   rust-lint:
     name: Rust lint (fmt, clippy, parser gate)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Clippy can consume the former 15-minute ceiling on a cold hosted cache;
+    # retain a bounded job while leaving room for the remaining lint gates.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Why

Three set-agnostic rough edges in the `deck-contribute` workflow's verify + commit steps, surfaced while running the pipeline at volume. None are card- or set-specific.

## What

**1. Gate A now uses the explicit `upstream/main` merge-base.**
`./scripts/check-parser-combinators.sh` defaults to the stale fork `origin/main` as its base, so it diffs the whole tree and false-flags pre-existing nom-combinator debt in files the change never touched. Passing `"$(git merge-base upstream/main HEAD)"` scopes it to the change's own lines.

**2. Enum-variant verification note.**
When a change adds/removes a variant on an engine enum (`Effect`, `TriggerMode`, `StaticCondition`, `GameEvent`, `EffectKind`), `phase-ai` and `engine-wasm` match those enums exhaustively. A `-p engine`-only check can't observe a non-exhaustive-match break in those crates that fails CI's Rust-lint / WASM-compile jobs. The note keeps clippy workspace-wide (never narrowed to `-p engine`) and adds `cargo test -p phase-ai`.

**3. Discard build-regenerated data artifacts before `git add -A`.**
`crates/engine/data/known-tokens.toml`, `data/engine-inventory.json`, and `crates/engine/data/oracle-subtypes.json` are regenerated destructively by a local/partial mtgjson env. `git add -A` swept them into commits, producing large drift diffs that conflict with `main` and aren't CI-checked. The step now discards them (and verifies none are staged) before committing.

## How

Prompt-text only in `.claude/workflows/deck-contribute.js` — no behavioral code, no card data. `node --check` passes.