### PR TITLE
fix(engine): parse compound own-exiled + lesser-mana-value-others grant clause (Triple Triad)

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2130,7 +2130,10 @@ fn legacy_object_scope(s: &ObjectScope) -> bool {
         // Per-resolution local surfaced by THIS ability's own reveal — not one of
         // the 12 retained legacy refs (mirrors the LastRevealed precedent).
         | ObjectScope::OtherRevealedCard
-        | ObjectScope::EventTarget => false,
+        | ObjectScope::EventTarget
+        // Per-resolution local surfaced by THIS ability's own exile-link set
+        // (issue #5276) — likewise not a legacy ref.
+        | ObjectScope::OwnExiledThisWay => false,
     }
 }
 
@@ -3510,6 +3513,11 @@ fn read_object_scope(scope: &ObjectScope, kind: StateKind) -> RwProfile {
         // `ObjectScope::Recipient` and the `LastRevealed => empty` classification;
         // contributes no observable `reads_board`/`reads_src`.
         ObjectScope::OtherRevealedCard => RwProfile::empty(),
+        // Same §L7 precedent (issue #5276): a per-resolution local surfaced by
+        // THIS ability's own exile-link set, keyed by ownership match rather
+        // than reveal exclusion. Its read is the exiled card's intrinsic
+        // printed MV, not a mutable board characteristic a sibling reorders.
+        ObjectScope::OwnExiledThisWay => RwProfile::empty(),
         // D5 carrier: `CostPaidObject` is one of the 12 retained refs.
         ObjectScope::CostPaidObject => legacy_ref(),
     }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -2580,6 +2580,11 @@ fn scan_object_scope(x: &ObjectScope) -> Axes {
         // by exclusion within this ability's own resolution — no event/sibling
         // axis, like the demonstrative/anaphoric referents.
         ObjectScope::OtherRevealedCard => Axes::NONE,
+        // CR 608.2c (issue #5276): per-resolution local (the grantee's own
+        // exiled card), resolved via this ability's own exile-link set and
+        // current controller — no event/sibling axis, same as the reveal
+        // sibling above.
+        ObjectScope::OwnExiledThisWay => Axes::NONE,
         ObjectScope::AmassedArmy => Axes::NONE,
         ObjectScope::EventTarget => Axes {
             event: true,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1324,6 +1324,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
                 ObjectScope::CostPaidObject => "cost-paid object",
                 ObjectScope::OtherRevealedCard => "other revealed card",
                 ObjectScope::AmassedArmy => "amassed Army",
+                ObjectScope::OwnExiledThisWay => "own exiled card",
             };
             match counter_type {
                 Some(ct) => format!("{} counters on {scope_str}", ct.as_str()),
@@ -1350,6 +1351,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             ObjectScope::CostPaidObject => "referenced object's power".into(),
             ObjectScope::OtherRevealedCard => "other revealed card's power".into(),
             ObjectScope::AmassedArmy => "amassed Army's power".into(),
+            ObjectScope::OwnExiledThisWay => "own exiled card's power".into(),
         },
         QuantityRef::Toughness { scope } => match scope {
             ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
@@ -1362,6 +1364,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             ObjectScope::CostPaidObject => "referenced object's toughness".into(),
             ObjectScope::OtherRevealedCard => "other revealed card's toughness".into(),
             ObjectScope::AmassedArmy => "amassed Army's toughness".into(),
+            ObjectScope::OwnExiledThisWay => "own exiled card's toughness".into(),
         },
         QuantityRef::ObjectManaValue { scope } => match scope {
             ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
@@ -1374,6 +1377,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             ObjectScope::CostPaidObject => "referenced object's mana value".into(),
             ObjectScope::OtherRevealedCard => "other revealed card's mana value".into(),
             ObjectScope::AmassedArmy => "amassed Army's mana value".into(),
+            ObjectScope::OwnExiledThisWay => "own exiled card's mana value".into(),
         },
         QuantityRef::TargetObjectManaValue { .. } => "target object's mana value".into(),
         QuantityRef::ObjectColorCount { scope } => match scope {
@@ -1387,6 +1391,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             ObjectScope::CostPaidObject => "cost-paid object's colors".into(),
             ObjectScope::OtherRevealedCard => "other revealed card's colors".into(),
             ObjectScope::AmassedArmy => "amassed Army's colors".into(),
+            ObjectScope::OwnExiledThisWay => "own exiled card's colors".into(),
         },
         QuantityRef::ObjectTypelineComponentCount { scope } => match scope {
             ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
@@ -1399,6 +1404,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             ObjectScope::CostPaidObject => "typeline components on cost-paid object".into(),
             ObjectScope::OtherRevealedCard => "typeline components on other revealed card".into(),
             ObjectScope::AmassedArmy => "typeline components on amassed Army".into(),
+            ObjectScope::OwnExiledThisWay => "typeline components on own exiled card".into(),
         },
         QuantityRef::ObjectNameWordCount { scope } => match scope {
             ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
@@ -1411,6 +1417,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             ObjectScope::CostPaidObject => "words in cost-paid object's name".into(),
             ObjectScope::OtherRevealedCard => "words in other revealed card's name".into(),
             ObjectScope::AmassedArmy => "words in amassed Army's name".into(),
+            ObjectScope::OwnExiledThisWay => "words in own exiled card's name".into(),
         },
         QuantityRef::ManaSymbolsInManaCost { scope, color } => {
             let scope_str = match scope {
@@ -1422,6 +1429,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
                 ObjectScope::CostPaidObject => "cost-paid object",
                 ObjectScope::OtherRevealedCard => "other revealed card",
                 ObjectScope::AmassedArmy => "amassed Army",
+                ObjectScope::OwnExiledThisWay => "own exiled card",
             };
             match color {
                 Some(c) => format!("{c:?} mana symbols in {scope_str}'s mana cost"),
@@ -7303,6 +7311,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
             ObjectScope::CostPaidObject => ("CostPaidObjectPower", Handled),
             ObjectScope::OtherRevealedCard => ("OtherRevealedCardPower", Handled),
             ObjectScope::AmassedArmy => ("AmassedArmyPower", Handled),
+            ObjectScope::OwnExiledThisWay => ("OwnExiledThisWayPower", Handled),
         },
         QuantityRef::Toughness { scope } => match scope {
             ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
@@ -7315,6 +7324,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
             ObjectScope::CostPaidObject => ("CostPaidObjectToughness", Handled),
             ObjectScope::OtherRevealedCard => ("OtherRevealedCardToughness", Handled),
             ObjectScope::AmassedArmy => ("AmassedArmyToughness", Handled),
+            ObjectScope::OwnExiledThisWay => ("OwnExiledThisWayToughness", Handled),
         },
         QuantityRef::ObjectManaValue { scope } => match scope {
             ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
@@ -7327,6 +7337,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
             ObjectScope::CostPaidObject => ("CostPaidObjectManaValue", Handled),
             ObjectScope::OtherRevealedCard => ("OtherRevealedCardManaValue", Handled),
             ObjectScope::AmassedArmy => ("AmassedArmyManaValue", Handled),
+            ObjectScope::OwnExiledThisWay => ("OwnExiledThisWayManaValue", Handled),
         },
         QuantityRef::TargetObjectManaValue { .. } => ("TargetObjectManaValue", Handled),
         QuantityRef::ObjectColorCount { scope } => match scope {
@@ -7340,6 +7351,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
             ObjectScope::CostPaidObject => ("CostPaidObjectColorCount", Handled),
             ObjectScope::OtherRevealedCard => ("OtherRevealedCardColorCount", Handled),
             ObjectScope::AmassedArmy => ("AmassedArmyObjectColorCount", Handled),
+            ObjectScope::OwnExiledThisWay => ("OwnExiledThisWayObjectColorCount", Handled),
         },
         QuantityRef::ObjectNameWordCount { scope } => match scope {
             ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
@@ -7352,6 +7364,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
             ObjectScope::CostPaidObject => ("CostPaidObjectNameWordCount", Handled),
             ObjectScope::OtherRevealedCard => ("OtherRevealedCardNameWordCount", Handled),
             ObjectScope::AmassedArmy => ("AmassedArmyObjectNameWordCount", Handled),
+            ObjectScope::OwnExiledThisWay => ("OwnExiledThisWayObjectNameWordCount", Handled),
         },
         QuantityRef::ObjectTypelineComponentCount { scope } => match scope {
             ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
@@ -7364,6 +7377,9 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
             ObjectScope::CostPaidObject => ("CostPaidObjectTypelineComponentCount", Handled),
             ObjectScope::OtherRevealedCard => ("OtherRevealedCardTypelineComponentCount", Handled),
             ObjectScope::AmassedArmy => ("AmassedArmyObjectTypelineComponentCount", Handled),
+            ObjectScope::OwnExiledThisWay => {
+                ("OwnExiledThisWayObjectTypelineComponentCount", Handled)
+            }
         },
         QuantityRef::ManaSymbolsInManaCost { scope, .. } => match scope {
             ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
@@ -7376,6 +7392,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
             ObjectScope::CostPaidObject => ("CostPaidObjectManaSymbolsInManaCost", Handled),
             ObjectScope::OtherRevealedCard => ("OtherRevealedCardManaSymbolsInManaCost", Handled),
             ObjectScope::AmassedArmy => ("AmassedArmyManaSymbolsInManaCost", Handled),
+            ObjectScope::OwnExiledThisWay => ("OwnExiledThisWayManaSymbolsInManaCost", Handled),
         },
         QuantityRef::SelfManaValue => ("SelfManaValue", Handled),
         QuantityRef::Aggregate { .. } => ("Aggregate", Handled),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -8748,7 +8748,8 @@ pub(crate) fn evaluate_condition(
             | crate::types::ability::ObjectScope::CostPaidObject
             | crate::types::ability::ObjectScope::OtherRevealedCard
             | crate::types::ability::ObjectScope::EventTarget
-            | crate::types::ability::ObjectScope::AmassedArmy => false,
+            | crate::types::ability::ObjectScope::AmassedArmy
+            | crate::types::ability::ObjectScope::OwnExiledThisWay => false,
         },
         AbilityCondition::AlternativeManaCostPaid => ability.context.alternative_mana_cost_paid,
         AbilityCondition::EffectOutcome {
@@ -8969,7 +8970,8 @@ pub(crate) fn evaluate_condition(
                 | crate::types::ability::ObjectScope::CostPaidObject
                 | crate::types::ability::ObjectScope::OtherRevealedCard
                 | crate::types::ability::ObjectScope::EventTarget
-                | crate::types::ability::ObjectScope::AmassedArmy => None,
+                | crate::types::ability::ObjectScope::AmassedArmy
+                | crate::types::ability::ObjectScope::OwnExiledThisWay => None,
             };
             object_id
                 .and_then(|id| state.objects.get(&id))

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1277,7 +1277,8 @@ fn evaluate_condition_with_context(
             // Never produced for a duration tap condition; fails safely.
             | crate::types::ability::ObjectScope::OtherRevealedCard
             | crate::types::ability::ObjectScope::Demonstrative
-            | crate::types::ability::ObjectScope::AmassedArmy => false,
+            | crate::types::ability::ObjectScope::AmassedArmy
+            | crate::types::ability::ObjectScope::OwnExiledThisWay => false,
         },
         // CR 702.171b + CR 110.5d: off-battlefield permanents have no saddled designation.
         StaticCondition::SourceIsSaddled => state.objects.get(&source_id).is_some_and(|obj| {

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -244,7 +244,11 @@ pub(crate) fn quantity_expr_uses_resolution_only_object_scope(expr: &QuantityExp
             // resolved only at resolution time (never a static CDA read).
             | ObjectScope::OtherRevealedCard
             | ObjectScope::Demonstrative
-            | ObjectScope::AmassedArmy => true,
+            | ObjectScope::AmassedArmy
+            // CR 608.2c (issue #5276): the grantee's own exiled card is
+            // likewise a per-resolution exile-link lookup, never a static
+            // CDA read.
+            | ObjectScope::OwnExiledThisWay => true,
         }
     }
     match expr {
@@ -3673,11 +3677,15 @@ fn object_for_scope<'a>(
         // not plain live-board scopes available to this ability-free helper.
         // `OtherRevealedCard` is resolved specially in `resolve_object_mana_value`
         // by exclusion over `last_revealed_ids`, not via this generic path.
+        // `OwnExiledThisWay` (issue #5276) is likewise resolved specially in
+        // `resolve_object_mana_value` via an ownership-matched exile-link
+        // lookup, not via this generic (ability-free) path.
         ObjectScope::CostPaidObject
         | ObjectScope::Anaphoric
         | ObjectScope::OtherRevealedCard
         | ObjectScope::Demonstrative
-        | ObjectScope::AmassedArmy => None,
+        | ObjectScope::AmassedArmy
+        | ObjectScope::OwnExiledThisWay => None,
     }
 }
 
@@ -3726,11 +3734,15 @@ fn object_id_for_scope(
         // not plain live-board scopes available to this ability-free helper.
         // `OtherRevealedCard` is resolved specially in `resolve_object_mana_value`
         // by exclusion over `last_revealed_ids`, not via this generic path.
+        // `OwnExiledThisWay` (issue #5276) is likewise resolved specially in
+        // `resolve_object_mana_value` via an ownership-matched exile-link
+        // lookup, not via this generic (ability-free) path.
         ObjectScope::CostPaidObject
         | ObjectScope::Anaphoric
         | ObjectScope::OtherRevealedCard
         | ObjectScope::Demonstrative
-        | ObjectScope::AmassedArmy => None,
+        | ObjectScope::AmassedArmy
+        | ObjectScope::OwnExiledThisWay => None,
     }
 }
 
@@ -4264,6 +4276,13 @@ where
         // toughness, so this is a fail-closed placeholder. Extend by mirroring the
         // `last_revealed_ids` by-exclusion read in `resolve_object_mana_value`.
         ObjectScope::OtherRevealedCard => 0,
+        // CR 608.2c: MV-only class today (Triple Triad class, issue #5276 —
+        // "lesser mana value than it" reads only the grantee's own exiled
+        // card's mana value). No card reads its power or toughness, so this
+        // is a fail-closed placeholder mirroring `OtherRevealedCard` above.
+        // Extend by mirroring the exile-link owner-match read in
+        // `resolve_object_mana_value`.
+        ObjectScope::OwnExiledThisWay => 0,
     }
 }
 
@@ -4457,6 +4476,36 @@ fn resolve_object_mana_value(
                 .iter()
                 .find(|id| Some(**id) != own)
                 .and_then(|id| state.objects.get(id))
+                .map(|obj| {
+                    u32_to_i32_saturating(
+                        obj.mana_cost.mana_value_with_x(obj.zone, obj.cost_x_paid),
+                    )
+                })
+                .unwrap_or(0)
+        }
+        // CR 608.2c + CR 406.6 + CR 108.3 (issue #5276, Triple Triad class):
+        // "it" in "each other card exiled this way with lesser mana value
+        // than it" — the object matching `ExiledBySource` (this ability's
+        // `source_id`) whose OWNER is the ability's CURRENT controller.
+        // Re-derived on every read (not a pre-bound `effect_context_object`
+        // snapshot) so a `player_scope: All` fan-out over the enclosing grant
+        // — which rebinds `ability.controller` to each iterating player,
+        // CR 608.2 — yields THAT player's own exiled card on every
+        // iteration, not a single fixed card shared by every grantee.
+        // Fail-closed to 0 when no such link exists (no ability context, or
+        // this controller exiled nothing this way).
+        ObjectScope::OwnExiledThisWay => {
+            let Some(ability) = ability else {
+                return 0;
+            };
+            state
+                .exile_links
+                .iter()
+                .filter(|link| link.source_id == ability.source_id)
+                .find_map(|link| {
+                    let obj = state.objects.get(&link.exiled_id)?;
+                    (obj.owner == ability.controller).then_some(obj)
+                })
                 .map(|obj| {
                     u32_to_i32_saturating(
                         obj.mana_cost.mana_value_with_x(obj.zone, obj.cost_x_paid),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -19779,6 +19779,107 @@ fn parse_cast_copies_count_prefix(input: &str) -> (&str, Option<QuantityExpr>) {
     (input, None)
 }
 
+/// CR 608.2c + CR 406.6 + CR 118.9 (issue #5276, Triple Triad class): "the
+/// card you own exiled this way and each other card exiled this way with
+/// lesser mana value than it [without paying {its|their} mana cost(s)]" — a
+/// comparative impulse-play grant. The exiling player may always play the
+/// card they themselves exiled (unconditional disjunct); they may ALSO play
+/// any OTHER player's exiled card whose mana value compares favorably
+/// (usually "lesser") against their own — a per-grantee threshold, not a
+/// single fixed one, since each player exiled a different card.
+///
+/// Distinct from every anaphor branch below: those bind to either a single
+/// fixed object (`ParentTarget`) or the whole `ExiledBySource` set with no
+/// per-candidate filter. This clause needs a per-CANDIDATE comparator
+/// (`FilterProp::Cmc`) whose reference value is itself per-GRANTEE dynamic
+/// (`ObjectScope::OwnExiledThisWay`, resolved fresh on every read against the
+/// resolving ability's current `controller` — see its doc comment). That
+/// combination is unique to this clause shape, so it gets its own dedicated
+/// combinator rather than overloading the generic "with lesser mana value
+/// than X" reference parser (`oracle_target::parse_relative_mana_value_suffix`),
+/// which has no notion of a per-grantee referent and is shared by many
+/// unrelated single-threshold cards (Kodama class) that must not change
+/// behavior.
+///
+/// Anchors: `try_parse_play_from_exile`'s "each player may play the card
+/// they exiled this way" class (Rocco, Street Chef) for the "own exiled
+/// card" half, and `parse_relative_mana_value_suffix` (oracle_target.rs) for
+/// the "with lesser mana value than X" comparator grammar.
+fn try_parse_own_exiled_and_compared_others(
+    rest: &str,
+    without_paying: bool,
+    constraint: Option<CastPermissionConstraint>,
+    mode: CardPlayMode,
+) -> Option<Effect> {
+    type E<'a> = OracleError<'a>;
+
+    let (rest, _) = tag::<_, _, E>("the card you own exiled this way")
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = tag::<_, _, E>(" and each other card exiled this way with ")
+        .parse(rest)
+        .ok()?;
+    // Reuses the same comparator vocabulary as
+    // `parse_relative_mana_value_suffix` ("with lesser/greater/equal[-or-]
+    // mana value") so future comparator axes stay in one place conceptually,
+    // even though the per-grantee referent forces a separate combinator here.
+    let (rest, comparator) = alt((
+        value(Comparator::LT, tag::<_, _, E>("lesser mana value")),
+        value(Comparator::GT, tag("greater mana value")),
+        value(Comparator::LE, tag("equal or lesser mana value")),
+        value(Comparator::GE, tag("equal or greater mana value")),
+        value(Comparator::EQ, tag("the same mana value")),
+    ))
+    .parse(rest)
+    .ok()?;
+    let (_rest, _) = tag::<_, _, E>(" than it").parse(rest).ok()?;
+
+    // CR 108.3: "the card you own exiled this way" — this ability's exile
+    // linkage, restricted to the object this SAME resolving ability's
+    // controller owns.
+    let own_disjunct = TargetFilter::And {
+        filters: vec![
+            TargetFilter::ExiledBySource,
+            TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Owned {
+                controller: ControllerRef::You,
+            }])),
+        ],
+    };
+    // CR 202.3: "each other card exiled this way with [comparator] mana
+    // value than it" — every exiled card (any owner) whose mana value
+    // compares against the per-grantee `OwnExiledThisWay` referent. A
+    // strict `LT`/`GT`/etc. comparator against your OWN card's mana value is
+    // never true for that same card, so this disjunct naturally excludes
+    // your own card without an explicit ownership exclusion.
+    let compared_disjunct = TargetFilter::And {
+        filters: vec![
+            TargetFilter::ExiledBySource,
+            TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Cmc {
+                comparator,
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectManaValue {
+                        scope: ObjectScope::OwnExiledThisWay,
+                    },
+                },
+            }])),
+        ],
+    };
+
+    Some(Effect::CastFromZone {
+        target: TargetFilter::Or {
+            filters: vec![own_disjunct, compared_disjunct],
+        },
+        without_paying_mana_cost: without_paying,
+        mode,
+        cast_transformed: false,
+        alt_ability_cost: None,
+        constraint,
+        duration: None,
+        driver: crate::types::ability::CastFromZoneDriver::LingeringPermission,
+        mana_spend_permission: None,
+    })
+}
+
 /// 1. Anaphoric — "cast it", "cast that spell", "cast those cards" — target is
 ///    `ParentTarget` (refers to the cards exiled / chosen by a prior effect).
 /// 2. Constrained — "cast a [type-phrase] [from <zone>] [with mana value <bound>]
@@ -19846,6 +19947,21 @@ fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
     let without_paying = scan_contains_phrase(rest, "without paying its mana cost")
         || scan_contains_phrase(rest, "without paying their mana cost");
     let constraint = parse_cast_permission_constraint(rest);
+
+    // CR 608.2c (issue #5276, Triple Triad class): "the card you own exiled
+    // this way and each other card exiled this way with lesser mana value
+    // than it" — a comparative own+other exile-play grant. Must run BEFORE
+    // Branch 1's anaphor scan: Branch 1 only matches when `rest` STARTS WITH
+    // a bare anaphor token ("it"/"that card"/"those cards"/…), but this
+    // clause starts with "the card you own exiled this way" instead, so
+    // Branch 1 would fall through to Branch 3's `TargetFilter::Any` fallback
+    // (a permission grant not scoped to the exiled cards at all — the
+    // reported bug) without this dedicated branch.
+    if let Some(effect) =
+        try_parse_own_exiled_and_compared_others(rest, without_paying, constraint.clone(), mode)
+    {
+        return Some(effect);
+    }
 
     // Branch 1: anaphoric forms. Order longer-first ("one of those cards"
     // before "those cards") so the prefix-match doesn't shadow the longer

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4915,6 +4915,23 @@ pub enum ObjectScope {
     /// hand. Fail-closed to a null read (→ 0) when no "other" entry exists (empty
     /// library or an illegal target on resolution, CR 608.2b).
     OtherRevealedCard,
+    /// CR 608.2c + CR 406.6 + CR 108.3 (issue #5276, Triple Triad class):
+    /// "it" in "... and each other card exiled this way with lesser mana
+    /// value than it" — the specific object matching `ExiledBySource` whose
+    /// owner is the ability's CURRENT controller. Distinct from
+    /// [`ObjectScope::Anaphoric`]/[`ObjectScope::Demonstrative`] (a single
+    /// `effect_context_object` snapshot fixed for the whole resolution):
+    /// this re-derives its referent from `state.exile_links` + object
+    /// ownership on every read instead of reading a pre-bound snapshot, so
+    /// it resolves correctly when the enclosing `GrantCastingPermission`/
+    /// `CastFromZone` runs under a `player_scope: All` fan-out — the driver
+    /// rebinds `ability.controller` to each iterating player (CR 608.2), and
+    /// re-deriving (rather than snapshotting once) yields THAT player's own
+    /// exiled card on every iteration. Mirrors `OtherRevealedCard`'s
+    /// by-exclusion resolution shape but keys by ownership match instead of
+    /// by exclusion, and reads the exile-link set instead of
+    /// `last_revealed_ids`.
+    OwnExiledThisWay,
 }
 
 /// Source set for counting distinct card types.

--- a/crates/engine/tests/integration/issue_5276_triple_triad.rs
+++ b/crates/engine/tests/integration/issue_5276_triple_triad.rs
@@ -1,0 +1,137 @@
+//! Issue #5276: Triple Triad exiles the cards but does not allow you to play
+//! them.
+//!
+//! Oracle (verified against the dispatched issue text):
+//! "At the beginning of your upkeep, each player exiles the top card of
+//! their library. Until end of turn, you may play the card you own exiled
+//! this way and each other card exiled this way with lesser mana value than
+//! it without paying their mana costs."
+//!
+//! Root cause: the comparative clause "... and each other card exiled this
+//! way with lesser mana value than it ..." has no dedicated parser path.
+//! `try_parse_cast_effect` fell through every anaphor/typed-filter branch to
+//! Branch 3's bare fallback, producing `Effect::CastFromZone { target:
+//! TargetFilter::Any, .. }` — a permission grant not scoped to the exiled
+//! cards at all, so the "may play" permission never actually let you cast
+//! anything (CR 608.2c + CR 406.6 + CR 118.9).
+//!
+//! Fix: a dedicated combinator (`try_parse_own_exiled_and_compared_others`)
+//! recognizes this compound clause and builds
+//! `TargetFilter::Or[ own-exiled-card, other-exiled-cards-with-lesser-mv ]`,
+//! where the per-grantee comparator threshold is a new `ObjectScope::
+//! OwnExiledThisWay` (re-derived per read from the exile-link set and the
+//! resolving ability's current controller, CR 608.2c + CR 108.3).
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::CastingPermission;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P2: PlayerId = PlayerId(2);
+
+const TRIPLE_TRIAD_ORACLE: &str = "At the beginning of your upkeep, each player exiles the top card of their library. Until end of turn, you may play the card you own exiled this way and each other card exiled this way with lesser mana value than it without paying their mana costs.";
+
+/// True when `state.objects[id]` carries a zero-cost `ExileWithAltCost`
+/// permission granted to `grantee` — the "may play ... without paying its
+/// mana cost" permission shape this clause must produce (CR 118.9 + CR 611.2a).
+fn has_free_exile_cast_permission(
+    state: &engine::types::game_state::GameState,
+    id: engine::types::identifiers::ObjectId,
+    grantee: PlayerId,
+) -> bool {
+    state.objects[&id].casting_permissions.iter().any(|p| {
+        matches!(
+            p,
+            CastingPermission::ExileWithAltCost {
+                cost,
+                granted_to: Some(g),
+                ..
+            } if *cost == ManaCost::zero() && *g == grantee
+        )
+    })
+}
+
+/// Triple Triad's controller (P0) must be able to play BOTH the card they
+/// own exiled this way AND any other exiled card with strictly lesser mana
+/// value — but NOT an exiled card with equal or greater mana value.
+#[test]
+fn triple_triad_grants_own_card_and_only_lesser_mv_others() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    // Start at Untap so advancing into Upkeep fires the synthesized phase
+    // trigger (CR 503.1a + CR 603.2), mirroring the Dreadhorde Invasion
+    // upkeep-trigger regression test.
+    scenario.at_phase(Phase::Untap);
+
+    scenario
+        .add_creature(P0, "Triple Triad", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(TRIPLE_TRIAD_ORACLE);
+
+    // P0's own top card: mana value 4 — the per-grantee comparator threshold.
+    let p0_card = scenario
+        .add_spell_to_library_top(P0, "P0 Own Card", false)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    // P1's top card: mana value 2 — LESSER than P0's own (4), must become
+    // playable by P0.
+    let p1_lesser = scenario
+        .add_spell_to_library_top(P1, "P1 Lesser Card", false)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    // P2's top card: mana value 5 — GREATER than P0's own (4), must NOT
+    // become playable by P0.
+    let p2_greater = scenario
+        .add_spell_to_library_top(P2, "P2 Greater Card", false)
+        .with_mana_cost(ManaCost::generic(5))
+        .id();
+
+    let mut runner = scenario.build();
+    runner.advance_to_upkeep();
+    // Resolve the upkeep trigger (ExileTop for each player -> the
+    // comparative CastFromZone grant).
+    runner.resolve_top();
+
+    // Precondition: all three cards actually left their libraries and
+    // landed in Exile (the exile half of the bug report was never broken,
+    // but pinning it here catches a regression that silently stopped
+    // exiling instead of just dropping the permission).
+    for &id in &[p0_card, p1_lesser, p2_greater] {
+        assert_eq!(
+            runner.state().objects[&id].zone,
+            Zone::Exile,
+            "each player's top card must be exiled at Triple Triad's upkeep trigger"
+        );
+    }
+
+    assert!(
+        has_free_exile_cast_permission(runner.state(), p0_card, P0),
+        "P0 must be able to play the card they own exiled this way, got permissions {:?}",
+        runner.state().objects[&p0_card].casting_permissions
+    );
+    assert!(
+        has_free_exile_cast_permission(runner.state(), p1_lesser, P0),
+        "P0 must be able to play another player's exiled card with LESSER mana value than their own, got permissions {:?}",
+        runner.state().objects[&p1_lesser].casting_permissions
+    );
+    assert!(
+        !has_free_exile_cast_permission(runner.state(), p2_greater, P0),
+        "P0 must NOT be able to play another player's exiled card with GREATER mana value than their own, got permissions {:?}",
+        runner.state().objects[&p2_greater].casting_permissions
+    );
+
+    // Negative control: P1 and P2 never receive any casting permission on
+    // these cards — only Triple Triad's controller (P0) does ("you may
+    // play", not "each player may play").
+    for &id in &[p0_card, p1_lesser, p2_greater] {
+        assert!(
+            !has_free_exile_cast_permission(runner.state(), id, P1),
+            "P1 must not receive a Triple Triad casting permission on {id:?}"
+        );
+        assert!(
+            !has_free_exile_cast_permission(runner.state(), id, P2),
+            "P2 must not receive a Triple Triad casting permission on {id:?}"
+        );
+    }
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -835,6 +835,7 @@ mod issue_4365_msh_legality;
 mod issue_4937_iona_chosen_color;
 mod issue_4945_zada_hedron_grinder;
 mod issue_5263_chaos_warp;
+mod issue_5276_triple_triad;
 mod karplusan_yeti_fight_back;
 mod kav_landseeker_delayed_sacrifice;
 mod kellan_daring_traveler_mana_value_gate;


### PR DESCRIPTION
## Root cause

Fixes #5276.

Triple Triad's oracle text grants abilities via a compound clause: *"the card you own exiled this way and each other card exiled this way with lesser mana value than it"* — the card the controller owns gets one treatment, the other exiled cards get a treatment gated by a mana-value comparison to it. There was no dedicated parser branch for this compound shape, so it fell through to an unscoped `TargetFilter::Any`, which granted the ability to every exiled card regardless of ownership or mana value.

## Fix

- Added `ObjectScope::OwnExiledThisWay`, a new grant-target scope distinguishing "the exiled card you own" from the other exiled cards.
- Added a dedicated parser combinator, `try_parse_own_exiled_and_compared_others`, in `crates/engine/src/parser/oracle_effect/mod.rs` that recognizes the compound clause and builds two separate, correctly scoped grants (own card vs. other-cards-with-lesser-mana-value).
- The new `ObjectScope` variant is matched exhaustively elsewhere in the engine (`layers.rs`, `coverage.rs`, `ability_scan.rs`, `ability_rw.rs`), so Rust's exhaustiveness checking forced corresponding match-arm additions at each of those call sites — mechanical additions, no behavior change beyond correctly handling the new variant.
- New regression test: `crates/engine/tests/integration/issue_5276_triple_triad.rs` (3-player scenario: own exiled card gets the granted ability, other exiled cards are correctly partitioned by mana value).

## Test output (isolated `CARGO_TARGET_DIR`, from-scratch build, verified both pre- and post-rebase onto latest `main`)

```
running 1 test
test issue_5276_triple_triad::triple_triad_grants_own_card_and_only_lesser_mv_others ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3071 filtered out; finished in 0.03s
```

## Validation

- Ran the new targeted integration test, not the full suite or clippy, due to local machine constraints. No `mtgish/` files touched.
- Did not go through the `/engine-implementer` skill pipeline.
- Honest confidence note: medium-high, not high. This diff is broader than my other PRs in this batch (touches 8 source files) because of the new enum variant's exhaustiveness-match ripple effect described above — each touched call site was reviewed individually to confirm it's a mechanical match-arm addition, not a behavioral change to existing scopes.