### PR TITLE
fix(parser): normalize sentence comma inside a quoted granted ability closing quote

### DIFF
--- a/crates/engine/src/parser/oracle_nom/return_as_aura.rs
+++ b/crates/engine/src/parser/oracle_nom/return_as_aura.rs
@@ -124,7 +124,7 @@ fn parse_loses_clause(input: &str) -> OracleResult<'_, ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{ControllerRef, TypeFilter, TypedFilter};
+    use crate::types::ability::{ControllerRef, Duration, TypeFilter, TypedFilter};
 
     fn lower(s: &str) -> String {
         s.to_ascii_lowercase()
@@ -176,17 +176,15 @@ mod tests {
         // turn,"). That trailing comma must be normalized away before the inner
         // sub-parse, so the duration survives as a typed `UntilEndOfTurn` rather
         // than being dropped into prose. Assert on the typed duration, not the
-        // leftover text.
-        let debug = format!("{grants:?}");
-        // The granted duration is nested inside a granted activated ability, so a
-        // Debug-substring check is clearer than walking the full AST.
-        // allow-noncombinator: string assertion in test
-        let has_typed_duration = debug.contains("UntilEndOfTurn");
-        assert!(
-            has_typed_duration,
-            "granted ability lost its UntilEndOfTurn duration to the trailing comma inside \
-             the closing quote: {debug}",
-        );
+        // debug representation.
+        let ContinuousModification::GrantAbility { definition } = grants
+            .iter()
+            .find(|grant| matches!(grant, ContinuousModification::GrantAbility { .. }))
+            .expect("expected the quoted activated ability to be granted")
+        else {
+            unreachable!()
+        };
+        assert_eq!(definition.duration, Some(Duration::UntilEndOfTurn));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/return_as_aura.rs
+++ b/crates/engine/src/parser/oracle_nom/return_as_aura.rs
@@ -171,6 +171,22 @@ mod tests {
         }
         assert!(!grants.is_empty());
         assert!(!loses_other);
+        // #5681: the granted ability's "until end of turn" is carried with the
+        // enclosing sentence's comma INSIDE the closing quote ("...until end of
+        // turn,"). That trailing comma must be normalized away before the inner
+        // sub-parse, so the duration survives as a typed `UntilEndOfTurn` rather
+        // than being dropped into prose. Assert on the typed duration, not the
+        // leftover text.
+        let debug = format!("{grants:?}");
+        // The granted duration is nested inside a granted activated ability, so a
+        // Debug-substring check is clearer than walking the full AST.
+        // allow-noncombinator: string assertion in test
+        let has_typed_duration = debug.contains("UntilEndOfTurn");
+        assert!(
+            has_typed_duration,
+            "granted ability lost its UntilEndOfTurn duration to the trailing comma inside \
+             the closing quote: {debug}",
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -1837,7 +1837,23 @@ pub(crate) fn parse_quoted_ability_modifications(text: &str) -> Vec<ContinuousMo
 /// canonical inner classifier without exposing the private
 /// `parse_quoted_ability` / `parse_quoted_rule_static_modifications` helpers.
 pub(crate) fn classify_quoted_inner(ability_text: &str) -> Vec<ContinuousModification> {
-    let ability_text = ability_text.trim();
+    // Oracle's punctuation convention carries the *enclosing* sentence's comma
+    // INSIDE the closing quote of a granted ability when a clause follows — e.g.
+    // Bronzehide Lion's `..."{G}{W}: Enchanted creature gains indestructible until
+    // end of turn," and it loses all other abilities.` That trailing `,` is
+    // sentence punctuation, not part of the ability; left attached it defeats the
+    // inner duration combinator ("until end of turn," ≠ "until end of turn") and
+    // the phrase falls through to prose, silently dropping the UntilEndOfTurn
+    // duration. Strip it here, at the single boundary every quoted-grant caller
+    // funnels through (aura grants, token grants, keyword-list grants), so a
+    // quoted ability parses identically to its unquoted form.
+    //
+    // Only the comma is stripped — a trailing PERIOD is the ability's own terminal
+    // punctuation ("{T}: Add {G}." / "...equal to the difference.") that must be
+    // preserved in the serialized `description` (#5599), and it does not defeat
+    // any inner combinator. `split_keyword_list` strips `['.', ',']` because there
+    // the text is consumed structurally, not surfaced as a description.
+    let ability_text = ability_text.trim().trim_end_matches(',').trim();
     if ability_text.is_empty() {
         return Vec::new();
     }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -58,6 +58,57 @@ fn dynamic_for_each_pump_recovers_trailing_quoted_ability() {
     );
 }
 
+/// #5681: `classify_quoted_inner` is the single boundary every quoted-ability
+/// grant funnels through. Oracle's punctuation convention carries the enclosing
+/// sentence's COMMA INSIDE the closing quote when a clause follows ("...until end
+/// of turn,"); that comma is not part of the ability and must be normalized away,
+/// or the inner duration matcher misses and the phrase falls through to prose. A
+/// comma-tailed body must parse identically to its clean form — building-block
+/// coverage, not a single card. A trailing PERIOD is the ability's own terminal
+/// punctuation and is deliberately left intact (it feeds the description, #5599).
+#[test]
+fn classify_quoted_inner_normalizes_trailing_sentence_comma() {
+    let base = "{G}{W}: Enchanted creature gains indestructible until end of turn";
+    let clean = classify_quoted_inner(base);
+    for suffix in [",", " ,", ",,"] {
+        let dirty = classify_quoted_inner(&format!("{base}{suffix}"));
+        assert_eq!(
+            format!("{dirty:?}"),
+            format!("{clean:?}"),
+            "trailing {suffix:?} changed the parse",
+        );
+    }
+    assert!(
+        clean
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::GrantAbility { .. })),
+        "expected a granted activated ability: {clean:?}",
+    );
+    // The granted duration is nested inside a granted activated ability; a
+    // Debug-substring check is clearer than walking the full AST.
+    // allow-noncombinator: string assertion in test
+    let clean_has_duration = format!("{clean:?}").contains("UntilEndOfTurn");
+    assert!(
+        clean_has_duration,
+        "granted ability's duration must survive as a typed UntilEndOfTurn: {clean:?}",
+    );
+    // A trailing period is NOT stripped — it is the ability's own terminal
+    // punctuation, preserved verbatim in the serialized description (#5599).
+    let with_period = classify_quoted_inner("{T}: Add {G}.");
+    let ContinuousModification::GrantAbility { definition } = with_period
+        .iter()
+        .find(|m| matches!(m, ContinuousModification::GrantAbility { .. }))
+        .expect("mana ability grant")
+    else {
+        unreachable!()
+    };
+    assert_eq!(
+        definition.description.as_deref(),
+        Some("{T}: Add {G}."),
+        "terminal period must be preserved in the granted description",
+    );
+}
+
 // Regression: a for-each pump with only a trailing KEYWORD is unchanged and gains
 // no spurious subtype/grant.
 #[test]

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -72,26 +72,16 @@ fn classify_quoted_inner_normalizes_trailing_sentence_comma() {
     let clean = classify_quoted_inner(base);
     for suffix in [",", " ,", ",,"] {
         let dirty = classify_quoted_inner(&format!("{base}{suffix}"));
-        assert_eq!(
-            format!("{dirty:?}"),
-            format!("{clean:?}"),
-            "trailing {suffix:?} changed the parse",
-        );
+        assert_eq!(dirty, clean, "trailing {suffix:?} changed the parse",);
     }
-    assert!(
-        clean
-            .iter()
-            .any(|m| matches!(m, ContinuousModification::GrantAbility { .. })),
-        "expected a granted activated ability: {clean:?}",
-    );
-    // The granted duration is nested inside a granted activated ability; a
-    // Debug-substring check is clearer than walking the full AST.
-    // allow-noncombinator: string assertion in test
-    let clean_has_duration = format!("{clean:?}").contains("UntilEndOfTurn");
-    assert!(
-        clean_has_duration,
-        "granted ability's duration must survive as a typed UntilEndOfTurn: {clean:?}",
-    );
+    let ContinuousModification::GrantAbility { definition } = clean
+        .iter()
+        .find(|m| matches!(m, ContinuousModification::GrantAbility { .. }))
+        .expect("expected a granted activated ability")
+    else {
+        unreachable!()
+    };
+    assert_eq!(definition.duration, Some(Duration::UntilEndOfTurn));
     // A trailing period is NOT stripped — it is the ability's own terminal
     // punctuation, preserved verbatim in the serialized description (#5599).
     let with_period = classify_quoted_inner("{T}: Add {G}.");

--- a/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_bronzehide_lion.snap
+++ b/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_bronzehide_lion.snap
@@ -118,10 +118,10 @@ expression: result
                         "effect_zone": null,
                         "active_zones": [],
                         "characteristic_defining": false,
-                        "description": "gain indestructible until end of turn,"
+                        "description": "gain indestructible"
                       }
                     ],
-                    "duration": null,
+                    "duration": "UntilEndOfTurn",
                     "target": null
                   },
                   "cost": {
@@ -136,8 +136,8 @@ expression: result
                     }
                   },
                   "sub_ability": null,
-                  "duration": null,
-                  "description": "{G}{W}: Enchanted creature gains indestructible until end of turn,",
+                  "duration": "UntilEndOfTurn",
+                  "description": "{G}{W}: Enchanted creature gains indestructible until end of turn",
                   "target_prompt": null,
                   "condition": null,
                   "optional_targeting": false,
@@ -188,24 +188,5 @@ expression: result
   ],
   "statics": [],
   "replacements": [],
-  "extractedKeywords": [],
-  "parseWarnings": [
-    {
-      "type": "SwallowedClause",
-      "detector": "Duration_UntilEndOfTurn",
-      "description": "When this creature dies, return it to the battlefield. It's an Aura enchantment with enchant creature you control and \"{G}{W}: Enchanted cre",
-      "line_index": 1,
-      "unit_span": {
-        "first_line": 1,
-        "last_line": 1,
-        "start_byte": 62,
-        "end_byte": 282,
-        "precision": "Exact",
-        "ordinal_within_span": 0
-      },
-      "items": [
-        1
-      ]
-    }
-  ]
+  "extractedKeywords": []
 }


### PR DESCRIPTION
Closes #5681.

## Problem
Oracle's punctuation convention puts the *enclosing* sentence's comma **inside** the closing quote of a granted ability when a clause follows. Bronzehide Lion:

> When this creature dies, return it to the battlefield. It's an Aura enchantment with enchant creature you control and "{G}{W}: Enchanted creature gains indestructible until end of turn," and it loses all other abilities.

The quoted body handed to the inner sub-parse was `...until end of turn,` (trailing comma). `.trim()` strips only whitespace, so the comma reached the duration combinator, which failed to match (`"until end of turn," != "until end of turn"`). The phrase fell through to prose and the `UntilEndOfTurn` duration was **silently dropped** — at runtime the granted ability made the creature indestructible **permanently** instead of until end of turn.

## Fix
Normalize the trailing comma at `classify_quoted_inner` — the single boundary every quoted-grant caller funnels through (aura grants, token grants, keyword-list grants) — so a quoted ability parses identically to its unquoted form.

**Only the comma is stripped.** A trailing *period* is the ability's own terminal punctuation (`"{T}: Add {G}."`, `"...equal to the difference."`) that must be preserved in the serialized `description` (#5599) and does not defeat any inner combinator. (An earlier draft that also stripped periods regressed the `compound_subject_granted_ability_description_keeps_original_case` and `conformer_shuriken` description snapshots — hence comma-only.)

## Tests
- **`classify_quoted_inner_normalizes_trailing_sentence_comma`** — building-block coverage: a comma-tailed body parses identically to its clean form, the `UntilEndOfTurn` duration survives, and a terminal period is preserved.
- **`try_parse_bronzehide_lion_chunk`** — strengthened to assert the granted ability keeps its typed `UntilEndOfTurn` duration (previously only checked the grant was non-empty, which passed even with the bug).
- **`snapshot_bronzehide_lion`** — re-accepted: the granted definition now carries `"duration": "UntilEndOfTurn"` and the `SwallowedClause / Duration_UntilEndOfTurn` parse warning is gone (the designed workflow per the issue).

Full engine lib suite: **16611 passed, 0 failed**. Integration suite: only the Bronzehide snapshot changed (harold_and_bob, old_growth_troll, and the other quoted-grant snapshots unchanged), confirming the blast radius matches the issue's class measurement.