### PR TITLE
refactor(engine): route cost zone moves through pipeline

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -14,8 +14,9 @@ use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{
     ActivationResidual, AssistState, CastPaymentMode, CastingVariant, ConvokeMode, CostResume,
     CounterCostChoice, CounterRemoveChoice, DeferredSacrificeSelection, DistributionUnit,
-    GameState, PayCostKind, PendingCast, PendingDiscardForCostResume, SpellCostSource, StackEntry,
-    StackEntryKind, StackPaidSnapshot, WaitingFor,
+    GameState, PayCostKind, PendingCast, PendingCostMoveCompletion, PendingCostPaymentResume,
+    PendingDiscardForCostResume, SpellCostSource, StackEntry, StackEntryKind, StackPaidSnapshot,
+    WaitingFor,
 };
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::keywords::Keyword;
@@ -34,6 +35,7 @@ use super::mana_sources::{self, ManaSourceOption};
 use super::priority;
 use super::restrictions;
 use super::stack;
+use super::zone_pipeline::{self, ZoneMoveRequest, ZoneMoveResult};
 
 use super::ability_utils::{
     assign_targets_in_chain, auto_select_targets_for_ability, begin_target_selection_for_ability,
@@ -1376,6 +1378,7 @@ pub(crate) fn handle_discard_for_cost(
                     pending: pending.clone(),
                     chosen: chosen.to_vec(),
                     paused_at_index: index,
+                    resume: PendingCostPaymentResume::Discard,
                 });
                 super::casting::pause_cost_payment_for_replacement_choice(state, choice_player);
                 // CR 603.2 + CR 603.3b: Earlier cards in a count>1 discard cost may
@@ -1383,7 +1386,7 @@ pub(crate) fn handle_discard_for_cost(
                 // replacement pause. Park them now — the post-action pipeline will
                 // not run over this action's `events` (engine.rs gates on Priority).
                 let waiting_for = state.waiting_for.clone();
-                park_discard_for_cost_triggers_if_paused(
+                park_cost_payment_triggers_if_paused(
                     state,
                     events,
                     cost_event_start,
@@ -1412,7 +1415,7 @@ pub(crate) fn handle_discard_for_cost(
     // observer (Sefris of the Hidden Ways) would under-observe a discard paid
     // before the remaining mana leg. Mirror the established B2 parking pattern
     // used by `handle_sacrifice_for_cost`.
-    park_discard_for_cost_triggers_if_paused(
+    park_cost_payment_triggers_if_paused(
         state,
         events,
         cost_event_start,
@@ -1429,7 +1432,7 @@ pub(crate) fn handle_discard_for_cost(
 /// `run_post_action_pipeline` does not drop them on the next action boundary
 /// (engine.rs gates the pipeline on `WaitingFor::Priority`). Mirrors
 /// `handle_sacrifice_for_cost`.
-fn park_discard_for_cost_triggers_if_paused(
+fn park_cost_payment_triggers_if_paused(
     state: &mut GameState,
     events: &[GameEvent],
     cost_event_start: usize,
@@ -1446,18 +1449,164 @@ fn park_discard_for_cost_triggers_if_paused(
     }
 }
 
-/// CR 601.2h + CR 616.1: After a replacement choice during discard-for-cost payment, finish
-/// discarding any remaining cards and continue the cast/activation pipeline.
+#[allow(clippy::too_many_arguments)]
+fn finish_cost_object_moves(
+    state: &mut GameState,
+    player: PlayerId,
+    pending: PendingCast,
+    chosen: Vec<ObjectId>,
+    start_at_index: usize,
+    destination: Zone,
+    completion: PendingCostMoveCompletion,
+    cost_event_start: usize,
+    park_events_after_completion: bool,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    for (index, &object_id) in chosen.iter().enumerate().skip(start_at_index) {
+        match zone_pipeline::move_object(
+            state,
+            ZoneMoveRequest::cost(object_id, destination, pending.object_id),
+            events,
+        ) {
+            ZoneMoveResult::Done => {}
+            ZoneMoveResult::NeedsChoice(choice_player) => {
+                state.pending_discard_for_cost = Some(PendingDiscardForCostResume {
+                    player,
+                    pending,
+                    chosen,
+                    paused_at_index: index,
+                    resume: PendingCostPaymentResume::Move {
+                        destination,
+                        completion,
+                    },
+                });
+                super::casting::pause_cost_payment_for_replacement_choice(state, choice_player);
+                let waiting_for = state.waiting_for.clone();
+                park_cost_payment_triggers_if_paused(
+                    state,
+                    events,
+                    cost_event_start,
+                    events.len(),
+                    &waiting_for,
+                );
+                return Ok(waiting_for);
+            }
+            ZoneMoveResult::NeedsAuraAttachmentChoice => {
+                unreachable!("a cost move to Hand or Exile cannot require an Aura attachment")
+            }
+        }
+    }
+
+    let waiting_for = match completion {
+        PendingCostMoveCompletion::FinishPending => {
+            finish_pending_cost_or_cast(state, player, pending, events)?
+        }
+        PendingCostMoveCompletion::PublishExileTrackedSet => {
+            // CR 614: a replacement may deliver a card elsewhere; the set must reflect
+            // what actually arrived in exile.
+            let delivered: Vec<ObjectId> = chosen
+                .into_iter()
+                .filter(|object_id| {
+                    state
+                        .objects
+                        .get(object_id)
+                        .is_some_and(|object| object.zone == Zone::Exile)
+                })
+                .collect();
+            let set_id = super::effects::publish_fresh_tracked_set(state, delivered);
+            let mut pending = pending;
+            pending.ability.bind_tracked_set_sentinel_recursive(set_id);
+            finish_pending_cost_or_cast(state, player, pending, events)?
+        }
+        PendingCostMoveCompletion::FinalizeCast {
+            phyrexian_choices,
+            cascade_cast_transformed,
+            resolution_success_waiting_for,
+            pool_before,
+            prepaid_actual_mana_spent,
+        } => {
+            let returned_creature = chosen
+                .first()
+                .copied()
+                .expect("finalized Sneak or Web-slinging cost has one returned creature");
+            if let Some(combat) = state.combat.as_mut() {
+                combat
+                    .attackers
+                    .retain(|attacker| attacker.object_id != returned_creature);
+                combat.blocker_assignments.remove(&returned_creature);
+            }
+            let pool_after = state
+                .players
+                .iter()
+                .find(|candidate| candidate.id == player)
+                .map(|candidate| candidate.mana_pool.produced_mana_total())
+                .unwrap_or(0);
+            let actual_mana_spent = prepaid_actual_mana_spent
+                .unwrap_or_else(|| pool_before.saturating_sub(pool_after) as u32);
+            finalize_cast_with_phyrexian_choices_inner(
+                state,
+                player,
+                pending.object_id,
+                pending.card_id,
+                pending.ability,
+                &pending.cost,
+                pending.casting_variant,
+                pending.cast_timing_permission,
+                pending.origin_zone,
+                phyrexian_choices.as_deref(),
+                Some(FinalizePrePaymentChecks {
+                    early_waiting_for: None,
+                    cascade_cast_transformed,
+                    resolution_success_waiting_for: resolution_success_waiting_for.map(|wf| *wf),
+                }),
+                Some(actual_mana_spent),
+                ReturnedCreatureCostMove::Delivered,
+                events,
+            )?
+        }
+    };
+    if park_events_after_completion {
+        park_cost_payment_triggers_if_paused(
+            state,
+            events,
+            cost_event_start,
+            events.len(),
+            &waiting_for,
+        );
+    }
+    Ok(waiting_for)
+}
+
+/// CR 601.2h + CR 616.1: After a replacement choice during sequential cost payment, finish
+/// the remaining cost moves and continue the cast/activation pipeline.
 ///
 /// `replacement_action_cost_event_start`, when set, is the `events` index at the
-/// start of the `ChooseReplacement` action that delivered the paused discard;
-/// it must include the replacement-resolved discard `ZoneChanged` record(s).
+/// start of the `ChooseReplacement` action that delivered the paused cost move;
+/// it must include the replacement-resolved `ZoneChanged` record(s).
 pub(crate) fn resume_interrupted_cost_payment(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
     replacement_action_cost_event_start: Option<usize>,
 ) -> Result<WaitingFor, EngineError> {
     if let Some(resume) = state.pending_discard_for_cost.take() {
+        if let PendingCostPaymentResume::Move {
+            destination,
+            completion,
+        } = resume.resume
+        {
+            return finish_cost_object_moves(
+                state,
+                resume.player,
+                resume.pending,
+                resume.chosen,
+                resume.paused_at_index + 1,
+                destination,
+                completion,
+                replacement_action_cost_event_start.unwrap_or(events.len()),
+                true,
+                events,
+            );
+        }
         let player = resume.player;
         let pending = resume.pending;
         let cost_event_start = replacement_action_cost_event_start.unwrap_or(events.len());
@@ -1475,6 +1624,7 @@ pub(crate) fn resume_interrupted_cost_payment(
                         pending: pending.clone(),
                         chosen: resume.chosen.clone(),
                         paused_at_index,
+                        resume: PendingCostPaymentResume::Discard,
                     });
                     super::casting::pause_cost_payment_for_replacement_choice(state, choice_player);
                     // CR 603.2 + CR 603.3b: Same mid-loop replacement pause as
@@ -1482,7 +1632,7 @@ pub(crate) fn resume_interrupted_cost_payment(
                     // cost events (including replacement-delivered discards in
                     // this action) before the non-Priority action boundary.
                     let waiting_for = state.waiting_for.clone();
-                    park_discard_for_cost_triggers_if_paused(
+                    park_cost_payment_triggers_if_paused(
                         state,
                         events,
                         cost_event_start,
@@ -1495,7 +1645,7 @@ pub(crate) fn resume_interrupted_cost_payment(
         }
         let cost_event_end = events.len();
         let waiting_for = finish_pending_cost_or_cast(state, player, pending, events)?;
-        park_discard_for_cost_triggers_if_paused(
+        park_cost_payment_triggers_if_paused(
             state,
             events,
             cost_event_start,
@@ -2181,6 +2331,7 @@ pub(crate) fn handle_return_to_hand_for_cost(
     chosen: &[ObjectId],
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
+    let cost_event_start = events.len();
     if chosen.len() != count {
         return Err(EngineError::InvalidAction(format!(
             "Must return exactly {} permanent(s), got {}",
@@ -2215,11 +2366,18 @@ pub(crate) fn handle_return_to_hand_for_cost(
     // Karoo lands, Cavern Harpy): `count` is almost always 1, so the stamp's
     // `len() < 2` guard would no-op. If a >=2-permanent return-to-hand cost ever
     // ships, mirror the A1 stamp from `handle_sacrifice_for_cost` here.
-    for &id in chosen {
-        super::zones::move_to_zone(state, id, Zone::Hand, events);
-    }
-
-    finish_pending_cost_or_cast(state, player, pending, events)
+    finish_cost_object_moves(
+        state,
+        player,
+        pending,
+        chosen.to_vec(),
+        0,
+        Zone::Hand,
+        PendingCostMoveCompletion::FinishPending,
+        cost_event_start,
+        false,
+        events,
+    )
 }
 
 /// CR 118.3 + CR 122.1 + CR 601.2b: Complete remove-counter-as-cost after
@@ -2667,6 +2825,7 @@ pub(crate) fn handle_behold_for_cost(
     chosen: &[ObjectId],
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
+    let cost_event_start = events.len();
     if chosen.len() != count {
         return Err(EngineError::InvalidAction(format!(
             "Must behold exactly {} object(s), got {}",
@@ -2713,9 +2872,22 @@ pub(crate) fn handle_behold_for_cost(
     }
 
     if action == BeholdCostAction::ExileChosen {
-        for &chosen_id in chosen {
-            super::zones::move_to_zone(state, chosen_id, Zone::Exile, events);
+        pending.ability.context.additional_cost_paid = true;
+        if let Some(snapshot) = snapshot {
+            pending.ability.set_cost_paid_object_recursive(snapshot);
         }
+        return finish_cost_object_moves(
+            state,
+            player,
+            pending,
+            chosen.to_vec(),
+            0,
+            Zone::Exile,
+            PendingCostMoveCompletion::FinishPending,
+            cost_event_start,
+            false,
+            events,
+        );
     } else if !revealed_ids.is_empty() {
         events.push(GameEvent::CardsRevealed {
             player,
@@ -2848,6 +3020,7 @@ fn finish_exile_selection_for_cost(
     illegal_message: &str,
     revalidate: impl Fn(&GameState, PlayerId, ObjectId, &PendingCast) -> Result<(), EngineError>,
 ) -> Result<WaitingFor, EngineError> {
+    let cost_event_start = events.len();
     let (min_count, max_count) = bounds;
     if chosen.len() < min_count || chosen.len() > max_count {
         let expected = if min_count == max_count {
@@ -2898,11 +3071,18 @@ fn finish_exile_selection_for_cost(
         }
     }
 
-    for &id in chosen {
-        super::zones::move_to_zone(state, id, Zone::Exile, events);
-    }
-
-    finish_pending_cost_or_cast(state, player, pending, events)
+    finish_cost_object_moves(
+        state,
+        player,
+        pending,
+        chosen.to_vec(),
+        0,
+        Zone::Exile,
+        PendingCostMoveCompletion::FinishPending,
+        cost_event_start,
+        false,
+        events,
+    )
 }
 
 /// CR 117.1 + CR 601.2b + CR 602.2b + CR 608.2c: Resolve an `ExileWithAggregate`
@@ -2939,6 +3119,7 @@ pub(crate) fn handle_exile_aggregate_for_cost(
     chosen: &[ObjectId],
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
+    let cost_event_start = events.len();
     // CR 601.2b: the chosen cards must be distinct.
     if (0..chosen.len()).any(|i| chosen[i + 1..].contains(&chosen[i])) {
         return Err(EngineError::InvalidAction(
@@ -2976,19 +3157,18 @@ pub(crate) fn handle_exile_aggregate_for_cost(
         )));
     }
 
-    for &id in chosen {
-        super::zones::move_to_zone(state, id, Zone::Exile, events);
-    }
-
-    // CR 608.2c: publish the exiled cards as a fresh tracked set and bind the
-    // resolving ability's `TrackedSetId(0)` sentinel to that concrete id before
-    // the ability reaches the stack (see the doc comment for the robustness
-    // rationale across the activation→resolution gap).
-    let set_id = super::effects::publish_fresh_tracked_set(state, chosen.to_vec());
-    let mut pending = pending;
-    pending.ability.bind_tracked_set_sentinel_recursive(set_id);
-
-    finish_pending_cost_or_cast(state, player, pending, events)
+    finish_cost_object_moves(
+        state,
+        player,
+        pending,
+        chosen.to_vec(),
+        0,
+        Zone::Exile,
+        PendingCostMoveCompletion::PublishExileTrackedSet,
+        cost_event_start,
+        false,
+        events,
+    )
 }
 
 /// CR 702.167a/b + CR 601.2b: Resolve a craft materials cost. The player has
@@ -6578,6 +6758,7 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
         phyrexian_choices,
         None,
         None,
+        ReturnedCreatureCostMove::Pending,
         events,
     )
     .map_err(|err| {
@@ -6594,6 +6775,15 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
     })
 }
 
+/// Whether the Sneak/Web-slinging returned creature's cost move (CR 702.190a /
+/// CR 702.188a) still needs to be delivered through the zone pipeline, or has
+/// already been delivered by `PendingCostMoveCompletion::FinalizeCast` re-entry.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReturnedCreatureCostMove {
+    Pending,
+    Delivered,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn finalize_cast_with_phyrexian_choices_inner(
     state: &mut GameState,
@@ -6608,8 +6798,10 @@ fn finalize_cast_with_phyrexian_choices_inner(
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
     pre_payment_checks: Option<FinalizePrePaymentChecks>,
     prepaid_actual_mana_spent: Option<u32>,
+    returned_creature_move: ReturnedCreatureCostMove,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
+    let cost_event_start = events.len();
     // CR 702.150a: Record how many of this spell's Phyrexian mana symbols are
     // being paid with life. A compleated planeswalker entering from this spell
     // exposes this as an intrinsic AddCounter replacement so it can order with
@@ -6695,14 +6887,31 @@ fn finalize_cast_with_phyrexian_choices_inner(
         | CastingVariant::WebSlinging { returned_creature } => Some(returned_creature),
         _ => None,
     };
-    if let Some(returned_creature) = returned_creature {
-        super::zones::move_to_zone(state, returned_creature, Zone::Hand, events);
-        if let Some(combat) = state.combat.as_mut() {
-            combat
-                .attackers
-                .retain(|a| a.object_id != returned_creature);
-            combat.blocker_assignments.remove(&returned_creature);
-        }
+    if let Some(returned_creature) =
+        returned_creature.filter(|_| returned_creature_move == ReturnedCreatureCostMove::Pending)
+    {
+        let mut resume_pending = PendingCast::new(object_id, card_id, ability, cost.clone());
+        resume_pending.casting_variant = casting_variant;
+        resume_pending.cast_timing_permission = cast_timing_permission;
+        resume_pending.origin_zone = origin_zone;
+        return finish_cost_object_moves(
+            state,
+            player,
+            resume_pending,
+            vec![returned_creature],
+            0,
+            Zone::Hand,
+            PendingCostMoveCompletion::FinalizeCast {
+                phyrexian_choices: phyrexian_choices.map(|choices| choices.to_vec()),
+                cascade_cast_transformed,
+                resolution_success_waiting_for: resolution_success_waiting_for.map(Box::new),
+                pool_before,
+                prepaid_actual_mana_spent,
+            },
+            cost_event_start,
+            false,
+            events,
+        );
     }
 
     // CR 700.14: Compute actual mana deducted from pool (not declared cost).
@@ -9451,6 +9660,7 @@ pub fn finalize_mana_payment(
                     None,
                     pre_payment_checks.clone(),
                     prepaid_actual_mana_spent,
+                    ReturnedCreatureCostMove::Pending,
                     events,
                 )?;
                 return Ok(drain_deferred_triggers_after_stack_object_announcement(
@@ -9490,6 +9700,7 @@ pub fn finalize_mana_payment(
             None,
             pre_payment_checks,
             prepaid_actual_mana_spent,
+            ReturnedCreatureCostMove::Pending,
             events,
         )?;
         let waiting_for =
@@ -9741,6 +9952,7 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
                     Some(phyrexian_choices),
                     pre_payment_checks.clone(),
                     prepaid_actual_mana_spent,
+                    ReturnedCreatureCostMove::Pending,
                     events,
                 )?;
                 let waiting_for = drain_deferred_triggers_after_stack_object_announcement(
@@ -9787,6 +9999,7 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
             Some(phyrexian_choices),
             pre_payment_checks,
             prepaid_actual_mana_spent,
+            ReturnedCreatureCostMove::Pending,
             events,
         )?;
         let waiting_for =

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -29084,6 +29084,13 @@ fn sneak_cast_succeeds_and_pays_sneak_cost() {
         Zone::Hand,
         "Returned creature should be bounced to hand"
     );
+    assert!(
+        !state.combat.as_ref().is_some_and(|combat| combat
+            .attackers
+            .iter()
+            .any(|entry| entry.object_id == attacker_id)),
+        "Returned attacker should be removed from combat"
+    );
     // Spell on stack.
     assert!(
         !state.stack.is_empty(),

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2378,15 +2378,44 @@ fn default_origin_zone() -> Zone {
     Zone::Hand
 }
 
-/// CR 601.2h + CR 616.1: Resume paying a discard cost after a replacement choice.
+/// CR 601.2h + CR 616.1: Tail behavior for a sequential cost move that paused
+/// on a replacement choice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingCostMoveCompletion {
+    FinishPending,
+    PublishExileTrackedSet,
+    FinalizeCast {
+        phyrexian_choices: Option<Vec<ShardChoice>>,
+        cascade_cast_transformed: bool,
+        resolution_success_waiting_for: Option<Box<WaitingFor>>,
+        pool_before: usize,
+        prepaid_actual_mana_spent: Option<u32>,
+    },
+}
+
+/// CR 601.2h + CR 616.1: Resumption kind for a cost payment that paused on a
+/// replacement choice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingCostPaymentResume {
+    Discard,
+    Move {
+        destination: Zone,
+        completion: PendingCostMoveCompletion,
+    },
+}
+
+/// CR 601.2h + CR 616.1: Resume paying a sequential cost after a replacement
+/// choice. The object at `paused_at_index` completes during
+/// `handle_replacement_choice`; resumption starts with the following object.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PendingDiscardForCostResume {
     pub player: PlayerId,
     pub pending: PendingCast,
     pub chosen: Vec<ObjectId>,
-    /// Index into `chosen` whose discard was paused; that discard completes
-    /// during `handle_replacement_choice` before this resume runs.
+    /// Index into `chosen` whose move was paused; that move completes during
+    /// `handle_replacement_choice` before this resume runs.
     pub paused_at_index: usize,
+    pub resume: PendingCostPaymentResume,
 }
 
 impl PendingCast {
@@ -8826,9 +8855,10 @@ pub struct GameState {
     #[serde(skip)]
     pub current_triggered_mana_override: Option<ProductionOverride>,
 
-    /// CR 601.2h + CR 616.1: Resume state when `handle_discard_for_cost` pauses mid-loop
-    /// for a replacement choice. The card at `paused_at_index` is completed by
-    /// `handle_replacement_choice`; resume continues at `paused_at_index + 1`.
+    /// CR 601.2h + CR 616.1: Resume state when a sequential cost move pauses
+    /// mid-loop for a replacement choice. The object at `paused_at_index` is
+    /// completed by `handle_replacement_choice`; resume continues at the next
+    /// object through the existing cost-payment seam.
     #[serde(skip)]
     pub pending_discard_for_cost: Option<PendingDiscardForCostResume>,
 

--- a/crates/engine/tests/integration/baron_helmut_zemo_boast.rs
+++ b/crates/engine/tests/integration/baron_helmut_zemo_boast.rs
@@ -19,7 +19,7 @@ use engine::game::zones::create_object;
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, Comparator, Effect,
-    ObjectProperty, QuantityExpr, TargetFilter,
+    ObjectProperty, QuantityExpr, ReplacementDefinition, TargetFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
@@ -28,6 +28,8 @@ use engine::types::identifiers::{CardId, ObjectId, TrackedSetId};
 use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
+use engine::types::replacements::ReplacementEvent;
+use engine::types::zones::{EtbTapState, Zone};
 
 const P0: PlayerId = PlayerId(0);
 const P1: PlayerId = PlayerId(1);
@@ -112,6 +114,29 @@ fn setup(gy: &[usize]) -> (GameRunner, ObjectId, Vec<ObjectId>) {
     runner.state_mut().priority_player = P0;
     runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
     (runner, zemo, gy_ids)
+}
+
+fn exile_to_graveyard_redirect() -> ReplacementDefinition {
+    ReplacementDefinition::new(ReplacementEvent::Moved)
+        .destination_zone(Zone::Exile)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                destination: Zone::Graveyard,
+                origin: None,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+        ))
 }
 
 /// Pass priority (both players) until the wait is no longer a priority window
@@ -442,6 +467,60 @@ fn zemo_boast_binds_cost_exiled_set_across_intervening_set() {
         }
         other => panic!("expected ChooseFromZoneChoice, got {other:?}"),
     }
+}
+
+#[test]
+fn zemo_boast_tracks_only_cards_delivered_to_exile_after_replacement_choices() {
+    let (mut runner, zemo, gy) = setup(&[3, 3, 3, 3, 3]);
+    let redirect = exile_to_graveyard_redirect();
+    let redirects = vec![redirect.clone(), redirect];
+    let zemo_obj = runner
+        .state_mut()
+        .objects
+        .get_mut(&zemo)
+        .expect("Zemo exists");
+    zemo_obj.replacement_definitions = redirects.clone().into();
+    zemo_obj.base_replacement_definitions = Arc::new(redirects);
+
+    let idx = boast_index(&runner, zemo);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: zemo,
+            ability_index: idx,
+        })
+        .expect("Boast is payable");
+    let result = runner
+        .act(GameAction::SelectCards { cards: gy.clone() })
+        .expect("select Boast cost cards");
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let mut prompts_answered = 0;
+    while matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ) {
+        runner
+            .act(GameAction::ChooseReplacement { index: 0 })
+            .expect("answer exile replacement ordering");
+        prompts_answered += 1;
+        assert!(prompts_answered <= gy.len(), "each cost card pauses once");
+    }
+
+    assert_eq!(prompts_answered, gy.len());
+    assert!(
+        gy.iter()
+            .all(|object_id| runner.state().objects[object_id].zone == Zone::Graveyard),
+        "every selected card is redirected away from exile"
+    );
+    let tracked_set = TrackedSetId(runner.state().next_tracked_set_id - 1);
+    assert_eq!(
+        runner.state().tracked_object_sets.get(&tracked_set),
+        Some(&vec![]),
+        "the cost's tracked set must contain only cards actually delivered to exile"
+    );
 }
 
 /// Regression guard for the `fold_cast_copy_of_card_defs` broadening (PR-4b/Zemo).

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -1,0 +1,284 @@
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle_cost::parse_oracle_cost;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, ReplacementDefinition, SpellCastingOption, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::events::GameEvent;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::replacements::ReplacementEvent;
+use engine::types::zones::{EtbTapState, Zone};
+
+fn redirect_moved_to(destination: Zone, redirected_to: Zone) -> ReplacementDefinition {
+    ReplacementDefinition::new(ReplacementEvent::Moved)
+        .destination_zone(destination)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                destination: redirected_to,
+                origin: None,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+        ))
+}
+
+#[test]
+fn pitch_exile_cost_honors_moved_redirect_and_completes_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let shoal = scenario
+        .add_creature_to_hand(P0, "Nourishing Shoal", 0, 0)
+        .as_instant()
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::X, ManaCostShard::Green, ManaCostShard::Green],
+            generic: 0,
+        })
+        .with_ability(Effect::GainLife {
+            amount: engine::types::ability::QuantityExpr::Ref {
+                qty: engine::types::ability::QuantityRef::Variable {
+                    name: "X".to_string(),
+                },
+            },
+            player: TargetFilter::Controller,
+        })
+        .id();
+    let pitched = scenario.add_creature_to_hand(P0, "Green Filler", 2, 2).id();
+    scenario
+        .add_creature(P0, "Exile Redirect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        let shoal_obj = state.objects.get_mut(&shoal).expect("shoal exists");
+        shoal_obj
+            .casting_options
+            .push(SpellCastingOption::alternative_cost(parse_oracle_cost(
+                "exile a green card with mana value X from your hand",
+            )));
+        shoal_obj.color.push(ManaColor::Green);
+
+        let pitched_obj = state
+            .objects
+            .get_mut(&pitched)
+            .expect("pitched card exists");
+        pitched_obj.card_types.core_types.push(CoreType::Creature);
+        pitched_obj.color.push(ManaColor::Green);
+        pitched_obj.mana_cost = ManaCost::generic(3);
+    }
+    let card_id = runner.state().objects[&shoal].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: shoal,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Nourishing Shoal");
+    runner
+        .act(GameAction::DecideOptionalCost { pay: true })
+        .expect("accept pitch cost");
+
+    let result = runner
+        .act(GameAction::SelectCards {
+            cards: vec![pitched],
+        })
+        .expect("pay pitch exile cost");
+
+    assert!(
+        result.events.iter().any(|event| matches!(
+            event,
+            GameEvent::ZoneChanged {
+                object_id,
+                from: Some(Zone::Hand),
+                to: Zone::Graveyard,
+                ..
+            } if *object_id == pitched
+        )),
+        "the redirect must modify the pitch cost's exile event"
+    );
+    assert_eq!(runner.state().objects[&pitched].zone, Zone::Graveyard);
+    assert!(
+        !runner.state().stack.is_empty(),
+        "the cast must complete after the redirected pitch cost"
+    );
+}
+
+#[test]
+fn multi_card_exile_cost_resumes_after_each_replacement_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let spell = scenario
+        .add_creature_to_hand(P0, "Two-card Pitch Witness", 0, 0)
+        .as_instant()
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let first = scenario
+        .add_creature_to_hand(P0, "First Green Filler", 2, 2)
+        .id();
+    let second = scenario
+        .add_creature_to_hand(P0, "Second Green Filler", 2, 2)
+        .id();
+    scenario
+        .add_creature(P0, "First Exile Redirect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    scenario
+        .add_creature(P0, "Second Exile Redirect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+
+    let mut runner = scenario.build();
+    {
+        let spell_obj = runner
+            .state_mut()
+            .objects
+            .get_mut(&spell)
+            .expect("spell exists");
+        spell_obj
+            .casting_options
+            .push(SpellCastingOption::alternative_cost(parse_oracle_cost(
+                "exile two green cards from your hand",
+            )));
+        for object_id in [first, second] {
+            let filler = runner
+                .state_mut()
+                .objects
+                .get_mut(&object_id)
+                .expect("green filler exists");
+            filler.card_types.core_types.push(CoreType::Creature);
+            filler.color.push(ManaColor::Green);
+        }
+    }
+    let card_id = runner.state().objects[&spell].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast two-card pitch witness");
+    runner
+        .act(GameAction::DecideOptionalCost { pay: true })
+        .expect("accept two-card pitch cost");
+    let result = runner
+        .act(GameAction::SelectCards {
+            cards: vec![first, second],
+        })
+        .expect("select both green cards");
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let mut prompts_answered = 0;
+    while matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ) {
+        runner
+            .act(GameAction::ChooseReplacement { index: 0 })
+            .expect("answer the cost-move replacement choice");
+        prompts_answered += 1;
+        assert!(prompts_answered <= 2, "each selected card pauses once");
+    }
+
+    assert_eq!(
+        prompts_answered, 2,
+        "resume must continue with the next card"
+    );
+    assert_eq!(runner.state().objects[&first].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Graveyard);
+    assert!(
+        !runner.state().stack.is_empty(),
+        "the cast must complete after both replacement choices"
+    );
+}
+
+#[test]
+fn return_to_hand_cost_honors_moved_redirect_and_completes_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let spell = scenario
+        .add_creature_to_hand(P0, "Daze Cost Witness", 0, 0)
+        .as_instant()
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let returned_land = scenario.add_basic_land(P0, ManaColor::Blue);
+    scenario
+        .add_creature(P0, "Hand Redirect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to(Zone::Hand, Zone::Exile));
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&spell)
+        .expect("spell exists")
+        .casting_options
+        .push(SpellCastingOption::alternative_cost(parse_oracle_cost(
+            "Return a land you control to its owner's hand",
+        )));
+    let card_id = runner.state().objects[&spell].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Daze cost witness");
+    runner
+        .act(GameAction::DecideOptionalCost { pay: true })
+        .expect("accept return-to-hand cost");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::PayCost { .. }
+    ));
+
+    let result = runner
+        .act(GameAction::SelectCards {
+            cards: vec![returned_land],
+        })
+        .expect("pay return-to-hand cost");
+
+    assert!(
+        result.events.iter().any(|event| matches!(
+            event,
+            GameEvent::ZoneChanged {
+                object_id,
+                from: Some(Zone::Battlefield),
+                to: Zone::Exile,
+                ..
+            } if *object_id == returned_land
+        )),
+        "the redirect must modify the return-to-hand cost event"
+    );
+    assert_eq!(runner.state().objects[&returned_land].zone, Zone::Exile);
+    assert!(
+        !runner.state().stack.is_empty(),
+        "the cast must complete after the redirected return-to-hand cost"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -62,6 +62,7 @@ mod consuming_vapors_rebound;
 mod copy_retarget_past_rider;
 mod copy_token_except_keyword_and_quoted_ability;
 mod cost_x_carrier_runtime;
+mod cost_zone_pipeline;
 mod council_of_four_nth_per_turn;
 mod counter_anaphor_created_token_binding;
 mod counter_double_redirect_choice;

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -21,12 +21,7 @@ crates/engine/src/analysis/resource.rs	eq_except_growable	exempt	2
 crates/engine/src/game/archenemy.rs	set_in_motion	container	1
 crates/engine/src/game/archenemy.rs	turn_face_down_to_bottom_of_scheme_deck	container	1
 crates/engine/src/game/casting.rs	handle_foretell	mover	1
-crates/engine/src/game/casting_costs.rs	finalize_cast_with_phyrexian_choices_inner	mover	1
-crates/engine/src/game/casting_costs.rs	finish_exile_selection_for_cost	mover	1
-crates/engine/src/game/casting_costs.rs	handle_behold_for_cost	mover	1
-crates/engine/src/game/casting_costs.rs	handle_exile_aggregate_for_cost	mover	1
 crates/engine/src/game/casting_costs.rs	handle_resolution_cast_rejection	mover	1
-crates/engine/src/game/casting_costs.rs	handle_return_to_hand_for_cost	mover	1
 crates/engine/src/game/conspiracy.rs	start_with_conspiracy	container	1
 crates/engine/src/game/conspiracy.rs	start_with_conspiracy	zone-assign	1
 crates/engine/src/game/costs.rs	pay_ability_cost_inner	mover	3


### PR DESCRIPTION
Plan 03 step 6, cost tranche PR 1 of 3 (unit t154). Migrates the five raw zone-mover call sites in `casting_costs.rs` onto `zone_pipeline::move_object` with `ZoneMoveRequest::cost` — behavior-identical except the ruled Zemo delivered-set fix.

## Sites
- `handle_return_to_hand_for_cost` (Battlefield→Hand; CR 603.10a co-departure stamping stays excluded, comment intact)
- `handle_behold_for_cost` ExileChosen arm (reveal branch untouched)
- `finish_exile_selection_for_cost` (escape/pitch/Food Chain; CR 608.2k cost-paid snapshot still taken before the move)
- `handle_exile_aggregate_for_cost` (Zemo's Boast; tracked set now built from DELIVERED destinations per CR 614 — a replacement may deliver a card elsewhere)
- `finalize_cast_with_phyrexian_choices_inner` (Sneak/Web-slinging return; delivery → combat cleanup → actual-mana-spent ordering preserved via `PendingCostMoveCompletion::FinalizeCast`)

## NeedsChoice wiring
Reuses the existing discard-for-cost pause seam: `PendingDiscardForCostResume` gains a typed `PendingCostPaymentResume` (`Discard` | `Move { destination, completion }`); resume flows through the existing `resume_interrupted_cost_payment`. No new continuation channel. No exile links added (default `ExileLinkSpec` everywhere).

## Witnesses (watched red-first, red output recorded in the unit log)
- pitch-exile cost + synthetic Moved-redirect: FAILED pre-migration (raw mover bypassed the consult), passes now
- return-to-hand cost + synthetic Hand-origin redirect: same protocol
- two-card exile cost resumes after each replacement choice
- Zemo five-card redirected aggregate: tracked set contains only cards actually delivered to exile
- strengthened Sneak pin: returned attacker is out of combat and in hand

## Mechanics
- zone-authority ratchet regenerated in-commit: 71 hits / 50 rows → 66 / 45; delta is exactly the five casting_costs.rs rows
- `cargo test -p engine --lib` (16,629) and `--test integration` (3,103) green