### PR TITLE
Fix damage redirection for Palisade Giant / Veteran Bodyguard / Weathered Bodyguards

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -4,10 +4,10 @@ use std::sync::LazyLock;
 
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, CombatDamageScope, ControllerRef, DamageModification,
-    DamageTargetFilter, DamageTargetPlayerScope, Effect, EffectScope, PostReplacementContinuation,
-    PreventionAmount, QuantityExpr, QuantityModification, ReplacementCondition,
-    ReplacementDefinition, ReplacementMode, ResolvedAbility, ShieldKind, TapStateChange,
-    TargetFilter, TargetRef,
+    DamageRedirectTarget, DamageTargetFilter, DamageTargetPlayerScope, Effect, EffectScope,
+    PostReplacementContinuation, PreventionAmount, QuantityExpr, QuantityModification,
+    ReplacementCondition, ReplacementDefinition, ReplacementMode, ResolvedAbility, ShieldKind,
+    TapStateChange, TargetFilter, TargetRef,
 };
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
@@ -1134,6 +1134,178 @@ fn redirect_chosen_object_for_rid(state: &GameState, rid: ReplacementId) -> Opti
     }
 }
 
+/// CR 614.9: Read back the `redirect_target` filter stored on the matched
+/// replacement. Mirrors `redirect_chosen_object_for_rid`'s repl-lookup shape,
+/// but `TargetFilter` (unlike the `Copy` `ShieldKind`) is not `Copy`, so the
+/// stored filter is cloned. Used by the continuous `ShieldKind::Prevention`
+/// path to detect a `TargetFilter::SelfRef` redirect (Palisade Giant, Veteran
+/// Bodyguard, Weathered Bodyguards) and reuse the shared redirection mechanics.
+fn redirect_target_for_rid(state: &GameState, rid: ReplacementId) -> Option<TargetFilter> {
+    let repl = if rid.source == ObjectId(0) {
+        state.pending_damage_replacements.get(rid.index)
+    } else {
+        state
+            .objects
+            .get(&rid.source)
+            .and_then(|obj| obj.replacement_definitions.get(rid.index))
+    };
+    repl.and_then(|repl| repl.redirect_target.clone())
+}
+
+/// CR 614.9: Resolve and apply a damage redirection. Shared by the one-shot
+/// `ShieldKind::Redirection` path (always consumes the shield afterward) and
+/// the continuous `ShieldKind::Prevention` + `redirect_target` path (never
+/// consumes `PreventionAmount::All` shields — that continuous, re-firing
+/// lifecycle is governed by the host permanent's presence, not by depletion).
+/// `consume_after_redirect` reflects which `ShieldKind` invariant governs this
+/// shield's lifecycle at its call site — a fixed, hard-coded literal at both of
+/// this function's two call sites, never a value threaded from parsed Oracle
+/// text or player choice, so a bool is the idiomatic choice over a
+/// purpose-built enum with no third state to grow into.
+#[allow(clippy::too_many_arguments)]
+fn redirect_damage_event(
+    state: &mut GameState,
+    rid: ReplacementId,
+    recipient: DamageRedirectTarget,
+    redirect_amount: PreventionAmount,
+    source_id: ObjectId,
+    target: TargetRef,
+    damage_amount: u32,
+    is_combat: bool,
+    applied: HashSet<AppliedReplacementKey>,
+    consume_after_redirect: bool,
+    events: &mut Vec<GameEvent>,
+) -> ApplyResult {
+    // CR 614.7a: A source that would deal 0 damage deals no damage at all —
+    // there is no damage event to redirect. Pass through and do not consume the
+    // shield (no opportunity was spent).
+    if damage_amount == 0 {
+        return ApplyResult::Modified(ProposedEvent::Damage {
+            source_id,
+            target,
+            amount: damage_amount,
+            is_combat,
+            applied,
+        });
+    }
+
+    let chosen = redirect_chosen_object_for_rid(state, rid);
+    let new_recipient = super::effects::create_damage_replacement::resolve_redirect_recipient(
+        state, recipient, rid.source, chosen,
+    )
+    .filter(|new_target| {
+        super::effects::create_damage_replacement::redirect_recipient_is_legal(state, new_target)
+    });
+
+    match redirect_amount {
+        PreventionAmount::All => {
+            // CR 614.5: The one-shot opportunity is spent on this event whether
+            // or not the redirection succeeds — consume the shield in both the
+            // success and the "does nothing" (illegal recipient per CR 614.9)
+            // outcomes. Continuous `ShieldKind::Prevention` + `redirect_target`
+            // shields pass `consume_after_redirect: false` and re-fire for every
+            // damage event within their lifetime.
+            if consume_after_redirect {
+                consume_prevention_shield(state, rid, None);
+            }
+
+            // CR 614.9: A legal recipient takes the damage instead; an illegal
+            // one (left the battlefield, no longer a battle/creature/
+            // planeswalker, or a player who left the game) makes the redirection
+            // do nothing, so the damage stays on the original recipient.
+            ApplyResult::Modified(ProposedEvent::Damage {
+                source_id,
+                target: new_recipient.unwrap_or(target),
+                amount: damage_amount,
+                is_combat,
+                applied,
+            })
+        }
+        PreventionAmount::AllBut(_) => {
+            // CR 615.1a vs CR 614.9: `AllBut` is exclusively a *prevention*
+            // amount ("prevent all but N damage", Temple Altisaur) and is never
+            // assigned to a `ShieldKind::Redirection`. The continuous
+            // `ShieldKind::Prevention` call site gates on
+            // `matches!(amount, PreventionAmount::All)` before reaching here, so
+            // an `AllBut` prevention shield with a `redirect_target` never routes
+            // into this helper either. Inventing a partial-redirect rule here
+            // would violate CR 614.9 (an illegal recipient must make the
+            // redirection do nothing rather than silently drop the excess), so
+            // this state is treated as impossible rather than guessed at.
+            unreachable!("PreventionAmount::AllBut is never assigned to a ShieldKind::Redirection")
+        }
+        PreventionAmount::Next(n) => {
+            let redirected_amount = damage_amount.min(n);
+            let remaining_amount = damage_amount.saturating_sub(redirected_amount);
+            if consume_after_redirect {
+                if redirected_amount == n {
+                    consume_prevention_shield(state, rid, None);
+                } else {
+                    update_redirection_shield(
+                        state,
+                        rid,
+                        recipient,
+                        PreventionAmount::Next(n - redirected_amount),
+                    );
+                }
+            }
+
+            if let Some(new_target) = new_recipient.filter(|_| redirected_amount > 0) {
+                let redirected_event = ProposedEvent::Damage {
+                    source_id,
+                    target: new_target,
+                    amount: redirected_amount,
+                    is_combat,
+                    applied: applied.clone(),
+                };
+                match replace_event(state, redirected_event, events) {
+                    ReplacementResult::Execute(event) => {
+                        let ctx = super::effects::deal_damage::DamageContext::from_source(
+                            state, source_id,
+                        )
+                        .unwrap_or_else(|| {
+                            let controller = state
+                                .objects
+                                .get(&source_id)
+                                .map(|obj| obj.controller)
+                                .unwrap_or(PlayerId(0));
+                            super::effects::deal_damage::DamageContext::fallback(
+                                source_id, controller,
+                            )
+                        });
+                        let _ = super::effects::deal_damage::apply_damage_after_replacement(
+                            state, &ctx, event, is_combat, events,
+                        );
+                    }
+                    ReplacementResult::Prevented => {}
+                    ReplacementResult::NeedsChoice(_) => {
+                        state.pending_replacement = None;
+                    }
+                }
+            } else {
+                return ApplyResult::Modified(ProposedEvent::Damage {
+                    source_id,
+                    target,
+                    amount: damage_amount,
+                    is_combat,
+                    applied,
+                });
+            }
+
+            if remaining_amount == 0 {
+                return ApplyResult::Prevented;
+            }
+            ApplyResult::Modified(ProposedEvent::Damage {
+                source_id,
+                target,
+                amount: remaining_amount,
+                is_combat,
+                applied,
+            })
+        }
+    }
+}
+
 /// CR 614.1a: Apply damage modification or prevention from the replacement definition.
 fn damage_done_applier(
     event: ProposedEvent,
@@ -1268,133 +1440,21 @@ fn damage_done_applier(
             applied,
         } = event
         {
-            // CR 614.7a: A source that would deal 0 damage deals no damage at
-            // all — there is no damage event to redirect. Pass through and do
-            // not consume the shield (no opportunity was spent).
-            if damage_amount == 0 {
-                return ApplyResult::Modified(ProposedEvent::Damage {
-                    source_id,
-                    target,
-                    amount: damage_amount,
-                    is_combat,
-                    applied,
-                });
-            }
-
-            let chosen = redirect_chosen_object_for_rid(state, rid);
-            let new_recipient =
-                super::effects::create_damage_replacement::resolve_redirect_recipient(
-                    state, recipient, rid.source, chosen,
-                )
-                .filter(|new_target| {
-                    super::effects::create_damage_replacement::redirect_recipient_is_legal(
-                        state, new_target,
-                    )
-                });
-
-            match redirect_amount {
-                PreventionAmount::All => {
-                    // CR 614.5: The one-shot opportunity is spent on this event
-                    // whether or not the redirection succeeds — consume the
-                    // shield in both the success and the "does nothing" (illegal
-                    // recipient per CR 614.9) outcomes.
-                    consume_prevention_shield(state, rid, None);
-
-                    // CR 614.9: A legal recipient takes the damage instead; an
-                    // illegal one (left the battlefield, no longer a
-                    // battle/creature/planeswalker, or a player who left the
-                    // game) makes the redirection do nothing, so the damage
-                    // stays on the original recipient.
-                    return ApplyResult::Modified(ProposedEvent::Damage {
-                        source_id,
-                        target: new_recipient.unwrap_or(target),
-                        amount: damage_amount,
-                        is_combat,
-                        applied,
-                    });
-                }
-                PreventionAmount::AllBut(_) => {
-                    // CR 615.1a vs CR 614.9: `AllBut` is exclusively a *prevention*
-                    // amount ("prevent all but N damage", Temple Altisaur) and is
-                    // never produced for a redirection shield — `redirection_shield`
-                    // defaults a missing amount to `PreventionAmount::All` and every
-                    // other redirect constructor uses `PreventionAmount::Next`.
-                    // Inventing a partial-redirect rule here would violate CR 614.9
-                    // (an illegal recipient must make the redirection do nothing
-                    // rather than silently drop the excess), so this state is
-                    // treated as impossible rather than guessed at.
-                    unreachable!(
-                        "PreventionAmount::AllBut is never assigned to a ShieldKind::Redirection"
-                    )
-                }
-                PreventionAmount::Next(n) => {
-                    let redirected_amount = damage_amount.min(n);
-                    let remaining_amount = damage_amount.saturating_sub(redirected_amount);
-                    if redirected_amount == n {
-                        consume_prevention_shield(state, rid, None);
-                    } else {
-                        update_redirection_shield(
-                            state,
-                            rid,
-                            recipient,
-                            PreventionAmount::Next(n - redirected_amount),
-                        );
-                    }
-
-                    if let Some(new_target) = new_recipient.filter(|_| redirected_amount > 0) {
-                        let redirected_event = ProposedEvent::Damage {
-                            source_id,
-                            target: new_target,
-                            amount: redirected_amount,
-                            is_combat,
-                            applied: applied.clone(),
-                        };
-                        match replace_event(state, redirected_event, events) {
-                            ReplacementResult::Execute(event) => {
-                                let ctx = super::effects::deal_damage::DamageContext::from_source(
-                                    state, source_id,
-                                )
-                                .unwrap_or_else(|| {
-                                    let controller = state
-                                        .objects
-                                        .get(&source_id)
-                                        .map(|obj| obj.controller)
-                                        .unwrap_or(PlayerId(0));
-                                    super::effects::deal_damage::DamageContext::fallback(
-                                        source_id, controller,
-                                    )
-                                });
-                                let _ = super::effects::deal_damage::apply_damage_after_replacement(
-                                    state, &ctx, event, is_combat, events,
-                                );
-                            }
-                            ReplacementResult::Prevented => {}
-                            ReplacementResult::NeedsChoice(_) => {
-                                state.pending_replacement = None;
-                            }
-                        }
-                    } else {
-                        return ApplyResult::Modified(ProposedEvent::Damage {
-                            source_id,
-                            target,
-                            amount: damage_amount,
-                            is_combat,
-                            applied,
-                        });
-                    }
-
-                    if remaining_amount == 0 {
-                        return ApplyResult::Prevented;
-                    }
-                    return ApplyResult::Modified(ProposedEvent::Damage {
-                        source_id,
-                        target,
-                        amount: remaining_amount,
-                        is_combat,
-                        applied,
-                    });
-                }
-            }
+            // CR 614.9: one-shot redirection shields always consume their single
+            // opportunity after the redirect resolves (or does nothing).
+            return redirect_damage_event(
+                state,
+                rid,
+                recipient,
+                redirect_amount,
+                source_id,
+                target,
+                damage_amount,
+                is_combat,
+                applied,
+                true,
+                events,
+            );
         }
         return ApplyResult::Modified(event);
     }
@@ -1424,6 +1484,42 @@ fn damage_done_applier(
             applied,
         } = event
         {
+            // CR 614.9: Continuous "all damage that would be dealt to you ... is
+            // dealt to this creature instead" statics (Palisade Giant, Veteran
+            // Bodyguard, Weathered Bodyguards) parse to a `ShieldKind::Prevention`
+            // shield carrying `redirect_target: Some(SelfRef)`. This is a
+            // *redirection* (CR 614.9), not a prevention (CR 615) — route it
+            // through the shared redirection mechanics with
+            // `consume_after_redirect: false` so the continuous shield re-fires
+            // for every damage event within its lifetime, and skip the
+            // DamagePrevented / `combat_prevention_tally` bookkeeping entirely
+            // (no damage is prevented — it is dealt to a new recipient). The
+            // `matches!(amount, PreventionAmount::All)` conjunct is required:
+            // `redirect_damage_event`'s body treats `PreventionAmount::AllBut` as
+            // `unreachable!()` (an invariant of `ShieldKind::Redirection`, not of
+            // `ShieldKind::Prevention`, which legitimately uses `AllBut` for
+            // Temple Altisaur), so any `AllBut`/`Next` prevention shield — even a
+            // hypothetical future one carrying a `redirect_target` — falls
+            // through to the ordinary prevention arms below rather than reaching
+            // that dead code.
+            if redirect_target_for_rid(state, rid) == Some(TargetFilter::SelfRef)
+                && matches!(amount, PreventionAmount::All)
+            {
+                return redirect_damage_event(
+                    state,
+                    rid,
+                    DamageRedirectTarget::SourceObject,
+                    PreventionAmount::All,
+                    source_id,
+                    target,
+                    dmg,
+                    is_combat,
+                    applied,
+                    false,
+                    events,
+                );
+            }
+
             let prevented_amount;
             let result;
             // CR 510.2 + CR 615.7: A `Prevention::All` shield encountered during a

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -621,6 +621,7 @@ mod overload_no_legal_target;
 mod oversimplify_per_player_fractal;
 mod ozolith_leaves_battlefield_counters;
 mod painters_servant_multi_zone_additive_color;
+mod palisade_giant_redirect;
 mod panther_habit_equipped_prevention_scope;
 mod peer_into_the_abyss;
 mod pendrell_flux_unless_pay_own_cost;

--- a/crates/engine/tests/integration/palisade_giant_redirect.rs
+++ b/crates/engine/tests/integration/palisade_giant_redirect.rs
@@ -1,0 +1,313 @@
+//! Runtime regression for continuous damage-redirection statics that parse to a
+//! `ShieldKind::Prevention` shield carrying `redirect_target: Some(SelfRef)`
+//! (CR 614.9). Palisade Giant, Veteran Bodyguard, and Weathered Bodyguards all
+//! route through `game::replacement::damage_done_applier`'s Branch 2
+//! (`ShieldKind::Prevention`), which previously never read `redirect_target` —
+//! it fully *prevented* the damage instead of *redirecting* it to the intended
+//! recipient. These tests drive the real damage-resolution pipeline and would
+//! fail if the Branch 2 redirect check were reverted (the damage would vanish
+//! and the recipient's `damage_marked` would stay 0).
+//!
+//! Oracle text under test is verbatim / Scryfall-verified for the redirect line;
+//! the dealt-damage trigger in `..._fires_dealt_damage_trigger_on_recipient` is a
+//! second, independently real ability template combined onto the test permanent
+//! to exercise the "redirected damage flows through ordinary damage/trigger
+//! machinery" seam (building-block coverage, not a claim about the real card).
+
+use engine::game::effects::deal_damage;
+use engine::game::sba::check_state_based_actions;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::triggers::process_triggers;
+use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+use super::rules::run_combat;
+
+/// Verbatim Palisade Giant redirection text (Scryfall-verified). The recipient-
+/// list half ("and other permanents you control") is a separate, pre-existing
+/// gap and is not exercised here.
+const PALISADE_GIANT_TEXT: &str =
+    "All damage that would be dealt to you and other permanents you control is dealt to this creature instead.";
+
+/// Verbatim Weathered Bodyguards redirection text (Scryfall-verified) — combat
+/// only, from unblocked creatures, gated on being untapped.
+const WEATHERED_BODYGUARDS_TEXT: &str = "As long as this creature is untapped, all combat damage \
+    that would be dealt to you by unblocked creatures is dealt to this creature instead.";
+
+/// A non-combat damage source dealing `amount` to `target`, controlled by P1
+/// (the opponent of the shield's controller in these fixtures).
+fn damage_ability(source_id: ObjectId, target: TargetRef, amount: i32) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::DealDamage {
+            amount: QuantityExpr::Fixed { value: amount },
+            target: TargetFilter::Any,
+            damage_source: None,
+            excess: None,
+        },
+        vec![target],
+        source_id,
+        P1,
+    )
+}
+
+/// CR 614.9: Palisade Giant redirects damage that would be dealt to its
+/// controller onto itself — lethal damage marks it and it dies to SBA
+/// (CR 704.5g), while the controller takes none of the damage.
+///
+/// Revert guard: without the Branch 2 redirect check, Palisade Giant's
+/// `damage_marked` stays 0 (the damage is merely prevented) and the redirect
+/// never happens.
+#[test]
+fn palisade_giant_redirects_lethal_damage_to_itself_and_dies() {
+    let mut scenario = GameScenario::new();
+    let giant = scenario
+        .add_creature_from_oracle(P0, "Palisade Giant", 2, 6, PALISADE_GIANT_TEXT)
+        .id();
+    let source = scenario.add_creature(P1, "Damage Source", 6, 6).id();
+    let mut runner = scenario.build();
+
+    let p0_life_before = runner.life(P0);
+
+    let mut events = Vec::new();
+    deal_damage::resolve(
+        runner.state_mut(),
+        &damage_ability(source, TargetRef::Player(P0), 6),
+        &mut events,
+    )
+    .expect("damage to Palisade Giant's controller resolves");
+
+    assert_eq!(
+        runner.state().objects[&giant].damage_marked,
+        6,
+        "the 6 damage that would hit the controller must be redirected onto Palisade Giant"
+    );
+    // Positive reach-guard: the redirect did NOT also hit the controller.
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before,
+        "the controller takes no damage — it was redirected, not dealt twice"
+    );
+
+    // CR 704.5g: 6 damage marked on a creature with toughness 6 is lethal.
+    let mut sba_events = Vec::new();
+    check_state_based_actions(runner.state_mut(), &mut sba_events);
+    assert_ne!(
+        runner.state().objects[&giant].zone,
+        Zone::Battlefield,
+        "Palisade Giant dies to state-based actions after taking lethal redirected damage"
+    );
+}
+
+/// CR 614.9 + CR 615.1a: The shield is continuous (never consumed) — it must
+/// redirect across multiple separate damage events in the same turn. This
+/// proves `consume_after_redirect: false` is actually taking effect; if the
+/// shield were wrongly consumed after the first redirect, the second event
+/// would bypass it and hit the controller.
+#[test]
+fn palisade_giant_redirect_survives_multiple_damage_events() {
+    let mut scenario = GameScenario::new();
+    let giant = scenario
+        .add_creature_from_oracle(P0, "Palisade Giant", 2, 6, PALISADE_GIANT_TEXT)
+        .id();
+    let source = scenario.add_creature(P1, "Damage Source", 2, 2).id();
+    let mut runner = scenario.build();
+
+    let p0_life_before = runner.life(P0);
+
+    for _ in 0..2 {
+        let mut events = Vec::new();
+        deal_damage::resolve(
+            runner.state_mut(),
+            &damage_ability(source, TargetRef::Player(P0), 2),
+            &mut events,
+        )
+        .expect("damage to the controller resolves");
+    }
+
+    assert_eq!(
+        runner.state().objects[&giant].damage_marked,
+        4,
+        "both 2-damage events must redirect onto Palisade Giant (continuous shield, not consumed)"
+    );
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before,
+        "the controller takes none of either redirected damage instance"
+    );
+}
+
+/// CR 614.9: Redirected damage flows through the ordinary damage machinery, so a
+/// "whenever this creature is dealt damage" trigger on the recipient fires. Uses
+/// `TriggerMode::DamageReceived` — a fully wired matcher — to prove the redirect
+/// path is not a dead-end that swallows the damage event.
+#[test]
+fn palisade_giant_redirect_fires_dealt_damage_trigger_on_recipient() {
+    let oracle =
+        format!("{PALISADE_GIANT_TEXT}\nWhenever this creature is dealt damage, you gain 1 life.");
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let giant = scenario
+        .add_creature_from_oracle(P0, "Palisade Giant", 2, 6, &oracle)
+        .id();
+    let source = scenario.add_creature(P1, "Damage Source", 3, 3).id();
+    let mut runner = scenario.build();
+
+    // Reach guard: the dealt-damage trigger is actually installed and wired.
+    let trigger = runner.state().objects[&giant]
+        .trigger_definitions
+        .iter_unchecked()
+        .find(|t| t.mode == TriggerMode::DamageReceived)
+        .expect("Palisade Giant must carry a DamageReceived trigger for this fixture");
+    assert_eq!(trigger.valid_card, Some(TargetFilter::SelfRef));
+
+    let mut events = Vec::new();
+    deal_damage::resolve(
+        runner.state_mut(),
+        &damage_ability(source, TargetRef::Player(P0), 3),
+        &mut events,
+    )
+    .expect("damage to the controller resolves");
+    process_triggers(runner.state_mut(), &events);
+
+    let queued = runner
+        .stack_names()
+        .iter()
+        .filter(|name| name.contains("Palisade Giant"))
+        .count();
+    assert_eq!(
+        queued, 1,
+        "the redirected damage must fire the recipient's DamageReceived trigger exactly once"
+    );
+}
+
+/// CR 614.9: "If one of those permanents ... is no longer a battle, creature, or
+/// planeswalker when the damage would be redirected, the effect does nothing."
+/// The host stays ON the battlefield (so it is still a candidate and Branch 2
+/// runs) but loses its creature core type, failing `redirect_recipient_is_legal`
+/// — the redirect does nothing and the damage proceeds to the original recipient
+/// (the controller), neither prevented nor vanished.
+#[test]
+fn palisade_giant_illegal_recipient_makes_redirect_do_nothing() {
+    let mut scenario = GameScenario::new();
+    let giant = scenario
+        .add_creature_from_oracle(P0, "Palisade Giant", 2, 6, PALISADE_GIANT_TEXT)
+        .id();
+    let source = scenario.add_creature(P1, "Damage Source", 4, 4).id();
+    let mut runner = scenario.build();
+
+    // Strip Palisade Giant's core types while it remains on the battlefield —
+    // an illegal redirect recipient per CR 614.9. Mirrors the direct raw-state
+    // mutation used by veteran_bodyguard_tap_redirect.rs for `tapped`.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&giant)
+        .unwrap()
+        .card_types
+        .core_types = vec![];
+
+    let p0_life_before = runner.life(P0);
+
+    let mut events = Vec::new();
+    deal_damage::resolve(
+        runner.state_mut(),
+        &damage_ability(source, TargetRef::Player(P0), 4),
+        &mut events,
+    )
+    .expect("damage to the controller resolves");
+
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before - 4,
+        "with an illegal redirect recipient the damage does nothing special and hits the controller"
+    );
+    assert_eq!(
+        runner.state().objects[&giant].damage_marked,
+        0,
+        "no damage is redirected onto a non-creature recipient"
+    );
+}
+
+/// CR 614.9 candidate gate (pre-existing, unmodified behavior): once the shield
+/// host leaves the battlefield entirely, its replacement definition is filtered
+/// out of candidacy upstream of `damage_done_applier` — it neither prevents nor
+/// redirects. This guards that this fix does not disturb that boundary.
+#[test]
+fn destroyed_palisade_giant_neither_prevents_nor_redirects() {
+    let mut scenario = GameScenario::new();
+    let giant = scenario
+        .add_creature_from_oracle(P0, "Palisade Giant", 2, 6, PALISADE_GIANT_TEXT)
+        .id();
+    let source = scenario.add_creature(P1, "Damage Source", 4, 4).id();
+    let mut runner = scenario.build();
+
+    // Move Palisade Giant off the battlefield before any damage is dealt.
+    runner.state_mut().objects.get_mut(&giant).unwrap().zone = Zone::Graveyard;
+
+    let p0_life_before = runner.life(P0);
+
+    let mut events = Vec::new();
+    deal_damage::resolve(
+        runner.state_mut(),
+        &damage_ability(source, TargetRef::Player(P0), 4),
+        &mut events,
+    )
+    .expect("damage to the controller resolves");
+
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before - 4,
+        "an off-battlefield shield host must not prevent or redirect — the controller takes the damage"
+    );
+    assert_eq!(
+        runner.state().objects[&giant].damage_marked,
+        0,
+        "no damage is redirected onto a graveyard-resident former shield host"
+    );
+}
+
+/// CR 510.2 + CR 614.9: Simultaneous multi-attacker combat damage — two unblocked
+/// attackers deal combat damage to the same protected controller in one combat
+/// damage step. Every attacker's damage must redirect onto the Bodyguard (summed
+/// `damage_marked`), and the controller takes none of it. Uses Weathered
+/// Bodyguards deliberately: its "combat damage" qualifier makes it the cleanest
+/// combat-only fit for a combat-damage batch (Veteran Bodyguard redirects ALL
+/// unblocked-creature damage, combat or not).
+///
+/// Revert guard: if the redirect path double-counted, dropped a batch event, or
+/// bypassed the normal per-event survivor application, the summed `damage_marked`
+/// would be wrong.
+#[test]
+fn weathered_bodyguards_redirects_simultaneous_combat_damage_from_multiple_attackers() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // P1 (defending player, "you") controls an untapped Weathered Bodyguards with
+    // a large toughness so it survives the combined damage and the assertion is
+    // about the summed marked damage, not death.
+    let bodyguard = scenario
+        .add_creature_from_oracle(P1, "Weathered Bodyguards", 2, 20, WEATHERED_BODYGUARDS_TEXT)
+        .id();
+    // P0 (active player) attacks P1 with two unblocked creatures.
+    let attacker_a = scenario.add_creature(P0, "Charging Bear", 3, 3).id();
+    let attacker_b = scenario.add_creature(P0, "Snapping Badger", 2, 2).id();
+
+    let mut runner = scenario.build();
+    let p1_life_before = runner.life(P1);
+
+    // Both attackers unblocked (no blocker assignments); run_combat targets P1.
+    run_combat(&mut runner, vec![attacker_a, attacker_b], vec![]);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&bodyguard].damage_marked, 5,
+        "both attackers' combat damage (3 + 2) must redirect onto Weathered Bodyguards in the same batch"
+    );
+    assert_eq!(
+        runner.life(P1),
+        p1_life_before,
+        "the protected controller takes none of the simultaneous combat damage"
+    );
+}

--- a/crates/engine/tests/integration/veteran_bodyguard_tap_redirect.rs
+++ b/crates/engine/tests/integration/veteran_bodyguard_tap_redirect.rs
@@ -94,24 +94,18 @@ fn run_combat_unblocked(
 /// This asserts the in-scope behavior of this fix: while UNTAPPED, the shield
 /// FIRES and the controller is protected. It is the positive reach-guard that
 /// makes the tapped negative below non-vacuous (it proves the shield actually
-/// reaches the prevention arm for this fixture).
+/// reaches the redirect arm for this fixture).
 ///
-/// NOTE (out of scope — confirmed pre-existing runtime gap): per the card, the
-/// redirected damage should be *dealt to the Bodyguard* (marking damage on it,
-/// potentially lethal per CR 614.9). This test does NOT assert `damage_marked`
-/// on the Bodyguard because the runtime never actually redirects for this card
-/// class: `parse_replacement_line` emits `shield_kind = ShieldKind::Prevention
-/// { amount: PreventionAmount::All }` with `redirect_target: SelfRef` as a
-/// separate field, but `game::replacement::damage_done_applier`'s CR 614.9
-/// redirection logic ("Branch 1b", the `ShieldKind::Redirection { .. }` guard)
-/// only fires for `ShieldKind::Redirection`; the `ShieldKind::Prevention` arm
-/// ("Branch 2") returns `ApplyResult::Prevented` and never reads
-/// `redirect_target`. So `redirect_target: SelfRef` is dead data for the whole
-/// "damage is dealt to X instead" class (Pariah, Palisade Giant, and this
-/// cycle) — they currently only prevent, never redirect. That is a shared
-/// runtime-resolver gap with a wide blast radius, filed as a separate
-/// follow-up, NOT fixed by this parser-scoped PR. This test therefore asserts
-/// only the in-scope prevention half (controller protected while untapped).
+/// CR 614.9: per the card, the redirected damage is *dealt to the Bodyguard*
+/// (marking damage on it). `parse_replacement_line` emits `shield_kind =
+/// ShieldKind::Prevention { amount: PreventionAmount::All }` with
+/// `redirect_target: SelfRef`, and `game::replacement::damage_done_applier`'s
+/// Branch 2 now reads `redirect_target` and routes the whole
+/// "damage is dealt to X instead" class (Palisade Giant, Veteran Bodyguard,
+/// Weathered Bodyguards) through the shared CR 614.9 redirection mechanics —
+/// so the damage is redirected onto the Bodyguard, not merely prevented. This
+/// test therefore asserts BOTH halves: the controller is protected AND the
+/// unblocked attacker's damage lands on the Bodyguard.
 #[test]
 fn veteran_bodyguard_untapped_protects_controller_from_unblocked_damage() {
     let mut scenario = GameScenario::new_n_player(2, 42);
@@ -119,7 +113,7 @@ fn veteran_bodyguard_untapped_protects_controller_from_unblocked_damage() {
 
     // P1 (the defending player) controls Veteran Bodyguard, a 2/5 with the
     // tap-gated redirection static ability. Untapped by builder default.
-    scenario
+    let bodyguard = scenario
         .add_creature_from_oracle(P1, "Veteran Bodyguard", 2, 5, VETERAN_BODYGUARD_TEXT)
         .id();
 
@@ -138,6 +132,13 @@ fn veteran_bodyguard_untapped_protects_controller_from_unblocked_damage() {
         p1_life_before,
         "P1 must take NO life loss — while the Veteran Bodyguard is untapped, the \
          unblocked attacker's damage to P1 is redirected away (CR 604.2 + CR 614.9)"
+    );
+    // CR 614.9: the redirected damage is DEALT to the Bodyguard, not prevented.
+    // Revert guard for Branch 2's redirect check — without it this is 0.
+    assert_eq!(
+        runner.state().objects[&bodyguard].damage_marked,
+        3,
+        "the unblocked attacker's 3 damage must be redirected onto the untapped Veteran Bodyguard"
     );
 }
 


### PR DESCRIPTION
## Summary

Palisade Giant, Veteran Bodyguard, and Weathered Bodyguards all parse correctly today (`ShieldKind::Prevention { amount: PreventionAmount::All }` + `redirect_target: Some(TargetFilter::SelfRef)` on their `ReplacementDefinition`), but the runtime handler for `ShieldKind::Prevention` shields never read `redirect_target` — it fully prevented the damage instead of redirecting it. The intended recipient never actually took the damage, could never die from it, and never triggered "dealt damage" abilities off it.

A separate, already-correct branch for `ShieldKind::Redirection` does correctly replace the damage event's target per CR 614.9, but is one-shot (consumes the shield after firing) — correct for its own consumers (Soltari Guerrillas, Beacon of Destiny, Jade Monolith, Goblin Psychopath, the en-Kor cycle — all genuinely one-shot "the next time..." spell effects), but wrong for these 3 cards' continuous, ongoing static-ability lifecycle.

## Fix

Extracted the existing CR 614.9 redirect mechanics (resolve recipient → check legality → swap-or-fallback-to-original) out of the one-shot `Redirection` branch into a shared helper parameterized by `consume_after_redirect: bool`, and added a new gate in the `Prevention` branch:

```rust
if redirect_target_for_rid(state, rid) == Some(TargetFilter::SelfRef) && matches!(amount, PreventionAmount::All)
```

The `PreventionAmount::All` conjunct is required, not optional — the shared helper's body contains an `unreachable!()` arm for `PreventionAmount::AllBut` that's a true invariant only for the one-shot `Redirection` shield (which never produces `AllBut`), not for `Prevention` shields in general (which legitimately use `AllBut` for other cards, e.g. Temple Altisaur). Gating on `redirect_target.is_some()` alone would let a hypothetical future card pairing `AllBut`/`Next` with a redirect reach that arm and panic in production — no such card exists today, and this gate keeps it that way honestly.

When the gate passes, the redirect runs non-consuming, preserving the shield's continuous (re-firing every event) lifecycle.

## Scope

This PR fixes exactly 3 cards, verified against real Scryfall Oracle text (not name-substituted test fixtures — an earlier investigation round caught that trap on 2 other cards, see below). Explicitly **out of scope**, left untouched:

- **Pariah** — its real text is "...is dealt to **enchanted creature** instead," which the redirect-detection parser branch doesn't recognize at all today (only literal self-reference). Needs its own parser fix.
- **Pariah's Shield** — architecturally a CR 615.5 prevention-with-additional-effect card (not CR 614.9 redirection); applying this fix's mechanism to it would actually *regress* it, since it's an enchantment and would always fail the redirect-recipient legality check.
- **Palisade Giant's "and other permanents you control"** clause — a separate, pre-existing gap in the same conditional, already documented in an existing test's comments.

## CR references

- CR 614.9 (redirection effects; "the effect does nothing" on an illegal recipient)
- CR 510.2 (simultaneous combat damage)
- CR 614.5 / CR 614.7a (pre-existing, unmodified)
- CR 615 / CR 615.1a (pre-existing, unmodified)
- CR 704.5g (lethal damage → destroy, exercised by the new death test)

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- 6 new runtime tests (`crates/engine/tests/integration/palisade_giant_redirect.rs`): redirect + death, continuous (non-consumed) lifecycle across multiple events, downstream "dealt damage" trigger firing, illegal-recipient fallback (CR 614.9 "does nothing"), off-battlefield host correctly excluded from candidacy, simultaneous multi-attacker combat damage
- `veteran_bodyguard_tap_redirect.rs`: corrected a stale doc comment that narrated this exact bug as a known, deliberately-unfixed gap, and added the positive `damage_marked` assertion that test had previously and deliberately omitted
- 4 existing one-shot `ShieldKind::Redirection` regression tests pass unmodified (proves the shared-helper refactor is byte-identical for its existing consumers)
- 3 existing parser unit tests pass unmodified (this is a runtime-only fix; parser output is unchanged)