### PR TITLE
fix(parser): resolve off-battlefield-owned compound subject (Dune Chanter) [WIP]

### DIFF
--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -522,23 +522,15 @@ pub(crate) fn parse_spells_have_keyword(tp: &TextPair<'_>, text: &str) -> Option
     }
 
     // Pattern 2: "Creature cards you own that aren't on the battlefield have flash"
-    // This grants flash to cards in non-battlefield zones.
-    if nom_primitives::scan_contains(subject, "cards you own that aren't on the battlefield") {
-        let (prefix, _) = nom_primitives::scan_split_at_phrase(subject, |i| tag("cards").parse(i))?;
-        let type_end = prefix.len();
-        let type_part = &tp.original[..type_end];
-        let (base_filter, _) = parse_type_phrase(type_part);
-        let affected = match base_filter {
-            TargetFilter::Typed(mut typed) => {
-                typed = typed.controller(ControllerRef::You);
-                // "aren't on the battlefield" means any zone except battlefield
-                typed.properties.push(FilterProp::InAnyZone {
-                    zones: vec![Zone::Hand, Zone::Graveyard, Zone::Exile, Zone::Command],
-                });
-                TargetFilter::Typed(typed)
-            }
-            _ => base_filter,
-        };
+    // (Leyline of Anticipation class) — grants a casting keyword to cards in non-
+    // battlefield zones. The subject→filter grammar is the shared
+    // `parse_owned_off_battlefield_subject_filter`, reused (not reimplemented) so
+    // the generic continuous-subject resolver can reach the same off-battlefield-
+    // ownership shape (Dune Chanter's additive land-type static).
+    if let Some(affected) = super::shared::parse_owned_off_battlefield_subject_filter(
+        subject,
+        &tp.original[..subject.len()],
+    ) {
         let mut def = StaticDefinition::new(StaticMode::CastWithKeyword { keyword })
             .affected(affected)
             .description(text.to_string())

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3237,6 +3237,56 @@ fn parse_bare_compound_subtype_subject_filter(subject: &TextPair<'_>) -> Option<
     Some(TargetFilter::Or { filters })
 }
 
+/// CR 109.4 + CR 109.5 + CR 400.3: "`<type>` cards you own that aren't on the
+/// battlefield" — an owner-scoped subject naming cards in every zone EXCEPT the
+/// battlefield. Off the battlefield an object has no controller (CR 109.4), so
+/// "you own" reads the owner (CR 109.5); `FilterProp::InAnyZone` enumerates the
+/// non-battlefield zones (hand, graveyard, exile, command).
+///
+/// Shared by `parse_spells_have_keyword`'s casting-keyword Pattern 2 (Leyline of
+/// Anticipation: "Creature cards you own that aren't on the battlefield have
+/// flash.") and the generic continuous-subject resolver (Dune Chanter's additive
+/// land-type static, whose second conjunct is "land cards you own that aren't on
+/// the battlefield"). Returns `None` unless the phrase is present and the leading
+/// type phrase resolves to a `Typed` filter — a leading token that does not name a
+/// type is not a valid subject here, so it declines rather than widen to `Any`.
+///
+/// `subject_lower` and `subject_original` must share byte offsets (the lowercase
+/// and original-case views of the same slice).
+pub(crate) fn parse_owned_off_battlefield_subject_filter(
+    subject_lower: &str,
+    subject_original: &str,
+) -> Option<TargetFilter> {
+    if !nom_primitives::scan_contains(
+        subject_lower,
+        "cards you own that aren't on the battlefield",
+    ) {
+        return None;
+    }
+    let (prefix, _) =
+        nom_primitives::scan_split_at_phrase(subject_lower, |i| tag("cards").parse(i))?;
+    let type_part = &subject_original[..prefix.len()];
+    let (base_filter, type_rest) = parse_type_phrase(type_part);
+    // The text before "cards" must be EXACTLY a type phrase ("land ", "creature ").
+    // A non-empty remainder means this is a compound-subject prefix ("lands you
+    // control and land"), not a bare off-battlefield-owned subject — decline so the
+    // compound splitter handles it conjunct-by-conjunct instead.
+    if !type_rest.trim().is_empty() {
+        return None;
+    }
+    match base_filter {
+        TargetFilter::Typed(mut typed) => {
+            typed = typed.controller(ControllerRef::You);
+            // "aren't on the battlefield" = any zone except the battlefield.
+            typed.properties.push(FilterProp::InAnyZone {
+                zones: vec![Zone::Hand, Zone::Graveyard, Zone::Exile, Zone::Command],
+            });
+            Some(TargetFilter::Typed(typed))
+        }
+        _ => None,
+    }
+}
+
 pub(crate) fn parse_continuous_subject_filter(subject: &str) -> Option<TargetFilter> {
     let trimmed = subject.trim();
     let lower = trimmed.to_lowercase();
@@ -3369,6 +3419,20 @@ pub(crate) fn parse_continuous_subject_filter(subject: &str) -> Option<TargetFil
     }
 
     if let Some(filter) = parse_modified_creature_subject_filter(trimmed) {
+        return Some(filter);
+    }
+
+    // CR 109.4 + CR 109.5 + CR 205.1b: "<type> cards you own that aren't on the
+    // battlefield" — the off-battlefield-owned conjunct of a compound subject
+    // (Dune Chanter: "Lands you control and land cards you own that aren't on the
+    // battlefield are Deserts ..."). Tried BEFORE the lenient `you control` /
+    // creature / `parse_type_phrase` matchers below, which would otherwise consume
+    // only the leading type word and drop the ownership clause. The helper is
+    // precise (it requires the text before "cards" to be exactly a type phrase), so
+    // it never intercepts a compound subject — those are split by
+    // `parse_controlled_compound_continuous_subject_filter` above, which recurses
+    // here per conjunct. Reuses the same grammar as casting-keyword Pattern 2.
+    if let Some(filter) = parse_owned_off_battlefield_subject_filter(&lower, trimmed) {
         return Some(filter);
     }
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -4335,6 +4335,156 @@ fn life_and_limb_real_text_dual_subject_animation() {
     }
 }
 
+// #5814 + CR 611.3 + CR 205.1b + CR 305.7: Dune Chanter's compound-subject
+// additive land-type static — "Lands you control and land cards you own that
+// aren't on the battlefield are Deserts in addition to their other types." — must
+// affect BOTH conjuncts, not just the battlefield one: an `Or` of the "Lands you
+// control" filter (battlefield) and the off-battlefield-owned "land cards you own"
+// filter, both adding subtype Desert (CR 305.6: Desert is not a basic land type,
+// so it cannot route through the basic-land-type machinery).
+#[test]
+fn dune_chanter_compound_offbattlefield_land_type_static() {
+    let defs = parse_static_line_multi(
+        "Lands you control and land cards you own that aren't on the battlefield \
+         are Deserts in addition to their other types.",
+    );
+    assert_eq!(defs.len(), 1, "one compound additive-type static: {defs:?}");
+    let def = &defs[0];
+
+    // TEMP DIAG (#5814): dump the splitter's DIRECT return + the resolver layers to
+    // pinpoint why the compound collapses to Typed instead of Or.
+    let compound = "Lands you control and land cards you own that aren't on the battlefield";
+    let compound_l = compound.to_lowercase();
+    let split = parse_controlled_compound_continuous_subject_filter(
+        &crate::parser::oracle_util::TextPair::new(compound, &compound_l),
+    );
+    let whole = super::shared::parse_continuous_subject_filter(compound);
+    let left = super::shared::parse_continuous_subject_filter("Lands you control");
+    let right = super::shared::parse_continuous_subject_filter(
+        "land cards you own that aren't on the battlefield",
+    );
+    panic!("DIAG5814 split={split:?} ||| whole={whole:?} ||| left={left:?} ||| right={right:?}");
+    #[allow(unreachable_code)]
+    let Some(TargetFilter::Or { filters }) = def.affected.as_ref() else {
+        panic!(
+            "affected must be an Or of both conjuncts: {:?}",
+            def.affected
+        );
+    };
+    assert_eq!(filters.len(), 2, "one disjunct per conjunct: {filters:?}");
+
+    // Conjunct 1: "Lands you control" — battlefield, no off-battlefield zone prop.
+    assert!(
+        filters.iter().any(|f| matches!(f, TargetFilter::Typed(tf)
+            if tf.type_filters.contains(&TypeFilter::Land)
+                && tf.controller == Some(ControllerRef::You)
+                && !tf.properties.iter().any(|p| matches!(p, FilterProp::InAnyZone { .. })))),
+        "missing battlefield 'lands you control' conjunct: {:?}",
+        def.affected
+    );
+    // Conjunct 2: "land cards you own that aren't on the battlefield" — owner-scoped,
+    // restricted to the four non-battlefield zones.
+    assert!(
+        filters.iter().any(|f| matches!(f, TargetFilter::Typed(tf)
+            if tf.type_filters.contains(&TypeFilter::Land)
+                && tf.controller == Some(ControllerRef::You)
+                && tf.properties.iter().any(|p| matches!(p, FilterProp::InAnyZone { zones }
+                    if zones.contains(&Zone::Hand)
+                        && zones.contains(&Zone::Graveyard)
+                        && zones.contains(&Zone::Exile)
+                        && zones.contains(&Zone::Command)
+                        && !zones.contains(&Zone::Battlefield))))),
+        "missing off-battlefield 'land cards you own' conjunct: {:?}",
+        def.affected
+    );
+
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::AddSubtype {
+                subtype: "Desert".to_string()
+            }),
+        "must add subtype Desert to both conjuncts: {:?}",
+        def.modifications
+    );
+}
+
+// #5814 no-regression: a SINGLE-subject additive land-type line must stay a plain
+// `Typed` filter — the new off-battlefield branch must not widen it into an `Or`.
+#[test]
+fn single_subject_additive_land_type_stays_typed() {
+    let defs =
+        parse_static_line_multi("Lands you control are Deserts in addition to their other types.");
+    assert_eq!(defs.len(), 1, "one static: {defs:?}");
+    assert!(
+        matches!(defs[0].affected, Some(TargetFilter::Typed(_))),
+        "single subject must remain a Typed filter, not an Or: {:?}",
+        defs[0].affected
+    );
+}
+
+// #5814: the extracted `parse_owned_off_battlefield_subject_filter` helper is the
+// single grammar for "<type> cards you own that aren't on the battlefield". It must
+// scope to the owner (CR 109.5) across exactly the four non-battlefield zones, and
+// decline a leading token that names no type.
+#[test]
+fn owned_off_battlefield_subject_filter_shape() {
+    use super::shared::parse_owned_off_battlefield_subject_filter;
+
+    let subject = "creature cards you own that aren't on the battlefield";
+    let filter = parse_owned_off_battlefield_subject_filter(subject, subject)
+        .expect("off-battlefield-owned creature subject must resolve");
+    let TargetFilter::Typed(tf) = filter else {
+        panic!("expected Typed filter, got {filter:?}");
+    };
+    assert!(tf.type_filters.contains(&TypeFilter::Creature));
+    assert_eq!(tf.controller, Some(ControllerRef::You));
+    assert!(
+        tf.properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::InAnyZone { zones }
+            if zones == &vec![Zone::Hand, Zone::Graveyard, Zone::Exile, Zone::Command])),
+        "must restrict to the four non-battlefield zones: {:?}",
+        tf.properties
+    );
+    // A leading token that is not a type declines (no unscoped `Any`).
+    assert!(
+        parse_owned_off_battlefield_subject_filter("lands you control", "lands you control")
+            .is_none(),
+        "a subject without the off-battlefield-ownership phrase must decline",
+    );
+}
+
+// #5814 extraction guard: `parse_spells_have_keyword`'s Pattern 2 (Leyline of
+// Anticipation class) must be unchanged after moving its subject grammar into the
+// shared helper — "Creature cards you own that aren't on the battlefield have
+// flash." still lowers to a `CastWithKeyword { Flash }` static scoped to the
+// owner's off-battlefield creature cards.
+#[test]
+fn leyline_off_battlefield_flash_grant_unchanged() {
+    let def =
+        parse_static_line("Creature cards you own that aren't on the battlefield have flash.")
+            .expect("Leyline-class off-battlefield flash grant must parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::CastWithKeyword {
+            keyword: Keyword::Flash
+        }
+    );
+    let Some(TargetFilter::Typed(tf)) = &def.affected else {
+        panic!("affected must be a Typed filter, got {:?}", def.affected);
+    };
+    assert!(tf.type_filters.contains(&TypeFilter::Creature));
+    assert_eq!(tf.controller, Some(ControllerRef::You));
+    assert!(
+        tf.properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::InAnyZone { zones }
+            if zones == &vec![Zone::Hand, Zone::Graveyard, Zone::Exile, Zone::Command])),
+        "off-battlefield zone scoping must be preserved: {:?}",
+        tf.properties
+    );
+}
+
 // CR 205.1a vs CR 205.1b: compound-subject animation splits across two handlers.
 // Additive predicates ("in addition to their other types") route to
 // `parse_compound_all_subjects_type_change`; bare "are <P/T> <type> creatures"


### PR DESCRIPTION
WIP toward #5814. Extracts `parse_owned_off_battlefield_subject_filter` (shared by keyword_grant Pattern 2, behavior-preserving) and wires it into the generic continuous-subject resolver so "<type> cards you own that aren't on the battlefield" resolves. The standalone conjunct resolves correctly and the full suite is otherwise green, but the compound "Lands you control and land cards you own..." still collapses to the battlefield conjunct instead of a two-way `Or`. **Draft carries a temporary diagnostic** in the Dune test to surface the compound splitter's direct return from CI logs (local builds blocked by disk). Will remove the diagnostic and finalize once the splitter behavior is pinned.