### PR TITLE
fix(engine): wire "as ~ becomes attached, choose" replacement for Psychic Paper

### DIFF
--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -69,6 +69,55 @@ pub fn resolve(
         return Ok(());
     }
 
+    // CR 701.3a + CR 614.1a: Route the attach through the replacement pipeline
+    // so an "as it becomes attached, choose …" definition on the attachment
+    // (`ReplacementEvent::Attached`, Psychic Paper) can bind its choice as the
+    // attachment resolves — the attach-time analogue of "as ~ enters, choose".
+    let proposed = crate::types::proposed_event::ProposedEvent::Attach {
+        attachment_id,
+        target_id,
+        applied: Default::default(),
+    };
+    match crate::game::replacement::replace_event(state, proposed, events) {
+        crate::game::replacement::ReplacementResult::Execute(_) => {
+            if let Some(waiting_for) =
+                deliver_attach(state, attachment_id, target_id, source_id, events)
+            {
+                state.waiting_for = waiting_for;
+            }
+        }
+        crate::game::replacement::ReplacementResult::Prevented => {
+            events.push(GameEvent::EffectResolved {
+                kind: EffectKind::from(&ability.effect),
+                source_id,
+                subject: None,
+            });
+        }
+        crate::game::replacement::ReplacementResult::NeedsChoice(player) => {
+            // CR 616.1: multiple "becomes attached" replacements apply — park
+            // for the ordering choice. `handle_replacement_choice`'s
+            // `ProposedEvent::Attach` arm resumes via `deliver_attach` once
+            // the player orders them.
+            crate::game::replacement::park_waiting_for(state, player);
+        }
+    }
+
+    Ok(())
+}
+
+/// CR 701.3a + CR 614.1a: Perform the attach mutation and, if the attachment
+/// carries an "as it becomes attached, choose …" replacement, drain its
+/// stashed continuation (`ReplacementEvent::Attached`). Single authority for
+/// completing an attach after the replacement pipeline consult — used both by
+/// the immediate `resolve()` path and by `handle_replacement_choice`'s
+/// post-ordering-choice resume, so the two paths cannot drift apart.
+pub(crate) fn deliver_attach(
+    state: &mut GameState,
+    attachment_id: ObjectId,
+    target_id: ObjectId,
+    source_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> Option<WaitingFor> {
     if let Some(old_target) = attach_to(state, attachment_id, target_id) {
         events.push(GameEvent::Unattached {
             attachment_id,
@@ -77,12 +126,18 @@ pub fn resolve(
     }
 
     events.push(GameEvent::EffectResolved {
-        kind: EffectKind::from(&ability.effect),
+        kind: EffectKind::Attach,
         source_id,
         subject: None,
     });
 
-    Ok(())
+    crate::game::engine_replacement::apply_pending_post_replacement_effect(
+        state,
+        Some(attachment_id),
+        None,
+        Some(crate::types::replacements::ReplacementEvent::Attached),
+        events,
+    )
 }
 
 /// CR 701.3d: Unattach each matching Equipment from the matched host, leaving

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -411,6 +411,34 @@ pub(super) fn handle_replacement_choice(
                 // does not prevent the turn-up), so there is nothing to apply on
                 // the post-replacement Execute path here.
                 ProposedEvent::TurnFaceUp { .. } => {}
+                // CR 701.3a + CR 616.1: Attach accepted after a replacement
+                // ordering choice (2+ "as it becomes attached, choose …"
+                // definitions on the same attachment). Unreachable today — the
+                // parser pool has exactly one `ReplacementEvent::Attached`
+                // producer (Psychic Paper) — but wired for correctness if a
+                // future card shares the class. `source_id` for the
+                // `EffectResolved` push is approximated as `attachment_id`:
+                // `ProposedEvent::Attach` doesn't carry the original ability's
+                // source, which only differs from the attachment for a
+                // non-Equip "attach ~ to" effect (e.g. a triggered ability on
+                // another permanent) — no such card has BOTH that shape AND a
+                // second Attached-event replacement to order against today.
+                ProposedEvent::Attach {
+                    attachment_id,
+                    target_id,
+                    ..
+                } => {
+                    if let Some(waiting_for) = crate::game::effects::attach::deliver_attach(
+                        state,
+                        attachment_id,
+                        target_id,
+                        attachment_id,
+                        events,
+                    ) {
+                        state.waiting_for = waiting_for;
+                        return Ok(state.waiting_for.clone());
+                    }
+                }
                 // CR 121.1 + CR 614.6 + CR 614.11: Draw accepted after
                 // replacement choice — delegate to the shared post-replacement
                 // helper so library-zone move + per-turn accounting match the

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -3403,27 +3403,37 @@ fn counter_applier(
     ApplyResult::Modified(event)
 }
 
-// --- 15. Attached (ZoneChange to Battlefield for attachments) ---
+// --- 15. Attached (ZoneChange to Battlefield for attachments; Effect::Attach becoming attached) ---
 
 fn attached_matcher(event: &ProposedEvent, _source: ObjectId, state: &GameState) -> bool {
-    if let ProposedEvent::ZoneChange { object_id, to, .. } = event {
-        if *to != Zone::Battlefield {
-            return false;
+    let attachment_id = match event {
+        ProposedEvent::ZoneChange { object_id, to, .. } => {
+            if *to != Zone::Battlefield {
+                return false;
+            }
+            *object_id
         }
-        // Check if the entering object is an attachment (Aura or Equipment)
-        state
-            .objects
-            .get(object_id)
-            .map(|obj| {
-                obj.card_types
-                    .subtypes
-                    .iter()
-                    .any(|s| s == "Aura" || s == "Equipment")
-            })
-            .unwrap_or(false)
-    } else {
-        false
-    }
+        // CR 701.3a: An already-battlefield Aura/Equipment/Fortification
+        // becoming attached via `Effect::Attach` (Equip, or any other "attach
+        // ~ to" effect) is the same "becomes attached" event as an Aura
+        // entering already attached — just without the accompanying zone
+        // change. `valid_card` (typically `SelfRef`) scopes this to the
+        // specific attachment's own "as it becomes attached, choose …"
+        // definition (Psychic Paper).
+        ProposedEvent::Attach { attachment_id, .. } => *attachment_id,
+        _ => return false,
+    };
+    // Check if the (would-be) attached object is an attachment (Aura or Equipment)
+    state
+        .objects
+        .get(&attachment_id)
+        .map(|obj| {
+            obj.card_types
+                .subtypes
+                .iter()
+                .any(|s| s == "Aura" || s == "Equipment")
+        })
+        .unwrap_or(false)
 }
 
 fn attached_applier(
@@ -4820,6 +4830,9 @@ fn replacement_event_keys_for_event(event: &ProposedEvent) -> Vec<ReplacementEve
         }
         ProposedEvent::Planeswalk { .. } => {
             push_replacement_event_key(&mut keys, ReplacementEvent::Planeswalk);
+        }
+        ProposedEvent::Attach { .. } => {
+            push_replacement_event_key(&mut keys, ReplacementEvent::Attached);
         }
         ProposedEvent::Sacrifice { .. } | ProposedEvent::EmptyManaPool { .. } => {}
     }

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -3407,8 +3407,20 @@ fn counter_applier(
 
 fn attached_matcher(event: &ProposedEvent, _source: ObjectId, state: &GameState) -> bool {
     let attachment_id = match event {
-        ProposedEvent::ZoneChange { object_id, to, .. } => {
-            if *to != Zone::Battlefield {
+        ProposedEvent::ZoneChange {
+            object_id,
+            to,
+            attach_to,
+            ..
+        } => {
+            // CR 303.4f + CR 301.5b: an Aura/Equipment/Fortification entering
+            // the battlefield is only "becoming attached" (and thus only then
+            // eligible to trigger an "as ~ becomes attached, choose …"
+            // replacement) when this zone change actually carries an attach
+            // target. Equipment enters the battlefield like other artifacts —
+            // NOT attached to a creature (CR 301.5b) — so a bare Equipment
+            // ETB must NOT fire the attach-time replacement.
+            if *to != Zone::Battlefield || attach_to.is_none() {
                 return false;
             }
             *object_id

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -9,7 +9,9 @@ use nom::Parser;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_nom::primitives::scan_contains;
 use super::oracle_util::parse_mana_symbols;
-use crate::parser::oracle_effect::{split_leading_conditional, try_parse_named_choice};
+use crate::parser::oracle_effect::{
+    split_leading_conditional, try_parse_named_choice, try_parse_named_choice_conjunction,
+};
 
 pub(crate) fn is_cant_win_lose_compound(lower: &str) -> bool {
     scan_contains(lower, "can't win the game") && scan_contains(lower, "can't lose the game")
@@ -771,6 +773,11 @@ fn is_replacement_compound_pattern(lower: &str) -> bool {
     if is_as_enters_choose_pattern(lower) {
         return true;
     }
+    // CR 701.3a + CR 614.1: "As ~ becomes attached [to X], choose …" — the
+    // attach-time analogue of `is_as_enters_choose_pattern` (Psychic Paper).
+    if is_as_becomes_attached_choose_pattern(lower) {
+        return true;
+    }
     // CR 614.1c + CR 614.12: "As a [filter] enters, it becomes a [P/T] [type]
     // creature in addition to its other types" — a replacement from another
     // source affecting a subset of entrants (Displaced Dinosaurs). Routes to
@@ -959,6 +966,29 @@ fn is_as_enters_choose_pattern(lower: &str) -> bool {
     })
     .is_some();
     has_as && has_enters && has_choose
+}
+
+/// CR 701.3a + CR 614.1: the attach-time analogue of `is_as_enters_choose_pattern`
+/// (Psychic Paper: "As this Equipment becomes attached to a creature, choose a
+/// creature card name and a creature type."). Accepts both a single choice and
+/// a conjunction ("choose X and Y") sharing one "choose".
+fn is_as_becomes_attached_choose_pattern(lower: &str) -> bool {
+    let has_as = nom_primitives::scan_at_word_boundaries(lower, |i| {
+        tag::<_, _, OracleError<'_>>("as ").parse(i)
+    })
+    .is_some();
+    let has_becomes_attached = nom_primitives::scan_at_word_boundaries(lower, |i| {
+        tag::<_, _, OracleError<'_>>("becomes attached").parse(i)
+    })
+    .is_some();
+    let has_choose = nom_primitives::scan_at_word_boundaries(lower, |i| {
+        verify(tag::<_, _, OracleError<'_>>("choose "), |_: &&str| {
+            try_parse_named_choice(i).is_some() || try_parse_named_choice_conjunction(i).is_some()
+        })
+        .parse(i)
+    })
+    .is_some();
+    has_as && has_becomes_attached && has_choose
 }
 
 /// CR 603.2 vs CR 614.1c: "Whenever <subject> enters with a counter on it, <consequence>"

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -66,7 +66,7 @@ use crate::parser::oracle_trigger::parse_trigger_line;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::{anychar, multispace0, multispace1, space1};
-use nom::combinator::{all_consuming, eof, map, not, opt, peek, recognize, rest, value};
+use nom::combinator::{all_consuming, eof, map, map_opt, not, opt, peek, recognize, rest, value};
 use nom::multi::{many1, many_till, separated_list1};
 use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
@@ -21436,6 +21436,16 @@ pub(crate) fn try_parse_named_choice(lower: &str) -> Option<ChoiceType> {
     ))
     .parse(lower)
     .ok()?;
+    parse_named_choice_object(rest)
+}
+
+/// The object phrase of a named choice, with any leading "choose "/"secretly
+/// choose " already stripped (e.g. "a creature type", "a creature card name").
+/// Factored out of `try_parse_named_choice` so a conjunction of choices sharing
+/// one "choose" ("choose a creature card name and a creature type" — Psychic
+/// Paper) can re-dispatch each conjunct through this same phrase table instead
+/// of duplicating it or reconstructing a "choose "-prefixed string.
+pub(crate) fn parse_named_choice_object(rest: &str) -> Option<ChoiceType> {
     type E<'a> = OracleError<'a>;
     if tag::<_, _, E>("a creature type").parse(rest).is_ok() {
         Some(ChoiceType::creature_type())
@@ -21571,6 +21581,38 @@ pub(crate) fn try_parse_named_choice(lower: &str) -> Option<ChoiceType> {
         // semantics.
         try_parse_labeled_choice(rest).map(|options| ChoiceType::Labeled { options })
     }
+}
+
+/// CR 608.2d + CR 614.1c: A conjunction of named-choice phrases sharing one
+/// "choose" ("choose a creature card name and a creature type" — Psychic
+/// Paper). Strips the same "choose "/"secretly choose " prefix
+/// `try_parse_named_choice` strips, then splits on top-level " and " and
+/// re-dispatches each conjunct through `parse_named_choice_object` (the same
+/// phrase table `try_parse_named_choice` itself delegates to), so this stays
+/// additive rather than duplicating tags. `separated_list1` naturally extends
+/// to a future 3+-way conjunction. Returns `None` for a bare (non-conjunction)
+/// choice — callers fall back to `try_parse_named_choice` for that case.
+pub(crate) fn try_parse_named_choice_conjunction(choose_text: &str) -> Option<Vec<ChoiceType>> {
+    let (after_choose, _) = alt((
+        tag::<_, _, OracleError<'_>>("choose "),
+        nom::sequence::preceded(tag("secretly "), tag("choose ")),
+    ))
+    .parse(choose_text)
+    .ok()?;
+    let trimmed = after_choose.trim_end_matches('.').trim();
+
+    fn conjunct(input: &str) -> nom::IResult<&str, ChoiceType, OracleError<'_>> {
+        map_opt(
+            alt((take_until::<_, _, OracleError<'_>>(" and "), rest)),
+            parse_named_choice_object,
+        )
+        .parse(input)
+    }
+
+    let (_, choices) = all_consuming(separated_list1(tag(" and "), conjunct))
+        .parse(trimmed)
+        .ok()?;
+    (choices.len() >= 2).then_some(choices)
 }
 
 /// CR 608.2d + CR 113.3: Parse a typed keyword enumeration following "choose "

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -12,7 +12,7 @@ use nom::Parser;
 use super::oracle_effect::become_copy_except::parse_except_clause;
 use super::oracle_effect::{
     parse_effect_chain, parse_effect_chain_with_context, parse_effect_clause,
-    try_parse_named_choice,
+    try_parse_named_choice, try_parse_named_choice_conjunction,
 };
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::replacement::ReplacementIr;
@@ -106,6 +106,13 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
     // --- "As ~ enters, choose a [type]" → Moved replacement with persisted Choose ---
     // Must be checked BEFORE shock lands, which may contain this as a sub-pattern.
     if let Some(def) = parse_as_enters_choose(&norm_lower, &text) {
+        return Some(def);
+    }
+
+    // --- "As ~ becomes attached, choose a [type]" → Attached replacement with
+    //     persisted Choose (Psychic Paper). The attach-time analogue of the
+    //     enters-choose handler above. ---
+    if let Some(def) = parse_as_becomes_attached_choose(&norm_lower, &text) {
         return Some(def);
     }
 
@@ -2002,6 +2009,67 @@ fn parse_as_enters_choose(norm_lower: &str, original_text: &str) -> Option<Repla
             .valid_card(TargetFilter::SelfRef)
             // CR 614.1c: battlefield-entry-scoped (see destination-gate note above).
             .destination_zone(Zone::Battlefield)
+            .description(original_text.to_string()),
+    )
+}
+
+/// Parse "As ~ becomes attached [to a creature/permanent], choose …" into an
+/// `Attached`-event replacement with a persisted `Choose` (Psychic Paper: "As
+/// this Equipment becomes attached to a creature, choose a creature card name
+/// and a creature type."). The attach-time analogue of `parse_as_enters_choose`
+/// — the choice is bound generically from `Effect::Attach`'s single resolver
+/// (`game/effects/attach.rs`), so it fires regardless of which ability moves
+/// the attachment (Equip, or any other "attach ~ to" effect), not just this
+/// card's own Equip cost. Unlike the enters-choose sibling, no zone change is
+/// involved, so there is no `destination_zone` and no enters-tapped/leading-
+/// imperative composition — no printed card needs either for this shape yet.
+fn parse_as_becomes_attached_choose(
+    norm_lower: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
+    let has_phrase = |phrase: &'static str| {
+        nom_primitives::scan_at_word_boundaries(norm_lower, |input| {
+            tag::<_, _, OracleError<'_>>(phrase).parse(input)
+        })
+        .is_some()
+    };
+
+    if !has_phrase("as ") || !has_phrase("becomes attached") {
+        return None;
+    }
+
+    let (_, choose_text) = nom_primitives::scan_split_at_phrase(norm_lower, |i| {
+        tag::<_, _, OracleError<'_>>("choose ").parse(i)
+    })?;
+
+    // CR 608.2d: a conjunction ("choose a creature card name and a creature
+    // type") binds every conjunct as its own persisted `Choose`; a bare choice
+    // falls back to the single-`ChoiceType` parse.
+    let choice_types = try_parse_named_choice_conjunction(choose_text)
+        .or_else(|| try_parse_named_choice(choose_text).map(|choice_type| vec![choice_type]))?;
+
+    let execute = choice_types
+        .into_iter()
+        .rev()
+        .fold(None, |acc, choice_type| {
+            let step = AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Choose {
+                    choice_type,
+                    persist: true,
+                    selection: crate::types::ability::TargetSelectionMode::Chosen,
+                },
+            );
+            Some(match acc {
+                Some(next) => step.sub_ability(next),
+                None => step,
+            })
+        })?;
+
+    Some(
+        ReplacementDefinition::new(ReplacementEvent::Attached)
+            .execute(execute)
+            .valid_card(TargetFilter::SelfRef)
             .description(original_text.to_string()),
     )
 }

--- a/crates/engine/src/types/proposed_event.rs
+++ b/crates/engine/src/types/proposed_event.rs
@@ -589,6 +589,20 @@ pub enum ProposedEvent {
         player_id: PlayerId,
         applied: HashSet<AppliedReplacementKey>,
     },
+    /// CR 701.3a + CR 614.1a: An Aura, Equipment, or Fortification is about to
+    /// become attached to an object via `Effect::Attach` (Equip activation, or
+    /// any other "attach ~ to" effect). Carried through the replacement
+    /// pipeline so "as it becomes attached, choose …" replacements
+    /// (`ReplacementEvent::Attached`, Psychic Paper) can bind their choice as
+    /// the attachment resolves, mirroring the "as ~ enters, choose" ETB
+    /// analogue. Auras attaching to a PLAYER host use `attach_to_player`
+    /// directly and never propose this event — only object hosts route
+    /// through `Effect::Attach::resolve`.
+    Attach {
+        attachment_id: ObjectId,
+        target_id: ObjectId,
+        applied: HashSet<AppliedReplacementKey>,
+    },
 }
 
 fn default_produce_mana_count() -> u32 {
@@ -719,7 +733,8 @@ impl ProposedEvent {
             | ProposedEvent::BeginPhase { applied, .. }
             | ProposedEvent::ProduceMana { applied, .. }
             | ProposedEvent::EmptyManaPool { applied, .. }
-            | ProposedEvent::Planeswalk { applied, .. } => applied,
+            | ProposedEvent::Planeswalk { applied, .. }
+            | ProposedEvent::Attach { applied, .. } => applied,
         }
     }
 
@@ -751,7 +766,8 @@ impl ProposedEvent {
             | ProposedEvent::BeginPhase { applied, .. }
             | ProposedEvent::ProduceMana { applied, .. }
             | ProposedEvent::EmptyManaPool { applied, .. }
-            | ProposedEvent::Planeswalk { applied, .. } => applied,
+            | ProposedEvent::Planeswalk { applied, .. }
+            | ProposedEvent::Attach { applied, .. } => applied,
         }
     }
 
@@ -849,6 +865,15 @@ impl ProposedEvent {
                 .get(entry_ref)
                 .map(|entry| entry.object.controller)
                 .unwrap_or(PlayerId(0)),
+            // CR 701.3a: The attaching Aura/Equipment's controller is the
+            // affected player — they are the one who would choose a
+            // replacement order (CR 616.1) and bind any "as it becomes
+            // attached, choose" continuation.
+            ProposedEvent::Attach { attachment_id, .. } => state
+                .objects
+                .get(attachment_id)
+                .map(|o| o.controller)
+                .unwrap_or(PlayerId(0)),
         }
     }
 
@@ -899,6 +924,10 @@ impl ProposedEvent {
             // CR 701.31: a planeswalk has no affected object — the planar deck
             // rotation is not an object-scoped event.
             | ProposedEvent::Planeswalk { .. } => None,
+            // CR 701.3a: the attaching Aura/Equipment is the object
+            // `valid_card` filters (and "as it becomes attached" replacements)
+            // match against.
+            ProposedEvent::Attach { attachment_id, .. } => Some(*attachment_id),
         }
     }
 }
@@ -1055,8 +1084,13 @@ mod tests {
                 units: Vec::new(),
                 applied: HashSet::new(),
             },
+            ProposedEvent::Attach {
+                attachment_id: ObjectId(1),
+                target_id: ObjectId(2),
+                applied: HashSet::new(),
+            },
         ];
-        assert_eq!(events.len(), 23);
+        assert_eq!(events.len(), 24);
     }
 
     #[test]

--- a/crates/engine/tests/integration/issue_5821_psychic_paper_attach_choice.rs
+++ b/crates/engine/tests/integration/issue_5821_psychic_paper_attach_choice.rs
@@ -133,3 +133,45 @@ fn psychic_paper_equip_prompts_name_then_type_and_binds_both_on_attach() {
         "equipped creature must gain \"can't be blocked\""
     );
 }
+
+// CR 301.5b: Equipment enters the battlefield like other artifacts — it does
+// NOT enter attached to a creature. Casting bare Psychic Paper must NOT
+// prompt the "as it becomes attached, choose …" replacement, since no
+// attachment has occurred yet. The driver silently halts (does not panic) at
+// any `NamedChoice` it has no declared policy for, so the regression check
+// is on `final_waiting_for()` settling back at `Priority` rather than
+// stalling on a stray name/type prompt.
+#[test]
+fn psychic_paper_casting_unattached_does_not_prompt_attach_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let paper = scenario
+        .add_creature_to_hand(P0, "Psychic Paper", 0, 0)
+        .as_artifact()
+        .with_subtypes(vec!["Equipment"])
+        .from_oracle_text(PSYCHIC_PAPER_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(paper).resolve();
+
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "casting unattached Psychic Paper must settle back at Priority, not stall on \
+         an errant attach-time choice prompt: {:?}",
+        outcome.final_waiting_for()
+    );
+
+    let state = outcome.state();
+    assert_eq!(
+        state.objects[&paper].zone,
+        engine::types::zones::Zone::Battlefield,
+        "Psychic Paper must resolve onto the battlefield"
+    );
+    assert_eq!(
+        state.objects[&paper].attached_to, None,
+        "Psychic Paper must enter unattached — Equipment doesn't enter attached (CR 301.5b)"
+    );
+}

--- a/crates/engine/tests/integration/issue_5821_psychic_paper_attach_choice.rs
+++ b/crates/engine/tests/integration/issue_5821_psychic_paper_attach_choice.rs
@@ -1,0 +1,135 @@
+//! Issue #5821 — Psychic Paper: "As this Equipment becomes attached to a
+//! creature, choose a creature card name and a creature type." must actually
+//! prompt the two choices when Equip resolves, not just parse the downstream
+//! name/type-setting static (that half was already covered).
+//!
+//! https://github.com/phase-rs/phase/issues/5821
+
+use engine::game::game_object::AttachTarget;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::ChoiceType;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const PSYCHIC_PAPER_ORACLE: &str = "As this Equipment becomes attached to a creature, choose a creature card name and a creature type.\nEquipped creature has ward {1}, it can't be blocked, and its name and creature type are the last chosen name and creature type.\nEquip {2}";
+
+#[test]
+fn psychic_paper_equip_prompts_name_then_type_and_binds_both_on_attach() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+        ],
+    );
+
+    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let paper = scenario
+        .add_creature(P0, "Psychic Paper", 0, 0)
+        .as_artifact()
+        .with_subtypes(vec!["Equipment"])
+        .from_oracle_text(PSYCHIC_PAPER_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().all_card_names = vec!["Llanowar Elves".to_string()].into();
+
+    let equip_idx = runner.state().objects[&paper]
+        .abilities
+        .iter()
+        .position(|a| {
+            a.description
+                .as_deref()
+                .is_some_and(|d| d.contains("Equip"))
+        })
+        .expect("Psychic Paper must carry an Equip activated ability");
+
+    // Drive the real activation → targeting → mana payment → stack resolution
+    // path. The driver stops at the first `NamedChoice` it doesn't have a
+    // declared policy for — which must be the CardName choice fired by the
+    // new attach-time replacement (revert the parser gate or the
+    // `Effect::Attach` replacement hook and this never fires; the equip just
+    // attaches silently and `waiting_for` goes back to `Priority`).
+    runner
+        .activate(paper, equip_idx)
+        .target_object(bear)
+        .resolve();
+
+    match &runner.state().waiting_for {
+        WaitingFor::NamedChoice {
+            choice_type: ChoiceType::CardName,
+            source_id: Some(source),
+            ..
+        } => assert_eq!(
+            *source, paper,
+            "the card-name choice must bind to Psychic Paper"
+        ),
+        other => panic!("expected NamedChoice(CardName) right after attaching, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::ChooseOption {
+            choice: "Llanowar Elves".to_string(),
+        })
+        .expect("card name choice must be accepted");
+
+    match &runner.state().waiting_for {
+        WaitingFor::NamedChoice {
+            choice_type: ChoiceType::CreatureType { .. },
+            source_id: Some(source),
+            ..
+        } => assert_eq!(
+            *source, paper,
+            "the creature-type choice must bind to Psychic Paper"
+        ),
+        other => panic!("expected NamedChoice(CreatureType) after the card name, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::ChooseOption {
+            choice: "Zombie".to_string(),
+        })
+        .expect("creature type choice must be accepted");
+
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(
+            runner.state().objects[&paper].attached_to,
+            Some(AttachTarget::Object(id)) if id == bear
+        ),
+        "Psychic Paper must attach to Grizzly Bears once both choices are made"
+    );
+
+    let equipped = &runner.state().objects[&bear];
+    assert_eq!(
+        equipped.name, "Llanowar Elves",
+        "equipped creature's name must become the chosen card name (CR 612.8)"
+    );
+    assert_eq!(
+        equipped.card_types.subtypes,
+        vec!["Zombie".to_string()],
+        "equipped creature's subtypes must become exactly the chosen creature type (CR 205.1a)"
+    );
+    assert!(
+        equipped
+            .keywords
+            .iter()
+            .any(|k| matches!(k, Keyword::Ward(_))),
+        "equipped creature must gain ward {{1}} (CR 702.21)"
+    );
+    assert!(
+        equipped
+            .static_definitions
+            .as_slice()
+            .iter()
+            .any(|def| matches!(def.mode, engine::types::statics::StaticMode::CantBeBlocked)),
+        "equipped creature must gain \"can't be blocked\""
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -496,6 +496,7 @@ mod issue_566_ragavan_dash_cast;
 mod issue_5760_us_agent_equipment_attach;
 mod issue_580_solitude_evoke_prompt;
 mod issue_581_mystic_remora_cumulative_upkeep;
+mod issue_5821_psychic_paper_attach_choice;
 mod issue_583_vivi_ornitier_mana_source;
 mod issue_629_fractured_sanity_cycling;
 mod issue_654_stridehangar_automaton;

--- a/scripts/post-replacement-continuation-baseline.txt
+++ b/scripts/post-replacement-continuation-baseline.txt
@@ -25,6 +25,7 @@
 crates/engine/src/game/combat_damage.rs	fire_combat_prevention_riders	consumer	1
 crates/engine/src/game/combat_damage.rs	fire_combat_prevention_riders	install	1
 crates/engine/src/game/combat_damage.rs	fire_combat_prevention_riders	resolved	1
+crates/engine/src/game/effects/attach.rs	deliver_attach	consumer	1
 crates/engine/src/game/effects/deal_damage.rs	apply_damage_to_target	consumer	1
 crates/engine/src/game/effects/deal_damage.rs	resolve_each_source_deals_damage	consumer	1
 crates/engine/src/game/effects/deal_damage.rs	resolve_each_target_power_damage	consumer	1


### PR DESCRIPTION
Psychic Paper's continuous grant (ward, can't-be-blocked, name/type set
from the last chosen name/type) was already implemented and tested, but
the leading "As this Equipment becomes attached to a creature, choose a
creature card name and a creature type" clause parsed to Unimplemented —
nothing ever actually prompted the choice, so the grant read empty.

Reuses the existing ReplacementEvent::Attached matcher/applier (declared
but never produced by any parser) and routes Effect::Attach's single
resolver through the replacement pipeline, so any "as it becomes
attached, choose ..." definition fires regardless of which ability moves
the attachment. The two-part choice ("a creature card name and a
creature type") is parsed via a small conjunction combinator that
re-dispatches each conjunct through the existing named-choice phrase
table, extended generically rather than special-cased to this card.

Closes #5821
