### PR TITLE
Route activation cost moves through replacements

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13740,10 +13740,8 @@ fn apply_mana_spell_grants(
 // (Phase 1 of the cost-payment unification plan). These `pub use` shims keep
 // every existing `casting::*` / `super::casting::*` call site compiling
 // unchanged while the implementation lives in `game/costs.rs`.
-pub use super::costs::pay_ability_cost;
-pub(crate) use super::costs::{
-    pause_cost_payment_for_replacement_choice, pay_ability_cost_for_activation, PaymentOutcome,
-};
+pub use super::costs::pay_ability_cost_for_activation;
+pub(crate) use super::costs::{pause_cost_payment_for_replacement_choice, PaymentOutcome};
 
 fn pending_activation_after_cost_pause(
     source_id: ObjectId,
@@ -14273,6 +14271,77 @@ pub(super) fn find_return_to_hand_cost(cost: &AbilityCost) -> Option<(u32, Optio
     }
 }
 
+/// Removes the one return-to-hand leg currently represented by a
+/// `WaitingFor::PayCost` selection. Later return legs remain in the residual so
+/// each one receives its own choice after the preceding cost is paid.
+pub(super) fn remove_selected_return_to_hand_cost(cost: AbilityCost) -> Option<AbilityCost> {
+    match cost {
+        AbilityCost::ReturnToHand {
+            from_zone: None | Some(Zone::Battlefield),
+            ..
+        } => None,
+        AbilityCost::Composite { costs } => {
+            let mut removed = false;
+            let remaining = costs
+                .into_iter()
+                .filter_map(|cost| {
+                    if !removed && find_return_to_hand_cost(&cost).is_some() {
+                        removed = true;
+                        remove_selected_return_to_hand_cost(cost)
+                    } else {
+                        Some(cost)
+                    }
+                })
+                .collect();
+            combine_cost_legs(remaining)
+        }
+        other => Some(other),
+    }
+}
+
+/// Splits delayed return-to-hand legs from automatic activation-cost legs.
+/// The former must go back through `WaitingFor::PayCost`; the latter may be
+/// paid by the activation-cost authority before the selected move happens.
+pub(super) fn split_return_to_hand_cost_legs(
+    cost: AbilityCost,
+) -> (Option<AbilityCost>, Option<AbilityCost>) {
+    match cost {
+        cost @ AbilityCost::ReturnToHand { .. } => (None, Some(cost)),
+        AbilityCost::Composite { costs } => {
+            let mut automatic = Vec::new();
+            let mut returns = Vec::new();
+            for cost in costs {
+                let (automatic_leg, return_leg) = split_return_to_hand_cost_legs(cost);
+                automatic.extend(automatic_leg);
+                returns.extend(return_leg);
+            }
+            (combine_cost_legs(automatic), combine_cost_legs(returns))
+        }
+        cost => (Some(cost), None),
+    }
+}
+
+/// True only for a residual composed entirely of return-to-hand legs. A full
+/// activation cost may still contain a return leg after another chooser paid a
+/// different component; that legacy path continues through the cost authority.
+pub(super) fn has_only_return_to_hand_cost_legs(cost: &AbilityCost) -> bool {
+    match cost {
+        AbilityCost::ReturnToHand { .. } => true,
+        AbilityCost::Composite { costs } => {
+            !costs.is_empty() && costs.iter().all(has_only_return_to_hand_cost_legs)
+        }
+        _ => false,
+    }
+}
+
+fn combine_cost_legs(costs: Vec<AbilityCost>) -> Option<AbilityCost> {
+    match costs.len() {
+        0 => None,
+        1 => costs.into_iter().next(),
+        _ => Some(AbilityCost::Composite { costs }),
+    }
+}
+
 pub(crate) fn find_eligible_return_to_hand_targets(
     state: &GameState,
     player: PlayerId,
@@ -14580,6 +14649,7 @@ pub(crate) fn can_pay_ability_cost_now(
         &super::costs::PaymentScope::Activation {
             excluded_sources: &excluded_sources,
             ability_tag,
+            cost_move_handling: super::costs::ActivationCostMoveHandling::OutcomeAware,
         },
     )
 }
@@ -15685,12 +15755,17 @@ pub fn handle_activate_ability(
                     activation_ability_tag(state, source_id, ability_index),
                     events,
                 )? {
-                    state.pending_cast = Some(Box::new(pending_activation_after_cost_pause(
+                    let pending = pending_activation_after_cost_pause(
                         source_id,
                         resolved.clone(),
                         ability_index,
                         remaining_cost,
-                    )));
+                    );
+                    if let Some(pending) =
+                        casting_costs::attach_pending_cast_to_cost_move(state, Box::new(pending))
+                    {
+                        state.pending_cast = Some(pending);
+                    }
                     return Ok(state.waiting_for.clone());
                 }
             }
@@ -15807,12 +15882,17 @@ pub fn handle_activate_ability(
             activation_ability_tag(state, source_id, ability_index),
             events,
         )? {
-            state.pending_cast = Some(Box::new(pending_activation_after_cost_pause(
+            let pending = pending_activation_after_cost_pause(
                 source_id,
                 resolved.clone(),
                 ability_index,
                 remaining_cost,
-            )));
+            );
+            if let Some(pending) =
+                casting_costs::attach_pending_cast_to_cost_move(state, Box::new(pending))
+            {
+                state.pending_cast = Some(pending);
+            }
             return Ok(state.waiting_for.clone());
         }
     }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -14,7 +14,7 @@ use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{
     ActivationResidual, AssistState, CastPaymentMode, CastingVariant, ConvokeMode, CostResume,
     CounterCostChoice, CounterRemoveChoice, DeferredSacrificeSelection, DistributionUnit,
-    GameState, PayCostKind, PendingCast, PendingCostMoveCompletion, PendingCostPaymentResume,
+    GameState, PayCostKind, PendingCast, PendingCostMoveCompletion, PendingCostMoveResume,
     PendingDiscardForCostResume, SpellCostSource, StackEntry, StackEntryKind, StackPaidSnapshot,
     WaitingFor,
 };
@@ -1378,7 +1378,6 @@ pub(crate) fn handle_discard_for_cost(
                     pending: pending.clone(),
                     chosen: chosen.to_vec(),
                     paused_at_index: index,
-                    resume: PendingCostPaymentResume::Discard,
                 });
                 super::casting::pause_cost_payment_for_replacement_choice(state, choice_player);
                 // CR 603.2 + CR 603.3b: Earlier cards in a count>1 discard cost may
@@ -1470,15 +1469,13 @@ fn finish_cost_object_moves(
         ) {
             ZoneMoveResult::Done => {}
             ZoneMoveResult::NeedsChoice(choice_player) => {
-                state.pending_discard_for_cost = Some(PendingDiscardForCostResume {
+                state.pending_cost_move_resume = Some(PendingCostMoveResume::Cast {
                     player,
-                    pending,
+                    pending: Some(Box::new(pending)),
                     chosen,
                     paused_at_index: index,
-                    resume: PendingCostPaymentResume::Move {
-                        destination,
-                        completion,
-                    },
+                    destination,
+                    completion,
                 });
                 super::casting::pause_cost_payment_for_replacement_choice(state, choice_player);
                 let waiting_for = state.waiting_for.clone();
@@ -1501,6 +1498,19 @@ fn finish_cost_object_moves(
         PendingCostMoveCompletion::FinishPending => {
             finish_pending_cost_or_cast(state, player, pending, events)?
         }
+        PendingCostMoveCompletion::CompleteSelectedReturnToHand {
+            selected,
+            automatic_remaining,
+        } => finish_selected_return_to_hand_after_automatic(
+            state,
+            player,
+            pending,
+            selected,
+            automatic_remaining,
+            cost_event_start,
+            park_events_after_completion,
+            events,
+        )?,
         PendingCostMoveCompletion::PublishExileTrackedSet => {
             // CR 614: a replacement may deliver a card elsewhere; the set must reflect
             // what actually arrived in exile.
@@ -1577,6 +1587,94 @@ fn finish_cost_object_moves(
     Ok(waiting_for)
 }
 
+/// CR 601.2h + CR 602.2b + CR 616.1: A replacement can interrupt an automatic
+/// activation-cost leg before the chosen return-to-hand leg is delivered. Resume
+/// that automatic suffix first, then deliver the already selected return, so each
+/// cost leg is paid exactly once before later return legs re-surface.
+#[allow(clippy::too_many_arguments)]
+fn finish_selected_return_to_hand_after_automatic(
+    state: &mut GameState,
+    player: PlayerId,
+    pending: PendingCast,
+    selected: Vec<ObjectId>,
+    automatic_remaining: Option<AbilityCost>,
+    cost_event_start: usize,
+    park_events_after_completion: bool,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    if let Some(cost) = automatic_remaining {
+        let ability_index = pending.activation_ability_index.ok_or_else(|| {
+            EngineError::InvalidAction(
+                "return-cost continuation missing an activation ability index".to_string(),
+            )
+        })?;
+        match super::casting::pay_ability_cost_for_activation(
+            state,
+            player,
+            pending.object_id,
+            &cost,
+            super::casting::activation_ability_tag(state, pending.object_id, ability_index),
+            events,
+        )? {
+            super::casting::PaymentOutcome::Paid => {}
+            super::casting::PaymentOutcome::Paused { remaining_cost } => {
+                let Some(PendingCostMoveResume::Cast {
+                    pending: slot @ None,
+                    completion,
+                    ..
+                }) = state.pending_cost_move_resume.as_mut()
+                else {
+                    return Err(EngineError::InvalidAction(
+                        "automatic return-cost suffix paused without a cost-move continuation"
+                            .to_string(),
+                    ));
+                };
+                *slot = Some(Box::new(pending));
+                *completion = PendingCostMoveCompletion::CompleteSelectedReturnToHand {
+                    selected,
+                    automatic_remaining: remaining_cost,
+                };
+                return Ok(state.waiting_for.clone());
+            }
+            super::casting::PaymentOutcome::Failed { reason } => {
+                return Err(EngineError::ActionNotAllowed(reason.reason));
+            }
+        }
+    }
+
+    finish_cost_object_moves(
+        state,
+        player,
+        pending,
+        selected,
+        0,
+        Zone::Hand,
+        PendingCostMoveCompletion::FinishPending,
+        cost_event_start,
+        park_events_after_completion,
+        events,
+    )
+}
+
+/// CR 601.2h + CR 602.2b: An activation that paused while paying a self-move
+/// cost keeps its continuation with the typed cost-move resume, rather than in
+/// `GameState::pending_cast`. Returns the payload unchanged for every other
+/// kind of pause.
+pub(crate) fn attach_pending_cast_to_cost_move(
+    state: &mut GameState,
+    pending: Box<PendingCast>,
+) -> Option<Box<PendingCast>> {
+    let Some(PendingCostMoveResume::Cast {
+        pending: slot @ None,
+        ..
+    }) = state.pending_cost_move_resume.as_mut()
+    else {
+        return Some(pending);
+    };
+    *slot = Some(pending);
+    None
+}
+
 /// CR 601.2h + CR 616.1: After a replacement choice during sequential cost payment, finish
 /// the remaining cost moves and continue the cast/activation pipeline.
 ///
@@ -1588,25 +1686,41 @@ pub(crate) fn resume_interrupted_cost_payment(
     events: &mut Vec<GameEvent>,
     replacement_action_cost_event_start: Option<usize>,
 ) -> Result<WaitingFor, EngineError> {
-    if let Some(resume) = state.pending_discard_for_cost.take() {
-        if let PendingCostPaymentResume::Move {
+    if matches!(
+        state.pending_cost_move_resume,
+        Some(PendingCostMoveResume::Cast { .. })
+    ) {
+        let Some(PendingCostMoveResume::Cast {
+            player,
+            pending,
+            chosen,
+            paused_at_index,
             destination,
             completion,
-        } = resume.resume
-        {
-            return finish_cost_object_moves(
-                state,
-                resume.player,
-                resume.pending,
-                resume.chosen,
-                resume.paused_at_index + 1,
-                destination,
-                completion,
-                replacement_action_cost_event_start.unwrap_or(events.len()),
-                true,
-                events,
-            );
-        }
+        }) = state.pending_cost_move_resume.take()
+        else {
+            unreachable!("matched a cast cost-move continuation")
+        };
+        let Some(pending) = pending else {
+            return Ok(WaitingFor::Priority {
+                player: state.active_player,
+            });
+        };
+        return finish_cost_object_moves(
+            state,
+            player,
+            *pending,
+            chosen,
+            paused_at_index + 1,
+            destination,
+            completion,
+            replacement_action_cost_event_start.unwrap_or(events.len()),
+            true,
+            events,
+        );
+    }
+
+    if let Some(resume) = state.pending_discard_for_cost.take() {
         let player = resume.player;
         let pending = resume.pending;
         let cost_event_start = replacement_action_cost_event_start.unwrap_or(events.len());
@@ -1624,7 +1738,6 @@ pub(crate) fn resume_interrupted_cost_payment(
                         pending: pending.clone(),
                         chosen: resume.chosen.clone(),
                         paused_at_index,
-                        resume: PendingCostPaymentResume::Discard,
                     });
                     super::casting::pause_cost_payment_for_replacement_choice(state, choice_player);
                     // CR 603.2 + CR 603.3b: Same mid-loop replacement pause as
@@ -2347,13 +2460,55 @@ pub(crate) fn handle_return_to_hand_for_cost(
         }
     }
 
-    if pending.activation_ability_index.is_some() {
+    if let Some(ability_index) = pending.activation_ability_index {
         if let Some(cost) = pending.activation_cost.take() {
             // CR 118.3 + CR 601.2h + CR 602.2b: A player pays an activated ability's total
             // cost before that ability becomes activated. For self-bounce costs
             // such as Maze's End, pay automatic components like {T} while the
             // source is still on the battlefield, then perform the chosen return.
-            super::casting::pay_ability_cost(state, player, pending.object_id, &cost, events)?;
+            // This handler pays exactly the selected return below. Keep later
+            // return legs in the pending activation so they re-surface as their
+            // own choices after this move completes.
+            let residual = super::casting::remove_selected_return_to_hand_cost(cost);
+            let (automatic_cost, deferred_return_cost) = residual
+                .map(super::casting::split_return_to_hand_cost_legs)
+                .unwrap_or((None, None));
+            pending.activation_cost = deferred_return_cost;
+
+            if let Some(cost) = automatic_cost {
+                match super::casting::pay_ability_cost_for_activation(
+                    state,
+                    player,
+                    pending.object_id,
+                    &cost,
+                    super::casting::activation_ability_tag(state, pending.object_id, ability_index),
+                    events,
+                )? {
+                    super::casting::PaymentOutcome::Paid => {}
+                    super::casting::PaymentOutcome::Paused { remaining_cost } => {
+                        let Some(PendingCostMoveResume::Cast {
+                            pending: slot @ None,
+                            completion,
+                            ..
+                        }) = state.pending_cost_move_resume.as_mut()
+                        else {
+                            return Err(EngineError::InvalidAction(
+                                "automatic return-cost leg paused without a cost-move continuation"
+                                    .to_string(),
+                            ));
+                        };
+                        *slot = Some(Box::new(pending));
+                        *completion = PendingCostMoveCompletion::CompleteSelectedReturnToHand {
+                            selected: chosen.to_vec(),
+                            automatic_remaining: remaining_cost,
+                        };
+                        return Ok(state.waiting_for.clone());
+                    }
+                    super::casting::PaymentOutcome::Failed { reason } => {
+                        return Err(EngineError::ActionNotAllowed(reason.reason));
+                    }
+                }
+            }
         }
     }
 
@@ -2428,16 +2583,6 @@ pub(crate) fn handle_remove_counter_for_cost(
         ));
     }
 
-    if pending.activation_ability_index.is_some() {
-        if let Some(cost) = pending.activation_cost.take() {
-            // CR 601.2h + CR 602.2b: Pay automatic activation-cost components such as
-            // {T} before removing the chosen counter and putting the ability
-            // on the stack. The targeted RemoveCounter sub-cost no-ops in
-            // `pay_ability_cost` because this handler pays that choice.
-            super::casting::pay_ability_cost(state, player, pending.object_id, &cost, events)?;
-        }
-    }
-
     let mut remaining = count;
     for &object_id in chosen {
         if remaining == 0 {
@@ -2481,6 +2626,39 @@ pub(crate) fn handle_remove_counter_for_cost(
                 object_id: obj.0,
                 lki: obj.1.snapshot_for_mana_spent(),
             });
+    }
+
+    if let Some(ability_index) = pending.activation_ability_index {
+        if let Some(cost) = pending.activation_cost.take() {
+            // CR 601.2h + CR 602.2b: Counter selection is already committed, so
+            // pay the automatic residual through the outcome-aware authority.
+            // If a self-move pauses, the typed continuation resumes this pending
+            // activation only after the selected counter was paid exactly once.
+            let ability_tag =
+                super::casting::activation_ability_tag(state, pending.object_id, ability_index);
+            match super::casting::pay_ability_cost_for_activation(
+                state,
+                player,
+                pending.object_id,
+                &cost,
+                ability_tag,
+                events,
+            )? {
+                super::casting::PaymentOutcome::Paid => {}
+                super::casting::PaymentOutcome::Paused { remaining_cost } => {
+                    pending.activation_cost = remaining_cost;
+                    if let Some(pending) =
+                        attach_pending_cast_to_cost_move(state, Box::new(pending))
+                    {
+                        state.pending_cast = Some(pending);
+                    }
+                    return Ok(state.waiting_for.clone());
+                }
+                super::casting::PaymentOutcome::Failed { reason } => {
+                    return Err(EngineError::ActionNotAllowed(reason.reason));
+                }
+            }
+        }
     }
 
     finish_pending_cost_or_cast(state, player, pending, events)
@@ -2593,15 +2771,6 @@ pub(crate) fn handle_remove_counter_distribution_for_cost(
     super::effects::counters::validate_counter_selection(&available_by_type, &per_type)
         .map_err(|err| EngineError::InvalidAction(err.to_string()))?;
 
-    if pending.activation_ability_index.is_some() {
-        if let Some(cost) = pending.activation_cost.take() {
-            // CR 601.2h + CR 602.2b: Pay automatic activation-cost components
-            // such as {T} before removing the assigned counters and putting
-            // the ability on the stack.
-            super::casting::pay_ability_cost(state, player, pending.object_id, &cost, events)?;
-        }
-    }
-
     for choice in distribution {
         let removable = state
             .objects
@@ -2631,6 +2800,38 @@ pub(crate) fn handle_remove_counter_distribution_for_cost(
                     object_id: choice.object_id,
                     lki: obj.snapshot_for_mana_spent(),
                 });
+        }
+    }
+
+    if let Some(ability_index) = pending.activation_ability_index {
+        if let Some(cost) = pending.activation_cost.take() {
+            // CR 601.2h + CR 602.2b: The assigned counter payment is complete
+            // before an automatic residual can pause on a self-move replacement,
+            // so its typed continuation cannot replay the selected distribution.
+            let ability_tag =
+                super::casting::activation_ability_tag(state, pending.object_id, ability_index);
+            match super::casting::pay_ability_cost_for_activation(
+                state,
+                player,
+                pending.object_id,
+                &cost,
+                ability_tag,
+                events,
+            )? {
+                super::casting::PaymentOutcome::Paid => {}
+                super::casting::PaymentOutcome::Paused { remaining_cost } => {
+                    pending.activation_cost = remaining_cost;
+                    if let Some(pending) =
+                        attach_pending_cast_to_cost_move(state, Box::new(pending))
+                    {
+                        state.pending_cast = Some(pending);
+                    }
+                    return Ok(state.waiting_for.clone());
+                }
+                super::casting::PaymentOutcome::Failed { reason } => {
+                    return Err(EngineError::ActionNotAllowed(reason.reason));
+                }
+            }
         }
     }
 
@@ -3255,21 +3456,52 @@ pub(super) fn push_activated_ability_to_stack(
     activation_residual: ActivationResidual,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
-    // CR 702.170b: plot is a special action that never uses the stack — it is
-    // intercepted in `handle_activate_ability` before any stack push. No current
-    // plot cost can pause (mana auto-pays, the self-exile auto-moves), so this
-    // cost-pause resume path is unreachable for plot. If a future plot variant
-    // carries a pausing sub-cost it would reach here — relocate the special-action
-    // guard to this chokepoint then.
-    debug_assert!(
-        !super::casting::effect_is_plot_grant(&resolved.effect),
-        "plot special action reached the cost-pause resume path; relocate the CR 702.170b intercept to this chokepoint"
-    );
+    // CR 702.170b: Plot is a special action that never uses the stack. A Moved
+    // replacement can now pause its self-exile cost, so resume it here rather
+    // than falling through to the activated-ability stack path.
+    if super::casting::effect_is_plot_grant(&resolved.effect) {
+        super::effects::grant_permission::resolve(state, &resolved, events).map_err(|error| {
+            EngineError::ActionNotAllowed(format!("plot special action failed: {error}"))
+        })?;
+        priority::clear_priority_passes(state);
+        return Ok(WaitingFor::Priority { player });
+    }
 
     // Pay any activation-cost tail still outstanding. Cost-selection flows may
     // pass the original full cost; choice-based sub-costs already paid by a
     // WaitingFor handler are no-ops here.
     if let Some(cost) = remaining_cost {
+        // A residual return-to-hand leg is not auto-payable: it needs the same
+        // card-selection round-trip as the first leg. This also covers a second
+        // return in a composite after `handle_return_to_hand_for_cost` paid the
+        // first one.
+        if super::casting::has_only_return_to_hand_cost_legs(cost) {
+            if let Some((count, filter)) = super::casting::find_return_to_hand_cost(cost) {
+                let eligible = super::casting::find_eligible_return_to_hand_targets(
+                    state, player, source_id, filter,
+                );
+                if eligible.len() < count as usize {
+                    return Err(EngineError::ActionNotAllowed(
+                        "No eligible permanents to return".into(),
+                    ));
+                }
+                let mut pending_return =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending_return.activation_cost = Some(cost.clone());
+                pending_return.activation_ability_index = Some(ability_index);
+                return Ok(WaitingFor::PayCost {
+                    player,
+                    kind: PayCostKind::ReturnToHand,
+                    choices: eligible,
+                    count: count as usize,
+                    min_count: 0,
+                    resume: CostResume::Spell {
+                        spell: Box::new(pending_return),
+                    },
+                });
+            }
+        }
+
         // CR 601.2f + CR 601.2h + CR 701.9a: When the X-mana detour ran first
         // (e.g. the Momir Basic emblem's `{X}, Discard a card` cost), the non-self
         // "discard a card" sub-cost is still OUTSTANDING here AFTER mana payment,
@@ -3514,7 +3746,9 @@ pub(super) fn push_activated_ability_to_stack(
             let mut pending = PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
             pending.activation_cost = remaining_cost;
             pending.activation_ability_index = Some(ability_index);
-            state.pending_cast = Some(Box::new(pending));
+            if let Some(pending) = attach_pending_cast_to_cost_move(state, Box::new(pending)) {
+                state.pending_cast = Some(pending);
+            }
             return Ok(state.waiting_for.clone());
         }
         if should_record_loyalty {

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -633,7 +633,11 @@ fn pay_activation_costs_after_target_selection(
             let mut pending = pending.clone();
             pending.ability = assigned_ability;
             pending.activation_cost = remaining_cost;
-            state.pending_cast = Some(Box::new(pending));
+            if let Some(pending) =
+                super::casting_costs::attach_pending_cast_to_cost_move(state, Box::new(pending))
+            {
+                state.pending_cast = Some(pending);
+            }
             return Ok(Some(state.waiting_for.clone()));
         }
         if should_record_loyalty {

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -28271,7 +28271,7 @@ fn composite_activated_pay_life_cost_deducts_life() {
     let life_before = state.players[0].life;
     let mut events = Vec::new();
 
-    pay_ability_cost(&mut state, PlayerId(0), fetch, &cost, &mut events)
+    pay_ability_cost_for_activation(&mut state, PlayerId(0), fetch, &cost, None, &mut events)
         .expect("fetchland-style composite cost should be payable");
 
     assert_eq!(state.players[0].life, life_before - 1);
@@ -30275,7 +30275,7 @@ mod remove_counter_cost {
             selection: CounterCostSelection::SingleObject,
         };
         let mut events = Vec::new();
-        pay_ability_cost(&mut state, PlayerId(0), source, &cost, &mut events)
+        pay_ability_cost_for_activation(&mut state, PlayerId(0), source, &cost, None, &mut events)
             .expect("cost should pay with 2 +1/+1 counters available");
         let remaining = state
             .objects
@@ -30354,7 +30354,8 @@ mod remove_counter_cost {
             selection: CounterCostSelection::SingleObject,
         };
         let mut events = Vec::new();
-        pay_ability_cost(&mut state, PlayerId(0), source, &cost, &mut events).unwrap();
+        pay_ability_cost_for_activation(&mut state, PlayerId(0), source, &cost, None, &mut events)
+            .unwrap();
         let removed_count = events
             .iter()
             .filter_map(|e| match e {
@@ -31797,8 +31798,15 @@ mod unattach_cost {
         let cost = AbilityCost::Unattach;
 
         assert!(cost.is_payable(&state, PlayerId(0), equipment));
-        pay_ability_cost(&mut state, PlayerId(0), equipment, &cost, &mut Vec::new())
-            .expect("attached Equipment should be able to unattach as a cost");
+        pay_ability_cost_for_activation(
+            &mut state,
+            PlayerId(0),
+            equipment,
+            &cost,
+            None,
+            &mut Vec::new(),
+        )
+        .expect("attached Equipment should be able to unattach as a cost");
 
         assert_eq!(state.objects[&equipment].zone, Zone::Battlefield);
         assert!(state.objects[&equipment].attached_to.is_none());
@@ -33505,11 +33513,12 @@ mod exert_cost {
         state.objects.get_mut(&id).unwrap().tapped = true;
 
         let mut events = Vec::new();
-        pay_ability_cost(
+        pay_ability_cost_for_activation(
             &mut state,
             PlayerId(0),
             id,
             &AbilityCost::Exert,
+            None,
             &mut events,
         )
         .expect("exert cost pays");
@@ -33564,19 +33573,21 @@ mod exert_cost {
         let id = make_battlefield_permanent(&mut state);
 
         let mut events = Vec::new();
-        pay_ability_cost(
+        pay_ability_cost_for_activation(
             &mut state,
             PlayerId(0),
             id,
             &AbilityCost::Exert,
+            None,
             &mut events,
         )
         .expect("first exert");
-        pay_ability_cost(
+        pay_ability_cost_for_activation(
             &mut state,
             PlayerId(0),
             id,
             &AbilityCost::Exert,
+            None,
             &mut events,
         )
         .expect("second exert");
@@ -33619,11 +33630,12 @@ mod exert_cost {
         );
 
         let mut events = Vec::new();
-        let result = pay_ability_cost(
+        let result = pay_ability_cost_for_activation(
             &mut state,
             PlayerId(0),
             id,
             &AbilityCost::Exert,
+            None,
             &mut events,
         );
         assert!(matches!(result, Err(EngineError::ActionNotAllowed(_))));
@@ -33638,11 +33650,12 @@ mod exert_cost {
         let id = make_battlefield_permanent(&mut state);
 
         let mut events = Vec::new();
-        pay_ability_cost(
+        pay_ability_cost_for_activation(
             &mut state,
             PlayerId(0),
             id,
             &AbilityCost::Exert,
+            None,
             &mut events,
         )
         .expect("exert cost pays");

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -46,7 +46,9 @@ use crate::types::ability::{
     AbilityCost, EffectKind, TargetFilter, TypedFilter, REMOVE_COUNTER_COST_ALL,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::game_state::{
+    GameState, PendingCostMoveCompletion, PendingCostMoveResume, WaitingFor,
+};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::statics::StaticMode;
@@ -62,6 +64,7 @@ use super::filter::FilterContext;
 use super::life_costs::can_pay_life_cost;
 use super::quantity::{resolve_quantity, resolve_quantity_with_targets};
 use super::speed::{effective_speed, set_speed};
+use super::zone_pipeline::{self, ZoneMoveRequest, ZoneMoveResult};
 use crate::types::ability::ResolvedAbility;
 
 /// Helper to find eligible cards for exile cost payment at resolution.
@@ -181,6 +184,7 @@ pub(crate) enum PaymentScope<'a> {
         /// spend restrictions (Quinjet → power-up) gate eligible mana. Resolution
         /// scope never carries a tag (resolution-time costs aren't activations).
         ability_tag: Option<crate::types::ability::AbilityTag>,
+        cost_move_handling: ActivationCostMoveHandling,
     },
     /// `ability` is normally the PAYER-ADJUSTED `ResolvedAbility` clone
     /// (controller swapped to the resolved payer, per `effects/pay.rs`). All
@@ -194,7 +198,29 @@ pub(crate) enum PaymentScope<'a> {
     /// separately (`player`), so the right player's resources are deducted; only
     /// the `QuantityExpr` resolution reads the un-swapped controller. See the
     /// per-arm comments at those call sites.
-    Resolution { ability: &'a ResolvedAbility },
+    Resolution {
+        ability: &'a ResolvedAbility,
+        cost_move_root: ResolutionCostMoveRoot,
+    },
+}
+
+/// Whether an activation root retains the typed continuation for a self-move
+/// cost replacement. Only mana abilities use the synchronous path because they
+/// have no stack-root continuation until the dedicated ManaAbilityPayment unit.
+#[derive(Clone, Copy)]
+pub(crate) enum ActivationCostMoveHandling {
+    OutcomeAware,
+    ManaAbilitySynchronous,
+}
+
+/// The owner of a resolution-time non-self cost move. Only an accepted
+/// replacement MayCost has an outer replacement to re-enter after an inner
+/// `Moved` replacement choice; ordinary `Effect::PayCost` remains on its
+/// established choice-driven path.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResolutionCostMoveRoot {
+    EffectPayCost,
+    ReplacementMayCost,
 }
 
 /// A cost payment could not be completed. The reason string is the human-
@@ -202,7 +228,7 @@ pub(crate) enum PaymentScope<'a> {
 /// the activation adapter re-wraps it as `EngineError::ActionNotAllowed`, the
 /// resolution adapter discards it and sets `cost_payment_failed_flag`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct PaymentFailure {
+pub struct PaymentFailure {
     pub reason: String,
 }
 
@@ -222,7 +248,7 @@ fn payment_failed(reason: impl Into<String>) -> PaymentOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum PaymentOutcome {
+pub enum PaymentOutcome {
     /// The cost was paid in full.
     Paid,
     /// CR 616.1: a replacement-effect choice interrupted payment. Reserved
@@ -262,7 +288,9 @@ fn resolve_cost_quantity(
 ) -> i32 {
     match scope {
         PaymentScope::Activation { .. } => resolve_quantity(state, expr, player, source_id),
-        PaymentScope::Resolution { ability } => resolve_quantity_with_targets(state, expr, ability),
+        PaymentScope::Resolution { ability, .. } => {
+            resolve_quantity_with_targets(state, expr, ability)
+        }
     }
 }
 
@@ -274,25 +302,156 @@ pub(crate) fn pause_cost_payment_for_replacement_choice(
     state.waiting_for = super::replacement::replacement_choice_waiting_for(choice_player, state);
 }
 
-/// Pay an activated ability's cost. Handles auto-payable cost components
-/// (`Tap`, `Mana`, `PayLife`, `Composite`, and self-referential zone costs)
-/// and passes through cost types that require interactive resolution.
-pub fn pay_ability_cost(
+/// CR 601.2h + CR 602.2b + CR 616.1: Move a self-referential activation cost
+/// through the zone-change pipeline. The continuation has no `PendingCast`
+/// until the activation caller attaches it after this payment function returns.
+fn move_self_activation_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    destination: Zone,
+    events: &mut Vec<GameEvent>,
+) -> Option<PaymentOutcome> {
+    match zone_pipeline::move_object(
+        state,
+        ZoneMoveRequest::cost(source_id, destination, source_id),
+        events,
+    ) {
+        ZoneMoveResult::Done => None,
+        ZoneMoveResult::NeedsChoice(choice_player) => {
+            state.pending_cost_move_resume = Some(PendingCostMoveResume::Cast {
+                player,
+                pending: None,
+                chosen: vec![source_id],
+                paused_at_index: 0,
+                destination,
+                completion: PendingCostMoveCompletion::FinishPending,
+            });
+            pause_cost_payment_for_replacement_choice(state, choice_player);
+            Some(PaymentOutcome::Paused {
+                remaining_cost: None,
+            })
+        }
+        ZoneMoveResult::NeedsAuraAttachmentChoice => {
+            unreachable!("a cost move to Hand or Exile cannot require Aura attachment")
+        }
+    }
+}
+
+/// CR 406.6: Record an "exiled with [source] this turn" relation only for a
+/// cost object that actually arrived in exile after replacements applied.
+fn record_delivered_cost_exile(state: &mut GameState, exiled_id: ObjectId, source_id: ObjectId) {
+    if state
+        .objects
+        .get(&exiled_id)
+        .is_some_and(|object| object.zone == Zone::Exile)
+    {
+        super::exile_links::push_exiled_with_source_this_turn(state, exiled_id, source_id);
+    }
+}
+
+/// CR 614.12a + CR 616.1: Continue a forced MayCost exile after the inner
+/// replacement choice delivered or prevented its current object. The outer
+/// optional replacement resumes only after the whole cost has finished.
+pub(crate) fn resume_replacement_may_cost_move(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let Some(PendingCostMoveResume::ReplacementMayCost {
+        source_id,
+        current,
+        remaining,
+        paid_count,
+        outer_replacement,
+    }) = state.pending_cost_move_resume.take()
+    else {
+        unreachable!("replacement MayCost resume requires its typed continuation")
+    };
+
+    record_delivered_cost_exile(state, current, source_id);
+
+    for (index, &object_id) in remaining.iter().enumerate() {
+        match zone_pipeline::move_object(
+            state,
+            ZoneMoveRequest::cost(object_id, Zone::Exile, source_id),
+            events,
+        ) {
+            ZoneMoveResult::Done => record_delivered_cost_exile(state, object_id, source_id),
+            ZoneMoveResult::NeedsChoice(choice_player) => {
+                state.pending_cost_move_resume = Some(PendingCostMoveResume::ReplacementMayCost {
+                    source_id,
+                    current: object_id,
+                    remaining: remaining[index + 1..].to_vec(),
+                    paid_count,
+                    outer_replacement,
+                });
+                pause_cost_payment_for_replacement_choice(state, choice_player);
+                return Ok(state.waiting_for.clone());
+            }
+            ZoneMoveResult::NeedsAuraAttachmentChoice => {
+                unreachable!("a cost move to Exile cannot require Aura attachment")
+            }
+        }
+    }
+
+    let Some(outer_replacement) = outer_replacement else {
+        return Err(EngineError::InvalidAction(
+            "replacement MayCost cost-move resume is missing its outer replacement".to_string(),
+        ));
+    };
+    state.last_effect_count = Some(paid_count);
+    state.pending_replacement = Some(*outer_replacement);
+    super::engine_replacement::handle_replacement_choice(state, 0, events)
+}
+
+/// Pays a mana ability's synchronous auto-payable cost components. This is the
+/// only activation root that may bypass the zone-move pipeline until it owns a
+/// dedicated typed continuation.
+pub(crate) fn pay_mana_ability_cost_synchronously(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
     cost: &AbilityCost,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
-    pay_ability_cost_for_activation(state, player, source_id, cost, None, events).map(|_| ())
+    pay_ability_cost_for_activation_with_cost_move_replacement(
+        state,
+        player,
+        source_id,
+        cost,
+        None,
+        ActivationCostMoveHandling::ManaAbilitySynchronous,
+        events,
+    )
+    .map(|_| ())
 }
 
-pub(crate) fn pay_ability_cost_for_activation(
+pub fn pay_ability_cost_for_activation(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
     cost: &AbilityCost,
     ability_tag: Option<crate::types::ability::AbilityTag>,
+    events: &mut Vec<GameEvent>,
+) -> Result<PaymentOutcome, EngineError> {
+    pay_ability_cost_for_activation_with_cost_move_replacement(
+        state,
+        player,
+        source_id,
+        cost,
+        ability_tag,
+        ActivationCostMoveHandling::OutcomeAware,
+        events,
+    )
+}
+
+fn pay_ability_cost_for_activation_with_cost_move_replacement(
+    state: &mut GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    cost: &AbilityCost,
+    ability_tag: Option<crate::types::ability::AbilityTag>,
+    cost_move_handling: ActivationCostMoveHandling,
     events: &mut Vec<GameEvent>,
 ) -> Result<PaymentOutcome, EngineError> {
     let excluded_sources = ability_mana_payment_excluded_sources(cost, source_id);
@@ -305,6 +464,7 @@ pub(crate) fn pay_ability_cost_for_activation(
         &PaymentScope::Activation {
             excluded_sources: &excluded_sources,
             ability_tag,
+            cost_move_handling,
         },
     )?;
     // CR 601.2h: "Unpayable costs can't be paid." Activation scope maps a
@@ -327,13 +487,53 @@ pub(crate) fn pay_ability_cost_for_resolution(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<PaymentOutcome, EngineError> {
+    pay_ability_cost_for_resolution_with_cost_move_root(
+        state,
+        payer,
+        cost,
+        ability,
+        ResolutionCostMoveRoot::EffectPayCost,
+        events,
+    )
+}
+
+/// Pays a replacement's MayCost. Its dedicated root owns the outer
+/// replacement state required by [`PendingCostMoveResume::ReplacementMayCost`].
+pub(crate) fn pay_ability_cost_for_replacement_may_cost(
+    state: &mut GameState,
+    payer: PlayerId,
+    cost: &AbilityCost,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<PaymentOutcome, EngineError> {
+    pay_ability_cost_for_resolution_with_cost_move_root(
+        state,
+        payer,
+        cost,
+        ability,
+        ResolutionCostMoveRoot::ReplacementMayCost,
+        events,
+    )
+}
+
+fn pay_ability_cost_for_resolution_with_cost_move_root(
+    state: &mut GameState,
+    payer: PlayerId,
+    cost: &AbilityCost,
+    ability: &ResolvedAbility,
+    cost_move_root: ResolutionCostMoveRoot,
+    events: &mut Vec<GameEvent>,
+) -> Result<PaymentOutcome, EngineError> {
     pay_ability_cost_inner(
         state,
         payer,
         ability.source_id,
         cost,
         events,
-        &PaymentScope::Resolution { ability },
+        &PaymentScope::Resolution {
+            ability,
+            cost_move_root,
+        },
     )
 }
 
@@ -413,6 +613,7 @@ fn pay_ability_cost_inner(
             PaymentScope::Activation {
                 excluded_sources,
                 ability_tag,
+                ..
             } => {
                 if excluded_sources.is_empty() {
                     pay_ability_mana_cost(state, player, source_id, cost, *ability_tag, events)?;
@@ -639,7 +840,29 @@ fn pay_ability_cost_inner(
                     )));
                 }
             }
-            super::zones::move_to_zone(state, source_id, Zone::Exile, events);
+            let PaymentScope::Activation {
+                cost_move_handling,
+                ..
+            } = scope
+            else {
+                unreachable!("self-referential exile costs are not payable at resolution")
+            };
+            match cost_move_handling {
+                ActivationCostMoveHandling::OutcomeAware => {
+                    if let Some(outcome) = move_self_activation_cost(
+                        state,
+                        player,
+                        source_id,
+                        Zone::Exile,
+                        events,
+                    ) {
+                        return Ok(outcome);
+                    }
+                }
+                ActivationCostMoveHandling::ManaAbilitySynchronous => {
+                    super::zones::move_to_zone(state, source_id, Zone::Exile, events);
+                }
+            }
         }
         // CR 406.6: Non-self exile cost at resolution time (e.g., The Mimeoplasm's
         // "exile two creature cards from graveyards"). The interactive choice is
@@ -672,12 +895,42 @@ fn pay_ability_cost_inner(
             // Forced-choice fast path: when the eligible set exactly
             // fills the requirement there is no choice to surface, so the
             // exile executes immediately.
-            if eligible.len() == count {
-                for card_id in eligible {
-                    super::zones::move_to_zone(state, card_id, Zone::Exile, events);
-                    super::exile_links::push_exiled_with_source_this_turn(
-                        state, card_id, source_id,
-                    );
+            if eligible.len() == count
+                && matches!(
+                    scope,
+                    PaymentScope::Resolution {
+                        cost_move_root: ResolutionCostMoveRoot::ReplacementMayCost,
+                        ..
+                    }
+                )
+            {
+                for (index, &card_id) in eligible.iter().enumerate() {
+                    match zone_pipeline::move_object(
+                        state,
+                        ZoneMoveRequest::cost(card_id, Zone::Exile, source_id),
+                        events,
+                    ) {
+                        ZoneMoveResult::Done => {
+                            record_delivered_cost_exile(state, card_id, source_id);
+                        }
+                        ZoneMoveResult::NeedsChoice(choice_player) => {
+                            state.pending_cost_move_resume =
+                                Some(PendingCostMoveResume::ReplacementMayCost {
+                                    source_id,
+                                    current: card_id,
+                                    remaining: eligible[index + 1..].to_vec(),
+                                    paid_count: count as i32,
+                                    outer_replacement: None,
+                                });
+                            pause_cost_payment_for_replacement_choice(state, choice_player);
+                            return Ok(PaymentOutcome::Paused {
+                                remaining_cost: None,
+                            });
+                        }
+                        ZoneMoveResult::NeedsAuraAttachmentChoice => {
+                            unreachable!("a cost move to Exile cannot require Aura attachment")
+                        }
+                    }
                 }
                 state.last_effect_count = Some(count as i32);
             } else {
@@ -993,7 +1246,29 @@ fn pay_ability_cost_inner(
                     "cannot return source to hand: source is not in the required zone",
                 ));
             }
-            super::zones::move_to_zone(state, source_id, Zone::Hand, events);
+            let PaymentScope::Activation {
+                cost_move_handling,
+                ..
+            } = scope
+            else {
+                unreachable!("self-referential return costs are not payable at resolution")
+            };
+            match cost_move_handling {
+                ActivationCostMoveHandling::OutcomeAware => {
+                    if let Some(outcome) = move_self_activation_cost(
+                        state,
+                        player,
+                        source_id,
+                        Zone::Hand,
+                        events,
+                    ) {
+                        return Ok(outcome);
+                    }
+                }
+                ActivationCostMoveHandling::ManaAbilitySynchronous => {
+                    super::zones::move_to_zone(state, source_id, Zone::Hand, events);
+                }
+            }
         }
         // Other cost types require interactive resolution and are intercepted
         // before reaching pay_ability_cost, or are not yet auto-payable.
@@ -1133,7 +1408,7 @@ pub(crate) fn can_pay(
             // is now the correct verdict.
             true
         }
-        PaymentScope::Resolution { ability } => can_pay_resolution(state, payer, cost, ability),
+        PaymentScope::Resolution { ability, .. } => can_pay_resolution(state, payer, cost, ability),
     }
 }
 
@@ -1664,6 +1939,7 @@ mod tests {
             let scope = PaymentScope::Activation {
                 excluded_sources: &excluded,
                 ability_tag: None,
+                cost_move_handling: ActivationCostMoveHandling::OutcomeAware,
             };
             assert!(
                 can_pay(&scenario.state, P0, src, &cost, &scope),
@@ -1692,6 +1968,7 @@ mod tests {
         let scope = PaymentScope::Activation {
             excluded_sources: &excluded,
             ability_tag: None,
+            cost_move_handling: ActivationCostMoveHandling::OutcomeAware,
         };
         let mut events = Vec::new();
         let outcome =
@@ -1764,6 +2041,7 @@ mod tests {
             &PaymentScope::Activation {
                 excluded_sources: &excluded,
                 ability_tag: None,
+                cost_move_handling: ActivationCostMoveHandling::OutcomeAware,
             },
         )
     }
@@ -2340,7 +2618,10 @@ mod tests {
             src,
             P0,
         );
-        let scope = PaymentScope::Resolution { ability: &ability };
+        let scope = PaymentScope::Resolution {
+            ability: &ability,
+            cost_move_root: ResolutionCostMoveRoot::EffectPayCost,
+        };
 
         // (i) Waterbend at Resolution → Failed (was a silent no-op `Paid`).
         let waterbend = AbilityCost::Waterbend {

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -231,7 +231,10 @@ fn resolve_ability_cost_payment(
             payer,
             ability.source_id,
             cost,
-            &costs::PaymentScope::Resolution { ability },
+            &costs::PaymentScope::Resolution {
+                ability,
+                cost_move_root: costs::ResolutionCostMoveRoot::EffectPayCost,
+            },
         )
     {
         state.cost_payment_failed_flag = true;

--- a/crates/engine/src/game/engine_modes.rs
+++ b/crates/engine/src/game/engine_modes.rs
@@ -242,7 +242,34 @@ fn handle_activated_mode_choice(
             assign_targets_in_chain(state, &mut resolved, &targets)?;
 
             if let Some(cost) = &ability_cost {
-                casting::pay_ability_cost(state, player, source_id, cost, events)?;
+                let ability_tag = ability_index
+                    .and_then(|index| casting::activation_ability_tag(state, source_id, index));
+                match casting::pay_ability_cost_for_activation(
+                    state,
+                    player,
+                    source_id,
+                    cost,
+                    ability_tag,
+                    events,
+                )? {
+                    casting::PaymentOutcome::Paid => {}
+                    casting::PaymentOutcome::Paused { remaining_cost } => {
+                        let mut pending =
+                            PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                        pending.activation_cost = remaining_cost;
+                        pending.activation_ability_index = ability_index;
+                        if let Some(pending) = casting_costs::attach_pending_cast_to_cost_move(
+                            state,
+                            Box::new(pending),
+                        ) {
+                            state.pending_cast = Some(pending);
+                        }
+                        return Ok(state.waiting_for.clone());
+                    }
+                    casting::PaymentOutcome::Failed { reason } => {
+                        return Err(EngineError::ActionNotAllowed(reason.reason));
+                    }
+                }
             }
             casting::emit_targeting_events(
                 state,
@@ -299,7 +326,33 @@ fn handle_activated_mode_choice(
         }
     } else {
         if let Some(cost) = &ability_cost {
-            casting::pay_ability_cost(state, player, source_id, cost, events)?;
+            let ability_tag = ability_index
+                .and_then(|index| casting::activation_ability_tag(state, source_id, index));
+            match casting::pay_ability_cost_for_activation(
+                state,
+                player,
+                source_id,
+                cost,
+                ability_tag,
+                events,
+            )? {
+                casting::PaymentOutcome::Paid => {}
+                casting::PaymentOutcome::Paused { remaining_cost } => {
+                    let mut pending =
+                        PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                    pending.activation_cost = remaining_cost;
+                    pending.activation_ability_index = ability_index;
+                    if let Some(pending) =
+                        casting_costs::attach_pending_cast_to_cost_move(state, Box::new(pending))
+                    {
+                        state.pending_cast = Some(pending);
+                    }
+                    return Ok(state.waiting_for.clone());
+                }
+                casting::PaymentOutcome::Failed { reason } => {
+                    return Err(EngineError::ActionNotAllowed(reason.reason));
+                }
+            }
         }
         let entry_id = ObjectId(state.next_object_id);
         state.next_object_id += 1;

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -10,7 +10,7 @@ use crate::types::ability::{EffectScope, TapStateChange};
 use crate::types::counter::CounterType;
 use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{
-    GameState, PendingCounterPostAction, TokenEntryEventEmission, WaitingFor,
+    GameState, PendingCostMoveResume, PendingCounterPostAction, TokenEntryEventEmission, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
@@ -674,7 +674,14 @@ pub(super) fn handle_replacement_choice(
             state.waiting_for = waiting_for.clone();
 
             let mut replacement_ctx = None;
-            if let Some(ctx) = state.pending_spell_resolution.take() {
+            if zone_change_object_id
+                .zip(state.pending_spell_resolution.as_ref())
+                .is_some_and(|(object_id, ctx)| object_id == ctx.object_id)
+            {
+                let ctx = state
+                    .pending_spell_resolution
+                    .take()
+                    .expect("matching spell-resolution context was checked above");
                 if enters_battlefield {
                     apply_pending_spell_resolution(state, &ctx, events);
                 }
@@ -913,8 +920,34 @@ pub(super) fn handle_replacement_choice(
                 }
             }
 
-            // CR 601.2h + CR 602.2b + CR 616.1: Resume cast/activation cost payment paused for a
-            // replacement choice during discard or sacrifice cost payment.
+            // CR 601.2h + CR 602.2b + CR 616.1: Resume a cast or activation
+            // cost move after the replacement delivered its current object.
+            if matches!(waiting_for, WaitingFor::Priority { .. })
+                && matches!(
+                    state.pending_cost_move_resume,
+                    Some(PendingCostMoveResume::Cast { .. })
+                )
+            {
+                waiting_for = super::casting_costs::resume_interrupted_cost_payment(
+                    state,
+                    events,
+                    Some(replacement_action_event_start),
+                )?;
+            }
+
+            // CR 614.12a + CR 616.1: Finish the inner forced MayCost moves
+            // before re-entering the optional outer replacement they paid for.
+            if matches!(waiting_for, WaitingFor::Priority { .. })
+                && matches!(
+                    state.pending_cost_move_resume,
+                    Some(PendingCostMoveResume::ReplacementMayCost { .. })
+                )
+            {
+                waiting_for = super::costs::resume_replacement_may_cost_move(state, events)?;
+            }
+
+            // CR 601.2h + CR 602.2b + CR 616.1: Resume a non-move cast or
+            // activation cost payment paused during discard or sacrifice.
             if matches!(waiting_for, WaitingFor::Priority { .. })
                 && (state.pending_cast.is_some() || state.pending_discard_for_cost.is_some())
             {
@@ -1080,6 +1113,29 @@ pub(super) fn handle_replacement_choice(
                 };
                 crate::game::zone_pipeline::drain_pending_batch_deliveries(state, events);
                 return Ok(state.waiting_for.clone());
+            }
+            // CR 601.2h + CR 602.2b + CR 614.12a + CR 616.1: A fully
+            // substituted cost move still completes that cost-payment step.
+            // No fresh prompt remains at this point, so restore the normal
+            // reducer boundary before draining its typed continuation.
+            state.waiting_for = WaitingFor::Priority {
+                player: state.active_player,
+            };
+            if matches!(
+                state.pending_cost_move_resume,
+                Some(PendingCostMoveResume::Cast { .. })
+            ) {
+                return super::casting_costs::resume_interrupted_cost_payment(
+                    state,
+                    events,
+                    Some(replacement_action_event_start),
+                );
+            }
+            if matches!(
+                state.pending_cost_move_resume,
+                Some(PendingCostMoveResume::ReplacementMayCost { .. })
+            ) {
+                return super::costs::resume_replacement_may_cost_move(state, events);
             }
             // CR 608.3e: If the ETB was prevented during spell resolution,
             // the permanent goes to the graveyard instead.

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -765,16 +765,24 @@ pub fn activate_ninjutsu(
     let effective_cost = apply_ability_cost_reduction(state, player, "ninjutsu", mana_cost);
 
     // CR 702.49a/d: Pay the ninjutsu-family mana cost (after all validation, before mutations)
-    super::casting::pay_ability_cost(
+    match super::casting::pay_ability_cost_for_activation(
         state,
         player,
         ninjutsu_obj_id,
         &AbilityCost::Mana {
             cost: effective_cost,
         },
+        None,
         events,
     )
-    .map_err(|e| e.to_string())?;
+    .map_err(|e| e.to_string())?
+    {
+        super::casting::PaymentOutcome::Paid => {}
+        super::casting::PaymentOutcome::Paused { .. }
+        | super::casting::PaymentOutcome::Failed { .. } => {
+            return Err("ninjutsu mana payment unexpectedly paused".to_string());
+        }
+    }
 
     // 1. Return creature to owner's hand
     // CR 702.49a + CR 614.6: ninjutsu returns the unblocked attacker to its

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -2437,13 +2437,17 @@ where
                                 amount: amount.clone(),
                             },
                         };
-                        super::costs::pay_ability_cost(state, player, source_id, &cost, events)?;
+                        super::costs::pay_mana_ability_cost_synchronously(
+                            state, player, source_id, &cost, events,
+                        )?;
                     }
                     // Self-contained components (Untap {Q}, Exert, PayEnergy,
                     // self-ReturnToHand, EffectCost) delegate to the
                     // single-authority cost payer alongside the tap.
                     c if is_self_contained_mana_subcost(c) => {
-                        super::costs::pay_ability_cost(state, player, source_id, c, events)?;
+                        super::costs::pay_mana_ability_cost_synchronously(
+                            state, player, source_id, c, events,
+                        )?;
                     }
                     other => {
                         return Err(EngineError::InvalidAction(format!(
@@ -2469,12 +2473,14 @@ where
                     amount: amount.clone(),
                 },
             };
-            super::costs::pay_ability_cost(state, player, source_id, &cost, events)?;
+            super::costs::pay_mana_ability_cost_synchronously(
+                state, player, source_id, &cost, events,
+            )?;
         }
         // Self-contained components (Untap, Exert, PayEnergy, self-ReturnToHand,
         // EffectCost) delegate to the single-authority cost payer.
         Some(c) if is_self_contained_mana_subcost(c) => {
-            super::costs::pay_ability_cost(state, player, source_id, c, events)?;
+            super::costs::pay_mana_ability_cost_synchronously(state, player, source_id, c, events)?;
         }
         // CR 122.1 + CR 601.2b: Standalone RemoveCounter-on-self mana-ability
         // cost (Pentad Prism, Crystalline Crawler, Druids' Repository class).

--- a/crates/engine/src/game/planeswalker.rs
+++ b/crates/engine/src/game/planeswalker.rs
@@ -358,7 +358,7 @@ fn build_pw_resolved(
 /// CR 606.4: Pay the loyalty cost, push the ability onto the stack, and return Priority.
 /// Single exit point for non-targeted (and auto-target-resolved) loyalty activations.
 ///
-/// Loyalty counter adjustment is delegated to `casting::pay_ability_cost` — the single
+/// Loyalty counter adjustment is delegated to `casting::pay_ability_cost_for_activation` — the single
 /// authority for all ability cost resolution — to avoid duplicating counter logic here.
 fn finalize_loyalty_activation(
     state: &mut GameState,
@@ -373,8 +373,15 @@ fn finalize_loyalty_activation(
     let cost = crate::types::ability::AbilityCost::Loyalty {
         amount: loyalty_cost,
     };
-    super::casting::pay_ability_cost(state, player, pw_id, &cost, events)
-        .expect("loyalty validation passed in handle_activate_loyalty");
+    match super::casting::pay_ability_cost_for_activation(state, player, pw_id, &cost, None, events)
+        .expect("loyalty validation passed in handle_activate_loyalty")
+    {
+        super::casting::PaymentOutcome::Paid => {}
+        super::casting::PaymentOutcome::Paused { .. }
+        | super::casting::PaymentOutcome::Failed { .. } => {
+            unreachable!("a loyalty cost cannot pause on a self zone move")
+        }
+    }
     record_loyalty_activation(state, pw_id, player);
 
     let assigned_targets = flatten_targets_in_chain(&resolved);

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -814,6 +814,27 @@ fn combine_paused_may_cost(
     }
 }
 
+/// `ReplacementMode::MayCost` has no owner for an activation self-move
+/// continuation. The current card-data grammar has no such MayCost; keep that
+/// structural boundary explicit instead of reintroducing the synchronous raw
+/// activation mover at this call site.
+fn replacement_may_cost_has_self_zone_move(cost: &AbilityCost) -> bool {
+    match cost {
+        AbilityCost::Exile {
+            filter: Some(TargetFilter::SelfRef),
+            ..
+        }
+        | AbilityCost::ReturnToHand {
+            filter: Some(TargetFilter::SelfRef),
+            ..
+        } => true,
+        AbilityCost::Composite { costs } | AbilityCost::OneOf { costs } => {
+            costs.iter().any(replacement_may_cost_has_self_zone_move)
+        }
+        _ => false,
+    }
+}
+
 fn pay_replacement_may_cost(
     state: &mut GameState,
     player: PlayerId,
@@ -821,6 +842,13 @@ fn pay_replacement_may_cost(
     cost: &AbilityCost,
     events: &mut Vec<GameEvent>,
 ) -> MayCostOutcome {
+    if replacement_may_cost_has_self_zone_move(cost) {
+        debug_assert!(
+            false,
+            "ReplacementMode::MayCost cannot own an activation self-move continuation"
+        );
+        return MayCostOutcome::Unpaid;
+    }
     if !cost.is_payable(state, player, source_id) {
         return MayCostOutcome::Unpaid;
     }
@@ -898,7 +926,7 @@ fn pay_replacement_may_cost(
             // the interactive pause. Snapshot it to distinguish a synchronous
             // forced/auto discard (`Paid`, no choice) from a paused one.
             let prior_waiting_for = state.waiting_for.clone();
-            match crate::game::costs::pay_ability_cost_for_resolution(
+            match crate::game::costs::pay_ability_cost_for_replacement_may_cost(
                 state, player, cost, &ability, events,
             ) {
                 Ok(crate::game::costs::PaymentOutcome::Paid) => {
@@ -933,7 +961,7 @@ fn pay_replacement_may_cost(
                 player,
             );
             let prior_waiting_for = state.waiting_for.clone();
-            match crate::game::costs::pay_ability_cost_for_resolution(
+            match crate::game::costs::pay_ability_cost_for_replacement_may_cost(
                 state, player, cost, &ability, events,
             ) {
                 Ok(crate::game::costs::PaymentOutcome::Paid) => {
@@ -959,7 +987,15 @@ fn pay_replacement_may_cost(
                 Ok(crate::game::costs::PaymentOutcome::Failed { .. }) | Err(_) => false,
             }
         }
-        _ => crate::game::casting::pay_ability_cost(state, player, source_id, cost, events).is_ok(),
+        _ => match crate::game::casting::pay_ability_cost_for_activation(
+            state, player, source_id, cost, None, events,
+        ) {
+            Ok(crate::game::costs::PaymentOutcome::Paid) => true,
+            Ok(crate::game::costs::PaymentOutcome::Paused { remaining_cost }) => {
+                return MayCostOutcome::PausedForChoice { remaining_cost };
+            }
+            Ok(crate::game::costs::PaymentOutcome::Failed { .. }) | Err(_) => false,
+        },
     };
     if paid {
         MayCostOutcome::Paid
@@ -7388,7 +7424,7 @@ fn continue_replacement_impl(
                 // the resume finishes any `may_cost_remaining`. The carried
                 // `Execute` payload is inert — the flag short-circuits the caller
                 // before it is read.
-                state.pending_replacement = Some(crate::types::game_state::PendingReplacement {
+                let outer_replacement = crate::types::game_state::PendingReplacement {
                     proposed: proposed.clone(),
                     sacrifice_provenance: reparked_sacrifice_provenance,
                     candidates: reparked_candidates,
@@ -7402,7 +7438,21 @@ fn continue_replacement_impl(
                     lifelink_bonus: 0,
                     may_cost_paid: true,
                     may_cost_remaining: remaining_cost,
-                });
+                };
+                if let Some(crate::types::game_state::PendingCostMoveResume::ReplacementMayCost {
+                    outer_replacement: parked_outer,
+                    ..
+                }) = state.pending_cost_move_resume.as_mut()
+                {
+                    // CR 614.12a + CR 616.1: an inner cost move already owns
+                    // `pending_replacement` for its Moved replacement choice.
+                    // Keep that live inner prompt there and retain this outer
+                    // optional replacement only in the typed cost continuation.
+                    *parked_outer = Some(Box::new(outer_replacement));
+                    state.replacement_may_cost_paused = true;
+                    return ReplacementResult::Execute(proposed);
+                }
+                state.pending_replacement = Some(outer_replacement);
                 state.replacement_may_cost_paused = true;
                 return ReplacementResult::Execute(proposed);
             }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2432,9 +2432,20 @@ fn default_origin_zone() -> Zone {
 
 /// CR 601.2h + CR 616.1: Tail behavior for a sequential cost move that paused
 /// on a replacement choice.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PendingCostMoveCompletion {
     FinishPending,
+    /// The automatic prefix of an activation cost paused before its already
+    /// selected return-to-hand leg could move. Finish that selected leg before
+    /// the activation resumes and surfaces any later return costs.
+    CompleteSelectedReturnToHand {
+        selected: Vec<ObjectId>,
+        /// The automatic suffix left unpaid when its preceding self-move paused
+        /// for a replacement choice. It must finish before the selected return
+        /// move and any later return-to-hand chooser resume.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        automatic_remaining: Option<AbilityCost>,
+    },
     PublishExileTrackedSet,
     FinalizeCast {
         phyrexian_choices: Option<Vec<ShardChoice>>,
@@ -2445,14 +2456,32 @@ pub enum PendingCostMoveCompletion {
     },
 }
 
-/// CR 601.2h + CR 616.1: Resumption kind for a cost payment that paused on a
-/// replacement choice.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PendingCostPaymentResume {
-    Discard,
-    Move {
+/// CR 601.2h + CR 614.12a + CR 616.1: A cost move paused for a replacement
+/// choice. `Cast` resumes a cast or activation after its next object is
+/// delivered. `ReplacementMayCost` keeps the outer optional replacement parked
+/// while an inner MayCost move finishes through the replacement pipeline.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PendingCostMoveResume {
+    Cast {
+        player: PlayerId,
+        pending: Option<Box<PendingCast>>,
+        chosen: Vec<ObjectId>,
+        /// Index into `chosen` whose move completes during
+        /// `handle_replacement_choice`; resumption starts with the next object.
+        paused_at_index: usize,
         destination: Zone,
         completion: PendingCostMoveCompletion,
+    },
+    ReplacementMayCost {
+        source_id: ObjectId,
+        /// The object whose delivery is currently waiting on a replacement
+        /// choice. It is indexed only if it actually arrives in exile.
+        current: ObjectId,
+        remaining: Vec<ObjectId>,
+        paid_count: i32,
+        /// The outer optional replacement is restored only after every inner
+        /// cost move is delivered or prevented.
+        outer_replacement: Option<Box<PendingReplacement>>,
     },
 }
 
@@ -2467,7 +2496,6 @@ pub struct PendingDiscardForCostResume {
     /// Index into `chosen` whose move was paused; that move completes during
     /// `handle_replacement_choice` before this resume runs.
     pub paused_at_index: usize,
-    pub resume: PendingCostPaymentResume,
 }
 
 impl PendingCast {
@@ -9024,10 +9052,15 @@ pub struct GameState {
     #[serde(skip)]
     pub current_triggered_mana_override: Option<ProductionOverride>,
 
-    /// CR 601.2h + CR 616.1: Resume state when a sequential cost move pauses
-    /// mid-loop for a replacement choice. The object at `paused_at_index` is
-    /// completed by `handle_replacement_choice`; resume continues at the next
-    /// object through the existing cost-payment seam.
+    /// CR 601.2h + CR 614.12a + CR 616.1: Typed continuation for a sequential
+    /// cost move paused by a replacement choice. This remains serialized with
+    /// the matching `WaitingFor::ReplacementChoice`, so a host checkpoint can
+    /// resume the same cost-payment action after the player answers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_cost_move_resume: Option<PendingCostMoveResume>,
+
+    /// CR 601.2h + CR 616.1: Resume a sequential discard cost after a
+    /// replacement choice. Cost moves use `pending_cost_move_resume` above.
     #[serde(skip)]
     pub pending_discard_for_cost: Option<PendingDiscardForCostResume>,
 
@@ -10381,6 +10414,7 @@ impl GameState {
             cost_payment_failed_flag: false,
             pending_taps_for_mana_overrides: std::collections::HashMap::new(),
             current_triggered_mana_override: None,
+            pending_cost_move_resume: None,
             pending_discard_for_cost: None,
             pending_cast: None,
             ring_level: HashMap::new(),
@@ -11380,6 +11414,7 @@ fn _gamestate_partition_is_total(s: &GameState) {
         cost_payment_failed_flag: _,
         pending_taps_for_mana_overrides: _,
         current_triggered_mana_override: _,
+        pending_cost_move_resume: _,
         pending_discard_for_cost: _,
         pending_cast: _,
         ring_level: _,
@@ -11642,6 +11677,7 @@ impl PartialEq for GameState {
             && self.pending_batch_deliveries == other.pending_batch_deliveries
             && self.pending_counter_additions == other.pending_counter_additions
             && self.pending_proliferate_actions == other.pending_proliferate_actions
+            && self.pending_cost_move_resume == other.pending_cost_move_resume
             && self.may_trigger_auto_choices == other.may_trigger_auto_choices
             && self.decision_templates == other.decision_templates
             && self.priority_yields == other.priority_yields

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -1,16 +1,24 @@
-use engine::game::scenario::{GameScenario, P0};
+use engine::database::synthesis::synthesize_plot;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
 use engine::parser::oracle_cost::parse_oracle_cost;
 use engine::types::ability::{
-    AbilityDefinition, AbilityKind, Effect, ReplacementDefinition, SpellCastingOption, TargetFilter,
+    AbilityCost, AbilityDefinition, AbilityKind, CastingPermission, Effect, ModalChoice,
+    QuantityExpr, ReplacementDefinition, ReplacementMode, SpellCastingOption, TargetFilter,
 };
 use engine::types::actions::GameAction;
+use engine::types::card::CardFace;
 use engine::types::card_type::CoreType;
 use engine::types::events::GameEvent;
-use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::game_state::{
+    CastPaymentMode, GameState, PayCostKind, PendingCostMoveResume, WaitingFor,
+};
+use engine::types::keywords::Keyword;
 use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
 use engine::types::phase::Phase;
+use engine::types::proposed_event::ProposedEvent;
 use engine::types::replacements::ReplacementEvent;
 use engine::types::zones::{EtbTapState, Zone};
+use std::sync::Arc;
 
 fn redirect_moved_to(destination: Zone, redirected_to: Zone) -> ReplacementDefinition {
     ReplacementDefinition::new(ReplacementEvent::Moved)
@@ -280,5 +288,590 @@ fn return_to_hand_cost_honors_moved_redirect_and_completes_cast() {
     assert!(
         !runner.state().stack.is_empty(),
         "the cast must complete after the redirected return-to-hand cost"
+    );
+}
+
+#[test]
+fn self_exile_activation_cost_pauses_for_moved_redirect_without_pending_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let source = scenario
+        .add_creature(P0, "Self-Exile Cost Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Exile {
+                count: 1,
+                zone: None,
+                filter: Some(TargetFilter::SelfRef),
+            }),
+        )
+        .id();
+    for name in ["First Self-Exile Redirect", "Second Self-Exile Redirect"] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+
+    let mut runner = scenario.build();
+    let result = runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("announce self-exile activation");
+
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(
+        runner.state().pending_cast.is_none(),
+        "a self-exile activation cost must not use PendingCast to resume"
+    );
+
+    let json = serde_json::to_string(runner.state()).expect("paused cost move serializes");
+    assert!(
+        json.contains("pending_cost_move_resume"),
+        "a replacement choice must retain its cost-move continuation on the wire"
+    );
+    let restored: GameState = serde_json::from_str(&json).expect("paused cost move deserializes");
+    assert!(matches!(
+        restored.pending_cost_move_resume,
+        Some(PendingCostMoveResume::Cast {
+            pending: Some(_),
+            ..
+        })
+    ));
+    let mut runner = GameRunner::from_state(restored);
+
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("apply self-exile redirect");
+
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert!(
+        !runner.state().stack.is_empty(),
+        "the activation must finish after the redirected self-exile cost"
+    );
+}
+
+#[test]
+fn mimeoplasm_forced_exile_cost_resumes_after_redirects_and_tracks_delivered_exiles_only() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let first = scenario
+        .add_creature_to_graveyard(P0, "First Mimeoplasm Witness", 2, 2)
+        .id();
+    let second = scenario
+        .add_creature_to_graveyard(P0, "Second Mimeoplasm Witness", 3, 3)
+        .id();
+    let mimeoplasm = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Mimeoplasm Forced-Cost Witness",
+            5,
+            5,
+            "As ~ enters, you may exile two creature cards from graveyards. If you do, ~ enters as a copy of one of them, except it has +1/+1 counters equal to the other's power.",
+        )
+        .id();
+    for name in ["First Mimeoplasm Redirect", "Second Mimeoplasm Redirect"] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Hand));
+    }
+    scenario.add_basic_land(P0, ManaColor::Blue);
+    scenario.add_basic_land(P0, ManaColor::Blue);
+    scenario.add_basic_land(P0, ManaColor::Green);
+    scenario.add_basic_land(P0, ManaColor::Green);
+    scenario.add_basic_land(P0, ManaColor::Black);
+
+    let mut runner = scenario.build();
+    assert!(runner.state().players[P0.0 as usize]
+        .graveyard
+        .contains(&first));
+    assert!(runner.state().players[P0.0 as usize]
+        .graveyard
+        .contains(&second));
+    let mut forced_cost_only =
+        runner.state().objects[&mimeoplasm].replacement_definitions[0].clone();
+    assert!(matches!(
+        &forced_cost_only.mode,
+        ReplacementMode::MayCost {
+            cost: AbilityCost::Exile { count: 2, .. },
+            ..
+        }
+    ));
+    // The printed Oracle parse is the coverage pin. Strip only its independent
+    // copy/counter branch so this witness isolates the exact typed two-card MayCost.
+    forced_cost_only.execute = None;
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&mimeoplasm)
+        .expect("Mimeoplasm witness exists")
+        .replacement_definitions = vec![forced_cost_only].into();
+    runner.cast(mimeoplasm).resolve();
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("accept Mimeoplasm's replacement cost");
+
+    let state = runner.state();
+    let Some(PendingCostMoveResume::ReplacementMayCost { remaining, .. }) =
+        state.pending_cost_move_resume.as_ref()
+    else {
+        panic!("the first Mimeoplasm exile must retain its one-card cost tail");
+    };
+    assert_eq!(remaining.len(), 1);
+    let pending = state
+        .pending_replacement
+        .as_ref()
+        .expect("the first inner exile must own its replacement prompt");
+    assert_eq!(pending.candidates.len(), 2);
+    assert!(matches!(
+        &pending.proposed,
+        ProposedEvent::ZoneChange {
+            from: Zone::Graveyard,
+            to: Zone::Exile,
+            ..
+        }
+    ));
+    assert!(
+        state
+            .pending_spell_resolution
+            .as_ref()
+            .is_some_and(|ctx| ctx.object_id == mimeoplasm),
+        "the outer permanent-spell resolution must survive the inner cost prompt"
+    );
+
+    for prompt in 0..2 {
+        assert!(
+            matches!(
+                runner.state().waiting_for,
+                WaitingFor::ReplacementChoice { .. }
+            ),
+            "expected replacement choice for inner cost move {prompt}, got {:?}",
+            runner.state().waiting_for
+        );
+        runner
+            .act(GameAction::ChooseReplacement { index: 0 })
+            .expect("apply the forced Mimeoplasm cost redirect");
+        if prompt == 0 {
+            assert!(
+                runner.state().pending_cost_move_resume.is_some(),
+                "the first redirected exile must retain the second inner cost move"
+            );
+            assert_eq!(runner.state().objects[&first].zone, Zone::Hand);
+            assert_eq!(runner.state().objects[&second].zone, Zone::Graveyard);
+            assert_eq!(runner.state().objects[&mimeoplasm].zone, Zone::Stack);
+            assert!(
+                runner
+                    .state()
+                    .pending_spell_resolution
+                    .as_ref()
+                    .is_some_and(|ctx| ctx.object_id == mimeoplasm),
+                "an inner cost redirect must not consume the outer spell-resolution context"
+            );
+        } else {
+            assert!(
+                runner.state().pending_cost_move_resume.is_none(),
+                "both forced cost moves must finish before the outer replacement re-enters"
+            );
+        }
+    }
+
+    let state = runner.state();
+    assert_eq!(state.objects[&first].zone, Zone::Hand);
+    assert_eq!(state.objects[&second].zone, Zone::Hand);
+    assert!(
+        state
+            .cards_exiled_with_source_this_turn
+            .get(&mimeoplasm)
+            .is_none_or(Vec::is_empty),
+        "only cards delivered to exile may be indexed as exiled with Mimeoplasm"
+    );
+    assert!(
+        state
+            .exile_links
+            .iter()
+            .all(|link| link.source_id != mimeoplasm),
+        "Mimeoplasm's cost must not create a persistent ExileLink"
+    );
+    assert_eq!(state.objects[&mimeoplasm].zone, Zone::Battlefield);
+    assert!(
+        state.pending_spell_resolution.is_none(),
+        "the outer context is consumed only when Mimeoplasm's own entry completes"
+    );
+}
+
+#[test]
+fn self_return_activation_cost_pauses_for_moved_redirect_without_pending_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let source = scenario
+        .add_creature(P0, "Self-Return Cost Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::ReturnToHand {
+                count: 1,
+                filter: Some(TargetFilter::SelfRef),
+                from_zone: None,
+            }),
+        )
+        .id();
+    for name in ["First Self-Return Redirect", "Second Self-Return Redirect"] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Hand, Zone::Exile));
+    }
+
+    let mut runner = scenario.build();
+    let life_before = runner.state().players[P0.0 as usize].life;
+    let result = runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("announce self-return activation");
+
+    assert!(
+        matches!(
+            result.waiting_for,
+            WaitingFor::PayCost {
+                kind: PayCostKind::ReturnToHand,
+                ..
+            }
+        ),
+        "self-return activation should select its return cost before moving: {:?}",
+        result.waiting_for
+    );
+    let result = runner
+        .act(GameAction::SelectCards {
+            cards: vec![source],
+        })
+        .expect("select the self-return cost");
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(
+        runner.state().pending_cast.is_none(),
+        "a self-return activation cost must not use PendingCast to resume"
+    );
+
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("apply self-return redirect");
+
+    assert_eq!(runner.state().objects[&source].zone, Zone::Exile);
+    assert!(
+        !runner.state().stack.is_empty(),
+        "the redirected return-to-hand cost must finish the activation"
+    );
+    runner.advance_until_stack_empty();
+    assert!(runner.state().stack.is_empty());
+    assert_eq!(runner.state().players[P0.0 as usize].life, life_before + 1);
+}
+
+#[test]
+fn composite_return_cost_resurfaces_each_return_leg() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let source = scenario
+        .add_creature(P0, "Two Returns Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::ReturnToHand {
+                        count: 1,
+                        filter: None,
+                        from_zone: None,
+                    },
+                    AbilityCost::ReturnToHand {
+                        count: 1,
+                        filter: None,
+                        from_zone: None,
+                    },
+                ],
+            }),
+        )
+        .id();
+    let first = scenario.add_basic_land(P0, ManaColor::Blue);
+    let second = scenario
+        .add_creature(P0, "Second Return Witness", 1, 1)
+        .id();
+
+    let mut runner = scenario.build();
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("activate two-return witness");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::PayCost { .. }
+    ));
+
+    runner
+        .act(GameAction::SelectCards { cards: vec![first] })
+        .expect("pay first return leg");
+    assert_eq!(runner.state().objects[&first].zone, Zone::Hand);
+    assert!(
+        runner.state().objects[&source].tapped,
+        "automatic tap leg is paid once"
+    );
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::PayCost { .. }
+    ));
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![second],
+        })
+        .expect("pay second return leg");
+    assert_eq!(runner.state().objects[&second].zone, Zone::Hand);
+    assert!(
+        !runner.state().stack.is_empty(),
+        "both return legs must complete before the activation reaches the stack"
+    );
+}
+
+#[test]
+fn return_cost_keeps_selected_move_while_residual_self_move_pauses() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let source = scenario
+        .add_creature(P0, "Residual Self-Move Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::ReturnToHand {
+                        count: 1,
+                        filter: None,
+                        from_zone: None,
+                    },
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                    AbilityCost::PayLife {
+                        amount: QuantityExpr::Fixed { value: 2 },
+                    },
+                ],
+            }),
+        )
+        .id();
+    let returned = scenario.add_basic_land(P0, ManaColor::Blue);
+    for name in ["First Residual Redirect", "Second Residual Redirect"] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+
+    let mut runner = scenario.build();
+    let life_before = runner.state().players[P0.0 as usize].life;
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("activate residual self-move witness");
+    let result = runner
+        .act(GameAction::SelectCards {
+            cards: vec![returned],
+        })
+        .expect("select return before residual self-exile");
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume,
+        Some(PendingCostMoveResume::Cast { .. })
+    ));
+    assert_eq!(runner.state().objects[&returned].zone, Zone::Battlefield);
+
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirect residual self-exile");
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&returned].zone, Zone::Hand);
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        life_before - 2,
+        "the automatic PayLife suffix must resume exactly once before the selected return"
+    );
+    assert!(
+        !runner.state().stack.is_empty(),
+        "the selected return must finish after the paused automatic self-move"
+    );
+}
+
+#[test]
+fn modal_activation_self_exile_cost_resumes_after_moved_redirect() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let source = scenario
+        .add_creature(P0, "Modal Self-Exile Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Exile {
+                count: 1,
+                zone: None,
+                filter: Some(TargetFilter::SelfRef),
+            })
+            .with_modal(
+                ModalChoice {
+                    min_choices: 1,
+                    max_choices: 1,
+                    mode_count: 1,
+                    mode_descriptions: vec!["Gain life".to_string()],
+                    ..ModalChoice::default()
+                },
+                vec![AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::GainLife {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                        player: TargetFilter::Controller,
+                    },
+                )],
+            ),
+        )
+        .id();
+    for name in ["First Modal Redirect", "Second Modal Redirect"] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+
+    let mut runner = scenario.build();
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("announce modal activation");
+    let result = runner
+        .act(GameAction::SelectModes { indices: vec![0] })
+        .expect("select the only mode");
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirect modal activation self-exile cost");
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert!(
+        !runner.state().stack.is_empty(),
+        "the modal activation must reach the stack after its redirected cost completes"
+    );
+}
+
+#[test]
+fn synthesized_plot_redirect_resumes_as_special_action() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let plotted = scenario
+        .add_creature_to_hand(P0, "Synthesized Plot Redirect Witness", 1, 1)
+        .id();
+    for name in ["First Plot Redirect", "Second Plot Redirect"] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+
+    let mut runner = scenario.build();
+    let mut face = CardFace::default();
+    face.keywords.push(Keyword::Plot(ManaCost::generic(0)));
+    synthesize_plot(&mut face);
+    let object = runner
+        .state_mut()
+        .objects
+        .get_mut(&plotted)
+        .expect("plot witness exists");
+    object.keywords = face.keywords.clone();
+    object.base_keywords = face.keywords.clone();
+    *Arc::make_mut(&mut object.abilities) = face.abilities.clone();
+    *Arc::make_mut(&mut object.base_abilities) = face.abilities;
+
+    let first = runner
+        .act(GameAction::ActivateAbility {
+            source_id: plotted,
+            ability_index: 0,
+        })
+        .expect("start synthesized plot special action");
+    assert!(matches!(
+        first.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    let second = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirect plotted self-exile");
+
+    assert_eq!(runner.state().objects[&plotted].zone, Zone::Graveyard);
+    assert!(runner.state().objects[&plotted]
+        .casting_permissions
+        .iter()
+        .any(|permission| matches!(permission, CastingPermission::Plotted { .. })));
+    assert!(
+        runner.state().stack.is_empty(),
+        "plot must never use the stack"
+    );
+    assert!(
+        first
+            .events
+            .iter()
+            .chain(second.events.iter())
+            .all(|event| !matches!(event, GameEvent::AbilityActivated { .. })),
+        "plot is a special action and must not emit AbilityActivated"
     );
 }

--- a/crates/engine/tests/integration/issue_2862_teferi_loyalty.rs
+++ b/crates/engine/tests/integration/issue_2862_teferi_loyalty.rs
@@ -84,11 +84,12 @@ fn issue_2862_teferi_cast_minus_three_pays_loyalty_cost() {
     );
 
     let mut events = Vec::new();
-    engine::game::casting::pay_ability_cost(
+    engine::game::casting::pay_ability_cost_for_activation(
         runner.state_mut(),
         P0,
         teferi,
         &AbilityCost::Loyalty { amount: -3 },
+        None,
         &mut events,
     )
     .expect("pay [-3] loyalty cost through activation payment seam");

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -24,7 +24,7 @@ crates/engine/src/game/casting.rs	handle_foretell	mover	1
 crates/engine/src/game/casting_costs.rs	handle_resolution_cast_rejection	mover	1
 crates/engine/src/game/conspiracy.rs	start_with_conspiracy	container	1
 crates/engine/src/game/conspiracy.rs	start_with_conspiracy	zone-assign	1
-crates/engine/src/game/costs.rs	pay_ability_cost_inner	mover	3
+crates/engine/src/game/costs.rs	pay_ability_cost_inner	mover	2
 crates/engine/src/game/deck_loading.rs	create_attraction_deck_card	container	1
 crates/engine/src/game/deck_loading.rs	create_contraption_deck_card	container	1
 crates/engine/src/game/deck_loading.rs	create_planar_deck_card	container	1


### PR DESCRIPTION
## Summary
- add a typed cost-move continuation for casts, activations, and replacement May costs
- route self-exile/self-return costs and Mimeoplasm through the zone replacement pipeline
- preserve delivered-only exile indexing and exact-once composite-cost resumes

## Verification
- watched-red-first synthetic redirect witnesses (3 failures before migration)
- cargo fmt --all
- zone authority census: 65 hits / 45 classified rows
- Tilt clippy: passed
- Tilt test-engine: 19,786 passed, 9 skipped