### PR TITLE
Route Foretell through replacement-aware cost moves

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13,8 +13,8 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{
     ActivationResidual, CastOfferKind, CastPaymentMode, CastingVariant, CastingVariantChoiceOption,
     ConvokeMode, CostResume, GameState, NextSpellModifier, PayCostKind, PendingCast,
-    SneakPlacement, SpellCastRecord, SpellCostSource, StackEntry, StackEntryKind,
-    TargetSelectionSlot, WaitingFor,
+    PendingCostMoveResume, SneakPlacement, SpellCastRecord, SpellCostSource, StackEntry,
+    StackEntryKind, TargetSelectionSlot, WaitingFor,
 };
 use crate::types::identifiers::{CardId, ObjectId, TrackedSetId};
 use crate::types::keywords::{FlashbackCost, Keyword, KeywordKind};
@@ -52,6 +52,7 @@ use super::speed::effective_speed;
 use super::splice;
 use super::stack;
 use super::targeting;
+use super::zone_pipeline::{self, ZoneMoveRequest, ZoneMoveResult};
 
 const FORETELL_SPECIAL_ACTION_COST: u32 = 2;
 
@@ -1214,8 +1215,8 @@ pub fn can_foretell_card(state: &GameState, player: PlayerId, object_id: ObjectI
     can_pay_special_action_cost_after_auto_tap(state, player, &cost)
 }
 
-/// CR 702.143a-b: Pay {2}, exile the hand card, mark it foretold in exile, and
-/// grant the later-turn foretell-cost casting permission.
+/// CR 702.143a-b: Pay {2}, then begin the foretell special-action move through
+/// the replacement-aware zone pipeline.
 pub fn handle_foretell(
     state: &mut GameState,
     player: PlayerId,
@@ -1255,21 +1256,94 @@ pub fn handle_foretell(
         &ManaCost::generic(FORETELL_SPECIAL_ACTION_COST),
         events,
     )?;
-    super::zones::move_to_zone(state, object_id, Zone::Exile, events);
-    if let Some(obj) = state.objects.get_mut(&object_id) {
-        obj.foretold = true;
-        obj.face_down = true;
-        obj.casting_permissions.push(CastingPermission::Foretold {
-            cost: foretell_cost,
-            turn_foretold: state.turn_number,
-        });
-    }
-    events.push(GameEvent::Foretold {
-        player_id: player,
+    state.pending_cost_move_resume = Some(PendingCostMoveResume::Foretell {
+        player,
         object_id,
+        cost: foretell_cost,
+        turn_foretold: state.turn_number,
     });
 
-    Ok(WaitingFor::Priority { player })
+    let move_event_start = events.len();
+    match zone_pipeline::move_object(
+        state,
+        ZoneMoveRequest::cost(object_id, Zone::Exile, object_id),
+        events,
+    ) {
+        ZoneMoveResult::Done => Ok(resume_foretell_cost_move(state, events)),
+        ZoneMoveResult::NeedsChoice(_) => {
+            // `NeedsChoice` is overloaded by the zone pipeline: it can be the
+            // pre-delivery CR 616.1 ordering prompt, or a post-delivery prompt
+            // raised by a replacement's continuation. A delivery emits the
+            // card's `ZoneChanged` event, so it is the reliable boundary even
+            // if a post-effect has moved the card again before it prompts.
+            if events[move_event_start..].iter().any(|event| {
+                matches!(event, GameEvent::ZoneChanged { object_id: moved, .. } if *moved == object_id)
+            }) {
+                complete_foretell_cost_move(state, events);
+            }
+            Ok(state.waiting_for.clone())
+        }
+        ZoneMoveResult::NeedsAuraAttachmentChoice => {
+            unreachable!("foretell moves a hand card to exile, never an aura to the battlefield")
+        }
+    }
+}
+
+/// CR 702.143a-c + CR 614.1 + CR 616.1: A card is foretold only when the
+/// special action's replacement-aware move delivers it to exile. A redirected
+/// or prevented move still completes the special action without granting a
+/// foretell casting permission.
+pub(crate) fn resume_foretell_cost_move(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> WaitingFor {
+    WaitingFor::Priority {
+        player: complete_foretell_cost_move(state, events),
+    }
+}
+
+/// CR 702.143a-c + CR 614.6: Completes the paid Foretell special action after
+/// its zone move either delivers or is fully replaced. The caller owns the
+/// resulting `WaitingFor`, which makes completion safe at both the normal
+/// priority boundary and a post-replacement prompt boundary.
+pub(crate) fn complete_foretell_cost_move(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> PlayerId {
+    let Some(PendingCostMoveResume::Foretell {
+        player,
+        object_id,
+        cost,
+        turn_foretold,
+    }) = state.pending_cost_move_resume.take()
+    else {
+        unreachable!("foretell cost move resume must be pending")
+    };
+
+    if state
+        .objects
+        .get(&object_id)
+        .is_some_and(|object| object.zone == Zone::Exile)
+    {
+        let object = state
+            .objects
+            .get_mut(&object_id)
+            .expect("foretell object remains in game state");
+        object.foretold = true;
+        object.face_down = true;
+        object
+            .casting_permissions
+            .push(CastingPermission::Foretold {
+                cost,
+                turn_foretold,
+            });
+        events.push(GameEvent::Foretold {
+            player_id: player,
+            object_id,
+        });
+    }
+
+    player
 }
 
 // CR 702.34 (Flashback) / CR 702.81 (Retrace) / CR 702.127 (Aftermath) /

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -636,6 +636,38 @@ fn foretell_special_action_exiles_and_grants_later_turn_permission() {
     ));
 }
 
+#[test]
+fn foretell_completion_without_exile_clears_paid_continuation_without_stamp() {
+    let mut state = setup_game_at_main_phase();
+    let object_id = add_foretell_sorcery(&mut state);
+    let turn_foretold = state.turn_number;
+    state.pending_cost_move_resume = Some(PendingCostMoveResume::Foretell {
+        player: PlayerId(0),
+        object_id,
+        cost: foretell_test_cost(),
+        turn_foretold,
+    });
+    let mana_after_payment = state.players[0].mana_pool.total();
+    let mut events = Vec::new();
+
+    let waiting = resume_foretell_cost_move(&mut state, &mut events);
+
+    assert_eq!(
+        waiting,
+        WaitingFor::Priority {
+            player: PlayerId(0)
+        }
+    );
+    assert!(state.pending_cost_move_resume.is_none());
+    assert_eq!(state.players[0].mana_pool.total(), mana_after_payment);
+    let object = &state.objects[&object_id];
+    assert_eq!(object.zone, Zone::Hand);
+    assert!(!object.foretold);
+    assert!(!object.face_down);
+    assert!(object.casting_permissions.is_empty());
+    assert!(events.is_empty());
+}
+
 // CR 708.4 + CR 702.143a / CR 702.143c: a FORETOLD card is cast FACE UP from
 // exile, never as a face-down spell. Mana payment runs `build_spell_meta` while
 // the object still sits in exile with `obj.face_down == true`; the resulting

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -714,6 +714,23 @@ pub(super) fn handle_replacement_choice(
                 }
             }
 
+            // CR 702.143a-c + CR 614.1 + CR 616.1: A Foretell cost move may
+            // deliver its card and then surface an interactive post-replacement
+            // effect. Complete the special action at the delivery boundary,
+            // before preserving that non-priority prompt, so the card cannot be
+            // left face up or with a stranded cost continuation.
+            if zone_change_object_id.is_some_and(|object_id| {
+                matches!(
+                    state.pending_cost_move_resume.as_ref(),
+                    Some(PendingCostMoveResume::Foretell {
+                        object_id: pending_object_id,
+                        ..
+                    }) if *pending_object_id == object_id
+                )
+            }) {
+                super::casting::complete_foretell_cost_move(state, events);
+            }
+
             // CR 805.4b: a draw-step draw that paused on the choice just
             // resolved above may have queued teammate(s) still owed their
             // own draw this step (`turns::execute_draw` seeds the queue; the
@@ -946,6 +963,18 @@ pub(super) fn handle_replacement_choice(
                 waiting_for = super::costs::resume_replacement_may_cost_move(state, events)?;
             }
 
+            // CR 702.143a-c + CR 614.1 + CR 616.1: Finish a foretell special
+            // action after its replacement-aware move is delivered. The
+            // foretell resume stamps the card only if it arrived in exile.
+            if matches!(waiting_for, WaitingFor::Priority { .. })
+                && matches!(
+                    state.pending_cost_move_resume,
+                    Some(PendingCostMoveResume::Foretell { .. })
+                )
+            {
+                waiting_for = super::casting::resume_foretell_cost_move(state, events);
+            }
+
             // CR 601.2h + CR 602.2b + CR 616.1: Resume a non-move cast or
             // activation cost payment paused during discard or sacrifice.
             if matches!(waiting_for, WaitingFor::Priority { .. })
@@ -1136,6 +1165,15 @@ pub(super) fn handle_replacement_choice(
                 Some(PendingCostMoveResume::ReplacementMayCost { .. })
             ) {
                 return super::costs::resume_replacement_may_cost_move(state, events);
+            }
+            // CR 702.143a-c + CR 614.1 + CR 616.1: A fully substituted
+            // foretell move completes the special action without stamping a
+            // card that was not delivered to exile.
+            if matches!(
+                state.pending_cost_move_resume,
+                Some(PendingCostMoveResume::Foretell { .. })
+            ) {
+                return Ok(super::casting::resume_foretell_cost_move(state, events));
             }
             // CR 608.3e: If the ETB was prevented during spell resolution,
             // the permanent goes to the graveyard instead.

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -1280,14 +1280,16 @@ pub(crate) fn apply_zone_delivery_tail(
         if let Some(source_id) = cause.or(source_id) {
             let kind = match duration {
                 Some(Duration::UntilHostLeavesPlay) => {
-                    ExileLinkKind::UntilSourceLeaves { return_zone: from }
+                    Some(ExileLinkKind::UntilSourceLeaves { return_zone: from })
                 }
                 _ if matches!(exile_tracking, ZoneDeliveryExileTracking::TrackBySource) => {
-                    ExileLinkKind::TrackedBySource
+                    Some(ExileLinkKind::TrackedBySource)
                 }
-                _ => return ZoneDeliveryResult::Done,
+                _ => None,
             };
-            crate::game::exile_links::push_with_kind(state, object_id, source_id, kind);
+            if let Some(kind) = kind {
+                crate::game::exile_links::push_with_kind(state, object_id, source_id, kind);
+            }
         }
     }
     // CR 614.12a: Drain mandatory replacement post-effects after the zone

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2475,6 +2475,8 @@ pub enum PendingCostMoveCompletion {
 /// choice. `Cast` resumes a cast or activation after its next object is
 /// delivered. `ReplacementMayCost` keeps the outer optional replacement parked
 /// while an inner MayCost move finishes through the replacement pipeline.
+/// `Foretell` records the special action until its replacement-aware exile move
+/// has been delivered or prevented.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PendingCostMoveResume {
     Cast {
@@ -2497,6 +2499,12 @@ pub enum PendingCostMoveResume {
         /// The outer optional replacement is restored only after every inner
         /// cost move is delivered or prevented.
         outer_replacement: Option<Box<PendingReplacement>>,
+    },
+    Foretell {
+        player: PlayerId,
+        object_id: ObjectId,
+        cost: ManaCost,
+        turn_foretold: u32,
     },
 }
 

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -2,8 +2,9 @@ use engine::database::synthesis::synthesize_plot;
 use engine::game::scenario::{GameRunner, GameScenario, P0};
 use engine::parser::oracle_cost::parse_oracle_cost;
 use engine::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, CastingPermission, Effect, ModalChoice,
-    QuantityExpr, ReplacementDefinition, ReplacementMode, SpellCastingOption, TargetFilter,
+    AbilityCost, AbilityDefinition, AbilityKind, CastingPermission, ChoiceType, Effect,
+    ModalChoice, QuantityExpr, ReplacementDefinition, ReplacementMode, SpellCastingOption,
+    TargetFilter, TargetSelectionMode,
 };
 use engine::types::actions::GameAction;
 use engine::types::card::CardFace;
@@ -41,6 +42,335 @@ fn redirect_moved_to(destination: Zone, redirected_to: Zone) -> ReplacementDefin
                 enters_modified_if: None,
             },
         ))
+}
+
+fn prompt_after_moved_to_exile() -> ReplacementDefinition {
+    redirect_moved_to_with_post_effect(Zone::Exile, Zone::Exile)
+}
+
+fn redirect_moved_to_with_post_effect(
+    destination: Zone,
+    redirected_to: Zone,
+) -> ReplacementDefinition {
+    let mut replacement = redirect_moved_to(destination, redirected_to);
+    replacement
+        .execute
+        .as_mut()
+        .expect("redirect helper always provides its replacement effect")
+        .sub_ability = Some(Box::new(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Choose {
+            choice_type: ChoiceType::Labeled {
+                options: vec!["first".to_string(), "second".to_string()],
+            },
+            persist: false,
+            selection: TargetSelectionMode::Chosen,
+        },
+    )));
+    replacement
+}
+
+#[test]
+fn foretell_cost_honors_moved_redirect_and_completes_exactly_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let foretell_cost = ManaCost::generic(5);
+    let foretold = scenario
+        .add_spell_to_hand(P0, "Foretell Cost Redirect Witness", false)
+        .with_mana_cost(ManaCost::generic(7))
+        .with_keyword(Keyword::Foretell(foretell_cost.clone()))
+        .id();
+    for name in ["First Foretell Redirect", "Second Foretell Redirect"] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+    scenario.add_basic_land(P0, ManaColor::Blue);
+    scenario.add_basic_land(P0, ManaColor::Blue);
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&foretold].card_id;
+    let result = runner
+        .act(GameAction::Foretell {
+            object_id: foretold,
+            card_id,
+        })
+        .expect("foretell special action should pay its cost and consult Moved replacements");
+
+    assert!(
+        matches!(result.waiting_for, WaitingFor::ReplacementChoice { .. }),
+        "the foretell cost move must consult competing Moved redirects"
+    );
+
+    let turn_foretold = runner.state().turn_number;
+    let json = serde_json::to_string(runner.state()).expect("paused foretell serializes");
+    let restored: GameState = serde_json::from_str(&json).expect("paused foretell deserializes");
+    assert!(matches!(
+        restored.pending_cost_move_resume.as_ref(),
+        Some(&PendingCostMoveResume::Foretell {
+            player,
+            object_id,
+            ref cost,
+            turn_foretold: stamped_turn,
+        }) if player == P0 && object_id == foretold && cost == &foretell_cost && stamped_turn == turn_foretold
+    ));
+    let mut runner = GameRunner::from_state(restored);
+
+    let result = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirect the foretell exile");
+    let obj = &runner.state().objects[&foretold];
+    assert_eq!(obj.zone, Zone::Graveyard);
+    assert!(!obj.foretold, "only a card delivered to exile was foretold");
+    assert!(
+        !obj.face_down,
+        "a redirected card must not gain foretell concealment"
+    );
+    assert!(obj.casting_permissions.is_empty());
+    assert!(
+        !result.events.iter().any(
+            |event| matches!(event, GameEvent::Foretold { object_id, .. } if *object_id == foretold)
+        ),
+        "a redirected card must not emit Foretold"
+    );
+    assert_eq!(
+        result
+            .events
+            .iter()
+            .filter(|event| matches!(event, GameEvent::ReplacementApplied { .. }))
+            .count(),
+        1,
+        "the selected redirect must apply exactly once"
+    );
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P0));
+}
+
+#[test]
+fn foretell_delivery_finalizes_before_a_post_replacement_prompt() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let foretell_cost = ManaCost::generic(5);
+    let foretold = scenario
+        .add_spell_to_hand(P0, "Foretell Post-Effect Witness", false)
+        .with_mana_cost(ManaCost::generic(7))
+        .with_keyword(Keyword::Foretell(foretell_cost.clone()))
+        .id();
+    scenario
+        .add_creature(P0, "Foretell Post-Effect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(prompt_after_moved_to_exile());
+    scenario.add_basic_land(P0, ManaColor::Blue);
+    scenario.add_basic_land(P0, ManaColor::Blue);
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&foretold].card_id;
+    let turn_foretold = runner.state().turn_number;
+    let result = runner
+        .act(GameAction::Foretell {
+            object_id: foretold,
+            card_id,
+        })
+        .expect("foretell should deliver before the replacement post-effect prompts");
+
+    assert!(
+        matches!(
+            result.waiting_for,
+            WaitingFor::NamedChoice { ref options, .. }
+                if options == &vec!["first".to_string(), "second".to_string()]
+        ),
+        "the delivered Foretell move must preserve the replacement prompt"
+    );
+    let object = &runner.state().objects[&foretold];
+    assert_eq!(object.zone, Zone::Exile);
+    assert!(object.foretold);
+    assert!(object.face_down);
+    assert!(matches!(
+        object.casting_permissions.as_slice(),
+        [CastingPermission::Foretold { cost, turn_foretold: stamped_turn }]
+            if cost == &foretell_cost && *stamped_turn == turn_foretold
+    ));
+    assert_eq!(
+        result
+            .events
+            .iter()
+            .filter(|event| matches!(event, GameEvent::Foretold { object_id, .. } if *object_id == foretold))
+            .count(),
+        1,
+        "delivery must emit exactly one Foretold event before the prompt pauses"
+    );
+    assert_eq!(
+        result
+            .events
+            .iter()
+            .filter(|event| matches!(event, GameEvent::ReplacementApplied { .. }))
+            .count(),
+        1,
+        "the identity redirect must apply before its post-effect prompts"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+
+    let paused_waiting_for = runner.state().waiting_for.clone();
+    let json =
+        serde_json::to_string(runner.state()).expect("post-delivery foretell pause serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("post-delivery foretell pause deserializes");
+    assert_eq!(restored.waiting_for, paused_waiting_for);
+    assert!(restored.pending_cost_move_resume.is_none());
+    let mut runner = GameRunner::from_state(restored);
+
+    let resumed = runner
+        .act(GameAction::ChooseOption {
+            choice: "first".to_string(),
+        })
+        .expect("post-replacement choice should remain actionable after serialization");
+    let object = &runner.state().objects[&foretold];
+    assert_eq!(object.zone, Zone::Exile);
+    assert!(object.foretold);
+    assert!(object.face_down);
+    assert_eq!(object.casting_permissions.len(), 1);
+    assert!(
+        !resumed.events.iter().any(
+            |event| matches!(event, GameEvent::Foretold { object_id, .. } if *object_id == foretold)
+        ),
+        "resolving the post-effect must not re-finalize Foretell"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P0));
+}
+
+#[test]
+fn foretell_replacement_pause_then_post_effect_prompt_finalizes_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let foretell_cost = ManaCost::generic(5);
+    let foretold = scenario
+        .add_spell_to_hand(P0, "Foretell Replacement Resume Witness", false)
+        .with_mana_cost(ManaCost::generic(7))
+        .with_keyword(Keyword::Foretell(foretell_cost.clone()))
+        .id();
+    let exile_to_graveyard = scenario
+        .add_creature(P0, "Foretell Exile to Graveyard", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard))
+        .id();
+    scenario
+        .add_creature(P0, "Foretell Exile to Exile", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Exile));
+    let graveyard_to_exile = scenario
+        .add_creature(P0, "Foretell Graveyard to Exile", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to_with_post_effect(
+            Zone::Graveyard,
+            Zone::Exile,
+        ))
+        .id();
+    scenario
+        .add_creature(P0, "Foretell Graveyard to Hand", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to(Zone::Graveyard, Zone::Hand));
+    scenario.add_basic_land(P0, ManaColor::Blue);
+    scenario.add_basic_land(P0, ManaColor::Blue);
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&foretold].card_id;
+    let turn_foretold = runner.state().turn_number;
+    let initial = runner
+        .act(GameAction::Foretell {
+            object_id: foretold,
+            card_id,
+        })
+        .expect("competing Moved replacements should pause the Foretell cost move");
+    assert!(matches!(
+        initial.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let json =
+        serde_json::to_string(runner.state()).expect("pre-delivery foretell pause serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("pre-delivery foretell pause deserializes");
+    assert!(matches!(
+        restored.pending_cost_move_resume.as_ref(),
+        Some(&PendingCostMoveResume::Foretell {
+            player,
+            object_id,
+            ref cost,
+            turn_foretold: stamped_turn,
+        }) if player == P0 && object_id == foretold && cost == &foretell_cost && stamped_turn == turn_foretold
+    ));
+    let mut runner = GameRunner::from_state(restored);
+
+    let mut replacement_prompts = 0;
+    let mut delivered = None;
+    while let WaitingFor::ReplacementChoice { candidates, .. } = runner.state().waiting_for.clone()
+    {
+        let expected_source = match replacement_prompts {
+            0 => exile_to_graveyard,
+            1 => graveyard_to_exile,
+            _ => panic!("unexpected additional Foretell replacement prompt"),
+        };
+        let index = candidates
+            .iter()
+            .position(|candidate| candidate.source_id == expected_source)
+            .expect("the chosen redirect must appear in its CR 616.1 ordering prompt");
+        delivered = Some(
+            runner
+                .act(GameAction::ChooseReplacement { index })
+                .expect("apply the selected Foretell redirect"),
+        );
+        replacement_prompts += 1;
+    }
+    assert_eq!(
+        replacement_prompts, 2,
+        "both material Moved replacement collisions must be ordered before delivery"
+    );
+    let delivered = delivered.expect("the selected graveyard-to-exile redirect must deliver");
+    assert!(matches!(
+        delivered.waiting_for,
+        WaitingFor::NamedChoice { .. }
+    ));
+    let object = &runner.state().objects[&foretold];
+    assert_eq!(object.zone, Zone::Exile);
+    assert!(object.foretold);
+    assert!(object.face_down);
+    assert!(matches!(
+        object.casting_permissions.as_slice(),
+        [CastingPermission::Foretold { cost, turn_foretold: stamped_turn }]
+            if cost == &foretell_cost && *stamped_turn == turn_foretold
+    ));
+    assert_eq!(
+        delivered
+            .events
+            .iter()
+            .filter(|event| matches!(event, GameEvent::Foretold { object_id, .. } if *object_id == foretold))
+            .count(),
+        1
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+
+    let resumed = runner
+        .act(GameAction::ChooseOption {
+            choice: "first".to_string(),
+        })
+        .expect("the post-effect prompt remains actionable after Foretell completes");
+    assert!(!resumed.events.iter().any(
+        |event| matches!(event, GameEvent::Foretold { object_id, .. } if *object_id == foretold)
+    ));
+    assert_eq!(
+        runner.state().objects[&foretold].casting_permissions.len(),
+        1
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P0));
 }
 
 #[test]

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -20,7 +20,6 @@
 crates/engine/src/analysis/resource.rs	eq_except_growable	exempt	2
 crates/engine/src/game/archenemy.rs	set_in_motion	container	1
 crates/engine/src/game/archenemy.rs	turn_face_down_to_bottom_of_scheme_deck	container	1
-crates/engine/src/game/casting.rs	handle_foretell	mover	1
 crates/engine/src/game/casting_costs.rs	handle_resolution_cast_rejection	mover	1
 crates/engine/src/game/conspiracy.rs	start_with_conspiracy	container	1
 crates/engine/src/game/conspiracy.rs	start_with_conspiracy	zone-assign	1


### PR DESCRIPTION
## Summary
- route the paid Foretell hand-to-exile move through the replacement-aware zone pipeline
- serialize and resume Foretell cost moves across replacement choices, redirects, prevention, and post-effect prompts
- keep delivery completion exactly once and allow untracked exile deliveries to run the shared post-replacement drain

## Verification
- red witness: `/tmp/t155-foretell-witness-red.txt`
- `cargo fmt --all` and static census gates pass
- Tilt clippy: green
- Tilt test-engine: 19,818 passed, 9 skipped
- read-only final review: clean