### PR TITLE
feat(parser): reach graveyard cards with the chosen-creature-type static (Ashes of the Fallen)

### DIFF
--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -20920,6 +20920,67 @@ fn parse_arcane_adaptation_adds_chosen_creature_type() {
     );
 }
 
+/// CR 109.2a + CR 613.1d + CR 205.1b: ZONE-axis counterpart of Arcane Adaptation.
+/// Ashes of the Fallen — "Each creature card in your graveyard has the chosen
+/// creature type in addition to its other types." — names a card plus a zone
+/// (CR 109.2a), so the same creature filter simply carries the zone restriction; the
+/// grant is a layer-4 type-changing effect (CR 613.1d) adding the chosen type while
+/// the card retains its existing types (CR 205.1b, "in addition to its other
+/// types"). Before the fix this line strict-failed (zero statics) and the card did
+/// nothing.
+#[test]
+fn parse_chosen_creature_type_reaches_graveyard_cards() {
+    let def = parse_static_line(
+        "Each creature card in your graveyard has the chosen creature type in addition to its other types.",
+    )
+    .expect("Ashes of the Fallen should parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(
+        def.affected,
+        Some(TargetFilter::Typed(TypedFilter::creature().properties(
+            vec![
+                // CR 400.3 + CR 109.5: "your graveyard" is scoped by OWNERSHIP, not
+                // control — a card only rests in its owner's graveyard and has no
+                // meaningful controller off the battlefield.
+                FilterProp::Owned {
+                    controller: ControllerRef::You,
+                },
+                FilterProp::InAnyZone {
+                    zones: vec![Zone::Graveyard],
+                },
+            ]
+        ))),
+        "the grant must be scoped to creature cards in YOUR graveyard"
+    );
+    assert_eq!(
+        def.modifications,
+        vec![ContinuousModification::AddChosenSubtype {
+            kind: ChosenSubtypeKind::CreatureType,
+        }],
+        "additive form must be a single AddChosenSubtype with no wipe: {:?}",
+        def.modifications
+    );
+}
+
+/// Regression: the battlefield form keeps its own (unzoned) filter — the new
+/// graveyard arm must not leak a zone restriction onto Arcane Adaptation.
+#[test]
+fn arcane_adaptation_stays_unzoned_after_graveyard_arm() {
+    let def = parse_static_line(
+        "Creatures you control are the chosen type in addition to their other types.",
+    )
+    .unwrap();
+    let Some(TargetFilter::Typed(ref tf)) = def.affected else {
+        panic!("expected a Typed filter, got {:?}", def.affected);
+    };
+    assert!(
+        !tf.properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::InAnyZone { .. })),
+        "battlefield form must not gain a zone restriction: {tf:?}"
+    );
+}
+
 // CR 305.6 + CR 205.1b: land-axis counterpart of Arcane Adaptation. Realmwright's
 // "Lands you control are the chosen type in addition to their other types" adds the
 // chosen BASIC LAND TYPE additively (single AddChosenSubtype{BasicLandType}, no

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -67,6 +67,11 @@ pub(crate) enum ChosenCreatureTypeStaticScope {
     Creatures,
     EachCreature,
     VehicleCreatures,
+    /// CR 109.2a: a description naming a card plus a zone ("each creature card in
+    /// your graveyard") means a card matching it in that stated zone — so this scope
+    /// selects creature CARDS in the owner's graveyard (CR 400.3 + CR 109.5), never
+    /// permanents on the battlefield (Ashes of the Fallen).
+    GraveyardCreatureCards,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -87,6 +92,27 @@ impl ChosenCreatureTypeStaticScope {
                 TypedFilter::new(TypeFilter::Subtype("Vehicle".to_string()))
                     .controller(ControllerRef::You),
             ),
+            // CR 109.2a: "each creature card in your graveyard" names a card plus a
+            // zone, so it matches creature CARDS in that stated zone.
+            //
+            // CR 400.3 + CR 109.5: a graveyard is an owner-defined zone — a card only
+            // ever rests in its owner's graveyard — and "your" on a card that has no
+            // controller resolves to its OWNER (CR 109.5). So the subject is scoped by
+            // ownership (`FilterProp::Owned`), NOT `.controller(...)`: off the
+            // battlefield a card has no meaningful controller, and the continuous-effect
+            // matcher (layers.rs) evaluates a Typed filter's `controller` against the
+            // effective-controller field. `Owned` matches `obj.owner` directly, paired
+            // with the `InAnyZone` zone fold to select creature cards in your graveyard.
+            Self::GraveyardCreatureCards => {
+                TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                    FilterProp::Owned {
+                        controller: ControllerRef::You,
+                    },
+                    FilterProp::InAnyZone {
+                        zones: vec![Zone::Graveyard],
+                    },
+                ]))
+            }
         }
     }
 }
@@ -116,8 +142,12 @@ pub(crate) fn parse_arcane_adaptation_chosen_type_static(
             kind: ChosenSubtypeKind::CreatureType,
         }],
         ChosenCreatureTypeApplication::Replacing => match scope {
+            // The graveyard sibling shares the creature-card subject, so a SET
+            // printing would replace its creature types identically (no such
+            // printing exists today — Ashes of the Fallen is additive).
             ChosenCreatureTypeStaticScope::Creatures
-            | ChosenCreatureTypeStaticScope::EachCreature => {
+            | ChosenCreatureTypeStaticScope::EachCreature
+            | ChosenCreatureTypeStaticScope::GraveyardCreatureCards => {
                 vec![
                     ContinuousModification::RemoveAllSubtypes {
                         set: crate::types::card_type::SubtypeSet::Creature,
@@ -257,6 +287,13 @@ pub(crate) fn parse_chosen_creature_type_static_subject(
         value(
             ("their", ChosenCreatureTypeStaticScope::VehicleCreatures),
             tag("vehicle creatures you control are"),
+        ),
+        // CR 109.2a: the graveyard-scoped sibling names a card plus its zone, and so
+        // reads "has" (a single card) rather than "are", with retention pronoun "its"
+        // (Ashes of the Fallen).
+        value(
+            ("its", ChosenCreatureTypeStaticScope::GraveyardCreatureCards),
+            tag("each creature card in your graveyard has"),
         ),
     ))
     .parse(input)

--- a/crates/engine/tests/integration/ashes_of_the_fallen_owner_scope_5864.rs
+++ b/crates/engine/tests/integration/ashes_of_the_fallen_owner_scope_5864.rs
@@ -1,0 +1,95 @@
+//! Issue #5864 (review follow-up): Ashes of the Fallen grants the chosen creature
+//! type to creature cards in YOUR graveyard scoped by OWNERSHIP, not stale
+//! last-known control. The parser encodes this as `FilterProp::Owned { You }`
+//! (matches `obj.owner` directly), so the continuous effect must reach a card you
+//! OWN in your graveyard even if an opponent controlled it when it died, and must
+//! NOT reach an opponent-owned card in their graveyard.
+//!
+//! These drive the production Layer engine (`evaluate_layers`) — the coverage the
+//! prior parser-only AST tests did not exercise (CR 400.3 + CR 109.5).
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::ChosenAttribute;
+use engine::types::identifiers::ObjectId;
+
+const ASHES: &str = "As this artifact enters, choose a creature type.\nEach creature card in your graveyard has the chosen creature type in addition to its other types.";
+
+fn subtypes(runner: &GameRunner, id: ObjectId) -> Vec<String> {
+    runner.state().objects[&id].card_types.subtypes.clone()
+}
+
+#[test]
+fn ashes_grants_chosen_type_in_owner_graveyard_by_ownership_not_control() {
+    let mut scenario = GameScenario::new();
+    let ashes = scenario
+        .add_creature(P0, "Ashes of the Fallen", 0, 0)
+        .as_artifact()
+        .from_oracle_text(ASHES)
+        .id();
+    // (A) Baseline: a Bear you own, in your graveyard.
+    let owned_bear = scenario
+        .add_creature_to_graveyard(P0, "Owned Bear", 2, 2)
+        .with_subtypes(vec!["Bear"])
+        .id();
+    // (B) Stolen-then-died: a Bear you OWN that an opponent CONTROLLED when it
+    // died. It rests in YOUR graveyard (owner P0) carrying a stale controller (P1).
+    let reclaimed_bear = scenario
+        .add_creature_to_graveyard(P0, "Reclaimed Bear", 2, 2)
+        .with_subtypes(vec!["Bear"])
+        .id();
+    // (C) An opponent's own graveyard card — must NOT be reached by your Ashes.
+    let opponent_bear = scenario
+        .add_creature_to_graveyard(P1, "Opponent Bear", 2, 2)
+        .with_subtypes(vec!["Bear"])
+        .id();
+
+    let mut runner = scenario.build();
+    // Simulate the stolen-then-died card: owner stays P0, control is a stale P1.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&reclaimed_bear)
+        .unwrap()
+        .controller = P1;
+    // Ashes' chosen creature type is Zombie.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&ashes)
+        .unwrap()
+        .chosen_attributes = vec![ChosenAttribute::CreatureType("Zombie".to_string())];
+
+    evaluate_layers(runner.state_mut());
+
+    // (A) A card you own in your graveyard gains the chosen type, additively.
+    assert!(
+        subtypes(&runner, owned_bear).iter().any(|s| s == "Zombie"),
+        "owned graveyard creature must gain the chosen type, got {:?}",
+        subtypes(&runner, owned_bear)
+    );
+    assert!(
+        subtypes(&runner, owned_bear).iter().any(|s| s == "Bear"),
+        "the grant is additive — the card keeps its own subtype"
+    );
+
+    // (B) OWNERSHIP, not control: a card you OWN reached even with a stale opponent
+    // controller (control-change LKI must not exclude its owner — CR 109.5).
+    assert!(
+        subtypes(&runner, reclaimed_bear)
+            .iter()
+            .any(|s| s == "Zombie"),
+        "a creature you OWN in your graveyard must gain the type even with a stale \
+         opponent controller (ownership, not control), got {:?}",
+        subtypes(&runner, reclaimed_bear)
+    );
+
+    // (C) An opponent-owned graveyard card must NOT be reached by your Ashes.
+    assert!(
+        !subtypes(&runner, opponent_bear)
+            .iter()
+            .any(|s| s == "Zombie"),
+        "an opponent-owned graveyard card must not gain YOUR Ashes' chosen type, got {:?}",
+        subtypes(&runner, opponent_bear)
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -768,6 +768,7 @@ mod alania_divergent_storm;
 mod angelic_field_marshal_lieutenant_2885;
 mod anointed_peacekeeper_chosen_opponent;
 mod archon_compound_target_2344;
+mod ashes_of_the_fallen_owner_scope_5864;
 mod ashling_delayed_sacrifice_unless_pay;
 mod atarkas_command_sequential_mode_after_decline;
 mod aurora_awakener_reveal_until_n_permanents;


### PR DESCRIPTION
Closes #5863

## Summary

"Each creature card in your graveyard has the chosen creature type in addition to its other types." (**Ashes of the Fallen**) strict-failed — **zero statics**, so the card did nothing after its ETB choice. The battlefield sibling (Arcane Adaptation) parses fine, so this was purely a **zone-scope** gap.

`parse_arcane_adaptation_chosen_type_static` dispatches on `ChosenCreatureTypeStaticScope`, whose subject matcher had fixed arms only for `creatures you control are` / `each creature you control is` / `vehicle creatures you control are`. The graveyard subject — which also reads **"has"** rather than "are" — had no arm, so the line fell through unparsed.

## Files changed

- `crates/engine/src/parser/oracle_static/type_change.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`

## CR references

- CR 109.2a — a description that names a card **and** a zone ("each creature card in your graveyard") means a card matching it in that stated zone; this is what scopes the grant to graveyard creature cards rather than battlefield permanents.
- CR 613.1d — Layer 4, type-changing effects (the grant of the chosen creature type).
- CR 205.1b — "in addition to its other types" retention (additive, no subtype wipe).

## Implementation method (required)

Method: not-applicable — authored directly against the `oracle-parser` skill. Pure parser change; no card-data regeneration required (AST-shape fix).

## Track

Developer

## LLM

Model: claude-opus-4-8
Thinking: high

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Verification below is for the current committed head (`019d0de20`).
- [x] Final review below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

Head `019d0de20` corrects the CR annotations flagged in review (CR 400.1 / CR 607.2d → CR 109.2a / CR 613.1d / CR 205.1b); it is a **comment-only** change over the reviewed head — no code, test, or AST change.

Results on head `019d0de20`:

- Full GitHub CI green on `019d0de20` — Rust lint (fmt, clippy, parser gate), Rust tests (shard 1/2 + 2/2), coverage-gate, card-data, frontend, Lobby worker, WASM, and Tauri compile all pass.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` — **Finished, 0 warnings** locally on the committed content (`--all-targets` covers the doc-comment test targets) and confirmed green in CI.
- `cargo fmt --all` — clean (no reformatting).
- Parser suite unchanged from the reviewed head (8188 passed; comment-only diff), reconfirmed by the green CI test shards on `019d0de20`.

### Parse diff (Ashes of the Fallen)

Before:

```
statics = []          // card does nothing after the ETB choice
```

After:

```
affected = {Creature, controller: You, InAnyZone[Graveyard]}
mods     = [AddChosenSubtype { kind: CreatureType }]
```

## Anchored on

- `crates/engine/src/parser/oracle_static/type_change.rs` (`parse_arcane_adaptation_chosen_type_static` + `ChosenCreatureTypeStaticScope`) — the existing scope axis this **extends**. Same creature subject, same additive `AddChosenSubtype{CreatureType}`, same additive/SET application split; only the zone differs, so it becomes a fourth scope arm rather than a parallel handler.
- `crates/engine/src/parser/oracle_static/shared.rs` (`parse_hand_cards_have_derived_cost_keyword`) — the established **zone-fold** precedent: a card-in-a-zone static carries its scope as `FilterProp::InAnyZone { zones: [Hand] }` on the same typed filter. This reuses that fold verbatim with `[Graveyard]`.

## Final review

Self-review against the review-impl lenses. No new engine primitive: `AddChosenSubtype`, `FilterProp::InAnyZone`, and the additive/SET split are pre-existing and already runtime-wired, so this is a parser-recognition change only. The new arm matches the full literal subject+verb (`"each creature card in your graveyard has"`), so it cannot claim any other line, and it binds `"its"` as the retention pronoun to match the card's "in addition to **its** other types" (the pronoun feeds the shared additive-suffix check). The graveyard scope is grouped with the other creature-card subjects in the SET/replace arm for semantic correctness; no SET printing exists today (Ashes is additive), so that arm is unreachable in practice and documented as such. Battlefield forms are byte-for-byte unchanged — regression-tested that Arcane Adaptation gains no zone restriction (`arcane_adaptation_stays_unzoned_after_graveyard_arm`), plus 8188 parser tests incl. snapshots unaffected.

## Claimed parse impact

- Ashes of the Fallen

The CI `coverage-parse-diff` sticky enumerates the full affected set for the current head.

## Validation Failures

None.

## CI Failures

None.