### PR TITLE
Fix Emperor of Bones delayed sacrifice regression

### DIFF
--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -547,6 +547,38 @@ impl GameScenario {
         }
     }
 
+    /// Add a creature card to a player's exile. Returns a `CardBuilder` for
+    /// fluent chaining. Used to stage cards tracked by source-linked exile
+    /// effects.
+    pub fn add_creature_to_exile(
+        &mut self,
+        player: PlayerId,
+        name: &str,
+        power: i32,
+        toughness: i32,
+    ) -> CardBuilder<'_> {
+        let card_id = CardId(self.state.next_object_id);
+        let id = create_object(
+            &mut self.state,
+            card_id,
+            player,
+            name.to_string(),
+            Zone::Exile,
+        );
+        let obj = self.state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = Some(power);
+        obj.toughness = Some(toughness);
+        obj.base_power = Some(power);
+        obj.base_toughness = Some(toughness);
+
+        CardBuilder {
+            state: &mut self.state,
+            id,
+        }
+    }
+
     // --- Oracle text convenience constructors ---
 
     /// Add a creature to the battlefield with abilities parsed from Oracle text.

--- a/crates/engine/tests/integration/issue_1515_emperor_of_bones.rs
+++ b/crates/engine/tests/integration/issue_1515_emperor_of_bones.rs
@@ -4,14 +4,13 @@
 use engine::game::ability_utils::build_resolved_from_def;
 use engine::game::effects::resolve_ability_chain;
 use engine::game::scenario::{GameScenario, P0};
-use engine::game::zones::create_object;
 use engine::parser::oracle_effect::parse_effect_chain;
 use engine::types::ability::{
     AbilityKind, ContinuousModification, DelayedTriggerCondition, Effect, TargetFilter,
 };
 use engine::types::counter::CounterType;
 use engine::types::game_state::{ExileLink, ExileLinkKind, WaitingFor};
-use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
@@ -42,37 +41,16 @@ fn issue_1515_emperor_of_bones_binds_haste_and_delayed_sacrifice_to_returned_cre
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     let emperor = scenario.add_creature(P0, "Emperor of Bones", 2, 2).id();
+    let returned = scenario
+        .add_creature_to_exile(P0, "Linked Gravebeast", 3, 3)
+        .id();
 
     let mut runner = scenario.build();
-    let returned = {
-        let state = runner.state_mut();
-        let returned = create_object(
-            state,
-            CardId(900),
-            P0,
-            "Linked Gravebeast".to_string(),
-            Zone::Exile,
-        );
-        let object = state
-            .objects
-            .get_mut(&returned)
-            .expect("exiled card exists");
-        object
-            .card_types
-            .core_types
-            .push(engine::types::card_type::CoreType::Creature);
-        object.base_card_types = object.card_types.clone();
-        object.power = Some(3);
-        object.toughness = Some(3);
-        object.base_power = Some(3);
-        object.base_toughness = Some(3);
-        state.exile_links.push(ExileLink {
-            exiled_id: returned,
-            source_id: emperor,
-            kind: ExileLinkKind::TrackedBySource,
-        });
-        returned
-    };
+    runner.state_mut().exile_links.push(ExileLink {
+        exiled_id: returned,
+        source_id: emperor,
+        kind: ExileLinkKind::TrackedBySource,
+    });
 
     let def = parse_effect_chain(EMPEROR_COUNTER_TRIGGER_EFFECT, AbilityKind::Spell);
     let ability = build_resolved_from_def(&def, emperor, P0);

--- a/crates/engine/tests/integration/issue_1515_emperor_of_bones.rs
+++ b/crates/engine/tests/integration/issue_1515_emperor_of_bones.rs
@@ -1,0 +1,177 @@
+//! Issue #1515 — Emperor of Bones must grant haste to, and later sacrifice,
+//! the creature returned from its linked exile set.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{
+    AbilityKind, ContinuousModification, DelayedTriggerCondition, Effect, TargetFilter,
+};
+use engine::types::counter::CounterType;
+use engine::types::game_state::{ExileLink, ExileLinkKind, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const EMPEROR_COUNTER_TRIGGER_EFFECT: &str = "put a creature card exiled with this creature onto \
+the battlefield under your control with a finality counter on it. it gains haste. sacrifice it at \
+the beginning of the next end step.";
+
+fn creature_has_haste_from_transient_effects(
+    state: &engine::types::game_state::GameState,
+    creature: ObjectId,
+) -> bool {
+    state.transient_continuous_effects.iter().any(|effect| {
+        effect.affected == TargetFilter::SpecificObject { id: creature }
+            && effect.modifications.iter().any(|modification| {
+                matches!(
+                    modification,
+                    ContinuousModification::AddKeyword {
+                        keyword: Keyword::Haste
+                    }
+                )
+            })
+    })
+}
+
+#[test]
+fn issue_1515_emperor_of_bones_binds_haste_and_delayed_sacrifice_to_returned_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let emperor = scenario.add_creature(P0, "Emperor of Bones", 2, 2).id();
+
+    let mut runner = scenario.build();
+    let returned = {
+        let state = runner.state_mut();
+        let returned = create_object(
+            state,
+            CardId(900),
+            P0,
+            "Linked Gravebeast".to_string(),
+            Zone::Exile,
+        );
+        let object = state
+            .objects
+            .get_mut(&returned)
+            .expect("exiled card exists");
+        object
+            .card_types
+            .core_types
+            .push(engine::types::card_type::CoreType::Creature);
+        object.base_card_types = object.card_types.clone();
+        object.power = Some(3);
+        object.toughness = Some(3);
+        object.base_power = Some(3);
+        object.base_toughness = Some(3);
+        state.exile_links.push(ExileLink {
+            exiled_id: returned,
+            source_id: emperor,
+            kind: ExileLinkKind::TrackedBySource,
+        });
+        returned
+    };
+
+    let def = parse_effect_chain(EMPEROR_COUNTER_TRIGGER_EFFECT, AbilityKind::Spell);
+    let ability = build_resolved_from_def(&def, emperor, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("Emperor of Bones counter-trigger effect must resolve");
+
+    let state = runner.state();
+    assert_eq!(
+        state.objects[&returned].zone,
+        Zone::Battlefield,
+        "linked creature card must be returned to the battlefield"
+    );
+    assert_eq!(
+        state.objects[&emperor].zone,
+        Zone::Battlefield,
+        "Emperor must remain on the battlefield after returning the linked creature"
+    );
+    assert_eq!(
+        state.objects[&returned]
+            .counters
+            .get(&CounterType::Finality)
+            .copied()
+            .unwrap_or(0),
+        1,
+        "returned creature must enter with a finality counter"
+    );
+    assert!(
+        creature_has_haste_from_transient_effects(state, returned),
+        "haste grant must bind to the returned creature, not Emperor"
+    );
+    assert!(
+        !creature_has_haste_from_transient_effects(state, emperor),
+        "Emperor itself must not receive the returned creature's haste grant"
+    );
+    assert_eq!(
+        state.delayed_triggers.len(),
+        1,
+        "resolution must install exactly one delayed sacrifice trigger"
+    );
+    assert!(matches!(
+        state.delayed_triggers[0].condition,
+        DelayedTriggerCondition::AtNextPhase { phase: Phase::End }
+    ));
+    assert_eq!(
+        state.delayed_triggers[0].ability.targets,
+        vec![engine::types::ability::TargetRef::Object(returned)],
+        "delayed sacrifice trigger must snapshot the returned creature"
+    );
+    assert!(
+        matches!(
+            &state.delayed_triggers[0].ability.effect,
+            Effect::Sacrifice {
+                target: TargetFilter::ParentTarget,
+                ..
+            }
+        ),
+        "delayed trigger effect must sacrifice the snapshotted returned creature"
+    );
+
+    let mut guard = 0;
+    while !runner.state().delayed_triggers.is_empty() || !runner.state().stack.is_empty() {
+        guard += 1;
+        assert!(
+            guard < 256,
+            "delayed sacrifice trigger never fired; phase = {:?}, waiting_for = {:?}, \
+             delayed_triggers = {}, stack = {}",
+            runner.state().phase,
+            runner.state().waiting_for,
+            runner.state().delayed_triggers.len(),
+            runner.state().stack.len(),
+        );
+        match runner.state().waiting_for {
+            WaitingFor::DeclareAttackers { .. } => runner
+                .act(engine::types::actions::GameAction::DeclareAttackers {
+                    attacks: vec![],
+                    bands: vec![],
+                })
+                .expect("declare no attackers while advancing to end step"),
+            WaitingFor::DeclareBlockers { .. } => runner
+                .act(engine::types::actions::GameAction::DeclareBlockers {
+                    assignments: vec![],
+                })
+                .expect("declare no blockers while advancing to end step"),
+            _ => runner
+                .act(engine::types::actions::GameAction::PassPriority)
+                .expect("priority pass while waiting for delayed sacrifice"),
+        };
+    }
+
+    assert_eq!(
+        runner.state().objects[&returned].zone,
+        Zone::Exile,
+        "returned creature must be sacrificed at the beginning of the next end step; \
+         its finality counter sends it to exile"
+    );
+    assert_eq!(
+        runner.state().objects[&emperor].zone,
+        Zone::Battlefield,
+        "the delayed sacrifice must not sacrifice Emperor"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -224,6 +224,7 @@ mod issue_1354_coveted_jewel;
 mod issue_1374_atraxa_grand_unifier;
 mod issue_1499_arabella;
 mod issue_1509_sorcery_main_phase_cast;
+mod issue_1515_emperor_of_bones;
 mod issue_1524_serpents_soul_jar;
 mod issue_1526_harvest_season;
 mod issue_1535_braids;


### PR DESCRIPTION
## Summary
Fixes the Emperor of Bones returned-creature binding regression by adding an integration test that resolves its linked-exile counter-trigger body and verifies the returned creature, not Emperor, receives haste and the delayed sacrifice. Closes #1515.

## Files changed
- crates/engine/src/game/scenario.rs
- crates/engine/tests/integration/issue_1515_emperor_of_bones.rs
- crates/engine/tests/integration/main.rs

## CR references
None added or touched.

## Implementation method (required)
Method: not-applicable - regression-test and test-harness helper only; no production rules behavior changed.

## Track
Developer

## LLM
Model: codex-5
Thinking: high

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` - PASS
- `cargo test -p engine --test integration issue_1515_emperor_of_bones -- --nocapture` - PASS: 1 passed; 0 failed; 3134 filtered out.
- `cargo test -p engine --test integration no_top_level_test_binaries -- --nocapture` - PASS: 2 passed; 0 failed; 3133 filtered out.
- `./scripts/check-parser-combinators.sh` - PASS.
- `tilt get uiresource clippy` - unavailable in isolated worktree: `Error: No tilt apiserver found: tilt-default`; direct scoped Rust checks used.

## Gate A
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=2639ac4ad3fc1a1eceea25544df274acb167d03b base=c0d7e0f3a5d65c22b475491f0556a2655777980f

## Anchored on
- crates/engine/src/game/scenario.rs:521 - analogous `GameScenario::add_creature_to_graveyard` test builder for staging creature cards outside the battlefield.
- crates/engine/tests/integration/issue_2424_goryos_vengeance.rs:54 - analogous resolved-chain regression for granting haste and scheduling a delayed zone-change trigger on the returned object.

## Final review-impl
Final review-impl PASS head=2639ac4ad3fc1a1eceea25544df274acb167d03b

## Claimed parse impact
None.

## Validation Failures
None.

## CI Failures
None.
