### PR TITLE
fix(engine): thread the "Pay X {E}" X-announcement through Chthonian Nightmare's activated ability

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -15331,9 +15331,11 @@ pub fn handle_activate_ability(
 
         if casting_costs::activation_cost_needs_x_choice(&resolved, cost) {
             // CR 602.2b + CR 601.2f: A non-mana activation cost that removes
-            // X counters still needs the same X announcement step before any
-            // mana or counter payment happens. Split fixed mana out so it
-            // flows through ManaPayment, then pay the concretized residual cost.
+            // X counters (or pays a variable-X resource, e.g. "Pay X {E}" —
+            // Chthonian Nightmare, issue #1092) still needs the same X
+            // announcement step before any mana or counter/resource payment
+            // happens. Split fixed mana out so it flows through ManaPayment,
+            // then pay the concretized residual cost.
             let (mana_cost, remaining) = split_alt_cost_components(cost);
             let mut pending_x = PendingCast::new(
                 source_id,
@@ -15343,6 +15345,23 @@ pub fn handle_activate_ability(
             );
             pending_x.activation_cost = remaining;
             pending_x.activation_ability_index = Some(ability_index);
+            // CR 601.2g + CR 601.2h: if a non-self battlefield-removal sub-cost
+            // (Sacrifice / battlefield Exile / ReturnToHand) is still
+            // outstanding in the residual after X-announcement, mark the
+            // `ManaLeg` residual so `push_activated_ability_to_stack`
+            // re-surfaces it interactively via its existing hand-rolled
+            // detour (issue #1092: Chthonian Nightmare's Composite[PayEnergy{X},
+            // Sacrifice, ReturnToHand] was otherwise silently dropped by the
+            // fall-through `pay_ability_cost_for_activation` no-op — the same
+            // class of bug the `XMana` residual gate already documents for
+            // the mana-{X} case).
+            if pending_x
+                .activation_cost
+                .as_ref()
+                .is_some_and(|c| find_non_self_battlefield_removal_cost(c).is_some())
+            {
+                pending_x.activation_residual = ActivationResidual::ManaLeg;
+            }
             state.pending_cast = Some(Box::new(pending_x));
             return casting_costs::enter_payment_step(state, player, None, events);
         }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -3900,7 +3900,7 @@ fn concretize_chosen_x_cost(cost: &AbilityCost, chosen_x: u32) -> AbilityCost {
             zone: Some(Zone::Graveyard),
             filter: filter.clone(),
         },
-        // CR 107.9 + CR 601.2b: once X is announced, a variable "Pay X {E}"
+        // CR 107.3a + CR 601.2b: once X is announced, a variable "Pay X {E}"
         // activation cost (Chthonian Nightmare, issue #1092) becomes a fixed
         // energy amount before `pay_ability_cost_inner` deducts it — otherwise
         // the `Variable("X")` amount would resolve to 0 at payment time.
@@ -5998,7 +5998,7 @@ fn additional_cost_x_max(
         AbilityCost::PayLife { amount } if amount.contains_x() => {
             Some(max_pay_life_x(state, player))
         }
-        // CR 107.9 + CR 601.2b: X in a variable "Pay X {E}" activation cost
+        // CR 107.3a + CR 601.2b: X in a variable "Pay X {E}" activation cost
         // (Chthonian Nightmare, issue #1092) is capped by the player's current
         // energy counters, the same way `max_pay_life_x` caps life-X.
         AbilityCost::PayEnergy { amount } if amount.contains_x() => {
@@ -6108,7 +6108,7 @@ pub(super) fn activation_cost_needs_x_choice(
 
 /// True when an activated ability's cost carries a symbolic X that must be
 /// announced before payment: a variable counter-removal count (CR 601.2b) or a
-/// variable `{E}` amount (CR 107.9 + CR 601.2b, e.g. "Pay X {E}" — Chthonian
+/// variable `{E}` amount (CR 107.3a + CR 601.2b, e.g. "Pay X {E}" — Chthonian
 /// Nightmare, issue #1092). `AbilityCost::PayLife`/`PaySpeed` variable amounts
 /// are handled by a separate, older path (`additional_cost_x_max`'s `PayLife`
 /// arm feeds `pay_additional_cost_with_source` directly; `PaySpeed` rides the

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -3900,6 +3900,15 @@ fn concretize_chosen_x_cost(cost: &AbilityCost, chosen_x: u32) -> AbilityCost {
             zone: Some(Zone::Graveyard),
             filter: filter.clone(),
         },
+        // CR 107.9 + CR 601.2b: once X is announced, a variable "Pay X {E}"
+        // activation cost (Chthonian Nightmare, issue #1092) becomes a fixed
+        // energy amount before `pay_ability_cost_inner` deducts it — otherwise
+        // the `Variable("X")` amount would resolve to 0 at payment time.
+        AbilityCost::PayEnergy { amount } if amount.contains_x() => AbilityCost::PayEnergy {
+            amount: QuantityExpr::Fixed {
+                value: chosen_x as i32,
+            },
+        },
         AbilityCost::Composite { costs } => AbilityCost::Composite {
             costs: costs
                 .iter()
@@ -5989,6 +5998,12 @@ fn additional_cost_x_max(
         AbilityCost::PayLife { amount } if amount.contains_x() => {
             Some(max_pay_life_x(state, player))
         }
+        // CR 107.9 + CR 601.2b: X in a variable "Pay X {E}" activation cost
+        // (Chthonian Nightmare, issue #1092) is capped by the player's current
+        // energy counters, the same way `max_pay_life_x` caps life-X.
+        AbilityCost::PayEnergy { amount } if amount.contains_x() => {
+            Some(state.players[player.0 as usize].energy)
+        }
         AbilityCost::Sacrifice(cost)
             if cost.requirement == SacrificeRequirement::Count { count: u32::MAX } =>
         {
@@ -6088,13 +6103,22 @@ pub(super) fn activation_cost_needs_x_choice(
     ability: &ResolvedAbility,
     cost: &AbilityCost,
 ) -> bool {
-    ability.chosen_x.is_none() && cost_has_symbolic_counter_removal(cost)
+    ability.chosen_x.is_none() && cost_needs_activation_x_announcement(cost)
 }
 
-fn cost_has_symbolic_counter_removal(cost: &AbilityCost) -> bool {
+/// True when an activated ability's cost carries a symbolic X that must be
+/// announced before payment: a variable counter-removal count (CR 601.2b) or a
+/// variable `{E}` amount (CR 107.9 + CR 601.2b, e.g. "Pay X {E}" — Chthonian
+/// Nightmare, issue #1092). `AbilityCost::PayLife`/`PaySpeed` variable amounts
+/// are handled by a separate, older path (`additional_cost_x_max`'s `PayLife`
+/// arm feeds `pay_additional_cost_with_source` directly; `PaySpeed` rides the
+/// mana-ability `PayAmountChoice` channel) so are intentionally not duplicated
+/// here.
+fn cost_needs_activation_x_announcement(cost: &AbilityCost) -> bool {
     match cost {
         AbilityCost::RemoveCounter { count, .. } => is_chosen_remove_counter_cost_count(*count),
-        AbilityCost::Composite { costs } => costs.iter().any(cost_has_symbolic_counter_removal),
+        AbilityCost::PayEnergy { amount } => amount.contains_x(),
+        AbilityCost::Composite { costs } => costs.iter().any(cost_needs_activation_x_announcement),
         _ => false,
     }
 }

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -1053,13 +1053,9 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
         };
     }
 
-    // "Pay {E}" / "Pay {E}{E}" / "Pay N {E}" — energy costs (CR 107.14)
-    if let Some(energy) = try_parse_energy_cost(&lower) {
-        return AbilityCost::PayEnergy {
-            amount: QuantityExpr::Fixed {
-                value: energy as i32,
-            },
-        };
+    // "Pay {E}" / "Pay {E}{E}" / "Pay N {E}" / "Pay X {E}" — energy costs (CR 107.14)
+    if let Some(amount) = try_parse_energy_cost(&lower) {
+        return AbilityCost::PayEnergy { amount };
     }
 
     // "Return a land you control to its owner's hand" — bounce cost
@@ -1629,8 +1625,12 @@ fn try_parse_exile_top_library(rest: &str) -> Option<u32> {
     None
 }
 
-/// CR 107.9: Parse energy costs like "{E}", "{E}{E}", "pay N {e}", "pay eight {e}".
-fn try_parse_energy_cost(lower: &str) -> Option<u32> {
+/// CR 107.9: Parse energy costs like "{E}", "{E}{E}", "pay N {e}", "pay eight {e}",
+/// "pay x {e}" (Chthonian Nightmare / issue #1092). Returns a `QuantityExpr` rather
+/// than a bare count so a variable-X amount ("pay x {e}") can be represented as
+/// `QuantityExpr::Ref { qty: Variable("X") }`, mirroring the "pay x life" /
+/// "pay x speed" branches above instead of silently collapsing X to 0.
+fn try_parse_energy_cost(lower: &str) -> Option<QuantityExpr> {
     let text = nom_on_lower(lower, lower, |i| value((), tag("pay ")).parse(i))
         .map(|((), rest)| rest)
         .unwrap_or(lower)
@@ -1641,14 +1641,23 @@ fn try_parse_energy_cost(lower: &str) -> Option<u32> {
         // Verify the text is ONLY {E} symbols (no other text)
         let cleaned = text.replace("{e}", "").replace(' ', "");
         if cleaned.is_empty() {
-            return Some(count);
+            return Some(QuantityExpr::Fixed {
+                value: count as i32,
+            });
         }
     }
-    // "pay N {e}" / "pay eight {e}" / "pay six {e}"
+    // "pay N {e}" / "pay eight {e}" / "pay six {e}" / "pay x {e}"
     if text.ends_with("{e}") {
         let prefix = text.trim_end_matches("{e}").trim();
+        if prefix == "x" {
+            return Some(QuantityExpr::Ref {
+                qty: QuantityRef::Variable {
+                    name: "X".to_string(),
+                },
+            });
+        }
         if let Some((n, _)) = parse_number(prefix) {
-            return Some(n);
+            return Some(QuantityExpr::Fixed { value: n as i32 });
         }
     }
     None

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -1625,7 +1625,7 @@ fn try_parse_exile_top_library(rest: &str) -> Option<u32> {
     None
 }
 
-/// CR 107.9: Parse energy costs like "{E}", "{E}{E}", "pay N {e}", "pay eight {e}",
+/// CR 107.3a + CR 107.14: Parse energy costs like "{E}", "{E}{E}", "pay N {e}", "pay eight {e}",
 /// "pay x {e}" (Chthonian Nightmare / issue #1092). Returns a `QuantityExpr` rather
 /// than a bare count so a variable-X amount ("pay x {e}") can be represented as
 /// `QuantityExpr::Ref { qty: Variable("X") }`, mirroring the "pay x life" /

--- a/crates/engine/tests/integration/issue_1092_chthonian_nightmare.rs
+++ b/crates/engine/tests/integration/issue_1092_chthonian_nightmare.rs
@@ -1,0 +1,198 @@
+//! Issue #1092 — Chthonian Nightmare's activated ability could never be paid.
+//!
+//! Oracle text:
+//!   "When this enchantment enters, you get {E}{E}{E} (three energy counters).
+//!   Pay X {E}, Sacrifice a creature, Return this enchantment to its owner's
+//!   hand: Return target creature card with mana value X from your graveyard
+//!   to the battlefield. Activate only as a sorcery."
+//!
+//! Root cause: `try_parse_energy_cost` (crates/engine/src/parser/oracle_cost.rs)
+//! had no variable-X branch, so "Pay X {E}" silently parsed as `PayEnergy {
+//! amount: Fixed(0) }` instead of `PayEnergy { amount: Ref(Variable("X")) }`
+//! (mirroring the existing "pay x life" / "pay x speed" branches). With X
+//! hard-pinned to 0: no energy was ever charged, no X-announcement step ever
+//! fired, and the ability's own effect ("mana value X") only ever matched a
+//! mana-value-0 graveyard creature — so on any realistic board (nonzero-MV
+//! creatures in the graveyard, the entire point of the card) the ability had
+//! no legal target and was, in the reporter's words, never activatable.
+//!
+//! This test drives the real `parse_oracle_text` + activation pipeline end to
+//! end: activate, announce X = 2, sacrifice a creature, and reanimate the
+//! chosen mana-value-2 graveyard creature — while a mana-value-0 decoy in the
+//! same graveyard proves X is actually threaded into the target filter (pre-fix,
+//! X was pinned to 0 and only the decoy would ever be a legal target).
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{PayCostKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const CHTHONIAN_NIGHTMARE_ORACLE: &str = "When this enchantment enters, you get {E}{E}{E} (three energy counters).\nPay X {E}, Sacrifice a creature, Return this enchantment to its owner's hand: Return target creature card with mana value X from your graveyard to the battlefield. Activate only as a sorcery.";
+
+#[test]
+fn chthonian_nightmare_activates_pays_x_energy_and_reanimates_by_mana_value() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Colorless, ObjectId(9_998), false, vec![]),
+            ManaUnit::new(ManaType::Black, ObjectId(9_999), false, vec![]),
+        ],
+    );
+
+    let nightmare = scenario
+        .add_creature(P0, "Chthonian Nightmare", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(CHTHONIAN_NIGHTMARE_ORACLE)
+        .id();
+    let sacrifice = scenario.add_creature(P0, "Sacrifice Me", 1, 1).id();
+
+    // Mana-value-0 decoy: pre-fix, X was pinned to 0, so this would be the
+    // ONLY legal target — the actual bug's fingerprint.
+    let _decoy_mv0 = scenario
+        .add_creature_to_graveyard(P0, "Decoy MV0", 1, 1)
+        .id();
+    // Two mana-value-2 creatures, only matched when X is genuinely announced.
+    // A second same-MV candidate (mirroring `issue_1021_recurring_nightmare`'s
+    // approach) keeps target selection genuinely interactive instead of the
+    // engine silently auto-selecting a sole legal target.
+    let gy_creature = scenario
+        .add_creature_to_graveyard(P0, "Graveyard Return", 2, 2)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![],
+            generic: 2,
+        })
+        .id();
+    let _other_gy_creature = scenario
+        .add_creature_to_graveyard(P0, "Other Graveyard Resident", 2, 2)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![],
+            generic: 2,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].energy = 3;
+
+    let ability_index = runner.state().objects[&nightmare]
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, engine::types::ability::AbilityKind::Activated))
+        .expect("activated ability");
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: nightmare,
+            ability_index,
+        })
+        .expect("begin activation");
+
+    let mut saw_choose_x = false;
+    let mut saw_sacrifice = false;
+    let mut saw_target = false;
+
+    for _ in 0..32 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ChooseXValue { min, max, .. } => {
+                assert_eq!(min, 0, "X may legally be 0");
+                assert_eq!(
+                    max, 3,
+                    "max X must be bounded by the player's 3 energy counters (pre-fix: no announcement ever fired)"
+                );
+                runner
+                    .act(GameAction::ChooseX { value: 2 })
+                    .expect("announce X = 2");
+                saw_choose_x = true;
+            }
+            WaitingFor::PayCost {
+                kind: PayCostKind::Sacrifice,
+                ..
+            } => {
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![sacrifice],
+                    })
+                    .expect("sacrifice creature");
+                saw_sacrifice = true;
+            }
+            WaitingFor::TargetSelection { ref selection, .. } => {
+                assert!(
+                    selection
+                        .current_legal_targets
+                        .contains(&TargetRef::Object(gy_creature)),
+                    "mana-value-2 creature must be a legal target when X = 2"
+                );
+                assert!(
+                    !selection
+                        .current_legal_targets
+                        .contains(&TargetRef::Object(_decoy_mv0)),
+                    "mana-value-0 decoy must NOT be a legal target when X = 2 \
+                     (pre-fix, X was pinned to 0 and only this decoy would ever qualify)"
+                );
+                runner
+                    .act(GameAction::SelectTargets {
+                        targets: vec![TargetRef::Object(gy_creature)],
+                    })
+                    .expect("select the mana-value-2 graveyard creature");
+                saw_target = true;
+            }
+            WaitingFor::TriggerTargetSelection { .. } => {
+                runner
+                    .act(GameAction::SelectTargets {
+                        targets: vec![TargetRef::Object(gy_creature)],
+                    })
+                    .expect("select the mana-value-2 graveyard creature");
+                saw_target = true;
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pay activation mana from pool");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() {
+                    break;
+                }
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority to resolve ability");
+            }
+            other => panic!("unexpected waiting state during activation: {other:?}"),
+        }
+    }
+
+    assert!(saw_choose_x, "activation must require announcing X");
+    assert!(
+        saw_sacrifice,
+        "activation must require sacrificing a creature"
+    );
+    assert!(
+        saw_target,
+        "activation must require choosing a graveyard creature"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize].energy,
+        1,
+        "3 energy - X(2) = 1 must actually be deducted"
+    );
+    assert_eq!(
+        runner.state().objects[&nightmare].zone,
+        Zone::Hand,
+        "Chthonian Nightmare must return itself to hand as part of the activation cost"
+    );
+    assert_eq!(
+        runner.state().objects[&gy_creature].zone,
+        Zone::Battlefield,
+        "ability must reanimate the chosen mana-value-2 graveyard creature"
+    );
+    assert_eq!(
+        runner.state().objects[&sacrifice].zone,
+        Zone::Graveyard,
+        "sacrificed creature must be in the graveyard"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -187,6 +187,7 @@ mod issue_1021_recurring_nightmare;
 mod issue_1022_savai_triome_cycling;
 mod issue_1023_oversold_cemetery;
 mod issue_1025_rishkars_expertise;
+mod issue_1092_chthonian_nightmare;
 mod issue_1120_warden_of_the_grove;
 mod issue_1124_ohran_frostfang_attacking_deathtouch;
 mod issue_1135_ents_fury_fight;


### PR DESCRIPTION
Fixes #1092.

Chthonian Nightmare: "Pay X {E}, Sacrifice a creature, Return this enchantment to its owner's hand: Return target creature card with mana value X from your graveyard to the battlefield. Activate only as a sorcery." — the ability could never be found/activated at all.

## Root cause (two independent gaps)

1. **Parser**: `try_parse_energy_cost` had no variable-X branch, so "Pay X {E}" silently parsed as `PayEnergy { amount: Fixed(0) }` instead of `Ref(Variable("X"))`, unlike the neighboring "pay x life"/"pay x speed" branches. With X pinned to 0, the reanimation target filter ("mana value X") could only ever match a mana-value-0 graveyard creature — no legal target on any realistic board.
2. **Runtime**: even after fixing the parser, the X-announcement machinery (`cost_needs_activation_x_announcement`, `additional_cost_x_max`, `concretize_chosen_x_cost`) only recognized `RemoveCounter`-shaped variable costs, and the resumed-cost re-surfacing for the sibling Sacrifice/ReturnToHand costs needed an `ActivationResidual::ManaLeg` tag that was never applied for this combination.

## Testing

New end-to-end integration test driving the real activation pipeline: announces X=2 bounded by energy, sacrifices a creature, chooses between two identical-mana-value graveyard creatures (plus a wrong-mana-value decoy to prove X is genuinely threaded into the target filter), verifies energy/zones land correctly.

Verified locally (rebased onto main): fmt clean, clippy clean, 16672 lib tests pass, 3121 integration tests pass.