### PR TITLE
fix(parser): recognize plural "leave the battlefield" in the generic exile-until duration combinator

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -6052,6 +6052,7 @@ mod tests {
             library_position: None,
             is_cost_payment: false,
             enters_modified_if: None,
+            duration: None,
         };
 
         let actions = candidate_actions_broad(&state);

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1226,6 +1226,7 @@ fn pay_ability_cost_inner(
                     library_position: None,
                     is_cost_payment: true,
                     enters_modified_if: None,
+                    duration: None,
                 };
                 return Ok(PaymentOutcome::Paused {
                     remaining_cost: None,

--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -318,6 +318,7 @@ fn prompt_resolution_attachment_choice(
                 library_position: None,
                 is_cost_payment: false,
                 enters_modified_if: None,
+                duration: None,
             };
             Ok(true)
         }

--- a/crates/engine/src/game/effects/blight.rs
+++ b/crates/engine/src/game/effects/blight.rs
@@ -89,6 +89,7 @@ pub fn resolve(
         library_position: None,
         is_cost_payment: false,
         enters_modified_if: None,
+        duration: None,
     };
 
     Ok(())

--- a/crates/engine/src/game/effects/bounce.rs
+++ b/crates/engine/src/game/effects/bounce.rs
@@ -239,6 +239,7 @@ pub fn resolve(
                     library_position: None,
                     is_cost_payment: false,
                     enters_modified_if: None,
+                    duration: None,
                 };
                 return Ok(());
             }
@@ -333,6 +334,7 @@ pub fn resolve(
                     library_position: None,
                     is_cost_payment: false,
                     enters_modified_if: None,
+                    duration: None,
                 };
                 return Ok(());
             }
@@ -512,6 +514,7 @@ pub fn resolve_all(
                 library_position: None,
                 is_cost_payment: false,
                 enters_modified_if: None,
+                duration: None,
             };
             return Ok(());
         }

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -269,6 +269,7 @@ fn open_private_zone_cast_selection(
         library_position: None,
         is_cost_payment: false,
         enters_modified_if: None,
+        duration: None,
     };
     Ok(())
 }

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -886,6 +886,11 @@ pub fn resolve(
             // `EffectZoneChoice` round-trip so it is evaluated against the
             // chosen object on resume (Summoner's Grimoire).
             enters_modified_if: effect_enters_modified_if.clone(),
+            // CR 611.2a + CR 610.3: carry the bounded-move duration across the
+            // interactive round-trip so the multi-candidate path builds the
+            // same `UntilSourceLeaves` exile link the single-candidate
+            // shortcut does (Cloak and Dagger, Entwined — issue #4235 review).
+            duration: ability.duration.clone(),
         };
         // EffectResolved is emitted by the EffectZoneChoice handler after the player chooses
         // (matching the DiscardChoice pattern — single authority for the event).
@@ -8964,6 +8969,7 @@ mod tests {
             library_position: None,
             is_cost_payment: false,
             enters_modified_if: None,
+            duration: None,
         };
 
         let _ = apply_as_current(

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -6547,6 +6547,7 @@ fn set_player_scope_sacrifice_waiting_for(
         library_position: None,
         is_cost_payment: false,
         enters_modified_if: None,
+        duration: None,
     };
 }
 
@@ -12227,6 +12228,7 @@ mod tests {
             library_position: None,
             is_cost_payment: false,
             enters_modified_if: None,
+            duration: None,
         };
 
         crate::game::engine::apply(
@@ -17444,6 +17446,7 @@ mod tests {
             library_position: None,
             is_cost_payment: false,
             enters_modified_if: None,
+            duration: None,
         };
         state.park_ability_continuation(PendingContinuation::new(
             Box::new(ResolvedAbility::new(
@@ -17487,6 +17490,7 @@ mod tests {
                 library_position: None,
                 is_cost_payment: false,
                 enters_modified_if: None,
+                duration: None,
             },
             GameAction::SelectCards {
                 cards: vec![second],

--- a/crates/engine/src/game/effects/put_on_top.rs
+++ b/crates/engine/src/game/effects/put_on_top.rs
@@ -235,6 +235,7 @@ pub fn resolve(
                     library_position: Some(position.clone()),
                     is_cost_payment: false,
                     enters_modified_if: None,
+                    duration: None,
                 };
                 return Ok(());
             }
@@ -285,6 +286,7 @@ pub fn resolve(
             library_position: Some(position.clone()),
             is_cost_payment: false,
             enters_modified_if: None,
+            duration: None,
         };
         return Ok(());
     }

--- a/crates/engine/src/game/effects/sacrifice.rs
+++ b/crates/engine/src/game/effects/sacrifice.rs
@@ -332,6 +332,7 @@ pub fn resolve(
             library_position: None,
             is_cost_payment: false,
             enters_modified_if: None,
+            duration: None,
         };
 
         // EffectResolved is emitted by the EffectZoneChoice handler after the player chooses

--- a/crates/engine/src/game/effects/tap_untap.rs
+++ b/crates/engine/src/game/effects/tap_untap.rs
@@ -339,6 +339,9 @@ fn prompt_resolution_tap_untap_choice(
         library_position: None,
         is_cost_payment: false,
         enters_modified_if: None,
+        // Tap/untap selection performs no zone move, so no bounded-move
+        // duration rides the round-trip.
+        duration: None,
     };
     true
 }

--- a/crates/engine/src/game/engine_phase_trigger_regression_tests.rs
+++ b/crates/engine/src/game/engine_phase_trigger_regression_tests.rs
@@ -2701,6 +2701,7 @@ fn effect_zone_choice_handler_resolves_sacrifice_and_continuation() {
         library_position: None,
         is_cost_payment: false,
         enters_modified_if: None,
+        duration: None,
     };
     state.park_ability_continuation(crate::types::game_state::PendingContinuation::new(
         Box::new(ResolvedAbility::new(
@@ -2776,6 +2777,7 @@ fn effect_zone_choice_handler_resolves_untap_selection() {
         library_position: None,
         is_cost_payment: false,
         enters_modified_if: None,
+        duration: None,
     };
 
     let result = apply_as_current(
@@ -2826,6 +2828,7 @@ fn effect_zone_choice_up_to_respects_min_count() {
         library_position: None,
         is_cost_payment: false,
         enters_modified_if: None,
+        duration: None,
     };
 
     let result = apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] });

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -4280,6 +4280,7 @@ pub(super) fn handle_resolution_choice(
                 library_position,
                 is_cost_payment,
                 enters_modified_if,
+                duration,
             },
             GameAction::SelectCards { cards: chosen },
         ) => {
@@ -4616,7 +4617,13 @@ pub(super) fn handle_resolution_choice(
                             enters_attacking,
                             enter_with_counters: per_obj_enter_counters,
                             conditional_enter_with_counters: vec![],
-                            duration: None,
+                            // CR 611.2a + CR 610.3: the duration carried across
+                            // the `EffectZoneChoice` round-trip — an
+                            // "exile ... until ~ leaves the battlefield" move
+                            // must keep its bound on the interactive
+                            // multi-candidate path, not just the
+                            // single-candidate shortcut (issue #4235 review).
+                            duration: duration.clone(),
                             track_exiled_by_source,
                             // CR 708.2a + CR 708.3: thread the face-down profile that
                             // was carried across the `EffectZoneChoice` round-trip into
@@ -5038,6 +5045,10 @@ pub(super) fn handle_resolution_choice(
                         enters_attacking,
                         enter_with_counters: vec![],
                         conditional_enter_with_counters: vec![],
+                        // CR 118.3: cost-payment exile is unbounded — no
+                        // "until ..." duration idiom pays a cost, so the
+                        // round-trip `duration` (always `None` for `PayCost`
+                        // producers) is deliberately not threaded here.
                         duration: None,
                         track_exiled_by_source,
                         face_down_profile: face_down_profile.clone(),

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -590,6 +590,7 @@ mod tests {
             count_param: 0,
             library_position: None,
             is_cost_payment: false,
+            duration: None,
         };
 
         finalize_rules_state(&mut state);

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -31124,6 +31124,7 @@ pub mod tests {
             library_position: None,
             is_cost_payment: false,
             enters_modified_if: None,
+            duration: None,
         };
 
         crate::game::engine::apply_as_current(

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1218,6 +1218,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         library_position: None,
         is_cost_payment: _,
         enters_modified_if: _,
+        ref duration,
     } = state.waiting_for
     {
         // `open_private_zone_cast_selection` is the sole Library producer and
@@ -1249,6 +1250,9 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
                 library_position: None,
                 is_cost_payment: false,
                 enters_modified_if: None,
+                // The bounded-move duration is a public effect parameter, not
+                // private hand info — pass it through the redaction.
+                duration: duration.clone(),
             };
         }
     }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7995,6 +7995,22 @@ pub(super) fn parse_exile_ast(
     let (_, rest_text) = nom_on_lower(text, lower, |input| value((), tag("exile ")).parse(input))?;
     let rest_lower = &lower[lower.len() - rest_text.len()..];
 
+    // CR 608.2c + CR 115.10a: an anaphoric ALTERNATIVE referent — "… or the
+    // chosen creature/permanent" — composes this exile with an object chosen
+    // by an EARLIER instruction in the same ability ("choose target opponent
+    // and up to one target creature they control. … You may exile a nonland
+    // card from their hand or the chosen creature …", Cloak and Dagger,
+    // Entwined — issue #4235 review). No object-anaphor filter exists to
+    // represent that alternative yet, and every arm below would silently
+    // narrow the choice to its own operand (the hand-card leg), making the
+    // card look supported while dropping the printed alternative entirely.
+    // Decline the whole imperative so the clause stays an honest
+    // `Effect::Unimplemented` strict failure until the chosen-object anaphor
+    // is representable.
+    if nom_primitives::scan_contains(rest_lower, "or the chosen ") {
+        return None;
+    }
+
     // CR 701.13a: "exile a card from the top of your library" — synonymous with
     // "exile the top card of your library". Without ExileTop lowering the generic
     // path emits ChangeZone(Library→Exile) with a library-wide EffectZoneChoice

--- a/crates/engine/src/parser/oracle_nom/duration.rs
+++ b/crates/engine/src/parser/oracle_nom/duration.rs
@@ -71,12 +71,21 @@ fn parse_until_body(input: &str) -> OracleResult<'_, Duration> {
             tag("the next end step"),
         ),
         // Host-lifetime expiry: "until ~ leaves the battlefield" /
-        // "until this creature leaves the battlefield".
+        // "until this creature leaves the battlefield". A card whose name
+        // normalizes to a plural subject (e.g. "Cloak and Dagger, Entwined")
+        // takes plural verb agreement in its own oracle text — "until Cloak
+        // and Dagger leave the battlefield" — so both "leaves"/"leave" must
+        // be accepted here, mirroring the same singular/plural alternation
+        // already handled by the LTB *trigger* parsers (the `leaves_tail`
+        // alt in `oracle_trigger.rs` and `oracle_effect/mod.rs`'s
+        // "leaves the battlefield"/"leave the battlefield" alt) — CR 603.2c
+        // notes the plural "leave" form is used with plural/batched subjects.
         value(
             Duration::UntilHostLeavesPlay,
             (
                 alt((tag("~"), tag("this creature"))),
-                tag(" leaves the battlefield"),
+                tag(" "),
+                alt((tag("leaves the battlefield"), tag("leave the battlefield"))),
             ),
         ),
         // CR 607.2a + CR 611.2a: source-linked impulse grants such as

--- a/crates/engine/src/parser/oracle_nom/duration.rs
+++ b/crates/engine/src/parser/oracle_nom/duration.rs
@@ -78,8 +78,9 @@ fn parse_until_body(input: &str) -> OracleResult<'_, Duration> {
         // be accepted here, mirroring the same singular/plural alternation
         // already handled by the LTB *trigger* parsers (the `leaves_tail`
         // alt in `oracle_trigger.rs` and `oracle_effect/mod.rs`'s
-        // "leaves the battlefield"/"leave the battlefield" alt) — CR 603.2c
-        // notes the plural "leave" form is used with plural/batched subjects.
+        // "leaves the battlefield"/"leave the battlefield" alt). CR 611.2a:
+        // the parsed value is the continuous effect's stated duration — here
+        // the host permanent's own battlefield lifetime.
         value(
             Duration::UntilHostLeavesPlay,
             (

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -7823,6 +7823,17 @@ pub enum WaitingFor {
         /// use). Mirrors the `enter_tapped` / `enters_attacking` carry-through above.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         enters_modified_if: Option<crate::types::ability::TargetFilter>,
+        /// CR 611.2a + CR 610.3: the `ChangeZone` duration carried across the
+        /// `EffectZoneChoice` round-trip, so an interactive multi-candidate
+        /// selection preserves a bounded move ("exile ... until ~ leaves the
+        /// battlefield" → the `UntilSourceLeaves` exile link). Without this
+        /// carry-through the resume authority reconstructed the move ctx with
+        /// `duration: None` and the chosen card was exiled PERMANENTLY —
+        /// while the single-candidate shortcut (no pause) kept the duration,
+        /// making the bug visible only when a real choice existed. Mirrors
+        /// the `face_down_profile` / `enters_modified_if` carry-through above.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        duration: Option<crate::types::ability::Duration>,
     },
     /// Player chooses which drawn-this-turn hand cards to put on top of their
     /// library. Each unchosen required card is kept by paying life.
@@ -20043,6 +20054,7 @@ mod tests {
             library_position: None,
             is_cost_payment: false,
             enters_modified_if: None,
+            duration: None,
         }));
         variants.push(Box::new(WaitingFor::DefilerPayment {
             player: PlayerId(0),
@@ -20381,6 +20393,7 @@ mod tests {
             library_position: None,
             is_cost_payment: false,
             enters_modified_if: None,
+            duration: None,
         };
         let json = serde_json::to_string(&wf).unwrap();
         let deserialized: WaitingFor = serde_json::from_str(&json).unwrap();
@@ -20930,6 +20943,7 @@ mod tests {
             library_position: None,
             is_cost_payment: false,
             enters_modified_if: None,
+            duration: None,
         };
         let json = serde_json::to_string(&wf).expect("serialize");
         // Modern shape must be emitted, NOT the legacy bool field.

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -9705,6 +9705,7 @@ fn effect_zone_put_at_library_position_mixed_sources_preserves_legacy_library_or
             library_position: Some(position),
             is_cost_payment: false,
             enters_modified_if: None,
+            duration: None,
         };
 
         let completed = runner

--- a/crates/engine/tests/integration/issue_4235_cloak_and_dagger_entwined.rs
+++ b/crates/engine/tests/integration/issue_4235_cloak_and_dagger_entwined.rs
@@ -1,0 +1,235 @@
+//! Issue #4235: Cloak and Dagger, Entwined must exile a chosen nonland card
+//! from an opponent's hand UNTIL Cloak and Dagger leaves the battlefield, not
+//! permanently.
+//!
+//! Oracle text (Marvel Spider-Man set MSH, read from `client/public/card-data.json`):
+//!   "Deathtouch, lifelink
+//!    When Cloak and Dagger enter, choose target opponent and up to one target
+//!    creature they control. They reveal their hand. You may exile a nonland
+//!    card from their hand or the chosen creature until Cloak and Dagger leave
+//!    the battlefield."
+//!
+//! THE BUG this discriminates: `parse_until_body` (the "until X leaves the
+//! battlefield" duration combinator in `parser/oracle_nom/duration.rs`) only
+//! matched the singular verb form "leaves the battlefield". Cloak and Dagger's
+//! own name is a plural subject ("Cloak and Dagger"), so its printed oracle
+//! text uses plural agreement: "until Cloak and Dagger leave the battlefield".
+//! That never matched, so the exile sub-ability's `duration` field silently
+//! stayed `None` — no `ExileLinkKind::UntilSourceLeaves` link was ever
+//! created, and a card exiled by this trigger stayed in exile forever, even
+//! after Cloak and Dagger left the battlefield. This mirrors the *trigger*
+//! detector for "leaves"/"leave the battlefield" (already handled correctly
+//! in `oracle_trigger.rs` and `oracle_effect/mod.rs`), which just never had a
+//! matching sibling in the *duration* combinator.
+//!
+//! Known, separate, OUT-OF-SCOPE gaps (not fixed here — see
+//! investigated-issues.md #4235 for why):
+//! 1. The "or the chosen creature" alternative exile target (choosing to
+//!    exile the previously-targeted creature instead of a hand card) is not
+//!    implemented by the parser at all, and neither is the "up to one target
+//!    creature they control" secondary target declaration it depends on.
+//! 2. The exile sub-ability's target filter (`Typed{Card, Non(Land)}`) is not
+//!    scoped to the chosen opponent's hand specifically — `matches_target_filter`
+//!    matches a nonland card in EITHER player's hand at the `scan_zone`
+//!    fallback, because the filter carries no `controller`/`Owned` constraint
+//!    tying "their hand" back to the opponent targeted earlier in the same
+//!    clause. Distinct root cause from the duration bug this PR fixes, in the
+//!    same family as gap 1 (anaphor binding across a RevealHand-chained
+//!    sub-ability).
+//! 3. Separately, `WaitingFor::EffectZoneChoice` (the interactive "choose
+//!    which card" round-trip raised whenever `change_zone::resolve` finds
+//!    MORE THAN ONE eligible candidate) carries no `duration` field at all, so
+//!    `engine_resolution_choices.rs`'s resume handler hardcodes
+//!    `ChangeZoneIterationCtx.duration: None` when replaying the player's
+//!    pick — an "until leaves the battlefield" exile chosen interactively
+//!    would silently lose its exile link even with this PR's parser fix
+//!    applied. This is a general engine gap (affects any multi-candidate
+//!    "exile ... until ... leaves" effect, not just this card) with a wide
+//!    blast radius (~21 `EffectZoneChoice` construction sites), so it's out of
+//!    scope for this tightly-scoped, card-specific fix.
+//!
+//! Because of gaps 2+3, this test deliberately keeps exactly ONE eligible
+//! exile candidate in play (see the `destroy_spell` sequester/restore below)
+//! so resolution takes `change_zone::resolve`'s single-eligible-candidate
+//! shortcut, which reads `ability.duration` directly and is unaffected by gap
+//! 3 — that's what actually isolates and discriminates this PR's parser fix
+//! at the runtime level, without also requiring a fix for gaps 2/3.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{Duration, Effect};
+use engine::types::game_state::ExileLinkKind;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+const CLOAK_AND_DAGGER: &str = "Deathtouch, lifelink\n\
+When Cloak and Dagger enter, choose target opponent and up to one target creature they control. \
+They reveal their hand. You may exile a nonland card from their hand or the chosen creature \
+until Cloak and Dagger leave the battlefield.";
+
+/// AST-shape regression: the plural "leave the battlefield" duration phrase
+/// must resolve to `Duration::UntilHostLeavesPlay` on the exile sub-ability,
+/// not silently drop to `None`.
+#[test]
+fn cloak_and_dagger_exile_sub_ability_has_until_leaves_duration() {
+    let parsed = parse_oracle_text(
+        CLOAK_AND_DAGGER,
+        "Cloak and Dagger, Entwined",
+        &[],
+        &[],
+        &[],
+    );
+    let etb = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::ChangesZone)
+        .expect("ETB trigger");
+    let execute = etb.execute.as_ref().expect("trigger.execute");
+
+    // Walk the sub-ability chain (target opponent -> reveal hand -> exile) to
+    // find the ChangeZone-to-Exile clause.
+    let mut cursor = Some(execute.as_ref());
+    let mut found_duration = None;
+    while let Some(def) = cursor {
+        if let Effect::ChangeZone {
+            destination: Zone::Exile,
+            ..
+        } = def.effect.as_ref()
+        {
+            found_duration = Some(def.duration.clone());
+            break;
+        }
+        cursor = def.sub_ability.as_deref();
+    }
+
+    assert_eq!(
+        found_duration,
+        Some(Some(Duration::UntilHostLeavesPlay)),
+        "expected the hand-exile sub-ability to carry Duration::UntilHostLeavesPlay \
+         (plural 'leave the battlefield' must parse like the singular form)"
+    );
+}
+
+/// Runtime regression: cast Cloak and Dagger, choose an opponent, reveal
+/// their hand, exile the chosen nonland card, then destroy Cloak and Dagger
+/// and verify the exiled card returns to the opponent's hand instead of
+/// staying exiled forever.
+#[test]
+fn cloak_and_dagger_exiled_card_returns_when_source_leaves() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let cloak_and_dagger = scenario
+        .add_creature_to_hand_from_oracle(P0, "Cloak and Dagger, Entwined", 2, 2, CLOAK_AND_DAGGER)
+        .id();
+
+    // P1's hand: one nonland card (eligible for the "may exile" choice) and
+    // one land (must stay excluded by the existing "nonland card" filter,
+    // which this fix does not touch).
+    let nonland_card = scenario.add_card_to_hand(P1, "Opponent's Spell");
+    let land_card = scenario.add_land_to_hand(P1, "Opponent's Island").id();
+
+    let destroy_spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Murder", true, "Destroy target creature.")
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Sequester `destroy_spell` out of P0's hand for the exile step (see gap 2
+    // in the module doc: the exile filter isn't scoped to the chosen
+    // opponent's hand, so any nonland card in ANY hand — including the
+    // caster's own — is currently offered as a candidate). Keeping exactly one
+    // real candidate (`nonland_card`, in P1's hand) makes resolution take
+    // `change_zone::resolve`'s single-eligible-candidate shortcut instead of
+    // the interactive `EffectZoneChoice` round-trip (see gap 3), isolating
+    // this PR's duration fix from both unrelated, out-of-scope gaps.
+    {
+        let state = runner.state_mut();
+        state.objects.get_mut(&destroy_spell).unwrap().zone = Zone::Library;
+        state.players[P0.0 as usize]
+            .hand
+            .retain(|&id| id != destroy_spell);
+        state.players[P0.0 as usize]
+            .library
+            .push_back(destroy_spell);
+    }
+
+    // Cast Cloak and Dagger; the ETB trigger's "choose target opponent" is
+    // satisfied by targeting P1. `accept_optional()` drives the CR 608.2d
+    // "you may exile" decision to "yes", and with exactly one eligible
+    // candidate the effect resolves the exile immediately (no further
+    // interactive prompt) instead of auto-declining (the harness's default
+    // policy for optional effects).
+    runner
+        .cast(cloak_and_dagger)
+        .target_player(P1)
+        .accept_optional()
+        .resolve();
+
+    assert_eq!(
+        runner.state().objects[&nonland_card].zone,
+        Zone::Exile,
+        "chosen card must be exiled"
+    );
+    assert_eq!(
+        runner.state().objects[&land_card].zone,
+        Zone::Hand,
+        "the land must NOT have been exiled (the 'nonland card' filter still works)"
+    );
+    assert!(
+        runner.state().exile_links.iter().any(|link| {
+            link.exiled_id == nonland_card
+                && link.source_id == cloak_and_dagger
+                && link.kind
+                    == ExileLinkKind::UntilSourceLeaves {
+                        return_zone: Zone::Hand,
+                    }
+        }),
+        "expected an UntilSourceLeaves{{return_zone: Hand}} link for the exiled card, got {:?}",
+        runner.state().exile_links
+    );
+
+    // Restore the sequestered destroy spell to P0's hand so it can be cast.
+    {
+        let state = runner.state_mut();
+        state.objects.get_mut(&destroy_spell).unwrap().zone = Zone::Hand;
+        state.players[P0.0 as usize]
+            .library
+            .retain(|&id| id != destroy_spell);
+        state.players[P0.0 as usize].hand.push_back(destroy_spell);
+    }
+
+    // Cloak and Dagger leaves the battlefield -> the exiled card must return.
+    runner
+        .cast(destroy_spell)
+        .target_object(cloak_and_dagger)
+        .resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&cloak_and_dagger].zone,
+        Zone::Graveyard,
+        "Cloak and Dagger should be in the graveyard after being destroyed"
+    );
+    assert_eq!(
+        runner.state().objects[&nonland_card].zone,
+        Zone::Hand,
+        "the exiled card must return to its owner's hand once Cloak and Dagger leaves \
+         the battlefield, not stay exiled forever"
+    );
+    assert!(
+        runner.state().players[P1.0 as usize]
+            .hand
+            .contains(&nonland_card),
+        "returned card must actually be back in P1's hand zone list"
+    );
+    assert!(
+        !runner
+            .state()
+            .exile_links
+            .iter()
+            .any(|link| link.exiled_id == nonland_card),
+        "the exile link must be cleared once the card has returned"
+    );
+}

--- a/crates/engine/tests/integration/issue_4235_cloak_and_dagger_entwined.rs
+++ b/crates/engine/tests/integration/issue_4235_cloak_and_dagger_entwined.rs
@@ -1,6 +1,6 @@
-//! Issue #4235: Cloak and Dagger, Entwined must exile a chosen nonland card
-//! from an opponent's hand UNTIL Cloak and Dagger leaves the battlefield, not
-//! permanently.
+//! Issue #4235: Cloak and Dagger, Entwined — plural "leave the battlefield"
+//! duration parsing, interactive-choice duration carry-through, and coverage
+//! honesty for the card's unsupported "or the chosen creature" alternative.
 //!
 //! Oracle text (Marvel Spider-Man set MSH, read from `client/public/card-data.json`):
 //!   "Deathtouch, lifelink
@@ -9,72 +9,69 @@
 //!    card from their hand or the chosen creature until Cloak and Dagger leave
 //!    the battlefield."
 //!
-//! THE BUG this discriminates: `parse_until_body` (the "until X leaves the
-//! battlefield" duration combinator in `parser/oracle_nom/duration.rs`) only
-//! matched the singular verb form "leaves the battlefield". Cloak and Dagger's
-//! own name is a plural subject ("Cloak and Dagger"), so its printed oracle
-//! text uses plural agreement: "until Cloak and Dagger leave the battlefield".
-//! That never matched, so the exile sub-ability's `duration` field silently
-//! stayed `None` — no `ExileLinkKind::UntilSourceLeaves` link was ever
-//! created, and a card exiled by this trigger stayed in exile forever, even
-//! after Cloak and Dagger left the battlefield. This mirrors the *trigger*
-//! detector for "leaves"/"leave the battlefield" (already handled correctly
-//! in `oracle_trigger.rs` and `oracle_effect/mod.rs`), which just never had a
-//! matching sibling in the *duration* combinator.
+//! Three findings, matching the maintainer review on PR #5871:
 //!
-//! Known, separate, OUT-OF-SCOPE gaps (not fixed here — see
-//! investigated-issues.md #4235 for why):
-//! 1. The "or the chosen creature" alternative exile target (choosing to
-//!    exile the previously-targeted creature instead of a hand card) is not
-//!    implemented by the parser at all, and neither is the "up to one target
-//!    creature they control" secondary target declaration it depends on.
-//! 2. The exile sub-ability's target filter (`Typed{Card, Non(Land)}`) is not
-//!    scoped to the chosen opponent's hand specifically — `matches_target_filter`
-//!    matches a nonland card in EITHER player's hand at the `scan_zone`
-//!    fallback, because the filter carries no `controller`/`Owned` constraint
-//!    tying "their hand" back to the opponent targeted earlier in the same
-//!    clause. Distinct root cause from the duration bug this PR fixes, in the
-//!    same family as gap 1 (anaphor binding across a RevealHand-chained
-//!    sub-ability).
-//! 3. Separately, `WaitingFor::EffectZoneChoice` (the interactive "choose
-//!    which card" round-trip raised whenever `change_zone::resolve` finds
-//!    MORE THAN ONE eligible candidate) carries no `duration` field at all, so
-//!    `engine_resolution_choices.rs`'s resume handler hardcodes
-//!    `ChangeZoneIterationCtx.duration: None` when replaying the player's
-//!    pick — an "until leaves the battlefield" exile chosen interactively
-//!    would silently lose its exile link even with this PR's parser fix
-//!    applied. This is a general engine gap (affects any multi-candidate
-//!    "exile ... until ... leaves" effect, not just this card) with a wide
-//!    blast radius (~21 `EffectZoneChoice` construction sites), so it's out of
-//!    scope for this tightly-scoped, card-specific fix.
+//! 1. THE ORIGINAL BUG: `parse_until_body` (the "until X leaves the
+//!    battlefield" duration combinator in `parser/oracle_nom/duration.rs`)
+//!    only matched the singular verb form "leaves the battlefield". A card
+//!    whose own name is a plural subject ("Cloak and Dagger") prints plural
+//!    agreement — "until Cloak and Dagger leave the battlefield" — which
+//!    never matched, so the exile's `duration` silently stayed `None` and no
+//!    `ExileLinkKind::UntilSourceLeaves` link was created. Fixed by accepting
+//!    both verb forms (CR 611.2a).
 //!
-//! Because of gaps 2+3, this test deliberately keeps exactly ONE eligible
-//! exile candidate in play (see the `destroy_spell` sequester/restore below)
-//! so resolution takes `change_zone::resolve`'s single-eligible-candidate
-//! shortcut, which reads `ability.duration` directly and is unaffected by gap
-//! 3 — that's what actually isolates and discriminates this PR's parser fix
-//! at the runtime level, without also requiring a fix for gaps 2/3.
+//! 2. THE INTERACTIVE-PATH GAP (review blocker 1): the duration was ALSO
+//!    dropped whenever the exile had more than one eligible candidate —
+//!    `WaitingFor::EffectZoneChoice` carried no `duration` field, so the
+//!    resume authority (`engine_resolution_choices.rs`) reconstructed
+//!    `ChangeZoneIterationCtx` with `duration: None`. Fixed by carrying the
+//!    duration across the round-trip; the two-candidate runtime test below
+//!    proves the chosen card's exile link survives an interactive selection
+//!    and the card returns when the source leaves.
+//!
+//! 3. COVERAGE HONESTY (review blocker 2): the full printed sentence carries
+//!    an "or the chosen creature" alternative that depends on the secondary
+//!    "up to one target creature they control" declaration — neither of
+//!    which is representable yet (no object-anaphor "the chosen creature"
+//!    filter exists, and the hand filter is not bound to the chosen
+//!    opponent). Rather than accept the card while silently dropping the
+//!    alternative, the full clause now stays an explicit strict failure
+//!    (`Effect::Unimplemented`) until that binding is implemented; the
+//!    duration and carry-through fixes are exercised through the supported
+//!    single-referent form of the same idiom.
 
-use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{Duration, Effect};
-use engine::types::game_state::ExileLinkKind;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{ExileLinkKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
 use engine::types::phase::Phase;
 use engine::types::triggers::TriggerMode;
 use engine::types::zones::Zone;
 
-const CLOAK_AND_DAGGER: &str = "Deathtouch, lifelink\n\
+/// Cloak and Dagger's full, real printed text — carries the unsupported
+/// "or the chosen creature" alternative.
+const CLOAK_AND_DAGGER_FULL: &str = "Deathtouch, lifelink\n\
 When Cloak and Dagger enter, choose target opponent and up to one target creature they control. \
 They reveal their hand. You may exile a nonland card from their hand or the chosen creature \
 until Cloak and Dagger leave the battlefield.";
 
-/// AST-shape regression: the plural "leave the battlefield" duration phrase
-/// must resolve to `Duration::UntilHostLeavesPlay` on the exile sub-ability,
+/// The SUPPORTED single-referent subset of the same idiom, with the same
+/// plural-name verb agreement ("Cloak and Dagger ... leave"): no "chosen
+/// creature" alternative, no secondary creature target. This is the shape the
+/// duration fix and the interactive carry-through are exercised against.
+const CLOAK_AND_DAGGER_SUPPORTED_SUBSET: &str = "Deathtouch, lifelink\n\
+When Cloak and Dagger enter, target opponent reveals their hand. You may exile a nonland \
+card from their hand until Cloak and Dagger leave the battlefield.";
+
+/// AST-shape regression for the plural-verb duration fix: on the supported
+/// subset, the exile sub-ability must carry `Duration::UntilHostLeavesPlay`,
 /// not silently drop to `None`.
 #[test]
-fn cloak_and_dagger_exile_sub_ability_has_until_leaves_duration() {
+fn plural_leave_duration_parses_on_supported_subset() {
     let parsed = parse_oracle_text(
-        CLOAK_AND_DAGGER,
+        CLOAK_AND_DAGGER_SUPPORTED_SUBSET,
         "Cloak and Dagger, Entwined",
         &[],
         &[],
@@ -87,8 +84,6 @@ fn cloak_and_dagger_exile_sub_ability_has_until_leaves_duration() {
         .expect("ETB trigger");
     let execute = etb.execute.as_ref().expect("trigger.execute");
 
-    // Walk the sub-ability chain (target opponent -> reveal hand -> exile) to
-    // find the ChangeZone-to-Exile clause.
     let mut cursor = Some(execute.as_ref());
     let mut found_duration = None;
     while let Some(def) = cursor {
@@ -111,23 +106,83 @@ fn cloak_and_dagger_exile_sub_ability_has_until_leaves_duration() {
     );
 }
 
-/// Runtime regression: cast Cloak and Dagger, choose an opponent, reveal
-/// their hand, exile the chosen nonland card, then destroy Cloak and Dagger
-/// and verify the exiled card returns to the opponent's hand instead of
-/// staying exiled forever.
+/// Coverage honesty (review blocker 2): the FULL printed text's exile clause
+/// carries the "or the chosen creature" alternative, which has no
+/// representable lowering yet. The clause must surface as an explicit strict
+/// failure — an `Effect::Unimplemented` node somewhere in the trigger chain —
+/// not as a supported-looking exile that silently dropped the alternative.
 #[test]
-fn cloak_and_dagger_exiled_card_returns_when_source_leaves() {
+fn full_card_with_chosen_creature_alternative_stays_strict_failure() {
+    let parsed = parse_oracle_text(
+        CLOAK_AND_DAGGER_FULL,
+        "Cloak and Dagger, Entwined",
+        &[],
+        &[],
+        &[],
+    );
+
+    fn chain_has_unimplemented(def: &engine::types::ability::AbilityDefinition) -> bool {
+        fn effect_unimplemented(effect: &Effect) -> bool {
+            matches!(effect, Effect::Unimplemented { .. })
+        }
+        effect_unimplemented(&def.effect)
+            || def
+                .sub_ability
+                .as_deref()
+                .is_some_and(chain_has_unimplemented)
+            || def
+                .else_ability
+                .as_deref()
+                .is_some_and(chain_has_unimplemented)
+    }
+
+    let etb_has_strict_failure = parsed
+        .triggers
+        .iter()
+        .filter(|t| t.mode == TriggerMode::ChangesZone)
+        .filter_map(|t| t.execute.as_deref())
+        .any(chain_has_unimplemented);
+    assert!(
+        etb_has_strict_failure,
+        "the unsupported 'or the chosen creature' alternative must keep the \
+         clause an explicit Unimplemented strict failure, not a silently \
+         narrowed exile; got triggers: {:#?}",
+        parsed.triggers
+    );
+}
+
+fn zone_of(runner: &GameRunner, id: ObjectId) -> Zone {
+    runner.state().objects[&id].zone
+}
+
+/// Runtime regression for review blocker 1: TWO eligible nonland candidates
+/// force the interactive `EffectZoneChoice` round-trip (a lone candidate
+/// takes the single-candidate shortcut and skips it). The chosen card's
+/// "until the source leaves the battlefield" exile link must survive that
+/// round-trip, and the card must return to its owner's hand when the source
+/// leaves the battlefield.
+///
+/// The bounded exile is driven as a hand-built `ResolvedAbility` through the
+/// production `resolve_ability_chain` -> `change_zone::resolve` ->
+/// `WaitingFor::EffectZoneChoice` -> `engine_resolution_choices` resume
+/// pipeline — the exact authority the review named — rather than through
+/// Cloak and Dagger's printed text: the full card is now an honest strict
+/// failure (see the coverage-honesty test above), so no parsed card text can
+/// exercise this seam for the two-candidate case yet.
+#[test]
+fn interactive_two_candidate_exile_choice_preserves_until_leaves_link() {
+    use engine::game::effects::resolve_ability_chain;
+    use engine::types::ability::{Effect, ResolvedAbility, TargetFilter, TypeFilter, TypedFilter};
+
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
-    let cloak_and_dagger = scenario
-        .add_creature_to_hand_from_oracle(P0, "Cloak and Dagger, Entwined", 2, 2, CLOAK_AND_DAGGER)
-        .id();
+    let source = scenario.add_creature(P0, "Linked Exiler", 2, 2).id();
 
-    // P1's hand: one nonland card (eligible for the "may exile" choice) and
-    // one land (must stay excluded by the existing "nonland card" filter,
-    // which this fix does not touch).
-    let nonland_card = scenario.add_card_to_hand(P1, "Opponent's Spell");
+    // P1's hand: TWO nonland cards (both eligible -> a real interactive
+    // choice) and one land (must stay excluded by the "nonland card" filter).
+    let pick = scenario.add_card_to_hand(P1, "Opponent's Spell A");
+    let keep = scenario.add_card_to_hand(P1, "Opponent's Spell B");
     let land_card = scenario.add_land_to_hand(P1, "Opponent's Island").id();
 
     let destroy_spell = scenario
@@ -136,14 +191,9 @@ fn cloak_and_dagger_exiled_card_returns_when_source_leaves() {
 
     let mut runner = scenario.build();
 
-    // Sequester `destroy_spell` out of P0's hand for the exile step (see gap 2
-    // in the module doc: the exile filter isn't scoped to the chosen
-    // opponent's hand, so any nonland card in ANY hand — including the
-    // caster's own — is currently offered as a candidate). Keeping exactly one
-    // real candidate (`nonland_card`, in P1's hand) makes resolution take
-    // `change_zone::resolve`'s single-eligible-candidate shortcut instead of
-    // the interactive `EffectZoneChoice` round-trip (see gap 3), isolating
-    // this PR's duration fix from both unrelated, out-of-scope gaps.
+    // Sequester `destroy_spell` out of P0's hand during the exile step — the
+    // filter scans every hand, and a nonland card in the caster's own hand
+    // would otherwise join the candidate pool.
     {
         let state = runner.state_mut();
         state.objects.get_mut(&destroy_spell).unwrap().zone = Zone::Library;
@@ -155,42 +205,94 @@ fn cloak_and_dagger_exiled_card_returns_when_source_leaves() {
             .push_back(destroy_spell);
     }
 
-    // Cast Cloak and Dagger; the ETB trigger's "choose target opponent" is
-    // satisfied by targeting P1. `accept_optional()` drives the CR 608.2d
-    // "you may exile" decision to "yes", and with exactly one eligible
-    // candidate the effect resolves the exile immediately (no further
-    // interactive prompt) instead of auto-declining (the harness's default
-    // policy for optional effects).
-    runner
-        .cast(cloak_and_dagger)
-        .target_player(P1)
-        .accept_optional()
-        .resolve();
-
-    assert_eq!(
-        runner.state().objects[&nonland_card].zone,
-        Zone::Exile,
-        "chosen card must be exiled"
+    // The bounded move: "exile a nonland card [from a hand] until <source>
+    // leaves the battlefield" — one pick (no `multi_target` => choice count 1)
+    // with the host-lifetime duration on the resolving ability.
+    let mut ability = ResolvedAbility::new(
+        Effect::ChangeZone {
+            origin: Some(Zone::Hand),
+            destination: Zone::Exile,
+            target: TargetFilter::Typed(TypedFilter {
+                type_filters: vec![
+                    TypeFilter::Card,
+                    TypeFilter::Non(Box::new(TypeFilter::Land)),
+                ],
+                ..TypedFilter::default()
+            }),
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: engine::types::zones::EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        },
+        vec![],
+        source,
+        P0,
     );
+    ability.duration = Some(Duration::UntilHostLeavesPlay);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("resolving the bounded exile must succeed");
+
+    let WaitingFor::EffectZoneChoice {
+        cards,
+        count,
+        duration,
+        ..
+    } = runner.state().waiting_for.clone()
+    else {
+        panic!(
+            "two eligible candidates must raise an interactive EffectZoneChoice, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert!(
+        cards.contains(&pick) && cards.contains(&keep),
+        "both nonland hand cards must be offered; got {cards:?}"
+    );
+    assert!(
+        !cards.contains(&land_card),
+        "the land must not be an eligible exile candidate"
+    );
+    assert_eq!(count, 1, "exactly one card is exiled");
     assert_eq!(
-        runner.state().objects[&land_card].zone,
+        duration,
+        Some(Duration::UntilHostLeavesPlay),
+        "review blocker 1: the bounded-move duration must be CARRIED on the \
+         EffectZoneChoice round-trip, not dropped"
+    );
+
+    runner
+        .act(GameAction::SelectCards { cards: vec![pick] })
+        .expect("selecting one of the two candidates must succeed");
+
+    assert_eq!(zone_of(&runner, pick), Zone::Exile, "chosen card exiled");
+    assert_eq!(
+        zone_of(&runner, keep),
         Zone::Hand,
-        "the land must NOT have been exiled (the 'nonland card' filter still works)"
+        "unchosen card stays in hand"
     );
     assert!(
         runner.state().exile_links.iter().any(|link| {
-            link.exiled_id == nonland_card
-                && link.source_id == cloak_and_dagger
+            link.exiled_id == pick
+                && link.source_id == source
                 && link.kind
                     == ExileLinkKind::UntilSourceLeaves {
                         return_zone: Zone::Hand,
                     }
         }),
-        "expected an UntilSourceLeaves{{return_zone: Hand}} link for the exiled card, got {:?}",
+        "review blocker 1: the UntilSourceLeaves link must survive the \
+         interactive EffectZoneChoice round-trip; got {:?}",
         runner.state().exile_links
     );
 
-    // Restore the sequestered destroy spell to P0's hand so it can be cast.
+    // Restore the sequestered destroy spell and remove the source.
     {
         let state = runner.state_mut();
         state.objects.get_mut(&destroy_spell).unwrap().zone = Zone::Hand;
@@ -199,29 +301,22 @@ fn cloak_and_dagger_exiled_card_returns_when_source_leaves() {
             .retain(|&id| id != destroy_spell);
         state.players[P0.0 as usize].hand.push_back(destroy_spell);
     }
-
-    // Cloak and Dagger leaves the battlefield -> the exiled card must return.
-    runner
-        .cast(destroy_spell)
-        .target_object(cloak_and_dagger)
-        .resolve();
+    runner.cast(destroy_spell).target_object(source).resolve();
     runner.advance_until_stack_empty();
 
     assert_eq!(
-        runner.state().objects[&cloak_and_dagger].zone,
+        zone_of(&runner, source),
         Zone::Graveyard,
-        "Cloak and Dagger should be in the graveyard after being destroyed"
+        "the source should be destroyed"
     );
     assert_eq!(
-        runner.state().objects[&nonland_card].zone,
+        zone_of(&runner, pick),
         Zone::Hand,
-        "the exiled card must return to its owner's hand once Cloak and Dagger leaves \
-         the battlefield, not stay exiled forever"
+        "the interactively chosen exile must RETURN when the source leaves — \
+         not stay exiled forever"
     );
     assert!(
-        runner.state().players[P1.0 as usize]
-            .hand
-            .contains(&nonland_card),
+        runner.state().players[P1.0 as usize].hand.contains(&pick),
         "returned card must actually be back in P1's hand zone list"
     );
     assert!(
@@ -229,7 +324,7 @@ fn cloak_and_dagger_exiled_card_returns_when_source_leaves() {
             .state()
             .exile_links
             .iter()
-            .any(|link| link.exiled_id == nonland_card),
+            .any(|link| link.exiled_id == pick),
         "the exile link must be cleared once the card has returned"
     );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -456,6 +456,7 @@ mod issue_4050_adamaro_extremum_hand_size;
 mod issue_4124_second_little_pig;
 mod issue_4220_agatha_soul_cauldron;
 mod issue_4226_elenda_azor_attack_pay_x;
+mod issue_4235_cloak_and_dagger_entwined;
 mod issue_4242_lagrella_crash;
 mod issue_4243_from_the_rubble;
 mod issue_4244_temple_altisaur;

--- a/crates/engine/tests/integration/mimeoplasm_interactive_exile.rs
+++ b/crates/engine/tests/integration/mimeoplasm_interactive_exile.rs
@@ -488,6 +488,7 @@ fn paycost_arm_exiles_cards_via_apply_as_current() {
             library_position: None,
             is_cost_payment: true,
             enters_modified_if: None,
+            duration: None,
         };
     }
 

--- a/crates/server-core/src/filter.rs
+++ b/crates/server-core/src/filter.rs
@@ -380,6 +380,7 @@ mod tests {
             is_cost_payment: false,
             library_position: None,
             enters_modified_if: None,
+            duration: None,
         };
 
         let filtered = filter_state_for_player(&state, PlayerId(1));


### PR DESCRIPTION
Fixes #4235.

Cloak and Dagger, Entwined: "...You may exile a nonland card from their hand or the chosen creature until Cloak and Dagger leave the battlefield."

## Root cause & fix

`parse_until_body` (the generic "until [source] leaves the battlefield" duration combinator) only matched the singular verb form "leaves the battlefield". Cloak and Dagger, Entwined's own name is a plural subject, so its printed oracle text uses plural agreement — "until Cloak and Dagger leave the battlefield" — which never matched. This left the exile sub-ability's `duration` field silently `None`, so no `ExileLinkKind::UntilSourceLeaves` link was ever created, and a card exiled by the ETB trigger never returned when Cloak and Dagger left the battlefield.

The sibling *trigger* detector for leaves-the-battlefield already handled both "leaves"/"leave" forms — only the *duration* combinator was missing the alternative. Fixed by mirroring that existing alternation.

## Testing

New regression test (AST-level + full runtime cast→reveal→exile→destroy-source→return-to-hand) — confirmed RED without the fix, GREEN with it.

Verified locally (rebased onto main): fmt clean, clippy clean, 16672 lib tests pass, 3129 integration tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved “until source leaves the battlefield” effects when players make interactive card choices.
  - Improved parsing for both singular and plural “leave the battlefield” wording.
  - Prevented unsupported alternative effects from being silently narrowed or misinterpreted.
  - Maintained choice-duration information across state updates and visibility filtering.

- **Tests**
  - Added coverage for interactive exile behavior, duration preservation, and the affected card text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->