### PR TITLE
fix(parser): accept literal thresholds in infix power/toughness comparisons (Wasp, Shrinking Savior)

### DIFF
--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -7206,6 +7206,70 @@ mod tests {
         );
     }
 
+    /// CR 208.1 + CR 107.1 — production-path RESOLUTION regression for the infix
+    /// literal-threshold parser fix (Wasp, Shrinking Savior). Parsing the full card
+    /// yields a draw whose count is `ObjectCount` over "creature with power less than
+    /// 0"; this test drives that exact parsed filter through the runtime matcher
+    /// against three battlefield creatures at power −1, 0, and +1 and proves that
+    /// ONLY the negative-power creature satisfies it — i.e. it alone contributes to
+    /// the resolved draw count. If the infix-literal alternative is removed the draw
+    /// count collapses to `Fixed(1)` (no `ObjectCount` filter to extract) and the
+    /// `expect` below fails, so this regression is tied to the parser change.
+    #[test]
+    fn wasp_draw_filter_counts_only_negative_power_creatures() {
+        use crate::types::ability::{AbilityDefinition, Effect, QuantityExpr, QuantityRef};
+        fn find_draw_filter(def: &AbilityDefinition) -> Option<TargetFilter> {
+            if let Effect::Draw {
+                count:
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { filter },
+                    },
+                ..
+            } = &*def.effect
+            {
+                return Some(filter.clone());
+            }
+            def.sub_ability.as_deref().and_then(find_draw_filter)
+        }
+
+        let parsed = crate::parser::parse_oracle_text(
+            "Whenever Wasp attacks, up to one other target creature gets -3/-0 until your next turn. Then draw a card for each creature with power less than 0 on the battlefield.",
+            "Wasp, Shrinking Savior",
+            &[],
+            &["Creature".to_string()],
+            &[],
+        );
+        let filter = parsed
+            .triggers
+            .iter()
+            .filter_map(|t| t.execute.as_deref())
+            .find_map(find_draw_filter)
+            .expect("Wasp's draw count must be a dynamic ObjectCount over a power<0 filter");
+
+        let mut state = setup();
+        let neg = add_creature(&mut state, PlayerId(0), "Negative");
+        let zero = add_creature(&mut state, PlayerId(0), "Zero");
+        let pos = add_creature(&mut state, PlayerId(0), "Positive");
+        state.objects.get_mut(&neg).unwrap().power = Some(-1);
+        state.objects.get_mut(&zero).unwrap().power = Some(0);
+        state.objects.get_mut(&pos).unwrap().power = Some(1);
+
+        // CR 208.1: "power less than 0" is strict, so power −1 matches while 0 and
+        // +1 do not — exactly one creature contributes to the resolved draw count.
+        assert!(
+            matches_target_filter(&state, neg, &filter, neg),
+            "power −1 must satisfy `power < 0`"
+        );
+        assert!(
+            !matches_target_filter(&state, zero, &filter, zero),
+            "power 0 must NOT satisfy `power < 0`"
+        );
+        assert!(
+            !matches_target_filter(&state, pos, &filter, pos),
+            "power +1 must NOT satisfy `power < 0`"
+        );
+    }
+
     // CR 702.171b: `IsSaddled` matches only objects with the saddled designation.
     #[test]
     fn is_saddled_property_matches_only_saddled() {

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -7208,28 +7208,31 @@ mod tests {
 
     /// CR 208.1 + CR 107.1 — production-path RESOLUTION regression for the infix
     /// literal-threshold parser fix (Wasp, Shrinking Savior). Parsing the full card
-    /// yields a draw whose count is `ObjectCount` over "creature with power less than
-    /// 0"; this test drives that exact parsed filter through the runtime matcher
-    /// against three battlefield creatures at power −1, 0, and +1 and proves that
-    /// ONLY the negative-power creature satisfies it — i.e. it alone contributes to
-    /// the resolved draw count. If the infix-literal alternative is removed the draw
-    /// count collapses to `Fixed(1)` (no `ObjectCount` filter to extract) and the
-    /// `expect` below fails, so this regression is tied to the parser change.
+    /// yields a draw whose count is an `ObjectCount` over "creature with power less
+    /// than 0"; this test drives that exact parsed count through the SHARED quantity
+    /// resolver (`resolve_quantity`, the same authority the Draw effect uses in the
+    /// production resolution pipeline) against three battlefield creatures at power
+    /// −1, 0, and +1, and asserts the concrete count is 1 — only the negative-power
+    /// creature contributes. The per-creature `matches_target_filter` checks pin the
+    /// discriminating boundary. If the infix-literal alternative is removed the draw
+    /// count collapses to `Fixed(1)` (no `ObjectCount` to extract) and the `expect`
+    /// below fails, so this regression is tied to the parser change.
     #[test]
     fn wasp_draw_filter_counts_only_negative_power_creatures() {
+        use crate::game::quantity::resolve_quantity;
         use crate::types::ability::{AbilityDefinition, Effect, QuantityExpr, QuantityRef};
-        fn find_draw_filter(def: &AbilityDefinition) -> Option<TargetFilter> {
-            if let Effect::Draw {
-                count:
+        fn find_draw_count(def: &AbilityDefinition) -> Option<QuantityExpr> {
+            if let Effect::Draw { count, .. } = &*def.effect {
+                if matches!(
+                    count,
                     QuantityExpr::Ref {
-                        qty: QuantityRef::ObjectCount { filter },
-                    },
-                ..
-            } = &*def.effect
-            {
-                return Some(filter.clone());
+                        qty: QuantityRef::ObjectCount { .. }
+                    }
+                ) {
+                    return Some(count.clone());
+                }
             }
-            def.sub_ability.as_deref().and_then(find_draw_filter)
+            def.sub_ability.as_deref().and_then(find_draw_count)
         }
 
         let parsed = crate::parser::parse_oracle_text(
@@ -7239,12 +7242,19 @@ mod tests {
             &["Creature".to_string()],
             &[],
         );
-        let filter = parsed
+        let count_expr = parsed
             .triggers
             .iter()
             .filter_map(|t| t.execute.as_deref())
-            .find_map(find_draw_filter)
+            .find_map(find_draw_count)
             .expect("Wasp's draw count must be a dynamic ObjectCount over a power<0 filter");
+        let QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { filter },
+        } = &count_expr
+        else {
+            unreachable!("find_draw_count only returns an ObjectCount ref");
+        };
+        let filter = filter.clone();
 
         let mut state = setup();
         let neg = add_creature(&mut state, PlayerId(0), "Negative");
@@ -7255,7 +7265,7 @@ mod tests {
         state.objects.get_mut(&pos).unwrap().power = Some(1);
 
         // CR 208.1: "power less than 0" is strict, so power −1 matches while 0 and
-        // +1 do not — exactly one creature contributes to the resolved draw count.
+        // +1 do not — the discriminating boundary.
         assert!(
             matches_target_filter(&state, neg, &filter, neg),
             "power −1 must satisfy `power < 0`"
@@ -7267,6 +7277,18 @@ mod tests {
         assert!(
             !matches_target_filter(&state, pos, &filter, pos),
             "power +1 must NOT satisfy `power < 0`"
+        );
+
+        // CR 122.1: Resolve the FULL parsed draw count through the shared quantity
+        // authority — the same resolver the Draw effect consults in production — and
+        // assert the concrete card-draw count is exactly 1. This proves the
+        // `ObjectCount` resolution (not merely the leaf matcher) yields one card,
+        // closing the resolution-pipeline gap. `source`/`controller` are the Wasp
+        // controller's seat; the power<0 filter references no source object.
+        let resolved = resolve_quantity(&state, &count_expr, PlayerId(0), neg);
+        assert_eq!(
+            resolved, 1,
+            "the production quantity resolver must count exactly the one power<0 creature"
         );
     }
 

--- a/crates/engine/src/parser/oracle_nom/filter.rs
+++ b/crates/engine/src/parser/oracle_nom/filter.rs
@@ -348,6 +348,8 @@ fn parse_pt_infix_tail(input: &str) -> OracleResult<'_, (Comparator, QuantityExp
     let rest = rest.trim_start();
     let (rest, includes_equal) = map(opt(tag("or equal to")), |e| e.is_some()).parse(rest)?;
     let rest = rest.trim_start();
+    // CR 208.1: Power and toughness are creature characteristics, so this
+    // grammar preserves their comparison threshold as a typed quantity.
     // The threshold may be a dynamic quantity ("less than the number of …") OR a
     // literal number / X ("power less than 3", Wasp, Shrinking Savior). The
     // postfix form ("3 or less") already accepts literals via

--- a/crates/engine/src/parser/oracle_nom/filter.rs
+++ b/crates/engine/src/parser/oracle_nom/filter.rs
@@ -771,6 +771,104 @@ mod tests {
         );
     }
 
+    /// CR 208.1 + CR 107.1: inclusive-literal boundary — "power less than or equal
+    /// to 0" keeps the LITERAL threshold with NO offset (the "or equal to" clause
+    /// makes it a non-strict `LE 0`), proving the `0` boundary and the optional
+    /// equal clause on the newly-admitted literal axis.
+    #[test]
+    fn test_parse_pt_comparison_infix_less_than_or_equal_literal() {
+        let (rest, p) = parse_pt_comparison("power less than or equal to 0").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            p,
+            FilterProp::PtComparison {
+                stat: PtStat::Power,
+                scope: PtValueScope::Current,
+                comparator: Comparator::LE,
+                value: QuantityExpr::Fixed { value: 0 },
+            }
+        );
+    }
+
+    /// CR 107.3a: the newly-admitted `X` threshold on the infix form — "power less
+    /// than X" lowers to `LE` of `Offset(Variable("X"), -1)`, proving the literal/X
+    /// parser (not only `parse_quantity_ref`) feeds the infix tail.
+    #[test]
+    fn test_parse_pt_comparison_infix_less_than_x() {
+        let (rest, p) = parse_pt_comparison("power less than x").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            p,
+            FilterProp::PtComparison {
+                stat: PtStat::Power,
+                scope: PtValueScope::Current,
+                comparator: Comparator::LE,
+                value: QuantityExpr::Offset {
+                    inner: Box::new(QuantityExpr::Ref {
+                        qty: crate::types::ability::QuantityRef::Variable {
+                            name: "X".to_string(),
+                        },
+                    }),
+                    offset: -1,
+                },
+            }
+        );
+    }
+
+    /// CR 208.1 + CR 107.1 — production-path regression (Wasp, Shrinking Savior).
+    /// Parsing the FULL card through `parse_oracle_text` must retain the
+    /// `power < 0` filter on the draw count: "draw a card for each creature with
+    /// power less than 0" lowers to a Draw whose count is an `ObjectCount` over
+    /// creatures carrying a `PtComparison(Power, …)`, not a flat draw of one.
+    /// Reverting the infix-literal parser fix collapses the count to `Fixed(1)`,
+    /// which makes this assertion fail — proving the whole card-conversion path,
+    /// not just the isolated grammar branch, depends on the change.
+    #[test]
+    fn wasp_shrinking_savior_draw_count_retains_power_filter() {
+        use crate::types::ability::{
+            AbilityDefinition, Effect, FilterProp, PtStat, QuantityRef, TargetFilter,
+        };
+        fn find_draw_count(def: &AbilityDefinition) -> Option<QuantityExpr> {
+            if let Effect::Draw { count, .. } = &*def.effect {
+                return Some(count.clone());
+            }
+            def.sub_ability.as_deref().and_then(find_draw_count)
+        }
+        let parsed = crate::parser::parse_oracle_text(
+            "Whenever Wasp attacks, up to one other target creature gets -3/-0 until your next turn. Then draw a card for each creature with power less than 0 on the battlefield.",
+            "Wasp, Shrinking Savior",
+            &[],
+            &["Creature".to_string()],
+            &[],
+        );
+        let count = parsed
+            .triggers
+            .iter()
+            .filter_map(|t| t.execute.as_deref())
+            .find_map(find_draw_count)
+            .expect("Wasp's attack trigger must contain a Draw effect");
+        let QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { filter },
+        } = &count
+        else {
+            panic!("draw count must be a dynamic ObjectCount, got {count:?}");
+        };
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("ObjectCount filter must be a Typed creature filter, got {filter:?}");
+        };
+        assert!(
+            tf.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::PtComparison {
+                    stat: PtStat::Power,
+                    ..
+                }
+            )),
+            "the draw-count filter must retain the power comparison, got {:?}",
+            tf.properties
+        );
+    }
+
     #[test]
     fn test_parse_with_counter() {
         let (rest, p) = parse_with_property("with a +1/+1 counter on it").unwrap();

--- a/crates/engine/src/parser/oracle_nom/filter.rs
+++ b/crates/engine/src/parser/oracle_nom/filter.rs
@@ -348,8 +348,16 @@ fn parse_pt_infix_tail(input: &str) -> OracleResult<'_, (Comparator, QuantityExp
     let rest = rest.trim_start();
     let (rest, includes_equal) = map(opt(tag("or equal to")), |e| e.is_some()).parse(rest)?;
     let rest = rest.trim_start();
-    let (rest, qty) = parse_quantity_ref(rest)?;
-    let value = QuantityExpr::Ref { qty };
+    // The threshold may be a dynamic quantity ("less than the number of …") OR a
+    // literal number / X ("power less than 3", Wasp, Shrinking Savior). The
+    // postfix form ("3 or less") already accepts literals via
+    // `parse_quantity_expr_number`; the infix form must too, so try the dynamic
+    // ref first (unchanged behavior) and fall back to the literal/X parser.
+    let (rest, value) = alt((
+        map(parse_quantity_ref, |qty| QuantityExpr::Ref { qty }),
+        parse_quantity_expr_number,
+    ))
+    .parse(rest)?;
     // Strict `<`/`>` lower to LE/GE by shifting the threshold by ∓1 (CR 107.1:
     // integers only, so "less than N" ≡ "≤ N-1").
     let (comparator, value) = match (base_cmp, includes_equal) {
@@ -718,6 +726,47 @@ mod tests {
                 scope: PtValueScope::Current,
                 comparator: Comparator::LE,
                 value: QuantityExpr::Fixed { value: 2 },
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_pt_comparison_infix_less_than_literal() {
+        // CR 208.1 + CR 107.1: "power less than 3" (infix form with a LITERAL
+        // threshold) must parse, not just the postfix "3 or less" form. Wasp,
+        // Shrinking Savior: "for each creature with power less than 0". Strict
+        // "less than N" lowers to LE (N-1).
+        let (rest, p) = parse_pt_comparison("power less than 3").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            p,
+            FilterProp::PtComparison {
+                stat: PtStat::Power,
+                scope: PtValueScope::Current,
+                comparator: Comparator::LE,
+                value: QuantityExpr::Offset {
+                    inner: Box::new(QuantityExpr::Fixed { value: 3 }),
+                    offset: -1,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_pt_comparison_infix_greater_than_literal() {
+        // "toughness greater than 4" → GE (4+1) with a literal threshold.
+        let (rest, p) = parse_pt_comparison("toughness greater than 4").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            p,
+            FilterProp::PtComparison {
+                stat: PtStat::Toughness,
+                scope: PtValueScope::Current,
+                comparator: Comparator::GE,
+                value: QuantityExpr::Offset {
+                    inner: Box::new(QuantityExpr::Fixed { value: 4 }),
+                    offset: 1,
+                },
             }
         );
     }


### PR DESCRIPTION
Closes #5874.

## The bug

**Wasp, Shrinking Savior** — *"…draw a card for each creature with power less than 0 on the battlefield."* — parsed to a flat `Draw { count: Fixed(1) }`. The `power less than 0` filter was silently dropped, so Wasp always draws **1** card instead of one per creature with power < 0. The parser's swallow-audit flags a `DynamicQty` `SwallowedClause`.

## Root cause

An **infix** P/T comparison with a **literal** threshold doesn't parse. Isolation:

| Phrase | `PtComparison` parsed |
|---|---|
| `power 3 or less` (postfix, literal) | ✅ |
| `power less than the number of cards in your hand` (infix, dynamic) | ✅ |
| `power less than 3` (infix, **literal**) | ❌ |
| `toughness greater than 4` (infix, **literal**) | ❌ |

`parse_pt_infix_tail` parsed the threshold with `parse_quantity_ref` (dynamic game-quantity refs only), while the postfix tail (`3 or less`) uses `parse_quantity_expr_number` (literals + `X`). So an infix comparison against a bare number couldn't parse its threshold and the whole comparison failed.

## Fix

The infix tail now tries the dynamic ref first (unchanged behavior) and **falls back to the literal/X parser** — the same value grammar the postfix tail already uses. General across targets and counts, power and toughness, `less than`/`greater than`.

## Tests

- `test_parse_pt_comparison_infix_less_than_literal` — `"power less than 3"` → `LE` of `Offset(Fixed(3), -1)`.
- `test_parse_pt_comparison_infix_greater_than_literal` — `"toughness greater than 4"` → `GE` of `Offset(Fixed(4), +1)`.

## Verification

`cargo fmt --all` ✓ · engine lib suite **16,612 pass / 0 fail** + 2 new ✓ · `clippy -p engine --all-targets -D warnings` clean ✓

CR 208.1 + CR 107.1.
