### PR TITLE
fix(parser): split imperative sibling sentence after a token's quoted ability (Alien Invasion)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1444,15 +1444,30 @@ fn quote_closes_sentence_before_sequence(current: &str, remainder: &str) -> bool
 /// `quote_closes_sentence_before_sequence`); only a bare imperative verb marks a
 /// genuine sibling effect here.
 fn starts_imperative_action_continuation(remainder_lower: &str) -> bool {
-    let first_word = remainder_lower.split_whitespace().next().unwrap_or("");
-    // Anaphoric-subject / determiner starters — keep attached (existing behavior).
-    if matches!(
-        first_word,
-        "it" | "its" | "that" | "this" | "those" | "they" | "you" | "all" | "each" | "the"
-    ) {
-        return false;
-    }
-    starts_clause_text_lower(remainder_lower)
+    !starts_anaphoric_subject(remainder_lower) && starts_clause_text_lower(remainder_lower)
+}
+
+/// True iff `remainder_lower` begins with a pronoun/determiner subject word — the
+/// anaphoric continuations ("It becomes …", "The token is goaded", "That creature
+/// gains …") that must stay attached to a granted quote rather than split as a
+/// sibling imperative. Each starter carries a trailing space so only a complete
+/// word matches (e.g. "it " does not fire on "item"), mirroring the whitespace
+/// convention of `starts_clause_text_lower`'s verb tags.
+fn starts_anaphoric_subject(remainder_lower: &str) -> bool {
+    alt((
+        tag::<_, _, OracleError<'_>>("it "),
+        tag("its "),
+        tag("that "),
+        tag("this "),
+        tag("those "),
+        tag("they "),
+        tag("you "),
+        tag("all "),
+        tag("each "),
+        tag("the "),
+    ))
+    .parse(remainder_lower)
+    .is_ok()
 }
 
 fn parse_search_exile_name_suffix(input: &str) -> Result<(&str, ()), nom::Err<OracleError<'_>>> {

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -7926,9 +7926,11 @@ mod tests {
             "create a 1/1 red Alien creature token with haste and \"This token attacks each combat if able.\"",
             "the token + quoted ability must be its own chunk: {chunks:?}"
         );
+        // allow-noncombinator: structural test assertion over the pre-tokenized chunk vector, not parser dispatch
+        let counter_clause_split_off = chunks.len() >= 2
+            && chunks[1].starts_with("Put a +1/+1 counter on it for each invasion counter"); // allow-noncombinator: same, on the `.starts_with` line
         assert!(
-            chunks.len() >= 2
-                && chunks[1].starts_with("Put a +1/+1 counter on it for each invasion counter"),
+            counter_clause_split_off,
             "the imperative counter sentence must split into its own chunk: {chunks:?}"
         );
     }

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1403,6 +1403,22 @@ fn quote_closes_sentence_before_sequence(current: &str, remainder: &str) -> bool
     {
         return true;
     }
+    // CR 111.3 + CR 608.2c (issue #5844): a token/permanent granted-ability quote
+    // that ends a sentence can be followed by a fresh IMPERATIVE sibling sentence
+    // that acts on the created object — Alien Invasion: `… and "This token
+    // attacks each combat if able." Put a +1/+1 counter on it for each invasion
+    // counter on this enchantment, then …`. Without splitting here the whole
+    // remainder is swallowed into the token-creation clause: its "for each
+    // invasion counter" is mis-read as the token COUNT and the "+1/+1 counter"
+    // pump is dropped entirely. Split when the continuation begins with an
+    // imperative game-action verb; anaphoric-subject continuations ("It becomes
+    // a 2/2 …", "The token is goaded", "That creature gains …") begin with a
+    // pronoun/determiner, NOT a verb, and stay attached so the token-creation
+    // path handles them inline.
+    if starts_imperative_action_continuation(trimmed_lower.as_str()) {
+        return true;
+    }
+
     // CR 608.2c: read the whole text and apply the rules of English — a
     // granted-ability quote that ends a sentence can be followed by a fresh
     // causative "may have …" sentence directed at the affected object's
@@ -1414,6 +1430,29 @@ fn quote_closes_sentence_before_sequence(current: &str, remainder: &str) -> bool
         tag::<_, _, OracleError<'_>>("may have ").parse(i)
     })
     .is_some()
+}
+
+/// True iff `remainder_lower` begins a fresh IMPERATIVE sibling sentence — a game-
+/// action verb such as "put "/"exile "/"create "/"tap " — as opposed to an
+/// anaphoric-subject continuation ("It becomes …", "The token is goaded", "That
+/// creature gains …") that the token-creation path keeps attached to the quote.
+///
+/// Reuses the shared clause-starter verb table (`starts_clause_text_lower`) but
+/// first excludes the pronoun/determiner/subject starters it also recognizes for
+/// comma / "then" / bare-"and" splits. Those subject starters, after a granted
+/// quote, are anaphors that must stay attached (per the guardrail in
+/// `quote_closes_sentence_before_sequence`); only a bare imperative verb marks a
+/// genuine sibling effect here.
+fn starts_imperative_action_continuation(remainder_lower: &str) -> bool {
+    let first_word = remainder_lower.split_whitespace().next().unwrap_or("");
+    // Anaphoric-subject / determiner starters — keep attached (existing behavior).
+    if matches!(
+        first_word,
+        "it" | "its" | "that" | "this" | "those" | "they" | "you" | "all" | "each" | "the"
+    ) {
+        return false;
+    }
+    starts_clause_text_lower(remainder_lower)
 }
 
 fn parse_search_exile_name_suffix(input: &str) -> Result<(&str, ()), nom::Err<OracleError<'_>>> {
@@ -7870,6 +7909,44 @@ mod tests {
             "create a 1/1 red Goblin creature token with \"This creature attacks each combat if able.\" The token is goaded.",
         );
         assert_eq!(chunks.len(), 1, "unexpected split: {chunks:?}");
+    }
+
+    #[test]
+    fn quoted_grant_splits_before_imperative_sibling_sentence() {
+        // CR 111.3 + CR 608.2c (issue #5844): Alien Invasion — the token's quoted
+        // ability ends the sentence (`able."`); the following IMPERATIVE sentence
+        // ("Put a +1/+1 counter on it …") is a sibling effect and must split off.
+        // Without the split the token-creation clause swallows it, mis-reading
+        // "for each invasion counter" as the token COUNT and dropping the pump.
+        let chunks = clause_texts(
+            "create a 1/1 red Alien creature token with haste and \"This token attacks each combat if able.\" Put a +1/+1 counter on it for each invasion counter on this enchantment, then put an invasion counter on this enchantment.",
+        );
+        assert_eq!(
+            chunks[0],
+            "create a 1/1 red Alien creature token with haste and \"This token attacks each combat if able.\"",
+            "the token + quoted ability must be its own chunk: {chunks:?}"
+        );
+        assert!(
+            chunks.len() >= 2
+                && chunks[1].starts_with("Put a +1/+1 counter on it for each invasion counter"),
+            "the imperative counter sentence must split into its own chunk: {chunks:?}"
+        );
+    }
+
+    #[test]
+    fn quoted_grant_keeps_anaphoric_subject_continuation() {
+        // The exclusion side of #5844: an anaphoric-SUBJECT continuation after a
+        // token quote ("It gains …", "That creature gets …") begins with a
+        // pronoun/determiner, not an imperative verb, and must stay attached — the
+        // token-creation path resolves the anaphor inline.
+        let chunks = clause_texts(
+            "create a 1/1 white Soldier creature token with \"This creature can't block.\" It gains haste until end of turn.",
+        );
+        assert_eq!(
+            chunks.len(),
+            1,
+            "anaphoric 'It gains …' must not split: {chunks:?}"
+        );
     }
 
     // --- Bare " and " splitting: positive cases (should split) ---

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1447,12 +1447,20 @@ fn starts_imperative_action_continuation(remainder_lower: &str) -> bool {
     !starts_anaphoric_subject(remainder_lower) && starts_clause_text_lower(remainder_lower)
 }
 
-/// True iff `remainder_lower` begins with a pronoun/determiner subject word — the
-/// anaphoric continuations ("It becomes …", "The token is goaded", "That creature
-/// gains …") that must stay attached to a granted quote rather than split as a
-/// sibling imperative. Each starter carries a trailing space so only a complete
-/// word matches (e.g. "it " does not fire on "item"), mirroring the whitespace
-/// convention of `starts_clause_text_lower`'s verb tags.
+/// True iff `remainder_lower` begins with a demonstrative/pronoun word that, after
+/// a token/permanent's granted-ability quote, refers back to the CREATED object —
+/// an anaphor ("It becomes …", "Its power …", "That creature gains …", "Those
+/// tokens …", "They gain haste") that must stay attached to the quote rather than
+/// split as a sibling imperative. Each starter carries a trailing space so only a
+/// complete word matches (e.g. "it " does not fire on "item").
+///
+/// Restricted to genuine last-created anaphors. Independent subject-led clauses
+/// that `starts_clause_text_lower` recognizes as fresh instructions — "You gain
+/// …", "Each opponent …", "All creatures …" — are NOT token anaphors and must be
+/// allowed to split, so they are deliberately absent here (issue #5844 review).
+/// "The …" is likewise absent: it is not a `starts_clause_text_lower` starter, so
+/// "The token is goaded" already fails the authority check and stays attached
+/// without an explicit guard.
 fn starts_anaphoric_subject(remainder_lower: &str) -> bool {
     alt((
         tag::<_, _, OracleError<'_>>("it "),
@@ -1461,10 +1469,6 @@ fn starts_anaphoric_subject(remainder_lower: &str) -> bool {
         tag("this "),
         tag("those "),
         tag("they "),
-        tag("you "),
-        tag("all "),
-        tag("each "),
-        tag("the "),
     ))
     .parse(remainder_lower)
     .is_ok()
@@ -7950,11 +7954,48 @@ mod tests {
         );
     }
 
+    /// CR 608.2c (#5844 review): an INDEPENDENT subject-led continuation after a
+    /// granted-ability quote — "You gain …", "Each opponent …", "All creatures …" —
+    /// is a fresh sibling instruction, NOT an anaphor to the created token, so it
+    /// must split off. `starts_clause_text_lower` already recognizes `you `,
+    /// `each `/`each opponent `, and `all ` as clause starters; the anaphor guard
+    /// must not reject them before that authority is consulted, or they stay glued
+    /// to the token clause and are swallowed — the very bug class this PR fixes.
+    #[test]
+    fn quoted_grant_splits_before_independent_subject_continuation() {
+        for (text, expected_head) in [
+            (
+                "create a 1/1 white Soldier creature token with \"This creature can't block.\" You gain 3 life.",
+                "You gain 3 life",
+            ),
+            (
+                "create a 1/1 white Soldier creature token with \"This creature can't block.\" Each opponent loses 2 life.",
+                "Each opponent loses 2 life",
+            ),
+            (
+                "create a 1/1 white Soldier creature token with \"This creature can't block.\" All creatures you control get +1/+1 until end of turn.",
+                "All creatures you control get +1/+1 until end of turn",
+            ),
+        ] {
+            let chunks = clause_texts(text);
+            assert_eq!(
+                chunks[0],
+                "create a 1/1 white Soldier creature token with \"This creature can't block.\"",
+                "the token + quoted ability must stay its own chunk: {chunks:?}"
+            );
+            assert_eq!(
+                chunks.get(1).map(String::as_str),
+                Some(expected_head),
+                "an independent subject-led continuation must split into its own chunk: {chunks:?}"
+            );
+        }
+    }
+
     #[test]
     fn quoted_grant_keeps_anaphoric_subject_continuation() {
         // The exclusion side of #5844: an anaphoric-SUBJECT continuation after a
-        // token quote ("It gains …", "That creature gets …") begins with a
-        // pronoun/determiner, not an imperative verb, and must stay attached — the
+        // token quote ("It gains …", "That creature gets …") refers back to the
+        // CREATED object, not a fresh instruction, so it must stay attached — the
         // token-creation path resolves the anaphor inline.
         let chunks = clause_texts(
             "create a 1/1 white Soldier creature token with \"This creature can't block.\" It gains haste until end of turn.",

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -46483,3 +46483,95 @@ fn bandits_talent_level3_draw_counts_hellbent_opponents() {
         parsed.parse_warnings
     );
 }
+
+/// CR 111.3 + CR 122.1 + CR 608.2c (issue #5844) — production-path regression for
+/// Alien Invasion. The token's quoted granted ability ends the first sentence
+/// (`able."`); the following imperative sentence pumps the created token. Before
+/// the sentence-splitter fix, the whole remainder was swallowed into the token
+/// clause: the token COUNT became `CountersOn(invasion)` (creating one token per
+/// invasion counter) and the "+1/+1 counter on it for each invasion counter"
+/// pump was dropped entirely. The corrected parse creates exactly ONE token and
+/// keeps the pump as a sibling `PutCounter` on the last-created token.
+#[test]
+fn alien_invasion_creates_one_token_and_pumps_it_per_counter() {
+    use crate::types::ability::{
+        AbilityDefinition, Effect, ObjectScope, QuantityExpr, QuantityRef,
+    };
+    use crate::types::counter::CounterType;
+
+    // Flatten the trigger's execute chain (def -> sub_ability -> ...).
+    fn collect_effects(def: &AbilityDefinition, out: &mut Vec<Effect>) {
+        out.push((*def.effect).clone());
+        if let Some(sub) = def.sub_ability.as_deref() {
+            collect_effects(sub, out);
+        }
+    }
+
+    let parsed = parse_oracle_text(
+        "At the beginning of combat on your turn, create a 1/1 red Alien creature token with haste and \"This token attacks each combat if able.\" Put a +1/+1 counter on it for each invasion counter on this enchantment, then put an invasion counter on this enchantment.",
+        "Alien Invasion",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_deref())
+        .expect("Alien Invasion must lower to a combat trigger with an execute chain");
+    let mut effects = Vec::new();
+    collect_effects(trigger, &mut effects);
+
+    // 1) Exactly one token is created (count is a literal 1, NOT CountersOn).
+    let token_count = effects
+        .iter()
+        .find_map(|e| match e {
+            Effect::Token { count, .. } => Some(count.clone()),
+            _ => None,
+        })
+        .expect("must emit a Token effect");
+    assert_eq!(
+        token_count,
+        QuantityExpr::Fixed { value: 1 },
+        "the token count must be a literal 1, not scaled by invasion counters: {token_count:?}"
+    );
+
+    // 2) The "+1/+1 counter on it for each invasion counter" pump survives as a
+    //    PutCounter on the last-created token, counted by the enchantment's
+    //    invasion counters.
+    let has_pump = effects.iter().any(|e| {
+        matches!(
+            e,
+            Effect::PutCounter {
+                target: TargetFilter::LastCreated,
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::CountersOn {
+                        scope: ObjectScope::Source,
+                        counter_type: Some(inner),
+                    },
+                },
+            } if *inner == CounterType::Generic("invasion".to_string())
+        )
+    });
+    assert!(
+        has_pump,
+        "the '+1/+1 counter on it for each invasion counter' pump must survive: {effects:#?}"
+    );
+
+    // 3) The enchantment still accrues one invasion counter.
+    let has_self_counter = effects.iter().any(|e| {
+        matches!(
+            e,
+            Effect::PutCounter {
+                target: TargetFilter::SelfRef,
+                counter_type: ct,
+                count: QuantityExpr::Fixed { value: 1 },
+            } if *ct == CounterType::Generic("invasion".to_string())
+        )
+    });
+    assert!(
+        has_self_counter,
+        "the enchantment must still gain one invasion counter: {effects:#?}"
+    );
+}


### PR DESCRIPTION
## Problem

Alien Invasion (#5844) reads:

> At the beginning of combat on your turn, create a 1/1 red Alien creature token with haste and "This token attacks each combat if able." Put a +1/+1 counter on it for each invasion counter on this enchantment, then put an invasion counter on this enchantment.

The engine created **one Alien token per invasion counter** and the "+1/+1 counter â¦ for each invasion counter" pump was **missing entirely**.

## Root cause

The clause splitter (`split_clause_sequence`) closes a sentence after a token/permanent's quoted granted ability (a span ending in `."`) only when the following sentence starts with a whitelisted continuation (`then` / `if` / `otherwise` / `may have` / emblem head). A fresh **imperative** sibling sentence was not recognized, so the whole remainder was swallowed into the token-creation clause:

- its `for each invasion counter` was mis-read as the token **count** â `Token { count: CountersOn(invasion) }` (one token per counter), and
- the `+1/+1 counter on it` pump was dropped.

Isolation probe: with the quoted ability removed, the same card parses correctly (`Token { count: 1 }` + `PutCounter { P1P1, CountersOn(invasion), LastCreated }` + `PutCounter { invasion, 1, SelfRef }`) â confirming the quoted-ability sentence boundary is the sole trigger.

## Fix

Extend `quote_closes_sentence_before_sequence` to also close the sentence when the continuation begins with an imperative game-action verb, via a new `starts_imperative_action_continuation` helper. It reuses the shared clause-starter verb table (`starts_clause_text_lower`) but first excludes the pronoun/determiner subject starters it also recognizes (`it` / `that` / `this` / `those` / `they` / `you` / `all` / `each` / `the`). Those, after a granted quote, are anaphors the token-creation path resolves inline ("It becomes a 2/2 â¦", "The token is goaded"), so they stay attached; only a bare imperative verb marks a genuine sibling effect.

This is a **class-level** fix: every `create a token with "<ability.>" <imperative on the token>` card benefits, not just Alien Invasion.

## Tests

- `sequence.rs`:
  - `quoted_grant_splits_before_imperative_sibling_sentence` â the Alien Invasion remainder splits off.
  - `quoted_grant_keeps_anaphoric_subject_continuation` â an "It gains â¦" anaphor stays attached.
  - Existing guardrails still pass: `quoted_grant_keeps_nonrecognized_capitalized_continuation` ("The token is goaded") and `quoted_grant_splits_before_following_sentence` (Requiem Monolith "may have").
- `oracle_effect/tests.rs`:
  - `alien_invasion_creates_one_token_and_pumps_it_per_counter` parses the full card and asserts (1) the token count is a literal `1`, (2) the "+1/+1 counter â¦ for each invasion counter" pump survives as a `PutCounter` on the last-created token, (3) the enchantment still accrues one invasion counter.

Full `engine` lib suite green (16,682 passed, 0 failed; snapshot tests included); `cargo fmt` and `clippy -p engine --tests` clean.

Closes #5844
