### PR TITLE
fix(parser): parse subtype-gated token substitution replacements (Fisher's Talent #5636)

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -746,7 +746,10 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
     // by the "create <spec> instead" one-for-one swap tail (no "plus" / "one of
     // each"); the Manufactor block above already claimed the "instead create one
     // of each" variant.
-    if nom_primitives::scan_contains(&lower, "you would create a ")
+    // "you would create a" is a prefix of both the "a " and "an " articles (and of
+    // "another …", which the parser's exact frame then rejects), so the guard
+    // covers vowel-starting subtypes ("an Elf token") too.
+    if nom_primitives::scan_contains(&lower, "you would create a")
         && nom_primitives::scan_contains(&lower, "instead")
     {
         if let Some(def) = parse_subtype_token_substitution(&lower, &text) {
@@ -7807,10 +7810,13 @@ fn parse_subtype_token_substitution(
     // CR 109.5: require the first-person "you would create" antecedent so the
     // hardcoded `token_owner_scope(You)` below is provably correct -- an
     // "if an effect / an opponent would create a <subtype> token ... instead"
-    // line is a different scope and must not be captured here.
+    // line is a different scope and must not be captured here. The subtype's
+    // article is "a" or "an" (a vowel-starting subtype -- Elf, Insect, Octopus --
+    // reads "create an Elf token"), so accept either.
     let ((subtype, descriptor), _) = nom_on_lower(lower, lower, |i| {
-        let (i, _) = take_until::<_, _, OracleError<'_>>("you would create a ").parse(i)?;
-        let (i, _) = tag("you would create a ").parse(i)?;
+        let (i, _) = take_until::<_, _, OracleError<'_>>("you would create ").parse(i)?;
+        let (i, _) = tag("you would create ").parse(i)?;
+        let (i, _) = alt((tag("a "), tag("an "))).parse(i)?;
         let (i, subtype) = take_until::<_, _, OracleError<'_>>(" token, ").parse(i)?;
         let (i, _) = tag(" token, create ").parse(i)?;
         let (i, descriptor) = take_until::<_, _, OracleError<'_>>(" instead").parse(i)?;
@@ -16456,6 +16462,23 @@ mod tests {
             )
             .is_none(),
             "must not capture a non-substitution 'instead' effect"
+        );
+
+        // L2 sibling coverage: a vowel-starting subtype takes the "an" article and
+        // must parse identically to the "a" form (Elf/Insect/Octopus, etc.).
+        let an = parse_subtype_token_substitution(
+            "if you would create an elf token, create a 1/1 white soldier creature token instead.",
+            "vowel-subtype substitution",
+        )
+        .expect("an <vowel-subtype> token antecedent must parse via the \"an\" article");
+        assert!(
+            matches!(
+                an.condition,
+                Some(ReplacementCondition::TokenSubtypeMatches { ref subtypes })
+                    if subtypes == &vec!["Elf".to_string()]
+            ),
+            "expected TokenSubtypeMatches([Elf]) for the \"an Elf\" antecedent, got {:?}",
+            an.condition
         );
     }
 

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -740,6 +740,20 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
         }
     }
 
+    // CR 614.1a + CR 111.1: Subtype-gated token SUBSTITUTION —
+    // "If you would create a <subtype> token, create <token spec> instead"
+    // (Fisher's Talent). Distinguished from the doubling/additional shapes above
+    // by the "create <spec> instead" one-for-one swap tail (no "plus" / "one of
+    // each"); the Manufactor block above already claimed the "instead create one
+    // of each" variant.
+    if nom_primitives::scan_contains(&lower, "you would create a ")
+        && nom_primitives::scan_contains(&lower, "instead")
+    {
+        if let Some(def) = parse_subtype_token_substitution(&lower, &text) {
+            return Some(def);
+        }
+    }
+
     // --- Copy-count replacement: "If you would copy a spell one or more times,
     //     instead copy it that many times plus an additional time." (Twinning
     //     Staff) ---
@@ -7776,6 +7790,64 @@ fn parse_token_substitute_shape(lower: &str) -> Option<Effect> {
     let mut ctx = ParseContext::default();
     let effect = super::oracle_effect::try_parse_token(descriptor, descriptor, &mut ctx)?;
     matches!(effect, Effect::Token { .. }).then_some(effect)
+}
+
+/// CR 614.1a + CR 111.1: Subtype-gated mandatory token substitution --
+/// "If you would create a <subtype> token, create <token spec> instead."
+/// (Fisher's Talent levels 2/3). Combines the Xorn subtype gate
+/// (`ReplacementCondition::TokenSubtypeMatches`) with the Divine Visitation
+/// substitution payload (the substitute `Effect::Token` carried in `execute`).
+/// The applier substitutes only the token's characteristics and keeps the
+/// proposed event's count, so one <subtype> token becomes one substitute token
+/// (and N -> N). "If *you* would create" scopes it to the source's controller.
+fn parse_subtype_token_substitution(
+    lower: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
+    // CR 109.5: require the first-person "you would create" antecedent so the
+    // hardcoded `token_owner_scope(You)` below is provably correct -- an
+    // "if an effect / an opponent would create a <subtype> token ... instead"
+    // line is a different scope and must not be captured here.
+    let ((subtype, descriptor), _) = nom_on_lower(lower, lower, |i| {
+        let (i, _) = take_until::<_, _, OracleError<'_>>("you would create a ").parse(i)?;
+        let (i, _) = tag("you would create a ").parse(i)?;
+        let (i, subtype) = take_until::<_, _, OracleError<'_>>(" token, ").parse(i)?;
+        let (i, _) = tag(" token, create ").parse(i)?;
+        let (i, descriptor) = take_until::<_, _, OracleError<'_>>(" instead").parse(i)?;
+        Ok((
+            i,
+            (subtype.trim().to_string(), descriptor.trim().to_string()),
+        ))
+    })?;
+
+    // The gated subtype must be a single canonical token subtype ("Fish"). A
+    // multi-word capture means the "a <subtype> token," frame didn't isolate one
+    // (e.g. a Manufactor comma list) -- bail rather than emit a bogus gate.
+    if subtype.is_empty() || subtype.contains(' ') {
+        return None;
+    }
+    let canonical_subtype = canonicalize_subtype(&subtype);
+
+    // Parse the substitute token spec. The leading article on a P/T-led spec
+    // ("a 3/3 blue Shark creature token") is required by `try_parse_token`, so
+    // the descriptor is handed over verbatim.
+    let mut ctx = ParseContext::default();
+    let effect = super::oracle_effect::try_parse_token(&descriptor, &descriptor, &mut ctx)?;
+    if !matches!(effect, Effect::Token { .. }) {
+        return None;
+    }
+
+    Some(
+        ReplacementDefinition::new(ReplacementEvent::CreateToken)
+            .condition(ReplacementCondition::TokenSubtypeMatches {
+                subtypes: vec![canonical_subtype],
+            })
+            // CR 614.1a + CR 109.5: "If *you* would create..." scopes the
+            // replacement to the source's controller.
+            .token_owner_scope(ControllerRef::You)
+            .execute(AbilityDefinition::new(AbilityKind::Spell, effect))
+            .description(original_text.to_string()),
+    )
 }
 
 /// CR 111.1: Extract the gated core card type from "if one or more <core type>
@@ -16311,6 +16383,80 @@ mod tests {
             Some(ReplacementCondition::TokenCoreTypeMatches { ref core_types })
                 if core_types == &vec![crate::types::card_type::CoreType::Creature]
         ));
+    }
+
+    #[test]
+    fn subtype_gated_token_substitution_fishers_talent() {
+        // #5636 / CR 614.1a: "If you would create a <subtype> token, create
+        // <token> instead" is a subtype-gated one-for-one token substitution
+        // (Fisher's Talent level 2). It must lower to a CreateToken replacement
+        // gated on the subtype, carrying the substitute token in `execute` --
+        // previously it dropped the "instead" wrapper and parsed as a bare Token
+        // effect, so levels 2/3 silently did nothing.
+        let def = parse_replacement_line(
+            "If you would create a Fish token, create a 3/3 blue Shark creature token instead.",
+            "Fisher's Talent",
+        )
+        .expect("subtype-gated token substitution must lower to a CreateToken replacement");
+        assert_eq!(def.event, ReplacementEvent::CreateToken);
+        // CR 109.5: "If *you* would create" scopes to the source's controller.
+        assert_eq!(def.token_owner_scope, Some(ControllerRef::You));
+        // CR 111.1: gated on the Fish token being the one created.
+        assert!(
+            matches!(
+                def.condition,
+                Some(ReplacementCondition::TokenSubtypeMatches { ref subtypes })
+                    if subtypes == &vec!["Fish".to_string()]
+            ),
+            "expected TokenSubtypeMatches([Fish]), got {:?}",
+            def.condition
+        );
+        // Mandatory swap -- not the optional Jinnie Fay choice shape.
+        assert_eq!(def.mode, ReplacementMode::Mandatory);
+        // The substitute carried in `execute` is a 3/3 blue Shark creature token.
+        let Some(Effect::Token {
+            power,
+            toughness,
+            types,
+            colors,
+            ..
+        }) = def.execute.as_deref().map(|a| &*a.effect)
+        else {
+            panic!("execute must be an Effect::Token, got {:?}", def.execute);
+        };
+        assert!(
+            types.iter().any(|t| t == "Shark"),
+            "substitute must be a Shark token, got types {types:?}"
+        );
+        assert_eq!(*power, crate::types::ability::PtValue::Fixed(3));
+        assert_eq!(*toughness, crate::types::ability::PtValue::Fixed(3));
+        assert!(
+            colors.contains(&ManaColor::Blue),
+            "substitute must be blue, got {colors:?}"
+        );
+
+        // Must NOT steal the Manufactor "instead create one of each" ensure-all
+        // shape: the comma-listed subtypes make `take_until(" token, ")` capture a
+        // multi-word subtype, which the single-subtype guard rejects (returns
+        // None), so it falls through to parse_manufactor_ensure_all_token_replacement.
+        assert!(
+            parse_subtype_token_substitution(
+                "if you would create a clue, food, or treasure token, instead create one of each of those tokens.",
+                "Academy Manufactor",
+            )
+            .is_none(),
+            "must not capture the Manufactor comma-list ensure-all shape"
+        );
+        // And an "if you would create a <subtype> token, <non-create effect>"
+        // line (no " token, create ") is not a substitution -- return None.
+        assert!(
+            parse_subtype_token_substitution(
+                "if you would create a treasure token, you gain 2 life instead.",
+                "hypothetical non-substitution",
+            )
+            .is_none(),
+            "must not capture a non-substitution 'instead' effect"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #5636.

## Problem
Fisher's Talent's levels 2/3 — "If you would create a Fish token, create a 3/3 blue Shark creature token instead" (and Shark→Octopus) — parsed to `replacements: 0` plus two inert `Spell`-kind Token abilities. A Spell-kind ability on a permanent never fires, so **levels 2 and 3 silently did nothing** in shipped data (the card still counted as supported).

## Fix
`parse_replacement_line` had no arm for the **subtype-gated one-for-one token substitution** shape "if you would create a `<subtype>` token, create `<token>` instead". The existing token-creation arms cover doubling/additional shapes (Doubling Season "a token" / "one or more tokens"; Xorn "instead create those tokens plus"; Manufactor "instead create one of each") but not substitution.

Add `parse_subtype_token_substitution`, composing two existing, runtime-supported mechanisms:
- the **Xorn subtype gate** (`ReplacementCondition::TokenSubtypeMatches`) so it fires only for the named subtype, and
- the **Divine Visitation substitution payload** — the substitute `Effect::Token` carried in `execute`; the applier (`game/replacement.rs`) swaps only the token's characteristics and keeps the proposed event's count, so N `<subtype>` tokens become N substitute tokens.

The arm requires the first-person **"you would create"** antecedent so the `token_owner_scope(You)` is provably correct (an "if an effect / an opponent would create … instead" line is a different scope and is not captured). `oracle_class.rs` wraps the result with the class-level gate, so the swap is active only at the level that grants it.

No new engine types or variants — a pure parser addition.

## Verification
- New unit test `subtype_gated_token_substitution_fishers_talent` drives `parse_replacement_line` and asserts the `CreateToken` event, `TokenSubtypeMatches([Fish])` condition, `token_owner_scope(You)`, exact `Mandatory` mode, and the 3/3 blue Shark substitute — plus negative cases proving it does **not** steal the Manufactor comma-list shape or a non-substitution "instead" effect.
- `cargo test -p engine --lib` (new test) — green.
- Card-data regen: Fisher's Talent now emits **two** Mandatory `CreateToken` substitution replacements (Fish→Shark, Shark→Octopus); the L2→L3 cascade sequences correctly (create-Fish → Shark → Octopus) through the replacement loop.
- `cargo clippy -p engine --lib -- -D warnings` — clean.
- CR 614.1a / CR 111.1 / CR 109.5 annotated.

Model: claude-opus-4-8[1m]
