### PR TITLE
fix(engine): parse and resolve Nether Spirit's dropped self-reanimation intervening-if

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -9967,8 +9967,6 @@ fn line_has_condition_text(lower: &str) -> Option<&'static str> {
             || lower.contains("had no cards in hand")
             // "if no permanents left the battlefield" — turn-event check
             || lower.contains("no permanents left")
-            // "if [this card is] the only creature card in your graveyard" — zone state check
-            || lower.contains("only creature card in your graveyard")
             // "if you discarded a card this turn" — turn-event action check
             || lower.contains("if you discarded")
             // "if 4 or more damage was dealt" — turn-event damage check

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -275,6 +275,11 @@ fn parse_remaining_state_presence_conditions(input: &str) -> OracleResult<'_, St
         parse_there_exists_compound_zone_condition,
         parse_there_exists_condition,
         parse_subject_first_zone_count,
+        // CR 603.4 + CR 113.6b: "~ is the only <type> [card] in <zone>" —
+        // self-referential count-equals-one gate (Nether Spirit). Anchored on
+        // the self-token + literal " is the only ", so it never mis-claims the
+        // non-self "a <type> card is in a graveyard" phrase below.
+        parse_source_is_only_type_in_zone,
         // CR 611.3a + CR 702: "a <type> card [with <keyword>] is in a graveyard"
         // — graveyard-presence gate for conditional continuous statics
         // (Tarmogoyf, Cairn Wanderer). Guarded by the "is in a graveyard"
@@ -4117,6 +4122,63 @@ fn parse_creature_has_keyword(input: &str) -> OracleResult<'_, StaticCondition> 
 /// Graveyard }` (plus any `FilterProp::WithKeyword` the type phrase's "with
 /// <keyword>" clause supplies).
 ///
+/// CR 603.4 + CR 113.6 + CR 113.6b: "~ is the only <type> [card] in <zone>" —
+/// self-referential count-equals-one gate (Nether Spirit's intervening-if:
+/// "if this card is the only creature card in your graveyard, ...").
+///
+/// Composes existing building blocks only:
+///   - `parse_source_self_token` — the self-reference subject (`~` /
+///     `this card`; "this card" is a parse-only self-reference not yet
+///     normalized to `~`, so the literal `tag("this card")` arm in that
+///     combinator is required here).
+///   - `parse_type_phrase` — folds the informational " card" qualifier and the
+///     attached "in your <zone>" clause into one `TargetFilter` (the same
+///     grammar shape `parse_card_in_graveyard` relies on).
+///   - `make_quantity_comparison` — the shared `ObjectCount == N` shape.
+///
+/// When the filter carries an explicit non-battlefield zone
+/// (graveyard/hand/library/exile), conjoin an explicit `SourceInZone` predicate
+/// so the EXISTING `trigger_condition_source_zones` walker (oracle_trigger.rs)
+/// derives `trigger_zones` and `ChangeZone.origin` automatically — the CR
+/// 113.6/113.6b off-battlefield self-function class. Precedent: Jocasta,
+/// Automaton Avenger (issue #4566), whose `{SourceInZone, Graveyard}` condition
+/// already drives this exact derivation with zero special-casing (see
+/// `stamp_self_return_origin_from_trigger_condition`'s doc comment). A
+/// battlefield-only "the only <type> you control" static omits the redundant
+/// `SourceInZone` conjunct since `trigger_zones` already defaults to
+/// battlefield-only.
+fn parse_source_is_only_type_in_zone(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, ()) = parse_source_self_token(input)?;
+    let (rest, _) = tag(" is the only ").parse(rest)?;
+    let (filter, remainder) = parse_type_phrase(rest);
+    if matches!(filter, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    let quantity = make_quantity_comparison(
+        QuantityRef::ObjectCount {
+            filter: filter.clone(),
+        },
+        Comparator::EQ,
+        1,
+    );
+    // CR 113.6b: an ability that states which zone it functions in functions
+    // only from that zone. Wrapping the count gate in `And{SourceInZone, ...}`
+    // for an explicit non-battlefield zone lets the trigger's zone derivation
+    // (oracle_trigger.rs) hoist that zone into `trigger_zones` and the return
+    // effect's `ChangeZone.origin` — mirroring Jocasta, Automaton Avenger.
+    let condition = match filter.extract_in_zone() {
+        Some(zone) if zone != Zone::Battlefield => StaticCondition::And {
+            conditions: vec![StaticCondition::SourceInZone { zone }, quantity],
+        },
+        _ => quantity,
+    };
+    let consumed = remainder.as_ptr() as usize - input.as_ptr() as usize;
+    Ok((&input[consumed..], condition))
+}
+
 /// Graveyard-presence sibling of `parse_creature_has_keyword`: instead of a "has
 /// <keyword>" battlefield predicate, the subject's presence is checked in a
 /// graveyard. This is the gate half of a conditional continuous static (CR
@@ -9797,6 +9859,85 @@ mod tests {
                 zone: crate::types::zones::Zone::Graveyard
             }
         ));
+    }
+
+    /// CR 603.4 + CR 113.6b: Nether Spirit's intervening-if. The off-battlefield
+    /// zone must be hoisted into an explicit `SourceInZone` conjunct so
+    /// `trigger_condition_source_zones` can derive `trigger_zones == [Graveyard]`
+    /// and `ChangeZone.origin == Graveyard` (Jocasta, Automaton Avenger precedent).
+    #[test]
+    fn parse_condition_source_is_only_creature_card_in_graveyard() {
+        let (rest, c) =
+            parse_condition("if ~ is the only creature card in your graveyard").unwrap();
+        assert_eq!(rest, "");
+        let StaticCondition::And { conditions } = c else {
+            panic!("expected And, got {c:?}");
+        };
+        assert_eq!(conditions.len(), 2);
+        assert!(
+            matches!(
+                conditions[0],
+                StaticCondition::SourceInZone {
+                    zone: crate::types::zones::Zone::Graveyard
+                }
+            ),
+            "first conjunct must be SourceInZone(Graveyard): {:?}",
+            conditions[0]
+        );
+        let StaticCondition::QuantityComparison {
+            lhs,
+            comparator,
+            rhs,
+        } = &conditions[1]
+        else {
+            panic!("expected QuantityComparison, got {:?}", conditions[1]);
+        };
+        assert_eq!(*comparator, Comparator::EQ);
+        assert_eq!(*rhs, QuantityExpr::Fixed { value: 1 });
+        let QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { filter },
+        } = lhs
+        else {
+            panic!("expected ObjectCount ref, got {lhs:?}");
+        };
+        // The count is scoped to your graveyard by the folded zone suffix.
+        assert_eq!(
+            filter.extract_in_zone(),
+            Some(crate::types::zones::Zone::Graveyard)
+        );
+    }
+
+    /// A battlefield-scoped "the only <type> you control" omits the redundant
+    /// `SourceInZone` conjunct — `trigger_zones` already defaults to battlefield.
+    #[test]
+    fn parse_condition_source_is_only_creature_you_control_omits_source_in_zone() {
+        let (rest, c) = parse_condition("if ~ is the only creature you control").unwrap();
+        assert_eq!(rest, "");
+        let StaticCondition::QuantityComparison {
+            lhs,
+            comparator,
+            rhs,
+        } = c
+        else {
+            panic!("expected bare QuantityComparison (no And/SourceInZone), got {c:?}");
+        };
+        assert_eq!(comparator, Comparator::EQ);
+        assert_eq!(rhs, QuantityExpr::Fixed { value: 1 });
+        let QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { filter },
+        } = lhs
+        else {
+            panic!("expected ObjectCount ref, got {lhs:?}");
+        };
+        assert_eq!(filter.extract_in_zone(), None);
+    }
+
+    /// Rejection guard: without "only" the arm must not spuriously fire.
+    #[test]
+    fn parse_source_is_only_type_in_zone_rejects_without_only() {
+        assert!(
+            parse_source_is_only_type_in_zone("~ is a creature card in your graveyard").is_err()
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -4175,8 +4175,7 @@ fn parse_source_is_only_type_in_zone(input: &str) -> OracleResult<'_, StaticCond
         },
         _ => quantity,
     };
-    let consumed = remainder.as_ptr() as usize - input.as_ptr() as usize;
-    Ok((&input[consumed..], condition))
+    Ok((remainder, condition))
 }
 
 /// Graveyard-presence sibling of `parse_creature_has_keyword`: instead of a "has

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -838,6 +838,42 @@ fn trigger_card_leaves_your_graveyard_during_your_turn_once_each_turn() {
     assert!(def.execute.is_some());
 }
 
+/// CR 603.4 + CR 113.6b: Nether Spirit's intervening-if
+/// ("if this card is the only creature card in your graveyard") must be hoisted
+/// into `def.condition`. The `{SourceInZone, Graveyard}` conjunct then drives
+/// `trigger_condition_source_zones` to derive `trigger_zones == [Graveyard]`
+/// (so the trigger is even detectable while the card sits in the graveyard) and
+/// `stamp_self_return_origin_from_trigger_condition` to stamp the return
+/// effect's `ChangeZone.origin == Graveyard` — the same auto-derivation Jocasta,
+/// Automaton Avenger (issue #4566) already relies on. SHAPE TEST — the end-to-end
+/// runtime behavior is covered by the
+/// `nether_spirit_only_creature_card_intervening_if` integration suite.
+#[test]
+fn nether_spirit_intervening_if_hoists_condition_zone_and_origin() {
+    let def = parse_trigger_line(
+        "At the beginning of your upkeep, if this card is the only creature card \
+             in your graveyard, you may return this card to the battlefield.",
+        "Nether Spirit",
+    );
+    // The intervening-if is hoisted out of the effect text into the trigger.
+    assert!(
+        def.condition.is_some(),
+        "intervening-if must be hoisted to def.condition, got None"
+    );
+    // The off-battlefield zone is derived so the trigger is detectable from the
+    // graveyard, not stuck at the structural [Battlefield] default.
+    assert_eq!(def.trigger_zones, vec![Zone::Graveyard]);
+    // The return effect's origin is stamped from the derived source zone.
+    let execute = def.execute.expect("execute");
+    let Effect::ChangeZone { origin, .. } = execute.effect.as_ref() else {
+        panic!(
+            "expected ChangeZone return effect, got {:?}",
+            execute.effect
+        );
+    };
+    assert_eq!(*origin, Some(Zone::Graveyard));
+}
+
 /// CR 603.2b + CR 103.8: "at the beginning of the first upkeep of the game"
 /// names the one unique step that occurs exactly once per game (the starting
 /// player's first upkeep), so the trigger must carry `OncePerGame` — NOT fire

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -611,6 +611,7 @@ mod mystic_forge_regression;
 mod narset_jeskai_waymaster_draw_spells_cast;
 mod natural_balance;
 mod necrodominance_pay_any_life_draw;
+mod nether_spirit_only_creature_card_intervening_if;
 mod nettling_imp_continuity_target;
 mod niko_light_of_hope;
 mod ninjutsu_cluster;

--- a/crates/engine/tests/integration/nether_spirit_only_creature_card_intervening_if.rs
+++ b/crates/engine/tests/integration/nether_spirit_only_creature_card_intervening_if.rs
@@ -1,0 +1,268 @@
+//! Runtime regression for Nether Spirit's intervening-if self-reanimation.
+//!
+//! Oracle (verbatim):
+//!   "At the beginning of your upkeep, if this card is the only creature card in
+//!    your graveyard, you may return this card to the battlefield."
+//!
+//! Root cause (pre-fix): the parser dropped the intervening-if entirely, leaving
+//! `TriggerDefinition.condition == None` and `trigger_zones == [Battlefield]`, so
+//! the trigger could never even be DETECTED while Nether Spirit sat in the
+//! graveyard, and — when force-fired — never checked the "only creature card"
+//! gate. The parser fix hoists the clause into
+//! `And { [SourceInZone { Graveyard }, ObjectCount(creature card in your
+//! graveyard) == 1] }`; the EXISTING `trigger_condition_source_zones` walker then
+//! derives `trigger_zones == [Graveyard]` and the return effect's
+//! `ChangeZone.origin == Graveyard` (Jocasta, Automaton Avenger precedent,
+//! issue #4566), with zero runtime changes.
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 603.4: intervening-if is checked when the event occurs AND rechecked as
+//!     the ability resolves; if false at resolution the ability does nothing.
+//!   - CR 113.6b: an ability that states which zone it functions in functions
+//!     only from that zone (the derived `SourceInZone { Graveyard }`).
+//!
+//! These drive the real trigger-collection + stack-resolution pipeline
+//! (`process_triggers` off-zone graveyard scan + CR 603.4 recheck in
+//! `stack.rs`), not a parsed-AST shape assertion.
+
+use super::rules::{GameRunner, GameScenario, Phase, WaitingFor, P0};
+use engine::game::zones::create_object;
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{GameState, StackEntryKind};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const NETHER_SPIRIT: &str = "At the beginning of your upkeep, if this card is the only creature card in your graveyard, you may return this card to the battlefield.";
+
+/// True iff a triggered ability sourced by `source` is currently on the stack —
+/// i.e. the intervening-if held at fire time (CR 603.4 first check) and the
+/// trigger was placed on the stack.
+fn nether_trigger_on_stack(runner: &GameRunner, source: ObjectId) -> bool {
+    runner.state().stack.iter().any(|entry| {
+        matches!(
+            &entry.kind,
+            StackEntryKind::TriggeredAbility { source_id, .. } if *source_id == source
+        )
+    })
+}
+
+/// Put a bare creature card directly into `owner`'s graveyard mid-game (models a
+/// mill/discard in response). Mirrors `GameScenario::add_creature_to_graveyard`,
+/// which is unavailable once the scenario has been built into a `GameRunner`.
+fn add_creature_card_to_graveyard(
+    state: &mut GameState,
+    owner: PlayerId,
+    name: &str,
+    power: i32,
+    toughness: i32,
+) -> ObjectId {
+    let card_id = CardId(state.next_object_id);
+    let id = create_object(state, card_id, owner, name.to_string(), Zone::Graveyard);
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = Some(power);
+    obj.toughness = Some(toughness);
+    obj.base_power = Some(power);
+    obj.base_toughness = Some(toughness);
+    id
+}
+
+/// Position the runner at P0's upkeep with the phase-change event delivered, so
+/// any beginning-of-upkeep trigger has been collected and placed on the stack.
+/// Mirrors `dark_confidant_upkeep`'s proven Untap→Upkeep setup.
+fn build_at_p0_upkeep(scenario: GameScenario) -> GameRunner {
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().phase = Phase::Untap;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+    runner.advance_to_upkeep();
+    runner
+}
+
+/// Resolve Nether Spirit's optional trigger by passing priority until it
+/// resolves, answering the "you may return" prompt with `accept`, and returning
+/// once the stack settles.
+fn resolve_optional_and_settle(runner: &mut GameRunner, accept: bool) {
+    for _ in 0..60 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept })
+                    .expect("answer Nether Spirit's may-return prompt");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() {
+                    return;
+                }
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority to resolve Nether Spirit trigger");
+            }
+            other => panic!("unexpected prompt resolving Nether Spirit trigger: {other:?}"),
+        }
+    }
+    panic!("Nether Spirit trigger did not settle within 60 steps");
+}
+
+fn spirit_zone(runner: &GameRunner, id: ObjectId) -> Zone {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .expect("Nether Spirit object")
+        .zone
+}
+
+/// CR 603.4: with two creature cards in the graveyard the intervening-if is
+/// false, so the trigger must NOT fire — nothing reaches the stack.
+#[test]
+fn does_not_fire_with_two_creature_cards_in_graveyard() {
+    let mut scenario = GameScenario::new();
+    let nether = scenario
+        .add_creature_to_graveyard(P0, "Nether Spirit", 2, 2)
+        .from_oracle_text(NETHER_SPIRIT)
+        .id();
+    // A second creature card makes the count 2 → intervening-if false.
+    scenario.add_creature_to_graveyard(P0, "Grizzly Bears", 2, 2);
+
+    let runner = build_at_p0_upkeep(scenario);
+
+    assert!(
+        !nether_trigger_on_stack(&runner, nether),
+        "trigger must not fire while a second creature card is in the graveyard (CR 603.4)"
+    );
+}
+
+/// Positive reach-guard for the negative above: the SAME harness (minus the
+/// filler creature) DOES put the trigger on the stack, proving the negative test
+/// actually exercises the intervening-if rather than passing vacuously.
+#[test]
+fn fires_reach_guard_when_sole_creature_card() {
+    let mut scenario = GameScenario::new();
+    let nether = scenario
+        .add_creature_to_graveyard(P0, "Nether Spirit", 2, 2)
+        .from_oracle_text(NETHER_SPIRIT)
+        .id();
+
+    let runner = build_at_p0_upkeep(scenario);
+
+    assert!(
+        nether_trigger_on_stack(&runner, nether),
+        "trigger must fire (reach the stack) when Nether Spirit is the sole creature card"
+    );
+}
+
+/// The trigger fires and — on accept — returns Nether Spirit to the battlefield.
+/// A noncreature card also sits in the graveyard, proving the gate is
+/// creature-card-specific (not merely "alone in the graveyard").
+#[test]
+fn fires_and_returns_when_sole_creature_card() {
+    let mut scenario = GameScenario::new();
+    let nether = scenario
+        .add_creature_to_graveyard(P0, "Nether Spirit", 2, 2)
+        .from_oracle_text(NETHER_SPIRIT)
+        .id();
+    // A noncreature (instant) card — a graveyard card that is NOT a creature card.
+    scenario.add_spell_to_graveyard(P0, "Lightning Bolt", true);
+
+    let mut runner = build_at_p0_upkeep(scenario);
+    assert!(
+        nether_trigger_on_stack(&runner, nether),
+        "trigger must fire: a noncreature graveyard card does not break the creature-card gate"
+    );
+
+    resolve_optional_and_settle(&mut runner, true);
+
+    assert_eq!(
+        spirit_zone(&runner, nether),
+        Zone::Battlefield,
+        "accepting the may-return must move Nether Spirit to the battlefield"
+    );
+}
+
+/// Decline path: the "may" is respected — Nether Spirit stays in the graveyard.
+#[test]
+fn declining_leaves_nether_spirit_in_graveyard() {
+    let mut scenario = GameScenario::new();
+    let nether = scenario
+        .add_creature_to_graveyard(P0, "Nether Spirit", 2, 2)
+        .from_oracle_text(NETHER_SPIRIT)
+        .id();
+
+    let mut runner = build_at_p0_upkeep(scenario);
+    assert!(
+        nether_trigger_on_stack(&runner, nether),
+        "trigger must fire so the decline path is reachable"
+    );
+
+    resolve_optional_and_settle(&mut runner, false);
+
+    assert_eq!(
+        spirit_zone(&runner, nether),
+        Zone::Graveyard,
+        "declining the optional trigger must leave Nether Spirit in the graveyard"
+    );
+}
+
+/// CR 603.4 resolution-time recheck: the trigger fires (sole creature card at
+/// upkeep), but a second creature card enters the graveyard in response. Even
+/// after accepting the may-return, the recheck fails and Nether Spirit stays put.
+#[test]
+fn resolution_recheck_fizzles_when_second_creature_card_appears() {
+    let mut scenario = GameScenario::new();
+    let nether = scenario
+        .add_creature_to_graveyard(P0, "Nether Spirit", 2, 2)
+        .from_oracle_text(NETHER_SPIRIT)
+        .id();
+
+    let mut runner = build_at_p0_upkeep(scenario);
+    assert!(
+        nether_trigger_on_stack(&runner, nether),
+        "trigger must fire at upkeep while Nether Spirit is the sole creature card"
+    );
+
+    // In response (trigger on the stack, unresolved), a second creature card is
+    // milled/discarded into P0's graveyard — count becomes 2.
+    add_creature_card_to_graveyard(runner.state_mut(), P0, "Grizzly Bears", 2, 2);
+
+    // Accept the may-return: the CR 603.4 recheck now sees 2 creature cards and
+    // removes the ability from the stack without returning Nether Spirit.
+    resolve_optional_and_settle(&mut runner, true);
+
+    assert_eq!(
+        spirit_zone(&runner, nether),
+        Zone::Graveyard,
+        "CR 603.4 resolution recheck must fizzle the return once a second creature card is present"
+    );
+}
+
+/// Two-Nether-Spirits ruling: with two copies in the graveyard, each copy sees
+/// TWO creature cards, so neither copy's intervening-if holds — no trigger fires.
+#[test]
+fn two_copies_neither_fires() {
+    let mut scenario = GameScenario::new();
+    let first = scenario
+        .add_creature_to_graveyard(P0, "Nether Spirit", 2, 2)
+        .from_oracle_text(NETHER_SPIRIT)
+        .id();
+    let second = scenario
+        .add_creature_to_graveyard(P0, "Nether Spirit", 2, 2)
+        .from_oracle_text(NETHER_SPIRIT)
+        .id();
+
+    let runner = build_at_p0_upkeep(scenario);
+
+    assert!(
+        !nether_trigger_on_stack(&runner, first),
+        "first Nether Spirit must not fire with a second creature card (its twin) present"
+    );
+    assert!(
+        !nether_trigger_on_stack(&runner, second),
+        "second Nether Spirit must not fire with a second creature card (its twin) present"
+    );
+}


### PR DESCRIPTION
## Summary

Nether Spirit (`{1}{B}{B}`, Tempest): "At the beginning of your upkeep, if this card is the only creature card in your graveyard, you may return this card to the battlefield."

The intervening-if was dropped entirely by the parser (`condition: null` in card-data.json). `split_trigger` splits Oracle text at the first unrecognized comma; since "At the beginning of your upkeep" has no comma, the whole "if this card is the only creature card in your graveyard, you may return this card to the battlefield" fell through to the effect side untouched — there was no combinator in `parse_remaining_state_presence_conditions` recognizing "`~` is the only `<type>` [card] in `<zone>`". That also left `trigger_zones` stuck at the structural default `["Battlefield"]` (making the trigger undetectable while the card sits in the graveyard) and `ChangeZone.origin` null.

- Adds `parse_source_is_only_type_in_zone` (`oracle_nom/condition.rs`), composed entirely from existing building blocks (`parse_source_self_token`, `parse_type_phrase`, an `ObjectCount == 1` `QuantityComparison`). When the type-phrase filter carries a non-battlefield zone, wraps the condition in `StaticCondition::And{[SourceInZone{zone}, quantity]}` so the existing, unmodified `trigger_condition_source_zones` walker auto-derives `trigger_zones`/`ChangeZone.origin` — **zero runtime code changed**. Precedent: Jocasta, Automaton Avenger already drives the identical `And{SourceInZone, ...}` derivation end-to-end.
- Removes a stale `game/coverage.rs` exclusion that was silencing the semantic auditor for this exact bug (confirmed via card-data.json scan: the excluded substring matches exactly this one card).

CR 603.4 (intervening-if, checked at trigger time and re-checked at resolution), CR 113.6 / CR 113.6b (ability functions off-battlefield only from the zone it states).

## Test plan

- [x] 3 new parser unit tests (`condition.rs`): graveyard form → `And[SourceInZone(Graveyard), ObjectCount==1]`; battlefield form → bare `QuantityComparison` (no spurious `SourceInZone`); rejection guard (no "only" → parse error)
- [x] Parser-shape test (`oracle_trigger_tests.rs`): asserts `condition.is_some()`, `trigger_zones == [Graveyard]`, `ChangeZone.origin == Some(Graveyard)` for Nether Spirit's verbatim Oracle text
- [x] 6 integration tests (`nether_spirit_only_creature_card_intervening_if.rs`) driving the real `process_triggers`/`stack::resolve_top` pipeline: does-not-fire with 2 creature cards, positive reach-guard, fires-and-returns when sole, decline leaves it in graveyard, CR 603.4 resolution-time recheck fizzles when a 2nd creature card enters in response, two-copies-neither-fires
- [x] Live-revert-and-rerun proof: disabling the new combinator's registration reproduces failure in the parser-shape test and 4/6 integration tests (2 negative-guard tests pass vacuously as expected, guarded by the positive reach-guard test)
- [x] `cargo fmt --all`, parser combinator gate, CR-annotation gate all pass
- [x] `cargo clippy -p engine --lib --tests -- -D warnings` clean
- [x] Full `cargo test -p engine --lib` (16687+ tests) and `--test integration` green after rebase onto current main