### PR TITLE
fix(parser): scope spell-cast triggers to a required spell keyword (#4754)

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -14713,6 +14713,33 @@ pub(crate) fn parse_post_spell_modifier(modifier: &str) -> Option<TargetFilter> 
         }
     }
 
+    // CR 702.8a + CR 603.2: "that has <keyword>" / "with <keyword>" — the spell
+    // must possess the named keyword ability (Slitherwisp: "another spell that
+    // has flash"). Without this the keyword clause is dropped and the trigger
+    // over-fires on every spell (e.g. a non-flash counterspell). Gated on a
+    // recognized keyword whose text is fully consumed by `parse_keyword_line_core`
+    // so the numeric/colored "with mana value …" / "with … mana symbol" qualifiers
+    // handled above keep their arms and a non-keyword tail ("with power 3 …")
+    // still declines here. Emits `FilterProp::WithKeyword`, which the object
+    // matcher honors via `obj.has_keyword` (filter.rs).
+    if let Ok((keyword_text, ())) = alt((
+        value((), tag::<_, _, OracleError<'_>>("that has ")),
+        value((), tag("with ")),
+    ))
+    .parse(modifier)
+    {
+        if let Some((keyword, remainder)) =
+            super::oracle_keyword::parse_keyword_line_core(keyword_text.trim())
+        {
+            if remainder.trim().is_empty() {
+                return Some(TargetFilter::Typed(
+                    TypedFilter::default()
+                        .properties(vec![FilterProp::WithKeyword { value: keyword }]),
+                ));
+            }
+        }
+    }
+
     None
 }
 

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -8111,6 +8111,37 @@ fn trigger_you_cast_another_spell_keeps_another_filter() {
     );
 }
 
+/// CR 702.8a + CR 603.2 (issue #4754): Slitherwisp — "Whenever you cast another
+/// spell that has flash" must scope the trigger to flash spells. The "that has
+/// flash" keyword clause was dropped by `parse_type_phrase`, leaving only the
+/// `Another` prop, so the trigger over-fired on every non-first spell (a
+/// counterspell without flash wrongly triggered it). The spell filter must now
+/// carry BOTH `WithKeyword(Flash)` and `Another`.
+#[test]
+fn slitherwisp_cast_another_flash_spell_scopes_to_flash() {
+    let def = parse_trigger_line(
+        "Whenever you cast another spell that has flash, you draw a card and each opponent loses 1 life.",
+        "Slitherwisp",
+    );
+    assert_eq!(def.mode, TriggerMode::SpellCast);
+    assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+    let Some(TargetFilter::Typed(tf)) = &def.valid_card else {
+        panic!("expected Typed valid_card, got {:?}", def.valid_card);
+    };
+    assert!(
+        tf.properties.contains(&FilterProp::WithKeyword {
+            value: Keyword::Flash
+        }),
+        "expected WithKeyword(Flash) in {:?}",
+        tf.properties
+    );
+    assert!(
+        tf.properties.contains(&FilterProp::Another),
+        "expected Another retained in {:?}",
+        tf.properties
+    );
+}
+
 /// CR 701.47a + CR 603.1 (issue #5341): Dreadhorde Invasion upkeep trigger —
 /// "you lose 1 life and amass Zombies 1" must keep Amass as a sub_ability.
 /// Coverage previously claimed support while only emitting LoseLife.

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -673,6 +673,7 @@ mod serras_emissary_chosen_card_type_protection;
 mod sin_spiras_punishment_repeat;
 mod skullwinder_chosen_opponent;
 mod slaughter_the_strong_total_power_4380;
+mod slitherwisp_flash_spell_cast_trigger;
 mod sliver_static_grants;
 mod sothera_supervoid_edict_reanimate;
 mod special_action_x_runtime;

--- a/crates/engine/tests/integration/slitherwisp_flash_spell_cast_trigger.rs
+++ b/crates/engine/tests/integration/slitherwisp_flash_spell_cast_trigger.rs
@@ -1,0 +1,87 @@
+//! Runtime regression for issue #4754 — Slitherwisp.
+//!
+//! Oracle: "Flash\nWhenever you cast another spell that has flash, you draw a
+//! card and each opponent loses 1 life."
+//!
+//! The parser previously dropped the "that has flash" clause, leaving the
+//! spell-cast trigger's `valid_card` with only the `Another` prop — so it fired
+//! on EVERY other spell (the reported bug: casting a counterspell without flash
+//! wrongly triggered Slitherwisp). The parser now emits `FilterProp::WithKeyword`
+//! for the flash restriction; a parser-shape test alone can't prove the runtime
+//! honors it, so these drive the real cast pipeline and assert the trigger's
+//! observable effect (each opponent loses 1 life) fires ONLY for a flash spell.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+const SLITHERWISP: &str = "Flash\nWhenever you cast another spell that has flash, you draw a \
+card and each opponent loses 1 life.";
+
+/// Casting a spell WITH flash triggers Slitherwisp: its controller draws a card
+/// and each opponent loses 1 life.
+#[test]
+fn slitherwisp_triggers_on_flash_spell_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Slitherwisp", 1, 3, SLITHERWISP);
+    let flash_spell = scenario
+        .add_spell_to_hand(P0, "Flash Bolt", true)
+        .from_oracle_text_with_keywords(&["Flash"], "Flash\nYou gain 1 life.")
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    scenario.with_library_top(P0, &["P0 Library A"]);
+
+    let mut runner = scenario.build();
+    let p1_life_before = runner.state().players[P1.0 as usize].life;
+    let p0_hand_before = runner.state().players[P0.0 as usize].hand.len();
+
+    runner.cast(flash_spell).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        p1_life_before - 1,
+        "casting a flash spell must trigger Slitherwisp — each opponent loses 1 life"
+    );
+    // Hand: the flash spell left hand (-1) and Slitherwisp's draw added one (+1),
+    // so the net is the pre-cast count.
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        p0_hand_before,
+        "Slitherwisp's controller must draw a card (net hand unchanged after the cast)"
+    );
+}
+
+/// Casting a spell WITHOUT flash must NOT trigger Slitherwisp — no opponent life
+/// loss, no draw. This is the exact reported bug (a non-flash spell wrongly
+/// triggering it).
+#[test]
+fn slitherwisp_does_not_trigger_on_nonflash_spell_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Slitherwisp", 1, 3, SLITHERWISP);
+    let plain_spell = scenario
+        .add_spell_to_hand(P0, "Plain Bolt", true)
+        .from_oracle_text("You gain 1 life.")
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    scenario.with_library_top(P0, &["P0 Library A"]);
+
+    let mut runner = scenario.build();
+    let p1_life_before = runner.state().players[P1.0 as usize].life;
+
+    runner.cast(plain_spell).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        p1_life_before,
+        "casting a non-flash spell must NOT trigger Slitherwisp — opponent life unchanged"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        0,
+        "no Slitherwisp draw for a non-flash spell — the P0 library card stays in the library"
+    );
+}


### PR DESCRIPTION
Fixes #4754

## Problem

Slitherwisp reads "Flash\nWhenever you cast **another spell that has flash**, you draw a card and each opponent loses 1 life." The spell-cast trigger dropped the "that has flash" clause: for the payload `spell that has flash`, `parse_spell_qualifier_payload` → `parse_post_spell_modifier("that has flash")` returned `None`, so the parse fell back to `parse_type_phrase`, which consumed "spell" and discarded "that has flash" as leftover. The trigger's `valid_card` ended up with only `FilterProp::Another`, so it fired on **every** other spell — the reported bug: casting a counterspell (no flash) wrongly triggered Slitherwisp.

## Fix

Add a `parse_post_spell_modifier` arm that recognizes a `"that has <keyword>"` / `"with <keyword>"` suffix and emits `FilterProp::WithKeyword { value }`. It is gated on a **fully consumed recognized keyword** (via `parse_keyword_line_core`, checking the remainder is empty), so:

- the numeric/colored qualifiers handled by earlier arms — `"with mana value N"`, `"with {X} in its mana cost"`, `"with one or more <color> mana symbol"` — keep their arms (they run first and return early), and
- a non-keyword tail (`"with power 3 or greater"`, `"with an {X}"`) still declines here and falls through unchanged.

The `Another` prop is still appended by the caller's `add_another_prop`, so Slitherwisp's filter becomes `[WithKeyword(Flash), Another]`. The object matcher already honors `FilterProp::WithKeyword` via `obj.has_keyword` (`game/filter.rs`), so **no runtime change is required** — the existing `valid_card_matches` → `target_filter_matches_object` path now filters cast spells by keyword.

## Tests

- **Parser** (`slitherwisp_cast_another_flash_spell_scopes_to_flash`): the trigger's `valid_card` carries both `WithKeyword(Flash)` and `Another`.
- **Runtime** (`slitherwisp_flash_spell_cast_trigger.rs`, 2 cases): drives the real cast pipeline and asserts Slitherwisp's observable effect (each opponent loses 1 life + controller draws) fires **only** for a flash spell — a plain spell leaves opponent life and hand untouched. This proves the fix is not merely parse-correct-but-inert.

CR references: 702.8a (flash), 603.2 (trigger events).
