### PR TITLE
Add Arashin Sovereign

### DIFF
--- a/crates/engine/src/game/effects/put_on_top_or_bottom.rs
+++ b/crates/engine/src/game/effects/put_on_top_or_bottom.rs
@@ -1,4 +1,6 @@
-use crate::types::ability::{EffectError, EffectKind, ResolvedAbility, TargetRef};
+use crate::types::ability::{
+    Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
+};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 /// CR 401.4: Target's owner puts it on top or bottom of their library.
@@ -8,8 +10,19 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let object_id = ability
-        .targets
+    // CR 608.2c + CR 603.10: Delegate target resolution to the unified 3-tier
+    // dispatch (`resolved_targets`) so this resolver picks up the same self-ref
+    // handling `Effect::Bounce` and the other zone-change resolvers use.
+    // `resolved_targets` short-circuits `SelfRef` to `ability.source_id`
+    // regardless of `ability.targets`, so a self-tuck (Arashin Sovereign: "When
+    // ~ dies, put it on your choice of the top or bottom of its owner's library")
+    // resolves to the source; a chosen/parent target is unchanged (tier 3
+    // returns the pre-selected targets satisfying the filter).
+    let target_filter = match &ability.effect {
+        Effect::PutOnTopOrBottom { target } => target,
+        _ => &TargetFilter::None,
+    };
+    let object_id = crate::game::targeting::resolved_targets(ability, target_filter, state)
         .iter()
         .find_map(|t| {
             if let TargetRef::Object(id) = t {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -8052,6 +8052,14 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return clause;
     }
 
+    // CR 608.2k + CR 401.4: self/controller-framing sibling of the above —
+    // "[you may ]put it/~ on [your choice of ]the top or bottom of its owner's
+    // library" (Arashin Sovereign). Routes the SELF form to the same
+    // Effect::PutOnTopOrBottom the owner-framing patterns produce.
+    if let Some(clause) = try_parse_self_put_on_top_or_bottom(tp, ctx) {
+        return clause;
+    }
+
     // CR 701.24a + CR 400.3: "the owner of target [filter] shuffles it into their library"
     if let Some(clause) = try_parse_owner_of_target_shuffle(tp, ctx) {
         return clause;
@@ -10040,6 +10048,49 @@ fn try_parse_put_on_top_or_bottom(
     }
 
     None
+}
+
+/// CR 608.2k + CR 401.4: "put it/~ on [your choice of ]the top or bottom of its
+/// owner's library" — the self/controller-framing sibling of the owner-framing
+/// patterns in [`try_parse_put_on_top_or_bottom`]. Arashin Sovereign: "When this
+/// creature dies, you may put it on your choice of the top or bottom of its
+/// owner's library." The dying source's owner IS the controller the card tells to
+/// choose, so `Effect::PutOnTopOrBottom`'s owner-chooses resolution (CR 401.4)
+/// matches the "your choice" text with no new effect variant and no runtime path.
+///
+/// Scoped to the SELF reference via `resolve_it_pronoun` (CR 608.2k): a non-self
+/// "it" — a triggering object another player owns, where "your choice" is NOT the
+/// owner's choice (S.N.E.A.K. Dispatcher) — or a "that card" subject (Hinder) is
+/// declined so it stays an honest coverage gap rather than letting the wrong
+/// player choose the library position.
+fn try_parse_self_put_on_top_or_bottom(
+    tp: TextPair,
+    ctx: &mut ParseContext,
+) -> Option<ParsedEffectClause> {
+    let tp = tp.trim_end_matches('.');
+
+    let matched = super::oracle_nom::bridge::nom_on_lower(tp.original, tp.lower, |i| {
+        let (i, _) = tag("put ").parse(i)?;
+        let (i, _) = alt((tag("it"), tag("~"))).parse(i)?;
+        let (i, _) = tag(" on ").parse(i)?;
+        let (i, _) = opt(tag("your choice of ")).parse(i)?;
+        let (i, _) = tag("the top or bottom of its owner's library").parse(i)?;
+        value((), eof).parse(i)
+    })
+    .is_some();
+    if !matched {
+        return None;
+    }
+
+    // CR 608.2k: "it"/"~" names the source only in a self context. Restrict the
+    // owner-chooses `PutOnTopOrBottom` to that case so a non-self reference (whose
+    // owner is not the "your choice" controller) is never mis-modelled.
+    let target = resolve_it_pronoun(ctx);
+    if !matches!(target, TargetFilter::SelfRef) {
+        return None;
+    }
+
+    Some(parsed_clause(Effect::PutOnTopOrBottom { target }))
 }
 
 /// CR 701.57a: Parse "[player] discover[s] N/X" and return the discovering

--- a/crates/engine/tests/integration/arashin_sovereign_self_tuck.rs
+++ b/crates/engine/tests/integration/arashin_sovereign_self_tuck.rs
@@ -1,0 +1,127 @@
+//! Surface parser near-miss: a SELF-reflexive library tuck — "you may put it on
+//! your choice of the top or bottom of its owner's library" (Arashin Sovereign's
+//! dies trigger) — was not routed to the existing `Effect::PutOnTopOrBottom`.
+//!
+//! The owner-framing patterns in `try_parse_put_on_top_or_bottom`
+//! (`oracle_effect/mod.rs`) recognize "its owner puts it on their choice of the
+//! top or bottom of their library" (Aether Gust, Subtlety, Aetherspouts). The
+//! controller-framing self form ("you may put it on your choice of the top or
+//! bottom of its owner's library") had no arm, so the effect body lowered to
+//! `Effect::Unimplemented` and nothing happened at resolution — Arashin stayed
+//! in the graveyard, and the whole card rendered unsupported.
+//!
+//! The one-arm fix (`try_parse_self_put_on_top_or_bottom`) routes the self form
+//! to the SAME `Effect::PutOnTopOrBottom` the owner-framing patterns produce. It
+//! is scoped to the SELF reference (`resolve_it_pronoun == SelfRef`): for the
+//! dying source's own library tuck the owner IS the controller, so the effect's
+//! owner-chooses resolution (CR 401.4) matches the card's "your choice" with no
+//! new runtime. A non-self "it" (S.N.E.A.K. Dispatcher, whose "it" is another
+//! player's card) or a "that card" subject (Hinder) is declined so the wrong
+//! player never chooses the position — those cards stay honest coverage gaps.
+//!
+//! This test drives the REAL dies-trigger -> resolve -> ChooseTopOrBottom
+//! pipeline and FAILS on `main`: the clause parses to `Unimplemented`, so no
+//! `TopOrBottomChoice` is ever offered and Arashin never leaves the graveyard.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::triggers::process_triggers;
+use engine::types::actions::GameAction;
+use engine::types::zones::Zone;
+
+// Arashin Sovereign's real Oracle text (verified against card-data.json).
+const ARASHIN_SOVEREIGN: &str = "Flying\nWhen this creature dies, you may put it on your \
+choice of the top or bottom of its owner's library.";
+
+/// After Arashin Sovereign dies and its optional dies trigger resolves with the
+/// controller choosing "top", the creature card must be on TOP of its owner's
+/// library. On `main` the effect body is `Unimplemented`, so no
+/// `TopOrBottomChoice` is ever offered and the card stays in the graveyard —
+/// both the "reached a choice" and the "now in library" assertions fail.
+#[test]
+fn arashin_sovereign_self_tuck_to_top_of_owner_library() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+
+    // Two filler cards already on top, so "top" placement is observable: after the
+    // tuck Arashin must sit at library[0], ABOVE the fillers (proves the chosen
+    // position, not merely that the card landed somewhere in the library).
+    scenario.with_library_top(P0, &["Filler A", "Filler B"]);
+
+    let arashin = scenario
+        .add_creature_from_oracle(P0, "Arashin Sovereign", 5, 7, ARASHIN_SOVEREIGN)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Kill Arashin: move it to the graveyard as a game event so the dies trigger
+    // observes the death (mirrors issue_1332_bronzehide_lion).
+    let mut events = Vec::new();
+    engine::game::zones::move_to_zone(runner.state_mut(), arashin, Zone::Graveyard, &mut events);
+    process_triggers(runner.state_mut(), &events);
+
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "Arashin's dies trigger must be on the stack"
+    );
+
+    // Drive resolution: pass priority to resolve the trigger, accept the optional
+    // "you may", then choose the TOP of the library.
+    let mut guard = 0;
+    let reached_choice = loop {
+        guard += 1;
+        assert!(
+            guard < 64,
+            "resolution exceeded safety bound; waiting_for = {} stack = {}",
+            runner.waiting_for_kind(),
+            runner.state().stack.len()
+        );
+        match runner.waiting_for_kind() {
+            "OptionalEffectChoice" => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept the optional dies trigger");
+            }
+            "TopOrBottomChoice" => {
+                runner
+                    .act(GameAction::ChooseTopOrBottom { top: true })
+                    .expect("choose top of library");
+                break true;
+            }
+            "Priority" => {
+                if runner.state().stack.is_empty() {
+                    break false;
+                }
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break false;
+                }
+            }
+            _ => break false,
+        }
+    };
+
+    assert!(
+        reached_choice,
+        "the self-tuck must reach a TopOrBottomChoice; on `main` the clause is \
+         Unimplemented so no choice is offered and Arashin never leaves the graveyard"
+    );
+
+    // End-to-end runtime delta: Arashin is now the TOP card of its owner's (P0's)
+    // library, not in the graveyard. On `main` it is still in the graveyard.
+    let arashin_obj = &runner.state().objects[&arashin];
+    assert_eq!(
+        arashin_obj.zone,
+        Zone::Library,
+        "Arashin must be in its owner's library after the self-tuck resolves; got {:?}",
+        arashin_obj.zone
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .library
+            .iter()
+            .next()
+            .copied(),
+        Some(arashin),
+        "Arashin must be on TOP of P0's library (the chosen position)"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -13,6 +13,7 @@ mod ancient_bronze_dragon_roll_d20;
 mod ancient_copper_dragon_roll_d20;
 mod announce_locked_x_runtime;
 mod another_round_repeat;
+mod arashin_sovereign_self_tuck;
 mod archmage_ascension_gated_draw_replacement;
 mod ark_of_hunger_play_from_graveyard_751;
 mod armored_kincaller_or_condition;


### PR DESCRIPTION
## Summary

Adds **Arashin Sovereign** by routing its self-reflexive dies-trigger library tuck — "you may put it on your choice of the top or bottom of its owner's library" — to the existing `Effect::PutOnTopOrBottom`. The owner-framing patterns in `try_parse_put_on_top_or_bottom` already recognize "its owner puts it on their choice of the top or bottom of their library" (Aether Gust, Subtlety, Aetherspouts), but the controller/self-framing form had no arm, so the effect body lowered to `Effect::Unimplemented` and the whole card rendered unsupported.

**Parser:** `try_parse_self_put_on_top_or_bottom` adds one recognizer arm (sibling of the owner-framing arms in `try_parse_put_on_top_or_bottom`) that routes the SELF form to the same `Effect::PutOnTopOrBottom` — no new effect variant, no new runtime path. It is scoped to the self reference (`resolve_it_pronoun == SelfRef`): for the dying source's own library tuck the owner IS the controller, so the effect's owner-chooses resolution (CR 401.4) matches the card's "your choice". A non-self "it" (S.N.E.A.K. Dispatcher) or a "that card" subject (Hinder) is declined so it stays an honest coverage gap rather than letting the wrong player choose the library position.

**Resolver (sibling-consistency fix, existing behavior unchanged):** `PutOnTopOrBottom`'s resolver read `ability.targets` directly, which is empty for a `SelfRef` effect (SelfRef is not a chosen target). It now delegates to the shared `resolved_targets` 3-tier dispatch, matching `Effect::Bounce` and the other zone-change resolvers. `resolved_targets` short-circuits `SelfRef` to `ability.source_id`; for the pre-existing chosen/parent-target cards it returns the pre-selected targets satisfying the filter (`ability.targets.clone()`) — the exact pre-fix binding. The existing owner-framing PutOnTopOrBottom cards are unaffected.

**Test:** Adds a discriminating integration test driving the real dies-trigger -> resolve -> ChooseTopOrBottom pipeline; it fails on `main`.

## Method
- Method: /engine-implementer
- Track: Developer
- Model: claude-opus-4-8, Thinking: high

## Verification
- Gate A PASS head=faf2d36a68b3109ade7443a8825953e09dc96431 base=6146e6348af1dd38e6e3b76562b8d8d8803c67c2
- Anchored on: `try_parse_put_on_top_or_bottom` owner-framing arms + `bounce.rs` / `change_zone.rs` `resolved_targets`
- Final review-impl PASS head=faf2d36a68b3109ade7443a8825953e09dc96431
- `cargo fmt --all --check`: clean
- `cargo test -p engine -- arashin put_on_top_or_bottom`: 6 unit + 1 integration passed, 0 failed
- `cargo test -p engine`: full suite passed, 0 failed
- Claimed parse impact: +1 supported (Arashin Sovereign), 0 regressions
- Validation/CI Failures: None
