### PR TITLE
fix(parser): compose Class-level trigger conditions instead of overwriting them (#5638)

### DIFF
--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -352,6 +352,10 @@ fn parse_class_level_trigger(line: &str, card_name: &str, level: u8) -> Option<T
 fn wrap_trigger_with_class_level(trigger: &mut TriggerDefinition, level: u8) {
     let level_cond = TriggerCondition::ClassLevelGE { level };
     trigger.condition = Some(match trigger.condition.take() {
+        Some(TriggerCondition::And { mut conditions }) => {
+            conditions.insert(0, level_cond);
+            TriggerCondition::And { conditions }
+        }
         Some(existing) => TriggerCondition::And {
             conditions: vec![level_cond, existing],
         },
@@ -394,6 +398,8 @@ fn wrap_replacement_with_class_level(
 mod tests {
     use crate::parser::oracle::parse_oracle_text;
     use crate::types::ability::{ContinuousModification, Effect, TriggerCondition};
+    use crate::types::phase::Phase;
+    use crate::types::triggers::TriggerMode;
 
     /// CR 716.2a: A level-3+ trigger that already carries a printed
     /// intervening-if ("if a modified creature died under your control this
@@ -421,11 +427,7 @@ mod tests {
         let level_3_trigger = result
             .triggers
             .iter()
-            .find(|t| {
-                t.description
-                    .as_deref()
-                    .is_some_and(|d| d.contains("end step"))
-            })
+            .find(|t| t.mode == TriggerMode::Phase && t.phase == Some(Phase::End))
             .expect("level-3 end-step trigger should be present");
 
         match level_3_trigger

--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -173,9 +173,7 @@ pub(crate) fn parse_class_oracle_text(
                 // CR 716.2a: Gate continuous triggers at levels > 1.
                 if section.level > 1 {
                     for trigger in &mut triggers {
-                        trigger.condition = Some(TriggerCondition::ClassLevelGE {
-                            level: section.level,
-                        });
+                        wrap_trigger_with_class_level(trigger, section.level);
                     }
                 }
                 items.extend(
@@ -243,9 +241,7 @@ pub(crate) fn parse_class_oracle_text(
                     );
                     if section.level > 1 {
                         for trigger in &mut triggers {
-                            trigger.condition = Some(TriggerCondition::ClassLevelGE {
-                                level: section.level,
-                            });
+                            wrap_trigger_with_class_level(trigger, section.level);
                         }
                     }
                     items.extend(
@@ -347,6 +343,22 @@ fn parse_class_level_trigger(line: &str, card_name: &str, level: u8) -> Option<T
     )
 }
 
+/// CR 716.2a: Gate a Class-level trigger's intervening-if on the source Class
+/// being at `level` or higher. If the trigger already carries a condition
+/// (e.g. a printed intervening-if like "if a modified creature died under
+/// your control this turn"), compose both predicates with And instead of
+/// overwriting — mirrors `wrap_static_with_class_level` /
+/// `wrap_replacement_with_class_level` below.
+fn wrap_trigger_with_class_level(trigger: &mut TriggerDefinition, level: u8) {
+    let level_cond = TriggerCondition::ClassLevelGE { level };
+    trigger.condition = Some(match trigger.condition.take() {
+        Some(existing) => TriggerCondition::And {
+            conditions: vec![level_cond, existing],
+        },
+        None => level_cond,
+    });
+}
+
 /// Wrap a static definition's condition with ClassLevelGE.
 /// If the static already has a condition, compose with And.
 fn wrap_static_with_class_level(mut static_def: StaticDefinition, level: u8) -> StaticDefinition {
@@ -381,7 +393,68 @@ fn wrap_replacement_with_class_level(
 #[cfg(test)]
 mod tests {
     use crate::parser::oracle::parse_oracle_text;
-    use crate::types::ability::{ContinuousModification, Effect};
+    use crate::types::ability::{ContinuousModification, Effect, TriggerCondition};
+
+    /// CR 716.2a: A level-3+ trigger that already carries a printed
+    /// intervening-if ("if a modified creature died under your control this
+    /// turn") must keep BOTH the printed condition and the level gate. Before
+    /// this fix, `parse_class_oracle_text` unconditionally overwrote
+    /// `trigger.condition` with `ClassLevelGE`, silently dropping the printed
+    /// intervening-if (issue #5638 — Intermediate Chirography's level-3
+    /// ability parsed as "at the beginning of each end step, create a token"
+    /// with no death check at all).
+    #[test]
+    fn class_level_trigger_composes_printed_condition_with_class_level_gate() {
+        let oracle_text = "When this Class enters, create a 2/1 white and black Inkling creature token with flying.\n\
+             {1}{B}: Level 2\n\
+             Whenever you lose life for the first time each turn, put a +1/+1 counter on target creature you control.\n\
+             {2}{B}: Level 3\n\
+             At the beginning of each end step, if a modified creature died under your control this turn, create a 2/1 white and black Inkling creature token with flying.";
+        let result = parse_oracle_text(
+            oracle_text,
+            "Intermediate Chirography",
+            &[],
+            &["Enchantment".to_string()],
+            &["Class".to_string()],
+        );
+
+        let level_3_trigger = result
+            .triggers
+            .iter()
+            .find(|t| {
+                t.description
+                    .as_deref()
+                    .is_some_and(|d| d.contains("end step"))
+            })
+            .expect("level-3 end-step trigger should be present");
+
+        match level_3_trigger
+            .condition
+            .as_ref()
+            .expect("level-3 trigger must carry a condition")
+        {
+            TriggerCondition::And { conditions } => {
+                assert!(
+                    conditions
+                        .iter()
+                        .any(|c| matches!(c, TriggerCondition::ClassLevelGE { level: 3 })),
+                    "expected ClassLevelGE(3) among composed conditions, got {conditions:?}"
+                );
+                assert!(
+                    conditions
+                        .iter()
+                        .any(|c| matches!(c, TriggerCondition::QuantityComparison { .. })),
+                    "expected the printed 'died under your control this turn' \
+                     intervening-if to survive as a QuantityComparison, got {conditions:?}"
+                );
+            }
+            other => panic!(
+                "expected TriggerCondition::And composing the class-level gate \
+                 with the printed intervening-if, got {other:?} — the printed \
+                 condition was likely overwritten"
+            ),
+        }
+    }
 
     /// CR 707.9a + CR 716.2a: A Class-level trigger body using "becomes a copy
     /// of <X>, except <pronoun> has this ability" must resolve

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -42,24 +42,27 @@ fn parse_two_layer_with_keywords(
 /// to give it a private one. `OracleDocIr.diagnostics` is the single warning
 /// channel; `parse_warnings` is a copy of it.
 ///
-/// Fixture is pool-verified, not synthetic: Intermediate Chirography's Oracle text
-/// is verbatim MTGJSON, and it carries a live `Duration_ThisTurn` swallowed-clause
-/// warning in shipped `card-data.json` (M1 defect ledger → issue #5638) — the
-/// "this turn" in its level-3 trigger is not represented in the parse. A synthetic
-/// fixture could go vacuously green if the detector stopped firing; this one cannot
-/// without that separately-tracked defect being fixed.
+/// Fixture is pool-verified, not synthetic: Boing!'s Oracle text is verbatim
+/// MTGJSON, and it carries a live `DynamicQty` swallowed-clause warning — "scry
+/// a number of cards equal to the result" lowers to a fixed `Scry` count, so
+/// the die-result-dependent quantity is genuinely dropped from the parse. A
+/// synthetic fixture could go vacuously green if the detector stopped firing;
+/// this one cannot without that separately-tracked defect being fixed.
+///
+/// (Intermediate Chirography previously served as this fixture, but issue
+/// #5638's fix taught `parse_class_oracle_text` to compose a level-gated
+/// trigger's printed intervening-if with its `ClassLevelGE` condition instead
+/// of overwriting it — the card's `Duration_ThisTurn` warning was that
+/// overwrite silently dropping the "this turn" scoped condition, and is gone
+/// now that the condition survives.)
 #[test]
 fn swallow_diagnostics_are_homed_in_the_doc_ir_channel() {
     let (ir, lowered) = parse_two_layer(
-        "(Gain the next level as a sorcery to add its ability.)\n\
-         When this Class enters, create a 2/1 white and black Inkling creature token with flying.\n\
-         {1}{B}: Level 2\n\
-         Whenever you lose life for the first time each turn, put a +1/+1 counter on target creature you control.\n\
-         {2}{B}: Level 3\n\
-         At the beginning of each end step, if a modified creature died under your control this turn, create a 2/1 white and black Inkling creature token with flying. (Equipment, Auras you control, and counters are modifications.)",
-        "Intermediate Chirography",
-        &["Enchantment"],
-        &["Class"],
+        "Return target creature to its owner's hand, then roll a six-sided die. \
+         If the result is 3 or less, scry a number of cards equal to the result.",
+        "Boing!",
+        &["Instant"],
+        &[],
     );
 
     // (a) The re-homing itself. Before this change the audit wrote to a private vec


### PR DESCRIPTION
fix(parser): compose Class-level trigger conditions instead of overwriting them (#5638)

parse_class_oracle_text gated level-2+ triggers by unconditionally
assigning trigger.condition = ClassLevelGE, which silently dropped any
printed intervening-if already parsed onto the trigger. Intermediate
Chirography's level-3 ability ("if a modified creature died under your
control this turn") lost its death check entirely and always created
a token at end step. Compose with TriggerCondition::And instead,
mirroring the existing static/replacement class-level wrappers.

Closes #5638

