### PR TITLE
fix(engine): don't offer an optional counter removal with zero counters (Sun Droplet #4776)

### DIFF
--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -1488,17 +1488,27 @@ pub fn resolve_multiply(
     Ok(())
 }
 
-/// CR 118.12 + CR 601.2f (by analogy) + CR 122.1: True when a `RemoveCounter`
-/// effect used as an optional "you may" gate cannot be performed because none of
-/// its resolved target object(s) hold a matching counter — "you may remove a
-/// charge counter from this artifact" with zero charge counters (Sun Droplet).
+/// CR 608.2d + CR 118.12 + CR 122.1: True when a `RemoveCounter` effect used as
+/// an optional "you may" gate cannot be performed — none of its resolved target
+/// object(s) hold a matching counter that is *permitted to be removed*. "You may
+/// remove a charge counter from this artifact" with zero charge counters (Sun
+/// Droplet), or with the counter present but frozen by a `CountersCantBeRemoved`
+/// static (Fear of Sleep Paralysis class).
 ///
-/// Removing a counter that isn't there is doing nothing, so the up-front "you
-/// may" must not be offered (and its `EffectOutcome::OptionalEffectPerformed`
-/// rider — "If you do, gain 1 life" — must not fire). Delegates to the same
-/// `resolve_defined_or_targets` authority the resolver uses, so feasibility and
-/// resolution never diverge. Returns `false` (feasible) for any non-`RemoveCounter`
-/// effect so the caller's other arms are unaffected.
+/// CR 608.2d: a player can't choose an impossible option. Removing a counter that
+/// isn't there — or one an effect forbids removing — does nothing, so the
+/// up-front "you may" must not be offered. CR 118.12: the `EffectOutcome::
+/// OptionalEffectPerformed` rider ("If you do, gain 1 life") checks whether the
+/// player chose to perform the action; if the action is impossible the choice is
+/// never offered, so the rider must not fire.
+///
+/// Both the presence check and the removal-prohibition check use the resolver's
+/// own authorities (`resolve_defined_or_targets`, `counter_removal_blocked`), so
+/// feasibility and resolution can never diverge. A `count > 1` request is still
+/// feasible whenever ≥1 permitted counter exists — the resolver removes as many
+/// as available (CR 122.1 "as much as possible"), a nonzero action. Returns
+/// `false` (feasible) for any non-`RemoveCounter` effect so the caller's other
+/// arms are unaffected.
 pub(crate) fn remove_counter_optional_is_infeasible(
     state: &GameState,
     ability: &ResolvedAbility,
@@ -1507,17 +1517,20 @@ pub(crate) fn remove_counter_optional_is_infeasible(
         return false;
     };
     let targets = resolve_defined_or_targets(state, ability);
-    // Infeasible iff NO resolved target holds a matching counter. `counter_type`
-    // is `Option<CounterType>`: `Some(ct)` matches that specific kind ("a charge
-    // counter"), `None` means any kind ("a counter"). An empty target set is
-    // likewise infeasible (nothing to remove from).
-    !targets.iter().any(|obj_id| {
+    // Feasible iff SOME resolved target holds a matching counter that is not
+    // removal-blocked. `counter_type` is `Option<CounterType>`: `Some(ct)`
+    // matches that specific kind ("a charge counter"), `None` means any kind
+    // ("a counter"). An empty target set is infeasible (nothing to remove from).
+    let feasible = targets.iter().any(|obj_id| {
         state.objects.get(obj_id).is_some_and(|obj| {
             obj.counters.iter().any(|(ct, &n)| {
-                n > 0 && counter_type.as_ref().is_none_or(|expected| expected == ct)
+                n > 0
+                    && counter_type.as_ref().is_none_or(|expected| expected == ct)
+                    && !counter_removal_blocked(state, *obj_id, ct)
             })
         })
-    })
+    });
+    !feasible
 }
 
 /// Resolve targeting to object IDs using the typed TargetFilter.

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -1488,6 +1488,38 @@ pub fn resolve_multiply(
     Ok(())
 }
 
+/// CR 118.12 + CR 601.2f (by analogy) + CR 122.1: True when a `RemoveCounter`
+/// effect used as an optional "you may" gate cannot be performed because none of
+/// its resolved target object(s) hold a matching counter — "you may remove a
+/// charge counter from this artifact" with zero charge counters (Sun Droplet).
+///
+/// Removing a counter that isn't there is doing nothing, so the up-front "you
+/// may" must not be offered (and its `EffectOutcome::OptionalEffectPerformed`
+/// rider — "If you do, gain 1 life" — must not fire). Delegates to the same
+/// `resolve_defined_or_targets` authority the resolver uses, so feasibility and
+/// resolution never diverge. Returns `false` (feasible) for any non-`RemoveCounter`
+/// effect so the caller's other arms are unaffected.
+pub(crate) fn remove_counter_optional_is_infeasible(
+    state: &GameState,
+    ability: &ResolvedAbility,
+) -> bool {
+    let Effect::RemoveCounter { counter_type, .. } = &ability.effect else {
+        return false;
+    };
+    let targets = resolve_defined_or_targets(state, ability);
+    // Infeasible iff NO resolved target holds a matching counter. `counter_type`
+    // is `Option<CounterType>`: `Some(ct)` matches that specific kind ("a charge
+    // counter"), `None` means any kind ("a counter"). An empty target set is
+    // likewise infeasible (nothing to remove from).
+    !targets.iter().any(|obj_id| {
+        state.objects.get(obj_id).is_some_and(|obj| {
+            obj.counters.iter().any(|(ct, &n)| {
+                n > 0 && counter_type.as_ref().is_none_or(|expected| expected == ct)
+            })
+        })
+    })
+}
+
 /// Resolve targeting to object IDs using the typed TargetFilter.
 fn resolve_defined_or_targets(
     state: &GameState,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4718,6 +4718,13 @@ fn optional_effect_is_infeasible(state: &GameState, ability: &ResolvedAbility) -
                     .any(|attr| matches!(attr, ChosenAttribute::Counter(_)))
             })
         }
+        // CR 122.1: "you may remove a <kind> counter from <object>. If you do, X"
+        // with zero matching counters cannot be performed — removing a counter
+        // that isn't there does nothing, so the up-front prompt (and its
+        // `OptionalEffectPerformed` rider) must be suppressed (Sun Droplet #4776).
+        Effect::RemoveCounter { .. } => {
+            counters::remove_counter_optional_is_infeasible(state, ability)
+        }
         _ => false,
     }
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -705,6 +705,7 @@ mod std_s07_damage_doublers;
 mod steadfast_armasaur_lki_toughness;
 mod steelform_sliver_toughness_anthem;
 mod stensian_sanguinist_prepare;
+mod sun_droplet_remove_counter_infeasible_4776;
 mod support;
 mod suppressor_skyguard_prevent_2924;
 mod surveil_rest_pile_redirect_continuation;

--- a/crates/engine/tests/integration/sun_droplet_remove_counter_infeasible_4776.rs
+++ b/crates/engine/tests/integration/sun_droplet_remove_counter_infeasible_4776.rs
@@ -14,14 +14,17 @@
 //!
 //! CR references (verified against docs/MagicCompRules.txt):
 //! - CR 122.1: counters; removing a counter that isn't present does nothing.
-//! - CR 603.12 + CR 608.2c: "If you do" gates the rider on the optional action
-//!   actually occurring.
+//! - CR 608.2d: a player can't choose an impossible option.
+//! - CR 118.12: "If you do" gates the rider on the optional action being chosen;
+//!   an impossible action is never offered, so the rider never fires.
 
 use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{ControllerRef, StaticDefinition, TargetFilter, TypedFilter};
 use engine::types::actions::GameAction;
 use engine::types::counter::CounterType;
 use engine::types::game_state::WaitingFor;
 use engine::types::phase::Phase;
+use engine::types::statics::StaticMode;
 
 const SUN_DROPLET: &str = "Whenever you're dealt damage, put that many charge counters on this artifact.\nAt the beginning of each upkeep, you may remove a charge counter from this artifact. If you do, you gain 1 life.";
 
@@ -143,5 +146,73 @@ fn sun_droplet_with_counter_prompts_and_gains_life_on_accept() {
         runner.life(P0),
         life_before + 1,
         "removing a counter must gain 1 life"
+    );
+}
+
+/// Review regression (matthewevans, #6022): a charge counter IS present but a
+/// `CountersCantBeRemoved(charge)` static (Fear of Sleep Paralysis class) makes
+/// its removal impossible. The optional prompt must STILL be suppressed — a
+/// removal the rules forbid is an impossible option (CR 608.2d), so accepting it
+/// must not fire the "if you do, gain 1 life" rider (CR 118.12). Reverting the
+/// `counter_removal_blocked` check re-exposes the phantom lifegain.
+#[test]
+fn sun_droplet_counter_present_but_removal_blocked_no_prompt_no_lifegain() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    let droplet = {
+        let mut b = scenario.add_creature_from_oracle(P0, "Sun Droplet", 0, 0, SUN_DROPLET);
+        b.as_artifact();
+        b.id()
+    };
+    scenario.with_counter(droplet, charge(), 2);
+    // A separate permanent contributing a CountersCantBeRemoved(charge) static
+    // that affects Sun Droplet (all permanents), freezing its charge counters.
+    let warden = scenario.add_creature(P0, "Counter Warden", 2, 2).id();
+    for _ in 0..10 {
+        scenario.add_card_to_library_top(P0, "Plains");
+    }
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&warden)
+        .unwrap()
+        .static_definitions
+        .push(
+            StaticDefinition::new(StaticMode::CountersCantBeRemoved {
+                counter_type: charge(),
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::permanent().controller(ControllerRef::You),
+            )),
+        );
+    let life_before = runner.life(P0);
+
+    runner.advance_to_upkeep();
+    runner.advance_until_stack_empty();
+
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ),
+        "a removal-blocked counter is an impossible option — no prompt: {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        runner.life(P0),
+        life_before,
+        "removal forbidden by a static means no life gained (CR 118.12)"
+    );
+    // The counter itself is untouched.
+    assert_eq!(
+        runner.state().objects[&droplet]
+            .counters
+            .get(&charge())
+            .copied()
+            .unwrap_or(0),
+        2,
+        "the frozen charge counters must remain"
     );
 }

--- a/crates/engine/tests/integration/sun_droplet_remove_counter_infeasible_4776.rs
+++ b/crates/engine/tests/integration/sun_droplet_remove_counter_infeasible_4776.rs
@@ -1,0 +1,147 @@
+//! Issue #4776 — Sun Droplet: "you may remove a charge counter. If you do,
+//! gain 1 life" must NOT be offered when the artifact has zero charge counters.
+//!
+//! Oracle (Scryfall-verified):
+//!   "Whenever you're dealt damage, put that many charge counters on this
+//!    artifact. At the beginning of each upkeep, you may remove a charge counter
+//!    from this artifact. If you do, you gain 1 life."
+//!
+//! Root cause: the up-front optional-effect feasibility gate
+//! (`optional_effect_is_infeasible`) only special-cased `PutChosenCounter`;
+//! `RemoveCounter` fell through to "always feasible", so with zero counters the
+//! player was still prompted, could accept, `OptionalEffectPerformed` was
+//! recorded true, and the `GainLife` rider fired — life from nothing.
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//! - CR 122.1: counters; removing a counter that isn't present does nothing.
+//! - CR 603.12 + CR 608.2c: "If you do" gates the rider on the optional action
+//!   actually occurring.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+const SUN_DROPLET: &str = "Whenever you're dealt damage, put that many charge counters on this artifact.\nAt the beginning of each upkeep, you may remove a charge counter from this artifact. If you do, you gain 1 life.";
+
+fn charge() -> CounterType {
+    CounterType::Generic("charge".to_string())
+}
+
+/// Zero charge counters: the upkeep trigger must NOT surface the "you may
+/// remove a charge counter?" optional prompt, and P0's life must not change.
+/// Reverting the fix re-exposes the prompt and (on accept) the phantom lifegain.
+#[test]
+fn sun_droplet_zero_counters_no_optional_prompt_no_lifegain() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    let droplet = {
+        let mut b = scenario.add_creature_from_oracle(P0, "Sun Droplet", 0, 0, SUN_DROPLET);
+        b.as_artifact();
+        b.id()
+    };
+    // Library padding so advancing the turn doesn't deck anyone.
+    for _ in 0..10 {
+        scenario.add_card_to_library_top(P0, "Plains");
+    }
+
+    let mut runner = scenario.build();
+    assert_eq!(
+        runner.state().objects[&droplet]
+            .counters
+            .get(&charge())
+            .copied()
+            .unwrap_or(0),
+        0,
+        "precondition: Sun Droplet has no charge counters"
+    );
+    let life_before = runner.life(P0);
+
+    runner.advance_to_upkeep();
+    runner.advance_until_stack_empty();
+
+    // No optional prompt was ever surfaced for the infeasible removal.
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ),
+        "the infeasible 'remove a charge counter' must not prompt: {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        runner.life(P0),
+        life_before,
+        "no counter to remove means no life gained (CR 603.12 'if you do')"
+    );
+}
+
+/// With a charge counter present the ability IS feasible: the optional prompt is
+/// offered, and accepting removes the counter and gains 1 life. This is the
+/// positive reach-guard proving the fix does not over-suppress a real choice.
+#[test]
+fn sun_droplet_with_counter_prompts_and_gains_life_on_accept() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    let droplet = {
+        let mut b = scenario.add_creature_from_oracle(P0, "Sun Droplet", 0, 0, SUN_DROPLET);
+        b.as_artifact();
+        b.id()
+    };
+    scenario.with_counter(droplet, charge(), 2);
+    for _ in 0..10 {
+        scenario.add_card_to_library_top(P0, "Plains");
+    }
+
+    let mut runner = scenario.build();
+    let life_before = runner.life(P0);
+
+    runner.advance_to_upkeep();
+    // Resolve the upkeep trigger; it must surface the optional prompt. Pass
+    // priority until either the optional choice appears or the stack drains.
+    for _ in 0..40 {
+        if matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ) {
+            break;
+        }
+        if runner.state().stack.is_empty()
+            && !matches!(runner.state().waiting_for, WaitingFor::OrderTriggers { .. })
+        {
+            break;
+        }
+        if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+    }
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ),
+        "with a charge counter, the removal must be offered: {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accepting the counter removal must be allowed");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&droplet]
+            .counters
+            .get(&charge())
+            .copied()
+            .unwrap_or(0),
+        1,
+        "accepting must remove exactly one charge counter (2 -> 1)"
+    );
+    assert_eq!(
+        runner.life(P0),
+        life_before + 1,
+        "removing a counter must gain 1 life"
+    );
+}


### PR DESCRIPTION
Fixes #4776 (claimed there). Verified the card (Sun Droplet) on Scryfall and reproduced end-to-end before building.

## The bug
Sun Droplet: *"At the beginning of each upkeep, you may remove a charge counter from this artifact. If you do, you gain 1 life."* With **zero** charge counters, the player was still prompted to remove one; accepting recorded `OptionalEffectPerformed = true` and fired the `GainLife` rider — **life from nothing**.

## Root cause
The up-front optional-effect feasibility gate `optional_effect_is_infeasible` (`effects/mod.rs`) only special-cased `Effect::PutChosenCounter`; every other optional effect — including `RemoveCounter` — fell through to `_ => false` (always feasible). So the "you may" was offered even when nothing could be removed, and its "if you do" rider then fired.

## The fix
Extend the gate to recognize a `RemoveCounter` whose resolved target object(s) hold **zero** matching counters. The new `counters::remove_counter_optional_is_infeasible` reuses the resolver's own `resolve_defined_or_targets` authority (so feasibility and resolution can't diverge) and honors `RemoveCounter`'s `Option<CounterType>` — `Some(kind)` matches that specific counter, `None` matches any. When infeasible, the up-front prompt is suppressed and its rider does not fire (CR 122.1: removing an absent counter does nothing; CR 603.12 + CR 608.2c: the "if you do" gates on the action occurring). This covers the whole *"you may remove a counter. If you do, X"* class — not just Sun Droplet.

## A note on the reproduction
While building the test I initially wrote Sun Droplet's two abilities on one line and saw only the `DamageReceived` trigger parse (no upkeep trigger) — which would have made this a parser issue. Tracing it, the parser produces **both** triggers correctly when the abilities are newline-separated (how card-data actually stores them); the single-line form was a test artifact. So the upkeep trigger DOES fire in production, and this engine gate is the operative fix. The test uses the real newline-separated text.

## Tests (integration, real upkeep-trigger pipeline, verbatim Oracle text)
- **zero counters**: the optional prompt is NOT surfaced and life is unchanged. **Revert-probed** — restoring the old `_ => false` re-exposes the phantom prompt/lifegain and this test fails.
- **with two counters** (positive reach-guard): the prompt IS offered; accepting removes exactly one counter (2 → 1) and gains 1 life — proving the gate doesn't over-suppress a feasible choice.

## Verification
Full engine lib: **16733 passed, 0 failed**. Integration: **3173 passed, 0 failed**. Clippy `-D warnings` clean; fmt clean. CR annotations (122.1, 603.12, 608.2c) grep-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)